### PR TITLE
feat(policy): add the typed policy IR, indexed match sets, and IR-backed evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Typed, compiled policy IR (ADR-0096 slice 1): indexed match sets
+  behind the existing engine, zero behavior change.** TOML policy
+  chains now lazily compile into a public, analyzable IR
+  (`rustbgpd_policy::ir` — typed guard expressions, named terms,
+  `CompiledPolicy`/`CompiledChain`) evaluated by a tree-walk engine
+  behind the unchanged `evaluate_chain_with_attribution` choke point;
+  all 14 import/export seams are untouched and existing configs behave
+  identically. Match *data* compiles out of the expression tree into
+  `Arc`-shared, content-deduplicated indexed structures
+  (`rustbgpd_policy::sets`): prefix sets with ge/le ranges resolved in
+  one hash probe per distinct member length, community/RT/RO/large
+  criteria sets, and interned AS-path regexes — the OpenBGPd lesson
+  that set-heavy policy cost lives in the index layer. In-repo
+  measurement of the ADR's headline (`policy_eval.rs` `set_heavy`
+  group): a 1,000-prefix list costs ~3.8 µs as a statement chain but
+  ~14 ns as one IR set-match — ~270×. Realistic single/short-chain and
+  short-circuit shapes improved 20-50% (the IR walks only configured
+  predicates instead of checking ~18 optional fields per statement);
+  the one measured step backwards is the walk-every-statement long
+  chain (~5.2 → ~7.2 ns/statement, `policy_chain_eval/32` +27%), the
+  tree-walk's And-children indirection — the ADR's deferred
+  linearized-bytecode pass is the recovery path if that shape ever
+  dominates a profile. The `requires_as_path_string` /
+  `requires_rpki_validation` / `requires_aspa_validation` hot-path
+  gates are reimplemented as IR analyses with identical results.
+  Decision compatibility is pinned by a golden corpus
+  (`engine/tests/ir_parity.rs`, ~4,500 chain×route cases asserting the
+  legacy walker and the IR path return byte-identical `PolicyResult`
+  *and* `PolicyEvaluation`); the legacy walker stays in-tree as the
+  oracle until a later slice deletes it. The `.rpol` language frontend
+  (lexer/parser/typechecker, `rbgp policy test`) arrives in later
+  ADR-0096 slices — this slice is the IR substrate that makes them
+  surface work.
+
 - **IPv4/IPv6 labeled-unicast (RFC 8277, SAFI 4) route reflection — the
   ADR-0077 quartet is complete.** The last family of the ADR-0077 scope
   (BGP-LS, VPNv4/v6, RT-Constrain, labeled-unicast) ships as one complete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "criterion",
  "regex",
  "rustbgpd-wire",
+ "rustc-hash 2.1.2",
  "thiserror 2.0.18",
 ]
 

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 regex = "1"
+rustc-hash.workspace = true
 rustbgpd-wire.workspace = true
 thiserror.workspace = true
 

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -4,12 +4,17 @@
 //! UPDATE (and per route on export distribution), so its cost scales the
 //! whole control plane under churn.
 //!
-//! Two benchmark groups:
+//! Three benchmark groups:
 //!
 //! - `policy_chain_eval` — the dominant shape, a community-filter chain
 //!   walked statement-by-statement at a few chain lengths, plus the
 //!   early-terminate (first-statement deny) contrast that bounds the best
-//!   case. This is the cross-ref regression baseline (it should stay flat).
+//!   case. This is the cross-ref regression baseline. Known step (ADR-0096):
+//!   the IR tree-walk costs ~7.2 ns/statement on this walk-everything shape
+//!   vs ~5.2 for the old flat-struct matcher (the And-children `Vec` is one
+//!   dependent load per statement) while every other shape below improved
+//!   20-50%; the ADR's deferred linearized-bytecode pass is the recovery
+//!   path if a fully-walked long chain ever dominates a profile.
 //! - `policy_predicate_eval` — characterizes the cost-ordered short-circuit
 //!   matcher. The `regex_heavy` and `community_heavy` arms each pair an
 //!   `evaluated` case (the expensive predicate runs) against a `skipped`
@@ -21,6 +26,9 @@
 //!   `prefix_heavy` walks a chain whose statements all run a full prefix
 //!   evaluation (mask + ge/le bounds) — its absolute cost gates whether a
 //!   build-time prefix-mask precompute is worth pursuing.
+//! - `set_heavy` — the ADR-0096 set-index claim measured in-repo: a
+//!   1,000-prefix list as a statement chain (legacy walker and IR term
+//!   walk) vs one indexed `PrefixInSet` IR term. See `bench_set_heavy`.
 //!
 //! Run: `cargo bench -p rustbgpd-policy --bench policy_eval`
 //! Compare across refs: `bench/compare-criterion.sh --package
@@ -30,6 +38,10 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
+use rustbgpd_policy::ir::{
+    CompiledChain, CompiledPolicy, MatchExpr, PolicySource, SetId, Term, TermAction,
+};
+use rustbgpd_policy::sets::{PrefixSetEntry, SetStore};
 use rustbgpd_policy::{
     AsPathRegex, CommunityMatch, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
     RouteModifications, evaluate_chain_with_attribution,
@@ -359,5 +371,100 @@ fn bench_policy_predicate_eval(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_policy_eval, bench_policy_predicate_eval);
+/// The ADR-0096 headline measurement: a 1,000-prefix customer list
+/// expressed the only way TOML chains allow (1,000 statements) versus
+/// a single indexed set-match IR term. Three arms over the same
+/// non-member route — the worst case, where every statement (or the
+/// one set probe) runs to completion:
+///
+/// - `legacy_1000_stmts` — the pre-IR statement walker (the corpus
+///   oracle), i.e. what this cost *was*.
+/// - `ir_1000_terms` — the same 1,000-statement chain through the IR
+///   term walk: what existing TOML configs get automatically.
+/// - `ir_prefix_set` — one `PrefixInSet` term over the interned set:
+///   what the `.rpol` frontend (and any set-aware frontend) emits.
+fn bench_set_heavy(c: &mut Criterion) {
+    let prefixes: Vec<Prefix> = (0..1000u32)
+        .map(|i| {
+            Prefix::V4(Ipv4Prefix::new(
+                Ipv4Addr::new(10, u8::try_from(i / 256).unwrap(), (i % 256) as u8, 0),
+                24,
+            ))
+        })
+        .collect();
+
+    let statements: Vec<PolicyStatement> = prefixes
+        .iter()
+        .map(|p| {
+            let mut s = blank_permit();
+            s.prefix = Some(*p);
+            s
+        })
+        .collect();
+    let stmt_chain = PolicyChain::new(vec![Policy {
+        entries: statements,
+        default_action: PolicyAction::Deny,
+    }]);
+
+    let entries: Vec<PrefixSetEntry> = prefixes
+        .iter()
+        .map(|p| PrefixSetEntry {
+            prefix: *p,
+            ge: None,
+            le: None,
+        })
+        .collect();
+    let mut store = SetStore::new();
+    let set = store.prefix_set(&entries);
+    let set_chain = CompiledChain {
+        policies: vec![CompiledPolicy {
+            name: None,
+            terms: vec![Term {
+                name: None,
+                guard: MatchExpr::PrefixInSet(SetId(0)),
+                action: TermAction::Permit(RouteModifications::default()),
+            }],
+            default_action: PolicyAction::Deny,
+            source: PolicySource::Toml,
+        }],
+        prefix_sets: vec![set],
+        community_sets: Vec::new(),
+        as_path_regexes: Vec::new(),
+    };
+
+    // 172.16.0.0/24 is in no member's 10.x.y.0/24 — full walk / probe miss.
+    let miss = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(172, 16, 0, 0), 24));
+    let communities: Vec<u32> = Vec::new();
+    let as_path_str = String::new();
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let ctx = predicate_ctx(miss, &communities, &as_path_str, peer_ip);
+
+    let mut group = c.benchmark_group("set_heavy");
+    group.bench_function("legacy_1000_stmts", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&stmt_chain).evaluate_with_attribution_legacy(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("ir_1000_terms", |b| {
+        b.iter(|| {
+            let r = evaluate_chain_with_attribution(Some(std::hint::black_box(&stmt_chain)), &ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("ir_prefix_set", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&set_chain).evaluate_with_attribution(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_policy_eval,
+    bench_policy_predicate_eval,
+    bench_set_heavy
+);
 criterion_main!(benches);

--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -1,0 +1,182 @@
+//! TOML-chain → IR compiler (ADR-0096 Decision 5).
+//!
+//! Every `PolicyStatement` compiles to one [`Term`] whose guard is the
+//! And of its configured predicates — exactly mirroring the legacy
+//! matcher's semantics, including the RFC 4271 implicit `LOCAL_PREF`
+//! 100 / `MED` 0 defaults (those live in the evaluator's `Cmp`
+//! handling), first-match-wins within a policy, and `GoBGP` chain
+//! semantics across policies. Decision compatibility with the legacy
+//! evaluator is pinned by the golden corpus in
+//! `engine/tests/ir_parity.rs`.
+//!
+//! Match data with more than one member (a statement's
+//! `match_community` OR-list) is interned through the [`SetStore`]
+//! into indexed, content-deduplicated sets; single-criterion matches
+//! stay inline (no set indirection for the trivial case). TOML
+//! statements carry at most one prefix, so this frontend never emits
+//! [`MatchExpr::PrefixInSet`] — prefix sets arrive with the `.rpol`
+//! frontend (and are already evaluable for hand-built IR).
+
+use std::sync::Arc;
+
+use crate::engine::{AsPathRegex, PolicyAction, PolicyChain, PolicyStatement};
+use crate::ir::{
+    Cmp, CompiledChain, CompiledPolicy, MatchExpr, PolicySource, RegexId, SetId, Term, TermAction,
+};
+use crate::sets::{CommunitySet, SetStore};
+
+/// Compile a TOML policy chain into the IR, interning match sets and
+/// regexes through `store` (identical set data across policies — or
+/// across chains compiled through the same store — shares one `Arc`'d
+/// structure).
+#[must_use]
+pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain {
+    let mut sets = ChainSets::default();
+    let policies = chain
+        .policies
+        .iter()
+        .map(|named| CompiledPolicy {
+            name: named.name.clone(),
+            terms: named
+                .policy
+                .entries
+                .iter()
+                .map(|statement| compile_statement(statement, store, &mut sets))
+                .collect(),
+            default_action: named.policy.default_action,
+            source: PolicySource::Toml,
+        })
+        .collect();
+    CompiledChain {
+        policies,
+        prefix_sets: Vec::new(),
+        community_sets: sets.community_sets,
+        as_path_regexes: sets.as_path_regexes,
+    }
+}
+
+fn compile_statement(
+    statement: &PolicyStatement,
+    store: &mut SetStore,
+    sets: &mut ChainSets,
+) -> Term {
+    let mut children = Vec::new();
+
+    // Emit in the legacy matcher's tier order (scalars → prefix →
+    // neighbor-set → community → regex); the cost-class sort below is
+    // then a stable no-op for TOML input but keeps the invariant
+    // explicit for any future frontend that emits out of order.
+    if let Some(route_type) = statement.match_route_type {
+        children.push(MatchExpr::RouteTypeIs(route_type));
+    }
+    if let Some(evpn_type) = statement.match_evpn_route_type {
+        children.push(MatchExpr::EvpnRouteTypeIs(evpn_type));
+    }
+    if let Some(state) = statement.match_rpki_validation {
+        children.push(MatchExpr::RpkiIs(state));
+    }
+    if let Some(state) = statement.match_aspa_validation {
+        children.push(MatchExpr::AspaIs(state));
+    }
+    if let Some(v) = statement.match_as_path_length_ge {
+        children.push(MatchExpr::AsPathLen(Cmp::Ge(v)));
+    }
+    if let Some(v) = statement.match_as_path_length_le {
+        children.push(MatchExpr::AsPathLen(Cmp::Le(v)));
+    }
+    if let Some(v) = statement.match_local_pref_ge {
+        children.push(MatchExpr::LocalPref(Cmp::Ge(v)));
+    }
+    if let Some(v) = statement.match_local_pref_le {
+        children.push(MatchExpr::LocalPref(Cmp::Le(v)));
+    }
+    if let Some(v) = statement.match_med_ge {
+        children.push(MatchExpr::Med(Cmp::Ge(v)));
+    }
+    if let Some(v) = statement.match_med_le {
+        children.push(MatchExpr::Med(Cmp::Le(v)));
+    }
+    if let Some(next_hop) = statement.match_next_hop {
+        children.push(MatchExpr::NextHopEq(next_hop));
+    }
+    if let Some(prefix) = statement.prefix {
+        children.push(MatchExpr::PrefixEq {
+            prefix,
+            ge: statement.ge,
+            le: statement.le,
+        });
+    }
+    if let Some(set) = statement.match_neighbor_set.as_ref() {
+        children.push(MatchExpr::NeighborIn(Box::new(set.clone())));
+    }
+    match statement.match_community.as_slice() {
+        [] => {}
+        [single] => children.push(MatchExpr::CommunityContains(*single)),
+        criteria => {
+            let set = store.community_set(criteria);
+            children.push(MatchExpr::CommunityInSet(sets.community_set_id(set)));
+        }
+    }
+    if let Some(regex) = statement.match_as_path.as_ref() {
+        let interned = store.as_path_regex(regex);
+        children.push(MatchExpr::AsPathMatches(sets.regex_id(interned)));
+    }
+
+    // And is commutative and side-effect-free; order cheapest-first so
+    // a cheap miss skips the expensive community/regex work.
+    children.sort_by_key(MatchExpr::cost_class);
+
+    let guard = match children.len() {
+        0 => MatchExpr::True,
+        1 => children.pop().expect("len checked"),
+        _ => MatchExpr::And(children),
+    };
+
+    Term {
+        name: None,
+        guard,
+        // A Deny statement's configured modifications are dropped at
+        // compile time — the legacy evaluator returns
+        // `PolicyResult::deny()` and never applies them.
+        action: match statement.action {
+            PolicyAction::Permit => TermAction::Permit(statement.modifications.clone()),
+            PolicyAction::Deny => TermAction::Deny,
+        },
+    }
+}
+
+/// Chain-local set tables under construction: maps store-interned
+/// `Arc`s to chain-local [`SetId`] / [`RegexId`] indexes, deduplicating
+/// by `Arc` identity (chains are small; a linear scan beats a side
+/// table).
+#[derive(Default)]
+struct ChainSets {
+    community_sets: Vec<Arc<CommunitySet>>,
+    as_path_regexes: Vec<Arc<AsPathRegex>>,
+}
+
+impl ChainSets {
+    fn community_set_id(&mut self, set: Arc<CommunitySet>) -> SetId {
+        let index = self
+            .community_sets
+            .iter()
+            .position(|existing| Arc::ptr_eq(existing, &set))
+            .unwrap_or_else(|| {
+                self.community_sets.push(set);
+                self.community_sets.len() - 1
+            });
+        SetId(u32::try_from(index).expect("set table fits u32"))
+    }
+
+    fn regex_id(&mut self, regex: Arc<AsPathRegex>) -> RegexId {
+        let index = self
+            .as_path_regexes
+            .iter()
+            .position(|existing| Arc::ptr_eq(existing, &regex))
+            .unwrap_or_else(|| {
+                self.as_path_regexes.push(regex);
+                self.as_path_regexes.len() - 1
+            });
+        RegexId(u32::try_from(index).expect("regex table fits u32"))
+    }
+}

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -2,12 +2,16 @@ use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::OnceLock;
 
 use regex::Regex;
 use rustbgpd_wire::{
-    AsPath, AsPathSegment, AspaValidation, ExtendedCommunity, Ipv4Prefix, Ipv6Prefix,
-    LargeCommunity, PathAttribute, Prefix, RpkiValidation,
+    AsPath, AsPathSegment, AspaValidation, ExtendedCommunity, LargeCommunity, PathAttribute,
+    Prefix, RpkiValidation,
 };
+
+use crate::ir::CompiledChain;
+use crate::sets::SetStore;
 
 /// Implicit `LOCAL_PREF` used when a route arrives without the
 /// attribute (e.g. eBGP-received with no `LOCAL_PREF` on the wire).
@@ -359,7 +363,8 @@ impl CommunityMatch {
         }
     }
 
-    fn matches_route_communities(&self, ctx: &RouteContext<'_>) -> bool {
+    #[inline]
+    pub(crate) fn matches_route_communities(&self, ctx: &RouteContext<'_>) -> bool {
         match self {
             CommunityMatch::RouteTarget { .. } | CommunityMatch::RouteOrigin { .. } => ctx
                 .extended_communities
@@ -730,53 +735,9 @@ impl PolicyStatement {
     }
 
     fn matches_prefix(&self, entry_prefix: Prefix, candidate: Prefix) -> bool {
-        match (entry_prefix, candidate) {
-            (Prefix::V4(entry), Prefix::V4(cand)) => self.matches_v4(entry, cand),
-            (Prefix::V6(entry), Prefix::V6(cand)) => self.matches_v6(entry, cand),
-            _ => false,
-        }
-    }
-
-    fn matches_v4(&self, entry: Ipv4Prefix, candidate: Ipv4Prefix) -> bool {
-        let entry_bits = u32::from(entry.addr);
-        let cand_bits = u32::from(candidate.addr);
-
-        if entry.len > 0 {
-            let mask = !((1u32 << (32 - entry.len)) - 1);
-            if (entry_bits & mask) != (cand_bits & mask) {
-                return false;
-            }
-        }
-
-        let (min_len, max_len) = match (self.ge, self.le) {
-            (None, None) => (entry.len, entry.len),
-            (Some(ge), None) => (ge, 32),
-            (None, Some(le)) => (entry.len, le),
-            (Some(ge), Some(le)) => (ge, le),
-        };
-
-        candidate.len >= min_len && candidate.len <= max_len
-    }
-
-    fn matches_v6(&self, entry: Ipv6Prefix, candidate: Ipv6Prefix) -> bool {
-        let entry_bits = u128::from(entry.addr);
-        let cand_bits = u128::from(candidate.addr);
-
-        if entry.len > 0 {
-            let mask = !((1u128 << (128 - entry.len)) - 1);
-            if (entry_bits & mask) != (cand_bits & mask) {
-                return false;
-            }
-        }
-
-        let (min_len, max_len) = match (self.ge, self.le) {
-            (None, None) => (entry.len, entry.len),
-            (Some(ge), None) => (ge, 128),
-            (None, Some(le)) => (entry.len, le),
-            (Some(ge), Some(le)) => (ge, le),
-        };
-
-        candidate.len >= min_len && candidate.len <= max_len
+        // Single scalar implementation shared with the IR evaluator's
+        // `PrefixEq` node and the indexed `PrefixSet`.
+        crate::sets::prefix_entry_matches(entry_prefix, self.ge, self.le, candidate)
     }
 }
 
@@ -886,10 +847,52 @@ pub struct PolicyEvaluation {
 /// continues to the next policy. If a policy returns `Deny`, the route
 /// is rejected immediately. After all policies, the route is permitted
 /// with the accumulated modifications.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Default)]
 pub struct PolicyChain {
     /// Policies evaluated in order; modifications accumulate across permits.
     pub policies: Vec<NamedPolicy>,
+    /// Lazily-compiled IR (ADR-0096), built on first evaluation and
+    /// reused for every route thereafter. Deliberately excluded from
+    /// `PartialEq`/`Clone`/`Debug`: chain identity is the configured
+    /// `policies` (the ADR-0076 planner diffs chains structurally),
+    /// and the cache is derived state. Invariant: `policies` must not
+    /// be mutated after the first evaluation — config construction
+    /// finishes all mutation (including the implicit gshut/blackhole
+    /// appends) before a chain ever sees a route.
+    compiled: OnceLock<Box<CompiledChain>>,
+}
+
+impl Clone for PolicyChain {
+    fn clone(&self) -> Self {
+        // The clone gets a fresh cache: cloning is a construction-time
+        // operation (config resolve, per-session distribution), and a
+        // shared cache would leak stale IR into clones whose
+        // `policies` are still being edited.
+        Self {
+            policies: self.policies.clone(),
+            compiled: OnceLock::new(),
+        }
+    }
+}
+
+impl PartialEq for PolicyChain {
+    fn eq(&self, other: &Self) -> bool {
+        self.policies == other.policies
+    }
+}
+
+impl Eq for PolicyChain {}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "the compiled-IR cache is derived state, not chain identity"
+)]
+impl fmt::Debug for PolicyChain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PolicyChain")
+            .field("policies", &self.policies)
+            .finish()
+    }
 }
 
 impl PolicyChain {
@@ -901,13 +904,32 @@ impl PolicyChain {
     pub fn new(policies: Vec<Policy>) -> Self {
         Self {
             policies: policies.into_iter().map(NamedPolicy::from).collect(),
+            compiled: OnceLock::new(),
         }
     }
 
     /// Create a chain from a list of already-named policies.
     #[must_use]
     pub fn from_named(policies: Vec<NamedPolicy>) -> Self {
-        Self { policies }
+        Self {
+            policies,
+            compiled: OnceLock::new(),
+        }
+    }
+
+    /// The compiled IR backing this chain (ADR-0096), compiled on
+    /// first use. Each chain compiles through its own private
+    /// [`SetStore`], so sets dedupe across the chain's policies;
+    /// cross-chain sharing arrives when the config resolver compiles
+    /// eagerly through one store (a later ADR-0096 slice —
+    /// `crate::compile::compile_chain` already takes the store).
+    #[must_use]
+    pub fn compiled(&self) -> &CompiledChain {
+        // Boxed so an uncompiled chain stays pointer-sized — chains are
+        // embedded in config/session structs (and api event enums) that
+        // mostly never evaluate routes themselves.
+        self.compiled
+            .get_or_init(|| Box::new(crate::compile::compile_chain(self, &mut SetStore::new())))
     }
 
     /// Whether evaluating this chain needs the rendered `AS_PATH` string.
@@ -920,9 +942,7 @@ impl PolicyChain {
     /// is otherwise allocated per (route × peer) for nothing.
     #[must_use]
     pub fn requires_as_path_string(&self) -> bool {
-        self.policies
-            .iter()
-            .any(|np| np.policy.entries.iter().any(|e| e.match_as_path.is_some()))
+        self.compiled().requires_as_path_string()
     }
 
     /// Whether evaluating this chain depends on RPKI origin-validation state.
@@ -933,23 +953,13 @@ impl PolicyChain {
     /// be refreshed.
     #[must_use]
     pub fn requires_rpki_validation(&self) -> bool {
-        self.policies.iter().any(|np| {
-            np.policy
-                .entries
-                .iter()
-                .any(|e| e.match_rpki_validation.is_some())
-        })
+        self.compiled().requires_rpki_validation()
     }
 
     /// Whether evaluating this chain depends on ASPA path-validation state.
     #[must_use]
     pub fn requires_aspa_validation(&self) -> bool {
-        self.policies.iter().any(|np| {
-            np.policy
-                .entries
-                .iter()
-                .any(|e| e.match_aspa_validation.is_some())
-        })
+        self.compiled().requires_aspa_validation()
     }
 
     /// Whether evaluating this chain depends on any external validation cache.
@@ -974,6 +984,20 @@ impl PolicyChain {
     /// `PolicyResult.action`.
     #[must_use]
     pub fn evaluate_with_attribution(
+        &self,
+        ctx: &RouteContext<'_>,
+    ) -> (PolicyResult, PolicyEvaluation) {
+        self.compiled().evaluate_with_attribution(ctx)
+    }
+
+    /// The pre-IR chain walker, kept intact as the oracle for the
+    /// golden decision-compatibility corpus
+    /// (`engine/tests/ir_parity.rs`) and the `set_heavy` benchmark
+    /// contrast. Not public API; deleted in a later ADR-0096 slice
+    /// once the corpus has soaked.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn evaluate_with_attribution_legacy(
         &self,
         ctx: &RouteContext<'_>,
     ) -> (PolicyResult, PolicyEvaluation) {

--- a/crates/policy/src/engine/tests/ir_parity.rs
+++ b/crates/policy/src/engine/tests/ir_parity.rs
@@ -1,0 +1,826 @@
+//! Golden decision-compatibility corpus (ADR-0096 PR-1).
+//!
+//! Pins the IR path — `PolicyChain::evaluate_with_attribution`, which
+//! compiles through `crate::compile` and evaluates through the
+//! `CompiledChain` evaluator — decision-identical to the legacy
+//! statement walker (`evaluate_with_attribution_legacy`) across a broad
+//! (chain-shape × route-context) matrix:
+//!
+//! - every match field kind, including the indexed community-set path
+//!   (multi-criterion OR-lists) and the inline single-criterion path;
+//! - prefix ge/le boundaries, len-0 entries, and the mask-only corner
+//!   where the member is longer than the candidate;
+//! - the RFC 4271 implicit `LOCAL_PREF` 100 / `MED` 0 defaults at
+//!   their exact boundaries, against both explicit and absent
+//!   attributes;
+//! - first-match-wins within a policy, chain accumulation and
+//!   deny-termination across policies, modification merge conflicts,
+//!   deny statements carrying (dropped) modifications;
+//! - attribution names for named / unnamed / empty / `None` chains;
+//! - `requires_*` introspection parity (legacy field scan vs IR walk).
+//!
+//! Both `PolicyResult` and `PolicyEvaluation` must be equal on every
+//! case. The legacy walker stays in-tree solely as this oracle until a
+//! later ADR-0096 slice deletes it.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use rustbgpd_wire::{
+    AspaValidation, ExtendedCommunity, Ipv6Prefix, LargeCommunity, Prefix, RpkiValidation,
+};
+
+use super::*;
+
+fn v6_prefix(len: u8) -> Prefix {
+    Prefix::V6(Ipv6Prefix::new(
+        Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 0),
+        len,
+    ))
+}
+
+fn base(action: PolicyAction) -> PolicyStatement {
+    stmt(None, action, vec![])
+}
+
+fn full_mods() -> RouteModifications {
+    RouteModifications {
+        set_local_pref: Some(200),
+        set_med: Some(10),
+        set_next_hop: Some(NextHopAction::Self_),
+        communities_add: vec![(65001 << 16) | 0x2A],
+        communities_remove: vec![(65001 << 16) | 0x64],
+        extended_communities_add: vec![make_rt(65010, 1)],
+        extended_communities_remove: vec![make_ro(65002, 9)],
+        large_communities_add: vec![LargeCommunity {
+            global_admin: 65009,
+            local_data1: 1,
+            local_data2: 1,
+        }],
+        large_communities_remove: vec![LargeCommunity {
+            global_admin: 65001,
+            local_data1: 1,
+            local_data2: 2,
+        }],
+        as_path_prepend: Some((65001, 2)),
+    }
+}
+
+/// One statement shape per match-field kind (plus combinations), all
+/// built with `Permit`; the harness derives the Deny / with-mods /
+/// default-action versions.
+#[expect(clippy::too_many_lines, reason = "the corpus is the point")]
+fn statement_variants() -> Vec<(&'static str, PolicyStatement)> {
+    let mut variants: Vec<(&'static str, PolicyStatement)> = Vec::new();
+
+    variants.push(("unconditional", base(PolicyAction::Permit)));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 30, 0], 24));
+    variants.push(("prefix_exact_24", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.ge = Some(24);
+    variants.push(("prefix_16_ge24", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.le = Some(28);
+    variants.push(("prefix_16_le28", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.ge = Some(24);
+    s.le = Some(28);
+    variants.push(("prefix_16_ge24_le28", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([0, 0, 0, 0], 0));
+    variants.push(("prefix_default_only", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([0, 0, 0, 0], 0));
+    s.ge = Some(0);
+    s.le = Some(32);
+    variants.push(("prefix_any_v4", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 30, 40], 32));
+    variants.push(("prefix_host_32", s));
+
+    // Mask-only corner: member longer than candidate, ge below member.
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.ge = Some(8);
+    variants.push(("prefix_16_ge8_below_len", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v6_prefix(32));
+    s.ge = Some(48);
+    s.le = Some(64);
+    variants.push(("prefix_v6_32_ge48_le64", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v6_prefix(48));
+    variants.push(("prefix_v6_exact_48", s));
+
+    // Single community criterion → inline CommunityContains.
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![CommunityMatch::Standard {
+        value: (65001 << 16) | 0x64,
+    }];
+    variants.push(("community_std_single", s));
+
+    // Multi-criterion OR-list → indexed CommunityInSet.
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0x64,
+        },
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0xC8,
+        },
+        CommunityMatch::Standard {
+            value: (65500 << 16) | 0x01,
+        },
+    ];
+    variants.push(("community_std_set", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![CommunityMatch::RouteTarget {
+        global: 65001,
+        local: 7,
+    }];
+    variants.push(("community_rt", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![CommunityMatch::RouteOrigin {
+        global: 65002,
+        local: 9,
+    }];
+    variants.push(("community_ro", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![CommunityMatch::LargeCommunity {
+        global_admin: 65001,
+        local_data1: 1,
+        local_data2: 2,
+    }];
+    variants.push(("community_lc", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_community = vec![
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0xC8,
+        },
+        CommunityMatch::RouteTarget {
+            global: 65001,
+            local: 7,
+        },
+        CommunityMatch::LargeCommunity {
+            global_admin: 65001,
+            local_data1: 1,
+            local_data2: 2,
+        },
+        CommunityMatch::RouteOrigin {
+            global: 65002,
+            local: 9,
+        },
+    ];
+    variants.push(("community_mixed_set", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    variants.push(("as_path_regex_mid", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_as_path = Some(AsPathRegex::new("^65001").unwrap());
+    variants.push(("as_path_regex_anchor", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.ge = Some(16);
+    s.le = Some(24);
+    s.match_community = vec![CommunityMatch::Standard {
+        value: (65001 << 16) | 0x64,
+    }];
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    variants.push(("prefix_community_regex", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))],
+        remote_asns: vec![],
+        peer_groups: vec![],
+    });
+    variants.push(("neighbor_addr", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![65001],
+        peer_groups: vec![],
+    });
+    variants.push(("neighbor_asn", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![],
+        peer_groups: vec!["leaf".to_string()],
+    });
+    variants.push(("neighbor_group", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))],
+        remote_asns: vec![65001],
+        peer_groups: vec!["spine".to_string()],
+    });
+    variants.push(("neighbor_mixed", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_route_type = Some(RouteType::Internal);
+    variants.push(("route_type_internal", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_route_type = Some(RouteType::External);
+    variants.push(("route_type_external", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_evpn_route_type = Some(2);
+    variants.push(("evpn_type_2", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_rpki_validation = Some(RpkiValidation::Invalid);
+    variants.push(("rpki_invalid", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_rpki_validation = Some(RpkiValidation::Valid);
+    variants.push(("rpki_valid", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_aspa_validation = Some(AspaValidation::Invalid);
+    variants.push(("aspa_invalid", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_as_path_length_ge = Some(3);
+    variants.push(("as_path_len_ge3", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_as_path_length_le = Some(2);
+    variants.push(("as_path_len_le2", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_as_path_length_ge = Some(1);
+    s.match_as_path_length_le = Some(3);
+    variants.push(("as_path_len_ge1_le3", s));
+
+    // Implicit LOCAL_PREF (100) boundaries.
+    let mut s = base(PolicyAction::Permit);
+    s.match_local_pref_ge = Some(100);
+    variants.push(("lp_ge100", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_local_pref_ge = Some(101);
+    variants.push(("lp_ge101", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_local_pref_le = Some(99);
+    variants.push(("lp_le99", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_local_pref_le = Some(100);
+    variants.push(("lp_le100", s));
+
+    // Implicit MED (0) boundaries.
+    let mut s = base(PolicyAction::Permit);
+    s.match_med_ge = Some(1);
+    variants.push(("med_ge1", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_med_le = Some(0);
+    variants.push(("med_le0", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_med_ge = Some(0);
+    s.match_med_le = Some(50);
+    variants.push(("med_ge0_le50", s));
+
+    let mut s = base(PolicyAction::Permit);
+    s.match_next_hop = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)));
+    variants.push(("next_hop_eq", s));
+
+    // Every field at once — the widest And guard.
+    let mut s = base(PolicyAction::Permit);
+    s.prefix = Some(v4_prefix([10, 20, 0, 0], 16));
+    s.ge = Some(16);
+    s.le = Some(32);
+    s.match_community = vec![
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0x64,
+        },
+        CommunityMatch::RouteTarget {
+            global: 65001,
+            local: 7,
+        },
+    ];
+    s.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    s.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![65001],
+        peer_groups: vec![],
+    });
+    s.match_route_type = Some(RouteType::External);
+    s.match_rpki_validation = Some(RpkiValidation::NotFound);
+    s.match_aspa_validation = Some(AspaValidation::Unknown);
+    s.match_as_path_length_ge = Some(1);
+    s.match_as_path_length_le = Some(5);
+    s.match_local_pref_ge = Some(50);
+    s.match_local_pref_le = Some(150);
+    s.match_med_ge = Some(0);
+    s.match_med_le = Some(100);
+    s.match_next_hop = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)));
+    variants.push(("kitchen_sink", s));
+
+    variants
+}
+
+/// Backing storage for the borrowed `RouteContext` fields.
+struct Backing {
+    comm_hit: Vec<u32>,
+    comm_alt: Vec<u32>,
+    ext: Vec<ExtendedCommunity>,
+    large: Vec<LargeCommunity>,
+    path_a: String,
+    path_b: String,
+}
+
+impl Backing {
+    fn new() -> Self {
+        Self {
+            comm_hit: vec![(65001 << 16) | 0x64, (65500 << 16) | 0x01],
+            comm_alt: vec![(65001 << 16) | 0xC8],
+            ext: vec![make_rt(65001, 7), make_ro(65002, 9)],
+            large: vec![LargeCommunity {
+                global_admin: 65001,
+                local_data1: 1,
+                local_data2: 2,
+            }],
+            path_a: "65001 65100 65200".to_string(),
+            path_b: "65010".to_string(),
+        }
+    }
+}
+
+fn blank_ctx() -> RouteContext<'static> {
+    RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+#[expect(clippy::too_many_lines, reason = "the corpus is the point")]
+fn contexts(b: &Backing) -> Vec<(&'static str, RouteContext<'_>)> {
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let next_hop = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+
+    vec![
+        (
+            "full_v4_hit",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                next_hop: Some(next_hop),
+                extended_communities: &b.ext,
+                communities: &b.comm_hit,
+                large_communities: &b.large,
+                as_path_str: &b.path_a,
+                as_path_len: 3,
+                peer_address: Some(peer),
+                peer_asn: Some(65001),
+                peer_group: Some("leaf"),
+                route_type: Some(RouteType::External),
+                local_pref: Some(100),
+                med: Some(50),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "implicit_attrs_alt_comm",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                next_hop: Some(next_hop),
+                communities: &b.comm_alt,
+                as_path_str: &b.path_b,
+                as_path_len: 1,
+                validation_state: RpkiValidation::Valid,
+                peer_asn: Some(65002),
+                route_type: Some(RouteType::Internal),
+                local_pref: None,
+                med: None,
+                ..blank_ctx()
+            },
+        ),
+        (
+            "lp99_med0_explicit",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                as_path_str: &b.path_a,
+                as_path_len: 3,
+                local_pref: Some(99),
+                med: Some(0),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "lp101_med1",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                local_pref: Some(101),
+                med: Some(1),
+                ..blank_ctx()
+            },
+        ),
+        ("prefixless_bgp_ls", blank_ctx()),
+        (
+            "v6_route",
+            RouteContext {
+                prefix: Some(v6_prefix(48)),
+                next_hop: Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                as_path_str: &b.path_a,
+                as_path_len: 3,
+                ..blank_ctx()
+            },
+        ),
+        (
+            "v4_default_route",
+            RouteContext {
+                prefix: Some(v4_prefix([0, 0, 0, 0], 0)),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "v4_host_route",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 40], 32)),
+                communities: &b.comm_hit,
+                ..blank_ctx()
+            },
+        ),
+        (
+            "unrelated_invalid",
+            RouteContext {
+                prefix: Some(v4_prefix([192, 0, 2, 0], 24)),
+                validation_state: RpkiValidation::Invalid,
+                aspa_state: AspaValidation::Invalid,
+                ..blank_ctx()
+            },
+        ),
+        (
+            "evpn_mac_ip",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                route_type: Some(RouteType::Local),
+                evpn_route_type: Some(2),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "evpn_ip_prefix",
+            RouteContext {
+                evpn_route_type: Some(5),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "v4_short_8",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 0, 0], 8)),
+                ..blank_ctx()
+            },
+        ),
+        (
+            "group_only_peer",
+            RouteContext {
+                prefix: Some(v4_prefix([10, 20, 30, 0], 24)),
+                peer_group: Some("leaf"),
+                ..blank_ctx()
+            },
+        ),
+    ]
+}
+
+/// A leading statement no corpus context matches, so single-statement
+/// chains still exercise the first-match-wins walk.
+fn never_matches() -> PolicyStatement {
+    stmt(
+        Some(v4_prefix([203, 0, 113, 0], 24)),
+        PolicyAction::Deny,
+        vec![],
+    )
+}
+
+fn named(name: &str, policy: Policy) -> NamedPolicy {
+    NamedPolicy {
+        name: Some(name.to_string()),
+        policy,
+    }
+}
+
+/// Generated single-statement chains: every variant × action ×
+/// default-action × with/without modifications.
+fn generated_chains() -> Vec<(String, PolicyChain)> {
+    let mut chains = Vec::new();
+    for (variant_name, statement) in statement_variants() {
+        for action in [PolicyAction::Permit, PolicyAction::Deny] {
+            for default_action in [PolicyAction::Permit, PolicyAction::Deny] {
+                for with_mods in [false, true] {
+                    let mut s = statement.clone();
+                    s.action = action;
+                    if with_mods {
+                        // Also attached to Deny statements: the legacy
+                        // path drops their modifications, the compiler
+                        // must too.
+                        s.modifications = full_mods();
+                    }
+                    let chain = PolicyChain::from_named(vec![named(
+                        "p0",
+                        Policy {
+                            entries: vec![never_matches(), s],
+                            default_action,
+                        },
+                    )]);
+                    chains.push((
+                        format!(
+                            "{variant_name}/{action:?}/default_{default_action:?}/mods_{with_mods}"
+                        ),
+                        chain,
+                    ));
+                }
+            }
+        }
+    }
+    chains
+}
+
+/// Hand-built multi-policy chains covering chain-level semantics.
+#[expect(clippy::too_many_lines, reason = "the corpus is the point")]
+fn composed_chains() -> Vec<(String, PolicyChain)> {
+    let permit_all = |mods: RouteModifications| {
+        let mut s = base(PolicyAction::Permit);
+        s.modifications = mods;
+        s
+    };
+    let deny_on_prefix =
+        |addr: [u8; 4], len: u8| stmt(Some(v4_prefix(addr, len)), PolicyAction::Deny, vec![]);
+
+    let mut chains: Vec<(String, PolicyChain)> = Vec::new();
+
+    chains.push(("empty_chain".to_string(), PolicyChain::default()));
+
+    for default_action in [PolicyAction::Permit, PolicyAction::Deny] {
+        chains.push((
+            format!("entryless_policy_default_{default_action:?}"),
+            PolicyChain::from_named(vec![named(
+                "fallthrough",
+                Policy {
+                    entries: vec![],
+                    default_action,
+                },
+            )]),
+        ));
+    }
+
+    // Merge conflicts: later policy wins scalars; a later remove
+    // cancels an earlier add (exact and RT-equivalence lists).
+    let mods_a = RouteModifications {
+        set_local_pref: Some(200),
+        communities_add: vec![(65001 << 16) | 0x2A],
+        extended_communities_add: vec![make_rt(65010, 1)],
+        ..RouteModifications::default()
+    };
+    let mods_b = RouteModifications {
+        set_local_pref: Some(300),
+        communities_remove: vec![(65001 << 16) | 0x2A],
+        extended_communities_remove: vec![make_rt_as4(65010, 1)],
+        ..RouteModifications::default()
+    };
+    chains.push((
+        "merge_conflicts".to_string(),
+        PolicyChain::from_named(vec![
+            named(
+                "first",
+                Policy {
+                    entries: vec![permit_all(mods_a.clone())],
+                    default_action: PolicyAction::Deny,
+                },
+            ),
+            named(
+                "second",
+                Policy {
+                    entries: vec![permit_all(mods_b)],
+                    default_action: PolicyAction::Deny,
+                },
+            ),
+        ]),
+    ));
+
+    // Permit then deny-on-hit: attribution goes to the denying policy.
+    chains.push((
+        "permit_then_deny_on_hit".to_string(),
+        PolicyChain::from_named(vec![
+            named(
+                "open",
+                Policy {
+                    entries: vec![permit_all(mods_a.clone())],
+                    default_action: PolicyAction::Permit,
+                },
+            ),
+            named(
+                "guard",
+                Policy {
+                    entries: vec![deny_on_prefix([10, 20, 30, 0], 24)],
+                    default_action: PolicyAction::Permit,
+                },
+            ),
+        ]),
+    ));
+
+    // Unconditional deny first: the second policy (with mods) is never
+    // consulted.
+    chains.push((
+        "deny_terminates_chain".to_string(),
+        PolicyChain::from_named(vec![
+            named(
+                "wall",
+                Policy {
+                    entries: vec![base(PolicyAction::Deny)],
+                    default_action: PolicyAction::Permit,
+                },
+            ),
+            named(
+                "unreached",
+                Policy {
+                    entries: vec![permit_all(full_mods())],
+                    default_action: PolicyAction::Deny,
+                },
+            ),
+        ]),
+    ));
+
+    // Unnamed terminal policy: attribution must be None.
+    chains.push((
+        "unnamed_terminal".to_string(),
+        PolicyChain::new(vec![Policy {
+            entries: vec![permit_all(mods_a)],
+            default_action: PolicyAction::Deny,
+        }]),
+    ));
+
+    // First-match-wins: the guarded statement shadows the
+    // unconditional one when it matches.
+    let mut guarded = base(PolicyAction::Permit);
+    guarded.match_local_pref_ge = Some(100);
+    guarded.modifications = RouteModifications {
+        set_med: Some(1),
+        ..RouteModifications::default()
+    };
+    let mut fallback = base(PolicyAction::Permit);
+    fallback.modifications = RouteModifications {
+        set_med: Some(2),
+        ..RouteModifications::default()
+    };
+    chains.push((
+        "first_match_wins".to_string(),
+        PolicyChain::from_named(vec![named(
+            "ordered",
+            Policy {
+                entries: vec![guarded, fallback],
+                default_action: PolicyAction::Deny,
+            },
+        )]),
+    ));
+
+    // Mixed set/regex chain: community-set policy then regex policy.
+    let mut set_stmt = base(PolicyAction::Permit);
+    set_stmt.match_community = vec![
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0x64,
+        },
+        CommunityMatch::Standard {
+            value: (65001 << 16) | 0xC8,
+        },
+    ];
+    let mut regex_stmt = base(PolicyAction::Permit);
+    regex_stmt.match_as_path = Some(AsPathRegex::new("_65100_").unwrap());
+    chains.push((
+        "set_then_regex".to_string(),
+        PolicyChain::from_named(vec![
+            named(
+                "sets",
+                Policy {
+                    entries: vec![set_stmt],
+                    default_action: PolicyAction::Deny,
+                },
+            ),
+            named(
+                "paths",
+                Policy {
+                    entries: vec![regex_stmt],
+                    default_action: PolicyAction::Deny,
+                },
+            ),
+        ]),
+    ));
+
+    chains
+}
+
+#[test]
+fn golden_corpus_ir_matches_legacy() {
+    let backing = Backing::new();
+    let contexts = contexts(&backing);
+
+    let mut chains = generated_chains();
+    chains.extend(composed_chains());
+
+    let mut cases = 0usize;
+    for (chain_name, chain) in &chains {
+        // requires_* parity: legacy field scan vs IR analysis.
+        let legacy_regex = chain
+            .policies
+            .iter()
+            .any(|np| np.entries.iter().any(|e| e.match_as_path.is_some()));
+        let legacy_rpki = chain
+            .policies
+            .iter()
+            .any(|np| np.entries.iter().any(|e| e.match_rpki_validation.is_some()));
+        let legacy_aspa = chain
+            .policies
+            .iter()
+            .any(|np| np.entries.iter().any(|e| e.match_aspa_validation.is_some()));
+        assert_eq!(
+            chain.requires_as_path_string(),
+            legacy_regex,
+            "requires_as_path_string diverges on {chain_name}"
+        );
+        assert_eq!(
+            chain.requires_rpki_validation(),
+            legacy_rpki,
+            "requires_rpki_validation diverges on {chain_name}"
+        );
+        assert_eq!(
+            chain.requires_aspa_validation(),
+            legacy_aspa,
+            "requires_aspa_validation diverges on {chain_name}"
+        );
+        assert_eq!(
+            chain.requires_validation_state(),
+            legacy_rpki || legacy_aspa,
+            "requires_validation_state diverges on {chain_name}"
+        );
+
+        for (ctx_name, route) in &contexts {
+            let legacy = chain.evaluate_with_attribution_legacy(route);
+            let ir = chain.evaluate_with_attribution(route);
+            assert_eq!(
+                legacy, ir,
+                "IR/legacy divergence: chain={chain_name} ctx={ctx_name}"
+            );
+            cases += 1;
+        }
+    }
+
+    // 42 variants × 2 actions × 2 defaults × 2 mods + composed, × 13
+    // contexts. Guard against the corpus silently shrinking.
+    assert!(cases >= 4000, "corpus shrank to {cases} cases");
+}
+
+/// `None`-chain contract: implicit permit with no attribution, on both
+/// free functions.
+#[test]
+fn none_chain_is_implicit_permit() {
+    let route = blank_ctx();
+    let (result, eval) = evaluate_chain_with_attribution(None, &route);
+    assert_eq!(result, PolicyResult::permit());
+    assert_eq!(eval.action, PolicyAction::Permit);
+    assert_eq!(eval.matched_policy, None);
+    assert_eq!(
+        super::super::evaluate_chain(None, &route),
+        PolicyResult::permit()
+    );
+}

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -9,6 +9,7 @@ mod aspath_regex;
 mod chain;
 mod community;
 mod evpn_route_type;
+mod ir_parity;
 mod large_community;
 mod modifications;
 mod peer_context;

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -1,0 +1,272 @@
+//! The IR evaluator (ADR-0096) — the single evaluation engine behind
+//! `evaluate_chain_with_attribution`.
+//!
+//! Semantics are decision-identical to the legacy statement walker
+//! (pinned by the golden corpus in `engine/tests/ir_parity.rs`):
+//! first-match-wins within a policy, `GoBGP` chain semantics across
+//! policies (permits accumulate modifications and continue, a deny
+//! terminates), RFC 4271 implicit `LOCAL_PREF`/`MED` defaults in
+//! comparisons, and the same attribution rules.
+//!
+//! The no-match / no-modification path allocates nothing: guard
+//! evaluation is all borrows, modifications are cloned only when a
+//! matched permit term actually carries some, and the attribution name
+//! is cloned only for a named terminal policy (exactly as before).
+
+use crate::engine::{
+    IMPLICIT_LOCAL_PREF, IMPLICIT_MED, PolicyAction, PolicyEvaluation, PolicyResult, RouteContext,
+    RouteModifications,
+};
+use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, TermAction};
+use crate::sets::prefix_entry_matches;
+
+/// A policy's disposition of the route, borrowing the matched term's
+/// modifications (cloned only if merged).
+enum PolicyDecision<'a> {
+    Permit(Option<&'a RouteModifications>),
+    Deny,
+}
+
+impl CompiledChain {
+    /// Evaluate a route against this chain. Identical to
+    /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
+    /// without the attribution.
+    #[must_use]
+    pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {
+        self.evaluate_with_attribution(ctx).0
+    }
+
+    /// Evaluate a route against this chain with attribution to the
+    /// terminal-decision policy — the IR backend of
+    /// `PolicyChain::evaluate_with_attribution`, with identical
+    /// semantics and results.
+    #[must_use]
+    pub fn evaluate_with_attribution(
+        &self,
+        ctx: &RouteContext<'_>,
+    ) -> (PolicyResult, PolicyEvaluation) {
+        let mut accumulated = RouteModifications::default();
+        for policy in &self.policies {
+            match self.evaluate_policy(policy, ctx) {
+                PolicyDecision::Deny => {
+                    return (
+                        PolicyResult::deny(),
+                        PolicyEvaluation {
+                            action: PolicyAction::Deny,
+                            matched_policy: policy.name.clone(),
+                        },
+                    );
+                }
+                PolicyDecision::Permit(Some(mods)) if !mods.is_empty() => {
+                    accumulated.merge_from(mods.clone());
+                }
+                PolicyDecision::Permit(_) => {}
+            }
+        }
+        // All policies permitted (including an empty chain). Attribute
+        // to the last policy in the chain since chain evaluation
+        // completes only after every policy permits.
+        let matched_policy = self.policies.last().and_then(|p| p.name.clone());
+        (
+            PolicyResult {
+                action: PolicyAction::Permit,
+                modifications: accumulated,
+            },
+            PolicyEvaluation {
+                action: PolicyAction::Permit,
+                matched_policy,
+            },
+        )
+    }
+
+    /// First-match-wins term walk; the policy's default action decides
+    /// on fallthrough.
+    fn evaluate_policy<'a>(
+        &self,
+        policy: &'a CompiledPolicy,
+        ctx: &RouteContext<'_>,
+    ) -> PolicyDecision<'a> {
+        for term in &policy.terms {
+            if self.eval_expr(&term.guard, ctx) {
+                return match &term.action {
+                    TermAction::Permit(mods) => PolicyDecision::Permit(Some(mods)),
+                    TermAction::Deny => PolicyDecision::Deny,
+                };
+            }
+        }
+        match policy.default_action {
+            PolicyAction::Permit => PolicyDecision::Permit(None),
+            PolicyAction::Deny => PolicyDecision::Deny,
+        }
+    }
+
+    /// Evaluate one guard node. Pure and allocation-free; set/regex
+    /// ids index this chain's tables directly (out-of-range ids are a
+    /// compiler bug, not reachable from operator input).
+    fn eval_expr(&self, expr: &MatchExpr, ctx: &RouteContext<'_>) -> bool {
+        match expr {
+            MatchExpr::True => true,
+            MatchExpr::And(children) => children.iter().all(|child| self.eval_expr(child, ctx)),
+            MatchExpr::Or(children) => children.iter().any(|child| self.eval_expr(child, ctx)),
+            MatchExpr::Not(inner) => !self.eval_expr(inner, ctx),
+            MatchExpr::PrefixEq { prefix, ge, le } => ctx
+                .prefix
+                .is_some_and(|candidate| prefix_entry_matches(*prefix, *ge, *le, candidate)),
+            MatchExpr::PrefixInSet(id) => ctx
+                .prefix
+                .is_some_and(|candidate| self.prefix_sets[id.0 as usize].matches(candidate)),
+            MatchExpr::CommunityContains(cm) => cm.matches_route_communities(ctx),
+            MatchExpr::CommunityInSet(id) => self.community_sets[id.0 as usize].matches(ctx),
+            MatchExpr::AsPathMatches(id) => {
+                self.as_path_regexes[id.0 as usize].is_match(ctx.as_path_str)
+            }
+            MatchExpr::AsPathLen(cmp) => cmp_len(*cmp, ctx.as_path_len),
+            MatchExpr::LocalPref(cmp) => {
+                cmp_value(*cmp, ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF))
+            }
+            MatchExpr::Med(cmp) => cmp_value(*cmp, ctx.med.unwrap_or(IMPLICIT_MED)),
+            MatchExpr::NextHopEq(next_hop) => ctx.next_hop == Some(*next_hop),
+            MatchExpr::NeighborIn(set) => {
+                set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
+            }
+            MatchExpr::RouteTypeIs(route_type) => ctx.route_type == Some(*route_type),
+            MatchExpr::EvpnRouteTypeIs(evpn_type) => ctx.evpn_route_type == Some(*evpn_type),
+            MatchExpr::RpkiIs(state) => ctx.validation_state == *state,
+            MatchExpr::AspaIs(state) => ctx.aspa_state == *state,
+        }
+    }
+}
+
+#[inline]
+fn cmp_value(cmp: Cmp, value: u32) -> bool {
+    match cmp {
+        Cmp::Ge(bound) => value >= bound,
+        Cmp::Le(bound) => value <= bound,
+    }
+}
+
+/// `AS_PATH` length comparison — mirrors the legacy `v as usize`
+/// widening against the context's `usize` count.
+#[inline]
+fn cmp_len(cmp: Cmp, len: usize) -> bool {
+    match cmp {
+        Cmp::Ge(bound) => len >= bound as usize,
+        Cmp::Le(bound) => len <= bound as usize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+
+    use rustbgpd_wire::{AspaValidation, Ipv4Prefix, Prefix, RpkiValidation};
+
+    use crate::engine::{PolicyAction, RouteContext, RouteModifications};
+    use crate::ir::{
+        CompiledChain, CompiledPolicy, MatchExpr, PolicySource, SetId, Term, TermAction,
+    };
+    use crate::sets::{PrefixSet, PrefixSetEntry};
+
+    fn ctx(prefix: Option<Prefix>) -> RouteContext<'static> {
+        RouteContext {
+            prefix,
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[],
+            large_communities: &[],
+            as_path_str: "",
+            as_path_len: 0,
+            validation_state: RpkiValidation::NotFound,
+            aspa_state: AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        }
+    }
+
+    fn single_term_chain(guard: MatchExpr, prefix_sets: Vec<Arc<PrefixSet>>) -> CompiledChain {
+        CompiledChain {
+            policies: vec![CompiledPolicy {
+                name: None,
+                terms: vec![Term {
+                    name: None,
+                    guard,
+                    action: TermAction::Permit(RouteModifications::default()),
+                }],
+                default_action: PolicyAction::Deny,
+                source: PolicySource::Toml,
+            }],
+            prefix_sets,
+            community_sets: Vec::new(),
+            as_path_regexes: Vec::new(),
+        }
+    }
+
+    fn v4(addr: [u8; 4], len: u8) -> Prefix {
+        Prefix::V4(Ipv4Prefix::new(
+            Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]),
+            len,
+        ))
+    }
+
+    /// Or / Not / True have no TOML frontend yet, so the golden corpus
+    /// cannot reach them — pin their truth tables directly.
+    #[test]
+    fn or_not_true_semantics() {
+        let route = ctx(Some(v4([10, 0, 0, 0], 24)));
+        let hit = MatchExpr::PrefixEq {
+            prefix: v4([10, 0, 0, 0], 24),
+            ge: None,
+            le: None,
+        };
+        let miss = MatchExpr::PrefixEq {
+            prefix: v4([192, 0, 2, 0], 24),
+            ge: None,
+            le: None,
+        };
+
+        for (guard, expect) in [
+            (MatchExpr::True, true),
+            (MatchExpr::Or(vec![miss.clone(), hit.clone()]), true),
+            (MatchExpr::Or(vec![miss.clone(), miss.clone()]), false),
+            (MatchExpr::Or(vec![]), false),
+            (MatchExpr::And(vec![]), true),
+            (MatchExpr::Not(Box::new(miss.clone())), true),
+            (MatchExpr::Not(Box::new(hit.clone())), false),
+        ] {
+            let chain = single_term_chain(guard.clone(), Vec::new());
+            let (result, _) = chain.evaluate_with_attribution(&route);
+            assert_eq!(
+                result.action,
+                if expect {
+                    PolicyAction::Permit
+                } else {
+                    PolicyAction::Deny
+                },
+                "guard {guard:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_in_set_respects_prefixless_routes() {
+        let set = Arc::new(PrefixSet::new([PrefixSetEntry {
+            prefix: v4([10, 0, 0, 0], 8),
+            ge: Some(8),
+            le: Some(32),
+        }]));
+        let chain = single_term_chain(MatchExpr::PrefixInSet(SetId(0)), vec![set]);
+
+        let (result, _) = chain.evaluate_with_attribution(&ctx(Some(v4([10, 1, 2, 0], 24))));
+        assert_eq!(result.action, PolicyAction::Permit);
+
+        // A prefixless route (e.g. BGP-LS) never matches prefix nodes.
+        let (result, _) = chain.evaluate_with_attribution(&ctx(None));
+        assert_eq!(result.action, PolicyAction::Deny);
+    }
+}

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -1,0 +1,283 @@
+//! The typed, compiled policy IR (ADR-0096).
+//!
+//! This is the single evaluation representation every policy frontend
+//! compiles into: TOML statement chains today (`crate::compile`), the
+//! `.rpol` language in a later slice. It is a **public, analyzable**
+//! surface (ADR-0096 Decision 3) because four consumers introspect it:
+//! the `requires_*` hot-path gates (IR analyses below), the ADR-0076
+//! live-impact planner (structural diff), explain rendering, and
+//! `rbgp policy test`.
+//!
+//! Match *data* lives outside the expression tree in indexed,
+//! `Arc`-shared structures ([`crate::sets`]); expression nodes
+//! reference them by [`SetId`] / [`RegexId`] into the owning
+//! [`CompiledChain`]'s tables. Guards are side-effect-free, so
+//! And-children may be (and are, at compile time) ordered by static
+//! cost class without changing results.
+//!
+//! Spans and term names are optional carriers for the future `.rpol`
+//! frontend; the TOML compiler leaves term names empty.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use rustbgpd_wire::{AspaValidation, Prefix, RpkiValidation};
+
+use crate::engine::{
+    AsPathRegex, CommunityMatch, NeighborSetMatch, PolicyAction, RouteModifications, RouteType,
+};
+use crate::sets::{CommunitySet, PrefixSet};
+
+/// Index of a match set within its owning [`CompiledChain`]'s table
+/// (`prefix_sets` or `community_sets`, per the referencing node).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetId(pub u32);
+
+/// Index of a compiled AS-path regex within its owning
+/// [`CompiledChain`]'s `as_path_regexes` table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegexId(pub u32);
+
+/// An inclusive comparison against an unsigned attribute value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cmp {
+    /// Value must be `>=` the operand.
+    Ge(u32),
+    /// Value must be `<=` the operand.
+    Le(u32),
+}
+
+/// A typed match expression — the guard side of a [`Term`].
+///
+/// Every node is a pure, side-effect-free predicate over a
+/// `RouteContext`. Semantics mirror the legacy `PolicyStatement`
+/// matcher exactly (pinned by the golden corpus in
+/// `engine/tests/ir_parity.rs`):
+///
+/// - Prefix nodes never match a prefixless route (e.g. BGP-LS NLRIs).
+/// - [`Cmp`] on `LocalPref` / `Med` sees the RFC 4271 implicit defaults
+///   (`LOCAL_PREF` 100, `MED` 0) when the attribute is absent.
+/// - `RouteTypeIs` / `EvpnRouteTypeIs` / `NextHopEq` never match when
+///   the corresponding context field is `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchExpr {
+    /// Always matches (an unconditional term).
+    True,
+    /// The route's prefix is a member of an indexed prefix set.
+    PrefixInSet(SetId),
+    /// The route's prefix matches one inline `(prefix, ge, le)` triple
+    /// (see [`crate::sets::prefix_entry_matches`]). Single-prefix
+    /// matches stay inline rather than paying a set indirection.
+    PrefixEq {
+        /// The covering prefix; candidates are masked at its length.
+        prefix: Prefix,
+        /// Minimum candidate prefix length (inclusive).
+        ge: Option<u8>,
+        /// Maximum candidate prefix length (inclusive).
+        le: Option<u8>,
+    },
+    /// Any route community satisfies this single criterion.
+    CommunityContains(CommunityMatch),
+    /// Any route community satisfies any criterion in an indexed set.
+    CommunityInSet(SetId),
+    /// The rendered `AS_PATH` string matches a compiled regex.
+    AsPathMatches(RegexId),
+    /// Comparison against the `AS_PATH` ASN count.
+    AsPathLen(Cmp),
+    /// Comparison against `LOCAL_PREF` (implicit default 100).
+    LocalPref(Cmp),
+    /// Comparison against `MED` (implicit default 0).
+    Med(Cmp),
+    /// The route's next-hop equals this address.
+    NextHopEq(IpAddr),
+    /// The evaluation peer matches a neighbor set (address, ASN, or
+    /// peer-group membership — OR within the set). Boxed: the set is
+    /// three `Vec`s (72 bytes) and would otherwise dominate every
+    /// `MatchExpr`'s size — And-children are walked as a contiguous
+    /// `Vec`, so small nodes are cache locality.
+    NeighborIn(Box<NeighborSetMatch>),
+    /// The route's source class equals this type.
+    RouteTypeIs(RouteType),
+    /// The route is an EVPN NLRI of this route type (RFC 7432 §7).
+    EvpnRouteTypeIs(u8),
+    /// RPKI origin validation state equals this state (RFC 6811).
+    RpkiIs(RpkiValidation),
+    /// ASPA path verification state equals this state.
+    AspaIs(AspaValidation),
+    /// All children match (empty = true).
+    And(Vec<MatchExpr>),
+    /// Any child matches (empty = false).
+    Or(Vec<MatchExpr>),
+    /// The child does not match.
+    Not(Box<MatchExpr>),
+}
+
+impl MatchExpr {
+    /// Static evaluation cost class, used to order And-children
+    /// cheapest-first at compile time (mirroring the legacy matcher's
+    /// tiers): scalar comparisons (0) < prefix (1) < neighbor-set (2) <
+    /// community probe/scan (3) < AS-path regex (4). Compound nodes
+    /// take their most expensive descendant.
+    #[must_use]
+    pub fn cost_class(&self) -> u8 {
+        match self {
+            MatchExpr::True
+            | MatchExpr::AsPathLen(_)
+            | MatchExpr::LocalPref(_)
+            | MatchExpr::Med(_)
+            | MatchExpr::NextHopEq(_)
+            | MatchExpr::RouteTypeIs(_)
+            | MatchExpr::EvpnRouteTypeIs(_)
+            | MatchExpr::RpkiIs(_)
+            | MatchExpr::AspaIs(_) => 0,
+            MatchExpr::PrefixInSet(_) | MatchExpr::PrefixEq { .. } => 1,
+            MatchExpr::NeighborIn(_) => 2,
+            MatchExpr::CommunityContains(_) | MatchExpr::CommunityInSet(_) => 3,
+            MatchExpr::AsPathMatches(_) => 4,
+            MatchExpr::Not(inner) => inner.cost_class(),
+            MatchExpr::And(children) | MatchExpr::Or(children) => {
+                children.iter().map(Self::cost_class).max().unwrap_or(0)
+            }
+        }
+    }
+
+    /// Depth-first structural walk: does any node (including `self`)
+    /// satisfy `pred`? This is the primitive the `requires_*` analyses
+    /// build on.
+    pub fn any_node(&self, pred: &impl Fn(&MatchExpr) -> bool) -> bool {
+        if pred(self) {
+            return true;
+        }
+        match self {
+            MatchExpr::And(children) | MatchExpr::Or(children) => {
+                children.iter().any(|child| child.any_node(pred))
+            }
+            MatchExpr::Not(inner) => inner.any_node(pred),
+            _ => false,
+        }
+    }
+}
+
+/// What a matched term does with the route.
+///
+/// Chain continuation semantics live at the *chain* level, matching
+/// today's GoBGP-style rules: within a policy the first matching term
+/// decides; across the chain a `Permit` accumulates its modifications
+/// and evaluation continues to the next policy, while a `Deny`
+/// terminates the whole chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TermAction {
+    /// Accept the route, contributing these attribute modifications.
+    Permit(RouteModifications),
+    /// Reject the route (terminates chain evaluation; contributes no
+    /// modifications).
+    Deny,
+}
+
+/// One guarded action inside a [`CompiledPolicy`] — the compiled form
+/// of a TOML `PolicyStatement` or (later) an `.rpol` `term` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Term {
+    /// Term name for explain surfaces. `None` for TOML statements
+    /// (they are unnamed); the `.rpol` frontend populates it.
+    pub name: Option<String>,
+    /// The match guard; [`MatchExpr::True`] for an unconditional term.
+    pub guard: MatchExpr,
+    /// The action taken when the guard matches.
+    pub action: TermAction,
+}
+
+/// Which frontend produced a compiled policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PolicySource {
+    /// Compiled from a TOML `PolicyStatement` chain.
+    Toml,
+}
+
+/// One compiled policy: ordered terms with first-match-wins semantics
+/// and a default action when no term matches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledPolicy {
+    /// Configured policy name (`None` for inline / anonymous policies);
+    /// carried for chain attribution.
+    pub name: Option<String>,
+    /// Ordered terms; the first whose guard matches decides.
+    pub terms: Vec<Term>,
+    /// Action when no term matches.
+    pub default_action: PolicyAction,
+    /// The frontend this policy was compiled from.
+    pub source: PolicySource,
+}
+
+/// A compiled policy chain plus the indexed match data its expression
+/// nodes reference.
+///
+/// The set tables are `Arc`-shared with the [`crate::sets::SetStore`]
+/// that interned them, so identical set data is stored once across
+/// policies and chains. [`SetId`] / [`RegexId`] values index these
+/// tables; constructing a chain whose nodes reference out-of-range ids
+/// is a compiler bug (the evaluator indexes directly).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledChain {
+    /// Policies evaluated in order (`GoBGP` chain semantics: permits
+    /// accumulate modifications and continue; a deny terminates).
+    pub policies: Vec<CompiledPolicy>,
+    /// Prefix sets referenced by [`MatchExpr::PrefixInSet`].
+    pub prefix_sets: Vec<Arc<PrefixSet>>,
+    /// Community sets referenced by [`MatchExpr::CommunityInSet`].
+    pub community_sets: Vec<Arc<CommunitySet>>,
+    /// Compiled regexes referenced by [`MatchExpr::AsPathMatches`].
+    pub as_path_regexes: Vec<Arc<AsPathRegex>>,
+}
+
+impl CompiledChain {
+    /// An empty chain (matches an empty `PolicyChain`: implicit permit).
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            policies: Vec::new(),
+            prefix_sets: Vec::new(),
+            community_sets: Vec::new(),
+            as_path_regexes: Vec::new(),
+        }
+    }
+
+    /// Whether evaluating this chain needs the rendered `AS_PATH`
+    /// string — true iff some guard contains an
+    /// [`MatchExpr::AsPathMatches`] node ([`MatchExpr::AsPathLen`] uses
+    /// the cheap ASN count instead and does not count here).
+    #[must_use]
+    pub fn requires_as_path_string(&self) -> bool {
+        self.any_guard_node(&|expr| matches!(expr, MatchExpr::AsPathMatches(_)))
+    }
+
+    /// Whether evaluating this chain depends on RPKI origin-validation
+    /// state (any [`MatchExpr::RpkiIs`] node).
+    #[must_use]
+    pub fn requires_rpki_validation(&self) -> bool {
+        self.any_guard_node(&|expr| matches!(expr, MatchExpr::RpkiIs(_)))
+    }
+
+    /// Whether evaluating this chain depends on ASPA path-validation
+    /// state (any [`MatchExpr::AspaIs`] node).
+    #[must_use]
+    pub fn requires_aspa_validation(&self) -> bool {
+        self.any_guard_node(&|expr| matches!(expr, MatchExpr::AspaIs(_)))
+    }
+
+    /// Whether evaluating this chain depends on any external validation
+    /// cache (RPKI or ASPA).
+    #[must_use]
+    pub fn requires_validation_state(&self) -> bool {
+        self.requires_rpki_validation() || self.requires_aspa_validation()
+    }
+
+    /// Does any guard node across all policies satisfy `pred`?
+    fn any_guard_node(&self, pred: &impl Fn(&MatchExpr) -> bool) -> bool {
+        self.policies
+            .iter()
+            .flat_map(|policy| policy.terms.iter())
+            .any(|term| term.guard.any_node(pred))
+    }
+}

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -10,6 +10,12 @@
 /// Policy engine core — match, modify, and filter routes.
 pub mod engine;
 
+pub mod compile;
+pub mod ir;
+pub mod sets;
+
+mod eval;
+
 pub use engine::explain::{ChainStatementTrace, StatementAttribution, explain_chain_statements};
 pub use engine::{
     AsPathRegex, CommunityMatch, NamedPolicy, NeighborSetMatch, NextHopAction, Policy,

--- a/crates/policy/src/sets.rs
+++ b/crates/policy/src/sets.rs
@@ -1,0 +1,558 @@
+//! Indexed match-set layer for the compiled policy IR (ADR-0096).
+//!
+//! Match *data* compiles out of policy programs into shared indexed
+//! structures: prefix sets with ge/le ranges, community hash sets, and
+//! interned AS-path regexes. [`SetStore`] deduplicates them by content
+//! across policies and chains — the `OpenBGPd` lesson that evaluation
+//! speed lives in the set-index layer, not the expression interpreter —
+//! so a thousand-entry customer list costs one hash probe per route
+//! instead of a thousand-statement walk.
+
+use std::sync::Arc;
+
+use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, Prefix};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::engine::{AsPathRegex, CommunityMatch, RouteContext};
+
+/// Check a candidate prefix against an `(entry, ge, le)` triple using
+/// the exact `PolicyStatement` prefix semantics: the candidate address
+/// is masked at the entry's length and compared against the entry's
+/// masked address, then the candidate's length must fall inside the
+/// range derived from `ge`/`le`. This is the single scalar
+/// implementation — the statement matcher delegates here and
+/// [`PrefixSet`] is its indexed equivalent.
+///
+/// Range derivation (both address families):
+/// - no `ge`, no `le` → exact-length match (`entry.len ..= entry.len`)
+/// - `ge` only → `ge ..= address_bits`
+/// - `le` only → `entry.len ..= le`
+/// - both → `ge ..= le`
+#[must_use]
+#[inline]
+pub fn prefix_entry_matches(
+    entry: Prefix,
+    ge: Option<u8>,
+    le: Option<u8>,
+    candidate: Prefix,
+) -> bool {
+    match (entry, candidate) {
+        (Prefix::V4(entry), Prefix::V4(cand)) => matches_v4(entry, ge, le, cand),
+        (Prefix::V6(entry), Prefix::V6(cand)) => matches_v6(entry, ge, le, cand),
+        _ => false,
+    }
+}
+
+#[inline]
+fn matches_v4(entry: Ipv4Prefix, ge: Option<u8>, le: Option<u8>, candidate: Ipv4Prefix) -> bool {
+    let mask = mask_v4(entry.len);
+    if (u32::from(entry.addr) & mask) != (u32::from(candidate.addr) & mask) {
+        return false;
+    }
+    let (min_len, max_len) = length_bounds(entry.len, ge, le, 32);
+    candidate.len >= min_len && candidate.len <= max_len
+}
+
+#[inline]
+fn matches_v6(entry: Ipv6Prefix, ge: Option<u8>, le: Option<u8>, candidate: Ipv6Prefix) -> bool {
+    let mask = mask_v6(entry.len);
+    if (u128::from(entry.addr) & mask) != (u128::from(candidate.addr) & mask) {
+        return false;
+    }
+    let (min_len, max_len) = length_bounds(entry.len, ge, le, 128);
+    candidate.len >= min_len && candidate.len <= max_len
+}
+
+#[inline]
+fn length_bounds(entry_len: u8, ge: Option<u8>, le: Option<u8>, max_bits: u8) -> (u8, u8) {
+    match (ge, le) {
+        (None, None) => (entry_len, entry_len),
+        (Some(ge), None) => (ge, max_bits),
+        (None, Some(le)) => (entry_len, le),
+        (Some(ge), Some(le)) => (ge, le),
+    }
+}
+
+#[inline]
+fn mask_v4(len: u8) -> u32 {
+    if len == 0 {
+        0
+    } else if len >= 32 {
+        u32::MAX
+    } else {
+        !((1u32 << (32 - len)) - 1)
+    }
+}
+
+#[inline]
+fn mask_v6(len: u8) -> u128 {
+    if len == 0 {
+        0
+    } else if len >= 128 {
+        u128::MAX
+    } else {
+        !((1u128 << (128 - len)) - 1)
+    }
+}
+
+/// One member of a [`PrefixSet`]: a prefix plus the optional ge/le
+/// length bounds, with the same semantics as a `PolicyStatement`'s
+/// `prefix`/`ge`/`le` fields (see [`prefix_entry_matches`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrefixSetEntry {
+    /// The covering prefix; candidates are masked at its length.
+    pub prefix: Prefix,
+    /// Minimum candidate prefix length (inclusive).
+    pub ge: Option<u8>,
+    /// Maximum candidate prefix length (inclusive).
+    pub le: Option<u8>,
+}
+
+impl PrefixSetEntry {
+    /// Canonical ordering/interning key.
+    fn key(&self) -> PrefixEntryKey {
+        match self.prefix {
+            Prefix::V4(p) => (4, u128::from(u32::from(p.addr)), p.len, self.ge, self.le),
+            Prefix::V6(p) => (6, u128::from(p.addr), p.len, self.ge, self.le),
+        }
+    }
+}
+
+type PrefixEntryKey = (u8, u128, u8, Option<u8>, Option<u8>);
+
+/// Canonical ordering/interning key for a community criterion.
+type CommunityKey = (u8, u32, u32, u32);
+
+/// An indexed prefix set: membership is one hash probe per *distinct
+/// member prefix length* instead of a scan over every member.
+///
+/// The index groups members by (address family, member length); a
+/// lookup masks the candidate address at each member length, probes a
+/// hash map, and checks the stored ge/le length ranges. Real-world sets
+/// use a handful of distinct member lengths, so lookups are effectively
+/// O(1) regardless of set size.
+///
+/// This deliberately is *not* a containment trie: the statement matcher
+/// it replaces uses pure mask-plus-range semantics, where a member
+/// *longer* than the candidate can still match when `ge` reaches below
+/// the member length. The per-length mask groups reproduce that
+/// exactly; a trie ancestor-walk would not.
+#[derive(Debug, Clone)]
+pub struct PrefixSet {
+    /// Canonically sorted, deduplicated members — the set's identity.
+    entries: Vec<PrefixSetEntry>,
+    v4: Vec<LenGroup<u32>>,
+    v6: Vec<LenGroup<u128>>,
+}
+
+#[derive(Debug, Clone)]
+struct LenGroup<B> {
+    member_len: u8,
+    /// Masked member address → inclusive candidate-length ranges.
+    buckets: FxHashMap<B, Vec<(u8, u8)>>,
+}
+
+impl PrefixSet {
+    /// Build an indexed set from members. Members are canonicalized
+    /// (sorted, deduplicated), so construction order does not affect
+    /// identity or behavior.
+    #[must_use]
+    pub fn new(entries: impl IntoIterator<Item = PrefixSetEntry>) -> Self {
+        let mut entries: Vec<PrefixSetEntry> = entries.into_iter().collect();
+        entries.sort_unstable_by_key(PrefixSetEntry::key);
+        entries.dedup();
+
+        let mut v4: Vec<LenGroup<u32>> = Vec::new();
+        let mut v6: Vec<LenGroup<u128>> = Vec::new();
+        for entry in &entries {
+            match entry.prefix {
+                Prefix::V4(p) => {
+                    let bounds = length_bounds(p.len, entry.ge, entry.le, 32);
+                    let masked = u32::from(p.addr) & mask_v4(p.len);
+                    push_group(&mut v4, p.len, masked, bounds);
+                }
+                Prefix::V6(p) => {
+                    let bounds = length_bounds(p.len, entry.ge, entry.le, 128);
+                    let masked = u128::from(p.addr) & mask_v6(p.len);
+                    push_group(&mut v6, p.len, masked, bounds);
+                }
+            }
+        }
+        Self { entries, v4, v6 }
+    }
+
+    /// Whether any member matches the candidate — equivalent to
+    /// [`prefix_entry_matches`] over every member, evaluated in
+    /// O(distinct member lengths).
+    #[must_use]
+    #[inline]
+    pub fn matches(&self, candidate: Prefix) -> bool {
+        match candidate {
+            Prefix::V4(c) => {
+                let bits = u32::from(c.addr);
+                self.v4.iter().any(|group| {
+                    group
+                        .buckets
+                        .get(&(bits & mask_v4(group.member_len)))
+                        .is_some_and(|ranges| {
+                            ranges.iter().any(|&(lo, hi)| c.len >= lo && c.len <= hi)
+                        })
+                })
+            }
+            Prefix::V6(c) => {
+                let bits = u128::from(c.addr);
+                self.v6.iter().any(|group| {
+                    group
+                        .buckets
+                        .get(&(bits & mask_v6(group.member_len)))
+                        .is_some_and(|ranges| {
+                            ranges.iter().any(|&(lo, hi)| c.len >= lo && c.len <= hi)
+                        })
+                })
+            }
+        }
+    }
+
+    /// The canonical (sorted, deduplicated) member list.
+    #[must_use]
+    pub fn entries(&self) -> &[PrefixSetEntry] {
+        &self.entries
+    }
+}
+
+impl PartialEq for PrefixSet {
+    fn eq(&self, other: &Self) -> bool {
+        // The index is derived deterministically from the canonical
+        // member list, so members alone are the identity.
+        self.entries == other.entries
+    }
+}
+
+impl Eq for PrefixSet {}
+
+fn push_group<B: std::hash::Hash + Eq>(
+    groups: &mut Vec<LenGroup<B>>,
+    member_len: u8,
+    key: B,
+    bounds: (u8, u8),
+) {
+    let group = if let Some(pos) = groups.iter().position(|g| g.member_len == member_len) {
+        &mut groups[pos]
+    } else {
+        groups.push(LenGroup {
+            member_len,
+            buckets: FxHashMap::default(),
+        });
+        groups.last_mut().expect("just pushed")
+    };
+    group.buckets.entry(key).or_default().push(bounds);
+}
+
+/// An indexed community criteria set with the OR-any semantics of a
+/// `PolicyStatement`'s `match_community` list: the set matches when any
+/// route community satisfies any member criterion. Standard, RT, RO,
+/// and large criteria are partitioned into hash sets so each route
+/// community is one probe against its own kind.
+#[derive(Debug, Clone, Default)]
+pub struct CommunitySet {
+    /// Canonically sorted, deduplicated criteria — the set's identity.
+    criteria: Vec<CommunityMatch>,
+    standard: FxHashSet<u32>,
+    route_targets: FxHashSet<(u32, u32)>,
+    route_origins: FxHashSet<(u32, u32)>,
+    large: FxHashSet<(u32, u32, u32)>,
+}
+
+impl CommunitySet {
+    /// Build an indexed set from criteria. Criteria are canonicalized
+    /// (sorted, deduplicated), so construction order does not affect
+    /// identity or behavior.
+    #[must_use]
+    pub fn new(criteria: impl IntoIterator<Item = CommunityMatch>) -> Self {
+        let mut criteria: Vec<CommunityMatch> = criteria.into_iter().collect();
+        criteria.sort_unstable_by_key(|cm| community_key(*cm));
+        criteria.dedup();
+
+        let mut set = Self {
+            criteria,
+            ..Self::default()
+        };
+        for cm in &set.criteria {
+            match *cm {
+                CommunityMatch::Standard { value } => {
+                    set.standard.insert(value);
+                }
+                CommunityMatch::RouteTarget { global, local } => {
+                    set.route_targets.insert((global, local));
+                }
+                CommunityMatch::RouteOrigin { global, local } => {
+                    set.route_origins.insert((global, local));
+                }
+                CommunityMatch::LargeCommunity {
+                    global_admin,
+                    local_data1,
+                    local_data2,
+                } => {
+                    set.large.insert((global_admin, local_data1, local_data2));
+                }
+            }
+        }
+        set
+    }
+
+    /// Whether any route community matches any member criterion —
+    /// equivalent to `CommunityMatch::matches_route_communities` OR'd
+    /// over every member.
+    #[must_use]
+    #[inline]
+    pub fn matches(&self, ctx: &RouteContext<'_>) -> bool {
+        if !self.standard.is_empty() && ctx.communities.iter().any(|c| self.standard.contains(c)) {
+            return true;
+        }
+        if (!self.route_targets.is_empty() || !self.route_origins.is_empty())
+            && ctx.extended_communities.iter().any(|ec| {
+                ec.route_target()
+                    .is_some_and(|key| self.route_targets.contains(&key))
+                    || ec
+                        .route_origin()
+                        .is_some_and(|key| self.route_origins.contains(&key))
+            })
+        {
+            return true;
+        }
+        !self.large.is_empty()
+            && ctx.large_communities.iter().any(|lc| {
+                self.large
+                    .contains(&(lc.global_admin, lc.local_data1, lc.local_data2))
+            })
+    }
+
+    /// The canonical (sorted, deduplicated) criteria list.
+    #[must_use]
+    pub fn criteria(&self) -> &[CommunityMatch] {
+        &self.criteria
+    }
+}
+
+impl PartialEq for CommunitySet {
+    fn eq(&self, other: &Self) -> bool {
+        self.criteria == other.criteria
+    }
+}
+
+impl Eq for CommunitySet {}
+
+/// Canonical ordering/interning key for a community criterion.
+fn community_key(cm: CommunityMatch) -> CommunityKey {
+    match cm {
+        CommunityMatch::Standard { value } => (0, value, 0, 0),
+        CommunityMatch::RouteTarget { global, local } => (1, global, local, 0),
+        CommunityMatch::RouteOrigin { global, local } => (2, global, local, 0),
+        CommunityMatch::LargeCommunity {
+            global_admin,
+            local_data1,
+            local_data2,
+        } => (3, global_admin, local_data1, local_data2),
+    }
+}
+
+/// Content-hash interner for match sets and AS-path regexes.
+///
+/// Two policies — or two chains compiled through the same store —
+/// referencing identical set data share one `Arc`'d indexed structure.
+/// Keys are canonicalized (sorted, deduplicated) member lists, so any
+/// ordering of the same data interns to the same set.
+#[derive(Debug, Default)]
+pub struct SetStore {
+    prefix_sets: FxHashMap<Vec<PrefixEntryKey>, Arc<PrefixSet>>,
+    community_sets: FxHashMap<Vec<CommunityKey>, Arc<CommunitySet>>,
+    as_path_regexes: FxHashMap<String, Arc<AsPathRegex>>,
+}
+
+impl SetStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Intern a prefix set built from `entries`.
+    #[must_use]
+    pub fn prefix_set(&mut self, entries: &[PrefixSetEntry]) -> Arc<PrefixSet> {
+        let mut key: Vec<PrefixEntryKey> = entries.iter().map(PrefixSetEntry::key).collect();
+        key.sort_unstable();
+        key.dedup();
+        Arc::clone(
+            self.prefix_sets
+                .entry(key)
+                .or_insert_with(|| Arc::new(PrefixSet::new(entries.iter().copied()))),
+        )
+    }
+
+    /// Intern a community set built from `criteria`.
+    #[must_use]
+    pub fn community_set(&mut self, criteria: &[CommunityMatch]) -> Arc<CommunitySet> {
+        let mut key: Vec<CommunityKey> = criteria.iter().map(|cm| community_key(*cm)).collect();
+        key.sort_unstable();
+        key.dedup();
+        Arc::clone(
+            self.community_sets
+                .entry(key)
+                .or_insert_with(|| Arc::new(CommunitySet::new(criteria.iter().copied()))),
+        )
+    }
+
+    /// Intern a compiled AS-path regex by its configured pattern.
+    #[must_use]
+    pub fn as_path_regex(&mut self, regex: &AsPathRegex) -> Arc<AsPathRegex> {
+        Arc::clone(
+            self.as_path_regexes
+                .entry(regex.pattern().to_string())
+                .or_insert_with(|| Arc::new(regex.clone())),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    fn v4(addr: [u8; 4], len: u8) -> Prefix {
+        Prefix::V4(Ipv4Prefix::new(
+            Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]),
+            len,
+        ))
+    }
+
+    fn v6(len: u8) -> Prefix {
+        Prefix::V6(Ipv6Prefix::new(
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+            len,
+        ))
+    }
+
+    fn entry(prefix: Prefix, ge: Option<u8>, le: Option<u8>) -> PrefixSetEntry {
+        PrefixSetEntry { prefix, ge, le }
+    }
+
+    /// The indexed set must agree with the scalar matcher on every
+    /// (member, candidate-length) combination, including the odd
+    /// mask-only corners (entry longer than candidate, len-0 entries).
+    #[test]
+    fn prefix_set_agrees_with_scalar_matcher() {
+        let members = [
+            entry(v4([10, 0, 0, 0], 8), None, None),
+            entry(v4([10, 10, 0, 0], 16), Some(24), Some(28)),
+            entry(v4([192, 0, 2, 0], 24), Some(8), None),
+            entry(v4([0, 0, 0, 0], 0), None, None),
+            entry(v4([172, 16, 0, 0], 12), None, Some(20)),
+            entry(v6(32), Some(48), Some(64)),
+            entry(v6(64), None, None),
+        ];
+        let set = PrefixSet::new(members.iter().copied());
+
+        let mut candidates = Vec::new();
+        for len in 0..=32u8 {
+            candidates.push(v4([10, 10, 3, 0], len));
+            candidates.push(v4([192, 0, 2, 128], len));
+            candidates.push(v4([172, 16, 5, 0], len));
+            candidates.push(v4([8, 8, 8, 8], len));
+        }
+        for len in 0..=128u8 {
+            candidates.push(v6(len));
+        }
+
+        for cand in candidates {
+            let scalar = members
+                .iter()
+                .any(|m| prefix_entry_matches(m.prefix, m.ge, m.le, cand));
+            assert_eq!(
+                set.matches(cand),
+                scalar,
+                "prefix set diverges from scalar matcher on {cand:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn community_set_agrees_with_criteria_scan() {
+        let criteria = [
+            CommunityMatch::Standard {
+                value: (65001 << 16) | 0x64,
+            },
+            CommunityMatch::RouteTarget {
+                global: 65001,
+                local: 7,
+            },
+            CommunityMatch::RouteOrigin {
+                global: 65002,
+                local: 9,
+            },
+            CommunityMatch::LargeCommunity {
+                global_admin: 65001,
+                local_data1: 1,
+                local_data2: 2,
+            },
+        ];
+        let set = CommunitySet::new(criteria.iter().copied());
+
+        // Route carrying only the large community.
+        let large = [rustbgpd_wire::LargeCommunity {
+            global_admin: 65001,
+            local_data1: 1,
+            local_data2: 2,
+        }];
+        let ctx = RouteContext {
+            prefix: None,
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[(65500 << 16) | 0x01],
+            large_communities: &large,
+            as_path_str: "",
+            as_path_len: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        };
+        assert!(set.matches(&ctx));
+
+        let empty_ctx = RouteContext {
+            large_communities: &[],
+            ..ctx
+        };
+        assert!(!set.matches(&empty_ctx));
+    }
+
+    #[test]
+    fn store_dedupes_by_content_regardless_of_order() {
+        let mut store = SetStore::new();
+        let a = [
+            entry(v4([10, 0, 0, 0], 8), None, None),
+            entry(v4([192, 0, 2, 0], 24), Some(24), Some(32)),
+        ];
+        let b = [a[1], a[0], a[0]]; // reordered + duplicated
+        let first = store.prefix_set(&a);
+        let second = store.prefix_set(&b);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let cm = [CommunityMatch::Standard { value: 1 }];
+        assert!(Arc::ptr_eq(
+            &store.community_set(&cm),
+            &store.community_set(&cm)
+        ));
+
+        let re = AsPathRegex::new("_65001_").unwrap();
+        assert!(Arc::ptr_eq(
+            &store.as_path_regex(&re),
+            &store.as_path_regex(&AsPathRegex::new("_65001_").unwrap())
+        ));
+    }
+}


### PR DESCRIPTION
**PR-1 of the ADR-0096 policy-language arc**: the public typed IR (`MatchExpr`/`Term`/`CompiledPolicy`/`CompiledChain`), the interned indexed set store, the TOML-chain→IR compiler, and the IR evaluator slotted behind the unchanged `evaluate_chain_with_attribution` choke point — all 14 seam call sites untouched, zero behavior change.

- **Parity proven, not asserted**: a 4,485-case golden corpus (42 statement shapes × chain compositions × 13 route contexts) pins legacy ≡ IR on both `PolicyResult` and `PolicyEvaluation`, red-checked with two seeded bugs; the legacy walker is retained `#[doc(hidden)]` as the oracle. The explain agreement matrix stays green on the IR path.
- **The compiled cache is invisible to semantics**: lazy boxed `OnceLock` on `PolicyChain` with manual `PartialEq` (policies only — the ADR-0076 live-impact planner's structural diff is unaffected) and manual `Clone` (fresh cache).
- **Set store semantics over cleverness**: deliberately not a containment trie (its ancestor walk mis-handles ge-below-member-length ranges — property-swept against the scalar matcher); per-(family, member-length) hash probes, content-interned `Arc`-shared sets.
- **Bench**: set-heavy policy (1,000-prefix list) **3.82 µs → 14.1 ns (~270×; the ADR claimed 51×)**; existing groups −20% to −52% across the board; one honest +27% on fully-walked 32-statement chains (documented; the ADR's deferred linearization is the remedy).

Everything after this slice is surface: PR-2 brings the `.rpol` parser.