### PR TITLE
feat(wire+rib): add labeled-unicast wire codec and inert RIB substrate

### DIFF
--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -27,8 +27,8 @@ use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
 use crate::route::{
-    BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute,
-    RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
+    BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, LabeledRibRoute,
+    LabeledRibRouteKey, Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
@@ -69,6 +69,12 @@ pub struct AdjRibIn {
     /// it (the SAFI 128 analog of `prefix_index`). `SmallVec<[u32; 1]>`
     /// inlines the non-Add-Path case (`path_id=0`) without heap allocation.
     vpn_key_index: HashMap<rustbgpd_wire::VpnRouteKey, SmallVec<[u32; 1]>>,
+    /// Labeled-unicast routes keyed by RFC 8277 prefix + path-id identity.
+    /// Deliberately separate from the unicast `routes` map (ADR-0077 §2).
+    labeled_routes: HashMap<LabeledRibRouteKey, LabeledRibRoute>,
+    /// Secondary index: labeled prefix → Add-Path path IDs stored for it
+    /// (the SAFI 4 analog of `vpn_key_index`).
+    labeled_key_index: HashMap<Prefix, SmallVec<[u32; 1]>>,
     /// RT-Constrain routes keyed by RFC 4684 RT membership identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
     /// EVPN route keys where `LLGR_STALE` was injected locally by this daemon
@@ -82,6 +88,9 @@ pub struct AdjRibIn {
     /// VPN route keys where `LLGR_STALE` was injected locally (see
     /// `evpn_llgr_stale_local_tags`).
     vpn_llgr_stale_local_tags: HashSet<VpnRibRouteKey>,
+    /// Labeled-unicast route keys where `LLGR_STALE` was injected locally
+    /// (see `evpn_llgr_stale_local_tags`).
+    labeled_llgr_stale_local_tags: HashSet<LabeledRibRouteKey>,
     /// RTC route keys where `LLGR_STALE` was injected locally (see
     /// `evpn_llgr_stale_local_tags`).
     rtc_llgr_stale_local_tags: HashSet<RtcRibRouteKey>,
@@ -115,10 +124,13 @@ impl AdjRibIn {
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
             vpn_key_index: HashMap::default(),
+            labeled_routes: HashMap::default(),
+            labeled_key_index: HashMap::default(),
             rtc_routes: HashMap::default(),
             evpn_llgr_stale_local_tags: HashSet::default(),
             bgpls_llgr_stale_local_tags: HashSet::default(),
             vpn_llgr_stale_local_tags: HashSet::default(),
+            labeled_llgr_stale_local_tags: HashSet::default(),
             rtc_llgr_stale_local_tags: HashSet::default(),
             attr_intern: HashSet::with_capacity_and_hasher(
                 route_capacity.clamp(16, 64),
@@ -175,9 +187,10 @@ impl AdjRibIn {
     }
 
     /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
-    /// BGP-LS, VPN, and RTC — plus all secondary indices, stale tags, and the
-    /// attribute intern table. Used when the per-peer Adj-RIB-In needs to be
-    /// wiped without also dropping the [`AdjRibIn`] struct itself.
+    /// BGP-LS, VPN, labeled-unicast, and RTC — plus all secondary indices,
+    /// stale tags, and the attribute intern table. Used when the per-peer
+    /// Adj-RIB-In needs to be wiped without also dropping the [`AdjRibIn`]
+    /// struct itself.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_index.clear();
@@ -186,12 +199,15 @@ impl AdjRibIn {
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
         self.vpn_key_index.clear();
+        self.labeled_routes.clear();
+        self.labeled_key_index.clear();
         self.rtc_routes.clear();
         self.llgr_stale_local_tags.clear();
         self.flowspec_llgr_stale_local_tags.clear();
         self.evpn_llgr_stale_local_tags.clear();
         self.bgpls_llgr_stale_local_tags.clear();
         self.vpn_llgr_stale_local_tags.clear();
+        self.labeled_llgr_stale_local_tags.clear();
         self.rtc_llgr_stale_local_tags.clear();
         self.attr_intern.clear();
     }
@@ -1320,6 +1336,315 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_vpn_community(&clear_local_llgr);
     }
 
+    /// Insert or replace a labeled-unicast route, interning its attribute set.
+    ///
+    /// Returns `true` if an existing route at the same prefix + path-id was
+    /// replaced (RFC 8277 §2.3 implicit-replace: a relabel of the same prefix
+    /// lands on the same key). A replacement may strand the previous route's
+    /// interned attribute set; labeled batch callers run
+    /// [`Self::gc_intern_table`] once after any replacement or real
+    /// withdrawal, after Loc-RIB recomputation has dropped any selected-route
+    /// clone.
+    pub fn insert_labeled(&mut self, mut route: LabeledRibRoute) -> bool {
+        let key = route.key();
+        // Mirror unicast `insert` / `insert_vpn`: a re-advertised key drops
+        // any record that *we* locally injected LLGR_STALE on its prior
+        // version, so a later EoR never strips a peer-originated community.
+        self.labeled_llgr_stale_local_tags.remove(&key);
+        if let Some(existing) = self.attr_intern.get(&route.attributes) {
+            route.attributes = existing.clone();
+        } else {
+            self.attr_intern.insert(route.attributes.clone());
+        }
+        let ids = self.labeled_key_index.entry(key.prefix).or_default();
+        if !ids.contains(&key.path_id) {
+            ids.push(key.path_id);
+        }
+        self.labeled_routes.insert(key, route).is_some()
+    }
+
+    /// Withdraw a labeled-unicast route. Returns `true` if it existed.
+    pub fn withdraw_labeled(&mut self, key: &LabeledRibRouteKey) -> bool {
+        self.remove_labeled_entry(key)
+    }
+
+    /// Shared labeled removal: drops the route, its locally-injected LLGR
+    /// tag, and its `labeled_key_index` entry. Every labeled removal path
+    /// (withdraw and the GR/LLGR stale sweeps) must route through here so
+    /// the secondary index never dangles.
+    fn remove_labeled_entry(&mut self, key: &LabeledRibRouteKey) -> bool {
+        // A removed key can no longer carry a locally-injected LLGR_STALE tag.
+        self.labeled_llgr_stale_local_tags.remove(key);
+        let removed = self.labeled_routes.remove(key).is_some();
+        if removed && let Some(ids) = self.labeled_key_index.get_mut(&key.prefix) {
+            ids.retain(|id| *id != key.path_id);
+            if ids.is_empty() {
+                self.labeled_key_index.remove(&key.prefix);
+            }
+        }
+        removed
+    }
+
+    /// Iterate the labeled routes stored for one prefix identity across all
+    /// Add-Path path IDs (the SAFI 4 analog of `iter_vpn_for_nlri`).
+    pub fn iter_labeled_for_prefix<'a>(
+        &'a self,
+        prefix: &'a Prefix,
+    ) -> impl Iterator<Item = &'a LabeledRibRoute> + 'a {
+        self.labeled_key_index
+            .get(prefix)
+            .into_iter()
+            .flat_map(move |ids| {
+                ids.iter().filter_map(move |path_id| {
+                    self.labeled_routes.get(&LabeledRibRouteKey {
+                        prefix: *prefix,
+                        path_id: *path_id,
+                    })
+                })
+            })
+    }
+
+    /// Withdraw all labeled-unicast routes from this Adj-RIB-In.
+    ///
+    /// Labeled GR/LLGR stale preservation is not wired into GR entry yet (the
+    /// stale-lifecycle helpers below are the substrate), so GR entry uses this
+    /// helper to make the conservative exclusion explicit instead of
+    /// accidentally retaining stale labeled routes as live.
+    pub fn withdraw_all_labeled(&mut self) -> Vec<LabeledRibRouteKey> {
+        let keys: Vec<_> = self.labeled_routes.keys().copied().collect();
+        self.labeled_routes.clear();
+        self.labeled_key_index.clear();
+        self.labeled_llgr_stale_local_tags.clear();
+        keys
+    }
+
+    /// Look up a labeled route by prefix + path-id key.
+    #[must_use]
+    pub fn get_labeled(&self, key: &LabeledRibRouteKey) -> Option<&LabeledRibRoute> {
+        self.labeled_routes.get(key)
+    }
+
+    /// Iterate over all labeled routes in this Adj-RIB-In.
+    pub fn iter_labeled(&self) -> impl Iterator<Item = &LabeledRibRoute> {
+        self.labeled_routes.values()
+    }
+
+    /// Return the number of labeled routes stored.
+    #[must_use]
+    pub fn labeled_len(&self) -> usize {
+        self.labeled_routes.len()
+    }
+
+    // --- Labeled-unicast GR/LLGR stale handling (RFC 4724 + RFC 9494) ---
+    //
+    // Follows the VPN pattern: LabeledRibRoute attributes are
+    // Arc<Vec<PathAttribute>>, so community injection goes through
+    // Arc::make_mut to preserve the intern-table sharing invariant.
+    //
+    // Like VPN, labeled-unicast spans two family tuples — (Ipv4,
+    // LabeledUnicast) and (Ipv6, LabeledUnicast) — which the GR capability
+    // lists separately, so every helper filters by the exact tuple via
+    // LabeledRibRoute::afi_safi(). All of this is inert substrate until the
+    // receive slice wires GR entry for SAFI 4.
+
+    /// Mark labeled routes of the given family tuple as stale (RFC 4724 §4.1
+    /// helper retention on session drop).
+    ///
+    /// A route that is *already* stale (GR or LLGR) when a new mark arrives
+    /// survived a previous restart without ever being refreshed and is deleted
+    /// instead of re-marked (RFC 4724 §4.1: stale routes must not be retained
+    /// across consecutive restarts). Returns the deleted keys so the caller
+    /// can withdraw them downstream.
+    pub fn mark_stale_labeled(&mut self, family: (Afi, Safi)) -> Vec<LabeledRibRouteKey> {
+        if family.1 != Safi::LabeledUnicast {
+            return Vec::new();
+        }
+        let already_stale: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.afi_safi() == family)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &already_stale {
+            self.remove_labeled_entry(key);
+        }
+        for route in self.labeled_routes.values_mut() {
+            if route.afi_safi() == family {
+                route.is_stale = true;
+            }
+        }
+        already_stale
+    }
+
+    /// Clear the stale flag on labeled routes of the given family tuple (both
+    /// `is_stale` and `is_llgr_stale`), stripping any locally-injected
+    /// `LLGR_STALE` community. Peer-originated `LLGR_STALE` communities are
+    /// preserved. Called when the session re-establishes (RFC 4724 §4.1).
+    pub fn clear_stale_labeled(&mut self, family: (Afi, Safi)) {
+        if family.1 != Safi::LabeledUnicast {
+            return;
+        }
+        let mut clear_local_llgr = Vec::new();
+        for (key, route) in &mut self.labeled_routes {
+            if route.afi_safi() == family {
+                route.is_stale = false;
+                route.is_llgr_stale = false;
+                if self.labeled_llgr_stale_local_tags.contains(key) {
+                    clear_local_llgr.push(*key);
+                }
+            }
+        }
+        self.clear_local_llgr_stale_labeled_community(&clear_local_llgr);
+    }
+
+    /// Remove all stale labeled routes (both tuples), returning their keys.
+    /// Timer-expiry purge (RFC 4724 §4.1: stale routes deleted when the
+    /// restart timer expires or `EoR` sweeps).
+    pub fn sweep_stale_labeled(&mut self) -> Vec<LabeledRibRouteKey> {
+        let stale: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| r.is_stale)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &stale {
+            self.remove_labeled_entry(key);
+        }
+        stale
+    }
+
+    /// Remove stale labeled routes of the given family tuple, returning their
+    /// keys. Used when a family was in GR but not in the peer's LLGR
+    /// capability.
+    pub fn sweep_stale_family_labeled(&mut self, family: (Afi, Safi)) -> Vec<LabeledRibRouteKey> {
+        if family.1 != Safi::LabeledUnicast {
+            return Vec::new();
+        }
+        let stale: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| r.is_stale && r.afi_safi() == family)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &stale {
+            self.remove_labeled_entry(key);
+        }
+        stale
+    }
+
+    /// Promote GR-stale labeled routes of the given family tuple to
+    /// LLGR-stale (RFC 9494 §4.2/§4.3).
+    ///
+    /// - Routes with `NO_LLGR` community are removed (must not enter LLGR).
+    /// - Remaining stale routes: `is_stale=false`, `is_llgr_stale=true`,
+    ///   `LLGR_STALE` community added via `Arc::make_mut`.
+    ///
+    /// Returns keys affected (for best-path recalc).
+    pub fn promote_to_llgr_stale_labeled(
+        &mut self,
+        family: (Afi, Safi),
+    ) -> Vec<LabeledRibRouteKey> {
+        use rustbgpd_wire::{COMMUNITY_LLGR_STALE, COMMUNITY_NO_LLGR};
+
+        if family.1 != Safi::LabeledUnicast {
+            return Vec::new();
+        }
+
+        // First pass: remove routes carrying NO_LLGR
+        let no_llgr_keys: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| {
+                r.is_stale && r.afi_safi() == family && r.communities().contains(&COMMUNITY_NO_LLGR)
+            })
+            .map(|(k, _)| *k)
+            .collect();
+        let mut affected: Vec<LabeledRibRouteKey> = no_llgr_keys.clone();
+        for key in &no_llgr_keys {
+            self.remove_labeled_entry(key);
+        }
+
+        // Second pass: promote remaining stale routes to LLGR-stale
+        for route in self.labeled_routes.values_mut() {
+            if route.is_stale && route.afi_safi() == family {
+                route.is_stale = false;
+                route.is_llgr_stale = true;
+                let attrs = Arc::make_mut(&mut route.attributes);
+                if let Some(PathAttribute::Communities(comms)) = attrs
+                    .iter_mut()
+                    .find(|a| matches!(a, PathAttribute::Communities(_)))
+                {
+                    if !comms.contains(&COMMUNITY_LLGR_STALE) {
+                        comms.push(COMMUNITY_LLGR_STALE);
+                        self.labeled_llgr_stale_local_tags.insert(route.key());
+                    }
+                } else {
+                    attrs.push(PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE]));
+                    self.labeled_llgr_stale_local_tags.insert(route.key());
+                }
+                affected.push(route.key());
+            }
+        }
+
+        affected
+    }
+
+    /// Remove all LLGR-stale labeled routes, returning their keys
+    /// (RFC 9494 §4.3: LLGR timer expiry).
+    pub fn sweep_llgr_stale_labeled(&mut self) -> Vec<LabeledRibRouteKey> {
+        let stale: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &stale {
+            self.remove_labeled_entry(key);
+        }
+        stale
+    }
+
+    /// Remove LLGR-stale labeled routes of the given family tuple, returning
+    /// their keys. `EoR` during the LLGR phase deletes what was not
+    /// re-advertised (RFC 4724 §4.1 via RFC 9494 §4.2).
+    pub fn sweep_llgr_stale_family_labeled(
+        &mut self,
+        family: (Afi, Safi),
+    ) -> Vec<LabeledRibRouteKey> {
+        if family.1 != Safi::LabeledUnicast {
+            return Vec::new();
+        }
+        let stale: Vec<LabeledRibRouteKey> = self
+            .labeled_routes
+            .iter()
+            .filter(|(_, r)| r.is_llgr_stale && r.afi_safi() == family)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in &stale {
+            self.remove_labeled_entry(key);
+        }
+        stale
+    }
+
+    /// Clear the LLGR-stale flag on labeled routes of the given family tuple,
+    /// stripping only locally-injected `LLGR_STALE` communities. Called when
+    /// `EoR` is received during the LLGR phase (RFC 9494 §4.2).
+    pub fn clear_llgr_stale_labeled(&mut self, family: (Afi, Safi)) {
+        if family.1 != Safi::LabeledUnicast {
+            return;
+        }
+        let mut clear_local_llgr = Vec::new();
+        for (key, route) in &mut self.labeled_routes {
+            if route.afi_safi() == family {
+                route.is_llgr_stale = false;
+                if self.labeled_llgr_stale_local_tags.contains(key) {
+                    clear_local_llgr.push(*key);
+                }
+            }
+        }
+        self.clear_local_llgr_stale_labeled_community(&clear_local_llgr);
+    }
+
     /// Insert or replace an RT-Constrain route, interning its attribute set.
     ///
     /// Returns `true` if an existing route at the same NLRI + path-id was
@@ -1828,6 +2153,15 @@ impl AdjRibIn {
         }
     }
 
+    fn clear_local_llgr_stale_labeled_community(&mut self, keys: &[LabeledRibRouteKey]) {
+        for key in keys {
+            if let Some(route) = self.labeled_routes.get_mut(key) {
+                remove_llgr_stale_community_attrs(Arc::make_mut(&mut route.attributes));
+            }
+            self.labeled_llgr_stale_local_tags.remove(key);
+        }
+    }
+
     fn clear_local_llgr_stale_rtc_community(&mut self, keys: &[RtcRibRouteKey]) {
         for key in keys {
             if let Some(route) = self.rtc_routes.get_mut(key) {
@@ -1869,8 +2203,8 @@ mod tests {
     use std::time::Instant;
 
     use rustbgpd_wire::{
-        Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, MplsLabelEntry, Origin, PathAttribute,
-        RouteDistinguisher, RtcNlri, Safi, VpnNlri, VpnPrefix,
+        Afi, COMMUNITY_LLGR_STALE, Ipv4Prefix, Ipv6Prefix, LabeledNlri, MplsLabelEntry, Origin,
+        PathAttribute, RouteDistinguisher, RtcNlri, Safi, VpnNlri, VpnPrefix,
     };
 
     use super::*;
@@ -3051,6 +3385,8 @@ mod tests {
 
     const VPN_V4: (Afi, Safi) = (Afi::Ipv4, Safi::MplsVpn);
     const VPN_V6: (Afi, Safi) = (Afi::Ipv6, Safi::MplsVpn);
+    const LU_V4: (Afi, Safi) = (Afi::Ipv4, Safi::LabeledUnicast);
+    const LU_V6: (Afi, Safi) = (Afi::Ipv6, Safi::LabeledUnicast);
     const LS_BASE: (Afi, Safi) = (Afi::BgpLs, Safi::BgpLs);
     const LS_VPN: (Afi, Safi) = (Afi::BgpLs, Safi::BgpLsVpn);
     const RTC_FAM: (Afi, Safi) = (Afi::Ipv4, Safi::RtConstrain);
@@ -3278,6 +3614,416 @@ mod tests {
 
         assert!(rib.withdraw_vpn(&key));
         assert!(!rib.vpn_llgr_stale_local_tags.contains(&key));
+    }
+
+    fn labeled_nlri(addr: [u8; 4], len: u8, label: u32) -> LabeledNlri {
+        LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            prefix: rustbgpd_wire::Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len)),
+        }
+    }
+
+    fn labeled_nlri_v6(seg: u16, len: u8, label: u32) -> LabeledNlri {
+        LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            prefix: rustbgpd_wire::Prefix::V6(Ipv6Prefix::new(
+                Ipv6Addr::new(0x2001, 0xdb8, seg, 0, 0, 0, 0, 0),
+                len,
+            )),
+        }
+    }
+
+    fn make_labeled_route(nlri: LabeledNlri, peer_oct: u8) -> LabeledRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        LabeledRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    fn insert_labeled_with(
+        rib: &mut AdjRibIn,
+        nlri: LabeledNlri,
+        attrs: Vec<PathAttribute>,
+    ) -> LabeledRibRouteKey {
+        let mut route = make_labeled_route(nlri, 1);
+        route.attributes = Arc::new(attrs);
+        let key = route.key();
+        rib.insert_labeled(route);
+        key
+    }
+
+    #[test]
+    fn labeled_insert_get_replace_withdraw_round_trip() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let key = LabeledRibRouteKey {
+            prefix: nlri.key(),
+            path_id: 0,
+        };
+
+        assert!(!rib.insert_labeled(make_labeled_route(nlri.clone(), 1)));
+        assert_eq!(rib.labeled_len(), 1);
+        assert_eq!(rib.iter_labeled().count(), 1);
+        assert_eq!(
+            rib.get_labeled(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+        );
+
+        // Same prefix with a *different label* is the same key (labels are
+        // route data, not identity — RFC 8277 §2.3 implicit replace).
+        let relabeled = labeled_nlri([10, 0, 1, 0], 24, 999);
+        assert_eq!(
+            LabeledRibRouteKey {
+                prefix: relabeled.key(),
+                path_id: 0
+            },
+            key
+        );
+        assert!(rib.insert_labeled(make_labeled_route(relabeled, 2)));
+        assert_eq!(rib.labeled_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_labeled(&key).unwrap().next_hop,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+        assert_eq!(rib.get_labeled(&key).unwrap().nlri.labels[0].label, 999);
+
+        assert!(rib.withdraw_labeled(&key));
+        assert_eq!(rib.labeled_len(), 0);
+        assert!(!rib.withdraw_labeled(&key));
+    }
+
+    #[test]
+    fn labeled_path_ids_are_distinct_keys_and_iterable_per_prefix() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+
+        let mut path1 = make_labeled_route(nlri.clone(), 1);
+        path1.path_id = 1;
+        let mut path2 = make_labeled_route(nlri.clone(), 2);
+        path2.path_id = 2;
+        assert!(!rib.insert_labeled(path1));
+        assert!(!rib.insert_labeled(path2), "distinct path_id is a new key");
+        assert_eq!(rib.labeled_len(), 2);
+
+        let prefix = nlri.key();
+        let mut peers: Vec<_> = rib
+            .iter_labeled_for_prefix(&prefix)
+            .map(|r| r.peer)
+            .collect();
+        peers.sort();
+        assert_eq!(
+            peers,
+            vec![
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            ]
+        );
+
+        // Removing one path leaves the other reachable via the index.
+        assert!(rib.withdraw_labeled(&LabeledRibRouteKey { prefix, path_id: 1 }));
+        assert_eq!(rib.iter_labeled_for_prefix(&prefix).count(), 1);
+        assert!(rib.withdraw_labeled(&LabeledRibRouteKey { prefix, path_id: 2 }));
+        assert_eq!(rib.iter_labeled_for_prefix(&prefix).count(), 0);
+    }
+
+    #[test]
+    fn labeled_withdraw_all_returns_keys_and_empties_table() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let a = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let b = labeled_nlri([10, 0, 2, 0], 24, 200);
+        rib.insert_labeled(make_labeled_route(a.clone(), 1));
+        rib.insert_labeled(make_labeled_route(b.clone(), 1));
+        assert_eq!(rib.labeled_len(), 2);
+
+        let mut keys = rib.withdraw_all_labeled();
+        keys.sort_by_key(|k| k.prefix.to_string());
+        assert_eq!(
+            keys,
+            vec![
+                LabeledRibRouteKey {
+                    prefix: a.key(),
+                    path_id: 0
+                },
+                LabeledRibRouteKey {
+                    prefix: b.key(),
+                    path_id: 0
+                },
+            ]
+        );
+        assert_eq!(rib.labeled_len(), 0);
+    }
+
+    #[test]
+    fn labeled_insert_reports_replacement_for_intern_gc() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+
+        assert!(!rib.insert_labeled(make_labeled_route(nlri.clone(), 1)));
+        assert_eq!(rib.intern_len(), 1);
+
+        let mut replacement = make_labeled_route(nlri, 2);
+        replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+
+        assert!(rib.insert_labeled(replacement));
+        assert_eq!(
+            rib.intern_len(),
+            2,
+            "replacement strands the previous interned attribute set before GC"
+        );
+
+        rib.gc_intern_table();
+        assert_eq!(rib.intern_len(), 1);
+    }
+
+    #[test]
+    fn labeled_storage_is_isolated_from_unicast_and_vpn_tables() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+
+        // Unicast route at the *same prefix* as the labeled route: the two
+        // tables must not collide (ADR-0077 §2).
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 0, 9, 0), 24);
+        rib.insert(make_route(prefix, Ipv4Addr::new(10, 0, 0, 1)));
+        rib.insert_labeled(make_labeled_route(labeled_nlri([10, 0, 9, 0], 24, 100), 1));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 9, 0], 24, 100), 1));
+
+        assert_eq!(rib.labeled_len(), 1);
+        assert_eq!(rib.len(), 1, "labeled storage must not touch unicast count");
+        assert_eq!(rib.vpn_len(), 1, "labeled storage must not touch VPN count");
+
+        // Withdrawing the labeled route leaves unicast and VPN intact.
+        let key = LabeledRibRouteKey {
+            prefix: rustbgpd_wire::Prefix::V4(prefix),
+            path_id: 0,
+        };
+        assert!(rib.withdraw_labeled(&key));
+        assert_eq!(rib.len(), 1);
+        assert_eq!(rib.vpn_len(), 1);
+
+        rib.clear();
+        assert_eq!(rib.labeled_len(), 0);
+        assert!(rib.is_empty());
+    }
+
+    #[test]
+    fn mark_stale_labeled_scopes_to_family_tuple() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let v4_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        let v6_key = insert_labeled_with(&mut rib, labeled_nlri_v6(1, 48, 200), vec![]);
+
+        // Wrong SAFI: no-op
+        assert!(
+            rib.mark_stale_labeled((Afi::Ipv4, Safi::Unicast))
+                .is_empty()
+        );
+        assert!(!rib.labeled_routes[&v4_key].is_stale);
+
+        // IPv4 labeled: only the v4-tuple route becomes stale
+        assert!(rib.mark_stale_labeled(LU_V4).is_empty());
+        assert!(rib.labeled_routes[&v4_key].is_stale);
+        assert!(
+            !rib.labeled_routes[&v6_key].is_stale,
+            "v6 tuple must be untouched"
+        );
+    }
+
+    #[test]
+    fn mark_stale_labeled_deletes_already_stale_routes_on_consecutive_restart() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let gr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        let llgr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 2, 0], 24, 200), vec![]);
+
+        // First session drop: both routes go GR-stale; one then enters LLGR.
+        rib.mark_stale_labeled(LU_V4);
+        let llgr_route = rib.labeled_routes.get_mut(&llgr_key).unwrap();
+        llgr_route.is_stale = false;
+        llgr_route.is_llgr_stale = true;
+        // Second session drop before any refresh: both already-stale routes
+        // (GR-stale and LLGR-stale) are deleted, not re-marked.
+        let mut deleted = rib.mark_stale_labeled(LU_V4);
+        deleted.sort_by_key(|k| k.prefix.to_string());
+        assert_eq!(deleted, vec![gr_key, llgr_key]);
+        assert_eq!(rib.labeled_len(), 0);
+    }
+
+    #[test]
+    fn clear_stale_labeled_strips_local_llgr_community() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+
+        rib.mark_stale_labeled(LU_V4);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
+        let promoted = &rib.labeled_routes[&key];
+        assert!(promoted.is_llgr_stale);
+        assert!(promoted.communities().contains(&COMMUNITY_LLGR_STALE));
+        assert!(rib.labeled_llgr_stale_local_tags.contains(&key));
+
+        rib.clear_stale_labeled(LU_V4);
+        let route = &rib.labeled_routes[&key];
+        assert!(!route.is_stale);
+        assert!(!route.is_llgr_stale);
+        assert!(!route.communities().contains(&COMMUNITY_LLGR_STALE));
+    }
+
+    #[test]
+    fn clear_stale_labeled_preserves_peer_originated_llgr_community() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let peer_attrs = vec![PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE])];
+        let key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), peer_attrs);
+
+        rib.mark_stale_labeled(LU_V4);
+        rib.clear_stale_labeled(LU_V4);
+        let route = &rib.labeled_routes[&key];
+        assert!(!route.is_stale);
+        assert!(route.communities().contains(&COMMUNITY_LLGR_STALE));
+    }
+
+    #[test]
+    fn sweep_stale_family_labeled_sweeps_only_matching_tuple() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let v4_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        let v6_key = insert_labeled_with(&mut rib, labeled_nlri_v6(1, 48, 200), vec![]);
+        rib.mark_stale_labeled(LU_V4);
+        rib.mark_stale_labeled(LU_V6);
+
+        let swept = rib.sweep_stale_family_labeled(LU_V4);
+        assert_eq!(swept, vec![v4_key]);
+        assert_eq!(
+            rib.labeled_len(),
+            1,
+            "v6 stale route must survive a v4 sweep"
+        );
+
+        // Whole-table sweep purges the remaining stale route.
+        let swept = rib.sweep_stale_labeled();
+        assert_eq!(swept, vec![v6_key]);
+        assert_eq!(rib.labeled_len(), 0);
+    }
+
+    #[test]
+    fn promote_to_llgr_stale_labeled_drops_no_llgr_and_scopes_to_tuple() {
+        use rustbgpd_wire::COMMUNITY_NO_LLGR;
+
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let keep_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        let no_llgr_key = insert_labeled_with(
+            &mut rib,
+            labeled_nlri([10, 0, 2, 0], 24, 200),
+            vec![PathAttribute::Communities(vec![COMMUNITY_NO_LLGR])],
+        );
+        let v6_key = insert_labeled_with(&mut rib, labeled_nlri_v6(1, 48, 300), vec![]);
+
+        rib.mark_stale_labeled(LU_V4);
+        rib.mark_stale_labeled(LU_V6);
+        let affected = rib.promote_to_llgr_stale_labeled(LU_V4);
+
+        // NO_LLGR route removed entirely (RFC 9494 §4.3)
+        assert!(!rib.labeled_routes.contains_key(&no_llgr_key));
+        // Other v4 route promoted, community injected, local tag recorded
+        assert!(rib.labeled_routes[&keep_key].is_llgr_stale);
+        assert!(!rib.labeled_routes[&keep_key].is_stale);
+        assert!(
+            rib.labeled_routes[&keep_key]
+                .communities()
+                .contains(&COMMUNITY_LLGR_STALE)
+        );
+        assert!(rib.labeled_llgr_stale_local_tags.contains(&keep_key));
+        assert!(affected.contains(&keep_key));
+        assert!(affected.contains(&no_llgr_key));
+        // v6 tuple untouched: still GR-stale, not promoted
+        assert!(rib.labeled_routes[&v6_key].is_stale);
+        assert!(!rib.labeled_routes[&v6_key].is_llgr_stale);
+        assert!(!affected.contains(&v6_key));
+
+        // LLGR expiry sweep removes only the promoted route; the family
+        // variant is exercised by the EoR path below.
+        let swept = rib.sweep_llgr_stale_labeled();
+        assert_eq!(swept, vec![keep_key]);
+        assert_eq!(rib.labeled_len(), 1);
+    }
+
+    #[test]
+    fn sweep_llgr_stale_family_labeled_scopes_to_tuple() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let v4_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        insert_labeled_with(&mut rib, labeled_nlri_v6(1, 48, 200), vec![]);
+        rib.mark_stale_labeled(LU_V4);
+        rib.mark_stale_labeled(LU_V6);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
+        rib.promote_to_llgr_stale_labeled(LU_V6);
+
+        let swept = rib.sweep_llgr_stale_family_labeled(LU_V4);
+        assert_eq!(swept, vec![v4_key]);
+        assert_eq!(
+            rib.labeled_len(),
+            1,
+            "v6 LLGR-stale route must survive a v4 EoR sweep"
+        );
+    }
+
+    #[test]
+    fn insert_labeled_clears_llgr_stale_local_tag_on_readvertise() {
+        // Regression mirror of insert_vpn_clears_llgr_stale_local_tag_on_readvertise:
+        // a re-advertised key must drop our local-injection record so a later
+        // EoR does not strip a peer-originated LLGR_STALE community.
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let key = insert_labeled_with(&mut rib, nlri.clone(), vec![]);
+
+        rib.mark_stale_labeled(LU_V4);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
+        assert!(rib.labeled_llgr_stale_local_tags.contains(&key));
+
+        // Peer re-advertises the same key, itself carrying LLGR_STALE.
+        let readvertised = insert_labeled_with(
+            &mut rib,
+            nlri,
+            vec![PathAttribute::Communities(vec![COMMUNITY_LLGR_STALE])],
+        );
+        assert_eq!(readvertised, key);
+        assert!(!rib.labeled_llgr_stale_local_tags.contains(&key));
+
+        // EoR: the peer-originated LLGR_STALE must survive.
+        rib.clear_llgr_stale_labeled(LU_V4);
+        assert!(
+            rib.labeled_routes[&key]
+                .communities()
+                .contains(&COMMUNITY_LLGR_STALE)
+        );
+    }
+
+    #[test]
+    fn withdraw_labeled_clears_llgr_stale_local_tag() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        rib.mark_stale_labeled(LU_V4);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
+        assert!(rib.labeled_llgr_stale_local_tags.contains(&key));
+
+        assert!(rib.withdraw_labeled(&key));
+        assert!(!rib.labeled_llgr_stale_local_tags.contains(&key));
     }
 
     #[test]
@@ -3626,20 +4372,25 @@ mod tests {
         insert_vpn_with(&mut rib, vpn_nlri([10, 0, 1, 0], 24, 100), vec![]);
         insert_bgpls_with(&mut rib, BgpLsFamily::LinkState, bgpls_nlri(1), vec![]);
         insert_rtc_with(&mut rib, rtc_nlri(100), vec![]);
+        insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
         rib.mark_stale_vpn(VPN_V4);
         rib.mark_stale_bgpls(LS_BASE);
         rib.mark_stale_rtc(RTC_FAM);
+        rib.mark_stale_labeled(LU_V4);
         rib.promote_to_llgr_stale_vpn(VPN_V4);
         rib.promote_to_llgr_stale_bgpls(LS_BASE);
         rib.promote_to_llgr_stale_rtc(RTC_FAM);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
         assert!(!rib.vpn_llgr_stale_local_tags.is_empty());
         assert!(!rib.bgpls_llgr_stale_local_tags.is_empty());
         assert!(!rib.rtc_llgr_stale_local_tags.is_empty());
+        assert!(!rib.labeled_llgr_stale_local_tags.is_empty());
 
         rib.clear();
         assert!(rib.vpn_llgr_stale_local_tags.is_empty());
         assert!(rib.bgpls_llgr_stale_local_tags.is_empty());
         assert!(rib.rtc_llgr_stale_local_tags.is_empty());
+        assert!(rib.labeled_llgr_stale_local_tags.is_empty());
     }
 
     #[test]
@@ -3649,18 +4400,23 @@ mod tests {
         insert_vpn_with(&mut rib, vpn_nlri([10, 0, 1, 0], 24, 100), vec![]);
         insert_bgpls_with(&mut rib, BgpLsFamily::LinkState, bgpls_nlri(1), vec![]);
         insert_rtc_with(&mut rib, rtc_nlri(100), vec![]);
+        insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
         rib.mark_stale_vpn(VPN_V4);
         rib.mark_stale_bgpls(LS_BASE);
         rib.mark_stale_rtc(RTC_FAM);
+        rib.mark_stale_labeled(LU_V4);
         rib.promote_to_llgr_stale_vpn(VPN_V4);
         rib.promote_to_llgr_stale_bgpls(LS_BASE);
         rib.promote_to_llgr_stale_rtc(RTC_FAM);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
 
         rib.withdraw_all_vpn();
         rib.withdraw_all_bgpls();
         rib.withdraw_all_rtc();
+        rib.withdraw_all_labeled();
         assert!(rib.vpn_llgr_stale_local_tags.is_empty());
         assert!(rib.bgpls_llgr_stale_local_tags.is_empty());
         assert!(rib.rtc_llgr_stale_local_tags.is_empty());
+        assert!(rib.labeled_llgr_stale_local_tags.is_empty());
     }
 }

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -9,8 +9,8 @@ use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
 use crate::route::{
-    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
-    VpnRibRoute, VpnRibRouteKey,
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, LabeledRibRoute, LabeledRibRouteKey,
+    Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
@@ -37,6 +37,13 @@ pub struct AdjRibOut {
     /// (the SAFI 128 analog of `prefix_path_ids`). `SmallVec<[u32; 1]>` inlines
     /// the single-best case (`path_id=0`) without heap allocation.
     vpn_key_path_ids: HashMap<rustbgpd_wire::VpnRouteKey, SmallVec<[u32; 1]>>,
+    /// Labeled-unicast routes advertised to this peer, keyed by prefix +
+    /// path-id identity. Deliberately separate from the unicast `routes` map
+    /// (ADR-0077 §2).
+    labeled_routes: HashMap<LabeledRibRouteKey, LabeledRibRoute>,
+    /// Secondary index: labeled prefix → advertised Add-Path path IDs (the
+    /// SAFI 4 analog of `vpn_key_path_ids`).
+    labeled_key_path_ids: HashMap<Prefix, SmallVec<[u32; 1]>>,
     /// RT-Constrain routes advertised to this peer, keyed by RFC 4684 identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
@@ -63,6 +70,8 @@ impl AdjRibOut {
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
             vpn_key_path_ids: HashMap::default(),
+            labeled_routes: HashMap::default(),
+            labeled_key_path_ids: HashMap::default(),
             rtc_routes: HashMap::default(),
         }
     }
@@ -131,7 +140,7 @@ impl AdjRibOut {
     }
 
     /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS,
-    /// VPN, and RTC — and the secondary prefix index.
+    /// VPN, labeled-unicast, and RTC — and the secondary prefix index.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_path_ids.clear();
@@ -140,6 +149,8 @@ impl AdjRibOut {
         self.bgpls_routes.clear();
         self.vpn_routes.clear();
         self.vpn_key_path_ids.clear();
+        self.labeled_routes.clear();
+        self.labeled_key_path_ids.clear();
         self.rtc_routes.clear();
     }
 
@@ -323,6 +334,58 @@ impl AdjRibOut {
         self.vpn_routes.len()
     }
 
+    // --- Labeled-unicast methods (ADR-0077 outbound reflection substrate) ---
+
+    /// Insert or replace an advertised labeled route.
+    pub fn insert_labeled(&mut self, route: LabeledRibRoute) {
+        let key = route.key();
+        if self.labeled_routes.insert(key, route).is_none() {
+            let ids = self.labeled_key_path_ids.entry(key.prefix).or_default();
+            if !ids.contains(&key.path_id) {
+                ids.push(key.path_id);
+            }
+        }
+    }
+
+    /// Remove an advertised labeled route by key. Returns `true` if it
+    /// existed.
+    pub fn remove_labeled(&mut self, key: &LabeledRibRouteKey) -> bool {
+        let removed = self.labeled_routes.remove(key).is_some();
+        if removed && let Some(ids) = self.labeled_key_path_ids.get_mut(&key.prefix) {
+            ids.retain(|id| *id != key.path_id);
+            if ids.is_empty() {
+                self.labeled_key_path_ids.remove(&key.prefix);
+            }
+        }
+        removed
+    }
+
+    /// Return all Add-Path path IDs currently advertised for a labeled
+    /// prefix identity (the SAFI 4 analog of [`Self::path_ids_for_prefix`]).
+    #[must_use]
+    pub fn labeled_path_ids_for_key(&self, prefix: &Prefix) -> &[u32] {
+        self.labeled_key_path_ids
+            .get(prefix)
+            .map_or(&[], SmallVec::as_slice)
+    }
+
+    /// Look up an advertised labeled route by key.
+    #[must_use]
+    pub fn get_labeled(&self, key: &LabeledRibRouteKey) -> Option<&LabeledRibRoute> {
+        self.labeled_routes.get(key)
+    }
+
+    /// Iterate over all advertised labeled routes.
+    pub fn iter_labeled(&self) -> impl Iterator<Item = &LabeledRibRoute> {
+        self.labeled_routes.values()
+    }
+
+    /// Return the number of advertised labeled routes.
+    #[must_use]
+    pub fn labeled_len(&self) -> usize {
+        self.labeled_routes.len()
+    }
+
     // --- RT-Constrain methods (RFC 4684 outbound reflection substrate) ---
 
     /// Insert or replace an advertised RTC route.
@@ -455,6 +518,76 @@ mod tests {
         assert!(rib.remove_vpn(&key));
         assert_eq!(rib.vpn_len(), 0);
         assert!(!rib.remove_vpn(&key));
+    }
+
+    fn make_labeled_route(addr: [u8; 4], len: u8, path_id: u32, peer_oct: u8) -> LabeledRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        LabeledRibRoute {
+            nlri: rustbgpd_wire::LabeledNlri {
+                labels: vec![MplsLabelEntry::try_new(100, 0, true).unwrap()],
+                prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len)),
+            },
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id,
+        }
+    }
+
+    #[test]
+    fn labeled_insert_remove_iter_isolated_from_unicast_index() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        // Same prefix as prefix_a() to prove the tables cannot collide.
+        let route = make_labeled_route([10, 0, 0, 0], 24, 0, 1);
+        let key = route.key();
+
+        rib.insert_labeled(route);
+        assert_eq!(rib.labeled_len(), 1);
+        assert_eq!(rib.iter_labeled().count(), 1);
+        assert_eq!(rib.len(), 0);
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
+
+        // Same prefix + path_id replaces in place.
+        rib.insert_labeled(make_labeled_route([10, 0, 0, 0], 24, 0, 2));
+        assert_eq!(rib.labeled_len(), 1, "same key should replace");
+        assert_eq!(
+            rib.get_labeled(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+
+        assert!(rib.remove_labeled(&key));
+        assert_eq!(rib.labeled_len(), 0);
+        assert!(!rib.remove_labeled(&key));
+    }
+
+    #[test]
+    fn labeled_index_tracks_add_path_multiple_ids() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let prefix = prefix_a();
+
+        assert!(rib.labeled_path_ids_for_key(&prefix).is_empty());
+        rib.insert_labeled(make_labeled_route([10, 0, 0, 0], 24, 1, 1));
+        rib.insert_labeled(make_labeled_route([10, 0, 0, 0], 24, 2, 1));
+        rib.insert_labeled(make_labeled_route([10, 0, 0, 0], 24, 3, 1));
+
+        let mut ids = rib.labeled_path_ids_for_key(&prefix).to_vec();
+        ids.sort_unstable();
+        assert_eq!(ids, [1, 2, 3]);
+
+        rib.remove_labeled(&LabeledRibRouteKey { prefix, path_id: 2 });
+        let mut ids = rib.labeled_path_ids_for_key(&prefix).to_vec();
+        ids.sort_unstable();
+        assert_eq!(ids, [1, 3]);
+
+        rib.remove_labeled(&LabeledRibRouteKey { prefix, path_id: 1 });
+        rib.remove_labeled(&LabeledRibRouteKey { prefix, path_id: 3 });
+        assert!(rib.labeled_path_ids_for_key(&prefix).is_empty());
     }
 
     fn make_rtc_route(local_admin: u32, peer_oct: u8) -> RtcRibRoute {

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -51,8 +51,8 @@ pub use orr::{
 };
 pub use route::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FibInstallCandidate,
-    FibInstallNextHop, FlowSpecRoute, NextHopScope, Route, RouteOrigin, RtcRibRoute,
-    RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
+    FibInstallNextHop, FlowSpecRoute, LabeledRibRoute, LabeledRibRouteKey, NextHopScope, Route,
+    RouteOrigin, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 pub use update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -13,8 +13,8 @@ use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
 
 use crate::best_path::best_path_cmp;
 use crate::route::{
-    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, Route, RtcRibRoute, RtcRibRouteKey,
-    VpnRibRoute,
+    BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, LabeledRibRoute, Route, RtcRibRoute,
+    RtcRibRouteKey, VpnRibRoute,
 };
 
 /// The local RIB storing the best route per prefix.
@@ -31,6 +31,11 @@ pub struct LocRib {
     /// selection collapses Add-Path path IDs — the winning route's own
     /// `path_id` records which received path won.
     vpn_routes: HashMap<rustbgpd_wire::VpnRouteKey, VpnRibRoute>,
+    /// Labeled-unicast Loc-RIB: best route per prefix identity, collapsing
+    /// Add-Path path IDs like `vpn_routes` — the winning route's own
+    /// `path_id` records which received path won. Deliberately separate from
+    /// the unicast `routes` map (ADR-0077 §2).
+    labeled_routes: HashMap<Prefix, LabeledRibRoute>,
     /// RT-Constrain Loc-RIB: best route per RFC 4684 RT membership identity.
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
@@ -51,6 +56,7 @@ impl LocRib {
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
             vpn_routes: HashMap::default(),
+            labeled_routes: HashMap::default(),
             rtc_routes: HashMap::default(),
         }
     }
@@ -373,6 +379,69 @@ impl LocRib {
     /// Remove the selected VPN route for a key. Returns `true` if it existed.
     pub fn remove_vpn(&mut self, key: &rustbgpd_wire::VpnRouteKey) -> bool {
         self.vpn_routes.remove(key).is_some()
+    }
+
+    /// Recompute the best labeled-unicast route for `key` from the
+    /// candidates.
+    ///
+    /// Uses the same family-agnostic BGP preference chain as VPN: stale rank,
+    /// `LOCAL_PREF`, `AS_PATH`, `ORIGIN`, MED, eBGP/iBGP, cluster length,
+    /// originator ID, then peer address. The MPLS label stack is route data,
+    /// not a selection input; a same-peer relabel is caught by the `nlri`
+    /// change check so the reflected label stays current.
+    pub fn recompute_labeled<'a>(
+        &mut self,
+        key: Prefix,
+        candidates: impl Iterator<Item = &'a LabeledRibRoute>,
+    ) -> bool {
+        let best = candidates.min_by(|a, b| labeled_tiebreak(a, b)).cloned();
+        match best {
+            Some(new_best) => {
+                let changed = self.labeled_routes.get(&key).is_none_or(|old| {
+                    old.peer != new_best.peer
+                        || old.path_id != new_best.path_id
+                        || old.is_stale != new_best.is_stale
+                        || old.is_llgr_stale != new_best.is_llgr_stale
+                        || old.next_hop != new_best.next_hop
+                        || old.peer_router_id != new_best.peer_router_id
+                        || old.nlri != new_best.nlri
+                        || old.attributes != new_best.attributes
+                });
+                if changed {
+                    self.labeled_routes.insert(key, new_best);
+                }
+                changed
+            }
+            None => self.labeled_routes.remove(&key).is_some(),
+        }
+    }
+
+    /// Insert or replace the selected labeled route for a key.
+    pub fn insert_labeled(&mut self, route: LabeledRibRoute) {
+        self.labeled_routes.insert(route.nlri.key(), route);
+    }
+
+    /// Look up the selected labeled route for a prefix identity.
+    #[must_use]
+    pub fn get_labeled(&self, key: &Prefix) -> Option<&LabeledRibRoute> {
+        self.labeled_routes.get(key)
+    }
+
+    /// Iterate over all selected labeled routes.
+    pub fn iter_labeled(&self) -> impl Iterator<Item = &LabeledRibRoute> {
+        self.labeled_routes.values()
+    }
+
+    /// Return the number of selected labeled routes.
+    #[must_use]
+    pub fn labeled_len(&self) -> usize {
+        self.labeled_routes.len()
+    }
+
+    /// Remove the selected labeled route for a key. Returns `true` if it
+    /// existed.
+    pub fn remove_labeled(&mut self, key: &Prefix) -> bool {
+        self.labeled_routes.remove(key).is_some()
     }
 
     /// Recompute the best RT-Constrain route for `key` from the candidates.
@@ -894,6 +963,175 @@ fn vpn_originator_id(route: &VpnRibRoute) -> Option<std::net::Ipv4Addr> {
     })
 }
 
+pub(crate) fn labeled_tiebreak(a: &LabeledRibRoute, b: &LabeledRibRoute) -> Ordering {
+    labeled_cmp_chain(a, b, None)
+}
+
+/// Compare two labeled-unicast routes under RFC 9107 Optimal Route
+/// Reflection.
+///
+/// The standard [`labeled_tiebreak`] chain with one extra step between the
+/// eBGP/iBGP step and `CLUSTER_LIST` — the same slot as
+/// [`crate::best_path::best_path_cmp_orr`]: the configured vantage's
+/// interior (SPF) cost to each route's `NEXT_HOP`. Lower cost wins; a
+/// known cost beats an unknown one (RFC 9107 §3.1); equal or
+/// both-unknown falls through.
+// Tests exercise the ORR oracle today; the labeled receive/reflect slice
+// (mirroring `manager/distribution/vpn.rs` Add-Path staging) is the first
+// non-test consumer.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "inert ADR-0077 substrate until the labeled receive slice lands"
+    )
+)]
+pub(crate) fn labeled_tiebreak_orr(
+    a: &LabeledRibRoute,
+    b: &LabeledRibRoute,
+    cost_a: Option<u64>,
+    cost_b: Option<u64>,
+) -> Ordering {
+    labeled_cmp_chain(a, b, Some((cost_a, cost_b)))
+}
+
+/// The shared decision chain behind [`labeled_tiebreak`] (`orr_costs =
+/// None`, the Loc-RIB selection) and [`labeled_tiebreak_orr`] (`orr_costs =
+/// Some(..)`, per-vantage staging), mirroring `vpn_cmp_chain`.
+fn labeled_cmp_chain(
+    a: &LabeledRibRoute,
+    b: &LabeledRibRoute,
+    orr_costs: Option<(Option<u64>, Option<u64>)>,
+) -> Ordering {
+    let cmp = labeled_stale_rank(a).cmp(&labeled_stale_rank(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = labeled_local_pref(b).cmp(&labeled_local_pref(a));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let a_len = labeled_as_path(a).map_or(0, AsPath::len);
+    let b_len = labeled_as_path(b).map_or(0, AsPath::len);
+    let cmp = a_len.cmp(&b_len);
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = labeled_origin(a).cmp(&labeled_origin(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = labeled_med(a).cmp(&labeled_med(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    let cmp = b.is_ebgp().cmp(&a.is_ebgp());
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    // RFC 9107 ORR interior cost to NEXT_HOP — only when the caller
+    // supplies vantage costs (the Loc-RIB never does). Lower cost wins;
+    // Some beats None (unknown metric MUST be least preferred); equal
+    // or both-None falls through.
+    if let Some((cost_a, cost_b)) = orr_costs {
+        let cmp = match (cost_a, cost_b) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        };
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+    }
+
+    let cmp = labeled_cluster_list_len(a).cmp(&labeled_cluster_list_len(b));
+    if cmp != Ordering::Equal {
+        return cmp;
+    }
+
+    if let (Some(a_oid), Some(b_oid)) = (labeled_originator_id(a), labeled_originator_id(b)) {
+        let cmp = a_oid.cmp(&b_oid);
+        if cmp != Ordering::Equal {
+            return cmp;
+        }
+    }
+
+    cmp_ipaddr(&a.peer, &b.peer)
+}
+
+fn labeled_stale_rank(route: &LabeledRibRoute) -> u8 {
+    if route.is_llgr_stale {
+        2
+    } else {
+        u8::from(route.is_stale)
+    }
+}
+
+fn labeled_local_pref(route: &LabeledRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::LocalPref(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(100)
+}
+
+fn labeled_as_path(route: &LabeledRibRoute) -> Option<&AsPath> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::AsPath(path) => Some(path),
+        _ => None,
+    })
+}
+
+fn labeled_origin(route: &LabeledRibRoute) -> Origin {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Origin(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(Origin::Incomplete)
+}
+
+fn labeled_med(route: &LabeledRibRoute) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Med(value) => Some(*value),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn labeled_cluster_list_len(route: &LabeledRibRoute) -> usize {
+    route
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::ClusterList(ids) => Some(ids.len()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn labeled_originator_id(route: &LabeledRibRoute) -> Option<std::net::Ipv4Addr> {
+    route.attributes.iter().find_map(|attr| match attr {
+        PathAttribute::OriginatorId(id) => Some(*id),
+        _ => None,
+    })
+}
+
 fn rtc_tiebreak(a: &RtcRibRoute, b: &RtcRibRoute) -> Ordering {
     let cmp = rtc_stale_rank(a).cmp(&rtc_stale_rank(b));
     if cmp != Ordering::Equal {
@@ -1032,8 +1270,8 @@ mod tests {
 
     use rustbgpd_wire::{
         Afi, AsPath, AsPathSegment, ExtendedCommunity, FlowSpecComponent, FlowSpecRule, Ipv4Prefix,
-        MplsLabelEntry, NumericMatch, Origin, PathAttribute, RouteDistinguisher, RtcNlri, VpnNlri,
-        VpnPrefix,
+        LabeledNlri, MplsLabelEntry, NumericMatch, Origin, PathAttribute, RouteDistinguisher,
+        RtcNlri, VpnNlri, VpnPrefix,
     };
 
     use super::*;
@@ -1255,6 +1493,214 @@ mod tests {
         assert_eq!(loc.vpn_len(), 1);
         assert_eq!(loc.len(), 0);
         assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
+    }
+
+    fn labeled_nlri(addr: [u8; 4], len: u8, label: u32) -> LabeledNlri {
+        LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len)),
+        }
+    }
+
+    fn make_labeled_route(nlri: LabeledNlri, peer_oct: u8, local_pref: u32) -> LabeledRibRoute {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, peer_oct));
+        LabeledRibRoute {
+            nlri,
+            next_hop: peer,
+            peer,
+            attributes: Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::LocalPref(local_pref),
+            ]),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, peer_oct),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    #[test]
+    fn recompute_labeled_higher_local_pref_wins() {
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let key = nlri.key();
+        let r1 = make_labeled_route(nlri.clone(), 1, 100);
+        let r2 = make_labeled_route(nlri, 2, 200);
+        let mut loc = LocRib::new();
+
+        assert!(loc.recompute_labeled(key, [&r1, &r2].into_iter()));
+        assert_eq!(loc.labeled_len(), 1);
+        assert_eq!(
+            loc.get_labeled(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
+        );
+    }
+
+    #[test]
+    fn recompute_labeled_stale_demoted_despite_higher_local_pref() {
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let key = nlri.key();
+        let mut r_stale = make_labeled_route(nlri.clone(), 1, 200);
+        r_stale.is_stale = true;
+        let r_fresh = make_labeled_route(nlri, 2, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_labeled(key, [&r_stale, &r_fresh].into_iter());
+        assert_eq!(
+            loc.get_labeled(&key).unwrap().peer,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            "fresh route must beat GR-stale despite lower LOCAL_PREF"
+        );
+    }
+
+    #[test]
+    fn recompute_labeled_same_peer_relabel_triggers_change() {
+        // The label stack is route data, not identity: a same-peer relabel of
+        // the same prefix must still report a change (nlri differs) so the
+        // reflected label stays current.
+        let key = labeled_nlri([10, 0, 1, 0], 24, 100).key();
+        let r1 = make_labeled_route(labeled_nlri([10, 0, 1, 0], 24, 100), 1, 100);
+        let r2 = make_labeled_route(labeled_nlri([10, 0, 1, 0], 24, 999), 1, 100);
+        let mut loc = LocRib::new();
+
+        assert!(loc.recompute_labeled(key, [&r1].into_iter()));
+        assert!(
+            loc.recompute_labeled(key, [&r2].into_iter()),
+            "relabel must be a change"
+        );
+        assert_eq!(loc.get_labeled(&key).unwrap().nlri.labels[0].label, 999);
+        assert!(
+            !loc.recompute_labeled(key, [&r2].into_iter()),
+            "identical candidate must not be a change"
+        );
+    }
+
+    #[test]
+    fn recompute_labeled_empty_candidates_removes_existing_key() {
+        let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
+        let key = nlri.key();
+        let route = make_labeled_route(nlri, 1, 100);
+        let mut loc = LocRib::new();
+
+        loc.recompute_labeled(key, [&route].into_iter());
+        assert_eq!(loc.labeled_len(), 1);
+
+        let empty: [&LabeledRibRoute; 0] = [];
+        assert!(
+            loc.recompute_labeled(key, empty.into_iter()),
+            "removal is a change"
+        );
+        assert_eq!(loc.labeled_len(), 0);
+        assert!(loc.get_labeled(&key).is_none());
+
+        let empty: [&LabeledRibRoute; 0] = [];
+        assert!(
+            !loc.recompute_labeled(key, empty.into_iter()),
+            "removing an absent key is not a change"
+        );
+    }
+
+    /// Oracle: the public `labeled_tiebreak` chain is byte-identical to the
+    /// plain (no-ORR) behavior — `labeled_tiebreak_orr` with equal or
+    /// both-unknown costs must agree with `labeled_tiebreak` on every pair,
+    /// including the stale-rank step.
+    #[test]
+    fn labeled_tiebreak_unchanged_without_orr() {
+        let nlri = labeled_nlri([10, 0, 3, 0], 24, 100);
+        let base = make_labeled_route(nlri.clone(), 1, 100);
+        let higher_lp = make_labeled_route(nlri.clone(), 2, 200);
+        let mut stale = make_labeled_route(nlri.clone(), 3, 100);
+        stale.is_stale = true;
+        let mut llgr_stale = make_labeled_route(nlri.clone(), 4, 100);
+        llgr_stale.is_llgr_stale = true;
+        let mut longer_path = make_labeled_route(nlri.clone(), 5, 100);
+        Arc::make_mut(&mut longer_path.attributes).push(PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65001, 65002])],
+        }));
+        let mut clustered = make_labeled_route(nlri.clone(), 6, 100);
+        Arc::make_mut(&mut clustered.attributes).push(PathAttribute::ClusterList(vec![
+            Ipv4Addr::new(10, 255, 0, 1),
+            Ipv4Addr::new(10, 255, 0, 2),
+        ]));
+        let peer_tiebreak = make_labeled_route(nlri, 7, 100);
+        let routes = [
+            base,
+            higher_lp,
+            stale,
+            llgr_stale,
+            longer_path,
+            clustered,
+            peer_tiebreak,
+        ];
+
+        for a in &routes {
+            for b in &routes {
+                let plain = labeled_tiebreak(a, b);
+                assert_eq!(labeled_tiebreak_orr(a, b, None, None), plain);
+                assert_eq!(labeled_tiebreak_orr(a, b, Some(7), Some(7)), plain);
+            }
+        }
+    }
+
+    /// The ORR interior-cost step decides ONLY at its slot — below the
+    /// eBGP/iBGP step (`LOCAL_PREF` etc. still win first) and above
+    /// `CLUSTER_LIST` / peer-address (which it overrides on a tie), with a
+    /// known cost beating an unknown one (RFC 9107 §3.1).
+    #[test]
+    fn labeled_orr_cost_only_breaks_ties_below_ebgp_step() {
+        let nlri = labeled_nlri([10, 0, 4, 0], 24, 100);
+        // LOCAL_PREF outranks a better interior cost.
+        let preferred = make_labeled_route(nlri.clone(), 1, 200);
+        let closer = make_labeled_route(nlri.clone(), 2, 100);
+        assert_eq!(
+            labeled_tiebreak_orr(&preferred, &closer, Some(1000), Some(0)),
+            Ordering::Less,
+            "LOCAL_PREF must outrank interior cost"
+        );
+
+        // On an otherwise-tied pair, cost decides before the peer address.
+        let a = make_labeled_route(nlri.clone(), 1, 100);
+        let b = make_labeled_route(nlri, 2, 100);
+        assert_eq!(
+            labeled_tiebreak_orr(&a, &b, Some(10), Some(5)),
+            Ordering::Greater
+        );
+        assert_eq!(
+            labeled_tiebreak_orr(&a, &b, Some(5), Some(10)),
+            Ordering::Less
+        );
+        // Equal costs fall through to the peer-address step.
+        assert_eq!(
+            labeled_tiebreak_orr(&a, &b, Some(5), Some(5)),
+            Ordering::Less
+        );
+        // Known beats unknown regardless of magnitude.
+        assert_eq!(
+            labeled_tiebreak_orr(&a, &b, Some(u64::MAX), None),
+            Ordering::Less
+        );
+        assert_eq!(
+            labeled_tiebreak_orr(&a, &b, None, Some(u64::MAX)),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn labeled_loc_rib_is_isolated_from_unicast_best_routes() {
+        let mut loc = LocRib::new();
+        loc.insert_labeled(make_labeled_route(
+            labeled_nlri([10, 0, 2, 0], 24, 100),
+            1,
+            100,
+        ));
+
+        assert_eq!(loc.labeled_len(), 1);
+        assert_eq!(loc.len(), 0);
+        assert!(loc.is_empty(), "legacy unicast emptiness is unchanged");
+
+        assert!(loc.remove_labeled(&labeled_nlri([10, 0, 2, 0], 24, 100).key()));
+        assert_eq!(loc.labeled_len(), 0);
     }
 
     fn rtc_test_nlri(local_admin: u32) -> RtcNlri {

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -216,6 +216,7 @@ impl RibManager {
                         Safi::Unicast => "unicast",
                         Safi::FlowSpec => "flowspec",
                         Safi::Multicast => "multicast",
+                        Safi::LabeledUnicast => "labeled_unicast",
                         Safi::Evpn => "evpn",
                         Safi::BgpLs => "bgpls",
                         Safi::BgpLsVpn => "bgpls_vpn",

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -124,6 +124,9 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::BgpLs, Safi::BgpLsVpn) => "bgpls_vpn",
         (Afi::Ipv4, Safi::MplsVpn) => "l3vpn_ipv4_unicast",
         (Afi::Ipv6, Safi::MplsVpn) => "l3vpn_ipv6_unicast",
+        // ADR-0077 §8 / OpenConfig identity names.
+        (Afi::Ipv4, Safi::LabeledUnicast) => "ipv4_labeled_unicast",
+        (Afi::Ipv6, Safi::LabeledUnicast) => "ipv6_labeled_unicast",
         (Afi::Ipv4, Safi::Multicast) => "ipv4_multicast",
         (Afi::Ipv6, Safi::Multicast) => "ipv6_multicast",
         (Afi::Ipv4, Safi::RtConstrain) => "rtc",
@@ -131,7 +134,7 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
         | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
         | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
-        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn)
+        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn | Safi::LabeledUnicast)
         // RT-Constrain is AFI 1 only (RFC 4684 §7).
         | (Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => "unsupported",
     }

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 
 use rustbgpd_wire::{
     Afi, AsPath, AspaValidation, AspaValidationContext, EvpnRoute, EvpnRouteKey, ExtendedCommunity,
-    FlowSpecRule, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation, RtcNlri, Safi,
-    VpnAddressFamily, VpnNlri, VpnRouteKey,
+    FlowSpecRule, LabeledNlri, LargeCommunity, Origin, PathAttribute, Prefix, RpkiValidation,
+    RtcNlri, Safi, VpnAddressFamily, VpnNlri, VpnRouteKey,
     bgpls::{BgpLsNlri, BgpLsNlriKey},
 };
 
@@ -623,6 +623,107 @@ impl VpnRibRoute {
             .iter()
             .find_map(|attr| match attr {
                 PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
+                _ => None,
+            })
+            .unwrap_or(&[])
+    }
+}
+
+/// IPv4/IPv6 labeled-unicast (RFC 8277, SAFI 4) route identity for the RIB.
+///
+/// Route identity is the IP prefix plus Add-Path path-id; the MPLS label
+/// stack is route *data*, not identity (RFC 8277 §2.3 implicit-replace is
+/// per-prefix), matching the SAFI 128 VPN decision. The key deliberately
+/// wraps the unicast [`Prefix`] in a labeled-specific struct so the labeled
+/// table can never be confused with the unicast RIB maps (ADR-0077 §2).
+/// `path_id` is reserved for a future Add-Path-enabled slice and is always
+/// zero until negotiation grows that capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LabeledRibRouteKey {
+    /// The IP prefix (route identity within SAFI 4).
+    pub prefix: Prefix,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl LabeledRibRouteKey {
+    /// The wire AFI/SAFI pair for this key (`Ipv4`/`Ipv6` +
+    /// `LabeledUnicast`), derived from the prefix family.
+    #[must_use]
+    pub const fn afi_safi(&self) -> (Afi, Safi) {
+        let afi = match self.prefix {
+            Prefix::V4(_) => Afi::Ipv4,
+            Prefix::V6(_) => Afi::Ipv6,
+        };
+        (afi, Safi::LabeledUnicast)
+    }
+}
+
+/// A single IPv4/IPv6 labeled-unicast route stored by the ADR-0077
+/// route-reflector slice.
+///
+/// rustbgpd reflects labeled routes as a route reflector only: it preserves
+/// the MPLS label stack and next-hop unchanged and never allocates,
+/// rewrites, or programs labels (ADR-0077 §4/§6).
+#[derive(Debug, Clone)]
+pub struct LabeledRibRoute {
+    /// Full NLRI: prefix + MPLS label stack (preserved verbatim).
+    pub nlri: LabeledNlri,
+    /// Next-hop from `MP_REACH_NLRI`.
+    pub next_hop: IpAddr,
+    /// The peer that advertised this route.
+    pub peer: IpAddr,
+    /// BGP path attributes.
+    pub attributes: Arc<Vec<PathAttribute>>,
+    /// When this route was received (monotonic clock).
+    pub received_at: Instant,
+    /// How this route was learned (eBGP, iBGP, or local).
+    pub origin_type: RouteOrigin,
+    /// BGP router-id of the advertising peer.
+    pub peer_router_id: Ipv4Addr,
+    /// Whether this route is stale due to graceful restart.
+    pub is_stale: bool,
+    /// Whether this route is in LLGR stale phase (RFC 9494).
+    pub is_llgr_stale: bool,
+    /// Add-Path path identifier. Zero means no Add-Path.
+    pub path_id: u32,
+}
+
+impl LabeledRibRoute {
+    /// The wire AFI/SAFI pair for this route (`Ipv4`/`Ipv6` +
+    /// `LabeledUnicast`).
+    #[must_use]
+    pub const fn afi_safi(&self) -> (Afi, Safi) {
+        let afi = match self.nlri.prefix {
+            Prefix::V4(_) => Afi::Ipv4,
+            Prefix::V6(_) => Afi::Ipv6,
+        };
+        (afi, Safi::LabeledUnicast)
+    }
+
+    /// Whether this route was learned via an eBGP session.
+    #[must_use]
+    pub fn is_ebgp(&self) -> bool {
+        self.origin_type == RouteOrigin::Ebgp
+    }
+
+    /// Identity key suitable for labeled Adj-RIB-In, Loc-RIB, and
+    /// Adj-RIB-Out maps.
+    #[must_use]
+    pub const fn key(&self) -> LabeledRibRouteKey {
+        LabeledRibRouteKey {
+            prefix: self.nlri.key(),
+            path_id: self.path_id,
+        }
+    }
+
+    /// Extract COMMUNITIES values, returning an empty slice if absent.
+    #[must_use]
+    pub fn communities(&self) -> &[u32] {
+        self.attributes
+            .iter()
+            .find_map(|attr| match attr {
+                PathAttribute::Communities(values) => Some(values.as_slice()),
                 _ => None,
             })
             .unwrap_or(&[])

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -231,12 +231,20 @@ fn classify_mp_nlri_family(
         // RT-Constrain is AFI 1 only (RFC 4684 §7); (Ipv6, RtConstrain)
         // stays rejected below.
         (Afi::Ipv4, Safi::RtConstrain) => Ok(MpNlriFamily::Rtc),
+        // Labeled-unicast (SAFI 4, RFC 8277) is wire-codec substrate only
+        // today (ADR-0077 §3a): the family stays rejected here until the
+        // receive slice promotes it to a dispatched vertical.
         (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::Multicast | Safi::BgpLs | Safi::BgpLsVpn)
-        | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
-        | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec | Safi::MplsVpn)
+        | (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn | Safi::LabeledUnicast)
+        | (Afi::L2Vpn, Safi::Unicast | Safi::FlowSpec | Safi::MplsVpn | Safi::LabeledUnicast)
         | (
             Afi::BgpLs,
-            Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec | Safi::MplsVpn,
+            Safi::Unicast
+            | Safi::Multicast
+            | Safi::Evpn
+            | Safi::FlowSpec
+            | Safi::MplsVpn
+            | Safi::LabeledUnicast,
         )
         | (Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => {
             Err(unsupported_mp_nlri_family(attribute, afi, safi))
@@ -4167,6 +4175,45 @@ mod tests {
             DecodeError::MalformedField { detail, .. } => {
                 assert!(
                     detail.contains("unsupported AFI/SAFI 2/70"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+    }
+    #[test]
+    fn mp_reach_and_unreach_reject_labeled_unicast_safi_at_family_gate() {
+        // ADR-0077 §3a guardrail: the SAFI 4 codec in `crate::labeled` is
+        // substrate only — MP dispatch must keep rejecting labeled-unicast
+        // before NLRI parsing until the receive slice promotes the family.
+        let reach = vec![
+            0x00, 0x01, // AFI = Ipv4
+            4,    // SAFI = LabeledUnicast
+            4, 192, 0, 2, 1, // NH len + NH
+            0, // reserved
+            48, 0x00, 0x06, 0x41, 10, 0, 1, // valid RFC 8277 NLRI shape
+        ];
+        let err = decode_mp_reach_nlri(&reach, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 1/4"),
+                    "unexpected detail: {detail}"
+                );
+            }
+            other => panic!("expected MalformedField, got {other:?}"),
+        }
+
+        let unreach = vec![
+            0x00, 0x02, // AFI = Ipv6
+            4,    // SAFI = LabeledUnicast
+            24, 0x80, 0x00, 0x00, // withdraw-mode compatibility field, /0
+        ];
+        let err = decode_mp_unreach_nlri(&unreach, &[]).unwrap_err();
+        match err {
+            DecodeError::MalformedField { detail, .. } => {
+                assert!(
+                    detail.contains("unsupported AFI/SAFI 2/4"),
                     "unexpected detail: {detail}"
                 );
             }

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -39,6 +39,9 @@ pub enum Safi {
     Unicast = 1,
     /// Multicast forwarding (SAFI 2).
     Multicast = 2,
+    /// RFC 8277 labeled-unicast — only valid with [`Afi::Ipv4`] /
+    /// [`Afi::Ipv6`].
+    LabeledUnicast = 4,
     /// RFC 7432 EVPN — only valid with [`Afi::L2Vpn`].
     Evpn = 70,
     /// RFC 9552 BGP-LS — only valid with [`Afi::BgpLs`].
@@ -61,6 +64,7 @@ impl Safi {
         match value {
             1 => Some(Self::Unicast),
             2 => Some(Self::Multicast),
+            4 => Some(Self::LabeledUnicast),
             70 => Some(Self::Evpn),
             71 => Some(Self::BgpLs),
             72 => Some(Self::BgpLsVpn),

--- a/crates/wire/src/labeled.rs
+++ b/crates/wire/src/labeled.rs
@@ -1,0 +1,671 @@
+//! IPv4/IPv6 labeled-unicast NLRI codec (RFC 8277, SAFI 4).
+//!
+//! Pure codec pieces for the labeled-unicast wire layout
+//! `len | label stack | prefix` — the SAFI 128 VPN layout from
+//! [`crate::vpn`] minus the 8-byte Route Distinguisher — in both
+//! announce mode (BOS-terminated label stack) and RFC 8277 §2.4
+//! withdraw-compatibility mode (a single 3-octet compatibility field
+//! whose value the receiver MUST ignore).
+//!
+//! Per ADR-0077 §3a this codec is substrate only: MP_REACH/MP_UNREACH
+//! dispatch still rejects SAFI 4, so the family stays unreachable from
+//! peers until a complete typed vertical slice lands. Route identity is
+//! the IP prefix alone (RFC 8277 §2.3 implicit-replace is per-prefix);
+//! the label stack is route data, matching the SAFI 128 decision.
+
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use crate::error::{DecodeError, EncodeError};
+use crate::nlri::{Ipv4Prefix, Ipv6Prefix, Prefix};
+use crate::vpn::{
+    MPLS_LABEL_ENTRY_BITS, MPLS_LABEL_ENTRY_LEN, MplsLabelEntry, VPN_WITHDRAW_COMPATIBILITY,
+    decode_label_stack, encode_label_stack, validate_label_stack,
+};
+
+/// Address family carried by a labeled-unicast NLRI.
+///
+/// Display strings follow the ADR-0077 §8 / `OpenConfig` identity names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum LabeledAddressFamily {
+    /// IPv4 labeled-unicast, AFI 1 / SAFI 4.
+    V4,
+    /// IPv6 labeled-unicast, AFI 2 / SAFI 4.
+    V6,
+}
+
+impl LabeledAddressFamily {
+    const fn max_prefix_len(self) -> u8 {
+        match self {
+            Self::V4 => 32,
+            Self::V6 => 128,
+        }
+    }
+}
+
+impl fmt::Display for LabeledAddressFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V4 => write!(f, "ipv4_labeled_unicast"),
+            Self::V6 => write!(f, "ipv6_labeled_unicast"),
+        }
+    }
+}
+
+/// One IPv4/IPv6 labeled-unicast NLRI (RFC 8277 §2).
+///
+/// The prefix is an ordinary unicast [`Prefix`] — this family *is* IP
+/// prefixes — but labeled routes never enter the unicast RIB maps: the
+/// RIB layer wraps the prefix in a labeled-specific key (ADR-0077 §2
+/// scopes "do not extend `Prefix`" to route *keys*, not payloads).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LabeledNlri {
+    /// MPLS label stack bound to the prefix (route data, not identity).
+    pub labels: Vec<MplsLabelEntry>,
+    /// The IP prefix.
+    pub prefix: Prefix,
+}
+
+impl LabeledNlri {
+    /// Return the route-key identity for this NLRI: the prefix alone.
+    /// Labels are route data (RFC 8277 §2.3 implicit-replace is
+    /// per-prefix), matching the SAFI 128 VPN decision.
+    #[must_use]
+    pub const fn key(&self) -> Prefix {
+        self.prefix
+    }
+
+    /// Return the labeled address family, derived from the prefix.
+    #[must_use]
+    pub const fn family(&self) -> LabeledAddressFamily {
+        match self.prefix {
+            Prefix::V4(_) => LabeledAddressFamily::V4,
+            Prefix::V6(_) => LabeledAddressFamily::V6,
+        }
+    }
+
+    fn validate_for_family(&self, family: LabeledAddressFamily) -> Result<(), EncodeError> {
+        if self.family() != family {
+            return Err(EncodeError::ValueOutOfRange {
+                field: "labeled-unicast NLRI family",
+                value: self.family().to_string(),
+            });
+        }
+        validate_label_stack(&self.labels)?;
+        let total_bits = total_labeled_nlri_bits(self.labels.len(), self.prefix.prefix_len());
+        if total_bits > u16::from(u8::MAX) {
+            return Err(EncodeError::ValueOutOfRange {
+                field: "labeled-unicast NLRI length bits",
+                value: total_bits.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Decode announce-mode labeled-unicast NLRI bytes for the selected family
+/// (`MP_REACH_NLRI`, RFC 8277 §2.2): per entry, a one-octet bit length, a
+/// BOS-terminated label stack, then the prefix.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for malformed length, label stack, or prefix
+/// encodings.
+pub fn decode_labeled_nlri(
+    mut buf: &[u8],
+    family: LabeledAddressFamily,
+) -> Result<Vec<LabeledNlri>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let field_start = buf;
+        let total_len_bits = buf[0];
+        buf = &buf[1..];
+        let value_len = usize::from(total_len_bits.div_ceil(8));
+
+        if buf.len() < value_len {
+            return invalid_labeled_nlri(
+                format!(
+                    "{family} NLRI truncated: length {total_len_bits} bits requires {value_len} bytes, have {}",
+                    buf.len()
+                ),
+                field_start,
+                1 + buf.len(),
+            );
+        }
+
+        let value = &buf[..value_len];
+        buf = &buf[value_len..];
+
+        entries.push(decode_one_labeled_nlri(
+            value,
+            total_len_bits,
+            family,
+            field_start,
+        )?);
+    }
+
+    Ok(entries)
+}
+
+/// Encode announce-mode labeled-unicast NLRI bytes for the selected family.
+///
+/// On error, `buf` is restored to its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if an entry belongs to the wrong family, its
+/// label stack is invalid, or its encoded length cannot fit in the
+/// one-octet NLRI length.
+pub fn encode_labeled_nlri(
+    entries: &[LabeledNlri],
+    family: LabeledAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        if let Err(err) = encode_one_labeled_nlri(entry, family, buf) {
+            buf.truncate(start_len);
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+/// Decode withdraw-mode labeled-unicast NLRI bytes (`MP_UNREACH_NLRI`).
+///
+/// Per RFC 8277 §2.4 a withdrawn labeled-unicast NLRI carries a single
+/// 3-octet compatibility field in the label position, not a BOS-terminated
+/// label stack. The field's value is ignored entirely (it need not be
+/// 0x800000 and its S bit need not be set), so announce-mode label-stack
+/// parsing must not be used here. Decoded entries have an empty `labels`
+/// vec.
+///
+/// # Errors
+///
+/// Returns [`DecodeError`] for malformed length or prefix encodings.
+pub fn decode_labeled_withdraw_nlri(
+    mut buf: &[u8],
+    family: LabeledAddressFamily,
+) -> Result<Vec<LabeledNlri>, DecodeError> {
+    let mut entries = Vec::new();
+
+    while !buf.is_empty() {
+        let field_start = buf;
+        let total_len_bits = buf[0];
+        buf = &buf[1..];
+        let value_len = usize::from(total_len_bits.div_ceil(8));
+
+        if buf.len() < value_len {
+            return invalid_labeled_nlri(
+                format!(
+                    "{family} withdraw NLRI truncated: length {total_len_bits} bits requires {value_len} bytes, have {}",
+                    buf.len()
+                ),
+                field_start,
+                1 + buf.len(),
+            );
+        }
+
+        let value = &buf[..value_len];
+        buf = &buf[value_len..];
+
+        entries.push(decode_one_labeled_withdraw_nlri(
+            value,
+            total_len_bits,
+            family,
+            field_start,
+        )?);
+    }
+
+    Ok(entries)
+}
+
+/// Encode withdraw-mode labeled-unicast NLRI bytes (`MP_UNREACH_NLRI`).
+///
+/// Writes the RFC 8277 §2.4 3-octet compatibility value 0x800000 in the
+/// label position and ignores each entry's `labels`. On error, `buf` is
+/// restored to its original length.
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if an entry belongs to the wrong family.
+pub fn encode_labeled_withdraw_nlri(
+    entries: &[LabeledNlri],
+    family: LabeledAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    let start_len = buf.len();
+
+    for entry in entries {
+        if entry.family() != family {
+            buf.truncate(start_len);
+            return Err(EncodeError::ValueOutOfRange {
+                field: "labeled-unicast NLRI family",
+                value: entry.family().to_string(),
+            });
+        }
+        // One compatibility field + prefix always fits in u8:
+        // 24 + at most 128 = 152 bits.
+        let total_bits = MPLS_LABEL_ENTRY_BITS + entry.prefix.prefix_len();
+        buf.push(total_bits);
+        buf.extend_from_slice(&VPN_WITHDRAW_COMPATIBILITY);
+        push_prefix_octets(&entry.prefix, buf);
+    }
+
+    Ok(())
+}
+
+fn decode_one_labeled_nlri(
+    value: &[u8],
+    total_len_bits: u8,
+    family: LabeledAddressFamily,
+    field_start: &[u8],
+) -> Result<LabeledNlri, DecodeError> {
+    let (labels, label_octets, label_bits) =
+        decode_label_stack(value, total_len_bits, family, field_start)?;
+
+    // The stack loop only consumes an entry when at least 24 more bits fit
+    // in `total_len_bits`, so `label_bits <= total_len_bits` always holds
+    // and this subtraction cannot underflow.
+    let prefix_len = total_len_bits - label_bits;
+    if prefix_len > family.max_prefix_len() {
+        return invalid_labeled_nlri(
+            format!(
+                "{family} prefix length {prefix_len} exceeds {}",
+                family.max_prefix_len()
+            ),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix_octets = usize::from(prefix_len.div_ceil(8));
+    let prefix_end = label_octets + prefix_octets;
+    if value.len() < prefix_end {
+        return invalid_labeled_nlri(
+            format!("{family} NLRI truncated before prefix"),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix = decode_labeled_prefix(family, prefix_len, &value[label_octets..prefix_end]);
+    Ok(LabeledNlri { labels, prefix })
+}
+
+fn decode_one_labeled_withdraw_nlri(
+    value: &[u8],
+    total_len_bits: u8,
+    family: LabeledAddressFamily,
+    field_start: &[u8],
+) -> Result<LabeledNlri, DecodeError> {
+    if total_len_bits < MPLS_LABEL_ENTRY_BITS {
+        return invalid_labeled_nlri(
+            format!(
+                "{family} withdraw NLRI length {total_len_bits} bits is shorter than the compatibility field"
+            ),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    // Exactly one 3-octet compatibility field; its value is ignored.
+    let prefix_len = total_len_bits - MPLS_LABEL_ENTRY_BITS;
+    if prefix_len > family.max_prefix_len() {
+        return invalid_labeled_nlri(
+            format!(
+                "{family} prefix length {prefix_len} exceeds {}",
+                family.max_prefix_len()
+            ),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix_octets = usize::from(prefix_len.div_ceil(8));
+    let prefix_end = MPLS_LABEL_ENTRY_LEN + prefix_octets;
+    if value.len() < prefix_end {
+        return invalid_labeled_nlri(
+            format!("{family} withdraw NLRI truncated before prefix"),
+            field_start,
+            1 + value.len(),
+        );
+    }
+
+    let prefix =
+        decode_labeled_prefix(family, prefix_len, &value[MPLS_LABEL_ENTRY_LEN..prefix_end]);
+    Ok(LabeledNlri {
+        labels: vec![],
+        prefix,
+    })
+}
+
+/// Build a canonical [`Prefix`] from wire bytes; `Ipv4Prefix::new` /
+/// `Ipv6Prefix::new` mask host bits. `bytes` is exactly
+/// `ceil(len / 8)` long (callers slice it that way after bounds checks).
+fn decode_labeled_prefix(family: LabeledAddressFamily, len: u8, bytes: &[u8]) -> Prefix {
+    match family {
+        LabeledAddressFamily::V4 => {
+            let mut octets = [0u8; 4];
+            octets[..bytes.len()].copy_from_slice(bytes);
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(octets), len))
+        }
+        LabeledAddressFamily::V6 => {
+            let mut octets = [0u8; 16];
+            octets[..bytes.len()].copy_from_slice(bytes);
+            Prefix::V6(Ipv6Prefix::new(Ipv6Addr::from(octets), len))
+        }
+    }
+}
+
+fn encode_one_labeled_nlri(
+    entry: &LabeledNlri,
+    family: LabeledAddressFamily,
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    entry.validate_for_family(family)?;
+    let total_bits = total_labeled_nlri_bits(entry.labels.len(), entry.prefix.prefix_len());
+    let total_bits_u8 = u8::try_from(total_bits).map_err(|_| EncodeError::ValueOutOfRange {
+        field: "labeled-unicast NLRI length bits",
+        value: total_bits.to_string(),
+    })?;
+    buf.push(total_bits_u8);
+    encode_label_stack(&entry.labels, buf)?;
+    push_prefix_octets(&entry.prefix, buf);
+    Ok(())
+}
+
+fn push_prefix_octets(prefix: &Prefix, buf: &mut Vec<u8>) {
+    let byte_count = usize::from(prefix.prefix_len().div_ceil(8));
+    match prefix {
+        Prefix::V4(p) => buf.extend_from_slice(&p.addr.octets()[..byte_count]),
+        Prefix::V6(p) => buf.extend_from_slice(&p.addr.octets()[..byte_count]),
+    }
+}
+
+fn total_labeled_nlri_bits(label_count: usize, prefix_len: u8) -> u16 {
+    // Saturate like the VPN sibling: an extreme label_count saturates to
+    // u16::MAX and callers reject any total > u8::MAX downstream.
+    u16::try_from(label_count)
+        .unwrap_or(u16::MAX)
+        .saturating_mul(u16::from(MPLS_LABEL_ENTRY_BITS))
+        .saturating_add(u16::from(prefix_len))
+}
+
+fn invalid_labeled_nlri<T>(detail: String, data: &[u8], len: usize) -> Result<T, DecodeError> {
+    Err(DecodeError::InvalidNetworkField {
+        detail,
+        data: data[..len.min(data.len())].to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn label(value: u32, bos: bool) -> MplsLabelEntry {
+        MplsLabelEntry::try_new(value, 0, bos).unwrap()
+    }
+
+    fn v4(addr: [u8; 4], len: u8) -> Prefix {
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len))
+    }
+
+    #[test]
+    fn labeled_v4_single_label_roundtrip() {
+        let entry = LabeledNlri {
+            labels: vec![label(200, true)],
+            prefix: v4([10, 0, 1, 0], 24),
+        };
+        let mut buf = Vec::new();
+        encode_labeled_nlri(
+            std::slice::from_ref(&entry),
+            LabeledAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(buf[0], 24 + 24);
+
+        let decoded = decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap();
+        assert_eq!(decoded, vec![entry]);
+        assert_eq!(decoded[0].prefix.to_string(), "10.0.1.0/24");
+    }
+
+    #[test]
+    fn labeled_v6_multi_label_roundtrip() {
+        let prefix = Prefix::V6(Ipv6Prefix::new("2001:db8:100::".parse().unwrap(), 48));
+        let entry = LabeledNlri {
+            labels: vec![label(16_000, false), label(24_000, true)],
+            prefix,
+        };
+        let mut buf = Vec::new();
+        encode_labeled_nlri(
+            std::slice::from_ref(&entry),
+            LabeledAddressFamily::V6,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(buf[0], 48 + 48);
+
+        let decoded = decode_labeled_nlri(&buf, LabeledAddressFamily::V6).unwrap();
+        assert_eq!(decoded, vec![entry]);
+        assert_eq!(decoded[0].prefix.to_string(), "2001:db8:100::/48");
+    }
+
+    #[test]
+    fn multiple_nlri_preserve_order() {
+        let a = LabeledNlri {
+            labels: vec![label(100, true)],
+            prefix: v4([10, 0, 0, 0], 8),
+        };
+        let b = LabeledNlri {
+            labels: vec![label(101, true)],
+            prefix: v4([192, 0, 2, 0], 24),
+        };
+        let mut buf = Vec::new();
+        encode_labeled_nlri(&[a.clone(), b.clone()], LabeledAddressFamily::V4, &mut buf).unwrap();
+        assert_eq!(
+            decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap(),
+            vec![a, b]
+        );
+    }
+
+    /// GoBGP-shaped fixture, hand-derived from the RFC 8277 §2.2 wire
+    /// layout (`GoBGP`'s `LabeledIPAddrPrefix` encodes `-a ipv4-labeled`
+    /// NLRI the same way: Length = label-stack bits + mask length):
+    /// len = 48 bits, label 100 (TC 0, S=1) = 0x000641, 10.0.1.0/24.
+    #[test]
+    fn labeled_v4_gobgp_shaped_fixture() {
+        let buf = vec![
+            0x30, // 48 bits = 24 label + 24 prefix
+            0x00, 0x06, 0x41, // label 100, TC 0, S=1
+            10, 0, 1, // 10.0.1.0/24
+        ];
+        let decoded = decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].labels, vec![label(100, true)]);
+        assert_eq!(decoded[0].prefix.to_string(), "10.0.1.0/24");
+
+        let mut reencoded = Vec::new();
+        encode_labeled_nlri(&decoded, LabeledAddressFamily::V4, &mut reencoded).unwrap();
+        assert_eq!(reencoded, buf);
+    }
+
+    #[test]
+    fn route_key_excludes_label_stack() {
+        let prefix = v4([203, 0, 113, 0], 24);
+        let a = LabeledNlri {
+            labels: vec![label(100, true)],
+            prefix,
+        };
+        let b = LabeledNlri {
+            labels: vec![label(200, true)],
+            prefix,
+        };
+        assert_eq!(a.key(), b.key());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn withdraw_encode_emits_compatibility_value_and_ignores_labels() {
+        let entry = LabeledNlri {
+            labels: vec![label(200, true)], // ignored on withdraw encode
+            prefix: v4([10, 0, 1, 0], 24),
+        };
+        let mut buf = Vec::new();
+        encode_labeled_withdraw_nlri(
+            std::slice::from_ref(&entry),
+            LabeledAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(buf[0], 24 + 24);
+        assert_eq!(&buf[1..4], &VPN_WITHDRAW_COMPATIBILITY);
+
+        let decoded = decode_labeled_withdraw_nlri(&buf, LabeledAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].labels.is_empty());
+        assert_eq!(decoded[0].prefix, entry.prefix);
+    }
+
+    #[test]
+    fn withdraw_decode_ignores_arbitrary_compatibility_value() {
+        // RFC 8277 §2.4: receiver MUST ignore the field — even a value
+        // with no BOS bit set, which announce-mode parsing would reject
+        // or overrun.
+        let buf = vec![24 + 24, 0x0C, 0x35, 0x00, 10, 0, 1]; // label 50000, S=0
+        let decoded = decode_labeled_withdraw_nlri(&buf, LabeledAddressFamily::V4).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].labels.is_empty());
+        assert_eq!(decoded[0].prefix, v4([10, 0, 1, 0], 24));
+    }
+
+    #[test]
+    fn withdraw_decode_rejects_shorter_than_compatibility_field() {
+        let err =
+            decode_labeled_withdraw_nlri(&[16, 0x80, 0x00], LabeledAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn withdraw_encode_rejects_wrong_family_and_restores_buffer() {
+        let entry = LabeledNlri {
+            labels: vec![],
+            prefix: Prefix::V6(Ipv6Prefix::new(Ipv6Addr::LOCALHOST, 128)),
+        };
+        let mut buf = vec![0xAA];
+        let err =
+            encode_labeled_withdraw_nlri(&[entry], LabeledAddressFamily::V4, &mut buf).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xAA]);
+    }
+
+    #[test]
+    fn decode_rejects_truncated_value() {
+        let err = decode_labeled_nlri(&[48, 0x00, 0x06], LabeledAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_missing_bottom_of_stack() {
+        // Two label entries, both S=0, exhausting the 48-bit length: the
+        // stack never terminates within the declared bits.
+        let buf = vec![24 + 24, 0x00, 0x06, 0x40, 0x00, 0x06, 0x40];
+        let err = decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_prefix_too_long_for_family() {
+        let buf = vec![24 + 33, 0x00, 0x06, 0x41, 10, 0, 0, 0, 0];
+        let err = decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidNetworkField { .. }));
+    }
+
+    #[test]
+    fn encode_rejects_invalid_label_stack_and_restores_buffer() {
+        // Empty stack.
+        let empty = LabeledNlri {
+            labels: vec![],
+            prefix: v4([10, 0, 0, 0], 8),
+        };
+        let mut buf = vec![0xAA];
+        let err = encode_labeled_nlri(
+            std::slice::from_ref(&empty),
+            LabeledAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+        assert_eq!(buf, vec![0xAA]);
+
+        // Missing bottom-of-stack.
+        let no_bos = LabeledNlri {
+            labels: vec![label(100, false)],
+            prefix: v4([10, 0, 0, 0], 8),
+        };
+        assert!(matches!(
+            encode_labeled_nlri(&[no_bos], LabeledAddressFamily::V4, &mut Vec::new()),
+            Err(EncodeError::ValueOutOfRange { .. })
+        ));
+
+        // Bottom-of-stack before the final label.
+        let early_bos = LabeledNlri {
+            labels: vec![label(100, true), label(200, true)],
+            prefix: v4([10, 0, 0, 0], 8),
+        };
+        assert!(matches!(
+            encode_labeled_nlri(&[early_bos], LabeledAddressFamily::V4, &mut Vec::new()),
+            Err(EncodeError::ValueOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn encode_rejects_too_long_v6_nlri() {
+        // Six labels (144 bits) + /128 = 272 bits > 255-bit length octet.
+        let entry = LabeledNlri {
+            labels: (0..5)
+                .map(|i| label(100 + i, false))
+                .chain(std::iter::once(label(200, true)))
+                .collect(),
+            prefix: Prefix::V6(Ipv6Prefix::new(Ipv6Addr::UNSPECIFIED, 128)),
+        };
+        let err =
+            encode_labeled_nlri(&[entry], LabeledAddressFamily::V6, &mut Vec::new()).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+    }
+
+    #[test]
+    fn encode_rejects_wrong_family() {
+        let entry = LabeledNlri {
+            labels: vec![label(100, true)],
+            prefix: Prefix::V6(Ipv6Prefix::new(Ipv6Addr::LOCALHOST, 128)),
+        };
+        let err =
+            encode_labeled_nlri(&[entry], LabeledAddressFamily::V4, &mut Vec::new()).unwrap_err();
+        assert!(matches!(err, EncodeError::ValueOutOfRange { .. }));
+    }
+
+    #[test]
+    fn zero_length_prefix_roundtrips() {
+        let entry = LabeledNlri {
+            labels: vec![label(3, true)], // implicit-null-shaped label value
+            prefix: v4([0, 0, 0, 0], 0),
+        };
+        let mut buf = Vec::new();
+        encode_labeled_nlri(
+            std::slice::from_ref(&entry),
+            LabeledAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap();
+        assert_eq!(buf[0], 24);
+        assert_eq!(
+            decode_labeled_nlri(&buf, LabeledAddressFamily::V4).unwrap(),
+            vec![entry]
+        );
+    }
+}

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -47,6 +47,8 @@ pub mod flowspec;
 pub mod header;
 /// KEEPALIVE message encoding and validation.
 pub mod keepalive;
+/// IPv4/IPv6 labeled-unicast NLRI codec substrate (RFC 8277, SAFI 4).
+pub mod labeled;
 /// Top-level BGP message enum and codec dispatch.
 pub mod message;
 /// NLRI prefix types and codec (IPv4, IPv6, Add-Path).
@@ -81,6 +83,10 @@ pub use capability::{
 pub use constants::{EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN};
 pub use error::{DecodeError, EncodeError};
 pub use header::{BgpHeader, MessageType, peek_message_length};
+pub use labeled::{
+    LabeledAddressFamily, LabeledNlri, decode_labeled_nlri, decode_labeled_withdraw_nlri,
+    encode_labeled_nlri, encode_labeled_withdraw_nlri,
+};
 pub use message::{Message, decode_message, encode_message, encode_message_with_limit};
 pub use notification::NotificationCode;
 pub use notification_msg::NotificationMessage;

--- a/crates/wire/src/vpn.rs
+++ b/crates/wire/src/vpn.rs
@@ -802,10 +802,14 @@ fn decode_one_vpn_nlri(
     })
 }
 
-fn decode_label_stack(
+/// Decode a BOS-terminated RFC 8277 label stack from the front of `value`,
+/// returning `(labels, consumed_octets, consumed_bits)`. Shared by the SAFI
+/// 128 (VPN) and SAFI 4 (labeled-unicast) announce-mode decoders; `family`
+/// is display-only, for error messages.
+pub(crate) fn decode_label_stack(
     value: &[u8],
     total_len_bits: u8,
-    family: VpnAddressFamily,
+    family: impl fmt::Display + Copy,
     field_start: &[u8],
 ) -> Result<(Vec<MplsLabelEntry>, usize, u8), DecodeError> {
     let mut labels = Vec::new();
@@ -890,14 +894,7 @@ fn encode_one_vpn_nlri(
         value: total_bits.to_string(),
     })?;
     buf.push(total_bits_u8);
-
-    for label in &entry.labels {
-        let raw = label.raw_value()?;
-        buf.push(((raw >> 16) & 0xFF) as u8);
-        buf.push(((raw >> 8) & 0xFF) as u8);
-        buf.push((raw & 0xFF) as u8);
-    }
-
+    encode_label_stack(&entry.labels, buf)?;
     buf.extend_from_slice(&entry.route_distinguisher.0);
     let prefix_octets = entry.prefix.wire_octets();
     let prefix_byte_count = usize::from(entry.prefix.len().div_ceil(8));
@@ -905,10 +902,28 @@ fn encode_one_vpn_nlri(
     Ok(())
 }
 
-fn validate_label_stack(labels: &[MplsLabelEntry]) -> Result<(), EncodeError> {
+/// Encode an RFC 8277 label stack as raw 3-octet entries. Shared by the
+/// SAFI 128 (VPN) and SAFI 4 (labeled-unicast) announce-mode encoders.
+pub(crate) fn encode_label_stack(
+    labels: &[MplsLabelEntry],
+    buf: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    for label in labels {
+        let raw = label.raw_value()?;
+        buf.push(((raw >> 16) & 0xFF) as u8);
+        buf.push(((raw >> 8) & 0xFF) as u8);
+        buf.push((raw & 0xFF) as u8);
+    }
+    Ok(())
+}
+
+/// Validate an RFC 8277 label stack for encoding: non-empty, in-range
+/// values, and exactly one bottom-of-stack marker on the final entry.
+/// Shared by the SAFI 128 (VPN) and SAFI 4 (labeled-unicast) encoders.
+pub(crate) fn validate_label_stack(labels: &[MplsLabelEntry]) -> Result<(), EncodeError> {
     if labels.is_empty() {
         return Err(EncodeError::ValueOutOfRange {
-            field: "VPN label stack",
+            field: "MPLS label stack",
             value: "empty".to_string(),
         });
     }
@@ -917,14 +932,14 @@ fn validate_label_stack(labels: &[MplsLabelEntry]) -> Result<(), EncodeError> {
         validate_traffic_class(label.traffic_class)?;
         if label.bottom_of_stack && index + 1 != labels.len() {
             return Err(EncodeError::ValueOutOfRange {
-                field: "VPN label stack",
+                field: "MPLS label stack",
                 value: "bottom-of-stack before final label".to_string(),
             });
         }
     }
     if !labels.last().is_some_and(|label| label.bottom_of_stack) {
         return Err(EncodeError::ValueOutOfRange {
-            field: "VPN label stack",
+            field: "MPLS label stack",
             value: "missing bottom-of-stack".to_string(),
         });
     }


### PR DESCRIPTION
First slice of **labeled-unicast (RFC 8277, SAFI 4)** — the last ADR-0077 family. Inert: `classify_mp_nlri_family` still rejects SAFI 4 (guardrail test pins it, both AFIs).

- New `crates/wire/src/labeled.rs`: `LabeledNlri { labels, prefix }` — route identity is **prefix + path-id, labels are route data** (ADR-0077 §2 verbatim; RFC 8277 §2.3 implicit-replace), announce codec + the §2.4 withdraw compatibility-field codec, sharing the vpn.rs label-stack internals (extracted `encode_label_stack`, generalized `decode_label_stack`, shared 0x800000 constant).
- RIB substrate with everything the earlier arcs earned, from day one: attr-interned Adj-RIB-In, path-id secondary index in Adj-RIB-Out (#644-ready), `labeled_cmp_chain` with the `orr_costs` composition slot (None-≡-plain oracle), and the full **inert GR/LLGR stale substrate** (mark w/ consecutive-restart delete, EoR clear, sweeps, LLGR promote/tags — the #636 shapes).
- 28 tests incl. byte-exact fixtures, v4/v6 tuple scoping, relabel-same-key pins.

Next: the classifier flip + full reachable family in one pass (receive/reflect/API/GR/refresh/ORR), then M79 + docs — quartet complete.