### PR TITLE
feat(bmp): emit BMPv4 Path Marking TLV on Loc-RIB route monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **BMP Path Marking TLV on Loc-RIB monitoring
+  (draft-ietf-grow-bmp-path-marking-tlv-05, pre-IANA).** BMPv4
+  (`version = 4`) collectors monitoring `loc_rib` now receive the Path
+  Marking TLV on every Route Monitoring announcement (live best-path
+  changes and the collector-connect table dump): a 4-octet Path Status
+  bitmap marking the route `Best` (§3.1 — every Loc-RIB route is the
+  decision winner by definition) plus `Stale` when the GR/LLGR stale
+  machinery holds it, and — on live unicast announcements where a
+  competing path was compared — the optional 2-octet Reason Code (§3.2)
+  naming the decisive best-path step, re-derived at emit against the
+  runner-up from the existing explain ladder (the hot-path comparator
+  records nothing). Decisive steps without a registered draft code
+  (stale/RPKI/ASPA preference, cluster-list length) omit the optional
+  reason rather than mislabel it. Status bits a route reflector without
+  a forwarding plane cannot attest to (Primary/Backup/Non-installed/
+  Best-external/Filtered/Suppressed) are never fabricated; rib-in-pre
+  (taps before best-path selection) and rib-out-post (per-peer staged
+  output) streams carry no marking; withdrawals carry none (a gone path
+  has no status). Automatic on v4 — no new knob; v3 output stays
+  byte-identical (pinned by regression tests). **Type-code collision
+  caveat:** path-marking-05 self-assigns RM TLV type 5, which
+  draft-ietf-grow-bmp-tlv-20 §9 meanwhile assigned to the VRF/Table
+  Name TLV — rustbgpd never emits that TLV so its own v4 output is
+  unambiguous, but expect a renumber at RFC publication (annotated in
+  `crates/bmp/src/tlv.rs`).
+
 - **BMPv4 per-collector framing (draft-ietf-grow-bmp-tlv-20, pre-IANA).**
   New per-collector `version = 3 | 4` config field (default 3). A v4
   collector gets common-header version 4 on every message type (draft

--- a/crates/bmp/src/codec.rs
+++ b/crates/bmp/src/codec.rs
@@ -357,17 +357,26 @@ pub fn encode_loc_rib_peer_down(
 ///
 /// Carries a raw BGP UPDATE PDU (including 19-byte header): bare
 /// after the per-peer header in v3; enclosed in the mandatory BGP
-/// Message TLV (type 7, index 0) in v4 (draft §5.2).
+/// Message TLV (type 7, index 0) in v4 (draft §5.2), followed by the
+/// Path Marking TLV (path-marking-05 §2) when `path_status` is
+/// present. The Path Marking TLV is an RM TLV and cannot be framed in
+/// v3 — a v3 collector's output is byte-identical whether or not a
+/// payload is attached. Index 0 (all NLRIs) is correct because every
+/// synthesized Loc-RIB UPDATE carries exactly one NLRI.
 #[must_use]
 pub fn encode_route_monitoring(
     info: &BmpPeerInfo,
     update_pdu: &[u8],
+    path_status: Option<crate::types::BmpPathStatus>,
     version: BmpVersion,
 ) -> Bytes {
-    // v4 adds type(2) + length(2) + index(2) around the PDU.
+    // v4 adds type(2) + length(2) + index(2) around the PDU, plus the
+    // Path Marking TLV (6 + status(4) [+ reason(2)]) when attached.
     let tlv_overhead = match version {
         BmpVersion::V3 => 0,
-        BmpVersion::V4 => 6,
+        BmpVersion::V4 => {
+            6 + path_status.map_or(0, |ps| 10 + if ps.reason.is_some() { 2 } else { 0 })
+        }
     };
     let total = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN + tlv_overhead + update_pdu.len();
 
@@ -383,6 +392,9 @@ pub fn encode_route_monitoring(
                 tlv::INDEX_ALL_NLRI,
                 update_pdu,
             );
+            if let Some(ps) = path_status {
+                tlv::put_path_marking_tlv(&mut buf, tlv::INDEX_ALL_NLRI, ps.status, ps.reason);
+            }
         }
     }
 
@@ -597,7 +609,12 @@ mod tests {
     fn v3_golden_bytes_regression() {
         let info = sample_peer_info();
         assert_eq!(
-            hex(&encode_route_monitoring(&info, &[0xAB; 23], BmpVersion::V3)),
+            hex(&encode_route_monitoring(
+                &info,
+                &[0xAB; 23],
+                None,
+                BmpVersion::V3
+            )),
             "030000004700000000000000000000000000000000000000000000000a0000020000fdea0a00\
              00026553f10000000000ababababababababababababababababababababababab"
         );
@@ -663,7 +680,7 @@ mod tests {
     fn v4_route_monitoring_wraps_pdu_in_bgp_message_tlv() {
         let info = sample_peer_info();
         let pdu = [0xAB; 23];
-        let msg = encode_route_monitoring(&info, &pdu, BmpVersion::V4);
+        let msg = encode_route_monitoring(&info, &pdu, None, BmpVersion::V4);
 
         assert_eq!(msg[0], 4, "BMP version 4 (draft §3)");
         let len = u32::from_be_bytes(msg[1..5].try_into().unwrap());
@@ -693,11 +710,79 @@ mod tests {
         );
         assert_eq!(&tlv[6..], &pdu, "value = exact UPDATE PDU");
         // Everything before the TLV is byte-identical to v3.
-        let v3 = encode_route_monitoring(&info, &pdu, BmpVersion::V3);
+        let v3 = encode_route_monitoring(&info, &pdu, None, BmpVersion::V3);
         assert_eq!(
             &msg[5..BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN],
             &v3[5..BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN],
             "type + per-peer header unchanged"
+        );
+    }
+
+    /// Path Marking is v4-only: a v3 Route Monitoring message is
+    /// byte-identical whether or not a path-status payload is attached
+    /// (the RM TLV cannot be framed in RFC 7854 v3).
+    #[test]
+    fn v3_route_monitoring_unchanged_by_path_status() {
+        let info = sample_peer_info();
+        let pdu = [0xAB; 23];
+        let ps = crate::types::BmpPathStatus {
+            status: tlv::PATH_STATUS_BEST | tlv::PATH_STATUS_STALE,
+            reason: Some(tlv::REASON_LOCAL_PREF),
+        };
+        assert_eq!(
+            encode_route_monitoring(&info, &pdu, Some(ps), BmpVersion::V3),
+            encode_route_monitoring(&info, &pdu, None, BmpVersion::V3),
+        );
+    }
+
+    /// draft-ietf-grow-bmp-path-marking-tlv-05 §2 golden bytes: the v4
+    /// Route Monitoring message appends the Path Marking TLV (type 5,
+    /// index 0 — every synthesized Loc-RIB UPDATE carries one NLRI)
+    /// after the BGP Message TLV, with the 4-byte status bitmap and
+    /// the Reason Code present only when one applies.
+    #[test]
+    fn v4_route_monitoring_appends_path_marking_tlv() {
+        let info = sample_peer_info();
+        let pdu = [0xAB; 23];
+
+        // With reason: value = status(4) + reason(2).
+        let ps = crate::types::BmpPathStatus {
+            status: tlv::PATH_STATUS_BEST,
+            reason: Some(tlv::REASON_LOCAL_PREF),
+        };
+        let msg = encode_route_monitoring(&info, &pdu, Some(ps), BmpVersion::V4);
+        let unmarked = encode_route_monitoring(&info, &pdu, None, BmpVersion::V4);
+        let len = u32::from_be_bytes(msg[1..5].try_into().unwrap());
+        assert_eq!(len as usize, msg.len(), "common-header length");
+        assert_eq!(msg.len(), unmarked.len() + 12, "TLV adds 6 + 4 + 2 bytes");
+        assert_eq!(
+            &msg[5..unmarked.len()],
+            &unmarked[5..],
+            "everything before the Path Marking TLV is the plain v4 framing \
+             (common-header length field aside)"
+        );
+        let pm = &msg[unmarked.len()..];
+        assert_eq!(
+            pm,
+            &[
+                0x00, 0x05, // type 5 (path-marking-05 §7)
+                0x00, 0x06, // length: status(4) + reason(2), index excluded
+                0x00, 0x00, // index 0 = all NLRIs (single-NLRI UPDATE)
+                0x00, 0x00, 0x00, 0x02, // Best
+                0x00, 0x03, // reason: local preference
+            ]
+        );
+
+        // Without reason: the optional field is absent, not zeroed.
+        let ps = crate::types::BmpPathStatus {
+            status: tlv::PATH_STATUS_BEST | tlv::PATH_STATUS_STALE,
+            reason: None,
+        };
+        let msg = encode_route_monitoring(&info, &pdu, Some(ps), BmpVersion::V4);
+        let pm = &msg[unmarked.len()..];
+        assert_eq!(
+            pm,
+            &[0x00, 0x05, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x04, 0x02]
         );
     }
 
@@ -827,7 +912,7 @@ mod tests {
     fn route_monitoring_encoding() {
         let info = sample_peer_info();
         let update_pdu = vec![0xAA; 50];
-        let msg = encode_route_monitoring(&info, &update_pdu, BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &update_pdu, None, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         let pdu_offset = BMP_COMMON_HEADER_LEN + PER_PEER_HEADER_LEN;
         assert_eq!(&msg[pdu_offset..], &update_pdu[..]);
@@ -942,7 +1027,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.is_ipv6 = true;
         info.peer_addr = IpAddr::V6("2001:db8::2".parse().unwrap());
-        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], None, BmpVersion::V3);
         assert_ne!(msg[BMP_COMMON_HEADER_LEN + 1] & PEER_FLAG_V, 0);
     }
 
@@ -955,7 +1040,7 @@ mod tests {
         info.is_rib_out = true;
         info.is_post_policy = true;
         let pdu = [0xAB; 23];
-        let msg = encode_route_monitoring(&info, &pdu, BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &pdu, None, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         assert_eq!(msg[0], 3, "BMP version 3");
         assert_eq!(
@@ -1054,7 +1139,7 @@ mod tests {
     #[test]
     fn loc_rib_per_peer_header_golden() {
         let cfg = sample_loc_rib_config();
-        let msg = encode_route_monitoring(&cfg.peer_info(ts()), &[0xCD; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&cfg.peer_info(ts()), &[0xCD; 23], None, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
         let hdr = &msg[BMP_COMMON_HEADER_LEN..];
         assert_eq!(hdr[0], 3, "peer type 3 (Loc-RIB instance)");
@@ -1086,7 +1171,7 @@ mod tests {
             is_as4: false,
             timestamp: ts(),
         };
-        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], None, BmpVersion::V3);
         assert_eq!(msg[BMP_COMMON_HEADER_LEN + 1], 0);
     }
 
@@ -1192,7 +1277,7 @@ mod tests {
     fn ipv4_address_encoding_uses_12_zero_bytes() {
         // RFC 7854 §4.2: IPv4 peer address is 12 zero bytes + 4-byte IPv4 (NOT IPv4-mapped ::ffff:)
         let info = sample_peer_info(); // IPv4 10.0.0.2
-        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], None, BmpVersion::V3);
         // Per-peer header starts at offset 6 (after common header)
         // Address field is at offset 6 + 2 (type+flags) + 8 (distinguisher) = 16
         let addr_offset = BMP_COMMON_HEADER_LEN + 2 + 8;
@@ -1215,7 +1300,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.timestamp = UNIX_EPOCH + std::time::Duration::from_secs(u64::from(u32::MAX) + 1);
 
-        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], None, BmpVersion::V3);
         verify_common_header(&msg, BMP_MSG_ROUTE_MONITORING);
 
         let timestamp_offset = BMP_COMMON_HEADER_LEN + 34;
@@ -1233,7 +1318,7 @@ mod tests {
         let mut info = sample_peer_info();
         info.is_ipv6 = true;
         info.peer_addr = IpAddr::V6("2001:db8::2".parse().unwrap());
-        let msg = encode_route_monitoring(&info, &[0u8; 23], BmpVersion::V3);
+        let msg = encode_route_monitoring(&info, &[0u8; 23], None, BmpVersion::V3);
         let addr_offset = BMP_COMMON_HEADER_LEN + 2 + 8;
         let addr_bytes = &msg[addr_offset..addr_offset + 16];
         let expected: std::net::Ipv6Addr = "2001:db8::2".parse().unwrap();

--- a/crates/bmp/src/lib.rs
+++ b/crates/bmp/src/lib.rs
@@ -22,5 +22,6 @@ pub use client::BmpClient;
 pub use manager::BmpManager;
 pub use types::{
     BmpClientConfig, BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig,
-    BmpMonitorFilter, BmpPeerInfo, BmpPeerType, BmpVersion, LOC_RIB_TABLE_NAME, PeerDownReason,
+    BmpMonitorFilter, BmpPathStatus, BmpPeerInfo, BmpPeerType, BmpVersion, LOC_RIB_TABLE_NAME,
+    PeerDownReason,
 };

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -151,7 +151,11 @@ impl BmpManager {
             BmpEvent::RouteMonitoring {
                 peer_info,
                 update_pdu,
-            } => codec::encode_route_monitoring(peer_info, update_pdu, version),
+                // Path marking is Loc-RIB-only: the rib-in tap fires at
+                // receive time (before best-path selection) and rib-out
+                // is per-peer staged output — neither has an honest
+                // local decision status to mark.
+            } => codec::encode_route_monitoring(peer_info, update_pdu, None, version),
             BmpEvent::StatsReport {
                 peer_info,
                 adj_rib_in_routes,
@@ -204,9 +208,13 @@ impl BmpManager {
                 BmpEvent::LocRibRouteMonitoring {
                     update_pdu,
                     timestamp,
-                } => {
-                    codec::encode_route_monitoring(&cfg.peer_info(*timestamp), update_pdu, version)
-                }
+                    path_status,
+                } => codec::encode_route_monitoring(
+                    &cfg.peer_info(*timestamp),
+                    update_pdu,
+                    *path_status,
+                    version,
+                ),
                 BmpEvent::LocRibStats { per_family } => {
                     // RFC 9069 stat type 8 = Loc-RIB total (64-bit gauge),
                     // type 10 = its per-AFI/SAFI breakdown.
@@ -472,8 +480,13 @@ async fn forward_loc_rib_dump(
 ) {
     let mut sent: u64 = 0;
     while let Some(chunk) = chunk_rx.recv().await {
-        for (pdu, timestamp) in chunk.messages {
-            let msg = codec::encode_route_monitoring(&cfg.peer_info(timestamp), &pdu, version);
+        for (pdu, timestamp, path_status) in chunk.messages {
+            let msg = codec::encode_route_monitoring(
+                &cfg.peer_info(timestamp),
+                &pdu,
+                path_status,
+                version,
+            );
             match tokio::time::timeout(LOC_RIB_DUMP_SEND_TIMEOUT, collector_tx.send(msg)).await {
                 Ok(Ok(())) => sent += 1,
                 Ok(Err(_)) => {
@@ -1290,6 +1303,7 @@ mod tests {
             .send(BmpEvent::LocRibRouteMonitoring {
                 update_pdu: Bytes::from_static(&[0xCC; 23]),
                 timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+                path_status: None,
             })
             .await
             .unwrap();
@@ -1435,8 +1449,8 @@ mod tests {
             .reply
             .send(crate::types::BmpDumpChunk {
                 messages: vec![
-                    (Bytes::from_static(&[0xD1; 23]), install),
-                    (Bytes::from_static(&[0xD2; 23]), install),
+                    (Bytes::from_static(&[0xD1; 23]), install, None),
+                    (Bytes::from_static(&[0xD2; 23]), install, None),
                 ],
             })
             .await
@@ -1444,7 +1458,7 @@ mod tests {
         request
             .reply
             .send(crate::types::BmpDumpChunk {
-                messages: vec![(Bytes::from_static(&[0xE0; 23]), install)],
+                messages: vec![(Bytes::from_static(&[0xE0; 23]), install, None)],
             })
             .await
             .unwrap();
@@ -1464,11 +1478,77 @@ mod tests {
             .send(BmpEvent::LocRibRouteMonitoring {
                 update_pdu: Bytes::from_static(&[0xF7; 23]),
                 timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+                path_status: None,
             })
             .await
             .unwrap();
         let live = c_rx.recv().await.unwrap();
         assert_eq!(live[48], 0xF7);
+
+        drop(event_tx);
+        drop(control_tx);
+        handle.await.unwrap();
+    }
+
+    /// Mixed v3/v4 collectors, one marked Loc-RIB RM event: the v3
+    /// collector's message carries no TLV bytes at all (bare PDU after
+    /// the per-peer header) while the v4 collector gets the BGP
+    /// Message TLV followed by the Path Marking TLV with the event's
+    /// status bitmap and reason code.
+    #[tokio::test]
+    async fn mixed_version_collectors_loc_rib_path_marking() {
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (v3_tx, mut v3_rx) = mpsc::channel(16);
+        let (v4_tx, mut v4_rx) = mpsc::channel(16);
+        let (dump_tx, _dump_rx) = mpsc::channel(4);
+
+        let mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![
+                (collector_addr(0), v3_tx, loc_rib_filter(), BmpVersion::V3),
+                (collector_addr(1), v4_tx, loc_rib_filter(), BmpVersion::V4),
+            ],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+        let handle = tokio::spawn(mgr.run());
+
+        let pdu = [0xCC; 23];
+        event_tx
+            .send(BmpEvent::LocRibRouteMonitoring {
+                update_pdu: Bytes::copy_from_slice(&pdu),
+                timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+                path_status: Some(crate::types::BmpPathStatus {
+                    status: crate::tlv::PATH_STATUS_BEST,
+                    reason: Some(crate::tlv::REASON_LOCAL_PREF),
+                }),
+            })
+            .await
+            .unwrap();
+
+        // v3: bare PDU right after the per-peer header — no TLVs.
+        let msg = v3_rx.recv().await.unwrap();
+        assert_eq!(msg[0], 3);
+        assert_eq!(&msg[6 + 42..], &pdu, "v3 carries the bare PDU, no TLVs");
+
+        // v4: BGP Message TLV then the Path Marking TLV.
+        let msg = v4_rx.recv().await.unwrap();
+        assert_eq!(msg[0], 4);
+        let tlvs = &msg[6 + 42..];
+        assert_eq!(u16::from_be_bytes([tlvs[0], tlvs[1]]), 7, "BGP Message");
+        let pm = &tlvs[6 + pdu.len()..];
+        assert_eq!(
+            pm,
+            &[
+                0x00, 0x05, // Path Marking TLV (type 5)
+                0x00, 0x06, // status(4) + reason(2)
+                0x00, 0x00, // index 0
+                0x00, 0x00, 0x00, 0x02, // Best
+                0x00, 0x03, // local preference
+            ]
+        );
 
         drop(event_tx);
         drop(control_tx);

--- a/crates/bmp/src/tlv.rs
+++ b/crates/bmp/src/tlv.rs
@@ -33,6 +33,60 @@ pub const RM_TLV_STATELESS_PARSING: u16 = 6;
 /// every v4 Route Monitoring message, index 0.
 pub const RM_TLV_BGP_MESSAGE: u16 = 7;
 
+/// Path Marking TLV (draft-ietf-grow-bmp-path-marking-tlv-05 §2, §7):
+/// 4-octet Path Status bitmap + optional 2-octet Reason Code.
+///
+/// **Known type-code collision, renumber expected:** path-marking-05
+/// self-assigns type 5 against an old revision of the base TLV draft
+/// whose RM registry only held values 1-4 (its §7 says "populated with
+/// initial values 1-4. This document adds value 5"), but
+/// draft-ietf-grow-bmp-tlv-20 §9 has since taken 5 for the VRF/Table
+/// Name TLV ([`RM_TLV_VRF_TABLE_NAME`]) and grown to 7. We follow the
+/// latest path-marking revision verbatim; expect IANA to renumber this
+/// (likely to 8+) at RFC publication. We never emit the VRF/Table Name
+/// RM TLV, so our own v4 output stays unambiguous.
+pub const RM_TLV_PATH_MARKING: u16 = 5;
+
+// ── Path Status bits (path-marking-05 §3.1, Table 1) ───────────────
+// Only the bits rustbgpd can derive honestly are defined here. The
+// remaining registered bits (Invalid 0x01, Nonselected 0x04, Primary
+// 0x08, Backup 0x10, Non-installed 0x20, Best-external 0x40, Add-Path
+// 0x80, Filtered-in 0x100, Filtered-out 0x200, Suppressed 0x800) are
+// FIB/damping/filter concepts a route reflector without a forwarding
+// plane cannot attest to — left unset rather than fabricated.
+
+/// Best (§3.1): the RFC 4271 §9.1 decision-process winner. Every
+/// Loc-RIB route is Best by definition.
+pub const PATH_STATUS_BEST: u32 = 0x0000_0002;
+/// Stale (§3.1): declared stale by BGP Graceful Restart (RFC 4724
+/// §4.1). We also set it for RFC 9494 LLGR-stale — a strict subset of
+/// GR-stale semantics.
+pub const PATH_STATUS_STALE: u32 = 0x0000_0400;
+
+// ── Reason Codes (path-marking-05 §3.2, Table 2) ───────────────────
+// 2-octet optional codes naming the decisive decision-process step.
+// 0x0001/0x0002 (Invalid due to AS loop / unresolvable nexthop) and
+// 0x000B (AIGP) are never emitted — we don't mark Invalid, and the
+// selection ladder has no AIGP step.
+
+/// Not preferred for local preference (§3.2).
+pub const REASON_LOCAL_PREF: u16 = 0x0003;
+/// Not preferred for AS Path Length (§3.2).
+pub const REASON_AS_PATH_LEN: u16 = 0x0004;
+/// Not preferred for origin (§3.2).
+pub const REASON_ORIGIN: u16 = 0x0005;
+/// Not preferred for MED (§3.2).
+pub const REASON_MED: u16 = 0x0006;
+/// Not preferred for peer type (eBGP over iBGP, §3.2).
+pub const REASON_PEER_TYPE: u16 = 0x0007;
+/// Not preferred for IGP cost (§3.2).
+pub const REASON_IGP_COST: u16 = 0x0008;
+/// Not preferred for router ID (§3.2; RFC 4456 substitutes
+/// `ORIGINATOR_ID` for the BGP identifier on reflected routes).
+pub const REASON_ROUTER_ID: u16 = 0x0009;
+/// Not preferred for peer address (§3.2).
+pub const REASON_PEER_ADDRESS: u16 = 0x000A;
+
 // ── "BMP Stats Reports TLVs" registry (§9) ─────────────────────────
 // Stats Reports TLVs are *not* indexed — indexed TLVs apply only to
 // Route Monitoring (§4.3).
@@ -73,6 +127,23 @@ pub fn put_tlv(buf: &mut BytesMut, tlv_type: u16, value: &[u8]) {
     buf.put_u16(tlv_type);
     buf.put_u16(tlv_len(value));
     buf.put_slice(value);
+}
+
+/// Append a Path Marking TLV (path-marking-05 §2): 4-octet Path
+/// Status bitmap, then the optional 2-octet Reason Code only when one
+/// applies. Indexed like every RM TLV (tlv-20 §4.3); callers pass
+/// [`INDEX_ALL_NLRI`] when the enclosed UPDATE carries a single NLRI.
+pub fn put_path_marking_tlv(buf: &mut BytesMut, index: u16, status: u32, reason: Option<u16>) {
+    let mut value = [0u8; 6];
+    value[..4].copy_from_slice(&status.to_be_bytes());
+    let len = match reason {
+        Some(code) => {
+            value[4..6].copy_from_slice(&code.to_be_bytes());
+            6
+        }
+        None => 4,
+    };
+    put_indexed_tlv(buf, RM_TLV_PATH_MARKING, index, &value[..len]);
 }
 
 /// Append a Group TLV (§5.2.1): type 4, index = `group_index` with the
@@ -121,6 +192,37 @@ mod tests {
                 0x80, 0x0B, // G-bit | group index 0x000B
                 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x0A,
             ]
+        );
+    }
+
+    /// path-marking-05 §2 golden shape: type 5, 4-byte status bitmap,
+    /// reason code present only when supplied (it is optional), length
+    /// excluding the 2-byte index per tlv-20 §4.3.
+    #[test]
+    fn path_marking_tlv_with_and_without_reason() {
+        let mut buf = BytesMut::new();
+        put_path_marking_tlv(
+            &mut buf,
+            INDEX_ALL_NLRI,
+            PATH_STATUS_BEST | PATH_STATUS_STALE,
+            Some(REASON_LOCAL_PREF),
+        );
+        assert_eq!(
+            &buf[..],
+            &[
+                0x00, 0x05, // type 5 (Path Marking, path-marking-05 §7)
+                0x00, 0x06, // length: status(4) + reason(2)
+                0x00, 0x00, // index 0 = all NLRIs
+                0x00, 0x00, 0x04, 0x02, // Best | Stale
+                0x00, 0x03, // reason: local preference
+            ]
+        );
+
+        let mut buf = BytesMut::new();
+        put_path_marking_tlv(&mut buf, INDEX_ALL_NLRI, PATH_STATUS_BEST, None);
+        assert_eq!(
+            &buf[..],
+            &[0x00, 0x05, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02]
         );
     }
 

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -63,6 +63,10 @@ pub enum BmpEvent {
         update_pdu: Bytes,
         /// Route install time (RFC 9069 per-peer header timestamp).
         timestamp: SystemTime,
+        /// Path Marking payload for the announced route. `None` on
+        /// withdrawals (a gone path has no status to mark) and when the
+        /// RIB attaches no marking. Encoded only for v4 collectors.
+        path_status: Option<BmpPathStatus>,
     },
     /// RFC 9069 Loc-RIB statistics: per-AFI/SAFI Loc-RIB route counts.
     /// Encoded as stat type 10 entries plus their sum as type 8.
@@ -127,8 +131,24 @@ pub struct BmpDumpRequest {
 /// One bounded chunk of a Loc-RIB table dump.
 #[derive(Debug)]
 pub struct BmpDumpChunk {
-    /// Synthesized UPDATE PDUs with their route install times.
-    pub messages: Vec<(Bytes, SystemTime)>,
+    /// Synthesized UPDATE PDUs with their route install times and the
+    /// Path Marking payload (`None` on the End-of-RIB markers).
+    pub messages: Vec<(Bytes, SystemTime, Option<BmpPathStatus>)>,
+}
+
+/// Path Marking TLV payload (draft-ietf-grow-bmp-path-marking-tlv-05
+/// §2): the 4-octet Path Status bitmap plus the optional 2-octet
+/// Reason Code. Carried on Route Monitoring events by the RIB, encoded
+/// on the wire only for BMP v4 collectors (the TLV cannot be framed in
+/// RFC 7854 v3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BmpPathStatus {
+    /// Path Status bitmap (§3.1) — see the `PATH_STATUS_*` constants
+    /// in [`crate::tlv`].
+    pub status: u32,
+    /// Optional Reason Code (§3.2) — see the `REASON_*` constants in
+    /// [`crate::tlv`]. Omitted from the wire when `None`.
+    pub reason: Option<u16>,
 }
 
 /// Control-plane events sent from BMP clients to the BMP manager.

--- a/crates/rib/src/bmp_sync.rs
+++ b/crates/rib/src/bmp_sync.rs
@@ -18,6 +18,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 
 use bytes::{Bytes, BytesMut};
+use rustbgpd_bmp::{BmpPathStatus, tlv as bmp_tlv};
 use rustbgpd_wire::{
     Afi, Capability, EXTENDED_MAX_MESSAGE_LEN, Ipv4NlriEntry, Ipv4UnicastMode, MpReachNlri,
     MpUnreachNlri, NlriEntry, OpenMessage, PathAttribute, Prefix, Safi, UpdateMessage, VpnNlri,
@@ -25,6 +26,7 @@ use rustbgpd_wire::{
 };
 use tracing::warn;
 
+use crate::best_path::BestPathReason;
 use crate::route::{Route, VpnRibRoute};
 
 /// `AS_TRANS` (RFC 6793): 2-byte OPEN AS field stand-in for ASNs > 65535.
@@ -39,6 +41,52 @@ pub const LOC_RIB_FAMILIES: [(Afi, Safi); 4] = [
     (Afi::Ipv4, Safi::MplsVpn),
     (Afi::Ipv6, Safi::MplsVpn),
 ];
+
+/// Map a decisive best-path step to the draft's Reason Code
+/// (draft-ietf-grow-bmp-path-marking-tlv-05 §3.2, Table 2). Steps with
+/// no registered code (stale/RPKI/ASPA preference, cluster-list
+/// length, EVPN MAC mobility) map to `None` — the Reason Code is
+/// optional and omitting it beats mislabeling the step.
+#[must_use]
+pub fn path_marking_reason_code(reason: BestPathReason) -> Option<u16> {
+    match reason {
+        BestPathReason::HigherLocalPref => Some(bmp_tlv::REASON_LOCAL_PREF),
+        BestPathReason::ShorterAsPath => Some(bmp_tlv::REASON_AS_PATH_LEN),
+        BestPathReason::LowerOrigin => Some(bmp_tlv::REASON_ORIGIN),
+        BestPathReason::LowerMed => Some(bmp_tlv::REASON_MED),
+        BestPathReason::EbgpOverIbgp => Some(bmp_tlv::REASON_PEER_TYPE),
+        BestPathReason::OrrInteriorCost => Some(bmp_tlv::REASON_IGP_COST),
+        // RFC 4456 substitutes ORIGINATOR_ID for the BGP identifier on
+        // reflected routes — the same RFC 4271 §9.1.2.2 step the
+        // draft's "router ID" code names.
+        BestPathReason::LowerOriginatorId => Some(bmp_tlv::REASON_ROUTER_ID),
+        BestPathReason::LowerPeerAddress => Some(bmp_tlv::REASON_PEER_ADDRESS),
+        BestPathReason::StalePreference
+        | BestPathReason::RpkiPreference
+        | BestPathReason::AspaPreference
+        | BestPathReason::ShorterClusterList
+        | BestPathReason::EvpnMacMobility => None,
+    }
+}
+
+/// Path Marking payload (path-marking-05 §3.1) for a Loc-RIB best
+/// route: always Best (a Loc-RIB route is the decision-process winner
+/// by definition), plus Stale when the GR/LLGR machinery says so.
+/// `reason` is the decisive step versus the runner-up, when one was
+/// compared. Primary/Backup/Non-installed/Filtered/Suppressed bits are
+/// FIB, policy-drop, and damping concepts a route reflector without a
+/// forwarding plane cannot attest to — deliberately never set.
+#[must_use]
+pub fn loc_rib_path_status(is_stale: bool, reason: Option<BestPathReason>) -> BmpPathStatus {
+    let mut status = bmp_tlv::PATH_STATUS_BEST;
+    if is_stale {
+        status |= bmp_tlv::PATH_STATUS_STALE;
+    }
+    BmpPathStatus {
+        status,
+        reason: reason.and_then(path_marking_reason_code),
+    }
+}
 
 fn empty_mp_reach(afi: Afi, safi: Safi, next_hop: IpAddr) -> MpReachNlri {
     MpReachNlri {
@@ -469,6 +517,59 @@ mod tests {
             .expect("MP_UNREACH present");
         assert_eq!((mp.afi, mp.safi), (Afi::Ipv6, Safi::MplsVpn));
         assert!(mp.withdrawn.is_empty() && mp.vpn_withdrawn.is_empty());
+    }
+
+    /// path-marking-05 §3.2 mapping: every decisive step with a
+    /// registered Reason Code maps to it; steps the draft has no code
+    /// for map to `None` (the field is optional — omit, don't lie).
+    #[test]
+    fn reason_code_mapping_covers_every_variant() {
+        use rustbgpd_bmp::tlv;
+
+        use crate::best_path::BestPathReason as R;
+        let cases = [
+            (R::HigherLocalPref, Some(tlv::REASON_LOCAL_PREF)),
+            (R::ShorterAsPath, Some(tlv::REASON_AS_PATH_LEN)),
+            (R::LowerOrigin, Some(tlv::REASON_ORIGIN)),
+            (R::LowerMed, Some(tlv::REASON_MED)),
+            (R::EbgpOverIbgp, Some(tlv::REASON_PEER_TYPE)),
+            (R::OrrInteriorCost, Some(tlv::REASON_IGP_COST)),
+            (R::LowerOriginatorId, Some(tlv::REASON_ROUTER_ID)),
+            (R::LowerPeerAddress, Some(tlv::REASON_PEER_ADDRESS)),
+            (R::StalePreference, None),
+            (R::RpkiPreference, None),
+            (R::AspaPreference, None),
+            (R::ShorterClusterList, None),
+            (R::EvpnMacMobility, None),
+        ];
+        for (reason, expected) in cases {
+            assert_eq!(
+                path_marking_reason_code(reason),
+                expected,
+                "mapping for {reason:?}"
+            );
+        }
+        // Numeric pins straight from Table 2 so a constant edit in the
+        // bmp crate cannot silently shift the wire values.
+        assert_eq!(path_marking_reason_code(R::HigherLocalPref), Some(0x0003));
+        assert_eq!(path_marking_reason_code(R::LowerPeerAddress), Some(0x000A));
+    }
+
+    /// path-marking-05 §3.1: Loc-RIB payloads always carry Best
+    /// (0x00000002); the GR/LLGR stale flag adds Stale (0x00000400).
+    #[test]
+    fn loc_rib_path_status_bits() {
+        let fresh = loc_rib_path_status(false, None);
+        assert_eq!(fresh.status, 0x0000_0002);
+        assert_eq!(fresh.reason, None);
+
+        let stale = loc_rib_path_status(true, Some(BestPathReason::HigherLocalPref));
+        assert_eq!(stale.status, 0x0000_0402);
+        assert_eq!(stale.reason, Some(0x0003));
+
+        // A decisive step without a registered code yields no reason.
+        let unmapped = loc_rib_path_status(false, Some(BestPathReason::RpkiPreference));
+        assert_eq!(unmapped.reason, None);
     }
 
     /// The fabricated OPEN (RFC 9069 §5.2.1) carries the 4-octet-ASN

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -533,11 +533,34 @@ impl RibManager {
                 // Loc-RIB install time, i.e. now. Best-unchanged
                 // prefixes never reach this branch.
                 if self.bmp_tx.is_some() {
-                    let pdu = match current_best {
-                        Some(best) => crate::bmp_sync::synthesize_unicast_announce(best),
-                        None => crate::bmp_sync::synthesize_unicast_withdraw(*prefix),
+                    let (pdu, path_status) = match current_best {
+                        Some(best) => {
+                            // Path Marking reason = the decisive step
+                            // versus the runner-up (the closest
+                            // competitor), re-derived here from the
+                            // explain ladder — the hot-path comparator
+                            // records nothing, and a sole candidate
+                            // carries no reason (nothing was compared).
+                            let runner_up = self
+                                .ribs
+                                .values()
+                                .flat_map(|rib| rib.iter_prefix(prefix))
+                                .filter(|c| !(c.peer == best.peer && c.path_id == best.path_id))
+                                .min_by(|a, b| crate::best_path::best_path_cmp(a, b));
+                            let reason = runner_up
+                                .map(|r| crate::best_path::best_path_cmp_with_reason(best, r).1);
+                            let status = crate::bmp_sync::loc_rib_path_status(
+                                best.is_stale || best.is_llgr_stale,
+                                reason,
+                            );
+                            (
+                                crate::bmp_sync::synthesize_unicast_announce(best),
+                                Some(status),
+                            )
+                        }
+                        None => (crate::bmp_sync::synthesize_unicast_withdraw(*prefix), None),
                     };
-                    self.emit_bmp_loc_rib(pdu, std::time::SystemTime::now());
+                    self.emit_bmp_loc_rib(pdu, path_status, std::time::SystemTime::now());
                 }
                 match (previous_best, current_best) {
                     (None, Some(best)) => {

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -464,13 +464,25 @@ impl RibManager {
             if self.loc_rib.recompute_vpn(*key, candidates.iter()) {
                 changed_keys.insert(*key);
                 if self.bmp_tx.is_some() {
-                    let pdu = match self.loc_rib.get_vpn(key) {
-                        Some(best) => crate::bmp_sync::synthesize_vpn_announce(best),
-                        None => bmp_prev_nlri
-                            .as_ref()
-                            .and_then(crate::bmp_sync::synthesize_vpn_withdraw),
+                    let (pdu, path_status) = match self.loc_rib.get_vpn(key) {
+                        Some(best) => (
+                            crate::bmp_sync::synthesize_vpn_announce(best),
+                            // Status bits only: the VPN selection ladder
+                            // (`vpn_tiebreak`) has no with-reason variant,
+                            // and the Reason Code is optional.
+                            Some(crate::bmp_sync::loc_rib_path_status(
+                                best.is_stale || best.is_llgr_stale,
+                                None,
+                            )),
+                        ),
+                        None => (
+                            bmp_prev_nlri
+                                .as_ref()
+                                .and_then(crate::bmp_sync::synthesize_vpn_withdraw),
+                            None,
+                        ),
                     };
-                    self.emit_bmp_loc_rib(pdu, std::time::SystemTime::now());
+                    self.emit_bmp_loc_rib(pdu, path_status, std::time::SystemTime::now());
                 }
             }
         }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -675,16 +675,24 @@ impl RibManager {
     }
 
     /// Emit an RFC 9069 Loc-RIB Route Monitoring event. `pdu = None`
-    /// (synthesis failure, already warned) is a no-op. Uses `try_send`
+    /// (synthesis failure, already warned) is a no-op. `path_status`
+    /// carries the Path Marking payload for announcements (`None` on
+    /// withdrawals — a gone path has no status). Uses `try_send`
     /// — monitoring must never backpressure the RIB task; drops are
     /// surfaced with a warning.
-    fn emit_bmp_loc_rib(&self, pdu: Option<bytes::Bytes>, timestamp: std::time::SystemTime) {
+    fn emit_bmp_loc_rib(
+        &self,
+        pdu: Option<bytes::Bytes>,
+        path_status: Option<rustbgpd_bmp::BmpPathStatus>,
+        timestamp: std::time::SystemTime,
+    ) {
         let (Some(tx), Some(update_pdu)) = (self.bmp_tx.as_ref(), pdu) else {
             return;
         };
         if let Err(e) = tx.try_send(rustbgpd_bmp::BmpEvent::LocRibRouteMonitoring {
             update_pdu,
             timestamp,
+            path_status,
         }) {
             warn!(error = %e, "BMP event channel full or closed, dropping Loc-RIB route monitoring");
         }
@@ -1121,25 +1129,37 @@ impl RibManager {
         // receive instant (RFC 9069 per-peer header timestamp).
         let install_time =
             |received_at: std::time::Instant| now.checked_sub(received_at.elapsed()).unwrap_or(now);
-        let mut messages: Vec<(bytes::Bytes, std::time::SystemTime)> = Vec::with_capacity(
+        // Dump entries carry the Path Marking status bits (Best +
+        // stale flags) but no reason code — deriving one would mean a
+        // full best-path re-comparison per prefix; live emissions
+        // attach it where the comparison already ran.
+        let mut messages: Vec<(
+            bytes::Bytes,
+            std::time::SystemTime,
+            Option<rustbgpd_bmp::BmpPathStatus>,
+        )> = Vec::with_capacity(
             self.loc_rib.len() + self.loc_rib.vpn_len() + bmp_sync::LOC_RIB_FAMILIES.len(),
         );
         for route in self.loc_rib.iter() {
             if let Some(pdu) = bmp_sync::synthesize_unicast_announce(route) {
-                messages.push((pdu, install_time(route.received_at)));
+                let status =
+                    bmp_sync::loc_rib_path_status(route.is_stale || route.is_llgr_stale, None);
+                messages.push((pdu, install_time(route.received_at), Some(status)));
             }
         }
         for route in self.loc_rib.iter_vpn() {
             if let Some(pdu) = bmp_sync::synthesize_vpn_announce(route) {
-                messages.push((pdu, install_time(route.received_at)));
+                let status =
+                    bmp_sync::loc_rib_path_status(route.is_stale || route.is_llgr_stale, None);
+                messages.push((pdu, install_time(route.received_at), Some(status)));
             }
         }
         // End-of-RIB per family closes the dump; live emission continues
         // seamlessly after (dump→EoR→live, with the standard BMP overlap
-        // race accepted).
+        // race accepted). EoR markers announce no path — nothing to mark.
         for (afi, safi) in bmp_sync::LOC_RIB_FAMILIES {
             if let Some(pdu) = bmp_sync::synthesize_end_of_rib(afi, safi) {
-                messages.push((pdu, now));
+                messages.push((pdu, now, None));
             }
         }
         tokio::spawn(async move {

--- a/crates/rib/src/manager/tests/bmp.rs
+++ b/crates/rib/src/manager/tests/bmp.rs
@@ -4,7 +4,7 @@
 
 use std::time::SystemTime;
 
-use rustbgpd_bmp::{BmpDumpChunk, BmpEvent};
+use rustbgpd_bmp::{BmpDumpChunk, BmpEvent, BmpPathStatus, tlv as bmp_tlv};
 use rustbgpd_wire::UpdateMessage;
 
 use super::*;
@@ -25,7 +25,7 @@ fn decode_pdu(pdu: &bytes::Bytes) -> rustbgpd_wire::ParsedUpdate {
 
 async fn recv_loc_rib_rm(
     bmp_rx: &mut mpsc::Receiver<BmpEvent>,
-) -> (bytes::Bytes, std::time::SystemTime) {
+) -> (bytes::Bytes, std::time::SystemTime, Option<BmpPathStatus>) {
     let event = tokio::time::timeout(Duration::from_secs(2), bmp_rx.recv())
         .await
         .expect("expected a Loc-RIB BMP event")
@@ -34,7 +34,8 @@ async fn recv_loc_rib_rm(
         BmpEvent::LocRibRouteMonitoring {
             update_pdu,
             timestamp,
-        } => (update_pdu, timestamp),
+            path_status,
+        } => (update_pdu, timestamp, path_status),
         other => panic!("expected LocRibRouteMonitoring, got {other:?}"),
     }
 }
@@ -74,10 +75,15 @@ async fn recompute_best_changes_emit_loc_rib_route_monitoring() {
     })
     .await
     .unwrap();
-    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let (pdu, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
     let parsed = decode_pdu(&pdu);
     assert_eq!(parsed.announced.len(), 1);
     assert_eq!(parsed.announced[0].prefix, prefix);
+    // Path Marking: sole candidate is Best with no reason (nothing was
+    // compared against it).
+    let status = status.expect("announce carries a path status");
+    assert_eq!(status.status, bmp_tlv::PATH_STATUS_BEST);
+    assert_eq!(status.reason, None);
 
     // 2. Higher LOCAL_PREF from another peer → best changes → announce
     // of the new best (next-hop = peer B).
@@ -93,7 +99,7 @@ async fn recompute_best_changes_emit_loc_rib_route_monitoring() {
     })
     .await
     .unwrap();
-    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let (pdu, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
     let parsed = decode_pdu(&pdu);
     assert_eq!(parsed.announced[0].prefix, prefix);
     assert!(
@@ -103,6 +109,11 @@ async fn recompute_best_changes_emit_loc_rib_route_monitoring() {
             .any(|a| matches!(a, PathAttribute::NextHop(nh) if *nh == peer_b)),
         "announce must carry the NEW best's next-hop"
     );
+    // Two candidates decided on LOCAL_PREF: Best bit + the draft's
+    // "local preference" Reason Code re-derived vs the runner-up.
+    let status = status.expect("announce carries a path status");
+    assert_eq!(status.status, bmp_tlv::PATH_STATUS_BEST);
+    assert_eq!(status.reason, Some(bmp_tlv::REASON_LOCAL_PREF));
 
     // 3. Losing path withdrawn — the best (peer B) is unchanged → no
     // Loc-RIB emission.
@@ -135,11 +146,49 @@ async fn recompute_best_changes_emit_loc_rib_route_monitoring() {
     })
     .await
     .unwrap();
-    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let (pdu, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
     let parsed = decode_pdu(&pdu);
     assert!(parsed.announced.is_empty());
     assert_eq!(parsed.withdrawn.len(), 1);
     assert_eq!(parsed.withdrawn[0].prefix, prefix);
+    assert_eq!(status, None, "withdrawals carry no path status");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// path-marking-05 §3.1 Stale: a best route flagged by the GR/LLGR
+/// stale machinery carries Best | Stale in its Path Marking payload.
+#[tokio::test]
+async fn stale_best_route_sets_stale_path_status_bit() {
+    let (tx, rx) = mpsc::channel(64);
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(64);
+    let manager =
+        RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new()).with_bmp_tx(bmp_tx);
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(10, 7, 0, 0), 16);
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    let mut route = make_route_with_lp(prefix, peer, 100);
+    route.is_stale = true; // what the RFC 4724 helper marks at restart
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (_, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let status = status.expect("stale announce still carries a path status");
+    assert_eq!(
+        status.status,
+        bmp_tlv::PATH_STATUS_BEST | bmp_tlv::PATH_STATUS_STALE
+    );
 
     drop(tx);
     handle.await.unwrap();
@@ -166,7 +215,7 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
     })
     .await
     .unwrap();
-    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let (pdu, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
     let parsed = decode_pdu(&pdu);
     let mp = parsed
         .attributes
@@ -178,6 +227,11 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
         .expect("VPN announce rides in MP_REACH");
     assert_eq!(mp.vpn_announced.len(), 1);
     assert_eq!(mp.vpn_announced[0].nlri, nlri);
+    // VPN announces mark Best (bits only — the VPN ladder has no
+    // with-reason variant).
+    let status = status.expect("VPN announce carries a path status");
+    assert_eq!(status.status, bmp_tlv::PATH_STATUS_BEST);
+    assert_eq!(status.reason, None);
 
     tx.send(RibUpdate::VpnRoutesReceived {
         peer: IpAddr::V4(peer),
@@ -190,7 +244,7 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
     })
     .await
     .unwrap();
-    let (pdu, _) = recv_loc_rib_rm(&mut bmp_rx).await;
+    let (pdu, _, status) = recv_loc_rib_rm(&mut bmp_rx).await;
     let parsed = decode_pdu(&pdu);
     let mp = parsed
         .attributes
@@ -202,6 +256,7 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
         .expect("VPN withdraw rides in MP_UNREACH");
     assert_eq!(mp.vpn_withdrawn.len(), 1);
     assert_eq!(mp.vpn_withdrawn[0].nlri.key(), nlri.key());
+    assert_eq!(status, None, "VPN withdrawals carry no path status");
 
     drop(tx);
     handle.await.unwrap();
@@ -210,6 +265,10 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
 /// The Loc-RIB dump streams every best (unicast + VPN) in chunks and
 /// closes with exactly one End-of-RIB per streamed family; dump-entry
 /// timestamps reflect route install time, not dump time.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one end-to-end dump walk asserting order, timestamps, path status, and EoR set together"
+)]
 #[tokio::test]
 async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
     let (tx, rx) = mpsc::channel(64);
@@ -250,7 +309,7 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
         .await
         .unwrap();
 
-    let mut messages: Vec<(bytes::Bytes, SystemTime)> = Vec::new();
+    let mut messages: Vec<(bytes::Bytes, SystemTime, Option<BmpPathStatus>)> = Vec::new();
     while let Some(chunk) = tokio::time::timeout(Duration::from_secs(2), chunk_rx.recv())
         .await
         .expect("dump chunk within timeout")
@@ -266,7 +325,11 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
     let (route_msgs, eor_msgs) = messages.split_at(3);
     let mut dumped_prefixes = Vec::new();
     let mut dumped_vpn = 0;
-    for (pdu, timestamp) in route_msgs {
+    for (pdu, timestamp, status) in route_msgs {
+        // Dump entries are Loc-RIB bests: Best bit, no reason code.
+        let status = status.expect("dump route carries a path status");
+        assert_eq!(status.status, bmp_tlv::PATH_STATUS_BEST);
+        assert_eq!(status.reason, None);
         let parsed = decode_pdu(pdu);
         assert!(
             *timestamp < dump_started - Duration::from_millis(900),
@@ -293,7 +356,8 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
 
     // The trailing four PDUs are EoRs: no NLRI anywhere, one per family.
     let mut eor_families = Vec::new();
-    for (pdu, _) in eor_msgs {
+    for (pdu, _, status) in eor_msgs {
+        assert_eq!(*status, None, "EoR markers carry no path status");
         let parsed = decode_pdu(pdu);
         assert!(parsed.announced.is_empty() && parsed.withdrawn.is_empty());
         match parsed.attributes.iter().find_map(|a| match a {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1757,11 +1757,28 @@ provision TLV data in v3 and differ only in the version byte. Framing is
 per collector — v3 and v4 collectors can be mixed freely, and v3 output is
 byte-identical to previous releases.
 
+**Path marking (automatic, no knob):** on `loc_rib` Route Monitoring
+messages a v4 collector also receives the Path Marking TLV
+(draft-ietf-grow-bmp-path-marking-tlv-05): a Path Status bitmap marking
+every announced Loc-RIB route `Best` (plus `Stale` when the GR/LLGR
+machinery holds it stale) and, when a competing path was compared, the
+optional Reason Code naming the decisive best-path step (local
+preference, AS path length, origin, MED, peer type, router ID, peer
+address). Bits a route reflector cannot attest to (Primary/Backup/
+Non-installed/Filtered/Suppressed — FIB, policy-drop, and damping
+concepts) are never set. `rib_in_pre` and `rib_out_post` streams carry
+no marking: the rib-in tap fires before best-path selection and rib-out
+is per-peer staged output, so neither has an honest decision status.
+Withdrawals carry no marking. v3 collectors are unaffected.
+
 **Pre-IANA caveat:** BMPv4 is an IETF draft. The TLV code points are not
 yet IANA-assigned and may be renumbered when the draft is published as an
 RFC; pick `4` only for collectors that track the same draft revision
 (e.g. bleeding-edge pmacct/gobmp builds). The default `3` is the stable
-RFC 7854 encoding.
+RFC 7854 encoding. In particular the Path Marking TLV self-assigns type
+5, which collides with tlv-20's VRF/Table Name TLV (also type 5) —
+rustbgpd never emits the latter, so its own v4 output is unambiguous,
+but expect a renumber at RFC publication.
 
 ### What is streamed
 


### PR DESCRIPTION
BMP arc slice 4: the Path Marking TLV per draft-ietf-grow-bmp-path-marking-tlv-05, emitted on Loc-RIB Route Monitoring toward BMPv4 collectors.

## What

- **v4-gated by construction**: the Path Marking TLV is an RM TLV and cannot be framed in RFC 7854 v3 — v3 collectors' output is byte-identical whether or not a status payload is attached (pinned by a dedicated regression test).
- **Loc-RIB stream only**, live tap + collector-connect dump. rib-in-pre is skipped because that tap fires at receive time, before best-path selection — any Best/Non-selected mark there would be a guess. rib-out-post mirrors per-peer staged output (ORR/Add-Path variants), not the local decision process. Both documented.
- **Status bits derived only from state we honestly hold**: Best always (a Loc-RIB route is the decision winner by definition), Stale from the GR/LLGR stale machinery (0x400). Primary/Backup/Non-installed/Filtered/Suppressed are FIB, policy-drop, and damping concepts an RR without a forwarding plane cannot attest to — deliberately never set.
- **Reason Code (optional, §3.2)**: on live unicast announces, re-derived at the `recompute_best` emit as best-vs-runner-up via the existing `best_path_cmp_with_reason` explain ladder. The runner-up scan uses the identical candidate expression the recompute itself uses, so the reason is consistent with the actual decision. Sole candidate → no reason (nothing was compared). Decisive steps with no registered draft code (stale/RPKI/ASPA preference, cluster-list length, EVPN MAC mobility) → omit rather than mislabel. VPN announces and dump entries carry bits only.
- **Type-code collision annotated**: path-marking-05 §7 self-assigns RM TLV type 5, written against an older base-draft registry; tlv-20 §9 has since assigned 5 to the VRF/Table Name TLV. rustbgpd never emits the VRF/Table Name RM TLV so our v4 output is self-consistent; the constant in `crates/bmp/src/tlv.rs` carries a dedicated renumber note.

## Tests

- v3 byte-identical with/without payload; v4 golden bytes for the TLV with and without the reason field (absent, not zeroed).
- Reason-mapping unit test covering every `BestPathReason` variant with numeric pins from Table 2.
- Stale-bit derivation; mixed v3/v4 collector fan-out extended.

## Perf note (for the scale profile)

The runner-up reason scan is one extra O(candidates) pass per best-changed prefix when BMP is enabled, alongside the already-paid PDU synthesis. For v3-only collector fleets it computes a reason nothing can carry; if the 1000-peer profile indicts it, the fix is plumbing an any-v4-collector flag to the RIB manager.

## Deferrals

Path Marking Statistics (§4: stat types are unassigned TBDs), reason codes on VPN/dump entries, Nonselected/Add-Path marking (needs a decision-aware rib-in seam that doesn't exist), Enterprise/E-bit TLVs and grouping (single-NLRI UPDATEs need neither).

Gates: workspace build/test (4816 passed), fmt, clippy `-D warnings`, clippy-reasons ratchet — all green.