### PR TITLE
feat(bgp): wire rpol policies into config, transactions, and the live-RIB policy test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`.rpol` policies in the running daemon (ADR-0096 slice 3): config
+  references, hot reload, and the `rbgp policy test` live-RIB dry
+  run.** `[policy] rpol_files = ["policies/core.rpol"]` compiles every
+  referenced file at config load (paths relative to the config file,
+  rewritten absolute; ariadne-rendered compile diagnostics are load
+  errors); the policies join the same namespace as
+  `[policy.definitions]` (collisions are load errors naming both
+  sources) and mix freely with TOML policies in chains, with
+  parameterized policies referenced by call-form —
+  `import_policy_chain = ["customer-in(200)", "bogon-filter"]` —
+  arity- and type-checked at load and monomorphized into pre-compiled
+  chain members. Chain identity for the ADR-0076 planner is compiled
+  content: an edited `.rpol` file classifies as a `policy_chain`
+  live-impact for exactly the referencing peers, and SIGHUP hot-applies
+  it through a new `SyncRpolPolicies` peer-manager step (same atomic
+  resolved-policy fan-out + Route Refresh as `[policy.definitions]`
+  edits); reloading unchanged content is a no-op. Config transactions
+  cannot stage `.rpol` file content (out-of-band files) — such
+  candidates are rejected as unsupported, and gNMI Set remains
+  TOML-surface-only. The differentiator verb: `rbgp policy test
+  <file.rpol> --policy name(args) --direction import|export [--peer]
+  [--family] [--limit] [--show-changes] [--json]` sends the candidate
+  source to the daemon (new `PolicyService.TestPolicy` RPC,
+  `SensitiveRead`), compiles it server-side, and evaluates it
+  read-only over a live Adj-RIB-In / Loc-RIB snapshot — accepted/
+  rejected/modified counts, per-term hit counters, and before/after
+  attribute diff samples, with zero route/session/counter impact
+  (V1 scope: IPv4/IPv6 unicast). Docs: `docs/rpol-language.md`
+  ("Using policies in the daemon"), `docs/CONFIGURATION.md`.
+
 - **The `.rpol` policy language frontend (ADR-0096 slice 2): lexer,
   parser, typechecker, in-language tests, and `rbgp policy check`.**
   `.rpol` source — `prefix-set`/`community-set` definitions (ge/le per
@@ -33,8 +63,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rbgp policy check <file.rpol>` verb (exit codes 0 clean /
   1 diagnostics / 2 test failures, `--json`) runs them with zero
   daemon involvement. Language reference: `docs/rpol-language.md`.
-  Daemon integration (config wiring, `rbgp policy test --rib live`) is
-  the next slice — nothing consumes `.rpol` from configuration yet.
+  Daemon integration (config wiring, `rbgp policy test`) ships in the
+  slice-3 entry above.
   New policy-crate-only dependencies: `logos` (MIT OR Apache-2.0),
   `ariadne` (MIT).
 

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -360,6 +360,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
     ),
     method(
         "rustbgpd.v1.PolicyService",
+        "TestPolicy",
+        "/rustbgpd.v1.PolicyService/TestPolicy",
+        AuthTier::SensitiveRead,
+    ),
+    method(
+        "rustbgpd.v1.PolicyService",
         "ClearNeighborExportChain",
         "/rustbgpd.v1.PolicyService/ClearNeighborExportChain",
         AuthTier::Mutating,
@@ -829,7 +835,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 96);
+        assert_eq!(METHODS.len(), 97);
     }
 
     #[test]
@@ -870,7 +876,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 54);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 55);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 23);
     }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -524,6 +524,19 @@ pub struct ResolvedPeerPolicy {
     pub export_policy: Option<PolicyChain>,
 }
 
+/// Reply payload of [`PeerManagerCommand::RuntimeConfigSnapshot`]: the
+/// normalized runtime TOML plus the live compiled `.rpol` registry
+/// (which the TOML deliberately excludes — see the command docs).
+#[derive(Debug, Clone)]
+pub struct RuntimeConfigSnapshotReply {
+    /// Normalized TOML for the current runtime snapshot.
+    pub toml: String,
+    /// Live `[policy] rpol_files` list (absolute paths).
+    pub rpol_files: Vec<String>,
+    /// Live compiled `.rpol` policy registry.
+    pub rpol: rustbgpd_policy::rpol::RpolPolicySet,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -641,9 +654,15 @@ pub enum PeerManagerCommand {
     /// coordinator so reload diffing starts from the latest transaction-updated
     /// peer-manager snapshot, not from main.rs' process-local startup/reload
     /// copy.
+    ///
+    /// The reply also carries the LIVE compiled `.rpol` registry
+    /// (ADR-0096): the registry is derived state excluded from the
+    /// TOML, and re-loading the TOML would recompile the `.rpol` files
+    /// from disk — masking exactly the disk edits a SIGHUP diff must
+    /// detect. Callers overlay it onto the re-loaded snapshot config.
     RuntimeConfigSnapshot {
-        /// Reply returns normalized TOML for the current runtime snapshot.
-        reply: oneshot::Sender<Result<String, String>>,
+        /// Reply returns normalized TOML plus the live rpol registry.
+        reply: oneshot::Sender<Result<RuntimeConfigSnapshotReply, String>>,
     },
     /// Atomically apply resolved import/export policy chains to a set of live
     /// peer sessions, returning each peer's PRIOR chains for rollback.
@@ -849,6 +868,20 @@ pub enum PeerManagerCommand {
         cache_size: usize,
         /// Reply channel acknowledging the snapshot update.
         reply: oneshot::Sender<()>,
+    },
+    /// ADR-0096: replace the compiled `.rpol` policy registry
+    /// (SIGHUP reload of `[policy] rpol_files` or of a referenced
+    /// file's content) and re-resolve every live peer's chains
+    /// through it. Route Refresh fires for peers whose import chain
+    /// materially changed, via the same atomic resolved-policy
+    /// snapshot path as `[policy.definitions]` edits.
+    SyncRpolPolicies {
+        /// New `[policy] rpol_files` list (paths already absolute).
+        rpol_files: Vec<String>,
+        /// New compiled registry.
+        rpol: rustbgpd_policy::rpol::RpolPolicySet,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), CatalogMutationError>>,
     },
     /// List all named policy definitions.
     ListPolicies {

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -280,6 +280,10 @@ pub struct PolicyService {
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
     runtime_config_lock: Arc<tokio::sync::Mutex<()>>,
     config_mutation_gate: Option<ConfigMutationGateFn>,
+    /// RIB query channel backing `TestPolicy`'s read-only snapshot
+    /// (ADR-0096 Decision 6). `None` when the service was built
+    /// without it — `TestPolicy` then reports `FAILED_PRECONDITION`.
+    rib_tx: Option<mpsc::Sender<rustbgpd_rib::RibUpdate>>,
 }
 
 impl PolicyService {
@@ -317,7 +321,16 @@ impl PolicyService {
             config_tx,
             runtime_config_lock,
             config_mutation_gate,
+            rib_tx: None,
         }
+    }
+
+    /// Attach the RIB query channel that backs `TestPolicy`'s
+    /// read-only route snapshot.
+    #[must_use]
+    pub fn with_rib_query(mut self, rib_tx: mpsc::Sender<rustbgpd_rib::RibUpdate>) -> Self {
+        self.rib_tx = Some(rib_tx);
+        self
     }
 
     /// Run `body` under the ADR-0080 detached-task shield with the
@@ -1368,6 +1381,302 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             matches,
         }))
     }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "linear request-validate, compile, snapshot, evaluate pipeline; splitting would scatter the dry-run contract"
+    )]
+    async fn test_policy(
+        &self,
+        request: Request<proto::TestPolicyRequest>,
+    ) -> Result<Response<proto::TestPolicyResponse>, Status> {
+        use rustbgpd_policy::rpol::{RpolFile, parse_call_form};
+        use rustbgpd_policy::sets::SetStore;
+        use rustbgpd_rib::RibUpdate;
+
+        let req = request.into_inner();
+        let import = match req.direction.as_str() {
+            "import" => true,
+            "export" => false,
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "direction must be \"import\" or \"export\", got {other:?}"
+                )));
+            }
+        };
+        let family_filter = match proto::AddressFamily::try_from(req.afi_safi) {
+            Ok(proto::AddressFamily::Unspecified) => None,
+            Ok(proto::AddressFamily::Ipv4Unicast) => Some(true),
+            Ok(proto::AddressFamily::Ipv6Unicast) => Some(false),
+            _ => {
+                return Err(Status::invalid_argument(
+                    "TestPolicy v1 supports IPv4-unicast and IPv6-unicast only",
+                ));
+            }
+        };
+        let peer_filter: Option<IpAddr> = if req.peer.is_empty() {
+            None
+        } else {
+            Some(
+                req.peer
+                    .parse()
+                    .map_err(|e| Status::invalid_argument(format!("invalid peer: {e}")))?,
+            )
+        };
+
+        // Compile the candidate source server-side. Diagnostics are a
+        // successful RPC with compiled=false — the dry run's answer.
+        let file = match RpolFile::parse(&req.rpol_source) {
+            Ok(file) => file,
+            Err(diagnostics) => {
+                return Ok(Response::new(proto::TestPolicyResponse {
+                    compiled: false,
+                    diagnostics: diagnostics.render("candidate.rpol", &req.rpol_source, false),
+                    ..Default::default()
+                }));
+            }
+        };
+        let (base, args) = parse_call_form(&req.policy).map_err(Status::invalid_argument)?;
+        let Some((_, params)) = file.policies().find(|(name, _)| *name == base) else {
+            let available: Vec<&str> = file.policies().map(|(name, _)| name).collect();
+            return Err(Status::invalid_argument(format!(
+                "policy {base:?} is not defined in the submitted source (available: {available:?})"
+            )));
+        };
+        if params != args.len() {
+            return Err(Status::invalid_argument(format!(
+                "policy {base:?} takes {params} parameter(s), {} given",
+                args.len()
+            )));
+        }
+        let mut store = SetStore::new();
+        let chain = file
+            .compile_policy(base, &args, &mut store)
+            .expect("existence checked above");
+
+        // Read-only route snapshot via the existing RIB query
+        // machinery. Import evaluates Adj-RIB-In (optionally one
+        // peer's); export evaluates Loc-RIB best routes.
+        let rib_tx = self.rib_tx.as_ref().ok_or_else(|| {
+            Status::failed_precondition("route snapshot runtime unavailable on this listener")
+        })?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let query = if import {
+            RibUpdate::QueryReceivedRoutes {
+                peer: peer_filter,
+                reply: reply_tx,
+            }
+        } else {
+            RibUpdate::QueryBestRoutes { reply: reply_tx }
+        };
+        rib_tx
+            .send(query)
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+        let routes = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+
+        // Peer context (ASN / peer-group) so guards on peer.* fields
+        // see real values.
+        let (peers_tx, peers_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::ListPeers { reply: peers_tx })
+            .await
+            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        let peer_context: std::collections::HashMap<IpAddr, (u32, Option<String>)> = peers_rx
+            .await
+            .map_err(|_| Status::internal("peer manager dropped reply"))?
+            .into_iter()
+            .map(|info| (info.address, (info.remote_asn, info.peer_group)))
+            .collect();
+
+        Ok(Response::new(run_test_policy(
+            &chain,
+            &routes,
+            &TestPolicyScope {
+                import,
+                target_peer: peer_filter,
+                family_filter,
+                limit: req.limit as usize,
+                show_changes: req.show_changes as usize,
+            },
+            &peer_context,
+        )))
+    }
+}
+
+/// Route selection scope for one `TestPolicy` dry run.
+struct TestPolicyScope {
+    /// Import (Adj-RIB-In snapshot, peer context from each route's
+    /// source peer) vs export (Loc-RIB snapshot, peer context from
+    /// `target_peer`).
+    import: bool,
+    /// Export evaluation target (also the import snapshot filter,
+    /// applied upstream by the RIB query).
+    target_peer: Option<IpAddr>,
+    /// `Some(true)` = IPv4 only, `Some(false)` = IPv6 only.
+    family_filter: Option<bool>,
+    /// Max routes evaluated; 0 = all.
+    limit: usize,
+    /// Max before/after diff samples returned.
+    show_changes: usize,
+}
+
+/// Evaluate the compiled candidate policy read-only over the route
+/// snapshot: counts, per-term hit counters, and up to
+/// `scope.show_changes` before/after diff samples. Pure function of
+/// its inputs — no daemon state is touched (ADR-0096 Decision 6).
+fn run_test_policy(
+    chain: &rustbgpd_policy::ir::CompiledChain,
+    routes: &[rustbgpd_rib::Route],
+    scope: &TestPolicyScope,
+    peer_context: &std::collections::HashMap<IpAddr, (u32, Option<String>)>,
+) -> proto::TestPolicyResponse {
+    use rustbgpd_policy::{PolicyAction, RouteContext, RouteType};
+    use rustbgpd_rib::RouteOrigin;
+
+    let needs_as_path_string = chain.requires_as_path_string();
+    let mut hits = chain.zero_term_hits();
+    let mut response = proto::TestPolicyResponse {
+        compiled: true,
+        ..Default::default()
+    };
+    for route in routes
+        .iter()
+        .filter(|route| {
+            scope
+                .family_filter
+                .is_none_or(|v4| matches!(route.prefix, Prefix::V4(_)) == v4)
+        })
+        .take(if scope.limit == 0 {
+            usize::MAX
+        } else {
+            scope.limit
+        })
+    {
+        let ctx_peer = if scope.import {
+            Some(route.peer)
+        } else {
+            scope.target_peer
+        };
+        let (peer_asn, peer_group) = ctx_peer
+            .and_then(|addr| peer_context.get(&addr))
+            .map_or((None, None), |(asn, group)| (Some(*asn), group.as_deref()));
+        let as_path_str = if needs_as_path_string {
+            route
+                .as_path()
+                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+        } else {
+            String::new()
+        };
+        let ctx = RouteContext {
+            prefix: Some(route.prefix),
+            next_hop: Some(route.next_hop),
+            extended_communities: route.extended_communities(),
+            communities: route.communities(),
+            large_communities: route.large_communities(),
+            as_path_str: &as_path_str,
+            as_path_len: route.as_path().map_or(0, rustbgpd_wire::AsPath::len),
+            validation_state: route.validation_state,
+            aspa_state: route.aspa_state,
+            peer_address: ctx_peer,
+            peer_asn,
+            peer_group,
+            route_type: Some(match route.origin_type {
+                RouteOrigin::Ebgp => RouteType::External,
+                RouteOrigin::Ibgp => RouteType::Internal,
+                RouteOrigin::Local => RouteType::Local,
+            }),
+            evpn_route_type: None,
+            local_pref: route.local_pref_attr(),
+            med: route.med_attr(),
+        };
+        response.routes_evaluated += 1;
+        let result = chain.evaluate_recording_hits(&ctx, &mut hits);
+        if result.action == PolicyAction::Permit {
+            response.accepted += 1;
+            if !result.modifications.is_empty() {
+                response.modified += 1;
+                if response.diffs.len() < scope.show_changes {
+                    response.diffs.push(proto::TestPolicyDiff {
+                        prefix: route.prefix.addr_string(),
+                        prefix_length: u32::from(route.prefix.prefix_len()),
+                        peer: route.peer.to_string(),
+                        changes: render_modification_changes(route, &result.modifications),
+                    });
+                }
+            }
+        } else {
+            response.rejected += 1;
+        }
+    }
+    response.term_hits = chain
+        .policies
+        .iter()
+        .zip(&hits)
+        .flat_map(|(policy, policy_hits)| {
+            policy
+                .terms
+                .iter()
+                .zip(policy_hits)
+                .enumerate()
+                .map(|(index, (term, count))| proto::TestPolicyTermHits {
+                    term: term.name.clone().unwrap_or_else(|| format!("term {index}")),
+                    hits: *count,
+                })
+        })
+        .collect();
+    response
+}
+
+/// Render one modified route's attribute changes as human-readable
+/// before/after lines (the `TestPolicyDiff.changes` contract).
+fn render_modification_changes(
+    route: &rustbgpd_rib::Route,
+    mods: &rustbgpd_policy::RouteModifications,
+) -> Vec<String> {
+    let fmt_community = |value: u32| format!("{}:{}", value >> 16, value & 0xFFFF);
+    let fmt_opt = |value: Option<u32>| value.map_or_else(|| "unset".to_string(), |v| v.to_string());
+    let mut changes = Vec::new();
+    if let Some(after) = mods.set_local_pref {
+        changes.push(format!(
+            "local_pref {} -> {after}",
+            fmt_opt(route.local_pref_attr())
+        ));
+    }
+    if let Some(after) = mods.set_med {
+        changes.push(format!("med {} -> {after}", fmt_opt(route.med_attr())));
+    }
+    if let Some(next_hop) = mods.set_next_hop.as_ref() {
+        let after = match next_hop {
+            rustbgpd_policy::NextHopAction::Self_ => "self".to_string(),
+            rustbgpd_policy::NextHopAction::Specific(addr) => addr.to_string(),
+        };
+        changes.push(format!("next_hop {} -> {after}", route.next_hop));
+    }
+    for value in &mods.communities_add {
+        changes.push(format!("communities + {}", fmt_community(*value)));
+    }
+    for value in &mods.communities_remove {
+        changes.push(format!("communities - {}", fmt_community(*value)));
+    }
+    for lc in &mods.large_communities_add {
+        changes.push(format!("large_communities + {lc}"));
+    }
+    for lc in &mods.large_communities_remove {
+        changes.push(format!("large_communities - {lc}"));
+    }
+    for ec in &mods.extended_communities_add {
+        changes.push(format!("extended_communities + 0x{:016x}", ec.as_u64()));
+    }
+    for ec in &mods.extended_communities_remove {
+        changes.push(format!("extended_communities - 0x{:016x}", ec.as_u64()));
+    }
+    if let Some((asn, count)) = mods.as_path_prepend {
+        changes.push(format!("as_path prepend {asn} x{count}"));
+    }
+    changes
 }
 
 #[cfg(test)]
@@ -2095,5 +2404,199 @@ mod tests {
             ],
             "rollback must re-set the prior per-neighbor chain"
         );
+    }
+
+    // ── TestPolicy (ADR-0096 Decision 6) ────────────────────────────
+
+    const TEST_RPOL: &str = r"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+
+policy customer-in(peer_lp: u32) {
+    term customer-routes {
+        if route.prefix in customers { set local-pref peer_lp; accept }
+    }
+    term everything-else { reject }
+}
+";
+
+    fn test_route(prefix: &str, len: u8) -> rustbgpd_rib::Route {
+        let addr: std::net::Ipv4Addr = prefix.parse().unwrap();
+        rustbgpd_rib::Route {
+            prefix: Prefix::V4(Ipv4Prefix::new(addr, len)),
+            next_hop: "10.0.0.9".parse().unwrap(),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: "10.0.0.9".parse().unwrap(),
+            attributes: std::sync::Arc::new(Vec::new()),
+            received_at: std::time::Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+            peer_router_id: std::net::Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        }
+    }
+
+    /// Fake daemon backends for `TestPolicy`: a RIB task answering
+    /// received/best route queries with the given snapshot, and a
+    /// peer manager answering `ListPeers` with an empty peer set.
+    fn test_policy_service(routes: Vec<rustbgpd_rib::Route>) -> PolicyService {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<rustbgpd_rib::RibUpdate>(8);
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::ListPeers { reply } => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+        tokio::spawn(async move {
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    rustbgpd_rib::RibUpdate::QueryReceivedRoutes { peer, reply } => {
+                        let filtered = routes
+                            .iter()
+                            .filter(|route| peer.is_none_or(|p| route.peer == p))
+                            .cloned()
+                            .collect();
+                        let _ = reply.send(filtered);
+                    }
+                    rustbgpd_rib::RibUpdate::QueryBestRoutes { reply } => {
+                        let _ = reply.send(routes.clone());
+                    }
+                    _ => panic!("unexpected RIB query"),
+                }
+            }
+        });
+        PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None).with_rib_query(rib_tx)
+    }
+
+    #[tokio::test]
+    async fn test_policy_reports_counts_term_hits_and_diffs() {
+        let svc = test_policy_service(vec![
+            test_route("10.10.1.0", 24),
+            test_route("10.10.2.0", 24),
+            test_route("203.0.113.0", 24),
+        ]);
+        let resp = PolicyServiceRpc::test_policy(
+            &svc,
+            Request::new(proto::TestPolicyRequest {
+                rpol_source: TEST_RPOL.to_string(),
+                policy: "customer-in(200)".to_string(),
+                direction: "import".to_string(),
+                peer: String::new(),
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                limit: 0,
+                show_changes: 1,
+            }),
+        )
+        .await
+        .expect("dry run succeeds")
+        .into_inner();
+
+        assert!(resp.compiled, "{}", resp.diagnostics);
+        assert_eq!(resp.routes_evaluated, 3);
+        assert_eq!(resp.accepted, 2);
+        assert_eq!(resp.rejected, 1);
+        assert_eq!(resp.modified, 2);
+        // Per-term hit counters, named from the source.
+        assert_eq!(resp.term_hits.len(), 2);
+        assert_eq!(resp.term_hits[0].term, "customer-routes");
+        assert_eq!(resp.term_hits[0].hits, 2);
+        assert_eq!(resp.term_hits[1].term, "everything-else");
+        assert_eq!(resp.term_hits[1].hits, 1);
+        // Diff samples are capped by show_changes and render
+        // before/after values (LOCAL_PREF absent on the route).
+        assert_eq!(resp.diffs.len(), 1);
+        assert_eq!(resp.diffs[0].prefix, "10.10.1.0");
+        assert_eq!(resp.diffs[0].prefix_length, 24);
+        assert_eq!(resp.diffs[0].changes, vec!["local_pref unset -> 200"]);
+    }
+
+    #[tokio::test]
+    async fn test_policy_compile_diagnostics_come_back_in_response() {
+        let svc = test_policy_service(Vec::new());
+        let resp = PolicyServiceRpc::test_policy(
+            &svc,
+            Request::new(proto::TestPolicyRequest {
+                rpol_source: "policy p { term t { if route.nosuch == 1 { reject } } }".to_string(),
+                policy: "p".to_string(),
+                direction: "import".to_string(),
+                peer: String::new(),
+                afi_safi: 0,
+                limit: 0,
+                show_changes: 0,
+            }),
+        )
+        .await
+        .expect("compile failure is a successful RPC")
+        .into_inner();
+        assert!(!resp.compiled);
+        assert!(
+            resp.diagnostics.contains("candidate.rpol"),
+            "{}",
+            resp.diagnostics
+        );
+        assert_eq!(resp.routes_evaluated, 0);
+    }
+
+    #[tokio::test]
+    async fn test_policy_rejects_bad_selection_and_direction() {
+        let svc = test_policy_service(Vec::new());
+        let request = |policy: &str, direction: &str| proto::TestPolicyRequest {
+            rpol_source: TEST_RPOL.to_string(),
+            policy: policy.to_string(),
+            direction: direction.to_string(),
+            peer: String::new(),
+            afi_safi: 0,
+            limit: 0,
+            show_changes: 0,
+        };
+        for (policy, direction) in [
+            ("customer-in", "import"),  // arity
+            ("nope", "import"),         // unknown policy
+            ("customer-in(200)", "up"), // bad direction
+        ] {
+            let status =
+                PolicyServiceRpc::test_policy(&svc, Request::new(request(policy, direction)))
+                    .await
+                    .expect_err("must reject");
+            assert_eq!(status.code(), tonic::Code::InvalidArgument, "{policy}");
+        }
+    }
+
+    /// Export direction with a limit and an IPv4 family filter walks
+    /// Loc-RIB best routes.
+    #[tokio::test]
+    async fn test_policy_export_respects_limit() {
+        let svc = test_policy_service(vec![
+            test_route("10.10.1.0", 24),
+            test_route("10.10.2.0", 24),
+            test_route("10.10.3.0", 24),
+        ]);
+        let resp = PolicyServiceRpc::test_policy(
+            &svc,
+            Request::new(proto::TestPolicyRequest {
+                rpol_source: TEST_RPOL.to_string(),
+                policy: "customer-in(50)".to_string(),
+                direction: "export".to_string(),
+                peer: String::new(),
+                afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+                limit: 2,
+                show_changes: 0,
+            }),
+        )
+        .await
+        .expect("dry run succeeds")
+        .into_inner();
+        assert_eq!(resp.routes_evaluated, 2);
+        assert_eq!(resp.accepted, 2);
+        assert!(resp.diffs.is_empty());
     }
 }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1134,7 +1134,8 @@ async fn run_tcp_listener(
             config_tx.clone(),
             config_mutation_gate.clone(),
             runtime_config_lock,
-        ),
+        )
+        .with_rib_query(rib_query_tx.clone()),
         interceptor.clone(),
     ));
     routes.add_service(GlobalServiceServer::with_interceptor(
@@ -1336,7 +1337,8 @@ async fn run_uds_listener(
             config_tx.clone(),
             config_mutation_gate.clone(),
             runtime_config_lock,
-        ),
+        )
+        .with_rib_query(rib_query_tx.clone()),
         interceptor.clone(),
     ));
     routes.add_service(GlobalServiceServer::with_interceptor(

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -240,6 +240,153 @@ pub fn check_local(path: &str, json: bool) -> i32 {
     }
 }
 
+/// Options for `rbgp policy test` (ADR-0096 live-RIB dry run).
+pub struct TestOptions<'a> {
+    /// Path to the local `.rpol` file (its text is sent to the daemon).
+    pub file: &'a str,
+    /// Policy selection: name or call-form (`"customer-in(200)"`).
+    pub policy: &'a str,
+    /// `"import"` or `"export"`.
+    pub direction: &'a str,
+    /// Optional peer scope / export target.
+    pub peer: Option<&'a str>,
+    /// Optional family filter (`ipv4_unicast`, `ipv6_unicast`).
+    pub family: Option<&'a str>,
+    /// Max routes evaluated (0 = all).
+    pub limit: u32,
+    /// Max before/after diff samples.
+    pub show_changes: u32,
+}
+
+/// `rbgp policy test` — send the local `.rpol` source to the daemon
+/// for a read-only dry run over a live-RIB snapshot.
+pub async fn test(
+    connection: Connection,
+    opts: TestOptions<'_>,
+    json: bool,
+) -> Result<(), CliError> {
+    let rpol_source = std::fs::read_to_string(opts.file)
+        .map_err(|error| CliError::Argument(format!("cannot read {}: {error}", opts.file)))?;
+    let afi_safi = match opts.family {
+        None => proto::AddressFamily::Unspecified,
+        Some("ipv4_unicast" | "ipv4") => proto::AddressFamily::Ipv4Unicast,
+        Some("ipv6_unicast" | "ipv6") => proto::AddressFamily::Ipv6Unicast,
+        Some(other) => {
+            return Err(CliError::Argument(format!(
+                "unsupported family {other:?}; expected ipv4_unicast or ipv6_unicast"
+            )));
+        }
+    };
+    let mut client =
+        PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .test_policy(proto::TestPolicyRequest {
+            rpol_source,
+            policy: opts.policy.to_string(),
+            direction: opts.direction.to_string(),
+            peer: opts.peer.unwrap_or_default().to_string(),
+            afi_safi: afi_safi as i32,
+            limit: opts.limit,
+            show_changes: opts.show_changes,
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        #[derive(Serialize)]
+        struct JsonTermHits<'a> {
+            term: &'a str,
+            hits: u64,
+        }
+        #[derive(Serialize)]
+        struct JsonDiff<'a> {
+            prefix: String,
+            peer: &'a str,
+            changes: &'a [String],
+        }
+        #[derive(Serialize)]
+        struct JsonTest<'a> {
+            file: &'a str,
+            policy: &'a str,
+            direction: &'a str,
+            compiled: bool,
+            #[serde(skip_serializing_if = "str::is_empty")]
+            diagnostics: &'a str,
+            routes_evaluated: u64,
+            accepted: u64,
+            rejected: u64,
+            modified: u64,
+            term_hits: Vec<JsonTermHits<'a>>,
+            diffs: Vec<JsonDiff<'a>>,
+        }
+        output::print_json_pretty(&JsonTest {
+            file: opts.file,
+            policy: opts.policy,
+            direction: opts.direction,
+            compiled: resp.compiled,
+            diagnostics: &resp.diagnostics,
+            routes_evaluated: resp.routes_evaluated,
+            accepted: resp.accepted,
+            rejected: resp.rejected,
+            modified: resp.modified,
+            term_hits: resp
+                .term_hits
+                .iter()
+                .map(|t| JsonTermHits {
+                    term: &t.term,
+                    hits: t.hits,
+                })
+                .collect(),
+            diffs: resp
+                .diffs
+                .iter()
+                .map(|d| JsonDiff {
+                    prefix: format!("{}/{}", d.prefix, d.prefix_length),
+                    peer: &d.peer,
+                    changes: &d.changes,
+                })
+                .collect(),
+        })?;
+        if !resp.compiled {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
+    if !resp.compiled {
+        eprint!("{}", resp.diagnostics);
+        eprintln!("{}: compile failed", opts.file);
+        std::process::exit(1);
+    }
+    println!(
+        "policy {:?} ({}) over {} route{}:",
+        opts.policy,
+        opts.direction,
+        resp.routes_evaluated,
+        if resp.routes_evaluated == 1 { "" } else { "s" }
+    );
+    println!(
+        "  accepted {}  rejected {}  modified {}",
+        resp.accepted, resp.rejected, resp.modified
+    );
+    if !resp.term_hits.is_empty() {
+        println!("Term hits:");
+        for t in &resp.term_hits {
+            println!("  {:<32} {}", t.term, t.hits);
+        }
+    }
+    if !resp.diffs.is_empty() {
+        println!("Changes (up to {}):", opts.show_changes);
+        for d in &resp.diffs {
+            println!("  {}/{} (from {}):", d.prefix, d.prefix_length, d.peer);
+            for change in &d.changes {
+                println!("    {change}");
+            }
+        }
+    }
+    Ok(())
+}
+
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -927,6 +1074,64 @@ mod tests {
         write!(tmp, "{content}").unwrap();
         tmp.flush().unwrap();
         tmp
+    }
+
+    #[tokio::test]
+    async fn test_sends_source_and_selection_and_renders() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let file = write_rpol("policy p { term t { reject } }");
+        test(
+            connection,
+            TestOptions {
+                file: file.path().to_str().unwrap(),
+                policy: "customer-in(200)",
+                direction: "import",
+                peer: Some("10.0.0.9"),
+                family: Some("ipv4_unicast"),
+                limit: 100,
+                show_changes: 5,
+            },
+            true,
+        )
+        .await
+        .unwrap();
+        let captured = server.state.last_test_policy.lock().await.clone().unwrap();
+        assert_eq!(captured.rpol_source, "policy p { term t { reject } }");
+        assert_eq!(captured.policy, "customer-in(200)");
+        assert_eq!(captured.direction, "import");
+        assert_eq!(captured.peer, "10.0.0.9");
+        assert_eq!(
+            captured.afi_safi,
+            crate::proto::AddressFamily::Ipv4Unicast as i32
+        );
+        assert_eq!(captured.limit, 100);
+        assert_eq!(captured.show_changes, 5);
+    }
+
+    #[tokio::test]
+    async fn test_rejects_unknown_family_and_missing_file() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+        let file = write_rpol("policy p { term t { reject } }");
+        let opts = |file: &str, family: Option<&'static str>| TestOptions {
+            file: Box::leak(file.to_string().into_boxed_str()),
+            policy: "p",
+            direction: "import",
+            peer: None,
+            family,
+            limit: 0,
+            show_changes: 0,
+        };
+        let path = file.path().to_str().unwrap();
+        let err = test(connection.clone(), opts(path, Some("l2vpn_evpn")), false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Argument(_)), "{err:?}");
+        let err = test(connection, opts("/nonexistent/x.rpol", None), false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Argument(_)), "{err:?}");
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -348,6 +348,36 @@ enum PolicyAction {
         /// Path to the `.rpol` file
         file: String,
     },
+    /// Dry-run a candidate `.rpol` policy against the daemon's live
+    /// RIB (ADR-0096): the file compiles server-side and evaluates
+    /// read-only over a route snapshot — counts, per-term hit
+    /// counters, and before/after attribute diffs. No route state or
+    /// session is touched. Exit codes: 0 ran, 1 compile diagnostics.
+    Test {
+        /// Path to the `.rpol` file
+        file: String,
+        /// Policy to evaluate: a name, or a call-form with u32
+        /// arguments for parameterized policies, e.g. "customer-in(200)"
+        #[arg(long)]
+        policy: String,
+        /// Evaluation direction: import (Adj-RIB-In) or export
+        /// (Loc-RIB best routes)
+        #[arg(long)]
+        direction: String,
+        /// Peer address: restricts the import snapshot to one peer's
+        /// Adj-RIB-In, or sets the export evaluation target peer
+        #[arg(long)]
+        peer: Option<String>,
+        /// Address family filter (ipv4_unicast, ipv6_unicast)
+        #[arg(short = 'a', long)]
+        family: Option<String>,
+        /// Maximum routes to evaluate (0 = all)
+        #[arg(long, default_value_t = 0)]
+        limit: u32,
+        /// Maximum before/after attribute diffs to show
+        #[arg(long, default_value_t = 10)]
+        show_changes: u32,
+    },
     /// Show one policy by name
     Get {
         /// Policy name
@@ -1917,6 +1947,30 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         }
         Command::Policy { action } => match action {
             PolicyAction::Check { .. } => unreachable!("handled before connect"),
+            PolicyAction::Test {
+                file,
+                policy,
+                direction,
+                peer,
+                family,
+                limit,
+                show_changes,
+            } => {
+                commands::policy::test(
+                    connection,
+                    commands::policy::TestOptions {
+                        file: &file,
+                        policy: &policy,
+                        direction: &direction,
+                        peer: peer.as_deref(),
+                        family: family.as_deref(),
+                        limit,
+                        show_changes,
+                    },
+                    json,
+                )
+                .await
+            }
             PolicyAction::List => commands::policy::list(connection, json).await,
             PolicyAction::Get { name } => commands::policy::get(connection, &name, json).await,
             PolicyAction::Set { name, from_file } => {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -60,6 +60,7 @@ pub(crate) struct MockState {
     pub(crate) last_set_policy: Mutex<Option<server_proto::SetPolicyRequest>>,
     pub(crate) last_delete_policy: Mutex<Option<server_proto::DeletePolicyRequest>>,
     pub(crate) last_explain_import: Mutex<Option<server_proto::ExplainImportPolicyRequest>>,
+    pub(crate) last_test_policy: Mutex<Option<server_proto::TestPolicyRequest>>,
     pub(crate) last_set_neighbor_set: Mutex<Option<server_proto::SetNeighborSetRequest>>,
     pub(crate) last_delete_neighbor_set: Mutex<Option<server_proto::DeleteNeighborSetRequest>>,
     pub(crate) last_add_dynamic_neighbor: Mutex<Option<server_proto::AddDynamicNeighborRequest>>,
@@ -1571,6 +1572,31 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             afi_safi: req.afi_safi,
             current_policy_generation: 3,
             matches,
+        }))
+    }
+
+    async fn test_policy(
+        &self,
+        request: Request<server_proto::TestPolicyRequest>,
+    ) -> Result<Response<server_proto::TestPolicyResponse>, Status> {
+        *self.state.last_test_policy.lock().await = Some(request.into_inner());
+        Ok(Response::new(server_proto::TestPolicyResponse {
+            compiled: true,
+            diagnostics: String::new(),
+            routes_evaluated: 3,
+            accepted: 2,
+            rejected: 1,
+            modified: 1,
+            term_hits: vec![server_proto::TestPolicyTermHits {
+                term: "customer-routes".to_string(),
+                hits: 2,
+            }],
+            diffs: vec![server_proto::TestPolicyDiff {
+                prefix: "10.10.1.0".to_string(),
+                prefix_length: 24,
+                peer: "10.0.0.9".to_string(),
+                changes: vec!["local_pref unset -> 200".to_string()],
+            }],
         }))
     }
 }

--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -23,19 +23,35 @@ use crate::engine::{AsPathRegex, PolicyAction, PolicyChain, PolicyStatement};
 use crate::ir::{
     Cmp, CompiledChain, CompiledPolicy, MatchExpr, PolicySource, RegexId, SetId, Term, TermAction,
 };
-use crate::sets::{CommunitySet, SetStore};
+use crate::sets::{CommunitySet, PrefixSet, SetStore};
 
 /// Compile a TOML policy chain into the IR, interning match sets and
 /// regexes through `store` (identical set data across policies — or
 /// across chains compiled through the same store — shares one `Arc`'d
 /// structure).
+///
+/// `.rpol`-backed chain members (`NamedPolicy.rpol`) arrive
+/// pre-compiled from the config resolver; they are spliced into the
+/// combined chain with their set/regex ids remapped into the chain's
+/// merged tables (`Arc` identity dedupes tables shared across
+/// members compiled from the same file).
 #[must_use]
 pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain {
     let mut sets = ChainSets::default();
-    let policies = chain
-        .policies
-        .iter()
-        .map(|named| CompiledPolicy {
+    let mut policies = Vec::with_capacity(chain.policies.len());
+    for named in &chain.policies {
+        if let Some(rpol) = named.rpol.as_deref() {
+            for policy in &rpol.policies {
+                let mut spliced = splice_policy(policy, rpol, &mut sets);
+                // Attribute to the configured chain-reference name
+                // (e.g. `"customer-in(200)"`), matching how TOML
+                // members are labeled for metrics / explain.
+                spliced.name.clone_from(&named.name);
+                policies.push(spliced);
+            }
+            continue;
+        }
+        policies.push(CompiledPolicy {
             name: named.name.clone(),
             terms: named
                 .policy
@@ -45,13 +61,68 @@ pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain
                 .collect(),
             default_action: named.policy.default_action,
             source: PolicySource::Toml,
-        })
-        .collect();
+        });
+    }
     CompiledChain {
         policies,
-        prefix_sets: Vec::new(),
+        prefix_sets: sets.prefix_sets,
         community_sets: sets.community_sets,
         as_path_regexes: sets.as_path_regexes,
+    }
+}
+
+/// Copy one pre-compiled `.rpol` policy into the combined chain,
+/// rewriting every `SetId` / `RegexId` from the donor chain's tables
+/// into the merged chain tables.
+fn splice_policy(
+    policy: &CompiledPolicy,
+    donor: &CompiledChain,
+    sets: &mut ChainSets,
+) -> CompiledPolicy {
+    let terms = policy
+        .terms
+        .iter()
+        .map(|term| Term {
+            name: term.name.clone(),
+            guard: remap_expr(&term.guard, donor, sets),
+            action: term.action.clone(),
+        })
+        .collect();
+    CompiledPolicy {
+        name: policy.name.clone(),
+        terms,
+        default_action: policy.default_action,
+        source: policy.source,
+    }
+}
+
+/// Rewrite set/regex table ids from `donor`'s tables into `sets`.
+/// Structure and semantics are otherwise preserved verbatim.
+fn remap_expr(expr: &MatchExpr, donor: &CompiledChain, sets: &mut ChainSets) -> MatchExpr {
+    match expr {
+        MatchExpr::PrefixInSet(id) => {
+            MatchExpr::PrefixInSet(sets.prefix_set_id(donor.prefix_sets[id.0 as usize].clone()))
+        }
+        MatchExpr::CommunityInSet(id) => MatchExpr::CommunityInSet(
+            sets.community_set_id(donor.community_sets[id.0 as usize].clone()),
+        ),
+        MatchExpr::AsPathMatches(id) => {
+            MatchExpr::AsPathMatches(sets.regex_id(donor.as_path_regexes[id.0 as usize].clone()))
+        }
+        MatchExpr::And(children) => MatchExpr::And(
+            children
+                .iter()
+                .map(|child| remap_expr(child, donor, sets))
+                .collect(),
+        ),
+        MatchExpr::Or(children) => MatchExpr::Or(
+            children
+                .iter()
+                .map(|child| remap_expr(child, donor, sets))
+                .collect(),
+        ),
+        MatchExpr::Not(inner) => MatchExpr::Not(Box::new(remap_expr(inner, donor, sets))),
+        other => other.clone(),
     }
 }
 
@@ -151,11 +222,24 @@ fn compile_statement(
 /// table).
 #[derive(Default)]
 struct ChainSets {
+    prefix_sets: Vec<Arc<PrefixSet>>,
     community_sets: Vec<Arc<CommunitySet>>,
     as_path_regexes: Vec<Arc<AsPathRegex>>,
 }
 
 impl ChainSets {
+    fn prefix_set_id(&mut self, set: Arc<PrefixSet>) -> SetId {
+        let index = self
+            .prefix_sets
+            .iter()
+            .position(|existing| Arc::ptr_eq(existing, &set))
+            .unwrap_or_else(|| {
+                self.prefix_sets.push(set);
+                self.prefix_sets.len() - 1
+            });
+        SetId(u32::try_from(index).expect("set table fits u32"))
+    }
+
     fn community_set_id(&mut self, set: Arc<CommunitySet>) -> SetId {
         let index = self
             .community_sets
@@ -178,5 +262,208 @@ impl ChainSets {
                 self.as_path_regexes.len() - 1
             });
         RegexId(u32::try_from(index).expect("regex table fits u32"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+
+    use rustbgpd_wire::{Ipv4Prefix, Prefix};
+
+    use crate::engine::{
+        NamedPolicy, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteContext,
+        RouteModifications,
+    };
+    use crate::ir::{MatchExpr, PolicySource};
+    use crate::rpol::RpolFile;
+    use crate::sets::SetStore;
+
+    const RPOL: &str = r#"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+
+policy customer-in(peer_lp: u32) {
+    term customer-routes {
+        if route.prefix in customers { set local-pref peer_lp; accept }
+    }
+    term transit-guard {
+        if route.as-path matches "_65010_" { reject }
+    }
+}
+
+policy bogon-filter {
+    term bogons { if route.prefix == 127.0.0.0/8 { reject } }
+}
+"#;
+
+    fn ctx(prefix: Prefix, as_path_str: &str) -> RouteContext<'_> {
+        RouteContext {
+            prefix: Some(prefix),
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[],
+            large_communities: &[],
+            as_path_str,
+            as_path_len: 1,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        }
+    }
+
+    fn v4(a: u8, b: u8, c: u8, d: u8, len: u8) -> Prefix {
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(a, b, c, d), len))
+    }
+
+    /// A TOML deny statement for 192.0.2.0/24, to mix into the chain.
+    fn toml_deny_policy() -> NamedPolicy {
+        NamedPolicy {
+            name: Some("toml-deny".to_string()),
+            policy: Policy {
+                entries: vec![PolicyStatement {
+                    prefix: Some(v4(192, 0, 2, 0, 24)),
+                    ge: None,
+                    le: None,
+                    action: PolicyAction::Deny,
+                    match_community: vec![],
+                    match_as_path: None,
+                    match_neighbor_set: None,
+                    match_route_type: None,
+                    match_evpn_route_type: None,
+                    match_rpki_validation: None,
+                    match_aspa_validation: None,
+                    match_as_path_length_ge: None,
+                    match_as_path_length_le: None,
+                    match_local_pref_ge: None,
+                    match_local_pref_le: None,
+                    match_med_ge: None,
+                    match_med_le: None,
+                    match_next_hop: None,
+                    modifications: RouteModifications::default(),
+                }],
+                default_action: PolicyAction::Permit,
+            },
+            rpol: None,
+        }
+    }
+
+    /// Mixed TOML + monomorphized-rpol chain: the rpol member splices
+    /// pre-compiled with its set/regex ids remapped into the merged
+    /// chain tables, and evaluates with its instantiation argument.
+    #[test]
+    fn chain_splices_rpol_members_with_id_remap() {
+        let file = RpolFile::parse(RPOL).expect("clean rpol");
+        let mut store = SetStore::new();
+        let customer = file
+            .compile_policy("customer-in", &[200], &mut store)
+            .expect("policy exists");
+        let bogon = file
+            .compile_policy("bogon-filter", &[], &mut store)
+            .expect("policy exists");
+
+        let chain = PolicyChain::from_named(vec![
+            toml_deny_policy(),
+            NamedPolicy::from_rpol("customer-in(200)".to_string(), Arc::new(customer)),
+            NamedPolicy::from_rpol("bogon-filter".to_string(), Arc::new(bogon)),
+        ]);
+        let compiled = chain.compiled();
+        assert_eq!(compiled.policies.len(), 3);
+        assert_eq!(compiled.policies[0].source, PolicySource::Toml);
+        assert_eq!(compiled.policies[1].source, PolicySource::Rpol);
+        // Attribution uses the configured chain-reference name.
+        assert_eq!(
+            compiled.policies[1].name.as_deref(),
+            Some("customer-in(200)")
+        );
+        // Both rpol members came from one file compiled through one
+        // store: the (single) prefix set dedupes by Arc identity.
+        assert_eq!(compiled.prefix_sets.len(), 1);
+        assert_eq!(compiled.as_path_regexes.len(), 1);
+        // The remapped PrefixInSet id must index the merged table.
+        assert!(
+            compiled.policies[1].terms[0]
+                .guard
+                .any_node(&|expr| matches!(expr, MatchExpr::PrefixInSet(id) if id.0 == 0))
+        );
+
+        // Evaluation end-to-end through the merged chain:
+        // customer prefix → permit with the monomorphized local-pref.
+        let (result, eval) = chain.evaluate_with_attribution(&ctx(v4(10, 10, 3, 0, 24), ""));
+        assert_eq!(result.action, PolicyAction::Permit);
+        assert_eq!(result.modifications.set_local_pref, Some(200));
+        assert_eq!(eval.matched_policy.as_deref(), Some("bogon-filter"));
+        // Transit AS in the path → the rpol regex guard denies.
+        let (result, eval) =
+            chain.evaluate_with_attribution(&ctx(v4(203, 0, 113, 0, 24), "65010 65020"));
+        assert_eq!(result.action, PolicyAction::Deny);
+        assert_eq!(eval.matched_policy.as_deref(), Some("customer-in(200)"));
+        // TOML member still denies its prefix first.
+        let (result, eval) = chain.evaluate_with_attribution(&ctx(v4(192, 0, 2, 0, 24), ""));
+        assert_eq!(result.action, PolicyAction::Deny);
+        assert_eq!(eval.matched_policy.as_deref(), Some("toml-deny"));
+    }
+
+    /// Chain identity (the ADR-0076 planner diff) is compiled content:
+    /// same source twice → equal; different instantiation or edited
+    /// source → unequal.
+    #[test]
+    fn rpol_member_partial_eq_is_compiled_content() {
+        let member = |source: &str, lp: u32| {
+            let file = RpolFile::parse(source).expect("clean rpol");
+            let mut store = SetStore::new();
+            NamedPolicy::from_rpol(
+                format!("customer-in({lp})"),
+                Arc::new(
+                    file.compile_policy("customer-in", &[lp], &mut store)
+                        .expect("policy exists"),
+                ),
+            )
+        };
+        assert_eq!(member(RPOL, 200), member(RPOL, 200));
+        assert_ne!(member(RPOL, 200), member(RPOL, 300));
+        let edited = RPOL.replace("ge 24 le 28", "ge 24 le 32");
+        assert_ne!(member(RPOL, 200), member(&edited, 200));
+    }
+
+    /// `requires_*` analyses see spliced rpol guards.
+    #[test]
+    fn requires_analyses_cover_rpol_members() {
+        let file = RpolFile::parse(RPOL).expect("clean rpol");
+        let mut store = SetStore::new();
+        let customer = file
+            .compile_policy("customer-in", &[200], &mut store)
+            .expect("policy exists");
+        let chain = PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+            "customer-in(200)".to_string(),
+            Arc::new(customer),
+        )]);
+        assert!(chain.requires_as_path_string());
+        assert!(!chain.requires_rpki_validation());
+    }
+
+    /// An rpol member's placeholder `policy` never reaches evaluation:
+    /// a Deny-defaulted placeholder must not leak a deny.
+    #[test]
+    fn rpol_member_placeholder_policy_is_ignored() {
+        let file = RpolFile::parse(RPOL).expect("clean rpol");
+        let mut store = SetStore::new();
+        let bogon = file
+            .compile_policy("bogon-filter", &[], &mut store)
+            .expect("policy exists");
+        let mut member = NamedPolicy::from_rpol("bogon-filter".to_string(), Arc::new(bogon));
+        member.policy = Policy {
+            entries: Vec::new(),
+            default_action: PolicyAction::Deny,
+        };
+        let chain = PolicyChain::from_named(vec![member]);
+        let (result, _) = chain.evaluate_with_attribution(&ctx(v4(10, 0, 0, 0, 24), ""));
+        assert_eq!(result.action, PolicyAction::Permit);
     }
 }

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use regex::Regex;
 use rustbgpd_wire::{
@@ -794,13 +794,44 @@ pub fn evaluate_policy(policy: Option<&Policy>, ctx: &RouteContext<'_>) -> Polic
 pub struct NamedPolicy {
     /// Configured policy name (`None` for inline / anonymous policies).
     pub name: Option<String>,
-    /// The policy itself.
+    /// The policy itself. For an `.rpol`-backed member (`rpol` is
+    /// `Some`) this is an empty placeholder — the chain compiler
+    /// splices the pre-compiled body instead of reading `entries`.
     pub policy: Policy,
+    /// Pre-compiled `.rpol` body (ADR-0096): a single-policy
+    /// [`CompiledChain`] plus the set tables its guards reference,
+    /// produced by the config resolver. `None` for TOML policies.
+    ///
+    /// Participates in `PartialEq`, so chain identity — what the
+    /// ADR-0076 planner diffs — is the *compiled content*: two loads
+    /// of the same `.rpol` source compare equal, an edited file
+    /// compares unequal.
+    pub rpol: Option<Arc<CompiledChain>>,
+}
+
+impl NamedPolicy {
+    /// An `.rpol`-backed chain member: `compiled` must be a
+    /// single-policy chain from `RpolFile::compile_policy`.
+    #[must_use]
+    pub fn from_rpol(name: String, compiled: Arc<CompiledChain>) -> Self {
+        Self {
+            name: Some(name),
+            policy: Policy {
+                entries: Vec::new(),
+                default_action: PolicyAction::Permit,
+            },
+            rpol: Some(compiled),
+        }
+    }
 }
 
 impl From<Policy> for NamedPolicy {
     fn from(policy: Policy) -> Self {
-        Self { name: None, policy }
+        Self {
+            name: None,
+            policy,
+            rpol: None,
+        }
     }
 }
 

--- a/crates/policy/src/engine/tests/ir_parity.rs
+++ b/crates/policy/src/engine/tests/ir_parity.rs
@@ -538,6 +538,7 @@ fn named(name: &str, policy: Policy) -> NamedPolicy {
     NamedPolicy {
         name: Some(name.to_string()),
         policy,
+        rpol: None,
     }
 }
 

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -18,6 +18,7 @@ fn named(name: &str, policy: Policy) -> NamedPolicy {
     NamedPolicy {
         name: Some(name.to_string()),
         policy,
+        rpol: None,
     }
 }
 

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -88,6 +88,85 @@ impl CompiledChain {
         )
     }
 
+    /// A zeroed per-term hit-counter grid shaped like this chain, for
+    /// [`evaluate_recording_hits`](Self::evaluate_recording_hits).
+    #[must_use]
+    pub fn zero_term_hits(&self) -> Vec<Vec<u64>> {
+        self.policies
+            .iter()
+            .map(|policy| vec![0; policy.terms.len()])
+            .collect()
+    }
+
+    /// Evaluate recording per-term guard hits — the `rbgp policy test`
+    /// backend (ADR-0096 Decision 6). Decision semantics are identical
+    /// to [`evaluate_with_attribution`](Self::evaluate_with_attribution)
+    /// (same walk, same merge rules); additionally `hits[p][t]` is
+    /// incremented whenever policy `p`'s term `t`'s guard matches
+    /// during the walk (`Continue` terms included; terms after the
+    /// deciding term are not evaluated, mirroring first-match-wins).
+    ///
+    /// # Panics
+    ///
+    /// If `hits` is not shaped like `policies` (one counter per term).
+    #[must_use]
+    pub fn evaluate_recording_hits(
+        &self,
+        ctx: &RouteContext<'_>,
+        hits: &mut [Vec<u64>],
+    ) -> PolicyResult {
+        assert_eq!(hits.len(), self.policies.len(), "hits shaped like chain");
+        let mut accumulated = RouteModifications::default();
+        for (policy, policy_hits) in self.policies.iter().zip(hits.iter_mut()) {
+            assert_eq!(policy_hits.len(), policy.terms.len());
+            let mut continued: Option<RouteModifications> = None;
+            // `Some(None)` = permit with no deciding-term mods;
+            // `None` after the loop = fell through to default_action.
+            let mut permit_mods: Option<Option<&RouteModifications>> = None;
+            let mut denied = false;
+            for (term, hit) in policy.terms.iter().zip(policy_hits.iter_mut()) {
+                if self.eval_expr(&term.guard, ctx) {
+                    *hit += 1;
+                    match &term.action {
+                        TermAction::Permit(mods) => {
+                            permit_mods = Some(Some(mods));
+                            break;
+                        }
+                        TermAction::Deny => {
+                            denied = true;
+                            break;
+                        }
+                        TermAction::Continue(mods) => {
+                            continued
+                                .get_or_insert_with(RouteModifications::default)
+                                .merge_from(mods.clone());
+                        }
+                    }
+                }
+            }
+            if permit_mods.is_none() && !denied {
+                match policy.default_action {
+                    PolicyAction::Permit => permit_mods = Some(None),
+                    PolicyAction::Deny => denied = true,
+                }
+            }
+            if denied {
+                return PolicyResult::deny();
+            }
+            let mut merged = continued.unwrap_or_default();
+            if let Some(Some(mods)) = permit_mods {
+                merged.merge_from(mods.clone());
+            }
+            if !merged.is_empty() {
+                accumulated.merge_from(merged);
+            }
+        }
+        PolicyResult {
+            action: PolicyAction::Permit,
+            modifications: accumulated,
+        }
+    }
+
     /// First-match-wins term walk; the policy's default action decides
     /// on fallthrough. [`TermAction::Continue`] terms are the one
     /// exception to first-match-wins: a matched Continue applies its
@@ -280,6 +359,81 @@ mod tests {
                 "guard {guard:?}"
             );
         }
+    }
+
+    /// `evaluate_recording_hits` must be decision-identical to
+    /// `evaluate_with_attribution` while counting matched guards —
+    /// including Continue terms and terms skipped after the decider.
+    #[test]
+    fn recording_hits_matches_plain_evaluation_and_counts() {
+        use crate::ir::CompiledPolicy;
+
+        let hit = MatchExpr::PrefixEq {
+            prefix: v4([10, 0, 0, 0], 8),
+            ge: Some(8),
+            le: Some(32),
+        };
+        let chain = CompiledChain {
+            policies: vec![CompiledPolicy {
+                name: Some("p".to_string()),
+                terms: vec![
+                    Term {
+                        name: Some("tag".to_string()),
+                        guard: hit.clone(),
+                        action: TermAction::Continue(RouteModifications {
+                            set_med: Some(5),
+                            ..RouteModifications::default()
+                        }),
+                    },
+                    Term {
+                        name: Some("accept-10".to_string()),
+                        guard: hit.clone(),
+                        action: TermAction::Permit(RouteModifications {
+                            set_local_pref: Some(200),
+                            ..RouteModifications::default()
+                        }),
+                    },
+                    Term {
+                        name: Some("unreached".to_string()),
+                        guard: MatchExpr::True,
+                        action: TermAction::Deny,
+                    },
+                ],
+                default_action: PolicyAction::Deny,
+                source: PolicySource::Toml,
+            }],
+            prefix_sets: Vec::new(),
+            community_sets: Vec::new(),
+            as_path_regexes: Vec::new(),
+        };
+
+        let mut hits = chain.zero_term_hits();
+        assert_eq!(hits, vec![vec![0, 0, 0]]);
+        for (route, expect_permit) in [
+            (ctx(Some(v4([10, 1, 0, 0], 24))), true),
+            (ctx(Some(v4([10, 2, 0, 0], 24))), true),
+            (ctx(Some(v4([192, 0, 2, 0], 24))), false),
+        ] {
+            let recorded = chain.evaluate_recording_hits(&route, &mut hits);
+            let (plain, _) = chain.evaluate_with_attribution(&route);
+            assert_eq!(recorded, plain);
+            assert_eq!(
+                recorded.action,
+                if expect_permit {
+                    PolicyAction::Permit
+                } else {
+                    PolicyAction::Deny
+                }
+            );
+            if expect_permit {
+                // Continue mods merged under the deciding permit.
+                assert_eq!(recorded.modifications.set_med, Some(5));
+                assert_eq!(recorded.modifications.set_local_pref, Some(200));
+            }
+        }
+        // Two 10/8 routes hit tag + accept-10; the miss hits only the
+        // unconditional deny (terms after a decider are not evaluated).
+        assert_eq!(hits, vec![vec![2, 2, 1]]);
     }
 
     #[test]

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -4,9 +4,9 @@
 //! definitions, `policy` blocks with named terms and parameters, and
 //! in-language `test` blocks — into the public typed IR
 //! ([`crate::ir`]), interning match data through a
-//! [`crate::sets::SetStore`]. Nothing in the daemon consumes
-//! this yet (config/API wiring is the next slice); the standalone
-//! entry points are:
+//! [`crate::sets::SetStore`]. The daemon consumes this through
+//! [`RpolFile`] / [`RpolPolicySet`] (config `rpol_files` references
+//! and the `TestPolicy` RPC); the standalone entry points are:
 //!
 //! - [`compile_rpol`] — source → [`CompiledChain`] (every
 //!   zero-parameter policy; parameterized policies are templates
@@ -31,8 +31,156 @@ mod typeck;
 pub use diag::{Diagnostic, Diagnostics, Span, Spanned};
 pub use testing::{TestFailure, TestReport};
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use crate::ir::CompiledChain;
 use crate::sets::SetStore;
+
+/// A parsed + typechecked `.rpol` source file, retained (with its
+/// source text) so config chain references — including parameterized
+/// call-forms like `"customer-in(200)"` — can be monomorphized at
+/// chain-resolve time.
+#[derive(Debug)]
+pub struct RpolFile {
+    source: String,
+    file: ast::SourceFile,
+}
+
+impl RpolFile {
+    /// Parse and typecheck `.rpol` source, retaining it for later
+    /// per-policy compilation.
+    ///
+    /// # Errors
+    ///
+    /// All lex, parse, and type errors found in one pass.
+    pub fn parse(source: &str) -> Result<Self, Diagnostics> {
+        let (file, _) = front(source)?;
+        Ok(Self {
+            source: source.to_string(),
+            file,
+        })
+    }
+
+    /// The original source text.
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// `(name, parameter count)` for every policy defined in the file,
+    /// in source order.
+    pub fn policies(&self) -> impl Iterator<Item = (&str, usize)> {
+        self.file
+            .policies
+            .iter()
+            .map(|p| (p.name.node.as_str(), p.params.len()))
+    }
+
+    /// Monomorphize one policy with concrete arguments into a
+    /// single-policy [`CompiledChain`] carrying the file's set tables.
+    /// Returns `None` for an unknown policy name.
+    ///
+    /// # Panics
+    ///
+    /// If `args.len()` does not match the policy's declared parameter
+    /// count — callers check arity first (via [`Self::policies`]).
+    #[must_use]
+    pub fn compile_policy(
+        &self,
+        name: &str,
+        args: &[u32],
+        store: &mut SetStore,
+    ) -> Option<CompiledChain> {
+        let def = self.file.policies.iter().find(|p| p.name.node == name)?;
+        assert_eq!(
+            def.params.len(),
+            args.len(),
+            "rpol chain reference arity is checked at config resolve"
+        );
+        let mut lowerer = lower::Lowerer::new(&self.file, store);
+        Some(lowerer.instantiate_chain(name, args, store))
+    }
+}
+
+/// One named `.rpol` policy available to config chain references.
+#[derive(Debug, Clone)]
+pub struct RpolPolicyEntry {
+    /// The owning parsed file (shared across every policy it defines).
+    pub file: Arc<RpolFile>,
+    /// Declared parameter count (all parameters are `u32` in V1).
+    pub params: usize,
+    /// Display path of the source file, for error messages.
+    pub path: String,
+}
+
+/// The compiled `.rpol` policy registry a loaded daemon config carries:
+/// policy name → owning file + arity. Lives in this crate (not the
+/// daemon's config module) so the peer manager's command surface can
+/// carry it across the api/binary crate boundary.
+///
+/// `PartialEq` is semantic content: two loads of the same `.rpol`
+/// source compare equal, an edited file compares unequal. The display
+/// `path` is deliberately excluded — moving unchanged source to a new
+/// path is not a policy change (the `rpol_files` TOML list diff covers
+/// path edits).
+#[derive(Debug, Clone, Default)]
+pub struct RpolPolicySet {
+    /// Policy name → registry entry.
+    pub policies: HashMap<String, RpolPolicyEntry>,
+}
+
+/// Split a policy chain reference into base name + `u32` arguments:
+/// `"bogon-filter"` → `("bogon-filter", [])`,
+/// `"customer-in(200)"` → `("customer-in", [200])`. Used by the daemon
+/// config resolver and `rbgp policy test`'s selection argument.
+///
+/// # Errors
+///
+/// A human-readable description of the malformed call-form.
+pub fn parse_call_form(reference: &str) -> Result<(&str, Vec<u32>), String> {
+    let Some(open) = reference.find('(') else {
+        return Ok((reference, Vec::new()));
+    };
+    let inner = reference[open..]
+        .strip_prefix('(')
+        .and_then(|rest| rest.strip_suffix(')'))
+        .ok_or_else(|| format!("invalid reference {reference:?}: expected `name(arg, ...)`"))?;
+    let base = reference[..open].trim();
+    if base.is_empty() {
+        return Err(format!(
+            "invalid reference {reference:?}: missing policy name before `(`"
+        ));
+    }
+    if inner.trim().is_empty() {
+        return Err(format!(
+            "invalid reference {reference:?}: empty argument list — write the bare name instead"
+        ));
+    }
+    let args = inner
+        .split(',')
+        .map(|arg| {
+            let arg = arg.trim();
+            arg.parse::<u32>().map_err(|e| {
+                format!("invalid reference {reference:?}: argument {arg:?} is not a u32: {e}")
+            })
+        })
+        .collect::<Result<Vec<u32>, _>>()?;
+    Ok((base, args))
+}
+
+impl PartialEq for RpolPolicySet {
+    fn eq(&self, other: &Self) -> bool {
+        self.policies.len() == other.policies.len()
+            && self.policies.iter().all(|(name, entry)| {
+                other.policies.get(name).is_some_and(|o| {
+                    o.params == entry.params && o.file.source() == entry.file.source()
+                })
+            })
+    }
+}
+
+impl Eq for RpolPolicySet {}
 
 /// Compile `.rpol` source into a [`CompiledChain`] holding every
 /// zero-parameter policy (in source order) plus the indexed set tables

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4180,6 +4180,7 @@ async fn explain_statement_trace_attributes_hit_and_skips_stale() {
             entries: vec![deny_stmt, permit_stmt],
             default_action: PolicyAction::Permit,
         },
+        rpol: None,
     }]);
     let mut session = PeerSession::new(
         config,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1343,6 +1343,59 @@ chain.
 **Mutual exclusion:** Inline policy and policy chain cannot both be set for the
 same direction on the same neighbor. This is a config validation error.
 
+### `.rpol` policy files (`rpol_files`, ADR-0096)
+
+Policies written in the rustbgpd policy language
+([`rpol-language.md`](rpol-language.md)) load from files referenced in
+`[policy]`:
+
+```toml
+[policy]
+rpol_files = ["policies/core.rpol", "policies/customers.rpol"]
+```
+
+- **Paths** are relative to the config file's directory (absolute paths
+  work too). After a successful load the daemon carries them as
+  absolute paths, so runtime config snapshots and transaction
+  candidates stay loadable regardless of working directory.
+- **Compile-at-load:** every file is parsed and typechecked at config
+  load; any diagnostic (rendered with source excerpts, like
+  `rbgp policy check`) is a config load error — a broken `.rpol` file
+  never half-loads.
+- **One namespace:** `.rpol` policies and `[policy.definitions]` TOML
+  policies share the named-policy namespace. A name defined by both —
+  or by two `.rpol` files — is a load error naming both sources.
+- **Chain references:** chains mix TOML and `.rpol` policies freely.
+  Parameterized `.rpol` policies are referenced in call-form with
+  `u32` arguments, monomorphized at load:
+
+```toml
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+import_policy_chain = ["customer-in(200)", "bogon-filter", "toml-defined"]
+```
+
+  Unknown names, wrong arity, and non-`u32` arguments are load errors.
+- **Reload:** editing a referenced `.rpol` file and sending SIGHUP
+  recompiles it and hot-applies the changed chains to exactly the
+  peers whose resolved policy actually changed (Route Refresh fires
+  for materially changed import chains — same mechanism as
+  `[policy.definitions]` edits). `rbgp config diff` reports the change
+  under the policy section.
+- **Scope notes:** config *transactions* cannot stage `.rpol` file
+  content (the files live outside the candidate TOML) — a candidate
+  whose `rpol_files` list changed is rejected as unsupported; apply
+  `.rpol` changes via SIGHUP. gNMI Set likewise edits only the TOML
+  surface, not `.rpol` file content. `rbgp policy explain` statement
+  traces for `.rpol` chain members arrive with the ADR-0096 explain
+  slice.
+
+Test `.rpol` policies without touching the daemon
+(`rbgp policy check file.rpol` — runs the file's in-language `test`
+blocks locally) or against the daemon's live RIB read-only
+(`rbgp policy test` — see [`rpol-language.md`](rpol-language.md)).
+
 ### Import-decision explain (`[policy.explain]`)
 
 Optional. Controls the per-session import-decision cache that backs

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 96,
+  "method_count": 97,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 54,
+    "sensitive_read": 55,
     "mutating": 19,
     "operator_only": 23
   },
@@ -55,6 +55,7 @@
     { "service": "rustbgpd.v1.PolicyService", "method": "SetNeighborExportChain", "path": "/rustbgpd.v1.PolicyService/SetNeighborExportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborImportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborImportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ExplainImportPolicy", "path": "/rustbgpd.v1.PolicyService/ExplainImportPolicy", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.PolicyService", "method": "TestPolicy", "path": "/rustbgpd.v1.PolicyService/TestPolicy", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborExportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborExportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PeerGroupService", "method": "ListPeerGroups", "path": "/rustbgpd.v1.PeerGroupService/ListPeerGroups", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PeerGroupService", "method": "GetPeerGroup", "path": "/rustbgpd.v1.PeerGroupService/GetPeerGroup", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -88,7 +88,7 @@ shape itself does not raise the tier.
 | `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. |
 | `SetGracefulShutdown` | `operator_only` | Network-wide when `address` is empty; listed here because the proto puts it in `NeighborService`. |
 
-### PolicyService (19 RPCs)
+### PolicyService (20 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -110,6 +110,7 @@ shape itself does not raise the tier.
 | `SetNeighborExportChain` | `mutating` | Per-neighbor. |
 | `ClearNeighborImportChain` | `mutating` | Per-neighbor. |
 | `ExplainImportPolicy` | `sensitive_read` | ADR-0073. Reads the per-session import-decision cache to explain why a prefix was permitted / denied / withdrawn on import. Side-effect-free; no RIB or counter mutation. |
+| `TestPolicy` | `sensitive_read` | ADR-0096. Compiles a submitted .rpol policy server-side and dry-runs it read-only over a live-RIB snapshot (counts, per-term hits, before/after diffs). Side-effect-free; no RIB, session, or counter mutation. |
 | `ClearNeighborExportChain` | `mutating` | Per-neighbor. |
 
 ### PeerGroupService (6 RPCs)
@@ -214,13 +215,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 53 | 55.8% |
-| `mutating` | 19 | 20.0% |
-| `operator_only` | 23 | 24.2% |
-| **Total** | **95** | **100%** |
+| `sensitive_read` | 55 | 56.7% |
+| `mutating` | 19 | 19.6% |
+| `operator_only` | 23 | 23.7% |
+| **Total** | **97** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 95
-total is 91 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 97
+total is 93 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -1,10 +1,12 @@
 # The rustbgpd policy language (`.rpol`) — reference draft
 
-Status: **draft** (ADR-0096 slice 2). The frontend — lexer, parser,
-typechecker, in-language tests, and `rbgp policy check` — is complete;
-daemon integration (referencing `.rpol` policies from configuration,
-`rbgp policy test --rib live`) ships in a later slice. Nothing in this
-document is wired into a running daemon yet.
+Status: **integrated** (ADR-0096 slices 2–3). The frontend — lexer,
+parser, typechecker, in-language tests, and `rbgp policy check` — and
+the daemon integration — `[policy] rpol_files` config references,
+mixed TOML/rpol chains, SIGHUP hot-apply, and the `rbgp policy test`
+live-RIB dry run — are complete (see "Using policies in the daemon"
+below). Explain-surface traces for `.rpol` terms ship in the next
+slice.
 
 `.rpol` compiles to the same public typed IR (`rustbgpd_policy::ir`)
 that TOML policy chains compile to, and is evaluated by the same
@@ -342,6 +344,73 @@ Error: unknown prefix-set `custmers`
    │ Note: did you mean `customers`?
 ───╯
 ```
+
+## Using policies in the daemon
+
+`.rpol` files become live daemon policy through `[policy] rpol_files`
+in the config (full reference:
+[`CONFIGURATION.md`](CONFIGURATION.md)):
+
+```toml
+[policy]
+rpol_files = ["policies/core.rpol"]        # relative to the config file
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+import_policy_chain = ["customer-in(200)", "bogon-filter"]
+```
+
+Every file compiles (parse + typecheck) at config load; diagnostics
+are load errors. Policies join the same namespace as
+`[policy.definitions]` TOML policies — chains mix both freely, and
+parameterized policies are instantiated by call-form (`u32` arguments,
+arity-checked at load). Editing a referenced file + SIGHUP hot-applies
+the change to exactly the peers whose resolved chains moved, with
+Route Refresh for materially changed import policy.
+
+### `rbgp policy test` — dry-run against the live RIB
+
+`rbgp policy check` runs a file's own `test` blocks locally (CI-able,
+no daemon). `rbgp policy test` goes further: it sends the candidate
+source to a running daemon, which compiles it server-side and
+evaluates the selected policy **read-only over a snapshot of the live
+RIB** — no route state changes, no session impact, no policy counters
+move (`SensitiveRead` authorization).
+
+```console
+$ rbgp policy test policies/core.rpol --policy "customer-in(200)" \
+    --direction import --peer 10.0.0.2 --show-changes 2
+policy "customer-in(200)" (import) over 1204 routes:
+  accepted 990  rejected 214  modified 990
+Term hits:
+  rpki-guard                       3
+  customer-routes                  990
+  bogon-guard                      211
+Changes (up to 2):
+  10.10.1.0/24 (from 10.0.0.2):
+    local_pref 100 -> 200
+    communities + 65001:999
+  10.10.2.0/24 (from 10.0.0.2):
+    local_pref 100 -> 200
+    communities + 65001:999
+```
+
+- `--direction import` evaluates Adj-RIB-In routes (all peers, or one
+  with `--peer`); `--direction export` evaluates Loc-RIB best routes,
+  with `--peer` setting the peer context guards see (`peer.address`,
+  `peer.asn`, `peer.group`).
+- `--family ipv4_unicast|ipv6_unicast` filters the snapshot; V1 scope
+  is IPv4/IPv6 unicast routes (other families are not walked).
+- `--limit N` caps how many routes are evaluated; `--show-changes N`
+  caps the before/after attribute diff samples.
+- Compile diagnostics come back rendered exactly as `policy check`
+  prints them (exit code 1); a clean run exits 0.
+- `--json` emits the counts, per-term hits, and diffs structurally.
+
+Per-term hit counters answer "which term is doing the work" (the
+IOS-XR `show pcl` idea); a term lowered to several IR steps reports as
+`name.1`, `name.2`, ....
 
 ## Deliberate V1 exclusions
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -489,6 +489,20 @@ service PolicyService {
   // Side-effect free read. Does not touch RIB, does not increment
   // any policy counter, does not log a new policy decision.
   rpc ExplainImportPolicy(ExplainImportPolicyRequest) returns (ExplainImportPolicyResponse);
+
+  // TestPolicy — dry-run a candidate .rpol policy against a snapshot
+  // of the live RIB (ADR-0096 Decision 6). The daemon compiles the
+  // submitted source server-side (compile diagnostics are returned in
+  // the response instead of routes), snapshots matching routes through
+  // the existing RIB query machinery, evaluates the selected policy
+  // read-only, and reports accepted / rejected / modified counts,
+  // per-term hit counters, and up to show_changes before/after
+  // attribute diffs.
+  //
+  // Side-effect free: no route state is touched, no session is
+  // affected, no policy counters increment. V1 scope is IPv4 / IPv6
+  // unicast routes.
+  rpc TestPolicy(TestPolicyRequest) returns (TestPolicyResponse);
 }
 
 service PeerGroupService {
@@ -928,6 +942,67 @@ message ExplainImportPolicyResponse {
   // when it does not, every matching path_id appears (Add-Path
   // disambiguation).
   repeated ImportExplainMatch matches = 6;
+}
+
+message TestPolicyRequest {
+  // Full .rpol source text; compiled server-side. Compile diagnostics
+  // fail the dry run with compiled=false and rendered diagnostics.
+  string rpol_source = 1;
+  // Which policy in the file to evaluate. Bare name for zero-parameter
+  // policies; call-form with u32 arguments for parameterized ones,
+  // e.g. "customer-in(200)".
+  string policy = 2;
+  // "import" evaluates over Adj-RIB-In routes (optionally one peer's);
+  // "export" evaluates over Loc-RIB best routes.
+  string direction = 3;
+  // Optional peer address. For import: restrict the snapshot to this
+  // peer's Adj-RIB-In. For export: evaluate as if advertising to this
+  // peer (peer context fields in guards see its address).
+  string peer = 4;
+  // Address family filter. UNSPECIFIED evaluates IPv4 + IPv6 unicast;
+  // only the unicast families are supported in V1.
+  AddressFamily afi_safi = 5;
+  // Maximum routes to evaluate; 0 = the whole snapshot.
+  uint32 limit = 6;
+  // Maximum before/after attribute diffs to return (routes the policy
+  // accepted with modifications). 0 = none.
+  uint32 show_changes = 7;
+}
+
+// Per-term guard-hit counter (the IOS-XR "show pcl" idea): how many
+// evaluated routes matched this term during the walk.
+message TestPolicyTermHits {
+  // Term name from the .rpol source (multi-step terms are suffixed
+  // ".1", ".2", ... by the compiler).
+  string term = 1;
+  uint64 hits = 2;
+}
+
+// One before/after sample for a route the policy modified.
+message TestPolicyDiff {
+  string prefix = 1;
+  uint32 prefix_length = 2;
+  // Source peer of the route (import) / snapshot origin (export).
+  string peer = 3;
+  // Human-readable attribute changes, e.g. "local_pref 100 - 200" or
+  // "communities + 65001:999".
+  repeated string changes = 4;
+}
+
+message TestPolicyResponse {
+  // False when the source failed to compile or the policy selection
+  // was invalid; diagnostics carries the rendered error report and the
+  // route counts are all zero.
+  bool compiled = 1;
+  string diagnostics = 2;
+  uint64 routes_evaluated = 3;
+  uint64 accepted = 4;
+  uint64 rejected = 5;
+  // Accepted routes whose attributes the policy changed.
+  uint64 modified = 6;
+  repeated TestPolicyTermHits term_hits = 7;
+  // Up to request.show_changes samples, in snapshot order.
+  repeated TestPolicyDiff diffs = 8;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ mod validation;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use rustbgpd_evpn::{
     BridgeVlan, DfAlgorithm, DuplicateMacAction, DuplicateMacConfig, EthernetSegment, EvpnInstance,
@@ -41,8 +42,12 @@ impl Config {
             .map_err(|err| format!("interface {interface:?} does not exist or is invalid: {err}"))
     }
 
-    fn load_from_toml_source(content: &str, source_name: &str) -> Result<Self, String> {
-        let config: Config = match toml::from_str(content) {
+    fn load_from_toml_source(
+        content: &str,
+        source_name: &str,
+        base_dir: Option<&std::path::Path>,
+    ) -> Result<Self, String> {
+        let mut config: Config = match toml::from_str(content) {
             Ok(c) => c,
             Err(e) => {
                 let error = ConfigError::Parse(e);
@@ -50,11 +55,89 @@ impl Config {
                     .unwrap_or_else(|| format!("error: {error}")));
             }
         };
+        // Compile referenced .rpol files before validation: chain
+        // references resolve against the combined TOML + rpol policy
+        // namespace, and rpol compile diagnostics (already
+        // ariadne-rendered against the .rpol source) are config load
+        // errors in their own right.
+        if let Err(error) = config.load_rpol_files(base_dir) {
+            return Err(match &error {
+                ConfigError::InvalidRpolFile { .. } => format!("error: {error}"),
+                other => diagnostic::render_diagnostic(content, source_name, other)
+                    .unwrap_or_else(|| format!("error: {other}")),
+            });
+        }
         if let Err(error) = config.validate() {
             return Err(diagnostic::render_diagnostic(content, source_name, &error)
                 .unwrap_or_else(|| format!("error: {error}")));
         }
         Ok(config)
+    }
+
+    /// Read, parse, and typecheck every `[policy] rpol_files` entry
+    /// (ADR-0096), populating the compiled registry and rewriting
+    /// relative paths to absolute against `base_dir` (the config
+    /// file's directory when known, the process working directory
+    /// otherwise). Name collisions — with `[policy.definitions]` or
+    /// across `.rpol` files — are load errors naming both sources.
+    fn load_rpol_files(&mut self, base_dir: Option<&std::path::Path>) -> Result<(), ConfigError> {
+        use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry};
+
+        let mut owner_by_name: HashMap<String, String> = HashMap::new();
+        for entry in &mut self.policy.rpol_files {
+            let mut path = PathBuf::from(&*entry);
+            if path.is_relative()
+                && let Some(base) = base_dir
+            {
+                path = base.join(path);
+            }
+            let display = path.display().to_string();
+            let source =
+                std::fs::read_to_string(&path).map_err(|e| ConfigError::InvalidRpolFile {
+                    path: display.clone(),
+                    reason: format!("failed to read: {e}"),
+                })?;
+            let file = match RpolFile::parse(&source) {
+                Ok(file) => Arc::new(file),
+                Err(diagnostics) => {
+                    return Err(ConfigError::InvalidRpolFile {
+                        path: display.clone(),
+                        reason: format!(
+                            "compile failed\n{}",
+                            diagnostics.render(&display, &source, false)
+                        ),
+                    });
+                }
+            };
+            for (name, params) in file.policies() {
+                if self.policy.definitions.contains_key(name) {
+                    return Err(ConfigError::InvalidRpolFile {
+                        path: display.clone(),
+                        reason: format!(
+                            "policy {name:?} is already defined in [policy.definitions.{name}]; \
+                             rpol and TOML policies share one namespace"
+                        ),
+                    });
+                }
+                if let Some(previous) = owner_by_name.get(name) {
+                    return Err(ConfigError::InvalidRpolFile {
+                        path: display.clone(),
+                        reason: format!("policy {name:?} is already defined in {previous:?}"),
+                    });
+                }
+                owner_by_name.insert(name.to_string(), display.clone());
+                self.policy.rpol.policies.insert(
+                    name.to_string(),
+                    RpolPolicyEntry {
+                        file: Arc::clone(&file),
+                        params,
+                        path: display.clone(),
+                    },
+                );
+            }
+            *entry = display;
+        }
+        Ok(())
     }
 
     /// Load config from TOML text and render diagnostics against `source_name`.
@@ -64,7 +147,11 @@ impl Config {
     /// not expose a `file_path`.
     pub fn load_toml_with_diagnostics(content: &str, source_name: &str) -> Result<Self, String> {
         let content = test_only_inject_legacy_grpc_security(content);
-        Self::load_from_toml_source(content.as_ref(), source_name)
+        // No config-file directory here: relative `rpol_files` paths
+        // resolve against the process working directory. Initial load
+        // rewrites them absolute, so snapshots / candidates derived
+        // from a running config are unaffected.
+        Self::load_from_toml_source(content.as_ref(), source_name, None)
     }
 
     /// Load config and, on failure, render a diagnostic with source context.
@@ -78,7 +165,8 @@ impl Config {
             Err(e) => return Err(format!("error: failed to read {path}: {e}")),
         };
         let content = test_only_inject_legacy_grpc_security(&content);
-        let mut config = Self::load_from_toml_source(content.as_ref(), path)?;
+        let base_dir = std::path::Path::new(path).parent().map(PathBuf::from);
+        let mut config = Self::load_from_toml_source(content.as_ref(), path, base_dir.as_deref())?;
         config.file_path = Some(PathBuf::from(path));
         Ok(config)
     }
@@ -261,6 +349,7 @@ impl Config {
             let chain = resolve_chain(
                 &self.policy.import_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?;
@@ -282,6 +371,7 @@ impl Config {
             resolve_chain(
                 &self.policy.export_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )
@@ -388,6 +478,10 @@ impl Config {
     /// receiver rule. iBGP is intentionally exempt — these are EBGP-edge
     /// receiver behaviors, and re-applying them per iBGP hop would overwrite
     /// values or scoping set legitimately upstream at the EBGP edge.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear inheritance resolution (global, group, neighbor, implicit tails); splitting would hide the precedence order"
+    )]
     pub fn effective_policy_chains_for_neighbor(
         &self,
         neighbor: &Neighbor,
@@ -408,6 +502,7 @@ impl Config {
                 resolve_chain(
                     &group.import_policy_chain,
                     &self.policy.definitions,
+                    &self.policy.rpol,
                     &self.policy.neighbor_sets,
                     &self.peer_groups,
                 )?
@@ -427,6 +522,7 @@ impl Config {
                 resolve_chain(
                     &group.export_policy_chain,
                     &self.policy.definitions,
+                    &self.policy.rpol,
                     &self.policy.neighbor_sets,
                     &self.peer_groups,
                 )?
@@ -450,6 +546,7 @@ impl Config {
             resolve_chain(
                 &neighbor.import_policy_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?
@@ -470,6 +567,7 @@ impl Config {
             resolve_chain(
                 &neighbor.export_policy_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?
@@ -1585,6 +1683,11 @@ pub struct PolicyDiff {
     pub export_changed: bool,
     pub import_chain_changed: bool,
     pub export_chain_changed: bool,
+    /// The `[policy] rpol_files` list or any referenced `.rpol` file's
+    /// compiled content changed (ADR-0096). Reload-applied: chains
+    /// referencing rpol policies re-resolve and hot-swap through the
+    /// same live-policy path as `[policy.definitions]` edits.
+    pub rpol_changed: bool,
 }
 
 impl PolicyDiff {
@@ -1599,6 +1702,7 @@ impl PolicyDiff {
             || self.export_changed
             || self.import_chain_changed
             || self.export_chain_changed
+            || self.rpol_changed
     }
 }
 
@@ -1856,6 +1960,7 @@ impl ConfigDiff {
             || !self.policy.neighbor_sets_changed.is_empty()
             || self.policy.import_chain_changed
             || self.policy.export_chain_changed
+            || self.policy.rpol_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
             || self.dynamic_neighbors_changed
@@ -2099,6 +2204,15 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .unsupported_sections
             .push("mixed transaction families".to_string());
     }
+    if diff.policy.rpol_changed {
+        // No v1 transaction executor owns the .rpol file catalog — the
+        // files live outside the candidate TOML, so a transaction
+        // cannot atomically stage their content. Apply .rpol changes
+        // via SIGHUP reload (which re-reads and hot-swaps them).
+        class
+            .unsupported_sections
+            .push("[policy] rpol_files (apply .rpol changes via SIGHUP reload)".to_string());
+    }
     if diff.honor_graceful_shutdown_changed {
         class
             .unsupported_sections
@@ -2289,6 +2403,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "neighbor_sets_changed": &diff.policy.neighbor_sets_changed,
             "import_chain_changed": diff.policy.import_chain_changed,
             "export_chain_changed": diff.policy.export_chain_changed,
+            "rpol_changed": diff.policy.rpol_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
             "dynamic_neighbors_changed": diff.dynamic_neighbors_changed,
@@ -2383,7 +2498,8 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
         || !p.neighbor_sets_removed.is_empty()
         || !p.neighbor_sets_changed.is_empty()
         || p.import_chain_changed
-        || p.export_chain_changed;
+        || p.export_chain_changed
+        || p.rpol_changed;
 
     if diff.has_reload_applied_changes() {
         let _ = writeln!(out, "{}\n", style.reload_header);
@@ -2453,6 +2569,13 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             }
             if p.export_chain_changed {
                 let _ = writeln!(out, "    {} export_chain", style.change_marker);
+            }
+            if p.rpol_changed {
+                let _ = writeln!(
+                    out,
+                    "    {} rpol_files / .rpol content",
+                    style.change_marker
+                );
             }
             out.push('\n');
         }
@@ -3768,6 +3891,12 @@ fn attribute_chain_move_reasons(
             reasons.push(entry);
         }
     }
+    if policy.rpol_changed {
+        let entry = "rpol policy file changed".to_string();
+        if !reasons.contains(&entry) {
+            reasons.push(entry);
+        }
+    }
 }
 
 /// Walk neighbors that exist in both configs and surface those whose
@@ -4164,6 +4293,7 @@ pub fn diff_policy(old: &PolicyConfig, new: &PolicyConfig) -> PolicyDiff {
         export_changed: old.export != new.export,
         import_chain_changed: old.import_chain != new.import_chain,
         export_chain_changed: old.export_chain != new.export_chain,
+        rpol_changed: old.rpol_files != new.rpol_files || old.rpol != new.rpol,
     }
 }
 

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -295,29 +295,81 @@ pub(super) fn parse_named_policy(
 /// tagged with its configured name so the chain-eval attribution path
 /// (used by `bgp_policy_routes_total` and the explain surface) can
 /// report which named policy made the decision.
+///
+/// Names resolve against the combined namespace: `[policy.definitions]`
+/// TOML policies and `.rpol` policies from `[policy] rpol_files`
+/// (ADR-0096). Parameterized `.rpol` policies are referenced by
+/// call-form — `"customer-in(200)"` — and monomorphized here; the
+/// resulting chain member carries its pre-compiled IR, so evaluation
+/// and the ADR-0076 planner's structural diff both see the compiled
+/// content. Every `.rpol` member of one chain compiles through one
+/// `SetStore`, so identical set data dedupes within the chain.
 pub(super) fn resolve_chain(
     names: &[String],
     definitions: &HashMap<String, NamedPolicyConfig>,
+    rpol: &rustbgpd_policy::rpol::RpolPolicySet,
     neighbor_sets: &HashMap<String, NeighborSetConfig>,
     peer_groups: &HashMap<String, PeerGroupConfig>,
 ) -> Result<Option<PolicyChain>, ConfigError> {
     if names.is_empty() {
         return Ok(None);
     }
+    let mut store = rustbgpd_policy::sets::SetStore::new();
     let policies = names
         .iter()
         .map(|name| {
-            definitions
-                .get(name.as_str())
-                .ok_or_else(|| ConfigError::UndefinedPolicy { name: name.clone() })
-                .and_then(|cfg| parse_named_policy(name, cfg, neighbor_sets, peer_groups))
-                .map(|policy| rustbgpd_policy::NamedPolicy {
-                    name: Some(name.clone()),
-                    policy,
-                })
+            if let Some(cfg) = definitions.get(name.as_str()) {
+                return parse_named_policy(name, cfg, neighbor_sets, peer_groups).map(|policy| {
+                    rustbgpd_policy::NamedPolicy {
+                        name: Some(name.clone()),
+                        policy,
+                        rpol: None,
+                    }
+                });
+            }
+            resolve_rpol_chain_ref(name, rpol, &mut store)
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Some(PolicyChain::from_named(policies)))
+}
+
+/// Resolve one `.rpol` chain reference — `"name"` or a call-form
+/// `"name(arg, ...)"` with `u32` arguments — into a pre-compiled chain
+/// member. Arity is checked against the policy's declaration.
+fn resolve_rpol_chain_ref(
+    reference: &str,
+    rpol: &rustbgpd_policy::rpol::RpolPolicySet,
+    store: &mut rustbgpd_policy::sets::SetStore,
+) -> Result<rustbgpd_policy::NamedPolicy, ConfigError> {
+    let (base, args) = rustbgpd_policy::rpol::parse_call_form(reference).map_err(|detail| {
+        ConfigError::InvalidPolicyEntry {
+            reason: format!("invalid chain reference: {detail}"),
+        }
+    })?;
+    let Some(entry) = rpol.policies.get(base) else {
+        return Err(ConfigError::UndefinedPolicy {
+            name: reference.to_string(),
+        });
+    };
+    if args.len() != entry.params {
+        return Err(ConfigError::InvalidPolicyEntry {
+            reason: format!(
+                "chain reference {reference:?}: policy {base:?} (defined in {:?}) takes {} \
+                 parameter(s), {} given",
+                entry.path,
+                entry.params,
+                args.len()
+            ),
+        });
+    }
+    let compiled = entry
+        .file
+        .compile_policy(base, &args, store)
+        .expect("registry entry names a policy defined in its file");
+    Ok(rustbgpd_policy::NamedPolicy::from_rpol(
+        reference.to_string(),
+        std::sync::Arc::new(compiled),
+    ))
 }
 
 fn resolve_neighbor_set(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -874,6 +874,23 @@ pub struct PolicyConfig {
     /// retention only — does not affect which routes are accepted.
     #[serde(default)]
     pub explain: PolicyExplainConfig,
+    /// `.rpol` policy-language files (ADR-0096) compiled at config
+    /// load. Relative paths resolve against the config file's
+    /// directory and are rewritten to absolute paths after load (so
+    /// runtime config snapshots and transaction candidates stay
+    /// loadable regardless of the daemon's working directory).
+    /// Compile diagnostics are config load errors. The policies they
+    /// define share one namespace with `[policy.definitions]`; chains
+    /// reference them by name, parameterized policies by call-form
+    /// (`"customer-in(200)"`).
+    #[serde(default)]
+    pub rpol_files: Vec<String>,
+    /// Compiled `.rpol` policy registry (populated at load, not
+    /// serialized). `PartialEq` is source-content-based, so config
+    /// diffs see an edited `.rpol` file as a policy change and an
+    /// unchanged reload as a no-op.
+    #[serde(skip)]
+    pub rpol: rustbgpd_policy::rpol::RpolPolicySet,
 }
 
 /// Tuning for the per-session import-decision cache that backs
@@ -1618,4 +1635,6 @@ pub enum ConfigError {
     InvalidFibTable { reason: String },
     #[error("invalid BFD config: {reason}")]
     InvalidBfd { reason: String },
+    #[error("rpol policy file {path:?}: {reason}")]
+    InvalidRpolFile { path: String, reason: String },
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11339,3 +11339,265 @@ fn managed_netdevs_diff_marks_restart_required() {
     let text = format_config_diff(&diff);
     assert!(text.contains("[managed_netdevs] changed"));
 }
+
+// ── ADR-0096: `.rpol` policy files in config ─────────────────────────
+
+const RPOL_SOURCE: &str = r"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+
+policy customer-in(peer_lp: u32) {
+    term customer-routes {
+        if route.prefix in customers { set local-pref peer_lp; accept }
+    }
+}
+
+policy bogon-filter {
+    term bogons { if route.prefix == 127.0.0.0/8 { reject } }
+}
+";
+
+/// Write a config dir: `config.toml` + `policies/core.rpol`
+/// (referenced by relative path), one neighbor with an rpol import
+/// chain and one TOML-only neighbor. Returns the tempdir (keep alive).
+fn rpol_config_dir(rpol_source: &str, chain: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(dir.path().join("policies")).expect("mkdir");
+    fs::write(dir.path().join("policies/core.rpol"), rpol_source).expect("write rpol");
+    let toml = format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[policy]
+rpol_files = ["policies/core.rpol"]
+
+[policy.definitions.toml-pass]
+default_action = "permit"
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+import_policy_chain = [{chain}]
+
+[[neighbors]]
+address = "192.0.2.2"
+remote_asn = 65003
+import_policy_chain = ["toml-pass"]
+"#,
+    );
+    fs::write(dir.path().join("config.toml"), toml).expect("write config");
+    dir
+}
+
+fn load_dir(dir: &tempfile::TempDir) -> Result<Config, String> {
+    Config::load_with_diagnostics(dir.path().join("config.toml").to_str().unwrap())
+}
+
+#[test]
+fn rpol_files_load_resolve_and_evaluate_in_chains() {
+    let dir = rpol_config_dir(
+        RPOL_SOURCE,
+        r#""customer-in(200)", "bogon-filter", "toml-pass""#,
+    );
+    let config = load_dir(&dir).expect("config with rpol files loads");
+
+    // Relative path rewritten absolute against the config dir.
+    assert_eq!(config.policy.rpol_files.len(), 1);
+    assert!(
+        Path::new(&config.policy.rpol_files[0]).is_absolute(),
+        "{:?}",
+        config.policy.rpol_files[0]
+    );
+    assert_eq!(config.policy.rpol.policies.len(), 2);
+
+    // Resolver equivalence: the neighbor's effective import chain
+    // carries pre-compiled rpol members mixed with the TOML policy,
+    // and routes flow / are denied per the policy through the same
+    // chain-eval seam sessions use.
+    let neighbor = &config.neighbors[0];
+    let (import, _) = config
+        .effective_policy_chains_for_neighbor(neighbor)
+        .expect("chains resolve");
+    let import = import.expect("import chain configured");
+    assert_eq!(import.policies.len(), 3);
+    assert_eq!(import.policies[0].name.as_deref(), Some("customer-in(200)"));
+    assert!(import.policies[0].rpol.is_some());
+    assert!(import.policies[2].rpol.is_none());
+
+    let ctx = |prefix: Prefix| rustbgpd_policy::RouteContext {
+        prefix: Some(prefix),
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+    let customer = Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+        "10.10.3.0".parse().unwrap(),
+        24,
+    ));
+    let bogon = Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+        "127.0.0.0".parse().unwrap(),
+        8,
+    ));
+    let (result, eval) =
+        rustbgpd_policy::evaluate_chain_with_attribution(Some(&import), &ctx(customer));
+    assert_eq!(result.action, rustbgpd_policy::PolicyAction::Permit);
+    assert_eq!(result.modifications.set_local_pref, Some(200));
+    assert_eq!(eval.matched_policy.as_deref(), Some("toml-pass"));
+    let (result, eval) =
+        rustbgpd_policy::evaluate_chain_with_attribution(Some(&import), &ctx(bogon));
+    assert_eq!(result.action, rustbgpd_policy::PolicyAction::Deny);
+    assert_eq!(eval.matched_policy.as_deref(), Some("bogon-filter"));
+}
+
+#[test]
+fn rpol_compile_diagnostics_fail_config_load() {
+    let dir = rpol_config_dir(
+        "policy broken { term t { if route.nosuch == 1 { reject } } }",
+        r#""broken""#,
+    );
+    let error = load_dir(&dir).expect_err("bad rpol file must fail the load");
+    assert!(error.contains("core.rpol"), "{error}");
+    // The ariadne-rendered diagnostic is embedded in the error string.
+    assert!(
+        error.contains("route.nosuch") || error.contains("nosuch"),
+        "{error}"
+    );
+}
+
+#[test]
+fn rpol_missing_file_fails_config_load() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""bogon-filter""#);
+    fs::remove_file(dir.path().join("policies/core.rpol")).unwrap();
+    let error = load_dir(&dir).expect_err("missing rpol file must fail the load");
+    assert!(error.contains("failed to read"), "{error}");
+}
+
+#[test]
+fn rpol_name_collision_with_toml_definition_fails() {
+    let dir = rpol_config_dir("policy toml-pass { term t { reject } }", r#""toml-pass""#);
+    let error = load_dir(&dir).expect_err("collision must fail the load");
+    assert!(error.contains("toml-pass"), "{error}");
+    assert!(error.contains("policy.definitions"), "{error}");
+}
+
+#[test]
+fn rpol_name_collision_across_files_fails() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""bogon-filter""#);
+    fs::write(
+        dir.path().join("policies/dup.rpol"),
+        "policy bogon-filter { term t { reject } }",
+    )
+    .unwrap();
+    let toml_path = dir.path().join("config.toml");
+    let toml = fs::read_to_string(&toml_path).unwrap().replace(
+        r#"rpol_files = ["policies/core.rpol"]"#,
+        r#"rpol_files = ["policies/core.rpol", "policies/dup.rpol"]"#,
+    );
+    fs::write(&toml_path, toml).unwrap();
+    let error = load_dir(&dir).expect_err("cross-file collision must fail the load");
+    assert!(error.contains("bogon-filter"), "{error}");
+    assert!(error.contains("already defined"), "{error}");
+}
+
+#[test]
+fn rpol_chain_reference_arity_and_argument_errors() {
+    // Missing required argument.
+    let error = load_dir(&rpol_config_dir(RPOL_SOURCE, r#""customer-in""#))
+        .expect_err("arity error must fail the load");
+    assert!(error.contains("takes 1 parameter(s), 0 given"), "{error}");
+    // Extra argument on a zero-param policy.
+    let error = load_dir(&rpol_config_dir(RPOL_SOURCE, r#""bogon-filter(1)""#))
+        .expect_err("arity error must fail the load");
+    assert!(error.contains("takes 0 parameter(s), 1 given"), "{error}");
+    // Non-u32 argument.
+    let error = load_dir(&rpol_config_dir(RPOL_SOURCE, r#""customer-in(high)""#))
+        .expect_err("argument type error must fail the load");
+    assert!(error.contains("is not a u32"), "{error}");
+    // Unknown policy.
+    let error = load_dir(&rpol_config_dir(RPOL_SOURCE, r#""nope(1)""#))
+        .expect_err("unknown policy must fail the load");
+    assert!(error.contains("undefined policy"), "{error}");
+}
+
+/// ADR-0076 planner classification: an edited `.rpol` file whose
+/// compiled content differs is a `policy_chain` impact for exactly the
+/// peers referencing it; reloading unchanged content is a no-op.
+#[test]
+fn rpol_edit_classifies_policy_chain_impact_for_referencing_peers_only() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""customer-in(200)""#);
+    let old = load_dir(&dir).expect("initial load");
+
+    // Same content reloaded → no diff at all.
+    let same = load_dir(&dir).expect("reload");
+    let diff = diff_config(&old, &same);
+    assert!(!diff.policy.rpol_changed);
+    assert!(!diff.has_any_changes(), "{diff:?}");
+
+    // Edited file, materially different compiled content.
+    fs::write(
+        dir.path().join("policies/core.rpol"),
+        RPOL_SOURCE.replace("ge 24 le 28", "ge 24 le 32"),
+    )
+    .unwrap();
+    let new = load_dir(&dir).expect("reload after edit");
+    let diff = diff_config(&old, &new);
+    assert!(diff.policy.rpol_changed);
+    assert!(diff.has_reload_applied_changes());
+    // Exactly the referencing neighbor is impacted, as a pure
+    // policy-chain move (live-impact executor eligible).
+    assert_eq!(diff.effective_neighbor_impact.len(), 1);
+    let impact = &diff.effective_neighbor_impact[0];
+    assert_eq!(impact.address, "192.0.2.1");
+    assert!(impact.kind.is_policy_chain());
+    assert!(
+        impact
+            .reasons
+            .iter()
+            .any(|r| r == "rpol policy file changed"),
+        "{:?}",
+        impact.reasons
+    );
+    // v1 transactions cannot stage .rpol content — fail closed.
+    let class = classify_config_transaction_v1(&diff);
+    assert!(
+        class
+            .unsupported_sections
+            .iter()
+            .any(|s| s.contains("rpol_files")),
+        "{class:?}"
+    );
+
+    // Comment-only edits compile to identical content → the resolved
+    // chains compare equal, but the source-level registry diff still
+    // reports the file as changed (refresh is idempotent).
+    fs::write(
+        dir.path().join("policies/core.rpol"),
+        format!("# comment\n{RPOL_SOURCE}"),
+    )
+    .unwrap();
+    let commented = load_dir(&dir).expect("reload after comment edit");
+    let diff = diff_config(&old, &commented);
+    assert!(diff.policy.rpol_changed);
+    // No resolved chain moved, so no per-neighbor impact.
+    assert!(diff.effective_neighbor_impact.is_empty(), "{diff:?}");
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -228,6 +228,7 @@ impl Config {
                 name,
                 group,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?;
@@ -242,12 +243,14 @@ impl Config {
         let _global_import_chain = resolve_chain(
             &self.policy.import_chain,
             &self.policy.definitions,
+            &self.policy.rpol,
             &self.policy.neighbor_sets,
             &self.peer_groups,
         )?;
         resolve_chain(
             &self.policy.export_chain,
             &self.policy.definitions,
+            &self.policy.rpol,
             &self.policy.neighbor_sets,
             &self.peer_groups,
         )?;
@@ -624,12 +627,14 @@ impl Config {
             let _neighbor_import_chain = resolve_chain(
                 &neighbor.import_policy_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?;
             resolve_chain(
                 &neighbor.export_policy_chain,
                 &self.policy.definitions,
+                &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
             )?;
@@ -1665,6 +1670,7 @@ fn validate_peer_group(
     name: &str,
     group: &PeerGroupConfig,
     definitions: &std::collections::HashMap<String, super::NamedPolicyConfig>,
+    rpol: &rustbgpd_policy::rpol::RpolPolicySet,
     neighbor_sets: &std::collections::HashMap<String, super::NeighborSetConfig>,
     peer_groups: &std::collections::HashMap<String, PeerGroupConfig>,
 ) -> Result<(), ConfigError> {
@@ -1772,12 +1778,14 @@ fn validate_peer_group(
     let _group_import_chain = resolve_chain(
         &group.import_policy_chain,
         definitions,
+        rpol,
         neighbor_sets,
         peer_groups,
     )?;
     resolve_chain(
         &group.export_policy_chain,
         definitions,
+        rpol,
         neighbor_sets,
         peer_groups,
     )?;

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -2818,7 +2818,11 @@ peer_group = "edge"
                     let _ = reply.send(Ok(()));
                 }
                 PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
-                    let _ = reply.send(Ok(snapshot_toml.lock().await.clone()));
+                    let _ = reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                        toml: snapshot_toml.lock().await.clone(),
+                        rpol_files: Vec::new(),
+                        rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                    }));
                 }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
                     let mut peers = peers.lock().await;
@@ -2947,7 +2951,11 @@ peer_group = "edge"
                     let _ = reply.send(Ok(()));
                 }
                 PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
-                    let _ = reply.send(Ok(snapshot_toml.lock().await.clone()));
+                    let _ = reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                        toml: snapshot_toml.lock().await.clone(),
+                        rpol_files: Vec::new(),
+                        rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                    }));
                 }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
                     peers.lock().await.push(config);
@@ -3002,7 +3010,11 @@ peer_group = "edge"
                     let _ = reply.send(Ok(()));
                 }
                 PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
-                    let _ = reply.send(Ok(snapshot_toml.lock().await.clone()));
+                    let _ = reply.send(Ok(rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                        toml: snapshot_toml.lock().await.clone(),
+                        rpol_files: Vec::new(),
+                        rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+                    }));
                 }
                 PeerManagerCommand::AddPeer { config, reply, .. } => {
                     let mut peers = peers.lock().await;

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -683,13 +683,19 @@ impl PeerManager {
                             }
                         }
                         PeerManagerCommand::RuntimeConfigSnapshot { reply } => {
-                            let result = toml::to_string_pretty(&self.current_config).map_err(
-                                |error| {
+                            let result = toml::to_string_pretty(&self.current_config)
+                                .map_err(|error| {
                                     format!(
                                         "failed to serialize runtime config snapshot: {error}"
                                     )
-                                },
-                            );
+                                })
+                                .map(|toml| {
+                                    rustbgpd_api::peer_types::RuntimeConfigSnapshotReply {
+                                        toml,
+                                        rpol_files: self.current_config.policy.rpol_files.clone(),
+                                        rpol: self.current_config.policy.rpol.clone(),
+                                    }
+                                });
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::ApplyResolvedPolicySnapshot { targets, reply } => {
@@ -770,6 +776,10 @@ impl PeerManager {
                             self.current_config.policy.explain.enabled = enabled;
                             self.current_config.policy.explain.cache_size = cache_size;
                             let _ = reply.send(());
+                        }
+                        PeerManagerCommand::SyncRpolPolicies { rpol_files, rpol, reply } => {
+                            let result = self.sync_rpol_policies(rpol_files, rpol).await;
+                            let _ = reply.send(result);
                         }
                         PeerManagerCommand::ListPolicies { reply } => {
                             let _ = reply.send(named_policies_from_config(&self.current_config));

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -779,10 +779,61 @@ impl PeerManager {
                 });
             }
         }
+        // ADR-0096: TOML definitions and .rpol policies share one
+        // namespace; creating a TOML definition that shadows an .rpol
+        // policy would silently change every chain referencing it.
+        if let ConfigEvent::SetPolicy { name, .. } = &event
+            && let Some(entry) = self.current_config.policy.rpol.policies.get(name)
+        {
+            return Err(CatalogMutationError::internal(format!(
+                "policy {name:?} is defined by rpol file {:?}; \
+                 rpol and TOML policies share one namespace",
+                entry.path
+            )));
+        }
 
         let mut next_config = self.current_config.clone();
         apply_config_event(&mut next_config, &event).map_err(catalog_config_error)?;
 
+        let applied = self
+            .refresh_policies_for_config(next_config, affected_peers)
+            .await?;
+        self.publish_policy_config_event(&event, applied);
+        Ok(())
+    }
+
+    /// ADR-0096: adopt a new compiled `.rpol` registry (SIGHUP reload
+    /// of `[policy] rpol_files` or of referenced file content) and
+    /// re-resolve every live peer's chains through it, using the same
+    /// atomic two-phase fan-out as catalog policy edits. Peers whose
+    /// import chain materially changed get a Route Refresh inside
+    /// `apply_resolved_policy_snapshot`.
+    pub(super) async fn sync_rpol_policies(
+        &mut self,
+        rpol_files: Vec<String>,
+        rpol: rustbgpd_policy::rpol::RpolPolicySet,
+    ) -> Result<(), CatalogMutationError> {
+        let mut next_config = self.current_config.clone();
+        next_config.policy.rpol_files = rpol_files;
+        next_config.policy.rpol = rpol;
+        let applied = self.refresh_policies_for_config(next_config, None).await?;
+        info!(
+            peers = applied,
+            "rpol policy registry replaced; live peer chains re-resolved"
+        );
+        Ok(())
+    }
+
+    /// Shared catalog-change fan-out: resolve every affected peer's
+    /// chains against `next_config`, commit them through the atomic
+    /// resolved-policy snapshot path, then adopt `next_config` as the
+    /// manager's snapshot. Returns the number of peers whose chains
+    /// were applied.
+    async fn refresh_policies_for_config(
+        &mut self,
+        next_config: Config,
+        affected_peers: Option<Vec<IpAddr>>,
+    ) -> Result<usize, CatalogMutationError> {
         let peers: Vec<PeerKey> = affected_peers.map_or_else(
             || self.peers.keys().cloned().collect(),
             |peers| {
@@ -856,8 +907,7 @@ impl PeerManager {
             .map_err(CatalogMutationError::internal)?;
 
         self.current_config = next_config;
-        self.publish_policy_config_event(&event, applied.len());
-        Ok(())
+        Ok(applied.len())
     }
 
     pub(super) fn policy_resolution_neighbor(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -637,7 +637,8 @@ async fn runtime_config_snapshot_returns_current_staged_config() {
         .await
         .unwrap();
     let snapshot_toml = reply_rx.await.unwrap().unwrap();
-    let snapshot = Config::load_toml_with_diagnostics(&snapshot_toml, "runtime snapshot").unwrap();
+    let snapshot =
+        Config::load_toml_with_diagnostics(&snapshot_toml.toml, "runtime snapshot").unwrap();
     assert_eq!(snapshot.dynamic_neighbors.len(), 1);
     assert_eq!(snapshot.dynamic_neighbors[0].prefix, "10.30.0.0/16");
     assert_eq!(snapshot.dynamic_neighbors[0].remote_asn, 65030);
@@ -3577,6 +3578,113 @@ async fn apply_policy_change_fans_out_to_scoped_peers() {
 
     assert_eq!(eth0.query_state.load(Ordering::SeqCst), 1);
     assert_eq!(eth1.query_state.load(Ordering::SeqCst), 1);
+    drop(mgr);
+    rib_drainer.await.unwrap();
+}
+
+/// ADR-0096: `sync_rpol_policies` adopts the new compiled registry,
+/// re-resolves live chains through it (Route Refresh for the material
+/// import change), and `SetPolicy` cannot shadow an rpol-defined name.
+#[tokio::test]
+async fn sync_rpol_policies_reresolves_chains_and_rejects_shadowing() {
+    use rustbgpd_api::peer_types::NamedPolicyDefinition;
+    use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry, RpolPolicySet};
+
+    fn registry(source: &str) -> RpolPolicySet {
+        let file = std::sync::Arc::new(RpolFile::parse(source).expect("clean rpol"));
+        let mut set = RpolPolicySet::default();
+        set.policies.insert(
+            "edge-in".to_string(),
+            RpolPolicyEntry {
+                file,
+                params: 0,
+                path: "policies/core.rpol".to_string(),
+            },
+        );
+        set
+    }
+
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut mgr,
+        peer,
+        acking_counted_policy_handle(peer, counters.clone()),
+        false,
+    );
+    let mut neighbor = config_neighbor(peer, 65002);
+    neighbor.import_policy_chain = vec!["edge-in".to_string()];
+    mgr.current_config.neighbors = vec![neighbor];
+    mgr.current_config.policy.rpol =
+        registry("policy edge-in { term all { set local-pref 150; accept } }");
+
+    // New registry content: chains re-resolve and the peer's import
+    // policy now carries the edited compiled body.
+    mgr.sync_rpol_policies(
+        vec!["policies/core.rpol".to_string()],
+        registry("policy edge-in { term all { set local-pref 250; accept } }"),
+    )
+    .await
+    .expect("sync succeeds");
+    let managed = mgr.peers.values().next().expect("peer present");
+    let chain = managed.import_policy.as_ref().expect("import chain set");
+    assert!(chain.policies[0].rpol.is_some());
+    let ctx = rustbgpd_policy::RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+    assert_eq!(chain.evaluate(&ctx).modifications.set_local_pref, Some(250));
+
+    // The rpol name cannot be shadowed by a TOML SetPolicy.
+    let err = mgr
+        .apply_policy_change(
+            ConfigEvent::SetPolicy {
+                name: "edge-in".to_string(),
+                definition: NamedPolicyDefinition {
+                    default_action: "permit".to_string(),
+                    statements: vec![],
+                },
+                ack: None,
+            },
+            None,
+        )
+        .await
+        .expect_err("shadowing an rpol policy must be rejected");
+    assert!(err.to_string().contains("rpol"), "{err}");
+
     drop(mgr);
     rib_drainer.await.unwrap();
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -161,10 +161,18 @@ pub(crate) async fn runtime_config_snapshot(
         .send(PeerManagerCommand::RuntimeConfigSnapshot { reply: reply_tx })
         .await
         .map_err(|e| format!("send to peer manager failed: {e}"))?;
-    let snapshot_toml = reply_rx
+    let snapshot = reply_rx
         .await
         .map_err(|e| format!("peer manager dropped runtime snapshot reply: {e}"))??;
-    Config::load_toml_with_diagnostics(&snapshot_toml, "runtime config snapshot")
+    let mut config = Config::load_toml_with_diagnostics(&snapshot.toml, "runtime config snapshot")?;
+    // Overlay the LIVE compiled `.rpol` registry (ADR-0096): loading
+    // the TOML recompiled the `.rpol` files from disk, which would
+    // mask exactly the disk edits a reload diff must detect (both
+    // sides would see the new content). The registry the daemon is
+    // actually running is the one the snapshot reply carries.
+    config.policy.rpol_files = snapshot.rpol_files;
+    config.policy.rpol = snapshot.rpol;
+    Ok(config)
 }
 
 fn fib_table_snapshots(tables: &[config::FibTableConfig]) -> Vec<FibTableSnapshot> {
@@ -687,6 +695,16 @@ pub(crate) async fn reload_config(
     // prior state" to "matching live state", which is the practical
     // step short of true rollback.
     let mut working_config = current.clone();
+    // `current` came from the runtime snapshot round-trip
+    // (`load_toml_with_diagnostics`), which never carries a
+    // `file_path`. The advanced in-memory config main.rs keeps after
+    // this reload must still know where the config file lives, or the
+    // NEXT SIGHUP reloads from an empty path and fails ("failed to
+    // read : No such file or directory"). Stamp it from the
+    // just-loaded desired config (which was read from `config_path`).
+    working_config
+        .file_path
+        .clone_from(&desired_config.file_path);
     // EVPN runtime edits are applied before the staged peer-manager/FIB
     // sequence. Carry their accepted-or-pinned state into partial snapshots
     // returned by halt_partial paths.
@@ -752,6 +770,54 @@ pub(crate) async fn reload_config(
                     error: "peer manager unavailable while syncing explain snapshot".to_string(),
                 },
             );
+        }
+    }
+
+    // ADR-0096: sync the compiled `.rpol` registry BEFORE any chain /
+    // neighbor / peer-group step below resolves policies — those
+    // resolve inside the peer manager against its `current_config`,
+    // which must already carry the new registry for chains that
+    // reference (new or edited) rpol policies. The command itself
+    // re-resolves every live peer's chains and Route-Refreshes the
+    // materially changed ones, so an rpol-content-only reload is fully
+    // applied by this single step.
+    if policy_diff.rpol_changed {
+        working_config
+            .policy
+            .rpol_files
+            .clone_from(&new_config.policy.rpol_files);
+        working_config.policy.rpol = new_config.policy.rpol.clone();
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let send_failed = peer_mgr_tx
+            .send(PeerManagerCommand::SyncRpolPolicies {
+                rpol_files: new_config.policy.rpol_files.clone(),
+                rpol: new_config.policy.rpol.clone(),
+                reply: ack_tx,
+            })
+            .await
+            .is_err();
+        let result = if send_failed {
+            Err("peer manager unavailable while syncing rpol policies".to_string())
+        } else {
+            match ack_rx.await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(error)) => Err(error.to_string()),
+                Err(_) => Err("peer manager dropped rpol sync reply".to_string()),
+            }
+        };
+        match result {
+            Ok(()) => info!("reload: rpol policy registry synced"),
+            Err(error) => {
+                return halt_partial(
+                    working_config,
+                    &desired_config,
+                    ReloadStepFailure {
+                        bucket: "policy.rpol.sync",
+                        target: "[policy] rpol_files".to_string(),
+                        error,
+                    },
+                );
+            }
         }
     }
 
@@ -3536,6 +3602,9 @@ hold_time = 90
             } => {
                 format!("SyncExplainConfig(enabled={enabled},cache_size={cache_size})")
             }
+            PeerManagerCommand::SyncRpolPolicies { rpol, .. } => {
+                format!("SyncRpolPolicies({})", rpol.policies.len())
+            }
             PeerManagerCommand::SetFibTablesSnapshot { tables, .. } => {
                 format!("SetFibTablesSnapshot({})", tables.len())
             }
@@ -3576,7 +3645,8 @@ hold_time = 90
                     | PeerManagerCommand::SetGlobalImportChain { reply, .. }
                     | PeerManagerCommand::SetGlobalExportChain { reply, .. }
                     | PeerManagerCommand::ClearGlobalImportChain { reply }
-                    | PeerManagerCommand::ClearGlobalExportChain { reply } => {
+                    | PeerManagerCommand::ClearGlobalExportChain { reply }
+                    | PeerManagerCommand::SyncRpolPolicies { reply, .. } => {
                         let _ = reply.send(Ok(()));
                     }
                     PeerManagerCommand::SoftResetIn { reply, .. } => {
@@ -3609,6 +3679,94 @@ hold_time = 90
         let tags = mock.await.unwrap();
         std::fs::remove_file(&path).ok();
         (returned, tags)
+    }
+
+    /// ADR-0096: an rpol-content-only reload sends `SyncRpolPolicies`
+    /// (which re-resolves live chains in the manager) and adopts the
+    /// new registry into the returned snapshot; the TOML itself is
+    /// byte-identical, so no other command fires.
+    #[tokio::test]
+    async fn reload_rpol_content_change_syncs_registry() {
+        let rpol_path = unique_temp_path("reload-rpol-file");
+        std::fs::write(
+            &rpol_path,
+            "policy edge-in { term all { set local-pref 150; accept } }",
+        )
+        .unwrap();
+        let toml = format!(
+            "{}\n[policy]\nrpol_files = [{:?}]\nimport_chain = [\"edge-in\"]\n",
+            baseline_toml(),
+            rpol_path.to_str().unwrap(),
+        );
+
+        let path = unique_temp_path("reload-rpol-config");
+        std::fs::write(&path, &toml).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+
+        // Edit ONLY the .rpol file; the TOML is unchanged.
+        std::fs::write(
+            &rpol_path,
+            "policy edge-in { term all { set local-pref 250; accept } }",
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+        let mock = tokio::spawn(async move {
+            let mut tags = Vec::new();
+            while let Some(cmd) = peer_mgr_rx.recv().await {
+                tags.push(cmd_tag(&cmd));
+                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
+                    let _ = reply.send(Ok(()));
+                }
+            }
+            tags
+        });
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            None,
+        )
+        .await;
+        drop(peer_mgr_tx);
+        let tags = mock.await.unwrap();
+        assert_eq!(tags, vec!["SyncRpolPolicies(1)".to_string()]);
+
+        // The returned snapshot resolves chains against the NEW
+        // compiled registry: the edited local-pref value evaluates.
+        let reloaded = returned.expect("reload completes");
+        let chain = reloaded
+            .import_chain()
+            .expect("chain resolves")
+            .expect("chain configured");
+        let ctx = rustbgpd_policy::RouteContext {
+            prefix: None,
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[],
+            large_communities: &[],
+            as_path_str: "",
+            as_path_len: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        };
+        let result = chain.evaluate(&ctx);
+        assert_eq!(result.modifications.set_local_pref, Some(250));
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(&rpol_path).ok();
     }
 
     fn baseline_toml() -> &'static str {


### PR DESCRIPTION
**PR-3 of the ADR-0096 arc**: `.rpol` policies are now live in the daemon.

- **Config**: `[policy] rpol_files = [...]` (paths relative to the config file); compile diagnostics fail the load with ariadne rendering; rpol + TOML policies share one namespace (collisions rejected naming both sources); parameterized policies referenced call-form in chain lists (`"customer-in(200)"`) with arity/type errors at resolve.
- **Representation**: `NamedPolicy` gains `rpol: Option<Arc<CompiledChain>>` (Deref preserved, ~30 call sites untouched); chain compile splices rpol members with SetId/RegexId remap; **PartialEq compares compiled content** — so the ADR-0076 planner classifies an edited file as `policy_chain` impact for exactly the referencing peers, and comment-only edits as no impact (test-pinned).
- **Reload correctness**: the SIGHUP snapshot now carries the live rpol registry (was re-reading disk → new-vs-new diffs); content edits apply atomically via the shared policy fan-out. **Pre-existing bug found on clean main and fixed**: an applied reload dropped `file_path`, breaking every subsequent SIGHUP. Proven by a live daemon edit→SIGHUP→no-op→edit→SIGHUP smoke.
- **Transactions fail closed** on `rpol_files` diffs (unsupported → "apply via SIGHUP"); runtime `SetPolicy` cannot shadow rpol names; gNMI documented TOML-surface-only.
- **`rbgp policy test`** (ADR Decision 6): candidate `.rpol` source → server-side compile → read-only evaluation over live RIB snapshots (import: Adj-RIB-In, optional per-peer; export: best routes) → accepted/rejected/modified counts, **per-term hit counters**, before/after attribute diffs. IPv4/IPv6 unicast V1. Verified live end-to-end.

4,744 workspace tests green; M13/M34 interop configs untouched. PR-4 brings per-term explain traces; PR-5 the M80 FRR parity receipt.