### PR TITLE
perf: batch three audit quick wins on the route hot paths

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -662,7 +663,7 @@ impl RibManager {
             // `force_outbound_peers`.
             let is_force = self.force_outbound_peers.contains(&peer);
             let resync = is_dirty || is_force;
-            let effective_prefixes: HashSet<Prefix> = if resync {
+            let effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
                 let mut all: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
                 // For multi-path dirty resync, also include all Adj-RIB-In prefixes
                 if self.peer_has_any_add_path_send(peer) {
@@ -673,9 +674,8 @@ impl RibManager {
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(rib_out.iter().map(|r| r.prefix));
                 }
-                all
+                Cow::Owned(all)
             } else {
-                let mut prefixes = best_changed.clone();
                 // An RFC 9107 ORR peer selects from the per-target
                 // candidate set, not the Loc-RIB best — a candidate
                 // change that leaves the Loc-RIB best untouched can
@@ -685,13 +685,26 @@ impl RibManager {
                     .peer_orr_vantage
                     .get(&peer)
                     .is_some_and(|vantage| self.orr.spf.contains_key(vantage));
-                for prefix in all_affected {
-                    if peer_has_resolved_orr || self.add_path_send_max_for_prefix(peer, prefix) > 0
-                    {
-                        prefixes.insert(*prefix);
-                    }
+                let extras: Vec<Prefix> = all_affected
+                    .iter()
+                    .filter(|prefix| {
+                        (peer_has_resolved_orr
+                            || self.add_path_send_max_for_prefix(peer, prefix) > 0)
+                            && !best_changed.contains(*prefix)
+                    })
+                    .copied()
+                    .collect();
+                // Common case (no ORR vantage, no Add-Path extras):
+                // borrow the shared changed set instead of re-hashing a
+                // per-peer clone of it — this loop runs once per
+                // outbound peer per distribution pass.
+                if extras.is_empty() {
+                    Cow::Borrowed(best_changed)
+                } else {
+                    let mut prefixes = best_changed.clone();
+                    prefixes.extend(extras);
+                    Cow::Owned(prefixes)
                 }
-                prefixes
             };
             let effective_flowspec_rules: HashSet<FlowSpecRule> = if resync {
                 let mut all: HashSet<FlowSpecRule> = self
@@ -884,7 +897,7 @@ impl RibManager {
                 .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
 
             // Stage: compute delta without mutating AdjRibOut
-            for prefix in &effective_prefixes {
+            for prefix in &*effective_prefixes {
                 let family = prefix_family(prefix);
                 // RFC 5291 §6 gate: suppress this family's advertisement (incl.
                 // ongoing churn) until the peer's first ROUTE-REFRESH lifts it.

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,8 +1,51 @@
 //! Prometheus metrics for session, RIB, policy, EVPN, GR, and RPKI counters/gauges.
 
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry};
+
+/// Monotonic id distinguishing `BgpMetrics` instances (tests create
+/// several on one thread). Clones share the id — they share the
+/// underlying metric vecs, so a memoized counter handle stays valid
+/// across clones.
+static NEXT_METRICS_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
+
+/// Bumped whenever peer series are reaped ([`BgpMetrics::reap_peer_series`]),
+/// invalidating every thread's [`POLICY_ROUTES_MEMO`]. Without this, a
+/// memoized handle would keep incrementing a child detached from the
+/// vec — invisible to scrapes — instead of re-resolving (and thereby
+/// recreating, from zero) the series like `with_label_values` does.
+static POLICY_ROUTES_REAP_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+/// One memoized `bgp_policy_routes_total` child handle.
+///
+/// `record_policy_routes` fires once per route × policy evaluation —
+/// O(peers × prefixes) on a distribution pass, per-NLRI on ingest —
+/// and `with_label_values` pays a `RwLock` read + four label-string
+/// hashes + a map probe every time. The evaluation loops are
+/// synchronous and label-uniform in the common case, so a single-slot
+/// thread-local memo (plain string compares, no lock) absorbs almost
+/// every resolve. Cloned children share the underlying atomic, so
+/// increments through the memo are indistinguishable from
+/// `with_label_values(..).inc()` to `gather()`.
+// ponytail: single slot — alternating label sets within one loop fall
+// back to per-call resolution (today's cost); widen to a tiny LRU if a
+// profile ever shows thrash.
+struct PolicyRoutesMemo {
+    instance: u64,
+    reap_epoch: u64,
+    peer: String,
+    policy: String,
+    direction: String,
+    action: String,
+    counter: IntCounter,
+}
+
+thread_local! {
+    static POLICY_ROUTES_MEMO: RefCell<Option<PolicyRoutesMemo>> = const { RefCell::new(None) };
+}
 
 /// Prometheus metrics for the BGP daemon.
 ///
@@ -22,6 +65,8 @@ use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registr
 #[derive(Debug, Clone)]
 pub struct BgpMetrics {
     registry: Registry,
+    /// See [`NEXT_METRICS_INSTANCE_ID`].
+    instance_id: u64,
 
     // ── Session ────────────────────────────────────────────────────
     state_transitions: IntCounterVec,
@@ -1428,6 +1473,7 @@ impl BgpMetrics {
 
         Self {
             registry,
+            instance_id: NEXT_METRICS_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
             state_transitions,
             session_flaps,
             session_established,
@@ -1594,6 +1640,15 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.route_refresh_in_progress, peer);
         Self::reap_peer_series_from_vec(&self.route_refresh_stale_entries, peer);
         Self::reap_peer_series_from_vec(&self.bmp_source_drops, peer);
+        // Invalidate memoized policy-routes handles AFTER the removal:
+        // every memo taken before this point (including one resolved
+        // mid-reap, whose series the loop above may just have removed)
+        // carries an older epoch and re-resolves on next use — a stale
+        // handle must never keep incrementing a child detached from the
+        // vec. An increment racing the removal itself can still be
+        // lost, exactly as a bare `with_label_values` racing
+        // `remove_label_values` could before the memo existed.
+        POLICY_ROUTES_REAP_EPOCH.fetch_add(1, Ordering::Release);
     }
 
     /// Remove every series of one Vec metric whose `peer` label equals
@@ -2099,10 +2154,39 @@ impl BgpMetrics {
     /// - `action`: `"permit"` or `"deny"`.
     ///
     /// Cardinality stays bounded by config (no free-form labels).
+    /// Hot path (fires per route × policy evaluation): a thread-local
+    /// single-slot memo of the resolved child skips the prometheus
+    /// `RwLock` + label hashing when consecutive calls carry the same
+    /// labels — see [`PolicyRoutesMemo`]. Totals and label sets are
+    /// identical to unmemoized `with_label_values(..).inc()`.
     pub fn record_policy_routes(&self, peer: &str, policy: &str, direction: &str, action: &str) {
-        self.policy_routes
-            .with_label_values(&[peer, policy, direction, action])
-            .inc();
+        let reap_epoch = POLICY_ROUTES_REAP_EPOCH.load(Ordering::Acquire);
+        POLICY_ROUTES_MEMO.with_borrow_mut(|memo| {
+            if let Some(m) = memo
+                && m.instance == self.instance_id
+                && m.reap_epoch == reap_epoch
+                && m.peer == peer
+                && m.policy == policy
+                && m.direction == direction
+                && m.action == action
+            {
+                m.counter.inc();
+                return;
+            }
+            let counter = self
+                .policy_routes
+                .with_label_values(&[peer, policy, direction, action]);
+            counter.inc();
+            *memo = Some(PolicyRoutesMemo {
+                instance: self.instance_id,
+                reap_epoch,
+                peer: peer.to_owned(),
+                policy: policy.to_owned(),
+                direction: direction.to_owned(),
+                action: action.to_owned(),
+                counter,
+            });
+        });
     }
 
     /// Set the GR active flag for a peer (1 = in GR, 0 = not).
@@ -2932,6 +3016,62 @@ mod tests {
         assert!(text.contains(r#"policy="ingress-filter""#));
         assert!(text.contains(r#"direction="import""#));
         assert!(text.contains(r#"action="deny""#));
+    }
+
+    /// Reaping a peer must invalidate the thread-local memoized counter
+    /// handle: a later record for the same labels re-resolves (series
+    /// recreated from zero), never increments the detached child.
+    #[test]
+    fn policy_routes_memo_invalidated_by_reap() {
+        let m = BgpMetrics::new();
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+
+        m.reap_peer_series("10.0.0.2");
+        assert!(
+            !gather_text(&m).contains("bgp_policy_routes_total{"),
+            "reap must remove the peer's policy-routes series"
+        );
+
+        // Same labels again — must land on a fresh series, not the
+        // memoized pre-reap child.
+        m.record_policy_routes("10.0.0.2", "ingress-filter", "import", "permit");
+        assert_eq!(
+            m.policy_routes
+                .with_label_values(&["10.0.0.2", "ingress-filter", "import", "permit"])
+                .get(),
+            1,
+            "post-reap series restarts from zero and receives the increment"
+        );
+    }
+
+    /// Two `BgpMetrics` instances on one thread (the ubiquitous test
+    /// topology) must not cross-increment through the shared
+    /// thread-local memo, while clones of ONE instance share it.
+    #[test]
+    fn policy_routes_memo_is_per_instance_but_shared_across_clones() {
+        let a = BgpMetrics::new();
+        let b = BgpMetrics::new();
+        let a2 = a.clone();
+
+        a.record_policy_routes("10.0.0.2", "p", "import", "permit");
+        b.record_policy_routes("10.0.0.2", "p", "import", "permit");
+        a2.record_policy_routes("10.0.0.2", "p", "import", "permit");
+
+        assert_eq!(
+            a.policy_routes
+                .with_label_values(&["10.0.0.2", "p", "import", "permit"])
+                .get(),
+            2,
+            "instance A counts its own and its clone's increment"
+        );
+        assert_eq!(
+            b.policy_routes
+                .with_label_values(&["10.0.0.2", "p", "import", "permit"])
+                .get(),
+            1,
+            "instance B must not absorb increments memoized for A"
+        );
     }
 
     #[test]

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -98,7 +98,7 @@ impl PeerSession {
                 ControlFlow::Continue(())
             }
             PeerCommand::UpdateImportPolicy { policy, reply } => {
-                self.import_policy = policy;
+                self.install_import_policy(policy);
                 // ADR-0073: advancing the session-local generation makes
                 // every decision recorded under the prior chain read as
                 // STALE on a subsequent explain lookup. saturating_add so

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -185,7 +185,15 @@ pub(super) struct PolicyAttrSummary<'a> {
     pub(super) med: Option<u32>,
 }
 impl<'a> PolicyAttrSummary<'a> {
-    pub(super) fn from_route_attrs(attrs: &'a [PathAttribute]) -> Self {
+    /// `needs_as_path_string` gates the `as_path_str` build (String +
+    /// per-ASN `to_string` + join): callers pass the session's cached
+    /// `import_needs_as_path_string` so an import chain with no
+    /// `AS_PATH` regex terms (or no chain at all) never pays for it —
+    /// the same `requires_as_path_string` gate the export-side RIB
+    /// distribution modules apply. When `false`, `as_path_str` is
+    /// empty; `as_path_len` / `origin_asn` are still extracted (cheap,
+    /// and RPKI/ASPA need them regardless of policy).
+    pub(super) fn from_route_attrs(attrs: &'a [PathAttribute], needs_as_path_string: bool) -> Self {
         let mut extended_communities: Option<&'a [rustbgpd_wire::ExtendedCommunity]> = None;
         let mut communities: Option<&'a [u32]> = None;
         let mut large_communities: Option<&'a [rustbgpd_wire::LargeCommunity]> = None;
@@ -220,7 +228,11 @@ impl<'a> PolicyAttrSummary<'a> {
             communities: communities.unwrap_or_default(),
             large_communities: large_communities.unwrap_or_default(),
             as_path,
-            as_path_str: as_path.map(AsPath::to_aspath_string).unwrap_or_default(),
+            as_path_str: if needs_as_path_string {
+                as_path.map(AsPath::to_aspath_string).unwrap_or_default()
+            } else {
+                String::new()
+            },
             as_path_len: as_path.map_or(0, AsPath::len),
             origin_asn: as_path.and_then(AsPath::origin_asn),
             local_pref,
@@ -1098,7 +1110,8 @@ impl PeerSession {
         // / `origin_asn` feed ASPA (per-family) and RPKI (per-prefix)
         // validation below.
         let explain_enabled = self.import_explain_enabled;
-        let policy_summary = PolicyAttrSummary::from_route_attrs(&route_attrs);
+        let policy_summary =
+            PolicyAttrSummary::from_route_attrs(&route_attrs, self.import_needs_as_path_string);
         let cached_policy_context = explain_enabled.then(|| policy_summary.to_cached_context());
         let PolicyAttrSummary {
             extended_communities: update_ecs,
@@ -2032,7 +2045,7 @@ mod policy_attr_summary_tests {
     #[test]
     fn empty_attrs_use_defaults() {
         let attrs: Vec<PathAttribute> = Vec::new();
-        let s = PolicyAttrSummary::from_route_attrs(&attrs);
+        let s = PolicyAttrSummary::from_route_attrs(&attrs, true);
         assert!(s.extended_communities.is_empty());
         assert!(s.communities.is_empty());
         assert!(s.large_communities.is_empty());
@@ -2053,7 +2066,7 @@ mod policy_attr_summary_tests {
             PathAttribute::LocalPref(150),
             PathAttribute::Med(42),
         ];
-        let s = PolicyAttrSummary::from_route_attrs(&attrs);
+        let s = PolicyAttrSummary::from_route_attrs(&attrs, true);
         assert_eq!(s.communities, [100u32, 200].as_slice());
         assert_eq!(s.extended_communities.len(), 1);
         assert_eq!(s.large_communities.len(), 1);
@@ -2082,7 +2095,7 @@ mod policy_attr_summary_tests {
             PathAttribute::Med(5),
             PathAttribute::Med(9), // later — must be ignored
         ];
-        let s = PolicyAttrSummary::from_route_attrs(&attrs);
+        let s = PolicyAttrSummary::from_route_attrs(&attrs, true);
         assert_eq!(
             s.communities,
             [100u32, 200].as_slice(),

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -142,6 +142,14 @@ pub(crate) struct PeerSession {
     outbound_tx: mpsc::Sender<OutboundRouteUpdate>,
     /// Import policy (prefix filter applied to inbound UPDATEs).
     import_policy: Option<PolicyChain>,
+    /// Whether the inbound hot path must build the per-UPDATE `AS_PATH`
+    /// match string (`PolicyAttrSummary::as_path_str`). Derived from
+    /// the import chain via `PolicyChain::requires_as_path_string`
+    /// (mirroring the export-side gate in the RIB distribution
+    /// modules) plus the explain toggle — cached decisions store the
+    /// evaluation-time context verbatim. Recomputed once per chain
+    /// install (`install_import_policy`), not per UPDATE.
+    import_needs_as_path_string: bool,
     /// Export policy (sent to RIB manager on `PeerUp` for per-peer filtering).
     export_policy: Option<PolicyChain>,
     /// RFC 8326 graceful-shutdown initiator toggle: when `true`, every
@@ -439,6 +447,8 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let import_needs_as_path_string =
+            Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
         Self {
             config,
@@ -465,6 +475,7 @@ impl PeerSession {
             outbound_rx,
             outbound_tx,
             import_policy,
+            import_needs_as_path_string,
             export_policy,
             advertise_graceful_shutdown,
             session_notify_tx,
@@ -532,6 +543,8 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let import_needs_as_path_string =
+            Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
         // Split the inbound stream and spawn the writer immediately —
         // we're in async context here (inside `tokio::spawn` from
@@ -569,6 +582,7 @@ impl PeerSession {
             outbound_rx,
             outbound_tx,
             import_policy,
+            import_needs_as_path_string,
             export_policy,
             advertise_graceful_shutdown,
             session_notify_tx,
@@ -608,6 +622,26 @@ impl PeerSession {
             ),
             import_policy_generation: 0,
         }
+    }
+
+    /// Whether an import chain (plus the explain toggle) needs the
+    /// per-UPDATE `AS_PATH` match string. See
+    /// [`Self::install_import_policy`].
+    fn import_chain_needs_as_path_string(
+        import_policy: Option<&PolicyChain>,
+        explain_enabled: bool,
+    ) -> bool {
+        explain_enabled || import_policy.is_some_and(PolicyChain::requires_as_path_string)
+    }
+
+    /// Install (or clear) the import chain, recomputing the cached
+    /// `as_path_str` gate. The single mutation point for
+    /// `import_policy` after construction — assigning the field
+    /// directly would desynchronize the gate.
+    pub(super) fn install_import_policy(&mut self, policy: Option<PolicyChain>) {
+        self.import_needs_as_path_string =
+            Self::import_chain_needs_as_path_string(policy.as_ref(), self.import_explain_enabled);
+        self.import_policy = policy;
     }
 
     fn build_bmp_peer_info(&self) -> BmpPeerInfo {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2780,7 +2780,7 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
     const ADDED_COMMUNITY: u32 = 0xFDE9_0064; // 65001:100
     let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
     session.negotiated = Some(negotiated_session(65002, false));
-    session.import_policy = Some(PolicyChain::new(vec![Policy {
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),
             ge: None,
@@ -2806,7 +2806,7 @@ async fn modified_policy_update_owns_distinct_arc_per_nlri() {
             },
         }],
         default_action: PolicyAction::Permit,
-    }]));
+    }])));
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath {
@@ -3341,7 +3341,7 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
         .clone_from(&negotiated.negotiated_families);
     session.negotiated = Some(negotiated);
     let replacement_next_hop: IpAddr = "2001:db8::99".parse().unwrap();
-    session.import_policy = Some(PolicyChain::new(vec![Policy {
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: None,
             ge: None,
@@ -3369,7 +3369,7 @@ async fn import_policy_next_hop_rewrite_clears_ipv4_mp_link_local_companion() {
             },
         }],
         default_action: PolicyAction::Deny,
-    }]));
+    }])));
     let received_next_hop: Ipv6Addr = "fe80::1".parse().unwrap();
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),


### PR DESCRIPTION
Three CPU-shaped quick wins from the 2026-07-03 repo-wide perf audit (items 1, 5, 6). All behavior-neutral; full workspace suite green.

## A — Prometheus handle resolution per route × policy evaluation

`record_policy_routes` fires O(peers×prefixes) per distribution pass and per-NLRI on ingest; each call paid prometheus's RwLock read + four label hashes + a map probe. Now a thread-local single-slot memo of the resolved `IntCounter` child: a hit is four string compares + one atomic inc. Fixed in the telemetry crate only — both call sites benefit with zero churn. Guards: a reap epoch bumped after `reap_peer_series` removals (Release/Acquire) so a stale handle can never increment a detached child, and a per-instance id so multiple registries on one thread (every test) can't cross-increment. Cloned children share the underlying atomic, so `gather()` output is identical. One audit correction: the suggested per-peer permit/deny handle pair was wrong as written — the `policy` label varies per evaluation; the memo compares all four labels.

## B — ingest built `as_path_str` for every received UPDATE

The `requires_as_path_string` gate existed and was used by all 7 RIB distribution modules, but not the transport ingest path — every received route paid String + per-ASN to_string + join even with no as-path-matching import policy. Gate now computed once per chain install (new `install_import_policy` single mutation point), not per UPDATE; explain-enabled sessions keep the string so ADR-0073 cached decisions store evaluation-time context verbatim. `origin_asn`/`as_path_len` still extracted (RPKI/ASPA need them).

## C — `distribute_changes` cloned the changed-prefix HashSet per peer

Now `Cow`: the shared set is borrowed unless the peer actually has ORR/Add-Path extras (the rare case), which builds the owned superset as before. Existing ORR tests cover mixed ORR+plain peers in one pass, divergent bests, and Add-Path ranking — all pass unchanged.

Gates: workspace build/test (64 suites), fmt, clippy -D warnings (pedantic), clippy-reasons — green. New tests: memo invalidation on reap, per-instance isolation.