### PR TITLE
docs(telemetry): drop intra-doc link from public item to private PolicyRoutesMemo

### DIFF
--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2157,7 +2157,7 @@ impl BgpMetrics {
     /// Hot path (fires per route × policy evaluation): a thread-local
     /// single-slot memo of the resolved child skips the prometheus
     /// `RwLock` + label hashing when consecutive calls carry the same
-    /// labels — see [`PolicyRoutesMemo`]. Totals and label sets are
+    /// labels — see `PolicyRoutesMemo`. Totals and label sets are
     /// identical to unmemoized `with_label_values(..).inc()`.
     pub fn record_policy_routes(&self, peer: &str, policy: &str, direction: &str, action: &str) {
         let reap_epoch = POLICY_ROUTES_REAP_EPOCH.load(Ordering::Acquire);


### PR DESCRIPTION
cargo doc -D warnings rejects a public item's doc linking a private
type; plain code span keeps the pointer without the link.
