### PR TITLE
feat(rib): add update-group fingerprinting and registry in shadow mode

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -169,6 +169,23 @@ async fn query_export_policy_stats(
         .map_err(|_| Status::internal("RIB manager dropped reply"))
 }
 
+async fn query_update_group(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    peer: std::net::IpAddr,
+) -> Result<String, Status> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    rib_tx
+        .send(RibUpdate::QueryPeerUpdateGroup {
+            peer,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| Status::internal("RIB manager unavailable"))?;
+    reply_rx
+        .await
+        .map_err(|_| Status::internal("RIB manager dropped reply"))
+}
+
 fn dynamic_range_error_status(error: DynamicRangeError) -> Status {
     match error {
         DynamicRangeError::AlreadyExists(message) => Status::already_exists(message),
@@ -410,6 +427,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
         import_policy_routes_denied: info.import_policy_routes_denied,
         export_policy_routes_permitted: info.export_policy_routes_permitted,
         export_policy_routes_denied: info.export_policy_routes_denied,
+        update_group: String::new(),
     }
 }
 
@@ -689,6 +707,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             let policy_stats = query_export_policy_stats(&self.rib_tx, info.address).await?;
             state.export_policy_routes_permitted = policy_stats.export_policy_routes_permitted;
             state.export_policy_routes_denied = policy_stats.export_policy_routes_denied;
+            state.update_group = query_update_group(&self.rib_tx, info.address).await?;
             neighbors.push(state);
         }
 
@@ -721,6 +740,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let policy_stats = query_export_policy_stats(&self.rib_tx, info.address).await?;
         state.export_policy_routes_permitted = policy_stats.export_policy_routes_permitted;
         state.export_policy_routes_denied = policy_stats.export_policy_routes_denied;
+        state.update_group = query_update_group(&self.rib_tx, info.address).await?;
         Ok(Response::new(state))
     }
 
@@ -1683,6 +1703,9 @@ mod tests {
                             ..Default::default()
                         });
                     }
+                    RibUpdate::QueryPeerUpdateGroup { reply, .. } => {
+                        let _ = reply.send("group:0".to_string());
+                    }
                     _ => {}
                 }
             }
@@ -1700,6 +1723,7 @@ mod tests {
         assert_eq!(resp.prefixes_sent, 7);
         assert_eq!(resp.export_policy_routes_permitted, 3);
         assert_eq!(resp.export_policy_routes_denied, 4);
+        assert_eq!(resp.update_group, "group:0");
     }
 
     #[test]

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -97,6 +97,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             import_policy_routes_denied: n.import_policy_routes_denied,
             export_policy_routes_permitted: n.export_policy_routes_permitted,
             export_policy_routes_denied: n.export_policy_routes_denied,
+            update_group: n.update_group.clone(),
         };
         output::print_json_pretty(&out)?;
     } else {
@@ -186,6 +187,9 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             "  Export — permitted: {} denied: {}",
             n.export_policy_routes_permitted, n.export_policy_routes_denied
         );
+        if !n.update_group.is_empty() {
+            println!("Update Group:          {}", n.update_group);
+        }
         println!("Flap Count:            {}", n.flap_count);
         if !n.last_error.is_empty() {
             println!("Last Error:            {}", n.last_error);

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -256,6 +256,9 @@ pub struct JsonNeighborDetail {
     pub add_path_send: bool,
     #[serde(skip_serializing_if = "is_zero")]
     pub add_path_send_max: u32,
+    /// Update-group membership: `group:N` or the ungrouped reason.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub update_group: String,
 }
 
 #[cfg(test)]
@@ -770,6 +773,7 @@ mod tests {
             add_path_receive: true,
             add_path_send: true,
             add_path_send_max: 4,
+            update_group: "group:0".to_string(),
         };
 
         let value: Value =

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -628,6 +628,7 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
             import_policy_routes_denied: 0,
             export_policy_routes_permitted: 0,
             export_policy_routes_denied: 0,
+            update_group: "group:0".to_string(),
         }))
     }
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1036,6 +1036,16 @@ impl PolicyChain {
         self.requires_rpki_validation() || self.requires_aspa_validation()
     }
 
+    /// Whether evaluating this chain depends on the evaluation peer's
+    /// identity (peer address / ASN / peer-group matching, TOML
+    /// `match_neighbor_set` or rpol `peer.*` comparisons). Update-group
+    /// fingerprinting treats such chains as ungroupable: content-equal
+    /// chains can still yield peer-different verdicts.
+    #[must_use]
+    pub fn requires_peer_context(&self) -> bool {
+        self.compiled().requires_peer_context()
+    }
+
     /// Evaluate a route against this chain of policies.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {

--- a/crates/policy/src/engine/tests/ir_parity.rs
+++ b/crates/policy/src/engine/tests/ir_parity.rs
@@ -774,6 +774,10 @@ fn golden_corpus_ir_matches_legacy() {
             .policies
             .iter()
             .any(|np| np.entries.iter().any(|e| e.match_aspa_validation.is_some()));
+        let legacy_peer_ctx = chain
+            .policies
+            .iter()
+            .any(|np| np.entries.iter().any(|e| e.match_neighbor_set.is_some()));
         assert_eq!(
             chain.requires_as_path_string(),
             legacy_regex,
@@ -793,6 +797,11 @@ fn golden_corpus_ir_matches_legacy() {
             chain.requires_validation_state(),
             legacy_rpki || legacy_aspa,
             "requires_validation_state diverges on {chain_name}"
+        );
+        assert_eq!(
+            chain.requires_peer_context(),
+            legacy_peer_ctx,
+            "requires_peer_context diverges on {chain_name}"
         );
 
         for (ctx_name, route) in &contexts {

--- a/crates/policy/src/engine/tests/peer_context.rs
+++ b/crates/policy/src/engine/tests/peer_context.rs
@@ -242,3 +242,96 @@ fn next_hop_match_requires_exact_address() {
     route_ctx.next_hop = Some(IpAddr::V6(Ipv6Addr::LOCALHOST));
     assert_eq!(policy.evaluate(&route_ctx).action, PolicyAction::Permit);
 }
+
+// --- requires_peer_context (update-group fingerprinting) ---
+
+#[test]
+fn requires_peer_context_true_for_toml_neighbor_set() {
+    let mut statement = stmt(None, PolicyAction::Deny, vec![]);
+    statement.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![65020],
+        peer_groups: vec![],
+    });
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }]);
+    assert!(chain.requires_peer_context());
+    // Second call goes through the cached (OnceLock) compiled chain.
+    assert!(chain.requires_peer_context());
+}
+
+#[test]
+fn requires_peer_context_false_without_peer_set_terms() {
+    let statement = stmt(
+        Some(v4_prefix([192, 0, 2, 0], 24)),
+        PolicyAction::Deny,
+        vec![],
+    );
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }]);
+    assert!(!chain.requires_peer_context());
+    assert!(!chain.requires_peer_context());
+    assert!(!PolicyChain::default().requires_peer_context());
+}
+
+#[test]
+fn requires_peer_context_for_rpol_compiled_chains() {
+    use std::sync::Arc;
+
+    use crate::rpol::RpolFile;
+    use crate::sets::SetStore;
+
+    let with_peer = r#"
+policy peer-gate {
+    term drop-leaf { if peer.group == "leaf" { reject } }
+}
+"#;
+    let without_peer = r"
+policy med-tag {
+    term tag { if route.med >= 10 { set med 5; accept } }
+}
+";
+    let mut store = SetStore::new();
+    let compiled = RpolFile::parse(with_peer)
+        .expect("clean rpol")
+        .compile_policy("peer-gate", &[], &mut store)
+        .expect("policy exists");
+    let chain = PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        "peer-gate".to_string(),
+        Arc::new(compiled),
+    )]);
+    assert!(chain.requires_peer_context());
+
+    let mut store = SetStore::new();
+    let compiled = RpolFile::parse(without_peer)
+        .expect("clean rpol")
+        .compile_policy("med-tag", &[], &mut store)
+        .expect("policy exists");
+    let chain = PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        "med-tag".to_string(),
+        Arc::new(compiled),
+    )]);
+    assert!(!chain.requires_peer_context());
+}
+
+#[test]
+fn requires_peer_context_survives_share_and_clone() {
+    let mut statement = stmt(None, PolicyAction::Deny, vec![]);
+    statement.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9))],
+        remote_asns: vec![],
+        peer_groups: vec![],
+    });
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }]);
+    assert!(chain.requires_peer_context());
+    // `share()` reuses the compiled IR; `clone()` recompiles fresh.
+    assert!(chain.share().requires_peer_context());
+    assert!(chain.clone().requires_peer_context());
+}

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -298,6 +298,16 @@ impl CompiledChain {
         self.requires_rpki_validation() || self.requires_aspa_validation()
     }
 
+    /// Whether evaluating this chain depends on the evaluation peer's
+    /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
+    /// ASN, or peer-group matching). Content-equal chains with such a
+    /// guard can still yield peer-different verdicts, so update-group
+    /// fingerprinting must not group peers that share one.
+    #[must_use]
+    pub fn requires_peer_context(&self) -> bool {
+        self.any_guard_node(&|expr| matches!(expr, MatchExpr::NeighborIn(_)))
+    }
+
     /// Does any guard node across all policies satisfy `pred`?
     fn any_guard_node(&self, pred: &impl Fn(&MatchExpr) -> bool) -> bool {
         self.policies

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -282,6 +282,12 @@ impl RibManager {
         }
 
         self.peer_export_policies.insert(peer, export_policy);
+        // Shadow-mode update-group fingerprint: recompute on the policy
+        // replacement seam (per-peer gRPC edits, ADR-0076 live-impact
+        // txns, and SIGHUP rpol overlays all funnel through this
+        // handler). Content-equality keying makes a reinstall of an
+        // identical chain key-stable — no regroup is recorded.
+        self.recompute_update_group(peer);
         self.dirty_peers.insert(peer);
         self.distribute_changes(&HashSet::new(), &HashSet::new());
         let _ = reply.send(Ok(()));

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -5,6 +5,7 @@ mod graceful_restart;
 mod helpers;
 mod peer_lifecycle;
 mod route_refresh;
+mod update_groups;
 
 #[cfg(test)]
 mod tests;
@@ -290,6 +291,10 @@ pub struct RibManager {
     /// re-arm) becomes deterministically observable. `None` in
     /// production — the only cost when unset is an `is_some()` check.
     test_ingest_stall: Option<std::time::Duration>,
+    /// Update-group fingerprint registry (shadow mode, slice 1):
+    /// records which peers *could* share staged output and why the
+    /// rest can't. Distribution never reads it yet.
+    update_groups: update_groups::UpdateGroupRegistry,
 }
 
 /// Bound on `live_sessions` entries per peer address. The RFC 4271 §6.8
@@ -608,6 +613,7 @@ impl RibManager {
             peer_asn: HashMap::new(),
             peer_group: HashMap::new(),
             peer_bgp_id: HashMap::new(),
+            update_groups: update_groups::UpdateGroupRegistry::default(),
             vrp_table: None,
             aspa_table: None,
             route_events_tx,
@@ -978,6 +984,9 @@ impl RibManager {
             }
             RibUpdate::QueryNeighborPolicyStats { peer, reply } => {
                 self.handle_query_neighbor_policy_stats(peer, reply);
+            }
+            RibUpdate::QueryPeerUpdateGroup { peer, reply } => {
+                self.handle_query_peer_update_group(peer, reply);
             }
             RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
                 self.handle_query_export_policy_term_hits(peer, reply);

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -466,6 +466,7 @@ impl RibManager {
         // totals can subtract Prometheus snapshots
         // (`bgp_policy_routes_total` is monotonic per process).
         self.export_policy_stats.remove(&peer);
+        self.remove_update_group_member(peer);
         self.clear_peer_refresh_state(peer);
     }
 
@@ -683,6 +684,11 @@ impl RibManager {
         self.peer_add_path_send_families
             .insert(peer, add_path_send_families);
         self.peer_add_path_send_max.insert(peer, add_path_send_max);
+        // Shadow-mode update-group fingerprint (slice 1): record this
+        // registration's group membership / ungrouped reason. Runs after
+        // every fingerprint input map above is populated; distribution
+        // (including the initial dump below) does not read it.
+        self.recompute_update_group(peer);
         self.send_initial_table(peer);
     }
 

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -905,4 +905,5 @@ mod refresh;
 mod rpki;
 mod rtc;
 mod unicast;
+mod update_groups;
 mod vpn;

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -1,0 +1,377 @@
+//! Shadow-mode update-group fingerprint registry (slice 1): membership
+//! labels, gauges, ungrouped reasons, and — the risk-3 property — key
+//! stability under a content-identical export-policy reinstall.
+
+use rustbgpd_policy::{
+    NeighborSetMatch, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+};
+
+use super::*;
+
+/// A minimal deny-one-prefix statement (everything else unset).
+fn deny_statement(prefix: Ipv4Prefix) -> PolicyStatement {
+    PolicyStatement {
+        prefix: Some(Prefix::V4(prefix)),
+        ge: None,
+        le: None,
+        action: PolicyAction::Deny,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    }
+}
+
+/// A chain denying one prefix — rebuilt fresh per call so two calls
+/// yield content-equal but instance-distinct chains.
+fn deny_chain(prefix: Ipv4Prefix) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![deny_statement(prefix)],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+/// A chain with a peer-set criterion (matches on peer ASN).
+fn peer_context_chain() -> PolicyChain {
+    let mut statement = deny_statement(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 8));
+    statement.match_neighbor_set = Some(NeighborSetMatch {
+        addresses: vec![],
+        remote_asns: vec![65099],
+        peer_groups: vec![],
+    });
+    PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+/// `PeerUp` with update-group-relevant knobs; the rest defaulted.
+struct PeerUpSpec {
+    peer: IpAddr,
+    export_policy: Option<PolicyChain>,
+    is_ebgp: bool,
+    route_reflector_client: bool,
+    orr_vantage: Option<IpAddr>,
+    add_path_send_max: u32,
+    negotiated_orf_recv: Vec<(Afi, Safi)>,
+    negotiated_llgr_families: Vec<(Afi, Safi)>,
+}
+
+impl PeerUpSpec {
+    fn ibgp(peer: IpAddr) -> Self {
+        Self {
+            peer,
+            export_policy: None,
+            is_ebgp: false,
+            route_reflector_client: false,
+            orr_vantage: None,
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        }
+    }
+}
+
+/// Send the `PeerUp` and drain its initial-table End-of-RIB.
+async fn peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    spec: PeerUpSpec,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    let add_path_send_families = if spec.add_path_send_max > 0 {
+        ipv4_sendable()
+    } else {
+        vec![]
+    };
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: spec.peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: spec.export_policy,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: spec.is_ebgp,
+        route_reflector_client: spec.route_reflector_client,
+        orr_vantage: spec.orr_vantage,
+        add_path_send_families,
+        add_path_send_max: spec.add_path_send_max,
+        negotiated_orf_recv: spec.negotiated_orf_recv,
+        negotiated_llgr_families: spec.negotiated_llgr_families,
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    out_rx
+}
+
+async fn query_update_group(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> String {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryPeerUpdateGroup {
+        peer,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
+fn regroups_total(metrics: &BgpMetrics) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .iter()
+        .find(|family| family.name() == "bgp_update_group_regroups_total")
+        .map_or(0.0, |family| family.metric[0].get_counter().value())
+}
+
+/// Epsilon-compare a gauge/counter reading (clippy `float_cmp`).
+fn assert_metric(observed: f64, expected: f64, what: &str) {
+    assert!(
+        (observed - expected).abs() < f64::EPSILON,
+        "{what}: expected {expected}, observed {observed}"
+    );
+}
+
+#[tokio::test]
+async fn identical_peers_group_together_and_gauges_track_membership() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let _rx_a = peer_up(&tx, PeerUpSpec::ibgp(a)).await;
+    let _rx_b = peer_up(&tx, PeerUpSpec::ibgp(b)).await;
+
+    assert_eq!(query_update_group(&tx, a).await, "group:0");
+    assert_eq!(query_update_group(&tx, b).await, "group:0");
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_groups", &[]),
+        1.0,
+        "bgp_update_groups",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_members", &[("group", "0")]),
+        2.0,
+        "bgp_update_group_members{group=0}",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_fallback_peers", &[]),
+        0.0,
+        "bgp_update_group_fallback_peers",
+    );
+
+    // A fingerprint-different peer (eBGP) lands in a second group.
+    let c = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut spec = PeerUpSpec::ibgp(c);
+    spec.is_ebgp = true;
+    let _rx_c = peer_up(&tx, spec).await;
+    assert_eq!(query_update_group(&tx, c).await, "group:1");
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_groups", &[]),
+        2.0,
+        "bgp_update_groups",
+    );
+
+    // Departures shrink membership; an emptied group's series is removed.
+    tx.send(RibUpdate::PeerDown {
+        peer: a,
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::PeerDown {
+        peer: b,
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+    assert_eq!(query_update_group(&tx, a).await, "");
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_members", &[("group", "0")]),
+        0.0,
+        "emptied group's member series must be gone (helper reads absent as 0)",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_groups", &[]),
+        1.0,
+        "bgp_update_groups",
+    );
+    // Membership churn is join/leave, not a regroup.
+    assert_metric(regroups_total(&metrics), 0.0, "regroups_total");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn ungrouped_reasons_surface_per_disqualifier() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let policy_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let add_path_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 2));
+    let orr_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 3));
+    let orf_negotiated_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 4));
+
+    let mut spec = PeerUpSpec::ibgp(policy_peer);
+    spec.export_policy = Some(peer_context_chain());
+    let _rx1 = peer_up(&tx, spec).await;
+
+    let mut spec = PeerUpSpec::ibgp(add_path_peer);
+    spec.add_path_send_max = 2;
+    let _rx2 = peer_up(&tx, spec).await;
+
+    let mut spec = PeerUpSpec::ibgp(orr_peer);
+    spec.orr_vantage = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    let _rx3 = peer_up(&tx, spec).await;
+
+    let mut spec = PeerUpSpec::ibgp(orf_negotiated_peer);
+    spec.negotiated_orf_recv = ipv4_sendable();
+    // The RFC 5291 §6 gate holds the ORF peer's initial dump (no EoR
+    // yet), so send PeerUp by hand instead of the helper.
+    let (out_tx, _out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: orf_negotiated_peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: spec.export_policy,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: spec.is_ebgp,
+        route_reflector_client: spec.route_reflector_client,
+        orr_vantage: spec.orr_vantage,
+        add_path_send_families: vec![],
+        add_path_send_max: spec.add_path_send_max,
+        negotiated_orf_recv: spec.negotiated_orf_recv,
+        negotiated_llgr_families: spec.negotiated_llgr_families,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        query_update_group(&tx, policy_peer).await,
+        "policy_peer_context"
+    );
+    assert_eq!(
+        query_update_group(&tx, add_path_peer).await,
+        "add_path_send"
+    );
+    assert_eq!(query_update_group(&tx, orr_peer).await, "orr_vantage");
+    assert_eq!(
+        query_update_group(&tx, orf_negotiated_peer).await,
+        "orf_installed"
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_fallback_peers", &[]),
+        4.0,
+        "bgp_update_group_fallback_peers",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_groups", &[]),
+        0.0,
+        "bgp_update_groups",
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Design risk 3: a no-op policy reload (ADR-0076 txn / SIGHUP rpol
+/// overlay reinstalling a content-identical chain through
+/// `ReplacePeerExportPolicy`) must keep the group key stable and must
+/// NOT count as a regroup — content-equality keying, not instance
+/// identity. A materially different chain must regroup.
+#[tokio::test]
+async fn content_identical_policy_replace_is_key_stable() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let mut spec = PeerUpSpec::ibgp(peer);
+    spec.export_policy = Some(deny_chain(prefix));
+    let _out_rx = peer_up(&tx, spec).await;
+
+    assert_eq!(query_update_group(&tx, peer).await, "group:0");
+    assert_metric(regroups_total(&metrics), 0.0, "regroups_total");
+
+    // Reinstall a content-identical chain: freshly constructed, so a
+    // distinct instance with a cold compiled-IR cache. Same content ⇒
+    // same interned index ⇒ identical key ⇒ no regroup.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(deny_chain(prefix)),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+
+    assert_eq!(
+        query_update_group(&tx, peer).await,
+        "group:0",
+        "content-identical reinstall must not move the peer"
+    );
+    assert_metric(
+        regroups_total(&metrics),
+        0.0,
+        "content-identical reinstall must not count as a regroup",
+    );
+
+    // A materially different chain regroups the peer.
+    let other = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(deny_chain(other)),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+
+    assert_eq!(query_update_group(&tx, peer).await, "group:1");
+    assert_metric(regroups_total(&metrics), 1.0, "regroups_total");
+
+    // And replacing with a peer-context chain moves it to the fallback
+    // path with the recorded reason (also a regroup).
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(peer_context_chain()),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+    assert_eq!(query_update_group(&tx, peer).await, "policy_peer_context");
+    assert_metric(regroups_total(&metrics), 2.0, "regroups_total");
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_fallback_peers", &[]),
+        1.0,
+        "bgp_update_group_fallback_peers",
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1,0 +1,260 @@
+//! Update-group fingerprint registry — SHADOW MODE (slice 1 of the
+//! update-groups arc).
+//!
+//! Peers whose staged outbound routes would be identical share a
+//! [`GroupKey`]; peers hitting a v1 disqualifier fall back to the
+//! per-peer path with a recorded reason. In this slice the registry is
+//! purely observational: membership is computed at session
+//! registration, recomputed on export-policy replacement, and removed
+//! on teardown — but **nothing reads it for distribution decisions**.
+//! Every peer stays on today's per-peer distribution path.
+//!
+//! The one load-bearing property proven here: the export-chain
+//! component is keyed by chain **content** (interned via `PolicyChain`
+//! `PartialEq`), never by `Arc`/instance identity — so a SIGHUP / rpol
+//! overlay / ADR-0076 txn that reinstalls a content-identical chain
+//! keeps the key stable and does not count as a regroup.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use rustbgpd_policy::PolicyChain;
+use rustbgpd_wire::{Afi, Safi};
+
+use super::RibManager;
+
+/// Fingerprint of every RIB-staging input that makes per-peer staged
+/// output differ (design §1). Per-peer wire preparation (next-hop
+/// rewrite, AS prepend, `ORIGINATOR_ID`/`CLUSTER_LIST` stamping, …) lives
+/// in transport and deliberately stays out of the key.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "the fingerprint key IS a set of independent staging predicates; \
+              packing them into a bitset would only obscure the design table"
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GroupKey {
+    /// Index into [`UpdateGroupRegistry::chains`] — the interned
+    /// **content** of the peer's effective export chain (per-peer if
+    /// set, else the global fallback). `None` = no export chain at all.
+    chain: Option<usize>,
+    /// eBGP target (split-horizon / LLGR §4.4 gate input).
+    target_is_ebgp: bool,
+    /// RFC 4456 route-reflector client (with the global `cluster_id`
+    /// this fully captures the reflection semantics split).
+    target_is_rr_client: bool,
+    /// Sendable IPv4-unicast (v1 keys the unicast subset exactly).
+    sendable_ipv4_unicast: bool,
+    /// Sendable IPv6-unicast.
+    sendable_ipv6_unicast: bool,
+    /// Exact set of families the peer advertised LLGR for (RFC 9494
+    /// export-restriction input), sorted raw `(afi, safi)` values.
+    llgr_families: Vec<(u16, u8)>,
+}
+
+/// Where a registered peer stands in the registry: grouped under a
+/// stable group id, or ungrouped with the v1 disqualifier that put it
+/// on the per-peer fallback path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum GroupMembership {
+    /// Fingerprint matched — member of the identified group.
+    Grouped(usize),
+    /// Export chain matches on peer address/ASN/group: content-equal
+    /// chains can still yield peer-different verdicts.
+    PolicyPeerContext,
+    /// Add-Path send negotiated: the multipath candidate set is
+    /// per-target (ranks shift when the target's own path is excluded).
+    AddPathSend,
+    /// ORR vantage bound: per-vantage winners are per-target
+    /// (ADR-0095 Decision 5).
+    OrrVantage,
+    /// ORF-receive negotiated: the peer can push arbitrary per-peer
+    /// prefix filters (RFC 5291).
+    OrfInstalled,
+}
+
+impl GroupMembership {
+    /// Operator-facing label: `group:N` or the ungrouped reason.
+    pub(super) fn label(&self) -> String {
+        match self {
+            Self::Grouped(id) => format!("group:{id}"),
+            Self::PolicyPeerContext => "policy_peer_context".to_string(),
+            Self::AddPathSend => "add_path_send".to_string(),
+            Self::OrrVantage => "orr_vantage".to_string(),
+            Self::OrfInstalled => "orf_installed".to_string(),
+        }
+    }
+}
+
+/// The shadow-mode registry: interned chain contents, group keys, and
+/// per-peer membership. Owned by the [`RibManager`] task like all other
+/// RIB state — no locking.
+#[derive(Debug, Default)]
+pub(super) struct UpdateGroupRegistry {
+    /// Interned export-chain contents; a [`GroupKey::chain`] indexes
+    /// here. Content-equality (`PolicyChain: PartialEq` on `policies`)
+    /// is what keeps a no-op reload key-stable.
+    // ponytail: linear content-eq scan and no eviction — distinct chain
+    // contents per fleet are few; intern-with-refcount if that changes.
+    chains: Vec<PolicyChain>,
+    /// Group id = index. Ids stay stable for a process lifetime; an
+    /// emptied group's slot is kept and reused when its key recurs.
+    groups: Vec<GroupKey>,
+    /// Membership (group id or ungrouped reason) per registered peer.
+    members: HashMap<IpAddr, GroupMembership>,
+}
+
+impl UpdateGroupRegistry {
+    /// Intern a chain by content, returning its stable index.
+    fn intern_chain(&mut self, chain: &PolicyChain) -> usize {
+        if let Some(idx) = self.chains.iter().position(|c| c == chain) {
+            return idx;
+        }
+        self.chains.push(chain.clone());
+        self.chains.len() - 1
+    }
+
+    /// Look up (or create) the group for a key, returning its id.
+    fn group_for(&mut self, key: GroupKey) -> usize {
+        if let Some(idx) = self.groups.iter().position(|g| *g == key) {
+            return idx;
+        }
+        self.groups.push(key);
+        self.groups.len() - 1
+    }
+
+    /// A registered peer's membership, if any.
+    pub(super) fn membership(&self, peer: IpAddr) -> Option<&GroupMembership> {
+        self.members.get(&peer)
+    }
+}
+
+impl RibManager {
+    /// Compute (or recompute) a registered peer's update-group
+    /// membership from the fingerprint inputs already in hand, record
+    /// it, and refresh the observability gauges. Called at the session
+    /// registration seam and the export-policy replacement seam (which
+    /// is also where SIGHUP rpol overlays and ADR-0076 live-impact txns
+    /// land). Shadow mode: distribution never reads the result.
+    pub(super) fn recompute_update_group(&mut self, peer: IpAddr) {
+        let membership = self.compute_update_group_membership(peer);
+        let previous = self.update_groups.members.insert(peer, membership.clone());
+        // A regroup is an already-registered peer whose membership
+        // moved; first registration and content-identical policy
+        // reinstalls (same interned index ⇒ same key) don't count.
+        if previous.is_some_and(|prev| prev != membership) {
+            self.metrics.record_update_group_regroup();
+        }
+        self.refresh_update_group_gauges();
+    }
+
+    /// Drop a departing peer's membership (the
+    /// `clear_outbound_peer_state` seam — `PeerDown`, `PeerDeleted`, GR
+    /// teardown, and collision replacement all route through it).
+    pub(super) fn remove_update_group_member(&mut self, peer: IpAddr) {
+        if self.update_groups.members.remove(&peer).is_some() {
+            self.refresh_update_group_gauges();
+        }
+    }
+
+    /// The fingerprint itself: disqualifiers first (design §1), then
+    /// the group key from RIB-staging inputs.
+    fn compute_update_group_membership(&mut self, peer: IpAddr) -> GroupMembership {
+        if self
+            .export_policy_for(peer)
+            .is_some_and(PolicyChain::requires_peer_context)
+        {
+            return GroupMembership::PolicyPeerContext;
+        }
+        if self.peer_has_any_add_path_send(peer) {
+            return GroupMembership::AddPathSend;
+        }
+        if self.peer_orr_vantage.contains_key(&peer) {
+            return GroupMembership::OrrVantage;
+        }
+        // ORF-receive negotiated ⇒ ungrouped from the start (the RFC
+        // 5291 §6 gate never meets grouping). Read from the live
+        // session record — `peer_orf_pending` drains as gates lift, so
+        // it can't answer "was ORF negotiated" later in the session.
+        let orf_negotiated = self
+            .live_sessions
+            .get(&peer)
+            .and_then(|sessions| sessions.last())
+            .is_some_and(|record| !record.negotiated_orf_recv.is_empty());
+        if orf_negotiated || self.peer_orf_filters.contains_key(&peer) {
+            return GroupMembership::OrfInstalled;
+        }
+
+        // Clone released before the &mut intern below; chains are small
+        // and this runs at config/session-lifecycle frequency only.
+        let chain = self.export_policy_for(peer).cloned();
+        let chain_idx = chain
+            .as_ref()
+            .map(|chain| self.update_groups.intern_chain(chain));
+        let sendable = self.peer_sendable_families.get(&peer);
+        let contains = |family: (Afi, Safi)| sendable.is_some_and(|f| f.contains(&family));
+        let mut llgr_families: Vec<(u16, u8)> = self
+            .peer_advertised_llgr_families
+            .get(&peer)
+            .map(|families| {
+                families
+                    .iter()
+                    .map(|&(afi, safi)| (afi as u16, safi as u8))
+                    .collect()
+            })
+            .unwrap_or_default();
+        llgr_families.sort_unstable();
+        llgr_families.dedup();
+        let key = GroupKey {
+            chain: chain_idx,
+            target_is_ebgp: self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
+            target_is_rr_client: self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),
+            sendable_ipv4_unicast: contains((Afi::Ipv4, Safi::Unicast)),
+            sendable_ipv6_unicast: contains((Afi::Ipv6, Safi::Unicast)),
+            llgr_families,
+        };
+        GroupMembership::Grouped(self.update_groups.group_for(key))
+    }
+
+    /// Re-derive every update-group gauge from the membership map.
+    /// Registered peers are at most low-thousands and this runs only on
+    /// lifecycle/config events, so a full recount beats incremental
+    /// bookkeeping.
+    fn refresh_update_group_gauges(&self) {
+        let mut member_counts: HashMap<usize, i64> = HashMap::new();
+        let mut fallback = 0i64;
+        for membership in self.update_groups.members.values() {
+            match membership {
+                GroupMembership::Grouped(id) => *member_counts.entry(*id).or_default() += 1,
+                _ => fallback += 1,
+            }
+        }
+        self.metrics
+            .set_update_groups(i64::try_from(member_counts.len()).unwrap_or(i64::MAX));
+        self.metrics.set_update_group_fallback_peers(fallback);
+        for id in 0..self.update_groups.groups.len() {
+            match member_counts.get(&id) {
+                Some(count) => self
+                    .metrics
+                    .set_update_group_members(&id.to_string(), *count),
+                None => self.metrics.remove_update_group_members(&id.to_string()),
+            }
+        }
+    }
+
+    /// Answer `RibUpdate::QueryPeerUpdateGroup`: the membership label
+    /// (`group:N` or the ungrouped reason), or empty for a peer with no
+    /// outbound registration.
+    pub(super) fn handle_query_peer_update_group(
+        &mut self,
+        peer: IpAddr,
+        reply: tokio::sync::oneshot::Sender<String>,
+    ) {
+        let label = self
+            .update_groups
+            .membership(peer)
+            .map(GroupMembership::label)
+            .unwrap_or_default();
+        let _ = reply.send(label);
+    }
+}

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -638,6 +638,18 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<NeighborPolicyStats>,
     },
+    /// Query: return a peer's update-group membership label — `group:N`
+    /// when the fingerprint grouped it, an ungrouped reason
+    /// (`policy_peer_context` / `add_path_send` / `orr_vantage` /
+    /// `orf_installed`) when a v1 disqualifier applies, or empty for a
+    /// peer with no outbound registration. Shadow mode: observational
+    /// only; distribution still runs per peer.
+    QueryPeerUpdateGroup {
+        /// The target peer.
+        peer: IpAddr,
+        /// Response channel.
+        reply: oneshot::Sender<String>,
+    },
     /// Query: snapshot the live per-term guard-hit counters of the
     /// installed export chains (ADR-0096 Decision 3.3). Counters
     /// accumulate since a chain instance was installed and reset when

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -121,6 +121,12 @@ pub struct BgpMetrics {
     rib_outbound_registration_failover: IntCounterVec,
     rib_dirty_resync: IntCounterVec,
     rib_ingest_channel_depth: IntGauge,
+
+    // ── Update groups (shadow-mode fingerprint registry) ────────
+    update_groups: IntGauge,
+    update_group_members: IntGaugeVec,
+    update_group_regroups: IntCounter,
+    update_group_fallback_peers: IntGauge,
     blackhole_discard_installed: IntCounter,
     blackhole_discard_withdrawn: IntCounter,
     blackhole_discard_adopted: IntCounter,
@@ -545,6 +551,43 @@ impl BgpMetrics {
             "Queued RibUpdate messages in the RIB manager ingest channel, sampled \
              once per manager loop iteration. Pegged at the channel capacity means \
              producers (sessions, local originators) are parked on backpressure.",
+        )
+        .expect("valid metric definition");
+
+        let update_groups = IntGauge::new(
+            "bgp_update_groups",
+            "Update groups with at least one member peer in the RIB manager's \
+             fingerprint registry (shadow mode: membership is recorded and \
+             observable, but distribution still runs per peer).",
+        )
+        .expect("valid metric definition");
+
+        let update_group_members = IntGaugeVec::new(
+            Opts::new(
+                "bgp_update_group_members",
+                "Member peers per update group. The group label is the registry's \
+                 stable group id; a group's series is removed when its last member \
+                 leaves.",
+            ),
+            &["group"],
+        )
+        .expect("valid metric definition");
+
+        let update_group_regroups = IntCounter::new(
+            "bgp_update_group_regroups_total",
+            "Times an already-registered peer's update-group membership changed \
+             (moved between groups, or between grouped and ungrouped). A no-op \
+             policy reload that reinstalls content-identical chains must NOT \
+             increment this: content-equality keying keeps the group key stable.",
+        )
+        .expect("valid metric definition");
+
+        let update_group_fallback_peers = IntGauge::new(
+            "bgp_update_group_fallback_peers",
+            "Peers ungrouped by a v1 disqualifier (peer-context policy, Add-Path \
+             send, ORR vantage, or negotiated ORF) and therefore permanently on \
+             the per-peer distribution path. Per-peer reasons surface in the \
+             neighbor status API.",
         )
         .expect("valid metric definition");
 
@@ -1258,6 +1301,18 @@ impl BgpMetrics {
             .register(Box::new(rib_ingest_channel_depth.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(update_groups.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(update_group_members.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(update_group_regroups.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(update_group_fallback_peers.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(blackhole_discard_installed.clone()))
             .expect("metric not already registered");
         registry
@@ -1508,6 +1563,10 @@ impl BgpMetrics {
             rib_outbound_registration_failover,
             rib_dirty_resync,
             rib_ingest_channel_depth,
+            update_groups,
+            update_group_members,
+            update_group_regroups,
+            update_group_fallback_peers,
             blackhole_discard_installed,
             blackhole_discard_withdrawn,
             blackhole_discard_adopted,
@@ -1934,6 +1993,34 @@ impl BgpMetrics {
     /// for outbound route distribution.
     pub fn set_rib_outbound_registered_peers(&self, count: i64) {
         self.rib_outbound_registered_peers.set(count);
+    }
+
+    /// Set the number of update groups with at least one member.
+    pub fn set_update_groups(&self, count: i64) {
+        self.update_groups.set(count);
+    }
+
+    /// Set the member count of one update group.
+    pub fn set_update_group_members(&self, group: &str, count: i64) {
+        self.update_group_members
+            .with_label_values(&[group])
+            .set(count);
+    }
+
+    /// Remove an emptied update group's member-count series.
+    pub fn remove_update_group_members(&self, group: &str) {
+        // Removal fails only if the series never existed — fine either way.
+        let _ = self.update_group_members.remove_label_values(&[group]);
+    }
+
+    /// Record an update-group membership change for a registered peer.
+    pub fn record_update_group_regroup(&self) {
+        self.update_group_regroups.inc();
+    }
+
+    /// Set the number of peers on the ungrouped (per-peer) fallback path.
+    pub fn set_update_group_fallback_peers(&self, count: i64) {
+        self.update_group_fallback_peers.set(count);
     }
 
     /// Record a `PeerUp` that replaced a still-registered outbound sender

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -364,6 +364,11 @@ message NeighborState {
   uint64 export_policy_routes_permitted = 20;
   // Export policy evaluations that denied a route.
   uint64 export_policy_routes_denied = 21;
+  // Update-group membership (shadow mode): "group:N" when the RIB
+  // fingerprint grouped this peer, or the ungrouped reason
+  // ("policy_peer_context", "add_path_send", "orr_vantage",
+  // "orf_installed"). Empty when the peer has no outbound registration.
+  string update_group = 22;
 }
 
 message DynamicNeighborRange {


### PR DESCRIPTION
Update-groups arc, slice 1 of 4 (design: the 2026-07-03 report — RIB-level grouping; measured basis: 83% of RR-fanout CPU is per-peer RIB distribution, ~10-30× wall-clock prize at 1000 uniform peers). SHADOW MODE: the registry records membership and reasons; nothing reads it for distribution decisions — zero behavior change.

## What

- **`GroupKey`** (`manager/update_groups.rs`): export-chain content (interned via linear content-eq — `PolicyChain` has `PartialEq` but no stable hash; chains per fleet are few), eBGP bit, RR-client bit, sendable unicast families, LLGR family set. Group id = registry index, stable for process lifetime.
- **Ungrouped reasons**: `PolicyPeerContext | AddPathSend | OrrVantage | OrfInstalled` — the design's v1 disqualifiers. ORF reads the live-session negotiated state, not the draining pending-gate set.
- **`CompiledChain::requires_peer_context()`** in the policy crate (any `NeighborIn` match node), exact mirror of the `requires_as_path_string` pattern; covered for TOML and rpol frontends plus the OnceLock/share/clone paths and the ir_parity golden corpus.
- **Seams**: join at `register_active_session`; regroup at `handle_replace_peer_export_policy` (verified as the single funnel — SIGHUP rpol overlays, ADR-0076 txns, and gRPC edits all route through it); leave at `clear_outbound_peer_state`.
- **Key-stability proof (design risk 3)**: a freshly-constructed content-identical chain replace keeps `group:0` with zero regroups — a 1000-peer no-op policy reload cannot shatter groups. Material change and peer-context change each regroup exactly once.
- **Observability**: `bgp_update_groups`, `bgp_update_group_members{group}`, `bgp_update_group_regroups_total`, `bgp_update_group_fallback_peers`; `NeighborState.update_group` (additive proto field) surfaced in ListNeighbors/GetNeighborState and `rbgp neighbor` detail — operators can ask "why is this peer ungrouped" from day one.

Runtime-verified: daemon booted, all three new metric families scraped live on /metrics; non-established peer shows empty label by design.

Gates: workspace build/test (all suites), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.

Next: slice 2 (group staging + delta fanout + membership lifecycle, differential forced-ungrouped oracle).