### PR TITLE
fix(policy): satisfy the clippy-reason ratchet in the rpol frontend

### DIFF
--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -362,7 +362,6 @@ impl<'a> Lowerer<'a> {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 fn lower_cmp(
     field: &super::ast::FieldPath,
     op: CmpOp,

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -290,7 +290,10 @@ impl Checker<'_> {
 
     // ── expressions ─────────────────────────────────────────────────
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "exhaustive per-field/type dispatch; splitting would scatter the match"
+    )]
     fn check_expr(&mut self, expr: &Expr, params: &[&str]) {
         match expr {
             Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
@@ -409,7 +412,6 @@ impl Checker<'_> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     fn check_cmp(&mut self, field: &FieldPath, op: CmpOp, rhs: &Rhs, params: &[&str]) {
         let resolved = match resolve_field(field) {
             Ok(resolved) => resolved,


### PR DESCRIPTION
The check-clippy-reasons ratchet (not cargo clippy, hence green local gates) flagged three reason-less `#[allow(clippy::too_many_lines)]` from #655. Converting to `#[expect(..., reason)]` revealed two were unfulfilled — the allows were masking that `lower_cmp` and `check_cmp` don't trip the lint at all. Dropped those two; `check_expr` keeps the one real expect with a reason. Ratchet + clippy -D warnings + fmt verified.