### PR TITLE
fix(rib): bring unicast, FlowSpec, and EVPN GR/LLGR semantics in line with RFC 4724/9494

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-establish (no strict-empty blackout); and an ORR topology source's
   restart no longer unresolves vantages mid-window. The new families
   implement the RFC-strict consecutive-restart deletion and EoR sweep of
-  non-readvertised stale routes; three pre-existing legacy gaps in the
-  unicast/FlowSpec/EVPN paths are documented in KNOWN_ISSUES rather than
-  silently changed. M77 is the live peer-restart interop receipt.
+  non-readvertised stale routes; the pre-existing unicast/FlowSpec/EVPN
+  paths were brought in line afterwards (see Fixed below), leaving only
+  the LLGR-stale export restriction documented in KNOWN_ISSUES. M77 is
+  the live peer-restart interop receipt.
 
 - **Optimal Route Reflection (RFC 9107, ADR-0095) — per-client best paths
   via BGP-LS-sourced SPF.** A route reflector normally reflects *its own*
@@ -130,6 +131,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   no-dataplane-install against a GoBGP source and sink.
 
 ### Fixed
+
+- **Unicast, FlowSpec, and EVPN GR/LLGR semantics brought in line with
+  RFC 4724/9494.** The legacy families now match the strict semantics the
+  RR families (VPN/BGP-LS/RTC) shipped with: a route still stale from a
+  previous restart is deleted — not re-marked in place — when the peer
+  enters graceful restart again (RFC 4724 §4.1: no retention across
+  consecutive restarts), and End-of-RIB removes routes still marked
+  stale or LLGR-stale for that family instead of only clearing flags
+  (RFC 4724 §4.1 / RFC 9494 §4.2), withdrawing them downstream. The EoR
+  sweep is family-scoped (IPv4 and IPv6 unicast/FlowSpec are independent)
+  and also covers the re-establish-during-LLGR path for every family,
+  including the typed ones. The remaining legacy gap — no LLGR-stale
+  export restriction toward non-LLGR peers — stays documented in
+  KNOWN_ISSUES.
 
 - **Audit-tail hardening for BGP-LS, durable cursors, and GR/LLGR intern GC.**
   BGP-LS known-NLRI descriptor TLV ordering errors now discard only the

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -236,12 +236,13 @@ resolved.
   subtleties, and Add-Path remain deferred — see the ADR-0077
   amendment). GR/LLGR stale preservation now covers all of these RR
   families (RFC 4724 helper retention + RFC 9494 two-phase LLGR, M77
-  receipt) — with three documented legacy gaps confined to the
-  pre-existing unicast/FlowSpec/EVPN paths: consecutive-restart
-  re-marking (RFC 4724 says delete), EoR clear-only handling of
-  non-readvertised stale routes, and no LLGR-stale export restriction
-  toward non-LLGR peers (RFC 9494 SHOULD); the new families implement
-  the strict semantics. Other families such as labeled-unicast (SAFI 4)
+  receipt), and the pre-existing unicast/FlowSpec/EVPN paths implement
+  the same RFC-strict consecutive-restart deletion and End-of-RIB sweep
+  of non-readvertised stale routes (RFC 4724 §4.1 / RFC 9494 §4.2). One
+  legacy gap remains across all families: no LLGR-stale export
+  restriction toward non-LLGR peers (RFC 9494 SHOULD; the intra-AS
+  NO_EXPORT + LOCAL_PREF-0 exception also unbuilt). Other families such
+  as labeled-unicast (SAFI 4)
   and VPN FlowSpec (AFI 1/2, SAFI 134) are not implemented.
 - **Graceful Restart: no forwarding-state preservation.** RFC 4724 is
   implemented as helper (receiving speaker) plus minimal restarting speaker

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,9 +106,10 @@ has it, no broad performance sprints without profile evidence.
   The RR role is restart-real: no table dump on a PE restart, no VPN
   blackout at RR-client re-establish, ORR vantages survive a topology
   source restart. The new families implement RFC-strict
-  consecutive-restart deletion and EoR sweeps; three legacy gaps in the
-  pre-existing unicast/FlowSpec/EVPN paths are recorded under tech debt
-  below.
+  consecutive-restart deletion and EoR sweeps; the pre-existing
+  unicast/FlowSpec/EVPN paths have since been brought in line (gaps 1+2
+  of the legacy tech-debt item below), leaving only the LLGR-stale
+  export restriction open.
 - **RR-composition follow-ons** *(queued behind the GR arc, in order)*:
   `distribution.rs` module split (three arcs of growth; pure relocation);
   ORR explainability (`rbgp explain` answering "why did client X get path
@@ -1115,14 +1116,16 @@ branch is between features.
 
 - [ ] **Legacy GR/LLGR RFC gaps in unicast/FlowSpec/EVPN.** The RR families
   (VPN/BGP-LS/RTC, #636–#638) implement the strict semantics; the
-  pre-existing paths have three documented divergences to bring in line:
-  (1) consecutive-restart re-marks already-stale routes in place where
-  RFC 4724 says delete; (2) the EoR arms only clear flags — non-readvertised
-  stale routes survive where RFC 4724 §4.1 says remove; (3) no LLGR-stale
-  export restriction toward peers that didn't advertise LLGR (RFC 9494
-  SHOULD; the intra-AS NO_EXPORT + LOCAL_PREF-0 exception also unbuilt).
-  Each is a small, test-driven change with the new families' code as the
-  in-repo exemplar; (3) is repo-wide and needs a distribution-layer gate.
+  pre-existing paths had three documented divergences. Two are now
+  resolved: (1) consecutive-restart deletes already-stale routes instead
+  of re-marking them in place (RFC 4724 §4.1), and (2) the EoR arms sweep
+  non-readvertised stale/LLGR-stale routes before clearing flags on the
+  re-advertised remainder (RFC 4724 §4.1 / RFC 9494 §4.2) — including the
+  re-establish-during-LLGR path, closed for all families. Remaining:
+  (3) no LLGR-stale export restriction toward peers that didn't advertise
+  LLGR (RFC 9494 SHOULD; the intra-AS NO_EXPORT + LOCAL_PREF-0 exception
+  also unbuilt) — repo-wide, needs a distribution-layer gate at the
+  per-peer Adj-RIB-Out staging point.
 
 - [x] **EVPN origination cross-actor seam audit — RESOLVED** (2026-06-12,
   PR #477). The seam inventory (drain vs. replay, withdrawal ordering,

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -277,13 +277,34 @@ impl AdjRibIn {
         })
     }
 
-    /// Mark all routes matching the given address family as stale.
-    pub fn mark_stale(&mut self, family: (Afi, Safi)) {
+    /// Mark all routes matching the given address family as stale
+    /// (RFC 4724 §4.1 helper retention on session drop).
+    ///
+    /// A route that is *already* stale (GR or LLGR) when a new mark arrives
+    /// survived a previous restart without ever being refreshed and is deleted
+    /// instead of re-marked (RFC 4724 §4.1: stale routes must not be retained
+    /// across consecutive restarts). Returns the deleted prefixes so the
+    /// caller can withdraw them downstream.
+    pub fn mark_stale(&mut self, family: (Afi, Safi)) -> Vec<Prefix> {
+        let already_stale: Vec<(Prefix, u32)> = self
+            .routes
+            .iter()
+            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && route_matches_family(r, family))
+            .map(|(k, _)| *k)
+            .collect();
+        let mut deleted = Vec::new();
+        for key in &already_stale {
+            deleted.push(key.0);
+            self.llgr_stale_local_tags.remove(key);
+            self.routes.remove(key);
+            self.remove_from_prefix_index(&key.0, key.1);
+        }
         for route in self.routes.values_mut() {
             if route_matches_family(route, family) {
                 route.is_stale = true;
             }
         }
+        deleted
     }
 
     /// Clear the stale flag on routes matching the given address family.
@@ -432,6 +453,26 @@ impl AdjRibIn {
         prefixes
     }
 
+    /// Remove LLGR-stale routes for a specific family, returning their
+    /// prefixes. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family(&mut self, family: (Afi, Safi)) -> Vec<Prefix> {
+        let stale: Vec<(Prefix, u32)> = self
+            .routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale && route_matches_family(r, family))
+            .map(|(k, _)| *k)
+            .collect();
+        let mut prefixes = Vec::new();
+        for key in &stale {
+            prefixes.push(key.0);
+            self.llgr_stale_local_tags.remove(key);
+            self.routes.remove(key);
+            self.remove_from_prefix_index(&key.0, key.1);
+        }
+        prefixes
+    }
+
     /// Clear the LLGR-stale flag on routes matching the given family.
     /// Called when `EoR` is received during LLGR phase.
     pub fn clear_llgr_stale(&mut self, family: (Afi, Safi)) {
@@ -551,13 +592,30 @@ impl AdjRibIn {
     // match checks reduce to direct equality.
 
     /// Mark all EVPN routes as stale if `family == (L2Vpn, Evpn)`.
-    pub fn mark_stale_evpn(&mut self, family: (Afi, Safi)) {
+    ///
+    /// A route that is *already* stale (GR or LLGR) when a new mark arrives
+    /// survived a previous restart without ever being refreshed and is deleted
+    /// instead of re-marked (RFC 4724 §4.1: stale routes must not be retained
+    /// across consecutive restarts). Returns the deleted keys so the caller
+    /// can withdraw them downstream.
+    pub fn mark_stale_evpn(&mut self, family: (Afi, Safi)) -> Vec<EvpnRouteKey> {
         if family != (Afi::L2Vpn, Safi::Evpn) {
-            return;
+            return Vec::new();
+        }
+        let already_stale: Vec<EvpnRouteKey> = self
+            .evpn_routes
+            .iter()
+            .filter(|(_, r)| r.is_stale || r.is_llgr_stale)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &already_stale {
+            self.evpn_llgr_stale_local_tags.remove(key);
+            self.evpn_routes.remove(key);
         }
         for route in self.evpn_routes.values_mut() {
             route.is_stale = true;
         }
+        already_stale
     }
 
     /// Clear the stale flag on EVPN routes (both `is_stale` and
@@ -667,6 +725,16 @@ impl AdjRibIn {
             self.evpn_routes.remove(key);
         }
         stale
+    }
+
+    /// Remove LLGR-stale EVPN routes if `family == (L2Vpn, Evpn)`, returning
+    /// their keys. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family_evpn(&mut self, family: (Afi, Safi)) -> Vec<EvpnRouteKey> {
+        if family != (Afi::L2Vpn, Safi::Evpn) {
+            return Vec::new();
+        }
+        self.sweep_llgr_stale_evpn()
     }
 
     /// Clear the LLGR-stale flag on EVPN routes. Called when `EoR` is
@@ -1502,15 +1570,34 @@ impl AdjRibIn {
     }
 
     /// Mark `FlowSpec` routes matching the given address family as stale.
-    pub fn mark_stale_flowspec(&mut self, family: (Afi, Safi)) {
+    ///
+    /// A route that is *already* stale (GR or LLGR) when a new mark arrives
+    /// survived a previous restart without ever being refreshed and is deleted
+    /// instead of re-marked (RFC 4724 §4.1: stale routes must not be retained
+    /// across consecutive restarts). Returns the deleted rules so the caller
+    /// can withdraw them downstream.
+    pub fn mark_stale_flowspec(&mut self, family: (Afi, Safi)) -> Vec<FlowSpecRule> {
         if family.1 != Safi::FlowSpec {
-            return;
+            return Vec::new();
+        }
+        let already_stale: Vec<(FlowSpecRule, u32)> = self
+            .flowspec_routes
+            .iter()
+            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.afi == family.0)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut deleted = Vec::new();
+        for key in &already_stale {
+            deleted.push(key.0.clone());
+            self.flowspec_llgr_stale_local_tags.remove(key);
+            self.flowspec_routes.remove(key);
         }
         for route in self.flowspec_routes.values_mut() {
             if route.afi == family.0 {
                 route.is_stale = true;
             }
         }
+        deleted
     }
 
     /// Remove all stale `FlowSpec` routes, returning their rules.
@@ -1635,6 +1722,28 @@ impl AdjRibIn {
             .flowspec_routes
             .iter()
             .filter(|(_, r)| r.is_llgr_stale)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut rules = Vec::new();
+        for key in &stale {
+            rules.push(key.0.clone());
+            self.flowspec_llgr_stale_local_tags.remove(key);
+            self.flowspec_routes.remove(key);
+        }
+        rules
+    }
+
+    /// Remove LLGR-stale `FlowSpec` routes for a specific family, returning
+    /// their rules. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_flowspec_family(&mut self, family: (Afi, Safi)) -> Vec<FlowSpecRule> {
+        if family.1 != Safi::FlowSpec {
+            return Vec::new();
+        }
+        let stale: Vec<(FlowSpecRule, u32)> = self
+            .flowspec_routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale && r.afi == family.0)
             .map(|(k, _)| k.clone())
             .collect();
         let mut rules = Vec::new();
@@ -2260,6 +2369,57 @@ mod tests {
     }
 
     #[test]
+    fn mark_stale_deletes_already_stale_routes_on_consecutive_restart() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let gr_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+        let llgr_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+        rib.insert(make_route(gr_prefix, Ipv4Addr::new(10, 0, 0, 1)));
+        rib.insert(make_route(llgr_prefix, Ipv4Addr::new(10, 0, 0, 1)));
+
+        // First session drop: both routes go GR-stale; one then enters LLGR.
+        rib.mark_stale((Afi::Ipv4, Safi::Unicast));
+        let llgr_route = rib.routes.get_mut(&(Prefix::V4(llgr_prefix), 0)).unwrap();
+        llgr_route.is_stale = false;
+        llgr_route.is_llgr_stale = true;
+
+        // Second session drop before any refresh: both already-stale routes
+        // (GR-stale and LLGR-stale) are deleted, not re-marked
+        // (RFC 4724 §4.1: no retention across consecutive restarts).
+        let mut deleted = rib.mark_stale((Afi::Ipv4, Safi::Unicast));
+        deleted.sort_by_key(std::string::ToString::to_string);
+        assert_eq!(
+            deleted,
+            vec![Prefix::V4(gr_prefix), Prefix::V4(llgr_prefix)]
+        );
+        assert_eq!(rib.len(), 0);
+        // The secondary prefix index is maintained through the deletion.
+        assert_eq!(rib.iter_prefix(&Prefix::V4(gr_prefix)).count(), 0);
+        assert_eq!(rib.iter_prefix(&Prefix::V4(llgr_prefix)).count(), 0);
+    }
+
+    #[test]
+    fn sweep_llgr_stale_family_scopes_to_family() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let v4 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+        let v6 = Ipv6Prefix::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 32);
+        rib.insert(make_route(v4, Ipv4Addr::new(10, 0, 0, 1)));
+        rib.insert(make_v6_route(
+            v6,
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+        ));
+        for route in rib.iter_mut() {
+            route.is_llgr_stale = true;
+        }
+
+        let swept = rib.sweep_llgr_stale_family((Afi::Ipv4, Safi::Unicast));
+        assert_eq!(swept, vec![Prefix::V4(v4)]);
+        assert_eq!(rib.len(), 1, "v6 LLGR-stale route must survive a v4 sweep");
+        assert!(rib.get(&Prefix::V6(v6), 0).unwrap().is_llgr_stale);
+    }
+
+    #[test]
     fn insert_replaces_existing() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
@@ -2434,6 +2594,50 @@ mod tests {
         assert!(!route.attributes.iter().any(
             |a| matches!(a, PathAttribute::Communities(c) if c.contains(&COMMUNITY_LLGR_STALE))
         ));
+    }
+
+    #[test]
+    fn mark_stale_flowspec_deletes_already_stale_routes_on_consecutive_restart() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+        let rule = route.rule.clone();
+        rib.insert_flowspec(route);
+
+        // First session drop marks the rule stale; a second drop before any
+        // refresh deletes it (RFC 4724 §4.1: no retention across
+        // consecutive restarts).
+        assert!(
+            rib.mark_stale_flowspec((Afi::Ipv4, Safi::FlowSpec))
+                .is_empty()
+        );
+        let deleted = rib.mark_stale_flowspec((Afi::Ipv4, Safi::FlowSpec));
+        assert_eq!(deleted, vec![rule]);
+        assert_eq!(rib.flowspec_len(), 0);
+    }
+
+    #[test]
+    fn sweep_llgr_stale_flowspec_family_scopes_to_family() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let mut v4_route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+        v4_route.is_llgr_stale = true;
+        let v4_rule = v4_route.rule.clone();
+        let mut v6_route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+        v6_route.afi = Afi::Ipv6;
+        v6_route.path_id = 1; // distinct key from the v4 fixture rule
+        v6_route.is_llgr_stale = true;
+        rib.insert_flowspec(v4_route);
+        rib.insert_flowspec(v6_route);
+
+        let swept = rib.sweep_llgr_stale_flowspec_family((Afi::Ipv4, Safi::FlowSpec));
+        assert_eq!(swept, vec![v4_rule]);
+        assert_eq!(
+            rib.flowspec_len(),
+            1,
+            "v6 LLGR-stale rule must survive a v4 sweep"
+        );
+        assert!(rib.iter_flowspec().next().unwrap().is_llgr_stale);
     }
 
     #[test]
@@ -2626,6 +2830,29 @@ mod tests {
         // Sanity: the EVPN key is still present
         assert_eq!(rib.evpn_len(), 1);
         let _ = evpn_key;
+    }
+
+    #[test]
+    fn mark_stale_evpn_deletes_already_stale_routes_on_consecutive_restart() {
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer_ip);
+        let gr_key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+        let llgr_key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 200, vec![]);
+
+        // First session drop: both routes go GR-stale; one then enters LLGR.
+        rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        let llgr_route = rib.evpn_routes.get_mut(&llgr_key).unwrap();
+        llgr_route.is_stale = false;
+        llgr_route.is_llgr_stale = true;
+
+        // Second session drop before any refresh: both already-stale routes
+        // (GR-stale and LLGR-stale) are deleted, not re-marked
+        // (RFC 4724 §4.1: no retention across consecutive restarts).
+        let deleted = rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
+        assert_eq!(deleted.len(), 2);
+        assert!(deleted.contains(&gr_key));
+        assert!(deleted.contains(&llgr_key));
+        assert_eq!(rib.evpn_len(), 0);
     }
 
     #[test]

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -64,28 +64,24 @@ impl RibManager {
         let mut rtc_affected: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
 
         if let Some(rib) = self.ribs.get_mut(&peer) {
-            // EVPN has a single family tuple, so the inner mark_stale_evpn
-            // call is identical for every entry in `gr_families`. Hoist
-            // it out of the loop and call once when (L2Vpn, Evpn) is
-            // among the GR-preserved families.
+            // RFC 4724 helper retention: mark GR-covered families stale.
+            // Every mark helper returns the keys of routes that were
+            // ALREADY stale from a previous restart and were deleted
+            // (RFC 4724 §4.1: no retention across consecutive restarts) —
+            // collect them so the recompute below withdraws them
+            // downstream. Each helper is a family-scoped no-op for
+            // non-matching tuples. EVPN has a single family tuple, so its
+            // mark call is hoisted out of the loop and made once when
+            // (L2Vpn, Evpn) is among the GR-preserved families.
             for &family in &gr_families {
-                rib.mark_stale(family);
-                rib.mark_stale_flowspec(family);
-            }
-            if gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
-                rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
-            }
-            // RFC 4724 helper retention for the typed RIBs (VPN, BGP-LS,
-            // RTC): mark GR-covered families stale. The returned keys are
-            // routes that were ALREADY stale from a previous restart and
-            // were deleted (RFC 4724 §4.1: no retention across consecutive
-            // restarts) — collect them so the recompute below withdraws
-            // them downstream. Each mark helper is a family-scoped no-op
-            // for non-matching tuples.
-            for &family in &gr_families {
+                affected.extend(rib.mark_stale(family));
+                fs_affected.extend(rib.mark_stale_flowspec(family));
                 vpn_affected.extend(rib.mark_stale_vpn(family));
                 bgpls_affected.extend(rib.mark_stale_bgpls(family));
                 rtc_affected.extend(rib.mark_stale_rtc(family));
+            }
+            if gr_families.contains(&(Afi::L2Vpn, Safi::Evpn)) {
+                evpn_affected.extend(rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn)));
             }
             let withdrawn = rib.withdraw_families_except(&gr_families);
             if !withdrawn.is_empty() {

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -169,30 +169,50 @@ impl RibManager {
             };
 
             let mut rtc_swept = false;
+            let mut swept_prefixes: Vec<Prefix> = Vec::new();
             if let Some(rib) = self.ribs.get_mut(&peer) {
+                // RFC 4724 §4.1 End-of-RIB removal for every family: a
+                // route still marked stale here was not re-advertised
+                // during the restart window and is deleted (re-advertised
+                // routes had their flag cleared on insert). Routes still
+                // LLGR-stale are swept too: a peer that re-established
+                // DURING the LLGR phase moved back to `gr_peers`
+                // (`handle_peer_up`) while its unrefreshed routes kept
+                // their LLGR-stale flag — they were equally not
+                // re-advertised (RFC 9494 §4.2). The trailing clear is
+                // flag/LLGR-community hygiene for the retained routes.
+                // Each helper is a family-scoped no-op for non-matching
+                // tuples.
+                swept_prefixes = rib.sweep_stale_family((afi, safi));
+                swept_prefixes.extend(rib.sweep_llgr_stale_family((afi, safi)));
                 rib.clear_stale((afi, safi));
+                rib.sweep_stale_flowspec_family((afi, safi));
+                rib.sweep_llgr_stale_flowspec_family((afi, safi));
                 rib.clear_stale_flowspec((afi, safi));
+                rib.sweep_stale_family_evpn((afi, safi));
+                rib.sweep_llgr_stale_family_evpn((afi, safi));
                 rib.clear_stale_evpn((afi, safi));
-                // Typed families (VPN, BGP-LS, RTC) implement the RFC 4724
-                // §4.1 End-of-RIB removal: a route still marked stale here
-                // was not re-advertised during the restart window and is
-                // deleted (re-advertised routes had their flag cleared on
-                // insert). The trailing clear is flag/LLGR-community
-                // hygiene for the retained routes. Each helper is a
-                // family-scoped no-op for non-matching tuples.
                 rib.sweep_stale_family_vpn((afi, safi));
+                rib.sweep_llgr_stale_family_vpn((afi, safi));
                 rib.clear_stale_vpn((afi, safi));
                 rib.sweep_stale_family_bgpls((afi, safi));
+                rib.sweep_llgr_stale_family_bgpls((afi, safi));
                 rib.clear_stale_bgpls((afi, safi));
                 rtc_swept = !rib.sweep_stale_family_rtc((afi, safi)).is_empty();
+                rtc_swept |= !rib.sweep_llgr_stale_family_rtc((afi, safi)).is_empty();
                 rib.clear_stale_rtc((afi, safi));
             }
 
-            let affected: HashSet<Prefix> = self
+            // FlowSpec/EVPN affected keys were collected BEFORE the sweep,
+            // so removed keys are already in their sets; the unicast set is
+            // collected from the retained routes and needs the swept
+            // prefixes joined in so their withdrawals distribute.
+            let mut affected: HashSet<Prefix> = self
                 .ribs
                 .get(&peer)
                 .map(|rib| rib.iter().map(|r| r.prefix).collect())
                 .unwrap_or_default();
+            affected.extend(swept_prefixes);
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
             if !fs_affected.is_empty() {
@@ -312,17 +332,21 @@ impl RibManager {
             };
 
             let mut rtc_swept = false;
+            let mut swept_prefixes: Vec<Prefix> = Vec::new();
             if let Some(rib) = self.ribs.get_mut(&peer) {
+                // RFC-strict End-of-RIB removal for every family, matching
+                // the GR arm: a route still LLGR-stale here was not
+                // re-advertised during the LLGR window and is deleted
+                // (RFC 4724 §4.1 via RFC 9494 §4.2). The trailing clear is
+                // flag/LLGR-community hygiene for the retained routes.
+                // Each helper is a family-scoped no-op for non-matching
+                // tuples.
+                swept_prefixes = rib.sweep_llgr_stale_family((afi, safi));
                 rib.clear_llgr_stale((afi, safi));
+                rib.sweep_llgr_stale_flowspec_family((afi, safi));
                 rib.clear_llgr_stale_flowspec((afi, safi));
+                rib.sweep_llgr_stale_family_evpn((afi, safi));
                 rib.clear_llgr_stale_evpn((afi, safi));
-                // Typed families (VPN, BGP-LS, RTC) implement the RFC-strict
-                // End-of-RIB removal, matching the GR arm: a route still
-                // LLGR-stale here was not re-advertised during the LLGR
-                // window and is deleted (RFC 4724 §4.1 via RFC 9494 §4.2).
-                // The trailing clear is flag/LLGR-community hygiene for the
-                // retained routes. The unicast/FlowSpec/EVPN clears above
-                // keep the legacy clear-only behavior (documented gap).
                 rib.sweep_llgr_stale_family_vpn((afi, safi));
                 rib.clear_llgr_stale_vpn((afi, safi));
                 rib.sweep_llgr_stale_family_bgpls((afi, safi));
@@ -331,11 +355,15 @@ impl RibManager {
                 rib.clear_llgr_stale_rtc((afi, safi));
             }
 
-            let affected: HashSet<Prefix> = self
+            // Same shape as the GR arm: FlowSpec/EVPN affected keys already
+            // include the swept ones (collected pre-sweep); join the swept
+            // unicast prefixes so their withdrawals distribute.
+            let mut affected: HashSet<Prefix> = self
                 .ribs
                 .get(&peer)
                 .map(|rib| rib.iter().map(|r| r.prefix).collect())
                 .unwrap_or_default();
+            affected.extend(swept_prefixes);
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
             if !fs_affected.is_empty() {

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -10612,6 +10612,10 @@ async fn gr_marks_stale_and_demotes_routes() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "covers the stale demotion, RFC 4724 §4.1 re-advertise-before-EoR, and best-path flip-back in one scenario"
+)]
 async fn gr_flowspec_eor_recomputes_and_redistributes() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
@@ -10652,7 +10656,7 @@ async fn gr_flowspec_eor_recomputes_and_redistributes() {
         peer: source_a,
         announced: vec![],
         withdrawn: vec![],
-        flowspec_announced: vec![route_a],
+        flowspec_announced: vec![route_a.clone()],
         flowspec_withdrawn: vec![],
         evpn_announced: vec![],
         evpn_withdrawn: vec![],
@@ -10702,6 +10706,21 @@ async fn gr_flowspec_eor_recomputes_and_redistributes() {
     assert_eq!(best_during_gr.len(), 1);
     assert_eq!(best_during_gr[0].peer, source_b);
 
+    // RFC 4724 §4.1: a route still marked stale at End-of-RIB is removed,
+    // so source_a must re-advertise its rule for it to survive (and win
+    // the best-path back from source_b).
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source_a,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![route_a],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         session_id: 0,
         peer: source_a,
@@ -10724,6 +10743,230 @@ async fn gr_flowspec_eor_recomputes_and_redistributes() {
     handle.await.unwrap();
 }
 
+/// A `FlowSpec` rule distinct from the shared `make_flowspec_route` fixture
+/// rule, so one source peer can hold two Adj-RIB-In entries.
+fn make_flowspec_route_alt(peer: Ipv4Addr) -> FlowSpecRoute {
+    let mut route = make_flowspec_route(peer);
+    route.rule.components = vec![rustbgpd_wire::FlowSpecComponent::DestinationPrefix(
+        rustbgpd_wire::FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24)),
+    )];
+    route
+}
+
+/// A second GR entry while `FlowSpec` routes are still stale deletes them
+/// (RFC 4724 §4.1: no retention across consecutive restarts).
+#[tokio::test]
+async fn flowspec_gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1))],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let gr_entry = || RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::FlowSpec)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry()).await.unwrap();
+    let stale = query_flowspec_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tx.send(gr_entry()).await.unwrap();
+    assert!(
+        query_flowspec_routes(&tx).await.is_empty(),
+        "a rule still stale at the next restart must be deleted, not re-marked"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4724 §4.1: a `FlowSpec` rule still marked stale at End-of-RIB was
+/// not re-advertised during the restart window and must be removed; the
+/// re-advertised rule survives with its stale flag cleared.
+#[tokio::test]
+async fn flowspec_gr_eor_sweeps_non_readvertised() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+    let dropped = make_flowspec_route_alt(Ipv4Addr::new(10, 0, 0, 1));
+    let kept_rule = kept.rule.clone();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![kept.clone(), dropped],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::FlowSpec)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_flowspec_routes(&tx).await;
+    assert_eq!(stale.len(), 2);
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![kept],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::FlowSpec,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_flowspec_routes(&tx).await;
+    assert_eq!(
+        after_eor.len(),
+        1,
+        "the non-readvertised stale FlowSpec rule must be removed at End-of-RIB"
+    );
+    assert_eq!(after_eor[0].rule, kept_rule);
+    assert!(!after_eor[0].is_stale, "EoR must clear the stale flag");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 4724 §4.1 via RFC 9494 §4.2: a `FlowSpec` rule still LLGR-stale at
+/// End-of-RIB was not re-advertised during the LLGR window and must be
+/// removed; the re-advertised rule survives with flags cleared.
+#[tokio::test]
+async fn flowspec_llgr_eor_sweeps_non_readvertised() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+    let dropped = make_flowspec_route_alt(Ipv4Addr::new(10, 0, 0, 1));
+    let kept_rule = kept.rule.clone();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![kept.clone(), dropped],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 2,
+        stale_routes_time: 5,
+        gr_families: vec![(Afi::Ipv4, Safi::FlowSpec)],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::FlowSpec,
+            forwarding_preserved: false,
+            stale_time: 3600,
+        }],
+        llgr_stale_time: 3600,
+    })
+    .await
+    .unwrap();
+    let stale = query_flowspec_routes(&tx).await;
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    // Advance past GR timer → LLGR phase
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let promoted = query_flowspec_routes(&tx).await;
+    assert!(promoted.iter().all(|r| r.is_llgr_stale));
+
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![kept],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::FlowSpec,
+    })
+    .await
+    .unwrap();
+
+    let after_eor = query_flowspec_routes(&tx).await;
+    assert_eq!(
+        after_eor.len(),
+        1,
+        "the non-readvertised LLGR-stale FlowSpec rule must be removed at End-of-RIB"
+    );
+    assert_eq!(after_eor[0].rule, kept_rule);
+    assert!(!after_eor[0].is_llgr_stale, "EoR must clear the LLGR flag");
+    assert!(!after_eor[0].is_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn gr_eor_clears_stale() {
     let (tx, rx) = mpsc::channel(64);
@@ -10731,13 +10974,17 @@ async fn gr_eor_clears_stale() {
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let kept_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let dropped_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
 
-    // Source sends a route
+    // Source sends two routes
     tx.send(RibUpdate::RoutesReceived {
         session_id: 0,
         peer: source,
-        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        announced: vec![
+            make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_route(dropped_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+        ],
         withdrawn: vec![],
         flowspec_announced: vec![],
         flowspec_withdrawn: vec![],
@@ -10762,14 +11009,23 @@ async fn gr_eor_clears_stale() {
     .unwrap();
 
     // Verify stale
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
-    assert!(best[0].is_stale);
+    let best = query_best_routes(&tx).await;
+    assert_eq!(best.len(), 2);
+    assert!(best.iter().all(|r| r.is_stale));
 
-    // Send End-of-RIB
+    // Only `kept_prefix` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         session_id: 0,
         peer: source,
@@ -10779,16 +11035,133 @@ async fn gr_eor_clears_stale() {
     .await
     .unwrap();
 
-    // Route should no longer be stale
-    let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
-        .await
-        .unwrap();
-    let best = reply_rx.await.unwrap();
-    assert_eq!(best.len(), 1);
+    // RFC 4724 §4.1: a route still marked stale at End-of-RIB was not
+    // re-advertised during the restart window and must be removed; the
+    // re-advertised route survives with its stale flag cleared.
+    let best = query_best_routes(&tx).await;
+    assert_eq!(
+        best.len(),
+        1,
+        "the non-readvertised stale route must be removed at End-of-RIB"
+    );
+    assert_eq!(best[0].prefix, Prefix::V4(kept_prefix));
     assert!(
         !best[0].is_stale,
         "route should no longer be stale after EoR"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A second GR entry while unicast routes are still stale deletes them
+/// (RFC 4724 §4.1: no retention across consecutive restarts).
+#[tokio::test]
+async fn gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let gr_entry = || RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry()).await.unwrap();
+    let stale = query_best_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tx.send(gr_entry()).await.unwrap();
+    assert!(
+        query_best_routes(&tx).await.is_empty(),
+        "a route still stale at the next restart must be deleted, not re-marked"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The RFC 4724 §4.1 End-of-RIB sweep is family-scoped: an (IPv4, Unicast)
+/// `EoR` removes only non-readvertised IPv4 stale routes — an IPv6 unicast
+/// route from the same peer stays stale, awaiting its own `EoR`.
+#[tokio::test]
+async fn gr_eor_sweep_scopes_to_family() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source: IpAddr = "10.0.0.1".parse().unwrap();
+    let v4_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let v6_prefix = Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32);
+    let mut v6_route = make_v6_route(v6_prefix, "2001:db8::1".parse().unwrap());
+    v6_route.peer = source;
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(v4_prefix, Ipv4Addr::new(10, 0, 0, 1)), v6_route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+    let stale = query_best_routes(&tx).await;
+    assert_eq!(stale.len(), 2);
+    assert!(stale.iter().all(|r| r.is_stale));
+
+    // IPv4 EoR without re-advertisement: the v4 route is removed
+    // (RFC 4724 §4.1), the v6 route is untouched and still stale.
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+
+    let best = query_best_routes(&tx).await;
+    assert_eq!(best.len(), 1, "only the IPv6 route survives the IPv4 EoR");
+    assert_eq!(best[0].prefix, Prefix::V6(v6_prefix));
+    assert!(
+        best[0].is_stale,
+        "the IPv6 route still awaits its own End-of-RIB"
     );
 
     drop(tx);
@@ -10933,6 +11306,22 @@ async fn gr_peer_up_defers_stale_to_eor() {
     let best = reply_rx.await.unwrap();
     assert_eq!(best.len(), 1);
     assert!(best[0].is_stale, "route should still be stale after PeerUp");
+
+    // Re-advertise before End-of-RIB: RFC 4724 §4.1 removes any route
+    // still marked stale when the EoR arrives, so only a re-advertised
+    // route survives GR completion.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
 
     // End-of-RIB clears stale and completes GR
     tx.send(RibUpdate::EndOfRib {
@@ -11327,12 +11716,16 @@ async fn llgr_eor_clears_llgr_stale() {
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let kept_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let dropped_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
 
     tx.send(RibUpdate::RoutesReceived {
         session_id: 0,
         peer: source,
-        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        announced: vec![
+            make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_route(dropped_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+        ],
         withdrawn: vec![],
         flowspec_announced: vec![],
         flowspec_withdrawn: vec![],
@@ -11362,14 +11755,14 @@ async fn llgr_eor_clears_llgr_stale() {
 
     // Ensure manager processes PeerGracefulRestart
     let best = query_best_routes(&tx).await;
-    assert!(best[0].is_stale);
+    assert!(best.iter().all(|r| r.is_stale));
 
     // Advance past GR timer → LLGR phase
     tokio::time::advance(Duration::from_secs(3)).await;
     tokio::task::yield_now().await;
 
     let best = query_best_routes(&tx).await;
-    assert!(best[0].is_llgr_stale);
+    assert!(best.iter().all(|r| r.is_llgr_stale));
 
     // Peer re-establishes during LLGR
     let (out_tx, mut out_rx) = mpsc::channel(64);
@@ -11392,7 +11785,19 @@ async fn llgr_eor_clears_llgr_stale() {
     .unwrap();
     drain_eor(&mut out_rx).await;
 
-    // EoR should clear LLGR-stale
+    // Only `kept_prefix` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         session_id: 0,
         peer: source,
@@ -11402,8 +11807,16 @@ async fn llgr_eor_clears_llgr_stale() {
     .await
     .unwrap();
 
+    // RFC 4724 §4.1 via RFC 9494 §4.2: a route still LLGR-stale at
+    // End-of-RIB was not re-advertised during the LLGR window and must be
+    // removed; the re-advertised route survives with flags cleared.
     let best = query_best_routes(&tx).await;
-    assert_eq!(best.len(), 1);
+    assert_eq!(
+        best.len(),
+        1,
+        "the non-readvertised LLGR-stale route must be removed at End-of-RIB"
+    );
+    assert_eq!(best[0].prefix, Prefix::V4(kept_prefix));
     assert!(
         !best[0].is_llgr_stale,
         "LLGR-stale should be cleared by EoR"
@@ -16548,7 +16961,9 @@ async fn evpn_gr_eor_clears_stale() {
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    let imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let kept = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let dropped = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 200);
+    let kept_key = kept.key();
     tx.send(RibUpdate::RoutesReceived {
         session_id: 0,
         peer: source,
@@ -16556,7 +16971,7 @@ async fn evpn_gr_eor_clears_stale() {
         withdrawn: vec![],
         flowspec_announced: vec![],
         flowspec_withdrawn: vec![],
-        evpn_announced: vec![imet],
+        evpn_announced: vec![kept.clone(), dropped],
         evpn_withdrawn: vec![],
     })
     .await
@@ -16576,8 +16991,22 @@ async fn evpn_gr_eor_clears_stale() {
     .unwrap();
 
     let best = query_evpn_routes(&tx).await;
-    assert!(best[0].is_stale);
+    assert_eq!(best.len(), 2);
+    assert!(best.iter().all(|r| r.is_stale));
 
+    // Only `kept` is re-advertised before End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![kept],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         session_id: 0,
         peer: source,
@@ -16587,9 +17016,65 @@ async fn evpn_gr_eor_clears_stale() {
     .await
     .unwrap();
 
+    // RFC 4724 §4.1: an EVPN route still marked stale at End-of-RIB was
+    // not re-advertised during the restart window and must be removed;
+    // the re-advertised route survives with its stale flag cleared.
     let best = query_evpn_routes(&tx).await;
-    assert_eq!(best.len(), 1);
+    assert_eq!(
+        best.len(),
+        1,
+        "the non-readvertised stale EVPN route must be removed at End-of-RIB"
+    );
+    assert_eq!(best[0].key(), kept_key);
     assert!(!best[0].is_stale, "EoR should clear stale flag");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A second GR entry while EVPN routes are still stale deletes them
+/// (RFC 4724 §4.1: no retention across consecutive restarts).
+#[tokio::test]
+async fn evpn_gr_consecutive_restart_deletes_stale_routes() {
+    let (tx, rx) = mpsc::channel(64);
+    let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
+    let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100)],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let gr_entry = || RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::L2Vpn, Safi::Evpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    };
+    tx.send(gr_entry()).await.unwrap();
+    let stale = query_evpn_routes(&tx).await;
+    assert_eq!(stale.len(), 1);
+    assert!(stale[0].is_stale);
+
+    tx.send(gr_entry()).await.unwrap();
+    assert!(
+        query_evpn_routes(&tx).await.is_empty(),
+        "a route still stale at the next restart must be deleted, not re-marked"
+    );
 
     drop(tx);
     handle.await.unwrap();
@@ -16789,7 +17274,9 @@ async fn evpn_llgr_eor_clears_llgr_stale() {
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-    let imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let kept = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let dropped = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 200);
+    let kept_key = kept.key();
     tx.send(RibUpdate::RoutesReceived {
         session_id: 0,
         peer: source,
@@ -16797,7 +17284,7 @@ async fn evpn_llgr_eor_clears_llgr_stale() {
         withdrawn: vec![],
         flowspec_announced: vec![],
         flowspec_withdrawn: vec![],
-        evpn_announced: vec![imet],
+        evpn_announced: vec![kept.clone(), dropped],
         evpn_withdrawn: vec![],
     })
     .await
@@ -16823,21 +17310,34 @@ async fn evpn_llgr_eor_clears_llgr_stale() {
 
     // Force the manager to process PeerGracefulRestart before advancing time
     let best = query_evpn_routes(&tx).await;
-    assert_eq!(best.len(), 1);
-    assert!(best[0].is_stale);
+    assert_eq!(best.len(), 2);
+    assert!(best.iter().all(|r| r.is_stale));
 
     tokio::time::advance(Duration::from_secs(3)).await;
     tokio::task::yield_now().await;
     let best = query_evpn_routes(&tx).await;
-    assert!(best[0].is_llgr_stale);
-    assert!(
-        best[0]
-            .communities()
+    assert!(best.iter().all(|r| r.is_llgr_stale));
+    assert!(best.iter().all(|r| {
+        r.communities()
             .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
-    );
+    }));
 
-    // EoR during LLGR phase: clears is_llgr_stale + strips locally-injected
-    // LLGR_STALE community
+    // Only `kept` is re-advertised before End-of-RIB. EoR during the LLGR
+    // phase removes what was not re-advertised (RFC 4724 §4.1 via RFC 9494
+    // §4.2) and clears is_llgr_stale + strips the locally-injected
+    // LLGR_STALE community on the retained route.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![kept],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         session_id: 0,
         peer: source,
@@ -16848,7 +17348,12 @@ async fn evpn_llgr_eor_clears_llgr_stale() {
     .unwrap();
 
     let best = query_evpn_routes(&tx).await;
-    assert_eq!(best.len(), 1);
+    assert_eq!(
+        best.len(),
+        1,
+        "the non-readvertised LLGR-stale EVPN route must be removed at End-of-RIB"
+    );
+    assert_eq!(best[0].key(), kept_key);
     assert!(!best[0].is_llgr_stale, "LLGR-stale flag must be cleared");
     assert!(
         !best[0]
@@ -20883,6 +21388,14 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
         "GR expiry must reclaim the pre-promotion interned set after Loc-RIB recompute"
     );
 
+    // Re-advertise the route during the LLGR window: RFC 4724 §4.1 (via
+    // RFC 9494 §4.2) removes any route still LLGR-stale at End-of-RIB, so
+    // only a re-advertised route exercises the retained-route stale-clear
+    // path this test pins.
+    let mut readvertised = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    readvertised.attributes = Arc::new(vec![PathAttribute::Med(100)]);
+    manager.process_announce_chunk(peer, vec![readvertised]);
+
     manager.handle_update(RibUpdate::EndOfRib {
         session_id: 0,
         peer,
@@ -20900,8 +21413,9 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
     );
     assert_eq!(
         manager.ribs[&peer].intern_len(),
-        0,
-        "LLGR EoR stale-clear must reclaim the orphaned pre-promotion interned set"
+        1,
+        "only the re-advertised route's live interned set survives EoR — the \
+         orphaned pre-promotion set stays reclaimed"
     );
 }
 


### PR DESCRIPTION
Closes gaps 1+2 of the three legacy GR/LLGR RFC divergences documented in tech debt, using the RR families' strict code (#636–#638) as the exemplar:

1. **Consecutive-restart delete-on-remark** (RFC 4724 §4.1): `mark_stale`/`_flowspec`/`_evpn` now delete already-stale routes and return the keys for downstream withdrawal (prefix-index integrity maintained), instead of re-marking in place.
2. **EoR sweeps non-readvertised stale routes** (RFC 4724 §4.1, and via RFC 9494 §4.2 in the LLGR arm): sweep-then-clear for all six families, family-scoped (v4/v6 independent).

**Bonus repo-wide fix the strict tests exposed**: a peer re-establishing *during LLGR* is moved back to GR while its routes remain LLGR-stale — the GR EoR arm previously only flag-cleared those (for every family, including the new ones). The GR arm now also runs the LLGR-family sweeps.

Seven existing tests updated to the strict expectations, each citing its RFC clause; ~10 new tests. M11/M16 interop scripts read through — nothing depends on the lenient behavior. Gap 3 (LLGR export restriction toward non-LLGR peers) remains documented, now with a concrete scoping note (PeerUp LLGR-capability plumbing + a staging-layer gate + the intra-AS NO_EXPORT/LOCAL_PREF-0 exception).

Workspace green (549 rib tests).