### PR TITLE
feat(rib): extend per-vantage ORR best selection to VPNv4/VPNv6 reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   plus SPF/topology telemetry. Zero cost and zero behavior change when no
   vantage is configured (pinned by an output-equality guardrail test).
   Deferred (ADR-0095): backup vantages, inter-RR Add-Path (multi-cluster),
-  VPN-ORR, TE/multi-topology metrics. M76 proves live divergence: two
+  TE/multi-topology metrics. M76 proves live divergence: two
   GoBGP clients of one RR receive different best paths for the same
   prefix, flip on a topology metric change, and collapse to the identical
   standard best when the topology is withdrawn. **No other open-source
   BGP daemon ships ORR.**
+
+- **VPN-ORR: per-vantage best selection for VPNv4/VPNv6 reflection.**
+  ORR now composes with the SAFI-128 route reflector (the ADR-0095
+  deferral, un-deferred): an ORR client's VPN routes are ranked with its
+  vantage's interior cost to each candidate's next-hop, exactly like
+  unicast — same candidate filtering (split horizon + RFC 4456
+  suppression before ranking), same interior-cost slot in the tiebreak
+  chain, same unknown-cost-least-preferred and unresolved-vantage
+  fallback semantics, live across receive, initial dump, dirty resync,
+  route-refresh replay, and topology-driven restage. The RFC 4684
+  RT-Constrain gate applies to the vantage winner's Route Targets (the
+  route actually advertised), not the Loc-RIB best's. Non-ORR peers are
+  byte-identical to before. (M76 pins the unicast ORR wire behavior;
+  VPN-ORR is the same engine — a VPN-ORR interop receipt can join a
+  future M-job if demanded.)
 
 - **RT-Constrain (RFC 4684, AFI 1 / SAFI 132) — constrained VPN route
   distribution.** The scalability companion to the VPNv4/v6 route reflector:

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -734,6 +734,34 @@ fn bgpls_originator_id(route: &BgpLsRibRoute) -> Option<std::net::Ipv4Addr> {
 }
 
 fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
+    vpn_cmp_chain(a, b, None)
+}
+
+/// Compare two VPN routes under RFC 9107 Optimal Route Reflection.
+///
+/// The standard [`vpn_tiebreak`] chain with one extra step between the
+/// eBGP/iBGP step and `CLUSTER_LIST` — the same slot as
+/// [`crate::best_path::best_path_cmp_orr`]: the configured vantage's
+/// interior (SPF) cost to each route's `NEXT_HOP`. Lower cost wins; a
+/// known cost beats an unknown one (RFC 9107 §3.1); equal or
+/// both-unknown falls through.
+pub(crate) fn vpn_tiebreak_orr(
+    a: &VpnRibRoute,
+    b: &VpnRibRoute,
+    cost_a: Option<u64>,
+    cost_b: Option<u64>,
+) -> Ordering {
+    vpn_cmp_chain(a, b, Some((cost_a, cost_b)))
+}
+
+/// The shared decision chain behind [`vpn_tiebreak`] (`orr_costs = None`,
+/// the Loc-RIB selection — byte-identical to the pre-ORR chain) and
+/// [`vpn_tiebreak_orr`] (`orr_costs = Some(..)`, per-vantage staging).
+fn vpn_cmp_chain(
+    a: &VpnRibRoute,
+    b: &VpnRibRoute,
+    orr_costs: Option<(Option<u64>, Option<u64>)>,
+) -> Ordering {
     let cmp = vpn_stale_rank(a).cmp(&vpn_stale_rank(b));
     if cmp != Ordering::Equal {
         return cmp;
@@ -764,6 +792,22 @@ fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
     let cmp = b.is_ebgp().cmp(&a.is_ebgp());
     if cmp != Ordering::Equal {
         return cmp;
+    }
+
+    // RFC 9107 ORR interior cost to NEXT_HOP — only when the caller
+    // supplies vantage costs (the Loc-RIB never does). Lower cost wins;
+    // Some beats None (unknown metric MUST be least preferred); equal
+    // or both-None falls through.
+    if let Some((cost_a, cost_b)) = orr_costs {
+        let cmp = match (cost_a, cost_b) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        };
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
     }
 
     let cmp = vpn_cluster_list_len(a).cmp(&vpn_cluster_list_len(b));
@@ -1122,6 +1166,91 @@ mod tests {
             !loc.recompute_vpn(key, empty.into_iter()),
             "removing an absent key returns false"
         );
+    }
+
+    /// Oracle: the public `vpn_tiebreak` chain is byte-identical to the
+    /// pre-ORR behavior — `vpn_tiebreak_orr` with equal or both-unknown
+    /// costs yields the same ordering across a matrix of pairs that
+    /// exercise every decision step.
+    #[test]
+    fn vpn_tiebreak_unchanged_without_orr() {
+        let nlri = vpn_nlri([10, 0, 3, 0], 24, 100);
+        let base = make_vpn_route(nlri.clone(), 1, 100);
+        let higher_lp = make_vpn_route(nlri.clone(), 2, 200);
+        let mut stale = make_vpn_route(nlri.clone(), 3, 100);
+        stale.is_stale = true;
+        let mut longer_path = make_vpn_route(nlri.clone(), 4, 100);
+        Arc::make_mut(&mut longer_path.attributes).push(PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001, 65002])],
+        }));
+        let mut clustered = make_vpn_route(nlri.clone(), 5, 100);
+        Arc::make_mut(&mut clustered.attributes).push(PathAttribute::ClusterList(vec![
+            Ipv4Addr::new(10, 255, 0, 1),
+            Ipv4Addr::new(10, 255, 0, 2),
+        ]));
+        let peer_tiebreak = make_vpn_route(nlri, 6, 100);
+        let routes = [
+            base,
+            higher_lp,
+            stale,
+            longer_path,
+            clustered,
+            peer_tiebreak,
+        ];
+
+        for a in &routes {
+            for b in &routes {
+                let plain = vpn_tiebreak(a, b);
+                assert_eq!(vpn_tiebreak_orr(a, b, None, None), plain);
+                assert_eq!(vpn_tiebreak_orr(a, b, Some(7), Some(7)), plain);
+            }
+        }
+    }
+
+    /// The ORR interior-cost step decides ONLY at its slot — below the
+    /// eBGP/iBGP step (`LOCAL_PREF` etc. still win first) and above
+    /// `CLUSTER_LIST` / peer-address (which it overrides on a tie).
+    #[test]
+    fn vpn_orr_cost_only_breaks_ties_below_ebgp_step() {
+        let nlri = vpn_nlri([10, 0, 4, 0], 24, 100);
+        // LOCAL_PREF outranks a better interior cost.
+        let preferred = make_vpn_route(nlri.clone(), 1, 200);
+        let closer = make_vpn_route(nlri.clone(), 2, 100);
+        assert_eq!(
+            vpn_tiebreak_orr(&preferred, &closer, Some(1000), Some(0)),
+            Ordering::Less,
+            "LOCAL_PREF wins before the interior-cost step"
+        );
+        // On a full upper-chain tie, the lower cost beats the lower peer
+        // address (route 1 would win the final tiebreak).
+        let a = make_vpn_route(nlri.clone(), 1, 100);
+        let b = make_vpn_route(nlri, 2, 100);
+        assert_eq!(
+            vpn_tiebreak_orr(&a, &b, Some(10), Some(5)),
+            Ordering::Greater
+        );
+        assert_eq!(vpn_tiebreak_orr(&a, &b, Some(5), Some(10)), Ordering::Less);
+        // Equal costs fall through to the peer-address tiebreak.
+        assert_eq!(vpn_tiebreak_orr(&a, &b, Some(5), Some(5)), Ordering::Less);
+    }
+
+    /// RFC 9107 §3.1: an unknown metric-to-next-hop MUST be least
+    /// preferred — a known cost beats None regardless of magnitude.
+    #[test]
+    fn vpn_orr_unknown_cost_least_preferred() {
+        let nlri = vpn_nlri([10, 0, 5, 0], 24, 100);
+        let a = make_vpn_route(nlri.clone(), 1, 100);
+        let b = make_vpn_route(nlri, 2, 100);
+        assert_eq!(
+            vpn_tiebreak_orr(&a, &b, Some(u64::MAX), None),
+            Ordering::Less
+        );
+        assert_eq!(
+            vpn_tiebreak_orr(&a, &b, None, Some(u64::MAX)),
+            Ordering::Greater
+        );
+        // Both unknown falls through (peer address decides).
+        assert_eq!(vpn_tiebreak_orr(&a, &b, None, None), Ordering::Less);
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -935,6 +935,7 @@ impl RibManager {
             if resync && !effective_l3vpn_keys.is_empty() {
                 Self::stage_vpn_routes(
                     loc_rib,
+                    &self.ribs,
                     rib_out,
                     &self.peer_is_rr_client,
                     &effective_l3vpn_keys,
@@ -946,6 +947,7 @@ impl RibManager {
                     cluster_id,
                     sendable.as_ref(),
                     rtc_filter.as_ref(),
+                    orr_ctx,
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -1,8 +1,33 @@
 use super::{
-    AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, NeighborPolicyStats,
-    PolicyChain, RibManager, RouteContext, Safi, gauge_val, record_export_policy_eval, route_type,
-    should_suppress_ibgp_inner, vpn_routes_equal, warn,
+    AdjRibIn, AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib,
+    NeighborPolicyStats, PolicyChain, RibManager, RouteContext, Safi, gauge_val,
+    record_export_policy_eval, route_type, should_suppress_ibgp_inner, vpn_routes_equal, warn,
 };
+use crate::loc_rib::vpn_tiebreak_orr;
+
+/// A unicast-shaped probe of a VPN route for the shared RFC 4456
+/// suppression helper: `should_suppress_ibgp_inner` only reads
+/// peer/origin identity, so the inner prefix stands in and the
+/// attributes stay empty (same shape the pre-ORR staging used).
+fn vpn_suppression_probe(route: &crate::route::VpnRibRoute) -> crate::route::Route {
+    crate::route::Route {
+        prefix: route.inner_prefix(),
+        next_hop: route.next_hop,
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: route.peer,
+        attributes: std::sync::Arc::new(vec![]),
+        received_at: route.received_at,
+        origin_type: route.origin_type,
+        peer_router_id: route.peer_router_id,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
 
 impl RibManager {
     /// Stage VPNv4/VPNv6 announces and withdrawals for a set of affected keys.
@@ -20,6 +45,7 @@ impl RibManager {
     )]
     pub(in crate::manager) fn stage_vpn_routes(
         loc_rib: &LocRib,
+        ribs: &HashMap<IpAddr, AdjRibIn>,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         keys: &HashSet<crate::route::VpnRibRouteKey>,
@@ -31,6 +57,7 @@ impl RibManager {
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
         rtc_filter: Option<&crate::manager::RtcMembership>,
+        orr_ctx: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -49,11 +76,50 @@ impl RibManager {
                 continue;
             }
 
-            let Some(best) = loc_rib.get_vpn(key) else {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
-                }
-                continue;
+            // Per-key best. An RFC 9107 ORR peer with a resolved vantage
+            // does NOT take the Loc-RIB best: the per-target candidate
+            // set (every Adj-RIB-In entry for the key that survives split
+            // horizon and RFC 4456 reflection — the unicast
+            // `orr_candidates` filter adapted to `VpnRibRoute`) is ranked
+            // with the vantage's interior cost to each candidate's
+            // next-hop. A plain peer keeps the Loc-RIB best, unchanged.
+            let best = if let Some((orr_topology, orr_spf)) = orr_ctx {
+                let winner = ribs
+                    .values()
+                    .filter_map(|rib| rib.get_vpn(key))
+                    .filter(|candidate| {
+                        candidate.peer != target_peer
+                            && !should_suppress_ibgp_inner(
+                                &vpn_suppression_probe(candidate),
+                                target_is_ebgp,
+                                target_is_rr_client,
+                                cluster_id,
+                                peer_is_rr_client,
+                            )
+                    })
+                    .min_by(|a, b| {
+                        vpn_tiebreak_orr(
+                            a,
+                            b,
+                            orr_spf.cost_to(orr_topology, a.next_hop),
+                            orr_spf.cost_to(orr_topology, b.next_hop),
+                        )
+                    });
+                let Some(winner) = winner else {
+                    if rib_out.get_vpn(key).is_some() {
+                        vpn_withdraw.push(key.clone());
+                    }
+                    continue;
+                };
+                winner
+            } else {
+                let Some(best) = loc_rib.get_vpn(key) else {
+                    if rib_out.get_vpn(key).is_some() {
+                        vpn_withdraw.push(key.clone());
+                    }
+                    continue;
+                };
+                best
             };
 
             // RFC 4684 outbound gate: a peer that negotiated RT-Constrain
@@ -61,7 +127,10 @@ impl RibManager {
             // advertised membership (`None` = SAFI 132 not negotiated ⇒
             // unfiltered). Membership is per-peer, so the one gate covers
             // both VPNv4 and VPNv6 keys. Miss ⇒ withdraw-if-present,
-            // exactly the sendable-family gate shape above.
+            // exactly the sendable-family gate shape above. For an ORR
+            // peer the gate applies to the vantage WINNER's extended
+            // communities — the route actually being advertised — not the
+            // Loc-RIB best's.
             if let Some(membership) = rtc_filter
                 && !membership.matches_any(best.extended_communities())
             {
@@ -71,6 +140,9 @@ impl RibManager {
                 continue;
             }
 
+            // The two suppression checks below are no-ops for an ORR
+            // winner (its candidate set is pre-filtered above); they
+            // decide only for the Loc-RIB best of a plain peer.
             if best.peer == target_peer {
                 if rib_out.get_vpn(key).is_some() {
                     vpn_withdraw.push(key.clone());
@@ -78,25 +150,8 @@ impl RibManager {
                 continue;
             }
 
-            let probe = crate::route::Route {
-                prefix: best.inner_prefix(),
-                next_hop: best.next_hop,
-                link_local_next_hop: None,
-                next_hop_scope: None,
-                peer: best.peer,
-                attributes: std::sync::Arc::new(vec![]),
-                received_at: best.received_at,
-                origin_type: best.origin_type,
-                peer_router_id: best.peer_router_id,
-                is_stale: false,
-                is_llgr_stale: false,
-                path_id: 0,
-                validation_state: rustbgpd_wire::RpkiValidation::NotFound,
-                aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-                aspa_context: rustbgpd_wire::AspaValidationContext::default(),
-            };
             if should_suppress_ibgp_inner(
-                &probe,
+                &vpn_suppression_probe(best),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -172,6 +227,10 @@ impl RibManager {
     /// The selected route is reflected as received: Route Distinguisher,
     /// MPLS label stack, and next-hop pass through unchanged (ADR-0077 §6),
     /// with ordinary BGP attribute handling applied by transport.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "VPN recompute keeps loc-rib selection and per-peer ORR staging together"
+    )]
     pub(in crate::manager) fn recompute_and_distribute_vpn(
         &mut self,
         affected: &HashSet<crate::route::VpnRibRouteKey>,
@@ -190,17 +249,42 @@ impl RibManager {
             }
         }
 
-        if changed_keys.is_empty() {
+        // An RFC 9107 ORR peer selects from the per-target candidate set,
+        // not the Loc-RIB best — a candidate change that leaves the
+        // Loc-RIB best untouched can still flip a vantage best, so
+        // ORR-bound peers stage every affected key (the VPN parallel of
+        // the unicast `all_affected` inclusion in `distribute_changes`).
+        let any_resolved_orr_peer = self.outbound_peers.keys().any(|peer| {
+            self.peer_orr_vantage
+                .get(peer)
+                .is_some_and(|vantage| self.orr.spf.contains_key(vantage))
+        });
+        if changed_keys.is_empty() && !any_resolved_orr_peer {
             return;
         }
 
-        self.metrics
-            .set_loc_rib_prefixes("vpn", gauge_val(self.loc_rib.vpn_len()));
+        if !changed_keys.is_empty() {
+            self.metrics
+                .set_loc_rib_prefixes("vpn", gauge_val(self.loc_rib.vpn_len()));
+        }
 
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
+            // A peer bound to a vantage that resolved this pass takes the
+            // per-vantage best; an unresolved vantage silently falls back
+            // to the standard Loc-RIB best (same shape as unicast).
+            let orr_ctx = self
+                .peer_orr_vantage
+                .get(&peer)
+                .and_then(|vantage| self.orr.spf.get(vantage))
+                .map(|spf| (&self.orr.topology, spf));
+            let staged_keys = if orr_ctx.is_some() {
+                affected
+            } else {
+                &changed_keys
+            };
             let sendable = self.peer_sendable_families.get(&peer).cloned();
-            if !changed_keys.iter().any(|key| {
+            if !staged_keys.iter().any(|key| {
                 sendable
                     .as_ref()
                     .is_some_and(|families| families.contains(&key.afi_safi()))
@@ -228,9 +312,10 @@ impl RibManager {
             let mut vpn_withdraw = Vec::new();
             Self::stage_vpn_routes(
                 &self.loc_rib,
+                &self.ribs,
                 rib_out,
                 &self.peer_is_rr_client,
-                &changed_keys,
+                staged_keys,
                 peer,
                 target_peer_asn,
                 target_peer_group,
@@ -239,6 +324,7 @@ impl RibManager {
                 self.cluster_id,
                 sendable.as_ref(),
                 rtc_filter.as_ref(),
+                orr_ctx,
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1005,6 +1005,7 @@ impl RibManager {
         if !all_l3vpn_keys.is_empty() {
             Self::stage_vpn_routes(
                 loc_rib,
+                &self.ribs,
                 &initial_view,
                 &self.peer_is_rr_client,
                 &all_l3vpn_keys,
@@ -1016,6 +1017,7 @@ impl RibManager {
                 cluster_id,
                 sendable.as_ref(),
                 rtc_filter.as_ref(),
+                orr_ctx,
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -660,6 +660,7 @@ impl RibManager {
             if !vpn_keys.is_empty() {
                 Self::stage_vpn_routes(
                     loc_rib,
+                    &self.ribs,
                     &refresh_view,
                     &self.peer_is_rr_client,
                     &vpn_keys,
@@ -671,6 +672,7 @@ impl RibManager {
                     cluster_id,
                     sendable.as_ref(),
                     rtc_filter.as_ref(),
+                    orr_ctx,
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -21068,3 +21068,544 @@ fn vpn_peer_down_during_refresh_clears_stale_state() {
         "peer-down must drop the peer's refresh-stale counters"
     );
 }
+
+// --- RFC 9107 VPN-ORR: per-vantage best selection for SAFI 128 ---
+
+/// Sendable families for a VPNv6-only test peer.
+fn vpn6_sendable() -> Vec<(Afi, Safi)> {
+    vec![(Afi::Ipv6, Safi::MplsVpn)]
+}
+
+/// A `VPNv4` route from `peer` with an explicit next-hop (identical
+/// attributes across sources so only the ORR interior-cost step and the
+/// final peer-address tiebreak can decide).
+fn vpn_route_at(peer: Ipv4Addr, next_hop: IpAddr, prefix_octet: u8) -> VpnRibRoute {
+    let mut route = make_vpn_rib_route(peer, prefix_octet, 100, 100);
+    route.next_hop = next_hop;
+    route
+}
+
+/// A `VPNv6` route from `peer` with an explicit next-hop.
+fn vpn6_route_at(peer: Ipv4Addr, next_hop: IpAddr, segment: u16) -> VpnRibRoute {
+    let mut route = make_vpn6_rib_route_with_rts(peer, segment, vec![]);
+    route.next_hop = next_hop;
+    route
+}
+
+/// Bring up an iBGP VPN-capable peer with the given ORR vantage and
+/// RR-client flag, draining the initial-table `EoR`.
+async fn vpn_orr_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    vantage: Option<IpAddr>,
+    sendable_families: Vec<(Afi, Safi)>,
+    route_reflector_client: bool,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families,
+        is_ebgp: false,
+        route_reflector_client,
+        orr_vantage: vantage,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    out_rx
+}
+
+/// Announce VPN routes from `peer` through the normal receive path.
+async fn announce_vpn(tx: &mpsc::Sender<RibUpdate>, peer: Ipv4Addr, announced: Vec<VpnRibRoute>) {
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(peer),
+        announced,
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+}
+
+/// The VPN divergence scenario: the SAME RD+prefix key from two iBGP
+/// PEs with next-hops at node X and node Y, followed by a sync point.
+/// Returns the contested key.
+async fn announce_divergent_vpn_bests(
+    tx: &mpsc::Sender<RibUpdate>,
+    prefix_octet: u8,
+) -> crate::route::VpnRibRouteKey {
+    let route_x = vpn_route_at(ORR_SRC_X, orr_nh_x(), prefix_octet);
+    let key = route_x.key();
+    announce_vpn(tx, ORR_SRC_X, vec![route_x]).await;
+    announce_vpn(
+        tx,
+        ORR_SRC_Y,
+        vec![vpn_route_at(ORR_SRC_Y, orr_nh_y(), prefix_octet)],
+    )
+    .await;
+    let _ = query_vpn_routes(tx).await;
+    key
+}
+
+/// Drain every queued outbound update and fold to the final advertised
+/// VPN state: key → the last announced route.
+fn drain_final_vpn(
+    rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+) -> HashMap<crate::route::VpnRibRouteKey, VpnRibRoute> {
+    let mut state = HashMap::new();
+    while let Ok(update) = rx.try_recv() {
+        for route in &update.vpn_announce {
+            state.insert(route.key(), route.clone());
+        }
+        for key in &update.vpn_withdraw {
+            state.remove(key);
+        }
+    }
+    state
+}
+
+/// The composed differentiators: two RR clients bound to different
+/// vantages receive DIVERGENT VPN bests for the same RD+prefix — each
+/// exits via the PE closest to its own IGP location, not the RR's.
+#[tokio::test]
+async fn two_vpn_clients_different_vantages_receive_divergent_bests() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_a = vpn_orr_peer_up(
+        &tx,
+        client_a,
+        Some(vantage_at_node_a()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+    let mut out_b = vpn_orr_peer_up(
+        &tx,
+        client_b,
+        Some(vantage_at_node_b()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+
+    let key = announce_divergent_vpn_bests(&tx, 80).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_a = drain_final_vpn(&mut out_a);
+    let final_b = drain_final_vpn(&mut out_b);
+    assert_eq!(
+        final_a.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "client at A exits via X (cost 1 < 10)"
+    );
+    assert_eq!(
+        final_b.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "client at B exits via Y (cost 1 < 10)"
+    );
+}
+
+/// `VPNv6` divergence — the candidate handling is family-agnostic, so
+/// the same scenario over SAFI 128 IPv6 keys diverges identically.
+#[tokio::test]
+async fn two_vpn6_clients_different_vantages_receive_divergent_bests() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_a = vpn_orr_peer_up(
+        &tx,
+        client_a,
+        Some(vantage_at_node_a()),
+        vpn6_sendable(),
+        true,
+    )
+    .await;
+    let mut out_b = vpn_orr_peer_up(
+        &tx,
+        client_b,
+        Some(vantage_at_node_b()),
+        vpn6_sendable(),
+        true,
+    )
+    .await;
+
+    let route_x = vpn6_route_at(ORR_SRC_X, orr_nh_x(), 0x60);
+    let key = route_x.key();
+    announce_vpn(&tx, ORR_SRC_X, vec![route_x]).await;
+    announce_vpn(
+        &tx,
+        ORR_SRC_Y,
+        vec![vpn6_route_at(ORR_SRC_Y, orr_nh_y(), 0x60)],
+    )
+    .await;
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_a = drain_final_vpn(&mut out_a);
+    let final_b = drain_final_vpn(&mut out_b);
+    assert_eq!(final_a.get(&key).map(|r| r.next_hop), Some(orr_nh_x()));
+    assert_eq!(final_b.get(&key).map(|r| r.next_hop), Some(orr_nh_y()));
+}
+
+/// A topology metric flip re-stages ONLY the peers bound to the vantage
+/// whose SPF surface changed: the affected client's VPN best flips,
+/// while the other vantage's client and a non-ORR client see zero
+/// messages.
+#[tokio::test]
+async fn vpn_orr_topology_metric_flip_moves_only_affected_client() {
+    use crate::orr::fixtures::{A, X, link_route, v4_interface, v4_neighbor};
+
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_c = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut out_a = vpn_orr_peer_up(
+        &tx,
+        client_a,
+        Some(vantage_at_node_a()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+    let mut out_b = vpn_orr_peer_up(
+        &tx,
+        client_b,
+        Some(vantage_at_node_b()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+    let mut out_c = vpn_orr_peer_up(&tx, client_c, None, vpn_sendable(), true).await;
+
+    let key = announce_divergent_vpn_bests(&tx, 81).await;
+    // Steady state reached — empty every channel before the flip.
+    let _ = drain_final_vpn(&mut out_a);
+    let _ = drain_final_vpn(&mut out_b);
+    let _ = drain_final_vpn(&mut out_c);
+
+    // Flip A→X to metric 100: from A the SPF now prefers Y (10 < 100).
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(ORR_FEED),
+        announced: vec![link_route(
+            ORR_FEED,
+            A,
+            X,
+            Some(100),
+            &[
+                v4_interface(Ipv4Addr::new(10, 0, A, X)),
+                v4_neighbor(Ipv4Addr::new(10, 0, X, A)),
+            ],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_a = drain_final_vpn(&mut out_a);
+    assert_eq!(
+        final_a.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "affected client's VPN best flips to Y (cost 10 < 100)"
+    );
+    assert!(
+        out_b.try_recv().is_err(),
+        "unaffected vantage's client must see zero messages"
+    );
+    assert!(
+        out_c.try_recv().is_err(),
+        "non-ORR client must see zero messages"
+    );
+}
+
+/// A vantage that does not resolve to a topology node silently falls
+/// back to the standard Loc-RIB best: the ORR client's VPN
+/// advertisement is identical to a vantage-less peer's.
+#[tokio::test]
+async fn vpn_orr_unresolved_vantage_falls_back_to_loc_rib_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let orr_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let plain_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let outside = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+    let mut out_orr = vpn_orr_peer_up(&tx, orr_client, Some(outside), vpn_sendable(), true).await;
+    let mut out_plain = vpn_orr_peer_up(&tx, plain_client, None, vpn_sendable(), true).await;
+
+    let key = announce_divergent_vpn_bests(&tx, 82).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_orr = drain_final_vpn(&mut out_orr);
+    let final_plain = drain_final_vpn(&mut out_plain);
+    let unresolved = final_orr
+        .get(&key)
+        .expect("unresolved-vantage client is advertised the key");
+    let plain = final_plain
+        .get(&key)
+        .expect("vantage-less client is advertised the key");
+    assert_eq!(unresolved.next_hop, orr_nh_x(), "the Loc-RIB best");
+    assert_eq!(unresolved.next_hop, plain.next_hop);
+    assert_eq!(unresolved.attributes, plain.attributes);
+    assert_eq!(unresolved.peer, plain.peer);
+    assert_eq!(unresolved.nlri, plain.nlri);
+}
+
+/// Regression guard: a VPN peer with NO ORR vantage keeps the exact
+/// pre-ORR behavior in the divergence scenario — the Loc-RIB best, with
+/// no re-advertisement when the losing candidate arrives.
+#[tokio::test]
+async fn non_orr_vpn_peer_unchanged() {
+    let (tx, handle) = orr_rr_manager().await;
+    let plain_client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+    let mut out = vpn_orr_peer_up(&tx, plain_client, None, vpn_sendable(), true).await;
+
+    let key = announce_divergent_vpn_bests(&tx, 83).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let mut announces = 0;
+    let mut last = None;
+    while let Ok(update) = out.try_recv() {
+        for route in &update.vpn_announce {
+            announces += 1;
+            last = Some(route.clone());
+        }
+        assert!(update.vpn_withdraw.is_empty());
+    }
+    assert_eq!(
+        announces, 1,
+        "the second candidate must not re-stage a non-ORR peer"
+    );
+    let last = last.unwrap();
+    assert_eq!(last.key(), key);
+    assert_eq!(last.next_hop, orr_nh_x(), "the Loc-RIB best");
+}
+
+/// RFC 4684 composes with VPN-ORR on the WINNER: the RT-Constrain
+/// membership gate applies to the vantage winner's Route Targets — the
+/// route actually being advertised — not the Loc-RIB best's.
+#[tokio::test]
+async fn vpn_orr_rtc_filter_applies_to_vantage_winner() {
+    let (tx, handle) = orr_rr_manager().await;
+
+    // Same key from two PEs: the Loc-RIB best (X, lower peer address)
+    // carries RT 100; the vantage-B winner (Y, cost 1 < 10) carries
+    // RT 200.
+    let mut route_x = make_vpn_rib_route_with_rts(ORR_SRC_X, 84, vec![rt(100)]);
+    route_x.next_hop = orr_nh_x();
+    let key = route_x.key();
+    let mut route_y = make_vpn_rib_route_with_rts(ORR_SRC_Y, 84, vec![rt(200)]);
+    route_y.next_hop = orr_nh_y();
+    announce_vpn(&tx, ORR_SRC_X, vec![route_x]).await;
+    announce_vpn(&tx, ORR_SRC_Y, vec![route_y]).await;
+    let _ = query_vpn_routes(&tx).await;
+
+    // An iBGP RR client at vantage B that negotiated VPNv4 + RTC.
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv4, Safi::RtConstrain)],
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    assert!(
+        drain_final_vpn(&mut out_rx).is_empty(),
+        "strict RFC 4684: empty membership withholds every VPN route"
+    );
+
+    // Interest in the LOC-RIB BEST's RT only: the vantage winner (RT
+    // 200) misses the gate, so nothing may be advertised — gating on
+    // the Loc-RIB best's RT 100 would wrongly announce here.
+    send_rtc_interest(&tx, Ipv4Addr::new(10, 0, 0, 3), &[100]).await;
+    let _ = query_vpn_routes(&tx).await;
+    assert!(
+        !drain_final_vpn(&mut out_rx).contains_key(&key),
+        "the gate must apply to the vantage winner's RTs, not the Loc-RIB best's"
+    );
+
+    // Interest in the WINNER's RT: the vantage best flows.
+    send_rtc_interest(&tx, Ipv4Addr::new(10, 0, 0, 3), &[200]).await;
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+    let advertised = drain_final_vpn(&mut out_rx);
+    assert_eq!(
+        advertised.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "matching the winner's RT admits the vantage best"
+    );
+}
+
+/// Split horizon and RFC 4456 reflection suppression run BEFORE the ORR
+/// ranking: a cost-0 VPN candidate the target must not receive can
+/// never win.
+#[tokio::test]
+async fn vpn_orr_split_horizon_and_rr_suppression_before_ranking() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_b_v4 = Ipv4Addr::new(10, 0, 0, 3);
+    let mut out_b = vpn_orr_peer_up(
+        &tx,
+        client_b,
+        Some(vantage_at_node_b()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+    // A non-client iBGP peer bound to the same vantage (the RIB layer
+    // trusts PeerUp; the suppression seam must hold regardless).
+    let peer_d = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut out_d = vpn_orr_peer_up(
+        &tx,
+        peer_d,
+        Some(vantage_at_node_b()),
+        vpn_sendable(),
+        false,
+    )
+    .await;
+
+    // key1 — split-horizon probe: client B's OWN route has interior
+    // cost 0 (next-hop at its vantage node); a non-client source offers
+    // cost 10 via NH-X.
+    let own = vpn_route_at(client_b_v4, vantage_at_node_b(), 85);
+    let key1 = own.key();
+    announce_vpn(&tx, client_b_v4, vec![own]).await;
+    announce_vpn(
+        &tx,
+        ORR_SRC_X,
+        vec![vpn_route_at(ORR_SRC_X, orr_nh_x(), 85)],
+    )
+    .await;
+
+    // key2 — RR-suppression probe: the cost-0 candidate comes from a
+    // NON-client (never reflectable to the non-client target D); client
+    // B offers cost 10 via NH-X (client routes reflect to everyone).
+    let non_client_route = vpn_route_at(ORR_SRC_Y, vantage_at_node_b(), 86);
+    let key2 = non_client_route.key();
+    announce_vpn(&tx, ORR_SRC_Y, vec![non_client_route]).await;
+    announce_vpn(
+        &tx,
+        client_b_v4,
+        vec![vpn_route_at(client_b_v4, orr_nh_x(), 86)],
+    )
+    .await;
+
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_vpn(&mut out_b);
+    assert_eq!(
+        final_b.get(&key1).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "the target's own cost-0 route is split-horizoned before ranking"
+    );
+    let final_d = drain_final_vpn(&mut out_d);
+    assert_eq!(
+        final_d.get(&key2).map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "the cost-0 non-client candidate is RR-suppressed before ranking"
+    );
+}
+
+/// A client that establishes AFTER the VPN routes and topology are in
+/// place gets its per-vantage best in the initial table dump.
+#[tokio::test]
+async fn vpn_orr_initial_dump_gets_vantage_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let key = announce_divergent_vpn_bests(&tx, 87).await;
+
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (out_tx, mut out_b) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: client_b,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_vpn(&mut out_b);
+    assert_eq!(
+        final_b.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "initial dump carries the vantage best, not the Loc-RIB best"
+    );
+}
+
+/// A ROUTE-REFRESH replay re-derives the same per-vantage VPN best the
+/// live distribution path sent.
+#[tokio::test]
+async fn vpn_orr_route_refresh_replays_vantage_best() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut out_b = vpn_orr_peer_up(
+        &tx,
+        client_b,
+        Some(vantage_at_node_b()),
+        vpn_sendable(),
+        true,
+    )
+    .await;
+
+    let key = announce_divergent_vpn_bests(&tx, 88).await;
+    let _ = drain_final_vpn(&mut out_b);
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: client_b,
+        session_id: 0,
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let final_b = drain_final_vpn(&mut out_b);
+    assert_eq!(
+        final_b.get(&key).map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "the replay is the vantage best"
+    );
+}

--- a/docs/adr/0095-optimal-route-reflection.md
+++ b/docs/adr/0095-optimal-route-reflection.md
@@ -93,8 +93,11 @@ BIRD/GoBGP/OpenBGPd lack it); only commercial routers do.
   vantage redundancy.
 - **Inter-RR Add-Path** (required by RFC 9107 only for multi-cluster
   deployments) — when a second-RR topology lands.
-- **VPN-ORR** (vantage ranking for SAFI 128) — natural composition,
-  queued as a follow-on candidate.
+- **VPN-ORR** (vantage ranking for SAFI 128) — **shipped**: an ORR
+  client's VPNv4/VPNv6 routes are ranked with its vantage's interior
+  cost to each candidate's next-hop, exactly like unicast
+  (`vpn_tiebreak_orr`, same slot in the chain; the RFC 4684 RTC gate
+  applies to the vantage winner).
 - **TE / Multi-Topology metrics** — operator demand.
 - **RFC 9107 §3.2 per-policy multiple Decision Processes** — policy
   divergence below step (e) is out of scope until a concrete case appears.


### PR DESCRIPTION
**VPN-ORR** — the ADR-0095 deferral, un-deferred: an ORR client's L3VPN routes are now ranked with *its* vantage's interior cost, composing the two differentiators (RFC 9107 ORR + the VPNv4/v6 RR). Same-engine extension: `vpn_tiebreak` factored into the composition pattern (`None` delegation byte-identical, oracle-pinned), the interior-cost step at the same slot, per-target candidate collection with identical split-horizon/suppression semantics, and the RFC 4684 RTC gate applying to the **vantage winner's** Route Targets (pinned by test).

**Real gap found & red-checked during implementation**: the VPN receive path staged only loc-rib-best changes — a candidate change invisible to the loc-rib best would never reach an ORR peer whose vantage prefers it. ORR-resolved peers now stage all affected keys (the unicast ORR parallel); reverting just that fix fails the divergence test.

12 new tests incl. VPNv4+VPNv6 divergence, metric-flip-moves-only-affected, RTC-on-winner, fallback, initial-dump/refresh-replay. Full VPN/ORR/RTC matrices untouched; 4552 tests green. M76 pins the shared engine's wire behavior; a VPN-ORR interop receipt can join a future M-job if demanded.