### PR TITLE
feat(bmp): add BMPv4 per-collector TLV framing (draft-ietf-grow-bmp-tlv-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **BMPv4 per-collector framing (draft-ietf-grow-bmp-tlv-20, pre-IANA).**
+  New per-collector `version = 3 | 4` config field (default 3). A v4
+  collector gets common-header version 4 on every message type (draft
+  §3); Route Monitoring encloses the UPDATE PDU in the mandatory BGP
+  Message TLV (type 7, index 0, §5.2) and Stats Reports enclose Stats
+  Count + stats data in the mandatory Stats TLV (code point 1, §5.4);
+  Peer Up/Down, Initiation, and Termination already provision TLV data
+  in v3 and change only their version byte (§5.5). Internal BMP events
+  stay version-agnostic — framing happens per collector at fan-out, so
+  mixed v3/v4 collector fleets each get correctly framed messages and
+  v3 output stays byte-identical (pinned by golden-bytes regression
+  tests). Indexed-TLV (§4.3) and Group-TLV (§5.2.1, type 4) encode
+  infrastructure lands with this slice for the upcoming path-marking
+  TLVs. Draft code points are pre-IANA and may renumber at RFC
+  publication; they live in one annotated module
+  (`crates/bmp/src/tlv.rs`).
+
 - **BMP Loc-RIB route monitoring with collector-connect table sync
   (RFC 9069).** New per-collector `monitor = ["loc_rib"]` view: the
   daemon streams its post-best-path Loc-RIB as Route Monitoring

--- a/crates/bmp/src/client.rs
+++ b/crates/bmp/src/client.rs
@@ -106,8 +106,10 @@ impl BmpClient {
                 }
             };
 
-            // Send Initiation message
-            let init_msg = codec::encode_initiation(&self.sys_name, &self.sys_descr);
+            // Send Initiation message (framed at this collector's
+            // configured BMP version)
+            let init_msg =
+                codec::encode_initiation(&self.sys_name, &self.sys_descr, self.config.version);
             if let Err(e) = Self::write_all_with_timeout(&mut stream, &init_msg).await {
                 warn!(collector = %addr, error = %e, "failed to send BMP Initiation");
                 continue; // reconnect
@@ -164,7 +166,8 @@ impl BmpClient {
             loop {
                 let Some(msg) = self.rx.recv().await else {
                     // Channel closed — send Termination and exit
-                    let term = codec::encode_termination(0, "daemon shutting down");
+                    let term =
+                        codec::encode_termination(0, "daemon shutting down", self.config.version);
                     let _ = Self::write_all_with_timeout(&mut stream, &term).await;
                     let _ = Self::flush_with_timeout(&mut stream).await;
                     info!(collector = %addr, "BMP client shutting down");
@@ -207,6 +210,7 @@ impl BmpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::BmpVersion;
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
 
@@ -223,6 +227,7 @@ mod tests {
                 collector_id: 7,
                 collector_addr: addr,
                 reconnect_interval: 1,
+                version: BmpVersion::V3,
             },
             msg_rx,
             "rustbgpd".to_string(),
@@ -287,6 +292,7 @@ mod tests {
                 collector_id: 7,
                 collector_addr: addr,
                 reconnect_interval: 1,
+                version: BmpVersion::V3,
             },
             msg_rx,
             "rustbgpd".to_string(),

--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -1,14 +1,26 @@
-//! BMP message encoding (RFC 7854).
+//! BMP message encoding (RFC 7854, plus BMP version 4 framing per
+//! draft-ietf-grow-bmp-tlv-20).
 //!
 //! Encodes BMP messages for transmission to collectors.
 //! No decode is needed — BMP is unidirectional (router → collector).
+//!
+//! Every encoder takes a [`BmpVersion`]. Under `V3` the output is
+//! byte-identical to the pre-v4 encoders. Under `V4` (§3 of the
+//! draft) the common-header version byte is 4 on every message type;
+//! Route Monitoring wraps the UPDATE PDU in the BGP Message TLV
+//! (§5.2) and Stats Reports wrap count + stats in the Stats TLV
+//! (§5.4). All other message types already provision TLV data in v3
+//! (§5.5), so only their version byte changes.
 
 use std::net::IpAddr;
 use std::time::UNIX_EPOCH;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-use crate::types::{BmpLocRibConfig, BmpPeerInfo, BmpPeerType, LOC_RIB_TABLE_NAME, PeerDownReason};
+use crate::tlv;
+use crate::types::{
+    BmpLocRibConfig, BmpPeerInfo, BmpPeerType, BmpVersion, LOC_RIB_TABLE_NAME, PeerDownReason,
+};
 
 // BMP message types (RFC 7854 §4.1)
 const BMP_MSG_ROUTE_MONITORING: u8 = 0;
@@ -17,9 +29,6 @@ const BMP_MSG_PEER_DOWN: u8 = 2;
 const BMP_MSG_PEER_UP: u8 = 3;
 const BMP_MSG_INITIATION: u8 = 4;
 const BMP_MSG_TERMINATION: u8 = 5;
-
-// BMP version
-const BMP_VERSION: u8 = 3;
 
 // BMP common header length: version(1) + length(4) + type(1) = 6
 const BMP_COMMON_HEADER_LEN: usize = 6;
@@ -144,8 +153,8 @@ fn encode_per_peer_header(info: &BmpPeerInfo, buf: &mut BytesMut) {
 }
 
 /// Write the BMP common header (6 bytes) at the beginning of a buffer.
-fn write_common_header(buf: &mut [u8], msg_type: u8) {
-    buf[0] = BMP_VERSION;
+fn write_common_header(buf: &mut [u8], msg_type: u8, version: BmpVersion) {
+    buf[0] = version.header_byte();
     #[expect(
         clippy::cast_possible_truncation,
         reason = "BMP common header length is a 32-bit field and callers build bounded in-memory messages"
@@ -197,8 +206,9 @@ fn put_ipaddr_16(buf: &mut BytesMut, addr: IpAddr) {
 }
 
 /// Encode BMP Initiation message (Type 4, RFC 7854 §4.3).
+/// Already TLV-based in v3 — v4 changes only the version byte.
 #[must_use]
-pub fn encode_initiation(sys_name: &str, sys_descr: &str) -> Bytes {
+pub fn encode_initiation(sys_name: &str, sys_descr: &str, version: BmpVersion) -> Bytes {
     let tlv_len = tlv_string_wire_len(sys_name) + tlv_string_wire_len(sys_descr);
     let total = BMP_COMMON_HEADER_LEN + tlv_len;
 
@@ -207,11 +217,12 @@ pub fn encode_initiation(sys_name: &str, sys_descr: &str) -> Bytes {
     put_tlv_string(&mut buf, BMP_INIT_TLV_SYS_DESCR, sys_descr);
     put_tlv_string(&mut buf, BMP_INIT_TLV_SYS_NAME, sys_name);
 
-    write_common_header(&mut buf, BMP_MSG_INITIATION);
+    write_common_header(&mut buf, BMP_MSG_INITIATION, version);
     buf.freeze()
 }
 
 /// Encode BMP Peer Up Notification (Type 3, RFC 7854 §4.10).
+/// Already TLV-provisioned in v3 — v4 changes only the version byte.
 #[must_use]
 pub fn encode_peer_up(
     info: &BmpPeerInfo,
@@ -220,6 +231,7 @@ pub fn encode_peer_up(
     remote_port: u16,
     local_open: &[u8],
     remote_open: &[u8],
+    version: BmpVersion,
 ) -> Bytes {
     let total =
         BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 20 + local_open.len() + remote_open.len();
@@ -233,13 +245,15 @@ pub fn encode_peer_up(
     buf.put_slice(local_open);
     buf.put_slice(remote_open);
 
-    write_common_header(&mut buf, BMP_MSG_PEER_UP);
+    write_common_header(&mut buf, BMP_MSG_PEER_UP, version);
     buf.freeze()
 }
 
 /// Encode BMP Peer Down Notification (Type 2, RFC 7854 §4.9).
+/// In v4 optional TLV data may trail the reason (draft §5.3); we emit
+/// none, so only the version byte changes.
 #[must_use]
-pub fn encode_peer_down(info: &BmpPeerInfo, reason: &PeerDownReason) -> Bytes {
+pub fn encode_peer_down(info: &BmpPeerInfo, reason: &PeerDownReason, version: BmpVersion) -> Bytes {
     let reason_len = match reason {
         PeerDownReason::LocalNotification(pdu) | PeerDownReason::RemoteNotification(pdu) => {
             1 + pdu.len()
@@ -271,7 +285,7 @@ pub fn encode_peer_down(info: &BmpPeerInfo, reason: &PeerDownReason) -> Bytes {
         }
     }
 
-    write_common_header(&mut buf, BMP_MSG_PEER_DOWN);
+    write_common_header(&mut buf, BMP_MSG_PEER_DOWN, version);
     buf.freeze()
 }
 
@@ -284,7 +298,11 @@ pub fn encode_peer_down(info: &BmpPeerInfo, reason: &PeerDownReason) -> Bytes {
 /// VRF/Table Name Information TLV (type 3) carries `"global"` for the
 /// default Loc-RIB instance.
 #[must_use]
-pub fn encode_loc_rib_peer_up(cfg: &BmpLocRibConfig, timestamp: std::time::SystemTime) -> Bytes {
+pub fn encode_loc_rib_peer_up(
+    cfg: &BmpLocRibConfig,
+    timestamp: std::time::SystemTime,
+    version: BmpVersion,
+) -> Bytes {
     let info = cfg.peer_info(timestamp);
     let table_name = LOC_RIB_TABLE_NAME.as_bytes();
     let total = BMP_COMMON_HEADER_LEN
@@ -306,7 +324,7 @@ pub fn encode_loc_rib_peer_up(cfg: &BmpLocRibConfig, timestamp: std::time::Syste
     buf.put_u16(u16::try_from(table_name.len()).unwrap_or(u16::MAX));
     buf.put_slice(table_name);
 
-    write_common_header(&mut buf, BMP_MSG_PEER_UP);
+    write_common_header(&mut buf, BMP_MSG_PEER_UP, version);
     buf.freeze()
 }
 
@@ -314,7 +332,11 @@ pub fn encode_loc_rib_peer_up(cfg: &BmpLocRibConfig, timestamp: std::time::Syste
 /// instance peer: reason code 6 ("Local system closed, TLV data
 /// follows") with the VRF/Table Name TLV echoed from the Peer Up.
 #[must_use]
-pub fn encode_loc_rib_peer_down(cfg: &BmpLocRibConfig, timestamp: std::time::SystemTime) -> Bytes {
+pub fn encode_loc_rib_peer_down(
+    cfg: &BmpLocRibConfig,
+    timestamp: std::time::SystemTime,
+    version: BmpVersion,
+) -> Bytes {
     let info = cfg.peer_info(timestamp);
     let table_name = LOC_RIB_TABLE_NAME.as_bytes();
     let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 1 + 4 + table_name.len();
@@ -327,23 +349,44 @@ pub fn encode_loc_rib_peer_down(cfg: &BmpLocRibConfig, timestamp: std::time::Sys
     buf.put_u16(u16::try_from(table_name.len()).unwrap_or(u16::MAX));
     buf.put_slice(table_name);
 
-    write_common_header(&mut buf, BMP_MSG_PEER_DOWN);
+    write_common_header(&mut buf, BMP_MSG_PEER_DOWN, version);
     buf.freeze()
 }
 
 /// Encode BMP Route Monitoring message (Type 0, RFC 7854 §4.6).
 ///
-/// Wraps a raw BGP UPDATE PDU (including 19-byte header).
+/// Carries a raw BGP UPDATE PDU (including 19-byte header): bare
+/// after the per-peer header in v3; enclosed in the mandatory BGP
+/// Message TLV (type 7, index 0) in v4 (draft §5.2).
 #[must_use]
-pub fn encode_route_monitoring(info: &BmpPeerInfo, update_pdu: &[u8]) -> Bytes {
-    let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + update_pdu.len();
+pub fn encode_route_monitoring(
+    info: &BmpPeerInfo,
+    update_pdu: &[u8],
+    version: BmpVersion,
+) -> Bytes {
+    // v4 adds type(2) + length(2) + index(2) around the PDU.
+    let tlv_overhead = match version {
+        BmpVersion::V3 => 0,
+        BmpVersion::V4 => 6,
+    };
+    let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + tlv_overhead + update_pdu.len();
 
     let mut buf = BytesMut::with_capacity(total);
     buf.put_bytes(0, BMP_COMMON_HEADER_LEN);
     encode_per_peer_header(info, &mut buf);
-    buf.put_slice(update_pdu);
+    match version {
+        BmpVersion::V3 => buf.put_slice(update_pdu),
+        BmpVersion::V4 => {
+            tlv::put_indexed_tlv(
+                &mut buf,
+                tlv::RM_TLV_BGP_MESSAGE,
+                tlv::INDEX_ALL_NLRI,
+                update_pdu,
+            );
+        }
+    }
 
-    write_common_header(&mut buf, BMP_MSG_ROUTE_MONITORING);
+    write_common_header(&mut buf, BMP_MSG_ROUTE_MONITORING, version);
     buf.freeze()
 }
 
@@ -352,11 +395,16 @@ pub fn encode_route_monitoring(info: &BmpPeerInfo, update_pdu: &[u8]) -> Bytes {
 /// `counters` are RFC 7854 numeric stat types (0-8, 11-13).
 /// `afi_counters` are AFI/SAFI-qualified stat types (9-10).
 /// Stat types placed in the wrong list are silently skipped.
+///
+/// In v4 the Stats Count and stats data are enclosed in the mandatory
+/// Stats TLV, code point 1 (draft §5.4; not indexed — indexed TLVs
+/// apply only to Route Monitoring, §4.3).
 #[must_use]
 pub fn encode_stats_report(
     info: &BmpPeerInfo,
     counters: &[StatCounter],
     afi_counters: &[AfiStatCounter],
+    version: BmpVersion,
 ) -> Bytes {
     let numeric_len: usize = counters
         .iter()
@@ -376,11 +424,22 @@ pub fn encode_stats_report(
             .iter()
             .filter(|c| is_afi_stat(c.stat_type))
             .count();
-    let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 4 + numeric_len + afi_len;
+    let stats_body_len = 4 + numeric_len + afi_len; // Stats Count + stats data
+    // v4 adds the Stats TLV header: type(2) + length(2).
+    let tlv_overhead = match version {
+        BmpVersion::V3 => 0,
+        BmpVersion::V4 => 4,
+    };
+    let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + tlv_overhead + stats_body_len;
 
     let mut buf = BytesMut::with_capacity(total);
     buf.put_bytes(0, BMP_COMMON_HEADER_LEN);
     encode_per_peer_header(info, &mut buf);
+
+    if version == BmpVersion::V4 {
+        buf.put_u16(tlv::STATS_TLV_STATS);
+        buf.put_u16(u16::try_from(stats_body_len).unwrap_or(u16::MAX));
+    }
 
     #[expect(
         clippy::cast_possible_truncation,
@@ -415,13 +474,14 @@ pub fn encode_stats_report(
         }
     }
 
-    write_common_header(&mut buf, BMP_MSG_STATS_REPORT);
+    write_common_header(&mut buf, BMP_MSG_STATS_REPORT, version);
     buf.freeze()
 }
 
 /// Encode BMP Termination message (Type 5, RFC 7854 §4.5).
+/// Already TLV-based in v3 — v4 changes only the version byte.
 #[must_use]
-pub fn encode_termination(reason: u16, message: &str) -> Bytes {
+pub fn encode_termination(reason: u16, message: &str, version: BmpVersion) -> Bytes {
     let reason_tlv_len = 4 + 2; // type(2) + len(2) + value(2)
     let msg_tlv_len = tlv_string_wire_len(message);
     let total = BMP_COMMON_HEADER_LEN + reason_tlv_len + msg_tlv_len;
@@ -435,7 +495,7 @@ pub fn encode_termination(reason: u16, message: &str) -> Bytes {
     buf.put_u16(2);
     buf.put_u16(reason);
 
-    write_common_header(&mut buf, BMP_MSG_TERMINATION);
+    write_common_header(&mut buf, BMP_MSG_TERMINATION, version);
     buf.freeze()
 }
 
@@ -462,7 +522,7 @@ mod tests {
 
     fn verify_common_header(buf: &[u8], expected_type: u8) {
         assert!(buf.len() >= BMP_COMMON_HEADER_LEN);
-        assert_eq!(buf[0], BMP_VERSION, "version");
+        assert_eq!(buf[0], 3, "version");
         let len = u32::from_be_bytes([buf[1], buf[2], buf[3], buf[4]]);
         assert_eq!(len as usize, buf.len(), "length");
         assert_eq!(buf[5], expected_type, "message type");
@@ -487,7 +547,7 @@ mod tests {
 
     #[test]
     fn initiation_message_encoding() {
-        let msg = encode_initiation("rustbgpd", "test daemon");
+        let msg = encode_initiation("rustbgpd", "test daemon", BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_INITIATION);
 
         let payload = &msg[BMP_COMMON_HEADER_LEN..];
@@ -512,6 +572,7 @@ mod tests {
             12345,
             &[0xFF; 29],
             &[0xFE; 29],
+            BmpVersion::V3,
         );
         verify_common_header(&msg, BMP_MSG_PEER_UP);
         verify_per_peer_header(&msg[BMP_COMMON_HEADER_LEN..], &info);
@@ -521,11 +582,233 @@ mod tests {
         );
     }
 
+    fn hex(b: &[u8]) -> String {
+        use std::fmt::Write;
+        b.iter().fold(String::new(), |mut s, x| {
+            let _ = write!(s, "{x:02x}");
+            s
+        })
+    }
+
+    /// draft-ietf-grow-bmp-tlv-20 pin: v3 output stays byte-identical.
+    /// Full-message hex fixtures captured from the pre-v4 encoders —
+    /// any diff here is a v3 wire regression.
+    #[test]
+    fn v3_golden_bytes_regression() {
+        let info = sample_peer_info();
+        assert_eq!(
+            hex(&encode_route_monitoring(&info, &[0xAB; 23], BmpVersion::V3)),
+            "030000004700000000000000000000000000000000000000000000000a0000020000fdea0a00\
+             00026553f10000000000ababababababababababababababababababababababab"
+        );
+        let counters = vec![StatCounter {
+            stat_type: 7,
+            value: 42,
+        }];
+        let afi_counters = vec![AfiStatCounter {
+            stat_type: 17,
+            afi: 1,
+            safi: 1,
+            value: 10,
+        }];
+        assert_eq!(
+            hex(&encode_stats_report(
+                &info,
+                &counters,
+                &afi_counters,
+                BmpVersion::V3
+            )),
+            "030000004f01000000000000000000000000000000000000000000000a0000020000fdea0a00\
+             00026553f100000000000000000200070008000000000000002a0011000b00010100000000000\
+             0000a"
+        );
+        assert_eq!(
+            hex(&encode_peer_up(
+                &info,
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                179,
+                54321,
+                &[0xFF; 21],
+                &[0xFE; 21],
+                BmpVersion::V3,
+            )),
+            "030000006e03000000000000000000000000000000000000000000000a0000020000fdea0a00\
+             00026553f100000000000000000000000000000000000a00000100b3d431ffffffffffffffff\
+             fffffffffffffffffffffffffffefefefefefefefefefefefefefefefefefefefefe"
+        );
+        assert_eq!(
+            hex(&encode_peer_down(
+                &info,
+                &PeerDownReason::LocalNoNotification(6),
+                BmpVersion::V3
+            )),
+            "030000003302000000000000000000000000000000000000000000000a0000020000fdea0a00\
+             00026553f10000000000020006"
+        );
+        assert_eq!(
+            hex(&encode_initiation("rustbgpd", "test", BmpVersion::V3)),
+            "030000001a040001000474657374000200087275737462677064"
+        );
+        assert_eq!(
+            hex(&encode_termination(0, "bye", BmpVersion::V3)),
+            "03000000130500000003627965000100020000"
+        );
+    }
+
+    /// draft-ietf-grow-bmp-tlv-20 §5.2: v4 Route Monitoring golden
+    /// bytes — version byte 4, per-peer header, then the mandatory BGP
+    /// Message TLV (type 7, index 0) whose value is the exact UPDATE
+    /// PDU.
+    #[test]
+    fn v4_route_monitoring_wraps_pdu_in_bgp_message_tlv() {
+        let info = sample_peer_info();
+        let pdu = [0xAB; 23];
+        let msg = encode_route_monitoring(&info, &pdu, BmpVersion::V4);
+
+        assert_eq!(msg[0], 4, "BMP version 4 (draft §3)");
+        let len = u32::from_be_bytes(msg[1..5].try_into().unwrap());
+        assert_eq!(len as usize, msg.len(), "common-header length");
+        assert_eq!(
+            msg.len(),
+            BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + 6 + pdu.len(),
+            "TLV adds type(2)+length(2)+index(2)"
+        );
+        assert_eq!(msg[5], BMP_MSG_ROUTE_MONITORING);
+
+        let tlv = &msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(
+            u16::from_be_bytes([tlv[0], tlv[1]]),
+            crate::tlv::RM_TLV_BGP_MESSAGE,
+            "BGP Message TLV type 7 (§5.2, §9)"
+        );
+        assert_eq!(
+            u16::from_be_bytes([tlv[2], tlv[3]]) as usize,
+            pdu.len(),
+            "length excludes the 2-byte index (§4.3)"
+        );
+        assert_eq!(
+            u16::from_be_bytes([tlv[4], tlv[5]]),
+            0,
+            "index 0 = whole message (§5.2)"
+        );
+        assert_eq!(&tlv[6..], &pdu, "value = exact UPDATE PDU");
+        // Everything before the TLV is byte-identical to v3.
+        let v3 = encode_route_monitoring(&info, &pdu, BmpVersion::V3);
+        assert_eq!(
+            &msg[5..BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN],
+            &v3[5..BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN],
+            "type + per-peer header unchanged"
+        );
+    }
+
+    /// draft-ietf-grow-bmp-tlv-20 §5.4: v4 Stats Report golden bytes —
+    /// Stats Count + stats data enclosed in the mandatory Stats TLV
+    /// (code point 1, not indexed — §4.3 scopes indexed TLVs to Route
+    /// Monitoring only).
+    #[test]
+    fn v4_stats_report_wraps_in_stats_tlv() {
+        let info = sample_peer_info();
+        let counters = vec![StatCounter {
+            stat_type: 7,
+            value: 42,
+        }];
+        let afi_counters = vec![AfiStatCounter {
+            stat_type: 17,
+            afi: 1,
+            safi: 1,
+            value: 10,
+        }];
+        let v3 = encode_stats_report(&info, &counters, &afi_counters, BmpVersion::V3);
+        let msg = encode_stats_report(&info, &counters, &afi_counters, BmpVersion::V4);
+
+        assert_eq!(msg[0], 4, "BMP version 4");
+        let len = u32::from_be_bytes(msg[1..5].try_into().unwrap());
+        assert_eq!(len as usize, msg.len());
+        assert_eq!(msg.len(), v3.len() + 4, "Stats TLV adds type(2)+length(2)");
+        assert_eq!(msg[5], BMP_MSG_STATS_REPORT);
+
+        let tlv = &msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(
+            u16::from_be_bytes([tlv[0], tlv[1]]),
+            crate::tlv::STATS_TLV_STATS,
+            "Stats TLV code point 1 (§5.4, §9)"
+        );
+        let stats_body = &v3[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
+        assert_eq!(
+            u16::from_be_bytes([tlv[2], tlv[3]]) as usize,
+            stats_body.len(),
+            "TLV length = Stats Count + stats data"
+        );
+        assert_eq!(
+            &tlv[4..],
+            stats_body,
+            "value = the exact v3 count + stats bytes"
+        );
+    }
+
+    /// draft-ietf-grow-bmp-tlv-20 §3 + §5.5: message types that already
+    /// provision TLV data in v3 (Peer Up/Down incl. the RFC 9069
+    /// Loc-RIB variants, Initiation, Termination) change only the
+    /// common-header version byte in v4.
+    #[test]
+    fn v4_version_byte_only_for_tlv_provisioned_messages() {
+        let info = sample_peer_info();
+        let cfg = sample_loc_rib_config();
+        let local = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let pairs: Vec<(Bytes, Bytes)> = vec![
+            (
+                encode_peer_up(
+                    &info,
+                    local,
+                    179,
+                    54321,
+                    &[0xFF; 21],
+                    &[0xFE; 21],
+                    BmpVersion::V3,
+                ),
+                encode_peer_up(
+                    &info,
+                    local,
+                    179,
+                    54321,
+                    &[0xFF; 21],
+                    &[0xFE; 21],
+                    BmpVersion::V4,
+                ),
+            ),
+            (
+                encode_peer_down(&info, &PeerDownReason::RemoteNoNotification, BmpVersion::V3),
+                encode_peer_down(&info, &PeerDownReason::RemoteNoNotification, BmpVersion::V4),
+            ),
+            (
+                encode_loc_rib_peer_up(&cfg, ts(), BmpVersion::V3),
+                encode_loc_rib_peer_up(&cfg, ts(), BmpVersion::V4),
+            ),
+            (
+                encode_loc_rib_peer_down(&cfg, ts(), BmpVersion::V3),
+                encode_loc_rib_peer_down(&cfg, ts(), BmpVersion::V4),
+            ),
+            (
+                encode_initiation("rustbgpd", "test", BmpVersion::V3),
+                encode_initiation("rustbgpd", "test", BmpVersion::V4),
+            ),
+            (
+                encode_termination(0, "bye", BmpVersion::V3),
+                encode_termination(0, "bye", BmpVersion::V4),
+            ),
+        ];
+        for (v3, v4) in pairs {
+            assert_eq!(v3[0], 3);
+            assert_eq!(v4[0], 4);
+            assert_eq!(v3[1..], v4[1..], "v4 differs only in the version byte");
+        }
+    }
+
     #[test]
     fn peer_down_local_notification() {
         let info = sample_peer_info();
         let reason = PeerDownReason::LocalNotification(Bytes::from_static(&[0xFF; 21]));
-        let msg = encode_peer_down(&info, &reason);
+        let msg = encode_peer_down(&info, &reason, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_PEER_DOWN);
         assert_eq!(msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN], 1);
     }
@@ -533,7 +816,7 @@ mod tests {
     #[test]
     fn peer_down_remote_no_notification() {
         let info = sample_peer_info();
-        let msg = encode_peer_down(&info, &PeerDownReason::RemoteNoNotification);
+        let msg = encode_peer_down(&info, &PeerDownReason::RemoteNoNotification, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_PEER_DOWN);
         let offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         assert_eq!(msg[offset], 4);
@@ -544,7 +827,7 @@ mod tests {
     fn route_monitoring_encoding() {
         let info = sample_peer_info();
         let update_pdu = vec![0xAA; 50];
-        let msg = encode_route_monitoring(&info, &update_pdu);
+        let msg = encode_route_monitoring(&info, &update_pdu, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         let pdu_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         assert_eq!(&msg[pdu_offset..], &update_pdu[..]);
@@ -563,7 +846,7 @@ mod tests {
             safi: 1,
             value: 1000,
         }];
-        let msg = encode_stats_report(&info, &counters, &afi_counters);
+        let msg = encode_stats_report(&info, &counters, &afi_counters, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_STATS_REPORT);
         let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         let count = u32::from_be_bytes([
@@ -583,7 +866,7 @@ mod tests {
             stat_type: 9,
             value: 42,
         }];
-        let msg = encode_stats_report(&info, &counters, &[]);
+        let msg = encode_stats_report(&info, &counters, &[], BmpVersion::V3);
         let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         let count = u32::from_be_bytes([
             msg[count_offset],
@@ -596,13 +879,13 @@ mod tests {
 
     #[test]
     fn termination_encoding() {
-        let msg = encode_termination(0, "shutting down");
+        let msg = encode_termination(0, "shutting down", BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_TERMINATION);
     }
 
     #[test]
     fn initiation_empty_fields() {
-        let msg = encode_initiation("", "");
+        let msg = encode_initiation("", "", BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_INITIATION);
         assert_eq!(msg.len(), BMP_COMMON_HEADER_LEN);
     }
@@ -610,7 +893,7 @@ mod tests {
     #[test]
     fn initiation_oversized_tlv_string_truncates_without_length_wrap() {
         let sys_descr = "a".repeat(BMP_TLV_STRING_MAX_LEN + 1);
-        let msg = encode_initiation("rustbgpd", &sys_descr);
+        let msg = encode_initiation("rustbgpd", &sys_descr, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_INITIATION);
 
         let payload = &msg[BMP_COMMON_HEADER_LEN..];
@@ -631,7 +914,7 @@ mod tests {
     #[test]
     fn initiation_oversized_tlv_string_truncates_on_char_boundary() {
         let sys_descr = format!("{}é", "a".repeat(BMP_TLV_STRING_MAX_LEN - 1));
-        let msg = encode_initiation("", &sys_descr);
+        let msg = encode_initiation("", &sys_descr, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_INITIATION);
 
         let payload = &msg[BMP_COMMON_HEADER_LEN..];
@@ -643,7 +926,11 @@ mod tests {
     #[test]
     fn peer_down_local_no_notification() {
         let info = sample_peer_info();
-        let msg = encode_peer_down(&info, &PeerDownReason::LocalNoNotification(6));
+        let msg = encode_peer_down(
+            &info,
+            &PeerDownReason::LocalNoNotification(6),
+            BmpVersion::V3,
+        );
         verify_common_header(&msg, BMP_MSG_PEER_DOWN);
         let offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         assert_eq!(msg[offset], 2);
@@ -655,7 +942,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.is_ipv6 = true;
         info.peer_addr = IpAddr::V6("2001:db8::2".parse().unwrap());
-        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
         assert_ne!(msg[BMP_COMMON_HEADER_LEN + 1] & PEER_FLAG_V, 0);
     }
 
@@ -668,7 +955,7 @@ mod tests {
         info.is_rib_out = true;
         info.is_post_policy = true;
         let pdu = [0xAB; 23];
-        let msg = encode_route_monitoring(&info, &pdu);
+        let msg = encode_route_monitoring(&info, &pdu, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         assert_eq!(msg[0], 3, "BMP version 3");
         assert_eq!(
@@ -692,9 +979,11 @@ mod tests {
             12345,
             &[0xFF; 29],
             &[0xFE; 29],
+            BmpVersion::V3,
         );
-        let peer_down = encode_peer_down(&info, &PeerDownReason::RemoteNoNotification);
-        let stats = encode_stats_report(&info, &[], &[]);
+        let peer_down =
+            encode_peer_down(&info, &PeerDownReason::RemoteNoNotification, BmpVersion::V3);
+        let stats = encode_stats_report(&info, &[], &[], BmpVersion::V3);
         for msg in [&peer_up, &peer_down, &stats] {
             assert_eq!(
                 msg[BMP_COMMON_HEADER_LEN + 1] & PEER_FLAG_O,
@@ -719,7 +1008,7 @@ mod tests {
             safi: 128,
             value: 77,
         }];
-        let msg = encode_stats_report(&info, &counters, &afi_counters);
+        let msg = encode_stats_report(&info, &counters, &afi_counters, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_STATS_REPORT);
         let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         let count = u32::from_be_bytes(msg[count_offset..count_offset + 4].try_into().unwrap());
@@ -765,7 +1054,7 @@ mod tests {
     #[test]
     fn loc_rib_per_peer_header_golden() {
         let cfg = sample_loc_rib_config();
-        let msg = encode_route_monitoring(&cfg.peer_info(ts()), &[0xCD; 23]);
+        let msg = encode_route_monitoring(&cfg.peer_info(ts()), &[0xCD; 23], BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         let hdr = &msg[BMP_COMMON_HEADER_LEN..];
         assert_eq!(hdr[0], 3, "peer type 3 (Loc-RIB instance)");
@@ -797,7 +1086,7 @@ mod tests {
             is_as4: false,
             timestamp: ts(),
         };
-        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
         assert_eq!(msg[BMP_COMMON_HEADER_LEN + 1], 0);
     }
 
@@ -807,7 +1096,7 @@ mod tests {
     #[test]
     fn loc_rib_peer_up_fabricated_open_and_table_name_tlv() {
         let cfg = sample_loc_rib_config();
-        let msg = encode_loc_rib_peer_up(&cfg, ts());
+        let msg = encode_loc_rib_peer_up(&cfg, ts(), BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_PEER_UP);
         assert_eq!(msg[BMP_COMMON_HEADER_LEN], 3, "peer type 3");
 
@@ -836,7 +1125,7 @@ mod tests {
     #[test]
     fn loc_rib_peer_down_reason_6_with_table_name_tlv() {
         let cfg = sample_loc_rib_config();
-        let msg = encode_loc_rib_peer_down(&cfg, ts());
+        let msg = encode_loc_rib_peer_down(&cfg, ts(), BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_PEER_DOWN);
         assert_eq!(msg[BMP_COMMON_HEADER_LEN], 3, "peer type 3");
         let body = &msg[BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN..];
@@ -860,7 +1149,12 @@ mod tests {
             safi: 1,
             value: 15,
         }];
-        let msg = encode_stats_report(&cfg.peer_info(ts()), &counters, &afi_counters);
+        let msg = encode_stats_report(
+            &cfg.peer_info(ts()),
+            &counters,
+            &afi_counters,
+            BmpVersion::V3,
+        );
         verify_common_header(&msg, BMP_MSG_STATS_REPORT);
         let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         assert_eq!(
@@ -889,7 +1183,7 @@ mod tests {
 
     #[test]
     fn termination_no_message() {
-        let msg = encode_termination(1, "");
+        let msg = encode_termination(1, "", BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_TERMINATION);
         assert_eq!(msg.len(), BMP_COMMON_HEADER_LEN + 6);
     }
@@ -898,7 +1192,7 @@ mod tests {
     fn ipv4_address_encoding_uses_12_zero_bytes() {
         // RFC 7854 §4.2: IPv4 peer address is 12 zero bytes + 4-byte IPv4 (NOT IPv4-mapped ::ffff:)
         let info = sample_peer_info(); // IPv4 10.0.0.2
-        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
         // Per-peer header starts at offset 6 (after common header)
         // Address field is at offset 6 + 2 (type+flags) + 8 (distinguisher) = 16
         let addr_offset = BMP_COMMON_HEADER_LEN + 2 + 8;
@@ -921,7 +1215,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.timestamp = UNIX_EPOCH + std::time::Duration::from_secs(u64::from(u32::MAX) + 1);
 
-        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
 
         let timestamp_offset = BMP_COMMON_HEADER_LEN + 34;
@@ -939,7 +1233,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.is_ipv6 = true;
         info.peer_addr = IpAddr::V6("2001:db8::2".parse().unwrap());
-        let msg = encode_route_monitoring(&info, &[0u8; 23]);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
         let addr_offset = BMP_COMMON_HEADER_LEN + 2 + 8;
         let addr_bytes = &msg[addr_offset..addr_offset + 16];
         let expected: std::net::Ipv6Addr = "2001:db8::2".parse().unwrap();
@@ -956,6 +1250,7 @@ mod tests {
             12345,
             &[0xFF; 29],
             &[0xFE; 29],
+            BmpVersion::V3,
         );
         // Local address is right after per-peer header
         let local_addr_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
@@ -981,7 +1276,7 @@ mod tests {
             safi: 1,
             value: 500,
         }];
-        let msg = encode_stats_report(&info, &[], &afi_counters);
+        let msg = encode_stats_report(&info, &[], &afi_counters, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_STATS_REPORT);
         let count_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         let count = u32::from_be_bytes([

--- a/crates/bmp/src/lib.rs
+++ b/crates/bmp/src/lib.rs
@@ -4,7 +4,9 @@
 //! session state and raw UPDATE PDUs to configured collectors,
 //! including post-policy Adj-RIB-Out monitoring (RFC 8671) and
 //! Loc-RIB instance monitoring with collector-connect table sync
-//! (RFC 9069).
+//! (RFC 9069). Collectors are framed per configured [`BmpVersion`]:
+//! v3 (default) or v4 TLV framing per draft-ietf-grow-bmp-tlv-20
+//! (pre-IANA; see [`tlv`]).
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -13,11 +15,12 @@
 pub mod client;
 pub mod codec;
 pub mod manager;
+pub mod tlv;
 pub mod types;
 
 pub use client::BmpClient;
 pub use manager::BmpManager;
 pub use types::{
     BmpClientConfig, BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig,
-    BmpMonitorFilter, BmpPeerInfo, BmpPeerType, LOC_RIB_TABLE_NAME, PeerDownReason,
+    BmpMonitorFilter, BmpPeerInfo, BmpPeerType, BmpVersion, LOC_RIB_TABLE_NAME, PeerDownReason,
 };

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -2,6 +2,11 @@
 //!
 //! Receives `BmpEvent`s from transport, encodes them into BMP wire
 //! format, and distributes the encoded bytes to all collector channels.
+//!
+//! Internal events are version-agnostic (raw PDU + peer metadata);
+//! framing happens per collector at fan-out time — each collector is
+//! configured v3 or v4 ([`BmpVersion`]) and an event is encoded at
+//! most once per version actually in use.
 
 use std::net::SocketAddr;
 
@@ -13,6 +18,7 @@ use tracing::{debug, info, warn};
 use crate::codec;
 use crate::types::{
     BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig, BmpMonitorFilter,
+    BmpVersion,
 };
 
 /// Per-message send timeout for a Loc-RIB dump forwarder. Paces the dump
@@ -25,12 +31,19 @@ const LOC_RIB_DUMP_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from
 pub struct BmpManager {
     event_rx: mpsc::Receiver<BmpEvent>,
     control_rx: mpsc::Receiver<BmpControlEvent>,
-    /// Per-collector address + sender + monitoring filter, paired by
-    /// index. The address is the operator-facing identifier used as the
-    /// `collector` label on `bmp_*` Prometheus counters.
-    collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>, BmpMonitorFilter)>,
-    /// Latest encoded `PeerUp` message per peer address.
-    peer_up_cache: std::collections::HashMap<std::net::IpAddr, Bytes>,
+    /// Per-collector address + sender + monitoring filter + BMP wire
+    /// version, paired by index. The address is the operator-facing
+    /// identifier used as the `collector` label on `bmp_*` Prometheus
+    /// counters.
+    collectors: Vec<(
+        SocketAddr,
+        mpsc::Sender<Bytes>,
+        BmpMonitorFilter,
+        BmpVersion,
+    )>,
+    /// Latest encoded `PeerUp` message per peer address, one encoding
+    /// per BMP version (indexed by [`BmpVersion::idx`]).
+    peer_up_cache: std::collections::HashMap<std::net::IpAddr, [Bytes; 2]>,
     /// RFC 9069 Loc-RIB instance-peer identity. `None` = no collector
     /// monitors `loc_rib`; Loc-RIB events are dropped.
     loc_rib: Option<BmpLocRibConfig>,
@@ -46,7 +59,12 @@ impl BmpManager {
     pub fn new(
         event_rx: mpsc::Receiver<BmpEvent>,
         control_rx: mpsc::Receiver<BmpControlEvent>,
-        collectors: Vec<(SocketAddr, mpsc::Sender<Bytes>, BmpMonitorFilter)>,
+        collectors: Vec<(
+            SocketAddr,
+            mpsc::Sender<Bytes>,
+            BmpMonitorFilter,
+            BmpVersion,
+        )>,
         metrics: BgpMetrics,
     ) -> Self {
         Self {
@@ -106,7 +124,7 @@ impl BmpManager {
         debug!("BMP manager shutting down");
     }
 
-    fn encode_event(event: &BmpEvent) -> Bytes {
+    fn encode_event(event: &BmpEvent, version: BmpVersion) -> Bytes {
         match event {
             BmpEvent::LocRibRouteMonitoring { .. } | BmpEvent::LocRibStats { .. } => {
                 unreachable!("Loc-RIB events are encoded in handle_loc_rib_event")
@@ -125,12 +143,15 @@ impl BmpManager {
                 *remote_port,
                 local_open,
                 remote_open,
+                version,
             ),
-            BmpEvent::PeerDown { peer_info, reason } => codec::encode_peer_down(peer_info, reason),
+            BmpEvent::PeerDown { peer_info, reason } => {
+                codec::encode_peer_down(peer_info, reason, version)
+            }
             BmpEvent::RouteMonitoring {
                 peer_info,
                 update_pdu,
-            } => codec::encode_route_monitoring(peer_info, update_pdu),
+            } => codec::encode_route_monitoring(peer_info, update_pdu, version),
             BmpEvent::StatsReport {
                 peer_info,
                 adj_rib_in_routes,
@@ -158,7 +179,7 @@ impl BmpManager {
                         });
                     }
                 }
-                codec::encode_stats_report(peer_info, &counters, &afi_counters)
+                codec::encode_stats_report(peer_info, &counters, &afi_counters, version)
             }
         }
     }
@@ -170,36 +191,48 @@ impl BmpManager {
         let Some(ref cfg) = self.loc_rib else {
             return;
         };
-        let encoded = match event {
-            BmpEvent::LocRibRouteMonitoring {
-                update_pdu,
-                timestamp,
-            } => codec::encode_route_monitoring(&cfg.peer_info(*timestamp), update_pdu),
-            BmpEvent::LocRibStats { per_family } => {
-                // RFC 9069 stat type 8 = Loc-RIB total (64-bit gauge),
-                // type 10 = its per-AFI/SAFI breakdown.
-                let counters = vec![codec::StatCounter {
-                    stat_type: 8,
-                    value: per_family.iter().map(|(_, _, count)| count).sum(),
-                }];
-                let afi_counters: Vec<codec::AfiStatCounter> = per_family
-                    .iter()
-                    .map(|&(afi, safi, value)| codec::AfiStatCounter {
-                        stat_type: 10,
-                        afi,
-                        safi,
-                        value,
-                    })
-                    .collect();
-                codec::encode_stats_report(
-                    &cfg.peer_info(std::time::SystemTime::now()),
-                    &counters,
-                    &afi_counters,
-                )
-            }
-            _ => return,
-        };
-        self.fan_out_filtered(&encoded, |f| f.loc_rib);
+        if !matches!(
+            event,
+            BmpEvent::LocRibRouteMonitoring { .. } | BmpEvent::LocRibStats { .. }
+        ) {
+            return;
+        }
+        let now = std::time::SystemTime::now();
+        self.fan_out_filtered(
+            |f| f.loc_rib,
+            |version| match event {
+                BmpEvent::LocRibRouteMonitoring {
+                    update_pdu,
+                    timestamp,
+                } => {
+                    codec::encode_route_monitoring(&cfg.peer_info(*timestamp), update_pdu, version)
+                }
+                BmpEvent::LocRibStats { per_family } => {
+                    // RFC 9069 stat type 8 = Loc-RIB total (64-bit gauge),
+                    // type 10 = its per-AFI/SAFI breakdown.
+                    let counters = vec![codec::StatCounter {
+                        stat_type: 8,
+                        value: per_family.iter().map(|(_, _, count)| count).sum(),
+                    }];
+                    let afi_counters: Vec<codec::AfiStatCounter> = per_family
+                        .iter()
+                        .map(|&(afi, safi, value)| codec::AfiStatCounter {
+                            stat_type: 10,
+                            afi,
+                            safi,
+                            value,
+                        })
+                        .collect();
+                    codec::encode_stats_report(
+                        &cfg.peer_info(now),
+                        &counters,
+                        &afi_counters,
+                        version,
+                    )
+                }
+                _ => unreachable!("guarded above"),
+            },
+        );
     }
 
     fn handle_event(&mut self, event: &BmpEvent) {
@@ -208,33 +241,37 @@ impl BmpManager {
                 self.handle_loc_rib_event(event);
             }
             BmpEvent::PeerUp { peer_info, .. } => {
-                let encoded = Self::encode_event(event);
-                self.peer_up_cache
-                    .insert(peer_info.peer_addr, encoded.clone());
-                self.fan_out(&encoded);
+                // Encode both versions eagerly: the cache must be able
+                // to replay to any collector version on reconnect.
+                let encoded = [
+                    Self::encode_event(event, BmpVersion::V3),
+                    Self::encode_event(event, BmpVersion::V4),
+                ];
+                self.fan_out(|version| encoded[version.idx()].clone());
+                self.peer_up_cache.insert(peer_info.peer_addr, encoded);
             }
             BmpEvent::PeerDown { peer_info, .. } => {
                 self.peer_up_cache.remove(&peer_info.peer_addr);
-                let encoded = Self::encode_event(event);
-                self.fan_out(&encoded);
+                self.fan_out(|version| Self::encode_event(event, version));
             }
             // Route monitoring is the only per-collector-filtered
             // message: rib-in RM only to `rib_in_pre` collectors,
             // rib-out RM only to `rib_out_post` collectors.
             BmpEvent::RouteMonitoring { peer_info, .. } => {
-                let encoded = Self::encode_event(event);
                 let rib_out = peer_info.is_rib_out;
-                self.fan_out_filtered(&encoded, |f| {
-                    if rib_out {
-                        f.rib_out_post
-                    } else {
-                        f.rib_in_pre
-                    }
-                });
+                self.fan_out_filtered(
+                    |f| {
+                        if rib_out {
+                            f.rib_out_post
+                        } else {
+                            f.rib_in_pre
+                        }
+                    },
+                    |version| Self::encode_event(event, version),
+                );
             }
             BmpEvent::StatsReport { .. } => {
-                let encoded = Self::encode_event(event);
-                self.fan_out(&encoded);
+                self.fan_out(|version| Self::encode_event(event, version));
             }
         }
     }
@@ -272,8 +309,11 @@ impl BmpManager {
                 // RFC 9069 §5.3: the Loc-RIB instance peer goes down with
                 // reason 6 + the VRF/Table Name TLV when monitoring stops.
                 if let Some(ref cfg) = self.loc_rib {
-                    let down = codec::encode_loc_rib_peer_down(cfg, std::time::SystemTime::now());
-                    self.fan_out_filtered(&down, |f| f.loc_rib);
+                    let now = std::time::SystemTime::now();
+                    self.fan_out_filtered(
+                        |f| f.loc_rib,
+                        |version| codec::encode_loc_rib_peer_down(cfg, now, version),
+                    );
                 }
                 true
             }
@@ -281,7 +321,7 @@ impl BmpManager {
     }
 
     fn replay_peer_up_to_collector(&self, collector_id: usize) {
-        let Some((addr, tx, _)) = self.collectors.get(collector_id) else {
+        let Some((addr, tx, _, version)) = self.collectors.get(collector_id) else {
             warn!(
                 collector_id,
                 "BMP replay target collector index out of range, skipping"
@@ -295,7 +335,11 @@ impl BmpManager {
         // remaining cached-PeerUp message as dropped — otherwise a
         // single saturation event under-reports thousands of skipped
         // peers as one drop.
-        let cache_values: Vec<&Bytes> = self.peer_up_cache.values().collect();
+        let cache_values: Vec<&Bytes> = self
+            .peer_up_cache
+            .values()
+            .map(|encoded| &encoded[version.idx()])
+            .collect();
         for (idx, msg) in cache_values.iter().enumerate() {
             if let Err(e) = tx.try_send((*msg).clone()) {
                 let reason = trysend_reason(&e);
@@ -328,7 +372,7 @@ impl BmpManager {
         let Some(ref cfg) = self.loc_rib else {
             return;
         };
-        let Some((addr, collector_tx, filter)) = self.collectors.get(collector_id) else {
+        let Some((addr, collector_tx, filter, version)) = self.collectors.get(collector_id) else {
             return;
         };
         if !filter.loc_rib {
@@ -336,7 +380,8 @@ impl BmpManager {
         }
 
         let addr_label = addr.to_string();
-        let peer_up = codec::encode_loc_rib_peer_up(cfg, std::time::SystemTime::now());
+        let version = *version;
+        let peer_up = codec::encode_loc_rib_peer_up(cfg, std::time::SystemTime::now(), version);
         if let Err(e) = collector_tx.try_send(peer_up) {
             let reason = trysend_reason(&e);
             self.metrics
@@ -372,21 +417,32 @@ impl BmpManager {
             chunk_rx,
             collector_tx,
             cfg,
+            version,
             metrics,
             addr_label,
         ));
     }
 
-    fn fan_out(&self, msg: &Bytes) {
-        self.fan_out_filtered(msg, |_| true);
+    fn fan_out(&self, encode: impl Fn(BmpVersion) -> Bytes) {
+        self.fan_out_filtered(|_| true, encode);
     }
 
-    fn fan_out_filtered(&self, msg: &Bytes, want: impl Fn(&BmpMonitorFilter) -> bool) {
-        for (addr, tx, filter) in &self.collectors {
+    /// Fan out one event, framing per collector version. `encode` is
+    /// called at most once per BMP version in use (two-slot memo).
+    fn fan_out_filtered(
+        &self,
+        want: impl Fn(&BmpMonitorFilter) -> bool,
+        encode: impl Fn(BmpVersion) -> Bytes,
+    ) {
+        let mut memo: [Option<Bytes>; 2] = [None, None];
+        for (addr, tx, filter, version) in &self.collectors {
             if !want(filter) {
                 continue;
             }
-            if let Err(e) = tx.try_send(msg.clone()) {
+            let msg = memo[version.idx()]
+                .get_or_insert_with(|| encode(*version))
+                .clone();
+            if let Err(e) = tx.try_send(msg) {
                 let reason = trysend_reason(&e);
                 self.metrics
                     .record_bmp_collector_drop(&addr.to_string(), "fan_out", reason, 1);
@@ -410,13 +466,14 @@ async fn forward_loc_rib_dump(
     mut chunk_rx: mpsc::Receiver<BmpDumpChunk>,
     collector_tx: mpsc::Sender<Bytes>,
     cfg: BmpLocRibConfig,
+    version: BmpVersion,
     metrics: BgpMetrics,
     addr_label: String,
 ) {
     let mut sent: u64 = 0;
     while let Some(chunk) = chunk_rx.recv().await {
         for (pdu, timestamp) in chunk.messages {
-            let msg = codec::encode_route_monitoring(&cfg.peer_info(timestamp), &pdu);
+            let msg = codec::encode_route_monitoring(&cfg.peer_info(timestamp), &pdu, version);
             match tokio::time::timeout(LOC_RIB_DUMP_SEND_TIMEOUT, collector_tx.send(msg)).await {
                 Ok(Ok(())) => sent += 1,
                 Ok(Err(_)) => {
@@ -491,8 +548,18 @@ mod tests {
             event_rx,
             control_rx,
             vec![
-                (collector_addr(0), c1_tx, BmpMonitorFilter::default()),
-                (collector_addr(1), c2_tx, BmpMonitorFilter::default()),
+                (
+                    collector_addr(0),
+                    c1_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
+                (
+                    collector_addr(1),
+                    c2_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
             ],
             BgpMetrics::new(),
         );
@@ -524,6 +591,112 @@ mod tests {
         handle.await.unwrap();
     }
 
+    /// Mixed-version fan-out (draft-ietf-grow-bmp-tlv-20): one v3 and
+    /// one v4 collector receive the same events, each framed at its
+    /// configured version. Route Monitoring: bare PDU for v3, BGP
+    /// Message TLV (type 7, index 0) for v4. Peer Up (TLV-provisioned
+    /// already in v3) differs only in the version byte — including the
+    /// cached copy replayed on reconnect.
+    #[tokio::test]
+    async fn mixed_version_collectors_get_version_correct_framing() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (v3_tx, mut v3_rx) = mpsc::channel(16);
+        let (v4_tx, mut v4_rx) = mpsc::channel(16);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![
+                (
+                    collector_addr(0),
+                    v3_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
+                (
+                    collector_addr(1),
+                    v4_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V4,
+                ),
+            ],
+            BgpMetrics::new(),
+        );
+        let handle = tokio::spawn(mgr.run());
+
+        // Peer Up: same bytes except the version byte.
+        event_tx
+            .send(BmpEvent::PeerUp {
+                peer_info: sample_peer_info(),
+                local_open: Bytes::from_static(&[0xFF; 29]),
+                remote_open: Bytes::from_static(&[0xFE; 29]),
+                local_addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                local_port: 179,
+                remote_port: 54321,
+            })
+            .await
+            .unwrap();
+        let up3 = v3_rx.recv().await.unwrap();
+        let up4 = v4_rx.recv().await.unwrap();
+        assert_eq!(up3[0], 3);
+        assert_eq!(up4[0], 4);
+        assert_eq!(up3[1..], up4[1..], "Peer Up: version byte only");
+
+        // Route Monitoring: v3 bare PDU, v4 BGP Message TLV wrap.
+        let pdu = [0xAA; 23];
+        event_tx
+            .send(BmpEvent::RouteMonitoring {
+                peer_info: sample_peer_info(),
+                update_pdu: Bytes::copy_from_slice(&pdu),
+            })
+            .await
+            .unwrap();
+        let rm3 = v3_rx.recv().await.unwrap();
+        let rm4 = v4_rx.recv().await.unwrap();
+        assert_eq!(rm3[0], 3);
+        assert_eq!(&rm3[6 + 42..], &pdu, "v3: bare PDU after per-peer header");
+        assert_eq!(rm4[0], 4);
+        let tlv = &rm4[6 + 42..];
+        assert_eq!(u16::from_be_bytes([tlv[0], tlv[1]]), 7, "BGP Message TLV");
+        assert_eq!(u16::from_be_bytes([tlv[2], tlv[3]]) as usize, pdu.len());
+        assert_eq!(u16::from_be_bytes([tlv[4], tlv[5]]), 0, "index 0");
+        assert_eq!(&tlv[6..], &pdu);
+
+        // Stats Report: v4 wraps in the Stats TLV (code point 1).
+        event_tx
+            .send(BmpEvent::StatsReport {
+                peer_info: sample_peer_info(),
+                adj_rib_in_routes: 42,
+                adj_rib_out_post: None,
+            })
+            .await
+            .unwrap();
+        let st3 = v3_rx.recv().await.unwrap();
+        let st4 = v4_rx.recv().await.unwrap();
+        assert_eq!(st3[0], 3);
+        assert_eq!(st4[0], 4);
+        let tlv = &st4[6 + 42..];
+        assert_eq!(u16::from_be_bytes([tlv[0], tlv[1]]), 1, "Stats TLV");
+        assert_eq!(&tlv[4..], &st3[6 + 42..], "value = v3 count + stats bytes");
+
+        // Reconnect of the v4 collector replays the v4-framed Peer Up.
+        control_tx
+            .send(BmpControlEvent::CollectorConnected {
+                collector_id: 1,
+                collector_addr: collector_addr(1),
+            })
+            .await
+            .unwrap();
+        let replay = v4_rx.recv().await.unwrap();
+        assert_eq!(replay[0], 4, "replayed Peer Up framed at collector version");
+        assert_eq!(replay[..], up4[..], "replay = original v4 Peer Up");
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
     /// Per-collector monitor filtering: collector A monitors rib-in
     /// only (default), collector B monitors both. A rib-in RM reaches
     /// both; a rib-out RM reaches only B. Non-RM messages (stats)
@@ -539,7 +712,12 @@ mod tests {
             event_rx,
             control_rx,
             vec![
-                (collector_addr(0), a_tx, BmpMonitorFilter::default()),
+                (
+                    collector_addr(0),
+                    a_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
                 (
                     collector_addr(1),
                     b_tx,
@@ -548,6 +726,7 @@ mod tests {
                         rib_out_post: true,
                         loc_rib: false,
                     },
+                    BmpVersion::V3,
                 ),
             ],
             BgpMetrics::new(),
@@ -608,7 +787,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -642,7 +826,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -672,7 +861,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -715,7 +909,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -737,8 +936,18 @@ mod tests {
             event_rx,
             control_rx,
             vec![
-                (collector_addr(0), c1_tx, BmpMonitorFilter::default()),
-                (collector_addr(1), c2_tx, BmpMonitorFilter::default()),
+                (
+                    collector_addr(0),
+                    c1_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
+                (
+                    collector_addr(1),
+                    c2_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
             ],
             BgpMetrics::new(),
         );
@@ -853,7 +1062,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(addr, c_tx, BmpMonitorFilter::default())],
+            vec![(addr, c_tx, BmpMonitorFilter::default(), BmpVersion::V3)],
             metrics.clone(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -909,7 +1118,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(addr, c_tx.clone(), BmpMonitorFilter::default())],
+            vec![(
+                addr,
+                c_tx.clone(),
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             metrics.clone(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -987,7 +1201,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(addr, c_tx, BmpMonitorFilter::default())],
+            vec![(addr, c_tx, BmpMonitorFilter::default(), BmpVersion::V3)],
             metrics.clone(),
         );
         let handle = tokio::spawn(mgr.run());
@@ -1054,8 +1268,18 @@ mod tests {
             event_rx,
             control_rx,
             vec![
-                (collector_addr(0), rib_in_tx, BmpMonitorFilter::default()),
-                (collector_addr(1), loc_rib_tx, loc_rib_filter()),
+                (
+                    collector_addr(0),
+                    rib_in_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
+                (
+                    collector_addr(1),
+                    loc_rib_tx,
+                    loc_rib_filter(),
+                    BmpVersion::V3,
+                ),
             ],
             BgpMetrics::new(),
         )
@@ -1117,8 +1341,18 @@ mod tests {
             event_rx,
             control_rx,
             vec![
-                (collector_addr(0), rib_in_tx, BmpMonitorFilter::default()),
-                (collector_addr(1), loc_rib_tx, loc_rib_filter()),
+                (
+                    collector_addr(0),
+                    rib_in_tx,
+                    BmpMonitorFilter::default(),
+                    BmpVersion::V3,
+                ),
+                (
+                    collector_addr(1),
+                    loc_rib_tx,
+                    loc_rib_filter(),
+                    BmpVersion::V3,
+                ),
             ],
             BgpMetrics::new(),
         )
@@ -1169,7 +1403,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, loc_rib_filter())],
+            vec![(collector_addr(0), c_tx, loc_rib_filter(), BmpVersion::V3)],
             BgpMetrics::new(),
         )
         .with_loc_rib(loc_rib_config(), dump_tx);
@@ -1253,7 +1487,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         )
         .with_loc_rib(loc_rib_config(), dump_tx);
@@ -1297,7 +1536,7 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, loc_rib_filter())],
+            vec![(collector_addr(0), c_tx, loc_rib_filter(), BmpVersion::V3)],
             BgpMetrics::new(),
         )
         .with_loc_rib(loc_rib_config(), dump_tx);
@@ -1324,7 +1563,12 @@ mod tests {
         let mgr = BmpManager::new(
             event_rx,
             control_rx,
-            vec![(collector_addr(0), c_tx, BmpMonitorFilter::default())],
+            vec![(
+                collector_addr(0),
+                c_tx,
+                BmpMonitorFilter::default(),
+                BmpVersion::V3,
+            )],
             BgpMetrics::new(),
         );
         let mut handle = tokio::spawn(mgr.run());

--- a/crates/bmp/src/tlv.rs
+++ b/crates/bmp/src/tlv.rs
@@ -1,0 +1,133 @@
+//! BMP version 4 TLV code points and encode helpers
+//! (draft-ietf-grow-bmp-tlv-20).
+//!
+//! **Pre-IANA caveat:** every code point in this module comes from the
+//! IANA Considerations of draft-ietf-grow-bmp-tlv-20 (§9) and may be
+//! renumbered when the draft is published as an RFC. Keep all
+//! draft-tlv code points in this one module so a renumber is a
+//! single-file change.
+//!
+//! Encode-only, like the rest of this crate: BMP is unidirectional
+//! (router → collector) and the daemon never parses BMP.
+
+use bytes::{BufMut, BytesMut};
+
+// ── "BMP Route Monitoring TLVs" registry (§9) ──────────────────────
+// TLVs in Route Monitoring messages are always *indexed* (§4.3).
+
+/// Sequence Number TLV (§5.6.2).
+pub const RM_TLV_SEQUENCE_NUMBER: u16 = 1;
+/// Extended Flags TLV (§5.6.3).
+pub const RM_TLV_EXTENDED_FLAGS: u16 = 2;
+/// Timestamp TLV (§5.6.1).
+pub const RM_TLV_TIMESTAMP: u16 = 3;
+/// Group TLV (§5.2.1): binds a Group Index (G-bit set) to a list of
+/// NLRI indexes.
+pub const RM_TLV_GROUP: u16 = 4;
+/// VRF/Table Name TLV (§5.2.2).
+pub const RM_TLV_VRF_TABLE_NAME: u16 = 5;
+/// Stateless Parsing TLV (§5.2.3): one BGP capability per TLV, encoded
+/// exactly as in the BGP OPEN.
+pub const RM_TLV_STATELESS_PARSING: u16 = 6;
+/// BGP Message TLV (§5.2): carries the BGP UPDATE PDU. Mandatory in
+/// every v4 Route Monitoring message, index 0.
+pub const RM_TLV_BGP_MESSAGE: u16 = 7;
+
+// ── "BMP Stats Reports TLVs" registry (§9) ─────────────────────────
+// Stats Reports TLVs are *not* indexed — indexed TLVs apply only to
+// Route Monitoring (§4.3).
+
+/// Stats TLV (§5.4): mandatory container enclosing the RFC 7854 Stats
+/// Count and stats data in a v4 Stats Report.
+pub const STATS_TLV_STATS: u16 = 1;
+
+// ── Index field (§4.3) ─────────────────────────────────────────────
+
+/// G-bit: top-most bit of the 2-byte index flags a Group Index
+/// (§4.3, §5.2.1).
+pub const INDEX_G_BIT: u16 = 0x8000;
+/// Index 0: the TLV applies to all NLRIs in the BGP UPDATE (§4.3).
+pub const INDEX_ALL_NLRI: u16 = 0;
+
+/// TLV length field: value length only. Indexed TLVs exclude the
+/// 2-byte index from the reported length (§4.3). BGP framing bounds
+/// PDUs at 65535 (RFC 8654), so a v4 TLV value always fits.
+fn tlv_len(value: &[u8]) -> u16 {
+    debug_assert!(u16::try_from(value.len()).is_ok(), "TLV value overflow");
+    u16::try_from(value.len()).unwrap_or(u16::MAX)
+}
+
+/// Append an IANA-registered indexed TLV (§4.3, Figure 4):
+/// type(2, E=0) + length(2, value only) + index(2, G-bit included in
+/// `index`) + value. Used for Route Monitoring message TLVs.
+pub fn put_indexed_tlv(buf: &mut BytesMut, tlv_type: u16, index: u16, value: &[u8]) {
+    buf.put_u16(tlv_type);
+    buf.put_u16(tlv_len(value));
+    buf.put_u16(index);
+    buf.put_slice(value);
+}
+
+/// Append an IANA-registered non-indexed TLV (§4.1, Figure 1):
+/// type(2, E=0) + length(2) + value. Used for Stats Reports TLVs.
+pub fn put_tlv(buf: &mut BytesMut, tlv_type: u16, value: &[u8]) {
+    buf.put_u16(tlv_type);
+    buf.put_u16(tlv_len(value));
+    buf.put_slice(value);
+}
+
+/// Append a Group TLV (§5.2.1): type 4, index = `group_index` with the
+/// G-bit forced on, value = the 2-byte NLRI indexes (1-based, §4.3).
+pub fn put_group_tlv(buf: &mut BytesMut, group_index: u16, nlri_indexes: &[u16]) {
+    debug_assert!(nlri_indexes.len() >= 2, "Group TLV needs 2+ NLRI indexes");
+    let mut value = Vec::with_capacity(nlri_indexes.len() * 2);
+    for idx in nlri_indexes {
+        debug_assert!(
+            *idx != 0 && *idx & INDEX_G_BIT == 0,
+            "Group TLV must reference plain non-zero NLRI indexes"
+        );
+        value.extend_from_slice(&idx.to_be_bytes());
+    }
+    put_indexed_tlv(buf, RM_TLV_GROUP, INDEX_G_BIT | group_index, &value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexed_tlv_shape_length_excludes_index() {
+        let mut buf = BytesMut::new();
+        put_indexed_tlv(&mut buf, RM_TLV_BGP_MESSAGE, INDEX_ALL_NLRI, &[0xAA, 0xBB]);
+        // type=7, length=2 (value only, §4.3), index=0, value.
+        assert_eq!(&buf[..], &[0x00, 0x07, 0x00, 0x02, 0x00, 0x00, 0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn plain_tlv_shape() {
+        let mut buf = BytesMut::new();
+        put_tlv(&mut buf, STATS_TLV_STATS, &[0x01, 0x02, 0x03]);
+        assert_eq!(&buf[..], &[0x00, 0x01, 0x00, 0x03, 0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn group_tlv_sets_g_bit_and_packs_nlri_indexes() {
+        let mut buf = BytesMut::new();
+        put_group_tlv(&mut buf, 0x000B, &[1, 2, 3, 10]);
+        assert_eq!(
+            &buf[..],
+            &[
+                0x00, 0x04, // type 4 (Group TLV, §5.2.1)
+                0x00, 0x08, // length: 4 × 2-byte NLRI indexes
+                0x80, 0x0B, // G-bit | group index 0x000B
+                0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x0A,
+            ]
+        );
+    }
+
+    #[test]
+    fn indexed_tlv_with_nlri_ordinal() {
+        let mut buf = BytesMut::new();
+        put_indexed_tlv(&mut buf, RM_TLV_TIMESTAMP, 7, &[0xFF]);
+        assert_eq!(&buf[..], &[0x00, 0x03, 0x00, 0x01, 0x00, 0x07, 0xFF]);
+    }
+}

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -210,6 +210,41 @@ pub enum PeerDownReason {
     RemoteNoNotification,
 }
 
+/// BMP wire version a collector receives.
+///
+/// V3 output is the RFC 7854/8671/9069 encoding, byte-identical to
+/// pre-v4 releases. V4 frames per draft-ietf-grow-bmp-tlv-20
+/// (pre-IANA; code points may renumber at RFC publication).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BmpVersion {
+    /// RFC 7854 BMP version 3 (default).
+    #[default]
+    V3,
+    /// draft-ietf-grow-bmp-tlv-20 BMP version 4.
+    V4,
+}
+
+impl BmpVersion {
+    /// Common-header version byte (§3 of the draft: 4 for every
+    /// message type on a v4 session).
+    #[must_use]
+    pub fn header_byte(self) -> u8 {
+        match self {
+            Self::V3 => 3,
+            Self::V4 => 4,
+        }
+    }
+
+    /// Dense index for per-version memoization (0 or 1).
+    #[must_use]
+    pub fn idx(self) -> usize {
+        match self {
+            Self::V3 => 0,
+            Self::V4 => 1,
+        }
+    }
+}
+
 /// Which route-monitoring streams a collector receives.
 ///
 /// Non-monitoring messages (Peer Up/Down, Stats, Initiation,
@@ -247,4 +282,6 @@ pub struct BmpClientConfig {
     pub collector_addr: SocketAddr,
     /// Seconds between reconnection attempts (default: 30).
     pub reconnect_interval: u64,
+    /// BMP wire version framed for this collector (default: v3).
+    pub version: BmpVersion,
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1744,6 +1744,24 @@ monitor = ["rib_in_pre", "rib_out_post"]   # + RFC 8671 Adj-RIB-Out
 | `address`            | string | yes      | --      | Collector `host:port` socket address  |
 | `reconnect_interval` | u64   | no       | 30      | Seconds between reconnect attempts    |
 | `monitor`            | array  | no       | `["rib_in_pre"]` | Route-monitoring streams: `rib_in_pre` (RFC 7854 pre-policy Adj-RIB-In), `rib_out_post` (RFC 8671 post-policy Adj-RIB-Out), and/or `loc_rib` (RFC 9069 Loc-RIB instance with collector-connect table sync) |
+| `version`            | u8     | no       | 3       | BMP wire version framed for this collector: `3` (RFC 7854) or `4` (BMPv4 TLV framing, see below) |
+
+### BMPv4 framing (`version = 4`)
+
+With `version = 4` on a collector, every BMP message carries common-header
+version 4 per draft-ietf-grow-bmp-tlv-20: Route Monitoring messages enclose
+the BGP UPDATE PDU in the mandatory BGP Message TLV (type 7, index 0) and
+Stats Reports enclose the Stats Count + stats data in the mandatory Stats
+TLV (code point 1). Peer Up/Down, Initiation, and Termination already
+provision TLV data in v3 and differ only in the version byte. Framing is
+per collector — v3 and v4 collectors can be mixed freely, and v3 output is
+byte-identical to previous releases.
+
+**Pre-IANA caveat:** BMPv4 is an IETF draft. The TLV code points are not
+yet IANA-assigned and may be renumbered when the draft is published as an
+RFC; pick `4` only for collectors that track the same draft revision
+(e.g. bleeding-edge pmacct/gobmp builds). The default `3` is the stable
+RFC 7854 encoding.
 
 ### What is streamed
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -304,6 +304,11 @@ pub struct BmpCollector {
     /// Default preserves pre-RFC 8671 behavior: pre-policy Adj-RIB-In only.
     #[serde(default = "default_bmp_monitor")]
     pub monitor: Vec<BmpMonitorView>,
+    /// BMP wire version framed for this collector: 3 (RFC 7854,
+    /// default) or 4 (TLV framing per draft-ietf-grow-bmp-tlv-20 —
+    /// pre-IANA; code points may renumber at RFC publication).
+    #[serde(default = "default_bmp_version")]
+    pub version: u8,
 }
 
 /// A BMP route-monitoring stream selection (per collector).
@@ -345,6 +350,10 @@ fn default_bmp_sys_name() -> String {
 
 fn default_bmp_reconnect() -> u64 {
     30
+}
+
+fn default_bmp_version() -> u8 {
+    3
 }
 
 fn default_bmp_monitor() -> Vec<BmpMonitorView> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3168,6 +3168,30 @@ fn bmp_zero_reconnect_interval_rejected() {
 }
 
 #[test]
+fn bmp_version_defaults_to_3() {
+    let config = parse(&bmp_toml("")).unwrap();
+    assert_eq!(
+        config.bmp.as_ref().unwrap().collectors[0].version,
+        3,
+        "BMP wire version defaults to RFC 7854 v3"
+    );
+}
+
+#[test]
+fn bmp_version_4_accepted() {
+    let config = parse(&bmp_toml("version = 4")).unwrap();
+    assert_eq!(config.bmp.as_ref().unwrap().collectors[0].version, 4);
+}
+
+#[test]
+fn bmp_invalid_version_rejected() {
+    for bad in ["version = 2", "version = 5"] {
+        let err = parse(&bmp_toml(bad)).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidBmpCollector { .. }));
+    }
+}
+
+#[test]
 fn bmp_custom_reconnect_interval_accepted() {
     let config = parse(&bmp_toml("reconnect_interval = 60")).unwrap();
     let bmp = config.bmp.as_ref().unwrap();

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -693,6 +693,14 @@ impl Config {
                         ),
                     });
                 }
+                if !matches!(collector.version, 3 | 4) {
+                    return Err(ConfigError::InvalidBmpCollector {
+                        reason: format!(
+                            "collectors[{i}]: version must be 3 or 4 (got {})",
+                            collector.version
+                        ),
+                    });
+                }
             }
 
             // Reject duplicate collector addresses (canonicalize through SocketAddr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1279,6 +1279,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             std::net::SocketAddr,
             mpsc::Sender<bytes::Bytes>,
             rustbgpd_bmp::BmpMonitorFilter,
+            rustbgpd_bmp::BmpVersion,
         )> = Vec::new();
         let mut client_handles = Vec::new();
         for collector in &bmp_config.collectors {
@@ -1304,12 +1305,19 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                     .contains(&config::BmpMonitorView::RibOutPost),
                 loc_rib: collector.monitor.contains(&config::BmpMonitorView::LocRib),
             };
-            collectors.push((addr, msg_tx, filter));
+            // Validation pins collector.version to 3 | 4.
+            let version = if collector.version == 4 {
+                rustbgpd_bmp::BmpVersion::V4
+            } else {
+                rustbgpd_bmp::BmpVersion::V3
+            };
+            collectors.push((addr, msg_tx, filter, version));
             let client = rustbgpd_bmp::BmpClient::new(
                 rustbgpd_bmp::BmpClientConfig {
                     collector_id,
                     collector_addr: addr,
                     reconnect_interval: collector.reconnect_interval,
+                    version,
                 },
                 msg_rx,
                 sys_name.clone(),
@@ -1321,7 +1329,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
             client_handles.push(tokio::spawn(client.run()));
         }
 
-        let loc_rib_enabled = collectors.iter().any(|(_, _, filter)| filter.loc_rib);
+        let loc_rib_enabled = collectors.iter().any(|(_, _, filter, _)| filter.loc_rib);
         let mut mgr = rustbgpd_bmp::BmpManager::new(
             bmp_event_rx,
             bmp_control_rx,


### PR DESCRIPTION
BMP arc slice 3: BMPv4 TLV framing per draft-ietf-grow-bmp-tlv-20, selected per collector.

## What

- New per-collector config field `version = 3 | 4` (default **3**; validation rejects anything else). v3 output stays **byte-identical** to previous releases, pinned by golden-bytes regression tests.
- `version = 4`: common-header version 4 on every message type (draft §3); Route Monitoring encloses the UPDATE PDU in the mandatory BGP Message TLV (type 7, index 0, §5.2); Stats Reports enclose Stats Count + stats data in the mandatory Stats TLV (code point 1, §5.4). Peer Up/Down, Initiation, Termination already provision TLV data in v3 — only the version byte changes (§5.3/§5.5).
- **One codepoint module** (`crates/bmp/src/tlv.rs`): every draft TLV code point lives there with section citations and a pre-IANA renumber note, so an IANA renumber at RFC publication is a single-file change. Indexed-TLV (§4.3: 2-byte index after length, excluded from the length value, G-bit top bit) and Group TLV (type 4, §5.2.1) encode infrastructure lands now for the upcoming path-marking slice.
- Framing seam: internal `BmpEvent`s stay version-agnostic; the manager frames per collector at fan-out with a two-slot per-version memo (an event is encoded at most once per version in use — v3-only fleets do zero extra work). The PeerUp replay cache stores both encodings so reconnect replay is version-correct; the Loc-RIB collector-connect dump forwarder frames at the collector's version.

## Draft notes

- Codepoints independently re-verified against §9 of the draft: BGP Message = 7, Stats = 1, Group = 4, VRF/Table Name = 5, Sequence = 1, Extended Flags = 2, Timestamp = 3, Stateless Parsing = 6.
- The draft's Appendix A wire example shows Group TLVs with `type=2`, contradicting its own normative §5.2.1/§9 (`type 4`). We follow the normative text.

## Tests

- v3 golden-bytes regression for route monitoring, stats, peer up/down (byte-identical proof).
- v4 golden structure tests: version byte, BGP Message TLV wrap, Stats TLV wrap.
- Version-byte-only proof for the six TLV-provisioned message types.
- Mixed v3/v4 collector fan-out + PeerUp replay test.
- TLV shape tests (indexed length excludes index; Group TLV G-bit + NLRI index packing).
- Config schema/validation tests for the new field.

Gates: workspace build/test (4809 passed), fmt, clippy `-D warnings`, clippy-reasons ratchet — all green.

Pre-IANA caveat documented in CHANGELOG and docs/CONFIGURATION.md: code points may renumber at RFC publication; default stays 3.