### PR TITLE
feat(policy): add the rpol language frontend (lexer, parser, typechecker, tests runner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The `.rpol` policy language frontend (ADR-0096 slice 2): lexer,
+  parser, typechecker, in-language tests, and `rbgp policy check`.**
+  `.rpol` source — `prefix-set`/`community-set` definitions (ge/le per
+  member; standard/large/RT/RO literals), `policy` blocks with named
+  terms and `u32` parameters, `if`/`else` guards over the full
+  route/peer context (prefix, the three community kinds, AS-path
+  len/contains/matches, local-pref/MED with the RFC 4271 implicit
+  defaults, next-hop, RPKI/ASPA state, route-type, EVPN route type,
+  peer address/ASN/group), `apply(policy)` composition (compile-time
+  DAG check, no recursion), and `accept`/`reject`/`set`/`add`/
+  `remove`/`prepend` actions — compiles into the existing public typed
+  IR with match data interned through the shared `SetStore`.
+  Parameterized policies are templates monomorphized at each use site;
+  term fallthrough (modify-and-continue) lowers through a new surgical
+  `TermAction::Continue` IR variant (the TOML frontend never emits
+  it). Diagnostics are ariadne-rendered with labeled spans,
+  multi-error recovery, and did-you-mean suggestions. In-language
+  `test` blocks (route/peer fixtures + verdict/attribute expectations)
+  run through the real IR evaluator; the new local-only
+  `rbgp policy check <file.rpol>` verb (exit codes 0 clean /
+  1 diagnostics / 2 test failures, `--json`) runs them with zero
+  daemon involvement. Language reference: `docs/rpol-language.md`.
+  Daemon integration (config wiring, `rbgp policy test --rib live`) is
+  the next slice — nothing consumes `.rpol` from configuration yet.
+  New policy-crate-only dependencies: `logos` (MIT OR Apache-2.0),
+  `ariadne` (MIT).
+
 - **Typed, compiled policy IR (ADR-0096 slice 1): indexed match sets
   behind the existing engine, zero behavior change.** TOML policy
   chains now lazily compile into a public, analyzable IR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "array-const-fn-init"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1505,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,6 +2679,7 @@ dependencies = [
  "ratatui",
  "rustbgpd-api",
  "rustbgpd-evpn",
+ "rustbgpd-policy",
  "rustbgpd-wire",
  "serde",
  "serde_json",
@@ -2832,7 +2875,9 @@ dependencies = [
 name = "rustbgpd-policy"
 version = "0.45.0"
 dependencies = [
+ "ariadne",
  "criterion",
+ "logos",
  "regex",
  "rustbgpd-wire",
  "rustc-hash 2.1.2",
@@ -4432,6 +4477,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 owo-colors.workspace = true
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }
+rustbgpd-policy.workspace = true
 rustbgpd-wire.workspace = true
 
 [build-dependencies]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -140,6 +140,106 @@ struct JsonChains {
     export_policy_names: Vec<String>,
 }
 
+/// `rbgp policy check <file.rpol>` — run the `.rpol` frontend
+/// in-process (parse, typecheck, in-language tests); no daemon.
+///
+/// Returns the process exit code: 0 clean, 1 diagnostics (or an
+/// unreadable file), 2 test failures. Diagnostics render to stderr,
+/// results to stdout.
+pub fn check_local(path: &str, json: bool) -> i32 {
+    use std::io::IsTerminal;
+
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) => {
+            eprintln!("Error: cannot read {path}: {error}");
+            return 1;
+        }
+    };
+    let report = rustbgpd_policy::rpol::check_rpol(&source);
+
+    if json {
+        #[derive(Serialize)]
+        struct JsonFailure<'a> {
+            name: &'a str,
+            message: &'a str,
+        }
+        #[derive(Serialize)]
+        struct JsonCheck<'a> {
+            file: &'a str,
+            ok: bool,
+            diagnostics: Vec<String>,
+            tests_total: usize,
+            tests_passed: usize,
+            failures: Vec<JsonFailure<'a>>,
+        }
+        let out = JsonCheck {
+            file: path,
+            ok: report.is_ok(),
+            diagnostics: report
+                .diagnostics
+                .0
+                .iter()
+                .map(|diag| diag.message.clone())
+                .collect(),
+            tests_total: report.tests.as_ref().map_or(0, |t| t.total),
+            tests_passed: report
+                .tests
+                .as_ref()
+                .map_or(0, rustbgpd_policy::rpol::TestReport::passed),
+            failures: report.tests.as_ref().map_or_else(Vec::new, |t| {
+                t.failures
+                    .iter()
+                    .map(|f| JsonFailure {
+                        name: &f.name,
+                        message: &f.message,
+                    })
+                    .collect()
+            }),
+        };
+        if output::print_json_pretty(&out).is_err() {
+            return 1;
+        }
+    } else if !report.diagnostics.is_empty() {
+        let color = std::io::stderr().is_terminal();
+        eprint!("{}", report.diagnostics.render(path, &source, color));
+        eprintln!(
+            "{path}: {} error{}",
+            report.diagnostics.len(),
+            if report.diagnostics.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+    } else if let Some(tests) = &report.tests {
+        if tests.total == 0 {
+            println!("{path}: ok (no tests)");
+        } else {
+            for failure in &tests.failures {
+                eprintln!("test {} ... FAILED: {}", failure.name, failure.message);
+            }
+            println!(
+                "{path}: {} passed, {} failed",
+                tests.passed(),
+                tests.failures.len()
+            );
+        }
+    }
+
+    if !report.diagnostics.is_empty() {
+        1
+    } else if report
+        .tests
+        .as_ref()
+        .is_some_and(|tests| !tests.all_passed())
+    {
+        2
+    } else {
+        0
+    }
+}
+
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -821,6 +921,46 @@ mod tests {
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
     use std::io::Write;
+
+    fn write_rpol(content: &str) -> tempfile::NamedTempFile {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "{content}").unwrap();
+        tmp.flush().unwrap();
+        tmp
+    }
+
+    #[test]
+    fn check_local_clean_file_exits_zero() {
+        let tmp = write_rpol(
+            "policy p { term t { if route.rpki == invalid { reject } } }
+             test rejects-invalid {
+                 route { prefix 10.0.0.0/24; rpki invalid }
+                 expect p == reject
+             }",
+        );
+        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 0);
+        assert_eq!(check_local(tmp.path().to_str().unwrap(), true), 0);
+    }
+
+    #[test]
+    fn check_local_diagnostics_exit_one() {
+        let tmp = write_rpol("policy p { term t { if route.zzz == 1 { accept } } }");
+        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 1);
+        // Unreadable file is also exit 1.
+        assert_eq!(check_local("/nonexistent/nope.rpol", false), 1);
+    }
+
+    #[test]
+    fn check_local_failing_test_exits_two() {
+        let tmp = write_rpol(
+            "policy p { term t { reject } }
+             test should-fail {
+                 route { prefix 10.0.0.0/24 }
+                 expect p == accept
+             }",
+        );
+        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 2);
+    }
 
     #[tokio::test]
     async fn list_renders_empty() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -341,6 +341,13 @@ enum ConfigAction {
 enum PolicyAction {
     /// List configured policies (names + statement counts)
     List,
+    /// Check an `.rpol` policy file locally: parse, typecheck, and run
+    /// its in-language `test` blocks. No daemon connection. Exit codes:
+    /// 0 clean, 1 diagnostics, 2 test failures.
+    Check {
+        /// Path to the `.rpol` file
+        file: String,
+    },
     /// Show one policy by name
     Get {
         /// Policy name
@@ -1167,6 +1174,14 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         return Ok(());
     }
 
+    // `policy check` runs the .rpol frontend in-process — no daemon.
+    if let Command::Policy {
+        action: PolicyAction::Check { file },
+    } = &cli.command
+    {
+        std::process::exit(commands::policy::check_local(file, cli.json));
+    }
+
     let connection = connect(&cli.addr, cli.token_file.as_deref()).await?;
     let json = cli.json;
 
@@ -1901,6 +1916,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             tui::run(connection, interval).await
         }
         Command::Policy { action } => match action {
+            PolicyAction::Check { .. } => unreachable!("handled before connect"),
             PolicyAction::List => commands::policy::list(connection, json).await,
             PolicyAction::Get { name } => commands::policy::get(connection, &name, json).await,
             PolicyAction::Set { name, from_file } => {

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -12,6 +12,9 @@ description = "Minimal policy engine — prefix allow/deny, max-prefix enforceme
 readme = "README.md"
 
 [dependencies]
+# `.rpol` frontend: lexer + diagnostics (logos: MIT OR Apache-2.0; ariadne: MIT).
+ariadne = "0.6"
+logos = "0.16"
 regex = "1"
 rustc-hash.workspace = true
 rustbgpd-wire.workspace = true

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -21,9 +21,13 @@ use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, TermAction};
 use crate::sets::prefix_entry_matches;
 
 /// A policy's disposition of the route, borrowing the matched term's
-/// modifications (cloned only if merged).
+/// modifications (cloned only if merged). `PermitOwned` carries
+/// modifications accumulated from `Continue` terms merged with the
+/// deciding term's own — only policies that actually hit a `Continue`
+/// term (an `.rpol`-only construct) pay the clone.
 enum PolicyDecision<'a> {
     Permit(Option<&'a RouteModifications>),
+    PermitOwned(RouteModifications),
     Deny,
 }
 
@@ -61,6 +65,11 @@ impl CompiledChain {
                     accumulated.merge_from(mods.clone());
                 }
                 PolicyDecision::Permit(_) => {}
+                PolicyDecision::PermitOwned(mods) => {
+                    if !mods.is_empty() {
+                        accumulated.merge_from(mods);
+                    }
+                }
             }
         }
         // All policies permitted (including an empty chain). Attribute
@@ -80,23 +89,43 @@ impl CompiledChain {
     }
 
     /// First-match-wins term walk; the policy's default action decides
-    /// on fallthrough.
+    /// on fallthrough. [`TermAction::Continue`] terms are the one
+    /// exception to first-match-wins: a matched Continue applies its
+    /// modifications policy-locally and the walk keeps going; the
+    /// eventual Permit merges them (the deciding term's own
+    /// modifications winning scalar conflicts, mirroring chain-level
+    /// merge), while a Deny — matched term or default — discards them.
     fn evaluate_policy<'a>(
         &self,
         policy: &'a CompiledPolicy,
         ctx: &RouteContext<'_>,
     ) -> PolicyDecision<'a> {
+        let mut continued: Option<RouteModifications> = None;
         for term in &policy.terms {
             if self.eval_expr(&term.guard, ctx) {
-                return match &term.action {
-                    TermAction::Permit(mods) => PolicyDecision::Permit(Some(mods)),
-                    TermAction::Deny => PolicyDecision::Deny,
-                };
+                match &term.action {
+                    TermAction::Permit(mods) => {
+                        return match continued {
+                            Some(mut acc) => {
+                                acc.merge_from(mods.clone());
+                                PolicyDecision::PermitOwned(acc)
+                            }
+                            None => PolicyDecision::Permit(Some(mods)),
+                        };
+                    }
+                    TermAction::Deny => return PolicyDecision::Deny,
+                    TermAction::Continue(mods) => {
+                        continued
+                            .get_or_insert_with(RouteModifications::default)
+                            .merge_from(mods.clone());
+                    }
+                }
             }
         }
-        match policy.default_action {
-            PolicyAction::Permit => PolicyDecision::Permit(None),
-            PolicyAction::Deny => PolicyDecision::Deny,
+        match (policy.default_action, continued) {
+            (PolicyAction::Permit, Some(acc)) => PolicyDecision::PermitOwned(acc),
+            (PolicyAction::Permit, None) => PolicyDecision::Permit(None),
+            (PolicyAction::Deny, _) => PolicyDecision::Deny,
         }
     }
 

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -172,6 +172,18 @@ pub enum TermAction {
     /// Reject the route (terminates chain evaluation; contributes no
     /// modifications).
     Deny,
+    /// The guard matched: apply these modifications and continue to the
+    /// next term of the *same* policy (Junos-style modify-and-continue).
+    ///
+    /// This is the `.rpol` frontend's term-fallthrough carrier — a term
+    /// body that executes `set`/`add`/`remove` actions but ends without
+    /// an `accept`/`reject` verdict lowers to `Continue`. Continue
+    /// modifications accumulate policy-locally and are merged into the
+    /// policy's eventual `Permit` decision (its own modifications win
+    /// on scalar conflicts, matching chain merge semantics); a later
+    /// `Deny` discards them. The TOML frontend never emits this
+    /// variant.
+    Continue(RouteModifications),
 }
 
 /// One guarded action inside a [`CompiledPolicy`] — the compiled form
@@ -193,6 +205,9 @@ pub struct Term {
 pub enum PolicySource {
     /// Compiled from a TOML `PolicyStatement` chain.
     Toml,
+    /// Compiled from `.rpol` source (the language frontend,
+    /// [`crate::rpol`]).
+    Rpol,
 }
 
 /// One compiled policy: ordered terms with first-match-wins semantics

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -12,6 +12,7 @@ pub mod engine;
 
 pub mod compile;
 pub mod ir;
+pub mod rpol;
 pub mod sets;
 
 mod eval;

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -1,0 +1,505 @@
+//! The spanned `.rpol` AST — the parser's output, the typechecker's
+//! and lowerer's input.
+//!
+//! Every node that can appear in a diagnostic carries a [`Span`].
+//! Literals are already value-parsed (the parser validates ranges and
+//! address syntax so later passes never re-parse text).
+
+use std::net::IpAddr;
+
+use rustbgpd_wire::{LargeCommunity, Prefix};
+
+use crate::engine::CommunityMatch;
+
+use super::diag::{Span, Spanned};
+
+/// A parsed `.rpol` source file.
+#[derive(Debug, Default)]
+pub struct SourceFile {
+    /// `prefix-set` definitions.
+    pub prefix_sets: Vec<PrefixSetDef>,
+    /// `community-set` definitions.
+    pub community_sets: Vec<CommunitySetDef>,
+    /// `policy` definitions, in source order.
+    pub policies: Vec<PolicyDef>,
+    /// `test` blocks.
+    pub tests: Vec<TestDef>,
+}
+
+/// `prefix-set NAME { entries }`.
+#[derive(Debug)]
+pub struct PrefixSetDef {
+    /// Set name.
+    pub name: Spanned<String>,
+    /// Member prefixes with optional ge/le bounds.
+    pub entries: Vec<PrefixEntryAst>,
+}
+
+/// One prefix-set member: `10.0.0.0/8 ge 24 le 28`.
+#[derive(Debug)]
+pub struct PrefixEntryAst {
+    /// The member prefix.
+    pub prefix: Prefix,
+    /// Minimum candidate length (inclusive).
+    pub ge: Option<u8>,
+    /// Maximum candidate length (inclusive).
+    pub le: Option<u8>,
+}
+
+/// `community-set NAME { literals }`.
+#[derive(Debug)]
+pub struct CommunitySetDef {
+    /// Set name.
+    pub name: Spanned<String>,
+    /// Member community literals (standard / large / RT / RO mixed).
+    pub entries: Vec<Spanned<CommunityLit>>,
+}
+
+/// A community literal of any of the three kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommunityLit {
+    /// `65000:100` or a well-known name (`NO_EXPORT`, …) — RFC 1997.
+    Standard(u32),
+    /// `65000:1:2` / `LC:65000:1:2` — RFC 8092.
+    Large(LargeCommunity),
+    /// `RT:65001:100` / `RO:...` — RFC 4360 Route Target / Route Origin.
+    Ext {
+        /// True for Route Target (sub-type 0x02), false for Route
+        /// Origin (sub-type 0x03).
+        route_target: bool,
+        /// Global administrator (ASN, or an IPv4 address as u32).
+        global: u32,
+        /// Local administrator.
+        local: u32,
+        /// True when the global admin was written as a dotted-quad
+        /// IPv4 address (selects the type 0x01 wire encoding).
+        ipv4_admin: bool,
+    },
+}
+
+/// The community kind named by an action or fixture keyword
+/// (`community` / `large-community` / `ext-community`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommunityKind {
+    /// Standard (RFC 1997).
+    Standard,
+    /// Large (RFC 8092).
+    Large,
+    /// Extended (RFC 4360 RT/RO).
+    Ext,
+}
+
+impl CommunityLit {
+    /// The literal's kind.
+    #[must_use]
+    pub fn kind(self) -> CommunityKind {
+        match self {
+            CommunityLit::Standard(_) => CommunityKind::Standard,
+            CommunityLit::Large(_) => CommunityKind::Large,
+            CommunityLit::Ext { .. } => CommunityKind::Ext,
+        }
+    }
+
+    /// The equivalent match criterion (encoding-agnostic for RT/RO).
+    #[must_use]
+    pub fn to_match(self) -> CommunityMatch {
+        match self {
+            CommunityLit::Standard(value) => CommunityMatch::Standard { value },
+            CommunityLit::Large(lc) => CommunityMatch::LargeCommunity {
+                global_admin: lc.global_admin,
+                local_data1: lc.local_data1,
+                local_data2: lc.local_data2,
+            },
+            CommunityLit::Ext {
+                route_target: true,
+                global,
+                local,
+                ..
+            } => CommunityMatch::RouteTarget { global, local },
+            CommunityLit::Ext {
+                route_target: false,
+                global,
+                local,
+                ..
+            } => CommunityMatch::RouteOrigin { global, local },
+        }
+    }
+}
+
+/// `policy NAME(params) { terms }`.
+#[derive(Debug)]
+pub struct PolicyDef {
+    /// Policy name.
+    pub name: Spanned<String>,
+    /// Declared parameters (all `u32` in V1).
+    pub params: Vec<Spanned<String>>,
+    /// Named terms, in source order.
+    pub terms: Vec<TermDef>,
+}
+
+/// `term NAME { statements }`.
+#[derive(Debug)]
+pub struct TermDef {
+    /// Term name (carried into the IR for explain).
+    pub name: Spanned<String>,
+    /// Body statements, in source order.
+    pub stmts: Vec<Stmt>,
+}
+
+/// A term-body statement.
+#[derive(Debug)]
+pub enum Stmt {
+    /// `if <expr> { actions } [else { actions }]`.
+    If(IfStmt),
+    /// A bare action executed unconditionally.
+    Action(ActionStmt),
+}
+
+/// `if <cond> { then } [else { otherwise }]`. Bodies are flat action
+/// lists — V1 has no nested `if`.
+#[derive(Debug)]
+pub struct IfStmt {
+    /// The guard expression.
+    pub cond: Expr,
+    /// Actions when the guard matches.
+    pub then_actions: Vec<ActionStmt>,
+    /// Actions when it does not (optional `else`).
+    pub else_actions: Option<Vec<ActionStmt>>,
+    /// Span of the `if` keyword + condition.
+    pub span: Span,
+}
+
+/// A `u32`-valued argument position: literal or parameter reference.
+#[derive(Debug, Clone)]
+pub enum U32Arg {
+    /// Integer literal.
+    Lit(u32, Span),
+    /// Reference to a policy parameter (resolved by the typechecker,
+    /// substituted at instantiation).
+    Param(Spanned<String>),
+}
+
+impl U32Arg {
+    /// The argument's source span.
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            U32Arg::Lit(_, span) => *span,
+            U32Arg::Param(name) => name.span,
+        }
+    }
+}
+
+/// An action statement inside a term or `if` body.
+#[derive(Debug)]
+pub enum ActionStmt {
+    /// `accept` — terminal permit.
+    Accept(Span),
+    /// `reject` — terminal deny.
+    Reject(Span),
+    /// `set local-pref <u32>`.
+    SetLocalPref(U32Arg, Span),
+    /// `set med <u32>`.
+    SetMed(U32Arg, Span),
+    /// `set next-hop <ip|self>`.
+    SetNextHop(NextHopArg, Span),
+    /// `add`/`remove` `community`/`large-community`/`ext-community`.
+    Community {
+        /// True for `add`, false for `remove`.
+        add: bool,
+        /// The kind keyword written (must match the literal's kind).
+        kind: CommunityKind,
+        /// The community literal.
+        lit: Spanned<CommunityLit>,
+        /// Whole-statement span.
+        span: Span,
+    },
+    /// `prepend as <asn> <count>`.
+    Prepend {
+        /// ASN to prepend.
+        asn: U32Arg,
+        /// Number of copies (1–255, checked by the typechecker).
+        count: U32Arg,
+        /// Whole-statement span.
+        span: Span,
+    },
+}
+
+impl ActionStmt {
+    /// The action's source span.
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            ActionStmt::Accept(span)
+            | ActionStmt::Reject(span)
+            | ActionStmt::SetLocalPref(_, span)
+            | ActionStmt::SetMed(_, span)
+            | ActionStmt::SetNextHop(_, span)
+            | ActionStmt::Community { span, .. }
+            | ActionStmt::Prepend { span, .. } => *span,
+        }
+    }
+}
+
+/// `set next-hop` operand.
+#[derive(Debug)]
+pub enum NextHopArg {
+    /// `self` — rewrite to the local address.
+    Self_(Span),
+    /// A specific address.
+    Addr(IpAddr, Span),
+}
+
+/// The context object a field path starts from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldRoot {
+    /// `route.` — the route under evaluation.
+    Route,
+    /// `peer.` — the evaluation peer.
+    Peer,
+}
+
+/// A dotted field path: `route.local-pref`, `route.as-path.len`,
+/// `peer.asn`. Segments are contextual identifiers resolved by the
+/// typechecker.
+#[derive(Debug, Clone)]
+pub struct FieldPath {
+    /// `route` or `peer`.
+    pub root: FieldRoot,
+    /// Dotted segments after the root.
+    pub segs: Vec<Spanned<String>>,
+    /// Span of the whole path.
+    pub span: Span,
+}
+
+impl FieldPath {
+    /// The path rendered back to source form (`route.local-pref`).
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = match self.root {
+            FieldRoot::Route => String::from("route"),
+            FieldRoot::Peer => String::from("peer"),
+        };
+        for seg in &self.segs {
+            out.push('.');
+            out.push_str(&seg.node);
+        }
+        out
+    }
+}
+
+/// Comparison operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmpOp {
+    /// `==`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `>=`
+    Ge,
+    /// `<=`
+    Le,
+}
+
+/// A comparison right-hand side, resolved by the typechecker against
+/// the field's type.
+#[derive(Debug, Clone)]
+pub enum Rhs {
+    /// Integer literal.
+    Int(u32, Span),
+    /// Bare identifier: a policy parameter or an enum member
+    /// (`valid`, `internal`, …).
+    Ident(Spanned<String>),
+    /// IP address literal.
+    Ip(IpAddr, Span),
+    /// Prefix literal.
+    Prefix(Prefix, Span),
+    /// String literal (peer-group names).
+    Str(Spanned<String>),
+    /// Community literal (never valid in a comparison — accepted so
+    /// the typechecker can point at `has`/`in` instead).
+    Community(Spanned<CommunityLit>),
+}
+
+impl Rhs {
+    /// The operand's source span.
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Rhs::Int(_, span) | Rhs::Ip(_, span) | Rhs::Prefix(_, span) => *span,
+            Rhs::Ident(s) | Rhs::Str(s) => s.span,
+            Rhs::Community(lit) => lit.span,
+        }
+    }
+
+    /// Short description for type-mismatch diagnostics.
+    #[must_use]
+    pub fn describe(&self) -> &'static str {
+        match self {
+            Rhs::Int(..) => "integer",
+            Rhs::Ident(_) => "identifier",
+            Rhs::Ip(..) => "IP address",
+            Rhs::Prefix(..) => "prefix",
+            Rhs::Str(_) => "string",
+            Rhs::Community(_) => "community literal",
+        }
+    }
+}
+
+/// A boolean guard expression.
+#[derive(Debug)]
+pub enum Expr {
+    /// `a || b`
+    Or(Box<Expr>, Box<Expr>),
+    /// `a && b`
+    And(Box<Expr>, Box<Expr>),
+    /// `!a`
+    Not(Box<Expr>, Span),
+    /// `field <op> rhs`
+    Cmp {
+        /// Left-hand field.
+        field: FieldPath,
+        /// The operator.
+        op: CmpOp,
+        /// Right-hand operand.
+        rhs: Rhs,
+        /// Whole-comparison span.
+        span: Span,
+    },
+    /// `field in set-name`
+    In {
+        /// Left-hand field (`route.prefix` or a community list).
+        field: FieldPath,
+        /// The referenced set.
+        set: Spanned<String>,
+    },
+    /// `field has <community literal>`
+    Has {
+        /// Left-hand community-list field.
+        field: FieldPath,
+        /// The community literal to probe for.
+        lit: Spanned<CommunityLit>,
+    },
+    /// `route.as-path matches "regex"`
+    Matches {
+        /// Left-hand field (must be `route.as-path`).
+        field: FieldPath,
+        /// The Cisco-style regex pattern.
+        pattern: Spanned<String>,
+    },
+    /// `route.as-path contains <asn>`
+    Contains {
+        /// Left-hand field (must be `route.as-path`).
+        field: FieldPath,
+        /// The ASN to look for (boundary-anchored).
+        asn: U32Arg,
+    },
+    /// `apply(policy)` / `apply(policy(args))` — policy-as-predicate.
+    Apply {
+        /// The referenced policy.
+        policy: Spanned<String>,
+        /// Instantiation arguments.
+        args: Vec<U32Arg>,
+        /// Whole-call span.
+        span: Span,
+    },
+}
+
+impl Expr {
+    /// The expression's source span.
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Expr::Or(l, r) | Expr::And(l, r) => l.span().to(r.span()),
+            Expr::Not(_, span) | Expr::Cmp { span, .. } | Expr::Apply { span, .. } => *span,
+            Expr::In { field, set } => field.span.to(set.span),
+            Expr::Has { field, lit } => field.span.to(lit.span),
+            Expr::Matches { field, pattern } => field.span.to(pattern.span),
+            Expr::Contains { field, asn } => field.span.to(asn.span()),
+        }
+    }
+}
+
+/// `test NAME { route {...} [peer {...}] expect ... }`.
+#[derive(Debug)]
+pub struct TestDef {
+    /// Test name.
+    pub name: Spanned<String>,
+    /// The route fixture.
+    pub route: Vec<RouteField>,
+    /// Optional peer fixture.
+    pub peer: Vec<PeerField>,
+    /// Expectations, in order.
+    pub expects: Vec<ExpectDef>,
+}
+
+/// One field of a `route { ... }` fixture.
+#[derive(Debug)]
+pub enum RouteField {
+    /// `prefix 10.0.0.0/24`
+    Prefix(Prefix, Span),
+    /// `communities [65000:100, ...]` (standard).
+    Communities(Vec<Spanned<CommunityLit>>, Span),
+    /// `large-communities [...]`.
+    LargeCommunities(Vec<Spanned<CommunityLit>>, Span),
+    /// `ext-communities [...]`.
+    ExtCommunities(Vec<Spanned<CommunityLit>>, Span),
+    /// `as-path "65001 65002"`.
+    AsPath(Spanned<String>),
+    /// `next-hop 10.0.0.1`.
+    NextHop(IpAddr, Span),
+    /// `local-pref 200`.
+    LocalPref(u32, Span),
+    /// `med 50`.
+    Med(u32, Span),
+    /// `rpki valid|invalid|not-found`.
+    Rpki(Spanned<String>),
+    /// `aspa valid|invalid|unknown`.
+    Aspa(Spanned<String>),
+    /// `route-type local|internal|external`.
+    RouteType(Spanned<String>),
+    /// `evpn-route-type 2`.
+    EvpnRouteType(u32, Span),
+}
+
+/// One field of a `peer { ... }` fixture.
+#[derive(Debug)]
+pub enum PeerField {
+    /// `address 10.0.0.1`.
+    Address(IpAddr),
+    /// `asn 65001`.
+    Asn(u32),
+    /// `group "leaf"`.
+    Group(Spanned<String>),
+}
+
+/// `expect policy(args) == accept|reject [with assertions]`.
+#[derive(Debug)]
+pub struct ExpectDef {
+    /// The policy under test.
+    pub policy: Spanned<String>,
+    /// Instantiation arguments (literals only in `expect`).
+    pub args: Vec<Spanned<u32>>,
+    /// True for `accept`, false for `reject`.
+    pub accept: bool,
+    /// `with` attribute assertions.
+    pub with: Vec<WithAssertion>,
+    /// Whole-expect span.
+    pub span: Span,
+}
+
+/// One `with` assertion — checked against the evaluation result's
+/// modifications.
+#[derive(Debug)]
+pub enum WithAssertion {
+    /// `local-pref 200` — `set_local_pref == Some(200)`.
+    LocalPref(u32),
+    /// `med 50`.
+    Med(u32),
+    /// `next-hop 10.0.0.1` / `next-hop self`.
+    NextHop(NextHopArg),
+    /// `community 65001:999` (any kind) — present in the adds.
+    Community(Spanned<CommunityLit>),
+    /// `prepend as 65001 3`.
+    Prepend(u32, u32),
+}

--- a/crates/policy/src/rpol/diag.rs
+++ b/crates/policy/src/rpol/diag.rs
@@ -1,0 +1,224 @@
+//! Diagnostics for the `.rpol` frontend: labeled source spans rendered
+//! through `ariadne`.
+//!
+//! Every parse and type error carries at least one span+label pair into
+//! the original source; [`Diagnostics::render`] produces the familiar
+//! excerpt-with-underline report. Rendering is colorless by default so
+//! output is byte-stable in tests; the CLI opts into color when stderr
+//! is a terminal.
+
+use std::fmt;
+use std::ops::Range;
+
+/// A byte range into the source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// Byte offset of the first character.
+    pub start: usize,
+    /// Byte offset one past the last character.
+    pub end: usize,
+}
+
+impl Span {
+    /// Construct a span from a byte range.
+    #[must_use]
+    pub fn new(range: Range<usize>) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+
+    /// The smallest span covering both `self` and `other`.
+    #[must_use]
+    pub fn to(self, other: Span) -> Span {
+        Span {
+            start: self.start.min(other.start),
+            end: self.end.max(other.end),
+        }
+    }
+
+    /// The span as a byte range.
+    #[must_use]
+    pub fn range(self) -> Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// A value paired with its source span.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spanned<T> {
+    /// The value.
+    pub node: T,
+    /// Where it came from in the source.
+    pub span: Span,
+}
+
+impl<T> Spanned<T> {
+    /// Pair a value with its span.
+    pub fn new(node: T, span: Span) -> Self {
+        Self { node, span }
+    }
+}
+
+/// One compile error: a message, labeled source spans (the first is
+/// primary), and free-form notes (used for did-you-mean suggestions).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// Top-line error message.
+    pub message: String,
+    /// Labeled spans; the first is the primary location.
+    pub labels: Vec<(Span, String)>,
+    /// Trailing notes (suggestions, semantics reminders).
+    pub notes: Vec<String>,
+}
+
+impl Diagnostic {
+    /// A diagnostic with one primary label.
+    #[must_use]
+    pub fn new(span: Span, message: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            labels: vec![(span, label.into())],
+            notes: Vec::new(),
+        }
+    }
+
+    /// Attach a secondary labeled span.
+    #[must_use]
+    pub fn with_label(mut self, span: Span, label: impl Into<String>) -> Self {
+        self.labels.push((span, label.into()));
+        self
+    }
+
+    /// Attach a note.
+    #[must_use]
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+}
+
+/// The accumulated diagnostics of one compile.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Diagnostics(pub Vec<Diagnostic>);
+
+impl Diagnostics {
+    /// True when no diagnostics were produced.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of diagnostics.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Render every diagnostic as an ariadne report against `source`,
+    /// attributed to `filename`. `color` enables ANSI styling.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: writing to an in-memory buffer is infallible.
+    #[must_use]
+    pub fn render(&self, filename: &str, source: &str, color: bool) -> String {
+        use ariadne::{Config, Label, Report, ReportKind};
+
+        let mut out = Vec::new();
+        for diag in &self.0 {
+            let primary = diag.labels.first().map_or(0..0, |(span, _)| span.range());
+            let mut report = Report::build(ReportKind::Error, (filename.to_string(), primary))
+                .with_config(Config::default().with_color(color))
+                .with_message(&diag.message);
+            for (index, (span, label)) in diag.labels.iter().enumerate() {
+                report = report.with_label(
+                    Label::new((filename.to_string(), span.range()))
+                        .with_message(label)
+                        .with_order(i32::try_from(index).unwrap_or(i32::MAX)),
+                );
+            }
+            for note in &diag.notes {
+                report = report.with_note(note);
+            }
+            report
+                .finish()
+                .write(
+                    ariadne::sources([(filename.to_string(), source.to_string())]),
+                    &mut out,
+                )
+                .expect("writing a diagnostic to an in-memory buffer cannot fail");
+        }
+        String::from_utf8_lossy(&out).into_owned()
+    }
+}
+
+impl fmt::Display for Diagnostics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for diag in &self.0 {
+            writeln!(f, "error: {}", diag.message)?;
+        }
+        Ok(())
+    }
+}
+
+/// Levenshtein edit distance, used for did-you-mean suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut row: Vec<usize> = (0..=b_chars.len()).collect();
+    for (i, ca) in a.chars().enumerate() {
+        let mut prev = row[0];
+        row[0] = i + 1;
+        for (j, &cb) in b_chars.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            let next = (prev + cost).min(row[j] + 1).min(row[j + 1] + 1);
+            prev = row[j + 1];
+            row[j + 1] = next;
+        }
+    }
+    *row.last().expect("row is never empty")
+}
+
+/// The closest candidate to `name` within a small edit distance, for
+/// "did you mean" notes. Candidates further than 1/3 of the name's
+/// length (minimum 2) away are not suggested.
+pub(crate) fn closest<'a>(
+    name: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let budget = (name.len() / 3).max(2);
+    candidates
+        .into_iter()
+        .map(|candidate| (edit_distance(name, candidate), candidate))
+        .filter(|&(distance, _)| distance <= budget)
+        .min_by_key(|&(distance, _)| distance)
+        .map(|(_, candidate)| candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closest_suggests_within_budget() {
+        assert_eq!(
+            closest("custmers", ["customers", "bogons"]),
+            Some("customers")
+        );
+        assert_eq!(closest("zzz", ["customers", "bogons"]), None);
+    }
+
+    #[test]
+    fn render_contains_label_text() {
+        let diags = Diagnostics(vec![
+            Diagnostic::new(Span::new(4..9), "unknown thing", "not defined")
+                .with_note("did you mean `known`?"),
+        ]);
+        let out = diags.render("test.rpol", "abc known", false);
+        assert!(out.contains("unknown thing"), "{out}");
+        assert!(out.contains("not defined"), "{out}");
+        assert!(out.contains("did you mean `known`?"), "{out}");
+        assert!(out.contains("test.rpol"), "{out}");
+    }
+}

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -1,0 +1,356 @@
+//! The `.rpol` lexer (`logos`-generated), producing spanned tokens.
+//!
+//! Design notes (documented in `docs/rpol-language.md`):
+//!
+//! - Structural words are reserved keywords; attribute/field names
+//!   (`local-pref`, `communities`, …) and enum members (`valid`,
+//!   `internal`, …) are *contextual* identifiers matched by the parser.
+//! - Identifiers are kebab-case: `[A-Za-z_][A-Za-z0-9_]*(-[part])*`.
+//!   There is no arithmetic in the language, so `-` inside a name is
+//!   unambiguous.
+//! - Community, prefix, and IP literals are single tokens resolved by
+//!   maximal munch: `10.0.0.0/8` is one prefix token, `65000:100` one
+//!   standard-community token, `65000:1:2` one large-community token,
+//!   `RT:65001:100` / `RO:...` extended-community tokens (`LC:` is an
+//!   accepted large-community spelling for parity with the TOML
+//!   frontend). IPv6 literals must use the compressed `::` form
+//!   (all-numeric full-form IPv6 would be ambiguous with community
+//!   literals).
+
+use logos::Logos;
+
+use super::diag::{Diagnostic, Span};
+
+/// One `.rpol` token kind. Text is recovered by slicing the source
+/// with the token's span.
+#[derive(Logos, Debug, Clone, Copy, PartialEq, Eq)]
+#[logos(skip r"[ \t\r\n\f]+")]
+#[logos(skip(r"#[^\n]*", allow_greedy = true))]
+pub enum Tok {
+    // ── literals (order/priority matters — see module docs) ────────
+    /// `RT:65001:100`, `RO:192.0.2.1:5` — extended-community literal.
+    #[regex(r"(RT|RO):([0-9]+|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):[0-9]+")]
+    ExtCommunityLit,
+    /// `65000:1:2` or `LC:65000:1:2` — large-community literal.
+    #[regex(r"(LC:)?[0-9]+:[0-9]+:[0-9]+")]
+    LargeCommunityLit,
+    /// `65000:100` — standard-community literal.
+    #[regex(r"[0-9]+:[0-9]+")]
+    StdCommunityLit,
+    /// `10.0.0.0/8`, `2001:db8::/32` — prefix literal.
+    #[regex(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+")]
+    #[regex(r"[0-9A-Fa-f:]*::[0-9A-Fa-f:.]*/[0-9]+")]
+    #[regex(r"([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}/[0-9]+")]
+    PrefixLit,
+    /// `192.0.2.1` — IPv4 address literal.
+    #[regex(r"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")]
+    Ipv4Lit,
+    /// `2001:db8::1`, `::1` — IPv6 address literal (compressed form).
+    #[regex(r"[0-9A-Fa-f:]*::[0-9A-Fa-f:.]*")]
+    #[regex(r"([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}")]
+    Ipv6Lit,
+    /// Unsigned integer literal.
+    #[regex(r"[0-9]+")]
+    Int,
+    /// Double-quoted string (AS-path regexes, peer-group names).
+    #[regex(r#""([^"\\]|\\.)*""#)]
+    Str,
+
+    // ── keywords ────────────────────────────────────────────────────
+    /// `prefix-set`
+    #[token("prefix-set")]
+    PrefixSetKw,
+    /// `community-set`
+    #[token("community-set")]
+    CommunitySetKw,
+    /// `policy`
+    #[token("policy")]
+    PolicyKw,
+    /// `term`
+    #[token("term")]
+    TermKw,
+    /// `test`
+    #[token("test")]
+    TestKw,
+    /// `if`
+    #[token("if")]
+    IfKw,
+    /// `else`
+    #[token("else")]
+    ElseKw,
+    /// `set`
+    #[token("set")]
+    SetKw,
+    /// `add`
+    #[token("add")]
+    AddKw,
+    /// `remove`
+    #[token("remove")]
+    RemoveKw,
+    /// `prepend`
+    #[token("prepend")]
+    PrependKw,
+    /// `accept`
+    #[token("accept")]
+    AcceptKw,
+    /// `reject`
+    #[token("reject")]
+    RejectKw,
+    /// `apply`
+    #[token("apply")]
+    ApplyKw,
+    /// `in`
+    #[token("in")]
+    InKw,
+    /// `has`
+    #[token("has")]
+    HasKw,
+    /// `matches`
+    #[token("matches")]
+    MatchesKw,
+    /// `contains`
+    #[token("contains")]
+    ContainsKw,
+    /// `ge`
+    #[token("ge")]
+    GeKw,
+    /// `le`
+    #[token("le")]
+    LeKw,
+    /// `route`
+    #[token("route")]
+    RouteKw,
+    /// `peer`
+    #[token("peer")]
+    PeerKw,
+    /// `expect`
+    #[token("expect")]
+    ExpectKw,
+    /// `with`
+    #[token("with")]
+    WithKw,
+    /// `as`
+    #[token("as")]
+    AsKw,
+    /// `self`
+    #[token("self")]
+    SelfKw,
+    /// `u32`
+    #[token("u32")]
+    U32Kw,
+
+    // ── identifiers ─────────────────────────────────────────────────
+    /// Kebab-case identifier: set / policy / term / field / enum names.
+    #[regex(r"[A-Za-z_][A-Za-z0-9_]*(-[A-Za-z0-9_]+)*")]
+    Ident,
+
+    // ── punctuation / operators ─────────────────────────────────────
+    /// `{`
+    #[token("{")]
+    LBrace,
+    /// `}`
+    #[token("}")]
+    RBrace,
+    /// `(`
+    #[token("(")]
+    LParen,
+    /// `)`
+    #[token(")")]
+    RParen,
+    /// `[`
+    #[token("[")]
+    LBracket,
+    /// `]`
+    #[token("]")]
+    RBracket,
+    /// `,`
+    #[token(",")]
+    Comma,
+    /// `;`
+    #[token(";")]
+    Semi,
+    /// `.`
+    #[token(".")]
+    Dot,
+    /// `:`
+    #[token(":")]
+    Colon,
+    /// `==`
+    #[token("==")]
+    EqEq,
+    /// `!=`
+    #[token("!=")]
+    NotEq,
+    /// `>=`
+    #[token(">=")]
+    GtEq,
+    /// `<=`
+    #[token("<=")]
+    LtEq,
+    /// `&&`
+    #[token("&&")]
+    AndAnd,
+    /// `||`
+    #[token("||")]
+    OrOr,
+    /// `!`
+    #[token("!")]
+    Bang,
+}
+
+impl Tok {
+    /// Human-readable token description for error messages.
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Tok::ExtCommunityLit => "extended-community literal",
+            Tok::LargeCommunityLit => "large-community literal",
+            Tok::StdCommunityLit => "community literal",
+            Tok::PrefixLit => "prefix literal",
+            Tok::Ipv4Lit | Tok::Ipv6Lit => "IP address literal",
+            Tok::Int => "integer",
+            Tok::Str => "string",
+            Tok::PrefixSetKw => "`prefix-set`",
+            Tok::CommunitySetKw => "`community-set`",
+            Tok::PolicyKw => "`policy`",
+            Tok::TermKw => "`term`",
+            Tok::TestKw => "`test`",
+            Tok::IfKw => "`if`",
+            Tok::ElseKw => "`else`",
+            Tok::SetKw => "`set`",
+            Tok::AddKw => "`add`",
+            Tok::RemoveKw => "`remove`",
+            Tok::PrependKw => "`prepend`",
+            Tok::AcceptKw => "`accept`",
+            Tok::RejectKw => "`reject`",
+            Tok::ApplyKw => "`apply`",
+            Tok::InKw => "`in`",
+            Tok::HasKw => "`has`",
+            Tok::MatchesKw => "`matches`",
+            Tok::ContainsKw => "`contains`",
+            Tok::GeKw => "`ge`",
+            Tok::LeKw => "`le`",
+            Tok::RouteKw => "`route`",
+            Tok::PeerKw => "`peer`",
+            Tok::ExpectKw => "`expect`",
+            Tok::WithKw => "`with`",
+            Tok::AsKw => "`as`",
+            Tok::SelfKw => "`self`",
+            Tok::U32Kw => "`u32`",
+            Tok::Ident => "identifier",
+            Tok::LBrace => "`{`",
+            Tok::RBrace => "`}`",
+            Tok::LParen => "`(`",
+            Tok::RParen => "`)`",
+            Tok::LBracket => "`[`",
+            Tok::RBracket => "`]`",
+            Tok::Comma => "`,`",
+            Tok::Semi => "`;`",
+            Tok::Dot => "`.`",
+            Tok::Colon => "`:`",
+            Tok::EqEq => "`==`",
+            Tok::NotEq => "`!=`",
+            Tok::GtEq => "`>=`",
+            Tok::LtEq => "`<=`",
+            Tok::AndAnd => "`&&`",
+            Tok::OrOr => "`||`",
+            Tok::Bang => "`!`",
+        }
+    }
+}
+
+/// A token with its source span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Token {
+    /// The token kind.
+    pub kind: Tok,
+    /// Its byte range in the source.
+    pub span: Span,
+}
+
+/// Lex the entire source. Unrecognized characters become diagnostics
+/// (one per contiguous bad region) and lexing continues, so the parser
+/// still sees — and can report on — the rest of the file.
+#[must_use]
+pub fn lex(source: &str) -> (Vec<Token>, Vec<Diagnostic>) {
+    let mut tokens = Vec::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    for (result, range) in Tok::lexer(source).spanned() {
+        let span = Span::new(range);
+        let Ok(kind) = result else {
+            // Coalesce adjacent error characters into one diagnostic.
+            if let Some(last) = diagnostics.last_mut()
+                && let Some((last_span, _)) = last.labels.first_mut()
+                && last_span.end == span.start
+            {
+                last_span.end = span.end;
+                continue;
+            }
+            diagnostics.push(Diagnostic::new(
+                span,
+                format!("unrecognized token `{}`", &source[span.range()]),
+                "not a valid `.rpol` token",
+            ));
+            continue;
+        };
+        tokens.push(Token { kind, span });
+    }
+    (tokens, diagnostics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<Tok> {
+        let (tokens, diags) = lex(src);
+        assert!(diags.is_empty(), "unexpected lex errors: {diags:?}");
+        tokens.into_iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn literals_use_maximal_munch() {
+        assert_eq!(kinds("10.10.0.0/16"), vec![Tok::PrefixLit]);
+        assert_eq!(kinds("10.10.0.1"), vec![Tok::Ipv4Lit]);
+        assert_eq!(kinds("2001:db8::/32"), vec![Tok::PrefixLit]);
+        assert_eq!(kinds("2001:db8::1"), vec![Tok::Ipv6Lit]);
+        assert_eq!(kinds("65000:100"), vec![Tok::StdCommunityLit]);
+        assert_eq!(kinds("65000:1:2"), vec![Tok::LargeCommunityLit]);
+        assert_eq!(kinds("LC:65000:1:2"), vec![Tok::LargeCommunityLit]);
+        assert_eq!(kinds("RT:65001:100"), vec![Tok::ExtCommunityLit]);
+        assert_eq!(kinds("RO:192.0.2.1:5"), vec![Tok::ExtCommunityLit]);
+        assert_eq!(kinds("42"), vec![Tok::Int]);
+    }
+
+    #[test]
+    fn keywords_vs_kebab_identifiers() {
+        assert_eq!(kinds("prefix-set"), vec![Tok::PrefixSetKw]);
+        assert_eq!(kinds("prefix-sets"), vec![Tok::Ident]);
+        assert_eq!(kinds("customer-in"), vec![Tok::Ident]);
+        assert_eq!(kinds("local-pref"), vec![Tok::Ident]);
+        assert_eq!(
+            kinds("route.rpki == invalid"),
+            vec![Tok::RouteKw, Tok::Dot, Tok::Ident, Tok::EqEq, Tok::Ident]
+        );
+    }
+
+    #[test]
+    fn comments_and_strings() {
+        assert_eq!(
+            kinds("accept # trailing comment\nreject"),
+            vec![Tok::AcceptKw, Tok::RejectKw]
+        );
+        assert_eq!(kinds(r#""_65001_""#), vec![Tok::Str]);
+    }
+
+    #[test]
+    fn unrecognized_tokens_are_reported_and_skipped() {
+        let (tokens, diags) = lex("policy @@ demo");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("unrecognized token"));
+        assert_eq!(
+            tokens.iter().map(|t| t.kind).collect::<Vec<_>>(),
+            vec![Tok::PolicyKw, Tok::Ident]
+        );
+    }
+}

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -1,0 +1,607 @@
+//! AST → IR lowering for `.rpol` (runs only on a typechecked AST).
+//!
+//! ## Term-fallthrough encoding
+//!
+//! `.rpol` terms are statement sequences; the IR's `Term` is a single
+//! `(guard, action)` pair with first-match-wins policy semantics. Each
+//! `.rpol` term therefore lowers to **one or more IR terms**:
+//!
+//! - Every `if` becomes its own IR term (guard = condition); an `else`
+//!   becomes a following IR term guarded by the negated condition.
+//! - A run of bare modification actions flushes as an unconditional
+//!   [`TermAction::Continue`] term before the next `if` (and at term
+//!   end), preserving execution order.
+//! - A body that ends in `accept` lowers to `TermAction::Permit` with
+//!   the body's modifications; `reject` lowers to `Deny` (its body
+//!   modifications are dropped — a denied route has no attributes to
+//!   modify); a body with no verdict lowers to `Continue` — matched
+//!   modifications apply and evaluation falls through to the next term.
+//! - When a `.rpol` term produces multiple IR terms they are named
+//!   `<term>.<n>` (1-based); a single IR term keeps the plain term
+//!   name. Explain surfaces (PR-4) render these names.
+//!
+//! End of policy without a verdict is `default_action: Permit` — the
+//! policy raises no objection and chain evaluation continues, matching
+//! `GoBGP` chain semantics (an empty chain permits).
+//!
+//! ## Parameters
+//!
+//! Parameterized policies are templates; every use site
+//! (`apply(p(42))`, `expect p(42)`, a PR-3 chain reference) is
+//! **monomorphized**: the template is lowered with a
+//! parameter→constant substitution. Policies are small, so
+//! clone-with-substitution costs microseconds at compile time and the
+//! evaluator stays constant-only.
+//!
+//! ## `apply` as a predicate
+//!
+//! `apply(p)` inlines the *decision* of `p` as a pure boolean guard:
+//! "would `p` permit this route?". Actions of the applied policy do
+//! NOT execute (unlike a Junos subroutine call) — it is a predicate,
+//! not a call. The inlining is first-match-faithful:
+//! `Or(over permit-terms i: guard_i && !guard_1..i-1) || (default
+//! Permit && no guard matched)`; `Continue` terms don't decide and are
+//! skipped. Quadratic in the applied policy's term count — fine for
+//! human-written policies, and the DAG check bounds the depth.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rustbgpd_wire::ExtendedCommunity;
+
+use crate::engine::{
+    AsPathRegex, CommunityMatch, NeighborSetMatch, NextHopAction, PolicyAction, RouteModifications,
+};
+use crate::ir::{
+    Cmp, CompiledChain, CompiledPolicy, MatchExpr, PolicySource, RegexId, SetId, Term, TermAction,
+};
+use crate::sets::{CommunitySet, PrefixSet, PrefixSetEntry, SetStore};
+
+use super::ast::{
+    ActionStmt, CmpOp, CommunityLit, Expr, NextHopArg, PolicyDef, Rhs, SourceFile, Stmt, U32Arg,
+};
+use super::typeck::{Field, resolve_field};
+
+/// Encode a community literal's concrete wire value (for
+/// `add`/`remove` actions and test assertions). RT/RO literals pick
+/// the RFC 4360 type from the global admin's shape, matching the
+/// daemon's other frontends: dotted-quad admin → type 0x01
+/// (IPv4-address specific), ASN > 65535 → type 0x02 (4-octet AS),
+/// otherwise type 0x00 (2-octet AS).
+pub(super) fn ext_community_value(
+    route_target: bool,
+    global: u32,
+    local: u32,
+    ipv4_admin: bool,
+) -> ExtendedCommunity {
+    let subtype: u8 = if route_target { 0x02 } else { 0x03 };
+    let raw = if ipv4_admin || global > u32::from(u16::MAX) {
+        let type_byte: u8 = if ipv4_admin { 0x01 } else { 0x02 };
+        let g = global.to_be_bytes();
+        let l = u16::try_from(local)
+            .expect("checked at parse time")
+            .to_be_bytes();
+        u64::from_be_bytes([type_byte, subtype, g[0], g[1], g[2], g[3], l[0], l[1]])
+    } else {
+        let g = u16::try_from(global)
+            .expect("2-octet form checked above")
+            .to_be_bytes();
+        let l = local.to_be_bytes();
+        u64::from_be_bytes([0x00, subtype, g[0], g[1], l[0], l[1], l[2], l[3]])
+    };
+    ExtendedCommunity::new(raw)
+}
+
+/// The lowering context: interned set tables shared by every policy
+/// (and test instantiation) compiled from one source file.
+pub(super) struct Lowerer<'a> {
+    file: &'a SourceFile,
+    prefix_sets: Vec<Arc<PrefixSet>>,
+    community_sets: Vec<Arc<CommunitySet>>,
+    as_path_regexes: Vec<Arc<AsPathRegex>>,
+    prefix_set_ids: HashMap<String, SetId>,
+    community_set_ids: HashMap<String, SetId>,
+    regex_ids: HashMap<String, RegexId>,
+}
+
+impl<'a> Lowerer<'a> {
+    /// Intern every defined set through `store` and build the chain
+    /// tables. Must only be called on a typechecked AST.
+    pub(super) fn new(file: &'a SourceFile, store: &mut SetStore) -> Self {
+        let mut lowerer = Self {
+            file,
+            prefix_sets: Vec::new(),
+            community_sets: Vec::new(),
+            as_path_regexes: Vec::new(),
+            prefix_set_ids: HashMap::new(),
+            community_set_ids: HashMap::new(),
+            regex_ids: HashMap::new(),
+        };
+        for def in &file.prefix_sets {
+            let entries: Vec<PrefixSetEntry> = def
+                .entries
+                .iter()
+                .map(|entry| PrefixSetEntry {
+                    prefix: entry.prefix,
+                    ge: entry.ge,
+                    le: entry.le,
+                })
+                .collect();
+            let set = store.prefix_set(&entries);
+            let id = SetId(u32::try_from(lowerer.prefix_sets.len()).expect("fits u32"));
+            lowerer.prefix_sets.push(set);
+            lowerer.prefix_set_ids.insert(def.name.node.clone(), id);
+        }
+        for def in &file.community_sets {
+            let criteria: Vec<CommunityMatch> =
+                def.entries.iter().map(|lit| lit.node.to_match()).collect();
+            let set = store.community_set(&criteria);
+            let id = SetId(u32::try_from(lowerer.community_sets.len()).expect("fits u32"));
+            lowerer.community_sets.push(set);
+            lowerer.community_set_ids.insert(def.name.node.clone(), id);
+        }
+        // Regexes are interned lazily at each use site (they can be
+        // parameter-dependent via `contains <param>`); `store` is
+        // borrowed per call instead of held in `self` because test-run
+        // instantiation happens after the main chain is built.
+        lowerer
+    }
+
+    /// A chain of every zero-parameter policy, in source order, with
+    /// the current set tables. Parameterized policies are templates —
+    /// they compile where instantiated (`apply`, tests, PR-3 chains).
+    pub(super) fn zero_param_chain(&mut self, store: &mut SetStore) -> CompiledChain {
+        let policies: Vec<CompiledPolicy> = self
+            .file
+            .policies
+            .iter()
+            .filter(|def| def.params.is_empty())
+            .map(|def| self.lower_policy(def, &[], store))
+            .collect();
+        CompiledChain {
+            policies,
+            prefix_sets: self.prefix_sets.clone(),
+            community_sets: self.community_sets.clone(),
+            as_path_regexes: self.as_path_regexes.clone(),
+        }
+    }
+
+    /// Monomorphize one policy with concrete arguments into a chain of
+    /// its own (used by the in-language test runner).
+    pub(super) fn instantiate_chain(
+        &mut self,
+        name: &str,
+        args: &[u32],
+        store: &mut SetStore,
+    ) -> CompiledChain {
+        let def = self
+            .file
+            .policies
+            .iter()
+            .find(|p| p.name.node == name)
+            .expect("typechecked: policy exists");
+        let policy = self.lower_policy(def, args, store);
+        CompiledChain {
+            policies: vec![policy],
+            prefix_sets: self.prefix_sets.clone(),
+            community_sets: self.community_sets.clone(),
+            as_path_regexes: self.as_path_regexes.clone(),
+        }
+    }
+
+    fn lower_policy(
+        &mut self,
+        def: &PolicyDef,
+        args: &[u32],
+        store: &mut SetStore,
+    ) -> CompiledPolicy {
+        debug_assert_eq!(def.params.len(), args.len(), "typechecked arity");
+        let env: HashMap<&str, u32> = def
+            .params
+            .iter()
+            .map(|p| p.node.as_str())
+            .zip(args.iter().copied())
+            .collect();
+        let mut terms = Vec::new();
+        for term_def in &def.terms {
+            let lowered = self.lower_term(term_def, &env, store);
+            let multi = lowered.len() > 1;
+            for (index, (guard, action)) in lowered.into_iter().enumerate() {
+                let name = if multi {
+                    format!("{}.{}", term_def.name.node, index + 1)
+                } else {
+                    term_def.name.node.clone()
+                };
+                terms.push(Term {
+                    name: Some(name),
+                    guard,
+                    action,
+                });
+            }
+        }
+        CompiledPolicy {
+            name: Some(def.name.node.clone()),
+            terms,
+            default_action: PolicyAction::Permit,
+            source: PolicySource::Rpol,
+        }
+    }
+
+    /// Lower one `.rpol` term to its IR terms (see module docs for the
+    /// fallthrough encoding).
+    fn lower_term(
+        &mut self,
+        term: &super::ast::TermDef,
+        env: &HashMap<&str, u32>,
+        store: &mut SetStore,
+    ) -> Vec<(MatchExpr, TermAction)> {
+        let mut out: Vec<(MatchExpr, TermAction)> = Vec::new();
+        let mut pending = RouteModifications::default();
+        for stmt in &term.stmts {
+            match stmt {
+                Stmt::Action(ActionStmt::Accept(_)) => {
+                    out.push((
+                        MatchExpr::True,
+                        TermAction::Permit(std::mem::take(&mut pending)),
+                    ));
+                    return out;
+                }
+                Stmt::Action(ActionStmt::Reject(_)) => {
+                    out.push((MatchExpr::True, TermAction::Deny));
+                    return out;
+                }
+                Stmt::Action(action) => {
+                    apply_action(&mut pending, action, env);
+                }
+                Stmt::If(if_stmt) => {
+                    if !pending.is_empty() {
+                        out.push((
+                            MatchExpr::True,
+                            TermAction::Continue(std::mem::take(&mut pending)),
+                        ));
+                    }
+                    let guard = self.lower_expr(&if_stmt.cond, env, store);
+                    let then_arm = lower_body(&if_stmt.then_actions, env);
+                    let needs_else_guard = if_stmt.else_actions.is_some();
+                    if let Some(action) = then_arm {
+                        out.push((guard.clone(), action));
+                    } else if needs_else_guard {
+                        // An empty/no-op then-branch still gates the else.
+                        out.push((
+                            guard.clone(),
+                            TermAction::Continue(RouteModifications::default()),
+                        ));
+                    }
+                    if let Some(action) = if_stmt
+                        .else_actions
+                        .as_ref()
+                        .and_then(|actions| lower_body(actions, env))
+                    {
+                        out.push((MatchExpr::Not(Box::new(guard)), action));
+                    }
+                }
+            }
+        }
+        if !pending.is_empty() {
+            out.push((MatchExpr::True, TermAction::Continue(pending)));
+        }
+        out
+    }
+
+    fn lower_expr(
+        &mut self,
+        expr: &Expr,
+        env: &HashMap<&str, u32>,
+        store: &mut SetStore,
+    ) -> MatchExpr {
+        match expr {
+            Expr::And(lhs, rhs) => {
+                let mut children = vec![
+                    self.lower_expr(lhs, env, store),
+                    self.lower_expr(rhs, env, store),
+                ];
+                // Guards are pure; order And-children cheapest-first
+                // (the IR invariant shared with the TOML compiler).
+                children.sort_by_key(MatchExpr::cost_class);
+                MatchExpr::And(children)
+            }
+            Expr::Or(lhs, rhs) => MatchExpr::Or(vec![
+                self.lower_expr(lhs, env, store),
+                self.lower_expr(rhs, env, store),
+            ]),
+            Expr::Not(inner, _) => MatchExpr::Not(Box::new(self.lower_expr(inner, env, store))),
+            Expr::Cmp { field, op, rhs, .. } => lower_cmp(field, *op, rhs, env),
+            Expr::In { field, set } => match resolve_field(field).expect("typechecked") {
+                Field::Prefix => MatchExpr::PrefixInSet(self.prefix_set_ids[&set.node]),
+                _ => MatchExpr::CommunityInSet(self.community_set_ids[&set.node]),
+            },
+            Expr::Has { lit, .. } => MatchExpr::CommunityContains(lit.node.to_match()),
+            Expr::Matches { pattern, .. } => {
+                MatchExpr::AsPathMatches(self.intern_regex(&pattern.node, store))
+            }
+            Expr::Contains { asn, .. } => {
+                let asn = resolve_u32(asn, env);
+                MatchExpr::AsPathMatches(self.intern_regex(&format!("_{asn}_"), store))
+            }
+            Expr::Apply { policy, args, .. } => {
+                let args: Vec<u32> = args.iter().map(|arg| resolve_u32(arg, env)).collect();
+                let def = self
+                    .file
+                    .policies
+                    .iter()
+                    .find(|p| p.name.node == policy.node)
+                    .expect("typechecked: apply target exists");
+                let inlined = self.lower_policy(def, &args, store);
+                accept_predicate(&inlined)
+            }
+        }
+    }
+
+    fn intern_regex(&mut self, pattern: &str, store: &mut SetStore) -> RegexId {
+        if let Some(&id) = self.regex_ids.get(pattern) {
+            return id;
+        }
+        let regex = AsPathRegex::new(pattern).expect("typechecked: regex compiles");
+        let interned = store.as_path_regex(&regex);
+        let id = RegexId(u32::try_from(self.as_path_regexes.len()).expect("fits u32"));
+        self.as_path_regexes.push(interned);
+        self.regex_ids.insert(pattern.to_string(), id);
+        id
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn lower_cmp(
+    field: &super::ast::FieldPath,
+    op: CmpOp,
+    rhs: &Rhs,
+    env: &HashMap<&str, u32>,
+) -> MatchExpr {
+    let resolved = resolve_field(field).expect("typechecked");
+    match resolved {
+        Field::LocalPref => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::LocalPref),
+        Field::Med => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::Med),
+        Field::AsPathLen => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::AsPathLen),
+        Field::EvpnRouteType => {
+            let Rhs::Int(value, _) = rhs else {
+                unreachable!("typechecked: evpn-route-type takes an integer literal")
+            };
+            let node = MatchExpr::EvpnRouteTypeIs(u8::try_from(*value).expect("typechecked range"));
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::Rpki => {
+            let node = MatchExpr::RpkiIs(match rhs_ident(rhs) {
+                "valid" => rustbgpd_wire::RpkiValidation::Valid,
+                "invalid" => rustbgpd_wire::RpkiValidation::Invalid,
+                _ => rustbgpd_wire::RpkiValidation::NotFound,
+            });
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::Aspa => {
+            let node = MatchExpr::AspaIs(match rhs_ident(rhs) {
+                "valid" => rustbgpd_wire::AspaValidation::Valid,
+                "invalid" => rustbgpd_wire::AspaValidation::Invalid,
+                _ => rustbgpd_wire::AspaValidation::Unknown,
+            });
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::RouteType => {
+            let node = MatchExpr::RouteTypeIs(match rhs_ident(rhs) {
+                "local" => crate::engine::RouteType::Local,
+                "internal" => crate::engine::RouteType::Internal,
+                _ => crate::engine::RouteType::External,
+            });
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::NextHop => {
+            let Rhs::Ip(addr, _) = rhs else {
+                unreachable!("typechecked: next-hop compares an IP")
+            };
+            negate_if(op == CmpOp::Ne, MatchExpr::NextHopEq(*addr))
+        }
+        Field::PeerAddress => {
+            let Rhs::Ip(addr, _) = rhs else {
+                unreachable!("typechecked: peer.address compares an IP")
+            };
+            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                addresses: vec![*addr],
+                ..NeighborSetMatch::default()
+            }));
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::PeerAsn => {
+            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                remote_asns: vec![rhs_u32(rhs, env)],
+                ..NeighborSetMatch::default()
+            }));
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::PeerGroup => {
+            let Rhs::Str(group) = rhs else {
+                unreachable!("typechecked: peer.group compares a string")
+            };
+            let node = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                peer_groups: vec![group.node.clone()],
+                ..NeighborSetMatch::default()
+            }));
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::Prefix => {
+            let Rhs::Prefix(prefix, _) = rhs else {
+                unreachable!("typechecked: prefix compares a prefix")
+            };
+            let node = MatchExpr::PrefixEq {
+                prefix: *prefix,
+                ge: None,
+                le: None,
+            };
+            negate_if(op == CmpOp::Ne, node)
+        }
+        Field::Communities | Field::LargeCommunities | Field::ExtCommunities | Field::AsPath => {
+            unreachable!("typechecked: no direct comparison on lists")
+        }
+    }
+}
+
+/// Lower an `if` body (a flat action list) to its term action:
+/// `Some(Permit)` on `accept`, `Some(Deny)` on `reject`,
+/// `Some(Continue)` when it only modifies, `None` when it does nothing.
+fn lower_body(actions: &[ActionStmt], env: &HashMap<&str, u32>) -> Option<TermAction> {
+    let mut mods = RouteModifications::default();
+    for action in actions {
+        match action {
+            ActionStmt::Accept(_) => return Some(TermAction::Permit(mods)),
+            ActionStmt::Reject(_) => return Some(TermAction::Deny),
+            other => apply_action(&mut mods, other, env),
+        }
+    }
+    if mods.is_empty() {
+        None
+    } else {
+        Some(TermAction::Continue(mods))
+    }
+}
+
+fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMap<&str, u32>) {
+    match action {
+        ActionStmt::Accept(_) | ActionStmt::Reject(_) => {
+            unreachable!("verdicts handled by callers")
+        }
+        ActionStmt::SetLocalPref(arg, _) => mods.set_local_pref = Some(resolve_u32(arg, env)),
+        ActionStmt::SetMed(arg, _) => mods.set_med = Some(resolve_u32(arg, env)),
+        ActionStmt::SetNextHop(arg, _) => {
+            mods.set_next_hop = Some(match arg {
+                NextHopArg::Self_(_) => NextHopAction::Self_,
+                NextHopArg::Addr(addr, _) => NextHopAction::Specific(*addr),
+            });
+        }
+        ActionStmt::Community { add, lit, .. } => match lit.node {
+            CommunityLit::Standard(value) => {
+                if *add {
+                    mods.communities_add.push(value);
+                } else {
+                    mods.communities_remove.push(value);
+                }
+            }
+            CommunityLit::Large(lc) => {
+                if *add {
+                    mods.large_communities_add.push(lc);
+                } else {
+                    mods.large_communities_remove.push(lc);
+                }
+            }
+            CommunityLit::Ext {
+                route_target,
+                global,
+                local,
+                ipv4_admin,
+            } => {
+                let value = ext_community_value(route_target, global, local, ipv4_admin);
+                if *add {
+                    mods.extended_communities_add.push(value);
+                } else {
+                    mods.extended_communities_remove.push(value);
+                }
+            }
+        },
+        ActionStmt::Prepend { asn, count, .. } => {
+            let count = resolve_u32(count, env);
+            mods.as_path_prepend = Some((
+                resolve_u32(asn, env),
+                u8::try_from(count).expect("typechecked: count is a 1-255 literal"),
+            ));
+        }
+    }
+}
+
+fn resolve_u32(arg: &U32Arg, env: &HashMap<&str, u32>) -> u32 {
+    match arg {
+        U32Arg::Lit(value, _) => *value,
+        U32Arg::Param(name) => *env
+            .get(name.node.as_str())
+            .expect("typechecked: parameter in scope"),
+    }
+}
+
+fn rhs_u32(rhs: &Rhs, env: &HashMap<&str, u32>) -> u32 {
+    match rhs {
+        Rhs::Int(value, _) => *value,
+        Rhs::Ident(name) => *env
+            .get(name.node.as_str())
+            .expect("typechecked: parameter in scope"),
+        _ => unreachable!("typechecked: u32 operand"),
+    }
+}
+
+fn rhs_ident(rhs: &Rhs) -> &str {
+    match rhs {
+        Rhs::Ident(name) => &name.node,
+        _ => unreachable!("typechecked: enum operand"),
+    }
+}
+
+fn u32_cmp(op: CmpOp, value: u32, make: impl Fn(Cmp) -> MatchExpr) -> MatchExpr {
+    match op {
+        CmpOp::Ge => make(Cmp::Ge(value)),
+        CmpOp::Le => make(Cmp::Le(value)),
+        CmpOp::Eq => MatchExpr::And(vec![make(Cmp::Ge(value)), make(Cmp::Le(value))]),
+        CmpOp::Ne => MatchExpr::Not(Box::new(MatchExpr::And(vec![
+            make(Cmp::Ge(value)),
+            make(Cmp::Le(value)),
+        ]))),
+    }
+}
+
+fn negate_if(negate: bool, node: MatchExpr) -> MatchExpr {
+    if negate {
+        MatchExpr::Not(Box::new(node))
+    } else {
+        node
+    }
+}
+
+/// The pure boolean "would this policy permit the route?" — the
+/// `apply` predicate. First-match-faithful over decision-bearing terms
+/// (`Continue` terms don't decide and are skipped).
+fn accept_predicate(policy: &CompiledPolicy) -> MatchExpr {
+    let mut not_prior: Vec<MatchExpr> = Vec::new();
+    let mut arms: Vec<MatchExpr> = Vec::new();
+    for term in &policy.terms {
+        match term.action {
+            TermAction::Continue(_) => {}
+            TermAction::Permit(_) => {
+                let mut children = not_prior.clone();
+                children.push(term.guard.clone());
+                arms.push(and_of(children));
+                not_prior.push(MatchExpr::Not(Box::new(term.guard.clone())));
+            }
+            TermAction::Deny => {
+                not_prior.push(MatchExpr::Not(Box::new(term.guard.clone())));
+            }
+        }
+    }
+    if policy.default_action == PolicyAction::Permit {
+        arms.push(and_of(not_prior));
+    }
+    or_of(arms)
+}
+
+fn and_of(mut children: Vec<MatchExpr>) -> MatchExpr {
+    children.retain(|child| *child != MatchExpr::True);
+    match children.len() {
+        0 => MatchExpr::True,
+        1 => children.pop().expect("len checked"),
+        _ => MatchExpr::And(children),
+    }
+}
+
+fn or_of(mut children: Vec<MatchExpr>) -> MatchExpr {
+    if children.contains(&MatchExpr::True) {
+        return MatchExpr::True;
+    }
+    match children.len() {
+        0 => MatchExpr::Or(Vec::new()), // never matches
+        1 => children.pop().expect("len checked"),
+        _ => MatchExpr::Or(children),
+    }
+}

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -1,0 +1,112 @@
+//! The `.rpol` policy-language frontend (ADR-0096 slice 2).
+//!
+//! Compiles `.rpol` source — `prefix-set` / `community-set`
+//! definitions, `policy` blocks with named terms and parameters, and
+//! in-language `test` blocks — into the public typed IR
+//! ([`crate::ir`]), interning match data through a
+//! [`crate::sets::SetStore`]. Nothing in the daemon consumes
+//! this yet (config/API wiring is the next slice); the standalone
+//! entry points are:
+//!
+//! - [`compile_rpol`] — source → [`CompiledChain`] (every
+//!   zero-parameter policy; parameterized policies are templates
+//!   monomorphized at their use sites).
+//! - [`check_rpol`] — parse + typecheck + run the in-language tests;
+//!   what `rbgp policy check` calls.
+//! - [`run_rpol_tests`] — just the test blocks.
+//!
+//! The pipeline is `lex (logos) → recursive-descent parse → typecheck
+//! → lower to IR`, with multi-error recovery and ariadne-rendered
+//! diagnostics throughout. See `docs/rpol-language.md` for the
+//! language reference and the lowering/semantics decisions.
+
+mod ast;
+mod diag;
+mod lexer;
+mod lower;
+mod parser;
+mod testing;
+mod typeck;
+
+pub use diag::{Diagnostic, Diagnostics, Span, Spanned};
+pub use testing::{TestFailure, TestReport};
+
+use crate::ir::CompiledChain;
+use crate::sets::SetStore;
+
+/// Compile `.rpol` source into a [`CompiledChain`] holding every
+/// zero-parameter policy (in source order) plus the indexed set tables
+/// their guards reference. Parameterized policies typecheck here but
+/// compile only where instantiated. `test` blocks are validated, not
+/// run — use [`check_rpol`] for that.
+///
+/// # Errors
+///
+/// All lex, parse, and type errors found in one pass.
+pub fn compile_rpol(source: &str, store: &mut SetStore) -> Result<CompiledChain, Diagnostics> {
+    let (file, diags) = front(source)?;
+    debug_assert!(diags.is_empty());
+    let mut lowerer = lower::Lowerer::new(&file, store);
+    Ok(lowerer.zero_param_chain(store))
+}
+
+/// Parse, typecheck, and run the in-language `test` blocks.
+///
+/// # Errors
+///
+/// All lex, parse, and type errors found in one pass (tests do not run
+/// when the file has diagnostics).
+pub fn run_rpol_tests(source: &str) -> Result<TestReport, Diagnostics> {
+    let (file, _) = front(source)?;
+    let mut store = SetStore::new();
+    let mut lowerer = lower::Lowerer::new(&file, &mut store);
+    Ok(testing::run_tests(&file.tests, &mut lowerer, &mut store))
+}
+
+/// The full `rbgp policy check` result: diagnostics (empty on a clean
+/// file) and, when the file compiled, the in-language test report.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CheckReport {
+    /// Lex/parse/type diagnostics (empty when the file is clean).
+    pub diagnostics: Diagnostics,
+    /// Test results; `None` when diagnostics prevented compilation.
+    pub tests: Option<TestReport>,
+}
+
+impl CheckReport {
+    /// True when the file compiled cleanly and every test passed.
+    #[must_use]
+    pub fn is_ok(&self) -> bool {
+        self.diagnostics.is_empty() && self.tests.as_ref().is_none_or(TestReport::all_passed)
+    }
+}
+
+/// Parse + typecheck + run tests, without touching a daemon — the
+/// backing of `rbgp policy check <file.rpol>`.
+#[must_use]
+pub fn check_rpol(source: &str) -> CheckReport {
+    match run_rpol_tests(source) {
+        Ok(tests) => CheckReport {
+            diagnostics: Diagnostics::default(),
+            tests: Some(tests),
+        },
+        Err(diagnostics) => CheckReport {
+            diagnostics,
+            tests: None,
+        },
+    }
+}
+
+/// Shared frontend: lex + parse + typecheck, all diagnostics combined.
+fn front(source: &str) -> Result<(ast::SourceFile, Vec<Diagnostic>), Diagnostics> {
+    let (file, mut diags) = parser::parse(source);
+    diags.extend(typeck::typecheck(&file));
+    if diags.is_empty() {
+        Ok((file, Vec::new()))
+    } else {
+        Err(Diagnostics(diags))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -1,0 +1,1205 @@
+//! Handwritten recursive-descent parser for `.rpol`.
+//!
+//! Error recovery: a failed top-level item skips to the next
+//! `prefix-set`/`community-set`/`policy`/`test` keyword at brace depth
+//! zero; a failed statement inside a policy skips to the next `term`,
+//! `;`, or closing brace. This is enough to report several independent
+//! errors per file in one pass.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, LargeCommunity, Prefix};
+
+use crate::engine::{CommunityMatch, parse_community_match};
+
+use super::ast::{
+    ActionStmt, CmpOp, CommunityKind, CommunityLit, CommunitySetDef, ExpectDef, Expr, FieldPath,
+    FieldRoot, IfStmt, NextHopArg, PeerField, PolicyDef, PrefixEntryAst, PrefixSetDef, Rhs,
+    RouteField, SourceFile, Stmt, TermDef, TestDef, U32Arg, WithAssertion,
+};
+use super::diag::{Diagnostic, Span, Spanned};
+use super::lexer::{Tok, Token, lex};
+
+/// Parse a source file, returning the AST and every diagnostic found
+/// (lex + parse). The AST contains every item that parsed cleanly even
+/// when diagnostics are present, so the typechecker can report further
+/// errors in the same run.
+#[must_use]
+pub fn parse(source: &str) -> (SourceFile, Vec<Diagnostic>) {
+    let (tokens, mut diags) = lex(source);
+    let mut parser = Parser {
+        src: source,
+        tokens,
+        pos: 0,
+        diags: Vec::new(),
+    };
+    let file = parser.source_file();
+    diags.append(&mut parser.diags);
+    (file, diags)
+}
+
+struct Parser<'src> {
+    src: &'src str,
+    tokens: Vec<Token>,
+    pos: usize,
+    diags: Vec<Diagnostic>,
+}
+
+/// Parse-failure marker; the diagnostic is already recorded.
+struct Fail;
+
+type PResult<T> = Result<T, Fail>;
+
+impl Parser<'_> {
+    // ── token plumbing ──────────────────────────────────────────────
+
+    fn peek(&self) -> Option<Token> {
+        self.tokens.get(self.pos).copied()
+    }
+
+    fn at(&self, kind: Tok) -> bool {
+        self.peek().is_some_and(|t| t.kind == kind)
+    }
+
+    fn bump(&mut self) -> Option<Token> {
+        let token = self.peek();
+        if token.is_some() {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn eat(&mut self, kind: Tok) -> Option<Token> {
+        if self.at(kind) { self.bump() } else { None }
+    }
+
+    fn text(&self, token: Token) -> &str {
+        &self.src[token.span.range()]
+    }
+
+    fn eof_span(&self) -> Span {
+        let end = self.src.len();
+        Span::new(end..end)
+    }
+
+    fn here(&self) -> Span {
+        self.peek().map_or_else(|| self.eof_span(), |t| t.span)
+    }
+
+    fn error_expected(&mut self, what: &str) -> Fail {
+        let (span, found) = match self.peek() {
+            Some(token) => (token.span, token.kind.describe().to_string()),
+            None => (self.eof_span(), "end of file".to_string()),
+        };
+        self.diags.push(Diagnostic::new(
+            span,
+            format!("expected {what}, found {found}"),
+            format!("expected {what} here"),
+        ));
+        Fail
+    }
+
+    fn expect(&mut self, kind: Tok, what: &str) -> PResult<Token> {
+        if self.at(kind) {
+            Ok(self.bump().expect("peeked"))
+        } else {
+            Err(self.error_expected(what))
+        }
+    }
+
+    fn expect_ident(&mut self, what: &str) -> PResult<Spanned<String>> {
+        let token = self.expect(Tok::Ident, what)?;
+        Ok(Spanned::new(self.text(token).to_string(), token.span))
+    }
+
+    /// Skip tokens until one of `stops` at local brace depth zero (or
+    /// EOF). A closing brace that would take the depth negative is
+    /// consumed and resets to zero — it closed the enclosing block the
+    /// error occurred in.
+    fn recover_to(&mut self, stops: &[Tok]) {
+        let mut depth: u32 = 0;
+        while let Some(token) = self.peek() {
+            if depth == 0 && stops.contains(&token.kind) {
+                return;
+            }
+            self.pos += 1;
+            match token.kind {
+                Tok::LBrace => depth += 1,
+                Tok::RBrace => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+    }
+
+    // ── literal parsing ─────────────────────────────────────────────
+
+    fn parse_u32_text(&mut self, text: &str, span: Span) -> PResult<u32> {
+        text.parse::<u32>().map_err(|_| {
+            self.diags.push(Diagnostic::new(
+                span,
+                format!("integer literal `{text}` does not fit in u32"),
+                "out of range",
+            ));
+            Fail
+        })
+    }
+
+    fn expect_u32(&mut self, what: &str) -> PResult<(u32, Span)> {
+        let token = self.expect(Tok::Int, what)?;
+        let text = self.text(token).to_string();
+        Ok((self.parse_u32_text(&text, token.span)?, token.span))
+    }
+
+    /// `u32` argument position: integer literal or parameter name.
+    fn u32_arg(&mut self, what: &str) -> PResult<U32Arg> {
+        match self.peek().map(|t| t.kind) {
+            Some(Tok::Int) => {
+                let (value, span) = self.expect_u32(what)?;
+                Ok(U32Arg::Lit(value, span))
+            }
+            Some(Tok::Ident) => Ok(U32Arg::Param(self.expect_ident(what)?)),
+            _ => Err(self.error_expected(what)),
+        }
+    }
+
+    fn parse_prefix_text(&mut self, text: &str, span: Span) -> PResult<Prefix> {
+        let fail = |parser: &mut Self, detail: &str| {
+            parser.diags.push(Diagnostic::new(
+                span,
+                format!("invalid prefix `{text}`: {detail}"),
+                "invalid prefix",
+            ));
+            Fail
+        };
+        let Some((addr, len)) = text.split_once('/') else {
+            return Err(fail(self, "missing `/length`"));
+        };
+        let Ok(len) = len.parse::<u8>() else {
+            return Err(fail(self, "invalid prefix length"));
+        };
+        let prefix = if let Ok(v4) = addr.parse::<Ipv4Addr>() {
+            if len > 32 {
+                return Err(fail(self, "IPv4 prefix length exceeds 32"));
+            }
+            let canonical = Ipv4Prefix::new(v4, len);
+            if canonical.addr != v4 {
+                return Err(fail(
+                    self,
+                    &format!("host bits set beyond /{len} (did you mean {canonical}?)"),
+                ));
+            }
+            Prefix::V4(canonical)
+        } else if let Ok(v6) = addr.parse::<Ipv6Addr>() {
+            if len > 128 {
+                return Err(fail(self, "IPv6 prefix length exceeds 128"));
+            }
+            let canonical = Ipv6Prefix::new(v6, len);
+            if canonical.addr != v6 {
+                return Err(fail(
+                    self,
+                    &format!("host bits set beyond /{len} (did you mean {canonical}?)"),
+                ));
+            }
+            Prefix::V6(canonical)
+        } else {
+            return Err(fail(self, "invalid address"));
+        };
+        Ok(prefix)
+    }
+
+    fn expect_prefix(&mut self) -> PResult<(Prefix, Span)> {
+        let token = self.expect(Tok::PrefixLit, "a prefix (e.g. `10.0.0.0/8`)")?;
+        let text = self.text(token).to_string();
+        Ok((self.parse_prefix_text(&text, token.span)?, token.span))
+    }
+
+    fn expect_ip(&mut self, what: &str) -> PResult<(IpAddr, Span)> {
+        let token = match self.peek().map(|t| t.kind) {
+            Some(Tok::Ipv4Lit | Tok::Ipv6Lit) => self.bump().expect("peeked"),
+            _ => return Err(self.error_expected(what)),
+        };
+        let text = self.text(token).to_string();
+        let Ok(addr) = text.parse::<IpAddr>() else {
+            self.diags.push(Diagnostic::new(
+                token.span,
+                format!("invalid IP address `{text}`"),
+                "invalid address",
+            ));
+            return Err(Fail);
+        };
+        Ok((addr, token.span))
+    }
+
+    fn expect_str(&mut self, what: &str) -> PResult<Spanned<String>> {
+        let token = self.expect(Tok::Str, what)?;
+        let raw = self.text(token);
+        // Strip quotes; unescape `\"` and `\\` (the only escapes).
+        let inner = &raw[1..raw.len() - 1];
+        let value = inner.replace("\\\"", "\"").replace("\\\\", "\\");
+        Ok(Spanned::new(value, token.span))
+    }
+
+    /// A community literal of any kind, including well-known names
+    /// (`NO_EXPORT`, `BLACKHOLE`, …).
+    fn community_lit(&mut self) -> PResult<Spanned<CommunityLit>> {
+        let Some(token) = self.peek() else {
+            return Err(self.error_expected("a community literal"));
+        };
+        let text = self.text(token).to_string();
+        let span = token.span;
+        let lit = match token.kind {
+            Tok::StdCommunityLit => {
+                self.bump();
+                let (asn, value) = text.split_once(':').expect("token shape");
+                let asn: u32 = self.parse_u32_text(asn, span)?;
+                let value: u32 = self.parse_u32_text(value, span)?;
+                if asn > u32::from(u16::MAX) || value > u32::from(u16::MAX) {
+                    self.diags.push(Diagnostic::new(
+                        span,
+                        format!("invalid standard community `{text}`: both parts must fit in u16"),
+                        "part exceeds 65535",
+                    ).with_note(
+                        "for 4-byte ASNs use a large community (`asn:local1:local2`) or an extended community (`RT:asn:value`)",
+                    ));
+                    return Err(Fail);
+                }
+                CommunityLit::Standard((asn << 16) | value)
+            }
+            Tok::LargeCommunityLit => {
+                self.bump();
+                let body = text.strip_prefix("LC:").unwrap_or(&text);
+                let mut parts = body.splitn(3, ':');
+                let global_admin = self.parse_u32_text(parts.next().expect("token shape"), span)?;
+                let local_data1 = self.parse_u32_text(parts.next().expect("token shape"), span)?;
+                let local_data2 = self.parse_u32_text(parts.next().expect("token shape"), span)?;
+                CommunityLit::Large(LargeCommunity {
+                    global_admin,
+                    local_data1,
+                    local_data2,
+                })
+            }
+            Tok::ExtCommunityLit => {
+                self.bump();
+                self.ext_community_lit(&text, span)?
+            }
+            Tok::Ident => {
+                // Well-known standard community names share the TOML
+                // frontend's alias table via `parse_community_match`.
+                match parse_community_match(&text) {
+                    Ok(CommunityMatch::Standard { value })
+                        if text.chars().all(|c| c.is_ascii_uppercase() || c == '_') =>
+                    {
+                        self.bump();
+                        CommunityLit::Standard(value)
+                    }
+                    _ => {
+                        return Err(self.error_expected(
+                            "a community literal (`65000:100`, `65000:1:2`, `RT:65001:100`, or a well-known name like `NO_EXPORT`)",
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(self.error_expected(
+                    "a community literal (`65000:100`, `65000:1:2`, `RT:65001:100`, or a well-known name like `NO_EXPORT`)",
+                ));
+            }
+        };
+        Ok(Spanned::new(lit, span))
+    }
+
+    fn ext_community_lit(&mut self, text: &str, span: Span) -> PResult<CommunityLit> {
+        let route_target = text.starts_with("RT:");
+        let body = &text[3..];
+        let (admin, local) = body.split_once(':').expect("token shape");
+        let local = self.parse_u32_text(local, span)?;
+        let (global, ipv4_admin) = if let Ok(v4) = admin.parse::<Ipv4Addr>() {
+            (u32::from(v4), true)
+        } else {
+            (self.parse_u32_text(admin, span)?, false)
+        };
+        // RFC 4360 encodings: IPv4-admin and 4-octet-AS forms carry a
+        // 2-octet local administrator.
+        if (ipv4_admin || global > u32::from(u16::MAX)) && local > u32::from(u16::MAX) {
+            self.diags.push(Diagnostic::new(
+                span,
+                format!(
+                    "invalid extended community `{text}`: local administrator exceeds 65535 for {} global admin",
+                    if ipv4_admin { "an IPv4" } else { "a 4-octet-AS" }
+                ),
+                "local admin out of range",
+            ));
+            return Err(Fail);
+        }
+        Ok(CommunityLit::Ext {
+            route_target,
+            global,
+            local,
+            ipv4_admin,
+        })
+    }
+
+    // ── top level ───────────────────────────────────────────────────
+
+    const TOP_LEVEL: &'static [Tok] = &[
+        Tok::PrefixSetKw,
+        Tok::CommunitySetKw,
+        Tok::PolicyKw,
+        Tok::TestKw,
+    ];
+
+    fn source_file(&mut self) -> SourceFile {
+        let mut file = SourceFile::default();
+        while let Some(token) = self.peek() {
+            let result = match token.kind {
+                Tok::PrefixSetKw => self.prefix_set_def().map(|def| file.prefix_sets.push(def)),
+                Tok::CommunitySetKw => self
+                    .community_set_def()
+                    .map(|def| file.community_sets.push(def)),
+                Tok::PolicyKw => self.policy_def().map(|def| file.policies.push(def)),
+                Tok::TestKw => self.test_def().map(|def| file.tests.push(def)),
+                _ => Err(self.error_expected(
+                    "a top-level item (`prefix-set`, `community-set`, `policy`, or `test`)",
+                )),
+            };
+            if result.is_err() {
+                // Ensure progress even when the failing token IS a
+                // top-level keyword (e.g. `policy` missing its name).
+                if self.peek().map(|t| t.kind) == Some(token.kind) && self.here() == token.span {
+                    self.pos += 1;
+                }
+                self.recover_to(Self::TOP_LEVEL);
+            }
+        }
+        file
+    }
+
+    fn prefix_set_def(&mut self) -> PResult<PrefixSetDef> {
+        self.expect(Tok::PrefixSetKw, "`prefix-set`")?;
+        let name = self.expect_ident("a set name")?;
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut entries = Vec::new();
+        while !self.at(Tok::RBrace) {
+            let (prefix, _) = self.expect_prefix()?;
+            let mut ge = None;
+            let mut le = None;
+            if self.eat(Tok::GeKw).is_some() {
+                let (value, value_span) = self.expect_u32("a prefix length after `ge`")?;
+                ge = Some(self.prefix_len_bound(prefix, value, value_span)?);
+            }
+            if self.eat(Tok::LeKw).is_some() {
+                let (value, value_span) = self.expect_u32("a prefix length after `le`")?;
+                le = Some(self.prefix_len_bound(prefix, value, value_span)?);
+            }
+            entries.push(PrefixEntryAst { prefix, ge, le });
+            if self.eat(Tok::Comma).is_none() {
+                break;
+            }
+        }
+        self.expect(Tok::RBrace, "`}` or `,` and another prefix")?;
+        Ok(PrefixSetDef { name, entries })
+    }
+
+    fn prefix_len_bound(&mut self, prefix: Prefix, value: u32, span: Span) -> PResult<u8> {
+        let max = match prefix {
+            Prefix::V4(_) => 32u32,
+            Prefix::V6(_) => 128,
+        };
+        if value > max {
+            self.diags.push(Diagnostic::new(
+                span,
+                format!("prefix length bound {value} exceeds {max}"),
+                "out of range",
+            ));
+            return Err(Fail);
+        }
+        Ok(u8::try_from(value).expect("bounded above"))
+    }
+
+    fn community_set_def(&mut self) -> PResult<CommunitySetDef> {
+        self.expect(Tok::CommunitySetKw, "`community-set`")?;
+        let name = self.expect_ident("a set name")?;
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut entries = Vec::new();
+        while !self.at(Tok::RBrace) {
+            entries.push(self.community_lit()?);
+            if self.eat(Tok::Comma).is_none() {
+                break;
+            }
+        }
+        self.expect(Tok::RBrace, "`}` or `,` and another community")?;
+        Ok(CommunitySetDef { name, entries })
+    }
+
+    // ── policies ────────────────────────────────────────────────────
+
+    fn policy_def(&mut self) -> PResult<PolicyDef> {
+        self.expect(Tok::PolicyKw, "`policy`")?;
+        let name = self.expect_ident("a policy name")?;
+        let mut params = Vec::new();
+        if self.eat(Tok::LParen).is_some() {
+            while !self.at(Tok::RParen) {
+                let param = self.expect_ident("a parameter name")?;
+                self.expect(Tok::Colon, "`:` and the parameter type")?;
+                self.expect(Tok::U32Kw, "`u32` (the only parameter type in V1)")?;
+                params.push(param);
+                if self.eat(Tok::Comma).is_none() {
+                    break;
+                }
+            }
+            self.expect(Tok::RParen, "`)`")?;
+        }
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut terms = Vec::new();
+        while !self.at(Tok::RBrace) {
+            if let Ok(term) = self.term_def() {
+                terms.push(term);
+            } else {
+                self.recover_to(&[Tok::TermKw, Tok::RBrace]);
+                if self.peek().is_none() {
+                    return Err(Fail);
+                }
+            }
+        }
+        self.expect(Tok::RBrace, "`}`")?;
+        Ok(PolicyDef {
+            name,
+            params,
+            terms,
+        })
+    }
+
+    fn term_def(&mut self) -> PResult<TermDef> {
+        self.expect(Tok::TermKw, "`term` (policy bodies are named terms)")?;
+        let name = self.expect_ident("a term name")?;
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut stmts = Vec::new();
+        while !self.at(Tok::RBrace) {
+            if let Ok(stmt) = self.stmt() {
+                stmts.push(stmt);
+            } else {
+                self.recover_to(&[Tok::Semi, Tok::RBrace, Tok::TermKw]);
+                if self.eat(Tok::Semi).is_none() {
+                    break;
+                }
+            }
+        }
+        self.expect(Tok::RBrace, "`}`")?;
+        Ok(TermDef { name, stmts })
+    }
+
+    fn stmt(&mut self) -> PResult<Stmt> {
+        if self.at(Tok::IfKw) {
+            return Ok(Stmt::If(self.if_stmt()?));
+        }
+        let action = self.action()?;
+        self.eat(Tok::Semi);
+        Ok(Stmt::Action(action))
+    }
+
+    fn if_stmt(&mut self) -> PResult<IfStmt> {
+        let start = self.expect(Tok::IfKw, "`if`")?.span;
+        let cond = self.expr()?;
+        let span = start.to(cond.span());
+        self.expect(Tok::LBrace, "`{`")?;
+        let then_actions = self.action_list()?;
+        self.expect(Tok::RBrace, "`}`")?;
+        let else_actions = if self.eat(Tok::ElseKw).is_some() {
+            self.expect(Tok::LBrace, "`{` (V1 has no `else if`)")?;
+            let actions = self.action_list()?;
+            self.expect(Tok::RBrace, "`}`")?;
+            Some(actions)
+        } else {
+            None
+        };
+        Ok(IfStmt {
+            cond,
+            then_actions,
+            else_actions,
+            span,
+        })
+    }
+
+    fn action_list(&mut self) -> PResult<Vec<ActionStmt>> {
+        let mut actions = Vec::new();
+        while !self.at(Tok::RBrace) {
+            if self.at(Tok::IfKw) {
+                self.diags.push(
+                    Diagnostic::new(
+                        self.here(),
+                        "nested `if` is not supported in V1",
+                        "`if` bodies contain only actions",
+                    )
+                    .with_note("split the condition with `&&`, or use another term"),
+                );
+                return Err(Fail);
+            }
+            actions.push(self.action()?);
+            self.eat(Tok::Semi);
+        }
+        Ok(actions)
+    }
+
+    fn action(&mut self) -> PResult<ActionStmt> {
+        let Some(token) = self.peek() else {
+            return Err(self.error_expected("an action"));
+        };
+        match token.kind {
+            Tok::AcceptKw => {
+                self.bump();
+                Ok(ActionStmt::Accept(token.span))
+            }
+            Tok::RejectKw => {
+                self.bump();
+                Ok(ActionStmt::Reject(token.span))
+            }
+            Tok::SetKw => {
+                self.bump();
+                let target = self.expect_ident("`local-pref`, `med`, or `next-hop`")?;
+                match target.node.as_str() {
+                    "local-pref" => {
+                        let arg = self.u32_arg("a u32 value or parameter")?;
+                        let span = token.span.to(arg.span());
+                        Ok(ActionStmt::SetLocalPref(arg, span))
+                    }
+                    "med" => {
+                        let arg = self.u32_arg("a u32 value or parameter")?;
+                        let span = token.span.to(arg.span());
+                        Ok(ActionStmt::SetMed(arg, span))
+                    }
+                    "next-hop" => {
+                        let arg = if let Some(self_token) = self.eat(Tok::SelfKw) {
+                            NextHopArg::Self_(self_token.span)
+                        } else {
+                            let (addr, span) = self.expect_ip("an IP address or `self`")?;
+                            NextHopArg::Addr(addr, span)
+                        };
+                        let end = match &arg {
+                            NextHopArg::Self_(span) | NextHopArg::Addr(_, span) => *span,
+                        };
+                        Ok(ActionStmt::SetNextHop(arg, token.span.to(end)))
+                    }
+                    other => {
+                        self.diags.push(
+                            Diagnostic::new(
+                                target.span,
+                                format!("unknown `set` target `{other}`"),
+                                "not a settable attribute",
+                            )
+                            .with_note("settable attributes: local-pref, med, next-hop"),
+                        );
+                        Err(Fail)
+                    }
+                }
+            }
+            Tok::AddKw | Tok::RemoveKw => {
+                let add = token.kind == Tok::AddKw;
+                self.bump();
+                let kind_ident =
+                    self.expect_ident("`community`, `large-community`, or `ext-community`")?;
+                let kind = match kind_ident.node.as_str() {
+                    "community" => CommunityKind::Standard,
+                    "large-community" => CommunityKind::Large,
+                    "ext-community" => CommunityKind::Ext,
+                    other => {
+                        self.diags.push(Diagnostic::new(
+                            kind_ident.span,
+                            format!("unknown community kind `{other}`"),
+                            "expected `community`, `large-community`, or `ext-community`",
+                        ));
+                        return Err(Fail);
+                    }
+                };
+                let lit = self.community_lit()?;
+                let span = token.span.to(lit.span);
+                Ok(ActionStmt::Community {
+                    add,
+                    kind,
+                    lit,
+                    span,
+                })
+            }
+            Tok::PrependKw => {
+                self.bump();
+                self.expect(Tok::AsKw, "`as` (`prepend as <asn> <count>`)")?;
+                let asn = self.u32_arg("an ASN")?;
+                let count = self.u32_arg("a prepend count")?;
+                let span = token.span.to(count.span());
+                Ok(ActionStmt::Prepend { asn, count, span })
+            }
+            _ => Err(self.error_expected(
+                "an action (`accept`, `reject`, `set`, `add`, `remove`, or `prepend`)",
+            )),
+        }
+    }
+
+    // ── expressions ─────────────────────────────────────────────────
+
+    fn expr(&mut self) -> PResult<Expr> {
+        let mut lhs = self.and_expr()?;
+        while self.eat(Tok::OrOr).is_some() {
+            let rhs = self.and_expr()?;
+            lhs = Expr::Or(Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn and_expr(&mut self) -> PResult<Expr> {
+        let mut lhs = self.unary_expr()?;
+        while self.eat(Tok::AndAnd).is_some() {
+            let rhs = self.unary_expr()?;
+            lhs = Expr::And(Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn unary_expr(&mut self) -> PResult<Expr> {
+        if let Some(bang) = self.eat(Tok::Bang) {
+            let inner = self.unary_expr()?;
+            let span = bang.span.to(inner.span());
+            return Ok(Expr::Not(Box::new(inner), span));
+        }
+        if self.eat(Tok::LParen).is_some() {
+            let inner = self.expr()?;
+            self.expect(Tok::RParen, "`)`")?;
+            return Ok(inner);
+        }
+        if self.at(Tok::ApplyKw) {
+            return self.apply_expr();
+        }
+        if self.at(Tok::RouteKw) || self.at(Tok::PeerKw) {
+            return self.predicate_expr();
+        }
+        Err(self.error_expected(
+            "a condition (`route.<field> ...`, `peer.<field> ...`, `apply(...)`, `!`, or `(`)",
+        ))
+    }
+
+    fn apply_expr(&mut self) -> PResult<Expr> {
+        let start = self.expect(Tok::ApplyKw, "`apply`")?.span;
+        self.expect(Tok::LParen, "`(`")?;
+        let policy = self.expect_ident("a policy name")?;
+        let mut args = Vec::new();
+        if self.eat(Tok::LParen).is_some() {
+            while !self.at(Tok::RParen) {
+                args.push(self.u32_arg("a u32 argument")?);
+                if self.eat(Tok::Comma).is_none() {
+                    break;
+                }
+            }
+            self.expect(Tok::RParen, "`)`")?;
+        }
+        let end = self.expect(Tok::RParen, "`)`")?.span;
+        Ok(Expr::Apply {
+            policy,
+            args,
+            span: start.to(end),
+        })
+    }
+
+    fn field_path(&mut self) -> PResult<FieldPath> {
+        let root_token = self.bump().expect("caller checked route/peer");
+        let root = if root_token.kind == Tok::RouteKw {
+            FieldRoot::Route
+        } else {
+            FieldRoot::Peer
+        };
+        let mut segs = Vec::new();
+        let mut span = root_token.span;
+        while self.eat(Tok::Dot).is_some() {
+            let seg = self.expect_ident("a field name")?;
+            span = span.to(seg.span);
+            segs.push(seg);
+        }
+        if segs.is_empty() {
+            return Err(self.error_expected("`.` and a field name"));
+        }
+        Ok(FieldPath { root, segs, span })
+    }
+
+    fn predicate_expr(&mut self) -> PResult<Expr> {
+        let field = self.field_path()?;
+        let Some(op_token) = self.peek() else {
+            return Err(self.error_expected(
+                "an operator (`==`, `!=`, `>=`, `<=`, `in`, `has`, `matches`, or `contains`)",
+            ));
+        };
+        match op_token.kind {
+            Tok::EqEq | Tok::NotEq | Tok::GtEq | Tok::LtEq => {
+                self.bump();
+                let op = match op_token.kind {
+                    Tok::EqEq => CmpOp::Eq,
+                    Tok::NotEq => CmpOp::Ne,
+                    Tok::GtEq => CmpOp::Ge,
+                    _ => CmpOp::Le,
+                };
+                let rhs = self.rhs()?;
+                let span = field.span.to(rhs.span());
+                Ok(Expr::Cmp {
+                    field,
+                    op,
+                    rhs,
+                    span,
+                })
+            }
+            Tok::InKw => {
+                self.bump();
+                let set = self.expect_ident("a set name")?;
+                Ok(Expr::In { field, set })
+            }
+            Tok::HasKw => {
+                self.bump();
+                let lit = self.community_lit()?;
+                Ok(Expr::Has { field, lit })
+            }
+            Tok::MatchesKw => {
+                self.bump();
+                let pattern = self.expect_str("a regex string")?;
+                Ok(Expr::Matches { field, pattern })
+            }
+            Tok::ContainsKw => {
+                self.bump();
+                let asn = self.u32_arg("an ASN")?;
+                Ok(Expr::Contains { field, asn })
+            }
+            _ => Err(self.error_expected(
+                "an operator (`==`, `!=`, `>=`, `<=`, `in`, `has`, `matches`, or `contains`)",
+            )),
+        }
+    }
+
+    fn rhs(&mut self) -> PResult<Rhs> {
+        let Some(token) = self.peek() else {
+            return Err(self.error_expected("a comparison operand"));
+        };
+        match token.kind {
+            Tok::Int => {
+                let (value, span) = self.expect_u32("an integer")?;
+                Ok(Rhs::Int(value, span))
+            }
+            Tok::Ident => Ok(Rhs::Ident(self.expect_ident("an operand")?)),
+            Tok::Ipv4Lit | Tok::Ipv6Lit => {
+                let (addr, span) = self.expect_ip("an IP address")?;
+                Ok(Rhs::Ip(addr, span))
+            }
+            Tok::PrefixLit => {
+                let (prefix, span) = self.expect_prefix()?;
+                Ok(Rhs::Prefix(prefix, span))
+            }
+            Tok::Str => Ok(Rhs::Str(self.expect_str("a string")?)),
+            Tok::StdCommunityLit | Tok::LargeCommunityLit | Tok::ExtCommunityLit => {
+                Ok(Rhs::Community(self.community_lit()?))
+            }
+            _ => Err(self.error_expected(
+                "a comparison operand (integer, identifier, IP, prefix, or string)",
+            )),
+        }
+    }
+
+    // ── tests ───────────────────────────────────────────────────────
+
+    fn test_def(&mut self) -> PResult<TestDef> {
+        self.expect(Tok::TestKw, "`test`")?;
+        let name = self.expect_ident("a test name")?;
+        self.expect(Tok::LBrace, "`{`")?;
+
+        self.expect(Tok::RouteKw, "a `route { ... }` fixture")?;
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut route = Vec::new();
+        while !self.at(Tok::RBrace) {
+            route.push(self.route_field()?);
+            self.eat(Tok::Semi);
+        }
+        self.expect(Tok::RBrace, "`}`")?;
+
+        let mut peer = Vec::new();
+        if self.eat(Tok::PeerKw).is_some() {
+            self.expect(Tok::LBrace, "`{`")?;
+            while !self.at(Tok::RBrace) {
+                peer.push(self.peer_field()?);
+                self.eat(Tok::Semi);
+            }
+            self.expect(Tok::RBrace, "`}`")?;
+        }
+
+        let mut expects = Vec::new();
+        while self.at(Tok::ExpectKw) {
+            expects.push(self.expect_def()?);
+        }
+        if expects.is_empty() {
+            self.diags.push(Diagnostic::new(
+                self.here(),
+                "test has no `expect`",
+                "expected at least one `expect <policy> == accept|reject`",
+            ));
+            return Err(Fail);
+        }
+        self.expect(Tok::RBrace, "`}`")?;
+        Ok(TestDef {
+            name,
+            route,
+            peer,
+            expects,
+        })
+    }
+
+    fn route_field(&mut self) -> PResult<RouteField> {
+        let field = self.expect_ident(
+            "a route fixture field (`prefix`, `communities`, `as-path`, `rpki`, ...)",
+        )?;
+        match field.node.as_str() {
+            "prefix" => {
+                let (prefix, span) = self.expect_prefix()?;
+                Ok(RouteField::Prefix(prefix, field.span.to(span)))
+            }
+            "communities" => {
+                let (lits, span) = self.community_list()?;
+                Ok(RouteField::Communities(lits, field.span.to(span)))
+            }
+            "large-communities" => {
+                let (lits, span) = self.community_list()?;
+                Ok(RouteField::LargeCommunities(lits, field.span.to(span)))
+            }
+            "ext-communities" => {
+                let (lits, span) = self.community_list()?;
+                Ok(RouteField::ExtCommunities(lits, field.span.to(span)))
+            }
+            "as-path" => Ok(RouteField::AsPath(
+                self.expect_str("a space-separated ASN string (e.g. \"65001 65002\")")?,
+            )),
+            "next-hop" => {
+                let (addr, span) = self.expect_ip("an IP address")?;
+                Ok(RouteField::NextHop(addr, field.span.to(span)))
+            }
+            "local-pref" => {
+                let (value, span) = self.expect_u32("a u32 value")?;
+                Ok(RouteField::LocalPref(value, field.span.to(span)))
+            }
+            "med" => {
+                let (value, span) = self.expect_u32("a u32 value")?;
+                Ok(RouteField::Med(value, field.span.to(span)))
+            }
+            "rpki" => Ok(RouteField::Rpki(
+                self.expect_ident("`valid`, `invalid`, or `not-found`")?,
+            )),
+            "aspa" => Ok(RouteField::Aspa(
+                self.expect_ident("`valid`, `invalid`, or `unknown`")?,
+            )),
+            "route-type" => Ok(RouteField::RouteType(
+                self.expect_ident("`local`, `internal`, or `external`")?,
+            )),
+            "evpn-route-type" => {
+                let (value, span) = self.expect_u32("an EVPN route type (1-5)")?;
+                Ok(RouteField::EvpnRouteType(value, field.span.to(span)))
+            }
+            other => {
+                let known = [
+                    "prefix",
+                    "communities",
+                    "large-communities",
+                    "ext-communities",
+                    "as-path",
+                    "next-hop",
+                    "local-pref",
+                    "med",
+                    "rpki",
+                    "aspa",
+                    "route-type",
+                    "evpn-route-type",
+                ];
+                let mut diag = Diagnostic::new(
+                    field.span,
+                    format!("unknown route fixture field `{other}`"),
+                    "not a route fixture field",
+                );
+                if let Some(suggestion) = super::diag::closest(other, known) {
+                    diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                }
+                self.diags.push(diag);
+                Err(Fail)
+            }
+        }
+    }
+
+    fn community_list(&mut self) -> PResult<(Vec<Spanned<CommunityLit>>, Span)> {
+        let start = self.expect(Tok::LBracket, "`[`")?.span;
+        let mut lits = Vec::new();
+        while !self.at(Tok::RBracket) {
+            lits.push(self.community_lit()?);
+            if self.eat(Tok::Comma).is_none() {
+                break;
+            }
+        }
+        let end = self.expect(Tok::RBracket, "`]`")?.span;
+        Ok((lits, start.to(end)))
+    }
+
+    fn peer_field(&mut self) -> PResult<PeerField> {
+        let field = self.expect_ident("a peer fixture field (`address`, `asn`, `group`)")?;
+        match field.node.as_str() {
+            "address" => {
+                let (addr, _) = self.expect_ip("an IP address")?;
+                Ok(PeerField::Address(addr))
+            }
+            "asn" => {
+                let (value, _) = self.expect_u32("an ASN")?;
+                Ok(PeerField::Asn(value))
+            }
+            "group" => Ok(PeerField::Group(self.expect_str("a group name string")?)),
+            other => {
+                let mut diag = Diagnostic::new(
+                    field.span,
+                    format!("unknown peer fixture field `{other}`"),
+                    "not a peer fixture field",
+                );
+                if let Some(suggestion) = super::diag::closest(other, ["address", "asn", "group"]) {
+                    diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                }
+                self.diags.push(diag);
+                Err(Fail)
+            }
+        }
+    }
+
+    fn expect_def(&mut self) -> PResult<ExpectDef> {
+        let start = self.expect(Tok::ExpectKw, "`expect`")?.span;
+        let policy = self.expect_ident("a policy name")?;
+        let mut args = Vec::new();
+        if self.eat(Tok::LParen).is_some() {
+            while !self.at(Tok::RParen) {
+                let (value, span) = self.expect_u32("a u32 argument")?;
+                args.push(Spanned::new(value, span));
+                if self.eat(Tok::Comma).is_none() {
+                    break;
+                }
+            }
+            self.expect(Tok::RParen, "`)`")?;
+        }
+        self.expect(Tok::EqEq, "`==`")?;
+        let accept = match self.peek().map(|t| t.kind) {
+            Some(Tok::AcceptKw) => {
+                self.bump();
+                true
+            }
+            Some(Tok::RejectKw) => {
+                self.bump();
+                false
+            }
+            _ => return Err(self.error_expected("`accept` or `reject`")),
+        };
+        let mut with = Vec::new();
+        let mut end = self.here();
+        if self.eat(Tok::WithKw).is_some() {
+            loop {
+                with.push(self.with_assertion()?);
+                if self.eat(Tok::Comma).is_none() {
+                    break;
+                }
+            }
+            end = self.here();
+        }
+        Ok(ExpectDef {
+            policy,
+            args,
+            accept,
+            with,
+            span: start.to(end),
+        })
+    }
+
+    fn with_assertion(&mut self) -> PResult<WithAssertion> {
+        if self.eat(Tok::PrependKw).is_some() {
+            self.expect(Tok::AsKw, "`as`")?;
+            let (asn, _) = self.expect_u32("an ASN")?;
+            let (count, _) = self.expect_u32("a prepend count")?;
+            return Ok(WithAssertion::Prepend(asn, count));
+        }
+        let field =
+            self.expect_ident("an assertion (`local-pref`, `med`, `next-hop`, `community`, ...)")?;
+        match field.node.as_str() {
+            "local-pref" => {
+                let (value, _) = self.expect_u32("a u32 value")?;
+                Ok(WithAssertion::LocalPref(value))
+            }
+            "med" => {
+                let (value, _) = self.expect_u32("a u32 value")?;
+                Ok(WithAssertion::Med(value))
+            }
+            "next-hop" => {
+                if let Some(self_token) = self.eat(Tok::SelfKw) {
+                    Ok(WithAssertion::NextHop(NextHopArg::Self_(self_token.span)))
+                } else {
+                    let (addr, span) = self.expect_ip("an IP address or `self`")?;
+                    Ok(WithAssertion::NextHop(NextHopArg::Addr(addr, span)))
+                }
+            }
+            "community" | "large-community" | "ext-community" => {
+                Ok(WithAssertion::Community(self.community_lit()?))
+            }
+            other => {
+                self.diags.push(
+                    Diagnostic::new(
+                        field.span,
+                        format!("unknown `with` assertion `{other}`"),
+                        "not an assertable attribute",
+                    )
+                    .with_note(
+                        "assertable: local-pref, med, next-hop, community, large-community, ext-community, prepend",
+                    ),
+                );
+                Err(Fail)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ADR_EXAMPLE: &str = r"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28, 192.0.2.0/24 }
+community-set tagged { 65000:100, 65000:200 }
+
+policy customer-in(peer_lp: u32) {
+    term rpki-guard {
+        if route.rpki == invalid { reject }
+    }
+    term customer-routes {
+        if route.prefix in customers && route.communities has 65000:100 {
+            set local-pref peer_lp;
+            add community 65001:999;
+            accept
+        }
+    }
+    term bogon-guard { if apply(bogon-filter) { reject } }
+}
+
+policy bogon-filter {
+    term bogons {
+        if route.prefix == 0.0.0.0/8 { accept }
+    }
+    term not-a-bogon { reject }
+}
+
+test customer-in-accepts-tagged {
+    route { prefix 10.10.1.0/24; communities [65000:100]; rpki valid }
+    expect customer-in(200) == accept with local-pref 200
+}
+";
+
+    #[test]
+    fn parses_the_adr_example() {
+        let (file, diags) = parse(ADR_EXAMPLE);
+        assert!(diags.is_empty(), "{diags:#?}");
+        assert_eq!(file.prefix_sets.len(), 1);
+        assert_eq!(file.prefix_sets[0].entries.len(), 2);
+        assert_eq!(file.prefix_sets[0].entries[0].ge, Some(24));
+        assert_eq!(file.prefix_sets[0].entries[0].le, Some(28));
+        assert_eq!(file.community_sets.len(), 1);
+        assert_eq!(file.policies.len(), 2);
+        assert_eq!(file.policies[0].params.len(), 1);
+        assert_eq!(file.policies[0].terms.len(), 3);
+        assert_eq!(file.tests.len(), 1);
+        assert_eq!(file.tests[0].expects.len(), 1);
+    }
+
+    #[test]
+    fn operator_precedence_not_binds_tighter_than_and_than_or() {
+        let (file, diags) = parse(
+            "policy p { term t { if !route.rpki == valid && route.med <= 5 || apply(q) { accept } } }",
+        );
+        // `!` applies to the comparison, not the whole conjunction:
+        // ((!(rpki==valid)) && (med<=5)) || apply(q)
+        assert!(diags.is_empty(), "{diags:#?}");
+        let Stmt::If(if_stmt) = &file.policies[0].terms[0].stmts[0] else {
+            panic!("expected if")
+        };
+        let Expr::Or(lhs, rhs) = &if_stmt.cond else {
+            panic!("top must be Or, got {:?}", if_stmt.cond)
+        };
+        assert!(matches!(**rhs, Expr::Apply { .. }));
+        let Expr::And(not_side, med_side) = &**lhs else {
+            panic!("lhs must be And")
+        };
+        assert!(matches!(**not_side, Expr::Not(..)));
+        assert!(matches!(**med_side, Expr::Cmp { .. }));
+    }
+
+    #[test]
+    fn reports_multiple_errors_in_one_pass() {
+        let src = "\
+policy first { term t { if route.rpki = valid { reject } } }
+policy second { term t { flarp } }
+";
+        let (file, diags) = parse(src);
+        assert!(
+            diags.len() >= 2,
+            "want one error per broken policy, got {diags:#?}"
+        );
+        // Both policies attempted; neither silently swallowed the file.
+        assert!(file.policies.len() <= 2);
+    }
+
+    #[test]
+    fn rejects_host_bits_and_oversized_communities() {
+        let (_, diags) = parse("prefix-set s { 10.0.0.1/24 }");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("host bits"), "{diags:#?}");
+
+        let (_, diags) = parse("community-set c { 70000:1 }");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("fit in u16"), "{diags:#?}");
+    }
+
+    #[test]
+    fn well_known_community_names_parse() {
+        let (file, diags) = parse("community-set c { NO_EXPORT, BLACKHOLE }");
+        assert!(diags.is_empty(), "{diags:#?}");
+        assert_eq!(file.community_sets[0].entries.len(), 2);
+        assert_eq!(
+            file.community_sets[0].entries[0].node,
+            CommunityLit::Standard(rustbgpd_wire::COMMUNITY_NO_EXPORT)
+        );
+    }
+
+    #[test]
+    fn parses_ext_and_large_community_forms() {
+        let (file, diags) =
+            parse("community-set c { RT:65001:100, RO:192.0.2.1:5, 65000:1:2, LC:65000:3:4 }");
+        assert!(diags.is_empty(), "{diags:#?}");
+        let entries = &file.community_sets[0].entries;
+        assert!(matches!(
+            entries[0].node,
+            CommunityLit::Ext {
+                route_target: true,
+                global: 65001,
+                local: 100,
+                ipv4_admin: false,
+            }
+        ));
+        assert!(matches!(
+            entries[1].node,
+            CommunityLit::Ext {
+                route_target: false,
+                ipv4_admin: true,
+                ..
+            }
+        ));
+        assert!(matches!(entries[2].node, CommunityLit::Large(_)));
+        assert!(matches!(entries[3].node, CommunityLit::Large(_)));
+    }
+
+    #[test]
+    fn else_branch_and_bare_actions_parse() {
+        let src = "policy p { term t { set med 5; if route.med >= 10 { accept } else { add community 65000:1; reject } } }";
+        let (file, diags) = parse(src);
+        assert!(diags.is_empty(), "{diags:#?}");
+        let term = &file.policies[0].terms[0];
+        assert_eq!(term.stmts.len(), 2);
+        let Stmt::If(if_stmt) = &term.stmts[1] else {
+            panic!("expected if")
+        };
+        assert_eq!(if_stmt.else_actions.as_ref().map(Vec::len), Some(2));
+    }
+}

--- a/crates/policy/src/rpol/testing.rs
+++ b/crates/policy/src/rpol/testing.rs
@@ -1,0 +1,311 @@
+//! The in-language `test` block runner: fixtures become
+//! [`RouteContext`]s, expectations run through the real IR evaluator.
+//!
+//! `with` assertions check the evaluation result's **modifications**
+//! (`set local-pref` produced `Some(200)`, an added community is in
+//! the add list, …), not a post-application attribute image — the
+//! frontend has no route to apply them to. Fixture defaults mirror
+//! evaluation semantics: omitted `local-pref`/`med` are absent
+//! attributes (so comparisons see the RFC 4271 implicit 100/0),
+//! omitted `rpki` is `not-found`, omitted `aspa` is `unknown`.
+
+use std::net::IpAddr;
+
+use rustbgpd_wire::{AspaValidation, ExtendedCommunity, LargeCommunity, Prefix, RpkiValidation};
+
+use crate::engine::{NextHopAction, PolicyAction, RouteContext, RouteType};
+use crate::sets::SetStore;
+
+use super::ast::{CommunityLit, NextHopArg, PeerField, RouteField, TestDef, WithAssertion};
+use super::lower::{Lowerer, ext_community_value};
+
+/// The outcome of running a source file's `test` blocks.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TestReport {
+    /// Number of `test` blocks executed.
+    pub total: usize,
+    /// Failed tests with human-readable reasons.
+    pub failures: Vec<TestFailure>,
+}
+
+impl TestReport {
+    /// Number of passing tests.
+    #[must_use]
+    pub fn passed(&self) -> usize {
+        self.total - self.failures.len()
+    }
+
+    /// True when every test passed.
+    #[must_use]
+    pub fn all_passed(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
+/// One failed in-language test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestFailure {
+    /// The `test` block's name.
+    pub name: String,
+    /// What went wrong (one line per failed expectation).
+    pub message: String,
+}
+
+/// An owned route/peer fixture backing a borrowed [`RouteContext`].
+#[derive(Debug, Default)]
+struct Fixture {
+    prefix: Option<Prefix>,
+    next_hop: Option<IpAddr>,
+    communities: Vec<u32>,
+    large_communities: Vec<LargeCommunity>,
+    extended_communities: Vec<ExtendedCommunity>,
+    as_path_str: String,
+    as_path_len: usize,
+    local_pref: Option<u32>,
+    med: Option<u32>,
+    rpki: RpkiValidation,
+    aspa: AspaValidation,
+    route_type: Option<RouteType>,
+    evpn_route_type: Option<u8>,
+    peer_address: Option<IpAddr>,
+    peer_asn: Option<u32>,
+    peer_group: Option<String>,
+}
+
+impl Fixture {
+    fn build(test: &TestDef) -> Self {
+        let mut fixture = Fixture::default();
+        for field in &test.route {
+            match field {
+                RouteField::Prefix(prefix, _) => fixture.prefix = Some(*prefix),
+                RouteField::NextHop(addr, _) => fixture.next_hop = Some(*addr),
+                RouteField::LocalPref(value, _) => fixture.local_pref = Some(*value),
+                RouteField::Med(value, _) => fixture.med = Some(*value),
+                RouteField::Communities(lits, _) => {
+                    for lit in lits {
+                        if let CommunityLit::Standard(value) = lit.node {
+                            fixture.communities.push(value);
+                        }
+                    }
+                }
+                RouteField::LargeCommunities(lits, _) => {
+                    for lit in lits {
+                        if let CommunityLit::Large(lc) = lit.node {
+                            fixture.large_communities.push(lc);
+                        }
+                    }
+                }
+                RouteField::ExtCommunities(lits, _) => {
+                    for lit in lits {
+                        if let CommunityLit::Ext {
+                            route_target,
+                            global,
+                            local,
+                            ipv4_admin,
+                        } = lit.node
+                        {
+                            fixture.extended_communities.push(ext_community_value(
+                                route_target,
+                                global,
+                                local,
+                                ipv4_admin,
+                            ));
+                        }
+                    }
+                }
+                RouteField::AsPath(path) => {
+                    // Fixture AS-path length is the whitespace-word
+                    // count of the string form (AS_SET braces count as
+                    // written) — documented in the language reference.
+                    path.node.clone_into(&mut fixture.as_path_str);
+                    fixture.as_path_len = path.node.split_whitespace().count();
+                }
+                RouteField::Rpki(state) => {
+                    fixture.rpki = match state.node.as_str() {
+                        "valid" => RpkiValidation::Valid,
+                        "invalid" => RpkiValidation::Invalid,
+                        _ => RpkiValidation::NotFound,
+                    };
+                }
+                RouteField::Aspa(state) => {
+                    fixture.aspa = match state.node.as_str() {
+                        "valid" => AspaValidation::Valid,
+                        "invalid" => AspaValidation::Invalid,
+                        _ => AspaValidation::Unknown,
+                    };
+                }
+                RouteField::RouteType(kind) => {
+                    fixture.route_type = Some(match kind.node.as_str() {
+                        "local" => RouteType::Local,
+                        "internal" => RouteType::Internal,
+                        _ => RouteType::External,
+                    });
+                }
+                RouteField::EvpnRouteType(value, _) => {
+                    fixture.evpn_route_type =
+                        Some(u8::try_from(*value).expect("typechecked range"));
+                }
+            }
+        }
+        for field in &test.peer {
+            match field {
+                PeerField::Address(addr) => fixture.peer_address = Some(*addr),
+                PeerField::Asn(asn) => fixture.peer_asn = Some(*asn),
+                PeerField::Group(group) => fixture.peer_group = Some(group.node.clone()),
+            }
+        }
+        fixture
+    }
+
+    fn context(&self) -> RouteContext<'_> {
+        RouteContext {
+            prefix: self.prefix,
+            next_hop: self.next_hop,
+            extended_communities: &self.extended_communities,
+            communities: &self.communities,
+            large_communities: &self.large_communities,
+            as_path_str: &self.as_path_str,
+            as_path_len: self.as_path_len,
+            validation_state: self.rpki,
+            aspa_state: self.aspa,
+            peer_address: self.peer_address,
+            peer_asn: self.peer_asn,
+            peer_group: self.peer_group.as_deref(),
+            route_type: self.route_type,
+            evpn_route_type: self.evpn_route_type,
+            local_pref: self.local_pref,
+            med: self.med,
+        }
+    }
+}
+
+/// Execute every `test` block against the lowered policies.
+pub(super) fn run_tests(
+    tests: &[TestDef],
+    lowerer: &mut Lowerer<'_>,
+    store: &mut SetStore,
+) -> TestReport {
+    let mut report = TestReport {
+        total: tests.len(),
+        failures: Vec::new(),
+    };
+    for test in tests {
+        let fixture = Fixture::build(test);
+        let ctx = fixture.context();
+        let mut problems: Vec<String> = Vec::new();
+        for expect in &test.expects {
+            let args: Vec<u32> = expect.args.iter().map(|arg| arg.node).collect();
+            let chain = lowerer.instantiate_chain(&expect.policy.node, &args, store);
+            let result = chain.evaluate(&ctx);
+            let call = render_call(&expect.policy.node, &args);
+            let accepted = result.action == PolicyAction::Permit;
+            if accepted != expect.accept {
+                problems.push(format!(
+                    "{call}: expected {}, got {}",
+                    verdict(expect.accept),
+                    verdict(accepted),
+                ));
+                continue;
+            }
+            for assertion in &expect.with {
+                if let Some(problem) = check_assertion(assertion, &result.modifications) {
+                    problems.push(format!("{call}: {problem}"));
+                }
+            }
+        }
+        if !problems.is_empty() {
+            report.failures.push(TestFailure {
+                name: test.name.node.clone(),
+                message: problems.join("; "),
+            });
+        }
+    }
+    report
+}
+
+fn verdict(accept: bool) -> &'static str {
+    if accept { "accept" } else { "reject" }
+}
+
+fn render_call(name: &str, args: &[u32]) -> String {
+    if args.is_empty() {
+        name.to_string()
+    } else {
+        format!(
+            "{name}({})",
+            args.iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn check_assertion(
+    assertion: &WithAssertion,
+    mods: &crate::engine::RouteModifications,
+) -> Option<String> {
+    match assertion {
+        WithAssertion::LocalPref(expected) => (mods.set_local_pref != Some(*expected)).then(|| {
+            format!(
+                "expected local-pref {expected}, got {}",
+                render_opt(mods.set_local_pref)
+            )
+        }),
+        WithAssertion::Med(expected) => (mods.set_med != Some(*expected))
+            .then(|| format!("expected med {expected}, got {}", render_opt(mods.set_med))),
+        WithAssertion::NextHop(arg) => {
+            let expected = match arg {
+                NextHopArg::Self_(_) => NextHopAction::Self_,
+                NextHopArg::Addr(addr, _) => NextHopAction::Specific(*addr),
+            };
+            (mods.set_next_hop.as_ref() != Some(&expected)).then(|| {
+                format!(
+                    "expected next-hop {}, got {}",
+                    render_next_hop(Some(&expected)),
+                    render_next_hop(mods.set_next_hop.as_ref()),
+                )
+            })
+        }
+        WithAssertion::Community(lit) => {
+            let present = match lit.node {
+                CommunityLit::Standard(value) => mods.communities_add.contains(&value),
+                CommunityLit::Large(lc) => mods.large_communities_add.contains(&lc),
+                CommunityLit::Ext {
+                    route_target,
+                    global,
+                    local,
+                    ipv4_admin,
+                } => mods.extended_communities_add.contains(&ext_community_value(
+                    route_target,
+                    global,
+                    local,
+                    ipv4_admin,
+                )),
+            };
+            (!present).then(|| "expected community was not added".to_string())
+        }
+        WithAssertion::Prepend(asn, count) => {
+            let expected = Some((*asn, u8::try_from(*count).unwrap_or(u8::MAX)));
+            (mods.as_path_prepend != expected).then(|| {
+                format!(
+                    "expected prepend as {asn} {count}, got {}",
+                    mods.as_path_prepend
+                        .map_or_else(|| "none".to_string(), |(a, c)| format!("as {a} {c}"))
+                )
+            })
+        }
+    }
+}
+
+fn render_opt(value: Option<u32>) -> String {
+    value.map_or_else(|| "none".to_string(), |v| v.to_string())
+}
+
+fn render_next_hop(action: Option<&NextHopAction>) -> String {
+    match action {
+        None => "none".to_string(),
+        Some(NextHopAction::Self_) => "self".to_string(),
+        Some(NextHopAction::Specific(addr)) => addr.to_string(),
+    }
+}

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1,0 +1,607 @@
+//! End-to-end `.rpol` frontend tests: compile → IR shape goldens,
+//! evaluation through the real IR evaluator, every diagnostic path
+//! (with rendering assertions), and the in-language test runner.
+
+use std::net::Ipv4Addr;
+
+use rustbgpd_wire::{Ipv4Prefix, Prefix, RpkiValidation};
+
+use crate::engine::{PolicyAction, RouteContext, RouteModifications};
+use crate::ir::{Cmp, MatchExpr, PolicySource, SetId, TermAction};
+use crate::sets::SetStore;
+
+use super::{TestReport, check_rpol, compile_rpol, run_rpol_tests};
+
+const ADR_EXAMPLE: &str = r"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28, 192.0.2.0/24 }
+community-set tagged { 65000:100, 65000:200 }
+
+policy bogon-filter {
+    term bogons {
+        if route.prefix == 0.0.0.0/8 || route.prefix == 127.0.0.0/8 { accept }
+    }
+    term everything-else { reject }
+}
+
+policy customer-in(peer_lp: u32) {
+    term rpki-guard {
+        if route.rpki == invalid { reject }
+    }
+    term customer-routes {
+        if route.prefix in customers && route.communities has 65000:100 {
+            set local-pref peer_lp;
+            add community 65001:999;
+            accept
+        }
+    }
+    term bogon-guard { if apply(bogon-filter) { reject } }
+}
+
+test customer-in-accepts-tagged {
+    route { prefix 10.10.1.0/24; communities [65000:100]; rpki valid }
+    expect customer-in(200) == accept with local-pref 200, community 65001:999
+}
+
+test customer-in-rejects-rpki-invalid {
+    route { prefix 10.10.1.0/24; communities [65000:100]; rpki invalid }
+    expect customer-in(200) == reject
+}
+
+test bogons-rejected {
+    route { prefix 127.0.0.0/8 }
+    expect customer-in(200) == reject
+}
+";
+
+fn route_ctx(prefix: Prefix, communities: &[u32], rpki: RpkiValidation) -> RouteContext<'static> {
+    RouteContext {
+        prefix: Some(prefix),
+        next_hop: None,
+        extended_communities: &[],
+        communities: Box::leak(communities.to_vec().into_boxed_slice()),
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: rpki,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+fn v4(a: u8, b: u8, c: u8, d: u8, len: u8) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(a, b, c, d), len))
+}
+
+fn compile_ok(source: &str) -> crate::ir::CompiledChain {
+    let mut store = SetStore::new();
+    match compile_rpol(source, &mut store) {
+        Ok(chain) => chain,
+        Err(diags) => panic!("{}", diags.render("test.rpol", source, false)),
+    }
+}
+
+fn diagnostics_of(source: &str) -> (super::Diagnostics, String) {
+    let mut store = SetStore::new();
+    let diags = compile_rpol(source, &mut store).expect_err("expected diagnostics");
+    let rendered = diags.render("test.rpol", source, false);
+    (diags, rendered)
+}
+
+// ── compile + IR shape goldens ─────────────────────────────────────
+
+#[test]
+fn adr_example_compiles_zero_param_policies_only() {
+    let chain = compile_ok(ADR_EXAMPLE);
+    // `customer-in` takes a parameter → template only; `bogon-filter`
+    // is the sole zero-param policy in the chain.
+    assert_eq!(chain.policies.len(), 1);
+    let bogon = &chain.policies[0];
+    assert_eq!(bogon.name.as_deref(), Some("bogon-filter"));
+    assert_eq!(bogon.source, PolicySource::Rpol);
+    assert_eq!(bogon.default_action, PolicyAction::Permit);
+    assert_eq!(bogon.terms.len(), 2);
+    assert_eq!(bogon.terms[0].name.as_deref(), Some("bogons"));
+    assert!(matches!(bogon.terms[0].guard, MatchExpr::Or(_)));
+    assert!(matches!(bogon.terms[0].action, TermAction::Permit(_)));
+    assert_eq!(bogon.terms[1].name.as_deref(), Some("everything-else"));
+    assert_eq!(bogon.terms[1].guard, MatchExpr::True);
+    assert_eq!(bogon.terms[1].action, TermAction::Deny);
+    // Set tables carry both defined sets even though only `customers`
+    // is referenced by a zero-param policy.
+    assert_eq!(chain.prefix_sets.len(), 1);
+    assert_eq!(chain.community_sets.len(), 1);
+}
+
+#[test]
+fn set_membership_lowers_to_indexed_sets() {
+    let chain = compile_ok(
+        "prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+         policy p {
+             term t { if route.prefix in customers { accept } }
+         }",
+    );
+    let term = &chain.policies[0].terms[0];
+    assert_eq!(term.guard, MatchExpr::PrefixInSet(SetId(0)));
+    assert!(chain.prefix_sets[0].matches(v4(10, 10, 3, 0, 24)));
+    assert!(!chain.prefix_sets[0].matches(v4(10, 10, 3, 0, 30)));
+}
+
+#[test]
+fn u32_equality_lowers_to_ge_and_le() {
+    let chain = compile_ok("policy p { term t { if route.med == 50 { reject } } }");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::And(vec![
+            MatchExpr::Med(Cmp::Ge(50)),
+            MatchExpr::Med(Cmp::Le(50))
+        ])
+    );
+}
+
+#[test]
+fn term_fallthrough_encoding() {
+    // A bare modification run + an if with a verdictless body + a
+    // final verdict term: exercises Continue flushing and `<term>.<n>`
+    // naming.
+    let chain = compile_ok(
+        "policy p {
+             term shape {
+                 set med 10;
+                 if route.local-pref >= 500 { add community 65000:1 }
+             }
+             term decide { accept }
+         }",
+    );
+    let terms = &chain.policies[0].terms;
+    assert_eq!(terms.len(), 3);
+    assert_eq!(terms[0].name.as_deref(), Some("shape.1"));
+    assert_eq!(terms[0].guard, MatchExpr::True);
+    let TermAction::Continue(mods) = &terms[0].action else {
+        panic!("bare mods flush as Continue, got {:?}", terms[0].action)
+    };
+    assert_eq!(mods.set_med, Some(10));
+    assert_eq!(terms[1].name.as_deref(), Some("shape.2"));
+    let TermAction::Continue(mods) = &terms[1].action else {
+        panic!("verdictless if body is Continue, got {:?}", terms[1].action)
+    };
+    assert_eq!(mods.communities_add, vec![(65000 << 16) | 1]);
+    assert_eq!(terms[2].name.as_deref(), Some("decide"));
+    assert_eq!(
+        terms[2].action,
+        TermAction::Permit(RouteModifications::default())
+    );
+
+    // And the evaluator honors it: both Continue mods survive into the
+    // accept.
+    let ctx = RouteContext {
+        local_pref: Some(600),
+        ..route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound)
+    };
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(10));
+    assert_eq!(
+        result.modifications.communities_add,
+        vec![(65000 << 16) | 1]
+    );
+
+    // Below the local-pref threshold only the unconditional mod applies.
+    let ctx = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.modifications.set_med, Some(10));
+    assert!(result.modifications.communities_add.is_empty());
+}
+
+#[test]
+fn else_lowers_to_negated_guard() {
+    let chain = compile_ok(
+        "policy p {
+             term t {
+                 if route.rpki == valid { accept } else { reject }
+             }
+         }",
+    );
+    let terms = &chain.policies[0].terms;
+    assert_eq!(terms.len(), 2);
+    assert_eq!(terms[0].guard, MatchExpr::RpkiIs(RpkiValidation::Valid));
+    assert!(matches!(terms[0].action, TermAction::Permit(_)));
+    assert_eq!(
+        terms[1].guard,
+        MatchExpr::Not(Box::new(MatchExpr::RpkiIs(RpkiValidation::Valid)))
+    );
+    assert_eq!(terms[1].action, TermAction::Deny);
+}
+
+#[test]
+fn apply_inlines_the_target_decision() {
+    let chain = compile_ok(
+        "policy inner {
+             term a { if route.med <= 5 { accept } }
+             term b { reject }
+         }
+         policy outer {
+             term guard { if apply(inner) { reject } }
+         }",
+    );
+    let outer = chain
+        .policies
+        .iter()
+        .find(|p| p.name.as_deref() == Some("outer"))
+        .expect("outer compiled");
+    // inner accepts iff med <= 5 (default-permit arm is unreachable
+    // behind the unconditional reject), so outer rejects exactly then.
+    let low_med = RouteContext {
+        med: Some(3),
+        ..route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound)
+    };
+    let high_med = RouteContext {
+        med: Some(50),
+        ..route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound)
+    };
+    let single = crate::ir::CompiledChain {
+        policies: vec![outer.clone()],
+        prefix_sets: chain.prefix_sets.clone(),
+        community_sets: chain.community_sets.clone(),
+        as_path_regexes: chain.as_path_regexes.clone(),
+    };
+    assert_eq!(single.evaluate(&low_med).action, PolicyAction::Deny);
+    assert_eq!(single.evaluate(&high_med).action, PolicyAction::Permit);
+}
+
+#[test]
+fn end_to_end_adr_example_evaluation() {
+    let chain = compile_ok(ADR_EXAMPLE);
+    // Evaluate `customer-in(200)` by instantiating through a test-run
+    // equivalent: reuse run_rpol_tests which does exactly that.
+    let report = run_rpol_tests(ADR_EXAMPLE).expect("compiles");
+    assert_eq!(report.total, 3);
+    assert!(
+        report.all_passed(),
+        "in-language tests failed: {:?}",
+        report.failures
+    );
+    // The zero-param bogon-filter is directly evaluable too.
+    let bogon_route = route_ctx(v4(127, 0, 0, 0, 8), &[], RpkiValidation::NotFound);
+    assert_eq!(chain.evaluate(&bogon_route).action, PolicyAction::Permit);
+    let normal = route_ctx(v4(8, 8, 8, 0, 24), &[], RpkiValidation::NotFound);
+    assert_eq!(chain.evaluate(&normal).action, PolicyAction::Deny);
+}
+
+#[test]
+fn as_path_and_peer_predicates_lower_and_evaluate() {
+    let chain = compile_ok(
+        r#"policy p {
+             term long-paths { if route.as-path.len >= 3 && route.as-path contains 65001 { reject } }
+             term from-leaf { if peer.group == "leaf" && route.as-path matches "^65010" { reject } }
+             term rest { accept }
+         }"#,
+    );
+    let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    let long = RouteContext {
+        as_path_str: "65005 65001 65002",
+        as_path_len: 3,
+        ..base
+    };
+    assert_eq!(chain.evaluate(&long).action, PolicyAction::Deny);
+    let leaf = RouteContext {
+        as_path_str: "65010 65011",
+        as_path_len: 2,
+        peer_group: Some("leaf"),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&leaf).action, PolicyAction::Deny);
+    assert_eq!(chain.evaluate(&base).action, PolicyAction::Permit);
+}
+
+#[test]
+fn modification_actions_lower_to_route_modifications() {
+    let chain = compile_ok(
+        "policy p {
+             term t {
+                 set next-hop self;
+                 remove community NO_EXPORT;
+                 add large-community 65000:1:2;
+                 add ext-community RT:65001:100;
+                 prepend as 65001 3;
+                 accept
+             }
+         }",
+    );
+    let TermAction::Permit(mods) = &chain.policies[0].terms[0].action else {
+        panic!("expected permit")
+    };
+    assert_eq!(mods.set_next_hop, Some(crate::engine::NextHopAction::Self_));
+    assert_eq!(
+        mods.communities_remove,
+        vec![rustbgpd_wire::COMMUNITY_NO_EXPORT]
+    );
+    assert_eq!(mods.large_communities_add.len(), 1);
+    assert_eq!(mods.as_path_prepend, Some((65001, 3)));
+    // RT:65001:100 with a 2-octet ASN admin → type 0x00, subtype 0x02.
+    let ec = mods.extended_communities_add[0];
+    assert_eq!(ec.type_byte(), 0x00);
+    assert_eq!(ec.route_target(), Some((65001, 100)));
+}
+
+// ── diagnostics (every error path asserts its rendering) ──────────
+
+#[test]
+fn unknown_set_suggests_and_renders() {
+    let (diags, rendered) = diagnostics_of(
+        "prefix-set customers { 10.0.0.0/8 }
+         policy p { term t { if route.prefix in custmers { accept } } }",
+    );
+    assert_eq!(diags.len(), 1);
+    assert!(
+        rendered.contains("unknown prefix-set `custmers`"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("no prefix-set with this name"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `customers`?"), "{rendered}");
+}
+
+#[test]
+fn unknown_policy_in_apply_suggests() {
+    let (_, rendered) = diagnostics_of(
+        "policy bogon-filter { term t { reject } }
+         policy p { term t { if apply(bogon-fitler) { reject } } }",
+    );
+    assert!(
+        rendered.contains("unknown policy `bogon-fitler`"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("did you mean `bogon-filter`?"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn unknown_field_suggests() {
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if route.local-perf >= 100 { accept } } }");
+    assert!(
+        rendered.contains("unknown field `route.local-perf`"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("did you mean `route.local-pref`?"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn type_mismatches_render() {
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.next-hop == 5 { accept } } }");
+    assert!(rendered.contains("type mismatch"), "{rendered}");
+    assert!(rendered.contains("expected an IP address"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.rpki >= valid { accept } } }");
+    assert!(
+        rendered.contains("supports only `==` and `!=`"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.rpki == vaild { accept } } }");
+    assert!(
+        rendered.contains("not a valid `route.rpki` value"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `valid`?"), "{rendered}");
+
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if route.communities == 65000:1 { accept } } }");
+    assert!(
+        rendered.contains("cannot be compared directly"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("use `has <community>`"), "{rendered}");
+}
+
+#[test]
+fn community_kind_mismatches_render() {
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if route.communities has 65000:1:2 { accept } } }");
+    assert!(rendered.contains("community kind mismatch"), "{rendered}");
+    assert!(rendered.contains("large-community literal"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy p { term t { add community RT:65001:1; accept } }");
+    assert!(rendered.contains("community kind mismatch"), "{rendered}");
+    assert!(
+        rendered.contains("use `add/remove ext-community`"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn apply_recursion_is_rejected() {
+    let (_, rendered) = diagnostics_of(
+        "policy a { term t { if apply(b) { reject } } }
+         policy b { term t { if apply(a) { reject } } }",
+    );
+    assert!(
+        rendered.contains("`apply` cycle: a -> b -> a"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("must form a DAG"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy a { term t { if apply(a) { reject } } }");
+    assert!(rendered.contains("`apply` cycle: a -> a"), "{rendered}");
+}
+
+#[test]
+fn arity_mismatch_is_rejected() {
+    let (_, rendered) = diagnostics_of(
+        "policy takes-one(lp: u32) { term t { accept } }
+         policy p { term t { if apply(takes-one) { reject } } }",
+    );
+    assert!(
+        rendered.contains("takes 1 argument but 0 were supplied"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("policy defined here"), "{rendered}");
+}
+
+#[test]
+fn duplicate_names_are_rejected() {
+    let (_, rendered) = diagnostics_of(
+        "policy p { term t { accept } }
+         policy p { term t { reject } }",
+    );
+    assert!(rendered.contains("duplicate policy `p`"), "{rendered}");
+    assert!(rendered.contains("first definition is here"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy q { term t { accept } term t { reject } }");
+    assert!(rendered.contains("duplicate term `t`"), "{rendered}");
+}
+
+#[test]
+fn unknown_parameter_suggests() {
+    let (_, rendered) =
+        diagnostics_of("policy p(peer_lp: u32) { term t { set local-pref peer_pl; accept } }");
+    assert!(
+        rendered.contains("unknown parameter `peer_pl`"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `peer_lp`?"), "{rendered}");
+}
+
+#[test]
+fn unreachable_statements_are_rejected() {
+    let (_, rendered) = diagnostics_of("policy p { term t { accept set med 5 } }");
+    assert!(rendered.contains("unreachable statement"), "{rendered}");
+    assert!(rendered.contains("already decided here"), "{rendered}");
+}
+
+#[test]
+fn bad_regex_is_rejected_at_compile_time() {
+    let (_, rendered) =
+        diagnostics_of(r#"policy p { term t { if route.as-path matches "[65001" { reject } } }"#);
+    assert!(rendered.contains("regex does not compile"), "{rendered}");
+}
+
+#[test]
+fn parse_errors_render_with_expected_token() {
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.rpki == { accept } } }");
+    assert!(
+        rendered.contains("expected a comparison operand"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of("policy p { accept }");
+    assert!(rendered.contains("expected `term`"), "{rendered}");
+}
+
+#[test]
+fn multiple_errors_reported_together() {
+    let (diags, rendered) = diagnostics_of(
+        "policy p { term t { if route.rpki == vaild { accept } } }
+         policy q { term t { if route.prefix in nowhere { reject } } }",
+    );
+    assert!(diags.len() >= 2, "{rendered}");
+    assert!(rendered.contains("vaild"), "{rendered}");
+    assert!(rendered.contains("nowhere"), "{rendered}");
+}
+
+// ── in-language test runner ────────────────────────────────────────
+
+#[test]
+fn failing_tests_are_reported_with_reasons() {
+    let source = r"
+policy p {
+    term t { if route.med <= 5 { set local-pref 300; accept } }
+    term rest { reject }
+}
+
+test wrong-verdict {
+    route { prefix 10.0.0.0/24; med 100 }
+    expect p == accept
+}
+
+test wrong-attribute {
+    route { prefix 10.0.0.0/24; med 3 }
+    expect p == accept with local-pref 999
+}
+
+test passing {
+    route { prefix 10.0.0.0/24; med 3 }
+    expect p == accept with local-pref 300
+}
+";
+    let report = run_rpol_tests(source).expect("compiles");
+    assert_eq!(report.total, 3);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failures.len(), 2);
+    let by_name: std::collections::HashMap<&str, &str> = report
+        .failures
+        .iter()
+        .map(|f| (f.name.as_str(), f.message.as_str()))
+        .collect();
+    assert!(by_name["wrong-verdict"].contains("expected accept, got reject"));
+    assert!(by_name["wrong-attribute"].contains("expected local-pref 999, got 300"));
+}
+
+#[test]
+fn tests_use_peer_fixture_and_parameters() {
+    let source = r#"
+policy per-peer(lp: u32) {
+    term from-leaf {
+        if peer.group == "leaf" && peer.asn == 65010 {
+            set local-pref lp;
+            accept
+        }
+    }
+    term rest { reject }
+}
+
+test leaf-peer-matches {
+    route { prefix 10.0.0.0/24 }
+    peer { address 192.0.2.1; asn 65010; group "leaf" }
+    expect per-peer(500) == accept with local-pref 500
+}
+
+test other-peer-rejected {
+    route { prefix 10.0.0.0/24 }
+    peer { asn 65099 }
+    expect per-peer(500) == reject
+}
+"#;
+    let report = run_rpol_tests(source).expect("compiles");
+    assert!(report.all_passed(), "{:?}", report.failures);
+}
+
+#[test]
+fn check_rpol_shapes() {
+    // Clean file, passing tests.
+    let report = check_rpol(ADR_EXAMPLE);
+    assert!(report.is_ok());
+    assert!(report.diagnostics.is_empty());
+    assert_eq!(report.tests.as_ref().map(TestReport::passed), Some(3));
+
+    // Diagnostics: no tests run.
+    let report = check_rpol("policy p { term t { if route.zzz == 1 { accept } } }");
+    assert!(!report.is_ok());
+    assert!(!report.diagnostics.is_empty());
+    assert!(report.tests.is_none());
+
+    // Clean compile, failing test.
+    let report = check_rpol(
+        "policy p { term t { reject } }
+         test should-fail {
+             route { prefix 10.0.0.0/24 }
+             expect p == accept
+         }",
+    );
+    assert!(!report.is_ok());
+    assert!(report.diagnostics.is_empty());
+    assert_eq!(report.tests.as_ref().map(|t| t.failures.len()), Some(1));
+}

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -1,0 +1,922 @@
+//! The `.rpol` typechecker: name resolution, per-field operator/type
+//! rules, parameter scoping, `apply` DAG validation, and did-you-mean
+//! suggestions. Runs on the full AST even after parse errors, so one
+//! `check` reports as much as possible.
+//!
+//! The type universe is fixed (ADR-0096 Decision 4): bool (guards),
+//! u32 (`local-pref`, `med`, `as-path.len`, `peer.asn`,
+//! `evpn-route-type`, parameters), prefix, the three community kinds,
+//! as-path, the `rpki`/`aspa`/`route-type` enums, IP addresses, and
+//! strings (regexes, peer groups). Inference is trivial by design —
+//! every field has a known type and every operator a fixed signature.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::engine::AsPathRegex;
+
+use super::ast::{
+    ActionStmt, CmpOp, CommunityKind, Expr, FieldPath, FieldRoot, PolicyDef, Rhs, RouteField,
+    SourceFile, Stmt, U32Arg,
+};
+use super::diag::{Diagnostic, Span, Spanned, closest};
+
+/// A resolved route/peer context field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Field {
+    Prefix,
+    Communities,
+    LargeCommunities,
+    ExtCommunities,
+    AsPath,
+    AsPathLen,
+    LocalPref,
+    Med,
+    NextHop,
+    Rpki,
+    Aspa,
+    RouteType,
+    EvpnRouteType,
+    PeerAddress,
+    PeerAsn,
+    PeerGroup,
+}
+
+const ROUTE_FIELDS: &[(&str, Field)] = &[
+    ("prefix", Field::Prefix),
+    ("communities", Field::Communities),
+    ("large-communities", Field::LargeCommunities),
+    ("ext-communities", Field::ExtCommunities),
+    ("as-path", Field::AsPath),
+    ("local-pref", Field::LocalPref),
+    ("med", Field::Med),
+    ("next-hop", Field::NextHop),
+    ("rpki", Field::Rpki),
+    ("aspa", Field::Aspa),
+    ("route-type", Field::RouteType),
+    ("evpn-route-type", Field::EvpnRouteType),
+];
+
+const PEER_FIELDS: &[(&str, Field)] = &[
+    ("address", Field::PeerAddress),
+    ("asn", Field::PeerAsn),
+    ("group", Field::PeerGroup),
+];
+
+/// Enum members per enum-typed field, in language spelling.
+pub(super) const RPKI_MEMBERS: &[&str] = &["valid", "invalid", "not-found"];
+pub(super) const ASPA_MEMBERS: &[&str] = &["valid", "invalid", "unknown"];
+pub(super) const ROUTE_TYPE_MEMBERS: &[&str] = &["local", "internal", "external"];
+
+/// Resolve a dotted field path to a [`Field`], or a diagnostic with a
+/// suggestion.
+pub(super) fn resolve_field(path: &FieldPath) -> Result<Field, Diagnostic> {
+    let (table, root_name) = match path.root {
+        FieldRoot::Route => (ROUTE_FIELDS, "route"),
+        FieldRoot::Peer => (PEER_FIELDS, "peer"),
+    };
+    let first = &path.segs[0];
+    let Some(&(_, field)) = table.iter().find(|(name, _)| *name == first.node) else {
+        let mut diag = Diagnostic::new(
+            first.span,
+            format!("unknown field `{root_name}.{}`", first.node),
+            format!("`{root_name}` has no field `{}`", first.node),
+        );
+        if let Some(suggestion) = closest(&first.node, table.iter().map(|(name, _)| *name)) {
+            diag = diag.with_note(format!("did you mean `{root_name}.{suggestion}`?"));
+        }
+        return Err(diag);
+    };
+    match path.segs.len() {
+        1 => Ok(field),
+        2 if field == Field::AsPath && path.segs[1].node == "len" => Ok(Field::AsPathLen),
+        _ => {
+            let extra = &path.segs[1];
+            Err(Diagnostic::new(
+                extra.span,
+                format!("field `{}` has no sub-field `{}`", first.node, extra.node),
+                "unexpected sub-field",
+            )
+            .with_note("the only sub-field is `route.as-path.len`"))
+        }
+    }
+}
+
+/// Typecheck a parsed source file. Returns every diagnostic found.
+#[must_use]
+pub fn typecheck(file: &SourceFile) -> Vec<Diagnostic> {
+    let mut checker = Checker {
+        file,
+        diags: Vec::new(),
+    };
+    checker.check_declarations();
+    for policy in &file.policies {
+        checker.check_policy(policy);
+    }
+    checker.check_apply_dag();
+    checker.check_tests();
+    checker.diags
+}
+
+struct Checker<'a> {
+    file: &'a SourceFile,
+    diags: Vec<Diagnostic>,
+}
+
+impl Checker<'_> {
+    fn policy(&self, name: &str) -> Option<&PolicyDef> {
+        self.file.policies.iter().find(|p| p.name.node == name)
+    }
+
+    fn duplicate_check<'n>(
+        &mut self,
+        kind: &str,
+        names: impl IntoIterator<Item = &'n Spanned<String>>,
+    ) {
+        let mut seen: HashMap<&str, Span> = HashMap::new();
+        for name in names {
+            if let Some(&first) = seen.get(name.node.as_str()) {
+                self.diags.push(
+                    Diagnostic::new(
+                        name.span,
+                        format!("duplicate {kind} `{}`", name.node),
+                        format!("`{}` is already defined", name.node),
+                    )
+                    .with_label(first, "first definition is here"),
+                );
+            } else {
+                seen.insert(&name.node, name.span);
+            }
+        }
+    }
+
+    fn check_declarations(&mut self) {
+        self.duplicate_check("prefix-set", self.file.prefix_sets.iter().map(|s| &s.name));
+        self.duplicate_check(
+            "community-set",
+            self.file.community_sets.iter().map(|s| &s.name),
+        );
+        self.duplicate_check("policy", self.file.policies.iter().map(|p| &p.name));
+        self.duplicate_check("test", self.file.tests.iter().map(|t| &t.name));
+    }
+
+    // ── policies ────────────────────────────────────────────────────
+
+    fn check_policy(&mut self, policy: &PolicyDef) {
+        self.duplicate_check("parameter", policy.params.iter());
+        self.duplicate_check("term", policy.terms.iter().map(|t| &t.name));
+        let params: Vec<&str> = policy.params.iter().map(|p| p.node.as_str()).collect();
+        for term in &policy.terms {
+            let mut terminated: Option<Span> = None;
+            for stmt in &term.stmts {
+                if let Some(verdict_span) = terminated {
+                    let span = match stmt {
+                        Stmt::If(if_stmt) => if_stmt.span,
+                        Stmt::Action(action) => action.span(),
+                    };
+                    self.diags.push(
+                        Diagnostic::new(
+                            span,
+                            "unreachable statement",
+                            "this statement can never execute",
+                        )
+                        .with_label(verdict_span, "the term already decided here"),
+                    );
+                    break;
+                }
+                match stmt {
+                    Stmt::Action(action) => {
+                        self.check_action(action, &params);
+                        if matches!(action, ActionStmt::Accept(_) | ActionStmt::Reject(_)) {
+                            terminated = Some(action.span());
+                        }
+                    }
+                    Stmt::If(if_stmt) => {
+                        self.check_expr(&if_stmt.cond, &params);
+                        self.check_action_list(&if_stmt.then_actions, &params);
+                        if let Some(else_actions) = &if_stmt.else_actions {
+                            self.check_action_list(else_actions, &params);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_action_list(&mut self, actions: &[ActionStmt], params: &[&str]) {
+        let mut terminated: Option<Span> = None;
+        for action in actions {
+            if let Some(verdict_span) = terminated {
+                self.diags.push(
+                    Diagnostic::new(
+                        action.span(),
+                        "unreachable action",
+                        "this action can never execute",
+                    )
+                    .with_label(verdict_span, "the branch already decided here"),
+                );
+                break;
+            }
+            self.check_action(action, params);
+            if matches!(action, ActionStmt::Accept(_) | ActionStmt::Reject(_)) {
+                terminated = Some(action.span());
+            }
+        }
+    }
+
+    fn check_action(&mut self, action: &ActionStmt, params: &[&str]) {
+        match action {
+            ActionStmt::Accept(_) | ActionStmt::Reject(_) | ActionStmt::SetNextHop(..) => {}
+            ActionStmt::SetLocalPref(arg, _) | ActionStmt::SetMed(arg, _) => {
+                self.check_u32_arg(arg, params);
+            }
+            ActionStmt::Community { kind, lit, .. } => {
+                if lit.node.kind() != *kind {
+                    let (kind_word, lit_word) =
+                        (kind_keyword(*kind), kind_keyword(lit.node.kind()));
+                    self.diags.push(
+                        Diagnostic::new(
+                            lit.span,
+                            format!(
+                                "community kind mismatch: `{kind_word}` action with a {} literal",
+                                kind_describe(lit.node.kind())
+                            ),
+                            format!("this is a {} literal", kind_describe(lit.node.kind())),
+                        )
+                        .with_note(format!("use `add/remove {lit_word}` for this literal")),
+                    );
+                }
+            }
+            ActionStmt::Prepend { asn, count, .. } => {
+                self.check_u32_arg(asn, params);
+                match count {
+                    U32Arg::Lit(value, span) => {
+                        if *value == 0 || *value > 255 {
+                            self.diags.push(Diagnostic::new(
+                                *span,
+                                format!("prepend count {value} out of range"),
+                                "must be 1-255",
+                            ));
+                        }
+                    }
+                    U32Arg::Param(name) => {
+                        self.diags.push(Diagnostic::new(
+                            name.span,
+                            "prepend count must be a literal",
+                            "parameters are not allowed here",
+                        ).with_note(
+                            "the count is encoded as a u8; a parameterized count cannot be range-checked at definition time",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_u32_arg(&mut self, arg: &U32Arg, params: &[&str]) {
+        if let U32Arg::Param(name) = arg
+            && !params.contains(&name.node.as_str())
+        {
+            let mut diag = Diagnostic::new(
+                name.span,
+                format!("unknown parameter `{}`", name.node),
+                "not a parameter of this policy",
+            );
+            if let Some(suggestion) = closest(&name.node, params.iter().copied()) {
+                diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+            }
+            self.diags.push(diag);
+        }
+    }
+
+    // ── expressions ─────────────────────────────────────────────────
+
+    #[allow(clippy::too_many_lines)]
+    fn check_expr(&mut self, expr: &Expr, params: &[&str]) {
+        match expr {
+            Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
+                self.check_expr(lhs, params);
+                self.check_expr(rhs, params);
+            }
+            Expr::Not(inner, _) => self.check_expr(inner, params),
+            Expr::Cmp { field, op, rhs, .. } => self.check_cmp(field, *op, rhs, params),
+            Expr::In { field, set } => self.check_in(field, set),
+            Expr::Has { field, lit } => match resolve_field(field) {
+                Err(diag) => self.diags.push(diag),
+                Ok(resolved) => {
+                    let expected = match resolved {
+                        Field::Communities => Some(CommunityKind::Standard),
+                        Field::LargeCommunities => Some(CommunityKind::Large),
+                        Field::ExtCommunities => Some(CommunityKind::Ext),
+                        _ => None,
+                    };
+                    match expected {
+                            None => self.diags.push(
+                                Diagnostic::new(
+                                    field.span,
+                                    format!("`has` is not defined on `{}`", field.render()),
+                                    "`has` probes a community list",
+                                )
+                                .with_note(
+                                    "`has` works on route.communities, route.large-communities, and route.ext-communities",
+                                ),
+                            ),
+                            Some(kind) if lit.node.kind() != kind => self.diags.push(
+                                Diagnostic::new(
+                                    lit.span,
+                                    format!(
+                                        "community kind mismatch: `{}` holds {} communities but this is a {} literal",
+                                        field.render(),
+                                        kind_describe(kind),
+                                        kind_describe(lit.node.kind()),
+                                    ),
+                                    "wrong community kind",
+                                )
+                                .with_note(format!(
+                                    "match it via `route.{}`",
+                                    kind_field(lit.node.kind())
+                                )),
+                            ),
+                            Some(_) => {}
+                        }
+                }
+            },
+            Expr::Matches { field, pattern } => {
+                self.require_as_path(field, "matches");
+                if let Err(error) = AsPathRegex::new(&pattern.node) {
+                    self.diags.push(Diagnostic::new(
+                        pattern.span,
+                        error,
+                        "regex does not compile",
+                    ));
+                }
+            }
+            Expr::Contains { field, asn } => {
+                self.require_as_path(field, "contains");
+                self.check_u32_arg(asn, params);
+            }
+            Expr::Apply { policy, args, span } => {
+                let Some(target) = self.policy(&policy.node) else {
+                    let mut diag = Diagnostic::new(
+                        policy.span,
+                        format!("unknown policy `{}`", policy.node),
+                        "no policy with this name",
+                    );
+                    let names: Vec<&str> = self
+                        .file
+                        .policies
+                        .iter()
+                        .map(|p| p.name.node.as_str())
+                        .collect();
+                    if let Some(suggestion) = closest(&policy.node, names) {
+                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    }
+                    self.diags.push(diag);
+                    return;
+                };
+                if target.params.len() != args.len() {
+                    self.diags.push(
+                        Diagnostic::new(
+                            *span,
+                            format!(
+                                "policy `{}` takes {} argument{} but {} {} supplied",
+                                policy.node,
+                                target.params.len(),
+                                if target.params.len() == 1 { "" } else { "s" },
+                                args.len(),
+                                if args.len() == 1 { "was" } else { "were" },
+                            ),
+                            "wrong number of arguments",
+                        )
+                        .with_label(target.name.span, "policy defined here"),
+                    );
+                }
+                for arg in args {
+                    self.check_u32_arg(arg, params);
+                }
+            }
+        }
+    }
+
+    fn require_as_path(&mut self, field: &FieldPath, op: &str) {
+        match resolve_field(field) {
+            Err(diag) => self.diags.push(diag),
+            Ok(Field::AsPath) => {}
+            Ok(_) => self.diags.push(Diagnostic::new(
+                field.span,
+                format!("`{op}` is not defined on `{}`", field.render()),
+                format!("`{op}` works on route.as-path"),
+            )),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn check_cmp(&mut self, field: &FieldPath, op: CmpOp, rhs: &Rhs, params: &[&str]) {
+        let resolved = match resolve_field(field) {
+            Ok(resolved) => resolved,
+            Err(diag) => {
+                self.diags.push(diag);
+                return;
+            }
+        };
+        let eq_only = |checker: &mut Self| {
+            if matches!(op, CmpOp::Ge | CmpOp::Le) {
+                checker.diags.push(Diagnostic::new(
+                    field.span.to(rhs.span()),
+                    format!("`{}` supports only `==` and `!=`", field.render()),
+                    "ordering comparison on an unordered field",
+                ));
+            }
+        };
+        match resolved {
+            Field::LocalPref | Field::Med | Field::AsPathLen => {
+                self.expect_u32_rhs(field, rhs, params);
+            }
+            Field::PeerAsn => {
+                eq_only(self);
+                self.expect_u32_rhs(field, rhs, params);
+            }
+            Field::EvpnRouteType => {
+                eq_only(self);
+                match rhs {
+                    Rhs::Int(value, span) if *value > 255 => {
+                        self.diags.push(Diagnostic::new(
+                            *span,
+                            format!("EVPN route type {value} out of range"),
+                            "must be 0-255 (RFC 7432 route types are 1-5)",
+                        ));
+                    }
+                    Rhs::Int(..) => {}
+                    other => {
+                        self.diags
+                            .push(type_mismatch(field, "an integer EVPN route type", other));
+                    }
+                }
+            }
+            Field::Rpki => {
+                eq_only(self);
+                self.expect_enum_rhs(field, rhs, RPKI_MEMBERS, params);
+            }
+            Field::Aspa => {
+                eq_only(self);
+                self.expect_enum_rhs(field, rhs, ASPA_MEMBERS, params);
+            }
+            Field::RouteType => {
+                eq_only(self);
+                self.expect_enum_rhs(field, rhs, ROUTE_TYPE_MEMBERS, params);
+            }
+            Field::NextHop | Field::PeerAddress => {
+                eq_only(self);
+                if !matches!(rhs, Rhs::Ip(..)) {
+                    self.diags.push(type_mismatch(field, "an IP address", rhs));
+                }
+            }
+            Field::PeerGroup => {
+                eq_only(self);
+                if !matches!(rhs, Rhs::Str(_)) {
+                    self.diags
+                        .push(type_mismatch(field, "a quoted group name", rhs));
+                }
+            }
+            Field::Prefix => {
+                eq_only(self);
+                if !matches!(rhs, Rhs::Prefix(..)) {
+                    self.diags.push(
+                        type_mismatch(field, "a prefix literal", rhs)
+                            .with_note("for set membership use `route.prefix in <prefix-set>`"),
+                    );
+                }
+            }
+            Field::Communities | Field::LargeCommunities | Field::ExtCommunities => {
+                self.diags.push(
+                    Diagnostic::new(
+                        field.span.to(rhs.span()),
+                        format!("`{}` cannot be compared directly", field.render()),
+                        "community lists have no `==`",
+                    )
+                    .with_note(
+                        "use `has <community>` for one value or `in <community-set>` for a set",
+                    ),
+                );
+            }
+            Field::AsPath => {
+                self.diags.push(
+                    Diagnostic::new(
+                        field.span.to(rhs.span()),
+                        "`route.as-path` cannot be compared directly",
+                        "AS paths have no `==`",
+                    )
+                    .with_note(
+                        "use `route.as-path.len` for length, `contains <asn>`, or `matches \"<regex>\"`",
+                    ),
+                );
+            }
+        }
+    }
+
+    fn expect_u32_rhs(&mut self, field: &FieldPath, rhs: &Rhs, params: &[&str]) {
+        match rhs {
+            Rhs::Int(..) => {}
+            Rhs::Ident(name) => {
+                self.check_u32_arg(&U32Arg::Param(name.clone()), params);
+            }
+            other => self
+                .diags
+                .push(type_mismatch(field, "a u32 value or parameter", other)),
+        }
+    }
+
+    fn expect_enum_rhs(&mut self, field: &FieldPath, rhs: &Rhs, members: &[&str], params: &[&str]) {
+        let Rhs::Ident(name) = rhs else {
+            self.diags.push(type_mismatch(
+                field,
+                &format!("one of {}", member_list(members)),
+                rhs,
+            ));
+            return;
+        };
+        if members.contains(&name.node.as_str()) {
+            return;
+        }
+        let mut diag = Diagnostic::new(
+            name.span,
+            format!("`{}` is not a valid `{}` value", name.node, field.render()),
+            format!("expected one of {}", member_list(members)),
+        );
+        if params.contains(&name.node.as_str()) {
+            diag = diag.with_note(format!(
+                "`{}` is a u32 parameter; `{}` is an enum field",
+                name.node,
+                field.render()
+            ));
+        } else if let Some(suggestion) = closest(&name.node, members.iter().copied()) {
+            diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+        }
+        self.diags.push(diag);
+    }
+
+    fn check_in(&mut self, field: &FieldPath, set: &Spanned<String>) {
+        let resolved = match resolve_field(field) {
+            Ok(resolved) => resolved,
+            Err(diag) => {
+                self.diags.push(diag);
+                return;
+            }
+        };
+        match resolved {
+            Field::Prefix => {
+                if !self
+                    .file
+                    .prefix_sets
+                    .iter()
+                    .any(|s| s.name.node == set.node)
+                {
+                    let mut diag = Diagnostic::new(
+                        set.span,
+                        format!("unknown prefix-set `{}`", set.node),
+                        "no prefix-set with this name",
+                    );
+                    if self
+                        .file
+                        .community_sets
+                        .iter()
+                        .any(|s| s.name.node == set.node)
+                    {
+                        diag = diag.with_note(format!(
+                            "`{}` is a community-set; `route.prefix in` needs a prefix-set",
+                            set.node
+                        ));
+                    } else if let Some(suggestion) = closest(
+                        &set.node,
+                        self.file.prefix_sets.iter().map(|s| s.name.node.as_str()),
+                    ) {
+                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    }
+                    self.diags.push(diag);
+                }
+            }
+            Field::Communities | Field::LargeCommunities | Field::ExtCommunities => {
+                if !self
+                    .file
+                    .community_sets
+                    .iter()
+                    .any(|s| s.name.node == set.node)
+                {
+                    let mut diag = Diagnostic::new(
+                        set.span,
+                        format!("unknown community-set `{}`", set.node),
+                        "no community-set with this name",
+                    );
+                    if self
+                        .file
+                        .prefix_sets
+                        .iter()
+                        .any(|s| s.name.node == set.node)
+                    {
+                        diag = diag.with_note(format!(
+                            "`{}` is a prefix-set; community membership needs a community-set",
+                            set.node
+                        ));
+                    } else if let Some(suggestion) = closest(
+                        &set.node,
+                        self.file
+                            .community_sets
+                            .iter()
+                            .map(|s| s.name.node.as_str()),
+                    ) {
+                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    }
+                    self.diags.push(diag);
+                }
+            }
+            _ => self.diags.push(
+                Diagnostic::new(
+                    field.span.to(set.span),
+                    format!("`in` is not defined on `{}`", field.render()),
+                    "`in` tests set membership",
+                )
+                .with_note(
+                    "`in` works on route.prefix (prefix-sets) and community lists (community-sets)",
+                ),
+            ),
+        }
+    }
+
+    // ── apply DAG ───────────────────────────────────────────────────
+
+    /// Policies referenced through `apply` must form a DAG. Reports one
+    /// diagnostic per cycle, naming the full path.
+    fn check_apply_dag(&mut self) {
+        let mut edges: HashMap<&str, Vec<(&str, Span)>> = HashMap::new();
+        for policy in &self.file.policies {
+            let mut targets = Vec::new();
+            for term in &policy.terms {
+                for stmt in &term.stmts {
+                    if let Stmt::If(if_stmt) = stmt {
+                        collect_applies(&if_stmt.cond, &mut targets);
+                    }
+                }
+            }
+            edges.insert(&policy.name.node, targets);
+        }
+        let mut done: HashSet<&str> = HashSet::new();
+        for policy in &self.file.policies {
+            let name = policy.name.node.as_str();
+            if done.contains(name) {
+                continue;
+            }
+            let mut path: Vec<&str> = Vec::new();
+            if let Some((cycle, span)) = find_cycle(name, &edges, &mut path, &mut done) {
+                self.diags.push(
+                    Diagnostic::new(
+                        span,
+                        format!("`apply` cycle: {}", cycle.join(" -> ")),
+                        "this `apply` closes the cycle",
+                    )
+                    .with_note("policy composition must form a DAG (no recursion)"),
+                );
+            }
+        }
+    }
+
+    // ── tests ───────────────────────────────────────────────────────
+
+    fn check_tests(&mut self) {
+        for test in &self.file.tests {
+            let mut seen_fields: HashMap<&'static str, Span> = HashMap::new();
+            for field in &test.route {
+                let (name, span) = route_field_name(field);
+                if let Some(&first) = seen_fields.get(name) {
+                    self.diags.push(
+                        Diagnostic::new(
+                            span,
+                            format!("duplicate route fixture field `{name}`"),
+                            "already set",
+                        )
+                        .with_label(first, "first set here"),
+                    );
+                } else {
+                    seen_fields.insert(name, span);
+                }
+                match field {
+                    RouteField::Rpki(value) => {
+                        self.check_fixture_enum(value, "rpki", RPKI_MEMBERS);
+                    }
+                    RouteField::Aspa(value) => {
+                        self.check_fixture_enum(value, "aspa", ASPA_MEMBERS);
+                    }
+                    RouteField::RouteType(value) => {
+                        self.check_fixture_enum(value, "route-type", ROUTE_TYPE_MEMBERS);
+                    }
+                    RouteField::EvpnRouteType(value, span) => {
+                        if *value > 255 {
+                            self.diags.push(Diagnostic::new(
+                                *span,
+                                format!("EVPN route type {value} out of range"),
+                                "must be 0-255",
+                            ));
+                        }
+                    }
+                    RouteField::Communities(lits, _) => {
+                        self.check_fixture_community_kinds(lits, CommunityKind::Standard);
+                    }
+                    RouteField::LargeCommunities(lits, _) => {
+                        self.check_fixture_community_kinds(lits, CommunityKind::Large);
+                    }
+                    RouteField::ExtCommunities(lits, _) => {
+                        self.check_fixture_community_kinds(lits, CommunityKind::Ext);
+                    }
+                    _ => {}
+                }
+            }
+            for expect in &test.expects {
+                let Some(target) = self.policy(&expect.policy.node) else {
+                    let mut diag = Diagnostic::new(
+                        expect.policy.span,
+                        format!("unknown policy `{}`", expect.policy.node),
+                        "no policy with this name",
+                    );
+                    if let Some(suggestion) = closest(
+                        &expect.policy.node,
+                        self.file.policies.iter().map(|p| p.name.node.as_str()),
+                    ) {
+                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    }
+                    self.diags.push(diag);
+                    continue;
+                };
+                if target.params.len() != expect.args.len() {
+                    self.diags.push(
+                        Diagnostic::new(
+                            expect.span,
+                            format!(
+                                "policy `{}` takes {} argument{} but {} {} supplied",
+                                expect.policy.node,
+                                target.params.len(),
+                                if target.params.len() == 1 { "" } else { "s" },
+                                expect.args.len(),
+                                if expect.args.len() == 1 {
+                                    "was"
+                                } else {
+                                    "were"
+                                },
+                            ),
+                            "wrong number of arguments",
+                        )
+                        .with_label(target.name.span, "policy defined here"),
+                    );
+                }
+            }
+        }
+    }
+
+    fn check_fixture_enum(&mut self, value: &Spanned<String>, field: &str, members: &[&str]) {
+        if !members.contains(&value.node.as_str()) {
+            let mut diag = Diagnostic::new(
+                value.span,
+                format!("`{}` is not a valid `{field}` value", value.node),
+                format!("expected one of {}", member_list(members)),
+            );
+            if let Some(suggestion) = closest(&value.node, members.iter().copied()) {
+                diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+            }
+            self.diags.push(diag);
+        }
+    }
+
+    fn check_fixture_community_kinds(
+        &mut self,
+        lits: &[Spanned<super::ast::CommunityLit>],
+        expected: CommunityKind,
+    ) {
+        for lit in lits {
+            if lit.node.kind() != expected {
+                self.diags.push(
+                    Diagnostic::new(
+                        lit.span,
+                        format!(
+                            "expected a {} literal in this list, found a {} literal",
+                            kind_describe(expected),
+                            kind_describe(lit.node.kind()),
+                        ),
+                        "wrong community kind",
+                    )
+                    .with_note(format!(
+                        "put it in the `{}` fixture field",
+                        kind_field(lit.node.kind())
+                    )),
+                );
+            }
+        }
+    }
+}
+
+fn collect_applies<'a>(expr: &'a Expr, out: &mut Vec<(&'a str, Span)>) {
+    match expr {
+        Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
+            collect_applies(lhs, out);
+            collect_applies(rhs, out);
+        }
+        Expr::Not(inner, _) => collect_applies(inner, out),
+        Expr::Apply { policy, span, .. } => out.push((&policy.node, *span)),
+        _ => {}
+    }
+}
+
+/// DFS cycle detection over the `apply` graph. `path` is the current
+/// DFS stack; returns the cycle (closed: `a -> b -> a`) and the span of
+/// the closing edge.
+fn find_cycle<'a>(
+    node: &'a str,
+    edges: &HashMap<&'a str, Vec<(&'a str, Span)>>,
+    path: &mut Vec<&'a str>,
+    done: &mut HashSet<&'a str>,
+) -> Option<(Vec<String>, Span)> {
+    if let Some(position) = path.iter().position(|&seen| seen == node) {
+        let mut cycle: Vec<String> = path[position..].iter().map(ToString::to_string).collect();
+        cycle.push(node.to_string());
+        // The span is filled in by the caller (the closing edge).
+        return Some((cycle, Span::new(0..0)));
+    }
+    if done.contains(node) {
+        return None;
+    }
+    path.push(node);
+    if let Some(targets) = edges.get(node) {
+        for &(target, span) in targets {
+            if let Some((cycle, cycle_span)) = find_cycle(target, edges, path, done) {
+                path.pop();
+                done.insert(node);
+                let span = if cycle_span == Span::new(0..0) {
+                    span
+                } else {
+                    cycle_span
+                };
+                return Some((cycle, span));
+            }
+        }
+    }
+    path.pop();
+    done.insert(node);
+    None
+}
+
+fn type_mismatch(field: &FieldPath, expected: &str, found: &Rhs) -> Diagnostic {
+    Diagnostic::new(
+        found.span(),
+        format!(
+            "type mismatch: `{}` compares against {expected}, found {}",
+            field.render(),
+            found.describe()
+        ),
+        format!("expected {expected}"),
+    )
+}
+
+fn member_list(members: &[&str]) -> String {
+    members
+        .iter()
+        .map(|member| format!("`{member}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn kind_describe(kind: CommunityKind) -> &'static str {
+    match kind {
+        CommunityKind::Standard => "standard-community",
+        CommunityKind::Large => "large-community",
+        CommunityKind::Ext => "extended-community",
+    }
+}
+
+fn kind_keyword(kind: CommunityKind) -> &'static str {
+    match kind {
+        CommunityKind::Standard => "community",
+        CommunityKind::Large => "large-community",
+        CommunityKind::Ext => "ext-community",
+    }
+}
+
+fn kind_field(kind: CommunityKind) -> &'static str {
+    match kind {
+        CommunityKind::Standard => "communities",
+        CommunityKind::Large => "large-communities",
+        CommunityKind::Ext => "ext-communities",
+    }
+}
+
+fn route_field_name(field: &RouteField) -> (&'static str, Span) {
+    match field {
+        RouteField::Prefix(_, span) => ("prefix", *span),
+        RouteField::Communities(_, span) => ("communities", *span),
+        RouteField::LargeCommunities(_, span) => ("large-communities", *span),
+        RouteField::ExtCommunities(_, span) => ("ext-communities", *span),
+        RouteField::AsPath(value) => ("as-path", value.span),
+        RouteField::NextHop(_, span) => ("next-hop", *span),
+        RouteField::LocalPref(_, span) => ("local-pref", *span),
+        RouteField::Med(_, span) => ("med", *span),
+        RouteField::Rpki(value) => ("rpki", value.span),
+        RouteField::Aspa(value) => ("aspa", value.span),
+        RouteField::RouteType(value) => ("route-type", value.span),
+        RouteField::EvpnRouteType(_, span) => ("evpn-route-type", *span),
+    }
+}

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -1,0 +1,355 @@
+# The rustbgpd policy language (`.rpol`) — reference draft
+
+Status: **draft** (ADR-0096 slice 2). The frontend — lexer, parser,
+typechecker, in-language tests, and `rbgp policy check` — is complete;
+daemon integration (referencing `.rpol` policies from configuration,
+`rbgp policy test --rib live`) ships in a later slice. Nothing in this
+document is wired into a running daemon yet.
+
+`.rpol` compiles to the same public typed IR (`rustbgpd_policy::ir`)
+that TOML policy chains compile to, and is evaluated by the same
+tree-walk engine. Match data (prefix sets, community sets, AS-path
+regexes) compiles out of the program into shared indexed structures —
+a thousand-member set costs one hash probe per route, not a
+thousand-statement walk.
+
+## Example
+
+```rpol
+# Sets: match data, compiled to indexed structures.
+prefix-set customers { 10.10.0.0/16 ge 24 le 28, 192.0.2.0/24 }
+community-set tagged { 65000:100, 65000:200 }
+
+# A predicate policy: matches bogons, rejects everything else.
+policy bogon-filter {
+    term bogons { if route.prefix == 0.0.0.0/8 { accept } }
+    term everything-else { reject }
+}
+
+# A parameterized policy: `peer_lp` is substituted at instantiation.
+policy customer-in(peer_lp: u32) {
+    term rpki-guard {
+        if route.rpki == invalid { reject }
+    }
+    term customer-routes {
+        if route.prefix in customers && route.communities has 65000:100 {
+            set local-pref peer_lp;
+            add community 65001:999;
+            accept
+        }
+    }
+    term bogon-guard { if apply(bogon-filter) { reject } }
+}
+
+# In-language tests, run by `rbgp policy check`.
+test customer-in-accepts-tagged {
+    route { prefix 10.10.1.0/24; communities [65000:100]; rpki valid }
+    expect customer-in(200) == accept with local-pref 200
+}
+```
+
+```console
+$ rbgp policy check customer-in.rpol
+customer-in.rpol: 1 passed, 0 failed
+$ echo $?
+0
+```
+
+Exit codes: `0` clean, `1` compile diagnostics (or unreadable file),
+`2` in-language test failures. `--json` emits a machine-readable
+report.
+
+## Lexical structure
+
+- **Comments**: `#` to end of line.
+- **Identifiers** (set, policy, term, test, parameter names) are
+  kebab-case: `[A-Za-z_][A-Za-z0-9_]*(-[A-Za-z0-9_]+)*`. There is no
+  arithmetic in the language, so `-` inside names is unambiguous.
+- **Reserved keywords** (not usable as names): `prefix-set`,
+  `community-set`, `policy`, `term`, `test`, `if`, `else`, `set`,
+  `add`, `remove`, `prepend`, `accept`, `reject`, `apply`, `in`,
+  `has`, `matches`, `contains`, `ge`, `le`, `route`, `peer`,
+  `expect`, `with`, `as`, `self`, `u32`. Field names (`local-pref`,
+  `communities`, …) and enum members (`valid`, `internal`, …) are
+  contextual, not reserved.
+- **Literals** are single tokens, longest-match:
+  - Prefix: `10.0.0.0/8`, `2001:db8::/32`. Host bits set beyond the
+    prefix length are a compile error (not silently masked). IPv6
+    literals must use the compressed `::` form — all-numeric
+    full-form IPv6 is ambiguous with community literals.
+  - IP address: `192.0.2.1`, `2001:db8::1`.
+  - Standard community: `65000:100` (both parts u16), or a well-known
+    name: `NO_EXPORT`, `NO_ADVERTISE`, `NO_EXPORT_SUBCONFED`,
+    `BLACKHOLE`, `GRACEFUL_SHUTDOWN`.
+  - Large community: `65000:1:2` (three u32), also accepted as
+    `LC:65000:1:2` for parity with the TOML frontend.
+  - Extended community (Route Target / Route Origin):
+    `RT:65001:100`, `RO:65001:100`, `RT:192.0.2.1:5` (IPv4 admin),
+    `RT:200000:100` (4-octet-AS admin). IPv4 and 4-octet-AS admins
+    take a u16 local part (RFC 4360 encodings).
+  - Strings (AS-path regexes, peer-group names): `"..."` with `\"`
+    and `\\` escapes.
+- **Statement separators**: `;` between statements is conventional
+  but optional (the grammar is unambiguous without it); the idiomatic
+  style semicolon-terminates everything except a final verdict.
+
+## Types
+
+The type universe is fixed; there are no user-defined types, maps, or
+loops (ADR-0096 Decision 2/4), and inference is trivial: every field
+has a known type and every operator a fixed signature.
+
+| Type | Values | Where |
+|---|---|---|
+| bool | guard expressions | `if` conditions |
+| u32 | integer literals, parameters | `local-pref`, `med`, `as-path.len`, `peer.asn`, arguments |
+| prefix | prefix literals | `route.prefix` |
+| community (3 kinds) | community literals | community lists, sets, actions |
+| as-path | — (matched, never named) | `route.as-path` |
+| rpki-state | `valid`, `invalid`, `not-found` | `route.rpki` |
+| aspa-state | `valid`, `invalid`, `unknown` | `route.aspa` |
+| route-type | `local`, `internal`, `external` | `route.route-type` |
+| IP address | address literals | `route.next-hop`, `peer.address` |
+| string | string literals | regexes, `peer.group` |
+
+## Sets
+
+```rpol
+prefix-set NAME { PREFIX [ge N] [le N], ... }
+community-set NAME { COMMUNITY-LITERAL, ... }
+```
+
+- `ge`/`le` bounds are per member, with the same semantics as the
+  TOML frontend (and Cisco/Juniper prefix lists): the candidate is
+  masked at the member's length and its length must fall in the
+  derived range (`ge` only → `ge..=address_bits`; `le` only →
+  `member_len..=le`; neither → exact length).
+- Community sets may mix standard, large, and extended members.
+  Membership (`in`) matches when **any route community of any kind
+  matches any member** — the set is kind-partitioned internally, and
+  the field you write it against (`route.communities in tagged`)
+  reads as documentation, not a kind filter.
+- Sets are content-interned: identical sets (in any member order)
+  share one indexed structure across all policies.
+- There is no `as-path-set` in V1 — inline
+  `route.as-path matches "regex"` covers the need (deliberately
+  deferred; the regex engine is the existing Cisco-style matcher).
+
+## Policies, terms, and evaluation order
+
+```rpol
+policy NAME[(param: u32, ...)] {
+    term NAME { statement... }
+    ...
+}
+```
+
+- Terms evaluate in order. Statements inside a term are: bare actions,
+  or `if <expr> { actions... } [else { actions... }]`. `if` bodies are
+  flat action lists — **no nested `if`** in V1 (split the condition
+  with `&&` or use another term).
+- **Verdicts**: `accept` permits the route (with all modifications
+  executed so far in this policy); `reject` denies it (a denied route
+  has no attributes — modifications in a rejecting branch are
+  discarded). A verdict ends the policy's evaluation.
+- **Fallthrough**: if a guard doesn't match, or a matched body ends
+  without a verdict, evaluation continues to the next term.
+  Modifications executed along the way (Junos-style
+  modify-and-continue) are kept and merged into the eventual accept.
+- **End of policy without a verdict = accept** (with any accumulated
+  modifications). In chain terms: the policy raises no objection and
+  the chain continues — this matches the GoBGP-style chain semantics
+  the daemon already uses (each policy's permit accumulates and
+  continues; a deny terminates the chain).
+- Statements after a bare `accept`/`reject` in the same term (or
+  actions after a verdict in the same `if` body) are **unreachable
+  and a compile error**.
+
+### Lowering into the IR (normative)
+
+The IR's `Term` is one `(guard, action)` pair; an `.rpol` term lowers
+to one or more IR terms:
+
+- Each `if` becomes an IR term (guard = condition); its `else`
+  becomes a following IR term guarded by the negated condition.
+- A run of bare modification actions flushes as an unconditional
+  `Continue` IR term (a small IR addition made for this frontend:
+  guard matched → apply modifications → keep walking this policy's
+  terms).
+- When one `.rpol` term produces multiple IR terms they are named
+  `<term>.<n>` (1-based); a lone IR term keeps the plain term name.
+  Explain surfaces will render these names.
+
+### Parameters
+
+Parameters are `u32` only in V1 and can appear anywhere a u32 is
+expected (`set local-pref peer_lp`, `route.local-pref >= peer_lp`,
+`apply(p(peer_lp))`, `route.as-path contains asn_param`). A
+parameterized policy is a **template**: each use site with concrete
+arguments is monomorphized at compile time (clone-with-substitution;
+policies are small, this is microseconds). The evaluator only ever
+sees constants. The `prepend` count must be a literal (1–255, it is
+wire-encoded as u8).
+
+## Expressions
+
+Boolean operators, loosest to tightest: `||`, `&&`, `!`. Parentheses
+group. Comparisons: `==`, `!=`, `>=`, `<=`.
+
+| Predicate | Meaning |
+|---|---|
+| `route.prefix == 10.0.0.0/24` | exact prefix (same network *and* length) |
+| `route.prefix in customers` | prefix-set membership (mask + ge/le ranges) |
+| `route.communities has 65000:100` | route carries this community (kind-checked against the field) |
+| `route.communities in tagged` | any route community matches any set member |
+| `route.as-path.len >= 3` | AS-path ASN count (RFC 4271 counting) |
+| `route.as-path contains 65001` | boundary-anchored ASN presence (sugar for `matches "_65001_"`) |
+| `route.as-path matches "^65010"` | Cisco/Quagga-style regex; `_` is a boundary anchor |
+| `route.local-pref >= 200`, `route.med <= 50` | u32 comparisons; `==`/`!=` also allowed |
+| `route.next-hop == 10.0.0.1` | next-hop equality (`==`/`!=` only) |
+| `route.rpki == invalid` | RPKI origin validation state |
+| `route.aspa == unknown` | ASPA verification state |
+| `route.route-type == external` | route source class |
+| `route.evpn-route-type == 2` | EVPN route type (integer literal 0–255; `==`/`!=` only) |
+| `peer.address == 192.0.2.1` | evaluation-peer address |
+| `peer.asn == 65010` | evaluation-peer ASN (`==`/`!=` only) |
+| `peer.group == "leaf"` | evaluation-peer group name |
+| `apply(other-policy)` / `apply(p(42))` | policy-as-predicate (below) |
+
+**Implicit defaults** (identical to the TOML engine and RFC 4271):
+comparisons against `route.local-pref` see **100** when the attribute
+is absent, `route.med` sees **0**. Prefix predicates never match a
+prefixless route (e.g. BGP-LS NLRIs); `route.next-hop`,
+`route.route-type`, and `route.evpn-route-type` never match when the
+corresponding attribute is absent.
+
+`==` on u32 fields lowers to `>= v && <= v`; `!=` is its negation.
+
+### `apply` — policy as predicate
+
+`apply(p)` is a **boolean**: "would policy `p` permit this route?".
+The applied policy's actions do *not* execute — this is a predicate,
+not a Junos-style subroutine call with side effects. The compiler
+inlines `p`'s first-match decision structure as a pure guard
+expression; `Continue`-style modify-and-fallthrough terms in `p`
+don't decide anything and are skipped.
+
+Two consequences worth internalizing:
+
+- Policy composition must form a **DAG** — recursion through `apply`
+  (including self-application) is a compile error naming the cycle.
+- Since end-of-policy defaults to accept, a policy that never
+  `reject`s is constant-true under `apply`. Predicate policies should
+  decide both ways (see `bogon-filter` above: match → `accept`,
+  final term → `reject`).
+
+## Actions
+
+| Action | Effect |
+|---|---|
+| `accept` / `reject` | terminal verdict (see evaluation order) |
+| `set local-pref <u32>` | override `LOCAL_PREF` |
+| `set med <u32>` | override `MED` |
+| `set next-hop <ip>` / `set next-hop self` | override `NEXT_HOP` |
+| `add community 65001:999` / `remove community ...` | standard communities |
+| `add large-community 65000:1:2` / `remove ...` | large communities |
+| `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO) |
+| `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
+
+The kind keyword must match the literal's kind (`add community
+RT:...` is a compile error pointing at `add ext-community`). Within a
+policy, later `set`s of the same attribute win; across a chain, the
+existing merge semantics apply (later policy wins scalars, add/remove
+lists merge with later-policy-wins cancellation).
+
+Extended-community wire encoding follows the daemon's other
+frontends: dotted-quad admin → RFC 4360 type 0x01, ASN > 65535 →
+type 0x02, otherwise type 0x00 (subtype 0x02 RT / 0x03 RO).
+
+## Tests
+
+```rpol
+test NAME {
+    route { FIELD VALUE; ... }
+    [peer { address IP; asn N; group "NAME" }]
+    expect POLICY[(args)] == accept|reject [with ASSERTION, ...]
+    [expect ...]
+}
+```
+
+Route fixture fields: `prefix`, `communities [..]`,
+`large-communities [..]`, `ext-communities [..]`, `as-path "65001
+65002"`, `next-hop`, `local-pref`, `med`, `rpki`, `aspa`,
+`route-type`, `evpn-route-type`. Omitted fields are absent attributes
+(so `local-pref`/`med` comparisons see the implicit 100/0, `rpki`
+defaults to `not-found`, `aspa` to `unknown`). The fixture AS-path
+length is the whitespace-word count of the string form.
+
+`with` assertions check the evaluation result's **modifications**
+(the frontend has no live route to apply them to): `local-pref N`,
+`med N`, `next-hop IP|self`, `community LIT` (and
+`large-community`/`ext-community`, asserting presence in the add
+lists), `prepend as ASN COUNT`.
+
+Tests run at check time (`rbgp policy check`, CI) with zero daemon
+involvement. Testing a *candidate* policy against a live RIB
+(`rbgp policy test --rib live`) is the later ADR-0096 slice.
+
+## Grammar sketch
+
+```text
+file        := (prefix-set-def | community-set-def | policy-def | test-def)*
+prefix-set-def    := "prefix-set" IDENT "{" [prefix-entry ("," prefix-entry)*] "}"
+prefix-entry      := PREFIX ["ge" INT] ["le" INT]
+community-set-def := "community-set" IDENT "{" [community ("," community)*] "}"
+policy-def  := "policy" IDENT ["(" param ("," param)* ")"] "{" term* "}"
+param       := IDENT ":" "u32"
+term        := "term" IDENT "{" stmt* "}"
+stmt        := if-stmt | action [";"]
+if-stmt     := "if" expr "{" (action [";"])* "}" ["else" "{" (action [";"])* "}"]
+action      := "accept" | "reject"
+             | "set" ("local-pref" | "med") u32arg
+             | "set" "next-hop" (IP | "self")
+             | ("add" | "remove") ("community" | "large-community" | "ext-community") community
+             | "prepend" "as" u32arg INT
+expr        := and ("||" and)*
+and         := unary ("&&" unary)*
+unary       := "!" unary | "(" expr ")" | "apply" "(" IDENT ["(" u32arg,* ")"] ")" | predicate
+predicate   := field (("=="|"!="|">="|"<=") rhs | "in" IDENT | "has" community
+             | "matches" STRING | "contains" u32arg)
+field       := ("route" | "peer") ("." IDENT)+
+u32arg      := INT | IDENT          # parameter reference
+test-def    := "test" IDENT "{" route-block [peer-block] expect+ "}"
+expect      := "expect" IDENT ["(" INT,* ")"] "==" ("accept"|"reject") ["with" assertion,*]
+```
+
+## Diagnostics
+
+Every error carries labeled source spans (ariadne rendering), and the
+compiler recovers to report multiple independent errors per file.
+Unknown names (sets, policies, fields, enum members, parameters, test
+fixture fields) get did-you-mean suggestions by edit distance;
+kind/type mismatches say what to write instead.
+
+```text
+Error: unknown prefix-set `custmers`
+   ╭─[ broken.rpol:5:28 ]
+   │
+ 5 │         if route.prefix in custmers && route.rpki == vaild { reject }
+   │                            ────┬───
+   │                                ╰───── no prefix-set with this name
+   │
+   │ Note: did you mean `customers`?
+───╯
+```
+
+## Deliberate V1 exclusions
+
+No loops, no user-defined types, no maps (safety is total by
+construction — ADR-0096 Decision 2). No `as-path-set`. No `else if`
+chains and no nested `if` (keep terms small; use `&&` or more terms).
+No arithmetic. EVPN route type takes only an integer literal (no
+parameters — the value is wire-encoded u8). Full-form all-numeric
+IPv6 literals (use `::` compression). These are scope decisions, not
+parser accidents; each has an error message steering to the
+supported form.


### PR DESCRIPTION
**PR-2 of the ADR-0096 arc**: the `.rpol` language exists. Logos lexer → recursive-descent parser with multi-error recovery → typechecker (inference, did-you-mean suggestions, `apply` DAG check with cycle-path naming) → lowering to the #654 IR → ariadne-rendered diagnostics, plus **in-language `test` blocks** and the local `rbgp policy check` verb (exit 0/1/2, `--json`).

Key semantics decisions (all in `docs/rpol-language.md`):
- Each `if` lowers to its own IR term; a verdictless matched body = modify-and-continue — the one surgical IR addition: `TermAction::Continue` with policy-local accumulation merged into the eventual Permit (deciding term wins scalar conflicts, mirroring chain merge) and discarded on Deny. The TOML frontend never emits it; the 4,485-case parity corpus is untouched and green.
- `apply(policy)` is a **pure predicate** (Junos-style composition without subroutine side effects), inlined as a first-match-faithful boolean, DAG-enforced.
- Parameterized policies monomorphize at compile time; end-of-policy = accept with accumulated modifications (GoBGP chain semantics).

38 frontend tests + 3 CLI exit-code tests (169 policy-crate total); every diagnostic has a rendering assertion. Deps: logos 0.16 + ariadne 0.6, policy crate only, both permissively licensed. No daemon integration yet — PR-3 wires config/API/planner and the live-RIB `rbgp policy test`.