### PR TITLE
feat(bmp): export post-policy Adj-RIB-Out route monitoring (RFC 8671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   IR + counter set per installed chain instead of recompiling per
   pass); import-side counters accumulate but their read surface is a
   follow-up. See the explain/stats chapter in `docs/rpol-language.md`.
+- **RFC 8671 post-policy Adj-RIB-Out BMP monitoring.** Per-collector
+  `monitor = ["rib_in_pre", "rib_out_post"]` selection on
+  `[[bmp.collectors]]` (default `["rib_in_pre"]` -- existing behavior
+  unchanged). With `rib_out_post`, every outbound UPDATE --
+  announcements, withdraws, and End-of-RIB markers across all address
+  families -- is mirrored to the collector byte-exact as transmitted,
+  with the per-peer header O flag (Adj-RIB-Out) and L flag
+  (post-policy) set and the remote peer's identity / advertise-time in
+  the header. Periodic Stats Reports now also carry the RFC 8671
+  gauges: type 15 (post-policy Adj-RIB-Out total) and type 17 (per
+  AFI/SAFI), sourced from per-peer Adj-RIB-Out sizes. The rib-out
+  stream is live-only (no table dump on collector connect -- see
+  KNOWN_ISSUES). Pre-policy Adj-RIB-Out is deliberately not
+  implemented.
 
 - **`.rpol` policies in the running daemon (ADR-0096 slice 3): config
   references, hot reload, and the `rbgp policy test` live-RIB dry

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -99,6 +99,17 @@ resolved.
 
 ## Limitations (by design, not bugs)
 
+- **BMP route-monitoring streams are live-only — no table dump on
+  collector (re)connect.** A collector that connects mid-life receives
+  the cached Peer Up replay but no synthesized Route Monitoring dump of
+  the current table contents: the RFC 8671 post-policy Adj-RIB-Out
+  stream (`monitor = ["rib_out_post"]`) starts at the next outbound
+  UPDATE, exactly as the pre-policy Adj-RIB-In stream has always
+  started at the next inbound UPDATE. Collectors should connect before
+  sessions establish (or trigger a route refresh) to observe full
+  state. Dump synthesis is planned alongside the Loc-Rib BMP slice's
+  replay machinery.
+
 - **Commit-confirmed config transactions do not survive a daemon restart.**
   The confirm timer and the captured pre-commit rollback snapshot are held in
   memory only. A restart inside the confirm window leaves the already-committed

--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -40,14 +40,16 @@ const BMP_TERM_TLV_REASON: u16 = 1;
 const PEER_FLAG_V: u8 = 0x80; // IPv6 peer
 const PEER_FLAG_L: u8 = 0x40; // Post-policy
 const PEER_FLAG_A: u8 = 0x20; // 2-byte AS in per-peer header (legacy)
+const PEER_FLAG_O: u8 = 0x10; // Adj-RIB-Out (RFC 8671)
 
 /// Stat counter for Stats Report messages.
 ///
 /// RFC 7854 numeric stat types (4-byte or 8-byte `Stat Data`):
 /// - 32-bit: 0-6, 11-13
-/// - 64-bit: 7-8
+/// - 64-bit: 7-8, plus RFC 8671 Adj-RIB-Out gauges 14-15
 ///
-/// AFI/SAFI-qualified stat types 9-10 must use [`AfiStatCounter`].
+/// AFI/SAFI-qualified stat types 9-10 and 16-17 must use
+/// [`AfiStatCounter`].
 #[derive(Debug, Clone)]
 pub struct StatCounter {
     /// RFC 7854 stat type code (0-8, 11-13).
@@ -56,11 +58,11 @@ pub struct StatCounter {
     pub value: u64,
 }
 
-/// AFI/SAFI-qualified stat counter (RFC 7854 stat types 9-10).
-/// Payload: AFI(2) + SAFI(1) + count(8).
+/// AFI/SAFI-qualified stat counter (RFC 7854 stat types 9-10,
+/// RFC 8671 types 16-17). Payload: AFI(2) + SAFI(1) + count(8).
 #[derive(Debug, Clone)]
 pub struct AfiStatCounter {
-    /// RFC 7854 stat type code (9 or 10).
+    /// Stat type code (9, 10, 16, or 17).
     pub stat_type: u16,
     /// Address Family Identifier.
     pub afi: u16,
@@ -76,8 +78,8 @@ fn numeric_stat_size(stat_type: u16) -> Option<usize> {
     match stat_type {
         // 4-byte counters: types 0-6, 11-13
         0..=6 | 11..=13 => Some(4),
-        // 64-bit gauges: types 7-8
-        7 | 8 => Some(8),
+        // 64-bit gauges: types 7-8, RFC 8671 Adj-RIB-Out types 14-15
+        7 | 8 | 14 | 15 => Some(8),
         // AFI/SAFI-qualified and unknown type formats are not encoded
         // by this numeric-only helper.
         _ => None,
@@ -85,7 +87,7 @@ fn numeric_stat_size(stat_type: u16) -> Option<usize> {
 }
 
 fn is_afi_stat(stat_type: u16) -> bool {
-    matches!(stat_type, 9 | 10)
+    matches!(stat_type, 9 | 10 | 16 | 17)
 }
 
 /// Encode the per-peer header (42 bytes, RFC 7854 §4.2).
@@ -101,6 +103,9 @@ fn encode_per_peer_header(info: &BmpPeerInfo, buf: &mut BytesMut) {
     }
     if !info.is_as4 {
         flags |= PEER_FLAG_A;
+    }
+    if info.is_rib_out {
+        flags |= PEER_FLAG_O;
     }
     buf.put_u8(flags);
 
@@ -380,6 +385,7 @@ mod tests {
             peer_type: BmpPeerType::Global,
             is_ipv6: false,
             is_post_policy: false,
+            is_rib_out: false,
             is_as4: true,
             timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
         }
@@ -399,7 +405,8 @@ mod tests {
 
         let expected_flags = if info.is_ipv6 { PEER_FLAG_V } else { 0 }
             | if info.is_post_policy { PEER_FLAG_L } else { 0 }
-            | if info.is_as4 { 0 } else { PEER_FLAG_A };
+            | if info.is_as4 { 0 } else { PEER_FLAG_A }
+            | if info.is_rib_out { PEER_FLAG_O } else { 0 };
         assert_eq!(buf[1], expected_flags, "flags");
 
         let asn = u32::from_be_bytes([buf[26], buf[27], buf[28], buf[29]]);
@@ -581,6 +588,91 @@ mod tests {
         info.peer_addr = IpAddr::V6("2001:db8::2".parse().unwrap());
         let msg = encode_route_monitoring(&info, &[0u8; 23]);
         assert_ne!(msg[BMP_COMMON_HEADER_LEN + 1] & PEER_FLAG_V, 0);
+    }
+
+    /// RFC 8671 golden bytes: post-policy Adj-RIB-Out route monitoring
+    /// carries O(0x10) + L(0x40) in the per-peer header flags, with the
+    /// version-3 common header and the exact PDU bytes.
+    #[test]
+    fn rib_out_route_monitoring_sets_o_and_l_flags() {
+        let mut info = sample_peer_info();
+        info.is_rib_out = true;
+        info.is_post_policy = true;
+        let pdu = [0xAB; 23];
+        let msg = encode_route_monitoring(&info, &pdu);
+        verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
+        assert_eq!(msg[0], 3, "BMP version 3");
+        assert_eq!(
+            msg[BMP_COMMON_HEADER_LEN + 1],
+            PEER_FLAG_O | PEER_FLAG_L,
+            "flags must be exactly O|L for post-policy Adj-RIB-Out"
+        );
+        assert_eq!(&msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..], &pdu);
+    }
+
+    /// Non-route-monitoring messages built from the normal (rib-in)
+    /// peer info keep O=0 — RFC 8671 receivers SHOULD ignore O in Peer
+    /// Up/Down, and we never set it there.
+    #[test]
+    fn non_route_monitoring_messages_keep_o_flag_clear() {
+        let info = sample_peer_info();
+        let peer_up = encode_peer_up(
+            &info,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            179,
+            12345,
+            &[0xFF; 29],
+            &[0xFE; 29],
+        );
+        let peer_down = encode_peer_down(&info, &PeerDownReason::RemoteNoNotification);
+        let stats = encode_stats_report(&info, &[], &[]);
+        for msg in [&peer_up, &peer_down, &stats] {
+            assert_eq!(
+                msg[BMP_COMMON_HEADER_LEN + 1] & PEER_FLAG_O,
+                0,
+                "O flag must be clear on non-route-monitoring messages"
+            );
+        }
+    }
+
+    /// RFC 8671 stat type 15 (post-policy Adj-RIB-Out total) is a
+    /// 64-bit gauge; type 17 is its per-AFI/SAFI variant.
+    #[test]
+    fn rib_out_stats_15_and_17_encoding() {
+        let info = sample_peer_info();
+        let counters = vec![StatCounter {
+            stat_type: 15,
+            value: 0x0102_0304_0506_0708,
+        }];
+        let afi_counters = vec![AfiStatCounter {
+            stat_type: 17,
+            afi: 2,
+            safi: 128,
+            value: 77,
+        }];
+        let msg = encode_stats_report(&info, &counters, &afi_counters);
+        verify_common_header(&msg, BMP_MSG_STATS_REPORT);
+        let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
+        let count = u32::from_be_bytes(msg[count_offset..count_offset + 4].try_into().unwrap());
+        assert_eq!(count, 2);
+        // Type 15: type(2)=15, len(2)=8, value(8)
+        let s = count_offset + 4;
+        assert_eq!(u16::from_be_bytes([msg[s], msg[s + 1]]), 15);
+        assert_eq!(u16::from_be_bytes([msg[s + 2], msg[s + 3]]), 8);
+        assert_eq!(
+            u64::from_be_bytes(msg[s + 4..s + 12].try_into().unwrap()),
+            0x0102_0304_0506_0708
+        );
+        // Type 17: type(2)=17, len(2)=11, AFI(2)=2, SAFI(1)=128, value(8)
+        let t = s + 12;
+        assert_eq!(u16::from_be_bytes([msg[t], msg[t + 1]]), 17);
+        assert_eq!(u16::from_be_bytes([msg[t + 2], msg[t + 3]]), 11);
+        assert_eq!(u16::from_be_bytes([msg[t + 4], msg[t + 5]]), 2);
+        assert_eq!(msg[t + 6], 128);
+        assert_eq!(
+            u64::from_be_bytes(msg[t + 7..t + 15].try_into().unwrap()),
+            77
+        );
     }
 
     #[test]

--- a/crates/bmp/src/lib.rs
+++ b/crates/bmp/src/lib.rs
@@ -1,7 +1,8 @@
-//! rustbgpd-bmp — BMP exporter (RFC 7854)
+//! rustbgpd-bmp — BMP exporter (RFC 7854, RFC 8671)
 //!
 //! Unidirectional BGP Monitoring Protocol exporter. Streams BGP
-//! session state and raw UPDATE PDUs to configured collectors.
+//! session state and raw UPDATE PDUs to configured collectors,
+//! including post-policy Adj-RIB-Out monitoring (RFC 8671).
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -15,5 +16,6 @@ pub mod types;
 pub use client::BmpClient;
 pub use manager::BmpManager;
 pub use types::{
-    BmpClientConfig, BmpControlEvent, BmpEvent, BmpPeerInfo, BmpPeerType, PeerDownReason,
+    BmpClientConfig, BmpControlEvent, BmpEvent, BmpMonitorFilter, BmpPeerInfo, BmpPeerType,
+    PeerDownReason,
 };

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -11,16 +11,16 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::codec;
-use crate::types::{BmpControlEvent, BmpEvent};
+use crate::types::{BmpControlEvent, BmpEvent, BmpMonitorFilter};
 
 /// BMP manager that fans out encoded messages to all collectors.
 pub struct BmpManager {
     event_rx: mpsc::Receiver<BmpEvent>,
     control_rx: mpsc::Receiver<BmpControlEvent>,
-    /// Per-collector address + sender, paired by index. The address is
-    /// the operator-facing identifier used as the `collector` label on
-    /// `bmp_*` Prometheus counters.
-    collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>)>,
+    /// Per-collector address + sender + monitoring filter, paired by
+    /// index. The address is the operator-facing identifier used as the
+    /// `collector` label on `bmp_*` Prometheus counters.
+    collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>, BmpMonitorFilter)>,
     /// Latest encoded `PeerUp` message per peer address.
     peer_up_cache: std::collections::HashMap<std::net::IpAddr, Bytes>,
     metrics: BgpMetrics,
@@ -32,7 +32,7 @@ impl BmpManager {
     pub fn new(
         event_rx: mpsc::Receiver<BmpEvent>,
         control_rx: mpsc::Receiver<BmpControlEvent>,
-        collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>)>,
+        collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>, BmpMonitorFilter)>,
         metrics: BgpMetrics,
     ) -> Self {
         Self {
@@ -101,14 +101,32 @@ impl BmpManager {
             BmpEvent::StatsReport {
                 peer_info,
                 adj_rib_in_routes,
-            } => codec::encode_stats_report(
-                peer_info,
-                &[codec::StatCounter {
+                adj_rib_out_post,
+            } => {
+                let mut counters = vec![codec::StatCounter {
                     stat_type: 7,
                     value: *adj_rib_in_routes,
-                }],
-                &[],
-            ),
+                }];
+                let mut afi_counters = Vec::new();
+                // RFC 8671: type 15 = post-policy Adj-RIB-Out total,
+                // type 17 = its per-AFI/SAFI breakdown. Omitted when
+                // the counts were unavailable this tick.
+                if let Some(per_family) = adj_rib_out_post {
+                    counters.push(codec::StatCounter {
+                        stat_type: 15,
+                        value: per_family.iter().map(|(_, _, count)| count).sum(),
+                    });
+                    for &(afi, safi, value) in per_family {
+                        afi_counters.push(codec::AfiStatCounter {
+                            stat_type: 17,
+                            afi,
+                            safi,
+                            value,
+                        });
+                    }
+                }
+                codec::encode_stats_report(peer_info, &counters, &afi_counters)
+            }
         }
     }
 
@@ -125,7 +143,21 @@ impl BmpManager {
                 let encoded = Self::encode_event(event);
                 self.fan_out(&encoded);
             }
-            BmpEvent::RouteMonitoring { .. } | BmpEvent::StatsReport { .. } => {
+            // Route monitoring is the only per-collector-filtered
+            // message: rib-in RM only to `rib_in_pre` collectors,
+            // rib-out RM only to `rib_out_post` collectors.
+            BmpEvent::RouteMonitoring { peer_info, .. } => {
+                let encoded = Self::encode_event(event);
+                let rib_out = peer_info.is_rib_out;
+                self.fan_out_filtered(&encoded, |f| {
+                    if rib_out {
+                        f.rib_out_post
+                    } else {
+                        f.rib_in_pre
+                    }
+                });
+            }
+            BmpEvent::StatsReport { .. } => {
                 let encoded = Self::encode_event(event);
                 self.fan_out(&encoded);
             }
@@ -167,7 +199,7 @@ impl BmpManager {
     }
 
     fn replay_peer_up_to_collector(&self, collector_id: usize) {
-        let Some((addr, tx)) = self.collectors.get(collector_id) else {
+        let Some((addr, tx, _)) = self.collectors.get(collector_id) else {
             warn!(
                 collector_id,
                 "BMP replay target collector index out of range, skipping"
@@ -201,7 +233,14 @@ impl BmpManager {
     }
 
     fn fan_out(&self, msg: &Bytes) {
-        for (addr, tx) in &self.collectors {
+        self.fan_out_filtered(msg, |_| true);
+    }
+
+    fn fan_out_filtered(&self, msg: &Bytes, want: impl Fn(&BmpMonitorFilter) -> bool) {
+        for (addr, tx, filter) in &self.collectors {
+            if !want(filter) {
+                continue;
+            }
             if let Err(e) = tx.try_send(msg.clone()) {
                 let reason = trysend_reason(&e);
                 self.metrics
@@ -245,6 +284,7 @@ mod tests {
             peer_type: BmpPeerType::Global,
             is_ipv6: false,
             is_post_policy: false,
+            is_rib_out: false,
             is_as4: true,
             timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
         }
@@ -260,7 +300,10 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c1_tx), (collector_addr(1), c2_tx)],
+            vec![
+                (collector_addr(0), c1_tx, BmpMonitorFilter::default()),
+                (collector_addr(1), c2_tx, BmpMonitorFilter::default()),
+            ],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -291,6 +334,80 @@ mod tests {
         handle.await.unwrap();
     }
 
+    /// Per-collector monitor filtering: collector A monitors rib-in
+    /// only (default), collector B monitors both. A rib-in RM reaches
+    /// both; a rib-out RM reaches only B. Non-RM messages (stats)
+    /// reach both regardless.
+    #[tokio::test]
+    async fn route_monitoring_filtered_per_collector_monitor_selection() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (a_tx, mut a_rx) = mpsc::channel(16);
+        let (b_tx, mut b_rx) = mpsc::channel(16);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![
+                (collector_addr(0), a_tx, BmpMonitorFilter::default()),
+                (
+                    collector_addr(1),
+                    b_tx,
+                    BmpMonitorFilter {
+                        rib_in_pre: true,
+                        rib_out_post: true,
+                    },
+                ),
+            ],
+            BgpMetrics::new(),
+        );
+        let handle = tokio::spawn(mgr.run());
+
+        // Rib-out RM: only collector B.
+        let mut rib_out_info = sample_peer_info();
+        rib_out_info.is_rib_out = true;
+        rib_out_info.is_post_policy = true;
+        event_tx
+            .send(BmpEvent::RouteMonitoring {
+                peer_info: rib_out_info,
+                update_pdu: Bytes::from_static(&[0xBB; 23]),
+            })
+            .await
+            .unwrap();
+
+        // Rib-in RM: both collectors.
+        event_tx
+            .send(BmpEvent::RouteMonitoring {
+                peer_info: sample_peer_info(),
+                update_pdu: Bytes::from_static(&[0xAA; 23]),
+            })
+            .await
+            .unwrap();
+
+        // B sees rib-out first (O flag set), then rib-in.
+        let b_first = b_rx.recv().await.unwrap();
+        assert_eq!(b_first[5], 0, "route monitoring type");
+        assert_ne!(b_first[6 + 1] & 0x10, 0, "O flag set on rib-out RM");
+        assert_ne!(b_first[6 + 1] & 0x40, 0, "L flag set on rib-out RM");
+        let b_second = b_rx.recv().await.unwrap();
+        assert_eq!(b_second[6 + 1] & 0x10, 0, "O flag clear on rib-in RM");
+
+        // A sees only the rib-in RM — the rib-out one was filtered.
+        let a_first = a_rx.recv().await.unwrap();
+        assert_eq!(a_first[5], 0);
+        assert_eq!(a_first[6 + 1] & 0x10, 0, "collector A must not see rib-out");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), a_rx.recv())
+                .await
+                .is_err(),
+            "collector A (rib-in only) must not receive the rib-out RM"
+        );
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
     #[tokio::test]
     async fn manager_handles_peer_up() {
         let (event_tx, event_rx) = mpsc::channel(16);
@@ -300,7 +417,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx)],
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -334,7 +451,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx)],
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -364,7 +481,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx)],
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -373,12 +490,25 @@ mod tests {
             .send(BmpEvent::StatsReport {
                 peer_info: sample_peer_info(),
                 adj_rib_in_routes: 42,
+                adj_rib_out_post: Some(vec![(1, 1, 10), (2, 1, 5)]),
             })
             .await
             .unwrap();
 
         let msg = c_rx.recv().await.unwrap();
         assert_eq!(msg[5], 1); // Stats Report type
+        // Stats count at offset 6 (common hdr) + 42 (per-peer hdr):
+        // type 7 + type 15 + two type-17 entries = 4.
+        let count = u32::from_be_bytes(msg[48..52].try_into().unwrap());
+        assert_eq!(count, 4);
+        // First: type 7 (len 8, value 42). Second: type 15 = sum 15.
+        assert_eq!(u16::from_be_bytes([msg[52], msg[53]]), 7);
+        assert_eq!(u64::from_be_bytes(msg[56..64].try_into().unwrap()), 42);
+        assert_eq!(u16::from_be_bytes([msg[64], msg[65]]), 15);
+        assert_eq!(u64::from_be_bytes(msg[68..76].try_into().unwrap()), 15);
+        // Then the two AFI/SAFI-qualified type-17 entries.
+        assert_eq!(u16::from_be_bytes([msg[76], msg[77]]), 17);
+        assert_eq!(u16::from_be_bytes([msg[91], msg[92]]), 17);
 
         drop(event_tx);
         drop(control_tx);
@@ -394,7 +524,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx)],
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -415,7 +545,10 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c1_tx), (collector_addr(1), c2_tx)],
+            vec![
+                (collector_addr(0), c1_tx, BmpMonitorFilter::default()),
+                (collector_addr(1), c2_tx, BmpMonitorFilter::default()),
+            ],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -526,7 +659,12 @@ mod tests {
         let addr = collector_addr(7);
 
         let metrics = BgpMetrics::new();
-        let mgr = BmpManager::new(event_rx, control_rx, vec![(addr, c_tx)], metrics.clone());
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(addr, c_tx, BmpMonitorFilter::default())],
+            metrics.clone(),
+        );
         let handle = tokio::spawn(mgr.run());
 
         event_tx
@@ -580,7 +718,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(addr, c_tx.clone())],
+            vec![(addr, c_tx.clone(), BmpMonitorFilter::default())],
             metrics.clone(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -655,7 +793,12 @@ mod tests {
         let addr = collector_addr(3);
 
         let metrics = BgpMetrics::new();
-        let mgr = BmpManager::new(event_rx, control_rx, vec![(addr, c_tx)], metrics.clone());
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(addr, c_tx, BmpMonitorFilter::default())],
+            metrics.clone(),
+        );
         let handle = tokio::spawn(mgr.run());
 
         control_tx
@@ -698,7 +841,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx)],
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
             BgpMetrics::new(),
         );
         let mut handle = tokio::spawn(mgr.run());

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -30,7 +30,9 @@ pub enum BmpEvent {
         /// Reason the session went down.
         reason: PeerDownReason,
     },
-    /// Inbound UPDATE received (pre-policy).
+    /// UPDATE monitoring. Inbound pre-policy Adj-RIB-In when
+    /// `peer_info.is_rib_out` is false; outbound post-policy Adj-RIB-Out
+    /// (RFC 8671) when true.
     RouteMonitoring {
         /// Per-peer header data.
         peer_info: BmpPeerInfo,
@@ -43,6 +45,11 @@ pub enum BmpEvent {
         peer_info: BmpPeerInfo,
         /// RFC 7854 type 7: routes in Adj-RIB-In.
         adj_rib_in_routes: u64,
+        /// RFC 8671 post-policy Adj-RIB-Out counts per `(afi, safi)`,
+        /// encoded as stat type 17 entries plus their sum as type 15.
+        /// `None` means the counts were unavailable this tick — types
+        /// 15/17 are omitted rather than reported as a false zero.
+        adj_rib_out_post: Option<Vec<(u16, u8, u64)>>,
     },
 }
 
@@ -71,6 +78,10 @@ pub enum BmpControlEvent {
 }
 
 /// Information about a monitored peer, used to build the BMP per-peer header.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "each bool mirrors one RFC 7854/8671 per-peer header flag bit (V/L/A/O)"
+)]
 #[derive(Debug, Clone)]
 pub struct BmpPeerInfo {
     /// Remote peer IP address.
@@ -85,6 +96,10 @@ pub struct BmpPeerInfo {
     pub is_ipv6: bool,
     /// Whether this is a post-policy view.
     pub is_post_policy: bool,
+    /// Whether this is an Adj-RIB-Out view (RFC 8671 O flag). Under
+    /// O=1 the L flag (`is_post_policy`) distinguishes pre/post-policy
+    /// Adj-RIB-Out; rustbgpd only emits post-policy (O=1, L=1).
+    pub is_rib_out: bool,
     /// Whether the peer uses 4-octet AS numbers.
     pub is_as4: bool,
     /// Timestamp of the event.
@@ -113,6 +128,28 @@ pub enum PeerDownReason {
     RemoteNotification(Bytes),
     /// Type 4: Remote system closed TCP without NOTIFICATION.
     RemoteNoNotification,
+}
+
+/// Which route-monitoring streams a collector receives.
+///
+/// Non-monitoring messages (Peer Up/Down, Stats, Initiation,
+/// Termination) always go to every collector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BmpMonitorFilter {
+    /// Pre-policy Adj-RIB-In route monitoring (RFC 7854, O=0).
+    pub rib_in_pre: bool,
+    /// Post-policy Adj-RIB-Out route monitoring (RFC 8671, O=1, L=1).
+    pub rib_out_post: bool,
+}
+
+impl Default for BmpMonitorFilter {
+    /// Pre-RFC 8671 behavior: Adj-RIB-In monitoring only.
+    fn default() -> Self {
+        Self {
+            rib_in_pre: true,
+            rib_out_post: false,
+        }
+    }
 }
 
 /// Configuration for a single BMP collector.

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use rustbgpd_wire::{EvpnRouteKey, FlowSpecRule, Prefix};
+use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, Prefix, Safi};
 // FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
 // rationale (internal keys, faster hasher on the convergence hot path).
 // Aliased to the std name so the storage types read unchanged.
@@ -414,6 +414,52 @@ impl AdjRibOut {
     pub fn rtc_len(&self) -> usize {
         self.rtc_routes.len()
     }
+
+    /// Per-AFI/SAFI advertised-route counts across every family map —
+    /// the source for RFC 8671 BMP stat type 17 (post-policy
+    /// Adj-RIB-Out per AFI/SAFI). Families with zero advertised routes
+    /// are omitted.
+    ///
+    /// The mixed-family maps (unicast, `FlowSpec`, VPN, labeled) are
+    /// bucketed by iterating their keys — O(total advertised routes),
+    /// paid once per peer per BMP stats tick (60s).
+    #[must_use]
+    pub fn family_counts(&self) -> Vec<((Afi, Safi), u64)> {
+        let mut counts: Vec<((Afi, Safi), u64)> = Vec::new();
+        let mut bump = |family: (Afi, Safi)| {
+            if let Some((_, count)) = counts.iter_mut().find(|(f, _)| *f == family) {
+                *count += 1;
+            } else {
+                counts.push((family, 1));
+            }
+        };
+        for (prefix, _) in self.routes.keys() {
+            let afi = match prefix {
+                Prefix::V4(_) => Afi::Ipv4,
+                Prefix::V6(_) => Afi::Ipv6,
+            };
+            bump((afi, Safi::Unicast));
+        }
+        for route in self.flowspec_routes.values() {
+            bump((route.afi, Safi::FlowSpec));
+        }
+        for key in self.vpn_routes.keys() {
+            bump(key.afi_safi());
+        }
+        for key in self.labeled_routes.keys() {
+            bump(key.afi_safi());
+        }
+        for key in self.bgpls_routes.keys() {
+            bump(key.family.to_afi_safi());
+        }
+        if !self.evpn_routes.is_empty() {
+            counts.push(((Afi::L2Vpn, Safi::Evpn), self.evpn_routes.len() as u64));
+        }
+        if !self.rtc_routes.is_empty() {
+            counts.push(((Afi::Ipv4, Safi::RtConstrain), self.rtc_routes.len() as u64));
+        }
+        counts
+    }
 }
 
 #[cfg(test)]
@@ -764,5 +810,35 @@ mod tests {
             )))
             .collect();
         assert!(routes_none.is_empty());
+    }
+
+    /// `family_counts` buckets every family map by AFI/SAFI (RFC 8671
+    /// BMP stat type 17 source) and omits empty families.
+    #[test]
+    fn family_counts_buckets_all_family_maps() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert!(rib.family_counts().is_empty());
+
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert(make_route(prefix_b(), 0));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(1), 1));
+
+        let counts = rib.family_counts();
+        let get = |family: (Afi, Safi)| {
+            counts
+                .iter()
+                .find(|(f, _)| *f == family)
+                .map(|(_, count)| *count)
+        };
+        assert_eq!(get((Afi::Ipv4, Safi::Unicast)), Some(2));
+        assert_eq!(get((Afi::Ipv4, Safi::MplsVpn)), Some(1));
+        assert_eq!(get((Afi::BgpLs, Safi::BgpLs)), Some(1));
+        assert_eq!(
+            get((Afi::L2Vpn, Safi::Evpn)),
+            None,
+            "empty families are omitted"
+        );
+        assert_eq!(counts.len(), 3);
     }
 }

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -55,7 +55,7 @@ pub use route::{
     RouteOrigin, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 pub use update::{
-    BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision, ExplainReason,
-    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate,
-    RibCommandError, RibUpdate,
+    AdjRibOutCounts, BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision,
+    ExplainReason, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OrrExplainCandidate,
+    OutboundRouteUpdate, RibCommandError, RibUpdate,
 };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -927,6 +927,9 @@ impl RibManager {
                 );
             }
             RibUpdate::QueryLocRibCount { reply } => self.handle_query_loc_rib_count(reply),
+            RibUpdate::QueryAdjRibOutCounts { reply } => {
+                self.handle_query_adj_rib_out_counts(reply);
+            }
             RibUpdate::QueryAdvertisedCount { peer, reply } => {
                 self.handle_query_advertised_count(peer, reply);
             }
@@ -1702,6 +1705,18 @@ impl RibManager {
     ) {
         let count = self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len);
         let _ = reply.send(count);
+    }
+
+    fn handle_query_adj_rib_out_counts(
+        &mut self,
+        reply: tokio::sync::oneshot::Sender<crate::update::AdjRibOutCounts>,
+    ) {
+        let counts = self
+            .adj_ribs_out
+            .iter()
+            .map(|(peer, rib)| (*peer, rib.family_counts()))
+            .collect();
+        let _ = reply.send(counts);
     }
 
     fn handle_query_neighbor_policy_stats(

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -18,6 +18,10 @@ use crate::route::{
     VpnRibRouteKey,
 };
 
+/// Per-peer post-policy Adj-RIB-Out route counts per AFI/SAFI —
+/// the RFC 8671 BMP stat type 15/17 source.
+pub type AdjRibOutCounts = HashMap<IpAddr, Vec<((Afi, Safi), u64)>>;
+
 /// Routes to be sent outbound to a peer.
 pub struct OutboundRouteUpdate {
     /// Routes to announce to this peer.
@@ -613,6 +617,12 @@ pub enum RibUpdate {
     QueryLocRibCount {
         /// Response channel.
         reply: oneshot::Sender<usize>,
+    },
+    /// Query: return every peer's post-policy Adj-RIB-Out route counts
+    /// per AFI/SAFI — the source for RFC 8671 BMP stat types 15/17.
+    QueryAdjRibOutCounts {
+        /// Response channel: peer -> `((afi, safi), count)` entries.
+        reply: oneshot::Sender<AdjRibOutCounts>,
     },
     /// Query: return the number of prefixes advertised to a specific peer.
     QueryAdvertisedCount {

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -143,6 +143,12 @@ pub struct TransportConfig {
     /// for `PolicyService.ExplainImportPolicy`. Operator knob:
     /// `[policy.explain] cache_size`.
     pub explain_cache_size: usize,
+    /// Emit RFC 8671 post-policy Adj-RIB-Out BMP route monitoring for
+    /// every outbound UPDATE. Set when at least one BMP collector
+    /// monitors `rib_out_post`; kept off otherwise so the lossy BMP
+    /// event channel is not doubled for collectors that never see the
+    /// rib-out stream.
+    pub bmp_rib_out: bool,
 }
 
 impl TransportConfig {
@@ -174,6 +180,7 @@ impl TransportConfig {
             cluster_id: None,
             explain_enabled: true,
             explain_cache_size: crate::session::import_decision_cache::DEFAULT_EXPLAIN_CACHE_SIZE,
+            bmp_rib_out: false,
         }
     }
 }

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -157,8 +157,31 @@ impl PeerSession {
             );
             return Ok(());
         };
-        match tx.try_send(Bytes::from(encoded)) {
-            Ok(()) => Ok(()),
+        let encoded = Bytes::from(encoded);
+        // RFC 8671 post-policy Adj-RIB-Out tap: every outbound UPDATE
+        // (announcements, withdraws, EoR markers — all families) funnels
+        // through here as final wire bytes, so the BMP mirror is
+        // byte-exact post-policy. Non-UPDATE bulk traffic (BoRR/EoRR
+        // ROUTE-REFRESH markers) is not route monitoring and is skipped.
+        let bmp_rib_out_pdu =
+            (self.config.bmp_rib_out && self.bmp_tx.is_some() && matches!(msg, Message::Update(_)))
+                .then(|| encoded.clone());
+        match tx.try_send(encoded) {
+            Ok(()) => {
+                if let Some(update_pdu) = bmp_rib_out_pdu {
+                    // Peer identity stays the REMOTE peer's; only the
+                    // direction flips (O=1), and L=1 marks post-policy.
+                    // Timestamp inside is the advertise time (now).
+                    let mut peer_info = self.build_bmp_peer_info();
+                    peer_info.is_rib_out = true;
+                    peer_info.is_post_policy = true;
+                    self.emit_bmp_event(BmpEvent::RouteMonitoring {
+                        peer_info,
+                        update_pdu,
+                    });
+                }
+                Ok(())
+            }
             Err(mpsc::error::TrySendError::Full(_)) => {
                 // Centralize the saturation policy here so all 13+
                 // bulk callers in `outbound.rs` get the same behavior:

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -626,6 +626,7 @@ impl PeerSession {
             peer_type: BmpPeerType::Global,
             is_ipv6: self.peer_ip.is_ipv6(),
             is_post_policy: false,
+            is_rib_out: false,
             is_as4,
             timestamp: SystemTime::now(),
         }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -470,6 +470,257 @@ async fn inbound_evpn_update_emits_bmp_route_monitoring() {
         other => panic!("expected BMP RouteMonitoring, got {other:?}"),
     }
 }
+/// Read one raw BGP message (header + body bytes) off the wire without
+/// decoding — for byte-exact comparison against BMP `update_pdu`.
+async fn read_single_raw_bgp_message(stream: &mut TcpStream) -> Vec<u8> {
+    let mut header = [0_u8; 19];
+    stream.read_exact(&mut header).await.unwrap();
+    let msg_len = usize::from(u16::from_be_bytes([header[16], header[17]]));
+    let mut body = vec![0_u8; msg_len - header.len()];
+    stream.read_exact(&mut body).await.unwrap();
+    let mut raw = header.to_vec();
+    raw.extend_from_slice(&body);
+    raw
+}
+/// All-empty `OutboundRouteUpdate` for the rib-out BMP tap tests.
+fn empty_outbound_update() -> OutboundRouteUpdate {
+    OutboundRouteUpdate {
+        announce: vec![],
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![],
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        labeled_announce: vec![],
+        rtc_announce: vec![],
+        vpn_withdraw: vec![],
+        labeled_withdraw: vec![],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    }
+}
+/// Expect the next BMP event to be a rib-out `RouteMonitoring` and
+/// return its PDU bytes, asserting the RFC 8671 marking.
+fn expect_rib_out_rm(event: BmpEvent) -> Bytes {
+    match event {
+        BmpEvent::RouteMonitoring {
+            peer_info,
+            update_pdu,
+        } => {
+            assert!(peer_info.is_rib_out, "O flag marking (Adj-RIB-Out)");
+            assert!(peer_info.is_post_policy, "L flag marking (post-policy)");
+            update_pdu
+        }
+        other => panic!("expected BMP RouteMonitoring, got {other:?}"),
+    }
+}
+/// Outbound UPDATE → RFC 8671 rib-out BMP `RouteMonitoring`, byte-exact
+/// with what went on the wire, remote peer identity preserved.
+#[tokio::test]
+async fn outbound_update_emits_rib_out_bmp_route_monitoring() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let mut update = empty_outbound_update();
+    update.announce = vec![make_route(100)];
+    update.next_hop_override = vec![None];
+    session.send_route_update(update);
+    let wire = read_single_raw_bgp_message(&mut server).await;
+    let pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    assert_eq!(
+        pdu.as_ref(),
+        &wire[..],
+        "BMP rib-out PDU must be byte-exact with the transmitted UPDATE"
+    );
+}
+/// Withdraws and End-of-RIB markers are UPDATEs through the same byte
+/// funnel — both are tapped (`EoR` for free, no special-casing).
+#[tokio::test]
+async fn outbound_withdraw_and_eor_emit_rib_out_bmp() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let mut update = empty_outbound_update();
+    update.withdraw = vec![(
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+        0,
+    )];
+    update.end_of_rib = vec![(Afi::Ipv4, Safi::Unicast)];
+    session.send_route_update(update);
+    // Wire order: withdraw UPDATE, then the 23-byte EoR UPDATE.
+    let withdraw_wire = read_single_raw_bgp_message(&mut server).await;
+    let eor_wire = read_single_raw_bgp_message(&mut server).await;
+    assert_eq!(eor_wire.len(), 23, "IPv4 unicast EoR is the empty UPDATE");
+    let withdraw_pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    let eor_pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    assert_eq!(withdraw_pdu.as_ref(), &withdraw_wire[..]);
+    assert_eq!(eor_pdu.as_ref(), &eor_wire[..]);
+}
+/// The rib-out tap is off by default (`bmp_rib_out = false`), and even
+/// when on it never taps non-UPDATE bulk traffic (ROUTE-REFRESH).
+#[tokio::test]
+async fn rib_out_tap_default_off_and_skips_non_update_messages() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_route_refresh = true;
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    // Default: bmp_rib_out is false — outbound UPDATE not tapped.
+    let mut update = empty_outbound_update();
+    update.announce = vec![make_route(100)];
+    update.next_hop_override = vec![None];
+    session.send_route_update(update);
+    let _ = read_single_raw_bgp_message(&mut server).await;
+    assert!(
+        bmp_rx.try_recv().is_err(),
+        "rib-out tap must be off unless a collector monitors rib_out_post"
+    );
+    // Enabled: ROUTE-REFRESH goes through the same bulk channel but is
+    // not route monitoring.
+    session.config.bmp_rib_out = true;
+    let mut refresh = empty_outbound_update();
+    refresh.request_refresh_all_negotiated = true;
+    session.send_route_update(refresh);
+    let _ = read_single_raw_bgp_message(&mut server).await;
+    assert!(
+        bmp_rx.try_recv().is_err(),
+        "non-UPDATE bulk messages must not be tapped"
+    );
+}
+/// Outbound `VPNv4` UPDATE (SAFI 128) → rib-out BMP, byte-exact — the tap
+/// sits below the family senders so `RD/label/MP_REACH` encoding is
+/// mirrored exactly as transmitted.
+#[tokio::test]
+async fn outbound_vpn_update_emits_rib_out_bmp_byte_exact() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv4, Safi::MplsVpn)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let mut update = empty_outbound_update();
+    update.vpn_announce = vec![make_vpn_rib_route(4093)];
+    session.send_route_update(update);
+    let wire = read_single_raw_bgp_message(&mut server).await;
+    let pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    assert_eq!(pdu.as_ref(), &wire[..]);
+}
+/// Outbound EVPN UPDATE (AFI 25 / SAFI 70) → rib-out BMP, byte-exact.
+#[tokio::test]
+async fn outbound_evpn_update_emits_rib_out_bmp_byte_exact() {
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MplsLabel,
+        RouteDistinguisher,
+    };
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::L2Vpn, Safi::Evpn)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    let evpn_route = rustbgpd_rib::EvpnRibRoute {
+        route: EvpnRoute::MacIp(EvpnMacIp {
+            rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(0),
+            mac: MacAddress([0xaa, 0xbb, 0xcc, 0x00, 0x00, 0x01]),
+            ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+            label1: MplsLabel::new(100),
+            label2: None,
+        }),
+        next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+        link_local_next_hop: None,
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        is_stale: false,
+        is_llgr_stale: false,
+    };
+    let mut update = empty_outbound_update();
+    update.evpn_announce = vec![evpn_route];
+    session.send_route_update(update);
+    let wire = read_single_raw_bgp_message(&mut server).await;
+    let pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    assert_eq!(pdu.as_ref(), &wire[..]);
+}
+/// The rib-out tap keeps the lossy posture: a full BMP event channel
+/// drops the event and bumps `bmp_source_drops_total` — it never blocks
+/// or tears down the session.
+#[tokio::test]
+async fn rib_out_tap_full_channel_increments_source_drop_counter() {
+    let (mut session, _rib_rx, _bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    // The helper's BMP channel holds 16 events; never drain it. The
+    // 17th tapped UPDATE hits Full and must count a source drop.
+    for _ in 0..17 {
+        let mut update = empty_outbound_update();
+        update.announce = vec![make_route(100)];
+        update.next_hop_override = vec![None];
+        session.send_route_update(update);
+    }
+    let drops: u64 = session
+        .metrics
+        .registry()
+        .gather()
+        .iter()
+        .filter(|f| f.name() == "bmp_source_drops_total")
+        .flat_map(|f| f.metric.iter())
+        .map(|m| {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "Prometheus counters are monotonic non-negative integers exposed as f64"
+            )]
+            let v = m.counter.value() as u64;
+            v
+        })
+        .sum();
+    assert_eq!(drops, 1, "17th event over a 16-deep channel drops once");
+}
 #[test]
 fn ebgp_prepends_asn() {
     let session = make_test_session(65001, 65002);

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -98,6 +98,7 @@ fn transport_config(addr: SocketAddr) -> TransportConfig {
         cluster_id: None,
         explain_enabled: true,
         explain_cache_size: 4096,
+        bmp_rib_out: false,
     }
 }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1708,10 +1708,10 @@ set_med = 50
 
 ## `[bmp]`
 
-Optional. Configures BMP (BGP Monitoring Protocol, RFC 7854) export to external
-collectors. rustbgpd acts as a BMP client, initiating TCP connections to each
-configured collector and streaming BGP state changes (peer up/down, route
-monitoring) as BMP messages.
+Optional. Configures BMP (BGP Monitoring Protocol, RFC 7854 + RFC 8671) export
+to external collectors. rustbgpd acts as a BMP client, initiating TCP
+connections to each configured collector and streaming BGP state changes (peer
+up/down, route monitoring) as BMP messages.
 
 ```toml
 [bmp]
@@ -1721,9 +1721,11 @@ sys_descr = "my bgp speaker"   # optional, default "rustbgpd <version>"
 [[bmp.collectors]]
 address = "10.0.0.100:11019"
 reconnect_interval = 30        # seconds, default 30
+# monitor defaults to ["rib_in_pre"] (RFC 7854 behavior)
 
 [[bmp.collectors]]
 address = "10.0.0.101:11019"
+monitor = ["rib_in_pre", "rib_out_post"]   # + RFC 8671 Adj-RIB-Out
 ```
 
 ### BMP section fields
@@ -1740,6 +1742,7 @@ address = "10.0.0.101:11019"
 |----------------------|--------|----------|---------|--------------------------------------|
 | `address`            | string | yes      | --      | Collector `host:port` socket address  |
 | `reconnect_interval` | u64   | no       | 30      | Seconds between reconnect attempts    |
+| `monitor`            | array  | no       | `["rib_in_pre"]` | Route-monitoring streams: `rib_in_pre` (RFC 7854 pre-policy Adj-RIB-In) and/or `rib_out_post` (RFC 8671 post-policy Adj-RIB-Out) |
 
 ### What is streamed
 
@@ -1750,13 +1753,28 @@ BMP messages sent to collectors:
 | **Initiation** (Type 4) | On TCP connect to collector |
 | **Peer Up** (Type 3) | BGP session reaches Established (includes raw OPEN PDUs) |
 | **Peer Down** (Type 2) | BGP session leaves Established |
-| **Route Monitoring** (Type 0) | Inbound UPDATE received (pre-policy, raw PDU) |
-| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In route count, type 7) |
+| **Route Monitoring** (Type 0) | Inbound UPDATE received (pre-policy, raw PDU); with `rib_out_post`, also every outbound UPDATE (post-policy Adj-RIB-Out, RFC 8671) |
+| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In count type 7; post-policy Adj-RIB-Out gauges type 15 + per-AFI/SAFI type 17) |
 | **Termination** (Type 5) | On coordinated daemon shutdown (and on client channel shutdown) |
 
 Route Monitoring messages carry the original raw BGP UPDATE PDU bytes
 (including the 19-byte BGP header), enabling collectors to decode the full
 UPDATE without loss.
+
+### RFC 8671 Adj-RIB-Out monitoring
+
+With `monitor = ["rib_out_post"]` (combinable with `rib_in_pre`), every
+outbound UPDATE — announcements, withdraws, and End-of-RIB markers, across all
+address families — is mirrored to the collector byte-exact as transmitted,
+with the per-peer header O flag set (Adj-RIB-Out) and L flag set
+(post-policy). The peer address/AS/BGP-ID identify the remote peer receiving
+the routes; the timestamp is the advertise time. Pre-policy Adj-RIB-Out
+(O=1, L=0) is deliberately not implemented.
+
+Note: the rib-out stream is live-only. A collector that connects (or
+reconnects) mid-session receives Peer Up state replay but no synthesized
+table dump of already-advertised routes — the same limitation the rib-in
+stream has today. See `KNOWN_ISSUES.md`.
 
 When BMP is not configured, overhead remains minimal: raw frame capture uses
 `Bytes` refcount clones (no message-data copy).

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -300,6 +300,20 @@ pub struct BmpCollector {
     pub address: String,
     #[serde(default = "default_bmp_reconnect")]
     pub reconnect_interval: u64,
+    /// Which route-monitoring streams this collector receives.
+    /// Default preserves pre-RFC 8671 behavior: pre-policy Adj-RIB-In only.
+    #[serde(default = "default_bmp_monitor")]
+    pub monitor: Vec<BmpMonitorView>,
+}
+
+/// A BMP route-monitoring stream selection (per collector).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BmpMonitorView {
+    /// Pre-policy Adj-RIB-In route monitoring (RFC 7854).
+    RibInPre,
+    /// Post-policy Adj-RIB-Out route monitoring (RFC 8671).
+    RibOutPost,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -328,6 +342,10 @@ fn default_bmp_sys_name() -> String {
 
 fn default_bmp_reconnect() -> u64 {
     30
+}
+
+fn default_bmp_monitor() -> Vec<BmpMonitorView> {
+    vec![BmpMonitorView::RibInPre]
 }
 
 fn default_rpki_refresh() -> u64 {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3116,6 +3116,32 @@ fn bmp_valid_config_accepted() {
     assert_eq!(bmp.sys_name, "rustbgpd");
     assert_eq!(bmp.collectors.len(), 1);
     assert_eq!(bmp.collectors[0].reconnect_interval, 30);
+    assert_eq!(
+        bmp.collectors[0].monitor,
+        vec![BmpMonitorView::RibInPre],
+        "default monitor selection is pre-RFC 8671 rib-in only"
+    );
+}
+
+#[test]
+fn bmp_monitor_rib_out_post_accepted() {
+    let config = parse(&bmp_toml(r#"monitor = ["rib_in_pre", "rib_out_post"]"#)).unwrap();
+    let bmp = config.bmp.as_ref().unwrap();
+    assert_eq!(
+        bmp.collectors[0].monitor,
+        vec![BmpMonitorView::RibInPre, BmpMonitorView::RibOutPost]
+    );
+}
+
+#[test]
+fn bmp_empty_monitor_rejected() {
+    let err = parse(&bmp_toml("monitor = []")).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidBmpCollector { .. }));
+}
+
+#[test]
+fn bmp_unknown_monitor_value_rejected() {
+    assert!(parse(&bmp_toml(r#"monitor = ["rib_out_pre"]"#)).is_err());
 }
 
 #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -685,6 +685,14 @@ impl Config {
                         reason: format!("collectors[{i}]: reconnect_interval must be > 0"),
                     });
                 }
+                if collector.monitor.is_empty() {
+                    return Err(ConfigError::InvalidBmpCollector {
+                        reason: format!(
+                            "collectors[{i}]: monitor must not be empty \
+                             (use [\"rib_in_pre\"] and/or [\"rib_out_post\"])"
+                        ),
+                    });
+                }
             }
 
             // Reject duplicate collector addresses (canonicalize through SocketAddr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1378,7 +1378,11 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             bmp_config.sys_descr.clone()
         };
 
-        let mut collectors: Vec<(std::net::SocketAddr, mpsc::Sender<bytes::Bytes>)> = Vec::new();
+        let mut collectors: Vec<(
+            std::net::SocketAddr,
+            mpsc::Sender<bytes::Bytes>,
+            rustbgpd_bmp::BmpMonitorFilter,
+        )> = Vec::new();
         let mut client_handles = Vec::new();
         for collector in &bmp_config.collectors {
             let addr: std::net::SocketAddr = match collector.address.parse() {
@@ -1394,7 +1398,15 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             };
             let (msg_tx, msg_rx) = mpsc::channel(4096);
             let collector_id = collectors.len();
-            collectors.push((addr, msg_tx));
+            let filter = rustbgpd_bmp::BmpMonitorFilter {
+                rib_in_pre: collector
+                    .monitor
+                    .contains(&config::BmpMonitorView::RibInPre),
+                rib_out_post: collector
+                    .monitor
+                    .contains(&config::BmpMonitorView::RibOutPost),
+            };
+            collectors.push((addr, msg_tx, filter));
             let client = rustbgpd_bmp::BmpClient::new(
                 rustbgpd_bmp::BmpClientConfig {
                     collector_id,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -519,6 +519,16 @@ impl PeerManager {
         // write-path gate at its `true` default regardless of config.
         transport.explain_enabled = self.current_config.policy.explain.enabled;
         transport.explain_cache_size = self.current_config.policy.explain.cache_size;
+        // RFC 8671: tap outbound UPDATEs for BMP only when some collector
+        // actually monitors the post-policy Adj-RIB-Out stream ([bmp]
+        // changes require a restart, so read-at-construction is
+        // authoritative for the session's lifetime).
+        transport.bmp_rib_out = self.current_config.bmp.as_ref().is_some_and(|bmp| {
+            bmp.collectors.iter().any(|c| {
+                c.monitor
+                    .contains(&crate::config::BmpMonitorView::RibOutPost)
+            })
+        });
         transport
     }
 

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -140,9 +140,26 @@ impl PeerManager {
             peer_type: BmpPeerType::Global,
             is_ipv6: peer_addr.is_ipv6(),
             is_post_policy: false,
+            is_rib_out: false,
             is_as4: four_octet_as.unwrap_or(true),
             timestamp: std::time::SystemTime::now(),
         }
+    }
+
+    /// One bounded RIB query for every peer's post-policy Adj-RIB-Out
+    /// counts per AFI/SAFI (RFC 8671 BMP stat types 15/17). `None` when
+    /// the RIB manager is unavailable or slow — the stats report then
+    /// omits types 15/17 rather than reporting a false zero.
+    async fn query_adj_rib_out_counts(&self) -> Option<rustbgpd_rib::AdjRibOutCounts> {
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        self.rib_tx
+            .send(rustbgpd_rib::RibUpdate::QueryAdjRibOutCounts { reply })
+            .await
+            .ok()?;
+        tokio::time::timeout(PEER_QUERY_TIMEOUT, rx)
+            .await
+            .ok()?
+            .ok()
     }
 
     pub(super) async fn emit_periodic_bmp_stats(&self) {
@@ -154,6 +171,7 @@ impl PeerManager {
         // any one TCP-back-pressured peer block the per-minute BMP tick and,
         // through it, every other admin command queued behind the BMP arm.
         let states = collect_session_states(&self.peers).await;
+        let rib_out_counts = self.query_adj_rib_out_counts().await;
         for (peer, managed) in &self.peers {
             let peer_addr = peer.address;
             let Some(Some(state)) = states.get(peer) else {
@@ -165,6 +183,20 @@ impl PeerManager {
 
             let prefix_count = u64::try_from(state.prefix_count).unwrap_or(u64::MAX);
             let remote_asn = effective_remote_asn(managed, Some(state));
+            // RFC 8671 types 15/17: a peer absent from the RIB's
+            // Adj-RIB-Out map simply has nothing advertised — report
+            // an honest empty set (type 15 = 0) rather than omitting.
+            let adj_rib_out_post = rib_out_counts.as_ref().map(|counts| {
+                counts
+                    .get(&peer_addr)
+                    .map(|families| {
+                        families
+                            .iter()
+                            .map(|&((afi, safi), count)| (afi as u16, safi as u8, count))
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            });
             let event = BmpEvent::StatsReport {
                 peer_info: Self::bmp_peer_info(
                     peer_addr,
@@ -173,6 +205,7 @@ impl PeerManager {
                     state.four_octet_as,
                 ),
                 adj_rib_in_routes: prefix_count,
+                adj_rib_out_post,
             };
 
             if let Err(e) = bmp_tx.try_send(event) {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -8765,3 +8765,75 @@ async fn back_to_idle_drops_candidate_while_bfd_withholding() {
     );
     assert!(mgr.peer_key_for_session(2).is_none());
 }
+
+/// The 60s BMP stats tick sources RFC 8671 types 15/17 from the RIB's
+/// per-peer Adj-RIB-Out family counts via one `QueryAdjRibOutCounts`
+/// round-trip, converting `(Afi, Safi)` to raw wire codes.
+#[tokio::test]
+async fn periodic_bmp_stats_carry_adj_rib_out_counts() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(16);
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        Some(bmp_tx),
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        fake_peer_handle(
+            addr,
+            SessionState::Established,
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            counters,
+        ),
+        false,
+    );
+
+    // Answer the single RIB-wide Adj-RIB-Out counts query.
+    let rib_task = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::QueryAdjRibOutCounts { reply } = update {
+                let mut counts = std::collections::HashMap::new();
+                counts.insert(
+                    addr,
+                    vec![
+                        ((Afi::Ipv4, Safi::Unicast), 12_u64),
+                        ((Afi::Ipv4, Safi::MplsVpn), 3_u64),
+                    ],
+                );
+                let _ = reply.send(counts);
+                return;
+            }
+        }
+        panic!("QueryAdjRibOutCounts never arrived");
+    });
+
+    mgr.emit_periodic_bmp_stats().await;
+    rib_task.await.unwrap();
+
+    match bmp_rx.recv().await.unwrap() {
+        rustbgpd_bmp::BmpEvent::StatsReport {
+            peer_info,
+            adj_rib_in_routes,
+            adj_rib_out_post,
+        } => {
+            assert_eq!(peer_info.peer_addr, addr);
+            assert_eq!(adj_rib_in_routes, 0);
+            assert_eq!(
+                adj_rib_out_post,
+                Some(vec![(1, 1, 12), (1, 128, 3)]),
+                "wire AFI/SAFI codes with AdjRibOut-derived counts"
+            );
+        }
+        other => panic!("expected StatsReport, got {other:?}"),
+    }
+}

--- a/tests/interop/scripts/bmp-receiver.py
+++ b/tests/interop/scripts/bmp-receiver.py
@@ -85,6 +85,13 @@ def main():
                 "length": length,
                 "timestamp": time.time(),
             }
+            # RouteMonitoring: per-peer header flags at body[1].
+            # RFC 8671 O flag (0x10) marks Adj-RIB-Out; under O=1 the
+            # L flag (0x40) marks post-policy.
+            if msg_type == 0 and len(body) >= 2:
+                flags = body[1]
+                entry["rib_out"] = bool(flags & 0x10)
+                entry["post_policy"] = bool(flags & 0x40)
             messages.append(entry)
             print(f"BMP: {type_name} ({length} bytes)", flush=True)
 


### PR DESCRIPTION
**Slice 1 of the BMP arc** (ROADMAP next anchor): RFC 8671 post-policy Adj-RIB-Out monitoring — the BMP view no open-source daemon ships (FRR/GoBGP stop at Loc-RIB; BIRD's BMP is experimental; only Junos has rib-out). Per-client rib-out is the observability twin of ORR: *prove what the RR actually sent each client*.

- **The tap is the outbound byte funnel** (`enqueue_bulk`): every family's announces, withdraws, and EoRs are already encoded bytes there — the BMP message wraps the *exact* PDU sent (refcount clone, zero re-encode), symmetric with the inbound raw-PDU tap. Byte-exactness pinned for VPN + EVPN in transport tests.
- RFC 8671 semantics verified against the RFC: O-flag 0x10, L=post-policy under O=1, peer identity stays the remote peer's, PeerUp/Down/Stats remain O=0 (test-locked). Stats 15 (post-out count) + 17 (per-AFI/SAFI) sourced from AdjRibOut via one batched RIB query per 60s tick — counts unavailable renders as omitted, never a false zero.
- **Config**: per-collector `monitor = ["rib_in_pre", "rib_out_post"]` (default preserves today's behavior); the session-side gate keeps the lossy BMP channel single-load when nobody subscribes. Lossy try_send + drop counters posture unchanged.
- Documented: rib-out (like rib-in today) is live-only until the Loc-RIB slice's collector-connect replay machinery; pre-policy-out deliberately skipped (weakest-specified corner).

24 files, +940/−52; 63 workspace binaries green.