### PR TITLE
feat(fsm+rib): preserve VPN, BGP-LS, and RT-Constrain routes as stale through graceful restart

### DIFF
--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -10,13 +10,20 @@ use rustbgpd_wire::{
 
 /// Whether the RIB currently has GR/LLGR stale-retention handling for a family.
 ///
-/// BGP-LS receive/API support stores opaque routes, but does not yet implement
-/// the GR/LLGR stale lifecycle for that typed RIB. Keep it out of restart
-/// preservation until that behavior is added.
+/// Every typed Adj-RIB-In with a wired stale lifecycle is listed: unicast,
+/// `FlowSpec`, EVPN, VPNv4/VPNv6 (SAFI 128), BGP-LS/BGP-LS-VPN (AFI 16388),
+/// and RT-Constrain (SAFI 132). A family absent here is excluded from the
+/// GR/LLGR capability sets and therefore withdrawn (not retained stale) on
+/// session drop.
 pub(crate) fn graceful_restart_preserves_family((afi, safi): (Afi, Safi)) -> bool {
     matches!(
         (afi, safi),
-        (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast | Safi::FlowSpec) | (Afi::L2Vpn, Safi::Evpn)
+        (
+            Afi::Ipv4 | Afi::Ipv6,
+            Safi::Unicast | Safi::FlowSpec | Safi::MplsVpn
+        ) | (Afi::L2Vpn, Safi::Evpn)
+            | (Afi::BgpLs, Safi::BgpLs | Safi::BgpLsVpn)
+            | (Afi::Ipv4, Safi::RtConstrain)
     )
 }
 
@@ -428,52 +435,46 @@ mod tests {
     }
 
     #[test]
-    fn restart_capabilities_omit_bgpls_families() {
+    fn restart_capabilities_include_preserved_typed_families() {
+        // The GR/LLGR stale lifecycle is wired for BGP-LS, VPN, and RTC,
+        // so the advertised GR and LLGR capability sets carry every
+        // configured family in the preservation allowlist.
         let mut cfg = test_config();
         cfg.families = vec![
             (Afi::Ipv4, Safi::Unicast),
             (Afi::BgpLs, Safi::BgpLs),
             (Afi::BgpLs, Safi::BgpLsVpn),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv6, Safi::MplsVpn),
+            (Afi::Ipv4, Safi::RtConstrain),
         ];
         cfg.graceful_restart = true;
         cfg.llgr_stale_time = 3600;
         let caps = cfg.local_capabilities();
 
-        let mp_families: Vec<_> = caps
-            .iter()
-            .filter_map(|cap| match cap {
-                Capability::MultiProtocol { afi, safi } => Some((*afi, *safi)),
-                _ => None,
-            })
-            .collect();
-        assert!(mp_families.contains(&(Afi::BgpLs, Safi::BgpLs)));
-        assert!(mp_families.contains(&(Afi::BgpLs, Safi::BgpLsVpn)));
-
-        let gr_families = caps
+        let gr_families: Vec<_> = caps
             .iter()
             .find_map(|cap| match cap {
                 Capability::GracefulRestart { families, .. } => Some(families),
                 _ => None,
             })
-            .expect("GR capability advertised for unicast");
-        assert_eq!(gr_families.len(), 1);
-        assert_eq!(
-            (gr_families[0].afi, gr_families[0].safi),
-            (Afi::Ipv4, Safi::Unicast)
-        );
+            .expect("GR capability advertised")
+            .iter()
+            .map(|f| (f.afi, f.safi))
+            .collect();
+        assert_eq!(gr_families, cfg.families);
 
-        let llgr_families = caps
+        let llgr_families: Vec<_> = caps
             .iter()
             .find_map(|cap| match cap {
                 Capability::LongLivedGracefulRestart(families) => Some(families),
                 _ => None,
             })
-            .expect("LLGR capability advertised for unicast");
-        assert_eq!(llgr_families.len(), 1);
-        assert_eq!(
-            (llgr_families[0].afi, llgr_families[0].safi),
-            (Afi::Ipv4, Safi::Unicast)
-        );
+            .expect("LLGR capability advertised")
+            .iter()
+            .map(|f| (f.afi, f.safi))
+            .collect();
+        assert_eq!(llgr_families, cfg.families);
     }
 
     #[test]

--- a/crates/fsm/src/negotiation.rs
+++ b/crates/fsm/src/negotiation.rs
@@ -902,7 +902,9 @@ mod tests {
     }
 
     #[test]
-    fn graceful_restart_filters_bgpls_from_peer_open() {
+    fn graceful_restart_keeps_bgpls_from_peer_open() {
+        // BGP-LS has a wired GR/LLGR stale lifecycle, so a negotiated
+        // (BgpLs, BgpLs) family survives the GR and LLGR capability filters.
         let mut cfg = test_config();
         cfg.graceful_restart = true;
         cfg.llgr_stale_time = 3600;
@@ -948,19 +950,83 @@ mod tests {
 
         let neg = validate_open(&open, &cfg).unwrap();
         assert!(neg.peer_gr_capable);
-        assert_eq!(neg.peer_gr_families.len(), 1);
+        let gr_families: Vec<(Afi, Safi)> = neg
+            .peer_gr_families
+            .iter()
+            .map(|f| (f.afi, f.safi))
+            .collect();
         assert_eq!(
-            (neg.peer_gr_families[0].afi, neg.peer_gr_families[0].safi),
-            (Afi::Ipv4, Safi::Unicast)
+            gr_families,
+            vec![(Afi::Ipv4, Safi::Unicast), (Afi::BgpLs, Safi::BgpLs)]
         );
         assert!(neg.peer_llgr_capable);
-        assert_eq!(neg.peer_llgr_families.len(), 1);
+        let llgr_families: Vec<(Afi, Safi)> = neg
+            .peer_llgr_families
+            .iter()
+            .map(|f| (f.afi, f.safi))
+            .collect();
         assert_eq!(
-            (
-                neg.peer_llgr_families[0].afi,
-                neg.peer_llgr_families[0].safi
-            ),
-            (Afi::Ipv4, Safi::Unicast)
+            llgr_families,
+            vec![(Afi::Ipv4, Safi::Unicast), (Afi::BgpLs, Safi::BgpLs)]
+        );
+    }
+
+    #[test]
+    fn graceful_restart_keeps_vpn_and_rtc_from_peer_open() {
+        // VPNv4/VPNv6 (SAFI 128) and RT-Constrain (SAFI 132) are in the GR
+        // preservation allowlist: negotiated tuples survive the capability
+        // filter, while a non-negotiated tuple (VPNv6 here) is still dropped.
+        let mut cfg = test_config();
+        cfg.graceful_restart = true;
+        cfg.families = vec![
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv4, Safi::RtConstrain),
+            (Afi::Ipv4, Safi::Unicast),
+        ];
+
+        let mut open = peer_open();
+        open.capabilities.push(Capability::MultiProtocol {
+            afi: Afi::Ipv4,
+            safi: Safi::MplsVpn,
+        });
+        open.capabilities.push(Capability::MultiProtocol {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+        });
+        open.capabilities.push(Capability::GracefulRestart {
+            restart_state: false,
+            notification: true,
+            restart_time: 120,
+            families: vec![
+                GracefulRestartFamily {
+                    afi: Afi::Ipv4,
+                    safi: Safi::MplsVpn,
+                    forwarding_preserved: true,
+                },
+                GracefulRestartFamily {
+                    afi: Afi::Ipv6,
+                    safi: Safi::MplsVpn,
+                    forwarding_preserved: true,
+                },
+                GracefulRestartFamily {
+                    afi: Afi::Ipv4,
+                    safi: Safi::RtConstrain,
+                    forwarding_preserved: true,
+                },
+            ],
+        });
+
+        let neg = validate_open(&open, &cfg).unwrap();
+        assert!(neg.peer_gr_capable);
+        let gr_families: Vec<(Afi, Safi)> = neg
+            .peer_gr_families
+            .iter()
+            .map(|f| (f.afi, f.safi))
+            .collect();
+        assert_eq!(
+            gr_families,
+            vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv4, Safi::RtConstrain)],
+            "negotiated VPN/RTC tuples must survive; non-negotiated VPNv6 must not"
         );
     }
 

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -55,38 +55,6 @@ impl RibManager {
         }
 
         info!(%peer, restart_time, stale_routes_time, llgr_stale_time, "peer entered graceful restart");
-        let bgpls_gr_families: Vec<(Afi, Safi)> = gr_families
-            .iter()
-            .copied()
-            .filter(|(afi, safi)| BgpLsFamily::from_afi_safi(*afi, *safi).is_some())
-            .collect();
-        if !bgpls_gr_families.is_empty() {
-            info!(
-                %peer,
-                families = ?bgpls_gr_families,
-                "excluding BGP-LS from GR stale preservation; typed stale lifecycle is not implemented"
-            );
-        }
-        let gr_families: Vec<(Afi, Safi)> = gr_families
-            .into_iter()
-            .filter(|(afi, safi)| BgpLsFamily::from_afi_safi(*afi, *safi).is_none())
-            .collect();
-        let vpn_gr_families: Vec<(Afi, Safi)> = gr_families
-            .iter()
-            .copied()
-            .filter(|&(afi, safi)| matches!(afi, Afi::Ipv4 | Afi::Ipv6) && safi == Safi::MplsVpn)
-            .collect();
-        if !vpn_gr_families.is_empty() {
-            info!(
-                %peer,
-                families = ?vpn_gr_families,
-                "excluding VPN from GR stale preservation; typed stale lifecycle is not implemented"
-            );
-        }
-        let gr_families: Vec<(Afi, Safi)> = gr_families
-            .into_iter()
-            .filter(|&(_, safi)| safi != Safi::MplsVpn)
-            .collect();
 
         let mut affected = HashSet::new();
         let mut fs_affected = HashSet::new();
@@ -107,6 +75,18 @@ impl RibManager {
             if gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
                 rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
             }
+            // RFC 4724 helper retention for the typed RIBs (VPN, BGP-LS,
+            // RTC): mark GR-covered families stale. The returned keys are
+            // routes that were ALREADY stale from a previous restart and
+            // were deleted (RFC 4724 §4.1: no retention across consecutive
+            // restarts) — collect them so the recompute below withdraws
+            // them downstream. Each mark helper is a family-scoped no-op
+            // for non-matching tuples.
+            for &family in &gr_families {
+                vpn_affected.extend(rib.mark_stale_vpn(family));
+                bgpls_affected.extend(rib.mark_stale_bgpls(family));
+                rtc_affected.extend(rib.mark_stale_rtc(family));
+            }
             let withdrawn = rib.withdraw_families_except(&gr_families);
             if !withdrawn.is_empty() {
                 info!(%peer, count = withdrawn.len(), "withdrew non-GR family routes");
@@ -114,37 +94,42 @@ impl RibManager {
             for prefix in withdrawn {
                 affected.insert(prefix);
             }
-            let withdrawn_bgpls = rib.withdraw_all_bgpls();
-            if !withdrawn_bgpls.is_empty() {
-                info!(
-                    %peer,
-                    count = withdrawn_bgpls.len(),
-                    "withdrew BGP-LS routes on GR entry; stale preservation is not implemented for BGP-LS"
-                );
+            // RFC 4724-critical negative: only families IN the peer's
+            // advertised GR capability are retained. A negotiated typed
+            // family whose tuple is absent from `gr_families` is withdrawn
+            // outright — mirroring the EVPN not-in-gr arm below.
+            for &family in &[(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv6, Safi::MplsVpn)] {
+                if !gr_families.contains(&family) {
+                    let keys: Vec<crate::route::VpnRibRouteKey> = rib
+                        .iter_vpn()
+                        .filter(|r| r.afi_safi() == family)
+                        .map(crate::route::VpnRibRoute::key)
+                        .collect();
+                    for key in keys {
+                        rib.withdraw_vpn(&key);
+                        vpn_affected.insert(key);
+                    }
+                }
             }
-            bgpls_affected.extend(withdrawn_bgpls);
-            let withdrawn_l3vpn = rib.withdraw_all_vpn();
-            if !withdrawn_l3vpn.is_empty() {
-                info!(
-                    %peer,
-                    count = withdrawn_l3vpn.len(),
-                    "withdrew VPN routes on GR entry; stale preservation is not implemented for VPN"
-                );
+            for &family in &[(Afi::BgpLs, Safi::BgpLs), (Afi::BgpLs, Safi::BgpLsVpn)] {
+                if !gr_families.contains(&family)
+                    && let Some(fam) = BgpLsFamily::from_afi_safi(family.0, family.1)
+                {
+                    let keys: Vec<BgpLsRouteKey> = rib
+                        .iter_bgpls()
+                        .filter(|r| r.family == fam)
+                        .map(crate::route::BgpLsRibRoute::key)
+                        .collect();
+                    for key in keys {
+                        rib.withdraw_bgpls(&key);
+                        bgpls_affected.insert(key);
+                    }
+                }
             }
-            vpn_affected.extend(withdrawn_l3vpn);
-            // RT-Constrain is conservatively withdrawn on GR entry. No
-            // rib-side family filter is needed: the fsm GR allowlist
-            // (`graceful_restart_preserves_family`) already excludes SAFI
-            // 132, so `gr_families` can never contain it.
-            let withdrawn_rtc = rib.withdraw_all_rtc();
-            if !withdrawn_rtc.is_empty() {
-                info!(
-                    %peer,
-                    count = withdrawn_rtc.len(),
-                    "withdrew RT-Constrain routes on GR entry; stale preservation is not implemented for RTC"
-                );
+            // RTC has a single family tuple (AFI 1 / SAFI 132).
+            if !gr_families.contains(&crate::route::RtcRibRouteKey::afi_safi()) {
+                rtc_affected.extend(rib.withdraw_all_rtc());
             }
-            rtc_affected.extend(withdrawn_rtc);
             // EVPN has a single family tuple; sweep all EVPN routes if
             // the peer didn't advertise GR for (L2Vpn, Evpn).
             if !gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
@@ -183,6 +168,27 @@ impl RibManager {
             if gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
                 for route in rib.iter_evpn() {
                     evpn_affected.insert(route.key());
+                }
+            }
+            // Stale marking demotes the tiebreak rank without removing the
+            // route, so every RETAINED key of a GR-covered typed family must
+            // be recomputed too — the same full re-add the unicast/EVPN
+            // paths do above. (BGP-LS stale routes deliberately stay in the
+            // topology feed: `iter_bgpls` includes them, which is what keeps
+            // ORR vantages resolved through the restart window.)
+            for route in rib.iter_vpn() {
+                if gr_families.contains(&route.afi_safi()) {
+                    vpn_affected.insert(route.key());
+                }
+            }
+            for route in rib.iter_bgpls() {
+                if gr_families.contains(&route.family.to_afi_safi()) {
+                    bgpls_affected.insert(route.key());
+                }
+            }
+            if gr_families.contains(&crate::route::RtcRibRouteKey::afi_safi()) {
+                for route in rib.iter_rtc() {
+                    rtc_affected.insert(route.key());
                 }
             }
             self.metrics
@@ -226,6 +232,12 @@ impl RibManager {
                 rib.gc_intern_table();
             }
         }
+        // No RTC membership rebuild here even when routes were deleted:
+        // `clear_outbound_peer_state` below drops this peer's
+        // `peer_rt_membership` entry with the rest of the outbound state,
+        // and the re-establish path (`register_active_session`) re-derives
+        // membership from the preserved (stale) RTC Adj-RIB-In — which by
+        // then reflects any deletions made above.
 
         // Shared per-session outbound teardown (Adj-RIB-Out, export
         // policies/stats, ORF filter + gate, refresh state, ...). Peer
@@ -257,6 +269,9 @@ impl RibManager {
             rib.iter().filter(|r| r.is_stale).count()
                 + rib.iter_flowspec().filter(|r| r.is_stale).count()
                 + rib.iter_evpn().filter(|r| r.is_stale).count()
+                + rib.iter_vpn().filter(|r| r.is_stale).count()
+                + rib.iter_bgpls().filter(|r| r.is_stale).count()
+                + rib.iter_rtc().filter(|r| r.is_stale).count()
         });
         self.metrics
             .set_gr_stale_routes(&peer_label, gauge_val(stale_count));
@@ -394,6 +409,9 @@ impl RibManager {
             let mut affected = HashSet::new();
             let mut fs_affected = HashSet::new();
             let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
+            let mut bgpls_affected: HashSet<BgpLsRouteKey> = HashSet::new();
+            let mut vpn_affected: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
+            let mut rtc_affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
             let mut rib_len = 0;
             let mut evpn_len = 0;
             if let Some(rib) = self.ribs.get_mut(&peer) {
@@ -427,6 +445,16 @@ impl RibManager {
                         evpn_affected.insert(k);
                     }
                 }
+                // VPN, BGP-LS, and RTC always purge at GR expiry — even for
+                // tuples in the LLGR intersection — because their LLGR
+                // promotion is not wired yet. PR-3 promotes these.
+                // Each sweep helper is a family-scoped no-op for
+                // non-matching tuples.
+                for &family in &gr_families {
+                    vpn_affected.extend(rib.sweep_stale_family_vpn(family));
+                    bgpls_affected.extend(rib.sweep_stale_family_bgpls(family));
+                    rtc_affected.extend(rib.sweep_stale_family_rtc(family));
+                }
                 rib_len = rib.len();
                 evpn_len = rib.evpn_len();
                 // First GC catches interned sets made unreachable by direct
@@ -450,10 +478,32 @@ impl RibManager {
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
             }
-            if (!affected.is_empty() || !fs_affected.is_empty() || !evpn_affected.is_empty())
+            if !bgpls_affected.is_empty() {
+                self.recompute_bgpls_keys(&bgpls_affected);
+            }
+            if !vpn_affected.is_empty() {
+                self.recompute_vpn_keys(&vpn_affected);
+            }
+            let rtc_swept = !rtc_affected.is_empty();
+            if rtc_swept {
+                self.recompute_rtc_keys(&rtc_affected);
+            }
+            if (!affected.is_empty()
+                || !fs_affected.is_empty()
+                || !evpn_affected.is_empty()
+                || !bgpls_affected.is_empty()
+                || !vpn_affected.is_empty()
+                || rtc_swept)
                 && let Some(rib) = self.ribs.get_mut(&peer)
             {
                 rib.gc_intern_table();
+            }
+            if rtc_swept {
+                // The purge just shrank this peer's RTC Adj-RIB-In; if the
+                // peer re-established (only its End-of-RIB was late), its RT
+                // membership must shrink with it so uncovered VPN routes are
+                // withdrawn from its Adj-RIB-Out.
+                self.rebuild_rtc_membership_and_restage_vpn(peer);
             }
             self.metrics
                 .set_rib_prefixes(&peer_label, "all", gauge_val(rib_len));
@@ -478,19 +528,31 @@ impl RibManager {
         self.metrics.set_gr_active(&peer_label, false);
         self.metrics.set_gr_stale_routes(&peer_label, 0);
 
-        let (swept, fs_swept, evpn_swept, rib_len, evpn_len) =
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                let swept = rib.sweep_stale();
-                let fs_swept = rib.sweep_stale_flowspec();
-                let evpn_swept = rib.sweep_stale_evpn();
-                rib.gc_intern_table();
-                (swept, fs_swept, evpn_swept, rib.len(), rib.evpn_len())
-            } else {
-                (Vec::new(), Vec::new(), Vec::new(), 0, 0)
-            };
+        let mut swept = Vec::new();
+        let mut fs_swept = Vec::new();
+        let mut evpn_swept = Vec::new();
+        let mut bgpls_swept = Vec::new();
+        let mut l3vpn_swept = Vec::new();
+        let mut rtc_swept = Vec::new();
+        let mut rib_len = 0;
+        let mut evpn_len = 0;
+        if let Some(rib) = self.ribs.get_mut(&peer) {
+            swept = rib.sweep_stale();
+            fs_swept = rib.sweep_stale_flowspec();
+            evpn_swept = rib.sweep_stale_evpn();
+            bgpls_swept = rib.sweep_stale_bgpls();
+            l3vpn_swept = rib.sweep_stale_vpn();
+            rtc_swept = rib.sweep_stale_rtc();
+            rib.gc_intern_table();
+            rib_len = rib.len();
+            evpn_len = rib.evpn_len();
+        }
         let had_swept = !swept.is_empty();
         let had_fs_swept = !fs_swept.is_empty();
         let had_evpn_swept = !evpn_swept.is_empty();
+        let had_bgpls_swept = !bgpls_swept.is_empty();
+        let had_l3vpn_swept = !l3vpn_swept.is_empty();
+        let had_rtc_swept = !rtc_swept.is_empty();
         if had_swept {
             info!(%peer, count = swept.len(), "swept stale routes");
             let affected: HashSet<Prefix> = swept.into_iter().collect();
@@ -509,10 +571,38 @@ impl RibManager {
                 .set_rib_prefixes(&peer_label, "evpn", gauge_val(evpn_len));
             self.recompute_and_distribute_evpn(&evpn_affected);
         }
-        if (had_swept || had_fs_swept || had_evpn_swept)
+        if had_bgpls_swept {
+            // The sweep drops the stale entries from the topology feed, so
+            // this recompute is also where ORR vantages resolved only by the
+            // departed peer's links finally unresolve.
+            let bgpls_affected: HashSet<BgpLsRouteKey> = bgpls_swept.into_iter().collect();
+            self.recompute_bgpls_keys(&bgpls_affected);
+        }
+        if had_l3vpn_swept {
+            let vpn_affected: HashSet<crate::route::VpnRibRouteKey> =
+                l3vpn_swept.into_iter().collect();
+            self.recompute_vpn_keys(&vpn_affected);
+        }
+        if had_rtc_swept {
+            let rtc_affected: HashSet<crate::route::RtcRibRouteKey> =
+                rtc_swept.into_iter().collect();
+            self.recompute_rtc_keys(&rtc_affected);
+        }
+        if (had_swept
+            || had_fs_swept
+            || had_evpn_swept
+            || had_bgpls_swept
+            || had_l3vpn_swept
+            || had_rtc_swept)
             && let Some(rib) = self.ribs.get_mut(&peer)
         {
             rib.gc_intern_table();
+        }
+        if had_rtc_swept {
+            // Same obligation as the LLGR branch: a re-established peer whose
+            // End-of-RIB never arrived just lost its preserved RT interest,
+            // so its VPN Adj-RIB-Out must restage under the shrunk membership.
+            self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
 
         self.release_peer_state_if_departed(peer);

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1862,6 +1862,23 @@ impl RibManager {
     /// equality machinery yields the RFC 4684 minimal update set, no
     /// session reset). An unchanged membership skips the restage entirely.
     fn rebuild_rtc_membership_and_restage_vpn(&mut self, peer: IpAddr) {
+        let membership = self.rtc_membership_from_rib(peer);
+        if self.peer_rt_membership.get(&peer) == Some(&membership) {
+            return;
+        }
+        self.peer_rt_membership.insert(peer, membership);
+        if self.outbound_peers.contains_key(&peer) {
+            self.dirty_peers.insert(peer);
+            self.distribute_changes(&HashSet::new(), &HashSet::new());
+        }
+    }
+
+    /// Derive `peer`'s RT-Constrain membership from its Adj-RIB-In (all
+    /// paths, stale included — GR-preserved interest keeps filtering VPN
+    /// advertisements through the restart window). Shared by the rebuild
+    /// seam above and the GR re-establish path in
+    /// `register_active_session`.
+    fn rtc_membership_from_rib(&self, peer: IpAddr) -> RtcMembership {
         let mut has_default = false;
         let mut entries: Vec<rustbgpd_wire::RtcNlri> = Vec::new();
         if let Some(rib) = self.ribs.get(&peer) {
@@ -1875,17 +1892,9 @@ impl RibManager {
         }
         entries.sort_unstable();
         entries.dedup();
-        let membership = RtcMembership {
+        RtcMembership {
             has_default,
             entries,
-        };
-        if self.peer_rt_membership.get(&peer) == Some(&membership) {
-            return;
-        }
-        self.peer_rt_membership.insert(peer, membership);
-        if self.outbound_peers.contains_key(&peer) {
-            self.dirty_peers.insert(peer);
-            self.distribute_changes(&HashSet::new(), &HashSet::new());
         }
     }
 

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -432,9 +432,10 @@ impl RibManager {
         self.peer_orf_filters.remove(&peer);
         self.peer_orf_pending.remove(&peer);
         // RT-Constrain membership is per-session too (RFC 4684 filters
-        // derive from the session's Adj-RIB-In, conservatively withdrawn on
-        // GR entry): `handle_peer_up` re-creates it empty-strict when the
-        // new session negotiates the family.
+        // derive from the session's Adj-RIB-In): `handle_peer_up` re-creates
+        // it when the new session negotiates the family — empty-strict
+        // normally, or re-derived from the GR-preserved (stale) RTC routes
+        // on a graceful-restart re-establish.
         self.peer_rt_membership.remove(&peer);
         // The GR-deferred EoR is per-session too: the deferral pairs with
         // THIS session's §6 gate; a new session re-derives it on `PeerUp`.
@@ -614,12 +615,23 @@ impl RibManager {
             self.ensure_default_rtc_originated();
             // RFC 4684 strict rule: a peer that negotiated SAFI 132 starts
             // with an EMPTY membership — no VPN routes are advertised
-            // (initial dump included) until its RT interest arrives. This
-            // also covers a GR re-establish: the previous session's
-            // membership was torn down, so the returning peer is strict
-            // until its RTC routes re-arrive.
-            self.peer_rt_membership
-                .insert(peer, super::RtcMembership::default());
+            // (initial dump included) until its RT interest arrives.
+            //
+            // A GR/LLGR re-establish is the exception: the previous
+            // session's RTC routes were preserved as stale in the
+            // Adj-RIB-In (RFC 4724 helper retention), so the returning
+            // peer's membership is re-derived from them — VPN routes flow
+            // in the initial dump immediately instead of stalling until
+            // the peer re-advertises its interest. Interest the peer does
+            // NOT re-advertise is swept at End-of-RIB (or timer expiry),
+            // which shrinks the membership and withdraws the uncovered
+            // VPN routes.
+            let membership = if self.gr_peers.contains_key(&peer) {
+                self.rtc_membership_from_rib(peer)
+            } else {
+                super::RtcMembership::default()
+            };
+            self.peer_rt_membership.insert(peer, membership);
         } else {
             // A replacement session that dropped the family must not
             // inherit its predecessor's filter (not-negotiated ⇒ unfiltered).

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -91,7 +91,7 @@ impl RibManager {
 
     #[expect(
         clippy::too_many_lines,
-        reason = "End-of-RIB handler covers GR and LLGR branches for all three families (unicast, FlowSpec, EVPN)"
+        reason = "End-of-RIB handler covers GR and LLGR branches across the per-family stale lifecycles (unicast, FlowSpec, EVPN, VPN, BGP-LS, RTC)"
     )]
     pub(super) fn handle_end_of_rib(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
         info!(%peer, ?afi, ?safi, "received End-of-RIB");
@@ -129,10 +129,63 @@ impl RibManager {
                 HashSet::new()
             };
 
+            // Collect the typed-family keys BEFORE the sweep below removes
+            // the non-readvertised ones, so the recompute both withdraws
+            // swept keys downstream and re-promotes the retained ones.
+            let vpn_affected: HashSet<crate::route::VpnRibRouteKey> = if safi == Safi::MplsVpn {
+                self.ribs
+                    .get(&peer)
+                    .map(|rib| {
+                        rib.iter_vpn()
+                            .filter(|route| route.afi_safi() == (afi, safi))
+                            .map(crate::route::VpnRibRoute::key)
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                HashSet::new()
+            };
+            let bgpls_affected: HashSet<crate::route::BgpLsRouteKey> =
+                if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
+                    self.ribs
+                        .get(&peer)
+                        .map(|rib| {
+                            rib.iter_bgpls()
+                                .filter(|route| route.family == bgpls_family)
+                                .map(crate::route::BgpLsRibRoute::key)
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    HashSet::new()
+                };
+            let rtc_affected: HashSet<crate::route::RtcRibRouteKey> = if safi == Safi::RtConstrain {
+                self.ribs
+                    .get(&peer)
+                    .map(|rib| rib.iter_rtc().map(crate::route::RtcRibRoute::key).collect())
+                    .unwrap_or_default()
+            } else {
+                HashSet::new()
+            };
+
+            let mut rtc_swept = false;
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.clear_stale((afi, safi));
                 rib.clear_stale_flowspec((afi, safi));
                 rib.clear_stale_evpn((afi, safi));
+                // Typed families (VPN, BGP-LS, RTC) implement the RFC 4724
+                // §4.1 End-of-RIB removal: a route still marked stale here
+                // was not re-advertised during the restart window and is
+                // deleted (re-advertised routes had their flag cleared on
+                // insert). The trailing clear is flag/LLGR-community
+                // hygiene for the retained routes. Each helper is a
+                // family-scoped no-op for non-matching tuples.
+                rib.sweep_stale_family_vpn((afi, safi));
+                rib.clear_stale_vpn((afi, safi));
+                rib.sweep_stale_family_bgpls((afi, safi));
+                rib.clear_stale_bgpls((afi, safi));
+                rtc_swept = !rib.sweep_stale_family_rtc((afi, safi)).is_empty();
+                rib.clear_stale_rtc((afi, safi));
             }
 
             let affected: HashSet<Prefix> = self
@@ -148,8 +201,23 @@ impl RibManager {
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
             }
+            if !vpn_affected.is_empty() {
+                self.recompute_vpn_keys(&vpn_affected);
+            }
+            if !bgpls_affected.is_empty() {
+                self.recompute_bgpls_keys(&bgpls_affected);
+            }
+            if !rtc_affected.is_empty() {
+                self.recompute_rtc_keys(&rtc_affected);
+            }
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+            }
+            if rtc_swept {
+                // The EoR sweep removed RT interest the peer did not
+                // re-advertise: shrink its membership so no-longer-covered
+                // VPN routes are withdrawn from its Adj-RIB-Out.
+                self.rebuild_rtc_membership_and_restage_vpn(peer);
             }
 
             let peer_label = peer.to_string();
@@ -157,6 +225,9 @@ impl RibManager {
                 rib.iter().filter(|r| r.is_stale).count()
                     + rib.iter_flowspec().filter(|r| r.is_stale).count()
                     + rib.iter_evpn().filter(|r| r.is_stale).count()
+                    + rib.iter_vpn().filter(|r| r.is_stale).count()
+                    + rib.iter_bgpls().filter(|r| r.is_stale).count()
+                    + rib.iter_rtc().filter(|r| r.is_stale).count()
             });
             self.metrics
                 .set_gr_stale_routes(&peer_label, gauge_val(stale_count));

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -770,12 +770,17 @@ async fn orr_status_reports_resolved_and_unresolved_vantages() {
     handle.await.unwrap();
 }
 
-/// The cached SPF state rebuilds at the BGP-LS mutation seams: a vantage
-/// registered before any topology is unresolved, resolves when BGP-LS
-/// routes arrive through the receive path, and unresolves again when the
-/// feed peer's GR entry sweeps its BGP-LS routes.
+/// The cached SPF state rebuilds at the BGP-LS mutation seams — and the GR
+/// stale window deliberately does NOT count as a mutation for the topology:
+/// a vantage registered before any topology is unresolved, resolves when
+/// BGP-LS routes arrive through the receive path, STAYS resolved while the
+/// feed peer's routes are GR-preserved as stale (the ORR-stability
+/// motivation — `iter_bgpls` keeps feeding stale entries to the topology),
+/// and unresolves only when the GR timer expiry finally sweeps them.
 #[tokio::test]
-async fn spf_cache_rebuilds_on_bgpls_receive_and_gr_sweep() {
+async fn bgpls_gr_stale_topology_keeps_orr_vantages_resolved() {
+    tokio::time::pause();
+
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
@@ -799,13 +804,13 @@ async fn spf_cache_rebuilds_on_bgpls_receive_and_gr_sweep() {
     let runs_after_receive = counter_metric_value(&metrics, "bgp_orr_spf_runs_total");
     assert!(runs_after_receive >= 1.0, "SPF ran for the vantage");
 
-    // GR entry for the feed peer withdraws its BGP-LS routes (BGP-LS is
-    // never GR-retained) and must recompute AFTER the sweep.
+    // GR entry with (BgpLs, BgpLs) in the capability preserves the feed
+    // peer's routes as stale — the topology, and the vantage, must survive.
     tx.send(RibUpdate::PeerGracefulRestart {
         session_id: 0,
         peer: IpAddr::V4(feed),
-        restart_time: 120,
-        stale_routes_time: 360,
+        restart_time: 2,
+        stale_routes_time: 5,
         gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
         peer_llgr_capable: false,
         peer_llgr_families: vec![],
@@ -816,8 +821,19 @@ async fn spf_cache_rebuilds_on_bgpls_receive_and_gr_sweep() {
 
     let status = query_orr_status(&tx).await;
     assert!(
+        status.vantages[0].resolved,
+        "GR-stale BGP-LS routes must keep feeding the topology"
+    );
+    assert_eq!(status.topology_nodes, 4);
+
+    // GR timer expiry sweeps the stale routes — NOW the vantage unresolves.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    let status = query_orr_status(&tx).await;
+    assert!(
         !status.vantages[0].resolved,
-        "GR sweep rebuilt the cache against the emptied topology"
+        "GR expiry sweep rebuilt the cache against the emptied topology"
     );
     assert_eq!(status.topology_nodes, 0);
 
@@ -1934,13 +1950,13 @@ async fn bgpls_peer_down_clears_or_falls_back_loc_rib() {
     handle.await.unwrap();
 }
 
-/// BGP-LS GR/LLGR stale preservation is deliberately not implemented in the
-/// receive/API tranche. A peer entering GR must therefore withdraw its BGP-LS
-/// objects conservatively instead of leaving them visible as live topology
-/// data. Two peers advertise the same key so the test pins both fallback and
-/// final removal.
+/// A peer entering GR with (`BgpLs`, `BgpLs`) in its capability keeps its
+/// BGP-LS objects as stale (RFC 4724 helper retention). Staleness demotes
+/// the tiebreak rank, so a fresh route from another peer takes over the
+/// Loc-RIB; when every advertiser is stale, the normal tiebreak order
+/// re-applies among the stale candidates and the key stays visible.
 #[tokio::test]
-async fn bgpls_gr_entry_withdraws_or_falls_back_loc_rib() {
+async fn bgpls_gr_marks_stale_and_demotes_routes() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
@@ -1981,25 +1997,20 @@ async fn bgpls_gr_entry_withdraws_or_falls_back_loc_rib() {
         restart_time: 120,
         stale_routes_time: 360,
         gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
-        peer_llgr_capable: true,
-        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
-            afi: Afi::BgpLs,
-            safi: Safi::BgpLs,
-            forwarding_preserved: true,
-            stale_time: 3600,
-        }],
-        llgr_stale_time: 3600,
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
     })
     .await
     .unwrap();
 
     let after_winner_gr = query_bgpls_routes(&tx).await;
+    assert_eq!(after_winner_gr.len(), 1);
     assert_eq!(
-        after_winner_gr.len(),
-        1,
-        "BGP-LS GR entry should fall back to the surviving peer"
+        after_winner_gr[0].peer, alternate_peer,
+        "stale demotion must hand the Loc-RIB to the fresh alternate route"
     );
-    assert_eq!(after_winner_gr[0].peer, alternate_peer);
+    assert!(!after_winner_gr[0].is_stale);
 
     tx.send(RibUpdate::PeerGracefulRestart {
         session_id: 0,
@@ -2015,9 +2026,577 @@ async fn bgpls_gr_entry_withdraws_or_falls_back_loc_rib() {
     .unwrap();
 
     let after_last_gr = query_bgpls_routes(&tx).await;
+    assert_eq!(
+        after_last_gr.len(),
+        1,
+        "GR must retain the stale BGP-LS route instead of dropping the key"
+    );
+    assert_eq!(
+        after_last_gr[0].peer, best_peer,
+        "with both candidates stale the normal tiebreak (higher LOCAL_PREF) re-applies"
+    );
+    assert!(after_last_gr[0].is_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer whose GR capability does NOT list (`BgpLs`, `BgpLs`) must have its
+/// BGP-LS routes withdrawn on GR entry — RFC 4724 retains only families in
+/// the advertised capability.
+#[tokio::test]
+async fn bgpls_gr_family_not_in_capability_is_withdrawn() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(advertiser);
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![make_bgpls_route(advertiser, 10, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    assert_eq!(query_bgpls_routes(&tx).await.len(), 1);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
     assert!(
-        after_last_gr.is_empty(),
-        "BGP-LS GR entry should not retain the last peer's route as stale/live"
+        query_bgpls_routes(&tx).await.is_empty(),
+        "BGP-LS absent from the GR capability must be withdrawn, not retained stale"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Re-advertisement during the restart window replaces the stale route;
+/// End-of-RIB clears the survivors' stale flags and removes what was not
+/// re-advertised (RFC 4724 §4.1).
+#[tokio::test]
+async fn bgpls_gr_eor_clears_stale() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(advertiser);
+    let kept = make_bgpls_route(advertiser, 10, 200);
+    let dropped = make_bgpls_route(advertiser, 20, 200);
+    let kept_key = kept.key();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![kept.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert_eq!(stale.len(), 2);
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![kept],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_bgpls_routes(&tx).await;
+    assert_eq!(
+        after_eor.len(),
+        1,
+        "the non-readvertised stale route must be removed at End-of-RIB"
+    );
+    assert_eq!(after_eor[0].key(), kept_key);
+    assert!(!after_eor[0].is_stale, "EoR must clear the stale flag");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// GR timer expiry without LLGR purges the stale BGP-LS routes.
+#[tokio::test]
+async fn bgpls_gr_timer_sweeps_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(advertiser);
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![make_bgpls_route(advertiser, 10, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time: 2,
+        stale_routes_time: 5,
+        gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        query_bgpls_routes(&tx).await.is_empty(),
+        "GR timer expiry must sweep stale BGP-LS routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A second GR entry while routes are still stale (consecutive restart
+/// without a refresh in between) deletes them instead of re-marking
+/// (RFC 4724 §4.1), and the deletion propagates to the Loc-RIB.
+#[tokio::test]
+async fn bgpls_gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(advertiser);
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer,
+        announced: vec![make_bgpls_route(advertiser, 10, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let gr_entry = |session_id| RibUpdate::PeerGracefulRestart {
+        session_id,
+        peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::BgpLs, Safi::BgpLs)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry(0)).await.unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    // The peer comes back and restarts again without re-advertising.
+    tx.send(gr_entry(0)).await.unwrap();
+    assert!(
+        query_bgpls_routes(&tx).await.is_empty(),
+        "a route still stale at the next restart must be deleted, not re-marked"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer entering GR with (IPv4, `MplsVpn`) in its capability keeps its VPN
+/// routes as stale. Staleness demotes the tiebreak rank, so a fresh route
+/// from another peer takes over; with every candidate stale the normal
+/// tiebreak re-applies and the key stays reflected.
+#[tokio::test]
+async fn vpn_gr_marks_stale_and_demotes_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let best_advertiser = Ipv4Addr::new(10, 0, 0, 1);
+    let alternate_advertiser = Ipv4Addr::new(10, 0, 0, 3);
+    let best_peer = IpAddr::V4(best_advertiser);
+    let alternate_peer = IpAddr::V4(alternate_advertiser);
+
+    // Same RD + prefix (octet) from both peers ⇒ same RIB key.
+    let route_a = make_vpn_rib_route(best_advertiser, 31, 100, 200);
+    let route_b = make_vpn_rib_route(alternate_advertiser, 31, 200, 100);
+    assert_eq!(route_a.key(), route_b.key());
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: best_peer,
+        announced: vec![route_a],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: alternate_peer,
+        announced: vec![route_b],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let best_before = query_vpn_routes(&tx).await;
+    assert_eq!(best_before.len(), 1);
+    assert_eq!(best_before[0].peer, best_peer);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: best_peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let after_winner_gr = query_vpn_routes(&tx).await;
+    assert_eq!(after_winner_gr.len(), 1);
+    assert_eq!(
+        after_winner_gr[0].peer, alternate_peer,
+        "stale demotion must hand the Loc-RIB to the fresh alternate route"
+    );
+    assert!(!after_winner_gr[0].is_stale);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: alternate_peer,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let after_last_gr = query_vpn_routes(&tx).await;
+    assert_eq!(
+        after_last_gr.len(),
+        1,
+        "GR must retain the stale VPN route instead of dropping the key"
+    );
+    assert_eq!(
+        after_last_gr[0].peer, best_peer,
+        "with both candidates stale the normal tiebreak (higher LOCAL_PREF) re-applies"
+    );
+    assert!(after_last_gr[0].is_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer whose GR capability does NOT list (IPv4, `MplsVpn`) must have its
+/// VPN routes withdrawn on GR entry and the withdrawal staged downstream.
+#[tokio::test]
+async fn vpn_gr_family_not_in_capability_is_withdrawn() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 1);
+
+    // GR capability carries only unicast: VPN is withdrawn, not retained.
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let withdraw = out_rx.recv().await.unwrap();
+    assert_eq!(
+        withdraw.vpn_withdraw,
+        vec![key],
+        "GR entry must withdraw VPN routes absent from the capability"
+    );
+    assert!(
+        query_vpn_routes(&tx).await.is_empty(),
+        "VPN absent from the GR capability must not be retained stale"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Re-advertisement during the restart window replaces the stale VPN route;
+/// End-of-RIB clears the survivor's stale flag and removes (and withdraws
+/// downstream) what was not re-advertised (RFC 4724 §4.1).
+#[tokio::test]
+async fn vpn_gr_eor_clears_stale() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 60, 100, 100);
+    let dropped = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 61, 100, 100);
+    let kept_key = kept.key();
+    let dropped_key = dropped.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 2);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert_eq!(stale.len(), 2);
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_vpn_routes(&tx).await;
+    assert_eq!(
+        after_eor.len(),
+        1,
+        "the non-readvertised stale VPN route must be removed at End-of-RIB"
+    );
+    assert_eq!(after_eor[0].key(), kept_key);
+    assert!(!after_eor[0].is_stale, "EoR must clear the stale flag");
+
+    // The removal must be withdrawn downstream.
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.vpn_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(update.vpn_withdraw, vec![dropped_key.clone()]);
+        break;
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// GR timer expiry without LLGR purges the stale VPN routes.
+#[tokio::test]
+async fn vpn_gr_timer_sweeps_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 2,
+        stale_routes_time: 5,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        query_vpn_routes(&tx).await.is_empty(),
+        "GR timer expiry must sweep stale VPN routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A second GR entry while VPN routes are still stale deletes them
+/// (RFC 4724 §4.1: no retention across consecutive restarts).
+#[tokio::test]
+async fn vpn_gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let gr_entry = || RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry()).await.unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tx.send(gr_entry()).await.unwrap();
+    assert!(
+        query_vpn_routes(&tx).await.is_empty(),
+        "a route still stale at the next restart must be deleted, not re-marked"
     );
 
     drop(tx);
@@ -2897,11 +3476,11 @@ async fn peer_down_withdraws_rtc_routes_from_other_peers() {
     handle.await.unwrap();
 }
 
-/// RTC has no GR stale lifecycle in this slice (the fsm allowlist excludes
-/// SAFI 132 from preservation): GR entry conservatively withdraws the
-/// restarting peer's RTC routes instead of retaining them stale.
+/// A peer whose GR capability does NOT list (IPv4, `RtConstrain`) must have
+/// its RTC routes withdrawn on GR entry — RFC 4724 retains only families in
+/// the advertised capability.
 #[tokio::test]
-async fn gr_entry_conservatively_withdraws_rtc() {
+async fn rtc_gr_family_not_in_capability_is_withdrawn() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
@@ -2924,8 +3503,8 @@ async fn gr_entry_conservatively_withdraws_rtc() {
     let announced = out_rx.recv().await.unwrap();
     assert_eq!(announced.rtc_announce.len(), 1);
 
-    // GR entry: the fsm allowlist can never hand the RIB an RTC family, so
-    // gr_families here carries only unicast.
+    // GR entry with only unicast in the capability: SAFI 132 is not
+    // covered, so the peer's RTC routes are withdrawn, not marked stale.
     tx.send(RibUpdate::PeerGracefulRestart {
         session_id: 0,
         peer: source,
@@ -2943,7 +3522,7 @@ async fn gr_entry_conservatively_withdraws_rtc() {
     assert_eq!(
         withdraw.rtc_withdraw,
         vec![key],
-        "GR entry must conservatively withdraw RTC routes"
+        "GR entry must withdraw RTC routes absent from the capability"
     );
 
     let remaining = query_rtc_routes(&tx).await;
@@ -2953,6 +3532,259 @@ async fn gr_entry_conservatively_withdraws_rtc() {
         "only the local default survives GR entry"
     );
     assert!(remaining[0].nlri.is_default());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer entering GR with (IPv4, `RtConstrain`) in its capability keeps its
+/// RTC routes as stale: they stay in the Loc-RIB (demoted-rank candidates)
+/// and are NOT withdrawn from other RTC peers.
+#[tokio::test]
+async fn rtc_gr_marks_stale_and_demotes_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 1);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::RtConstrain)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let retained = query_rtc_routes(&tx).await;
+    let stale_route = retained
+        .iter()
+        .find(|r| r.key() == key)
+        .expect("GR-covered RTC route must be retained in the Loc-RIB");
+    assert!(stale_route.is_stale, "retained RTC route must be stale");
+
+    // No withdraw may reach the other RTC peer during the retention window
+    // (a benign re-announce of the unchanged route is tolerated).
+    while let Ok(Some(update)) =
+        tokio::time::timeout(Duration::from_millis(50), out_rx.recv()).await
+    {
+        assert!(
+            update.rtc_withdraw.is_empty(),
+            "GR-preserved RTC routes must not be withdrawn from other peers"
+        );
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// End-of-RIB after re-establishment clears the re-advertised RTC route's
+/// stale flag and removes (and withdraws downstream) interest that was not
+/// re-advertised (RFC 4724 §4.1).
+#[tokio::test]
+async fn rtc_gr_eor_clears_stale() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let dropped = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 200, 100);
+    let kept_key = kept.key();
+    let dropped_key = dropped.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 2);
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::RtConstrain)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_rtc_routes(&tx).await;
+    assert!(
+        after_eor.iter().all(|r| r.key() != dropped_key),
+        "the non-readvertised stale RTC route must be removed at End-of-RIB"
+    );
+    let kept_route = after_eor
+        .iter()
+        .find(|r| r.key() == kept_key)
+        .expect("re-advertised RTC route survives EoR");
+    assert!(!kept_route.is_stale, "EoR must clear the stale flag");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// GR timer expiry without LLGR purges the stale RTC routes and withdraws
+/// them from other peers.
+#[tokio::test]
+async fn rtc_gr_timer_sweeps_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 2,
+        stale_routes_time: 5,
+        gr_families: vec![(Afi::Ipv4, Safi::RtConstrain)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let retained = query_rtc_routes(&tx).await;
+    assert!(retained.iter().any(|r| r.key() == key && r.is_stale));
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    let after_sweep = query_rtc_routes(&tx).await;
+    assert!(
+        after_sweep.iter().all(|r| r.key() != key),
+        "GR timer expiry must sweep stale RTC routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A second GR entry while RTC routes are still stale deletes them
+/// (RFC 4724 §4.1: no retention across consecutive restarts) and the
+/// deletion is withdrawn from other RTC peers.
+#[tokio::test]
+async fn rtc_gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 1);
+
+    let gr_entry = || RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::RtConstrain)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry()).await.unwrap();
+    let retained = query_rtc_routes(&tx).await;
+    assert!(retained.iter().any(|r| r.key() == key && r.is_stale));
+
+    tx.send(gr_entry()).await.unwrap();
+    let after_second = query_rtc_routes(&tx).await;
+    assert!(
+        after_second.iter().all(|r| r.key() != key),
+        "a route still stale at the next restart must be deleted"
+    );
+    // Skip any benign re-announce staged by the first GR entry; the
+    // deletion itself must surface as a downstream withdraw.
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.rtc_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(
+            update.rtc_withdraw,
+            vec![key],
+            "the consecutive-restart deletion must be withdrawn downstream"
+        );
+        break;
+    }
 
     drop(tx);
     handle.await.unwrap();
@@ -3607,11 +4439,11 @@ async fn rtc_refresh_eorr_sweep_restages_vpn() {
     handle.await.unwrap();
 }
 
-/// A peer re-establishing after graceful restart starts with a strict empty
-/// membership (the GR-entry conservative withdraw cleared its RTC routes) and
-/// only receives VPN routes once its interest re-arrives.
+/// A peer whose GR capability omits SAFI 132 has its RTC interest withdrawn
+/// on GR entry, so it re-establishes with a strict empty membership and only
+/// receives VPN routes once its interest re-arrives.
 #[tokio::test]
-async fn gr_reestablish_starts_strict_until_rtc_rearrives() {
+async fn gr_reestablish_without_rtc_in_capability_starts_strict() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
@@ -3635,6 +4467,8 @@ async fn gr_reestablish_starts_strict_until_rtc_rearrives() {
     let announced = out_rx.recv().await.unwrap();
     assert_eq!(announced.vpn_announce.len(), 1);
 
+    // GR capability covers only VPN — the peer's RTC interest is NOT
+    // retained (RFC 4724: only families in the capability are preserved).
     tx.send(RibUpdate::PeerGracefulRestart {
         session_id: 0,
         peer: IpAddr::V4(target),
@@ -3657,6 +4491,94 @@ async fn gr_reestablish_starts_strict_until_rtc_rearrives() {
     let reannounced = out_rx.recv().await.unwrap();
     assert_eq!(reannounced.vpn_announce.len(), 1);
     assert_eq!(reannounced.vpn_announce[0].key(), key);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer whose GR capability covers SAFI 132 keeps its RT interest as stale
+/// through the restart window: the re-establish initial dump serves VPN
+/// routes immediately from the preserved membership (no wait for the
+/// interest to re-arrive), and the End-of-RIB sweep of interest the peer did
+/// NOT re-advertise withdraws the corresponding VPN routes.
+#[tokio::test]
+async fn rtc_gr_preserves_vpn_membership_through_restart_window() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route_a = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 60, vec![rt(100)]);
+    let route_b = make_vpn_rib_route_with_rts(Ipv4Addr::new(10, 0, 0, 1), 61, vec![rt(200)]);
+    let key_a = route_a.key();
+    let key_b = route_b.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route_a, route_b],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+    send_rtc_interest(&tx, target, &[100, 200]).await;
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 2);
+
+    // GR capability covers both VPN and RTC: the peer's RT interest is
+    // preserved as stale.
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv4, Safi::RtConstrain)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Re-establish: VPN routes flow in the INITIAL dump, filtered by the
+    // stale membership — before any RTC re-advertisement arrives.
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    let dump = out_rx.recv().await.unwrap();
+    let dumped: Vec<_> = dump.vpn_announce.iter().map(VpnRibRoute::key).collect();
+    assert!(
+        dumped.contains(&key_a) && dumped.contains(&key_b),
+        "the initial dump must serve VPN routes from the GR-preserved membership, got {dumped:?}"
+    );
+
+    // The peer re-advertises interest in RT 100 only; RT 200 stays stale.
+    send_rtc_interest(&tx, target, &[100]).await;
+    // End-of-RIB for SAFI 132 sweeps the non-readvertised interest —
+    // membership shrinks and the uncovered VPN route is withdrawn.
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: IpAddr::V4(target),
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.vpn_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(
+            update.vpn_withdraw,
+            vec![key_b.clone()],
+            "the EoR sweep must withdraw the VPN route whose stale interest was not re-advertised"
+        );
+        assert!(update.vpn_announce.is_empty());
+        break;
+    }
 
     drop(tx);
     handle.await.unwrap();


### PR DESCRIPTION
Second slice of the **GR/LLGR arc**, on top of #636: the RFC 4724 helper wiring. A restarting RR peer's VPNv4/v6, BGP-LS, and RT-Constrain routes are now **preserved as stale** through the GR window instead of conservatively withdrawn.

- The `graceful_restart_preserves_family` allowlist gains the three families — negotiation now carries them in GR/LLGR capability sets end-to-end (fsm tests inverted/extended).
- GR entry: the three exclusion+withdraw blocks are replaced with per-tuple `mark_stale_*` (retained keys re-enter the affected sets so the stale-rank demotion recomputes; consecutive-restart-deleted keys withdraw downstream). **Families absent from the peer's advertised GR capability are withdrawn, not marked** — the RFC-critical negative, pinned per family.
- EoR per-family sweep: still-stale routes of that tuple are removed (RFC-strict; the pre-existing unicast/EVPN flags-only-clear gap is flagged as follow-up, not silently changed), flags cleared on re-advertised routes, RTC membership rebuilt when interest was swept.
- GR-timer expiry purges the three families (LLGR promote lands next slice — placeholder commented).
- **RTC**: a re-establishing RR client now derives its VPN filter membership from the preserved stale RTC Adj-RIB-In — VPN routes flow immediately at initial dump instead of the strict-empty blackout, then EoR trues it up (pinned by `rtc_gr_preserves_vpn_membership_through_restart_window`).
- **ORR**: a BGP-LS topology source entering GR keeps feeding SPF — vantages stay resolved through the stale window and unresolve only at the final sweep (pinned by test).

17 new/rewritten manager tests + fsm negotiation coverage. Workspace: 63 suites green.