### PR TITLE
feat(bgp): negotiate, receive, and send Add-Path for VPNv4/VPNv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Add-Path (RFC 7911) for VPNv4/VPNv6 (SAFI 128).** The family-blind
+  `add_path` knobs now cover the VPN families: negotiation advertises
+  Add-Path for configured `l3vpn_ipv4_unicast` / `l3vpn_ipv6_unicast`
+  alongside unicast, the wire codec encodes/decodes the 4-octet Path
+  Identifier prepended to each SAFI-128 NLRI (announce mode and the RFC
+  8277 §2.4 withdraw-compatibility mode alike), received path IDs are
+  distinct Adj-RIB-In entries withdrawn independently per path, and an
+  Add-Path-send peer receives up to `add_path_send_max` candidates per
+  RD+prefix with outbound path IDs `1..=N` ranked by the VPN best-path
+  chain — with the vantage-cost comparator for an RFC 9107 ORR client
+  (Add-Path between RRs is what RFC 9107 requires for multi-cluster ORR,
+  and VPN RR redundancy generally). Best-path selection and single-best
+  reflection collapse per RD+prefix identity, so non-Add-Path peers are
+  unchanged. BGP-LS and RT-Constrain keep their Add-Path rejections (no
+  demand; RTC membership Add-Path semantics are undefined-ish).
+  `ListVpnRoutes`/`rbgp rib vpn` surface the winning received path ID.
+
 - **GR/LLGR stale preservation for the RR families (VPNv4/v6, BGP-LS,
   RT-Constrain).** A restarting peer's SAFI-128/71/72/132 routes are now
   preserved as stale through the graceful-restart window (RFC 4724 helper

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -228,8 +228,8 @@ resolved.
   RFC 9552; local topology production remains deferred), and VPNv4/VPNv6
   (AFI 1/2, SAFI 128) route-reflection (RFC 4364 / RFC 4659 —
   RR/controller-feed only: RD, MPLS label stack, next-hop, and Route
-  Targets are preserved verbatim; no VRF import, no MPLS FIB install,
-  no Add-Path), and
+  Targets are preserved verbatim; no VRF import, no MPLS FIB install;
+  Add-Path per RFC 7911 is supported for SAFI 128), and
   RT-Constrain (AFI 1, SAFI 132) per RFC 4684 (strict per-peer VPN
   reflection filtering with self-originated default membership; §3.2(ii)
   non-client attribute-swap, the §6 60-second EoR delay, eBGP RTC

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -207,8 +207,12 @@ impl PeerConfig {
     /// Build Add-Path capability entries for our outgoing OPEN message.
     ///
     /// Advertises the appropriate mode (Receive, Send, or Both) for all
-    /// configured unicast families. Add-Path is not currently implemented
-    /// for non-unicast SAFIs such as `FlowSpec`, so those families are
+    /// configured unicast and VPNv4/VPNv6 (SAFI 128) families. The single
+    /// `add_path_receive`/`add_path_send` knob pair is family-blind: it
+    /// covers every family this filter admits. Add-Path is not implemented
+    /// for the other SAFIs — `FlowSpec`/EVPN (no demand), BGP-LS (no demand
+    /// for multi-path topology feeds), and RT-Constrain (Add-Path semantics
+    /// for membership NLRI are undefined-ish) — so those families are
     /// omitted from the advertised capability even when configured on the
     /// session. The RIB applies the configured `send_max` numerically per
     /// peer, but only to families that actually negotiate Add-Path Send/Both.
@@ -225,7 +229,7 @@ impl PeerConfig {
         };
         self.effective_families()
             .into_iter()
-            .filter(|(_, safi)| *safi == Safi::Unicast)
+            .filter(|(_, safi)| matches!(safi, Safi::Unicast | Safi::MplsVpn))
             .map(|(afi, safi)| AddPathFamily {
                 afi,
                 safi,
@@ -552,6 +556,33 @@ mod tests {
         assert_eq!(caps.len(), 2);
         assert_eq!(caps[0].afi, Afi::Ipv4);
         assert_eq!(caps[1].afi, Afi::Ipv6);
+    }
+
+    #[test]
+    fn add_path_capabilities_include_vpn_families() {
+        // The family-blind add_path knobs cover SAFI 128 (RFC 9107 needs
+        // Add-Path between RRs); BGP-LS and RT-Constrain stay excluded.
+        let mut cfg = test_config();
+        cfg.add_path_receive = true;
+        cfg.add_path_send = true;
+        cfg.families = vec![
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv6, Safi::MplsVpn),
+            (Afi::BgpLs, Safi::BgpLs),
+            (Afi::Ipv4, Safi::RtConstrain),
+        ];
+        let caps = cfg.add_path_capabilities();
+        let families: Vec<(Afi, Safi)> = caps.iter().map(|c| (c.afi, c.safi)).collect();
+        assert_eq!(
+            families,
+            vec![
+                (Afi::Ipv4, Safi::Unicast),
+                (Afi::Ipv4, Safi::MplsVpn),
+                (Afi::Ipv6, Safi::MplsVpn),
+            ]
+        );
+        assert!(caps.iter().all(|c| c.send_receive == AddPathMode::Both));
     }
 
     #[test]

--- a/crates/fsm/src/negotiation.rs
+++ b/crates/fsm/src/negotiation.rs
@@ -1125,6 +1125,29 @@ mod tests {
     }
 
     #[test]
+    fn negotiate_add_path_vpn_families_both_directions() {
+        // VPNv4/VPNv6 (SAFI 128) negotiate Add-Path exactly like unicast
+        // (RFC 9107 requires it between RRs for multi-cluster ORR).
+        let ours = vec![
+            AddPathFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::MplsVpn,
+                send_receive: AddPathMode::Both,
+            },
+            AddPathFamily {
+                afi: Afi::Ipv6,
+                safi: Safi::MplsVpn,
+                send_receive: AddPathMode::Both,
+            },
+        ];
+        let peers = ours.clone();
+        let result = negotiate_add_path(&ours, &peers);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[&(Afi::Ipv4, Safi::MplsVpn)], AddPathMode::Both);
+        assert_eq!(result[&(Afi::Ipv6, Safi::MplsVpn)], AddPathMode::Both);
+    }
+
+    #[test]
     fn negotiate_add_path_no_overlap() {
         // We want Receive, peer also wants Receive → no match
         let ours = vec![AddPathFamily {

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -65,6 +65,10 @@ pub struct AdjRibIn {
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 routes keyed by RFC 4364 RD + prefix identity.
     vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// Secondary index: VPN RD+prefix identity → Add-Path path IDs stored for
+    /// it (the SAFI 128 analog of `prefix_index`). `SmallVec<[u32; 1]>`
+    /// inlines the non-Add-Path case (`path_id=0`) without heap allocation.
+    vpn_key_index: HashMap<rustbgpd_wire::VpnRouteKey, SmallVec<[u32; 1]>>,
     /// RT-Constrain routes keyed by RFC 4684 RT membership identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
     /// EVPN route keys where `LLGR_STALE` was injected locally by this daemon
@@ -110,6 +114,7 @@ impl AdjRibIn {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            vpn_key_index: HashMap::default(),
             rtc_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             bgpls_llgr_stale_local_tags: HashSet::default(),
@@ -180,6 +185,7 @@ impl AdjRibIn {
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
+        self.vpn_key_index.clear();
         self.rtc_routes.clear();
         self.llgr_stale_local_tags.clear();
         self.flowspec_llgr_stale_local_tags.clear();
@@ -965,14 +971,52 @@ impl AdjRibIn {
         } else {
             self.attr_intern.insert(route.attributes.clone());
         }
+        let ids = self.vpn_key_index.entry(key.nlri_key).or_default();
+        if !ids.contains(&key.path_id) {
+            ids.push(key.path_id);
+        }
         self.vpn_routes.insert(key, route).is_some()
     }
 
     /// Withdraw a VPN route. Returns `true` if it existed.
     pub fn withdraw_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
-        // A withdrawn key can no longer carry a locally-injected LLGR_STALE tag.
+        self.remove_vpn_entry(key)
+    }
+
+    /// Shared VPN removal: drops the route, its locally-injected LLGR tag,
+    /// and its `vpn_key_index` entry. Every VPN removal path (withdraw and
+    /// the GR/LLGR stale sweeps) must route through here so the secondary
+    /// index never dangles.
+    fn remove_vpn_entry(&mut self, key: &VpnRibRouteKey) -> bool {
+        // A removed key can no longer carry a locally-injected LLGR_STALE tag.
         self.vpn_llgr_stale_local_tags.remove(key);
-        self.vpn_routes.remove(key).is_some()
+        let removed = self.vpn_routes.remove(key).is_some();
+        if removed && let Some(ids) = self.vpn_key_index.get_mut(&key.nlri_key) {
+            ids.retain(|id| *id != key.path_id);
+            if ids.is_empty() {
+                self.vpn_key_index.remove(&key.nlri_key);
+            }
+        }
+        removed
+    }
+
+    /// Iterate the VPN routes stored for one RD+prefix identity across all
+    /// Add-Path path IDs (the SAFI 128 analog of `iter_prefix`).
+    pub fn iter_vpn_for_nlri<'a>(
+        &'a self,
+        nlri_key: &'a rustbgpd_wire::VpnRouteKey,
+    ) -> impl Iterator<Item = &'a VpnRibRoute> + 'a {
+        self.vpn_key_index
+            .get(nlri_key)
+            .into_iter()
+            .flat_map(move |ids| {
+                ids.iter().filter_map(move |path_id| {
+                    self.vpn_routes.get(&VpnRibRouteKey {
+                        nlri_key: *nlri_key,
+                        path_id: *path_id,
+                    })
+                })
+            })
     }
 
     /// Withdraw all VPN routes from this Adj-RIB-In.
@@ -984,6 +1028,7 @@ impl AdjRibIn {
     pub fn withdraw_all_vpn(&mut self) -> Vec<VpnRibRouteKey> {
         let keys: Vec<_> = self.vpn_routes.keys().cloned().collect();
         self.vpn_routes.clear();
+        self.vpn_key_index.clear();
         self.vpn_llgr_stale_local_tags.clear();
         keys
     }
@@ -1034,8 +1079,7 @@ impl AdjRibIn {
             .map(|(k, _)| k.clone())
             .collect();
         for key in &already_stale {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
         for route in self.vpn_routes.values_mut() {
             if route.afi_safi() == family {
@@ -1077,8 +1121,7 @@ impl AdjRibIn {
             .map(|(k, _)| k.clone())
             .collect();
         for key in &stale {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
         stale
     }
@@ -1097,8 +1140,7 @@ impl AdjRibIn {
             .map(|(k, _)| k.clone())
             .collect();
         for key in &stale {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
         stale
     }
@@ -1129,8 +1171,7 @@ impl AdjRibIn {
             .collect();
         let mut affected: Vec<VpnRibRouteKey> = no_llgr_keys.clone();
         for key in &no_llgr_keys {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
 
         // Second pass: promote remaining stale routes to LLGR-stale
@@ -1168,8 +1209,7 @@ impl AdjRibIn {
             .map(|(k, _)| k.clone())
             .collect();
         for key in &stale {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
         stale
     }
@@ -1188,8 +1228,7 @@ impl AdjRibIn {
             .map(|(k, _)| k.clone())
             .collect();
         for key in &stale {
-            self.vpn_llgr_stale_local_tags.remove(key);
-            self.vpn_routes.remove(key);
+            self.remove_vpn_entry(key);
         }
         stale
     }

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -33,6 +33,10 @@ pub struct AdjRibOut {
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 routes advertised to this peer, keyed by RD + prefix identity.
     vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// Secondary index: VPN RD+prefix identity → advertised Add-Path path IDs
+    /// (the SAFI 128 analog of `prefix_path_ids`). `SmallVec<[u32; 1]>` inlines
+    /// the single-best case (`path_id=0`) without heap allocation.
+    vpn_key_path_ids: HashMap<rustbgpd_wire::VpnRouteKey, SmallVec<[u32; 1]>>,
     /// RT-Constrain routes advertised to this peer, keyed by RFC 4684 identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
@@ -58,6 +62,7 @@ impl AdjRibOut {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            vpn_key_path_ids: HashMap::default(),
             rtc_routes: HashMap::default(),
         }
     }
@@ -134,6 +139,7 @@ impl AdjRibOut {
         self.evpn_routes.clear();
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
+        self.vpn_key_path_ids.clear();
         self.rtc_routes.clear();
     }
 
@@ -270,12 +276,34 @@ impl AdjRibOut {
 
     /// Insert or replace an advertised VPN route.
     pub fn insert_vpn(&mut self, route: VpnRibRoute) {
-        self.vpn_routes.insert(route.key(), route);
+        let key = route.key();
+        if self.vpn_routes.insert(key.clone(), route).is_none() {
+            let ids = self.vpn_key_path_ids.entry(key.nlri_key).or_default();
+            if !ids.contains(&key.path_id) {
+                ids.push(key.path_id);
+            }
+        }
     }
 
     /// Remove an advertised VPN route by key. Returns `true` if it existed.
     pub fn remove_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
-        self.vpn_routes.remove(key).is_some()
+        let removed = self.vpn_routes.remove(key).is_some();
+        if removed && let Some(ids) = self.vpn_key_path_ids.get_mut(&key.nlri_key) {
+            ids.retain(|id| *id != key.path_id);
+            if ids.is_empty() {
+                self.vpn_key_path_ids.remove(&key.nlri_key);
+            }
+        }
+        removed
+    }
+
+    /// Return all Add-Path path IDs currently advertised for a VPN RD+prefix
+    /// identity (the SAFI 128 analog of [`Self::path_ids_for_prefix`]).
+    #[must_use]
+    pub fn vpn_path_ids_for_key(&self, key: &rustbgpd_wire::VpnRouteKey) -> &[u32] {
+        self.vpn_key_path_ids
+            .get(key)
+            .map_or(&[], SmallVec::as_slice)
     }
 
     /// Look up an advertised VPN route by key.

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -14,7 +14,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 use crate::best_path::best_path_cmp;
 use crate::route::{
     BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
-    VpnRibRoute, VpnRibRouteKey,
+    VpnRibRoute,
 };
 
 /// The local RIB storing the best route per prefix.
@@ -27,7 +27,10 @@ pub struct LocRib {
     /// BGP-LS Loc-RIB: best route per opaque RFC 9552 identity.
     bgpls_routes: HashMap<BgpLsRouteKey, BgpLsRibRoute>,
     /// VPNv4/VPNv6 Loc-RIB: best route per RFC 4364 RD + prefix identity.
-    vpn_routes: HashMap<VpnRibRouteKey, VpnRibRoute>,
+    /// Selected VPN routes keyed by RD+prefix identity alone: Loc-RIB best
+    /// selection collapses Add-Path path IDs — the winning route's own
+    /// `path_id` records which received path won.
+    vpn_routes: HashMap<rustbgpd_wire::VpnRouteKey, VpnRibRoute>,
     /// RT-Constrain Loc-RIB: best route per RFC 4684 RT membership identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
@@ -320,7 +323,7 @@ impl LocRib {
     /// check so the reflected label stays current.
     pub fn recompute_vpn<'a>(
         &mut self,
-        key: VpnRibRouteKey,
+        key: rustbgpd_wire::VpnRouteKey,
         candidates: impl Iterator<Item = &'a VpnRibRoute>,
     ) -> bool {
         let best = candidates.min_by(|a, b| vpn_tiebreak(a, b)).cloned();
@@ -347,12 +350,12 @@ impl LocRib {
 
     /// Insert or replace the selected VPN route for a key.
     pub fn insert_vpn(&mut self, route: VpnRibRoute) {
-        self.vpn_routes.insert(route.key(), route);
+        self.vpn_routes.insert(route.nlri.key(), route);
     }
 
-    /// Look up the selected VPN route for a key.
+    /// Look up the selected VPN route for an RD+prefix identity.
     #[must_use]
-    pub fn get_vpn(&self, key: &VpnRibRouteKey) -> Option<&VpnRibRoute> {
+    pub fn get_vpn(&self, key: &rustbgpd_wire::VpnRouteKey) -> Option<&VpnRibRoute> {
         self.vpn_routes.get(key)
     }
 
@@ -368,7 +371,7 @@ impl LocRib {
     }
 
     /// Remove the selected VPN route for a key. Returns `true` if it existed.
-    pub fn remove_vpn(&mut self, key: &VpnRibRouteKey) -> bool {
+    pub fn remove_vpn(&mut self, key: &rustbgpd_wire::VpnRouteKey) -> bool {
         self.vpn_routes.remove(key).is_some()
     }
 
@@ -733,7 +736,7 @@ fn bgpls_originator_id(route: &BgpLsRibRoute) -> Option<std::net::Ipv4Addr> {
     })
 }
 
-fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
+pub(crate) fn vpn_tiebreak(a: &VpnRibRoute, b: &VpnRibRoute) -> Ordering {
     vpn_cmp_chain(a, b, None)
 }
 
@@ -1103,15 +1106,12 @@ mod tests {
     #[test]
     fn recompute_vpn_higher_local_pref_wins() {
         let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
-        let key = VpnRibRouteKey {
-            nlri_key: nlri.key(),
-            path_id: 0,
-        };
+        let key = nlri.key();
         let r1 = make_vpn_route(nlri.clone(), 1, 100);
         let r2 = make_vpn_route(nlri, 2, 200);
         let mut loc = LocRib::new();
 
-        assert!(loc.recompute_vpn(key.clone(), [&r1, &r2].into_iter()));
+        assert!(loc.recompute_vpn(key, [&r1, &r2].into_iter()));
         assert_eq!(loc.vpn_len(), 1);
         assert_eq!(
             loc.get_vpn(&key).unwrap().peer,
@@ -1123,16 +1123,13 @@ mod tests {
     #[test]
     fn recompute_vpn_stale_demoted_despite_higher_local_pref() {
         let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
-        let key = VpnRibRouteKey {
-            nlri_key: nlri.key(),
-            path_id: 0,
-        };
+        let key = nlri.key();
         let mut r_stale = make_vpn_route(nlri.clone(), 1, 200);
         r_stale.is_stale = true;
         let r_fresh = make_vpn_route(nlri, 2, 100);
         let mut loc = LocRib::new();
 
-        loc.recompute_vpn(key.clone(), [&r_stale, &r_fresh].into_iter());
+        loc.recompute_vpn(key, [&r_stale, &r_fresh].into_iter());
         assert_eq!(
             loc.get_vpn(&key).unwrap().peer,
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
@@ -1143,19 +1140,16 @@ mod tests {
     #[test]
     fn recompute_vpn_empty_candidates_removes_existing_key() {
         let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
-        let key = VpnRibRouteKey {
-            nlri_key: nlri.key(),
-            path_id: 0,
-        };
+        let key = nlri.key();
         let route = make_vpn_route(nlri, 1, 100);
         let mut loc = LocRib::new();
 
-        loc.recompute_vpn(key.clone(), [&route].into_iter());
+        loc.recompute_vpn(key, [&route].into_iter());
         assert_eq!(loc.vpn_len(), 1);
 
         let empty: Vec<&VpnRibRoute> = vec![];
         assert!(
-            loc.recompute_vpn(key.clone(), empty.into_iter()),
+            loc.recompute_vpn(key, empty.into_iter()),
             "removing an existing key returns true"
         );
         assert_eq!(loc.vpn_len(), 0);

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -647,14 +647,21 @@ impl RibManager {
                 HashSet::new()
             };
 
-            let effective_l3vpn_keys: HashSet<crate::route::VpnRibRouteKey> = if resync {
-                let mut all: HashSet<crate::route::VpnRibRouteKey> = self
+            let effective_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = if resync {
+                let mut all: HashSet<rustbgpd_wire::VpnRouteKey> = self
                     .loc_rib
                     .iter_vpn()
-                    .map(crate::route::VpnRibRoute::key)
+                    .map(|route| route.nlri.key())
                     .collect();
+                // For a VPN Add-Path-send resync, the staged top-N draws from
+                // every Adj-RIB-In identity, not just the Loc-RIB bests.
+                if self.peer_vpn_add_path_send(peer) {
+                    for rib in self.ribs.values() {
+                        all.extend(rib.iter_vpn().map(|route| route.nlri.key()));
+                    }
+                }
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_vpn().map(crate::route::VpnRibRoute::key));
+                    all.extend(rib_out.iter_vpn().map(|route| route.nlri.key()));
                 }
                 all
             } else {
@@ -948,6 +955,8 @@ impl RibManager {
                     sendable.as_ref(),
                     rtc_filter.as_ref(),
                     orr_ctx,
+                    peer_add_path_send_max,
+                    &peer_add_path_send_families,
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -4,6 +4,8 @@ use super::{
     record_export_policy_eval, route_type, should_suppress_ibgp_inner, vpn_routes_equal, warn,
 };
 use crate::loc_rib::vpn_tiebreak_orr;
+use crate::route::{VpnRibRoute, VpnRibRouteKey};
+use rustbgpd_wire::{VpnAddressFamily, VpnRouteKey};
 
 /// A unicast-shaped probe of a VPN route for the shared RFC 4456
 /// suppression helper: `should_suppress_ibgp_inner` only reads
@@ -29,8 +31,28 @@ fn vpn_suppression_probe(route: &crate::route::VpnRibRoute) -> crate::route::Rou
     }
 }
 
+/// The wire AFI/SAFI pair for a VPN RD+prefix identity.
+fn vpn_afi_safi(key: &VpnRouteKey) -> (Afi, Safi) {
+    let afi = match key.prefix.family() {
+        VpnAddressFamily::V4 => Afi::Ipv4,
+        VpnAddressFamily::V6 => Afi::Ipv6,
+    };
+    (afi, Safi::MplsVpn)
+}
+
 impl RibManager {
-    /// Stage VPNv4/VPNv6 announces and withdrawals for a set of affected keys.
+    /// Whether Add-Path send is negotiated with `peer` for any VPN family
+    /// (SAFI 128) with a non-zero configured `send_max`.
+    pub(in crate::manager) fn peer_vpn_add_path_send(&self, peer: IpAddr) -> bool {
+        self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0) > 0
+            && self
+                .peer_add_path_send_families
+                .get(&peer)
+                .is_some_and(|families| families.iter().any(|(_, safi)| *safi == Safi::MplsVpn))
+    }
+
+    /// Stage VPNv4/VPNv6 announces and withdrawals for a set of affected
+    /// RD+prefix identities.
     ///
     /// ADR-0077 §6 guardrail: the next-hop, MPLS label stack, and Route
     /// Distinguisher pass through reflection unchanged — the staged route
@@ -38,17 +60,23 @@ impl RibManager {
     /// the VPN next-hop. Export policy matches on the RD-scoped inner prefix
     /// (honest, unlike the prefixless BGP-LS placeholder) plus communities,
     /// large communities, `AS_PATH`, peer, and route type.
+    ///
+    /// When the target negotiated Add-Path send for the key's family (RFC
+    /// 7911; RFC 9107 requires it between RRs), up to `add_path_send_max`
+    /// candidates per key are ranked — with the ORR vantage comparator when
+    /// a vantage is resolved — and staged with outbound path IDs `1..=N`.
+    /// Otherwise the single best is staged with `path_id = 0`.
     #[expect(
         clippy::too_many_arguments,
         clippy::too_many_lines,
-        reason = "VPN staging mirrors EVPN/BGP-LS distribution context for RR/export parity"
+        reason = "VPN staging mirrors unicast multipath/single-best distribution context for RR/export parity"
     )]
     pub(in crate::manager) fn stage_vpn_routes(
         loc_rib: &LocRib,
         ribs: &HashMap<IpAddr, AdjRibIn>,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
-        keys: &HashSet<crate::route::VpnRibRouteKey>,
+        keys: &HashSet<VpnRouteKey>,
         target_peer: IpAddr,
         target_peer_asn: Option<u32>,
         target_peer_group: Option<&str>,
@@ -58,25 +86,175 @@ impl RibManager {
         sendable: Option<&Vec<(Afi, Safi)>>,
         rtc_filter: Option<&crate::manager::RtcMembership>,
         orr_ctx: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
+        add_path_send_max: u32,
+        add_path_send_families: &[(Afi, Safi)],
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
-        vpn_announce: &mut Vec<crate::route::VpnRibRoute>,
-        vpn_withdraw: &mut Vec<crate::route::VpnRibRouteKey>,
+        vpn_announce: &mut Vec<VpnRibRoute>,
+        vpn_withdraw: &mut Vec<VpnRibRouteKey>,
         force: bool,
     ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         for key in keys {
-            let family = key.afi_safi();
+            let family = vpn_afi_safi(key);
+            // Path IDs currently advertised for this identity — the diff
+            // baseline for every withdraw decision below.
+            let existing_path_ids = rib_out.vpn_path_ids_for_key(key);
+            let withdraw_existing = |vpn_withdraw: &mut Vec<VpnRibRouteKey>, existing: &[u32]| {
+                for &path_id in existing {
+                    vpn_withdraw.push(VpnRibRouteKey {
+                        nlri_key: *key,
+                        path_id,
+                    });
+                }
+            };
+
             if !sendable.is_some_and(|f| f.contains(&family)) {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
+                withdraw_existing(vpn_withdraw, existing_path_ids);
+                continue;
+            }
+
+            let key_send_max = if add_path_send_max > 0 && add_path_send_families.contains(&family)
+            {
+                add_path_send_max
+            } else {
+                0
+            };
+
+            if key_send_max > 0 {
+                // Multi-path: collect the per-target candidate set (every
+                // Adj-RIB-In entry for the identity, any received path ID,
+                // that survives split horizon and RFC 4456 reflection),
+                // rank it, and stage the top N with path IDs 1..=N.
+                let mut candidates: Vec<&VpnRibRoute> = ribs
+                    .values()
+                    .flat_map(|rib| rib.iter_vpn_for_nlri(key))
+                    .filter(|candidate| {
+                        candidate.peer != target_peer
+                            && !should_suppress_ibgp_inner(
+                                &vpn_suppression_probe(candidate),
+                                target_is_ebgp,
+                                target_is_rr_client,
+                                cluster_id,
+                                peer_is_rr_client,
+                            )
+                    })
+                    .collect();
+                // Rank by the VPN best-path chain; an RFC 9107 ORR peer with
+                // a resolved vantage ranks by the vantage's interior cost to
+                // each candidate's next-hop (comparator swap only).
+                match orr_ctx {
+                    Some((orr_topology, orr_spf)) => candidates.sort_by(|a, b| {
+                        vpn_tiebreak_orr(
+                            a,
+                            b,
+                            orr_spf.cost_to(orr_topology, a.next_hop),
+                            orr_spf.cost_to(orr_topology, b.next_hop),
+                        )
+                    }),
+                    None => candidates.sort_by(|a, b| crate::loc_rib::vpn_tiebreak(a, b)),
+                }
+
+                let mut next_rank: u32 = 1;
+                let limit = if key_send_max == u32::MAX {
+                    usize::MAX
+                } else {
+                    key_send_max as usize
+                };
+                for candidate in &candidates {
+                    if (next_rank as usize) > limit {
+                        break;
+                    }
+
+                    // RFC 4684 outbound gate, per candidate — the route
+                    // actually being advertised must fall inside the peer's
+                    // RT membership (consistent with the single-best gate).
+                    if let Some(membership) = rtc_filter
+                        && !membership.matches_any(candidate.extended_communities())
+                    {
+                        continue;
+                    }
+
+                    let aspath_str = if needs_as_path_string {
+                        candidate
+                            .as_path()
+                            .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+                    } else {
+                        String::new()
+                    };
+                    let aspath_len = candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+                    let ctx = RouteContext {
+                        prefix: Some(candidate.inner_prefix()),
+                        next_hop: Some(candidate.next_hop),
+                        extended_communities: candidate.extended_communities(),
+                        communities: candidate.communities(),
+                        large_communities: candidate.large_communities(),
+                        as_path_str: &aspath_str,
+                        as_path_len: aspath_len,
+                        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+                        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+                        peer_address: Some(target_peer),
+                        peer_asn: target_peer_asn,
+                        peer_group: target_peer_group,
+                        route_type: Some(route_type(candidate.origin_type)),
+                        evpn_route_type: None,
+                        local_pref: candidate.local_pref_attr(),
+                        med: candidate.med_attr(),
+                    };
+                    let (result, evaluation) =
+                        rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+                    record_export_policy_eval(
+                        metrics,
+                        policy_stats,
+                        target_peer_label,
+                        &evaluation,
+                    );
+                    if result.action != rustbgpd_policy::PolicyAction::Permit {
+                        continue;
+                    }
+
+                    let mut modified = (*candidate).clone();
+                    if !result.modifications.is_empty() {
+                        let nh = rustbgpd_policy::apply_modifications(
+                            std::sync::Arc::make_mut(&mut modified.attributes),
+                            &result.modifications,
+                        );
+                        if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
+                            modified.next_hop = addr;
+                        }
+                    }
+                    modified.path_id = next_rank;
+
+                    let out_key = VpnRibRouteKey {
+                        nlri_key: *key,
+                        path_id: next_rank,
+                    };
+                    if force
+                        || rib_out
+                            .get_vpn(&out_key)
+                            .is_none_or(|existing| !vpn_routes_equal(existing, &modified))
+                    {
+                        vpn_announce.push(modified);
+                    }
+                    next_rank += 1;
+                }
+
+                // Withdraw previously advertised path IDs outside the new
+                // 1..next_rank set (including a stale single-best 0 entry).
+                for &path_id in existing_path_ids {
+                    if path_id == 0 || path_id >= next_rank {
+                        vpn_withdraw.push(VpnRibRouteKey {
+                            nlri_key: *key,
+                            path_id,
+                        });
+                    }
                 }
                 continue;
             }
 
-            // Per-key best. An RFC 9107 ORR peer with a resolved vantage
+            // Single-best. An RFC 9107 ORR peer with a resolved vantage
             // does NOT take the Loc-RIB best: the per-target candidate
             // set (every Adj-RIB-In entry for the key that survives split
             // horizon and RFC 4456 reflection — the unicast
@@ -86,7 +264,7 @@ impl RibManager {
             let best = if let Some((orr_topology, orr_spf)) = orr_ctx {
                 let winner = ribs
                     .values()
-                    .filter_map(|rib| rib.get_vpn(key))
+                    .flat_map(|rib| rib.iter_vpn_for_nlri(key))
                     .filter(|candidate| {
                         candidate.peer != target_peer
                             && !should_suppress_ibgp_inner(
@@ -106,17 +284,13 @@ impl RibManager {
                         )
                     });
                 let Some(winner) = winner else {
-                    if rib_out.get_vpn(key).is_some() {
-                        vpn_withdraw.push(key.clone());
-                    }
+                    withdraw_existing(vpn_withdraw, existing_path_ids);
                     continue;
                 };
                 winner
             } else {
                 let Some(best) = loc_rib.get_vpn(key) else {
-                    if rib_out.get_vpn(key).is_some() {
-                        vpn_withdraw.push(key.clone());
-                    }
+                    withdraw_existing(vpn_withdraw, existing_path_ids);
                     continue;
                 };
                 best
@@ -134,9 +308,7 @@ impl RibManager {
             if let Some(membership) = rtc_filter
                 && !membership.matches_any(best.extended_communities())
             {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
-                }
+                withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
             }
 
@@ -144,9 +316,7 @@ impl RibManager {
             // winner (its candidate set is pre-filtered above); they
             // decide only for the Loc-RIB best of a plain peer.
             if best.peer == target_peer {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
-                }
+                withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
             }
 
@@ -157,9 +327,7 @@ impl RibManager {
                 cluster_id,
                 peer_is_rr_client,
             ) {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
-                }
+                withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
             }
 
@@ -192,9 +360,7 @@ impl RibManager {
                 rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
             record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
             if result.action != rustbgpd_policy::PolicyAction::Permit {
-                if rib_out.get_vpn(key).is_some() {
-                    vpn_withdraw.push(key.clone());
-                }
+                withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
             }
 
@@ -210,14 +376,28 @@ impl RibManager {
             }
             modified.path_id = 0;
 
-            if !force
-                && rib_out
-                    .get_vpn(key)
-                    .is_some_and(|existing| vpn_routes_equal(existing, &modified))
+            let out_key = VpnRibRouteKey {
+                nlri_key: *key,
+                path_id: 0,
+            };
+            if force
+                || rib_out
+                    .get_vpn(&out_key)
+                    .is_none_or(|existing| !vpn_routes_equal(existing, &modified))
             {
-                continue;
+                vpn_announce.push(modified);
             }
-            vpn_announce.push(modified);
+
+            // Clean up stale multi-path entries if this identity was
+            // previously advertised via Add-Path and is now single-best.
+            for &path_id in existing_path_ids {
+                if path_id != 0 {
+                    vpn_withdraw.push(VpnRibRouteKey {
+                        nlri_key: *key,
+                        path_id,
+                    });
+                }
+            }
         }
     }
 
@@ -226,26 +406,29 @@ impl RibManager {
     ///
     /// The selected route is reflected as received: Route Distinguisher,
     /// MPLS label stack, and next-hop pass through unchanged (ADR-0077 §6),
-    /// with ordinary BGP attribute handling applied by transport.
+    /// with ordinary BGP attribute handling applied by transport. Selection
+    /// and staging operate per RD+prefix identity — received Add-Path path
+    /// IDs are distinct Adj-RIB-In entries but collapse into one candidate
+    /// set per identity.
     #[expect(
         clippy::too_many_lines,
-        reason = "VPN recompute keeps loc-rib selection and per-peer ORR staging together"
+        reason = "VPN recompute keeps loc-rib selection and per-peer ORR/Add-Path staging together"
     )]
     pub(in crate::manager) fn recompute_and_distribute_vpn(
         &mut self,
-        affected: &HashSet<crate::route::VpnRibRouteKey>,
+        affected: &HashSet<VpnRibRouteKey>,
     ) {
-        use crate::route::VpnRibRoute;
+        let affected_nlri: HashSet<VpnRouteKey> = affected.iter().map(|key| key.nlri_key).collect();
 
-        let mut changed_keys: HashSet<crate::route::VpnRibRouteKey> = HashSet::new();
-        for key in affected {
+        let mut changed_keys: HashSet<VpnRouteKey> = HashSet::new();
+        for key in &affected_nlri {
             let candidates: Vec<VpnRibRoute> = self
                 .ribs
                 .values()
-                .filter_map(|rib| rib.get_vpn(key).cloned())
+                .flat_map(|rib| rib.iter_vpn_for_nlri(key).cloned())
                 .collect();
-            if self.loc_rib.recompute_vpn(key.clone(), candidates.iter()) {
-                changed_keys.insert(key.clone());
+            if self.loc_rib.recompute_vpn(*key, candidates.iter()) {
+                changed_keys.insert(*key);
             }
         }
 
@@ -254,12 +437,15 @@ impl RibManager {
         // Loc-RIB best untouched can still flip a vantage best, so
         // ORR-bound peers stage every affected key (the VPN parallel of
         // the unicast `all_affected` inclusion in `distribute_changes`).
-        let any_resolved_orr_peer = self.outbound_peers.keys().any(|peer| {
+        // Add-Path-send peers need the same widening: a non-best candidate
+        // change can alter the staged top-N set.
+        let any_widened_peer = self.outbound_peers.keys().any(|peer| {
             self.peer_orr_vantage
                 .get(peer)
                 .is_some_and(|vantage| self.orr.spf.contains_key(vantage))
+                || self.peer_vpn_add_path_send(*peer)
         });
-        if changed_keys.is_empty() && !any_resolved_orr_peer {
+        if changed_keys.is_empty() && !any_widened_peer {
             return;
         }
 
@@ -278,8 +464,9 @@ impl RibManager {
                 .get(&peer)
                 .and_then(|vantage| self.orr.spf.get(vantage))
                 .map(|spf| (&self.orr.topology, spf));
-            let staged_keys = if orr_ctx.is_some() {
-                affected
+            let peer_add_path = self.peer_vpn_add_path_send(peer);
+            let staged_keys = if orr_ctx.is_some() || peer_add_path {
+                &affected_nlri
             } else {
                 &changed_keys
             };
@@ -287,7 +474,7 @@ impl RibManager {
             if !staged_keys.iter().any(|key| {
                 sendable
                     .as_ref()
-                    .is_some_and(|families| families.contains(&key.afi_safi()))
+                    .is_some_and(|families| families.contains(&vpn_afi_safi(key)))
             }) {
                 continue;
             }
@@ -298,6 +485,16 @@ impl RibManager {
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
             let export_pol = self.export_policy_for(peer).cloned();
             let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
+            let add_path_send_max = if peer_add_path {
+                self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0)
+            } else {
+                0
+            };
+            let add_path_send_families = self
+                .peer_add_path_send_families
+                .get(&peer)
+                .cloned()
+                .unwrap_or_default();
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 
@@ -325,6 +522,8 @@ impl RibManager {
                 sendable.as_ref(),
                 rtc_filter.as_ref(),
                 orr_ctx,
+                add_path_send_max,
+                &add_path_send_families,
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 
 use rustbgpd_policy::PolicyChain;
-use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix};
+use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix, Safi};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -996,12 +996,22 @@ impl RibManager {
 
         // VPNv4/VPNv6 initial dump — a peer that joins after the VPN table
         // has converged must still receive it before EoR. Mirrors the BGP-LS
-        // staging block.
-        let all_l3vpn_keys: HashSet<crate::route::VpnRibRouteKey> = self
+        // staging block. For an Add-Path-send peer the staged top-N draws
+        // from every Adj-RIB-In identity, not just the Loc-RIB bests.
+        let mut all_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = self
             .loc_rib
             .iter_vpn()
-            .map(crate::route::VpnRibRoute::key)
+            .map(|route| route.nlri.key())
             .collect();
+        if peer_add_path_send_max > 0
+            && peer_add_path_send_families
+                .iter()
+                .any(|(_, safi)| *safi == Safi::MplsVpn)
+        {
+            for rib in self.ribs.values() {
+                all_l3vpn_keys.extend(rib.iter_vpn().map(|route| route.nlri.key()));
+            }
+        }
         if !all_l3vpn_keys.is_empty() {
             Self::stage_vpn_routes(
                 loc_rib,
@@ -1018,6 +1028,8 @@ impl RibManager {
                 sendable.as_ref(),
                 rtc_filter.as_ref(),
                 orr_ctx,
+                peer_add_path_send_max,
+                &peer_add_path_send_families,
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -651,12 +651,27 @@ impl RibManager {
                 );
             }
         } else if safi == Safi::MplsVpn {
-            let vpn_keys: HashSet<crate::route::VpnRibRouteKey> = self
+            let mut vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = self
                 .loc_rib
                 .iter_vpn()
                 .filter(|route| route.afi_safi() == family)
-                .map(crate::route::VpnRibRoute::key)
+                .map(|route| route.nlri.key())
                 .collect();
+            // An Add-Path-send refresh re-emits the staged top-N, which
+            // draws from every Adj-RIB-In identity of the family.
+            if peer_add_path_send_max > 0
+                && peer_add_path_send_families
+                    .iter()
+                    .any(|(_, safi)| *safi == Safi::MplsVpn)
+            {
+                for rib in self.ribs.values() {
+                    vpn_keys.extend(
+                        rib.iter_vpn()
+                            .filter(|route| route.afi_safi() == family)
+                            .map(|route| route.nlri.key()),
+                    );
+                }
+            }
             if !vpn_keys.is_empty() {
                 Self::stage_vpn_routes(
                     loc_rib,
@@ -673,6 +688,8 @@ impl RibManager {
                     sendable.as_ref(),
                     rtc_filter.as_ref(),
                     orr_ctx,
+                    peer_add_path_send_max,
+                    &peer_add_path_send_families,
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -2798,6 +2798,203 @@ async fn vpn_routes_received_reflects_and_withdraws_to_eligible_peer() {
     handle.await.unwrap();
 }
 
+/// RFC 7911 VPN receive: distinct path IDs for the same RD+prefix are
+/// distinct Adj-RIB-In entries, and a withdraw keyed by path ID removes
+/// only that one — the surviving path takes over the Loc-RIB best.
+#[tokio::test]
+async fn vpn_addpath_ingest_distinct_path_ids_stored_and_withdrawn_independently() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let mut path_1 = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 200);
+    path_1.path_id = 1;
+    let mut path_2 = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    path_2.path_id = 2;
+    assert_eq!(path_1.nlri.key(), path_2.nlri.key());
+    assert_ne!(path_1.key(), path_2.key());
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![path_1.clone(), path_2.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let best = query_vpn_routes(&tx).await;
+    assert_eq!(best.len(), 1, "one Loc-RIB best per RD+prefix identity");
+    assert_eq!(
+        best[0].path_id, 1,
+        "the higher-LOCAL_PREF received path wins"
+    );
+
+    // Withdraw ONLY path 1 — path 2 must survive and take over.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![path_1.key()],
+    })
+    .await
+    .unwrap();
+    let best = query_vpn_routes(&tx).await;
+    assert_eq!(best.len(), 1, "path 2 must survive a path-1-only withdraw");
+    assert_eq!(best[0].path_id, 2);
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![path_2.key()],
+    })
+    .await
+    .unwrap();
+    assert!(query_vpn_routes(&tx).await.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 7911 VPN send: an Add-Path-send target receives up to `send_max`
+/// candidates per RD+prefix with outbound path IDs 1..=N ranked by the VPN
+/// tiebreak, a non-Add-Path target keeps single-best (`path_id = 0`), and
+/// a source withdraw shrinks the staged set by outbound path ID.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "covers Add-Path top-N, single-best parity, and withdraw re-ranking in one scenario"
+)]
+async fn vpn_addpath_send_stages_top_n_and_single_best_unchanged() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let addpath_target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (addpath_out_tx, mut addpath_out) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: addpath_target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: addpath_out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        add_path_send_max: 2,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut addpath_out).await;
+
+    let plain_target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (plain_out_tx, mut plain_out) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: plain_target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: plain_out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut plain_out).await;
+
+    // Same RD+prefix from three sources, ranked by LOCAL_PREF: 300 > 200 > 100.
+    let best = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 11), 31, 100, 300);
+    let second = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 12), 31, 200, 200);
+    let third = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 13), 31, 300, 100);
+    let nlri_key = best.nlri.key();
+    for route in [&best, &second, &third] {
+        tx.send(RibUpdate::VpnRoutesReceived {
+            session_id: 0,
+            peer: route.peer,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    let _ = query_vpn_routes(&tx).await; // sync point
+
+    let staged = drain_final_vpn(&mut addpath_out);
+    assert_eq!(
+        staged.len(),
+        2,
+        "send_max=2 caps the staged set at two paths, not three"
+    );
+    let rank_1 = staged
+        .get(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1,
+        })
+        .expect("outbound path_id 1 staged");
+    let rank_2 = staged
+        .get(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2,
+        })
+        .expect("outbound path_id 2 staged");
+    assert_eq!(rank_1.next_hop, best.next_hop, "rank 1 = best by tiebreak");
+    assert_eq!(rank_2.next_hop, second.next_hop, "rank 2 = runner-up");
+
+    let plain_staged = drain_final_vpn(&mut plain_out);
+    assert_eq!(plain_staged.len(), 1, "non-Add-Path peer stays single-best");
+    let single = plain_staged
+        .get(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 0,
+        })
+        .expect("single-best staged at path_id 0");
+    assert_eq!(single.next_hop, best.next_hop);
+
+    // The best source withdraws: the staged top-2 becomes {second, third}
+    // re-ranked as path IDs 1..2; the diff withdraws by outbound path ID.
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: best.peer,
+        announced: vec![],
+        withdrawn: vec![best.key()],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await; // sync point
+
+    let staged = drain_final_vpn(&mut addpath_out);
+    // drain_final_vpn folds over the earlier state: ranks 1..2 re-announced.
+    let rank_1 = staged
+        .get(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1,
+        })
+        .expect("outbound path_id 1 restaged after withdraw");
+    let rank_2 = staged
+        .get(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2,
+        })
+        .expect("outbound path_id 2 restaged after withdraw");
+    assert_eq!(rank_1.next_hop, second.next_hop);
+    assert_eq!(rank_2.next_hop, third.next_hop);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// RFC 4456 eligibility on VPN reflection: a non-client iBGP route is
 /// reflected to RR clients, suppressed toward other non-clients, and never
 /// echoed back to the source.
@@ -21212,6 +21409,62 @@ async fn two_vpn_clients_different_vantages_receive_divergent_bests() {
         final_b.get(&key).map(|r| r.next_hop),
         Some(orr_nh_y()),
         "client at B exits via Y (cost 1 < 10)"
+    );
+}
+
+/// RFC 9107 + RFC 7911 composed: an ORR client with Add-Path send ranks
+/// its staged top-N by the VANTAGE's interior costs — `path_id` 1 is the
+/// vantage-closest exit, not the RR-local best.
+#[tokio::test]
+async fn vpn_orr_addpath_ranking_uses_vantage_costs() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_a) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: client_a,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vpn_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_a()),
+        add_path_send_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
+        add_path_send_max: 2,
+        negotiated_orf_recv: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_a).await;
+
+    // Same RD+prefix via X (cost 1 from vantage A) and Y (cost 10).
+    let key = announce_divergent_vpn_bests(&tx, 81).await;
+    drop(tx);
+    handle.await.unwrap();
+
+    let staged = drain_final_vpn(&mut out_a);
+    assert_eq!(staged.len(), 2, "both candidates staged under send_max=2");
+    assert_eq!(
+        staged
+            .get(&crate::route::VpnRibRouteKey {
+                nlri_key: key.nlri_key,
+                path_id: 1,
+            })
+            .map(|r| r.next_hop),
+        Some(orr_nh_x()),
+        "path_id 1 = vantage-closest exit (cost 1 via X)"
+    );
+    assert_eq!(
+        staged
+            .get(&crate::route::VpnRibRouteKey {
+                nlri_key: key.nlri_key,
+                path_id: 2,
+            })
+            .map(|r| r.next_hop),
+        Some(orr_nh_y()),
+        "path_id 2 = the farther exit (cost 10 via Y)"
     );
 }
 

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -677,10 +677,10 @@ impl PeerSession {
                             }));
                         }
                         if mp.safi == Safi::MplsVpn {
-                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| {
+                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| {
                                 VpnRibRouteKey {
-                                    nlri_key: nlri.key(),
-                                    path_id: 0,
+                                    nlri_key: entry.nlri.key(),
+                                    path_id: entry.path_id,
                                 }
                             }));
                         }
@@ -702,10 +702,10 @@ impl PeerSession {
                     && mp.safi == Safi::MplsVpn
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|nlri| {
+                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|entry| {
                         VpnRibRouteKey {
-                            nlri_key: nlri.key(),
-                            path_id: 0,
+                            nlri_key: entry.nlri.key(),
+                            path_id: entry.path_id,
                         }
                     }));
                 }
@@ -860,10 +860,10 @@ impl PeerSession {
                             }));
                         }
                         if mp.safi == Safi::MplsVpn {
-                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| {
+                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| {
                                 VpnRibRouteKey {
-                                    nlri_key: nlri.key(),
-                                    path_id: 0,
+                                    nlri_key: entry.nlri.key(),
+                                    path_id: entry.path_id,
                                 }
                             }));
                         }
@@ -885,10 +885,10 @@ impl PeerSession {
                     && mp.safi == Safi::MplsVpn
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|nlri| {
+                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|entry| {
                         VpnRibRouteKey {
-                            nlri_key: nlri.key(),
-                            path_id: 0,
+                            nlri_key: entry.nlri.key(),
+                            path_id: entry.path_id,
                         }
                     }));
                 }
@@ -1437,9 +1437,9 @@ impl PeerSession {
                         // VPNv4/VPNv6 announced routes (RFC 4364 / RFC 4659).
                         // Unlike BGP-LS, the policy context carries the real
                         // inner prefix (ADR-0077 honest policy context).
-                        for nlri in &mp.vpn_announced {
+                        for entry in &mp.vpn_announced {
                             let ctx = RouteContext {
-                                prefix: Some(vpn_inner_prefix(&nlri.prefix)),
+                                prefix: Some(vpn_inner_prefix(&entry.nlri.prefix)),
                                 next_hop: Some(mp.next_hop),
                                 extended_communities: update_ecs,
                                 communities: update_communities,
@@ -1472,7 +1472,7 @@ impl PeerSession {
                                 let (attrs, _) =
                                     materialize_attrs(&attr_bundle.mp, &result.modifications);
                                 vpn_announced.push(VpnRibRoute {
-                                    nlri: nlri.clone(),
+                                    nlri: entry.nlri.clone(),
                                     next_hop: mp.next_hop,
                                     peer: self.peer_ip,
                                     attributes: attrs,
@@ -1484,7 +1484,7 @@ impl PeerSession {
                                         .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
                                     is_stale: false,
                                     is_llgr_stale: false,
-                                    path_id: 0,
+                                    path_id: entry.path_id,
                                 });
                             }
                         }
@@ -1675,9 +1675,9 @@ impl PeerSession {
                         }));
                     }
                     if mp.safi == Safi::MplsVpn {
-                        vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|nlri| VpnRibRouteKey {
-                            nlri_key: nlri.key(),
-                            path_id: 0,
+                        vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| VpnRibRouteKey {
+                            nlri_key: entry.nlri.key(),
+                            path_id: entry.path_id,
                         }));
                     }
                     if mp.safi == Safi::RtConstrain {
@@ -1745,6 +1745,10 @@ impl PeerSession {
             self.known_vpn.remove(key);
         }
         for route in &vpn_announced {
+            // Keyed by (RD+prefix, path_id): under VPN Add-Path each received
+            // path counts toward max-prefix separately. Deliberately stricter
+            // than unicast's unique-prefix refcount — over-counting tears the
+            // session down earlier, never lets a peer bypass the cap.
             self.known_vpn.insert(route.key());
         }
         for key in &rtc_withdrawn {

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -242,6 +242,29 @@ impl PeerSession {
                     )
                 })
         });
+        // VPNv4/VPNv6 (SAFI 128) negotiate Add-Path per family (RFC 7911);
+        // when send is negotiated, EVERY VPN NLRI to this peer carries the
+        // 4-octet path ID — announcements and withdrawals alike.
+        let add_path_vpnv4_send = self.negotiated.as_ref().is_some_and(|n| {
+            n.add_path_families
+                .get(&(Afi::Ipv4, Safi::MplsVpn))
+                .is_some_and(|m| {
+                    matches!(
+                        m,
+                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
+                    )
+                })
+        });
+        let add_path_vpnv6_send = self.negotiated.as_ref().is_some_and(|n| {
+            n.add_path_families
+                .get(&(Afi::Ipv6, Safi::MplsVpn))
+                .is_some_and(|m| {
+                    matches!(
+                        m,
+                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
+                    )
+                })
+        });
         // ROUTE-REFRESH *requests* toward the peer (RFC 2918), asked for by
         // the RIB manager (outbound-registration failover: the survivor's
         // Adj-RIB-In must be re-learned from the peer). The manager only
@@ -881,25 +904,37 @@ impl PeerSession {
             let mut v4_routes = Vec::new();
             let mut v6_routes = Vec::new();
             for key in &update.vpn_withdraw {
-                let nlri = rustbgpd_wire::VpnNlri {
-                    labels: vec![],
-                    route_distinguisher: key.nlri_key.route_distinguisher,
-                    prefix: key.nlri_key.prefix,
+                let entry = rustbgpd_wire::VpnNlriEntry {
+                    path_id: key.path_id,
+                    nlri: rustbgpd_wire::VpnNlri {
+                        labels: vec![],
+                        route_distinguisher: key.nlri_key.route_distinguisher,
+                        prefix: key.nlri_key.prefix,
+                    },
                 };
                 let family = key.afi_safi();
                 if !self.negotiated_families.contains(&family) {
                     continue;
                 }
                 match family.0 {
-                    Afi::Ipv4 => v4_routes.push(nlri),
-                    Afi::Ipv6 => v6_routes.push(nlri),
+                    Afi::Ipv4 => v4_routes.push(entry),
+                    Afi::Ipv6 => v6_routes.push(entry),
                     Afi::L2Vpn | Afi::BgpLs => {}
                 }
             }
             let max_len = usize::from(self.max_message_len());
-            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
+            for (afi, routes, add_path) in [
+                (Afi::Ipv4, v4_routes, add_path_vpnv4_send),
+                (Afi::Ipv6, v6_routes, add_path_vpnv6_send),
+            ] {
                 if !routes.is_empty()
-                    && !self.send_vpn_unreach_chunked(afi, &routes, four_octet_as, max_len)
+                    && !self.send_vpn_unreach_chunked(
+                        afi,
+                        &routes,
+                        four_octet_as,
+                        add_path,
+                        max_len,
+                    )
                 {
                     return;
                 }
@@ -1011,7 +1046,7 @@ impl PeerSession {
                 (Afi, Safi),
                 IpAddr,
                 Vec<PathAttribute>,
-                Vec<rustbgpd_wire::VpnNlri>,
+                Vec<rustbgpd_wire::VpnNlriEntry>,
             )> = Vec::new();
             for vpn_route in &update.vpn_announce {
                 let family = vpn_route.afi_safi();
@@ -1020,22 +1055,31 @@ impl PeerSession {
                 }
                 let attrs = self.prepare_outbound_attributes_vpn(vpn_route, is_ebgp);
                 let nh = vpn_route.next_hop;
+                let entry = rustbgpd_wire::VpnNlriEntry {
+                    path_id: vpn_route.path_id,
+                    nlri: vpn_route.nlri.clone(),
+                };
                 if let Some(group) = vpn_groups.iter_mut().find(|(g_family, g_nh, g_attrs, _)| {
                     *g_family == family && *g_nh == nh && *g_attrs == attrs
                 }) {
-                    group.3.push(vpn_route.nlri.clone());
+                    group.3.push(entry);
                 } else {
-                    vpn_groups.push((family, nh, attrs, vec![vpn_route.nlri.clone()]));
+                    vpn_groups.push((family, nh, attrs, vec![entry]));
                 }
             }
             let max_len = usize::from(self.max_message_len());
             for ((afi, _), next_hop, attrs, routes) in vpn_groups {
+                let add_path = match afi {
+                    Afi::Ipv4 => add_path_vpnv4_send,
+                    _ => add_path_vpnv6_send,
+                };
                 if !self.send_vpn_reach_chunked(
                     afi,
                     next_hop,
                     &attrs,
                     &routes,
                     four_octet_as,
+                    add_path,
                     max_len,
                 ) {
                     return;
@@ -1450,13 +1494,18 @@ impl PeerSession {
     /// default rewrite) is deliberately inert for this family — rewriting it
     /// would break the remote PE's transport-label resolution toward the
     /// originating PE.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "VPN chunked sender adds the RFC 7911 add_path flag to the shared chunking shape"
+    )]
     fn send_vpn_reach_chunked(
         &mut self,
         afi: Afi,
         next_hop: IpAddr,
         base_attrs: &[PathAttribute],
-        routes: &[rustbgpd_wire::VpnNlri],
+        routes: &[rustbgpd_wire::VpnNlriEntry],
         four_octet_as: bool,
+        add_path: bool,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
@@ -1481,7 +1530,7 @@ impl PeerSession {
                 &[],
                 &attrs,
                 four_octet_as,
-                false,
+                add_path,
                 Ipv4UnicastMode::Body,
             );
             if msg.encoded_len() > max_len {
@@ -1515,8 +1564,9 @@ impl PeerSession {
     fn send_vpn_unreach_chunked(
         &mut self,
         afi: Afi,
-        routes: &[rustbgpd_wire::VpnNlri],
+        routes: &[rustbgpd_wire::VpnNlriEntry],
         four_octet_as: bool,
+        add_path: bool,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
@@ -1538,7 +1588,7 @@ impl PeerSession {
                 &[],
                 &attrs,
                 four_octet_as,
-                false,
+                add_path,
                 Ipv4UnicastMode::Body,
             );
             if msg.encoded_len() > max_len {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1035,7 +1035,10 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
     );
     assert_eq!(
         mp.vpn_announced,
-        vec![route.nlri.clone()],
+        vec![rustbgpd_wire::VpnNlriEntry {
+            path_id: 0,
+            nlri: route.nlri.clone()
+        }],
         "RD + MPLS label stack must round-trip verbatim"
     );
     session.send_route_update(OutboundRouteUpdate {
@@ -1072,12 +1075,201 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
     assert_eq!(mp.safi, Safi::MplsVpn);
     assert_eq!(
         mp.vpn_withdrawn,
-        vec![VpnNlri {
-            labels: vec![],
-            route_distinguisher: route.nlri.route_distinguisher,
-            prefix: route.nlri.prefix,
+        vec![rustbgpd_wire::VpnNlriEntry {
+            path_id: 0,
+            nlri: VpnNlri {
+                labels: vec![],
+                route_distinguisher: route.nlri.route_distinguisher,
+                prefix: route.nlri.prefix,
+            }
         }],
         "withdraw-mode NLRI carries no label stack (RFC 8277 §2.4 compatibility field)"
+    );
+}
+/// RFC 7911 VPN outbound: with Add-Path send negotiated for (IPv4, SAFI
+/// 128), announcements and withdrawals both carry the 4-octet path ID.
+#[tokio::test]
+async fn send_route_update_emits_vpn_add_path_reach_and_unreach() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::MplsVpn), AddPathMode::Both);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let mut route = make_vpn_rib_route(4093);
+    route.path_id = 2;
+    let key = route.key();
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![route.clone()],
+        rtc_announce: vec![],
+        vpn_withdraw: vec![],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected VPN Add-Path MP_REACH UPDATE");
+    };
+    let vpn_add_path = [(Afi::Ipv4, Safi::MplsVpn)];
+    let parsed = msg.parse(true, false, &vpn_add_path).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN Add-Path announcement must use MP_REACH");
+    assert_eq!(
+        mp.vpn_announced,
+        vec![rustbgpd_wire::VpnNlriEntry {
+            path_id: 2,
+            nlri: route.nlri.clone()
+        }],
+        "announcement must carry the outbound path ID"
+    );
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        rtc_announce: vec![],
+        vpn_withdraw: vec![key],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected VPN Add-Path MP_UNREACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &vpn_add_path).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpUnreachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN Add-Path withdrawal must use MP_UNREACH");
+    assert_eq!(mp.vpn_withdrawn.len(), 1);
+    assert_eq!(
+        mp.vpn_withdrawn[0].path_id, 2,
+        "withdrawal must carry the outbound path ID"
+    );
+}
+/// RFC 7911 VPN inbound: with Add-Path receive negotiated for (IPv4, SAFI
+/// 128), the decoded path ID threads into the `VpnRibRouteKey`/`VpnRibRoute`
+/// delivered to the RIB — announcements and withdrawals alike.
+#[tokio::test]
+async fn process_update_threads_vpn_add_path_ids_into_rib_keys() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, true);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::MplsVpn), AddPathMode::Both);
+    install_test_negotiated_session(&mut session, negotiated);
+    let nlri = VpnNlri {
+        labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+        route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1]),
+        prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+    };
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::MplsVpn,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![
+                rustbgpd_wire::VpnNlriEntry {
+                    path_id: 1,
+                    nlri: nlri.clone(),
+                },
+                rustbgpd_wire::VpnNlriEntry {
+                    path_id: 2,
+                    nlri: nlri.clone(),
+                },
+            ],
+            rtc_announced: vec![],
+        }),
+    ];
+    let update = UpdateMessage::build(&[], &[], &attrs, true, true, Ipv4UnicastMode::Body);
+    session.process_update(update).await;
+    let RibUpdate::VpnRoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected VpnRoutesReceived");
+    };
+    assert_eq!(announced.len(), 2);
+    assert_eq!(announced[0].path_id, 1);
+    assert_eq!(announced[1].path_id, 2);
+    assert_eq!(announced[0].nlri, nlri);
+    assert_eq!(
+        announced[0].key(),
+        rustbgpd_rib::VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 1,
+        }
+    );
+
+    // Withdraw ONLY path 1 — the delivered key must carry the path ID.
+    let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
+        afi: Afi::Ipv4,
+        safi: Safi::MplsVpn,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: vec![],
+        vpn_withdrawn: vec![rustbgpd_wire::VpnNlriEntry {
+            path_id: 1,
+            nlri: VpnNlri {
+                labels: vec![],
+                route_distinguisher: nlri.route_distinguisher,
+                prefix: nlri.prefix,
+            },
+        }],
+        rtc_withdrawn: vec![],
+    })];
+    let update = UpdateMessage::build(&[], &[], &attrs, true, true, Ipv4UnicastMode::Body);
+    session.process_update(update).await;
+    let RibUpdate::VpnRoutesReceived { withdrawn, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected VpnRoutesReceived withdrawal");
+    };
+    assert_eq!(
+        withdrawn,
+        vec![rustbgpd_rib::VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 1,
+        }]
     );
 }
 /// iBGP reflection of a VPN route on an RR adds `ORIGINATOR_ID` and

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -176,8 +176,10 @@ pub struct MpReachNlri {
     pub evpn_announced: Vec<crate::evpn::EvpnRoute>,
     /// BGP-LS NLRI objects (RFC 9552). Populated only for SAFI 71/72.
     pub bgpls_announced: Vec<crate::bgpls::BgpLsNlri>,
-    /// VPNv4/VPNv6 NLRI entries (RFC 4364 / RFC 4659). Populated only for SAFI 128.
-    pub vpn_announced: Vec<crate::vpn::VpnNlri>,
+    /// VPNv4/VPNv6 NLRI entries (RFC 4364 / RFC 4659). Populated only for
+    /// SAFI 128. Carries an RFC 7911 Add-Path path ID per entry; for
+    /// non-Add-Path peers, `path_id` is always 0.
+    pub vpn_announced: Vec<crate::vpn::VpnNlriEntry>,
     /// RT-Constrain NLRI entries (RFC 4684). Populated only for SAFI 132.
     pub rtc_announced: Vec<crate::rtc::RtcNlri>,
 }
@@ -199,8 +201,10 @@ pub struct MpUnreachNlri {
     pub evpn_withdrawn: Vec<crate::evpn::EvpnRoute>,
     /// BGP-LS NLRI objects withdrawn (RFC 9552). Populated only for SAFI 71/72.
     pub bgpls_withdrawn: Vec<crate::bgpls::BgpLsNlri>,
-    /// VPNv4/VPNv6 NLRI entries withdrawn (RFC 4364 / RFC 4659). Populated only for SAFI 128.
-    pub vpn_withdrawn: Vec<crate::vpn::VpnNlri>,
+    /// VPNv4/VPNv6 NLRI entries withdrawn (RFC 4364 / RFC 4659). Populated
+    /// only for SAFI 128. Carries an RFC 7911 Add-Path path ID per entry;
+    /// for non-Add-Path peers, `path_id` is always 0.
+    pub vpn_withdrawn: Vec<crate::vpn::VpnNlriEntry>,
     /// RT-Constrain NLRI entries withdrawn (RFC 4684). Populated only for SAFI 132.
     pub rtc_withdrawn: Vec<crate::rtc::RtcNlri>,
 }
@@ -1163,6 +1167,9 @@ fn decode_mp_reach_nlri(
         }));
     }
     if family == MpNlriFamily::BgpLs {
+        // Deliberately kept even though VPN (SAFI 128) grew Add-Path: no
+        // demand for multi-path BGP-LS topology feeds, and negotiation never
+        // offers Add-Path for these families.
         if add_path_families.contains(&(afi, safi)) {
             return Err(DecodeError::MalformedField {
                 message_type: "UPDATE",
@@ -1188,16 +1195,18 @@ fn decode_mp_reach_nlri(
         }));
     }
     if family == MpNlriFamily::Vpn {
-        if add_path_families.contains(&(afi, safi)) {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: "MP_REACH_NLRI VPN Add-Path is not supported".to_string(),
-            });
-        }
-        let routes = if afi == Afi::Ipv4 {
-            crate::vpn::decode_vpnv4_nlri(nlri_bytes)?
+        let vpn_family = if afi == Afi::Ipv4 {
+            crate::vpn::VpnAddressFamily::V4
         } else {
-            crate::vpn::decode_vpnv6_nlri(nlri_bytes)?
+            crate::vpn::VpnAddressFamily::V6
+        };
+        let routes = if add_path_families.contains(&(afi, safi)) {
+            crate::vpn::decode_vpn_nlri_addpath(nlri_bytes, vpn_family)?
+        } else {
+            crate::vpn::decode_vpn_nlri(nlri_bytes, vpn_family)?
+                .into_iter()
+                .map(|nlri| crate::vpn::VpnNlriEntry { path_id: 0, nlri })
+                .collect()
         };
         return Ok(PathAttribute::MpReachNlri(MpReachNlri {
             afi,
@@ -1213,6 +1222,10 @@ fn decode_mp_reach_nlri(
         }));
     }
     if family == MpNlriFamily::Rtc {
+        // Deliberately kept even though VPN (SAFI 128) grew Add-Path:
+        // Add-Path semantics for RTC *membership* NLRI are undefined-ish
+        // (multiple paths for one RT membership have no useful meaning for
+        // the RFC 4684 outbound filter), and negotiation never offers it.
         if add_path_families.contains(&(afi, safi)) {
             return Err(DecodeError::MalformedField {
                 message_type: "UPDATE",
@@ -1383,6 +1396,8 @@ fn decode_bgpls_mp_unreach(
     withdrawn_bytes: &[u8],
     add_path_families: &[(Afi, Safi)],
 ) -> Result<PathAttribute, DecodeError> {
+    // Kept alongside the VPN Add-Path slice: no demand for multi-path
+    // BGP-LS feeds; negotiation never offers Add-Path for these families.
     if add_path_families.contains(&(afi, safi)) {
         return Err(DecodeError::MalformedField {
             message_type: "UPDATE",
@@ -1416,18 +1431,19 @@ fn decode_vpn_mp_unreach(
     withdrawn_bytes: &[u8],
     add_path_families: &[(Afi, Safi)],
 ) -> Result<PathAttribute, DecodeError> {
-    if add_path_families.contains(&(afi, safi)) {
-        return Err(DecodeError::MalformedField {
-            message_type: "UPDATE",
-            detail: "MP_UNREACH_NLRI VPN Add-Path is not supported".to_string(),
-        });
-    }
     let vpn_family = if afi == Afi::Ipv4 {
         crate::vpn::VpnAddressFamily::V4
     } else {
         crate::vpn::VpnAddressFamily::V6
     };
-    let routes = crate::vpn::decode_vpn_withdraw_nlri(withdrawn_bytes, vpn_family)?;
+    let routes = if add_path_families.contains(&(afi, safi)) {
+        crate::vpn::decode_vpn_withdraw_nlri_addpath(withdrawn_bytes, vpn_family)?
+    } else {
+        crate::vpn::decode_vpn_withdraw_nlri(withdrawn_bytes, vpn_family)?
+            .into_iter()
+            .map(|nlri| crate::vpn::VpnNlriEntry { path_id: 0, nlri })
+            .collect()
+    };
     Ok(PathAttribute::MpUnreachNlri(MpUnreachNlri {
         afi,
         safi,
@@ -1447,6 +1463,8 @@ fn decode_rtc_mp_unreach(
     withdrawn_bytes: &[u8],
     add_path_families: &[(Afi, Safi)],
 ) -> Result<PathAttribute, DecodeError> {
+    // Kept alongside the VPN Add-Path slice: Add-Path semantics for RTC
+    // membership NLRI are undefined-ish; negotiation never offers it.
     if add_path_families.contains(&(afi, safi)) {
         return Err(DecodeError::MalformedField {
             message_type: "UPDATE",
@@ -1928,7 +1946,13 @@ fn encode_mp_reach_nlri(
         } else {
             crate::vpn::VpnAddressFamily::V6
         };
-        crate::vpn::encode_vpn_nlri(&mp.vpn_announced, family, buf)?;
+        if add_path {
+            crate::vpn::encode_vpn_nlri_addpath(&mp.vpn_announced, family, buf)?;
+        } else {
+            for entry in &mp.vpn_announced {
+                crate::vpn::encode_vpn_nlri(std::slice::from_ref(&entry.nlri), family, buf)?;
+            }
+        }
         return Ok(());
     }
     // RTC (SAFI 132): ordinary host next-hop (same forms as unicast),
@@ -2018,8 +2042,19 @@ fn encode_mp_unreach_nlri(
             crate::vpn::VpnAddressFamily::V6
         };
         // RFC 8277 §2.4: withdraws carry the 3-octet compatibility value
-        // 0x800000 in the label position, never a real label stack.
-        crate::vpn::encode_vpn_withdraw_nlri(&mp.vpn_withdrawn, family, buf)?;
+        // 0x800000 in the label position, never a real label stack. Under
+        // Add-Path the 4-octet path ID is prepended to each entry.
+        if add_path {
+            crate::vpn::encode_vpn_withdraw_nlri_addpath(&mp.vpn_withdrawn, family, buf)?;
+        } else {
+            for entry in &mp.vpn_withdrawn {
+                crate::vpn::encode_vpn_withdraw_nlri(
+                    std::slice::from_ref(&entry.nlri),
+                    family,
+                    buf,
+                )?;
+            }
+        }
         return Ok(());
     }
     // RTC (SAFI 132): one codec for both directions (no withdraw split).
@@ -2398,6 +2433,9 @@ mod tests {
             prefix: crate::vpn::VpnPrefix::v6("2001:db8:100::".parse().unwrap(), 48).unwrap(),
         }
     }
+    fn vpn_entry(path_id: u32, nlri: crate::vpn::VpnNlri) -> crate::vpn::VpnNlriEntry {
+        crate::vpn::VpnNlriEntry { path_id, nlri }
+    }
     #[test]
     fn mp_reach_vpn_attribute_roundtrip() {
         let route = vpnv4_nlri(24_017);
@@ -2410,7 +2448,7 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
-            vpn_announced: vec![route.clone()],
+            vpn_announced: vec![vpn_entry(0, route.clone())],
             rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());
@@ -2422,9 +2460,12 @@ mod tests {
             panic!("not MP_REACH after decode");
         };
         assert_eq!(decoded_mp.next_hop, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
-        assert_eq!(decoded_mp.vpn_announced, vec![route]);
-        assert_eq!(decoded_mp.vpn_announced[0].labels[0].label, 24_017);
-        assert_eq!(decoded_mp.vpn_announced[0].route_distinguisher, vpn_rd());
+        assert_eq!(decoded_mp.vpn_announced, vec![vpn_entry(0, route)]);
+        assert_eq!(decoded_mp.vpn_announced[0].nlri.labels[0].label, 24_017);
+        assert_eq!(
+            decoded_mp.vpn_announced[0].nlri.route_distinguisher,
+            vpn_rd()
+        );
         assert!(decoded_mp.announced.is_empty());
     }
     #[test]
@@ -2441,7 +2482,7 @@ mod tests {
             flowspec_withdrawn: vec![],
             evpn_withdrawn: vec![],
             bgpls_withdrawn: vec![],
-            vpn_withdrawn: vec![route.clone()],
+            vpn_withdrawn: vec![vpn_entry(0, route.clone())],
             rtc_withdrawn: vec![],
         };
         let attr = PathAttribute::MpUnreachNlri(mp.clone());
@@ -2456,8 +2497,8 @@ mod tests {
         let PathAttribute::MpUnreachNlri(decoded_mp) = &decoded[0] else {
             panic!("not MP_UNREACH after decode");
         };
-        assert_eq!(decoded_mp.vpn_withdrawn, vec![route]);
-        assert!(decoded_mp.vpn_withdrawn[0].labels.is_empty());
+        assert_eq!(decoded_mp.vpn_withdrawn, vec![vpn_entry(0, route)]);
+        assert!(decoded_mp.vpn_withdrawn[0].nlri.labels.is_empty());
     }
     #[test]
     fn mp_unreach_vpn_withdraw_ignores_label_position_value() {
@@ -2482,13 +2523,16 @@ mod tests {
             panic!("not MP_UNREACH after decode");
         };
         assert_eq!(mp.vpn_withdrawn.len(), 1);
-        assert_eq!(mp.vpn_withdrawn[0].route_distinguisher, vpn_rd());
-        assert_eq!(mp.vpn_withdrawn[0].prefix.to_string(), "10.1.0.0/24");
-        assert!(mp.vpn_withdrawn[0].labels.is_empty());
+        assert_eq!(mp.vpn_withdrawn[0].nlri.route_distinguisher, vpn_rd());
+        assert_eq!(mp.vpn_withdrawn[0].nlri.prefix.to_string(), "10.1.0.0/24");
+        assert!(mp.vpn_withdrawn[0].nlri.labels.is_empty());
     }
     #[test]
-    fn mp_reach_vpn_addpath_rejected() {
-        let attr = PathAttribute::MpReachNlri(MpReachNlri {
+    fn mp_reach_vpn_addpath_roundtrip() {
+        // RFC 7911 for SAFI 128: each NLRI carries a 4-octet path ID when
+        // the family is in the negotiated Add-Path set — both encode and
+        // decode dispatch on `add_path_families` / `add_path_mp`.
+        let mp = MpReachNlri {
             afi: Afi::Ipv4,
             safi: Safi::MplsVpn,
             next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
@@ -2497,22 +2541,42 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
-            vpn_announced: vec![vpnv4_nlri(100)],
+            vpn_announced: vec![vpn_entry(1, vpnv4_nlri(100)), vpn_entry(2, vpnv4_nlri(200))],
             rtc_announced: vec![],
-        });
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
         let mut buf = Vec::new();
-        encode_path_attributes(&[attr], &mut buf, true, false).unwrap();
-        let err = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::MplsVpn)])
-            .expect_err("VPN Add-Path must fail closed");
-        match err {
-            DecodeError::MalformedField { detail, .. } => {
-                assert!(
-                    detail.contains("VPN Add-Path is not supported"),
-                    "unexpected detail: {detail}"
-                );
-            }
-            other => panic!("expected MalformedField, got: {other:?}"),
-        }
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, true).unwrap();
+        let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv4, Safi::MplsVpn)])
+            .expect("decode VPN Add-Path MP_REACH");
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+    }
+    #[test]
+    fn mp_unreach_vpn_addpath_roundtrip() {
+        // Withdraw-mode Add-Path: path_id(4) | len | compatibility field |
+        // RD | prefix per entry (RFC 7911 + RFC 8277 §2.4).
+        let mut route = vpnv6_nlri(0);
+        route.labels = vec![];
+        let mp = MpUnreachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::MplsVpn,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            vpn_withdrawn: vec![vpn_entry(7, route)],
+            rtc_withdrawn: vec![],
+        };
+        let attr = PathAttribute::MpUnreachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, true).unwrap();
+        // Wire layout: flags, type=15, len, AFI(2), SAFI(1), then path_id(4)
+        // and the compatibility field in the label position.
+        assert_eq!(&buf[6..10], &7u32.to_be_bytes(), "path_id");
+        assert_eq!(&buf[11..14], &[0x80, 0x00, 0x00], "compatibility field");
+        let decoded = decode_path_attributes(&buf, true, &[(Afi::Ipv6, Safi::MplsVpn)])
+            .expect("decode VPN Add-Path MP_UNREACH");
+        assert_eq!(decoded, vec![PathAttribute::MpUnreachNlri(mp)]);
     }
     #[test]
     fn mp_reach_vpn_rejects_nonzero_next_hop_rd() {
@@ -2553,7 +2617,7 @@ mod tests {
             flowspec_announced: vec![],
             evpn_announced: vec![],
             bgpls_announced: vec![],
-            vpn_announced: vec![route],
+            vpn_announced: vec![vpn_entry(0, route)],
             rtc_announced: vec![],
         };
         let attr = PathAttribute::MpReachNlri(mp.clone());

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -93,9 +93,10 @@ pub use rtc::{
 pub use update::{Ipv4UnicastMode, UpdateMessage};
 pub use vpn::{
     LABELED_UNICAST_SAFI, MPLS_VPN_SAFI, MplsLabelEntry, VPNV4_AFI, VPNV6_AFI, VpnAddressFamily,
-    VpnNlri, VpnPrefix, VpnRouteKey, decode_vpn_nlri, decode_vpn_withdraw_nlri, decode_vpnv4_nlri,
-    decode_vpnv6_nlri, encode_vpn_nlri, encode_vpn_withdraw_nlri, encode_vpnv4_nlri,
-    encode_vpnv6_nlri,
+    VpnNlri, VpnNlriEntry, VpnPrefix, VpnRouteKey, decode_vpn_nlri, decode_vpn_nlri_addpath,
+    decode_vpn_withdraw_nlri, decode_vpn_withdraw_nlri_addpath, decode_vpnv4_nlri,
+    decode_vpnv6_nlri, encode_vpn_nlri, encode_vpn_nlri_addpath, encode_vpn_withdraw_nlri,
+    encode_vpn_withdraw_nlri_addpath, encode_vpnv4_nlri, encode_vpnv6_nlri,
 };
 
 // ── Routing-domain result enums ──────────────────────────────────────

--- a/crates/wire/src/vpn.rs
+++ b/crates/wire/src/vpn.rs
@@ -1,10 +1,12 @@
-//! VPNv4/VPNv6 labeled NLRI codec substrate.
+//! VPNv4/VPNv6 labeled NLRI codec.
 //!
-//! This module is deliberately pure and unreachable from MP_REACH/MP_UNREACH
-//! dispatch today. It provides the RFC 8277 label-stack and RFC 4364 / RFC
-//! 4659 RD-prefixed VPN prefix codec pieces needed for a future typed
-//! VPNv4/VPNv6 route-reflector slice without treating VPN routes as unicast
-//! [`crate::nlri::Prefix`] values.
+//! Pure codec pieces dispatched from MP_REACH/MP_UNREACH for SAFI 128: the
+//! RFC 8277 label-stack and RFC 4364 / RFC 4659 RD-prefixed VPN prefix
+//! encodings (announce and withdraw-compatibility modes), plus their RFC
+//! 7911 Add-Path variants with the 4-octet Path Identifier prepended to
+//! each NLRI. VPN routes are deliberately not treated as unicast
+//! [`crate::nlri::Prefix`] values — the Route Distinguisher is part of the
+//! route key.
 
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -257,6 +259,19 @@ pub struct VpnNlri {
     pub prefix: VpnPrefix,
 }
 
+/// A VPNv4/VPNv6 NLRI with an optional Add-Path path ID (RFC 7911).
+///
+/// For non-Add-Path peers, `path_id` is always 0. Mirrors the unicast
+/// [`crate::nlri::NlriEntry`] shape: the 4-octet Path Identifier is
+/// prepended to the entire NLRI (length octet included) on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VpnNlriEntry {
+    /// Add-Path path identifier (0 when Add-Path is not in use).
+    pub path_id: u32,
+    /// The VPN NLRI.
+    pub nlri: VpnNlri,
+}
+
 impl VpnNlri {
     /// Return the route-key identity for this NLRI.
     #[must_use]
@@ -387,6 +402,170 @@ pub fn encode_vpn_nlri(
 
     for entry in entries {
         if let Err(err) = encode_one_vpn_nlri(entry, family, buf) {
+            buf.truncate(start_len);
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode Add-Path `VPNv4`/`VPNv6` NLRI bytes (RFC 7911 §3).
+///
+/// Wire format per entry: `[4-byte path_id BE]` prepended to the ordinary
+/// RFC 8277 NLRI (`len | label stack | RD | prefix`).
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for a truncated path ID or malformed length,
+/// label stack, RD, or prefix encodings.
+pub fn decode_vpn_nlri_addpath(
+    mut buf: &[u8],
+    family: VpnAddressFamily,
+) -> Result<Vec<VpnNlriEntry>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let (path_id, rest) = split_vpn_path_id(buf, family)?;
+        buf = rest;
+
+        let field_start = buf;
+        let (value, total_len_bits, rest) = split_vpn_nlri_value(buf, family, "NLRI")?;
+        buf = rest;
+
+        entries.push(VpnNlriEntry {
+            path_id,
+            nlri: decode_one_vpn_nlri(value, total_len_bits, family, field_start)?,
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Decode Add-Path withdraw-mode `VPNv4`/`VPNv6` NLRI bytes
+/// (`MP_UNREACH_NLRI`, RFC 7911 §3 + RFC 8277 §2.4).
+///
+/// The 4-octet Path Identifier is prepended to the whole withdraw-mode NLRI:
+/// `path_id(4) | len | 3-octet compatibility field | RD | prefix`. The
+/// compatibility field's value is ignored, exactly as in
+/// [`decode_vpn_withdraw_nlri`]. Decoded entries have an empty `labels` vec.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for a truncated path ID or malformed length, RD,
+/// or prefix encodings.
+pub fn decode_vpn_withdraw_nlri_addpath(
+    mut buf: &[u8],
+    family: VpnAddressFamily,
+) -> Result<Vec<VpnNlriEntry>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let (path_id, rest) = split_vpn_path_id(buf, family)?;
+        buf = rest;
+
+        let field_start = buf;
+        let (value, total_len_bits, rest) = split_vpn_nlri_value(buf, family, "withdraw NLRI")?;
+        buf = rest;
+
+        entries.push(VpnNlriEntry {
+            path_id,
+            nlri: decode_one_vpn_withdraw_nlri(value, total_len_bits, family, field_start)?,
+        });
+    }
+
+    Ok(entries)
+}
+
+/// Split a 4-octet RFC 7911 Path Identifier off the front of `buf`.
+fn split_vpn_path_id(buf: &[u8], family: VpnAddressFamily) -> Result<(u32, &[u8]), DecodeError> {
+    if buf.len() < 5 {
+        return invalid_vpn_nlri(
+            format!(
+                "{family} Add-Path NLRI truncated: need at least 5 bytes (path_id + length), have {}",
+                buf.len()
+            ),
+            buf,
+            buf.len(),
+        );
+    }
+    let path_id = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    Ok((path_id, &buf[4..]))
+}
+
+/// Split one length-prefixed NLRI value off the front of `buf`, returning
+/// `(value, total_len_bits, rest)`.
+fn split_vpn_nlri_value<'a>(
+    buf: &'a [u8],
+    family: VpnAddressFamily,
+    kind: &str,
+) -> Result<(&'a [u8], u8, &'a [u8]), DecodeError> {
+    let total_len_bits = buf[0];
+    let rest = &buf[1..];
+    let value_len = usize::from(total_len_bits.div_ceil(8));
+
+    if rest.len() < value_len {
+        return invalid_vpn_nlri(
+            format!(
+                "{family} {kind} truncated: length {total_len_bits} bits requires {value_len} bytes, have {}",
+                rest.len()
+            ),
+            buf,
+            1 + rest.len(),
+        );
+    }
+
+    Ok((&rest[..value_len], total_len_bits, &rest[value_len..]))
+}
+
+/// Encode Add-Path `VPNv4`/`VPNv6` NLRI bytes (RFC 7911 §3): each entry's
+/// 4-octet path ID is prepended to the ordinary RFC 8277 NLRI encoding.
+///
+/// On error, `buf` is restored to its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if an entry belongs to the wrong family, its label
+/// stack is invalid, or its encoded length cannot fit in the one-octet NLRI
+/// length.
+pub fn encode_vpn_nlri_addpath(
+    entries: &[VpnNlriEntry],
+    family: VpnAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        buf.extend_from_slice(&entry.path_id.to_be_bytes());
+        if let Err(err) = encode_one_vpn_nlri(&entry.nlri, family, buf) {
+            buf.truncate(start_len);
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+/// Encode Add-Path withdraw-mode `VPNv4`/`VPNv6` NLRI bytes
+/// (`MP_UNREACH_NLRI`, RFC 7911 §3 + RFC 8277 §2.4): each entry's 4-octet
+/// path ID is prepended to the withdraw-mode NLRI (compatibility field
+/// 0x800000 in the label position; each entry's `labels` are ignored).
+///
+/// On error, `buf` is restored to its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if an entry belongs to the wrong family.
+pub fn encode_vpn_withdraw_nlri_addpath(
+    entries: &[VpnNlriEntry],
+    family: VpnAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        buf.extend_from_slice(&entry.path_id.to_be_bytes());
+        if let Err(err) = encode_vpn_withdraw_nlri(std::slice::from_ref(&entry.nlri), family, buf) {
             buf.truncate(start_len);
             return Err(err);
         }
@@ -958,6 +1137,161 @@ mod tests {
         let err = encode_vpn_withdraw_nlri(&[entry], VpnAddressFamily::V4, &mut buf).unwrap_err();
         assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
         assert_eq!(buf, vec![0xAA]);
+    }
+
+    #[test]
+    fn addpath_vpnv4_roundtrip_multiple() {
+        let entries = vec![
+            VpnNlriEntry {
+                path_id: 1,
+                nlri: VpnNlri {
+                    labels: vec![label(200, true)],
+                    route_distinguisher: rd(),
+                    prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+                },
+            },
+            VpnNlriEntry {
+                path_id: 0xFFFF_FFFF,
+                nlri: VpnNlri {
+                    labels: vec![label(16_000, false), label(24_000, true)],
+                    route_distinguisher: rd(),
+                    prefix: VpnPrefix::v4(Ipv4Addr::new(192, 0, 2, 0), 24).unwrap(),
+                },
+            },
+        ];
+        let mut buf = Vec::new();
+        encode_vpn_nlri_addpath(&entries, VpnAddressFamily::V4, &mut buf).unwrap();
+        assert_eq!(
+            decode_vpn_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap(),
+            entries
+        );
+    }
+
+    #[test]
+    fn addpath_vpnv6_roundtrip() {
+        let entry = VpnNlriEntry {
+            path_id: 7,
+            nlri: VpnNlri {
+                labels: vec![label(300, true)],
+                route_distinguisher: rd(),
+                prefix: VpnPrefix::v6("2001:db8:100::".parse().unwrap(), 48).unwrap(),
+            },
+        };
+        let mut buf = Vec::new();
+        encode_vpn_nlri_addpath(std::slice::from_ref(&entry), VpnAddressFamily::V6, &mut buf)
+            .unwrap();
+        assert_eq!(
+            decode_vpn_nlri_addpath(&buf, VpnAddressFamily::V6).unwrap(),
+            vec![entry]
+        );
+    }
+
+    /// GoBGP-shaped `VPNv4` Add-Path fixture: the 4-octet Path Identifier is
+    /// prepended to the whole RFC 8277 NLRI (length octet included) —
+    /// `path_id=2`, then len=112 bits, label 100 (BOS), RD 65001:100,
+    /// 10.0.1.0/24.
+    #[test]
+    fn addpath_vpnv4_gobgp_shaped_fixture() {
+        let mut buf = vec![
+            0x00, 0x00, 0x00, 0x02, // path_id = 2
+            0x70, // 112 bits = 24 label + 64 RD + 24 prefix
+            0x00, 0x06, 0x41, // label 100, TC 0, S=1
+        ];
+        buf.extend_from_slice(&rd().0); // RD 65001:100
+        buf.extend_from_slice(&[10, 0, 1]); // 10.0.1.0/24
+
+        let decoded = decode_vpn_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].path_id, 2);
+        assert_eq!(decoded[0].nlri.labels, vec![label(100, true)]);
+        assert_eq!(decoded[0].nlri.route_distinguisher, rd());
+        assert_eq!(decoded[0].nlri.prefix.to_string(), "10.0.1.0/24");
+
+        let mut reencoded = Vec::new();
+        encode_vpn_nlri_addpath(&decoded, VpnAddressFamily::V4, &mut reencoded).unwrap();
+        assert_eq!(reencoded, buf);
+    }
+
+    #[test]
+    fn addpath_withdraw_roundtrip_emits_compatibility_value() {
+        let entry = VpnNlriEntry {
+            path_id: 3,
+            nlri: VpnNlri {
+                labels: vec![label(200, true)], // ignored on withdraw encode
+                route_distinguisher: rd(),
+                prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+            },
+        };
+        let mut buf = Vec::new();
+        encode_vpn_withdraw_nlri_addpath(
+            std::slice::from_ref(&entry),
+            VpnAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap();
+        // path_id(4) | len | compat(3) | RD(8) | prefix(3)
+        assert_eq!(&buf[..4], &3u32.to_be_bytes());
+        assert_eq!(buf[4], 24 + 64 + 24);
+        assert_eq!(&buf[5..8], &VPN_WITHDRAW_COMPATIBILITY);
+
+        let decoded = decode_vpn_withdraw_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].path_id, 3);
+        assert!(decoded[0].nlri.labels.is_empty());
+        assert_eq!(decoded[0].nlri.route_distinguisher, rd());
+        assert_eq!(decoded[0].nlri.prefix, entry.nlri.prefix);
+    }
+
+    #[test]
+    fn addpath_withdraw_decode_ignores_arbitrary_compatibility_value() {
+        // RFC 8277 §2.4 receiver-MUST-ignore holds under Add-Path too.
+        let mut buf = 9u32.to_be_bytes().to_vec();
+        buf.extend_from_slice(&[24 + 64, 0x0C, 0x35, 0x00]); // label 50000, S=0
+        buf.extend_from_slice(&rd().0);
+        let decoded = decode_vpn_withdraw_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].path_id, 9);
+        assert_eq!(decoded[0].nlri.route_distinguisher, rd());
+    }
+
+    #[test]
+    fn addpath_decode_rejects_truncated_path_id() {
+        let err = decode_vpn_nlri_addpath(&[0, 0, 1], VpnAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+        let err = decode_vpn_withdraw_nlri_addpath(&[0, 0, 1], VpnAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn addpath_decode_rejects_truncated_value() {
+        let mut buf = 1u32.to_be_bytes().to_vec();
+        buf.extend_from_slice(&[112, 0, 0x0C, 0x81]);
+        let err = decode_vpn_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn addpath_encode_rejects_wrong_family_and_restores_buffer() {
+        let entry = VpnNlriEntry {
+            path_id: 1,
+            nlri: VpnNlri {
+                labels: vec![label(100, true)],
+                route_distinguisher: rd(),
+                prefix: VpnPrefix::v6(Ipv6Addr::LOCALHOST, 128).unwrap(),
+            },
+        };
+        let mut buf = vec![0xAA];
+        let err =
+            encode_vpn_nlri_addpath(std::slice::from_ref(&entry), VpnAddressFamily::V4, &mut buf)
+                .unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xAA]);
+
+        let mut buf = vec![0xBB];
+        let err =
+            encode_vpn_withdraw_nlri_addpath(&[entry], VpnAddressFamily::V4, &mut buf).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xBB]);
     }
 
     #[test]

--- a/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
+++ b/docs/adr/0077-mpls-vpn-bgpls-address-family-boundary.md
@@ -419,9 +419,27 @@ derivable from RFC 4684 alone:
    revisit only if gradual-interest churn is observed); eBGP RTC
    distribution subtleties (§3.1 — the shipped arc is iBGP RR; GoBGP's own
    eBGP RTC filtering is broken upstream); RTC × ORF cross-validation
-   (filters compose independently today); Add-Path for SAFI 132 (rejected
-   at negotiation, matching the VPN/BGP-LS posture).
+   (filters compose independently today); Add-Path for SAFI 132 (still
+   rejected at negotiation, matching the BGP-LS posture — Add-Path
+   semantics for RT *membership* NLRI are undefined-ish; SAFI 128 has
+   since grown Add-Path, see the amendment below).
 
 M75 is the interop receipt: GoBGP source/sink, strict filtering, RTC
 reflection, widen/narrow membership without session resets, an unfiltered
 non-RTC peer, and no dataplane installs.
+
+## Amendment (2026-07-02): Add-Path for SAFI 128 shipped
+
+Add-Path (RFC 7911) now covers VPNv4/VPNv6: the family-blind `add_path`
+knobs advertise the capability for configured SAFI-128 families, the
+codec prepends the 4-octet Path Identifier to each VPN NLRI in both
+announce and RFC 8277 §2.4 withdraw-compatibility modes, received path
+IDs key distinct Adj-RIB-In entries, and Add-Path-send staging ranks up
+to `send_max` candidates per RD+prefix (vantage-cost comparator for ORR
+clients; the RFC 4684 RTC gate applies per staged candidate). Loc-RIB
+selection collapses per RD+prefix identity, so the `VpnRouteKey` +
+path-id substrate anticipated above is now live rather than always-zero.
+
+Still deferred from the SAFI-128 register: labeled-unicast (SAFI 4) and
+Add-Path for BGP-LS (SAFI 71/72, no demand) and RT-Constrain (SAFI 132,
+see the 2026-07-01 amendment).

--- a/docs/adr/0095-optimal-route-reflection.md
+++ b/docs/adr/0095-optimal-route-reflection.md
@@ -92,7 +92,11 @@ BIRD/GoBGP/OpenBGPd lack it); only commercial routers do.
 - **Backup IGP locations** (RFC 9107 SHOULD) — when an operator asks for
   vantage redundancy.
 - **Inter-RR Add-Path** (required by RFC 9107 only for multi-cluster
-  deployments) — when a second-RR topology lands.
+  deployments) — the protocol piece is now available: Add-Path for
+  VPNv4/VPNv6 (SAFI 128) negotiates, receives, and sends, and an ORR
+  client's Add-Path top-N is ranked by its vantage costs. Multi-cluster
+  ORR itself remains deferred until a second-RR topology lands to prove
+  it.
 - **VPN-ORR** (vantage ranking for SAFI 128) — **shipped**: an ORR
   client's VPNv4/VPNv6 routes are ranked with its vantage's interior
   cost to each candidate's next-hop, exactly like unicast


### PR DESCRIPTION
**Add-Path (RFC 7911) for SAFI 128** — previously rejected at MP decode. Drivers: RFC 9107 requires inter-RR Add-Path for multi-cluster ORR, and VPN RR redundancy generally. BGP-LS/RTC keep their rejections (rationale commented).

- **Wire**: path-id-prefixed VPN NLRI codec both directions, including the withdraw-mode composition (`path_id(4) | len | 0x800000 compat | RD | prefix` — the RFC 8277 §2.4 receiver-MUST-ignore rule holds under Add-Path, pinned). GoBGP-shaped fixture.
- **Negotiation**: the artificial `safi == Unicast` filter in `add_path_capabilities()` widened to include SAFI 128; everything downstream was already family-generic.
- **Structural fix the substrate needed**: Loc-RIB VPN selection was keyed on `(RD+prefix, path_id)` — harmless at path_id≡0, but real path IDs would have made every received path an independent "best" and single-best staging would advertise duplicates. Loc-RIB now selects per RD+prefix; Adj-RIB-In/Out keep full keys with `SmallVec` secondary indexes (the unicast prefix-index pattern).
- **Receive**: real path IDs thread into `VpnRibRouteKey` across ingest incl. both loop-detect branches; distinct IDs stored/withdrawn independently.
- **Send**: multipath staging mirrors unicast — top-N by `vpn_tiebreak` (or `vpn_tiebreak_orr` for ORR peers), per-candidate RTC gating, stale-path-id withdraws.
- Deliberate divergence (in-code doc): VPN max-prefix counts each (identity, path_id) — stricter than unicast's refcount, can only tear down earlier.

20 files, 17 new tests; full VPN/RTC/ORR/GR matrices untouched; 4568 tests green. Docs: CHANGELOG, KNOWN_ISSUES, ADR-0077 amendment, ADR-0095 inter-RR note (multi-cluster proof stays deferred pending a second-RR topology).