### PR TITLE
feat(rib): filter VPNv4/VPNv6 reflection by peer RT-Constrain membership

### DIFF
--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -1943,6 +1943,29 @@ impl RibManager {
         }
     }
 
+    /// Resolve the RFC 4684 VPN outbound filter for `peer`: `Some` iff the
+    /// peer negotiated `(IPv4, RtConstrain)`; a somehow-absent membership
+    /// entry resolves to the strict empty filter (advertise nothing) rather
+    /// than fail-open. Returns an owned clone because every caller holds a
+    /// `&mut` Adj-RIB-Out borrow through `self` while staging (the ORF
+    /// precedent) — memberships are small, present only for RTC peers.
+    pub(super) fn rtc_vpn_filter(
+        &self,
+        peer: IpAddr,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+    ) -> Option<super::RtcMembership> {
+        if sendable.is_some_and(|f| f.contains(&crate::route::RtcRibRouteKey::afi_safi())) {
+            Some(
+                self.peer_rt_membership
+                    .get(&peer)
+                    .cloned()
+                    .unwrap_or_default(),
+            )
+        } else {
+            None
+        }
+    }
+
     /// Stage VPNv4/VPNv6 announces and withdrawals for a set of affected keys.
     ///
     /// ADR-0077 §6 guardrail: the next-hop, MPLS label stack, and Route
@@ -1968,6 +1991,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        rtc_filter: Option<&super::RtcMembership>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -1992,6 +2016,21 @@ impl RibManager {
                 }
                 continue;
             };
+
+            // RFC 4684 outbound gate: a peer that negotiated RT-Constrain
+            // only receives VPN routes whose Route Targets fall inside its
+            // advertised membership (`None` = SAFI 132 not negotiated ⇒
+            // unfiltered). Membership is per-peer, so the one gate covers
+            // both VPNv4 and VPNv6 keys. Miss ⇒ withdraw-if-present,
+            // exactly the sendable-family gate shape above.
+            if let Some(membership) = rtc_filter
+                && !membership.matches_any(best.extended_communities())
+            {
+                if rib_out.get_vpn(key).is_some() {
+                    vpn_withdraw.push(key.clone());
+                }
+                continue;
+            }
 
             if best.peer == target_peer {
                 if rib_out.get_vpn(key).is_some() {
@@ -2421,6 +2460,7 @@ impl RibManager {
             // is cheap: ORF filters are small and present only for peers that
             // negotiated ORF (None for everyone else).
             let orf_filters = self.peer_orf_filters.get(&peer).cloned();
+            let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
             let orf_gated = self
                 .peer_orf_pending
                 .get(&peer)
@@ -2591,6 +2631,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    rtc_filter.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -3127,6 +3168,7 @@ impl RibManager {
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
             let export_pol = self.export_policy_for(peer).cloned();
+            let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 
@@ -3151,6 +3193,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                rtc_filter.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -35,6 +35,33 @@ use helpers::{DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, prefix_family};
 #[cfg(test)]
 use helpers::{ERR_REFRESH_TIMEOUT, LOCAL_PEER, validate_route_rpki};
 
+/// A peer's RT-Constrain membership (RFC 4684): the Route Targets the peer
+/// declared interest in via SAFI-132 NLRI. Rebuilt whole from the peer's OWN
+/// Adj-RIB-In (all paths — never the Loc-RIB best, whose tiebreak winner may
+/// belong to a different peer) whenever that Adj-RIB-In mutates.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RtcMembership {
+    /// Peer advertised the zero-length default NLRI: interest in every RT.
+    has_default: bool,
+    /// Non-default membership NLRI, sorted + deduped so rebuilds of the
+    /// same set compare equal regardless of `HashMap` iteration order.
+    entries: Vec<rustbgpd_wire::RtcNlri>,
+}
+
+impl RtcMembership {
+    /// Whether any of `rts` falls inside this membership. An empty
+    /// membership (SAFI 132 negotiated, no interest received yet) matches
+    /// nothing — the strict RFC 4684 rule, so a route with no Route Target
+    /// at all only passes via the default NLRI.
+    fn matches_any(&self, rts: &[rustbgpd_wire::ExtendedCommunity]) -> bool {
+        if self.has_default {
+            return true;
+        }
+        rts.iter()
+            .any(|&rt| self.entries.iter().any(|nlri| nlri.matches(rt)))
+    }
+}
+
 /// Central RIB manager that owns all Adj-RIB-In, Loc-RIB, and Adj-RIB-Out state.
 ///
 /// Runs as a single tokio task, receiving updates via an mpsc channel.
@@ -109,6 +136,8 @@ pub struct RibManager {
     refresh_stale_bgpls: HashMap<IpAddr, HashSet<crate::route::BgpLsRouteKey>>,
     /// VPNv4/VPNv6 routes still awaiting replacement during an inbound refresh.
     refresh_stale_vpn: HashMap<IpAddr, HashSet<crate::route::VpnRibRouteKey>>,
+    /// RT-Constrain routes still awaiting replacement during an inbound refresh.
+    refresh_stale_rtc: HashMap<IpAddr, HashSet<crate::route::RtcRibRouteKey>>,
     /// O(1) per-peer/per-family stale-entry counts for refresh observability.
     refresh_stale_counts: HashMap<(IpAddr, Afi, Safi), usize>,
     /// Peers currently undergoing graceful restart, keyed by peer address.
@@ -140,6 +169,13 @@ pub struct RibManager {
     /// `(AFI, SAFI)`. Consulted as an additional outbound filter before export
     /// policy when distributing to the peer. Absent ⇒ no ORF constraint.
     peer_orf_filters: HashMap<IpAddr, HashMap<(Afi, Safi), crate::orf::OrfFilterSet>>,
+    /// Per-peer RT-Constrain membership (RFC 4684) gating VPNv4/VPNv6
+    /// distribution. Present (possibly empty = advertise NO VPN routes,
+    /// the strict rule) from peer-up for every peer that negotiated
+    /// `(IPv4, RtConstrain)`; absent ⇒ no RTC constraint. Per-session
+    /// state: cleared with the rest of the outbound teardown, so a GR
+    /// re-establish starts strict until the peer's interest re-arrives.
+    peer_rt_membership: HashMap<IpAddr, RtcMembership>,
     /// Families whose initial advertisement is gated pending the peer's first
     /// ROUTE-REFRESH (RFC 5291 §6). While a `(peer, AFI, SAFI)` is here, the
     /// initial table dump skips it; the gate is lifted on the first refresh.
@@ -525,6 +561,7 @@ impl RibManager {
             refresh_stale_evpn: HashMap::new(),
             refresh_stale_bgpls: HashMap::new(),
             refresh_stale_vpn: HashMap::new(),
+            refresh_stale_rtc: HashMap::new(),
             refresh_stale_counts: HashMap::new(),
             gr_peers: HashMap::new(),
             gr_stale_deadlines: HashMap::new(),
@@ -535,6 +572,7 @@ impl RibManager {
             peer_add_path_send_max: HashMap::new(),
             peer_add_path_send_families: HashMap::new(),
             peer_orf_filters: HashMap::new(),
+            peer_rt_membership: HashMap::new(),
             peer_orf_pending: HashMap::new(),
             gr_deferred_eor: HashMap::new(),
             peer_asn: HashMap::new(),
@@ -639,6 +677,7 @@ impl RibManager {
         self.refresh_stale_evpn.remove(&peer);
         self.refresh_stale_bgpls.remove(&peer);
         self.refresh_stale_vpn.remove(&peer);
+        self.refresh_stale_rtc.remove(&peer);
         self.refresh_stale_counts
             .retain(|(stale_peer, _, _), _| *stale_peer != peer);
         self.refresh_deadlines
@@ -1732,16 +1771,22 @@ impl RibManager {
         self.recompute_and_distribute_vpn(affected);
     }
 
-    /// RT-Constrain ingest (RFC 4684). Mirrors the VPN receive path minus
-    /// the enhanced-refresh stale bookkeeping (no RTC refresh lifecycle yet)
-    /// and minus any VPN-filter membership rebuild — that is the next slice.
+    /// RT-Constrain ingest (RFC 4684). Mirrors the VPN receive path; after
+    /// the Adj-RIB-In mutation the peer's RT membership is rebuilt so the
+    /// VPNv4/VPNv6 Adj-RIB-Out restages under the new filter.
     fn handle_rtc_routes_received(
         &mut self,
         peer: IpAddr,
         announced: Vec<crate::route::RtcRibRoute>,
         withdrawn: Vec<crate::route::RtcRibRouteKey>,
     ) {
+        let family = crate::route::RtcRibRouteKey::afi_safi();
+        let active_refresh = self
+            .refresh_in_progress
+            .get(&peer)
+            .is_some_and(|families| families.contains(&family));
         let mut affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
+        let mut removed_stale = 0usize;
         let mut needs_intern_gc = false;
 
         {
@@ -1749,19 +1794,68 @@ impl RibManager {
             for key in withdrawn {
                 if rib.withdraw_rtc(&key) {
                     needs_intern_gc = true;
-                    affected.insert(key);
+                    affected.insert(key.clone());
+                }
+                if active_refresh
+                    && let Some(stale) = self.refresh_stale_rtc.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    removed_stale += 1;
                 }
             }
             for route in announced {
                 let key = route.key();
                 needs_intern_gc |= rib.insert_rtc(route);
+                if active_refresh
+                    && let Some(stale) = self.refresh_stale_rtc.get_mut(&peer)
+                    && stale.remove(&key)
+                {
+                    removed_stale += 1;
+                }
                 affected.insert(key);
             }
         }
 
+        self.decrement_refresh_stale_count(peer, family.0, family.1, removed_stale);
+        self.update_peer_refresh_metrics(peer);
         self.recompute_rtc_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+        }
+        self.rebuild_rtc_membership_and_restage_vpn(peer);
+    }
+
+    /// Rebuild `peer`'s RT-Constrain membership from its Adj-RIB-In (all
+    /// paths) and, when it changed, mark the peer dirty and run a resync so
+    /// the VPN Adj-RIB-Out restages under the new filter (the
+    /// `handle_replace_peer_export_policy` precedent — the Adj-RIB-Out
+    /// equality machinery yields the RFC 4684 minimal update set, no
+    /// session reset). An unchanged membership skips the restage entirely.
+    fn rebuild_rtc_membership_and_restage_vpn(&mut self, peer: IpAddr) {
+        let mut has_default = false;
+        let mut entries: Vec<rustbgpd_wire::RtcNlri> = Vec::new();
+        if let Some(rib) = self.ribs.get(&peer) {
+            for route in rib.iter_rtc() {
+                if route.nlri.is_default() {
+                    has_default = true;
+                } else {
+                    entries.push(route.nlri);
+                }
+            }
+        }
+        entries.sort_unstable();
+        entries.dedup();
+        let membership = RtcMembership {
+            has_default,
+            entries,
+        };
+        if self.peer_rt_membership.get(&peer) == Some(&membership) {
+            return;
+        }
+        self.peer_rt_membership.insert(peer, membership);
+        if self.outbound_peers.contains_key(&peer) {
+            self.dirty_peers.insert(peer);
+            self.distribute_changes(&HashSet::new(), &HashSet::new());
         }
     }
 

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -419,6 +419,11 @@ impl RibManager {
         // `negotiated_orf_recv`.
         self.peer_orf_filters.remove(&peer);
         self.peer_orf_pending.remove(&peer);
+        // RT-Constrain membership is per-session too (RFC 4684 filters
+        // derive from the session's Adj-RIB-In, conservatively withdrawn on
+        // GR entry): `handle_peer_up` re-creates it empty-strict when the
+        // new session negotiates the family.
+        self.peer_rt_membership.remove(&peer);
         // The GR-deferred EoR is per-session too: the deferral pairs with
         // THIS session's §6 gate; a new session re-derives it on `PeerUp`.
         self.gr_deferred_eor.remove(&peer);
@@ -592,6 +597,18 @@ impl RibManager {
         // `send_initial_table`.
         if sendable_families.contains(&crate::route::RtcRibRouteKey::afi_safi()) {
             self.ensure_default_rtc_originated();
+            // RFC 4684 strict rule: a peer that negotiated SAFI 132 starts
+            // with an EMPTY membership — no VPN routes are advertised
+            // (initial dump included) until its RT interest arrives. This
+            // also covers a GR re-establish: the previous session's
+            // membership was torn down, so the returning peer is strict
+            // until its RTC routes re-arrive.
+            self.peer_rt_membership
+                .insert(peer, super::RtcMembership::default());
+        } else {
+            // A replacement session that dropped the family must not
+            // inherit its predecessor's filter (not-negotiated ⇒ unfiltered).
+            self.peer_rt_membership.remove(&peer);
         }
 
         debug!(%peer, "peer up — registering for outbound updates");
@@ -696,6 +713,7 @@ impl RibManager {
         let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
+        let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
         // RFC 5291 §6 initial-advertisement gate: suppress route advertisement
         // for families still awaiting the peer's first ROUTE-REFRESH. For a
         // non-GR peer the EoR is still emitted (an honest "empty table so
@@ -911,6 +929,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                rtc_filter.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -301,6 +301,16 @@ impl RibManager {
                         stale_count += 1;
                     }
                 }
+            } else if safi == Safi::RtConstrain {
+                // RTC is a single family (AFI 1 only), so clearing the whole
+                // per-peer set is safe — the EVPN pattern, not the VPN one.
+                let stale = self.refresh_stale_rtc.entry(peer).or_default();
+                stale.clear();
+                for route in rib.iter_rtc() {
+                    if stale.insert(route.key()) {
+                        stale_count += 1;
+                    }
+                }
             } else {
                 let stale = self.refresh_stale_routes.entry(peer).or_default();
                 stale.retain(|(prefix, _)| prefix_family(prefix) != (afi, safi));
@@ -367,6 +377,7 @@ impl RibManager {
         let mut rtc_withdraw = Vec::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
+        let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
         let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
         let target_peer_asn = self.peer_asn.get(&peer).copied();
@@ -508,6 +519,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    rtc_filter.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -828,12 +840,21 @@ impl RibManager {
         } else {
             Vec::new()
         };
+        let stale_rtc_keys: Vec<crate::route::RtcRibRouteKey> = if safi == Safi::RtConstrain {
+            self.refresh_stale_rtc
+                .get(&peer)
+                .map(|stale| stale.iter().cloned().collect())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
         let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
         let mut bgpls_affected: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
         let mut vpn_affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+        let mut rtc_affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
         if let Some(rib) = self.ribs.get_mut(&peer) {
             for (prefix, path_id) in &stale_route_keys {
                 if rib.withdraw(prefix, *path_id) {
@@ -860,6 +881,11 @@ impl RibManager {
                     vpn_affected.insert(key.clone());
                 }
             }
+            for key in &stale_rtc_keys {
+                if rib.withdraw_rtc(key) {
+                    rtc_affected.insert(key.clone());
+                }
+            }
             // Reclaim attribute interns dropped by the bulk withdraw —
             // each withdraw above can leave a `strong_count==1` Arc in
             // the intern table that wouldn't otherwise be GC'd until
@@ -869,6 +895,7 @@ impl RibManager {
                 || !evpn_affected.is_empty()
                 || !bgpls_affected.is_empty()
                 || !vpn_affected.is_empty()
+                || !rtc_affected.is_empty()
             {
                 rib.gc_intern_table();
             }
@@ -907,6 +934,9 @@ impl RibManager {
 
         if family == (Afi::L2Vpn, Safi::Evpn) {
             self.refresh_stale_evpn.remove(&peer);
+        }
+        if safi == Safi::RtConstrain {
+            self.refresh_stale_rtc.remove(&peer);
         }
         if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
             let clear_bgpls_stale_entry =
@@ -973,6 +1003,16 @@ impl RibManager {
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
             }
+        }
+        if !rtc_affected.is_empty() {
+            self.recompute_rtc_keys(&rtc_affected);
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                rib.gc_intern_table();
+            }
+            // The sweep just mutated this peer's RTC Adj-RIB-In — its RT
+            // membership shrank, so VPN routes no longer covered must be
+            // withdrawn from this peer's Adj-RIB-Out.
+            self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
     }
 }

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -2056,6 +2056,736 @@ async fn route_refresh_rtc_re_advertises_routes() {
     handle.await.unwrap();
 }
 
+// --- RFC 4684 VPN reflection filter (RT-Constrain membership) ---
+
+/// Sendable families for a peer that negotiated VPNv4+VPNv6 and RT-Constrain.
+fn vpn_rtc_sendable() -> Vec<(Afi, Safi)> {
+    vec![
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv6, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::RtConstrain),
+    ]
+}
+
+/// A two-octet-AS Route Target `RT:65001:<local_admin>` — the family that
+/// `make_rtc_rib_route`'s /96 membership NLRI covers.
+fn rt(local_admin: u16) -> ExtendedCommunity {
+    ExtendedCommunity::new(0x0002_FDE9_0000_0000 | u64::from(local_admin))
+}
+
+/// An RT membership route from `peer` carrying an arbitrary NLRI.
+fn make_rtc_rib_route_with_nlri(
+    peer: Ipv4Addr,
+    nlri: rustbgpd_wire::RtcNlri,
+) -> crate::route::RtcRibRoute {
+    let mut route = make_rtc_rib_route(peer, 0, 100);
+    route.nlri = nlri;
+    route
+}
+
+/// A `VPNv4` route from `peer` carrying the given extended communities.
+fn make_vpn_rib_route_with_rts(
+    peer: Ipv4Addr,
+    prefix_octet: u8,
+    rts: Vec<ExtendedCommunity>,
+) -> VpnRibRoute {
+    let mut route = make_vpn_rib_route(peer, prefix_octet, 100, 100);
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::ExtendedCommunities(rts));
+    route
+}
+
+/// A `VPNv6` route from `peer` carrying the given extended communities.
+fn make_vpn6_rib_route_with_rts(
+    peer: Ipv4Addr,
+    segment: u16,
+    rts: Vec<ExtendedCommunity>,
+) -> VpnRibRoute {
+    let nlri = VpnNlri {
+        labels: vec![MplsLabelEntry::try_new(100, 0, true).unwrap()],
+        route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1]),
+        prefix: VpnPrefix::v6(Ipv6Addr::new(0x2001, 0xdb8, segment, 0, 0, 0, 0, 0), 48).unwrap(),
+    };
+    VpnRibRoute {
+        nlri,
+        next_hop: IpAddr::V4(peer),
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::LocalPref(100),
+            PathAttribute::ExtendedCommunities(rts),
+        ]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+/// Bring up an eBGP peer that negotiated VPN + RT-Constrain families.
+/// Does NOT drain — callers assert the initial dump.
+async fn vpn_rtc_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_rtc_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+/// Drain a VPN+RTC peer's initial dump + `EoR`, asserting the RFC 4684
+/// strict rule: the dump carries the local default RTC NLRI and ZERO VPN
+/// routes (SAFI 132 negotiated + empty membership ⇒ advertise nothing).
+async fn drain_strict_vpn_rtc_initial_dump(out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>) {
+    let dump = out_rx.recv().await.unwrap();
+    assert!(
+        dump.rtc_announce.iter().any(|r| r.nlri.is_default()),
+        "initial dump must carry the locally-originated default RTC NLRI"
+    );
+    assert!(
+        dump.vpn_announce.is_empty(),
+        "empty RTC membership must withhold every VPN route from the initial dump"
+    );
+    assert!(dump.vpn_withdraw.is_empty());
+    let eor = out_rx.recv().await.unwrap();
+    assert_eq!(eor.end_of_rib, vpn_rtc_sendable());
+}
+
+/// Send RT membership NLRI (interest in `RT:65001:<la>` per entry) from `peer`.
+async fn send_rtc_interest(tx: &mpsc::Sender<RibUpdate>, peer: Ipv4Addr, local_admins: &[u16]) {
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced: local_admins
+            .iter()
+            .map(|&la| make_rtc_rib_route(peer, la, 100))
+            .collect(),
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+}
+
+/// SAFI 132 negotiated + no RTC interest received ⇒ NO VPN routes advertised
+/// (the strict rule) — the initial dump stages zero VPN routes.
+#[tokio::test]
+async fn vpn_not_advertised_to_rtc_peer_with_empty_membership() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route_with_rts(
+            Ipv4Addr::new(10, 0, 0, 1),
+            60,
+            vec![rt(100)],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = vpn_rtc_peer_up(&tx, target).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// When a matching RTC NLRI arrives, the withheld VPN route is announced as a
+/// minimal delta — no session reset, and already-correct Adj-RIB-Out state is
+/// not re-sent.
+#[tokio::test]
+async fn vpn_advertised_after_matching_rtc_nlri_arrives_without_reset() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route_a = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let route_b = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 61, vec![rt(200)]);
+    let key_a = route_a.key();
+    let key_b = route_b.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route_a, route_b],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+    assert_eq!(first.vpn_announce[0].key(), key_a);
+    assert!(first.vpn_withdraw.is_empty());
+
+    // Widening the membership announces ONLY the newly-covered route — the
+    // already-advertised one is suppressed by the Adj-RIB-Out equality check.
+    send_rtc_interest(&tx, target, &[200]).await;
+    let second = out_rx.recv().await.unwrap();
+    assert_eq!(second.vpn_announce.len(), 1);
+    assert_eq!(second.vpn_announce[0].key(), key_b);
+    assert!(second.vpn_withdraw.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Withdrawing the covering RTC NLRI withdraws the VPN route from that peer.
+#[tokio::test]
+async fn vpn_withdrawn_when_rtc_nlri_withdrawn() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 62, vec![rt(100)]);
+    let vpn_key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 1);
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        announced: vec![],
+        withdrawn: vec![make_rtc_rib_route(target, 100, 100).key()],
+    })
+    .await
+    .unwrap();
+    let withdrawn = out_rx.recv().await.unwrap();
+    assert!(withdrawn.vpn_announce.is_empty());
+    assert_eq!(withdrawn.vpn_withdraw, vec![vpn_key]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The zero-length default NLRI is wildcard interest: every VPN route passes,
+/// including one with no Route Target extended community at all.
+#[tokio::test]
+async fn default_rtc_nlri_matches_all_vpn_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![
+            make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]),
+            // No extended communities at all — only default interest covers it.
+            make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 61, 100, 100),
+        ],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        announced: vec![make_rtc_rib_route_with_nlri(
+            target,
+            rustbgpd_wire::RtcNlri::DEFAULT,
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(
+        update.vpn_announce.len(),
+        2,
+        "default RTC NLRI must admit every VPN route"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A /48 membership NLRI (origin AS + RT type/subtype bytes) admits the whole
+/// two-octet-AS RT family regardless of local admin, while an RT of a
+/// different type encoding stays filtered — prefix matching is masked, not
+/// exact.
+#[tokio::test]
+async fn rtc_prefix_match_gates_by_masked_bits() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let covered_a = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let covered_b = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 61, vec![rt(999)]);
+    // Type 0x01 (IPv4-administrator) Route Target: outside the /48's
+    // type/subtype bits, so it must stay filtered.
+    let uncovered = make_vpn_rib_route_with_rts(
+        Ipv4Addr::new(10, 0, 0, 1),
+        62,
+        vec![ExtendedCommunity::new(0x0102_0A00_0001_0064)],
+    );
+    let covered_keys: HashSet<_> = [covered_a.key(), covered_b.key()].into();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![covered_a, covered_b, uncovered],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    // /48 = origin AS 65001 (32 bits) + RT type 0x00 / subtype 0x02 (16 bits).
+    let nlri = rustbgpd_wire::RtcNlri::new(65001, 0x0002_0000_0000_0000, 48).unwrap();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        announced: vec![make_rtc_rib_route_with_nlri(target, nlri)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let update = out_rx.recv().await.unwrap();
+    let announced_keys: HashSet<_> = update
+        .vpn_announce
+        .iter()
+        .map(crate::route::VpnRibRoute::key)
+        .collect();
+    assert_eq!(
+        announced_keys, covered_keys,
+        "the /48 must admit the whole RT:65001:* family and nothing else"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// One membership gates BOTH `VPNv4` and `VPNv6` keys.
+#[tokio::test]
+async fn rtc_filter_applies_to_both_vpnv4_and_vpnv6() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let v4_covered = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let v6_covered = make_vpn6_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 1, vec![rt(100)]);
+    let v4_other = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 61, vec![rt(200)]);
+    let v6_other = make_vpn6_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 2, vec![rt(200)]);
+    let covered_keys: HashSet<_> = [v4_covered.key(), v6_covered.key()].into();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![v4_covered, v6_covered, v4_other, v6_other],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let update = out_rx.recv().await.unwrap();
+    let announced_keys: HashSet<_> = update
+        .vpn_announce
+        .iter()
+        .map(crate::route::VpnRibRoute::key)
+        .collect();
+    assert_eq!(
+        announced_keys, covered_keys,
+        "the RTC gate must admit the matching VPNv4 AND VPNv6 routes only"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer that did NOT negotiate SAFI 132 keeps today's unfiltered VPN
+/// reflection — the regression guard for the `None`-filter path.
+#[tokio::test]
+async fn non_rtc_peer_reflection_unchanged() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A VPN route with several Route Targets passes when ANY of them matches
+/// the peer's membership.
+#[tokio::test]
+async fn route_with_any_matching_rt_passes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(555), rt(100)]);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Membership derives from the peer's OWN Adj-RIB-In — all paths, never the
+/// Loc-RIB best: when two peers advertise the same RTC NLRI, the tiebreak
+/// loser's interest still opens its VPN filter.
+#[tokio::test]
+async fn membership_rebuilt_from_all_adjribin_paths_not_locrib_best() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let winner = Ipv4Addr::new(10, 0, 0, 2);
+    let loser = Ipv4Addr::new(10, 0, 0, 3);
+    let mut winner_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(winner)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut winner_rx).await;
+    let mut loser_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(loser)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut loser_rx).await;
+
+    // Winner's copy of the NLRI takes the Loc-RIB tiebreak (higher LOCAL_PREF)
+    // and gets reflected to the loser.
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(winner),
+        announced: vec![make_rtc_rib_route(winner, 100, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let winner_vpn = winner_rx.recv().await.unwrap();
+    assert_eq!(winner_vpn.vpn_announce.len(), 1);
+    let reflected = loser_rx.recv().await.unwrap();
+    assert_eq!(reflected.rtc_announce.len(), 1);
+
+    // The loser advertises the SAME NLRI with a losing LOCAL_PREF: the
+    // Loc-RIB best is unchanged, but the loser's own membership must still
+    // open — the filter reads the peer's Adj-RIB-In, not the Loc-RIB.
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(loser),
+        announced: vec![make_rtc_rib_route(loser, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let loser_vpn = loser_rx.recv().await.unwrap();
+    assert_eq!(
+        loser_vpn.vpn_announce.len(),
+        1,
+        "tiebreak-losing RTC path must still open the loser's VPN filter"
+    );
+    assert_eq!(loser_vpn.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// An enhanced-refresh `EoRR` sweep that removes an unreplaced RTC route must
+/// shrink the peer's membership and withdraw the now-uncovered VPN route.
+#[tokio::test]
+async fn rtc_refresh_eorr_sweep_restages_vpn() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route_a = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let route_b = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 61, vec![rt(200)]);
+    let key_b = route_b.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route_a, route_b],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100, 200]).await;
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 2);
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        peer: IpAddr::V4(target),
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+    // Only the RT:100 interest is re-announced inside the window; RT:200
+    // stays marked stale.
+    send_rtc_interest(&tx, target, &[100]).await;
+    tx.send(RibUpdate::EndRouteRefresh {
+        peer: IpAddr::V4(target),
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+
+    let swept = out_rx.recv().await.unwrap();
+    assert!(swept.vpn_announce.is_empty());
+    assert_eq!(
+        swept.vpn_withdraw,
+        vec![key_b],
+        "the EoRR sweep must withdraw the VPN route whose RTC interest was not replayed"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer re-establishing after graceful restart starts with a strict empty
+/// membership (the GR-entry conservative withdraw cleared its RTC routes) and
+/// only receives VPN routes once its interest re-arrives.
+#[tokio::test]
+async fn gr_reestablish_starts_strict_until_rtc_rearrives() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+    send_rtc_interest(&tx, target, &[100]).await;
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 1);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Re-establish: the strict initial dump proves the membership did not
+    // survive the restart — no VPN routes until the interest re-arrives.
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let reannounced = out_rx.recv().await.unwrap();
+    assert_eq!(reannounced.vpn_announce.len(), 1);
+    assert_eq!(reannounced.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The initial table dump to an RTC peer stages zero VPN routes, and the
+/// table flows as soon as matching interest arrives — no flap needed.
+#[tokio::test]
+async fn initial_dump_to_rtc_peer_stages_no_vpn_then_flows_on_interest() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(update.vpn_announce.len(), 1);
+    assert_eq!(update.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A duplicate RTC announce leaves the rebuilt membership equal to the old
+/// one and must NOT trigger a dirty resync — nothing is re-sent.
+#[tokio::test]
+async fn rtc_membership_unchanged_skips_restage() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route_with_rts(
+            Ipv4Addr::new(10, 0, 0, 1),
+            60,
+            vec![rt(100)],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    send_rtc_interest(&tx, target, &[100]).await;
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+
+    // Duplicate announce: membership rebuild compares equal — no restage.
+    send_rtc_interest(&tx, target, &[100]).await;
+    let resend = tokio::time::timeout(Duration::from_millis(50), out_rx.recv()).await;
+    assert!(
+        resend.is_err(),
+        "unchanged RTC membership must skip the dirty resync entirely"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn closed_query_channel_does_not_block_primary_channel() {
     let (tx, rx) = mpsc::channel(64);


### PR DESCRIPTION
Third slice of the **RFC 4684 RT-Constrain** arc, on top of #624 — the point of the feature: **VPN (SAFI 128) reflection is now filtered per-peer by RTC membership**.

- `RtcMembership { has_default, entries }` — rebuilt whole from each peer's **own Adj-RIB-In** SAFI-132 routes (all paths, per §3.2's all-paths clause; never Loc-RIB best), sorted+deduped for stable equality. Unchanged membership skips the restage entirely.
- Membership changes go through `dirty_peers` + `distribute_changes` (the ReplacePeerExportPolicy precedent), so the existing Adj-RIB-Out equality machinery emits the **§6-minimal update set** — newly-matching routes announced, no-longer-matching withdrawn, everything else silent, no session resets.
- The gate sits in `stage_vpn_routes` right after the best-path fetch: `None` (SAFI 132 not negotiated) ⇒ unchanged; `Some` + match ⇒ pass; miss ⇒ withdraw-if-present. **Fail-closed**: negotiated-but-empty membership advertises nothing (strict, incl. the initial dump — the RR never floods-then-prunes). Gates both VPNv4 and VPNv6; passed at all four staging sites (receive-path distribute, dirty resync, initial dump, refresh replay).
- RTC Enhanced Route Refresh stale lifecycle (BoRR/EoRR mirroring #620) with the one template extension: the EoRR sweep rebuilds membership and restages VPN.
- GR re-establish starts strict until the peer's RTC interest re-arrives (pinned by test; no redundant rib-side GR code).

### Tests
13 spec-named behavior tests (strict-empty, widen-without-reset delta-only, narrow-withdraws, default-matches-all, /48 prefix gate, both-AFIs, non-RTC-peer regression guard, multi-RT, all-paths membership, EoRR-restage, GR-strict, initial-dump-zero-then-flows, duplicate-skips-restage) — plus the entire pre-existing VPN suite untouched.

Next: M75 GoBGP interop receipt → docs.