### PR TITLE
fix(rib): include empty AS_PATH on the self-originated default RTC NLRI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **RT-Constrain (RFC 4684, AFI 1 / SAFI 132) — constrained VPN route
+  distribution.** The scalability companion to the VPNv4/v6 route reflector:
+  peers advertise Route Target membership NLRI (a 0–96-bit prefix over
+  origin-AS + the 8-byte RT extended community; zero-length = default
+  wildcard), and the RR filters SAFI-128 reflection per-peer accordingly —
+  strict semantics (a peer that negotiated SAFI 132 with no advertised
+  interest receives no VPN routes; membership changes emit the RFC-minimal
+  announce/withdraw delta with no session resets). RTC routes are themselves
+  stored, best-path-selected, and reflected between clients, and rustbgpd
+  self-originates the default RTC NLRI (it has no VRFs, so its own interest
+  is always "everything" — required so RFC 4684-compliant PEs send it their
+  VPN routes). Configure with the `rtc` family; inspect with
+  `RibService.ListRtcRoutes` (SensitiveRead) or `rbgp rib rtc`. Includes the
+  RFC 7313 Enhanced Route Refresh stale lifecycle whose end-of-refresh sweep
+  re-derives membership and restages VPN. Matching is RFC-faithful 96-bit
+  prefix matching (documented divergence from GoBGP's exact-match shortcut in
+  ADR-0077). Deferred: RFC 4684 §3.2(ii) non-client attribute-swap, the §6
+  60-second EoR delay, eBGP RTC subtleties, RTC×ORF interaction, Add-Path.
+  M75 proves filtering, widen/narrow-without-reset, RTC reflection, and the
+  unfiltered non-RTC-peer path against GoBGP.
+
 - **VPNv4/VPNv6 L3VPN route-reflection (RFC 4364 / RFC 4659, SAFI 128).**
   rustbgpd now negotiates, receives, stores, reflects, and withdraws
   VPN-IPv4/VPN-IPv6 routes as a route reflector / controller feed

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -229,9 +229,13 @@ resolved.
   (AFI 1/2, SAFI 128) route-reflection (RFC 4364 / RFC 4659 —
   RR/controller-feed only: RD, MPLS label stack, next-hop, and Route
   Targets are preserved verbatim; no VRF import, no MPLS FIB install,
-  no Add-Path, GR does not preserve SAFI-128 routes as stale). Other
-  families such as labeled-unicast (SAFI 4), RT-Constrain (SAFI 132),
-  and VPN FlowSpec (AFI 1/2, SAFI 134) are not implemented.
+  no Add-Path, GR does not preserve SAFI-128 routes as stale), and
+  RT-Constrain (AFI 1, SAFI 132) per RFC 4684 (strict per-peer VPN
+  reflection filtering with self-originated default membership; §3.2(ii)
+  non-client attribute-swap, the §6 60-second EoR delay, eBGP RTC
+  subtleties, and Add-Path remain deferred — see the ADR-0077
+  amendment). Other families such as labeled-unicast (SAFI 4) and VPN
+  FlowSpec (AFI 1/2, SAFI 134) are not implemented.
 - **Graceful Restart: no forwarding-state preservation.** RFC 4724 is
   implemented as helper (receiving speaker) plus minimal restarting speaker
   (`R=1` after coordinated restart via marker file, ADR-0040). However,

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ diversity scripts remain local / manual gates. See
 - **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP, birdwatcher-compatible REST API
 - **Lab and test environments** — clean API, structured logs, containerlab interop
 
-BGP-LS receive/reflection/API export (RFC 9552) and VPNv4/VPNv6 L3VPN
+BGP-LS receive/reflection/API export (RFC 9552), VPNv4/VPNv6 L3VPN
 route-reflection (RFC 4364 / RFC 4659, SAFI 128 — RR/controller-feed with RD,
 MPLS label stack, next-hop, and Route Targets preserved verbatim; no VRF import
-or MPLS FIB) have shipped under ADR-0077; future BGP-LS local topology
-production, RTC, and labeled-unicast work stays scoped by
+or MPLS FIB), and RT-Constrain (RFC 4684, SAFI 132 — strict per-peer VPN
+reflection filtering) have shipped under ADR-0077; future BGP-LS local topology
+production and labeled-unicast work stays scoped by
 [ADR-0077](docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md): those
 families must land as typed route-family slices or unreachable substrate, not as
 unicast `Prefix` shortcuts or MPLS dataplane creep.
@@ -256,7 +257,7 @@ transaction-backed config subset:
 | `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `SetGracefulShutdown`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `ListDynamicNeighbors` | Peer lifecycle, inbound soft reset, RFC 8326 graceful-shutdown toggle, and dynamic-neighbor CRUD — `AddDynamicNeighbor` / `DeleteDynamicNeighbor` add and remove `[[dynamic_neighbors]]` prefix ranges at runtime (queued to config when started with `--config`), `ListDynamicNeighbors` for visibility |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `SetPolicy`, `DeletePolicy`, `List/Get/Set/DeleteNeighborSet`, `Get*Chain`, `Set*Chain`, `Clear*Chain`, `ExplainImportPolicy` | Named policy CRUD, neighbor sets, global/per-neighbor chain attachment, and import-policy decision explain |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup`, `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` | Peer-group CRUD and neighbor membership assignment |
-| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `ListBgpLsRoutes`, `ListVpnRoutes`, `ListBlackholeDiscards`, `ListFibRoutes`, `ListFibTables`, `SetFibTable`, `DeleteFibTable`, `ListRouteEvents`, `WatchRoutes`, `WatchRouteEvents` | RIB queries (incl. EVPN, BGP-LS, and VPNv4/v6), BLACKHOLE discard status, paginated FIB status, runtime FIB-table CRUD, explain, recent route-event history with per-prefix drilldown, and streaming |
+| `RibService` | `ListReceivedRoutes`, `ListBestRoutes`, `ListAdvertisedRoutes`, `ExplainAdvertisedRoute`, `ExplainBestPath`, `ListFlowSpecRoutes`, `ListEvpnRoutes`, `ListBgpLsRoutes`, `ListVpnRoutes`, `ListRtcRoutes`, `ListBlackholeDiscards`, `ListFibRoutes`, `ListFibTables`, `SetFibTable`, `DeleteFibTable`, `ListRouteEvents`, `WatchRoutes`, `WatchRouteEvents` | RIB queries (incl. EVPN, BGP-LS, VPNv4/v6, and RT-Constrain), BLACKHOLE discard status, paginated FIB status, runtime FIB-table CRUD, explain, recent route-event history with per-prefix drilldown, and streaming |
 | `BfdService` | `GetBfdSessions` | Single-hop BFD session inspection for configured static neighbors |
 | `EventService` | `WatchEvents`, `SubscribeFromEvent`, `ListEvpnEvents`, `ListSessionEvents`, `ListPolicyEvents` | Unified live stream for route, session lifecycle, BGP NOTIFICATION metadata, policy mutation, EVPN route events, BFD session events, and FIB / BLACKHOLE dataplane status-row summary events, with `stream_lagged` warnings for bounded-source backpressure; durable cursor replay via `SubscribeFromEvent` when `[event_history].enabled = true`; plus bounded after-the-fact EVPN, session-lifecycle, and policy-mutation history. Per-MAC EVPN dataplane categories remain follow-up work |
 | `InjectionService` | `AddPath`, `DeletePath`, `AddFlowSpec`, `DeleteFlowSpec`, `AddEvpnRoute`, `DeleteEvpnRoute` | Programmatic route, FlowSpec, and EVPN injection |
@@ -318,7 +319,7 @@ and more explicit internal architecture.
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
 | Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 4.3.0 and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
-| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72), RFC 4364/4659 VPNv4/VPNv6 route-reflection (SAFI 128, RR/controller-feed), RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
+| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72), RFC 4364/4659 VPNv4/VPNv6 route-reflection (SAFI 128, RR/controller-feed), RFC 4684 RT-Constrain (SAFI 132, constrained VPN distribution), RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,8 +148,8 @@ has it, no broad performance sprints without profile evidence.
   receipts for perf PRs, and memory tracking that covers full-table scale
   without relying only on bgperf2.
 - **MPLS / VPN / BGP-LS address-family arc** *(BGP-LS receive + reflection +
-  API-export and VPNv4/v6 route-reflection shipped; labeled-unicast, RTC
-  deferred).*
+  API-export, VPNv4/v6 route-reflection, and RT-Constrain shipped;
+  labeled-unicast deferred).*
   ADR-0077 draws the address-family-expansion boundaries while the
   substrate is still small: a control-plane AFI/SAFI route-key model for
   VPNv4/v6 (RFC 4364 / RFC 4659), labeled-unicast (RFC 8277), Route Target
@@ -183,6 +183,18 @@ has it, no broad performance sprints without profile evidence.
   Add-Path and next-hop rewriting stay rejected/inert per ADR-0077 §6. M74
   proves the VPNv4 reflection, preservation, withdrawal, and
   no-dataplane-install path with a GoBGP source and sink.
+  **Done:** RT-Constrain (RFC 4684, AFI 1 / SAFI 132) shipped as the VPN RR
+  scalability companion: RTC NLRI codec with RFC-faithful 96-bit prefix
+  matching (GoBGP-divergence documented in the ADR-0077 amendment), full
+  receive/reflect/API slice (`rtc` family, `ListRtcRoutes`, `rbgp rib rtc`),
+  self-originated default membership, and strict per-peer VPN reflection
+  filtering with RFC-minimal announce/withdraw deltas on membership change —
+  driven through the same dirty-restage machinery as export-policy
+  replacement. Enhanced Route Refresh sweeps re-derive membership and restage
+  VPN. Deferred (ADR-0077 amendment): §3.2(ii) non-client attribute-swap, §6
+  60s EoR delay, eBGP RTC subtleties, RTC×ORF, Add-Path. M75 proves strict
+  filtering, widen/narrow-without-reset, RTC reflection, and the unfiltered
+  non-RTC-peer path against GoBGP.
   **Explicit non-goal, stated up front: rustbgpd does not install MPLS labels
   in the dataplane** — these are BGP-carried families, not a step toward a full
   MPLS router (see Non-goals). The ADR also preserves the ORF Address-Prefix

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -636,7 +636,7 @@ impl RibManager {
     /// to any already-established RTC peers. Never withdrawn — harmless if
     /// no RTC peer remains. No config knob by design.
     fn ensure_default_rtc_originated(&mut self) {
-        use rustbgpd_wire::{Origin, PathAttribute, RtcNlri};
+        use rustbgpd_wire::{AsPath, Origin, PathAttribute, RtcNlri};
 
         use super::helpers::LOCAL_PEER;
         use crate::adj_rib_in::AdjRibIn;
@@ -657,7 +657,14 @@ impl RibManager {
             nlri: RtcNlri::DEFAULT,
             next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             peer: LOCAL_PEER,
-            attributes: std::sync::Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            // AS_PATH is well-known mandatory even when empty (local
+            // origination over iBGP): RFC 7606 peers treat-as-withdraw an
+            // UPDATE without it, which starves the RR of VPN routes (M75
+            // finding). Matches every other local originator.
+            attributes: std::sync::Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath { segments: vec![] }),
+            ]),
             received_at: std::time::Instant::now(),
             origin_type: RouteOrigin::Local,
             peer_router_id: Ipv4Addr::UNSPECIFIED,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -1816,6 +1816,16 @@ async fn peer_up_with_rtc_family_originates_default_rtc_to_peer() {
         default.next_hop.is_unspecified(),
         "local default stores an unspecified next-hop; transport emits the session-local address"
     );
+    // AS_PATH is well-known mandatory even when empty: without it, RFC 7606
+    // peers treat-as-withdraw the default-RTC UPDATE and never send the RR
+    // their VPN routes (M75 regression).
+    assert!(
+        default
+            .attributes
+            .iter()
+            .any(|attr| matches!(attr, rustbgpd_wire::PathAttribute::AsPath(_))),
+        "locally-originated default RTC NLRI must carry an (empty) AS_PATH"
+    );
 
     let eor = out_rx.recv().await.unwrap();
     assert_eq!(eor.end_of_rib, rtc_sendable());

--- a/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
+++ b/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
@@ -383,3 +383,45 @@ See also ADR-0023 (Prefix enum and AFI-agnostic RIB), ADR-0054 (EVPN Linux
 dataplane boundary), ADR-0061 (unicast Linux FIB integration), ADR-0070
 (gNMI / OpenConfig telemetry and Set adapter), and ADR-0075 (receive-side
 Address-Prefix ORF).
+
+## Amendment (2026-07-01): RT-Constrain shipped — recorded decisions
+
+RTC (AFI 1 / SAFI 132) shipped as the VPN RR scalability companion scoped
+above. Four implementation decisions are recorded here because they are not
+derivable from RFC 4684 alone:
+
+1. **Strict empty-membership semantics.** A peer that negotiated SAFI 132
+   but has advertised no RT membership receives **no** VPN routes (including
+   the initial table dump — the RR never floods-then-prunes). A peer that did
+   not negotiate SAFI 132 is unfiltered. The membership for each peer derives
+   from that peer's own Adj-RIB-In SAFI-132 routes (all paths, honoring
+   §3.2's all-paths clause), never from Loc-RIB best.
+2. **RFC-faithful prefix matching, with a documented GoBGP divergence.**
+   Matching builds a 96-bit candidate — the RT's global-administrator field
+   as the origin AS, concatenated with the full 8-byte RT extended
+   community — and prefix-compares against the membership NLRI. GoBGP
+   instead matches the 8-byte RT exactly and ignores the origin-AS bits;
+   the two agree whenever an RT's administrator equals the advertising AS
+   (the conventional case, and what GoBGP-originated /96 NLRI carry). When
+   an RT's administrator differs from the advertiser's AS, rustbgpd
+   under-advertises relative to GoBGP. This is RFC-defensible; if it bites
+   in practice, the recorded upgrade path is to additionally accept a match
+   when bits 32..len match the RT alone. Do not silently switch to exact
+   matching — that breaks legitimate sub-96-bit prefix filters.
+3. **Self-originated default membership.** rustbgpd has no VRFs, so its own
+   RT interest is always "everything": it lazily originates the zero-length
+   default RTC NLRI (LOCAL_PEER, no config knob) once any peer negotiates
+   SAFI 132. Without this, RFC 4684-compliant PEs filter their VPN routes
+   toward the RR and the reflector starves.
+4. **Deferral register** (each with its un-defer trigger): §3.2(ii)
+   non-client attribute-swap (multi-RR non-client meshes); §6 60-second VPN
+   delay until RTC EoR (strict-empty already prevents flood-then-prune;
+   revisit only if gradual-interest churn is observed); eBGP RTC
+   distribution subtleties (§3.1 — the shipped arc is iBGP RR; GoBGP's own
+   eBGP RTC filtering is broken upstream); RTC × ORF cross-validation
+   (filters compose independently today); Add-Path for SAFI 132 (rejected
+   at negotiation, matching the VPN/BGP-LS posture).
+
+M75 is the interop receipt: GoBGP source/sink, strict filtering, RTC
+reflection, widen/narrow membership without session resets, an unfiltered
+non-RTC peer, and no dataplane installs.


### PR DESCRIPTION
Found by the M75 interop lab before it ever reached CI: the self-originated default RTC NLRI (#624) was missing the well-known-mandatory **AS_PATH** attribute (empty for local origination). GoBGP logged `well-known mandatory attributes are not present. type : 2` and treat-as-withdrew the UPDATE per RFC 7606 — so compliant PEs kept RTC-filtering their VPN routes toward the RR, starving it. One-line fix matching every other local originator in the repo, plus a regression assert on the origination test.

RTC reflection itself was proven wire-correct in the same lab (ORIGINATOR_ID/CLUSTER_LIST intact, no source echo). M75 re-runs on top of this fix.