### PR TITLE
feat(rib): select per-vantage best paths for ORR clients

### DIFF
--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -55,6 +55,11 @@ pub enum BestPathReason {
     LowerMed,
     /// Step 5: eBGP preferred over iBGP.
     EbgpOverIbgp,
+    /// Step 5.3 (RFC 9107 ORR only): lower vantage interior cost to
+    /// `NEXT_HOP` wins; a known cost beats an unknown one. Never produced
+    /// by the Loc-RIB ladder (`best_path_cmp_with_reason` carries no
+    /// vantage costs) — it exists for ORR-path attribution and tests.
+    OrrInteriorCost,
     /// Step 5.5: shorter `CLUSTER_LIST` wins (RFC 4456).
     ShorterClusterList,
     /// Step 5.6: lower `ORIGINATOR_ID` wins (RFC 4456).
@@ -77,6 +82,7 @@ impl std::fmt::Display for BestPathReason {
             Self::LowerOrigin => write!(f, "lower_origin"),
             Self::LowerMed => write!(f, "lower_med"),
             Self::EbgpOverIbgp => write!(f, "ebgp_over_ibgp"),
+            Self::OrrInteriorCost => write!(f, "orr_interior_cost"),
             Self::ShorterClusterList => write!(f, "shorter_cluster_list"),
             Self::LowerOriginatorId => write!(f, "lower_originator_id"),
             Self::LowerPeerAddress => write!(f, "lower_peer_address"),
@@ -230,6 +236,10 @@ pub fn best_path_reason_detail(reason: BestPathReason, a: &Route, b: &Route) -> 
         // Not produced by the unicast ladder; EVPN MAC mobility carries
         // its sequence in EVPN-specific route state, not on `Route`.
         BestPathReason::EvpnMacMobility => "mac_mobility_sequence".to_string(),
+        // Not produced by `best_path_cmp_with_reason` either — the
+        // vantage costs live on the ORR distribution path, not on
+        // `Route`, so there are no compared values to render here.
+        BestPathReason::OrrInteriorCost => "orr_interior_cost_to_next_hop".to_string(),
     }
 }
 
@@ -286,11 +296,37 @@ pub fn multipath_eligibility(best: &Route, other: &Route) -> MultipathEligibilit
 /// 3. Lowest ORIGIN — IGP < EGP < INCOMPLETE
 /// 4. Lowest MED (default 0; always-compare / deterministic MED)
 /// 5. eBGP over iBGP
+///    5.3. ORR interior cost (RFC 9107) — [`best_path_cmp_orr`] only;
+///    this comparator never runs it
 ///    5.5. Shortest `CLUSTER_LIST` length (RFC 4456 §9)
 ///    5.6. Lowest `ORIGINATOR_ID` (RFC 4456 §9) — only when both present
 /// 6. Lowest peer address (tiebreaker)
 #[must_use]
 pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
+    cmp_chain(a, b, None)
+}
+
+/// Compare two routes under RFC 9107 Optimal Route Reflection.
+///
+/// The standard [`best_path_cmp`] chain with one extra step between
+/// step 5 (eBGP over iBGP) and step 5.5 (`CLUSTER_LIST`): the
+/// configured vantage's interior (SPF) cost to each route's `NEXT_HOP`.
+/// Lower cost wins; a known cost beats an unknown one (RFC 9107 §3.1:
+/// an unknown metric-to-next-hop MUST be least preferred); equal or
+/// both-unknown falls through to `CLUSTER_LIST`.
+#[must_use]
+pub fn best_path_cmp_orr(
+    a: &Route,
+    b: &Route,
+    cost_a: Option<u64>,
+    cost_b: Option<u64>,
+) -> Ordering {
+    cmp_chain(a, b, Some((cost_a, cost_b)))
+}
+
+/// The shared decision chain behind [`best_path_cmp`] (`orr_costs =
+/// None`) and [`best_path_cmp_orr`] (`orr_costs = Some(..)`).
+fn cmp_chain(a: &Route, b: &Route, orr_costs: Option<(Option<u64>, Option<u64>)>) -> Ordering {
     // 0. Three-tier stale demotion: fresh > GR-stale > LLGR-stale (RFC 4724 + RFC 9494)
     let cmp = stale_rank(a).cmp(&stale_rank(b));
     if cmp != Ordering::Equal {
@@ -343,6 +379,22 @@ pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
         return cmp;
     }
 
+    // 5.3. RFC 9107 ORR interior cost to NEXT_HOP — only when the
+    //      caller supplies vantage costs (the Loc-RIB never does).
+    //      Lower cost wins; Some beats None (unknown metric MUST be
+    //      least preferred); equal or both-None falls through.
+    if let Some((cost_a, cost_b)) = orr_costs {
+        let cmp = match (cost_a, cost_b) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        };
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+    }
+
     // 5.5. Shortest CLUSTER_LIST length (RFC 4456 §9)
     let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
     if cmp != Ordering::Equal {
@@ -380,8 +432,10 @@ pub fn best_path_cmp(a: &Route, b: &Route) -> Ordering {
 ///
 /// iBGP grouping is well-defined here despite the lack of an IGP: `best_path_cmp`
 /// has no IGP-metric step (the daemon carries a directly-usable next-hop and does
-/// no recursive resolution), so iBGP equal-cost is fully determined by the BGP
-/// decision chain above.
+/// no recursive resolution) — the metric step is absent except under RFC 9107
+/// ORR, where `best_path_cmp_orr` compares the configured vantage's SPF cost to
+/// `NEXT_HOP` at distribution time (never here or in the Loc-RIB) — so iBGP
+/// equal-cost is fully determined by the BGP decision chain above.
 ///
 /// Locally injected (controller) routes never participate in maximum-paths — they
 /// install as the single best path — so a `RouteOrigin::Local` on either side
@@ -986,6 +1040,69 @@ mod tests {
         }
     }
 
+    // --- RFC 9107 ORR interior-cost step (best_path_cmp_orr) ---
+
+    #[test]
+    fn orr_cost_only_breaks_ties_below_step5() {
+        // Steps 0-5 all outrank the ORR interior cost. A higher
+        // LOCAL_PREF wins regardless of a worse — or unknown — cost.
+        let a = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 1)), 200);
+        let b = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 2)), 100);
+        assert_eq!(
+            best_path_cmp_orr(&a, &b, Some(1000), Some(0)),
+            Ordering::Less
+        );
+        assert_eq!(best_path_cmp_orr(&a, &b, None, Some(0)), Ordering::Less);
+        assert_eq!(best_path_cmp_orr(&b, &a, Some(0), None), Ordering::Greater);
+
+        // Step 5 (eBGP over iBGP) also sits above the cost step.
+        let ebgp = base_route(Ipv4Addr::new(1, 0, 0, 2));
+        let ibgp = with_ibgp(base_route(Ipv4Addr::new(1, 0, 0, 1)));
+        assert_eq!(
+            best_path_cmp_orr(&ibgp, &ebgp, Some(0), Some(1000)),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn orr_unknown_cost_least_preferred() {
+        // RFC 9107 §3.1: an unknown metric-to-next-hop MUST be least
+        // preferred — a known cost wins even against a lower peer
+        // address (a is the higher-peer route here).
+        let a = base_route(Ipv4Addr::new(1, 0, 0, 2));
+        let b = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        assert_eq!(best_path_cmp_orr(&a, &b, Some(500), None), Ordering::Less);
+        assert_eq!(
+            best_path_cmp_orr(&b, &a, None, Some(500)),
+            Ordering::Greater
+        );
+        // And among known costs, the lower one wins.
+        assert_eq!(best_path_cmp_orr(&a, &b, Some(5), Some(10)), Ordering::Less);
+        assert_eq!(
+            best_path_cmp_orr(&a, &b, Some(10), Some(5)),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn orr_equal_costs_fall_through_to_cluster_list() {
+        // Equal known costs — and both-unknown — fall through to the
+        // CLUSTER_LIST step: the shorter list wins despite a's higher
+        // peer address.
+        let a = with_cluster_list(
+            base_route(Ipv4Addr::new(1, 0, 0, 2)),
+            vec![Ipv4Addr::new(10, 0, 0, 1)],
+        );
+        let b = with_cluster_list(
+            base_route(Ipv4Addr::new(1, 0, 0, 1)),
+            vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+        );
+        assert_eq!(best_path_cmp_orr(&a, &b, Some(7), Some(7)), Ordering::Less);
+        assert_eq!(best_path_cmp_orr(&a, &b, None, None), Ordering::Less);
+        // The fall-through outcome matches the plain comparator.
+        assert_eq!(best_path_cmp_orr(&a, &b, None, None), best_path_cmp(&a, &b));
+    }
+
     // --- best_path_reason_detail (explain-only compared-values render) ---
 
     #[test]
@@ -1245,6 +1362,25 @@ mod proptests {
         ]
     }
 
+    fn arb_stale_tier() -> impl Strategy<Value = (bool, bool)> {
+        // (is_stale, is_llgr_stale): fresh, GR-stale, LLGR-stale.
+        prop_oneof![
+            Just((false, false)),
+            Just((true, false)),
+            Just((false, true)),
+        ]
+    }
+
+    fn arb_rpki() -> impl Strategy<Value = rustbgpd_wire::RpkiValidation> {
+        use rustbgpd_wire::RpkiValidation as V;
+        prop_oneof![Just(V::Valid), Just(V::NotFound), Just(V::Invalid)]
+    }
+
+    fn arb_aspa() -> impl Strategy<Value = rustbgpd_wire::AspaValidation> {
+        use rustbgpd_wire::AspaValidation as V;
+        prop_oneof![Just(V::Valid), Just(V::Unknown), Just(V::Invalid)]
+    }
+
     fn arb_route() -> impl Strategy<Value = Route> {
         (
             1u8..=4,                                   // peer last octet
@@ -1255,9 +1391,24 @@ mod proptests {
             arb_route_origin(),            // origin_type
             proptest::option::of(1u8..=4), // originator_id last octet
             0u8..=3,                       // cluster_list length
+            arb_stale_tier(),
+            arb_rpki(),
+            arb_aspa(),
         )
             .prop_map(
-                |(peer_oct, lp, asns, origin, med, origin_type, oid_oct, cl_len)| {
+                |(
+                    peer_oct,
+                    lp,
+                    asns,
+                    origin,
+                    med,
+                    origin_type,
+                    oid_oct,
+                    cl_len,
+                    (is_stale, is_llgr_stale),
+                    validation_state,
+                    aspa_state,
+                )| {
                     let peer = Ipv4Addr::new(10, 0, 0, peer_oct);
                     let mut attributes = vec![
                         PathAttribute::LocalPref(lp),
@@ -1289,18 +1440,86 @@ mod proptests {
                         received_at: Instant::now(),
                         origin_type,
                         peer_router_id: Ipv4Addr::UNSPECIFIED,
-                        is_stale: false,
-                        is_llgr_stale: false,
+                        is_stale,
+                        is_llgr_stale,
                         path_id: 0,
-                        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-                        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                        validation_state,
+                        aspa_state,
                         aspa_context: rustbgpd_wire::AspaValidationContext::default(),
                     }
                 },
             )
     }
 
+    /// Verbatim fixture copy of `best_path_cmp` as it stood BEFORE the
+    /// `cmp_chain` refactor (the ORR arc) — the oracle for
+    /// `best_path_cmp_unchanged_without_orr`. Do not "fix" or refactor
+    /// this copy; its value is that it never changes.
+    fn legacy_best_path_cmp(a: &Route, b: &Route) -> Ordering {
+        let cmp = stale_rank(a).cmp(&stale_rank(b));
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = rpki_preference(b.validation_state).cmp(&rpki_preference(a.validation_state));
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = aspa_preference(b.aspa_state).cmp(&aspa_preference(a.aspa_state));
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = b.local_pref().cmp(&a.local_pref());
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let a_len = a.as_path().map_or(0, AsPath::len);
+        let b_len = b.as_path().map_or(0, AsPath::len);
+        let cmp = a_len.cmp(&b_len);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = a.origin().cmp(&b.origin());
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = a.med().cmp(&b.med());
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = b.is_ebgp().cmp(&a.is_ebgp());
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        let cmp = a.cluster_list().len().cmp(&b.cluster_list().len());
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+        if let (Some(a_oid), Some(b_oid)) = (a.originator_id(), b.originator_id()) {
+            let cmp = a_oid.cmp(&b_oid);
+            if cmp != Ordering::Equal {
+                return cmp;
+            }
+        }
+        a.peer.cmp(&b.peer)
+    }
+
     proptest! {
+        /// The `cmp_chain` refactor property: with no ORR costs the
+        /// public comparator is behavior-identical to the pre-refactor
+        /// chain (`legacy_best_path_cmp`, a verbatim fixture copy),
+        /// over the generated route corpus.
+        #[test]
+        fn best_path_cmp_unchanged_without_orr(a in arb_route(), b in arb_route()) {
+            prop_assert_eq!(best_path_cmp(&a, &b), legacy_best_path_cmp(&a, &b));
+        }
+
+        /// With both costs unknown the ORR comparator degenerates to
+        /// the standard chain — the both-None fall-through is total.
+        #[test]
+        fn orr_both_unknown_matches_plain_cmp(a in arb_route(), b in arb_route()) {
+            prop_assert_eq!(best_path_cmp_orr(&a, &b, None, None), best_path_cmp(&a, &b));
+        }
+
         /// The explain-only ladder (`best_path_cmp_with_reason`) must
         /// agree with the hot-path comparator on arbitrary inputs —
         /// the randomized counterpart of the per-step agreement matrix

--- a/crates/rib/src/manager/distribution.rs
+++ b/crates/rib/src/manager/distribution.rs
@@ -1189,6 +1189,7 @@ impl RibManager {
         sendable: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
+        orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
@@ -1198,7 +1199,7 @@ impl RibManager {
         policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
         force: bool,
     ) {
-        use crate::best_path::best_path_cmp;
+        use crate::best_path::{best_path_cmp, best_path_cmp_orr};
 
         // Sendable family check
         let family = match prefix {
@@ -1245,8 +1246,20 @@ impl RibManager {
             })
             .collect();
 
-        // Sort by best-path preference (best first)
-        candidates.sort_by(|a, b| best_path_cmp(a, b));
+        // Sort by best-path preference (best first). A target bound to a
+        // resolved ORR vantage ranks by the vantage's interior cost to
+        // each NEXT_HOP first (RFC 9107 §3.1) — comparator swap only.
+        match orr {
+            Some((topology, spf)) => candidates.sort_by(|a, b| {
+                best_path_cmp_orr(
+                    a,
+                    b,
+                    spf.cost_to(topology, a.next_hop),
+                    spf.cost_to(topology, b.next_hop),
+                )
+            }),
+            None => candidates.sort_by(|a, b| best_path_cmp(a, b)),
+        }
 
         // Walk candidates, evaluate export policy, assign path_ids 1..N
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
@@ -1494,6 +1507,192 @@ impl RibManager {
 
         // Clean up any stale multi-path entries if this prefix was previously
         // advertised via Add-Path and is now single-best.
+        for &path_id in existing_path_ids {
+            if path_id != 0 {
+                withdraw.push((*prefix, path_id));
+            }
+        }
+    }
+
+    /// RFC 9107 ORR single-best distribution for one prefix to one peer
+    /// bound to a *resolved* vantage.
+    ///
+    /// The best is NOT the Loc-RIB best: the candidate set is collected
+    /// and filtered per target peer exactly like
+    /// [`Self::distribute_multipath_prefix`] (all Adj-RIB-Ins, split
+    /// horizon, iBGP/RR suppression), then the winner is picked with
+    /// [`crate::best_path::best_path_cmp_orr`] using the vantage's SPF
+    /// cost to each candidate's `NEXT_HOP`. The export tail (policy,
+    /// modifications, Adj-RIB-Out diff) mirrors
+    /// [`Self::distribute_single_best_prefix`].
+    ///
+    /// Deliberately NO per-(vantage, prefix) winner memo — it would be
+    /// unsound: the candidate set is per-target-peer (split horizon and
+    /// RR suppression drop different routes for different targets), so a
+    /// memoized winner could be a route the next target must never
+    /// receive. The `SpfResult`'s internal NH-cost LRU is the sound
+    /// cache.
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "ORR export keeps peer, policy, and Adj-RIB-Out diff state together"
+    )]
+    pub(super) fn distribute_orr_best_prefix(
+        ribs: &HashMap<IpAddr, AdjRibIn>,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        orr_topology: &crate::orr::OrrTopology,
+        orr_spf: &crate::orr::SpfResult,
+        prefix: &Prefix,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        orf_filter: Option<&crate::orf::OrfFilterSet>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        announce: &mut Vec<crate::route::Route>,
+        withdraw: &mut Vec<(Prefix, u32)>,
+        nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
+        policy_filtered: &mut Vec<PolicyFilteredRouteKey>,
+        force: bool,
+    ) {
+        use crate::best_path::best_path_cmp_orr;
+
+        let existing_path_ids = rib_out.path_ids_for_prefix(prefix);
+
+        // Sendable family check
+        let family = prefix_family(prefix);
+        if !sendable.is_some_and(|f| f.contains(&family)) {
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
+
+        // Outbound Route Filter check (RFC 5291): silent withdraw, not a
+        // policy denial — see `distribute_single_best_prefix`.
+        if orf_filter.is_some_and(|f| !f.permits(prefix)) {
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
+
+        // Collect all candidates across all Adj-RIB-In entries —
+        // verbatim the multipath collector's per-target filter set.
+        let candidates = ribs
+            .values()
+            .flat_map(|rib| rib.iter_prefix(prefix))
+            .filter(|route| {
+                // Split horizon: exclude routes from the target peer
+                if route.peer == target_peer {
+                    return false;
+                }
+                // iBGP split-horizon / RFC 4456 reflection
+                if should_suppress_ibgp_inner(
+                    route,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    peer_is_rr_client,
+                ) {
+                    return false;
+                }
+                true
+            });
+
+        // Per-vantage best (RFC 9107): the vantage's interior cost to
+        // each NEXT_HOP breaks ties between step 5 and step 5.5.
+        let Some(best) = candidates.min_by(|a, b| {
+            best_path_cmp_orr(
+                a,
+                b,
+                orr_spf.cost_to(orr_topology, a.next_hop),
+                orr_spf.cost_to(orr_topology, b.next_hop),
+            )
+        }) else {
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        };
+
+        // Export policy check — same tail as `distribute_single_best_prefix`.
+        let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
+            best.as_path()
+                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+        } else {
+            String::new()
+        };
+        let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+        let ctx = RouteContext {
+            prefix: Some(*prefix),
+            next_hop: Some(best.next_hop),
+            extended_communities: best.extended_communities(),
+            communities: best.communities(),
+            large_communities: best.large_communities(),
+            as_path_str: &aspath_str,
+            as_path_len: aspath_len,
+            validation_state: best.validation_state,
+            aspa_state: best.aspa_state,
+            peer_address: Some(target_peer),
+            peer_asn: target_peer_asn,
+            peer_group: target_peer_group,
+            route_type: Some(route_type(best.origin_type)),
+            evpn_route_type: None,
+            local_pref: best.local_pref_attr(),
+            med: best.med_attr(),
+        };
+        let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+        record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+        if result.action != PolicyAction::Permit {
+            policy_filtered.push(PolicyFilteredRouteKey {
+                target_peer,
+                source_peer: best.peer,
+                prefix: *prefix,
+                path_id: best.path_id,
+            });
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
+
+        // Apply export modifications to a clone — skip the deep clone of
+        // the Arc<Vec<PathAttribute>> when no modifications are needed.
+        let mut modified = best.clone();
+        let nh_action = if result.modifications.is_empty() {
+            None
+        } else {
+            let nh = rustbgpd_policy::apply_modifications(
+                std::sync::Arc::make_mut(&mut modified.attributes),
+                &result.modifications,
+            );
+            if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = &nh {
+                modified.next_hop = *addr;
+            }
+            nh
+        };
+        modified.path_id = 0;
+
+        // `force` semantics as in `distribute_single_best_prefix`.
+        let changed = force
+            || rib_out
+                .get(prefix, 0)
+                .is_none_or(|existing| !routes_equal(existing, &modified));
+        if changed {
+            nh_override_flags.push(nh_action);
+            announce.push(modified);
+        }
+
+        // Clean up any stale multi-path entries if this prefix was
+        // previously advertised via Add-Path and is now single-best.
         for &path_id in existing_path_ids {
             if path_id != 0 {
                 withdraw.push((*prefix, path_id));
@@ -2323,8 +2522,18 @@ impl RibManager {
                 all
             } else {
                 let mut prefixes = best_changed.clone();
+                // An RFC 9107 ORR peer selects from the per-target
+                // candidate set, not the Loc-RIB best — a candidate
+                // change that leaves the Loc-RIB best untouched can
+                // still flip the vantage best, so ORR peers stage every
+                // affected prefix (same reasoning as Add-Path send).
+                let peer_has_resolved_orr = self
+                    .peer_orr_vantage
+                    .get(&peer)
+                    .is_some_and(|vantage| self.orr.spf.contains_key(vantage));
                 for prefix in all_affected {
-                    if self.add_path_send_max_for_prefix(peer, prefix) > 0 {
+                    if peer_has_resolved_orr || self.add_path_send_max_for_prefix(peer, prefix) > 0
+                    {
                         prefixes.insert(*prefix);
                     }
                 }
@@ -2460,6 +2669,15 @@ impl RibManager {
             // is cheap: ORF filters are small and present only for peers that
             // negotiated ORF (None for everyone else).
             let orf_filters = self.peer_orf_filters.get(&peer).cloned();
+            // RFC 9107 ORR: a peer bound to a vantage that resolved this
+            // pass takes the per-vantage best below; an unresolved
+            // vantage silently falls back to the standard single-best
+            // (the status is surfaced by `rbgp orr`).
+            let orr_ctx = self
+                .peer_orr_vantage
+                .get(&peer)
+                .and_then(|vantage| self.orr.spf.get(vantage))
+                .map(|spf| (&self.orr.topology, spf));
             let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
             let orf_gated = self
                 .peer_orf_pending
@@ -2505,6 +2723,36 @@ impl RibManager {
                         target_peer_asn,
                         target_peer_group,
                         prefix_send_max,
+                        target_is_ebgp,
+                        target_is_rr_client,
+                        cluster_id,
+                        sendable.as_ref(),
+                        export_pol.as_ref(),
+                        orf,
+                        orr_ctx,
+                        &metrics,
+                        policy_stats,
+                        &target_peer_label,
+                        &mut announce,
+                        &mut withdraw,
+                        &mut nh_override_flags,
+                        &mut policy_filtered,
+                        is_force,
+                    );
+                    current_policy_filtered_routes.extend(policy_filtered);
+                } else if let Some((orr_topology, orr_spf)) = orr_ctx {
+                    // ORR peer with a resolved vantage: per-vantage best.
+                    let mut policy_filtered = Vec::new();
+                    Self::distribute_orr_best_prefix(
+                        &self.ribs,
+                        rib_out,
+                        &self.peer_is_rr_client,
+                        orr_topology,
+                        orr_spf,
+                        prefix,
+                        peer,
+                        target_peer_asn,
+                        target_peer_group,
                         target_is_ebgp,
                         target_is_rr_client,
                         cluster_id,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1910,13 +1910,42 @@ impl RibManager {
         // (`handle_peer_graceful_restart`, recompute-then-GC ordering),
         // and BGP-LS-bearing peer teardown (`clear_peer_adj_rib_in`) —
         // so the ORR cache rebuild needs exactly one call site.
-        let _changed = self.recompute_orr(); // PR-4 consumes
+        let changed = self.recompute_orr();
+        self.resync_orr_bound_peers(&changed);
+    }
+
+    /// Resync every established peer bound to a changed ORR vantage: a
+    /// changed SPF surface (metric shift, vantage resolution flip) can
+    /// move those peers' per-vantage bests without any unicast RIB
+    /// change, so nothing else would re-stage them. Dirty + empty-set
+    /// `distribute_changes` is the `ReplacePeerExportPolicy` precedent —
+    /// the Adj-RIB-Out equality machinery reduces the full restage to
+    /// the minimal announce/withdraw delta per peer (unaffected peers
+    /// see zero messages).
+    fn resync_orr_bound_peers(&mut self, changed: &HashSet<IpAddr>) {
+        if changed.is_empty() {
+            return;
+        }
+        let bound: Vec<IpAddr> = self
+            .peer_orr_vantage
+            .iter()
+            .filter(|(peer, vantage)| {
+                changed.contains(*vantage) && self.outbound_peers.contains_key(*peer)
+            })
+            .map(|(peer, _)| *peer)
+            .collect();
+        if bound.is_empty() {
+            return;
+        }
+        self.dirty_peers.extend(bound);
+        self.distribute_changes(&HashSet::new(), &HashSet::new());
     }
 
     /// Rebuild the cached RFC 9107 ORR state: one topology from the
     /// BGP-LS Adj-RIB-In union, one SPF per DISTINCT configured vantage
     /// IP. Returns the vantages whose SPF distance surface changed
-    /// (consumed in PR-4 to dirty their bound peers). Early-outs with no
+    /// (consumed by [`Self::resync_orr_bound_peers`] to dirty their
+    /// bound peers). Early-outs with no
     /// topology build and no SPF while `peer_orr_vantage` is empty, so
     /// non-ORR deployments pay nothing on BGP-LS churn.
     pub(super) fn recompute_orr(&mut self) -> HashSet<IpAddr> {

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -411,9 +411,15 @@ impl RibManager {
         self.peer_is_rr_client.remove(&peer);
         // The ORR vantage binding is per-registration: dropping the last
         // peer bound to a vantage must also drop the vantage's cached
-        // SPF (and re-arm the empty-state early-out).
+        // SPF (and re-arm the empty-state early-out). Consuming the
+        // changed set is a defensive no-op here — removing a binding
+        // never alters a surviving vantage's SPF surface (the topology
+        // input is untouched; any topology change already ran through
+        // the `recompute_bgpls_keys` seam) — but if it ever fires, the
+        // affected peers still get their resync.
         if self.peer_orr_vantage.remove(&peer).is_some() {
-            let _changed = self.recompute_orr(); // PR-4 consumes
+            let changed = self.recompute_orr();
+            self.resync_orr_bound_peers(&changed);
         }
         self.peer_add_path_send_max.remove(&peer);
         self.peer_add_path_send_families.remove(&peer);
@@ -637,8 +643,13 @@ impl RibManager {
         if let Some(vantage) = orr_vantage {
             self.peer_orr_vantage.insert(peer, vantage);
             // The vantage may register after the BGP-LS routes arrived
-            // (no mutation seam would fire), so seed its SPF here.
-            let _changed = self.recompute_orr(); // PR-4 consumes
+            // (no mutation seam would fire), so seed its SPF here. The
+            // changed set is deliberately NOT consumed: it can only name
+            // this vantage when this peer is the first to bind it (other
+            // vantages see an unchanged topology), and this peer's
+            // per-vantage best flows through `send_initial_table` below —
+            // a resync here would double-send the table.
+            self.recompute_orr();
         }
         self.peer_add_path_send_families
             .insert(peer, add_path_send_families);
@@ -758,6 +769,15 @@ impl RibManager {
             .get(&peer)
             .cloned()
             .unwrap_or_default();
+        // RFC 9107 ORR: a late-joining peer bound to a resolved vantage
+        // gets the per-vantage best in its initial dump (the SPF was
+        // seeded at PeerUp); an unresolved vantage falls back to the
+        // standard single-best.
+        let orr_ctx = self
+            .peer_orr_vantage
+            .get(&peer)
+            .and_then(|vantage| self.orr.spf.get(vantage))
+            .map(|spf| (&self.orr.topology, spf));
         let loc_rib = &self.loc_rib;
         let target_peer_label = peer.to_string();
         let metrics = self.metrics.clone();
@@ -794,6 +814,38 @@ impl RibManager {
                     target_peer_asn,
                     target_peer_group,
                     prefix_send_max,
+                    target_is_ebgp,
+                    target_is_rr_client,
+                    cluster_id,
+                    sendable.as_ref(),
+                    export_pol.as_ref(),
+                    // ORF: gated families are skipped above; a non-gated family
+                    // has no installed filter during the initial dump.
+                    None,
+                    orr_ctx,
+                    &metrics,
+                    policy_stats,
+                    &target_peer_label,
+                    &mut announce,
+                    &mut withdraw,
+                    &mut nh_override_flags,
+                    &mut policy_filtered,
+                    false, // initial dump — equality check is correct
+                );
+                current_policy_filtered_routes.extend(policy_filtered);
+            } else if let Some((orr_topology, orr_spf)) = orr_ctx {
+                // ORR peer with a resolved vantage: per-vantage best.
+                let mut policy_filtered = Vec::new();
+                Self::distribute_orr_best_prefix(
+                    &self.ribs,
+                    &initial_view,
+                    &self.peer_is_rr_client,
+                    orr_topology,
+                    orr_spf,
+                    prefix,
+                    peer,
+                    target_peer_asn,
+                    target_peer_group,
                     target_is_ebgp,
                     target_is_rr_client,
                     cluster_id,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -389,6 +389,14 @@ impl RibManager {
             .get(&peer)
             .cloned()
             .unwrap_or_default();
+        // RFC 9107 ORR: the refresh replay re-derives the same
+        // per-vantage best the live distribution path would send; an
+        // unresolved vantage falls back to the standard single-best.
+        let orr_ctx = self
+            .peer_orr_vantage
+            .get(&peer)
+            .and_then(|vantage| self.orr.spf.get(vantage))
+            .map(|spf| (&self.orr.topology, spf));
         let loc_rib = &self.loc_rib;
         let target_peer_label = peer.to_string();
         let metrics = self.metrics.clone();
@@ -583,6 +591,7 @@ impl RibManager {
                         sendable.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
+                        orr_ctx,
                         &metrics,
                         policy_stats,
                         &target_peer_label,
@@ -591,6 +600,35 @@ impl RibManager {
                         &mut nh_override_flags,
                         &mut policy_filtered,
                         false, // route refresh re-emits all anyway via empty refresh_view
+                    );
+                    current_policy_filtered_routes.extend(policy_filtered);
+                } else if let Some((orr_topology, orr_spf)) = orr_ctx {
+                    // ORR peer with a resolved vantage: per-vantage best.
+                    let mut policy_filtered = Vec::new();
+                    Self::distribute_orr_best_prefix(
+                        &self.ribs,
+                        &refresh_view,
+                        &self.peer_is_rr_client,
+                        orr_topology,
+                        orr_spf,
+                        prefix,
+                        peer,
+                        target_peer_asn,
+                        target_peer_group,
+                        target_is_ebgp,
+                        target_is_rr_client,
+                        cluster_id,
+                        sendable.as_ref(),
+                        export_pol.as_ref(),
+                        orf_filter.as_ref(),
+                        &metrics,
+                        policy_stats,
+                        &target_peer_label,
+                        &mut announce,
+                        &mut withdraw,
+                        &mut nh_override_flags,
+                        &mut policy_filtered,
+                        false,
                     );
                     current_policy_filtered_routes.extend(policy_filtered);
                 } else {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -943,9 +943,12 @@ async fn unicast_stream_with_vantage(vantage: Option<IpAddr>) -> Vec<(Vec<String
     stream
 }
 
-/// THE PR guardrail: configuring an `orr_vantage` has ZERO effect on the
-/// staged unicast output — identical announce/withdraw streams with and
-/// without a vantage. The distribution switch lands in the next slice.
+/// Distribution-switch pin: this scenario's next-hop lies OUTSIDE the
+/// BGP-LS topology (unknown vantage cost) and each prefix has a single
+/// candidate, so the per-vantage ORR path must stage output identical
+/// to the standard path — a configured vantage may never perturb what
+/// it cannot rank. (Originally the pre-switch "zero effect" guardrail;
+/// still load-bearing as the unknown-cost/no-divergence pin.)
 #[tokio::test]
 async fn staged_output_identical_with_and_without_vantages() {
     let without = unicast_stream_with_vantage(None).await;
@@ -957,6 +960,515 @@ async fn staged_output_identical_with_and_without_vantages() {
     assert_eq!(
         without, with,
         "a configured vantage must not change the staged unicast stream"
+    );
+}
+
+// --- RFC 9107 ORR per-vantage best selection ---
+
+/// Feed peer for the square topology (never registered for outbound).
+const ORR_FEED: Ipv4Addr = Ipv4Addr::new(10, 9, 9, 9);
+/// iBGP source announcing via NH-X — lower peer address, so its route
+/// is the standard Loc-RIB best when everything else ties.
+const ORR_SRC_X: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+/// iBGP source announcing via NH-Y.
+const ORR_SRC_Y: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 2);
+
+/// Neighbor address of the A→X link — resolves to node X
+/// (interior cost 1 from vantage A, 10 from vantage B).
+fn orr_nh_x() -> IpAddr {
+    use crate::orr::fixtures::{A, X};
+    IpAddr::V4(Ipv4Addr::new(10, 0, X, A))
+}
+
+/// Neighbor address of the A→Y link — resolves to node Y
+/// (interior cost 10 from vantage A, 1 from vantage B).
+fn orr_nh_y() -> IpAddr {
+    use crate::orr::fixtures::{A, Y};
+    IpAddr::V4(Ipv4Addr::new(10, 0, Y, A))
+}
+
+/// Interface address of the B→X link (`10.0.B.X`) — resolves to B.
+fn vantage_at_node_b() -> IpAddr {
+    use crate::orr::fixtures::{B, X};
+    IpAddr::V4(Ipv4Addr::new(10, 0, B, X))
+}
+
+/// The contested prefix of the divergence scenario.
+fn orr_prefix() -> Ipv4Prefix {
+    Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)
+}
+
+/// Adj-RIB-Out map key of the scenario prefix as a single best.
+fn orr_prefix_key() -> (Prefix, u32) {
+    (Prefix::V4(orr_prefix()), 0)
+}
+
+/// An iBGP-learned route for `prefix` from `peer` with the given
+/// next-hop. Attributes are identical across sources so only the ORR
+/// interior-cost step and the final peer-address tiebreak can decide.
+fn ibgp_route(prefix: Ipv4Prefix, peer: Ipv4Addr, next_hop: IpAddr) -> Route {
+    Route {
+        prefix: Prefix::V4(prefix),
+        next_hop,
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::LocalPref(100),
+        ]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+/// An RR-mode manager (cluster id set, so iBGP-learned routes reflect
+/// to clients) with the square topology already fed from `ORR_FEED`.
+async fn orr_rr_manager() -> (mpsc::Sender<RibUpdate>, tokio::task::JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 255, 0, 1)),
+        BgpMetrics::new(),
+    );
+    let handle = tokio::spawn(manager.run());
+    feed_square_topology(&tx, ORR_FEED).await;
+    (tx, handle)
+}
+
+/// Announce unicast routes from `peer` (unregistered sources pass the
+/// stale-session gate with session id 0).
+async fn announce_unicast(tx: &mpsc::Sender<RibUpdate>, peer: Ipv4Addr, announced: Vec<Route>) {
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+}
+
+/// The arc's divergence scenario: the SAME prefix from two iBGP sources
+/// with next-hops at node X and node Y, followed by a sync point so both
+/// batches are recomputed and distributed.
+async fn announce_divergent_bests(tx: &mpsc::Sender<RibUpdate>) {
+    announce_unicast(
+        tx,
+        ORR_SRC_X,
+        vec![ibgp_route(orr_prefix(), ORR_SRC_X, orr_nh_x())],
+    )
+    .await;
+    announce_unicast(
+        tx,
+        ORR_SRC_Y,
+        vec![ibgp_route(orr_prefix(), ORR_SRC_Y, orr_nh_y())],
+    )
+    .await;
+    let _ = query_best_routes(tx).await;
+}
+
+/// Drain every queued outbound update and fold to the final advertised
+/// unicast state: `(prefix, path_id)` → the last announced route.
+fn drain_final_unicast(
+    rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+) -> HashMap<(Prefix, u32), Route> {
+    let mut state = HashMap::new();
+    while let Ok(update) = rx.try_recv() {
+        for route in &update.announce {
+            state.insert((route.prefix, route.path_id), route.clone());
+        }
+        for (prefix, path_id) in &update.withdraw {
+            state.remove(&(*prefix, *path_id));
+        }
+    }
+    state
+}
+
+/// THE arc's signature behavior: two RR clients bound to different
+/// vantages receive DIVERGENT bests for the same prefix — each exits
+/// via the next-hop closest to its own IGP location, not the RR's.
+#[tokio::test]
+async fn two_clients_different_vantages_receive_divergent_bests() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_a = orr_client_peer_up(&tx, client_a, Some(vantage_at_node_a())).await;
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    announce_divergent_bests(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_a = drain_final_unicast(&mut out_a);
+    let final_b = drain_final_unicast(&mut out_b);
+    assert_eq!(
+        final_a.get(&orr_prefix_key()).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "client at A exits via X (cost 1 < 10)"
+    );
+    assert_eq!(
+        final_b.get(&orr_prefix_key()).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "client at B exits via Y (cost 1 < 10)"
+    );
+}
+
+/// A topology metric flip re-stages ONLY the peers bound to the vantage
+/// whose SPF surface changed: the affected client's best flips, while
+/// the other vantage's client and a non-ORR client see zero messages.
+#[tokio::test]
+async fn topology_metric_flip_marks_only_affected_vantage_peers_dirty_and_flips_best() {
+    use crate::orr::fixtures::{A, X, link_route, v4_interface, v4_neighbor};
+
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_c = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut out_a = orr_client_peer_up(&tx, client_a, Some(vantage_at_node_a())).await;
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+    let mut out_c = orr_client_peer_up(&tx, client_c, None).await;
+
+    announce_divergent_bests(&tx).await;
+    // Steady state reached — empty every channel before the flip.
+    let _ = drain_final_unicast(&mut out_a);
+    let _ = drain_final_unicast(&mut out_b);
+    let _ = drain_final_unicast(&mut out_c);
+
+    // Flip A→X to metric 100 (the SAME Link NLRI — identical descriptors
+    // — so the entry is replaced, not duplicated). From A the SPF now
+    // prefers Y (10 < 100); distances from B are untouched.
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(ORR_FEED),
+        announced: vec![link_route(
+            ORR_FEED,
+            A,
+            X,
+            Some(100),
+            &[
+                v4_interface(Ipv4Addr::new(10, 0, A, X)),
+                v4_neighbor(Ipv4Addr::new(10, 0, X, A)),
+            ],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_a = drain_final_unicast(&mut out_a);
+    assert_eq!(
+        final_a.get(&orr_prefix_key()).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "affected client flips to Y (cost 10 < 100)"
+    );
+    assert!(
+        out_b.try_recv().is_err(),
+        "unaffected vantage's client must see zero messages"
+    );
+    assert!(
+        out_c.try_recv().is_err(),
+        "non-ORR client must see zero messages"
+    );
+}
+
+/// A vantage that does not resolve to a topology node silently falls
+/// back to the standard single-best: the ORR client's advertisement is
+/// identical to a vantage-less peer's.
+#[tokio::test]
+async fn unresolved_vantage_falls_back_to_loc_rib_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let orr_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let plain_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let outside = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+    let mut out_orr = orr_client_peer_up(&tx, orr_client, Some(outside)).await;
+    let mut out_plain = orr_client_peer_up(&tx, plain_client, None).await;
+
+    announce_divergent_bests(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_orr = drain_final_unicast(&mut out_orr);
+    let final_plain = drain_final_unicast(&mut out_plain);
+    let unresolved = final_orr
+        .get(&orr_prefix_key())
+        .expect("unresolved-vantage client is advertised the prefix");
+    let plain = final_plain
+        .get(&orr_prefix_key())
+        .expect("vantage-less client is advertised the prefix");
+    assert_eq!(unresolved.next_hop, orr_nh_x(), "the Loc-RIB best");
+    assert_eq!(unresolved.next_hop, plain.next_hop);
+    assert_eq!(unresolved.attributes, plain.attributes);
+    assert_eq!(unresolved.peer, plain.peer);
+    assert_eq!(unresolved.path_id, plain.path_id);
+}
+
+/// Withdrawing every BGP-LS link unresolves all vantages: ORR clients
+/// revert to the standard best. The client whose vantage best already
+/// matched it sees zero messages (equality suppression).
+#[tokio::test]
+async fn bgpls_withdrawal_of_all_links_reverts_orr_peers_to_standard_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_a = orr_client_peer_up(&tx, client_a, Some(vantage_at_node_a())).await;
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    announce_divergent_bests(&tx).await;
+    let _ = drain_final_unicast(&mut out_a);
+    let _ = drain_final_unicast(&mut out_b);
+
+    let keys: Vec<BgpLsRouteKey> = crate::orr::fixtures::square_topology(ORR_FEED)
+        .iter()
+        .map(BgpLsRibRoute::key)
+        .collect();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(ORR_FEED),
+        announced: vec![],
+        withdrawn: keys,
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_unicast(&mut out_b);
+    assert_eq!(
+        final_b.get(&orr_prefix_key()).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "client at B reverts from NH-Y to the standard best NH-X"
+    );
+    assert!(
+        out_a.try_recv().is_err(),
+        "client at A already held the standard best — zero messages"
+    );
+}
+
+/// A client that establishes AFTER the routes and topology are in place
+/// gets its per-vantage best in the initial table dump.
+#[tokio::test]
+async fn orr_client_initial_dump_gets_vantage_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    announce_divergent_bests(&tx).await;
+
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (out_tx, mut out_b) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: client_b,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_unicast(&mut out_b);
+    assert_eq!(
+        final_b.get(&orr_prefix_key()).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "initial dump carries the vantage best, not the Loc-RIB best"
+    );
+}
+
+/// A ROUTE-REFRESH replay re-derives the same per-vantage best the live
+/// distribution path sent.
+#[tokio::test]
+async fn route_refresh_replays_vantage_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    announce_divergent_bests(&tx).await;
+    let _ = drain_final_unicast(&mut out_b);
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: client_b,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_unicast(&mut out_b);
+    let replayed = final_b
+        .get(&orr_prefix_key())
+        .expect("refresh replays the prefix (empty refresh view forces a re-emit)");
+    assert_eq!(
+        replayed.next_hop,
+        orr_nh_y(),
+        "the replay is the vantage best"
+    );
+}
+
+/// Split horizon and RFC 4456 reflection suppression run BEFORE the ORR
+/// ranking: a cost-0 candidate the target must not receive can never
+/// win.
+#[tokio::test]
+async fn split_horizon_and_rr_suppression_apply_before_orr_ranking() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_b_v4 = Ipv4Addr::new(10, 0, 0, 3);
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    // A non-client iBGP peer bound to the same vantage. (Config
+    // validation rejects orr_vantage without rr-client; the RIB layer
+    // trusts PeerUp, and the suppression seam must hold regardless.)
+    let peer_d = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let (out_tx_d, mut out_d) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: peer_d,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx_d,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: false,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_d).await;
+
+    // prefix1 — split-horizon probe: client B's OWN route has interior
+    // cost 0 (next-hop at its vantage node); a non-client source offers
+    // cost 10 via NH-X.
+    let prefix1 = orr_prefix();
+    announce_unicast(
+        &tx,
+        client_b_v4,
+        vec![ibgp_route(prefix1, client_b_v4, vantage_at_node_b())],
+    )
+    .await;
+    announce_unicast(
+        &tx,
+        ORR_SRC_X,
+        vec![ibgp_route(prefix1, ORR_SRC_X, orr_nh_x())],
+    )
+    .await;
+
+    // prefix2 — RR-suppression probe: the cost-0 candidate comes from a
+    // NON-client (never reflectable to the non-client target D); client
+    // B offers cost 10 via NH-X (client routes reflect to everyone).
+    let prefix2 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 101, 0), 24);
+    announce_unicast(
+        &tx,
+        ORR_SRC_Y,
+        vec![ibgp_route(prefix2, ORR_SRC_Y, vantage_at_node_b())],
+    )
+    .await;
+    announce_unicast(
+        &tx,
+        client_b_v4,
+        vec![ibgp_route(prefix2, client_b_v4, orr_nh_x())],
+    )
+    .await;
+
+    let _ = query_best_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_unicast(&mut out_b);
+    assert_eq!(
+        final_b.get(&(Prefix::V4(prefix1), 0)).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "the target's own cost-0 route is split-horizoned before ranking"
+    );
+    let final_d = drain_final_unicast(&mut out_d);
+    assert_eq!(
+        final_d.get(&(Prefix::V4(prefix2), 0)).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "the cost-0 non-client candidate is RR-suppressed before ranking"
+    );
+}
+
+/// Add-Path send to an ORR peer ranks the advertised paths by the
+/// vantage's interior cost (comparator swap in the multipath sort):
+/// path id 1 is the vantage-closest exit, not the standard-chain
+/// winner.
+#[tokio::test]
+async fn orr_with_addpath_send_ranks_by_vantage_cost() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (out_tx, mut out_b) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: client_b,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        add_path_send_max: 2,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_b).await;
+
+    announce_divergent_bests(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_unicast(&mut out_b);
+    // Standard ranking would put NH-X first (lower peer address); from
+    // vantage B the costs are Y=1, X=10 — the ORR comparator must rank
+    // NH-Y as path 1.
+    assert_eq!(
+        final_b
+            .get(&(Prefix::V4(orr_prefix()), 1))
+            .map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "rank 1 is the vantage-closest path"
+    );
+    assert_eq!(
+        final_b
+            .get(&(Prefix::V4(orr_prefix()), 2))
+            .map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "rank 2 is the vantage-farther path"
     );
 }
 


### PR DESCRIPTION
Fourth slice of the **RFC 9107 ORR** arc, on top of #630 — **the core**: RR clients bound to a resolved vantage now receive the best path computed from *their* topological position.

- `best_path_cmp` refactored into a shared `cmp_chain` with an optional ORR interior-cost step at exactly RFC 4271's slot (after eBGP/iBGP, before CLUSTER_LIST): lower vantage-SPF-cost to NEXT_HOP wins; unknown cost is least-preferred per RFC 9107; ties fall through. The public `best_path_cmp` delegates with `None` — pinned behavior-identical by a proptest oracle against a verbatim legacy copy. New `BestPathReason::OrrInteriorCost`.
- `distribute_orr_best_prefix`: per-target candidate collection + split-horizon/RR-suppression filters lifted verbatim from the Add-Path multipath collector, ranked by `best_path_cmp_orr` with `SpfResult::cost_to`. Deliberately **no per-(vantage,prefix) winner memo** — unsound, since candidate sets are per-target (doc-commented); the NH-cost LRU is the sound cache.
- All three unicast staging paths switched (distribute loop incl. dirty/force resync, initial table dump, route-refresh replay); Add-Path send to ORR peers ranks by vantage cost; unresolved vantage = untouched single-best fallback.
- **Red-testing found and fixed a real staging gap**: a candidate change that leaves the Loc-RIB best untouched can still flip a vantage best, so ORR peers now stage every affected prefix (the Add-Path parallel, comment in `distribute_changes`).
- Changed-vantage SPF results now dirty their bound peers and trigger the minimal-delta resync.

### Tests
13 new: the four decision-chain pins incl. the proptest oracle, and the manager matrix — **`two_clients_different_vantages_receive_divergent_bests`** (the arc's signature), metric-flip-moves-only-the-affected-client (zero churn elsewhere), unresolved fallback byte-identity, all-links-withdrawn reversion, initial-dump/refresh-replay vantage bests, suppression-before-ranking, Add-Path vantage ranking. Full suite: 4471 passed, 0 failed.

Next: M76 divergent-best interop receipt (live GoBGP), ADR-0095.