### PR TITLE
feat(rib+api): explain per-vantage ORR best-path decisions

### DIFF
--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -913,6 +913,20 @@ fn explain_to_proto(explain: ExplainAdvertisedRoute) -> proto::ExplainAdvertised
             })
             .collect(),
         modifications: Some(explain_modifications_to_proto(&explain.modifications)),
+        orr_vantage: explain
+            .orr_vantage
+            .map_or_else(String::new, |vantage| vantage.to_string()),
+        orr_candidates: explain
+            .orr_candidates
+            .into_iter()
+            .map(|candidate| proto::OrrExplainCandidate {
+                peer_address: candidate.peer.to_string(),
+                path_id: candidate.path_id,
+                next_hop: candidate.next_hop.to_string(),
+                cost: candidate.cost,
+                selected: candidate.selected,
+            })
+            .collect(),
     }
 }
 
@@ -3616,6 +3630,23 @@ mod tests {
                     message: "export policy permitted this route".to_string(),
                 }],
                 modifications: rustbgpd_policy::RouteModifications::default(),
+                orr_vantage: Some("10.0.1.1".parse().unwrap()),
+                orr_candidates: vec![
+                    rustbgpd_rib::OrrExplainCandidate {
+                        peer: "198.51.100.2".parse().unwrap(),
+                        path_id: 0,
+                        next_hop: "198.51.100.1".parse().unwrap(),
+                        cost: Some(12),
+                        selected: true,
+                    },
+                    rustbgpd_rib::OrrExplainCandidate {
+                        peer: "198.51.100.3".parse().unwrap(),
+                        path_id: 0,
+                        next_hop: "198.51.100.4".parse().unwrap(),
+                        cost: None,
+                        selected: false,
+                    },
+                ],
             }))
             .unwrap();
 
@@ -3625,6 +3656,17 @@ mod tests {
         assert_eq!(resp.route_peer_address, "198.51.100.2");
         assert_eq!(resp.route_type, "external");
         assert_eq!(resp.reasons.len(), 1);
+        assert_eq!(resp.orr_vantage, "10.0.1.1");
+        assert_eq!(resp.orr_candidates.len(), 2);
+        assert_eq!(resp.orr_candidates[0].next_hop, "198.51.100.1");
+        assert_eq!(resp.orr_candidates[0].cost, Some(12));
+        assert!(resp.orr_candidates[0].selected);
+        assert_eq!(resp.orr_candidates[1].peer_address, "198.51.100.3");
+        assert_eq!(
+            resp.orr_candidates[1].cost, None,
+            "unreachable maps to absent"
+        );
+        assert!(!resp.orr_candidates[1].selected);
     }
 
     #[test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -2,6 +2,7 @@ use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{
     self, JsonExplainAdvertisedRoute, JsonExplainModifications, JsonExplainReason,
+    JsonOrrExplainCandidate,
 };
 use crate::proto::injection_service_client::InjectionServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
@@ -883,7 +884,23 @@ fn explain_to_json(
                 as_path_prepend_count: mods.as_path_prepend_count,
             },
         ),
+        orr_vantage: explain.orr_vantage.clone(),
+        orr_candidates: explain
+            .orr_candidates
+            .iter()
+            .map(|candidate| JsonOrrExplainCandidate {
+                peer_address: candidate.peer_address.clone(),
+                next_hop: candidate.next_hop.clone(),
+                cost: candidate.cost,
+                selected: candidate.selected,
+            })
+            .collect(),
     }
+}
+
+/// Render an ORR vantage cost for text output (`12` / `unreachable`).
+fn orr_cost_label(cost: Option<u64>) -> String {
+    cost.map_or_else(|| "unreachable".to_string(), |c| c.to_string())
 }
 
 fn print_explain_advertised(
@@ -918,6 +935,25 @@ fn print_explain_advertised(
     }
     if explain.path_id != 0 {
         println!("Path ID:    {}", explain.path_id);
+    }
+    if !explain.orr_vantage.is_empty() {
+        println!("ORR vantage: {}", explain.orr_vantage);
+    }
+    if !explain.orr_candidates.is_empty() {
+        println!("ORR candidates (per-vantage best first):");
+        for candidate in &explain.orr_candidates {
+            println!(
+                "- {} next-hop {} cost={}{}",
+                candidate.peer_address,
+                candidate.next_hop,
+                orr_cost_label(candidate.cost),
+                if candidate.selected {
+                    " (selected)"
+                } else {
+                    ""
+                }
+            );
+        }
     }
     if !explain.reasons.is_empty() {
         println!("Reasons:");
@@ -1845,6 +1881,55 @@ mod tests {
         })
         .unwrap_err();
         assert!(err.to_string().contains("invalid --peer address"));
+    }
+
+    #[test]
+    fn explain_advertised_json_maps_orr_fields() {
+        let resp = crate::proto::ExplainAdvertisedRouteResponse {
+            decision: ExplainDecision::Advertise as i32,
+            peer_address: "10.0.0.3".to_string(),
+            prefix: "198.51.100.0".to_string(),
+            prefix_length: 24,
+            next_hop: "10.0.2.1".to_string(),
+            orr_vantage: "10.0.1.1".to_string(),
+            orr_candidates: vec![
+                crate::proto::OrrExplainCandidate {
+                    peer_address: "192.0.2.2".to_string(),
+                    path_id: 0,
+                    next_hop: "10.0.2.1".to_string(),
+                    cost: Some(1),
+                    selected: true,
+                },
+                crate::proto::OrrExplainCandidate {
+                    peer_address: "192.0.2.1".to_string(),
+                    path_id: 0,
+                    next_hop: "203.0.113.99".to_string(),
+                    cost: None,
+                    selected: false,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let value = serde_json::to_value(explain_to_json(&resp)).unwrap();
+        assert_eq!(value["orr_vantage"], "10.0.1.1");
+        assert_eq!(value["orr_candidates"][0]["peer_address"], "192.0.2.2");
+        assert_eq!(value["orr_candidates"][0]["cost"], 1);
+        assert_eq!(value["orr_candidates"][0]["selected"], true);
+        assert!(
+            value["orr_candidates"][1]["cost"].is_null(),
+            "unreachable cost serializes as null"
+        );
+        assert_eq!(value["orr_candidates"][1]["selected"], false);
+    }
+
+    #[test]
+    fn explain_advertised_json_omits_orr_fields_when_not_orr() {
+        // Non-ORR responses keep the pre-ORR JSON shape byte-for-byte.
+        let resp = crate::proto::ExplainAdvertisedRouteResponse::default();
+        let value = serde_json::to_value(explain_to_json(&resp)).unwrap();
+        assert!(value.get("orr_vantage").is_none());
+        assert!(value.get("orr_candidates").is_none());
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -318,6 +318,21 @@ pub struct JsonExplainAdvertisedRoute {
     pub route_type: String,
     pub reasons: Vec<JsonExplainReason>,
     pub modifications: JsonExplainModifications,
+    /// RFC 9107 ORR vantage; both ORR fields are absent on non-ORR
+    /// explains so the pre-ORR JSON shape is unchanged.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub orr_vantage: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub orr_candidates: Vec<JsonOrrExplainCandidate>,
+}
+
+#[derive(Serialize)]
+pub struct JsonOrrExplainCandidate {
+    pub peer_address: String,
+    pub next_hop: String,
+    /// Vantage interior cost to `next_hop`; `null` = unreachable.
+    pub cost: Option<u64>,
+    pub selected: bool,
 }
 
 fn is_zero(v: &u32) -> bool {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -999,6 +999,8 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
                     as_path_prepend_asn: None,
                     as_path_prepend_count: None,
                 }),
+                orr_vantage: String::new(),
+                orr_candidates: vec![],
             },
         ))
     }

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -58,7 +58,7 @@ pub enum BestPathReason {
     /// Step 5.3 (RFC 9107 ORR only): lower vantage interior cost to
     /// `NEXT_HOP` wins; a known cost beats an unknown one. Never produced
     /// by the Loc-RIB ladder (`best_path_cmp_with_reason` carries no
-    /// vantage costs) — it exists for ORR-path attribution and tests.
+    /// vantage costs) — only [`best_path_cmp_orr_with_reason`] yields it.
     OrrInteriorCost,
     /// Step 5.5: shorter `CLUSTER_LIST` wins (RFC 4456).
     ShorterClusterList,
@@ -71,23 +71,32 @@ pub enum BestPathReason {
     EvpnMacMobility,
 }
 
+impl BestPathReason {
+    /// Stable `snake_case` identifier for this step (the string behind
+    /// `Display` — usable where a `&'static str` code is required).
+    #[must_use]
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::StalePreference => "stale_preference",
+            Self::RpkiPreference => "rpki_preference",
+            Self::AspaPreference => "aspa_preference",
+            Self::HigherLocalPref => "higher_local_pref",
+            Self::ShorterAsPath => "shorter_as_path",
+            Self::LowerOrigin => "lower_origin",
+            Self::LowerMed => "lower_med",
+            Self::EbgpOverIbgp => "ebgp_over_ibgp",
+            Self::OrrInteriorCost => "orr_interior_cost",
+            Self::ShorterClusterList => "shorter_cluster_list",
+            Self::LowerOriginatorId => "lower_originator_id",
+            Self::LowerPeerAddress => "lower_peer_address",
+            Self::EvpnMacMobility => "evpn_mac_mobility",
+        }
+    }
+}
+
 impl std::fmt::Display for BestPathReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::StalePreference => write!(f, "stale_preference"),
-            Self::RpkiPreference => write!(f, "rpki_preference"),
-            Self::AspaPreference => write!(f, "aspa_preference"),
-            Self::HigherLocalPref => write!(f, "higher_local_pref"),
-            Self::ShorterAsPath => write!(f, "shorter_as_path"),
-            Self::LowerOrigin => write!(f, "lower_origin"),
-            Self::LowerMed => write!(f, "lower_med"),
-            Self::EbgpOverIbgp => write!(f, "ebgp_over_ibgp"),
-            Self::OrrInteriorCost => write!(f, "orr_interior_cost"),
-            Self::ShorterClusterList => write!(f, "shorter_cluster_list"),
-            Self::LowerOriginatorId => write!(f, "lower_originator_id"),
-            Self::LowerPeerAddress => write!(f, "lower_peer_address"),
-            Self::EvpnMacMobility => write!(f, "evpn_mac_mobility"),
-        }
+        f.write_str(self.code())
     }
 }
 
@@ -151,6 +160,71 @@ pub fn best_path_cmp_with_reason(a: &Route, b: &Route) -> (Ordering, BestPathRea
     }
 
     (a.peer.cmp(&b.peer), BestPathReason::LowerPeerAddress)
+}
+
+/// Compare two routes under RFC 9107 ORR and return the decisive reason.
+///
+/// Same ordering as [`best_path_cmp_orr`], derived by composition rather
+/// than a third hand-maintained ladder: the plain reason ladder decides
+/// unless its decisive step is one of the tiebreakers *below* the ORR
+/// interior-cost step (`CLUSTER_LIST`, `ORIGINATOR_ID`, peer address) —
+/// in that case the vantage cost gets first shot and, when decisive,
+/// yields [`BestPathReason::OrrInteriorCost`].
+#[must_use]
+pub fn best_path_cmp_orr_with_reason(
+    a: &Route,
+    b: &Route,
+    cost_a: Option<u64>,
+    cost_b: Option<u64>,
+) -> (Ordering, BestPathReason) {
+    let (ord, reason) = best_path_cmp_with_reason(a, b);
+    let below_orr_step = matches!(
+        reason,
+        BestPathReason::ShorterClusterList
+            | BestPathReason::LowerOriginatorId
+            | BestPathReason::LowerPeerAddress
+    );
+    if ord != Ordering::Equal && !below_orr_step {
+        return (ord, reason);
+    }
+    let cost_cmp = match (cost_a, cost_b) {
+        (Some(x), Some(y)) => x.cmp(&y),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    };
+    if cost_cmp != Ordering::Equal {
+        return (cost_cmp, BestPathReason::OrrInteriorCost);
+    }
+    (ord, reason)
+}
+
+/// Render an ORR vantage cost for explain output: the interior metric,
+/// or `unreachable` when the vantage has no known cost to the next-hop.
+fn orr_cost_str(cost: Option<u64>) -> String {
+    cost.map_or_else(|| "unreachable".to_string(), |c| c.to_string())
+}
+
+/// Render the compared vantage costs behind a decisive
+/// [`BestPathReason::OrrInteriorCost`], `a`'s cost on the left —
+/// e.g. `"orr_cost 12 < 40"` or `"orr_cost 12 < unreachable"` (RFC 9107
+/// §3.1: an unknown metric-to-next-hop is least preferred).
+///
+/// Explain-only, like [`best_path_reason_detail`] — the costs live on
+/// the ORR distribution path, not on [`Route`], so they are passed in.
+#[must_use]
+pub fn orr_interior_cost_detail(cost_a: Option<u64>, cost_b: Option<u64>) -> String {
+    let symbol = match (cost_a, cost_b) {
+        (Some(x), Some(y)) => cmp_symbol(&x, &y),
+        (Some(_), None) => "<",
+        (None, Some(_)) => ">",
+        (None, None) => "=",
+    };
+    format!(
+        "orr_cost {} {symbol} {}",
+        orr_cost_str(cost_a),
+        orr_cost_str(cost_b)
+    )
 }
 
 /// Relational symbol for a compared pair, read left-to-right:
@@ -238,7 +312,7 @@ pub fn best_path_reason_detail(reason: BestPathReason, a: &Route, b: &Route) -> 
         BestPathReason::EvpnMacMobility => "mac_mobility_sequence".to_string(),
         // Not produced by `best_path_cmp_with_reason` either — the
         // vantage costs live on the ORR distribution path, not on
-        // `Route`, so there are no compared values to render here.
+        // `Route`; callers with costs use `orr_interior_cost_detail`.
         BestPathReason::OrrInteriorCost => "orr_interior_cost_to_next_hop".to_string(),
     }
 }
@@ -1101,6 +1175,108 @@ mod tests {
         assert_eq!(best_path_cmp_orr(&a, &b, None, None), Ordering::Less);
         // The fall-through outcome matches the plain comparator.
         assert_eq!(best_path_cmp_orr(&a, &b, None, None), best_path_cmp(&a, &b));
+    }
+
+    // --- RFC 9107 ORR reason ladder (best_path_cmp_orr_with_reason) ---
+
+    #[test]
+    fn orr_with_reason_winner_by_cost_yields_orr_interior_cost() {
+        // Attributes tie down to the cost step; the lower cost wins and
+        // the decisive reason is OrrInteriorCost with the right detail.
+        let a = base_route(Ipv4Addr::new(1, 0, 0, 2));
+        let b = base_route(Ipv4Addr::new(1, 0, 0, 1));
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, Some(12), Some(40));
+        assert_eq!(ord, Ordering::Less);
+        assert_eq!(reason, BestPathReason::OrrInteriorCost);
+        assert_eq!(
+            orr_interior_cost_detail(Some(12), Some(40)),
+            "orr_cost 12 < 40"
+        );
+
+        // Known beats unknown (RFC 9107 §3.1).
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, Some(12), None);
+        assert_eq!(ord, Ordering::Less);
+        assert_eq!(reason, BestPathReason::OrrInteriorCost);
+        assert_eq!(
+            orr_interior_cost_detail(Some(12), None),
+            "orr_cost 12 < unreachable"
+        );
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, None, Some(12));
+        assert_eq!(ord, Ordering::Greater);
+        assert_eq!(reason, BestPathReason::OrrInteriorCost);
+        assert_eq!(
+            orr_interior_cost_detail(None, Some(12)),
+            "orr_cost unreachable > 12"
+        );
+    }
+
+    #[test]
+    fn orr_with_reason_cost_tie_falls_through_to_next_step() {
+        // Equal (and both-unknown) costs fall through to CLUSTER_LIST —
+        // the same next step the plain ladder would use.
+        let a = with_cluster_list(
+            base_route(Ipv4Addr::new(1, 0, 0, 2)),
+            vec![Ipv4Addr::new(10, 0, 0, 1)],
+        );
+        let b = with_cluster_list(
+            base_route(Ipv4Addr::new(1, 0, 0, 1)),
+            vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+        );
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, Some(7), Some(7));
+        assert_eq!(ord, Ordering::Less);
+        assert_eq!(reason, BestPathReason::ShorterClusterList);
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, None, None);
+        assert_eq!(ord, Ordering::Less);
+        assert_eq!(reason, BestPathReason::ShorterClusterList);
+    }
+
+    #[test]
+    fn orr_with_reason_steps_above_cost_still_decide() {
+        // A step above 5.3 (LOCAL_PREF) outranks even a wildly better
+        // cost, and the reason names that step.
+        let a = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 1)), 200);
+        let b = with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 2)), 100);
+        let (ord, reason) = best_path_cmp_orr_with_reason(&a, &b, Some(1000), Some(0));
+        assert_eq!(ord, Ordering::Less);
+        assert_eq!(reason, BestPathReason::HigherLocalPref);
+    }
+
+    #[test]
+    fn orr_with_reason_ordering_matches_cmp_orr() {
+        // Drift guard: the composed reason ladder must agree with the
+        // hot-path ORR comparator at every cost combination over pairs
+        // that tie above, at, and below the cost step.
+        let pairs = [
+            (
+                base_route(Ipv4Addr::new(1, 0, 0, 1)),
+                base_route(Ipv4Addr::new(1, 0, 0, 2)),
+            ),
+            (
+                with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 1)), 200),
+                with_local_pref(base_route(Ipv4Addr::new(1, 0, 0, 2)), 100),
+            ),
+            (
+                with_cluster_list(
+                    base_route(Ipv4Addr::new(1, 0, 0, 2)),
+                    vec![Ipv4Addr::new(10, 0, 0, 1)],
+                ),
+                with_cluster_list(
+                    base_route(Ipv4Addr::new(1, 0, 0, 1)),
+                    vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+                ),
+            ),
+        ];
+        let costs = [None, Some(0_u64), Some(7), Some(1000)];
+        for (a, b) in &pairs {
+            for &ca in &costs {
+                for &cb in &costs {
+                    let (ord, _) = best_path_cmp_orr_with_reason(a, b, ca, cb);
+                    assert_eq!(ord, best_path_cmp_orr(a, b, ca, cb));
+                    let (rev, _) = best_path_cmp_orr_with_reason(b, a, cb, ca);
+                    assert_eq!(rev, best_path_cmp_orr(b, a, cb, ca));
+                }
+            }
+        }
     }
 
     // --- best_path_reason_detail (explain-only compared-values render) ---

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -56,6 +56,6 @@ pub use route::{
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,
-    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OutboundRouteUpdate, RibCommandError,
-    RibUpdate,
+    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate,
+    RibCommandError, RibUpdate,
 };

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -7,6 +7,37 @@ use super::{
     should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki,
 };
 
+/// Candidate paths for `prefix` visible to `target_peer` under RFC 9107
+/// ORR: every Adj-RIB-In entry that survives split horizon and the
+/// iBGP / RFC 4456 reflection rules. Shared by the ORR distribution and
+/// explain paths so both rank the exact same set.
+fn orr_candidates<'a>(
+    ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    peer_is_rr_client: &'a HashMap<IpAddr, bool>,
+    prefix: &'a Prefix,
+    target_peer: IpAddr,
+    target_is_ebgp: bool,
+    target_is_rr_client: bool,
+    cluster_id: Option<Ipv4Addr>,
+) -> impl Iterator<Item = &'a crate::route::Route> {
+    ribs.values()
+        .flat_map(move |rib| rib.iter_prefix(prefix))
+        .filter(move |route| {
+            // Split horizon: exclude routes from the target peer
+            if route.peer == target_peer {
+                return false;
+            }
+            // iBGP split-horizon / RFC 4456 reflection
+            !should_suppress_ibgp_inner(
+                route,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                peer_is_rr_client,
+            )
+        })
+}
+
 impl RibManager {
     #[expect(
         clippy::too_many_arguments,
@@ -15,6 +46,7 @@ impl RibManager {
     )]
     pub(in crate::manager) fn explain_single_best_prefix(
         loc_rib: &LocRib,
+        ribs: &HashMap<IpAddr, AdjRibIn>,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         prefix: Prefix,
         target_peer: IpAddr,
@@ -25,7 +57,13 @@ impl RibManager {
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
+        orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult, IpAddr)>,
     ) -> ExplainAdvertisedRoute {
+        use crate::best_path::{
+            BestPathReason, best_path_cmp_orr, best_path_cmp_orr_with_reason,
+            best_path_reason_detail, orr_interior_cost_detail,
+        };
+
         let mut explain = ExplainAdvertisedRoute {
             decision: ExplainDecision::NoBestRoute,
             peer: target_peer,
@@ -36,19 +74,94 @@ impl RibManager {
             route_type: None,
             reasons: Vec::new(),
             modifications: rustbgpd_policy::RouteModifications::default(),
+            orr_vantage: None,
+            orr_candidates: Vec::new(),
         };
 
-        let Some(best) = loc_rib.get(&prefix) else {
-            explain.reasons.push(ExplainReason {
-                code: "no_best_route",
-                message: "no best route exists for this prefix".to_string(),
+        // Select the route to explain. An ORR-bound peer's best is NOT
+        // the Loc-RIB best: rank the per-target candidate set with the
+        // vantage's interior costs, exactly like
+        // `distribute_orr_best_prefix` (same collection via
+        // `orr_candidates`, same comparator). A plain peer explains the
+        // Loc-RIB best, unchanged.
+        let best = if let Some((topology, spf, vantage)) = orr {
+            explain.orr_vantage = Some(vantage);
+            let mut ranked: Vec<&crate::route::Route> = orr_candidates(
+                ribs,
+                peer_is_rr_client,
+                &prefix,
+                target_peer,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+            )
+            .collect();
+            ranked.sort_by(|a, b| {
+                best_path_cmp_orr(
+                    a,
+                    b,
+                    spf.cost_to(topology, a.next_hop),
+                    spf.cost_to(topology, b.next_hop),
+                )
             });
-            return explain;
+            explain.orr_candidates = ranked
+                .iter()
+                .enumerate()
+                .map(|(i, route)| crate::update::OrrExplainCandidate {
+                    peer: route.peer,
+                    path_id: route.path_id,
+                    next_hop: route.next_hop,
+                    cost: spf.cost_to(topology, route.next_hop),
+                    selected: i == 0,
+                })
+                .collect();
+            let Some(&winner) = ranked.first() else {
+                explain.reasons.push(ExplainReason {
+                    code: "no_orr_candidate",
+                    message: "no candidate for this prefix survives split-horizon / \
+                              reflection filtering for this ORR peer"
+                        .to_string(),
+                });
+                return explain;
+            };
+            // The decision the winner had to survive vs the runner-up —
+            // the per-vantage counterpart of ExplainBestPath's
+            // best_reason. Rendered with the compared vantage costs when
+            // the interior-cost step decided.
+            if let Some(&runner_up) = ranked.get(1) {
+                let (cost_w, cost_r) = (
+                    spf.cost_to(topology, winner.next_hop),
+                    spf.cost_to(topology, runner_up.next_hop),
+                );
+                let (_, reason) = best_path_cmp_orr_with_reason(winner, runner_up, cost_w, cost_r);
+                let detail = if reason == BestPathReason::OrrInteriorCost {
+                    orr_interior_cost_detail(cost_w, cost_r)
+                } else {
+                    best_path_reason_detail(reason, winner, runner_up)
+                };
+                explain.reasons.push(ExplainReason {
+                    code: reason.code(),
+                    message: format!("selected over runner-up: {detail}"),
+                });
+            }
+            winner
+        } else {
+            let Some(best) = loc_rib.get(&prefix) else {
+                explain.reasons.push(ExplainReason {
+                    code: "no_best_route",
+                    message: "no best route exists for this prefix".to_string(),
+                });
+                return explain;
+            };
+            best
         };
 
         explain.route_peer = Some(best.peer);
         explain.route_type = Some(route_type(best.origin_type));
 
+        // The two suppression checks below are no-ops for an ORR winner
+        // (its candidate set is pre-filtered by `orr_candidates`); they
+        // decide only for the Loc-RIB best of a plain peer.
         if best.peer == target_peer {
             explain.decision = ExplainDecision::Deny;
             explain.reasons.push(ExplainReason {
@@ -780,26 +893,17 @@ impl RibManager {
 
         // Collect all candidates across all Adj-RIB-In entries —
         // verbatim the multipath collector's per-target filter set.
-        let candidates = ribs
-            .values()
-            .flat_map(|rib| rib.iter_prefix(prefix))
-            .filter(|route| {
-                // Split horizon: exclude routes from the target peer
-                if route.peer == target_peer {
-                    return false;
-                }
-                // iBGP split-horizon / RFC 4456 reflection
-                if should_suppress_ibgp_inner(
-                    route,
-                    target_is_ebgp,
-                    target_is_rr_client,
-                    cluster_id,
-                    peer_is_rr_client,
-                ) {
-                    return false;
-                }
-                true
-            });
+        // Shared with the ORR explain path (`explain_single_best_prefix`)
+        // so explain ranks exactly what distribution ranks.
+        let candidates = orr_candidates(
+            ribs,
+            peer_is_rr_client,
+            prefix,
+            target_peer,
+            target_is_ebgp,
+            target_is_rr_client,
+            cluster_id,
+        );
 
         // Per-vantage best (RFC 9107): the vantage's interior cost to
         // each NEXT_HOP breaks ties between step 5 and step 5.5.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1190,8 +1190,19 @@ impl RibManager {
             return;
         };
 
+        // Same resolved-vantage gate as live distribution: an ORR peer
+        // whose vantage did not resolve falls back to the standard
+        // Loc-RIB-best explain, exactly like `flush_pending_distribution`.
+        let orr_ctx = self.peer_orr_vantage.get(&peer).and_then(|vantage| {
+            self.orr
+                .spf
+                .get(vantage)
+                .map(|spf| (&self.orr.topology, spf, *vantage))
+        });
+
         let explanation = Self::explain_single_best_prefix(
             &self.loc_rib,
+            &self.ribs,
             &self.peer_is_rr_client,
             prefix,
             peer,
@@ -1202,6 +1213,7 @@ impl RibManager {
             self.cluster_id,
             Some(sendable),
             self.export_policy_for(peer),
+            orr_ctx,
         );
 
         if reply.send(Some(explanation)).is_err() {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -1350,6 +1350,130 @@ async fn route_refresh_replays_vantage_best() {
     );
 }
 
+/// `ExplainAdvertisedRoute` for an ORR-bound peer surfaces the vantage,
+/// every candidate with its interior cost (ranked per-vantage best
+/// first, unknown-cost last per RFC 9107 §3.1), and the decisive
+/// interior-cost reason with the compared costs.
+#[tokio::test]
+async fn explain_advertised_route_reports_orr_vantage_and_costs() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let _out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    announce_divergent_bests(&tx).await;
+    // A third source whose next-hop resolves nowhere in the topology —
+    // unknown cost, must rank least preferred.
+    let src_unknown = Ipv4Addr::new(192, 0, 2, 3);
+    let nh_unknown = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 99));
+    announce_unicast(
+        &tx,
+        src_unknown,
+        vec![ibgp_route(orr_prefix(), src_unknown, nh_unknown)],
+    )
+    .await;
+
+    let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Advertise);
+    assert_eq!(
+        explain.next_hop,
+        Some(orr_nh_y()),
+        "vantage B's best exits via Y, not the Loc-RIB best via X"
+    );
+    assert_eq!(explain.orr_vantage, Some(vantage_at_node_b()));
+
+    let candidates = &explain.orr_candidates;
+    assert_eq!(candidates.len(), 3, "all surviving candidates listed");
+    assert_eq!(candidates[0].next_hop, orr_nh_y());
+    assert_eq!(candidates[0].cost, Some(1));
+    assert!(candidates[0].selected);
+    assert_eq!(candidates[1].next_hop, orr_nh_x());
+    assert_eq!(candidates[1].cost, Some(10));
+    assert!(!candidates[1].selected);
+    assert_eq!(
+        candidates[2].next_hop, nh_unknown,
+        "unknown-cost candidate ranks last (RFC 9107 §3.1)"
+    );
+    assert_eq!(candidates[2].cost, None);
+    assert!(!candidates[2].selected);
+
+    let orr_reason = explain
+        .reasons
+        .iter()
+        .find(|reason| reason.code == "orr_interior_cost")
+        .expect("interior-cost step decided the winner");
+    assert!(
+        orr_reason.message.contains("orr_cost 1 < 10"),
+        "compared vantage costs rendered: {}",
+        orr_reason.message
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Regression: a peer with NO ORR vantage gets the pre-ORR explain
+/// shape in the same scenario — Loc-RIB best, no vantage, no candidate
+/// list, no ORR reason codes.
+#[tokio::test]
+async fn explain_advertised_route_non_orr_peer_unchanged() {
+    let (tx, handle) = orr_rr_manager().await;
+    let plain_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+    let _out = orr_client_peer_up(&tx, plain_client, None).await;
+
+    announce_divergent_bests(&tx).await;
+
+    let explain = query_explain_advertised_route(&tx, plain_client, Prefix::V4(orr_prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Advertise);
+    assert_eq!(
+        explain.next_hop,
+        Some(orr_nh_x()),
+        "non-ORR peer explains the Loc-RIB best"
+    );
+    assert_eq!(explain.orr_vantage, None);
+    assert!(explain.orr_candidates.is_empty());
+    assert!(
+        explain
+            .reasons
+            .iter()
+            .all(|reason| !reason.code.starts_with("orr")),
+        "no ORR reasons on a non-ORR explain"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// An ORR peer whose vantage-visible candidate set is empty (the only
+/// path came from the peer itself) explains as no-candidate instead of
+/// leaking the split-horizon-suppressed route.
+#[tokio::test]
+async fn explain_advertised_route_orr_no_surviving_candidate() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_b_v4 = Ipv4Addr::new(10, 0, 0, 3);
+    let _out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+
+    // The only path is client B's own announcement.
+    announce_unicast(
+        &tx,
+        client_b_v4,
+        vec![ibgp_route(orr_prefix(), client_b_v4, orr_nh_x())],
+    )
+    .await;
+
+    let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
+    assert_eq!(
+        explain.decision,
+        crate::update::ExplainDecision::NoBestRoute
+    );
+    assert_eq!(explain.orr_vantage, Some(vantage_at_node_b()));
+    assert!(explain.orr_candidates.is_empty());
+    assert_eq!(explain.reasons[0].code, "no_orr_candidate");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Split horizon and RFC 4456 reflection suppression run BEFORE the ORR
 /// ranking: a cost-0 candidate the target must not receive can never
 /// win.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -139,6 +139,30 @@ pub struct ExplainAdvertisedRoute {
     pub reasons: Vec<ExplainReason>,
     /// Export modifications that would be applied.
     pub modifications: rustbgpd_policy::RouteModifications,
+    /// RFC 9107 ORR vantage the target peer is bound to. `None` when
+    /// the peer has no *resolved* vantage — non-ORR explains are
+    /// byte-for-byte the pre-ORR shape.
+    pub orr_vantage: Option<IpAddr>,
+    /// Per-vantage candidate ranking behind an ORR explain, best
+    /// first — the same candidate set and order distribution would
+    /// use. Empty for non-ORR explains.
+    pub orr_candidates: Vec<OrrExplainCandidate>,
+}
+
+/// One candidate in an ORR (RFC 9107) advertised-route explanation.
+#[derive(Debug, Clone)]
+pub struct OrrExplainCandidate {
+    /// Adj-RIB-In source peer of this candidate path.
+    pub peer: IpAddr,
+    /// Add-Path identifier of the candidate in its Adj-RIB-In.
+    pub path_id: u32,
+    /// Candidate's `NEXT_HOP` — the input to the vantage cost lookup.
+    pub next_hop: IpAddr,
+    /// Vantage interior (SPF) cost to `next_hop`. `None` = unknown /
+    /// unreachable, ranked least preferred (RFC 9107 §3.1).
+    pub cost: Option<u64>,
+    /// True for the per-vantage winner (first in ORR best-path order).
+    pub selected: bool,
 }
 
 /// Final decision for an advertised-route explanation.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1099,6 +1099,21 @@ message ExplainModifications {
   optional uint32 as_path_prepend_count = 11;
 }
 
+// One candidate path in an RFC 9107 ORR advertised-route explanation.
+message OrrExplainCandidate {
+  // Adj-RIB-In source peer of this candidate path.
+  string peer_address = 1;
+  // Add-Path identifier of the candidate in its Adj-RIB-In.
+  uint32 path_id = 2;
+  // Candidate's NEXT_HOP - the input to the vantage cost lookup.
+  string next_hop = 3;
+  // Vantage interior (SPF) cost to next_hop. Absent = unknown /
+  // unreachable, ranked least preferred (RFC 9107 section 3.1).
+  optional uint64 cost = 4;
+  // True for the per-vantage winner (first in ORR best-path order).
+  bool selected = 5;
+}
+
 message ExplainAdvertisedRouteResponse {
   ExplainDecision decision = 1;
   string peer_address = 2;
@@ -1110,6 +1125,16 @@ message ExplainAdvertisedRouteResponse {
   string route_type = 8;
   repeated ExplainReason reasons = 9;
   ExplainModifications modifications = 10;
+  // RFC 9107 ORR: the vantage the target peer is bound to. Empty when
+  // the peer has no resolved ORR vantage - non-ORR explain responses
+  // are unchanged by these fields.
+  string orr_vantage = 11;
+  // Per-vantage candidate ranking behind an ORR explain, best first -
+  // the same candidate set and order distribution would use. The
+  // decisive step for the winner is reported through reasons (code
+  // orr_interior_cost when the vantage cost decided, with the compared
+  // costs in the message). Empty for non-ORR explains.
+  repeated OrrExplainCandidate orr_candidates = 12;
 }
 
 message ExplainBestPathRequest {


### PR DESCRIPTION
The RR-composition queue's operator gem: `rbgp explain <peer> <prefix>` now answers **"why did this ORR client get this path"** with the full per-vantage breakdown — every candidate with its SPF cost (`cost=unreachable` for RFC 9107 least-preferred), the vantage, and the decisive reason (`orr_interior_cost: orr_cost 1 < 10`). No vendor router exposes this view.

- `best_path_cmp_orr_with_reason` is built **by composition** over the existing reason ladder (no third hand-maintained chain), drift-guarded against `best_path_cmp_orr` across cost combinations.
- Explain ranks exactly what distribution ranks: the candidate collection + suppression filter is a pure-relocation shared helper out of `distribute_orr_best_prefix` (behavior unchanged, full ORR test matrix untouched).
- Additive proto fields only (no new RPC); non-ORR explain responses are byte-identical.

9 new tests across best_path/manager/API/CLI. Workspace green.