### PR TITLE
docs: add ADR-0095 and ORR documentation sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Optimal Route Reflection (RFC 9107, ADR-0095) — per-client best paths
+  via BGP-LS-sourced SPF.** A route reflector normally reflects *its own*
+  best path to every client; ORR computes each client's best from the
+  client's own topological position. Configure `orr_vantage = "<ip>"`
+  (an IP identifying a node in the BGP-LS topology) on an iBGP
+  route-reflector client or peer-group; the RR builds a topology graph
+  from all received BGP-LS routes (nodes interned by canonical descriptor
+  bytes; link costs from the IGP Metric TLV parsed lazily out of the
+  never-typed BGP-LS Attribute), runs one Dijkstra per distinct vantage,
+  and ranks that client's candidate set with the interior-cost tiebreak
+  at RFC 4271's step-(e) slot — unknown cost is least preferred, and an
+  unresolved vantage falls back silently to the standard best. Topology
+  changes re-stage exactly the affected clients with minimal deltas.
+  Observability: `rbgp topology nodes|links`, `rbgp orr`, and
+  `ListTopologyNodes`/`ListTopologyLinks`/`ListOrrStatus` (SensitiveRead),
+  plus SPF/topology telemetry. Zero cost and zero behavior change when no
+  vantage is configured (pinned by an output-equality guardrail test).
+  Deferred (ADR-0095): backup vantages, inter-RR Add-Path (multi-cluster),
+  VPN-ORR, TE/multi-topology metrics. M76 proves live divergence: two
+  GoBGP clients of one RR receive different best paths for the same
+  prefix, flip on a topology metric change, and collapse to the identical
+  standard best when the topology is withdrawn. **No other open-source
+  BGP daemon ships ORR.**
+
 - **RT-Constrain (RFC 4684, AFI 1 / SAFI 132) — constrained VPN route
   distribution.** The scalability companion to the VPNv4/v6 route reflector:
   peers advertise Route Target membership NLRI (a 0–96-bit prefix over

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ BGP-LS receive/reflection/API export (RFC 9552), VPNv4/VPNv6 L3VPN
 route-reflection (RFC 4364 / RFC 4659, SAFI 128 — RR/controller-feed with RD,
 MPLS label stack, next-hop, and Route Targets preserved verbatim; no VRF import
 or MPLS FIB), and RT-Constrain (RFC 4684, SAFI 132 — strict per-peer VPN
-reflection filtering) have shipped under ADR-0077; future BGP-LS local topology
+reflection filtering) have shipped under ADR-0077, and **Optimal Route
+Reflection (RFC 9107, ADR-0095)** computes per-client best paths via SPF over
+the BGP-LS-sourced topology — a capability no other open-source BGP daemon
+ships; future BGP-LS local topology
 production and labeled-unicast work stays scoped by
 [ADR-0077](docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md): those
 families must land as typed route-family slices or unreachable substrate, not as
@@ -319,7 +322,7 @@ and more explicit internal architecture.
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
 | Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 4.3.0 and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
-| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72), RFC 4364/4659 VPNv4/VPNv6 route-reflection (SAFI 128, RR/controller-feed), RFC 4684 RT-Constrain (SAFI 132, constrained VPN distribution), RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
+| Protocol coverage | RFC 4271 FSM + UPDATE validation, MP-BGP, GR/LLGR, Add-Path, FlowSpec, RFC 9552 BGP-LS receive + reflection + API export (SAFI 71/72), RFC 4364/4659 VPNv4/VPNv6 route-reflection (SAFI 128, RR/controller-feed), RFC 4684 RT-Constrain (SAFI 132, constrained VPN distribution), RFC 9107 Optimal Route Reflection (per-client best paths via BGP-LS-sourced SPF), RPKI, ASPA, Extended Messages, Extended Next Hop, Route Refresh/ERR, receive-side Prefix ORF, RFC 7999 BLACKHOLE receiver scoping + opt-in FIB discard, ADR-0061/0066/0068 configured-table unicast Linux FIB programming with ECMP / weighted multipath, RFC 5880/5881/5882 BFD, RFC 8326 Graceful Shutdown |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 
 ```bash

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -447,6 +447,7 @@ dynamic-only deployment where peers are added at runtime via gRPC.
 | `disable_ipv4_unicast` | bool     | no       | false   | True IPv6-only peering: never negotiate IPv4 unicast on this session (suppresses the RFC 4760 §8 implicit-IPv4 fallback; see below) |
 | `remove_private_as`   | string   | no       | --      | Remove private ASNs from AS_PATH: `"remove"`, `"all"`, or `"replace"` (eBGP only) |
 | `route_reflector_client` | bool   | no       | false   | Mark this iBGP peer as a route reflector client (RFC 4456) |
+| `orr_vantage`          | string   | no       | --      | RFC 9107 Optimal Route Reflection IGP location: an IP identifying a node in the BGP-LS-sourced topology; this client's best paths use the interior-cost tiebreak from that node's SPF. Requires `route_reflector_client = true` + iBGP; inherits from the peer-group; an unresolved vantage falls back silently to the standard best (see `rbgp orr`). ADR-0095 |
 | `local_ipv6_nexthop`   | string   | no       | --      | Override IPv6 next-hop for eBGP exports (must be valid non-link-local IPv6) |
 | `import_policy_chain`  | [string] | no       | --      | Named policy chain for import (mutually exclusive with inline import_policy) |
 | `export_policy_chain`  | [string] | no       | --      | Named policy chain for export (mutually exclusive with inline export_policy) |

--- a/docs/adr/0095-optimal-route-reflection.md
+++ b/docs/adr/0095-optimal-route-reflection.md
@@ -1,0 +1,111 @@
+# ADR-0095: Optimal Route Reflection via BGP-LS-sourced SPF (RFC 9107)
+
+**Status:** Accepted — shipped across #628 (typed BGP-LS topology accessors),
+#629 (topology graph + SPF engine + `rbgp topology`), #630 (`orr_vantage`
+config + vantage registry + cached SPF), #631 (per-vantage best selection),
+with the M76 divergent-best interop receipt.
+**Date:** 2026-07-02
+
+## Context
+
+A route reflector runs one best-path selection from its own position and
+reflects that single answer to every client. Clients far from the RR get
+exits that are optimal for the RR, not for them — the classic RR
+sub-optimality RFC 9107 exists to fix. ORR re-runs exactly one step of the
+RFC 4271 decision process — the interior-cost-to-NEXT_HOP tiebreak — from a
+configured **IGP location** ("vantage"): a node in the topology identified
+by one of its IP addresses.
+
+RFC 9107 §3.1 admits two topology sources: a link-state IGP (rustbgpd runs
+none and will not) or **BGP-LS** — which rustbgpd receives, stores, and
+reflects since the ADR-0077 arc. That made ORR implementable here without an
+IGP: the RR's clients' IGP feeds BGP-LS (directly or via the fabric's
+existing BGP-LS producers), and the RR runs SPF over that feed. No
+open-source BGP daemon ships ORR (FRR's request has been open since 2018;
+BIRD/GoBGP/OpenBGPd lack it); only commercial routers do.
+
+## Decisions
+
+1. **Node identity is the canonical descriptor byte string** — protocol-id +
+   identifier + the raw TLV-256/257 node-descriptor container value bytes
+   (`BgpLsNodeKey`). Link endpoints intern to nodes by byte equality; no
+   per-protocol IGP Router-ID interpretation is needed for graph
+   construction (RFC 9552's mandatory ascending TLV order, already enforced
+   by the decoder, makes byte equality sound). Router-ID parsing is
+   display-only (CLI).
+
+2. **The BGP-LS Attribute (path attribute 29) is never typed.** It stays
+   `PathAttribute::Unknown(RawAttribute)` end-to-end so reflection re-encodes
+   it verbatim (the fidelity M73 pins). The topology builder parses the raw
+   bytes lazily and locally: IGP Metric (TLV 1095, 1/2/3-byte forms) as link
+   cost — a link without it contributes no edge; Prefix Metric (TLV 1155)
+   for reachability cost; TE Default Metric (1092) parsed but unused;
+   Multi-Topology deferred.
+
+3. **Next-hop resolution**: exact match on link interface/neighbor addresses
+   (TLVs 259–262) wins outright — an unreachable owner is a real
+   unknown-cost answer, not a fall-through; otherwise longest-prefix match
+   over Topology Prefix NLRIs (min over advertisers of SPF distance +
+   prefix metric); otherwise unknown. Unknown cost is **least preferred**
+   per RFC 9107's mandate for unresolvable metrics.
+
+4. **Per-vantage bests are computed at distribution time — shadow
+   per-vantage Loc-RIBs were considered and rejected.** The Loc-RIB keeps
+   its single-best-per-prefix invariant. For a peer bound to a resolved
+   vantage, the per-target candidate set (all Adj-RIB-Ins, split-horizon and
+   RFC 4456 suppression applied per target, exactly the Add-Path multipath
+   collector) is ranked by the standard decision chain with one added step —
+   RFC 4271's interior-cost slot (after eBGP/iBGP, before CLUSTER_LIST) —
+   using the vantage's SPF cost. Shadow RIBs would multiply memory by the
+   vantage count and add an invalidation protocol; distribution-time
+   selection costs CPU only when topology or candidates change and only for
+   ORR peers.
+
+5. **No per-(vantage, prefix) winner memo — it would be unsound.** The
+   candidate set is per-target-peer (split horizon and reflection
+   suppression drop different routes for different targets), so a memoized
+   winner could be a route the next target must never receive. The sound
+   cache is the per-SPF next-hop-cost LRU. Similarly, because ORR peers
+   select from candidates rather than the Loc-RIB best, a candidate change
+   that leaves the Loc-RIB best untouched can still flip a vantage best —
+   ORR peers therefore stage every affected prefix (the Add-Path staging
+   parallel).
+
+6. **SPF is a hand-rolled binary-heap Dijkstra** (no graph dependency), one
+   run per **distinct** vantage, cached on the RibManager and rebuilt at
+   every BGP-LS mutation seam through the single `recompute_bgpls_keys`
+   chokepoint (receive, Enhanced-Refresh sweep, GR sweep in the
+   recompute-then-GC order, peer teardown). Change detection uses a
+   canonical key-addressed SPF signature — raw distance vectors are
+   unstable across interning orders. Changed vantages dirty their bound
+   peers; the Adj-RIB-Out equality machinery emits the minimal delta. With
+   no vantages configured the engine early-outs: zero steady-state cost.
+
+7. **Vantage config** (`orr_vantage = "<ip>"`, neighbor + peer-group with
+   standard inheritance) requires an iBGP route-reflector client; an
+   unresolved vantage falls back silently to the standard best (surfaced by
+   `rbgp orr` and a transition log, never a session error). Unicast v4+v6
+   only in v1.
+
+## Deferred (with un-defer triggers)
+
+- **Backup IGP locations** (RFC 9107 SHOULD) — when an operator asks for
+  vantage redundancy.
+- **Inter-RR Add-Path** (required by RFC 9107 only for multi-cluster
+  deployments) — when a second-RR topology lands.
+- **VPN-ORR** (vantage ranking for SAFI 128) — natural composition,
+  queued as a follow-on candidate.
+- **TE / Multi-Topology metrics** — operator demand.
+- **RFC 9107 §3.2 per-policy multiple Decision Processes** — policy
+  divergence below step (e) is out of scope until a concrete case appears.
+
+## Consequences
+
+rustbgpd is the first open-source BGP daemon with working ORR. The cost is
+a derived-state engine (topology + SPF) between BGP-LS ingest and unicast
+emission — bounded by the early-out, the distinct-vantage dedup, and the
+per-SPF LRU — and a second best-path entry point (`best_path_cmp_orr`)
+pinned to the legacy chain by a property-test oracle. M76 proves live
+divergence: two GoBGP clients of one RR receive different bests for the
+same prefix, flip correctly on a topology metric change, and collapse to
+the identical standard best when the topology is withdrawn.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -169,6 +169,7 @@ For release-by-release feature history, see [CHANGELOG.md](../CHANGELOG.md).
 | Lowest peer tiebreaker | Yes | Yes | |
 | Stale route demotion | Yes | Yes | GR step 0 |
 | RPKI preference | Yes | Yes | Step 0.5: Valid > NotFound > Invalid |
+| Optimal Route Reflection (RFC 9107) | No | **Yes** | Per-client interior-cost tiebreak from a configured vantage, SPF over the BGP-LS-sourced topology (ADR-0095, M76). No open-source daemon ships this |
 | AIGP | Yes | No | |
 | Multipath/ECMP | Yes | Yes | Classic unicast FIB ECMP ships via ADR-0066: `[[fib_tables]].maximum_paths`, per-class `maximum_paths_ebgp` / `maximum_paths_ibgp`, homogeneous eBGP or iBGP groups, and kernel `RTA_MULTIPATH` install. `[global].multipath_relax` provides FRR-style AS_PATH-length grouping; ADR-0068 adds Link Bandwidth weighted multipath. Add-Path multi-path send and EVPN aliasing ECMP also ship |
 


### PR DESCRIPTION
Final slice of the **RFC 9107 ORR** arc (#628–#633): the decision record and doc sweep.

- **ADR-0095**: the full record — descriptor-byte node identity, never-typed attr-29 with lazy contained parsing, distribution-time per-vantage bests with the shadow-Loc-RIB rejection rationale, the unsound-memo note, unknown-metric-least-preferred, the single-chokepoint recompute wiring, and the deferral register (backup vantages, inter-RR Add-Path, VPN-ORR, TE/MT, §3.2) with un-defer triggers.
- README (intro + protocol-coverage row: "a capability no other open-source BGP daemon ships"), CHANGELOG feature entry, CONFIGURATION.md `orr_vantage` row, gobgp-parity Best-Path row (**rustbgpd Yes / GoBGP No**).

The M76 receipt rows landed with #633.