### PR TITLE
feat(bmp): export Loc-RIB route monitoring with collector-connect table sync (RFC 9069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **BMP Loc-RIB route monitoring with collector-connect table sync
+  (RFC 9069).** New per-collector `monitor = ["loc_rib"]` view: the
+  daemon streams its post-best-path Loc-RIB as Route Monitoring
+  messages attributed to the emulated Loc-RIB instance peer (peer type
+  3, own flags registry always 0, zero-filled peer address, Peer
+  Distinguisher 0, Peer AS = local AS, BGP ID = local router-id,
+  timestamp = route install time). Peer Up carries a fabricated OPEN
+  (4-octet-ASN capability + one MP capability per streamed family,
+  received OPEN a byte-identical repeat) and the VRF/Table Name TLV
+  (`"global"`); Peer Down uses reason 6 with the TLV echoed; periodic
+  stats add types 8 (Loc-RIB total) and 10 (per-AFI/SAFI). UPDATE PDUs
+  are synthesized from the RIB (4-octet-ASN, no Add-Path); v1 synthesis
+  covers IPv4/IPv6 unicast and VPNv4/VPNv6 — other Loc-RIB families
+  land additively later and are deliberately absent from the fabricated
+  OPEN. **Collector (re)connect now performs a table sync** — closing
+  the RFC 7854 initial-sync gap: after the cached Peer Up replay, a
+  `loc_rib` collector receives a chunked Loc-RIB dump (install-time
+  timestamps) closed by one End-of-RIB per family, then the live stream
+  continues seamlessly (dump/live overlap is the standard BMP race;
+  collectors reconcile by prefix). The dump is produced by the RIB
+  manager as a bounded chunked query and paced to the collector's TCP
+  drain by a dedicated forwarder task — the RIB task and the BMP
+  fan-out loop never block on a slow collector. Adj-RIB-In/Out streams
+  remain live-only (see `KNOWN_ISSUES.md`).
+
 - **M80 interop receipt: `.rpol` policy parity against FRR route-maps —
   the ADR-0096 arc closer.** New `interop` CI job (4-node containerlab):
   rustbgpd runs its whole policy surface from an `.rpol` file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,6 +2894,7 @@ dependencies = [
  "lru",
  "prefix-trie",
  "proptest",
+ "rustbgpd-bmp",
  "rustbgpd-policy",
  "rustbgpd-rpki",
  "rustbgpd-telemetry",

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -99,16 +99,25 @@ resolved.
 
 ## Limitations (by design, not bugs)
 
-- **BMP route-monitoring streams are live-only — no table dump on
+- **BMP Adj-RIB-In/Adj-RIB-Out streams are live-only — no table dump on
   collector (re)connect.** A collector that connects mid-life receives
   the cached Peer Up replay but no synthesized Route Monitoring dump of
-  the current table contents: the RFC 8671 post-policy Adj-RIB-Out
-  stream (`monitor = ["rib_out_post"]`) starts at the next outbound
-  UPDATE, exactly as the pre-policy Adj-RIB-In stream has always
-  started at the next inbound UPDATE. Collectors should connect before
-  sessions establish (or trigger a route refresh) to observe full
-  state. Dump synthesis is planned alongside the Loc-Rib BMP slice's
-  replay machinery.
+  those views: the RFC 8671 post-policy Adj-RIB-Out stream
+  (`monitor = ["rib_out_post"]`) starts at the next outbound UPDATE,
+  exactly as the pre-policy Adj-RIB-In stream has always started at the
+  next inbound UPDATE. The RFC 9069 Loc-RIB view
+  (`monitor = ["loc_rib"]`) does NOT share this gap — it performs a
+  full table dump (closed by per-family End-of-RIB) on every collector
+  (re)connect, and for a route reflector the post-policy Loc-RIB is the
+  view most dump consumers actually want. Rib-out dump synthesis was
+  evaluated and deliberately deferred: `AdjRibOut` stores post-policy
+  routes *before* transport stamping, so a synthesized dump would miss
+  the session-side attribute rewrites (`ORIGINATOR_ID`/`CLUSTER_LIST`
+  on reflection, GShut community, LLGR §4.6 form) and not be
+  byte-faithful to what was advertised; pre-policy Adj-RIB-In is
+  unreconstructable post-import. Collectors needing those exact views
+  should connect before sessions establish (or trigger a route
+  refresh).
 
 - **Commit-confirmed config transactions do not survive a daemon restart.**
   The confirm timer and the captured pre-commit rollback snapshot are held in

--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -8,7 +8,7 @@ use std::time::UNIX_EPOCH;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-use crate::types::{BmpPeerInfo, PeerDownReason};
+use crate::types::{BmpLocRibConfig, BmpPeerInfo, BmpPeerType, LOC_RIB_TABLE_NAME, PeerDownReason};
 
 // BMP message types (RFC 7854 §4.1)
 const BMP_MSG_ROUTE_MONITORING: u8 = 0;
@@ -35,6 +35,12 @@ const BMP_TLV_STRING_MAX_LEN: usize = u16::MAX as usize;
 // BMP Termination TLV types
 const BMP_TERM_TLV_STRING: u16 = 0;
 const BMP_TERM_TLV_REASON: u16 = 1;
+
+// BMP Peer Up Information TLV: VRF/Table Name (RFC 9069 §5.2.2)
+const BMP_PEER_UP_TLV_VRF_TABLE_NAME: u16 = 3;
+
+// Peer Down reason: Local system closed, TLV data follows (RFC 9069 §5.3)
+const PEER_DOWN_REASON_LOCAL_TLV: u8 = 6;
 
 // Per-peer header flags
 const PEER_FLAG_V: u8 = 0x80; // IPv6 peer
@@ -95,17 +101,24 @@ fn encode_per_peer_header(info: &BmpPeerInfo, buf: &mut BytesMut) {
     buf.put_u8(info.peer_type as u8);
 
     let mut flags: u8 = 0;
-    if info.is_ipv6 {
-        flags |= PEER_FLAG_V;
-    }
-    if info.is_post_policy {
-        flags |= PEER_FLAG_L;
-    }
-    if !info.is_as4 {
-        flags |= PEER_FLAG_A;
-    }
-    if info.is_rib_out {
-        flags |= PEER_FLAG_O;
+    if info.peer_type == BmpPeerType::LocRib {
+        // RFC 9069 §4.2: peer type 3 has its OWN flags registry — only
+        // F (0x80, filtered view) is defined and we never filter, so
+        // the byte is always 0. The RFC 7854 V/L/A/O bits do not exist
+        // here (never V, even when the monitored routes are IPv6).
+    } else {
+        if info.is_ipv6 {
+            flags |= PEER_FLAG_V;
+        }
+        if info.is_post_policy {
+            flags |= PEER_FLAG_L;
+        }
+        if !info.is_as4 {
+            flags |= PEER_FLAG_A;
+        }
+        if info.is_rib_out {
+            flags |= PEER_FLAG_O;
+        }
     }
     buf.put_u8(flags);
 
@@ -257,6 +270,62 @@ pub fn encode_peer_down(info: &BmpPeerInfo, reason: &PeerDownReason) -> Bytes {
             buf.put_u8(4);
         }
     }
+
+    write_common_header(&mut buf, BMP_MSG_PEER_DOWN);
+    buf.freeze()
+}
+
+/// Encode the RFC 9069 Peer Up Notification for the emulated Loc-RIB
+/// instance peer (peer type 3).
+///
+/// Local address and ports are zero-filled ("not applicable"), the sent
+/// OPEN is the fabricated PDU from [`BmpLocRibConfig::open_pdu`], the
+/// received OPEN is a byte-identical repeat of it (§5.2), and the
+/// VRF/Table Name Information TLV (type 3) carries `"global"` for the
+/// default Loc-RIB instance.
+#[must_use]
+pub fn encode_loc_rib_peer_up(cfg: &BmpLocRibConfig, timestamp: std::time::SystemTime) -> Bytes {
+    let info = cfg.peer_info(timestamp);
+    let table_name = LOC_RIB_TABLE_NAME.as_bytes();
+    let total = BMP_COMMON_HEADER_LEN
+        + PER_PEER_HEADER_LEN
+        + 20
+        + 2 * cfg.open_pdu.len()
+        + 4
+        + table_name.len();
+
+    let mut buf = BytesMut::with_capacity(total);
+    buf.put_bytes(0, BMP_COMMON_HEADER_LEN);
+    encode_per_peer_header(&info, &mut buf);
+    buf.put_bytes(0, 16); // local address: zero-filled
+    buf.put_u16(0); // local port
+    buf.put_u16(0); // remote port
+    buf.put_slice(&cfg.open_pdu); // sent OPEN (fabricated)
+    buf.put_slice(&cfg.open_pdu); // received OPEN: repeat of the sent OPEN
+    buf.put_u16(BMP_PEER_UP_TLV_VRF_TABLE_NAME);
+    buf.put_u16(u16::try_from(table_name.len()).unwrap_or(u16::MAX));
+    buf.put_slice(table_name);
+
+    write_common_header(&mut buf, BMP_MSG_PEER_UP);
+    buf.freeze()
+}
+
+/// Encode the RFC 9069 Peer Down Notification for the emulated Loc-RIB
+/// instance peer: reason code 6 ("Local system closed, TLV data
+/// follows") with the VRF/Table Name TLV echoed from the Peer Up.
+#[must_use]
+pub fn encode_loc_rib_peer_down(cfg: &BmpLocRibConfig, timestamp: std::time::SystemTime) -> Bytes {
+    let info = cfg.peer_info(timestamp);
+    let table_name = LOC_RIB_TABLE_NAME.as_bytes();
+    let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 1 + 4 + table_name.len();
+
+    let mut buf = BytesMut::with_capacity(total);
+    buf.put_bytes(0, BMP_COMMON_HEADER_LEN);
+    encode_per_peer_header(&info, &mut buf);
+    buf.put_u8(PEER_DOWN_REASON_LOCAL_TLV);
+    buf.put_u16(BMP_PEER_UP_TLV_VRF_TABLE_NAME);
+    buf.put_u16(u16::try_from(table_name.len()).unwrap_or(u16::MAX));
+    buf.put_slice(table_name);
 
     write_common_header(&mut buf, BMP_MSG_PEER_DOWN);
     buf.freeze()
@@ -672,6 +741,149 @@ mod tests {
         assert_eq!(
             u64::from_be_bytes(msg[t + 7..t + 15].try_into().unwrap()),
             77
+        );
+    }
+
+    fn sample_loc_rib_config() -> BmpLocRibConfig {
+        BmpLocRibConfig {
+            local_asn: 65001,
+            router_id: Ipv4Addr::new(10, 0, 0, 1),
+            // Any opaque PDU stands in for the fabricated OPEN — the
+            // codec copies it verbatim into both OPEN fields.
+            open_pdu: Bytes::from_static(&[0xAB; 37]),
+        }
+    }
+
+    fn ts() -> std::time::SystemTime {
+        UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000)
+    }
+
+    /// RFC 9069 golden bytes for the Loc-RIB per-peer header: peer type
+    /// 3, flags 0 (its own registry — only F defined, never set by us),
+    /// zero-filled peer address, distinguisher 0 (global instance),
+    /// Peer AS = local AS, BGP ID = local router-id.
+    #[test]
+    fn loc_rib_per_peer_header_golden() {
+        let cfg = sample_loc_rib_config();
+        let msg = encode_route_monitoring(&cfg.peer_info(ts()), &[0xCD; 23]);
+        verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
+        let hdr = &msg[BMP_COMMON_HEADER_LEN..];
+        assert_eq!(hdr[0], 3, "peer type 3 (Loc-RIB instance)");
+        assert_eq!(hdr[1], 0, "flags 0 (F clear, no V/L/A/O bits exist)");
+        assert_eq!(&hdr[2..10], &[0u8; 8], "peer distinguisher 0");
+        assert_eq!(&hdr[10..26], &[0u8; 16], "peer address zero-filled");
+        assert_eq!(u32::from_be_bytes(hdr[26..30].try_into().unwrap()), 65001);
+        assert_eq!(&hdr[30..34], &[10, 0, 0, 1], "BGP ID = local router-id");
+        assert_eq!(
+            u32::from_be_bytes(hdr[34..38].try_into().unwrap()),
+            1_700_000_000,
+            "timestamp = route install time"
+        );
+    }
+
+    /// Even a hostile `BmpPeerInfo` with every RFC 7854 flag bool set
+    /// must encode flags 0 under peer type 3 — the registry is per
+    /// peer type and only F exists there.
+    #[test]
+    fn loc_rib_flags_zero_even_with_flag_bools_set() {
+        let info = BmpPeerInfo {
+            peer_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            peer_asn: 65001,
+            peer_bgp_id: Ipv4Addr::new(10, 0, 0, 1),
+            peer_type: BmpPeerType::LocRib,
+            is_ipv6: true,
+            is_post_policy: true,
+            is_rib_out: true,
+            is_as4: false,
+            timestamp: ts(),
+        };
+        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        assert_eq!(msg[BMP_COMMON_HEADER_LEN + 1], 0);
+    }
+
+    /// RFC 9069 §5.2 Peer Up: zero local address/ports, sent OPEN =
+    /// received OPEN = the fabricated PDU, VRF/Table Name TLV (type 3)
+    /// = "global".
+    #[test]
+    fn loc_rib_peer_up_fabricated_open_and_table_name_tlv() {
+        let cfg = sample_loc_rib_config();
+        let msg = encode_loc_rib_peer_up(&cfg, ts());
+        verify_common_header(&msg, BMP_MSG_PEER_UP);
+        assert_eq!(msg[BMP_COMMON_HEADER_LEN], 3, "peer type 3");
+
+        let body = &msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(&body[..16], &[0u8; 16], "local address zero-filled");
+        assert_eq!(&body[16..20], &[0u8; 4], "local + remote ports zero");
+        let open_len = cfg.open_pdu.len();
+        assert_eq!(&body[20..20 + open_len], &cfg.open_pdu[..], "sent OPEN");
+        assert_eq!(
+            &body[20 + open_len..20 + 2 * open_len],
+            &cfg.open_pdu[..],
+            "received OPEN is a byte-identical repeat of the sent OPEN"
+        );
+        let tlv = &body[20 + 2 * open_len..];
+        assert_eq!(u16::from_be_bytes([tlv[0], tlv[1]]), 3, "TLV type 3");
+        assert_eq!(
+            u16::from_be_bytes([tlv[2], tlv[3]]) as usize,
+            "global".len()
+        );
+        assert_eq!(&tlv[4..], b"global");
+        assert_eq!(tlv.len(), 4 + "global".len(), "nothing after the TLV");
+    }
+
+    /// RFC 9069 §5.3 Peer Down: reason code 6 with the VRF/Table Name
+    /// TLV echoed.
+    #[test]
+    fn loc_rib_peer_down_reason_6_with_table_name_tlv() {
+        let cfg = sample_loc_rib_config();
+        let msg = encode_loc_rib_peer_down(&cfg, ts());
+        verify_common_header(&msg, BMP_MSG_PEER_DOWN);
+        assert_eq!(msg[BMP_COMMON_HEADER_LEN], 3, "peer type 3");
+        let body = &msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(body[0], 6, "reason 6: local system closed, TLV follows");
+        assert_eq!(u16::from_be_bytes([body[1], body[2]]), 3, "TLV type 3");
+        assert_eq!(&body[5..], b"global");
+    }
+
+    /// RFC 9069 stats: type 8 (Loc-RIB total, 64-bit gauge) + type 10
+    /// (per-AFI/SAFI Loc-RIB count).
+    #[test]
+    fn loc_rib_stats_8_and_10_encoding() {
+        let cfg = sample_loc_rib_config();
+        let counters = vec![StatCounter {
+            stat_type: 8,
+            value: 15,
+        }];
+        let afi_counters = vec![AfiStatCounter {
+            stat_type: 10,
+            afi: 1,
+            safi: 1,
+            value: 15,
+        }];
+        let msg = encode_stats_report(&cfg.peer_info(ts()), &counters, &afi_counters);
+        verify_common_header(&msg, BMP_MSG_STATS_REPORT);
+        let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
+        assert_eq!(
+            u32::from_be_bytes(msg[count_offset..count_offset + 4].try_into().unwrap()),
+            2
+        );
+        // Type 8: type(2)=8, len(2)=8, value(8)
+        let s = count_offset + 4;
+        assert_eq!(u16::from_be_bytes([msg[s], msg[s + 1]]), 8);
+        assert_eq!(u16::from_be_bytes([msg[s + 2], msg[s + 3]]), 8);
+        assert_eq!(
+            u64::from_be_bytes(msg[s + 4..s + 12].try_into().unwrap()),
+            15
+        );
+        // Type 10: type(2)=10, len(2)=11, AFI(2)=1, SAFI(1)=1, value(8)
+        let t = s + 12;
+        assert_eq!(u16::from_be_bytes([msg[t], msg[t + 1]]), 10);
+        assert_eq!(u16::from_be_bytes([msg[t + 2], msg[t + 3]]), 11);
+        assert_eq!(u16::from_be_bytes([msg[t + 4], msg[t + 5]]), 1);
+        assert_eq!(msg[t + 6], 1);
+        assert_eq!(
+            u64::from_be_bytes(msg[t + 7..t + 15].try_into().unwrap()),
+            15
         );
     }
 

--- a/crates/bmp/src/lib.rs
+++ b/crates/bmp/src/lib.rs
@@ -1,8 +1,10 @@
-//! rustbgpd-bmp — BMP exporter (RFC 7854, RFC 8671)
+//! rustbgpd-bmp — BMP exporter (RFC 7854, RFC 8671, RFC 9069)
 //!
 //! Unidirectional BGP Monitoring Protocol exporter. Streams BGP
 //! session state and raw UPDATE PDUs to configured collectors,
-//! including post-policy Adj-RIB-Out monitoring (RFC 8671).
+//! including post-policy Adj-RIB-Out monitoring (RFC 8671) and
+//! Loc-RIB instance monitoring with collector-connect table sync
+//! (RFC 9069).
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -16,6 +18,6 @@ pub mod types;
 pub use client::BmpClient;
 pub use manager::BmpManager;
 pub use types::{
-    BmpClientConfig, BmpControlEvent, BmpEvent, BmpMonitorFilter, BmpPeerInfo, BmpPeerType,
-    PeerDownReason,
+    BmpClientConfig, BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig,
+    BmpMonitorFilter, BmpPeerInfo, BmpPeerType, LOC_RIB_TABLE_NAME, PeerDownReason,
 };

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -11,7 +11,15 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::codec;
-use crate::types::{BmpControlEvent, BmpEvent, BmpMonitorFilter};
+use crate::types::{
+    BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig, BmpMonitorFilter,
+};
+
+/// Per-message send timeout for a Loc-RIB dump forwarder. Paces the dump
+/// to the collector's TCP drain rate via the bounded collector channel;
+/// a collector that stalls longer than this aborts the dump (the next
+/// reconnect triggers a fresh one).
+const LOC_RIB_DUMP_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// BMP manager that fans out encoded messages to all collectors.
 pub struct BmpManager {
@@ -23,6 +31,12 @@ pub struct BmpManager {
     collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>, BmpMonitorFilter)>,
     /// Latest encoded `PeerUp` message per peer address.
     peer_up_cache: std::collections::HashMap<std::net::IpAddr, Bytes>,
+    /// RFC 9069 Loc-RIB instance-peer identity. `None` = no collector
+    /// monitors `loc_rib`; Loc-RIB events are dropped.
+    loc_rib: Option<BmpLocRibConfig>,
+    /// Loc-RIB table-dump request channel toward the RIB manager, used
+    /// on collector (re)connect to synthesize the initial table sync.
+    dump_tx: Option<mpsc::Sender<BmpDumpRequest>>,
     metrics: BgpMetrics,
 }
 
@@ -40,8 +54,24 @@ impl BmpManager {
             control_rx,
             collectors,
             peer_up_cache: std::collections::HashMap::new(),
+            loc_rib: None,
+            dump_tx: None,
             metrics,
         }
+    }
+
+    /// Enable RFC 9069 Loc-RIB monitoring: the emulated Loc-RIB instance
+    /// peer identity plus the table-dump request channel used to
+    /// synchronize a (re)connecting collector with the current Loc-RIB.
+    #[must_use]
+    pub fn with_loc_rib(
+        mut self,
+        cfg: BmpLocRibConfig,
+        dump_tx: mpsc::Sender<BmpDumpRequest>,
+    ) -> Self {
+        self.loc_rib = Some(cfg);
+        self.dump_tx = Some(dump_tx);
+        self
     }
 
     /// Run the manager loop. Receives events, encodes, and fans out.
@@ -78,6 +108,9 @@ impl BmpManager {
 
     fn encode_event(event: &BmpEvent) -> Bytes {
         match event {
+            BmpEvent::LocRibRouteMonitoring { .. } | BmpEvent::LocRibStats { .. } => {
+                unreachable!("Loc-RIB events are encoded in handle_loc_rib_event")
+            }
             BmpEvent::PeerUp {
                 peer_info,
                 local_open,
@@ -130,8 +163,50 @@ impl BmpManager {
         }
     }
 
+    /// Encode and fan out an RFC 9069 Loc-RIB event to `loc_rib`
+    /// collectors. Dropped silently when Loc-RIB monitoring is not
+    /// configured (no collector monitors the view).
+    fn handle_loc_rib_event(&self, event: &BmpEvent) {
+        let Some(ref cfg) = self.loc_rib else {
+            return;
+        };
+        let encoded = match event {
+            BmpEvent::LocRibRouteMonitoring {
+                update_pdu,
+                timestamp,
+            } => codec::encode_route_monitoring(&cfg.peer_info(*timestamp), update_pdu),
+            BmpEvent::LocRibStats { per_family } => {
+                // RFC 9069 stat type 8 = Loc-RIB total (64-bit gauge),
+                // type 10 = its per-AFI/SAFI breakdown.
+                let counters = vec![codec::StatCounter {
+                    stat_type: 8,
+                    value: per_family.iter().map(|(_, _, count)| count).sum(),
+                }];
+                let afi_counters: Vec<codec::AfiStatCounter> = per_family
+                    .iter()
+                    .map(|&(afi, safi, value)| codec::AfiStatCounter {
+                        stat_type: 10,
+                        afi,
+                        safi,
+                        value,
+                    })
+                    .collect();
+                codec::encode_stats_report(
+                    &cfg.peer_info(std::time::SystemTime::now()),
+                    &counters,
+                    &afi_counters,
+                )
+            }
+            _ => return,
+        };
+        self.fan_out_filtered(&encoded, |f| f.loc_rib);
+    }
+
     fn handle_event(&mut self, event: &BmpEvent) {
         match event {
+            BmpEvent::LocRibRouteMonitoring { .. } | BmpEvent::LocRibStats { .. } => {
+                self.handle_loc_rib_event(event);
+            }
             BmpEvent::PeerUp { peer_info, .. } => {
                 let encoded = Self::encode_event(event);
                 self.peer_up_cache
@@ -178,6 +253,7 @@ impl BmpManager {
                     "BMP collector connected, replaying current PeerUp state"
                 );
                 self.replay_peer_up_to_collector(collector_id);
+                self.start_loc_rib_sync(collector_id);
                 false
             }
             BmpControlEvent::CollectorDisconnected {
@@ -193,6 +269,12 @@ impl BmpManager {
             }
             BmpControlEvent::Shutdown => {
                 info!("BMP manager received shutdown request");
+                // RFC 9069 §5.3: the Loc-RIB instance peer goes down with
+                // reason 6 + the VRF/Table Name TLV when monitoring stops.
+                if let Some(ref cfg) = self.loc_rib {
+                    let down = codec::encode_loc_rib_peer_down(cfg, std::time::SystemTime::now());
+                    self.fan_out_filtered(&down, |f| f.loc_rib);
+                }
                 true
             }
         }
@@ -232,6 +314,69 @@ impl BmpManager {
         }
     }
 
+    /// RFC 9069 table sync for a (re)connected collector that monitors
+    /// `loc_rib`: replay the Loc-RIB instance Peer Up, then request a
+    /// Loc-RIB dump from the RIB manager and forward its chunks —
+    /// synthesized Route Monitoring PDUs ending with per-AFI/SAFI
+    /// End-of-RIB markers — to this collector only.
+    ///
+    /// The forwarder runs as its own task so the manager loop never
+    /// blocks on a slow collector; live Loc-RIB events keep fanning out
+    /// concurrently and may overlap the dump (the standard BMP
+    /// dump-vs-live race — collectors reconcile by prefix).
+    fn start_loc_rib_sync(&self, collector_id: usize) {
+        let Some(ref cfg) = self.loc_rib else {
+            return;
+        };
+        let Some((addr, collector_tx, filter)) = self.collectors.get(collector_id) else {
+            return;
+        };
+        if !filter.loc_rib {
+            return;
+        }
+
+        let addr_label = addr.to_string();
+        let peer_up = codec::encode_loc_rib_peer_up(cfg, std::time::SystemTime::now());
+        if let Err(e) = collector_tx.try_send(peer_up) {
+            let reason = trysend_reason(&e);
+            self.metrics
+                .record_bmp_collector_drop(&addr_label, "loc_rib_dump", reason, 1);
+            warn!(
+                collector = %addr,
+                error = %e,
+                "BMP collector channel full or closed for Loc-RIB PeerUp; skipping dump"
+            );
+            return;
+        }
+
+        let Some(ref dump_tx) = self.dump_tx else {
+            return;
+        };
+        let (chunk_tx, chunk_rx) = mpsc::channel::<BmpDumpChunk>(4);
+        if let Err(e) = dump_tx.try_send(BmpDumpRequest { reply: chunk_tx }) {
+            let reason = trysend_reason(&e);
+            self.metrics
+                .record_bmp_collector_drop(&addr_label, "loc_rib_dump", reason, 1);
+            warn!(
+                collector = %addr,
+                error = %e,
+                "Loc-RIB dump request channel full or closed; collector starts live-only"
+            );
+            return;
+        }
+
+        let cfg = cfg.clone();
+        let collector_tx = collector_tx.clone();
+        let metrics = self.metrics.clone();
+        tokio::spawn(forward_loc_rib_dump(
+            chunk_rx,
+            collector_tx,
+            cfg,
+            metrics,
+            addr_label,
+        ));
+    }
+
     fn fan_out(&self, msg: &Bytes) {
         self.fan_out_filtered(msg, |_| true);
     }
@@ -253,6 +398,51 @@ impl BmpManager {
             }
         }
     }
+}
+
+/// Forward one Loc-RIB dump — chunks of `(synthesized UPDATE PDU,
+/// install time)` from the RIB manager — to a single collector as
+/// Route Monitoring messages. The bounded collector channel plus a
+/// per-message send timeout pace the dump at the collector's drain
+/// rate; a timeout or closed channel aborts the dump (a fresh one runs
+/// on the next reconnect).
+async fn forward_loc_rib_dump(
+    mut chunk_rx: mpsc::Receiver<BmpDumpChunk>,
+    collector_tx: mpsc::Sender<Bytes>,
+    cfg: BmpLocRibConfig,
+    metrics: BgpMetrics,
+    addr_label: String,
+) {
+    let mut sent: u64 = 0;
+    while let Some(chunk) = chunk_rx.recv().await {
+        for (pdu, timestamp) in chunk.messages {
+            let msg = codec::encode_route_monitoring(&cfg.peer_info(timestamp), &pdu);
+            match tokio::time::timeout(LOC_RIB_DUMP_SEND_TIMEOUT, collector_tx.send(msg)).await {
+                Ok(Ok(())) => sent += 1,
+                Ok(Err(_)) => {
+                    metrics.record_bmp_collector_drop(
+                        &addr_label,
+                        "loc_rib_dump",
+                        "channel_closed",
+                        1,
+                    );
+                    warn!(collector = %addr_label, "collector channel closed mid Loc-RIB dump, aborting");
+                    return;
+                }
+                Err(_) => {
+                    metrics.record_bmp_collector_drop(
+                        &addr_label,
+                        "loc_rib_dump",
+                        "send_timeout",
+                        1,
+                    );
+                    warn!(collector = %addr_label, "collector stalled during Loc-RIB dump, aborting");
+                    return;
+                }
+            }
+        }
+    }
+    debug!(collector = %addr_label, messages = sent, "Loc-RIB dump forwarded");
 }
 
 /// Classify a `tokio::sync::mpsc::error::TrySendError` into the
@@ -356,6 +546,7 @@ mod tests {
                     BmpMonitorFilter {
                         rib_in_pre: true,
                         rib_out_post: true,
+                        loc_rib: false,
                     },
                 ),
             ],
@@ -830,6 +1021,298 @@ mod tests {
         drop(event_tx);
         drop(control_tx);
         handle.await.unwrap();
+    }
+
+    fn loc_rib_config() -> crate::types::BmpLocRibConfig {
+        crate::types::BmpLocRibConfig {
+            local_asn: 65001,
+            router_id: Ipv4Addr::new(10, 0, 0, 1),
+            open_pdu: Bytes::from_static(&[0xAB; 29]),
+        }
+    }
+
+    fn loc_rib_filter() -> BmpMonitorFilter {
+        BmpMonitorFilter {
+            rib_in_pre: false,
+            rib_out_post: false,
+            loc_rib: true,
+        }
+    }
+
+    /// Loc-RIB RM events reach only `loc_rib` collectors (peer type 3 in
+    /// the header); rib-in RM events do NOT reach a loc_rib-only
+    /// collector.
+    #[tokio::test]
+    async fn loc_rib_route_monitoring_filtered_per_collector() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (rib_in_tx, mut rib_in_rx) = mpsc::channel(16);
+        let (loc_rib_tx, mut loc_rib_rx) = mpsc::channel(16);
+        let (dump_tx, _dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![
+                (collector_addr(0), rib_in_tx, BmpMonitorFilter::default()),
+                (collector_addr(1), loc_rib_tx, loc_rib_filter()),
+            ],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        event_tx
+            .send(BmpEvent::LocRibRouteMonitoring {
+                update_pdu: Bytes::from_static(&[0xCC; 23]),
+                timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            })
+            .await
+            .unwrap();
+        event_tx
+            .send(BmpEvent::RouteMonitoring {
+                peer_info: sample_peer_info(),
+                update_pdu: Bytes::from_static(&[0xAA; 23]),
+            })
+            .await
+            .unwrap();
+
+        // loc_rib collector: exactly the Loc-RIB RM, peer type 3, flags 0.
+        let msg = loc_rib_rx.recv().await.unwrap();
+        assert_eq!(msg[5], 0, "route monitoring type");
+        assert_eq!(msg[6], 3, "peer type 3 (Loc-RIB instance)");
+        assert_eq!(msg[7], 0, "loc-rib flags always 0");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), loc_rib_rx.recv())
+                .await
+                .is_err(),
+            "loc_rib-only collector must not receive the rib-in RM"
+        );
+
+        // rib-in collector: only the rib-in RM (peer type 0).
+        let msg = rib_in_rx.recv().await.unwrap();
+        assert_eq!(msg[6], 0, "peer type 0 (global instance peer)");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), rib_in_rx.recv())
+                .await
+                .is_err(),
+            "rib-in collector must not receive the Loc-RIB RM"
+        );
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
+    /// RFC 9069 stats (types 8 + 10) fan out to `loc_rib` collectors only.
+    #[tokio::test]
+    async fn loc_rib_stats_reach_only_loc_rib_collectors() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (rib_in_tx, mut rib_in_rx) = mpsc::channel(16);
+        let (loc_rib_tx, mut loc_rib_rx) = mpsc::channel(16);
+        let (dump_tx, _dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![
+                (collector_addr(0), rib_in_tx, BmpMonitorFilter::default()),
+                (collector_addr(1), loc_rib_tx, loc_rib_filter()),
+            ],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        event_tx
+            .send(BmpEvent::LocRibStats {
+                per_family: vec![(1, 1, 10), (2, 1, 5)],
+            })
+            .await
+            .unwrap();
+
+        let msg = loc_rib_rx.recv().await.unwrap();
+        assert_eq!(msg[5], 1, "stats report type");
+        assert_eq!(msg[6], 3, "peer type 3");
+        // count(4) at offset 48: type 8 + two type-10 entries = 3.
+        assert_eq!(u32::from_be_bytes(msg[48..52].try_into().unwrap()), 3);
+        // First: type 8, len 8, value = 15 (sum).
+        assert_eq!(u16::from_be_bytes([msg[52], msg[53]]), 8);
+        assert_eq!(u64::from_be_bytes(msg[56..64].try_into().unwrap()), 15);
+        // Then the per-family type-10 entries.
+        assert_eq!(u16::from_be_bytes([msg[64], msg[65]]), 10);
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), rib_in_rx.recv())
+                .await
+                .is_err(),
+            "non-loc_rib collector must not receive Loc-RIB stats"
+        );
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
+    /// Collector connect triggers the RFC 9069 table sync: Loc-RIB Peer
+    /// Up first, then the dump chunks as RM messages (install-time
+    /// headers), then live Loc-RIB events keep flowing — and the dump
+    /// request goes out for `loc_rib` collectors only.
+    #[tokio::test]
+    async fn collector_connect_triggers_loc_rib_peer_up_then_dump_then_live() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (c_tx, mut c_rx) = mpsc::channel(16);
+        let (dump_tx, mut dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(collector_addr(0), c_tx, loc_rib_filter())],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        control_tx
+            .send(BmpControlEvent::CollectorConnected {
+                collector_id: 0,
+                collector_addr: collector_addr(0),
+            })
+            .await
+            .unwrap();
+
+        // 1. Loc-RIB Peer Up replay (peer type 3, fabricated OPEN twice,
+        // table-name TLV at the tail).
+        let peer_up = c_rx.recv().await.unwrap();
+        assert_eq!(peer_up[5], 3, "PeerUp message type");
+        assert_eq!(peer_up[6], 3, "peer type 3");
+        assert_eq!(&peer_up[peer_up.len() - 6..], b"global");
+
+        // 2. The manager requested a dump; answer with two chunks
+        // playing the RIB manager's role (2 routes + 1 "EoR" PDU).
+        let request = tokio::time::timeout(std::time::Duration::from_secs(2), dump_rx.recv())
+            .await
+            .expect("dump requested on connect")
+            .expect("dump channel open");
+        let install = UNIX_EPOCH + std::time::Duration::from_secs(1_600_000_000);
+        request
+            .reply
+            .send(crate::types::BmpDumpChunk {
+                messages: vec![
+                    (Bytes::from_static(&[0xD1; 23]), install),
+                    (Bytes::from_static(&[0xD2; 23]), install),
+                ],
+            })
+            .await
+            .unwrap();
+        request
+            .reply
+            .send(crate::types::BmpDumpChunk {
+                messages: vec![(Bytes::from_static(&[0xE0; 23]), install)],
+            })
+            .await
+            .unwrap();
+        drop(request);
+
+        for expected in [0xD1u8, 0xD2, 0xE0] {
+            let msg = c_rx.recv().await.unwrap();
+            assert_eq!(msg[5], 0, "route monitoring type");
+            assert_eq!(msg[6], 3, "peer type 3");
+            let ts = u32::from_be_bytes(msg[40..44].try_into().unwrap());
+            assert_eq!(ts, 1_600_000_000, "per-message install timestamp");
+            assert_eq!(msg[48], expected, "dump PDU order preserved");
+        }
+
+        // 3. Live emission continues seamlessly after the dump.
+        event_tx
+            .send(BmpEvent::LocRibRouteMonitoring {
+                update_pdu: Bytes::from_static(&[0xF7; 23]),
+                timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            })
+            .await
+            .unwrap();
+        let live = c_rx.recv().await.unwrap();
+        assert_eq!(live[48], 0xF7);
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
+    /// A collector that does not monitor `loc_rib` gets neither the
+    /// Loc-RIB Peer Up nor a dump request on connect.
+    #[tokio::test]
+    async fn non_loc_rib_collector_connect_skips_dump() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (c_tx, mut c_rx) = mpsc::channel(16);
+        let (dump_tx, mut dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        control_tx
+            .send(BmpControlEvent::CollectorConnected {
+                collector_id: 0,
+                collector_addr: collector_addr(0),
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), c_rx.recv())
+                .await
+                .is_err(),
+            "no Loc-RIB PeerUp for a non-loc_rib collector (empty PeerUp cache)"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), dump_rx.recv())
+                .await
+                .is_err(),
+            "no dump request for a non-loc_rib collector"
+        );
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
+    /// Shutdown sends the Loc-RIB Peer Down (reason 6 + table-name TLV)
+    /// to `loc_rib` collectors before the manager exits.
+    #[tokio::test]
+    async fn shutdown_emits_loc_rib_peer_down_reason_6() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (c_tx, mut c_rx) = mpsc::channel(16);
+        let (dump_tx, _dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(collector_addr(0), c_tx, loc_rib_filter())],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        control_tx.send(BmpControlEvent::Shutdown).await.unwrap();
+        handle.await.unwrap();
+
+        let msg = c_rx.recv().await.unwrap();
+        assert_eq!(msg[5], 2, "PeerDown message type");
+        assert_eq!(msg[6], 3, "peer type 3");
+        assert_eq!(msg[48], 6, "reason 6: local system closed, TLV follows");
+        assert_eq!(&msg[msg.len() - 6..], b"global");
+
+        drop(event_tx);
     }
 
     #[tokio::test]

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::SystemTime;
 
 use bytes::Bytes;
+use tokio::sync::mpsc;
 
 /// BMP event sent from transport to BMP manager.
 #[derive(Debug)]
@@ -51,6 +52,83 @@ pub enum BmpEvent {
         /// 15/17 are omitted rather than reported as a false zero.
         adj_rib_out_post: Option<Vec<(u16, u8, u64)>>,
     },
+    /// RFC 9069 Loc-RIB route monitoring: a synthesized UPDATE PDU for a
+    /// Loc-RIB best-path change, attributed to the emulated Loc-RIB
+    /// instance peer (peer type 3). The manager builds the per-peer
+    /// header from its [`BmpLocRibConfig`]; dropped when Loc-RIB
+    /// monitoring is not configured.
+    LocRibRouteMonitoring {
+        /// Synthesized BGP UPDATE PDU (including 19-byte BGP header),
+        /// 4-octet-ASN encoded per RFC 9069 §5.4.
+        update_pdu: Bytes,
+        /// Route install time (RFC 9069 per-peer header timestamp).
+        timestamp: SystemTime,
+    },
+    /// RFC 9069 Loc-RIB statistics: per-AFI/SAFI Loc-RIB route counts.
+    /// Encoded as stat type 10 entries plus their sum as type 8.
+    LocRibStats {
+        /// `(afi, safi, count)` for each monitored Loc-RIB family.
+        per_family: Vec<(u16, u8, u64)>,
+    },
+}
+
+/// Identity of the emulated RFC 9069 Loc-RIB instance peer (peer type 3).
+///
+/// Built once at startup; the manager uses it for every Loc-RIB per-peer
+/// header and for the fabricated Peer Up / Peer Down messages.
+#[derive(Debug, Clone)]
+pub struct BmpLocRibConfig {
+    /// Local (primary) BGP autonomous system number → Peer AS field.
+    pub local_asn: u32,
+    /// Local BGP router ID → Peer BGP ID field (global instance).
+    pub router_id: Ipv4Addr,
+    /// Fabricated BGP OPEN PDU (including 19-byte header) carrying the
+    /// 4-octet-ASN capability plus an MP capability for every AFI/SAFI
+    /// streamed on the Loc-RIB view (RFC 9069 §5.2.1). Used verbatim as
+    /// both the sent and received OPEN in the Peer Up notification.
+    pub open_pdu: Bytes,
+}
+
+/// RFC 9069 VRF/Table Name for the default (global) Loc-RIB instance.
+pub const LOC_RIB_TABLE_NAME: &str = "global";
+
+impl BmpLocRibConfig {
+    /// Per-peer header identity for the Loc-RIB instance peer at a given
+    /// timestamp: peer type 3, zero-filled peer address, distinguisher 0
+    /// (global instance), Peer AS = local AS, BGP ID = local router-id.
+    #[must_use]
+    pub fn peer_info(&self, timestamp: SystemTime) -> BmpPeerInfo {
+        BmpPeerInfo {
+            peer_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            peer_asn: self.local_asn,
+            peer_bgp_id: self.router_id,
+            peer_type: BmpPeerType::LocRib,
+            is_ipv6: false,
+            is_post_policy: false,
+            is_rib_out: false,
+            is_as4: true,
+            timestamp,
+        }
+    }
+}
+
+/// A Loc-RIB table-dump request from the BMP manager to the RIB manager,
+/// issued when a collector monitoring `loc_rib` (re)connects.
+///
+/// The RIB manager answers with bounded [`BmpDumpChunk`]s (synthesized
+/// UPDATE PDUs with per-route install timestamps, ending with one
+/// End-of-RIB PDU per dumped AFI/SAFI) and then drops the sender.
+#[derive(Debug)]
+pub struct BmpDumpRequest {
+    /// Chunk reply channel. Bounded — the dump producer paces on it.
+    pub reply: mpsc::Sender<BmpDumpChunk>,
+}
+
+/// One bounded chunk of a Loc-RIB table dump.
+#[derive(Debug)]
+pub struct BmpDumpChunk {
+    /// Synthesized UPDATE PDUs with their route install times.
+    pub messages: Vec<(Bytes, SystemTime)>,
 }
 
 /// Control-plane events sent from BMP clients to the BMP manager.
@@ -115,6 +193,8 @@ pub enum BmpPeerType {
     RdInstance = 1,
     /// Local Instance Peer.
     Local = 2,
+    /// Loc-RIB Instance Peer (RFC 9069).
+    LocRib = 3,
 }
 
 /// Reason for peer session going down (RFC 7854 §4.9).
@@ -140,6 +220,11 @@ pub struct BmpMonitorFilter {
     pub rib_in_pre: bool,
     /// Post-policy Adj-RIB-Out route monitoring (RFC 8671, O=1, L=1).
     pub rib_out_post: bool,
+    /// Loc-RIB instance monitoring (RFC 9069, peer type 3). Unlike the
+    /// other views, this also scopes the Loc-RIB pseudo-peer's Peer
+    /// Up/Down and Stats messages — a collector not monitoring
+    /// `loc_rib` never sees the emulated peer at all.
+    pub loc_rib: bool,
 }
 
 impl Default for BmpMonitorFilter {
@@ -148,6 +233,7 @@ impl Default for BmpMonitorFilter {
         Self {
             rib_in_pre: true,
             rib_out_post: false,
+            loc_rib: false,
         }
     }
 }

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -16,6 +16,8 @@ rustbgpd-wire.workspace = true
 rustbgpd-policy.workspace = true
 rustbgpd-telemetry.workspace = true
 rustbgpd-rpki.workspace = true
+rustbgpd-bmp.workspace = true
+bytes.workspace = true
 smallvec.workspace = true
 rustc-hash.workspace = true
 prefix-trie.workspace = true
@@ -34,7 +36,6 @@ tokio-stream.workspace = true
 bench-internals = []
 
 [dev-dependencies]
-bytes.workspace = true
 proptest = "1"
 tokio = { workspace = true, features = ["test-util"] }
 criterion.workspace = true

--- a/crates/rib/src/bmp_sync.rs
+++ b/crates/rib/src/bmp_sync.rs
@@ -1,0 +1,496 @@
+//! RFC 9069 Loc-RIB BMP synthesis: rebuild BGP UPDATE PDUs from RIB
+//! entries for Route Monitoring of the emulated Loc-RIB instance peer.
+//!
+//! Loc-RIB routes were stripped of their next-hop / `MP_REACH_NLRI`
+//! at decode (per MP-BGP architecture), so announcement PDUs
+//! reconstruct the appropriate reachability attribute — the same
+//! pattern as the MRT exporter's attribute synthesis, except the NLRI
+//! rides *inside* the UPDATE here rather than in a table-dump record
+//! header. All PDUs use 4-octet-ASN encoding and no Add-Path, matching
+//! the fabricated OPEN advertised in the Loc-RIB Peer Up (§5.2.1).
+//!
+//! V1 synthesis scope: IPv4/IPv6 unicast and VPNv4/VPNv6 (SAFI 128) —
+//! the families declared in `LOC_RIB_FAMILIES`. Other Loc-RIB
+//! families (EVPN, BGP-LS, labeled-unicast, FlowSpec, RTC) land
+//! additively later; they are deliberately absent from the fabricated
+//! OPEN so collectors are not promised streams that never arrive.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use bytes::{Bytes, BytesMut};
+use rustbgpd_wire::{
+    Afi, Capability, EXTENDED_MAX_MESSAGE_LEN, Ipv4NlriEntry, Ipv4UnicastMode, MpReachNlri,
+    MpUnreachNlri, NlriEntry, OpenMessage, PathAttribute, Prefix, Safi, UpdateMessage, VpnNlri,
+    VpnNlriEntry,
+};
+use tracing::warn;
+
+use crate::route::{Route, VpnRibRoute};
+
+/// `AS_TRANS` (RFC 6793): 2-byte OPEN AS field stand-in for ASNs > 65535.
+const AS_TRANS: u16 = 23456;
+
+/// The AFI/SAFI pairs streamed on the Loc-RIB view, and therefore the
+/// MP capabilities carried in the fabricated OPEN and the families that
+/// receive an End-of-RIB after a table dump.
+pub const LOC_RIB_FAMILIES: [(Afi, Safi); 4] = [
+    (Afi::Ipv4, Safi::Unicast),
+    (Afi::Ipv6, Safi::Unicast),
+    (Afi::Ipv4, Safi::MplsVpn),
+    (Afi::Ipv6, Safi::MplsVpn),
+];
+
+fn empty_mp_reach(afi: Afi, safi: Safi, next_hop: IpAddr) -> MpReachNlri {
+    MpReachNlri {
+        afi,
+        safi,
+        next_hop,
+        link_local_next_hop: None,
+        announced: vec![],
+        flowspec_announced: vec![],
+        evpn_announced: vec![],
+        bgpls_announced: vec![],
+        labeled_announced: vec![],
+        vpn_announced: vec![],
+        rtc_announced: vec![],
+    }
+}
+
+fn empty_mp_unreach(afi: Afi, safi: Safi) -> MpUnreachNlri {
+    MpUnreachNlri {
+        afi,
+        safi,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: vec![],
+        vpn_withdrawn: vec![],
+        labeled_withdrawn: vec![],
+        rtc_withdrawn: vec![],
+    }
+}
+
+/// Encode a built `UpdateMessage` into a complete PDU (with header),
+/// or `None` with a warning if it cannot be represented on the wire.
+fn encode_update(update: &UpdateMessage, what: &str) -> Option<Bytes> {
+    let mut buf = BytesMut::with_capacity(update.encoded_len());
+    match update.encode_with_limit(&mut buf, EXTENDED_MAX_MESSAGE_LEN) {
+        Ok(()) => Some(buf.freeze()),
+        Err(e) => {
+            warn!(error = %e, what, "failed to synthesize Loc-RIB BMP UPDATE, skipping");
+            None
+        }
+    }
+}
+
+fn build_update(
+    announced: &[Ipv4NlriEntry],
+    withdrawn: &[Ipv4NlriEntry],
+    attributes: &[PathAttribute],
+    what: &str,
+) -> Option<Bytes> {
+    match UpdateMessage::try_build(
+        announced,
+        withdrawn,
+        attributes,
+        true, // 4-octet ASN encoding (RFC 9069 §5.4)
+        false,
+        Ipv4UnicastMode::Body,
+    ) {
+        Ok(update) => encode_update(&update, what),
+        Err(e) => {
+            warn!(error = %e, what, "failed to synthesize Loc-RIB BMP UPDATE, skipping");
+            None
+        }
+    }
+}
+
+/// Synthesize an announcement UPDATE for a unicast Loc-RIB best route.
+///
+/// IPv4 with an IPv4 next-hop uses the classic body NLRI + `NEXT_HOP`
+/// attribute; IPv6 (and RFC 8950 IPv4-over-IPv6-next-hop) uses
+/// `MP_REACH_NLRI` with the prefix inside the attribute.
+#[must_use]
+pub fn synthesize_unicast_announce(route: &Route) -> Option<Bytes> {
+    let mut attrs = (*route.attributes).clone();
+    match (route.prefix, route.next_hop) {
+        (Prefix::V4(v4_prefix), IpAddr::V4(nh)) => {
+            // Insert NEXT_HOP after ORIGIN and AS_PATH (canonical order).
+            let insert_pos = attrs
+                .iter()
+                .position(|a| !matches!(a, PathAttribute::Origin(_) | PathAttribute::AsPath(_)))
+                .unwrap_or(attrs.len());
+            attrs.insert(insert_pos, PathAttribute::NextHop(nh));
+            build_update(
+                &[Ipv4NlriEntry {
+                    path_id: 0,
+                    prefix: v4_prefix,
+                }],
+                &[],
+                &attrs,
+                "unicast v4 announce",
+            )
+        }
+        (prefix, next_hop) => {
+            let afi = match prefix {
+                Prefix::V4(_) => Afi::Ipv4, // RFC 8950: IPv4 NLRI, IPv6 next-hop
+                Prefix::V6(_) => Afi::Ipv6,
+            };
+            let mut mp_reach = empty_mp_reach(afi, Safi::Unicast, next_hop);
+            mp_reach.link_local_next_hop = route.link_local_next_hop;
+            mp_reach.announced = vec![NlriEntry { path_id: 0, prefix }];
+            attrs.push(PathAttribute::MpReachNlri(mp_reach));
+            build_update(&[], &[], &attrs, "unicast mp announce")
+        }
+    }
+}
+
+/// Synthesize a withdrawal UPDATE for a unicast prefix that lost its
+/// Loc-RIB best (v4: body withdrawn field; v6: `MP_UNREACH_NLRI`).
+#[must_use]
+pub fn synthesize_unicast_withdraw(prefix: Prefix) -> Option<Bytes> {
+    match prefix {
+        Prefix::V4(v4_prefix) => build_update(
+            &[],
+            &[Ipv4NlriEntry {
+                path_id: 0,
+                prefix: v4_prefix,
+            }],
+            &[],
+            "unicast v4 withdraw",
+        ),
+        Prefix::V6(_) => {
+            let mut mp_unreach = empty_mp_unreach(Afi::Ipv6, Safi::Unicast);
+            mp_unreach.withdrawn = vec![NlriEntry { path_id: 0, prefix }];
+            build_update(
+                &[],
+                &[],
+                &[PathAttribute::MpUnreachNlri(mp_unreach)],
+                "unicast v6 withdraw",
+            )
+        }
+    }
+}
+
+/// The wire AFI for a VPN NLRI (SAFI is always `MplsVpn`).
+fn vpn_afi(nlri: &VpnNlri) -> Afi {
+    match nlri.prefix.family() {
+        rustbgpd_wire::VpnAddressFamily::V4 => Afi::Ipv4,
+        rustbgpd_wire::VpnAddressFamily::V6 => Afi::Ipv6,
+    }
+}
+
+/// Synthesize an announcement UPDATE for a VPNv4/VPNv6 Loc-RIB best
+/// route: `MP_REACH_NLRI` carrying the full NLRI (RD + label stack +
+/// prefix, preserved verbatim) with the route's VPN next-hop.
+#[must_use]
+pub fn synthesize_vpn_announce(route: &VpnRibRoute) -> Option<Bytes> {
+    let mut attrs = (*route.attributes).clone();
+    let mut mp_reach = empty_mp_reach(vpn_afi(&route.nlri), Safi::MplsVpn, route.next_hop);
+    mp_reach.vpn_announced = vec![VpnNlriEntry {
+        path_id: 0,
+        nlri: route.nlri.clone(),
+    }];
+    attrs.push(PathAttribute::MpReachNlri(mp_reach));
+    build_update(&[], &[], &attrs, "vpn announce")
+}
+
+/// Synthesize a withdrawal UPDATE for a VPN RD+prefix identity that
+/// lost its Loc-RIB best: `MP_UNREACH_NLRI` (the encoder emits the
+/// RFC 8277 §2.4 3-octet compatibility field in place of the label
+/// stack).
+#[must_use]
+pub fn synthesize_vpn_withdraw(nlri: &VpnNlri) -> Option<Bytes> {
+    let mut mp_unreach = empty_mp_unreach(vpn_afi(nlri), Safi::MplsVpn);
+    mp_unreach.vpn_withdrawn = vec![VpnNlriEntry {
+        path_id: 0,
+        nlri: nlri.clone(),
+    }];
+    build_update(
+        &[],
+        &[],
+        &[PathAttribute::MpUnreachNlri(mp_unreach)],
+        "vpn withdraw",
+    )
+}
+
+/// Synthesize the RFC 4724 End-of-RIB marker for a family: the empty
+/// UPDATE for IPv4 unicast, an empty `MP_UNREACH_NLRI` otherwise.
+#[must_use]
+pub fn synthesize_end_of_rib(afi: Afi, safi: Safi) -> Option<Bytes> {
+    if (afi, safi) == (Afi::Ipv4, Safi::Unicast) {
+        build_update(&[], &[], &[], "eor v4 unicast")
+    } else {
+        build_update(
+            &[],
+            &[],
+            &[PathAttribute::MpUnreachNlri(empty_mp_unreach(afi, safi))],
+            "eor mp",
+        )
+    }
+}
+
+/// Fabricate the RFC 9069 §5.2.1 OPEN PDU for the emulated Loc-RIB
+/// instance peer: 4-octet-ASN capability plus one MP capability per
+/// [`LOC_RIB_FAMILIES`] entry. Used verbatim as both the sent and the
+/// received OPEN of the Loc-RIB Peer Up.
+///
+/// # Panics
+///
+/// Panics if the fabricated OPEN cannot be encoded — impossible by
+/// construction (fixed capability set, bounded size).
+#[must_use]
+pub fn loc_rib_open_pdu(local_asn: u32, router_id: Ipv4Addr) -> Bytes {
+    let mut capabilities: Vec<Capability> = LOC_RIB_FAMILIES
+        .iter()
+        .map(|&(afi, safi)| Capability::MultiProtocol { afi, safi })
+        .collect();
+    capabilities.push(Capability::FourOctetAs { asn: local_asn });
+    let open = OpenMessage {
+        version: 4,
+        my_as: u16::try_from(local_asn).unwrap_or(AS_TRANS),
+        hold_time: 0,
+        bgp_identifier: router_id,
+        capabilities,
+    };
+    let mut buf = BytesMut::with_capacity(open.encoded_len());
+    open.encode(&mut buf)
+        .expect("fabricated Loc-RIB OPEN is bounded and always encodable");
+    buf.freeze()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use rustbgpd_wire::{
+        AsPath, AsPathSegment, BgpHeader, Ipv4Prefix, Ipv6Prefix, MplsLabelEntry, Origin,
+        RouteDistinguisher, VpnPrefix,
+    };
+
+    use super::*;
+    use crate::route::RouteOrigin;
+
+    fn base_attrs() -> Vec<PathAttribute> {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001, 4_200_000_001])],
+            }),
+        ]
+    }
+
+    fn unicast_route(prefix: Prefix, next_hop: IpAddr) -> Route {
+        Route {
+            prefix,
+            next_hop,
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: next_hop,
+            attributes: Arc::new(base_attrs()),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        }
+    }
+
+    fn vpn_nlri() -> VpnNlri {
+        VpnNlri {
+            labels: vec![MplsLabelEntry {
+                label: 1042,
+                traffic_class: 0,
+                bottom_of_stack: true,
+            }],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 7]),
+            prefix: VpnPrefix::V4 {
+                addr: Ipv4Addr::new(10, 40, 0, 0),
+                len: 24,
+            },
+        }
+    }
+
+    fn vpn_route() -> VpnRibRoute {
+        VpnRibRoute {
+            nlri: vpn_nlri(),
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9)),
+            peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            attributes: Arc::new(base_attrs()),
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    /// Decode a synthesized PDU back into a parsed UPDATE (4-octet ASN,
+    /// no Add-Path — the fabricated OPEN's session parameters).
+    fn decode_pdu(pdu: &Bytes) -> rustbgpd_wire::ParsedUpdate {
+        let mut buf = pdu.clone();
+        let header = BgpHeader::decode(&mut buf, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        let body_len = usize::from(header.length) - 19;
+        let update = UpdateMessage::decode(&mut buf, body_len).unwrap();
+        update.parse(true, false, &[]).unwrap()
+    }
+
+    #[test]
+    fn unicast_v4_announce_round_trips() {
+        let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 16));
+        let route = unicast_route(prefix, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+        let pdu = synthesize_unicast_announce(&route).unwrap();
+        let parsed = decode_pdu(&pdu);
+        assert_eq!(parsed.announced.len(), 1);
+        assert_eq!(Prefix::V4(parsed.announced[0].prefix), prefix);
+        assert!(parsed.withdrawn.is_empty());
+        assert!(parsed.attributes.iter().any(
+            |a| matches!(a, PathAttribute::NextHop(nh) if *nh == Ipv4Addr::new(192, 0, 2, 1))
+        ));
+        // 4-octet ASN encoding: the >65535 ASN survives the round-trip.
+        assert!(parsed.attributes.iter().any(|a| matches!(
+            a,
+            PathAttribute::AsPath(p) if matches!(
+                &p.segments[0],
+                AsPathSegment::AsSequence(asns) if asns.contains(&4_200_000_001)
+            )
+        )));
+    }
+
+    #[test]
+    fn unicast_v6_announce_round_trips_via_mp_reach() {
+        let prefix = Prefix::V6(Ipv6Prefix::new(
+            "2001:db8:40::".parse::<Ipv6Addr>().unwrap(),
+            48,
+        ));
+        let nh = IpAddr::V6("2001:db8::1".parse().unwrap());
+        let route = unicast_route(prefix, nh);
+        let pdu = synthesize_unicast_announce(&route).unwrap();
+        let parsed = decode_pdu(&pdu);
+        assert!(
+            parsed.announced.is_empty(),
+            "v6 NLRI must not be in the body"
+        );
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::MpReachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("MP_REACH present");
+        assert_eq!((mp.afi, mp.safi), (Afi::Ipv6, Safi::Unicast));
+        assert_eq!(mp.next_hop, nh);
+        assert_eq!(mp.announced, vec![NlriEntry { path_id: 0, prefix }]);
+    }
+
+    #[test]
+    fn unicast_withdraws_round_trip() {
+        let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 16));
+        let parsed = decode_pdu(&synthesize_unicast_withdraw(v4).unwrap());
+        assert_eq!(parsed.withdrawn.len(), 1);
+        assert_eq!(Prefix::V4(parsed.withdrawn[0].prefix), v4);
+
+        let v6 = Prefix::V6(Ipv6Prefix::new(
+            "2001:db8:41::".parse::<Ipv6Addr>().unwrap(),
+            48,
+        ));
+        let parsed = decode_pdu(&synthesize_unicast_withdraw(v6).unwrap());
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::MpUnreachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("MP_UNREACH present");
+        assert_eq!(
+            mp.withdrawn,
+            vec![NlriEntry {
+                path_id: 0,
+                prefix: v6
+            }]
+        );
+    }
+
+    #[test]
+    fn vpn_announce_and_withdraw_round_trip() {
+        let route = vpn_route();
+        let parsed = decode_pdu(&synthesize_vpn_announce(&route).unwrap());
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::MpReachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("MP_REACH present");
+        assert_eq!((mp.afi, mp.safi), (Afi::Ipv4, Safi::MplsVpn));
+        assert_eq!(mp.next_hop, route.next_hop);
+        assert_eq!(mp.vpn_announced.len(), 1);
+        assert_eq!(mp.vpn_announced[0].nlri, route.nlri);
+
+        // Withdraw: RD + prefix identity survives; the label field is
+        // the RFC 8277 §2.4 compatibility value, not the stack.
+        let parsed = decode_pdu(&synthesize_vpn_withdraw(&route.nlri).unwrap());
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::MpUnreachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("MP_UNREACH present");
+        assert_eq!(mp.vpn_withdrawn.len(), 1);
+        assert_eq!(mp.vpn_withdrawn[0].nlri.key(), route.nlri.key());
+    }
+
+    #[test]
+    fn end_of_rib_markers() {
+        // IPv4 unicast EoR is the canonical 23-byte empty UPDATE.
+        let eor = synthesize_end_of_rib(Afi::Ipv4, Safi::Unicast).unwrap();
+        assert_eq!(eor.len(), 23);
+        // MP EoR: only an empty MP_UNREACH for the family.
+        let parsed = decode_pdu(&synthesize_end_of_rib(Afi::Ipv6, Safi::MplsVpn).unwrap());
+        let mp = parsed
+            .attributes
+            .iter()
+            .find_map(|a| match a {
+                PathAttribute::MpUnreachNlri(mp) => Some(mp),
+                _ => None,
+            })
+            .expect("MP_UNREACH present");
+        assert_eq!((mp.afi, mp.safi), (Afi::Ipv6, Safi::MplsVpn));
+        assert!(mp.withdrawn.is_empty() && mp.vpn_withdrawn.is_empty());
+    }
+
+    /// The fabricated OPEN (RFC 9069 §5.2.1) carries the 4-octet-ASN
+    /// capability and one MP capability per streamed family, with
+    /// `AS_TRANS` in the 2-byte field for a >65535 local ASN.
+    #[test]
+    fn fabricated_open_carries_required_capabilities() {
+        let router_id = Ipv4Addr::new(10, 0, 0, 1);
+        let pdu = loc_rib_open_pdu(4_200_000_777, router_id);
+        let mut buf = pdu.clone();
+        let header = BgpHeader::decode(&mut buf, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        let open = OpenMessage::decode(&mut buf, usize::from(header.length) - 19).unwrap();
+        assert_eq!(open.my_as, AS_TRANS);
+        assert_eq!(open.bgp_identifier, router_id);
+        assert_eq!(open.four_byte_as(), 4_200_000_777);
+        for (afi, safi) in LOC_RIB_FAMILIES {
+            assert!(
+                open.capabilities
+                    .iter()
+                    .any(|c| *c == Capability::MultiProtocol { afi, safi }),
+                "missing MP capability for {afi:?}/{safi:?}"
+            );
+        }
+    }
+}

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -14,6 +14,8 @@ pub mod adj_rib_in;
 pub mod adj_rib_out;
 /// Best-path selection algorithm (RFC 4271 §9.1.2).
 pub mod best_path;
+/// RFC 9069 Loc-RIB BMP synthesis (UPDATE PDUs + fabricated OPEN).
+pub mod bmp_sync;
 /// Route change event types for broadcast subscribers.
 pub mod event;
 /// Sink boundary for handing route + EVPN events to an out-of-crate

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -526,6 +526,19 @@ impl RibManager {
             if did_change {
                 changed.insert(*prefix);
                 let current_best = self.loc_rib.get(prefix);
+                // RFC 9069 Loc-RIB tap: any change to the best is a
+                // Route Monitoring announce of the new best (BGP
+                // implicit withdraw covers replacement); a best that
+                // disappeared is an explicit withdraw. Timestamp = the
+                // Loc-RIB install time, i.e. now. Best-unchanged
+                // prefixes never reach this branch.
+                if self.bmp_tx.is_some() {
+                    let pdu = match current_best {
+                        Some(best) => crate::bmp_sync::synthesize_unicast_announce(best),
+                        None => crate::bmp_sync::synthesize_unicast_withdraw(*prefix),
+                    };
+                    self.emit_bmp_loc_rib(pdu, std::time::SystemTime::now());
+                }
                 match (previous_best, current_best) {
                     (None, Some(best)) => {
                         debug!(%prefix, peer = %best.peer, "best path added");

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -449,6 +449,13 @@ impl RibManager {
 
         let mut changed_keys: HashSet<VpnRouteKey> = HashSet::new();
         for key in &affected_nlri {
+            // RFC 9069 Loc-RIB tap: keep the previous best's NLRI so a
+            // disappeared best can be withdrawn with its full RD +
+            // prefix identity. Cloned only when the tap is installed.
+            let bmp_prev_nlri = self
+                .bmp_tx
+                .as_ref()
+                .and_then(|_| self.loc_rib.get_vpn(key).map(|route| route.nlri.clone()));
             let candidates: Vec<VpnRibRoute> = self
                 .ribs
                 .values()
@@ -456,6 +463,15 @@ impl RibManager {
                 .collect();
             if self.loc_rib.recompute_vpn(*key, candidates.iter()) {
                 changed_keys.insert(*key);
+                if self.bmp_tx.is_some() {
+                    let pdu = match self.loc_rib.get_vpn(key) {
+                        Some(best) => crate::bmp_sync::synthesize_vpn_announce(best),
+                        None => bmp_prev_nlri
+                            .as_ref()
+                            .and_then(crate::bmp_sync::synthesize_vpn_withdraw),
+                    };
+                    self.emit_bmp_loc_rib(pdu, std::time::SystemTime::now());
+                }
             }
         }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -247,6 +247,12 @@ pub struct RibManager {
     /// The binary installs an EHM-backed sink via
     /// [`Self::with_event_sink`] when `[event_history]` is enabled.
     event_sink: std::sync::Arc<dyn crate::event_sink::RibEventSink>,
+    /// RFC 9069 Loc-RIB BMP tap. When set, every Loc-RIB best-path
+    /// change on a streamed family (unicast + VPN) is synthesized into
+    /// an UPDATE PDU and sent as a `LocRibRouteMonitoring` event; `None`
+    /// (no collector monitors `loc_rib`) costs one `is_some()` check
+    /// per recompute.
+    bmp_tx: Option<mpsc::Sender<rustbgpd_bmp::BmpEvent>>,
     metrics: BgpMetrics,
     rx: mpsc::Receiver<RibUpdate>,
     /// Priority channel for read-only queries (gRPC).
@@ -315,6 +321,8 @@ pub(super) struct LiveSessionRecord {
 }
 
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
+/// Synthesized messages per RFC 9069 Loc-RIB dump chunk.
+const BMP_DUMP_CHUNK_SIZE: usize = 256;
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
@@ -611,6 +619,7 @@ impl RibManager {
             evpn_events_tx,
             evpn_route_event_history: VecDeque::with_capacity(EVPN_ROUTE_EVENT_HISTORY_CAPACITY),
             event_sink: std::sync::Arc::new(crate::event_sink::NoopRibEventSink),
+            bmp_tx: None,
             metrics,
             rx,
             query_rx,
@@ -653,6 +662,32 @@ impl RibManager {
     ) -> Self {
         self.event_sink = sink;
         self
+    }
+
+    /// Install the RFC 9069 Loc-RIB BMP tap. Called at startup by the
+    /// daemon binary when at least one BMP collector monitors the
+    /// `loc_rib` view; left `None` otherwise so non-monitored
+    /// deployments pay nothing for PDU synthesis.
+    #[must_use]
+    pub fn with_bmp_tx(mut self, bmp_tx: mpsc::Sender<rustbgpd_bmp::BmpEvent>) -> Self {
+        self.bmp_tx = Some(bmp_tx);
+        self
+    }
+
+    /// Emit an RFC 9069 Loc-RIB Route Monitoring event. `pdu = None`
+    /// (synthesis failure, already warned) is a no-op. Uses `try_send`
+    /// — monitoring must never backpressure the RIB task; drops are
+    /// surfaced with a warning.
+    fn emit_bmp_loc_rib(&self, pdu: Option<bytes::Bytes>, timestamp: std::time::SystemTime) {
+        let (Some(tx), Some(update_pdu)) = (self.bmp_tx.as_ref(), pdu) else {
+            return;
+        };
+        if let Err(e) = tx.try_send(rustbgpd_bmp::BmpEvent::LocRibRouteMonitoring {
+            update_pdu,
+            timestamp,
+        }) {
+            warn!(error = %e, "BMP event channel full or closed, dropping Loc-RIB route monitoring");
+        }
     }
 
     #[must_use]
@@ -1061,7 +1096,96 @@ impl RibManager {
             }
             RibUpdate::QueryOrrStatus { reply } => self.handle_query_orr_status(reply),
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
+            RibUpdate::QueryBmpLocRibDump { reply } => self.handle_query_bmp_loc_rib_dump(reply),
+            RibUpdate::QueryBmpLocRibStats { reply } => {
+                self.handle_query_bmp_loc_rib_stats(reply);
+            }
         }
+    }
+
+    /// RFC 9069 Loc-RIB table dump: synthesize one UPDATE PDU per
+    /// Loc-RIB best route (unicast + VPN) with its install-time
+    /// timestamp, append one End-of-RIB PDU per streamed family, and
+    /// stream the lot back in bounded chunks from a spawned drain task
+    /// — the RIB task never awaits the (slow-collector-paced) reply
+    /// channel.
+    ///
+    /// The whole table is synthesized up front in this handler; that is
+    /// the same O(table) burst the MRT snapshot query already takes.
+    // ponytail: full-table synthesis burst; switch to resumable per-chunk
+    // queries if dump CPU/memory at extreme scale ever bites.
+    fn handle_query_bmp_loc_rib_dump(&self, reply: mpsc::Sender<rustbgpd_bmp::BmpDumpChunk>) {
+        use crate::bmp_sync;
+        let now = std::time::SystemTime::now();
+        // Install time ≈ receive wall time, recovered from the monotonic
+        // receive instant (RFC 9069 per-peer header timestamp).
+        let install_time =
+            |received_at: std::time::Instant| now.checked_sub(received_at.elapsed()).unwrap_or(now);
+        let mut messages: Vec<(bytes::Bytes, std::time::SystemTime)> = Vec::with_capacity(
+            self.loc_rib.len() + self.loc_rib.vpn_len() + bmp_sync::LOC_RIB_FAMILIES.len(),
+        );
+        for route in self.loc_rib.iter() {
+            if let Some(pdu) = bmp_sync::synthesize_unicast_announce(route) {
+                messages.push((pdu, install_time(route.received_at)));
+            }
+        }
+        for route in self.loc_rib.iter_vpn() {
+            if let Some(pdu) = bmp_sync::synthesize_vpn_announce(route) {
+                messages.push((pdu, install_time(route.received_at)));
+            }
+        }
+        // End-of-RIB per family closes the dump; live emission continues
+        // seamlessly after (dump→EoR→live, with the standard BMP overlap
+        // race accepted).
+        for (afi, safi) in bmp_sync::LOC_RIB_FAMILIES {
+            if let Some(pdu) = bmp_sync::synthesize_end_of_rib(afi, safi) {
+                messages.push((pdu, now));
+            }
+        }
+        tokio::spawn(async move {
+            let mut iter = messages.into_iter().peekable();
+            while iter.peek().is_some() {
+                let chunk: Vec<_> = iter.by_ref().take(BMP_DUMP_CHUNK_SIZE).collect();
+                if reply
+                    .send(rustbgpd_bmp::BmpDumpChunk { messages: chunk })
+                    .await
+                    .is_err()
+                {
+                    debug!("BMP Loc-RIB dump consumer dropped, aborting dump");
+                    return;
+                }
+            }
+        });
+    }
+
+    /// Per-AFI/SAFI Loc-RIB route counts for the RFC 9069 BMP stats
+    /// report (stat type 10; type 8 is the sum). Scoped to the streamed
+    /// Loc-RIB families — counting families absent from the fabricated
+    /// OPEN would advertise routes the collector can never receive.
+    fn handle_query_bmp_loc_rib_stats(
+        &self,
+        reply: tokio::sync::oneshot::Sender<Vec<(u16, u8, u64)>>,
+    ) {
+        let (mut v4, mut v6) = (0u64, 0u64);
+        for route in self.loc_rib.iter() {
+            match route.prefix {
+                Prefix::V4(_) => v4 += 1,
+                Prefix::V6(_) => v6 += 1,
+            }
+        }
+        let (mut vpnv4, mut vpnv6) = (0u64, 0u64);
+        for route in self.loc_rib.iter_vpn() {
+            match route.family() {
+                rustbgpd_wire::VpnAddressFamily::V4 => vpnv4 += 1,
+                rustbgpd_wire::VpnAddressFamily::V6 => vpnv6 += 1,
+            }
+        }
+        let _ = reply.send(vec![
+            (Afi::Ipv4 as u16, Safi::Unicast as u8, v4),
+            (Afi::Ipv6 as u16, Safi::Unicast as u8, v6),
+            (Afi::Ipv4 as u16, Safi::MplsVpn as u8, vpnv4),
+            (Afi::Ipv6 as u16, Safi::MplsVpn as u8, vpnv6),
+        ]);
     }
 
     fn handle_query_received_routes(

--- a/crates/rib/src/manager/tests/bmp.rs
+++ b/crates/rib/src/manager/tests/bmp.rs
@@ -1,0 +1,410 @@
+//! RFC 9069 Loc-RIB BMP tap tests: recompute-commit emissions,
+//! VPN best-change emission, the collector-connect table dump, and
+//! install-time timestamps.
+
+use std::time::SystemTime;
+
+use rustbgpd_bmp::{BmpDumpChunk, BmpEvent};
+use rustbgpd_wire::UpdateMessage;
+
+use super::*;
+
+/// Decode a synthesized Loc-RIB PDU with the fabricated-OPEN session
+/// parameters (4-octet ASN, no Add-Path).
+fn decode_pdu(pdu: &bytes::Bytes) -> rustbgpd_wire::ParsedUpdate {
+    let mut buf = pdu.clone();
+    let header =
+        rustbgpd_wire::BgpHeader::decode(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)
+            .unwrap();
+    let body_len = usize::from(header.length) - 19;
+    UpdateMessage::decode(&mut buf, body_len)
+        .unwrap()
+        .parse(true, false, &[])
+        .unwrap()
+}
+
+async fn recv_loc_rib_rm(
+    bmp_rx: &mut mpsc::Receiver<BmpEvent>,
+) -> (bytes::Bytes, std::time::SystemTime) {
+    let event = tokio::time::timeout(Duration::from_secs(2), bmp_rx.recv())
+        .await
+        .expect("expected a Loc-RIB BMP event")
+        .expect("BMP channel open");
+    match event {
+        BmpEvent::LocRibRouteMonitoring {
+            update_pdu,
+            timestamp,
+        } => (update_pdu, timestamp),
+        other => panic!("expected LocRibRouteMonitoring, got {other:?}"),
+    }
+}
+
+fn assert_no_event(bmp_rx: &mut mpsc::Receiver<BmpEvent>) {
+    match bmp_rx.try_recv() {
+        Err(mpsc::error::TryRecvError::Empty) => {}
+        other => panic!("expected no BMP event, got {other:?}"),
+    }
+}
+
+/// New best → RM announce; better path from another peer → RM announce
+/// of the new best; a change that leaves the best untouched → no
+/// emission; best withdrawn entirely → RM withdraw.
+#[tokio::test]
+async fn recompute_best_changes_emit_loc_rib_route_monitoring() {
+    let (tx, rx) = mpsc::channel(64);
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(64);
+    let manager =
+        RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new()).with_bmp_tx(bmp_tx);
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 16);
+    let peer_a = Ipv4Addr::new(10, 0, 0, 1);
+    let peer_b = Ipv4Addr::new(10, 0, 0, 2);
+
+    // 1. New best → announce.
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer_a),
+        session_id: 0,
+        announced: vec![make_route_with_lp(prefix, peer_a, 100)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let parsed = decode_pdu(&pdu);
+    assert_eq!(parsed.announced.len(), 1);
+    assert_eq!(parsed.announced[0].prefix, prefix);
+
+    // 2. Higher LOCAL_PREF from another peer → best changes → announce
+    // of the new best (next-hop = peer B).
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer_b),
+        session_id: 0,
+        announced: vec![make_route_with_lp(prefix, peer_b, 200)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let parsed = decode_pdu(&pdu);
+    assert_eq!(parsed.announced[0].prefix, prefix);
+    assert!(
+        parsed
+            .attributes
+            .iter()
+            .any(|a| matches!(a, PathAttribute::NextHop(nh) if *nh == peer_b)),
+        "announce must carry the NEW best's next-hop"
+    );
+
+    // 3. Losing path withdrawn — the best (peer B) is unchanged → no
+    // Loc-RIB emission.
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer_a),
+        session_id: 0,
+        announced: vec![],
+        withdrawn: vec![(Prefix::V4(prefix), 0)],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    // Synchronize on the RIB task having processed the withdraw.
+    let _ = query_vpn_routes(&tx).await;
+    assert_no_event(&mut bmp_rx);
+
+    // 4. Best withdrawn entirely → RM withdraw.
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer_b),
+        session_id: 0,
+        announced: vec![],
+        withdrawn: vec![(Prefix::V4(prefix), 0)],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let parsed = decode_pdu(&pdu);
+    assert!(parsed.announced.is_empty());
+    assert_eq!(parsed.withdrawn.len(), 1);
+    assert_eq!(parsed.withdrawn[0].prefix, prefix);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A VPN best change emits an MP announce; losing the last candidate
+/// emits an MP withdraw carrying the RD+prefix identity.
+#[tokio::test]
+async fn vpn_best_change_emits_loc_rib_route_monitoring() {
+    let (tx, rx) = mpsc::channel(64);
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(64);
+    let manager =
+        RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new()).with_bmp_tx(bmp_tx);
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 5);
+    let route = make_vpn_rib_route(peer, 42, 1042, 100);
+    let nlri = route.nlri.clone();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let parsed = decode_pdu(&pdu);
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN announce rides in MP_REACH");
+    assert_eq!(mp.vpn_announced.len(), 1);
+    assert_eq!(mp.vpn_announced[0].nlri, nlri);
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![],
+        withdrawn: vec![crate::route::VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id: 0,
+        }],
+    })
+    .await
+    .unwrap();
+    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let parsed = decode_pdu(&pdu);
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::MpUnreachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN withdraw rides in MP_UNREACH");
+    assert_eq!(mp.vpn_withdrawn.len(), 1);
+    assert_eq!(mp.vpn_withdrawn[0].nlri.key(), nlri.key());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The Loc-RIB dump streams every best (unicast + VPN) in chunks and
+/// closes with exactly one End-of-RIB per streamed family; dump-entry
+/// timestamps reflect route install time, not dump time.
+#[tokio::test]
+async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![
+            make_route_with_lp(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 16), peer, 100),
+            make_route_with_lp(Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 16), peer, 100),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![make_vpn_rib_route(peer, 42, 1042, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // Let the routes age so install-time and dump-time are separable.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+
+    let (reply, mut chunk_rx) = mpsc::channel::<BmpDumpChunk>(4);
+    let dump_started = SystemTime::now();
+    tx.send(RibUpdate::QueryBmpLocRibDump { reply })
+        .await
+        .unwrap();
+
+    let mut messages: Vec<(bytes::Bytes, SystemTime)> = Vec::new();
+    while let Some(chunk) = tokio::time::timeout(Duration::from_secs(2), chunk_rx.recv())
+        .await
+        .expect("dump chunk within timeout")
+    {
+        messages.extend(chunk.messages);
+        if chunk_rx.is_closed() && chunk_rx.is_empty() {
+            break;
+        }
+    }
+    // 2 unicast + 1 VPN route, then 4 EoRs (v4u, v6u, vpnv4, vpnv6).
+    assert_eq!(messages.len(), 3 + 4, "routes then one EoR per family");
+
+    let (route_msgs, eor_msgs) = messages.split_at(3);
+    let mut dumped_prefixes = Vec::new();
+    let mut dumped_vpn = 0;
+    for (pdu, timestamp) in route_msgs {
+        let parsed = decode_pdu(pdu);
+        assert!(
+            *timestamp < dump_started - Duration::from_millis(900),
+            "dump timestamp must be the route install time, not the dump time"
+        );
+        if let Some(mp) = parsed.attributes.iter().find_map(|a| match a {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        }) {
+            dumped_vpn += mp.vpn_announced.len();
+        } else {
+            dumped_prefixes.extend(parsed.announced.iter().map(|e| e.prefix));
+        }
+    }
+    dumped_prefixes.sort_by_key(|p| p.addr);
+    assert_eq!(
+        dumped_prefixes,
+        vec![
+            Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 16),
+            Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 16),
+        ]
+    );
+    assert_eq!(dumped_vpn, 1);
+
+    // The trailing four PDUs are EoRs: no NLRI anywhere, one per family.
+    let mut eor_families = Vec::new();
+    for (pdu, _) in eor_msgs {
+        let parsed = decode_pdu(pdu);
+        assert!(parsed.announced.is_empty() && parsed.withdrawn.is_empty());
+        match parsed.attributes.iter().find_map(|a| match a {
+            PathAttribute::MpUnreachNlri(mp) => Some(mp),
+            _ => None,
+        }) {
+            Some(mp) => {
+                assert!(mp.withdrawn.is_empty() && mp.vpn_withdrawn.is_empty());
+                eor_families.push((mp.afi, mp.safi));
+            }
+            None => eor_families.push((Afi::Ipv4, Safi::Unicast)),
+        }
+    }
+    eor_families.sort_by_key(|&(afi, safi)| (afi as u16, safi as u8));
+    assert_eq!(
+        eor_families,
+        vec![
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv6, Safi::Unicast),
+            (Afi::Ipv6, Safi::MplsVpn),
+        ]
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Per-family Loc-RIB counts for the RFC 9069 stats report.
+#[tokio::test]
+async fn query_bmp_loc_rib_stats_counts_per_family() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![
+            make_route_with_lp(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 16), peer, 100),
+            make_route_with_lp(Ipv4Prefix::new(Ipv4Addr::new(10, 2, 0, 0), 16), peer, 100),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![make_vpn_rib_route(peer, 42, 1042, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let (reply, rx_stats) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibStats { reply })
+        .await
+        .unwrap();
+    let counts = rx_stats.await.unwrap();
+    assert_eq!(
+        counts,
+        vec![
+            (Afi::Ipv4 as u16, Safi::Unicast as u8, 2),
+            (Afi::Ipv6 as u16, Safi::Unicast as u8, 0),
+            (Afi::Ipv4 as u16, Safi::MplsVpn as u8, 1),
+            (Afi::Ipv6 as u16, Safi::MplsVpn as u8, 0),
+        ]
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Without the tap installed (no collector monitors `loc_rib`), best
+/// changes emit nothing and cost only the `is_some()` check — proven by
+/// the absence of any panic/blocking with no BMP channel at all, and
+/// the default construction path used by every other test in this
+/// suite.
+#[tokio::test]
+async fn no_bmp_tx_means_no_synthesis() {
+    let (tx, rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![make_route_with_lp(
+            Ipv4Prefix::new(Ipv4Addr::new(10, 9, 0, 0), 16),
+            peer,
+            100,
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (reply, rx_count) = oneshot::channel();
+    tx.send(RibUpdate::QueryLocRibCount { reply })
+        .await
+        .unwrap();
+    assert_eq!(rx_count.await.unwrap(), 1);
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -888,6 +888,7 @@ async fn llgr_gate_peer_up(
 
 mod attr_intern;
 mod bgpls;
+mod bmp;
 mod events_metrics;
 mod evpn;
 mod explain_mrt;

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -802,6 +802,24 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<MrtSnapshotData>,
     },
+    /// RFC 9069 Loc-RIB table dump for a (re)connected BMP collector:
+    /// synthesize one UPDATE PDU per Loc-RIB best route (unicast + VPN)
+    /// with its install time, ending with an End-of-RIB PDU per dumped
+    /// family, streamed back in bounded chunks. The synthesis runs in
+    /// the handler; the chunk sends are driven by a spawned drain task
+    /// so a slow collector never blocks the RIB task.
+    QueryBmpLocRibDump {
+        /// Bounded chunk reply channel (from the BMP manager's
+        /// `BmpDumpRequest`). Dropped when the dump completes.
+        reply: mpsc::Sender<rustbgpd_bmp::BmpDumpChunk>,
+    },
+    /// Query per-AFI/SAFI Loc-RIB route counts for the RFC 9069 BMP
+    /// statistics report (stat type 10 entries; type 8 is their sum).
+    /// Scope matches the streamed Loc-RIB families (unicast + VPN).
+    QueryBmpLocRibStats {
+        /// Response channel: `(afi, safi, count)` per family.
+        reply: oneshot::Sender<Vec<(u16, u8, u64)>>,
+    },
 }
 
 /// Peer metadata for MRT `PEER_INDEX_TABLE`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1709,8 +1709,8 @@ set_med = 50
 
 ## `[bmp]`
 
-Optional. Configures BMP (BGP Monitoring Protocol, RFC 7854 + RFC 8671) export
-to external collectors. rustbgpd acts as a BMP client, initiating TCP
+Optional. Configures BMP (BGP Monitoring Protocol, RFC 7854 + RFC 8671 +
+RFC 9069) export to external collectors. rustbgpd acts as a BMP client, initiating TCP
 connections to each configured collector and streaming BGP state changes (peer
 up/down, route monitoring) as BMP messages.
 
@@ -1743,7 +1743,7 @@ monitor = ["rib_in_pre", "rib_out_post"]   # + RFC 8671 Adj-RIB-Out
 |----------------------|--------|----------|---------|--------------------------------------|
 | `address`            | string | yes      | --      | Collector `host:port` socket address  |
 | `reconnect_interval` | u64   | no       | 30      | Seconds between reconnect attempts    |
-| `monitor`            | array  | no       | `["rib_in_pre"]` | Route-monitoring streams: `rib_in_pre` (RFC 7854 pre-policy Adj-RIB-In) and/or `rib_out_post` (RFC 8671 post-policy Adj-RIB-Out) |
+| `monitor`            | array  | no       | `["rib_in_pre"]` | Route-monitoring streams: `rib_in_pre` (RFC 7854 pre-policy Adj-RIB-In), `rib_out_post` (RFC 8671 post-policy Adj-RIB-Out), and/or `loc_rib` (RFC 9069 Loc-RIB instance with collector-connect table sync) |
 
 ### What is streamed
 
@@ -1754,8 +1754,8 @@ BMP messages sent to collectors:
 | **Initiation** (Type 4) | On TCP connect to collector |
 | **Peer Up** (Type 3) | BGP session reaches Established (includes raw OPEN PDUs) |
 | **Peer Down** (Type 2) | BGP session leaves Established |
-| **Route Monitoring** (Type 0) | Inbound UPDATE received (pre-policy, raw PDU); with `rib_out_post`, also every outbound UPDATE (post-policy Adj-RIB-Out, RFC 8671) |
-| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In count type 7; post-policy Adj-RIB-Out gauges type 15 + per-AFI/SAFI type 17) |
+| **Route Monitoring** (Type 0) | Inbound UPDATE received (pre-policy, raw PDU); with `rib_out_post`, also every outbound UPDATE (post-policy Adj-RIB-Out, RFC 8671); with `loc_rib`, every Loc-RIB best-path change plus the connect-time table dump (RFC 9069) |
+| **Stats Report** (Type 1) | Periodic per-peer export every 60s (Adj-RIB-In count type 7; post-policy Adj-RIB-Out gauges type 15 + per-AFI/SAFI type 17; with `loc_rib`, Loc-RIB gauges type 8 + per-AFI/SAFI type 10) |
 | **Termination** (Type 5) | On coordinated daemon shutdown (and on client channel shutdown) |
 
 Route Monitoring messages carry the original raw BGP UPDATE PDU bytes
@@ -1775,10 +1775,46 @@ the routes; the timestamp is the advertise time. Pre-policy Adj-RIB-Out
 Note: the rib-out stream is live-only. A collector that connects (or
 reconnects) mid-session receives Peer Up state replay but no synthesized
 table dump of already-advertised routes — the same limitation the rib-in
-stream has today. See `KNOWN_ISSUES.md`.
+stream has today. The `loc_rib` view below does not share this gap. See
+`KNOWN_ISSUES.md`.
+
+### RFC 9069 Loc-RIB monitoring
+
+With `monitor = ["loc_rib"]` (combinable with the other views), the daemon
+streams its post-best-path Loc-RIB attributed to an emulated *Loc-RIB
+instance peer* (peer type 3): zero-filled peer address, Peer Distinguisher 0
+(global instance), Peer AS = the local ASN, Peer BGP ID = the local
+router-id, and a per-message timestamp equal to the route's Loc-RIB install
+time. Route Monitoring PDUs are synthesized from the RIB with 4-octet-ASN
+encoding and no Add-Path. The Peer Up for the emulated peer carries a
+fabricated OPEN (4-octet-ASN capability plus one MP capability per streamed
+family; the received OPEN is a byte-identical repeat) and the VRF/Table Name
+Information TLV with the value `global`; on daemon shutdown the peer goes
+down with reason 6 and the TLV echoed. Periodic stats include type 8
+(Loc-RIB route total) and type 10 (per-AFI/SAFI counts).
+
+Streamed families (v1): IPv4/IPv6 unicast and VPNv4/VPNv6. Other Loc-RIB
+families (EVPN, BGP-LS, labeled-unicast, FlowSpec, RT-Constrain) are not yet
+synthesized and are deliberately absent from the fabricated OPEN; they land
+additively in a later slice.
+
+**Collector-connect table sync.** Unlike the rib-in/rib-out views, every
+collector (re)connect on a `loc_rib` collector triggers a full Loc-RIB dump:
+Peer Up for the emulated peer, then the current table as Route Monitoring
+messages (each stamped with its install time), closed by one End-of-RIB per
+streamed family, after which live updates continue seamlessly. Live changes
+racing the dump may be observed both in the dump and as live messages — the
+standard BMP overlap; collectors reconcile by prefix. The dump is paced to
+the collector's TCP drain rate and aborts (with a
+`bmp_collector_drops_total{phase="loc_rib_dump"}` increment) if the
+collector stalls for over 30 s; the next reconnect starts a fresh dump.
+
+All Loc-RIB messages — including the emulated peer's Peer Up/Down and stats
+— go only to collectors that monitor `loc_rib`.
 
 When BMP is not configured, overhead remains minimal: raw frame capture uses
-`Bytes` refcount clones (no message-data copy).
+`Bytes` refcount clones (no message-data copy). Loc-RIB PDU synthesis runs
+only when at least one collector monitors `loc_rib`.
 
 ---
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -314,6 +314,9 @@ pub enum BmpMonitorView {
     RibInPre,
     /// Post-policy Adj-RIB-Out route monitoring (RFC 8671).
     RibOutPost,
+    /// Loc-RIB instance monitoring with collector-connect table sync
+    /// (RFC 9069).
+    LocRib,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3134,6 +3134,17 @@ fn bmp_monitor_rib_out_post_accepted() {
 }
 
 #[test]
+fn bmp_monitor_loc_rib_accepted() {
+    let config = parse(&bmp_toml(r#"monitor = ["loc_rib"]"#)).unwrap();
+    let bmp = config.bmp.as_ref().unwrap();
+    assert_eq!(
+        bmp.collectors[0].monitor,
+        vec![BmpMonitorView::LocRib],
+        "RFC 9069 Loc-RIB view is selectable on its own"
+    );
+}
+
+#[test]
 fn bmp_empty_monitor_rejected() {
     let err = parse(&bmp_toml("monitor = []")).unwrap_err();
     assert!(matches!(err, ConfigError::InvalidBmpCollector { .. }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1257,6 +1257,120 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
     let cluster_id = config.cluster_id();
     let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(resolve_rib_channel_capacity());
     let (rib_query_tx, rib_query_rx) = mpsc::channel::<RibUpdate>(256);
+
+    // Spawn BMP subsystem (manager + per-collector clients). Spawned
+    // before the RIB manager so the RFC 9069 Loc-RIB tap and the
+    // collector-connect table-dump forwarder can be wired into both.
+    let mut bmp_runtime: Option<BmpRuntime> = None;
+    let mut bmp_loc_rib_tx: Option<mpsc::Sender<rustbgpd_bmp::BmpEvent>> = None;
+    let bmp_tx = if let Some(ref bmp_config) = config.bmp
+        && !bmp_config.collectors.is_empty()
+    {
+        let (bmp_event_tx, bmp_event_rx) = mpsc::channel(4096);
+        let (bmp_control_tx, bmp_control_rx) = mpsc::channel(256);
+        let sys_name = bmp_config.sys_name.clone();
+        let sys_descr = if bmp_config.sys_descr.is_empty() {
+            format!("rustbgpd {}", env!("CARGO_PKG_VERSION"))
+        } else {
+            bmp_config.sys_descr.clone()
+        };
+
+        let mut collectors: Vec<(
+            std::net::SocketAddr,
+            mpsc::Sender<bytes::Bytes>,
+            rustbgpd_bmp::BmpMonitorFilter,
+        )> = Vec::new();
+        let mut client_handles = Vec::new();
+        for collector in &bmp_config.collectors {
+            let addr: std::net::SocketAddr = match collector.address.parse() {
+                Ok(a) => a,
+                Err(e) => {
+                    error!(
+                        address = %collector.address,
+                        error = %e,
+                        "invalid BMP collector address — skipping"
+                    );
+                    continue;
+                }
+            };
+            let (msg_tx, msg_rx) = mpsc::channel(4096);
+            let collector_id = collectors.len();
+            let filter = rustbgpd_bmp::BmpMonitorFilter {
+                rib_in_pre: collector
+                    .monitor
+                    .contains(&config::BmpMonitorView::RibInPre),
+                rib_out_post: collector
+                    .monitor
+                    .contains(&config::BmpMonitorView::RibOutPost),
+                loc_rib: collector.monitor.contains(&config::BmpMonitorView::LocRib),
+            };
+            collectors.push((addr, msg_tx, filter));
+            let client = rustbgpd_bmp::BmpClient::new(
+                rustbgpd_bmp::BmpClientConfig {
+                    collector_id,
+                    collector_addr: addr,
+                    reconnect_interval: collector.reconnect_interval,
+                },
+                msg_rx,
+                sys_name.clone(),
+                sys_descr.clone(),
+                Some(bmp_control_tx.clone()),
+                metrics.clone(),
+            );
+            info!(collector = %addr, "spawning BMP client");
+            client_handles.push(tokio::spawn(client.run()));
+        }
+
+        let loc_rib_enabled = collectors.iter().any(|(_, _, filter)| filter.loc_rib);
+        let mut mgr = rustbgpd_bmp::BmpManager::new(
+            bmp_event_rx,
+            bmp_control_rx,
+            collectors,
+            metrics.clone(),
+        );
+        if loc_rib_enabled {
+            // RFC 9069 Loc-RIB monitoring: fabricate the emulated
+            // instance-peer identity and bridge the manager's
+            // collector-connect dump requests onto the RIB manager's
+            // priority query channel.
+            let open_pdu = rustbgpd_rib::bmp_sync::loc_rib_open_pdu(config.global.asn, router_id);
+            let (dump_tx, mut dump_rx) = mpsc::channel::<rustbgpd_bmp::BmpDumpRequest>(8);
+            let dump_rib_tx = rib_query_tx.clone();
+            tokio::spawn(async move {
+                while let Some(request) = dump_rx.recv().await {
+                    if dump_rib_tx
+                        .send(RibUpdate::QueryBmpLocRibDump {
+                            reply: request.reply,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            });
+            mgr = mgr.with_loc_rib(
+                rustbgpd_bmp::BmpLocRibConfig {
+                    local_asn: config.global.asn,
+                    router_id,
+                    open_pdu,
+                },
+                dump_tx,
+            );
+            bmp_loc_rib_tx = Some(bmp_event_tx.clone());
+        }
+        let manager_handle = tokio::spawn(mgr.run());
+        bmp_runtime = Some(BmpRuntime {
+            control_tx: bmp_control_tx,
+            manager_handle,
+            client_handles,
+        });
+
+        Some(bmp_event_tx)
+    } else {
+        None
+    };
+
     let mut rib_manager = RibManager::new(
         rib_rx,
         rib_query_rx,
@@ -1264,6 +1378,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         cluster_id,
         metrics.clone(),
     );
+    if let Some(tx) = bmp_loc_rib_tx {
+        rib_manager = rib_manager.with_bmp_tx(tx);
+    }
     if let Some(handle) = event_history_handle.clone() {
         rib_manager = rib_manager.with_event_sink(
             rustbgpd_api::event_history_sinks::make_rib_event_sink(handle, metrics.clone()),
@@ -1363,83 +1480,6 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             tokio::spawn(client.run());
         }
     }
-
-    // Spawn BMP subsystem (manager + per-collector clients)
-    let mut bmp_runtime: Option<BmpRuntime> = None;
-    let bmp_tx = if let Some(ref bmp_config) = config.bmp
-        && !bmp_config.collectors.is_empty()
-    {
-        let (bmp_event_tx, bmp_event_rx) = mpsc::channel(4096);
-        let (bmp_control_tx, bmp_control_rx) = mpsc::channel(256);
-        let sys_name = bmp_config.sys_name.clone();
-        let sys_descr = if bmp_config.sys_descr.is_empty() {
-            format!("rustbgpd {}", env!("CARGO_PKG_VERSION"))
-        } else {
-            bmp_config.sys_descr.clone()
-        };
-
-        let mut collectors: Vec<(
-            std::net::SocketAddr,
-            mpsc::Sender<bytes::Bytes>,
-            rustbgpd_bmp::BmpMonitorFilter,
-        )> = Vec::new();
-        let mut client_handles = Vec::new();
-        for collector in &bmp_config.collectors {
-            let addr: std::net::SocketAddr = match collector.address.parse() {
-                Ok(a) => a,
-                Err(e) => {
-                    error!(
-                        address = %collector.address,
-                        error = %e,
-                        "invalid BMP collector address — skipping"
-                    );
-                    continue;
-                }
-            };
-            let (msg_tx, msg_rx) = mpsc::channel(4096);
-            let collector_id = collectors.len();
-            let filter = rustbgpd_bmp::BmpMonitorFilter {
-                rib_in_pre: collector
-                    .monitor
-                    .contains(&config::BmpMonitorView::RibInPre),
-                rib_out_post: collector
-                    .monitor
-                    .contains(&config::BmpMonitorView::RibOutPost),
-            };
-            collectors.push((addr, msg_tx, filter));
-            let client = rustbgpd_bmp::BmpClient::new(
-                rustbgpd_bmp::BmpClientConfig {
-                    collector_id,
-                    collector_addr: addr,
-                    reconnect_interval: collector.reconnect_interval,
-                },
-                msg_rx,
-                sys_name.clone(),
-                sys_descr.clone(),
-                Some(bmp_control_tx.clone()),
-                metrics.clone(),
-            );
-            info!(collector = %addr, "spawning BMP client");
-            client_handles.push(tokio::spawn(client.run()));
-        }
-
-        let mgr = rustbgpd_bmp::BmpManager::new(
-            bmp_event_rx,
-            bmp_control_rx,
-            collectors,
-            metrics.clone(),
-        );
-        let manager_handle = tokio::spawn(mgr.run());
-        bmp_runtime = Some(BmpRuntime {
-            control_tx: bmp_control_tx,
-            manager_handle,
-            client_handles,
-        });
-
-        Some(bmp_event_tx)
-    } else {
-        None
-    };
 
     // Spawn MRT manager (periodic TABLE_DUMP_V2 snapshots)
     let mrt_trigger_tx: Option<mpsc::Sender<oneshot::Sender<Result<std::path::PathBuf, String>>>> =

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -162,6 +162,41 @@ impl PeerManager {
             .ok()
     }
 
+    /// RFC 9069 Loc-RIB stats (types 8 + 10) for the emulated Loc-RIB
+    /// instance peer, emitted on the same periodic tick as the per-peer
+    /// stats. Skipped entirely unless some collector monitors `loc_rib`.
+    async fn emit_loc_rib_bmp_stats(&self, bmp_tx: &tokio::sync::mpsc::Sender<BmpEvent>) {
+        let monitored = self.current_config.bmp.as_ref().is_some_and(|bmp| {
+            bmp.collectors.iter().any(|collector| {
+                collector
+                    .monitor
+                    .contains(&crate::config::BmpMonitorView::LocRib)
+            })
+        });
+        if !monitored {
+            return;
+        }
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        if self
+            .rib_tx
+            .send(rustbgpd_rib::RibUpdate::QueryBmpLocRibStats { reply })
+            .await
+            .is_err()
+        {
+            return;
+        }
+        let Ok(Ok(per_family)) = tokio::time::timeout(PEER_QUERY_TIMEOUT, rx).await else {
+            // Unavailable this tick — omit rather than report a false zero.
+            return;
+        };
+        if let Err(e) = bmp_tx.try_send(BmpEvent::LocRibStats { per_family }) {
+            warn!(
+                error = %e,
+                "BMP event channel full or closed, dropping periodic Loc-RIB stats report"
+            );
+        }
+    }
+
     pub(super) async fn emit_periodic_bmp_stats(&self) {
         let Some(ref bmp_tx) = self.bmp_tx else {
             return;
@@ -172,6 +207,7 @@ impl PeerManager {
         // through it, every other admin command queued behind the BMP arm.
         let states = collect_session_states(&self.peers).await;
         let rib_out_counts = self.query_adj_rib_out_counts().await;
+        self.emit_loc_rib_bmp_stats(bmp_tx).await;
         for (peer, managed) in &self.peers {
             let peer_addr = peer.address;
             let Some(Some(state)) = states.get(peer) else {

--- a/tests/interop/scripts/bmp-receiver.py
+++ b/tests/interop/scripts/bmp-receiver.py
@@ -85,13 +85,34 @@ def main():
                 "length": length,
                 "timestamp": time.time(),
             }
-            # RouteMonitoring: per-peer header flags at body[1].
-            # RFC 8671 O flag (0x10) marks Adj-RIB-Out; under O=1 the
-            # L flag (0x40) marks post-policy.
-            if msg_type == 0 and len(body) >= 2:
+            # Per-peer-header messages (RouteMonitoring, StatsReport,
+            # PeerDown, PeerUp): peer type at body[0], flags at body[1].
+            # RFC 9069 peer type 3 = Loc-RIB instance peer.
+            if msg_type in (0, 1, 2, 3) and len(body) >= 2:
+                entry["peer_type"] = body[0]
+            # RouteMonitoring: RFC 8671 O flag (0x10) marks Adj-RIB-Out;
+            # under O=1 the L flag (0x40) marks post-policy. Not
+            # applicable to peer type 3 (own flags registry, always 0).
+            if msg_type == 0 and len(body) >= 2 and body[0] != 3:
                 flags = body[1]
                 entry["rib_out"] = bool(flags & 0x10)
                 entry["post_policy"] = bool(flags & 0x40)
+            # Loc-RIB PeerUp: parse the VRF/Table Name TLV (type 3)
+            # after the two OPEN PDUs (RFC 9069 §5.2.2).
+            if msg_type == 3 and len(body) >= 2 and body[0] == 3:
+                # per-peer header (42) + local addr/ports (20)
+                off = 42 + 20
+                for _ in range(2):  # sent OPEN, received OPEN
+                    if off + 19 > len(body):
+                        break
+                    open_len = struct.unpack("!H", body[off + 16 : off + 18])[0]
+                    off += open_len
+                while off + 4 <= len(body):
+                    tlv_type, tlv_len = struct.unpack("!HH", body[off : off + 4])
+                    value = body[off + 4 : off + 4 + tlv_len]
+                    if tlv_type == 3:
+                        entry["table_name"] = value.decode("utf-8", "replace")
+                    off += 4 + tlv_len
             messages.append(entry)
             print(f"BMP: {type_name} ({length} bytes)", flush=True)
 


### PR DESCRIPTION
**Slice 2 of the BMP arc**: RFC 9069 Loc-RIB monitoring — completing the trio (Adj-RIB-In + #660's Adj-RIB-Out + Loc-RIB) that **no other open-source daemon ships** — plus the collector-connect table dump that fixes the long-standing RFC 7854 initial-sync gap.

- Emulated loc-rib peer per the RFC (web-verified): peer type 3, flags forced to zero (its own registry — never V, even for v6), fabricated sent-OPEN carrying the exact capability set streamed, `"global"` VRF/Table Name TLV, peer-down reason 6, stats 8/10.
- **Tap at the recompute commit points** (the same seams the event system observes — one observation layer, two egress formats): any best change emits announce/withdraw with install-time timestamps; V1 synthesis = unicast v4/v6 + VPNv4/v6 (other families additive; the fabricated OPEN honestly advertises only what's streamed).
- **Non-blocking dump**: collector connect → PeerUp replay → loc-rib PeerUp → chunked table dump streamed by a spawned drain task with send_timeout + drop counters → per-family EoR → live. The RIB task never awaits a slow collector.
- **Rib-out dumps deliberately deferred** (documented): AdjRibOut stores routes pre-transport-stamping (ORIGINATOR_ID/CLUSTER_LIST/GShut/LLGR-§4.6 apply session-side), so a synthesized dump wouldn't be byte-faithful — and the post-policy Loc-RIB dump covers what dump consumers want on an RR.

16 new tests incl. golden headers, synthesis round-trips through the wire crate, dump-then-EoR-then-live ordering, and per-collector isolation. 4,797 workspace tests green.