### PR TITLE
feat(rib): add LLGR two-phase lifecycle for VPN, BGP-LS, and RT-Constrain

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -908,6 +908,26 @@ impl AdjRibIn {
         stale
     }
 
+    /// Remove LLGR-stale BGP-LS routes of the given family tuple, returning
+    /// their keys. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family_bgpls(&mut self, family: (Afi, Safi)) -> Vec<BgpLsRouteKey> {
+        let Some(fam) = BgpLsFamily::from_afi_safi(family.0, family.1) else {
+            return Vec::new();
+        };
+        let stale: Vec<BgpLsRouteKey> = self
+            .bgpls_routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale && r.family == fam)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in &stale {
+            self.bgpls_llgr_stale_local_tags.remove(key);
+            self.bgpls_routes.remove(key);
+        }
+        stale
+    }
+
     /// Clear the LLGR-stale flag on BGP-LS routes of the given family tuple,
     /// stripping only locally-injected `LLGR_STALE` communities. Called when
     /// `EoR` is received during the LLGR phase (RFC 9494 §4.2).
@@ -1154,6 +1174,26 @@ impl AdjRibIn {
         stale
     }
 
+    /// Remove LLGR-stale VPN routes of the given family tuple, returning
+    /// their keys. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family_vpn(&mut self, family: (Afi, Safi)) -> Vec<VpnRibRouteKey> {
+        if family.1 != Safi::MplsVpn {
+            return Vec::new();
+        }
+        let stale: Vec<VpnRibRouteKey> = self
+            .vpn_routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale && r.afi_safi() == family)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in &stale {
+            self.vpn_llgr_stale_local_tags.remove(key);
+            self.vpn_routes.remove(key);
+        }
+        stale
+    }
+
     /// Clear the LLGR-stale flag on VPN routes of the given family tuple,
     /// stripping only locally-injected `LLGR_STALE` communities. Called when
     /// `EoR` is received during the LLGR phase (RFC 9494 §4.2).
@@ -1379,6 +1419,16 @@ impl AdjRibIn {
             self.rtc_routes.remove(key);
         }
         stale
+    }
+
+    /// Remove LLGR-stale RTC routes if `family == (Ipv4, RtConstrain)`,
+    /// returning their keys. `EoR` during the LLGR phase deletes what was
+    /// not re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family_rtc(&mut self, family: (Afi, Safi)) -> Vec<RtcRibRouteKey> {
+        if family != RtcRibRouteKey::afi_safi() {
+            return Vec::new();
+        }
+        self.sweep_llgr_stale_rtc()
     }
 
     /// Clear the LLGR-stale flag on RTC routes, stripping only

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -445,12 +445,19 @@ impl RibManager {
                         evpn_affected.insert(k);
                     }
                 }
-                // VPN, BGP-LS, and RTC always purge at GR expiry — even for
-                // tuples in the LLGR intersection — because their LLGR
-                // promotion is not wired yet. PR-3 promotes these.
-                // Each sweep helper is a family-scoped no-op for
-                // non-matching tuples.
-                for &family in &gr_families {
+                // Typed families (VPN, BGP-LS, RTC) follow the same split:
+                // LLGR-negotiated tuples promote to LLGR-stale (routes
+                // carrying NO_LLGR are removed instead and their keys join
+                // the affected sets so the recomputes below withdraw them
+                // downstream); tuples outside the LLGR capability purge.
+                // Each helper is a family-scoped no-op for non-matching
+                // tuples.
+                for &family in &llgr_families {
+                    vpn_affected.extend(rib.promote_to_llgr_stale_vpn(family));
+                    bgpls_affected.extend(rib.promote_to_llgr_stale_bgpls(family));
+                    rtc_affected.extend(rib.promote_to_llgr_stale_rtc(family));
+                }
+                for &family in &non_llgr_families {
                     vpn_affected.extend(rib.sweep_stale_family_vpn(family));
                     bgpls_affected.extend(rib.sweep_stale_family_bgpls(family));
                     rtc_affected.extend(rib.sweep_stale_family_rtc(family));
@@ -484,8 +491,8 @@ impl RibManager {
             if !vpn_affected.is_empty() {
                 self.recompute_vpn_keys(&vpn_affected);
             }
-            let rtc_swept = !rtc_affected.is_empty();
-            if rtc_swept {
+            let rtc_changed = !rtc_affected.is_empty();
+            if rtc_changed {
                 self.recompute_rtc_keys(&rtc_affected);
             }
             if (!affected.is_empty()
@@ -493,16 +500,19 @@ impl RibManager {
                 || !evpn_affected.is_empty()
                 || !bgpls_affected.is_empty()
                 || !vpn_affected.is_empty()
-                || rtc_swept)
+                || rtc_changed)
                 && let Some(rib) = self.ribs.get_mut(&peer)
             {
                 rib.gc_intern_table();
             }
-            if rtc_swept {
-                // The purge just shrank this peer's RTC Adj-RIB-In; if the
-                // peer re-established (only its End-of-RIB was late), its RT
+            if rtc_changed {
+                // A non-LLGR purge (or a NO_LLGR removal during promotion)
+                // shrank this peer's RTC Adj-RIB-In; if the peer
+                // re-established (only its End-of-RIB was late), its RT
                 // membership must shrink with it so uncovered VPN routes are
-                // withdrawn from its Adj-RIB-Out.
+                // withdrawn from its Adj-RIB-Out. A promotion-only change
+                // leaves the derived membership equal and the rebuild
+                // no-ops.
                 self.rebuild_rtc_membership_and_restage_vpn(peer);
             }
             self.metrics
@@ -620,19 +630,31 @@ impl RibManager {
         self.metrics.set_gr_active(&peer_label, false);
         self.metrics.set_gr_stale_routes(&peer_label, 0);
 
-        let (swept, fs_swept, evpn_swept, rib_len, evpn_len) =
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                let swept = rib.sweep_llgr_stale();
-                let fs_swept = rib.sweep_llgr_stale_flowspec();
-                let evpn_swept = rib.sweep_llgr_stale_evpn();
-                rib.gc_intern_table();
-                (swept, fs_swept, evpn_swept, rib.len(), rib.evpn_len())
-            } else {
-                (Vec::new(), Vec::new(), Vec::new(), 0, 0)
-            };
+        let mut swept = Vec::new();
+        let mut fs_swept = Vec::new();
+        let mut evpn_swept = Vec::new();
+        let mut bgpls_swept = Vec::new();
+        let mut l3vpn_swept = Vec::new();
+        let mut rtc_swept = Vec::new();
+        let mut rib_len = 0;
+        let mut evpn_len = 0;
+        if let Some(rib) = self.ribs.get_mut(&peer) {
+            swept = rib.sweep_llgr_stale();
+            fs_swept = rib.sweep_llgr_stale_flowspec();
+            evpn_swept = rib.sweep_llgr_stale_evpn();
+            bgpls_swept = rib.sweep_llgr_stale_bgpls();
+            l3vpn_swept = rib.sweep_llgr_stale_vpn();
+            rtc_swept = rib.sweep_llgr_stale_rtc();
+            rib.gc_intern_table();
+            rib_len = rib.len();
+            evpn_len = rib.evpn_len();
+        }
         let had_swept = !swept.is_empty();
         let had_fs_swept = !fs_swept.is_empty();
         let had_evpn_swept = !evpn_swept.is_empty();
+        let had_bgpls_swept = !bgpls_swept.is_empty();
+        let had_l3vpn_swept = !l3vpn_swept.is_empty();
+        let had_rtc_swept = !rtc_swept.is_empty();
         if had_swept {
             info!(%peer, count = swept.len(), "swept LLGR-stale routes");
             let affected: HashSet<Prefix> = swept.into_iter().collect();
@@ -651,10 +673,40 @@ impl RibManager {
                 .set_rib_prefixes(&peer_label, "evpn", gauge_val(evpn_len));
             self.recompute_and_distribute_evpn(&evpn_affected);
         }
-        if (had_swept || had_fs_swept || had_evpn_swept)
+        if had_bgpls_swept {
+            // The sweep drops the LLGR-stale entries from the topology feed,
+            // so this recompute is also where ORR vantages that survived the
+            // whole GR + LLGR retention on the departed peer's links finally
+            // unresolve.
+            let bgpls_affected: HashSet<BgpLsRouteKey> = bgpls_swept.into_iter().collect();
+            self.recompute_bgpls_keys(&bgpls_affected);
+        }
+        if had_l3vpn_swept {
+            let vpn_affected: HashSet<crate::route::VpnRibRouteKey> =
+                l3vpn_swept.into_iter().collect();
+            self.recompute_vpn_keys(&vpn_affected);
+        }
+        if had_rtc_swept {
+            let rtc_affected: HashSet<crate::route::RtcRibRouteKey> =
+                rtc_swept.into_iter().collect();
+            self.recompute_rtc_keys(&rtc_affected);
+        }
+        if (had_swept
+            || had_fs_swept
+            || had_evpn_swept
+            || had_bgpls_swept
+            || had_l3vpn_swept
+            || had_rtc_swept)
             && let Some(rib) = self.ribs.get_mut(&peer)
         {
             rib.gc_intern_table();
+        }
+        if had_rtc_swept {
+            // Same obligation as the GR-expiry sweeps: the down peer's
+            // preserved RT interest dies here, so `peer_rt_membership` must
+            // shrink with the Adj-RIB-In to stay consistent for the
+            // re-establish path (which re-derives membership from this RIB).
+            self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
 
         self.release_peer_state_if_departed(peer);

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -271,10 +271,64 @@ impl RibManager {
                 HashSet::new()
             };
 
+            // Collect the typed-family keys BEFORE the sweep below removes
+            // the non-readvertised ones, so the recompute both withdraws
+            // swept keys downstream and re-promotes the retained ones —
+            // the same shape as the GR arm above.
+            let vpn_affected: HashSet<crate::route::VpnRibRouteKey> = if safi == Safi::MplsVpn {
+                self.ribs
+                    .get(&peer)
+                    .map(|rib| {
+                        rib.iter_vpn()
+                            .filter(|route| route.afi_safi() == (afi, safi))
+                            .map(crate::route::VpnRibRoute::key)
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                HashSet::new()
+            };
+            let bgpls_affected: HashSet<crate::route::BgpLsRouteKey> =
+                if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
+                    self.ribs
+                        .get(&peer)
+                        .map(|rib| {
+                            rib.iter_bgpls()
+                                .filter(|route| route.family == bgpls_family)
+                                .map(crate::route::BgpLsRibRoute::key)
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    HashSet::new()
+                };
+            let rtc_affected: HashSet<crate::route::RtcRibRouteKey> = if safi == Safi::RtConstrain {
+                self.ribs
+                    .get(&peer)
+                    .map(|rib| rib.iter_rtc().map(crate::route::RtcRibRoute::key).collect())
+                    .unwrap_or_default()
+            } else {
+                HashSet::new()
+            };
+
+            let mut rtc_swept = false;
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.clear_llgr_stale((afi, safi));
                 rib.clear_llgr_stale_flowspec((afi, safi));
                 rib.clear_llgr_stale_evpn((afi, safi));
+                // Typed families (VPN, BGP-LS, RTC) implement the RFC-strict
+                // End-of-RIB removal, matching the GR arm: a route still
+                // LLGR-stale here was not re-advertised during the LLGR
+                // window and is deleted (RFC 4724 §4.1 via RFC 9494 §4.2).
+                // The trailing clear is flag/LLGR-community hygiene for the
+                // retained routes. The unicast/FlowSpec/EVPN clears above
+                // keep the legacy clear-only behavior (documented gap).
+                rib.sweep_llgr_stale_family_vpn((afi, safi));
+                rib.clear_llgr_stale_vpn((afi, safi));
+                rib.sweep_llgr_stale_family_bgpls((afi, safi));
+                rib.clear_llgr_stale_bgpls((afi, safi));
+                rtc_swept = !rib.sweep_llgr_stale_family_rtc((afi, safi)).is_empty();
+                rib.clear_llgr_stale_rtc((afi, safi));
             }
 
             let affected: HashSet<Prefix> = self
@@ -290,8 +344,23 @@ impl RibManager {
             if !evpn_affected.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn_affected);
             }
+            if !vpn_affected.is_empty() {
+                self.recompute_vpn_keys(&vpn_affected);
+            }
+            if !bgpls_affected.is_empty() {
+                self.recompute_bgpls_keys(&bgpls_affected);
+            }
+            if !rtc_affected.is_empty() {
+                self.recompute_rtc_keys(&rtc_affected);
+            }
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+            }
+            if rtc_swept {
+                // The EoR sweep removed LLGR-stale RT interest the peer did
+                // not re-advertise: shrink its membership so no-longer-
+                // covered VPN routes are withdrawn from its Adj-RIB-Out.
+                self.rebuild_rtc_membership_and_restage_vpn(peer);
             }
 
             let peer_label = peer.to_string();
@@ -299,6 +368,9 @@ impl RibManager {
                 rib.iter().filter(|r| r.is_llgr_stale).count()
                     + rib.iter_flowspec().filter(|r| r.is_llgr_stale).count()
                     + rib.iter_evpn().filter(|r| r.is_llgr_stale).count()
+                    + rib.iter_vpn().filter(|r| r.is_llgr_stale).count()
+                    + rib.iter_bgpls().filter(|r| r.is_llgr_stale).count()
+                    + rib.iter_rtc().filter(|r| r.is_llgr_stale).count()
             });
             self.metrics
                 .set_gr_stale_routes(&peer_label, gauge_val(llgr_stale_count));

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -16622,6 +16622,1265 @@ async fn evpn_gr_no_llgr_community_drops_route_on_promotion() {
     handle.await.unwrap();
 }
 
+// --- Typed-family LLGR two-phase lifecycle (RFC 9494): VPN, BGP-LS, RTC ---
+
+/// GR entry with LLGR negotiated for the given family tuples. The per-family
+/// LLGR stale time equals `llgr_stale_time`.
+fn gr_with_llgr(
+    peer: IpAddr,
+    restart_time: u16,
+    gr_families: Vec<(Afi, Safi)>,
+    llgr_families: Vec<(Afi, Safi)>,
+    llgr_stale_time: u32,
+) -> RibUpdate {
+    RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer,
+        restart_time,
+        stale_routes_time: 360,
+        gr_families,
+        peer_llgr_capable: true,
+        peer_llgr_families: llgr_families
+            .into_iter()
+            .map(|(afi, safi)| rustbgpd_wire::LlgrFamily {
+                afi,
+                safi,
+                forwarding_preserved: false,
+                stale_time: llgr_stale_time,
+            })
+            .collect(),
+        llgr_stale_time,
+    }
+}
+
+/// Bring up an iBGP route-reflector client negotiating `sendable`, for
+/// observing typed-family re-exports.
+async fn llgr_target_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    sendable: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: sendable,
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+/// GR-timer expiry with LLGR negotiated promotes GR-stale VPN routes to
+/// LLGR-stale: flag flip, locally-injected `LLGR_STALE` community, and a
+/// DEEPER tiebreak demotion — an LLGR-stale candidate loses to a GR-stale
+/// one regardless of `LOCAL_PREF` (RFC 9494 §4.3).
+#[tokio::test]
+async fn vpn_llgr_gr_timer_promotes_to_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    // Same key from both peers; A wins the LOCAL_PREF tiebreak.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: peer_a,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: peer_b,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 3), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(
+        peer_a,
+        2,
+        family.clone(),
+        family.clone(),
+        3600,
+    ))
+    .await
+    .unwrap();
+    tx.send(gr_with_llgr(peer_b, 10, family.clone(), family, 3600))
+        .await
+        .unwrap();
+
+    let best = query_vpn_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a, "both GR-stale: LOCAL_PREF tiebreak");
+    assert!(best[0].is_stale);
+    assert!(!best[0].is_llgr_stale);
+
+    // Past A's GR timer only: A is promoted to LLGR-stale and now ranks
+    // BELOW B's GR-stale route despite the higher LOCAL_PREF.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let best = query_vpn_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_b, "GR-stale must outrank LLGR-stale");
+    assert!(best[0].is_stale);
+
+    // Past B's GR timer too: both LLGR-stale, the LOCAL_PREF tiebreak
+    // re-applies and the promoted route carries the injected community.
+    tokio::time::advance(Duration::from_secs(8)).await;
+    tokio::task::yield_now().await;
+    let best = query_vpn_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a);
+    assert!(!best[0].is_stale);
+    assert!(best[0].is_llgr_stale);
+    assert!(
+        best[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "promoted VPN route must carry LLGR_STALE community"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_llgr_gr_timer_promotes_to_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    // Same key from both peers; A wins the LOCAL_PREF tiebreak.
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: peer_a,
+        announced: vec![make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x01, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: peer_b,
+        announced: vec![make_bgpls_route(Ipv4Addr::new(10, 0, 0, 3), 0x01, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(
+        peer_a,
+        2,
+        family.clone(),
+        family.clone(),
+        3600,
+    ))
+    .await
+    .unwrap();
+    tx.send(gr_with_llgr(peer_b, 10, family.clone(), family, 3600))
+        .await
+        .unwrap();
+
+    let best = query_bgpls_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a, "both GR-stale: LOCAL_PREF tiebreak");
+    assert!(best[0].is_stale);
+    assert!(!best[0].is_llgr_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let best = query_bgpls_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_b, "GR-stale must outrank LLGR-stale");
+    assert!(best[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(8)).await;
+    tokio::task::yield_now().await;
+    let best = query_bgpls_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a);
+    assert!(!best[0].is_stale);
+    assert!(best[0].is_llgr_stale);
+    assert!(
+        best[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "promoted BGP-LS route must carry LLGR_STALE community"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn rtc_llgr_gr_timer_promotes_to_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    // Same NLRI from both peers; A wins the LOCAL_PREF tiebreak.
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: peer_a,
+        announced: vec![make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 200)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: peer_b,
+        announced: vec![make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 3), 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    tx.send(gr_with_llgr(
+        peer_a,
+        2,
+        family.clone(),
+        family.clone(),
+        3600,
+    ))
+    .await
+    .unwrap();
+    tx.send(gr_with_llgr(peer_b, 10, family.clone(), family, 3600))
+        .await
+        .unwrap();
+
+    let best = query_rtc_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a, "both GR-stale: LOCAL_PREF tiebreak");
+    assert!(best[0].is_stale);
+    assert!(!best[0].is_llgr_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let best = query_rtc_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_b, "GR-stale must outrank LLGR-stale");
+    assert!(best[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(8)).await;
+    tokio::task::yield_now().await;
+    let best = query_rtc_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert_eq!(best[0].peer, peer_a);
+    assert!(!best[0].is_stale);
+    assert!(best[0].is_llgr_stale);
+    assert!(
+        best[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "promoted RTC route must carry LLGR_STALE community"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn vpn_llgr_timer_sweeps_llgr_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 10))
+        .await
+        .unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_vpn_routes(&tx).await;
+    assert!(promoted[0].is_llgr_stale);
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_vpn_routes(&tx).await.is_empty(),
+        "LLGR timer expiry must sweep LLGR-stale VPN routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_llgr_timer_sweeps_llgr_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x01, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 10))
+        .await
+        .unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_bgpls_routes(&tx).await;
+    assert!(promoted[0].is_llgr_stale);
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_bgpls_routes(&tx).await.is_empty(),
+        "LLGR timer expiry must sweep LLGR-stale BGP-LS routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn rtc_llgr_timer_sweeps_llgr_stale_routes() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 10))
+        .await
+        .unwrap();
+    let stale = query_rtc_routes(&tx).await;
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_rtc_routes(&tx).await;
+    assert!(promoted[0].is_llgr_stale);
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_rtc_routes(&tx).await.is_empty(),
+        "LLGR timer expiry must sweep LLGR-stale RTC routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// `EoR` during the LLGR phase: re-advertised routes survive with the flag
+/// cleared and the locally-injected `LLGR_STALE` community gone; a
+/// peer-originated `LLGR_STALE` community is preserved; what was NOT
+/// re-advertised is deleted and withdrawn downstream (RFC 4724 §4.1 via
+/// RFC 9494 §4.2).
+#[tokio::test]
+async fn vpn_llgr_eor_clears_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_target_peer_up(&tx, target, vpn_sendable()).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 60, 100, 100);
+    let mut kept_tagged = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 61, 100, 100);
+    Arc::make_mut(&mut kept_tagged.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_LLGR_STALE,
+    ]));
+    let dropped = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 62, 100, 100);
+    let kept_key = kept.key();
+    let kept_tagged_key = kept_tagged.key();
+    let dropped_key = dropped.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept.clone(), kept_tagged.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 3);
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_vpn_routes(&tx).await;
+    assert!(promoted.iter().all(|r| r.is_llgr_stale));
+
+    // Only the two `kept` routes are re-advertised before End-of-RIB; the
+    // tagged one still carries its peer-originated LLGR_STALE community.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept, kept_tagged],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_vpn_routes(&tx).await;
+    assert!(
+        after_eor.iter().all(|r| r.key() != dropped_key),
+        "the non-readvertised LLGR-stale VPN route must be removed at End-of-RIB"
+    );
+    let plain = after_eor
+        .iter()
+        .find(|r| r.key() == kept_key)
+        .expect("re-advertised VPN route survives EoR");
+    assert!(!plain.is_llgr_stale, "EoR must clear the LLGR-stale flag");
+    assert!(
+        !plain
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "the locally-injected LLGR_STALE community must not survive EoR"
+    );
+    let tagged = after_eor
+        .iter()
+        .find(|r| r.key() == kept_tagged_key)
+        .expect("re-advertised tagged VPN route survives EoR");
+    assert!(!tagged.is_llgr_stale);
+    assert!(
+        tagged
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "a peer-originated LLGR_STALE community must be preserved"
+    );
+
+    // The EoR removal must be withdrawn downstream.
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.vpn_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(update.vpn_withdraw, vec![dropped_key.clone()]);
+        break;
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_llgr_eor_clears_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_target_peer_up(&tx, target, bgpls_sendable()).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x60, 100);
+    let mut kept_tagged = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x61, 100);
+    Arc::make_mut(&mut kept_tagged.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_LLGR_STALE,
+    ]));
+    let dropped = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x62, 100);
+    let kept_key = kept.key();
+    let kept_tagged_key = kept_tagged.key();
+    let dropped_key = dropped.key();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept.clone(), kept_tagged.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.bgpls_announce.len(), 3);
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_bgpls_routes(&tx).await;
+    assert!(promoted.iter().all(|r| r.is_llgr_stale));
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept, kept_tagged],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::BgpLs,
+        safi: Safi::BgpLs,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_bgpls_routes(&tx).await;
+    assert!(
+        after_eor.iter().all(|r| r.key() != dropped_key),
+        "the non-readvertised LLGR-stale BGP-LS route must be removed at End-of-RIB"
+    );
+    let plain = after_eor
+        .iter()
+        .find(|r| r.key() == kept_key)
+        .expect("re-advertised BGP-LS route survives EoR");
+    assert!(!plain.is_llgr_stale, "EoR must clear the LLGR-stale flag");
+    assert!(
+        !plain
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "the locally-injected LLGR_STALE community must not survive EoR"
+    );
+    let tagged = after_eor
+        .iter()
+        .find(|r| r.key() == kept_tagged_key)
+        .expect("re-advertised tagged BGP-LS route survives EoR");
+    assert!(!tagged.is_llgr_stale);
+    assert!(
+        tagged
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "a peer-originated LLGR_STALE community must be preserved"
+    );
+
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.bgpls_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(update.bgpls_withdraw, vec![dropped_key.clone()]);
+        break;
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn rtc_llgr_eor_clears_llgr_stale() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let mut kept_tagged = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 101, 100);
+    Arc::make_mut(&mut kept_tagged.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_LLGR_STALE,
+    ]));
+    let dropped = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 102, 100);
+    let kept_key = kept.key();
+    let kept_tagged_key = kept_tagged.key();
+    let dropped_key = dropped.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept.clone(), kept_tagged.clone(), dropped],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.rtc_announce.len(), 3);
+
+    let family = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_rtc_routes(&tx).await;
+    assert!(stale.iter().all(|r| r.nlri.is_default() || r.is_stale));
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_rtc_routes(&tx).await;
+    assert!(
+        promoted
+            .iter()
+            .all(|r| r.nlri.is_default() || r.is_llgr_stale)
+    );
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![kept, kept_tagged],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::RtConstrain,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_rtc_routes(&tx).await;
+    assert!(
+        after_eor.iter().all(|r| r.key() != dropped_key),
+        "the non-readvertised LLGR-stale RTC route must be removed at End-of-RIB"
+    );
+    let plain = after_eor
+        .iter()
+        .find(|r| r.key() == kept_key)
+        .expect("re-advertised RTC route survives EoR");
+    assert!(!plain.is_llgr_stale, "EoR must clear the LLGR-stale flag");
+    assert!(
+        !plain
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "the locally-injected LLGR_STALE community must not survive EoR"
+    );
+    let tagged = after_eor
+        .iter()
+        .find(|r| r.key() == kept_tagged_key)
+        .expect("re-advertised tagged RTC route survives EoR");
+    assert!(!tagged.is_llgr_stale);
+    assert!(
+        tagged
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "a peer-originated LLGR_STALE community must be preserved"
+    );
+
+    loop {
+        let update = out_rx.recv().await.unwrap();
+        if update.rtc_withdraw.is_empty() {
+            continue;
+        }
+        assert_eq!(update.rtc_withdraw, vec![dropped_key.clone()]);
+        break;
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 9494 §4.3: a route carrying `NO_LLGR` must not enter the LLGR phase —
+/// it is removed at GR-timer expiry instead of being promoted.
+#[tokio::test]
+async fn vpn_llgr_no_llgr_community_drops_route_on_promotion() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_LLGR,
+    ]));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_vpn_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_vpn_routes(&tx).await.is_empty(),
+        "NO_LLGR VPN route must be dropped on GR timer expiry"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_llgr_no_llgr_community_drops_route_on_promotion() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut route = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x01, 100);
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_LLGR,
+    ]));
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_bgpls_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_bgpls_routes(&tx).await.is_empty(),
+        "NO_LLGR BGP-LS route must be dropped on GR timer expiry"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn rtc_llgr_no_llgr_community_drops_route_on_promotion() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_LLGR,
+    ]));
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let family = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let stale = query_rtc_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_rtc_routes(&tx).await.is_empty(),
+        "NO_LLGR RTC route must be dropped on GR timer expiry"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 9494 §4.3: a promoted LLGR-stale route re-exported to another iBGP
+/// peer carries the `LLGR_STALE` community — it must not be removed on
+/// re-advertisement.
+#[tokio::test]
+async fn vpn_llgr_stale_reexport_carries_community() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_target_peer_up(&tx, target, vpn_sendable()).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+    assert!(
+        !first.vpn_announce[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+    );
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    // Force the manager to process PeerGracefulRestart before advancing time.
+    assert!(query_vpn_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    // Sync point: promotion processed and distributed, then drain the
+    // staged updates. The GR-entry restage may re-announce the still-plain
+    // stale route first; the promotion restage must carry the community.
+    assert!(query_vpn_routes(&tx).await[0].is_llgr_stale);
+    let mut seen = false;
+    while let Ok(update) = out_rx.try_recv() {
+        if let Some(re) = update.vpn_announce.iter().find(|r| r.key() == key)
+            && re
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        {
+            seen = true;
+        }
+    }
+    assert!(
+        seen,
+        "re-exported LLGR-stale VPN route must carry LLGR_STALE"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bgpls_llgr_stale_reexport_carries_community() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_target_peer_up(&tx, target, bgpls_sendable()).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x01, 100);
+    let key = route.key();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.bgpls_announce.len(), 1);
+    assert!(
+        !first.bgpls_announce[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+    );
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    // Force the manager to process PeerGracefulRestart before advancing time.
+    assert!(query_bgpls_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    // Sync point: promotion processed and distributed.
+    assert!(query_bgpls_routes(&tx).await[0].is_llgr_stale);
+    let mut seen = false;
+    while let Ok(update) = out_rx.try_recv() {
+        if let Some(re) = update.bgpls_announce.iter().find(|r| r.key() == key)
+            && re
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        {
+            seen = true;
+        }
+    }
+    assert!(
+        seen,
+        "re-exported LLGR-stale BGP-LS route must carry LLGR_STALE"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn rtc_llgr_stale_reexport_carries_community() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, target, false, true).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_rtc_rib_route(Ipv4Addr::new(10, 0, 0, 1), 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.rtc_announce.len(), 1);
+    assert!(
+        !first.rtc_announce[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+    );
+
+    let family = vec![(Afi::Ipv4, Safi::RtConstrain)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    // Force the manager to process PeerGracefulRestart before advancing time.
+    assert!(
+        query_rtc_routes(&tx)
+            .await
+            .iter()
+            .any(|r| r.key() == key && r.is_stale)
+    );
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    // Sync point: promotion processed and distributed.
+    assert!(
+        query_rtc_routes(&tx)
+            .await
+            .iter()
+            .any(|r| r.key() == key && r.is_llgr_stale)
+    );
+    let mut seen = false;
+    while let Ok(update) = out_rx.try_recv() {
+        if let Some(re) = update.rtc_announce.iter().find(|r| r.key() == key)
+            && re
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        {
+            seen = true;
+        }
+    }
+    assert!(
+        seen,
+        "re-exported LLGR-stale RTC route must carry LLGR_STALE"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer whose LLGR capability covers VPN but NOT BGP-LS splits at GR-timer
+/// expiry: the VPN route is promoted to LLGR-stale, the BGP-LS route is
+/// purged (RFC 9494 §4.3: only LLGR-negotiated families are retained).
+#[tokio::test]
+async fn llgr_families_split_promote_vs_purge_for_typed_families() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_bgpls_route(Ipv4Addr::new(10, 0, 0, 1), 0x01, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(gr_with_llgr(
+        source,
+        2,
+        vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::BgpLs, Safi::BgpLs)],
+        vec![(Afi::Ipv4, Safi::MplsVpn)],
+        3600,
+    ))
+    .await
+    .unwrap();
+    assert!(query_vpn_routes(&tx).await[0].is_stale);
+    assert!(query_bgpls_routes(&tx).await[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    let vpn = query_vpn_routes(&tx).await;
+    assert_eq!(vpn.len(), 1, "LLGR-covered VPN route must be retained");
+    assert!(vpn[0].is_llgr_stale);
+    assert!(
+        vpn[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+    );
+    assert!(
+        query_bgpls_routes(&tx).await.is_empty(),
+        "BGP-LS outside the LLGR capability must purge at GR expiry"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The LLGR-expiry sweep is where a down peer's GR/LLGR-preserved RT
+/// interest finally dies: after the sweep, a re-established session's
+/// initial dump must withhold VPN routes again (empty membership), whereas
+/// during the retention window the preserved membership kept serving them.
+#[tokio::test]
+async fn rtc_llgr_sweep_drops_preserved_vpn_membership() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route_with_rts(
+            Ipv4Addr::new(10, 0, 0, 1),
+            60,
+            vec![rt(100)],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let target = Ipv4Addr::new(10, 0, 0, 2);
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+    send_rtc_interest(&tx, target, &[100]).await;
+    let announced = out_rx.recv().await.unwrap();
+    assert_eq!(announced.vpn_announce.len(), 1);
+
+    // GR entry preserving RTC through both retention phases.
+    tx.send(gr_with_llgr(
+        IpAddr::V4(target),
+        2,
+        vec![(Afi::Ipv4, Safi::RtConstrain)],
+        vec![(Afi::Ipv4, Safi::RtConstrain)],
+        10,
+    ))
+    .await
+    .unwrap();
+
+    // Past the GR timer: the interest is promoted, not purged.
+    // Force the manager to process PeerGracefulRestart before advancing time.
+    let marked = query_rtc_routes(&tx).await;
+    assert!(marked.iter().any(|r| !r.nlri.is_default() && r.is_stale));
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let retained = query_rtc_routes(&tx).await;
+    assert!(
+        retained
+            .iter()
+            .any(|r| !r.nlri.is_default() && r.is_llgr_stale),
+        "RT interest must survive the GR→LLGR promotion"
+    );
+
+    // Past the LLGR timer: the interest is swept and the membership dies.
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    let after_sweep = query_rtc_routes(&tx).await;
+    assert!(
+        after_sweep.iter().all(|r| r.nlri.is_default()),
+        "LLGR expiry must sweep the preserved RT interest"
+    );
+
+    // Re-establish: the strict dump helper asserts ZERO VPN routes — the
+    // preserved membership is gone, so nothing may be served.
+    let mut out_rx = vpn_rtc_peer_up(&tx, IpAddr::V4(target)).await;
+    drain_strict_vpn_rtc_initial_dump(&mut out_rx).await;
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LLGR-stale BGP-LS routes keep feeding the ORR topology (RFC 9107
+/// vantages stay resolved) through BOTH retention phases; the LLGR-expiry
+/// sweep is where the vantage finally unresolves.
+#[tokio::test]
+async fn bgpls_llgr_stale_topology_keeps_orr_vantages_resolved_until_llgr_sweep() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let _out_rx = orr_client_peer_up(&tx, client, Some(vantage_at_node_a())).await;
+
+    let feed = Ipv4Addr::new(10, 9, 9, 9);
+    feed_square_topology(&tx, feed).await;
+    let status = query_orr_status(&tx).await;
+    assert!(status.vantages[0].resolved);
+    assert_eq!(status.topology_nodes, 4);
+
+    let family = vec![(Afi::BgpLs, Safi::BgpLs)];
+    tx.send(gr_with_llgr(
+        IpAddr::V4(feed),
+        2,
+        family.clone(),
+        family,
+        10,
+    ))
+    .await
+    .unwrap();
+    let status = query_orr_status(&tx).await;
+    assert!(
+        status.vantages[0].resolved,
+        "GR-stale BGP-LS routes must keep feeding the topology"
+    );
+
+    // Past the GR timer: promotion to LLGR-stale keeps the routes in the
+    // Adj-RIB-In, so the topology (and the vantage) must survive.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let status = query_orr_status(&tx).await;
+    assert!(
+        status.vantages[0].resolved,
+        "LLGR-stale BGP-LS routes must keep feeding the topology"
+    );
+    assert_eq!(status.topology_nodes, 4);
+
+    // Past the LLGR timer: the sweep empties the topology — NOW the
+    // vantage unresolves.
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    let status = query_orr_status(&tx).await;
+    assert!(
+        !status.vantages[0].resolved,
+        "the LLGR expiry sweep must rebuild the cache against the emptied topology"
+    );
+    assert_eq!(status.topology_nodes, 0);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Gate 6: controller-driven EVPN injection. `InjectEvpn` places a
 /// `RouteOrigin::Local` EVPN route into the RR's Loc-RIB and reflects
 /// it to peers negotiating L2VPN/EVPN — same shape as `InjectFlowSpec`.


### PR DESCRIPTION
Third slice of the **GR/LLGR arc**, on top of #637: the RFC 9494 Long-Lived GR phase for the RR families.

- GR-timer expiry now **promotes** LLGR-negotiated family tuples to LLGR-stale (NO_LLGR carriers dropped first per §4.2; LLGR_STALE community injected via the interned-attributes mutation with local-tag bookkeeping) while non-LLGR tuples purge — the exact unicast/EVPN split.
- LLGR-timer expiry sweeps all six families; the EoR LLGR arm sweeps-then-clears for the new families (RFC-strict; the legacy clear-only gap is matched to #637's posture and flagged), preserving peer-originated LLGR_STALE communities.
- **Re-export**: the community rides the interned attributes through the normal per-family staging — pinned per family by re-export tests. Finding: unicast implements no LLGR export restriction toward non-LLGR peers (RFC SHOULD); mirrored, documented as a repo-wide gap for the docs slice.
- **RTC**: preserved VPN-filter membership survives promotion and dies at the LLGR sweep (with the membership rebuild), pinned end-to-end. **ORR**: vantages stay resolved through both retention phases, unresolve at the LLGR sweep.

18 new tests incl. the promote-vs-purge family split and two-peer deeper-demotion pins. Workspace: 63 suites green (rib 516).