### PR TITLE
perf(rib): share post-policy attribute sets across export fanout with a pass-scoped memo

### DIFF
--- a/crates/rib/src/manager/distribution/export_memo.rs
+++ b/crates/rib/src/manager/distribution/export_memo.rs
@@ -1,0 +1,303 @@
+//! Pass-scoped memo for the unicast export tail.
+//!
+//! A policy-modified export fanout used to deep-clone the route's
+//! `Arc<Vec<PathAttribute>>` once per (route, peer) — 76% of live heap in
+//! a modifying-chain RR fanout (2026-07-03 dhat profile, indictment #1) —
+//! even though the post-modification attribute set is identical for every
+//! peer whose chain evaluation produced the same `RouteModifications`.
+//!
+//! Soundness: [`rustbgpd_policy::apply_modifications`] is a pure function
+//! of `(source attributes, RouteModifications)`. Peer context (address,
+//! ASN, group) only influences chain *evaluation*, whose entire output is
+//! the `RouteModifications` value itself — so keying on
+//! (source-attribute identity, modifications equality) is exact, and
+//! peer-varying chains simply land in separate slots.
+//!
+//! The memo also caches the `AS_PATH` regex-match string per source
+//! attribute set (indictment #4: it was rebuilt per (prefix, peer)).
+//!
+//! Scope: one distribution pass (a `distribute_changes` fanout, a route
+//! refresh, or an initial peer dump). The memo is a local of that pass —
+//! no cross-pass interning, no lifetime questions. Source-attribute
+//! identity is the `Arc` pointer; each entry pins a clone of the source
+//! `Arc` so the pointer cannot be reused by a different allocation while
+//! the memo is alive.
+
+use std::sync::Arc;
+
+use rustbgpd_policy::{NextHopAction, RouteModifications};
+use rustbgpd_wire::PathAttribute;
+use rustc_hash::FxHashMap;
+
+use crate::route::Route;
+
+/// Memoized export-tail results for one distribution pass.
+#[derive(Default)]
+pub(in crate::manager) struct ExportMemo {
+    entries: FxHashMap<usize, MemoEntry>,
+}
+
+struct MemoEntry {
+    /// Pins the source allocation so the pointer key stays unique for
+    /// the memo's lifetime.
+    _source: Arc<Vec<PathAttribute>>,
+    /// Rendered `AS_PATH` match string (built at most once per source
+    /// attribute set).
+    aspath: Option<Arc<str>>,
+    /// Distinct post-modification outcomes for this source attribute
+    /// set. Expected tiny: one slot per distinct `RouteModifications`
+    /// produced by the export chains in this pass.
+    modified: Vec<(
+        RouteModifications,
+        Arc<Vec<PathAttribute>>,
+        Option<NextHopAction>,
+    )>,
+}
+
+impl ExportMemo {
+    fn entry(&mut self, attrs: &Arc<Vec<PathAttribute>>) -> &mut MemoEntry {
+        self.entries
+            .entry(Arc::as_ptr(attrs) as usize)
+            .or_insert_with(|| MemoEntry {
+                _source: Arc::clone(attrs),
+                aspath: None,
+                modified: Vec::new(),
+            })
+    }
+
+    /// `AS_PATH` string for policy regex matching, memoized per source
+    /// attribute set.
+    pub(in crate::manager) fn aspath_str(&mut self, route: &Route) -> Arc<str> {
+        let entry = self.entry(&route.attributes);
+        if entry.aspath.is_none() {
+            let s = route
+                .as_path()
+                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string);
+            entry.aspath = Some(Arc::from(s));
+        }
+        entry.aspath.clone().expect("aspath populated just above")
+    }
+
+    /// Clone `route` with `mods` applied to its attributes, sharing one
+    /// post-modification attribute `Arc` across every (route, peer) in
+    /// this pass with the same source attribute set and equal
+    /// modifications. Empty modifications keep sharing the source `Arc`
+    /// exactly as before.
+    pub(in crate::manager) fn apply(
+        &mut self,
+        route: &Route,
+        mods: &RouteModifications,
+    ) -> (Route, Option<NextHopAction>) {
+        let mut modified = route.clone();
+        if mods.is_empty() {
+            return (modified, None);
+        }
+        let entry = self.entry(&route.attributes);
+        let (attrs, nh) =
+            if let Some((_, attrs, nh)) = entry.modified.iter().find(|(m, _, _)| m == mods) {
+                (Arc::clone(attrs), nh.clone())
+            } else {
+                let mut new_attrs = (*route.attributes).clone();
+                let nh = rustbgpd_policy::apply_modifications(&mut new_attrs, mods);
+                let attrs = Arc::new(new_attrs);
+                entry
+                    .modified
+                    .push((mods.clone(), Arc::clone(&attrs), nh.clone()));
+                (attrs, nh)
+            };
+        modified.attributes = attrs;
+        if let Some(NextHopAction::Specific(addr)) = &nh {
+            modified.next_hop = *addr;
+        }
+        (modified, nh)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Instant;
+
+    use rustbgpd_wire::{
+        AsPath, AsPathSegment, ExtendedCommunity, Ipv4Prefix, LargeCommunity, Origin, Prefix,
+    };
+
+    use super::*;
+    use crate::route::RouteOrigin;
+
+    fn attrs(local_pref: u32) -> Vec<PathAttribute> {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65000, 65100, 65200])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(198, 51, 100, 1)),
+            PathAttribute::LocalPref(local_pref),
+            PathAttribute::Med(50),
+            PathAttribute::Communities(vec![0xFDE8_0064]), // 65000:100
+        ]
+    }
+
+    fn route(attributes: Arc<Vec<PathAttribute>>) -> Route {
+        Route {
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 1, 0, 0), 24)),
+            next_hop: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+            attributes,
+            received_at: Instant::now(),
+            origin_type: RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 10),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        }
+    }
+
+    /// The pre-memo export path, duplicated verbatim as the equivalence
+    /// oracle: private deep clone + `apply_modifications` per call.
+    fn bypass(route: &Route, mods: &RouteModifications) -> (Route, Option<NextHopAction>) {
+        let mut modified = route.clone();
+        let nh = if mods.is_empty() {
+            None
+        } else {
+            let nh =
+                rustbgpd_policy::apply_modifications(Arc::make_mut(&mut modified.attributes), mods);
+            if let Some(NextHopAction::Specific(addr)) = &nh {
+                modified.next_hop = *addr;
+            }
+            nh
+        };
+        (modified, nh)
+    }
+
+    fn mods_matrix() -> Vec<RouteModifications> {
+        let ext = ExtendedCommunity::new(0x0002_fde8_0000_0007);
+        let large = LargeCommunity {
+            global_admin: 65000,
+            local_data1: 1,
+            local_data2: 2,
+        };
+        vec![
+            RouteModifications::default(),
+            RouteModifications {
+                set_med: Some(200),
+                ..Default::default()
+            },
+            RouteModifications {
+                set_local_pref: Some(300),
+                communities_add: vec![0xFDE8_03E7], // 65000:999
+                ..Default::default()
+            },
+            RouteModifications {
+                communities_remove: vec![0xFDE8_0064], // 65000:100
+                ..Default::default()
+            },
+            RouteModifications {
+                extended_communities_add: vec![ext],
+                extended_communities_remove: vec![ext],
+                large_communities_add: vec![large],
+                large_communities_remove: vec![large],
+                ..Default::default()
+            },
+            RouteModifications {
+                as_path_prepend: Some((65000, 3)),
+                set_med: Some(0),
+                ..Default::default()
+            },
+            RouteModifications {
+                set_next_hop: Some(NextHopAction::Specific(IpAddr::V4(Ipv4Addr::new(
+                    203, 0, 113, 9,
+                )))),
+                ..Default::default()
+            },
+            RouteModifications {
+                set_next_hop: Some(NextHopAction::Self_),
+                communities_add: vec![1, 2, 3],
+                ..Default::default()
+            },
+        ]
+    }
+
+    /// Every (source attrs, modifications) cell must be byte-identical
+    /// to the pre-memo private-clone path, on both the miss and the hit.
+    #[test]
+    fn memo_matches_bypass_across_matrix() {
+        for source in [
+            attrs(100),
+            attrs(50),
+            vec![PathAttribute::Origin(Origin::Igp)],
+        ] {
+            let r = route(Arc::new(source));
+            for mods in mods_matrix() {
+                let mut memo = ExportMemo::default();
+                let (expect_route, expect_nh) = bypass(&r, &mods);
+                let (miss, miss_nh) = memo.apply(&r, &mods);
+                let (hit, hit_nh) = memo.apply(&r, &mods);
+                assert_eq!(*miss.attributes, *expect_route.attributes, "mods {mods:?}");
+                assert_eq!(miss.next_hop, expect_route.next_hop, "mods {mods:?}");
+                assert_eq!(miss_nh, expect_nh, "mods {mods:?}");
+                assert_eq!(*hit.attributes, *expect_route.attributes, "mods {mods:?}");
+                assert_eq!(hit.next_hop, expect_route.next_hop, "mods {mods:?}");
+                assert_eq!(hit_nh, expect_nh, "mods {mods:?}");
+                if mods.is_empty() {
+                    // No-modification exports keep sharing the source Arc.
+                    assert!(Arc::ptr_eq(&miss.attributes, &r.attributes));
+                } else {
+                    // Hits share the memoized allocation.
+                    assert!(Arc::ptr_eq(&miss.attributes, &hit.attributes));
+                    assert!(!Arc::ptr_eq(&miss.attributes, &r.attributes));
+                }
+            }
+        }
+    }
+
+    /// Distinct modifications against one source attr set — the
+    /// peer-varying-chain shape — must land in separate slots, and
+    /// distinct source Arcs must never cross-share.
+    #[test]
+    fn memo_keys_by_source_identity_and_modifications_value() {
+        let mut memo = ExportMemo::default();
+        let r1 = route(Arc::new(attrs(100)));
+        // Same content, different allocation: correctness must hold
+        // (no sharing expected — identity is the Arc pointer).
+        let r2 = route(Arc::new(attrs(100)));
+        let med100 = RouteModifications {
+            set_med: Some(100),
+            ..Default::default()
+        };
+        let med200 = RouteModifications {
+            set_med: Some(200),
+            ..Default::default()
+        };
+
+        let (a, _) = memo.apply(&r1, &med100);
+        let (b, _) = memo.apply(&r1, &med200);
+        let (c, _) = memo.apply(&r2, &med100);
+        assert!(!Arc::ptr_eq(&a.attributes, &b.attributes));
+        assert!(!Arc::ptr_eq(&a.attributes, &c.attributes));
+        assert_eq!(*a.attributes, *bypass(&r1, &med100).0.attributes);
+        assert_eq!(*b.attributes, *bypass(&r1, &med200).0.attributes);
+        assert_eq!(*c.attributes, *bypass(&r2, &med100).0.attributes);
+        // Same content from the same source: shared.
+        let (a2, _) = memo.apply(&r1, &med100);
+        assert!(Arc::ptr_eq(&a.attributes, &a2.attributes));
+    }
+
+    #[test]
+    fn aspath_str_memoized_per_source_attr_set() {
+        let mut memo = ExportMemo::default();
+        let r = route(Arc::new(attrs(100)));
+        let s1 = memo.aspath_str(&r);
+        let s2 = memo.aspath_str(&r);
+        assert_eq!(&*s1, "65000 65100 65200");
+        assert!(Arc::ptr_eq(&s1, &s2));
+
+        let no_aspath = route(Arc::new(vec![PathAttribute::Origin(Origin::Igp)]));
+        assert_eq!(&*memo.aspath_str(&no_aspath), "");
+    }
+}

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -31,11 +31,14 @@ use crate::update::{
 
 mod bgpls;
 mod evpn;
+mod export_memo;
 mod flowspec;
 mod labeled;
 mod rtc;
 mod unicast;
 mod vpn;
+
+pub(in crate::manager) use export_memo::ExportMemo;
 
 /// RFC 9494 §4.4 export restriction: an LLGR-stale route "SHOULD NOT be
 /// advertised to any neighbor from which the Long-Lived Graceful Restart
@@ -645,6 +648,11 @@ impl RibManager {
         }
 
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
+        // Pass-scoped export memo: shares post-modification attribute
+        // sets and AS_PATH match strings across the whole peer fanout —
+        // this outlives the per-peer iteration deliberately, since the
+        // win is identical modified attrs across peers sharing a chain.
+        let mut export_memo = ExportMemo::default();
         for peer in peers {
             // For dirty peers, compute full prefix set from Loc-RIB + AdjRibOut
             let is_dirty = self.dirty_peers.contains(&peer);
@@ -911,6 +919,7 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf,
                         orr_ctx,
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,
@@ -941,6 +950,7 @@ impl RibManager {
                         llgr.as_ref(),
                         export_pol.as_ref(),
                         orf,
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,
@@ -968,6 +978,7 @@ impl RibManager {
                         llgr.as_ref(),
                         export_pol.as_ref(),
                         orf,
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -525,6 +525,7 @@ impl RibManager {
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
+        memo: &mut super::ExportMemo,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
@@ -622,13 +623,7 @@ impl RibManager {
             }
 
             // Export policy check per-candidate
-            let aspath_str = if needs_as_path_string {
-                candidate
-                    .as_path()
-                    .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
-            } else {
-                String::new()
-            };
+            let aspath_str = needs_as_path_string.then(|| memo.aspath_str(candidate));
             let aspath_len = candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let ctx = RouteContext {
                 prefix: Some(*prefix),
@@ -636,7 +631,7 @@ impl RibManager {
                 extended_communities: candidate.extended_communities(),
                 communities: candidate.communities(),
                 large_communities: candidate.large_communities(),
-                as_path_str: &aspath_str,
+                as_path_str: aspath_str.as_deref().unwrap_or(""),
                 as_path_len: aspath_len,
                 validation_state: candidate.validation_state,
                 aspa_state: candidate.aspa_state,
@@ -660,20 +655,10 @@ impl RibManager {
                 continue;
             }
 
-            // Apply export modifications — skip deep clone when no mods needed
-            let mut modified = (*candidate).clone();
-            let nh_action = if result.modifications.is_empty() {
-                None
-            } else {
-                let nh = rustbgpd_policy::apply_modifications(
-                    std::sync::Arc::make_mut(&mut modified.attributes),
-                    &result.modifications,
-                );
-                if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = &nh {
-                    modified.next_hop = *addr;
-                }
-                nh
-            };
+            // Apply export modifications — the pass-scoped memo shares one
+            // post-modification attribute Arc across every (route, peer)
+            // with the same source attrs and equal modifications.
+            let (mut modified, nh_action) = memo.apply(candidate, &result.modifications);
             modified.path_id = next_rank;
 
             // Only announce if different from what's already in AdjRibOut.
@@ -719,6 +704,7 @@ impl RibManager {
         llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
+        memo: &mut super::ExportMemo,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
@@ -795,12 +781,9 @@ impl RibManager {
         }
 
         // Export policy check
-        let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
-            best.as_path()
-                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
-        } else {
-            String::new()
-        };
+        let aspath_str = export_pol
+            .is_some_and(PolicyChain::requires_as_path_string)
+            .then(|| memo.aspath_str(best));
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
             prefix: Some(*prefix),
@@ -808,7 +791,7 @@ impl RibManager {
             extended_communities: best.extended_communities(),
             communities: best.communities(),
             large_communities: best.large_communities(),
-            as_path_str: &aspath_str,
+            as_path_str: aspath_str.as_deref().unwrap_or(""),
             as_path_len: aspath_len,
             validation_state: best.validation_state,
             aspa_state: best.aspa_state,
@@ -835,21 +818,12 @@ impl RibManager {
             return;
         }
 
-        // Apply export modifications to a clone — skip the deep clone of
-        // the Arc<Vec<PathAttribute>> when no modifications are needed.
-        let mut modified = best.clone();
-        let nh_action = if result.modifications.is_empty() {
-            None
-        } else {
-            let nh = rustbgpd_policy::apply_modifications(
-                std::sync::Arc::make_mut(&mut modified.attributes),
-                &result.modifications,
-            );
-            if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = &nh {
-                modified.next_hop = *addr;
-            }
-            nh
-        };
+        // Apply export modifications to a clone. The pass-scoped memo
+        // shares one post-modification attribute Arc across every
+        // (route, peer) with the same source attribute set and equal
+        // modifications; no-modification exports keep sharing the
+        // source Arc as before.
+        let (mut modified, nh_action) = memo.apply(best, &result.modifications);
         modified.path_id = 0;
 
         // `force` mode: bypass the AdjRibOut equality suppression so
@@ -897,7 +871,6 @@ impl RibManager {
     /// cache.
     #[expect(
         clippy::too_many_arguments,
-        clippy::too_many_lines,
         reason = "ORR export keeps peer, policy, and Adj-RIB-Out diff state together"
     )]
     pub(in crate::manager) fn distribute_orr_best_prefix(
@@ -917,6 +890,7 @@ impl RibManager {
         llgr: Option<&Vec<(Afi, Safi)>>,
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
+        memo: &mut super::ExportMemo,
         metrics: &BgpMetrics,
         policy_stats: &mut NeighborPolicyStats,
         target_peer_label: &str,
@@ -996,12 +970,9 @@ impl RibManager {
         }
 
         // Export policy check — same tail as `distribute_single_best_prefix`.
-        let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
-            best.as_path()
-                .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
-        } else {
-            String::new()
-        };
+        let aspath_str = export_pol
+            .is_some_and(PolicyChain::requires_as_path_string)
+            .then(|| memo.aspath_str(best));
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
         let ctx = RouteContext {
             prefix: Some(*prefix),
@@ -1009,7 +980,7 @@ impl RibManager {
             extended_communities: best.extended_communities(),
             communities: best.communities(),
             large_communities: best.large_communities(),
-            as_path_str: &aspath_str,
+            as_path_str: aspath_str.as_deref().unwrap_or(""),
             as_path_len: aspath_len,
             validation_state: best.validation_state,
             aspa_state: best.aspa_state,
@@ -1036,21 +1007,14 @@ impl RibManager {
             return;
         }
 
-        // Apply export modifications to a clone — skip the deep clone of
-        // the Arc<Vec<PathAttribute>> when no modifications are needed.
-        let mut modified = best.clone();
-        let nh_action = if result.modifications.is_empty() {
-            None
-        } else {
-            let nh = rustbgpd_policy::apply_modifications(
-                std::sync::Arc::make_mut(&mut modified.attributes),
-                &result.modifications,
-            );
-            if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = &nh {
-                modified.next_hop = *addr;
-            }
-            nh
-        };
+        // Apply export modifications to a clone — the pass-scoped memo
+        // shares one post-modification attribute Arc across every
+        // (route, peer) with the same source attrs and equal
+        // modifications. NOTE: this is NOT the per-(vantage, prefix)
+        // winner memo the doc comment above rejects — the key here is
+        // (source attribute identity, modifications value), which is
+        // independent of which candidate won.
+        let (mut modified, nh_action) = memo.apply(best, &result.modifications);
         modified.path_id = 0;
 
         // `force` semantics as in `distribute_single_best_prefix`.

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -826,6 +826,10 @@ impl RibManager {
         // re-sends the full current table for this peer.
         let initial_view = AdjRibOut::new(peer);
 
+        // Pass-scoped export memo: routes sharing an inbound attribute
+        // set share the post-modification attributes across this dump.
+        let mut export_memo = super::distribution::ExportMemo::default();
+
         for prefix in &all_prefixes {
             if orf_gated.contains(&prefix_family(prefix)) {
                 continue;
@@ -858,6 +862,7 @@ impl RibManager {
                     // has no installed filter during the initial dump.
                     None,
                     orr_ctx,
+                    &mut export_memo,
                     &metrics,
                     policy_stats,
                     &target_peer_label,
@@ -890,6 +895,7 @@ impl RibManager {
                     // ORF: gated families are skipped above; a non-gated family
                     // has no installed filter during the initial dump.
                     None,
+                    &mut export_memo,
                     &metrics,
                     policy_stats,
                     &target_peer_label,
@@ -919,6 +925,7 @@ impl RibManager {
                     // ORF: gated families are skipped above; a non-gated family
                     // has no installed filter during the initial dump.
                     None,
+                    &mut export_memo,
                     &metrics,
                     policy_stats,
                     &target_peer_label,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -867,6 +867,10 @@ impl RibManager {
                 );
             }
         } else {
+            // Pass-scoped export memo: one refresh is a single peer, but
+            // routes sharing an inbound attribute set still share the
+            // post-modification attributes and AS_PATH match string.
+            let mut export_memo = super::distribution::ExportMemo::default();
             for prefix in &all_prefixes {
                 let prefix_send_max = if peer_add_path_send_max > 0
                     && peer_add_path_send_families.contains(&prefix_family(prefix))
@@ -894,6 +898,7 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         orr_ctx,
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,
@@ -924,6 +929,7 @@ impl RibManager {
                         llgr.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,
@@ -951,6 +957,7 @@ impl RibManager {
                         llgr.as_ref(),
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
+                        &mut export_memo,
                         &metrics,
                         policy_stats,
                         &target_peer_label,

--- a/crates/rib/src/manager/tests/policy.rs
+++ b/crates/rib/src/manager/tests/policy.rs
@@ -1312,3 +1312,172 @@ policy no-doc {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// Chain for the export-memo manager test. First-match-wins: ASN 65001
+/// takes the neighbor-set term (`mods.0`); everyone else takes the
+/// AS_PATH-regex term (`mods.1` — the regex also forces the
+/// `requires_as_path_string` / memoized-aspath evaluation path).
+fn export_memo_test_chain() -> (
+    rustbgpd_policy::PolicyChain,
+    rustbgpd_policy::RouteModifications,
+    rustbgpd_policy::RouteModifications,
+) {
+    use rustbgpd_policy::{
+        AsPathRegex, NeighborSetMatch, Policy, PolicyAction, PolicyChain, PolicyStatement,
+        RouteModifications,
+    };
+
+    let mods_asn65001 = RouteModifications {
+        set_med: Some(100),
+        communities_add: vec![0xFDE8_0001], // 65000:1
+        ..Default::default()
+    };
+    let mods_everyone_else = RouteModifications {
+        set_med: Some(200),
+        communities_add: vec![0xFDE8_0002], // 65000:2
+        ..Default::default()
+    };
+    let statement = |action| PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![
+            PolicyStatement {
+                match_neighbor_set: Some(NeighborSetMatch {
+                    addresses: vec![],
+                    remote_asns: vec![65001],
+                    peer_groups: vec![],
+                }),
+                modifications: mods_asn65001.clone(),
+                ..statement(PolicyAction::Permit)
+            },
+            PolicyStatement {
+                match_as_path: Some(AsPathRegex::new("_65100_").unwrap()),
+                modifications: mods_everyone_else.clone(),
+                ..statement(PolicyAction::Permit)
+            },
+        ],
+        default_action: PolicyAction::Deny,
+    }]);
+    (chain, mods_asn65001, mods_everyone_else)
+}
+
+/// Export-memo equivalence at the manager level: peers whose chain
+/// evaluation yields identical modifications must receive byte-identical
+/// attributes backed by ONE shared allocation, while a peer-varying
+/// match (neighbor-set) must land in its own correctly-modified set.
+/// Expected attributes are derived through the pre-memo path
+/// (private clone + `apply_modifications`) as the oracle.
+#[tokio::test]
+async fn export_memo_shares_identical_modified_attrs_and_keys_peer_varying_chains() {
+    use rustbgpd_policy::{RouteModifications, apply_modifications};
+
+    let (export_policy, mods_asn65001, mods_everyone_else) = export_memo_test_chain();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        Some(export_policy),
+        None,
+        BgpMetrics::new(),
+    );
+    let handle = tokio::spawn(manager.run());
+
+    // Peer A (ASN 65001) is the peer-varying case; B and C (ASN 65000)
+    // share the everyone-else verdict.
+    let mut receivers = Vec::new();
+    for (host, asn) in [(2u8, 65001u32), (3, 65000), (4, 65000)] {
+        let (out_tx, mut out_rx) = mpsc::channel(64);
+        tx.send(RibUpdate::PeerUp {
+            session_id: 0,
+            peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, host)),
+            peer_asn: asn,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: None,
+            sendable_families: ipv4_sendable(),
+            is_ebgp: true,
+            route_reflector_client: false,
+            orr_vantage: None,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+        receivers.push(out_rx);
+    }
+
+    // One route, flooded to all three peers in a single distribution pass.
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let route = make_route_with_as_path(prefix, Ipv4Addr::new(10, 0, 0, 1), vec![65100, 65200]);
+    let source_attrs = Arc::clone(&route.attributes);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let updates: Vec<OutboundRouteUpdate> = {
+        let mut v = Vec::new();
+        for rx in &mut receivers {
+            v.push(rx.recv().await.unwrap());
+        }
+        v
+    };
+    for update in &updates {
+        assert_eq!(update.announce.len(), 1);
+        assert_eq!(update.next_hop_override, vec![None]);
+    }
+
+    // Oracle: the pre-memo private-clone path.
+    let oracle = |mods: &RouteModifications| {
+        let mut attrs = (*source_attrs).clone();
+        assert!(apply_modifications(&mut attrs, mods).is_none());
+        attrs
+    };
+    let a = &updates[0].announce[0];
+    let b = &updates[1].announce[0];
+    let c = &updates[2].announce[0];
+    assert_eq!(*a.attributes, oracle(&mods_asn65001));
+    assert_eq!(*b.attributes, oracle(&mods_everyone_else));
+    assert_eq!(*c.attributes, oracle(&mods_everyone_else));
+
+    // Structural proof of the fix: identical verdicts share ONE
+    // allocation; the peer-varying verdict does not.
+    assert!(Arc::ptr_eq(&b.attributes, &c.attributes));
+    assert!(!Arc::ptr_eq(&a.attributes, &b.attributes));
+    assert!(!Arc::ptr_eq(&a.attributes, &source_attrs));
+    assert!(!Arc::ptr_eq(&b.attributes, &source_attrs));
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/tests/export_fanout_attr_memo.rs
+++ b/crates/rib/tests/export_fanout_attr_memo.rs
@@ -1,0 +1,268 @@
+//! Live-heap receipt for the export-fanout attribute memo (2026-07-03 dhat
+//! profile, indictment #1): a modifying export chain used to deep-clone the
+//! attribute set per (route, peer) — 5.5x the no-policy RR-fanout footprint
+//! at 256 peers x 10k prefixes. With the pass-scoped `ExportMemo`, the
+//! with-policy live heap must sit near the no-policy baseline.
+//!
+//! Reduced reproduction of the profile's `fanout_policy` scenario:
+//! 64 RR clients x 2k prefixes, one shared inbound attribute set, and a
+//! tagging chain (AS_PATH regex guard + med-set + community-add) so every
+//! permitted route carries modifications.
+//!
+//! Run: `cargo test -p rustbgpd-rib --test export_fanout_attr_memo -- --ignored --nocapture`
+//! `#[ignore]`d — a sizing receipt, not a regression test: it allocates
+//! ~100 MB transiently and its bound is a heap ratio, not exact bytes. Still
+//! compiled by a normal `cargo test` run, so it cannot bit-rot.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use rustbgpd_policy::{
+    AsPathRegex, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+};
+use rustbgpd_rib::RibManager;
+use rustbgpd_rib::route::{Route, RouteOrigin};
+use rustbgpd_rib::update::RibUpdate;
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{Afi, AsPath, AsPathSegment, Ipv4Prefix, Origin, PathAttribute, Prefix, Safi};
+use tokio::sync::{mpsc, oneshot};
+
+struct TrackingAllocator {
+    inner: System,
+    live: AtomicUsize,
+    total_allocs: AtomicUsize,
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { self.inner.alloc(layout) };
+        if !p.is_null() {
+            self.live.fetch_add(layout.size(), Ordering::Relaxed);
+            self.total_allocs.fetch_add(1, Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { self.inner.dealloc(ptr, layout) };
+        self.live.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            self.live.fetch_add(new_size, Ordering::Relaxed);
+            self.live.fetch_sub(layout.size(), Ordering::Relaxed);
+            self.total_allocs.fetch_add(1, Ordering::Relaxed);
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator {
+    inner: System,
+    live: AtomicUsize::new(0),
+    total_allocs: AtomicUsize::new(0),
+};
+
+/// Tagging export chain in the shape of the profile's M80 fixture:
+/// AS_PATH regex guard + med-set + community-add, so modifications are
+/// non-empty for every permitted route.
+fn tagging_chain() -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: Some(AsPathRegex::new("_65100_").unwrap()),
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications {
+                set_med: Some(200),
+                communities_add: vec![(65000 << 16) | 999],
+                ..Default::default()
+            },
+        }],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+fn route(prefix: Prefix, peer: IpAddr, attributes: Arc<Vec<PathAttribute>>) -> Route {
+    Route {
+        prefix,
+        next_hop: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer,
+        attributes,
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(192, 0, 2, 99),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+async fn barrier(tx: &mpsc::Sender<RibUpdate>) -> usize {
+    let (reply, rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryLocRibCount { reply })
+        .await
+        .unwrap();
+    rx.await.unwrap()
+}
+
+/// RR fanout through the real `RibManager::run()` loop. Returns
+/// (steady-state live-heap delta in bytes, total allocation count) for
+/// the scenario. Outbound channels are sized to hold the full flood, so
+/// steady state is deterministic — no sleeps.
+fn run_fanout(n_peers: usize, n_prefixes: u32, with_policy: bool) -> (usize, usize) {
+    let live_before = ALLOC.live.load(Ordering::Relaxed);
+    let allocs_before = ALLOC.total_allocs.load(Ordering::Relaxed);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let live_steady = rt.block_on(async {
+        let (tx, rx) = mpsc::channel(4096);
+        let (_qtx, qrx) = mpsc::channel::<RibUpdate>(64);
+        let manager = RibManager::new(
+            rx,
+            qrx,
+            None,
+            Some(Ipv4Addr::new(192, 0, 2, 1)),
+            BgpMetrics::new(),
+        );
+        let handle = tokio::spawn(manager.run());
+
+        let chain = with_policy.then(tagging_chain);
+        let mut receivers = Vec::with_capacity(n_peers);
+        for i in 0..n_peers {
+            let [_, b1, b2, b3] = (i as u32).to_be_bytes();
+            let (out_tx, out_rx) = mpsc::channel(n_prefixes as usize + 64);
+            tx.send(RibUpdate::PeerUp {
+                session_id: 1 + i as u64,
+                peer: IpAddr::V4(Ipv4Addr::new(10, b1, b2, b3.wrapping_add(1))),
+                peer_asn: 64_512,
+                peer_router_id: Ipv4Addr::new(192, 0, 2, 200),
+                outbound_tx: out_tx,
+                export_policy: chain.clone(),
+                sendable_families: vec![(Afi::Ipv4, Safi::Unicast)],
+                is_ebgp: false,
+                route_reflector_client: true,
+                orr_vantage: None,
+                add_path_send_families: vec![],
+                add_path_send_max: 0,
+                negotiated_orf_recv: Vec::new(),
+                negotiated_llgr_families: Vec::new(),
+            })
+            .await
+            .unwrap();
+            receivers.push(out_rx);
+        }
+        barrier(&tx).await;
+
+        // One source floods n_prefixes sharing a single attribute set
+        // (the profile harness shape: attrs maximally Arc-shared at
+        // ingest; per-peer structural fanout is what is measured).
+        let src = IpAddr::V4(Ipv4Addr::new(172, 20, 0, 10));
+        let shared: Arc<Vec<PathAttribute>> = Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65000, 65100, 65200])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(198, 51, 100, 1)),
+            PathAttribute::LocalPref(100),
+            PathAttribute::Med(50),
+            PathAttribute::Communities(vec![(65000 << 16) | 100]),
+        ]);
+        let mut i = 0u32;
+        while i < n_prefixes {
+            let hi = (i + 1000).min(n_prefixes);
+            let batch: Vec<Route> = (i..hi)
+                .map(|j| {
+                    let p = Prefix::V4(Ipv4Prefix::new(
+                        Ipv4Addr::new(20 + (j >> 16) as u8, (j >> 8) as u8, j as u8, 0),
+                        24,
+                    ));
+                    route(p, src, Arc::clone(&shared))
+                })
+                .collect();
+            i = hi;
+            tx.send(RibUpdate::RoutesReceived {
+                session_id: 0,
+                peer: src,
+                announced: batch,
+                withdrawn: vec![],
+                flowspec_announced: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            })
+            .await
+            .unwrap();
+        }
+        let count = barrier(&tx).await;
+        assert_eq!(count, n_prefixes as usize);
+
+        // Steady state: flood ingested + distributed; every per-peer copy
+        // is retained (Adj-RIB-Out + the undrained outbound buffers).
+        let live = ALLOC.live.load(Ordering::Relaxed) - live_before;
+
+        drop(tx);
+        handle.await.unwrap();
+        drop(receivers);
+        live
+    });
+    drop(rt);
+    (
+        live_steady,
+        ALLOC.total_allocs.load(Ordering::Relaxed) - allocs_before,
+    )
+}
+
+#[test]
+#[ignore = "sizing receipt, not a regression test; run on demand with --ignored --nocapture"]
+fn policy_fanout_live_heap_near_no_policy_baseline() {
+    const PEERS: usize = 64;
+    const PREFIXES: u32 = 2000;
+
+    let (base_live, base_allocs) = run_fanout(PEERS, PREFIXES, false);
+    let (policy_live, policy_allocs) = run_fanout(PEERS, PREFIXES, true);
+
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = policy_live as f64 / base_live as f64;
+    println!(
+        "no-policy: {:.1} MB live / {} allocs; tagging-policy: {:.1} MB live / {} allocs; ratio {ratio:.2}x",
+        base_live as f64 / 1e6,
+        base_allocs,
+        policy_live as f64 / 1e6,
+        policy_allocs,
+    );
+
+    // Pre-memo this ratio was ~4-5x at this shape (5.5x at the profile's
+    // 256x10k). The memo shares one modified attribute set across all
+    // (route, peer) pairs, so with-policy must sit near the baseline.
+    assert!(
+        ratio < 1.5,
+        "policy fanout live heap {policy_live} B is {ratio:.2}x the no-policy {base_live} B"
+    );
+}


### PR DESCRIPTION
Perf indictment #1 from the 2026-07-03 dhat profile — the top finding and the 1000-peer-receipt blocker: a modifying export chain deep-cloned the route's attribute `Arc` per (route × peer), 76% of live heap at 256 peers × 10k routes.

## Soundness (the load-bearing argument)

`rustbgpd_policy::apply_modifications(attrs, mods)` is a pure function of (source attributes, `RouteModifications`) — verified end to end; it takes no peer input and returns the `NextHopAction` for the caller to apply downstream. Peer context (address/ASN/group/neighbor-sets) influences only chain *evaluation*, whose entire output is the `RouteModifications` value. Keying the memo on (source-attr `Arc` identity, modifications equality) is therefore exact: peer-varying chains produce different values and land in separate slots automatically — no `uses_peer_context` flag, no bypass.

## Shape

Pass-scoped `ExportMemo` (new `distribution/export_memo.rs`): created once per `distribute_changes` fanout / route refresh / initial peer dump — no cross-pass interning, no lifetime questions. Pointer-keyed `FxHashMap` with each entry pinning a clone of the source `Arc` (no pointer-reuse ABA); per-entry tiny linear `Vec` of `(RouteModifications, Arc<Vec<PathAttribute>>, Option<NextHopAction>)`. Also hoists the AS_PATH regex-match string to once per source attr set (indictment #4 — was rebuilt per prefix × peer). Threaded through all three unicast export tails (single-best, multipath, ORR — the memo key is winner-independent, so ORR's per-vantage memo prohibition doesn't apply; noted in a comment). Empty-modification exports share the source Arc exactly as before. Labeled/EVPN/RTC/FlowSpec tails untouched (not indicted).

## Measured

- Profile scale (256 peers × 10k, tagging chain, host lock): live heap **4.21 GB → 763.7 MB = 1.001×** the no-policy baseline (was 5.5×); live blocks 12.85 M → 46 k; total allocs 36 M → 7.9 M. The ~130 GB 1000-peer extrapolation collapses to the structural no-policy ceiling.
- In-repo receipt: `crates/rib/tests/export_fanout_attr_memo.rs` (#[ignore]d, 64×2k, TrackingAllocator): 3.36×/246 MB/1.69 M allocs → **1.01×/74 MB/286 k**, asserted < 1.5×.

## Equivalence proof

- `memo_matches_bypass_across_matrix`: every modification kind × 3 attr sets, memo-miss AND memo-hit byte-identical to the pre-memo clone path (kept as oracle in test code); pointer-sharing asserted on hits.
- `memo_keys_by_source_identity_and_modifications_value`: distinct mods / distinct source Arcs never cross-share.
- Manager-level: 3 peers through the real run() loop with a neighbor-set peer-varying term + AS_PATH-regex term — per-peer oracle equality, `Arc::ptr_eq` across same-verdict peers, distinct set for the varying peer.

Gates: workspace build/test (64 suites, 627 rib tests incl. 4 new), fmt, clippy -D warnings (two now-unfulfilled `too_many_lines` expects removed), clippy-reasons — all green.