### PR TITLE
feat(rib): gate LLGR-stale route export on the receiver's LLGR capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **RFC 9494 LLGR-stale export gate (closes the last legacy GR/LLGR
+  gap).** LLGR-stale routes are no longer advertised to eBGP peers that
+  didn't advertise the Long-Lived Graceful Restart capability for the
+  route's family (§4.4: stale routes "SHOULD NOT be advertised to any
+  neighbor from which the Long-Lived Graceful Restart Capability has not
+  been received") — every family's Adj-RIB-Out staging (unicast
+  single-best/multipath/ORR, FlowSpec, EVPN, BGP-LS, VPNv4/v6 including
+  each Add-Path candidate individually, RT-Constrain, plus the initial
+  dump and route-refresh replay) suppresses them with the standard
+  withdraw-if-present shape. Non-LLGR **iBGP** peers take the §4.6
+  intra-AS exception instead: the route is advertised with NO_EXPORT
+  attached and LOCAL_PREF set to zero — applied in transport's per-peer
+  attribute rewrite — and the LLGR_STALE community rides through
+  unchanged ("MUST NOT be removed when the route is further
+  advertised"). This replaces the previous non-compliant behavior of
+  stripping LLGR_STALE toward non-LLGR peers while still advertising
+  the route. Receiver LLGR capabilities are plumbed from session
+  negotiation into the RIB via `PeerUp`. LLGR-capable peers and all
+  fresh-route advertisement are unchanged.
+
 - **Add-Path (RFC 7911) for VPNv4/VPNv6 (SAFI 128).** The family-blind
   `add_path` knobs now cover the VPN families: negotiation advertises
   Add-Path for configured `l3vpn_ipv4_unicast` / `l3vpn_ipv6_unicast`
@@ -44,9 +64,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   restart no longer unresolves vantages mid-window. The new families
   implement the RFC-strict consecutive-restart deletion and EoR sweep of
   non-readvertised stale routes; the pre-existing unicast/FlowSpec/EVPN
-  paths were brought in line afterwards (see Fixed below), leaving only
-  the LLGR-stale export restriction documented in KNOWN_ISSUES. M77 is
-  the live peer-restart interop receipt.
+  paths were brought in line afterwards (see Fixed below), and the
+  LLGR-stale export restriction is closed by the RFC 9494 export gate
+  above. M77 is the live peer-restart interop receipt.
 
 - **Optimal Route Reflection (RFC 9107, ADR-0095) — per-client best paths
   via BGP-LS-sourced SPF.** A route reflector normally reflects *its own*
@@ -142,9 +162,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (RFC 4724 §4.1 / RFC 9494 §4.2), withdrawing them downstream. The EoR
   sweep is family-scoped (IPv4 and IPv6 unicast/FlowSpec are independent)
   and also covers the re-establish-during-LLGR path for every family,
-  including the typed ones. The remaining legacy gap — no LLGR-stale
-  export restriction toward non-LLGR peers — stays documented in
-  KNOWN_ISSUES.
+  including the typed ones. The then-remaining legacy gap — no LLGR-stale
+  export restriction toward non-LLGR peers — is closed by the RFC 9494
+  export gate under Added above.
 
 - **Audit-tail hardening for BGP-LS, durable cursors, and GR/LLGR intern GC.**
   BGP-LS known-NLRI descriptor TLV ordering errors now discard only the

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -237,11 +237,12 @@ resolved.
   amendment). GR/LLGR stale preservation now covers all of these RR
   families (RFC 4724 helper retention + RFC 9494 two-phase LLGR, M77
   receipt), and the pre-existing unicast/FlowSpec/EVPN paths implement
-  the same RFC-strict consecutive-restart deletion and End-of-RIB sweep
-  of non-readvertised stale routes (RFC 4724 §4.1 / RFC 9494 §4.2). One
-  legacy gap remains across all families: no LLGR-stale export
-  restriction toward non-LLGR peers (RFC 9494 SHOULD; the intra-AS
-  NO_EXPORT + LOCAL_PREF-0 exception also unbuilt). Other families such
+  the same RFC-strict consecutive-restart deletion, End-of-RIB sweep
+  of non-readvertised stale routes (RFC 4724 §4.1 / RFC 9494 §4.2), and
+  the RFC 9494 §4.4 export restriction (LLGR-stale routes are withheld
+  from eBGP peers that didn't advertise the LLGR capability; non-LLGR
+  iBGP peers receive them per the §4.6 intra-AS exception with NO_EXPORT
+  and LOCAL_PREF 0, LLGR_STALE community intact). Other families such
   as labeled-unicast (SAFI 4)
   and VPN FlowSpec (AFI 1/2, SAFI 134) are not implemented.
 - **Graceful Restart: no forwarding-state preservation.** RFC 4724 is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,9 +107,10 @@ has it, no broad performance sprints without profile evidence.
   blackout at RR-client re-establish, ORR vantages survive a topology
   source restart. The new families implement RFC-strict
   consecutive-restart deletion and EoR sweeps; the pre-existing
-  unicast/FlowSpec/EVPN paths have since been brought in line (gaps 1+2
-  of the legacy tech-debt item below), leaving only the LLGR-stale
-  export restriction open.
+  unicast/FlowSpec/EVPN paths have since been brought in line, and the
+  RFC 9494 export restriction (gap 3) now gates LLGR-stale routes on the
+  receiver's LLGR capability repo-wide — the legacy tech-debt item below
+  is fully resolved.
 - **RR-composition follow-ons** *(queued behind the GR arc, in order)*:
   `distribution.rs` module split (three arcs of growth; pure relocation);
   ORR explainability (`rbgp explain` answering "why did client X get path
@@ -1114,18 +1115,22 @@ Cross-cutting cleanups that don't move user-facing capability on their own but
 lower the cost of every future PR. None block a release — grab one when your
 branch is between features.
 
-- [ ] **Legacy GR/LLGR RFC gaps in unicast/FlowSpec/EVPN.** The RR families
-  (VPN/BGP-LS/RTC, #636–#638) implement the strict semantics; the
-  pre-existing paths had three documented divergences. Two are now
-  resolved: (1) consecutive-restart deletes already-stale routes instead
-  of re-marking them in place (RFC 4724 §4.1), and (2) the EoR arms sweep
-  non-readvertised stale/LLGR-stale routes before clearing flags on the
-  re-advertised remainder (RFC 4724 §4.1 / RFC 9494 §4.2) — including the
-  re-establish-during-LLGR path, closed for all families. Remaining:
-  (3) no LLGR-stale export restriction toward peers that didn't advertise
-  LLGR (RFC 9494 SHOULD; the intra-AS NO_EXPORT + LOCAL_PREF-0 exception
-  also unbuilt) — repo-wide, needs a distribution-layer gate at the
-  per-peer Adj-RIB-Out staging point.
+- [x] **Legacy GR/LLGR RFC gaps in unicast/FlowSpec/EVPN — RESOLVED.**
+  The RR families (VPN/BGP-LS/RTC, #636–#638) implement the strict
+  semantics; the pre-existing paths had three documented divergences,
+  all now closed: (1) consecutive-restart deletes already-stale routes
+  instead of re-marking them in place (RFC 4724 §4.1); (2) the EoR arms
+  sweep non-readvertised stale/LLGR-stale routes before clearing flags
+  on the re-advertised remainder (RFC 4724 §4.1 / RFC 9494 §4.2) —
+  including the re-establish-during-LLGR path, all families; and
+  (3) the RFC 9494 §4.4 LLGR-stale export restriction, repo-wide: every
+  family's Adj-RIB-Out staging suppresses (withdraw-if-present)
+  LLGR-stale routes toward eBGP peers that didn't advertise the LLGR
+  capability for the family (receiver capabilities plumbed from session
+  negotiation via `PeerUp`), while non-LLGR iBGP peers take the §4.6
+  intra-AS exception — NO_EXPORT attached and LOCAL_PREF zeroed in
+  transport's per-peer attribute rewrite, LLGR_STALE community riding
+  unchanged.
 
 - [x] **EVPN origination cross-actor seam audit — RESOLVED** (2026-06-12,
   PR #477). The seam inventory (drain vs. replay, withdrawal ordering,

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -29,6 +29,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -53,6 +54,21 @@ impl RibManager {
                 }
                 continue;
             };
+
+            // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
+            // suppressed. See `llgr_stale_export_suppressed`.
+            if super::llgr_stale_export_suppressed(
+                best.is_llgr_stale,
+                best.communities(),
+                family,
+                target_is_ebgp,
+                llgr,
+            ) {
+                if rib_out.get_bgpls(key).is_some() {
+                    bgpls_withdraw.push(key.clone());
+                }
+                continue;
+            }
 
             if best.peer == target_peer {
                 if rib_out.get_bgpls(key).is_some() {
@@ -181,6 +197,7 @@ impl RibManager {
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             if !changed_keys.iter().any(|key| {
                 sendable
                     .as_ref()
@@ -218,6 +235,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -170,6 +170,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -196,6 +197,21 @@ impl RibManager {
                 }
                 continue;
             };
+
+            // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
+            // suppressed. See `llgr_stale_export_suppressed`.
+            if super::llgr_stale_export_suppressed(
+                best.is_llgr_stale,
+                best.communities(),
+                evpn_family,
+                target_is_ebgp,
+                llgr,
+            ) {
+                if rib_out.get_evpn(key).is_some() {
+                    evpn_withdraw.push(*key);
+                }
+                continue;
+            }
 
             // Split horizon: don't send an EVPN route back to its source peer.
             // Parallel to the unicast guard earlier in this module. Without
@@ -395,6 +411,7 @@ impl RibManager {
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             if !sendable.as_ref().is_some_and(|f| {
                 f.contains(&(rustbgpd_wire::Afi::L2Vpn, rustbgpd_wire::Safi::Evpn))
             }) {
@@ -430,6 +447,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -178,6 +178,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -190,6 +191,21 @@ impl RibManager {
             if let Some(best) = loc_rib.get_flowspec(rule) {
                 let fs_family = (best.afi, Safi::FlowSpec);
                 if !sendable.is_some_and(|f| f.contains(&fs_family)) {
+                    if rib_out.get_flowspec(rule).is_some() {
+                        fs_withdraw.push(rule.clone());
+                    }
+                    continue;
+                }
+
+                // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
+                // suppressed. See `llgr_stale_export_suppressed`.
+                if super::llgr_stale_export_suppressed(
+                    best.is_llgr_stale,
+                    best.communities(),
+                    fs_family,
+                    target_is_ebgp,
+                    llgr,
+                ) {
                     if rib_out.get_flowspec(rule).is_some() {
                         fs_withdraw.push(rule.clone());
                     }
@@ -308,6 +324,7 @@ impl RibManager {
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             let has_fs = sendable.as_ref().is_some_and(|families| {
                 families.contains(&(rustbgpd_wire::Afi::Ipv4, rustbgpd_wire::Safi::FlowSpec))
                     || families.contains(&(rustbgpd_wire::Afi::Ipv6, rustbgpd_wire::Safi::FlowSpec))
@@ -345,6 +362,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -36,6 +36,32 @@ mod rtc;
 mod unicast;
 mod vpn;
 
+/// RFC 9494 §4.4 export restriction: an LLGR-stale route "SHOULD NOT be
+/// advertised to any neighbor from which the Long-Lived Graceful Restart
+/// Capability has not been received". For an eBGP target that means
+/// suppression (withdraw-if-present, the standard ineligibility shape at
+/// staging). iBGP targets are NOT suppressed here — the §4.6 intra-AS
+/// exception permits advertising to them with `NO_EXPORT` attached and
+/// `LOCAL_PREF` zero, a per-peer attribute form applied in transport's
+/// `prepare_outbound_attributes_*` beside the other per-peer rewrites
+/// (`ORIGINATOR_ID`/`CLUSTER_LIST`, `GShut`).
+///
+/// Staleness is the locally-promoted `is_llgr_stale` flag OR a carried
+/// `LLGR_STALE` community: promotion sets both, but a route *received*
+/// already tagged by an upstream helper only carries the community
+/// (which "MUST NOT be removed when the route is further advertised").
+fn llgr_stale_export_suppressed(
+    is_llgr_stale: bool,
+    communities: &[u32],
+    family: (Afi, Safi),
+    target_is_ebgp: bool,
+    llgr: Option<&Vec<(Afi, Safi)>>,
+) -> bool {
+    target_is_ebgp
+        && !llgr.is_some_and(|families| families.contains(&family))
+        && (is_llgr_stale || communities.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
+}
+
 fn route_type(origin: crate::route::RouteOrigin) -> RouteType {
     match origin {
         crate::route::RouteOrigin::Local => RouteType::Local,
@@ -726,6 +752,7 @@ impl RibManager {
             // borrowing rib_out (which holds a &mut to self.adj_ribs_out).
             let export_pol = self.export_policy_for(peer).cloned();
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
@@ -800,6 +827,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf,
                         orr_ctx,
@@ -830,6 +858,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf,
                         &metrics,
@@ -856,6 +885,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf,
                         &metrics,
@@ -884,6 +914,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -906,6 +937,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -929,6 +961,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -953,6 +986,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     rtc_filter.as_ref(),
                     orr_ctx,
                     peer_add_path_send_max,
@@ -980,6 +1014,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -49,6 +49,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
@@ -74,6 +75,21 @@ impl RibManager {
                 }
                 continue;
             };
+
+            // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
+            // suppressed. See `llgr_stale_export_suppressed`.
+            if super::llgr_stale_export_suppressed(
+                best.is_llgr_stale,
+                best.communities(),
+                family,
+                target_is_ebgp,
+                llgr,
+            ) {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
 
             if best.peer == target_peer {
                 if rib_out.get_rtc(key).is_some() {
@@ -202,6 +218,7 @@ impl RibManager {
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             if !sendable
                 .as_ref()
                 .is_some_and(|families| families.contains(&rtc_family))
@@ -238,6 +255,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -494,6 +494,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
@@ -546,6 +547,18 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     peer_is_rr_client,
+                ) {
+                    return false;
+                }
+                // RFC 9494 §4.4: each staged candidate is gated
+                // individually — a stale candidate must not occupy an
+                // Add-Path rank toward a non-LLGR eBGP peer.
+                if super::llgr_stale_export_suppressed(
+                    route.is_llgr_stale,
+                    route.communities(),
+                    family,
+                    target_is_ebgp,
+                    llgr,
                 ) {
                     return false;
                 }
@@ -676,6 +689,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         metrics: &BgpMetrics,
@@ -721,6 +735,21 @@ impl RibManager {
         // Sendable family check
         let family = prefix_family(prefix);
         if !sendable.is_some_and(|f| f.contains(&family)) {
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
+
+        // RFC 9494 §4.4: LLGR-stale best toward a non-LLGR eBGP peer is
+        // suppressed (withdraw-if-present). See `llgr_stale_export_suppressed`.
+        if super::llgr_stale_export_suppressed(
+            best.is_llgr_stale,
+            best.communities(),
+            family,
+            target_is_ebgp,
+            llgr,
+        ) {
             for &path_id in existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
@@ -858,6 +887,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         metrics: &BgpMetrics,
@@ -920,6 +950,23 @@ impl RibManager {
             }
             return;
         };
+
+        // RFC 9494 §4.4: a per-vantage winner can only be LLGR-stale when
+        // every surviving candidate is (stale ranks below fresh in the
+        // comparator), so gating the winner suppresses exactly the
+        // stale-only case toward a non-LLGR eBGP peer.
+        if super::llgr_stale_export_suppressed(
+            best.is_llgr_stale,
+            best.communities(),
+            family,
+            target_is_ebgp,
+            llgr,
+        ) {
+            for &path_id in existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
 
         // Export policy check — same tail as `distribute_single_best_prefix`.
         let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -84,6 +84,7 @@ impl RibManager {
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
         sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
         rtc_filter: Option<&crate::manager::RtcMembership>,
         orr_ctx: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
         add_path_send_max: u32,
@@ -166,6 +167,19 @@ impl RibManager {
                 for candidate in &candidates {
                     if (next_rank as usize) > limit {
                         break;
+                    }
+
+                    // RFC 9494 §4.4, per candidate — an LLGR-stale path
+                    // must not occupy an Add-Path rank toward a non-LLGR
+                    // eBGP peer. See `llgr_stale_export_suppressed`.
+                    if super::llgr_stale_export_suppressed(
+                        candidate.is_llgr_stale,
+                        candidate.communities(),
+                        family,
+                        target_is_ebgp,
+                        llgr,
+                    ) {
+                        continue;
                     }
 
                     // RFC 4684 outbound gate, per candidate — the route
@@ -295,6 +309,19 @@ impl RibManager {
                 };
                 best
             };
+
+            // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
+            // suppressed. See `llgr_stale_export_suppressed`.
+            if super::llgr_stale_export_suppressed(
+                best.is_llgr_stale,
+                best.communities(),
+                family,
+                target_is_ebgp,
+                llgr,
+            ) {
+                withdraw_existing(vpn_withdraw, existing_path_ids);
+                continue;
+            }
 
             // RFC 4684 outbound gate: a peer that negotiated RT-Constrain
             // only receives VPN routes whose Route Targets fall inside its
@@ -471,6 +498,7 @@ impl RibManager {
                 &changed_keys
             };
             let sendable = self.peer_sendable_families.get(&peer).cloned();
+            let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             if !staged_keys.iter().any(|key| {
                 sendable
                     .as_ref()
@@ -520,6 +548,7 @@ impl RibManager {
                 target_is_rr_client,
                 self.cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 rtc_filter.as_ref(),
                 orr_ctx,
                 add_path_send_max,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -97,6 +97,12 @@ pub struct RibManager {
     peer_export_policies: HashMap<IpAddr, Option<PolicyChain>>,
     /// Families the transport can actually serialize per peer.
     peer_sendable_families: HashMap<IpAddr, Vec<(Afi, Safi)>>,
+    /// Families for which each registered outbound peer advertised the
+    /// Long-Lived Graceful Restart capability (RFC 9494). Gates the
+    /// export of LLGR-stale routes: absent family + eBGP target =
+    /// suppress (§4.4); absent family + iBGP target = advertise with
+    /// `NO_EXPORT` and `LOCAL_PREF` 0, rewritten in transport (§4.6).
+    peer_advertised_llgr_families: HashMap<IpAddr, Vec<(Afi, Safi)>>,
     /// Whether each registered outbound peer is eBGP (true) or iBGP (false).
     peer_is_ebgp: HashMap<IpAddr, bool>,
     /// Whether each registered outbound peer is a route reflector client.
@@ -302,6 +308,7 @@ pub(super) struct LiveSessionRecord {
     add_path_send_families: Vec<(Afi, Safi)>,
     add_path_send_max: u32,
     negotiated_orf_recv: Vec<(Afi, Safi)>,
+    negotiated_llgr_families: Vec<(Afi, Safi)>,
 }
 
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
@@ -555,6 +562,7 @@ impl RibManager {
             export_policy,
             peer_export_policies: HashMap::new(),
             peer_sendable_families: HashMap::new(),
+            peer_advertised_llgr_families: HashMap::new(),
             peer_is_ebgp: HashMap::new(),
             peer_is_rr_client: HashMap::new(),
             peer_orr_vantage: HashMap::new(),
@@ -788,6 +796,7 @@ impl RibManager {
                 add_path_send_families,
                 add_path_send_max,
                 negotiated_orf_recv,
+                negotiated_llgr_families,
             } => self.handle_peer_up(
                 peer,
                 session_id,
@@ -802,6 +811,7 @@ impl RibManager {
                 add_path_send_families,
                 add_path_send_max,
                 negotiated_orf_recv,
+                negotiated_llgr_families,
             ),
             RibUpdate::PeerOrfUpdate {
                 peer,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -407,6 +407,7 @@ impl RibManager {
         self.adj_ribs_out.remove(&peer);
         self.peer_export_policies.remove(&peer);
         self.peer_sendable_families.remove(&peer);
+        self.peer_advertised_llgr_families.remove(&peer);
         self.peer_is_ebgp.remove(&peer);
         self.peer_is_rr_client.remove(&peer);
         // The ORR vantage binding is per-registration: dropping the last
@@ -476,6 +477,7 @@ impl RibManager {
         add_path_send_families: Vec<(rustbgpd_wire::Afi, rustbgpd_wire::Safi)>,
         add_path_send_max: u32,
         negotiated_orf_recv: Vec<(rustbgpd_wire::Afi, rustbgpd_wire::Safi)>,
+        negotiated_llgr_families: Vec<(rustbgpd_wire::Afi, rustbgpd_wire::Safi)>,
     ) {
         // Two live sessions for one peer address can overlap during the
         // RFC 4271 §6.8 collision window. A `PeerUp` that finds a
@@ -523,6 +525,7 @@ impl RibManager {
             add_path_send_families,
             add_path_send_max,
             negotiated_orf_recv,
+            negotiated_llgr_families,
         };
         let sessions = self.live_sessions.entry(peer).or_default();
         // Same id = the same session re-announcing itself (legacy id-0
@@ -569,6 +572,7 @@ impl RibManager {
         let add_path_send_families = record.add_path_send_families.clone();
         let add_path_send_max = record.add_path_send_max;
         let negotiated_orf_recv = record.negotiated_orf_recv.clone();
+        let negotiated_llgr_families = record.negotiated_llgr_families.clone();
 
         self.peer_asn.insert(peer, peer_asn);
         self.peer_bgp_id.insert(peer, peer_router_id);
@@ -650,6 +654,8 @@ impl RibManager {
         self.peer_export_policies
             .insert(peer, export_policy.or_else(|| self.export_policy.clone()));
         self.peer_sendable_families.insert(peer, sendable_families);
+        self.peer_advertised_llgr_families
+            .insert(peer, negotiated_llgr_families);
         self.peer_is_ebgp.insert(peer, is_ebgp);
         self.peer_is_rr_client.insert(peer, route_reflector_client);
         if let Some(vantage) = orr_vantage {
@@ -758,6 +764,7 @@ impl RibManager {
         let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
+        let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
         let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
         // RFC 5291 §6 initial-advertisement gate: suppress route advertisement
         // for families still awaiting the peer's first ROUTE-REFRESH. For a
@@ -830,6 +837,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     // ORF: gated families are skipped above; a non-gated family
                     // has no installed filter during the initial dump.
@@ -862,6 +870,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     // ORF: gated families are skipped above; a non-gated family
                     // has no installed filter during the initial dump.
@@ -890,6 +899,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     // ORF: gated families are skipped above; a non-gated family
                     // has no installed filter during the initial dump.
@@ -925,6 +935,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,
@@ -956,6 +967,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,
@@ -984,6 +996,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,
@@ -1026,6 +1039,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 rtc_filter.as_ref(),
                 orr_ctx,
                 peer_add_path_send_max,
@@ -1061,6 +1075,7 @@ impl RibManager {
                 target_is_rr_client,
                 cluster_id,
                 sendable.as_ref(),
+                llgr.as_ref(),
                 export_pol.as_ref(),
                 &metrics,
                 policy_stats,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -548,6 +548,7 @@ impl RibManager {
         let mut rtc_withdraw = Vec::new();
         let export_pol = self.export_policy_for(peer).cloned();
         let sendable = self.peer_sendable_families.get(&peer).cloned();
+        let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
         let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
         let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
@@ -613,6 +614,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -640,6 +642,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -669,6 +672,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -714,6 +718,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     rtc_filter.as_ref(),
                     orr_ctx,
                     peer_add_path_send_max,
@@ -746,6 +751,7 @@ impl RibManager {
                     target_is_rr_client,
                     cluster_id,
                     sendable.as_ref(),
+                    llgr.as_ref(),
                     export_pol.as_ref(),
                     &metrics,
                     policy_stats,
@@ -779,6 +785,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         orr_ctx,
@@ -809,6 +816,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         &metrics,
@@ -835,6 +843,7 @@ impl RibManager {
                         target_is_rr_client,
                         cluster_id,
                         sendable.as_ref(),
+                        llgr.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         &metrics,

--- a/crates/rib/src/manager/tests.rs
+++ b/crates/rib/src/manager/tests.rs
@@ -644,6 +644,7 @@ async fn orr_client_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1301,6 +1302,7 @@ async fn orr_client_initial_dump_gets_vantage_best() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1503,6 +1505,7 @@ async fn split_horizon_and_rr_suppression_apply_before_orr_ranking() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1583,6 +1586,7 @@ async fn orr_with_addpath_send_ranks_by_vantage_cost() {
         add_path_send_families: vec![(Afi::Ipv4, Safi::Unicast)],
         add_path_send_max: 2,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1634,6 +1638,7 @@ async fn bgpls_routes_received_reflects_and_withdraws_to_eligible_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1698,6 +1703,7 @@ async fn bgpls_export_policy_does_not_match_dummy_default_prefix() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1753,6 +1759,7 @@ async fn bgpls_routes_received_does_not_reflect_back_to_source_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1773,6 +1780,7 @@ async fn bgpls_routes_received_does_not_reflect_back_to_source_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1826,6 +1834,7 @@ async fn bgpls_routes_received_does_not_reflect_to_unsendable_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1874,6 +1883,7 @@ async fn dirty_resync_includes_bgpls_routes_after_channel_full() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -1972,6 +1982,7 @@ async fn send_initial_table_includes_bgpls_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -2486,6 +2497,7 @@ async fn vpn_gr_family_not_in_capability_is_withdrawn() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -2559,6 +2571,7 @@ async fn vpn_gr_eor_clears_stale() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -2751,6 +2764,7 @@ async fn vpn_routes_received_reflects_and_withdraws_to_eligible_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -2888,6 +2902,7 @@ async fn vpn_addpath_send_stages_top_n_and_single_best_unchanged() {
         add_path_send_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
         add_path_send_max: 2,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -2909,6 +2924,7 @@ async fn vpn_addpath_send_stages_top_n_and_single_best_unchanged() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3026,6 +3042,7 @@ async fn vpn_rr_reflects_non_client_route_to_clients_only() {
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         })
         .await
         .unwrap();
@@ -3092,6 +3109,7 @@ async fn vpn_same_peer_relabel_triggers_re_advertise() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3163,6 +3181,7 @@ async fn vpn_dirty_resync_equality_skip_does_not_resend_unchanged_route() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3240,6 +3259,7 @@ async fn send_initial_table_includes_vpn_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3294,6 +3314,7 @@ async fn route_refresh_vpn_re_advertises_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3360,6 +3381,7 @@ async fn rtc_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -3699,6 +3721,7 @@ async fn default_rtc_not_originated_to_non_rtc_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -4246,6 +4269,7 @@ async fn vpn_rtc_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -4588,6 +4612,7 @@ async fn non_rtc_peer_reflection_unchanged() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5070,6 +5095,7 @@ async fn multi_chunk_flood_coalesces_into_one_outbound_batch() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5608,6 +5634,7 @@ async fn peer_up_triggers_initial_table_dump() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5644,6 +5671,7 @@ async fn route_change_distributes_to_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5694,6 +5722,7 @@ async fn single_best_send_normalizes_path_id_to_zero() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5747,6 +5776,7 @@ async fn split_horizon_prevents_echo() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5867,6 +5897,7 @@ async fn ibgp_route_not_sent_to_ibgp_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5918,6 +5949,7 @@ async fn ibgp_route_sent_to_ebgp_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -5973,6 +6005,7 @@ async fn ebgp_route_sent_to_ibgp_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6016,6 +6049,7 @@ async fn ibgp_split_horizon_withdraw_on_best_change() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6101,6 +6135,7 @@ async fn local_route_sent_to_ibgp_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6194,6 +6229,7 @@ async fn local_route_in_initial_table_to_ibgp_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6232,6 +6268,7 @@ async fn peer_down_cleans_up_outbound() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6281,6 +6318,7 @@ async fn inject_route_enters_loc_rib_and_distributes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6356,6 +6394,7 @@ async fn withdraw_injected_removes_and_distributes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6451,6 +6490,7 @@ async fn export_policy_counter_records_single_best_permit() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6534,6 +6574,7 @@ async fn graceful_restart_clears_export_policy_stats() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6605,6 +6646,7 @@ async fn explain_advertised_route_does_not_increment_export_policy_counter() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6677,6 +6719,7 @@ async fn export_policy_blocks_denied() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6740,6 +6783,7 @@ async fn query_advertised_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6831,6 +6875,7 @@ async fn per_peer_export_policy() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6851,6 +6896,7 @@ async fn per_peer_export_policy() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -6941,6 +6987,7 @@ async fn replace_peer_export_policy_resyncs_outbound_state_and_emits_policy_filt
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7074,6 +7121,7 @@ async fn export_policy_match_next_hop_filters_route() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7125,6 +7173,7 @@ async fn explain_advertised_route_reports_no_best_route() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7169,6 +7218,7 @@ async fn explain_advertised_route_reports_policy_deny_without_mutation() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7282,6 +7332,7 @@ async fn export_as_path_regex_still_filters_through_distribution() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7376,6 +7427,7 @@ async fn explain_advertised_route_reports_modifications() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7466,6 +7518,7 @@ async fn explain_advertised_route_reports_ipv6_next_hop_override() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7545,6 +7598,7 @@ async fn peer_down_cleans_up_export_policy() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7604,6 +7658,7 @@ async fn channel_full_marks_dirty_and_resyncs() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7759,6 +7814,7 @@ async fn dirty_resync_not_starved_by_query_traffic() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7904,6 +7960,7 @@ async fn initial_dump_failure_leaves_adjribout_empty() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -7992,6 +8049,7 @@ async fn initial_dump_failure_resyncs_via_timer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9149,6 +9207,7 @@ async fn adj_rib_out_gauge_tracks_advertised() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9247,6 +9306,7 @@ async fn query_advertised_count() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9324,6 +9384,7 @@ async fn distribute_changes_filters_unsendable_families() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9451,6 +9512,7 @@ async fn send_initial_table_filters_unsendable_families() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9539,6 +9601,7 @@ async fn dual_stack_peer_receives_both_families() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9590,6 +9653,7 @@ async fn send_initial_table_includes_flowspec_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9647,6 +9711,7 @@ async fn route_refresh_flowspec_re_advertises_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -9711,6 +9776,7 @@ async fn route_refresh_bgpls_re_advertises_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -10417,6 +10483,7 @@ async fn enhanced_route_refresh_vpn_eorr_reflects_withdrawal_to_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -10497,6 +10564,7 @@ async fn dirty_resync_retries_flowspec_updates() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -10563,6 +10631,7 @@ async fn gr_marks_stale_and_demotes_routes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -10637,6 +10706,7 @@ async fn gr_flowspec_eor_recomputes_and_redistributes() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -11294,6 +11364,7 @@ async fn gr_peer_up_defers_stale_to_eor() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -11407,6 +11478,7 @@ async fn gr_peer_up_timer_expires_sweeps_stale() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -11780,6 +11852,7 @@ async fn llgr_eor_clears_llgr_stale() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -11984,6 +12057,7 @@ fn establish_peer(manager: &mut RibManager, peer: IpAddr) -> mpsc::Receiver<Outb
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     });
     out_rx
 }
@@ -12316,6 +12390,7 @@ async fn rr_client_route_reflected_to_all_ibgp() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12336,6 +12411,7 @@ async fn rr_client_route_reflected_to_all_ibgp() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12357,6 +12433,7 @@ async fn rr_client_route_reflected_to_all_ibgp() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12422,6 +12499,7 @@ async fn rr_nonclient_route_reflected_to_clients_only() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12442,6 +12520,7 @@ async fn rr_nonclient_route_reflected_to_clients_only() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12463,6 +12542,7 @@ async fn rr_nonclient_route_reflected_to_clients_only() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12527,6 +12607,7 @@ async fn non_rr_ibgp_split_horizon_unchanged() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12585,6 +12666,7 @@ async fn rr_ebgp_route_to_all_ibgp() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -12642,6 +12724,7 @@ async fn rr_local_route_to_all_ibgp() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13209,6 +13292,7 @@ async fn rpki_cache_update_no_change_no_redistribution() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13392,6 +13476,7 @@ async fn multipath_send_advertises_multiple_routes() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13463,6 +13548,7 @@ async fn multipath_send_respects_send_max() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 2,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13544,6 +13630,7 @@ async fn multipath_send_split_horizon() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13590,6 +13677,7 @@ async fn multipath_withdrawal_on_candidate_removal() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13724,6 +13812,7 @@ async fn single_best_peer_unaffected_by_multipath_config() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13772,6 +13861,7 @@ async fn multipath_peer_down_cleans_up_state() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13821,6 +13911,7 @@ async fn multipath_peer_down_cleans_up_state() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13860,6 +13951,7 @@ async fn multipath_send_incremental_route_addition() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -13985,6 +14077,7 @@ async fn multipath_send_mixed_peers_single_and_multi() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14005,6 +14098,7 @@ async fn multipath_send_mixed_peers_single_and_multi() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14097,6 +14191,7 @@ async fn multipath_send_ipv6_advertises_multiple_routes() {
         add_path_send_families: vec![(Afi::Ipv6, Safi::Unicast)],
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14185,6 +14280,7 @@ async fn multipath_send_partial_negotiation_ipv4_only() {
         add_path_send_families: vec![(Afi::Ipv4, Safi::Unicast)],
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14282,6 +14378,7 @@ async fn multipath_send_partial_negotiation_ipv6_only() {
         add_path_send_families: vec![(Afi::Ipv6, Safi::Unicast)],
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14383,6 +14480,7 @@ async fn route_refresh_partial_negotiation_respects_family_mode() {
         add_path_send_families: vec![(Afi::Ipv4, Safi::Unicast)],
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14493,6 +14591,7 @@ async fn multipath_send_max_one_uses_path_id_one() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 1,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14580,6 +14679,7 @@ async fn multipath_policy_filtered_events_for_denied_candidates() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 5,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -14711,6 +14811,7 @@ async fn mrt_peer_metadata_retained_during_gr() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15039,6 +15140,7 @@ async fn explain_best_path_for_addpath_peer_marks_top_n_with_path_id() {
         add_path_send_families: ipv4_sendable(),
         add_path_send_max: 2,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15133,6 +15235,7 @@ async fn explain_best_path_single_best_does_not_fall_back_when_winner_is_target(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15203,6 +15306,7 @@ async fn explain_best_path_for_single_best_peer_marks_only_winner_path_id_zero()
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15277,6 +15381,7 @@ async fn explain_best_path_effective_send_max_zero_on_family_mismatch() {
         add_path_send_families: vec![(Afi::Ipv6, Safi::Unicast)],
         add_path_send_max: 4,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15400,6 +15505,7 @@ async fn peer_down_withdraws_evpn_routes_from_remaining_peers() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15424,6 +15530,7 @@ async fn peer_down_withdraws_evpn_routes_from_remaining_peers() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15516,6 +15623,7 @@ async fn evpn_is_not_reflected_back_to_source_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15537,6 +15645,7 @@ async fn evpn_is_not_reflected_back_to_source_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15593,6 +15702,10 @@ async fn evpn_is_not_reflected_back_to_source_peer() {
 /// rebuilt unicast prefixes + `FlowSpec` rules but never gathered EVPN keys
 /// or staged EVPN routes, so EVPN deltas could be silently dropped.
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "full channel-full → dirty-resync flow in one scenario"
+)]
 async fn dirty_resync_includes_evpn_routes_after_channel_full() {
     let (tx, rx) = mpsc::channel(64);
     let cluster_id = Some(Ipv4Addr::new(10, 0, 0, 100));
@@ -15619,6 +15732,7 @@ async fn dirty_resync_includes_evpn_routes_after_channel_full() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15640,6 +15754,7 @@ async fn dirty_resync_includes_evpn_routes_after_channel_full() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15759,6 +15874,7 @@ async fn stale_peer_down_after_replacement_peer_up_is_discarded() {
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         };
 
     // Session A (collision loser) reaches Established first and registers.
@@ -15830,6 +15946,7 @@ async fn stale_peer_down_after_replacement_peer_up_is_discarded() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -15903,6 +16020,7 @@ async fn stale_graceful_restart_from_superseded_session_is_discarded() {
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         };
 
     let (loser_tx, mut loser_rx) = mpsc::channel(8);
@@ -15945,6 +16063,7 @@ async fn stale_graceful_restart_from_superseded_session_is_discarded() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -16026,6 +16145,7 @@ async fn peer_down_of_replacement_session_fails_over_to_surviving_session() {
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         };
 
     // Session W (collision winner) registers first.
@@ -16152,6 +16272,7 @@ async fn peer_down_of_replacement_session_fails_over_to_surviving_session() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -16227,6 +16348,7 @@ async fn graceful_restart_of_replacement_session_fails_over_to_surviving_session
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         };
 
     // Winner registers first, loser's PeerUp replaces the registration.
@@ -16323,6 +16445,7 @@ async fn failover_inbound_refresh_covers_negotiated_but_not_sendable_families() 
             add_path_send_families: vec![],
             add_path_send_max: 0,
             negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
         };
 
     // Winner registers first, loser's PeerUp replaces the registration,
@@ -16389,6 +16512,7 @@ fn session_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     }
 }
 
@@ -17501,6 +17625,7 @@ async fn llgr_target_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -18082,8 +18207,11 @@ async fn rtc_llgr_eor_clears_llgr_stale() {
     let manager = RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
     let handle = tokio::spawn(manager.run());
 
+    // iBGP RR-client observer: an eBGP target without LLGR would now
+    // suppress the pre-tagged route below (RFC 9494 §4.4 export gate,
+    // pinned by its own tests); this test is about EoR clearing.
     let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
-    let mut out_rx = rtc_peer_up(&tx, target, true, false).await;
+    let mut out_rx = rtc_peer_up(&tx, target, false, true).await;
     drain_rtc_initial_dump(&mut out_rx).await;
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
@@ -18733,6 +18861,7 @@ async fn inject_evpn_reflects_to_peer() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -18844,6 +18973,7 @@ async fn late_joining_peer_receives_existing_evpn_routes_in_initial_dump() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -18887,6 +19017,7 @@ async fn late_joining_peer_receives_existing_evpn_routes_in_initial_dump() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -19060,6 +19191,7 @@ async fn evpn_export_policy_applies_modifications() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -19080,6 +19212,7 @@ async fn evpn_export_policy_applies_modifications() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -20204,6 +20337,7 @@ async fn orf_setup() -> (
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: vec![(Afi::Ipv4, Safi::Unicast)],
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -20545,6 +20679,7 @@ async fn graceful_restart_clears_stale_orf_gate() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: vec![],
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -20621,6 +20756,7 @@ async fn graceful_restart_clears_orf_filter() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: vec![],
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -20705,6 +20841,7 @@ async fn gr_flap_and_reup(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv,
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -20888,6 +21025,7 @@ async fn gr_restarter_deferred_eor_lifts_per_family() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: both.clone(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -21006,6 +21144,7 @@ async fn peer_down_clears_gr_deferred_eor() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: vec![],
+        negotiated_llgr_families: Vec::new(),
     });
     manager.handle_update(RibUpdate::PeerGracefulRestart {
         session_id: 0,
@@ -21034,6 +21173,7 @@ async fn peer_down_clears_gr_deferred_eor() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: vec![family],
+        negotiated_llgr_families: Vec::new(),
     });
     assert!(
         manager
@@ -21827,6 +21967,7 @@ async fn vpn_orr_peer_up(
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -21948,6 +22089,7 @@ async fn vpn_orr_addpath_ranking_uses_vantage_costs() {
         add_path_send_families: vec![(Afi::Ipv4, Safi::MplsVpn)],
         add_path_send_max: 2,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -22197,6 +22339,7 @@ async fn vpn_orr_rtc_filter_applies_to_vantage_winner() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -22324,6 +22467,7 @@ async fn vpn_orr_initial_dump_gets_vantage_best() {
         add_path_send_families: vec![],
         add_path_send_max: 0,
         negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
     })
     .await
     .unwrap();
@@ -22374,5 +22518,572 @@ async fn vpn_orr_route_refresh_replays_vantage_best() {
         final_b.get(&key).map(|r| r.next_hop),
         Some(orr_nh_y()),
         "the replay is the vantage best"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RFC 9494 §4.4 / §4.6 LLGR-stale export gate
+// ---------------------------------------------------------------------------
+
+/// Bring up an outbound target with an explicit eBGP/LLGR shape (and
+/// optional Add-Path send) for the RFC 9494 export-gate tests.
+async fn llgr_gate_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    sendable: Vec<(Afi, Safi)>,
+    is_ebgp: bool,
+    llgr_families: Vec<(Afi, Safi)>,
+    add_path: Option<((Afi, Safi), u32)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: sendable,
+        is_ebgp,
+        route_reflector_client: !is_ebgp,
+        orr_vantage: None,
+        add_path_send_families: add_path.map(|(family, _)| vec![family]).unwrap_or_default(),
+        add_path_send_max: add_path.map_or(0, |(_, max)| max),
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: llgr_families,
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+/// Announce a unicast route from `source`, then drive it GR-stale →
+/// LLGR-stale (short GR timer + promotion), with query sync points.
+async fn unicast_announce_and_promote_to_llgr(
+    tx: &mpsc::Sender<RibUpdate>,
+    source: IpAddr,
+    prefix: Ipv4Prefix,
+) {
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    // Sync: route present and fresh before GR.
+    assert_eq!(query_best_routes(tx).await.len(), 1);
+
+    let family = vec![(Afi::Ipv4, Safi::Unicast)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    assert!(query_best_routes(tx).await[0].is_stale);
+
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_best_routes(tx).await[0].is_llgr_stale);
+}
+
+/// RFC 9494 §4.4: an LLGR-stale route is withdrawn from (not announced
+/// to) an eBGP peer that did not advertise the LLGR capability for the
+/// family.
+#[tokio::test]
+async fn llgr_stale_suppressed_toward_ebgp_peer_without_llgr() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(&tx, target, ipv4_sendable(), true, vec![], None).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    unicast_announce_and_promote_to_llgr(&tx, source, prefix).await;
+
+    let mut withdrawn = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.announce.iter().any(|route| route
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)),
+            "LLGR-stale route must not be announced to a non-LLGR eBGP peer"
+        );
+        if update.withdraw.contains(&(Prefix::V4(prefix), 0)) {
+            withdrawn = true;
+        }
+    }
+    assert!(
+        withdrawn,
+        "previously advertised route must be withdrawn from the non-LLGR eBGP peer at promotion"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A peer that DID advertise LLGR for the family keeps receiving the
+/// stale route, community riding (RFC 9494 §4.3 — MUST NOT be removed).
+#[tokio::test]
+async fn llgr_stale_unchanged_toward_llgr_capable_peer() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(
+        &tx,
+        target,
+        ipv4_sendable(),
+        true,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        None,
+    )
+    .await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    unicast_announce_and_promote_to_llgr(&tx, source, prefix).await;
+
+    let mut reannounced = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.withdraw.contains(&(Prefix::V4(prefix), 0)),
+            "LLGR-stale route must not be withdrawn from an LLGR-capable peer"
+        );
+        if update.announce.iter().any(|route| {
+            route.prefix == Prefix::V4(prefix)
+                && route
+                    .communities()
+                    .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        }) {
+            reannounced = true;
+        }
+    }
+    assert!(
+        reannounced,
+        "promotion must re-announce the route with LLGR_STALE to the LLGR-capable peer"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 9494 §4.6 intra-AS exception: toward a non-LLGR iBGP peer the
+/// LLGR-stale route is still advertised at the RIB layer, community
+/// intact — transport rewrites it to the `NO_EXPORT` + `LOCAL_PREF`-0 form
+/// (pinned by `llgr_stale_to_non_llgr_ibgp_peer_carries_no_export_and_lpref_zero`
+/// in the transport crate).
+#[tokio::test]
+async fn llgr_stale_to_ibgp_peer_without_llgr_still_advertised_with_community() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(&tx, target, ipv4_sendable(), false, vec![], None).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    unicast_announce_and_promote_to_llgr(&tx, source, prefix).await;
+
+    let mut reannounced = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.withdraw.contains(&(Prefix::V4(prefix), 0)),
+            "the §4.6 exception permits advertising to a non-LLGR iBGP peer"
+        );
+        if update.announce.iter().any(|route| {
+            route.prefix == Prefix::V4(prefix)
+                && route
+                    .communities()
+                    .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        }) {
+            reannounced = true;
+        }
+    }
+    assert!(
+        reannounced,
+        "LLGR-stale route must flow to the iBGP peer with LLGR_STALE intact"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// No-behavior-change pin: fresh routes are advertised identically to
+/// peers with and without the LLGR capability (the gate only exists for
+/// LLGR-stale routes, a state that only occurs during an LLGR phase).
+#[tokio::test]
+async fn fresh_routes_unaffected_by_peer_llgr_capability() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let plain = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let capable = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut plain_rx = llgr_gate_peer_up(&tx, plain, ipv4_sendable(), true, vec![], None).await;
+    let mut capable_rx = llgr_gate_peer_up(
+        &tx,
+        capable,
+        ipv4_sendable(),
+        true,
+        vec![(Afi::Ipv4, Safi::Unicast)],
+        None,
+    )
+    .await;
+    drain_eor(&mut plain_rx).await;
+    drain_eor(&mut capable_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    for out_rx in [&mut plain_rx, &mut capable_rx] {
+        let update = out_rx.recv().await.unwrap();
+        assert_eq!(update.announce.len(), 1);
+        assert_eq!(update.announce[0].prefix, Prefix::V4(prefix));
+        assert!(!update.announce[0].is_llgr_stale);
+        assert!(
+            !update.announce[0]
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
+        assert!(update.withdraw.is_empty());
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// VPN counterpart of the eBGP suppression: an LLGR-stale VPN route is
+/// withdrawn from a non-LLGR eBGP peer at promotion.
+#[tokio::test]
+async fn vpn_llgr_stale_suppressed_toward_ebgp_peer_without_llgr() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(&tx, target, vpn_sendable(), true, vec![], None).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.vpn_announce.len(), 1);
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    assert!(query_vpn_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_vpn_routes(&tx).await[0].is_llgr_stale);
+
+    let mut withdrawn = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.vpn_announce.iter().any(|route| route
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)),
+            "LLGR-stale VPN route must not be announced to a non-LLGR eBGP peer"
+        );
+        if update.vpn_withdraw.contains(&key) {
+            withdrawn = true;
+        }
+    }
+    assert!(
+        withdrawn,
+        "previously advertised VPN route must be withdrawn from the non-LLGR eBGP peer"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// VPN toward an LLGR-capable eBGP peer: unchanged — the promoted route
+/// re-announces with the community riding.
+#[tokio::test]
+async fn vpn_llgr_stale_unchanged_toward_llgr_capable_ebgp_peer() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(
+        &tx,
+        target,
+        vpn_sendable(),
+        true,
+        vec![(Afi::Ipv4, Safi::MplsVpn)],
+        None,
+    )
+    .await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let route = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100);
+    let key = route.key();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    assert_eq!(out_rx.recv().await.unwrap().vpn_announce.len(), 1);
+
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    assert!(query_vpn_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_vpn_routes(&tx).await[0].is_llgr_stale);
+
+    let mut reannounced = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.vpn_withdraw.contains(&key),
+            "LLGR-stale VPN route must not be withdrawn from an LLGR-capable peer"
+        );
+        if update.vpn_announce.iter().any(|route| {
+            route.key().nlri_key == key.nlri_key
+                && route
+                    .communities()
+                    .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        }) {
+            reannounced = true;
+        }
+    }
+    assert!(reannounced, "community must ride to the LLGR-capable peer");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 9494 §4.4 in the VPN Add-Path branch: each staged candidate is
+/// gated individually — the LLGR-stale path loses its Add-Path rank
+/// toward a non-LLGR eBGP peer while the fresh path keeps flowing.
+#[tokio::test]
+async fn vpn_addpath_llgr_stale_candidates_gated_individually() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(
+        &tx,
+        target,
+        vpn_sendable(),
+        true,
+        vec![],
+        Some(((Afi::Ipv4, Safi::MplsVpn), 4)),
+    )
+    .await;
+    drain_eor(&mut out_rx).await;
+
+    // Same RD+prefix identity from two sources; A wins on LOCAL_PREF.
+    let source_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let source_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let route_a = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 200);
+    let route_b = make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 3), 31, 100, 100);
+    let nlri_key = route_a.nlri.key();
+    for (peer, route) in [(source_a, route_a), (source_b, route_b)] {
+        tx.send(RibUpdate::VpnRoutesReceived {
+            session_id: 0,
+            peer,
+            announced: vec![route],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    // Both paths staged with Add-Path ranks 1..=2 before the LLGR phase.
+    assert_eq!(query_vpn_routes(&tx).await.len(), 1);
+    let mut ranks_seen: HashSet<u32> = HashSet::new();
+    while let Ok(update) = out_rx.try_recv() {
+        for route in &update.vpn_announce {
+            ranks_seen.insert(route.path_id);
+        }
+    }
+    assert!(
+        ranks_seen.contains(&1) && ranks_seen.contains(&2),
+        "both candidates staged pre-LLGR, got ranks {ranks_seen:?}"
+    );
+
+    // B restarts and its path is promoted to LLGR-stale.
+    let family = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    tx.send(gr_with_llgr(source_b, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let _ = query_vpn_routes(&tx).await;
+
+    let mut rank2_withdrawn = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.vpn_announce.iter().any(|route| route
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)),
+            "the LLGR-stale candidate must not occupy an Add-Path rank"
+        );
+        if update.vpn_withdraw.contains(&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2,
+        }) {
+            rank2_withdrawn = true;
+        }
+    }
+    assert!(
+        rank2_withdrawn,
+        "the stale candidate's Add-Path rank must be withdrawn"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// EVPN spot-check of the eBGP suppression shape.
+#[tokio::test]
+async fn evpn_llgr_stale_suppressed_toward_ebgp_peer_without_llgr() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(&tx, target, evpn_sendable(), true, vec![], None).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let key = imet.key();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![imet],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.evpn_announce.len(), 1);
+
+    let family = vec![(Afi::L2Vpn, Safi::Evpn)];
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 3600))
+        .await
+        .unwrap();
+    assert!(query_evpn_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_evpn_routes(&tx).await[0].is_llgr_stale);
+
+    let mut withdrawn = false;
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.evpn_announce.iter().any(|route| route
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)),
+            "LLGR-stale EVPN route must not be announced to a non-LLGR eBGP peer"
+        );
+        if update.evpn_withdraw.contains(&key) {
+            withdrawn = true;
+        }
+    }
+    assert!(
+        withdrawn,
+        "previously advertised EVPN route must be withdrawn from the non-LLGR eBGP peer"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Plumbing: `PeerUp` carries the peer's advertised LLGR families into
+/// the per-peer map; session teardown clears it.
+#[tokio::test]
+async fn peer_up_registers_llgr_families_and_teardown_clears() {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+    let (out_tx, _out_rx) = mpsc::channel(8);
+    manager.handle_peer_up(
+        peer,
+        1,
+        65000,
+        Ipv4Addr::UNSPECIFIED,
+        out_tx,
+        None,
+        ipv4_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        0,
+        Vec::new(),
+        vec![(Afi::Ipv4, Safi::Unicast)],
+    );
+    assert_eq!(
+        manager.peer_advertised_llgr_families.get(&peer),
+        Some(&vec![(Afi::Ipv4, Safi::Unicast)])
+    );
+
+    manager.handle_peer_down(peer, 1);
+    assert!(
+        !manager.peer_advertised_llgr_families.contains_key(&peer),
+        "teardown must clear the per-peer LLGR-family registration"
     );
 }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -361,6 +361,13 @@ pub enum RibUpdate {
         /// entries (RFC 5291/5292). Initial advertisement for these families is
         /// gated until the peer sends a ROUTE-REFRESH (RFC 5291 §6).
         negotiated_orf_recv: Vec<(Afi, Safi)>,
+        /// Families for which the peer advertised the Long-Lived Graceful
+        /// Restart capability (RFC 9494). LLGR-stale routes must not be
+        /// advertised to an eBGP peer whose family is absent from this
+        /// list (RFC 9494 §4.4 export restriction); iBGP peers take the
+        /// §4.6 `NO_EXPORT` + `LOCAL_PREF`-0 form instead, applied in
+        /// transport.
+        negotiated_llgr_families: Vec<(Afi, Safi)>,
     },
     /// Peer pushed Address-Prefix ORF entries via ROUTE-REFRESH (RFC 5291).
     /// Install/update the per-peer outbound prefix filter for `(afi, safi)` and

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -461,6 +461,17 @@ impl PeerSession {
                                 .as_ref()
                                 .map(|n| n.negotiated_orf_recv.clone())
                                 .unwrap_or_default(),
+                            negotiated_llgr_families: self
+                                .negotiated
+                                .as_ref()
+                                .filter(|n| n.peer_llgr_capable)
+                                .map(|n| {
+                                    n.peer_llgr_families
+                                        .iter()
+                                        .map(|f| (f.afi, f.safi))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
                         })
                         .await;
                     let _ = self

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -109,17 +109,51 @@ impl PeerSession {
                     .any(|f| (f.afi, f.safi) == family)
         })
     }
-    fn strip_llgr_stale_if_needed(&self, attrs: &mut Vec<PathAttribute>, family: (Afi, Safi)) {
-        if self.peer_accepts_llgr_stale(family) {
+    /// RFC 9494 §4.6 outbound form for an LLGR-stale route toward a peer
+    /// that did NOT advertise the LLGR capability for the family. The RIB
+    /// staging gate suppresses such routes toward eBGP peers entirely, so
+    /// the only LLGR-stale routes that legitimately arrive here for a
+    /// non-LLGR peer are iBGP — permitted by the §4.6 intra-AS exception
+    /// only with `NO_EXPORT` attached and `LOCAL_PREF` set to zero. The
+    /// `LLGR_STALE` community itself "MUST NOT be removed when the route
+    /// is further advertised", so it rides through unchanged (toward
+    /// LLGR peers too). This lives beside the other per-peer attribute
+    /// rewrites (eBGP `LOCAL_PREF` strip, `ORIGINATOR_ID`/`CLUSTER_LIST`,
+    /// `GShut` attach) rather than at RIB staging.
+    fn apply_llgr_stale_export_form(
+        &self,
+        attrs: &mut Vec<PathAttribute>,
+        family: (Afi, Safi),
+        is_ebgp: bool,
+    ) {
+        if is_ebgp || self.peer_accepts_llgr_stale(family) {
             return;
         }
-        attrs.retain_mut(|attr| match attr {
-            PathAttribute::Communities(comms) => {
-                comms.retain(|&c| c != rustbgpd_wire::COMMUNITY_LLGR_STALE);
-                !comms.is_empty()
-            }
-            _ => true,
+        let is_llgr_stale = attrs.iter().any(|attr| {
+            matches!(attr, PathAttribute::Communities(comms)
+                if comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
         });
+        if !is_llgr_stale {
+            return;
+        }
+        let mut has_local_pref = false;
+        for attr in attrs.iter_mut() {
+            match attr {
+                PathAttribute::LocalPref(local_pref) => {
+                    *local_pref = 0;
+                    has_local_pref = true;
+                }
+                PathAttribute::Communities(comms)
+                    if !comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT) =>
+                {
+                    comms.push(rustbgpd_wire::COMMUNITY_NO_EXPORT);
+                }
+                _ => {}
+            }
+        }
+        if !has_local_pref {
+            attrs.push(PathAttribute::LocalPref(0));
+        }
     }
     /// RFC 8326 initiator: when `advertise_graceful_shutdown` is set
     /// (via gRPC `SetGracefulShutdown`), ensure every outbound update
@@ -1912,7 +1946,7 @@ impl PeerSession {
             Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
         };
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, family);
+        self.apply_llgr_stale_export_form(&mut attrs, family, is_ebgp);
         attrs
     }
     /// Prepare path attributes for outbound `FlowSpec` advertisement.
@@ -2010,7 +2044,7 @@ impl PeerSession {
             }
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, (route.afi, Safi::FlowSpec));
+        self.apply_llgr_stale_export_form(&mut attrs, (route.afi, Safi::FlowSpec), is_ebgp);
         attrs
     }
     /// Prepare outbound attributes for a reflected EVPN route. Mirrors
@@ -2108,7 +2142,7 @@ impl PeerSession {
             }
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, (Afi::L2Vpn, Safi::Evpn));
+        self.apply_llgr_stale_export_form(&mut attrs, (Afi::L2Vpn, Safi::Evpn), is_ebgp);
         attrs
     }
     /// Prepare outbound attributes for a reflected BGP-LS route. Mirrors
@@ -2202,7 +2236,7 @@ impl PeerSession {
             }
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, route.family.to_afi_safi());
+        self.apply_llgr_stale_export_form(&mut attrs, route.family.to_afi_safi(), is_ebgp);
         attrs
     }
 
@@ -2303,7 +2337,7 @@ impl PeerSession {
             }
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, route.afi_safi());
+        self.apply_llgr_stale_export_form(&mut attrs, route.afi_safi(), is_ebgp);
         attrs
     }
 
@@ -2399,7 +2433,7 @@ impl PeerSession {
             }
         }
         self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.strip_llgr_stale_if_needed(&mut attrs, route.afi_safi());
+        self.apply_llgr_stale_export_form(&mut attrs, route.afi_safi(), is_ebgp);
         attrs
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1756,9 +1756,15 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
         .unwrap();
     assert_eq!(mp.next_hop, IpAddr::V6("2001:db8::42".parse().unwrap()));
 }
+/// RFC 9494 §4.6 intra-AS exception: an LLGR-stale route advertised to
+/// an iBGP peer that did NOT advertise the LLGR capability carries
+/// `NO_EXPORT` and `LOCAL_PREF` zero — and keeps the `LLGR_STALE`
+/// community, which "MUST NOT be removed when the route is further
+/// advertised". (eBGP peers without LLGR never see the route: the RIB
+/// export gate suppresses it at staging.)
 #[test]
-fn non_llgr_peer_strips_llgr_stale_community() {
-    let session = make_test_session(65001, 65002);
+fn llgr_stale_to_non_llgr_ibgp_peer_carries_no_export_and_lpref_zero() {
+    let session = make_test_session(65001, 65001);
     let route = Route {
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1766,18 +1772,73 @@ fn non_llgr_peer_strips_llgr_stale_community() {
                 segments: vec![AsPathSegment::AsSequence(vec![65002])],
             }),
             PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::LocalPref(100),
             PathAttribute::Communities(vec![rustbgpd_wire::COMMUNITY_LLGR_STALE]),
         ]),
         ..make_route(100)
     };
-    let attrs = session.prepare_outbound_attributes(&route, true, Ipv4Addr::new(10, 0, 0, 1), None);
+    let attrs =
+        session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
+    let comms = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::Communities(comms) => Some(comms),
+            _ => None,
+        })
+        .expect("communities attribute present");
+    assert!(
+        comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "LLGR_STALE must not be removed on re-advertisement"
+    );
+    assert!(
+        comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT),
+        "§4.6 requires NO_EXPORT toward a non-LLGR iBGP peer"
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::LocalPref(0))),
+        "§4.6 requires LOCAL_PREF zero toward a non-LLGR iBGP peer"
+    );
+    // Everything else rides through untouched.
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::Origin(Origin::Igp)))
+    );
+}
+
+/// A fresh (non-LLGR-stale) route toward the same non-LLGR iBGP peer is
+/// untouched by the §4.6 rewrite: no `NO_EXPORT`, `LOCAL_PREF` preserved.
+#[test]
+fn fresh_route_to_non_llgr_ibgp_peer_unmodified() {
+    let session = make_test_session(65001, 65001);
+    let route = Route {
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::LocalPref(100),
+            PathAttribute::Communities(vec![0x0001_0001]),
+        ]),
+        ..make_route(100)
+    };
+    let attrs =
+        session.prepare_outbound_attributes(&route, false, Ipv4Addr::new(10, 0, 0, 1), None);
     assert!(!attrs.iter().any(|a| {
         matches!(
             a,
             PathAttribute::Communities(comms)
-                if comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+                if comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT)
         )
     }));
+    assert!(
+        attrs
+            .iter()
+            .any(|a| matches!(a, PathAttribute::LocalPref(100)))
+    );
 }
 #[test]
 fn llgr_peer_keeps_llgr_stale_community() {


### PR DESCRIPTION
Closes **gap 3** — the last documented GR/LLGR RFC divergence, repo-wide, all six families (RFC 9494 §4.4/§4.6):

- **eBGP peers without LLGR for the family**: LLGR-stale routes are suppressed at staging (withdraw-if-present shape).
- **iBGP peers without LLGR** (the §4.6 intra-AS exception): still advertised, but with NO_EXPORT attached and LOCAL_PREF forced to 0 — placed in the transport attribute-rewrite layer where every per-peer rewrite already lives.
- LLGR-capable peers: unchanged (community rides; the reexport tests stay green).

**Latent bug found and removed**: the pre-existing `strip_llgr_stale_if_needed` transport behavior *stripped* the LLGR_STALE community toward non-LLGR peers while still advertising the route — violating both the §4.4 SHOULD-NOT-advertise and the MUST-NOT-remove simultaneously.

**Marker subtlety**: `is_llgr_stale` is set only by local promotion; a route *received* already tagged from an upstream helper carries the community with the flag false — the gate checks flag **or** community.

Plumbing: `negotiated_llgr_families` on PeerUp → per-peer manager state → threaded beside `sendable` through all staging paths. Fresh routes provably unaffected (no-change pin). 11 new tests; 137 test PeerUp literals updated via probe-verified script; M16 read-through confirms FRR advertises LLGR there (gate never fires). Workspace green.