### PR TITLE
feat(policy+api): per-term explain traces and hit counters for rpol policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`.rpol` explain + live hit counters (ADR-0096 slice 4): the
+  language is now fully explainable through the existing surfaces.**
+  `ExplainImportPolicy` statement traces cover `.rpol` chain members at
+  term granularity: the step names the deciding term and carries one
+  rendered line per evaluated term — `term NAME: GUARD => ACTION
+  [matched|not matched]` — with guards pretty-printed back to `.rpol`
+  surface syntax (sets by their source name; additive proto fields
+  `term` / `term_traces`, rendered by `rbgp policy explain`). Guard
+  evaluation is shared with the live evaluator and the trace is pinned
+  against both `evaluate_with_attribution` and the counting evaluator
+  by an rpol agreement matrix. `ExplainAdvertisedRoute` extends its
+  policy attribution to `<chain-ref>:<term>` when the deciding export
+  member is `.rpol` (TOML members unchanged). New **live per-term hit
+  counters** (ADR-0096 Decision 3.3, the IOS-XR `show pcl` idea):
+  every live evaluation bumps its matched terms' relaxed-atomic
+  counters on the chain instance, surfaced by `rbgp policy stats
+  [--peer ADDR] [--json]` via the new `GetPolicyStats` RPC
+  (`SensitiveRead`). Counters read as since-chain-install and reset
+  when a chain is replaced; explain queries and `policy test` dry runs
+  never move them. V1 reads the export direction (the RIB manager owns
+  those chains — and its distribution passes now share one compiled
+  IR + counter set per installed chain instead of recompiling per
+  pass); import-side counters accumulate but their read surface is a
+  follow-up. See the explain/stats chapter in `docs/rpol-language.md`.
+
 - **`.rpol` policies in the running daemon (ADR-0096 slice 3): config
   references, hot reload, and the `rbgp policy test` live-RIB dry
   run.** `[policy] rpol_files = ["policies/core.rpol"]` compiles every

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -366,6 +366,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
     ),
     method(
         "rustbgpd.v1.PolicyService",
+        "GetPolicyStats",
+        "/rustbgpd.v1.PolicyService/GetPolicyStats",
+        AuthTier::SensitiveRead,
+    ),
+    method(
+        "rustbgpd.v1.PolicyService",
         "ClearNeighborExportChain",
         "/rustbgpd.v1.PolicyService/ClearNeighborExportChain",
         AuthTier::Mutating,
@@ -835,7 +841,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 97);
+        assert_eq!(METHODS.len(), 98);
     }
 
     #[test]
@@ -876,7 +882,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 55);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 56);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 23);
     }

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -126,6 +126,8 @@ fn statement_step_to_proto(
         },
         matched_conditions: step.matched_conditions.clone(),
         modifications: step.modifications.clone(),
+        term: step.term_name.clone().unwrap_or_default(),
+        term_traces: step.term_traces.clone(),
     }
 }
 
@@ -1504,6 +1506,74 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             &peer_context,
         )))
     }
+
+    async fn get_policy_stats(
+        &self,
+        request: Request<proto::GetPolicyStatsRequest>,
+    ) -> Result<Response<proto::GetPolicyStatsResponse>, Status> {
+        use rustbgpd_rib::RibUpdate;
+
+        let req = request.into_inner();
+        match req.direction.as_str() {
+            "" | "export" => {}
+            "import" => {
+                return Err(Status::unimplemented(
+                    "import-side hit counters have no read surface yet; \
+                     counters accumulate and the query arrives in a later slice",
+                ));
+            }
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "direction must be \"import\" or \"export\", got {other:?}"
+                )));
+            }
+        }
+        let peer: Option<IpAddr> = if req.peer_address.is_empty() {
+            None
+        } else {
+            Some(req.peer_address.parse().map_err(|_| {
+                Status::invalid_argument(format!("invalid peer address {:?}", req.peer_address))
+            })?)
+        };
+        let rib_tx = self.rib_tx.as_ref().ok_or_else(|| {
+            Status::failed_precondition("policy stats runtime unavailable on this listener")
+        })?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryExportPolicyTermHits {
+                peer,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::internal("RIB manager unavailable"))?;
+        let chains = reply_rx
+            .await
+            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+
+        Ok(Response::new(proto::GetPolicyStatsResponse {
+            chains: chains
+                .into_iter()
+                .map(|chain| proto::PolicyChainStats {
+                    peer_address: chain
+                        .peer
+                        .map_or_else(|| "global".to_string(), |peer| peer.to_string()),
+                    direction: "export".to_string(),
+                    routes_evaluated: chain.evals,
+                    terms: chain
+                        .terms
+                        .into_iter()
+                        .map(|row| proto::PolicyTermStat {
+                            policy_index: u32::try_from(row.policy_index).unwrap_or(u32::MAX),
+                            policy: row.policy.unwrap_or_default(),
+                            term_index: u32::try_from(row.term_index).unwrap_or(u32::MAX),
+                            term: row.term.unwrap_or_default(),
+                            hits: row.hits,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }))
+    }
 }
 
 /// Route selection scope for one `TestPolicy` dry run.
@@ -1762,6 +1832,11 @@ mod tests {
                     action: PolicyAction::Permit,
                     matched_conditions: vec!["community 65001:100".into()],
                     modifications: vec!["local_pref 100 -> 200".into()],
+                    term_name: Some("customer-routes".into()),
+                    term_traces: vec![
+                        "term customer-routes: route.communities has 65001:100 => accept [matched]"
+                            .into(),
+                    ],
                 },
                 StatementAttribution {
                     policy_index: 1,
@@ -1770,6 +1845,8 @@ mod tests {
                     action: PolicyAction::Permit,
                     matched_conditions: vec![],
                     modifications: vec![],
+                    term_name: None,
+                    term_traces: vec![],
                 },
             ],
         };
@@ -2598,5 +2675,109 @@ policy customer-in(peer_lp: u32) {
         assert_eq!(resp.routes_evaluated, 2);
         assert_eq!(resp.accepted, 2);
         assert!(resp.diffs.is_empty());
+    }
+
+    // -- GetPolicyStats (ADR-0096 Decision 3.3) ---------------------
+
+    /// Fake RIB backend answering the term-hits query with one
+    /// installed chain snapshot.
+    fn stats_service() -> PolicyService {
+        let (peer_tx, _peer_rx) = mpsc::channel(8);
+        let (rib_tx, mut rib_rx) = mpsc::channel::<rustbgpd_rib::RibUpdate>(8);
+        tokio::spawn(async move {
+            while let Some(update) = rib_rx.recv().await {
+                match update {
+                    rustbgpd_rib::RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
+                        assert_eq!(peer, Some("10.0.0.2".parse().unwrap()));
+                        let _ = reply.send(vec![rustbgpd_rib::update::ExportPolicyTermHits {
+                            peer,
+                            evals: 7,
+                            terms: vec![
+                                rustbgpd_policy::TermHitRow {
+                                    policy_index: 0,
+                                    policy: Some("customer-in(200)".to_string()),
+                                    term_index: 0,
+                                    term: Some("customer-routes".to_string()),
+                                    hits: 5,
+                                },
+                                rustbgpd_policy::TermHitRow {
+                                    policy_index: 0,
+                                    policy: Some("customer-in(200)".to_string()),
+                                    term_index: 1,
+                                    term: None,
+                                    hits: 2,
+                                },
+                            ],
+                        }]);
+                    }
+                    _ => panic!("unexpected RIB query"),
+                }
+            }
+        });
+        PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None).with_rib_query(rib_tx)
+    }
+
+    #[tokio::test]
+    async fn get_policy_stats_round_trips_term_rows() {
+        let svc = stats_service();
+        let resp = PolicyServiceRpc::get_policy_stats(
+            &svc,
+            Request::new(proto::GetPolicyStatsRequest {
+                peer_address: "10.0.0.2".to_string(),
+                direction: String::new(),
+            }),
+        )
+        .await
+        .expect("stats query succeeds")
+        .into_inner();
+        assert_eq!(resp.chains.len(), 1);
+        let chain = &resp.chains[0];
+        assert_eq!(chain.peer_address, "10.0.0.2");
+        assert_eq!(chain.direction, "export");
+        assert_eq!(chain.routes_evaluated, 7);
+        assert_eq!(chain.terms.len(), 2);
+        assert_eq!(chain.terms[0].policy, "customer-in(200)");
+        assert_eq!(chain.terms[0].term, "customer-routes");
+        assert_eq!(chain.terms[0].hits, 5);
+        assert_eq!(chain.terms[1].term, "", "TOML statements are unnamed");
+        assert_eq!(chain.terms[1].term_index, 1);
+        assert_eq!(chain.terms[1].hits, 2);
+    }
+
+    #[tokio::test]
+    async fn get_policy_stats_rejects_import_and_bad_direction() {
+        let svc = stats_service();
+        let err = PolicyServiceRpc::get_policy_stats(
+            &svc,
+            Request::new(proto::GetPolicyStatsRequest {
+                peer_address: String::new(),
+                direction: "import".to_string(),
+            }),
+        )
+        .await
+        .expect_err("import read surface is a follow-up");
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+
+        let err = PolicyServiceRpc::get_policy_stats(
+            &svc,
+            Request::new(proto::GetPolicyStatsRequest {
+                peer_address: String::new(),
+                direction: "sideways".to_string(),
+            }),
+        )
+        .await
+        .expect_err("unknown direction is invalid");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        let err = PolicyServiceRpc::get_policy_stats(
+            &svc,
+            Request::new(proto::GetPolicyStatsRequest {
+                peer_address: "not-an-ip".to_string(),
+                direction: String::new(),
+            }),
+        )
+        .await
+        .expect_err("bad peer literal is invalid");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -22,7 +22,7 @@ use crate::proto::{
     self, ClearGlobalExportChainRequest, ClearGlobalImportChainRequest,
     ClearNeighborExportChainRequest, ClearNeighborImportChainRequest, DeletePolicyRequest,
     ExplainImportPolicyRequest, GetGlobalPolicyChainsRequest, GetNeighborPolicyChainsRequest,
-    GetPolicyRequest, ListPoliciesRequest, SetGlobalExportChainRequest,
+    GetPolicyRequest, GetPolicyStatsRequest, ListPoliciesRequest, SetGlobalExportChainRequest,
     SetGlobalImportChainRequest, SetNeighborExportChainRequest, SetNeighborImportChainRequest,
     SetPolicyRequest,
 };
@@ -387,6 +387,93 @@ pub async fn test(
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+struct JsonPolicyStats {
+    peer_address: String,
+    direction: String,
+    routes_evaluated: u64,
+    terms: Vec<JsonPolicyTermStat>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonPolicyTermStat {
+    policy_index: u32,
+    policy: Option<String>,
+    term_index: u32,
+    term: Option<String>,
+    hits: u64,
+}
+
+/// `rbgp policy stats [--peer ADDR] [--direction export]` — live
+/// per-term hit counters of the installed chains (ADR-0096).
+pub async fn stats(
+    connection: Connection,
+    peer: Option<&str>,
+    direction: &str,
+    json: bool,
+) -> Result<(), CliError> {
+    let mut client =
+        PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .get_policy_stats(GetPolicyStatsRequest {
+            peer_address: peer.unwrap_or_default().to_string(),
+            direction: direction.to_string(),
+        })
+        .await?
+        .into_inner();
+
+    if json {
+        let out: Vec<JsonPolicyStats> = resp
+            .chains
+            .iter()
+            .map(|chain| JsonPolicyStats {
+                peer_address: chain.peer_address.clone(),
+                direction: chain.direction.clone(),
+                routes_evaluated: chain.routes_evaluated,
+                terms: chain
+                    .terms
+                    .iter()
+                    .map(|t| JsonPolicyTermStat {
+                        policy_index: t.policy_index,
+                        policy: (!t.policy.is_empty()).then(|| t.policy.clone()),
+                        term_index: t.term_index,
+                        term: (!t.term.is_empty()).then(|| t.term.clone()),
+                        hits: t.hits,
+                    })
+                    .collect(),
+            })
+            .collect();
+        output::print_json_pretty(&out)?;
+        return Ok(());
+    }
+
+    if resp.chains.is_empty() {
+        println!("No installed policy chains");
+        return Ok(());
+    }
+    for chain in &resp.chains {
+        println!(
+            "{} {} chain — {} routes evaluated since install",
+            chain.peer_address, chain.direction, chain.routes_evaluated
+        );
+        println!("  {:<32} {:<24} HITS", "POLICY", "TERM");
+        for t in &chain.terms {
+            let policy = if t.policy.is_empty() {
+                "inline".to_string()
+            } else {
+                t.policy.clone()
+            };
+            let term = if t.term.is_empty() {
+                format!("statement {}", t.term_index)
+            } else {
+                t.term.clone()
+            };
+            println!("  {policy:<32} {term:<24} {}", t.hits);
+        }
+    }
+    Ok(())
+}
+
 pub async fn list(connection: Connection, json: bool) -> Result<(), CliError> {
     let mut client =
         PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -519,6 +606,11 @@ struct JsonImportExplainStatement {
     action: String,
     matched_conditions: Vec<String>,
     modifications: Vec<String>,
+    // rpol deciding-term name (ADR-0096); `None` for TOML statements
+    // and fallthroughs.
+    term: Option<String>,
+    // rpol per-term trace lines; empty for TOML members.
+    term_traces: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -667,6 +759,9 @@ pub async fn explain_import(
                     println!("    statements:");
                 }
                 println!("      {}", statement_line(s));
+                for trace in &s.term_traces {
+                    println!("        {trace}");
+                }
             }
         }
     }
@@ -686,6 +781,15 @@ fn statement_line(s: &proto::ImportExplainStatementStep) -> String {
     let mut line = format!("[{}] policy {policy}", s.policy_index);
     if s.default_action {
         line.push_str(&format!(" default-action {}", s.action));
+    } else if !s.term.is_empty() {
+        // rpol member: the deciding term has a name.
+        line.push_str(&format!(" term {} {}", s.term, s.action));
+        if !s.matched_conditions.is_empty() {
+            line.push_str(&format!("  match: {}", s.matched_conditions.join(", ")));
+        }
+        if !s.modifications.is_empty() {
+            line.push_str(&format!("  set: {}", s.modifications.join(", ")));
+        }
     } else {
         line.push_str(&format!(" statement {} {}", s.statement_index, s.action));
         if !s.matched_conditions.is_empty() {
@@ -739,6 +843,8 @@ fn statement_to_json(s: &proto::ImportExplainStatementStep) -> JsonImportExplain
         action: s.action.clone(),
         matched_conditions: s.matched_conditions.clone(),
         modifications: s.modifications.clone(),
+        term: (!s.term.is_empty()).then(|| s.term.clone()),
+        term_traces: s.term_traces.clone(),
     }
 }
 
@@ -1280,6 +1386,39 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test]
+    async fn stats_renders_text_and_json() {
+        let server = spawn_mock_server(None).await;
+        let json_conn = connect(&server.addr, None).await.unwrap();
+        stats(json_conn, Some("10.0.0.2"), "export", true)
+            .await
+            .unwrap();
+        let text_conn = connect(&server.addr, None).await.unwrap();
+        stats(text_conn, None, "export", false).await.unwrap();
+    }
+
+    #[test]
+    fn statement_line_renders_rpol_term_name() {
+        let step = proto::ImportExplainStatementStep {
+            policy_index: 0,
+            policy_name: "customer-in(200)".to_string(),
+            default_action: false,
+            statement_index: 2,
+            action: "permit".to_string(),
+            matched_conditions: vec!["guard route.prefix in customers".to_string()],
+            modifications: vec!["local_pref 100 -> 200".to_string()],
+            term: "customer-routes".to_string(),
+            term_traces: vec![
+                "term rpki-guard: route.rpki == invalid => reject [not matched]".to_string(),
+            ],
+        };
+        assert_eq!(
+            statement_line(&step),
+            "[0] policy customer-in(200) term customer-routes permit  \
+             match: guard route.prefix in customers  set: local_pref 100 -> 200"
+        );
+    }
+
     #[test]
     fn statement_line_renders_match_and_set_clauses() {
         let step = proto::ImportExplainStatementStep {
@@ -1293,6 +1432,8 @@ mod tests {
                 "community 65001:100".to_string(),
             ],
             modifications: vec!["local_pref 100 -> 200".to_string()],
+            term: String::new(),
+            term_traces: vec![],
         };
         assert_eq!(
             statement_line(&step),
@@ -1312,6 +1453,8 @@ mod tests {
             action: "deny".to_string(),
             matched_conditions: vec![],
             modifications: vec![],
+            term: String::new(),
+            term_traces: vec![],
         };
         assert_eq!(
             statement_line(&step),
@@ -1329,6 +1472,8 @@ mod tests {
             action: "permit".to_string(),
             matched_conditions: vec!["any".to_string()],
             modifications: vec![],
+            term: String::new(),
+            term_traces: vec![],
         };
         let j = statement_to_json(&matched);
         assert_eq!(j.statement_index, Some(3));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -401,6 +401,18 @@ enum PolicyAction {
         #[command(subcommand)]
         action: PolicyChainAction,
     },
+    /// Show live per-term policy hit counters (ADR-0096): how many
+    /// routes matched each term of the installed export chains since
+    /// chain install. Counters reset when a chain is replaced (policy
+    /// reload / hot-apply). Import counters have no read surface yet.
+    Stats {
+        /// Restrict to one peer's installed chain
+        #[arg(long)]
+        peer: Option<String>,
+        /// Direction: export (default). import is reserved
+        #[arg(long, default_value = "export")]
+        direction: String,
+    },
     /// Explain the import-policy decision for a prefix on a neighbor
     /// (ADR-0073): why it was permitted / denied / withdrawn, or
     /// not-seen / evicted / stale. Reads the per-session decision
@@ -1978,6 +1990,9 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             }
             PolicyAction::Delete { name } => {
                 commands::policy::delete(connection, &name, json).await
+            }
+            PolicyAction::Stats { peer, direction } => {
+                commands::policy::stats(connection, peer.as_deref(), &direction, json).await
             }
             PolicyAction::Explain {
                 neighbor,

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1531,6 +1531,8 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
                 action: "permit".to_string(),
                 matched_conditions: vec!["community 65001:100".to_string()],
                 modifications: vec!["local_pref 100 -> 200".to_string()],
+                term: String::new(),
+                term_traces: vec![],
             }],
         };
         // When the caller pins a path_id, return exactly that path;
@@ -1561,6 +1563,8 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
                         action: "deny".to_string(),
                         matched_conditions: vec![],
                         modifications: vec![],
+                        term: String::new(),
+                        term_traces: vec![],
                     }],
                 },
             ],
@@ -1572,6 +1576,35 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             afi_safi: req.afi_safi,
             current_policy_generation: 3,
             matches,
+        }))
+    }
+
+    async fn get_policy_stats(
+        &self,
+        _request: Request<server_proto::GetPolicyStatsRequest>,
+    ) -> Result<Response<server_proto::GetPolicyStatsResponse>, Status> {
+        Ok(Response::new(server_proto::GetPolicyStatsResponse {
+            chains: vec![server_proto::PolicyChainStats {
+                peer_address: "10.0.0.2".to_string(),
+                direction: "export".to_string(),
+                routes_evaluated: 7,
+                terms: vec![
+                    server_proto::PolicyTermStat {
+                        policy_index: 0,
+                        policy: "customer-in(200)".to_string(),
+                        term_index: 0,
+                        term: "customer-routes".to_string(),
+                        hits: 5,
+                    },
+                    server_proto::PolicyTermStat {
+                        policy_index: 0,
+                        policy: "customer-in(200)".to_string(),
+                        term_index: 1,
+                        term: String::new(),
+                        hits: 2,
+                    },
+                ],
+            }],
         }))
     }
 

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -428,8 +428,7 @@ fn bench_set_heavy(c: &mut Criterion) {
             source: PolicySource::Toml,
         }],
         prefix_sets: vec![set],
-        community_sets: Vec::new(),
-        as_path_regexes: Vec::new(),
+        ..CompiledChain::empty()
     };
 
     // 172.16.0.0/24 is in no member's 10.x.y.0/24 — full walk / probe miss.

--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -68,6 +68,8 @@ pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain
         prefix_sets: sets.prefix_sets,
         community_sets: sets.community_sets,
         as_path_regexes: sets.as_path_regexes,
+        prefix_set_names: sets.prefix_set_names,
+        community_set_names: sets.community_set_names,
     }
 }
 
@@ -101,11 +103,19 @@ fn splice_policy(
 fn remap_expr(expr: &MatchExpr, donor: &CompiledChain, sets: &mut ChainSets) -> MatchExpr {
     match expr {
         MatchExpr::PrefixInSet(id) => {
-            MatchExpr::PrefixInSet(sets.prefix_set_id(donor.prefix_sets[id.0 as usize].clone()))
+            let index = id.0 as usize;
+            MatchExpr::PrefixInSet(sets.prefix_set_id(
+                donor.prefix_sets[index].clone(),
+                donor.prefix_set_names.get(index).cloned().flatten(),
+            ))
         }
-        MatchExpr::CommunityInSet(id) => MatchExpr::CommunityInSet(
-            sets.community_set_id(donor.community_sets[id.0 as usize].clone()),
-        ),
+        MatchExpr::CommunityInSet(id) => {
+            let index = id.0 as usize;
+            MatchExpr::CommunityInSet(sets.community_set_id(
+                donor.community_sets[index].clone(),
+                donor.community_set_names.get(index).cloned().flatten(),
+            ))
+        }
         MatchExpr::AsPathMatches(id) => {
             MatchExpr::AsPathMatches(sets.regex_id(donor.as_path_regexes[id.0 as usize].clone()))
         }
@@ -185,7 +195,7 @@ fn compile_statement(
         [single] => children.push(MatchExpr::CommunityContains(*single)),
         criteria => {
             let set = store.community_set(criteria);
-            children.push(MatchExpr::CommunityInSet(sets.community_set_id(set)));
+            children.push(MatchExpr::CommunityInSet(sets.community_set_id(set, None)));
         }
     }
     if let Some(regex) = statement.match_as_path.as_ref() {
@@ -225,28 +235,32 @@ struct ChainSets {
     prefix_sets: Vec<Arc<PrefixSet>>,
     community_sets: Vec<Arc<CommunitySet>>,
     as_path_regexes: Vec<Arc<AsPathRegex>>,
+    prefix_set_names: Vec<Option<String>>,
+    community_set_names: Vec<Option<String>>,
 }
 
 impl ChainSets {
-    fn prefix_set_id(&mut self, set: Arc<PrefixSet>) -> SetId {
+    fn prefix_set_id(&mut self, set: Arc<PrefixSet>, name: Option<String>) -> SetId {
         let index = self
             .prefix_sets
             .iter()
             .position(|existing| Arc::ptr_eq(existing, &set))
             .unwrap_or_else(|| {
                 self.prefix_sets.push(set);
+                self.prefix_set_names.push(name);
                 self.prefix_sets.len() - 1
             });
         SetId(u32::try_from(index).expect("set table fits u32"))
     }
 
-    fn community_set_id(&mut self, set: Arc<CommunitySet>) -> SetId {
+    fn community_set_id(&mut self, set: Arc<CommunitySet>, name: Option<String>) -> SetId {
         let index = self
             .community_sets
             .iter()
             .position(|existing| Arc::ptr_eq(existing, &set))
             .unwrap_or_else(|| {
                 self.community_sets.push(set);
+                self.community_set_names.push(name);
                 self.community_sets.len() - 1
             });
         SetId(u32::try_from(index).expect("set table fits u32"))

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -10,6 +10,7 @@ use rustbgpd_wire::{
     Prefix, RpkiValidation,
 };
 
+use crate::eval::PolicyHitCounters;
 use crate::ir::CompiledChain;
 use crate::sets::SetStore;
 
@@ -889,8 +890,17 @@ pub struct PolicyChain {
     /// and the cache is derived state. Invariant: `policies` must not
     /// be mutated after the first evaluation — config construction
     /// finishes all mutation (including the implicit gshut/blackhole
-    /// appends) before a chain ever sees a route.
-    compiled: OnceLock<Box<CompiledChain>>,
+    /// appends) before a chain ever sees a route. `Arc` so
+    /// [`share`](Self::share) handles reuse one compiled IR.
+    compiled: OnceLock<Arc<CompiledChain>>,
+    /// Live per-term guard-hit counters (ADR-0096 Decision 3.3),
+    /// created lazily alongside the compiled IR and bumped by every
+    /// [`evaluate_with_attribution`](Self::evaluate_with_attribution).
+    /// Derived state like `compiled` (excluded from
+    /// `PartialEq`/`Clone`/`Debug`); a cloned or replaced chain starts
+    /// from zero — stats read as "since this chain instance was
+    /// installed".
+    hits: OnceLock<Arc<PolicyHitCounters>>,
 }
 
 impl Clone for PolicyChain {
@@ -902,6 +912,7 @@ impl Clone for PolicyChain {
         Self {
             policies: self.policies.clone(),
             compiled: OnceLock::new(),
+            hits: OnceLock::new(),
         }
     }
 }
@@ -936,6 +947,7 @@ impl PolicyChain {
         Self {
             policies: policies.into_iter().map(NamedPolicy::from).collect(),
             compiled: OnceLock::new(),
+            hits: OnceLock::new(),
         }
     }
 
@@ -945,6 +957,7 @@ impl PolicyChain {
         Self {
             policies,
             compiled: OnceLock::new(),
+            hits: OnceLock::new(),
         }
     }
 
@@ -956,11 +969,35 @@ impl PolicyChain {
     /// `crate::compile::compile_chain` already takes the store).
     #[must_use]
     pub fn compiled(&self) -> &CompiledChain {
-        // Boxed so an uncompiled chain stays pointer-sized — chains are
-        // embedded in config/session structs (and api event enums) that
-        // mostly never evaluate routes themselves.
+        // Behind a pointer so an uncompiled chain stays pointer-sized —
+        // chains are embedded in config/session structs (and api event
+        // enums) that mostly never evaluate routes themselves.
         self.compiled
-            .get_or_init(|| Box::new(crate::compile::compile_chain(self, &mut SetStore::new())))
+            .get_or_init(|| Arc::new(crate::compile::compile_chain(self, &mut SetStore::new())))
+    }
+
+    /// A shallow evaluation handle onto an **installed** chain: shares
+    /// this chain's compiled IR and live hit counters instead of
+    /// resetting them the way [`Clone`] does. For read-only borrow
+    /// splitting (the RIB distribution passes clone the installed
+    /// chain to release a `&self` borrow): evaluations through the
+    /// handle land in the same counters, and the IR compiles once per
+    /// install instead of once per pass. Not for chains still under
+    /// construction — that is exactly what `Clone`'s fresh-cache
+    /// semantics exist for.
+    #[must_use]
+    pub fn share(&self) -> Self {
+        // `hit_counters()` materializes the compiled IR too.
+        let hits = Arc::clone(self.hit_counters());
+        Self {
+            policies: self.policies.clone(),
+            compiled: self
+                .compiled
+                .get()
+                .map(Arc::clone)
+                .map_or_else(OnceLock::new, OnceLock::from),
+            hits: OnceLock::from(hits),
+        }
     }
 
     /// Whether evaluating this chain needs the rendered `AS_PATH` string.
@@ -1018,7 +1055,39 @@ impl PolicyChain {
         &self,
         ctx: &RouteContext<'_>,
     ) -> (PolicyResult, PolicyEvaluation) {
-        self.compiled().evaluate_with_attribution(ctx)
+        self.compiled()
+            .evaluate_with_attribution_counting(ctx, self.hit_counters())
+    }
+
+    /// The chain's live per-term hit counters (ADR-0096 Decision 3.3),
+    /// shaped like [`compiled`](Self::compiled) and bumped on every
+    /// evaluation. `Arc`-shared so a stats reader can snapshot without
+    /// borrowing the chain.
+    #[must_use]
+    pub fn hit_counters(&self) -> &Arc<PolicyHitCounters> {
+        self.hits
+            .get_or_init(|| Arc::new(PolicyHitCounters::for_chain(self.compiled())))
+    }
+
+    /// Snapshot the per-term hit counters as labeled rows for the
+    /// policy-stats surface, in chain walk order.
+    #[must_use]
+    pub fn term_hit_rows(&self) -> Vec<TermHitRow> {
+        let compiled = self.compiled();
+        let grid = self.hit_counters().snapshot();
+        let mut rows = Vec::new();
+        for (policy_index, (policy, hits)) in compiled.policies.iter().zip(&grid).enumerate() {
+            for (term_index, (term, hits)) in policy.terms.iter().zip(hits).enumerate() {
+                rows.push(TermHitRow {
+                    policy_index,
+                    policy: policy.name.clone(),
+                    term_index,
+                    term: term.name.clone(),
+                    hits: *hits,
+                });
+            }
+        }
+        rows
     }
 
     /// The pre-IR chain walker, kept intact as the oracle for the
@@ -1063,6 +1132,22 @@ impl PolicyChain {
             },
         )
     }
+}
+
+/// One row of the policy-stats surface: a term's live guard-hit count
+/// with its naming context (see [`PolicyChain::term_hit_rows`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TermHitRow {
+    /// 0-based position of the policy within the chain.
+    pub policy_index: usize,
+    /// Chain-member name (`None` = inline / anonymous).
+    pub policy: Option<String>,
+    /// 0-based term index within the policy.
+    pub term_index: usize,
+    /// `.rpol` term name; `None` for TOML statements.
+    pub term: Option<String>,
+    /// Times this term's guard matched since chain install.
+    pub hits: u64,
 }
 
 /// Convenience: evaluate an optional policy chain. Returns `Permit` with no modifications if no chain.

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -23,12 +23,22 @@
 //! lists of `"<label> <detail>"` strings whose leading label is stable
 //! (`prefix`, `community`, `as_path`, `neighbor_set`, `route_type`,
 //! `evpn_route_type`, `rpki`, `aspa`, `as_path_len`, `local_pref`,
-//! `med`, `next_hop`, `any`; modification labels add
-//! `extended_community` / `large_community`). The detail portion is
-//! human-oriented and not a machine-parsable grammar — consume the
-//! structured indices and the leading label for automation, mirroring
-//! the `vs_best_reason` / `vs_best_detail` split on the best-path
-//! explain surface.
+//! `med`, `next_hop`, `any`, plus `guard` for an `.rpol` member's
+//! deciding guard; modification labels add `extended_community` /
+//! `large_community`). The detail portion is human-oriented and not a
+//! machine-parsable grammar — consume the structured indices and the
+//! leading label for automation, mirroring the `vs_best_reason` /
+//! `vs_best_detail` split on the best-path explain surface.
+//!
+//! `.rpol` chain members (ADR-0096) trace at term granularity: the
+//! step's `term_name`/`term_traces` carry the walk over the member's
+//! compiled IR terms, with guards rendered back to `.rpol` surface
+//! syntax by this module's pretty-printer (sets by source name). Guard
+//! *evaluation* is shared with the live evaluator
+//! (`CompiledChain::guard_matches`), so the two walks cannot disagree
+//! about whether a guard fires; the rpol agreement matrix in
+//! `statement_trace.rs` additionally pins the trace against
+//! `evaluate_recording_hits` term by term.
 
 use std::fmt::Write as _;
 
@@ -36,6 +46,7 @@ use super::{
     CommunityMatch, IMPLICIT_LOCAL_PREF, IMPLICIT_MED, NextHopAction, PolicyAction, PolicyChain,
     PolicyStatement, RouteContext, RouteModifications, RouteType,
 };
+use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, Term, TermAction};
 
 /// One step of a statement-level chain trace: how a single policy in
 /// the chain disposed of the route.
@@ -68,7 +79,21 @@ pub struct StatementAttribution {
     /// always the route's *pre-policy* value: chain semantics
     /// accumulate modifications and apply them once after the walk, so
     /// a later statement does not see an earlier statement's edits.
+    /// For an `.rpol` member this is the policy's merged contribution
+    /// (matched `Continue` terms folded under the deciding permit,
+    /// mirroring the live evaluator's merge).
     pub modifications: Vec<String>,
+    /// `.rpol` term name of the deciding term (ADR-0096). `None` for
+    /// TOML statements and for default-action fallthroughs.
+    pub term_name: Option<String>,
+    /// Per-term rendered trace lines for an `.rpol` member, in walk
+    /// order: `term <name>: <guard> => <action> [matched|not matched]`.
+    /// Terms after the deciding one were never evaluated and carry no
+    /// line (the same philosophy as chain policies after a deny); on a
+    /// default-action fallthrough every term appears. Empty for TOML
+    /// members. Guards render in `.rpol` surface syntax (sets by their
+    /// source name); human-oriented, not a machine-parsable grammar.
+    pub term_traces: Vec<String>,
 }
 
 /// A full statement-level trace of one chain evaluation.
@@ -103,6 +128,28 @@ pub fn explain_chain_statements(
 
     let mut steps = Vec::new();
     for (policy_index, named) in chain.policies.iter().enumerate() {
+        if let Some(rpol) = named.rpol.as_deref() {
+            // `.rpol` member: walk the pre-compiled IR terms against
+            // the donor chain's own set tables (guard evaluation goes
+            // through the live evaluator's `guard_matches`, so the two
+            // walks cannot disagree about a guard).
+            let mut denied = false;
+            for policy in &rpol.policies {
+                let step = trace_rpol_policy(policy_index, named.name.clone(), policy, rpol, ctx);
+                denied = step.action == PolicyAction::Deny;
+                steps.push(step);
+                if denied {
+                    break;
+                }
+            }
+            if denied {
+                return ChainStatementTrace {
+                    action: PolicyAction::Deny,
+                    steps,
+                };
+            }
+            continue;
+        }
         let matched = named.policy.entries.iter().position(|e| e.matches(ctx));
         let (statement_index, action, matched_conditions, modifications) = match matched {
             Some(index) => {
@@ -132,6 +179,8 @@ pub fn explain_chain_statements(
             action,
             matched_conditions,
             modifications,
+            term_name: None,
+            term_traces: Vec::new(),
         });
         if action == PolicyAction::Deny {
             // Chain semantics: a Deny terminates evaluation. Later
@@ -317,4 +366,344 @@ fn render_modifications(mods: &RouteModifications, ctx: &RouteContext<'_>) -> Ve
         out.push(format!("as_path prepend {asn} x{count}"));
     }
     out
+}
+
+// ---------------------------------------------------------------------
+// `.rpol` member tracing (ADR-0096 explain slice).
+// ---------------------------------------------------------------------
+
+/// Trace one pre-compiled `.rpol` policy: walk its terms exactly like
+/// `CompiledChain::evaluate_policy` (first decider wins, matched
+/// `Continue` modifications accumulate under an eventual permit and are
+/// discarded by a deny), rendering a `term_traces` line per evaluated
+/// term. `tables` is the member's donor chain — its set/regex tables
+/// and names are self-contained.
+fn trace_rpol_policy(
+    policy_index: usize,
+    policy_name: Option<String>,
+    policy: &CompiledPolicy,
+    tables: &CompiledChain,
+    ctx: &RouteContext<'_>,
+) -> StatementAttribution {
+    let mut term_traces = Vec::new();
+    let mut continued: Option<RouteModifications> = None;
+    let mut decided: Option<(usize, &Term)> = None;
+    for (index, term) in policy.terms.iter().enumerate() {
+        let matched = tables.guard_matches(&term.guard, ctx);
+        term_traces.push(format!(
+            "term {}: {} => {} [{}]",
+            term.name.as_deref().unwrap_or("<unnamed>"),
+            render_expr(&term.guard, tables),
+            render_term_action(&term.action),
+            if matched { "matched" } else { "not matched" },
+        ));
+        if !matched {
+            continue;
+        }
+        match &term.action {
+            TermAction::Continue(mods) => {
+                continued
+                    .get_or_insert_with(RouteModifications::default)
+                    .merge_from(mods.clone());
+            }
+            TermAction::Permit(_) | TermAction::Deny => {
+                decided = Some((index, term));
+                break;
+            }
+        }
+    }
+    if let Some((index, term)) = decided {
+        // Live-path parity: a deny discards accumulated Continue
+        // modifications and contributes none of its own.
+        let (action, modifications) = match &term.action {
+            TermAction::Permit(mods) => {
+                let mut merged = continued.unwrap_or_default();
+                merged.merge_from(mods.clone());
+                (PolicyAction::Permit, render_modifications(&merged, ctx))
+            }
+            _ => (PolicyAction::Deny, Vec::new()),
+        };
+        StatementAttribution {
+            policy_index,
+            policy_name,
+            statement_index: Some(index),
+            action,
+            matched_conditions: vec![format!("guard {}", render_expr(&term.guard, tables))],
+            modifications,
+            term_name: term.name.clone(),
+            term_traces,
+        }
+    } else {
+        // Fallthrough to the policy default; a permitting default
+        // keeps accumulated Continue modifications (live parity).
+        let modifications = match (policy.default_action, continued) {
+            (PolicyAction::Permit, Some(mods)) => render_modifications(&mods, ctx),
+            _ => Vec::new(),
+        };
+        StatementAttribution {
+            policy_index,
+            policy_name,
+            statement_index: None,
+            action: policy.default_action,
+            matched_conditions: Vec::new(),
+            modifications,
+            term_name: None,
+            term_traces,
+        }
+    }
+}
+
+/// Render a compiled term's action in `.rpol` surface syntax, e.g.
+/// `set local-pref 200; accept` / `reject` / `add community 65001:999;
+/// continue` (`continue` names the IR fallthrough — a term body that
+/// modified without a verdict).
+fn render_term_action(action: &TermAction) -> String {
+    let (mods, verdict) = match action {
+        TermAction::Permit(mods) => (Some(mods), "accept"),
+        TermAction::Deny => (None, "reject"),
+        TermAction::Continue(mods) => (Some(mods), "continue"),
+    };
+    let mut parts = mods.map_or_else(Vec::new, render_action_stmts);
+    parts.push(verdict.to_string());
+    parts.join("; ")
+}
+
+/// Modifications as `.rpol` action statements (static description of
+/// what the term *does* — contrast `render_modifications`, which
+/// renders the `before -> after` transition for a specific route).
+fn render_action_stmts(mods: &RouteModifications) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(lp) = mods.set_local_pref {
+        out.push(format!("set local-pref {lp}"));
+    }
+    if let Some(med) = mods.set_med {
+        out.push(format!("set med {med}"));
+    }
+    if let Some(action) = mods.set_next_hop.as_ref() {
+        let target = match action {
+            NextHopAction::Self_ => "self".to_string(),
+            NextHopAction::Specific(addr) => addr.to_string(),
+        };
+        out.push(format!("set next-hop {target}"));
+    }
+    for c in &mods.communities_add {
+        out.push(format!("add community {}", fmt_standard_community(*c)));
+    }
+    for c in &mods.communities_remove {
+        out.push(format!("remove community {}", fmt_standard_community(*c)));
+    }
+    for lc in &mods.large_communities_add {
+        out.push(format!(
+            "add community {}:{}:{}",
+            lc.global_admin, lc.local_data1, lc.local_data2
+        ));
+    }
+    for lc in &mods.large_communities_remove {
+        out.push(format!(
+            "remove community {}:{}:{}",
+            lc.global_admin, lc.local_data1, lc.local_data2
+        ));
+    }
+    for ec in &mods.extended_communities_add {
+        out.push(format!("add community {ec}"));
+    }
+    for ec in &mods.extended_communities_remove {
+        out.push(format!("remove community {ec}"));
+    }
+    if let Some((asn, count)) = mods.as_path_prepend {
+        out.push(format!("prepend {asn} {count}"));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
+// Guard pretty-printer: compiled MatchExpr back to `.rpol` surface
+// syntax. Sets render by their source name where the chain tables carry
+// one. Compact and human-oriented; a lowering round-trip is NOT
+// guaranteed (e.g. `==` on integers renders as its `>= && <=` pair,
+// `contains N` as its `matches "_N_"` regex).
+// ---------------------------------------------------------------------
+
+/// Binding strength for parenthesization: `Or` < `And` < atoms.
+/// A multi-member neighbor set renders as an internal `||`, so it
+/// binds like `Or`.
+fn binding(expr: &MatchExpr) -> u8 {
+    match expr {
+        MatchExpr::Or(_) => 0,
+        MatchExpr::NeighborIn(set)
+            if set.addresses.len() + set.remote_asns.len() + set.peer_groups.len() > 1 =>
+        {
+            0
+        }
+        MatchExpr::And(_) => 1,
+        _ => 2,
+    }
+}
+
+/// Render `expr` against `tables` (the chain whose set/regex ids the
+/// expression references).
+pub(crate) fn render_expr(expr: &MatchExpr, tables: &CompiledChain) -> String {
+    render_prec(expr, tables, 0)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "one arm per MatchExpr node type; splitting would scatter the rendering table"
+)]
+fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> String {
+    let rendered = match expr {
+        MatchExpr::True => "true".to_string(),
+        MatchExpr::PrefixInSet(id) => format!(
+            "route.prefix in {}",
+            set_label(&tables.prefix_set_names, id.0, "prefix-set")
+        ),
+        MatchExpr::PrefixEq { prefix, ge, le } => {
+            let mut out = format!("route.prefix == {prefix}");
+            if let Some(ge) = ge {
+                let _ = write!(out, " ge {ge}");
+            }
+            if let Some(le) = le {
+                let _ = write!(out, " le {le}");
+            }
+            out
+        }
+        MatchExpr::CommunityContains(cm) => {
+            format!(
+                "{} has {}",
+                community_field(&[*cm]),
+                fmt_community_match(cm)
+            )
+        }
+        MatchExpr::CommunityInSet(id) => {
+            let field = tables
+                .community_sets
+                .get(id.0 as usize)
+                .map_or("route.communities", |set| community_field(set.criteria()));
+            format!(
+                "{field} in {}",
+                set_label(&tables.community_set_names, id.0, "community-set")
+            )
+        }
+        MatchExpr::AsPathMatches(id) => format!(
+            "route.as-path matches {:?}",
+            tables
+                .as_path_regexes
+                .get(id.0 as usize)
+                .map_or("", |regex| regex.pattern())
+        ),
+        MatchExpr::AsPathLen(cmp) => render_cmp("route.as-path.len", *cmp),
+        MatchExpr::LocalPref(cmp) => render_cmp("route.local-pref", *cmp),
+        MatchExpr::Med(cmp) => render_cmp("route.med", *cmp),
+        MatchExpr::NextHopEq(addr) => format!("route.next-hop == {addr}"),
+        MatchExpr::NeighborIn(set) => {
+            let mut parts: Vec<String> = Vec::new();
+            for addr in &set.addresses {
+                parts.push(format!("peer.address == {addr}"));
+            }
+            for asn in &set.remote_asns {
+                parts.push(format!("peer.asn == {asn}"));
+            }
+            for group in &set.peer_groups {
+                parts.push(format!("peer.group == {group:?}"));
+            }
+            if parts.is_empty() {
+                // An empty neighbor set never matches.
+                "false".to_string()
+            } else {
+                parts.join(" || ")
+            }
+        }
+        MatchExpr::RouteTypeIs(route_type) => {
+            format!("route.route-type == {}", route_type_label(*route_type))
+        }
+        MatchExpr::EvpnRouteTypeIs(evpn_type) => {
+            format!("route.evpn-route-type == {evpn_type}")
+        }
+        MatchExpr::RpkiIs(state) => format!(
+            "route.rpki == {}",
+            match state {
+                rustbgpd_wire::RpkiValidation::Valid => "valid",
+                rustbgpd_wire::RpkiValidation::Invalid => "invalid",
+                rustbgpd_wire::RpkiValidation::NotFound => "not-found",
+            }
+        ),
+        MatchExpr::AspaIs(state) => format!(
+            "route.aspa == {}",
+            match state {
+                rustbgpd_wire::AspaValidation::Valid => "valid",
+                rustbgpd_wire::AspaValidation::Invalid => "invalid",
+                rustbgpd_wire::AspaValidation::Unknown => "unknown",
+            }
+        ),
+        MatchExpr::And(children) => {
+            if children.is_empty() {
+                "true".to_string()
+            } else {
+                children
+                    .iter()
+                    .map(|child| render_prec(child, tables, 2))
+                    .collect::<Vec<_>>()
+                    .join(" && ")
+            }
+        }
+        MatchExpr::Or(children) => {
+            if children.is_empty() {
+                // An empty Or never matches.
+                "false".to_string()
+            } else {
+                children
+                    .iter()
+                    .map(|child| render_prec(child, tables, 1))
+                    .collect::<Vec<_>>()
+                    .join(" || ")
+            }
+        }
+        MatchExpr::Not(inner) => {
+            // Always parenthesized: `!(...)` is unambiguous regardless
+            // of the inner expression's shape.
+            return format!("!({})", render_prec(inner, tables, 0));
+        }
+    };
+    if binding(expr) < min_binding {
+        format!("({rendered})")
+    } else {
+        rendered
+    }
+}
+
+fn render_cmp(field: &str, cmp: Cmp) -> String {
+    match cmp {
+        Cmp::Ge(bound) => format!("{field} >= {bound}"),
+        Cmp::Le(bound) => format!("{field} <= {bound}"),
+    }
+}
+
+/// The `.rpol` field a community criterion set reads: all-standard →
+/// `route.communities`, all-large → `route.large-communities`,
+/// all-RT/RO → `route.ext-communities`, mixed → the generic
+/// `route.communities`.
+fn community_field(criteria: &[CommunityMatch]) -> &'static str {
+    let mut fields = criteria.iter().map(|cm| match cm {
+        CommunityMatch::Standard { .. } => "route.communities",
+        CommunityMatch::LargeCommunity { .. } => "route.large-communities",
+        CommunityMatch::RouteTarget { .. } | CommunityMatch::RouteOrigin { .. } => {
+            "route.ext-communities"
+        }
+    });
+    let Some(first) = fields.next() else {
+        return "route.communities";
+    };
+    if fields.all(|field| field == first) {
+        first
+    } else {
+        "route.communities"
+    }
+}
+
+fn set_label(names: &[Option<String>], id: u32, kind: &str) -> String {
+    names
+        .get(id as usize)
+        .cloned()
+        .flatten()
+        .unwrap_or_else(|| format!("{kind}#{id}"))
 }

--- a/crates/policy/src/engine/tests/guard_render.rs
+++ b/crates/policy/src/engine/tests/guard_render.rs
@@ -1,0 +1,202 @@
+//! Golden renderings for the explain guard pretty-printer
+//! (`engine::explain::render_expr`): every `MatchExpr` node type has a
+//! pinned `.rpol`-surface form, sets render by their source name where
+//! the chain tables carry one, and `&&` / `||` / `!` parenthesize by
+//! binding strength.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+
+use super::super::explain::render_expr;
+use super::*;
+use crate::ir::{Cmp, CompiledChain, MatchExpr, SetId};
+use crate::sets::{CommunitySet, PrefixSet, PrefixSetEntry};
+
+/// A chain whose tables carry one named prefix set, one named
+/// community set (standard criteria), and one regex — enough for every
+/// table-referencing node.
+fn tables() -> CompiledChain {
+    CompiledChain {
+        prefix_sets: vec![Arc::new(PrefixSet::new([PrefixSetEntry {
+            prefix: v4_prefix([10, 10, 0, 0], 16),
+            ge: Some(24),
+            le: Some(28),
+        }]))],
+        community_sets: vec![Arc::new(CommunitySet::new([CommunityMatch::Standard {
+            value: (65000 << 16) | 0x0064,
+        }]))],
+        as_path_regexes: vec![Arc::new(AsPathRegex::new("_65010_").unwrap())],
+        prefix_set_names: vec![Some("customers".to_string())],
+        community_set_names: vec![Some("cust-tags".to_string())],
+        ..CompiledChain::empty()
+    }
+}
+
+fn atom() -> MatchExpr {
+    MatchExpr::RpkiIs(RpkiValidation::Invalid)
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one golden case per MatchExpr node type"
+)]
+fn every_node_type_renders_its_golden_form() {
+    let tables = tables();
+    let cases: Vec<(MatchExpr, &str)> = vec![
+        (MatchExpr::True, "true"),
+        (
+            MatchExpr::PrefixInSet(SetId(0)),
+            "route.prefix in customers",
+        ),
+        (
+            MatchExpr::PrefixEq {
+                prefix: v4_prefix([10, 0, 0, 0], 8),
+                ge: Some(16),
+                le: Some(24),
+            },
+            "route.prefix == 10.0.0.0/8 ge 16 le 24",
+        ),
+        (
+            MatchExpr::PrefixEq {
+                prefix: v4_prefix([192, 0, 2, 0], 24),
+                ge: None,
+                le: None,
+            },
+            "route.prefix == 192.0.2.0/24",
+        ),
+        (
+            MatchExpr::CommunityContains(CommunityMatch::Standard {
+                value: (65001 << 16) | 0x0064,
+            }),
+            "route.communities has 65001:100",
+        ),
+        (
+            MatchExpr::CommunityContains(CommunityMatch::LargeCommunity {
+                global_admin: 65000,
+                local_data1: 1,
+                local_data2: 2,
+            }),
+            "route.large-communities has LC:65000:1:2",
+        ),
+        (
+            MatchExpr::CommunityContains(CommunityMatch::RouteTarget {
+                global: 65001,
+                local: 100,
+            }),
+            "route.ext-communities has RT:65001:100",
+        ),
+        (
+            MatchExpr::CommunityInSet(SetId(0)),
+            "route.communities in cust-tags",
+        ),
+        (
+            MatchExpr::AsPathMatches(crate::ir::RegexId(0)),
+            "route.as-path matches \"_65010_\"",
+        ),
+        (MatchExpr::AsPathLen(Cmp::Ge(3)), "route.as-path.len >= 3"),
+        (MatchExpr::LocalPref(Cmp::Le(50)), "route.local-pref <= 50"),
+        (MatchExpr::Med(Cmp::Ge(10)), "route.med >= 10"),
+        (
+            MatchExpr::NextHopEq(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            "route.next-hop == 10.0.0.1",
+        ),
+        (
+            MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.address == 10.0.0.2",
+        ),
+        (
+            MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                remote_asns: vec![65001],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.asn == 65001",
+        ),
+        (
+            MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+                peer_groups: vec!["edge".to_string()],
+                ..NeighborSetMatch::default()
+            })),
+            "peer.group == \"edge\"",
+        ),
+        (
+            MatchExpr::RouteTypeIs(RouteType::Internal),
+            "route.route-type == internal",
+        ),
+        (MatchExpr::EvpnRouteTypeIs(2), "route.evpn-route-type == 2"),
+        (
+            MatchExpr::RpkiIs(RpkiValidation::NotFound),
+            "route.rpki == not-found",
+        ),
+        (
+            MatchExpr::AspaIs(rustbgpd_wire::AspaValidation::Unknown),
+            "route.aspa == unknown",
+        ),
+        (MatchExpr::Not(Box::new(atom())), "!(route.rpki == invalid)"),
+        // Empty compounds render their identity truth value.
+        (MatchExpr::And(vec![]), "true"),
+        (MatchExpr::Or(vec![]), "false"),
+        // An empty neighbor set never matches.
+        (MatchExpr::NeighborIn(Box::default()), "false"),
+    ];
+    for (expr, expected) in cases {
+        assert_eq!(render_expr(&expr, &tables), expected, "node {expr:?}");
+    }
+}
+
+#[test]
+fn unnamed_sets_fall_back_to_indexed_placeholders() {
+    let mut tables = tables();
+    tables.prefix_set_names = vec![None];
+    tables.community_set_names = Vec::new(); // shorter than the table
+    assert_eq!(
+        render_expr(&MatchExpr::PrefixInSet(SetId(0)), &tables),
+        "route.prefix in prefix-set#0"
+    );
+    assert_eq!(
+        render_expr(&MatchExpr::CommunityInSet(SetId(0)), &tables),
+        "route.communities in community-set#0"
+    );
+}
+
+#[test]
+fn compound_precedence_parenthesizes_or_under_and_and_multi_member_sets() {
+    let tables = tables();
+    let a = MatchExpr::LocalPref(Cmp::Ge(100));
+    let b = MatchExpr::Med(Cmp::Le(5));
+    let c = atom();
+
+    // Or under And needs parens; And under Or does not.
+    assert_eq!(
+        render_expr(
+            &MatchExpr::And(vec![a.clone(), MatchExpr::Or(vec![b.clone(), c.clone()])]),
+            &tables
+        ),
+        "route.local-pref >= 100 && (route.med <= 5 || route.rpki == invalid)"
+    );
+    assert_eq!(
+        render_expr(
+            &MatchExpr::Or(vec![MatchExpr::And(vec![a.clone(), b.clone()]), c.clone()]),
+            &tables
+        ),
+        "route.local-pref >= 100 && route.med <= 5 || route.rpki == invalid"
+    );
+    // A multi-member neighbor set is an internal `||`: parenthesized
+    // when embedded in an And.
+    let multi = MatchExpr::NeighborIn(Box::new(NeighborSetMatch {
+        addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))],
+        remote_asns: vec![65001],
+        ..NeighborSetMatch::default()
+    }));
+    assert_eq!(
+        render_expr(&multi, &tables),
+        "peer.address == 10.0.0.2 || peer.asn == 65001"
+    );
+    assert_eq!(
+        render_expr(&MatchExpr::And(vec![a, multi]), &tables),
+        "route.local-pref >= 100 && (peer.address == 10.0.0.2 || peer.asn == 65001)"
+    );
+}

--- a/crates/policy/src/engine/tests/hit_counters.rs
+++ b/crates/policy/src/engine/tests/hit_counters.rs
@@ -1,0 +1,157 @@
+//! Live per-term hit counters (ADR-0096 Decision 3.3): counts
+//! accumulate across evaluations on the standard
+//! `evaluate_with_attribution` path, reset when a chain instance is
+//! replaced (clone or reinstall), and are safe to read concurrently
+//! with evaluation.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::rpol::RpolFile;
+use crate::sets::SetStore;
+
+const RPOL: &str = r"
+policy tagger {
+    term rpki-guard {
+        if route.rpki == invalid { reject }
+    }
+    term tag {
+        set med 5;
+    }
+    term wide-open {
+        if route.local-pref >= 0 { accept }
+    }
+}
+";
+
+fn rpol_chain() -> PolicyChain {
+    let file = RpolFile::parse(RPOL).expect("clean rpol");
+    let mut store = SetStore::new();
+    let compiled = file
+        .compile_policy("tagger", &[], &mut store)
+        .expect("policy exists");
+    PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        "tagger".to_string(),
+        Arc::new(compiled),
+    )])
+}
+
+fn route(prefix: Prefix, rpki: RpkiValidation) -> RouteContext<'static> {
+    RouteContext {
+        prefix: Some(prefix),
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: rpki,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+#[test]
+fn counts_accumulate_across_evaluations() {
+    let chain = rpol_chain();
+    let clean = route(v4_prefix([10, 0, 0, 0], 24), RpkiValidation::NotFound);
+    let invalid = route(v4_prefix([10, 0, 1, 0], 24), RpkiValidation::Invalid);
+
+    // Two clean routes walk tag + wide-open; one invalid route stops
+    // at rpki-guard.
+    for _ in 0..2 {
+        let _ = chain.evaluate_with_attribution(&clean);
+    }
+    let _ = chain.evaluate_with_attribution(&invalid);
+
+    assert_eq!(chain.hit_counters().evals(), 3);
+    let rows = chain.term_hit_rows();
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        assert_eq!(row.policy.as_deref(), Some("tagger"));
+        assert_eq!(row.policy_index, 0);
+    }
+    assert_eq!(rows[0].term.as_deref(), Some("rpki-guard"));
+    assert_eq!(rows[0].hits, 1);
+    assert_eq!(rows[1].term.as_deref(), Some("tag"));
+    assert_eq!(rows[1].hits, 2);
+    assert_eq!(rows[2].term.as_deref(), Some("wide-open"));
+    assert_eq!(rows[2].hits, 2);
+}
+
+#[test]
+fn toml_terms_have_no_name_and_still_count() {
+    let chain = PolicyChain::from_named(vec![NamedPolicy {
+        name: Some("toml".to_string()),
+        policy: Policy {
+            entries: vec![stmt(
+                Some(v4_prefix([10, 0, 0, 0], 8)),
+                PolicyAction::Permit,
+                vec![],
+            )],
+            default_action: PolicyAction::Deny,
+        },
+        rpol: None,
+    }]);
+    // No ge/le on the statement = exact-length prefix match.
+    let _ = chain.evaluate_with_attribution(&route(
+        v4_prefix([10, 0, 0, 0], 8),
+        RpkiValidation::NotFound,
+    ));
+    let rows = chain.term_hit_rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].term, None, "TOML statements are unnamed");
+    assert_eq!(rows[0].term_index, 0);
+    assert_eq!(rows[0].hits, 1);
+}
+
+/// Replacing a chain means installing a new instance (config apply
+/// clones / rebuilds); the counters live on the instance, so the new
+/// chain starts from zero — the "since chain install" contract.
+#[test]
+fn replaced_chain_instance_starts_from_zero() {
+    let chain = rpol_chain();
+    let clean = route(v4_prefix([10, 0, 0, 0], 24), RpkiValidation::NotFound);
+    let _ = chain.evaluate_with_attribution(&clean);
+    assert_eq!(chain.hit_counters().evals(), 1);
+
+    let replacement = chain.clone();
+    assert_eq!(replacement.hit_counters().evals(), 0);
+    assert!(replacement.term_hit_rows().iter().all(|row| row.hits == 0));
+    // The original keeps counting independently.
+    let _ = chain.evaluate_with_attribution(&clean);
+    assert_eq!(chain.hit_counters().evals(), 2);
+    assert_eq!(replacement.hit_counters().evals(), 0);
+}
+
+#[test]
+fn concurrent_evaluation_and_reads_agree_on_totals() {
+    let chain = Arc::new(rpol_chain());
+    let threads = 4;
+    let per_thread = 1000;
+    std::thread::scope(|scope| {
+        for _ in 0..threads {
+            let chain = Arc::clone(&chain);
+            scope.spawn(move || {
+                let clean = route(v4_prefix([10, 0, 0, 0], 24), RpkiValidation::NotFound);
+                for _ in 0..per_thread {
+                    let _ = chain.evaluate_with_attribution(&clean);
+                    // Concurrent snapshot reads must never tear or panic.
+                    let _ = chain.hit_counters().snapshot();
+                }
+            });
+        }
+    });
+    let total = u64::try_from(threads * per_thread).unwrap();
+    assert_eq!(chain.hit_counters().evals(), total);
+    let rows = chain.term_hit_rows();
+    assert_eq!(rows[1].hits, total, "tag matched every route");
+    assert_eq!(rows[2].hits, total, "wide-open matched every route");
+    assert_eq!(rows[0].hits, 0, "rpki-guard never matched");
+}

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -9,6 +9,8 @@ mod aspath_regex;
 mod chain;
 mod community;
 mod evpn_route_type;
+mod guard_render;
+mod hit_counters;
 mod ir_parity;
 mod large_community;
 mod modifications;

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -519,3 +519,216 @@ fn statement_trace_agrees_with_live_evaluation_across_matrix() {
         }
     }
 }
+
+// ---------------------------------------------------------------------
+// `.rpol` members (ADR-0096): per-term traces + agreement.
+// ---------------------------------------------------------------------
+
+const RPOL: &str = r"
+prefix-set customers { 10.10.0.0/16 ge 24 le 28 }
+
+policy customer-in(peer_lp: u32) {
+    term rpki-guard {
+        if route.rpki == invalid { reject }
+    }
+    term tag {
+        set med 5;
+    }
+    term customer-routes {
+        if route.prefix in customers { set local-pref peer_lp; accept }
+    }
+}
+";
+
+fn rpol_member(lp: u32) -> NamedPolicy {
+    let file = crate::rpol::RpolFile::parse(RPOL).expect("clean rpol");
+    let mut store = crate::sets::SetStore::new();
+    let compiled = file
+        .compile_policy("customer-in", &[lp], &mut store)
+        .expect("policy exists");
+    NamedPolicy::from_rpol(format!("customer-in({lp})"), std::sync::Arc::new(compiled))
+}
+
+#[test]
+fn rpol_member_traces_terms_with_matched_status_and_merged_mods() {
+    let chain = PolicyChain::from_named(vec![rpol_member(200)]);
+    // A customer route: rpki-guard misses, tag continues, customer-routes decides.
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 10, 3, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    assert_eq!(trace.steps.len(), 1);
+    let step = &trace.steps[0];
+    assert_eq!(step.policy_name.as_deref(), Some("customer-in(200)"));
+    assert_eq!(step.statement_index, Some(2));
+    assert_eq!(step.term_name.as_deref(), Some("customer-routes"));
+    assert_eq!(step.action, PolicyAction::Permit);
+    assert_eq!(
+        step.matched_conditions,
+        vec!["guard route.prefix in customers".to_string()]
+    );
+    // Continue mods merge under the deciding permit, rendered
+    // before -> after against the pre-policy route.
+    assert_eq!(
+        step.modifications,
+        vec![
+            "local_pref 100 -> 200".to_string(),
+            "med 0 -> 5".to_string()
+        ]
+    );
+    assert_eq!(
+        step.term_traces,
+        vec![
+            "term rpki-guard: route.rpki == invalid => reject [not matched]".to_string(),
+            "term tag: true => set med 5; continue [matched]".to_string(),
+            "term customer-routes: route.prefix in customers => set local-pref 200; accept [matched]"
+                .to_string(),
+        ]
+    );
+}
+
+#[test]
+fn rpol_deny_term_stops_the_walk_and_claims_no_modifications() {
+    let chain = PolicyChain::from_named(vec![rpol_member(200)]);
+    let mut invalid = plain_ctx(v4_prefix([10, 10, 3, 0], 24));
+    invalid.validation_state = RpkiValidation::Invalid;
+    let trace = explain_chain_statements(Some(&chain), &invalid);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    let step = &trace.steps[0];
+    assert_eq!(step.statement_index, Some(0));
+    assert_eq!(step.term_name.as_deref(), Some("rpki-guard"));
+    assert_eq!(step.action, PolicyAction::Deny);
+    assert!(step.modifications.is_empty(), "a deny contributes nothing");
+    // Terms after the decider were never evaluated: one trace line.
+    assert_eq!(
+        step.term_traces,
+        vec!["term rpki-guard: route.rpki == invalid => reject [matched]".to_string()]
+    );
+}
+
+#[test]
+fn rpol_fallthrough_keeps_continue_mods_under_the_permit_default() {
+    let chain = PolicyChain::from_named(vec![rpol_member(200)]);
+    // Not a customer prefix: rpki-guard and customer-routes miss, tag
+    // continues, the policy's implicit permit default decides.
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([192, 0, 2, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Permit);
+    let step = &trace.steps[0];
+    assert_eq!(step.statement_index, None, "fallthrough has no term");
+    assert_eq!(step.term_name, None);
+    assert_eq!(step.action, PolicyAction::Permit);
+    assert!(step.matched_conditions.is_empty());
+    assert_eq!(step.modifications, vec!["med 0 -> 5".to_string()]);
+    assert_eq!(step.term_traces.len(), 3, "every term was evaluated");
+    assert!(step.term_traces[2].ends_with("[not matched]"));
+}
+
+/// The rpol agreement matrix: mixed TOML + rpol chains, contexts that
+/// exercise deny terms, Continue accumulation, and fallthrough.
+fn rpol_agreement_chains() -> Vec<(&'static str, PolicyChain)> {
+    let toml_deny = || {
+        named(
+            "toml-deny",
+            policy(
+                vec![stmt(
+                    Some(v4_entry([192, 0, 2, 0], 24)),
+                    PolicyAction::Deny,
+                    vec![],
+                )],
+                PolicyAction::Permit,
+            ),
+        )
+    };
+    vec![
+        ("rpol_only", PolicyChain::from_named(vec![rpol_member(200)])),
+        (
+            "toml_then_rpol",
+            PolicyChain::from_named(vec![toml_deny(), rpol_member(300)]),
+        ),
+        (
+            "rpol_then_toml",
+            PolicyChain::from_named(vec![rpol_member(200), toml_deny()]),
+        ),
+    ]
+}
+
+fn rpol_agreement_contexts() -> Vec<(&'static str, RouteContext<'static>)> {
+    let customer = plain_ctx(v4_prefix([10, 10, 3, 0], 24));
+    let mut invalid = plain_ctx(v4_prefix([10, 10, 4, 0], 24));
+    invalid.validation_state = RpkiValidation::Invalid;
+    let toml_blocked = plain_ctx(v4_prefix([192, 0, 2, 0], 24));
+    let fallthrough = plain_ctx(v4_prefix([203, 0, 113, 0], 24));
+    vec![
+        ("customer", customer),
+        ("rpki_invalid", invalid),
+        ("toml_blocked", toml_blocked),
+        ("fallthrough", fallthrough),
+    ]
+}
+
+/// The rpol extension of the agreement pin: over the rpol chain ×
+/// context matrix the trace must reach the live evaluator's terminal
+/// action / policy, its per-policy modifications must reproduce the
+/// live result's accumulated modifications (Continue-merge parity),
+/// and its matched-term view must equal `evaluate_recording_hits`'
+/// counted guards term by term.
+#[test]
+fn rpol_statement_trace_agrees_with_live_evaluation_and_recorded_hits() {
+    for (chain_name, chain) in rpol_agreement_chains() {
+        for (ctx_name, ctx) in rpol_agreement_contexts() {
+            let (live, evaluation) =
+                super::super::evaluate_chain_with_attribution(Some(&chain), &ctx);
+            let trace = explain_chain_statements(Some(&chain), &ctx);
+            assert_eq!(
+                trace.action, live.action,
+                "action diverged for chain={chain_name} ctx={ctx_name}"
+            );
+            let last = trace.steps.last().expect("non-empty chains");
+            assert_eq!(
+                last.policy_name, evaluation.matched_policy,
+                "terminal policy diverged for chain={chain_name} ctx={ctx_name}"
+            );
+
+            // Matched-term parity with the counting evaluator: a term
+            // counted a hit iff its trace line says [matched], and
+            // terms past the trace were never evaluated.
+            let compiled = chain.compiled();
+            let mut hits = compiled.zero_term_hits();
+            let recorded = compiled.evaluate_recording_hits(&ctx, &mut hits);
+            assert_eq!(recorded, live, "recording eval diverged");
+            for step in &trace.steps {
+                if step.term_traces.is_empty() {
+                    continue; // TOML member: no per-term trace.
+                }
+                let policy_hits = &hits[step.policy_index];
+                for (index, line) in step.term_traces.iter().enumerate() {
+                    let expected = u64::from(line.ends_with("[matched]"));
+                    assert_eq!(
+                        policy_hits[index], expected,
+                        "term hit diverged for chain={chain_name} ctx={ctx_name} \
+                         policy={:?} line={line:?}",
+                        step.policy_name
+                    );
+                }
+                for (index, hit) in policy_hits.iter().enumerate().skip(step.term_traces.len()) {
+                    assert_eq!(
+                        *hit, 0,
+                        "unevaluated term counted a hit for chain={chain_name} \
+                         ctx={ctx_name} term_index={index}"
+                    );
+                }
+                // The deciding term (when there is one) is the last
+                // matched line — the matched-term invariant.
+                if let Some(decider) = step.statement_index {
+                    assert!(
+                        step.term_traces[decider].ends_with("[matched]"),
+                        "decider not matched for chain={chain_name} ctx={ctx_name}"
+                    );
+                    assert_eq!(
+                        decider + 1,
+                        step.term_traces.len(),
+                        "walk continued past the decider for chain={chain_name} ctx={ctx_name}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -13,12 +13,67 @@
 //! matched permit term actually carries some, and the attribution name
 //! is cloned only for a named terminal policy (exactly as before).
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use crate::engine::{
     IMPLICIT_LOCAL_PREF, IMPLICIT_MED, PolicyAction, PolicyEvaluation, PolicyResult, RouteContext,
     RouteModifications,
 };
 use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, TermAction};
 use crate::sets::prefix_entry_matches;
+
+/// Live per-term guard-hit counters for one chain (ADR-0096 Decision
+/// 3.3, the IOS-XR `show pcl` idea): `hits[p][t]` counts how many
+/// evaluated routes matched policy `p`'s term `t`'s guard, plus a
+/// chain-level evaluation count as the denominator. Incremented with
+/// relaxed atomics on the live evaluation path (one uncontended add per
+/// matched term) and read by the policy-stats surface.
+///
+/// A counter set is shaped for — and only valid against — the
+/// [`CompiledChain`] it was built from. It lives on the owning
+/// `PolicyChain` instance, so replacing a chain resets the counts by
+/// construction ("since chain install" semantics).
+#[derive(Debug)]
+pub struct PolicyHitCounters {
+    policies: Vec<Vec<AtomicU64>>,
+    evals: AtomicU64,
+}
+
+impl PolicyHitCounters {
+    /// Zeroed counters shaped like `chain` (one per term).
+    #[must_use]
+    pub fn for_chain(chain: &CompiledChain) -> Self {
+        Self {
+            policies: chain
+                .policies
+                .iter()
+                .map(|policy| (0..policy.terms.len()).map(|_| AtomicU64::new(0)).collect())
+                .collect(),
+            evals: AtomicU64::new(0),
+        }
+    }
+
+    /// Routes evaluated through the chain since these counters were
+    /// created (= since the chain instance was installed).
+    #[must_use]
+    pub fn evals(&self) -> u64 {
+        self.evals.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot of the per-term hit grid (`snapshot()[p][t]`).
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<Vec<u64>> {
+        self.policies
+            .iter()
+            .map(|terms| {
+                terms
+                    .iter()
+                    .map(|hit| hit.load(Ordering::Relaxed))
+                    .collect()
+            })
+            .collect()
+    }
+}
 
 /// A policy's disposition of the route, borrowing the matched term's
 /// modifications (cloned only if merged). `PermitOwned` carries
@@ -49,9 +104,43 @@ impl CompiledChain {
         &self,
         ctx: &RouteContext<'_>,
     ) -> (PolicyResult, PolicyEvaluation) {
+        self.evaluate_attributed::<false>(ctx, None)
+    }
+
+    /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
+    /// plus live hit counting: every matched guard bumps its term's
+    /// counter (relaxed; `Continue` terms included, terms after the
+    /// decider are never evaluated and never count) and the chain-level
+    /// evaluation count increments once. `hits` must have been built
+    /// from this chain ([`PolicyHitCounters::for_chain`]); a mismatched
+    /// shape is a caller bug (the increment indexes directly).
+    #[must_use]
+    pub fn evaluate_with_attribution_counting(
+        &self,
+        ctx: &RouteContext<'_>,
+        hits: &PolicyHitCounters,
+    ) -> (PolicyResult, PolicyEvaluation) {
+        hits.evals.fetch_add(1, Ordering::Relaxed);
+        self.evaluate_attributed::<true>(ctx, Some(hits))
+    }
+
+    /// `COUNT` monomorphizes the walk: the non-counting instantiation
+    /// compiles the counter plumbing away entirely, so the plain
+    /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
+    /// path costs exactly what it did before counters existed.
+    fn evaluate_attributed<const COUNT: bool>(
+        &self,
+        ctx: &RouteContext<'_>,
+        hits: Option<&PolicyHitCounters>,
+    ) -> (PolicyResult, PolicyEvaluation) {
         let mut accumulated = RouteModifications::default();
-        for policy in &self.policies {
-            match self.evaluate_policy(policy, ctx) {
+        for (policy_index, policy) in self.policies.iter().enumerate() {
+            let policy_hits = if COUNT {
+                hits.map(|h| h.policies[policy_index].as_slice())
+            } else {
+                None
+            };
+            match self.evaluate_policy::<COUNT>(policy, ctx, policy_hits) {
                 PolicyDecision::Deny => {
                     return (
                         PolicyResult::deny(),
@@ -174,14 +263,18 @@ impl CompiledChain {
     /// eventual Permit merges them (the deciding term's own
     /// modifications winning scalar conflicts, mirroring chain-level
     /// merge), while a Deny — matched term or default — discards them.
-    fn evaluate_policy<'a>(
+    fn evaluate_policy<'a, const COUNT: bool>(
         &self,
         policy: &'a CompiledPolicy,
         ctx: &RouteContext<'_>,
+        hits: Option<&[AtomicU64]>,
     ) -> PolicyDecision<'a> {
         let mut continued: Option<RouteModifications> = None;
-        for term in &policy.terms {
+        for (term_index, term) in policy.terms.iter().enumerate() {
             if self.eval_expr(&term.guard, ctx) {
+                if COUNT && let Some(hits) = hits {
+                    hits[term_index].fetch_add(1, Ordering::Relaxed);
+                }
                 match &term.action {
                     TermAction::Permit(mods) => {
                         return match continued {
@@ -206,6 +299,15 @@ impl CompiledChain {
             (PolicyAction::Permit, None) => PolicyDecision::Permit(None),
             (PolicyAction::Deny, _) => PolicyDecision::Deny,
         }
+    }
+
+    /// Evaluate a single guard against this chain's set tables — the
+    /// explain walk's window into the live matcher, so explain and
+    /// evaluation cannot disagree about whether a guard fires (the
+    /// same discipline as the legacy walk sharing
+    /// `PolicyStatement::matches`).
+    pub(crate) fn guard_matches(&self, expr: &MatchExpr, ctx: &RouteContext<'_>) -> bool {
+        self.eval_expr(expr, ctx)
     }
 
     /// Evaluate one guard node. Pure and allocation-free; set/regex
@@ -310,8 +412,7 @@ mod tests {
                 source: PolicySource::Toml,
             }],
             prefix_sets,
-            community_sets: Vec::new(),
-            as_path_regexes: Vec::new(),
+            ..CompiledChain::empty()
         }
     }
 
@@ -402,9 +503,7 @@ mod tests {
                 default_action: PolicyAction::Deny,
                 source: PolicySource::Toml,
             }],
-            prefix_sets: Vec::new(),
-            community_sets: Vec::new(),
-            as_path_regexes: Vec::new(),
+            ..CompiledChain::empty()
         };
 
         let mut hits = chain.zero_term_hits();

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -244,6 +244,14 @@ pub struct CompiledChain {
     pub community_sets: Vec<Arc<CommunitySet>>,
     /// Compiled regexes referenced by [`MatchExpr::AsPathMatches`].
     pub as_path_regexes: Vec<Arc<AsPathRegex>>,
+    /// Source names of `prefix_sets` entries (same indexing), for
+    /// explain rendering. `None` for sets the frontend had no name for
+    /// (the TOML compiler; inline data). Participates in `PartialEq`
+    /// like everything else here: renaming a set changes chain
+    /// identity, which is honest — the rename is a config change.
+    pub prefix_set_names: Vec<Option<String>>,
+    /// Source names of `community_sets` entries (same indexing).
+    pub community_set_names: Vec<Option<String>>,
 }
 
 impl CompiledChain {
@@ -255,6 +263,8 @@ impl CompiledChain {
             prefix_sets: Vec::new(),
             community_sets: Vec::new(),
             as_path_regexes: Vec::new(),
+            prefix_set_names: Vec::new(),
+            community_set_names: Vec::new(),
         }
     }
 

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -21,6 +21,7 @@ pub use engine::explain::{ChainStatementTrace, StatementAttribution, explain_cha
 pub use engine::{
     AsPathRegex, CommunityMatch, NamedPolicy, NeighborSetMatch, NextHopAction, Policy,
     PolicyAction, PolicyChain, PolicyEvaluation, PolicyResult, PolicyStatement, RouteContext,
-    RouteModifications, RouteType, apply_modifications, evaluate_chain,
+    RouteModifications, RouteType, TermHitRow, apply_modifications, evaluate_chain,
     evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
 };
+pub use eval::PolicyHitCounters;

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -99,6 +99,8 @@ pub(super) struct Lowerer<'a> {
     prefix_sets: Vec<Arc<PrefixSet>>,
     community_sets: Vec<Arc<CommunitySet>>,
     as_path_regexes: Vec<Arc<AsPathRegex>>,
+    prefix_set_names: Vec<Option<String>>,
+    community_set_names: Vec<Option<String>>,
     prefix_set_ids: HashMap<String, SetId>,
     community_set_ids: HashMap<String, SetId>,
     regex_ids: HashMap<String, RegexId>,
@@ -113,6 +115,8 @@ impl<'a> Lowerer<'a> {
             prefix_sets: Vec::new(),
             community_sets: Vec::new(),
             as_path_regexes: Vec::new(),
+            prefix_set_names: Vec::new(),
+            community_set_names: Vec::new(),
             prefix_set_ids: HashMap::new(),
             community_set_ids: HashMap::new(),
             regex_ids: HashMap::new(),
@@ -130,6 +134,7 @@ impl<'a> Lowerer<'a> {
             let set = store.prefix_set(&entries);
             let id = SetId(u32::try_from(lowerer.prefix_sets.len()).expect("fits u32"));
             lowerer.prefix_sets.push(set);
+            lowerer.prefix_set_names.push(Some(def.name.node.clone()));
             lowerer.prefix_set_ids.insert(def.name.node.clone(), id);
         }
         for def in &file.community_sets {
@@ -138,6 +143,9 @@ impl<'a> Lowerer<'a> {
             let set = store.community_set(&criteria);
             let id = SetId(u32::try_from(lowerer.community_sets.len()).expect("fits u32"));
             lowerer.community_sets.push(set);
+            lowerer
+                .community_set_names
+                .push(Some(def.name.node.clone()));
             lowerer.community_set_ids.insert(def.name.node.clone(), id);
         }
         // Regexes are interned lazily at each use site (they can be
@@ -163,6 +171,8 @@ impl<'a> Lowerer<'a> {
             prefix_sets: self.prefix_sets.clone(),
             community_sets: self.community_sets.clone(),
             as_path_regexes: self.as_path_regexes.clone(),
+            prefix_set_names: self.prefix_set_names.clone(),
+            community_set_names: self.community_set_names.clone(),
         }
     }
 
@@ -186,6 +196,8 @@ impl<'a> Lowerer<'a> {
             prefix_sets: self.prefix_sets.clone(),
             community_sets: self.community_sets.clone(),
             as_path_regexes: self.as_path_regexes.clone(),
+            prefix_set_names: self.prefix_set_names.clone(),
+            community_set_names: self.community_set_names.clone(),
         }
     }
 

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -246,9 +246,7 @@ fn apply_inlines_the_target_decision() {
     };
     let single = crate::ir::CompiledChain {
         policies: vec![outer.clone()],
-        prefix_sets: chain.prefix_sets.clone(),
-        community_sets: chain.community_sets.clone(),
-        as_path_regexes: chain.as_path_regexes.clone(),
+        ..chain.clone()
     };
     assert_eq!(single.evaluate(&low_med).action, PolicyAction::Deny);
     assert_eq!(single.evaluate(&high_med).action, PolicyAction::Permit);

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -210,7 +210,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -422,7 +422,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -337,7 +337,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -489,7 +489,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let add_path_send_max = if peer_add_path {
                 self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0)
             } else {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -792,7 +792,9 @@ impl RibManager {
 
             // Resolve export policy, sendable families, and RR state before
             // borrowing rib_out (which holds a &mut to self.adj_ribs_out).
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let sendable = self.peer_sendable_families.get(&peer).cloned();
             let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
             let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -230,7 +230,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let target_peer_label = peer.to_string();
             let metrics = self.metrics.clone();
 

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -255,11 +255,37 @@ impl RibManager {
         };
         // Explain is a one-shot operator query path: enrich the deny /
         // permit reason with the terminal-decision policy name but do
-        // NOT increment bgp_policy_routes_total here — the actual
-        // distribution path counts each route once, and double-counting
-        // explain calls would skew the metric.
-        let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
-        let policy_label = evaluation.matched_policy.as_deref().unwrap_or("inline");
+        // NOT increment bgp_policy_routes_total or the ADR-0096
+        // per-term hit counters here — the actual distribution path
+        // counts each route once, and double-counting explain calls
+        // would skew both metrics (hence the IR-level non-counting
+        // evaluation instead of `PolicyChain::evaluate_with_attribution`).
+        let (result, evaluation) = match export_pol {
+            Some(chain) => chain.compiled().evaluate_with_attribution(&ctx),
+            None => (
+                rustbgpd_policy::PolicyResult::permit(),
+                rustbgpd_policy::PolicyEvaluation {
+                    action: PolicyAction::Permit,
+                    matched_policy: None,
+                },
+            ),
+        };
+        // When the deciding chain member is an .rpol policy, extend
+        // the label to `<chain-ref>:<term>` via the statement trace
+        // (explain-only re-walk, pinned to agree with the evaluation
+        // by the policy crate's agreement tests). TOML members carry
+        // no term name and render unchanged.
+        let term_suffix = rustbgpd_policy::explain_chain_statements(export_pol, &ctx)
+            .steps
+            .last()
+            .filter(|step| step.policy_name == evaluation.matched_policy)
+            .and_then(|step| step.term_name.as_deref())
+            .map(|term| format!(":{term}"))
+            .unwrap_or_default();
+        let policy_label = format!(
+            "{}{term_suffix}",
+            evaluation.matched_policy.as_deref().unwrap_or("inline")
+        );
         if result.action != PolicyAction::Permit {
             explain.decision = ExplainDecision::Deny;
             explain.reasons.push(ExplainReason {

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -511,7 +511,9 @@ impl RibManager {
             let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
             let target_peer_asn = self.peer_asn.get(&peer).copied();
             let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
-            let export_pol = self.export_policy_for(peer).cloned();
+            let export_pol = self
+                .export_policy_for(peer)
+                .map(rustbgpd_policy::PolicyChain::share);
             let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
             let add_path_send_max = if peer_add_path {
                 self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0)

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -933,6 +933,9 @@ impl RibManager {
             RibUpdate::QueryNeighborPolicyStats { peer, reply } => {
                 self.handle_query_neighbor_policy_stats(peer, reply);
             }
+            RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
+                self.handle_query_export_policy_term_hits(peer, reply);
+            }
             RibUpdate::ReplacePeerExportPolicy {
                 peer,
                 export_policy,
@@ -1712,6 +1715,49 @@ impl RibManager {
             .copied()
             .unwrap_or_default();
         let _ = reply.send(stats);
+    }
+
+    /// Snapshot the live per-term hit counters of installed export
+    /// chains (ADR-0096 Decision 3.3): one entry per peer with an
+    /// installed chain, plus the shared global fallback instance for
+    /// peers evaluated before any per-peer install. Read-only — no
+    /// counter is touched.
+    fn handle_query_export_policy_term_hits(
+        &mut self,
+        peer: Option<IpAddr>,
+        reply: tokio::sync::oneshot::Sender<Vec<crate::update::ExportPolicyTermHits>>,
+    ) {
+        let snapshot = |owner: Option<IpAddr>,
+                        chain: &rustbgpd_policy::PolicyChain|
+         -> crate::update::ExportPolicyTermHits {
+            crate::update::ExportPolicyTermHits {
+                peer: owner,
+                evals: chain.hit_counters().evals(),
+                terms: chain.term_hit_rows(),
+            }
+        };
+        let mut out = Vec::new();
+        if let Some(peer) = peer {
+            if let Some(chain) = self.export_policy_for(peer) {
+                out.push(snapshot(Some(peer), chain));
+            }
+        } else {
+            let mut peers: Vec<IpAddr> = self
+                .peer_export_policies
+                .iter()
+                .filter_map(|(peer, chain)| chain.as_ref().map(|_| *peer))
+                .collect();
+            peers.sort_unstable();
+            for peer in peers {
+                if let Some(Some(chain)) = self.peer_export_policies.get(&peer) {
+                    out.push(snapshot(Some(peer), chain));
+                }
+            }
+            if let Some(chain) = self.export_policy.as_ref() {
+                out.push(snapshot(None, chain));
+            }
+        }
+        let _ = reply.send(out);
     }
 
     fn handle_query_flowspec_routes(

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -775,7 +775,9 @@ impl RibManager {
         let mut rtc_announce = Vec::new();
         let mut rtc_withdraw = Vec::new();
         let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> = HashSet::new();
-        let export_pol = self.export_policy_for(peer).cloned();
+        let export_pol = self
+            .export_policy_for(peer)
+            .map(rustbgpd_policy::PolicyChain::share);
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
         let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -600,7 +600,9 @@ impl RibManager {
         let mut labeled_withdraw = Vec::new();
         let mut rtc_announce = Vec::new();
         let mut rtc_withdraw = Vec::new();
-        let export_pol = self.export_policy_for(peer).cloned();
+        let export_pol = self
+            .export_policy_for(peer)
+            .map(rustbgpd_policy::PolicyChain::share);
         let sendable = self.peer_sendable_families.get(&peer).cloned();
         let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
         let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());

--- a/crates/rib/src/manager/tests/policy.rs
+++ b/crates/rib/src/manager/tests/policy.rs
@@ -1173,3 +1173,142 @@ async fn peer_down_cleans_up_export_policy() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// ADR-0096 explain slice: when the deciding export-chain member is an
+/// `.rpol` policy, the explain reason labels the decision
+/// `<chain-ref>:<term>`, and the live per-term hit counters are
+/// queryable — with explain itself not counting (side-effect-free).
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one end-to-end walk: install, distribute, explain, query counters"
+)]
+async fn explain_names_rpol_term_and_term_hit_counters_are_queryable() {
+    const RPOL: &str = r"
+policy no-doc {
+    term block-doc {
+        if route.prefix == 203.0.113.0/24 { reject }
+    }
+}
+";
+    let file = rustbgpd_policy::rpol::RpolFile::parse(RPOL).expect("clean rpol");
+    let mut store = rustbgpd_policy::sets::SetStore::new();
+    let compiled = file
+        .compile_policy("no-doc", &[], &mut store)
+        .expect("policy exists");
+    let chain =
+        rustbgpd_policy::PolicyChain::from_named(vec![rustbgpd_policy::NamedPolicy::from_rpol(
+            "no-doc".to_string(),
+            Arc::new(compiled),
+        )]);
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(8);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: target,
+        peer_asn: 65002,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        outbound_tx: out_tx,
+        export_policy: Some(chain),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    // One route the rpol term rejects, one it falls through to permit.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![
+            make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+                Ipv4Addr::new(10, 0, 0, 1),
+            ),
+            make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+                Ipv4Addr::new(10, 0, 0, 1),
+            ),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24));
+    let explain = query_explain_advertised_route(&tx, target, prefix).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    assert_eq!(explain.reasons[0].code, "policy_denied");
+    assert!(
+        explain.reasons[0].message.contains("no-doc:block-doc"),
+        "expected the deciding rpol term in the label, got {:?}",
+        explain.reasons[0].message
+    );
+
+    // Live counters: the two distributed routes evaluated once each;
+    // the deny term matched exactly one. The explain above must not
+    // have counted (side-effect-free read).
+    let hits = {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryExportPolicyTermHits {
+            peer: None,
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        reply_rx.await.unwrap()
+    };
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].peer, Some(target));
+    assert_eq!(hits[0].evals, 2);
+    assert_eq!(hits[0].terms.len(), 1);
+    assert_eq!(hits[0].terms[0].policy.as_deref(), Some("no-doc"));
+    assert_eq!(hits[0].terms[0].term.as_deref(), Some("block-doc"));
+    assert_eq!(hits[0].terms[0].hits, 1);
+
+    // The peer-filtered form answers the same; an unknown peer answers
+    // empty.
+    let filtered = {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryExportPolicyTermHits {
+            peer: Some(target),
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        reply_rx.await.unwrap()
+    };
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].terms[0].hits, 1);
+    let missing = {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryExportPolicyTermHits {
+            peer: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))),
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        reply_rx.await.unwrap()
+    };
+    assert!(missing.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -92,6 +92,20 @@ pub struct NeighborPolicyStats {
     pub export_policy_routes_denied: u64,
 }
 
+/// Per-term hit-counter snapshot for one installed export chain
+/// (`RibUpdate::QueryExportPolicyTermHits`).
+#[derive(Debug, Clone)]
+pub struct ExportPolicyTermHits {
+    /// Peer the chain is installed for; `None` = the shared global
+    /// fallback chain instance (peers evaluated against the fallback
+    /// before any per-peer install).
+    pub peer: Option<IpAddr>,
+    /// Routes evaluated through the chain since install.
+    pub evals: u64,
+    /// Per-term labeled hit counts, in chain walk order.
+    pub terms: Vec<rustbgpd_policy::TermHitRow>,
+}
+
 /// Typed error for API-visible RIB command replies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RibCommandError {
@@ -613,6 +627,16 @@ pub enum RibUpdate {
         peer: IpAddr,
         /// Response channel.
         reply: oneshot::Sender<NeighborPolicyStats>,
+    },
+    /// Query: snapshot the live per-term guard-hit counters of the
+    /// installed export chains (ADR-0096 Decision 3.3). Counters
+    /// accumulate since a chain instance was installed and reset when
+    /// it is replaced.
+    QueryExportPolicyTermHits {
+        /// Optional peer filter; `None` = every installed chain.
+        peer: Option<IpAddr>,
+        /// Response channel.
+        reply: oneshot::Sender<Vec<ExportPolicyTermHits>>,
     },
     /// Replace the effective export policy for a peer and resync outbound state.
     ReplacePeerExportPolicy {

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 97,
+  "method_count": 98,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 55,
+    "sensitive_read": 56,
     "mutating": 19,
     "operator_only": 23
   },
@@ -56,6 +56,7 @@
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborImportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborImportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ExplainImportPolicy", "path": "/rustbgpd.v1.PolicyService/ExplainImportPolicy", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "TestPolicy", "path": "/rustbgpd.v1.PolicyService/TestPolicy", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.PolicyService", "method": "GetPolicyStats", "path": "/rustbgpd.v1.PolicyService/GetPolicyStats", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborExportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborExportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PeerGroupService", "method": "ListPeerGroups", "path": "/rustbgpd.v1.PeerGroupService/ListPeerGroups", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PeerGroupService", "method": "GetPeerGroup", "path": "/rustbgpd.v1.PeerGroupService/GetPeerGroup", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -88,7 +88,7 @@ shape itself does not raise the tier.
 | `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. |
 | `SetGracefulShutdown` | `operator_only` | Network-wide when `address` is empty; listed here because the proto puts it in `NeighborService`. |
 
-### PolicyService (20 RPCs)
+### PolicyService (21 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -111,6 +111,7 @@ shape itself does not raise the tier.
 | `ClearNeighborImportChain` | `mutating` | Per-neighbor. |
 | `ExplainImportPolicy` | `sensitive_read` | ADR-0073. Reads the per-session import-decision cache to explain why a prefix was permitted / denied / withdrawn on import. Side-effect-free; no RIB or counter mutation. |
 | `TestPolicy` | `sensitive_read` | ADR-0096. Compiles a submitted .rpol policy server-side and dry-runs it read-only over a live-RIB snapshot (counts, per-term hits, before/after diffs). Side-effect-free; no RIB, session, or counter mutation. |
+| `GetPolicyStats` | `sensitive_read` | ADR-0096 Decision 3.3. Snapshots the live per-term guard-hit counters of installed export chains (since chain install; reset on chain replace). Discloses policy structure and traffic shape. Side-effect-free; does not reset counters. |
 | `ClearNeighborExportChain` | `mutating` | Per-neighbor. |
 
 ### PeerGroupService (6 RPCs)
@@ -215,13 +216,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 55 | 56.7% |
-| `mutating` | 19 | 19.6% |
-| `operator_only` | 23 | 23.7% |
-| **Total** | **97** | **100%** |
+| `sensitive_read` | 56 | 57.1% |
+| `mutating` | 19 | 19.4% |
+| `operator_only` | 23 | 23.5% |
+| **Total** | **98** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 97
-total is 93 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 98
+total is 94 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -412,6 +412,68 @@ Per-term hit counters answer "which term is doing the work" (the
 IOS-XR `show pcl` idea); a term lowered to several IR steps reports as
 `name.1`, `name.2`, ....
 
+### Explain — which term decided, and why
+
+`.rpol` policies are first-class citizens of the daemon's explain
+surfaces (ADR-0073 / ADR-0096 Decision 3.3):
+
+- **`rbgp policy explain --neighbor A --prefix P`** (import): when the
+  deciding chain member is an `.rpol` policy, the statement trace
+  names the deciding **term** and lists every evaluated term with its
+  guard rendered back to `.rpol` syntax and a matched / not-matched
+  verdict:
+
+  ```console
+  $ rbgp policy explain --neighbor 10.0.0.2 --prefix 10.10.1.0/24
+  import policy explain — peer 10.0.0.2 prefix 10.10.1.0/24 (policy generation 3)
+    permit
+      policy:  customer-in(200)
+      statements:
+        [0] policy customer-in(200) term customer-routes permit  match: guard route.prefix in customers  set: local_pref 100 -> 200
+          term rpki-guard: route.rpki == invalid => reject [not matched]
+          term customer-routes: route.prefix in customers => set local-pref 200; accept [matched]
+  ```
+
+  Guards render with sets shown by their source name; terms after the
+  deciding one were never evaluated and carry no line. A term that
+  modified without a verdict shows as `... => set med 5; continue`.
+- **`rbgp rib advertised --explain`** (`ExplainAdvertisedRoute`,
+  export): the policy attribution extends to `<chain-ref>:<term>` when
+  the deciding member is `.rpol` — e.g.
+  `export policy "customer-in(200):transit-guard" denied this route`.
+  TOML members render unchanged.
+
+### `rbgp policy stats` — live per-term hit counters
+
+Where `policy test` counts hits over a one-shot dry run, `rbgp policy
+stats` reads the **live** counters of the chains actually installed on
+the daemon: every route evaluated on the export path bumps its matched
+terms' counters (relaxed atomics — no measurable eval cost), and the
+query snapshots them without resetting anything (`SensitiveRead`).
+
+```console
+$ rbgp policy stats --peer 10.0.0.2
+10.0.0.2 export chain — 1204 routes evaluated since install
+  POLICY                           TERM                     HITS
+  customer-in(200)                 rpki-guard               3
+  customer-in(200)                 customer-routes          990
+  bogon-filter                     bogons                   211
+```
+
+- Counters read as **since chain install**: replacing a peer's chain
+  (policy reload / hot-apply / gNMI Set) installs a fresh instance and
+  resets its counters to zero. A session flap does not reset the
+  RIB-side export counters (the chain instance survives).
+- TOML chain members count too; their unnamed statements report by
+  `term_index` (`statement 0`, `statement 1`, ...).
+- V1 surfaces the **export** direction (the RIB manager owns those
+  chains). Import-side counters accumulate identically inside each
+  session but have no read surface yet; `--direction import` says so
+  explicitly rather than guessing.
+- Explain queries and `policy test` dry runs never move these
+  counters — only live route evaluation counts.
+- `--json` emits the rows structurally.
+
 ## Deliberate V1 exclusions
 
 No loops, no user-defined types, no maps (safety is total by

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -503,6 +503,18 @@ service PolicyService {
   // affected, no policy counters increment. V1 scope is IPv4 / IPv6
   // unicast routes.
   rpc TestPolicy(TestPolicyRequest) returns (TestPolicyResponse);
+
+  // GetPolicyStats — live per-term guard-hit counters for installed
+  // policy chains (ADR-0096 Decision 3.3, the IOS-XR "show pcl" idea).
+  // Counters accumulate on the live evaluation path since a chain
+  // instance was installed and reset when the chain is replaced
+  // (policy reload / hot-apply installs a fresh instance). V1 surfaces
+  // the export direction (the RIB manager owns those chains); import
+  // counters accumulate in the session tasks but have no read surface
+  // yet.
+  //
+  // Side-effect free read; does not reset any counter.
+  rpc GetPolicyStats(GetPolicyStatsRequest) returns (GetPolicyStatsResponse);
 }
 
 service PeerGroupService {
@@ -917,8 +929,22 @@ message ImportExplainStatementStep {
   // Rendered attribute modifications this statement contributes, with
   // "before -> after" for scalar attributes (the before side is the
   // route's pre-policy value — chain modifications accumulate and
-  // apply once, so later statements never see earlier edits).
+  // apply once, so later statements never see earlier edits). For an
+  // rpol member this is the policy's merged contribution: matched
+  // continue-terms folded under the deciding permit, mirroring the
+  // live evaluator's merge.
   repeated string modifications = 7;
+  // rpol term name of the deciding term (ADR-0096). Empty for TOML
+  // statements and for default-action fallthroughs.
+  string term = 8;
+  // Per-term rendered trace lines for an rpol member, in walk order:
+  // "term NAME: GUARD => ACTION [matched|not matched]". Guards render
+  // in rpol surface syntax with sets shown by their source name;
+  // human-oriented, not a machine-parsable grammar. Terms after the
+  // deciding one were never evaluated and carry no line; on a
+  // default-action fallthrough every term appears. Empty for TOML
+  // members.
+  repeated string term_traces = 9;
 }
 
 message ExplainImportPolicyResponse {
@@ -987,6 +1013,51 @@ message TestPolicyDiff {
   // Human-readable attribute changes, e.g. "local_pref 100 - 200" or
   // "communities + 65001:999".
   repeated string changes = 4;
+}
+
+message GetPolicyStatsRequest {
+  // Optional peer filter (IPv4 or IPv6 literal). Empty = every peer
+  // with an installed chain.
+  string peer_address = 1;
+  // Direction filter: "export" (the default when empty). "import" is
+  // reserved — the daemon rejects it until the import-side read
+  // surface lands.
+  string direction = 2;
+}
+
+// One term's live hit counter within an installed chain.
+message PolicyTermStat {
+  // 0-based position of the policy within the chain.
+  uint32 policy_index = 1;
+  // Chain-member name. Empty when the policy is inline / anonymous
+  // (operators read "inline").
+  string policy = 2;
+  // 0-based term index within the policy.
+  uint32 term_index = 3;
+  // rpol term name (multi-step rpol terms are suffixed ".1", ".2", ...
+  // by the compiler). Empty for TOML statements — address those by
+  // term_index.
+  string term = 4;
+  // Times this term's guard matched since chain install.
+  uint64 hits = 5;
+}
+
+// Live counters for one installed chain instance.
+message PolicyChainStats {
+  // Peer the chain is installed for. "global" for the shared global
+  // fallback chain instance (peers evaluated against the fallback
+  // before any per-peer install).
+  string peer_address = 1;
+  // "export" (import arrives with the import-side read surface).
+  string direction = 2;
+  // Routes evaluated through this chain since install — the
+  // denominator for the per-term hit counts.
+  uint64 routes_evaluated = 3;
+  repeated PolicyTermStat terms = 4;
+}
+
+message GetPolicyStatsResponse {
+  repeated PolicyChainStats chains = 1;
 }
 
 message TestPolicyResponse {


### PR DESCRIPTION
**PR-4 of the ADR-0096 arc**: rpol policies are fully explainable.

- **Per-term traces** through the existing explain surfaces: each evaluated term renders `term NAME: GUARD => ACTION [matched|not matched]` (guard evaluation shares the live evaluator's matcher — explain ≡ eval by construction, pinned term-by-term against `evaluate_recording_hits` incl. Continue + fallthrough). Additive proto only.
- **Guard pretty-printer** with golden tests; set names preserved through lowering/splicing (surgical `CompiledChain` addition).
- **Live per-term hit counters** at the single eval choke point (both seams count; relaxed atomics; excluded from Eq/Clone so planner-diff semantics hold), read via new `GetPolicyStats` → `rbgp policy stats`. Export-side read ships now; the import-side read relay is a documented follow-up (`--direction import` returns Unimplemented with the message).
- **Real bug found + fixed**: RIB distribution `.cloned()` policy chains per pass — discarding compiled IR (recompile every distribution cycle) and counters. New `PolicyChain::share()` shares both; 9 sites switched.
- `ExplainAdvertisedRoute` names the deciding rpol term (`chain-ref:term`).

Bench: realistic groups −4 to −12% (improved); nano-scale deltas below host noise (quiet-runner re-measure is the standing deferred step). 63 binaries green; authz inventory 98.