### PR TITLE
perf(rib): incremental best-path with an announcing-peers reverse index

### DIFF
--- a/crates/rib/proptest-regressions/manager/tests/incremental_best.txt
+++ b/crates/rib/proptest-regressions/manager/tests/incremental_best.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 51932819f225a470fa617a5fe6650106ddd5ce95a0cf5f9f57f8819f14ba817d # shrinks to ops = [Announce { peer: 2, routes: [(3, 1, 0)] }, Announce { peer: 2, routes: [(3, 1, 1)] }]
+cc 890f0c8e75fbd15248a688c56260ab240df69069217d188a5205546da395ab00 # shrinks to ops = [Announce { peer: 3, routes: [(4, 1, 1)] }, Announce { peer: 0, routes: [(4, 0, 0)] }, Announce { peer: 3, routes: [(4, 1, 2), (4, 0, 0)] }]

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -91,6 +91,9 @@ impl RibManager {
             affected.insert(route.prefix);
             rib.insert(route);
         }
+        for prefix in &affected {
+            self.register_unicast_announcer(source, *prefix);
+        }
         self.recompute_best(&affected);
     }
 

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -20,7 +20,10 @@ use super::helpers::{
     prefix_family, routes_equal, rtc_routes_equal, should_suppress_ibgp_inner, validate_route_aspa,
     validate_route_rpki, vpn_routes_equal,
 };
-use super::{PendingRouteChunk, PendingRoutesReceived, PolicyFilteredRouteKey, RibManager};
+use super::{
+    PendingRouteChunk, PendingRoutesReceived, PolicyFilteredRouteKey, RibManager,
+    UnicastPrefixPeers,
+};
 use crate::adj_rib_in::AdjRibIn;
 use crate::adj_rib_out::AdjRibOut;
 use crate::event::{RouteEvent, RouteEventType};
@@ -524,6 +527,172 @@ impl RibManager {
         self.distribute_changes(&changed, &affected);
     }
 
+    /// Register `peer` as a unicast announcer for `prefix` in the reverse
+    /// index. MUST be called by every seam that inserts a unicast route
+    /// into an Adj-RIB-In — see the [`UnicastPrefixPeers`] contract.
+    pub(in crate::manager) fn register_unicast_announcer(&mut self, peer: IpAddr, prefix: Prefix) {
+        let peers = self.unicast_prefix_peers.entry(prefix).or_default();
+        if !peers.contains(&peer) {
+            peers.push(peer);
+        }
+    }
+
+    /// All Adj-RIB-In candidates for `prefix`, collected via the announcing-
+    /// peers reverse index: only peers indexed for the prefix are probed,
+    /// instead of every peer's Adj-RIB-In (mostly misses at RR scale). A
+    /// stale index entry (peer withdrew / went down and was not yet pruned)
+    /// yields no candidates and is skipped — over-counting is benign.
+    pub(in crate::manager) fn unicast_candidates<'a>(
+        ribs: &'a HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &'a UnicastPrefixPeers,
+        prefix: &'a Prefix,
+    ) -> impl Iterator<Item = &'a crate::route::Route> {
+        prefix_peers
+            .get(prefix)
+            .into_iter()
+            .flatten()
+            .filter_map(move |peer| ribs.get(peer))
+            .flat_map(move |rib| rib.iter_prefix(prefix))
+    }
+
+    /// Announce fast path: full per-prefix rescans only where the
+    /// announce could actually have changed the Loc-RIB best.
+    ///
+    /// All changes in an announce chunk are inserts/replacements in ONE
+    /// peer's Adj-RIB-In (already applied when this runs). Per prefix the
+    /// challenger is the announcing peer's own best candidate (its
+    /// `iter_prefix` minimum under `best_path_cmp`), compared against the
+    /// RIB-RESIDENT current best — not the Loc-RIB clone — so the decision
+    /// is grounded in the same objects a full rescan would compare.
+    /// Enumerated cases, with anything doubtful falling back to the full
+    /// (indexed) rescan:
+    ///
+    /// 1. No current best exists → full rescan (the announce almost
+    ///    certainly installs one; also re-establishes the "a best exists
+    ///    iff any candidate exists" invariant cheaply — few candidates).
+    /// 2. The announcing peer OWNS the current best → full rescan: the
+    ///    best itself may have been replaced (payload change, possibly now
+    ///    losing to another candidate), and same-peer Add-Path candidates
+    ///    are the only ones that can TIE it (`best_path_cmp` is a total
+    ///    order whose final step compares peer addresses), which only the
+    ///    full enumeration + `LocRib::recompute` payload arbitration
+    ///    resolves.
+    /// 3. The current best's own Adj-RIB-In entry is missing → full rescan
+    ///    (defensive; unreachable while every mutation seam recomputes its
+    ///    affected set).
+    /// 4. The challenger strictly LOSES to the rib-resident best → skip
+    ///    entirely. Sound: every candidate of the announcing peer loses
+    ///    (the challenger is their minimum), all other candidates are
+    ///    untouched and still lose to the best, and no payload changed —
+    ///    a full rescan would compute `did_change == false` (no Loc-RIB
+    ///    write, no route event, no BMP emission).
+    /// 5. The challenger strictly BEATS the rib-resident best → install it
+    ///    directly, no rescan: it beats the old minimum, hence every
+    ///    untouched candidate, and its own peer's other candidates by
+    ///    construction (within-peer ties resolve to the same first-in-
+    ///    `iter_prefix`-order object a full scan would pick, cross-peer
+    ///    ties are impossible) — so it IS the full scan's winner.
+    ///    `LocRib::recompute` over the singleton keeps the change
+    ///    detection identical. Only taken with the BMP Loc-RIB tap off:
+    ///    BMP path-marking needs the runner-up, which requires the full
+    ///    candidate enumeration anyway.
+    /// 6. Challenger ties the best → unreachable cross-peer (case 2 covers
+    ///    same-peer) → conservative full rescan.
+    pub(super) fn recompute_best_after_announce(
+        &mut self,
+        peer: IpAddr,
+        affected: &HashSet<Prefix>,
+    ) -> HashSet<Prefix> {
+        use std::cmp::Ordering;
+
+        // Some(true): install the challenger directly (case 5).
+        // Some(false): provably unchanged, skip (case 4).
+        // None: full rescan (cases 1-3, 6).
+        let mut changed = HashSet::new();
+        let mut needs_full = HashSet::new();
+        for prefix in affected {
+            let verdict = 'fast: {
+                let Some(best) = self.loc_rib.get(prefix) else {
+                    break 'fast None; // case 1
+                };
+                if best.peer == peer {
+                    break 'fast None; // case 2
+                }
+                let Some(best_in_rib) = self
+                    .ribs
+                    .get(&best.peer)
+                    .and_then(|rib| rib.get(prefix, best.path_id))
+                else {
+                    break 'fast None; // case 3
+                };
+                let challenger = self.ribs.get(&peer).and_then(|rib| {
+                    rib.iter_prefix(prefix)
+                        .min_by(|a, b| crate::best_path::best_path_cmp(a, b))
+                });
+                let Some(challenger) = challenger else {
+                    break 'fast None; // announce raced a removal: rescan
+                };
+                match crate::best_path::best_path_cmp(challenger, best_in_rib) {
+                    Ordering::Greater => Some(false),                      // case 4
+                    Ordering::Less if self.bmp_tx.is_none() => Some(true), // case 5
+                    _ => None, // case 5 with BMP on, or case 6
+                }
+            };
+            match verdict {
+                Some(false) => {}
+                None => {
+                    needs_full.insert(*prefix);
+                }
+                Some(true) => {
+                    let previous_best = self.loc_rib.get(prefix).map(|r| (r.peer, r.path_id));
+                    // Re-resolve the winner (the classification borrows
+                    // ended above): the announcing peer's best candidate.
+                    let Some(winner) = self.ribs.get(&peer).and_then(|rib| {
+                        rib.iter_prefix(prefix)
+                            .min_by(|a, b| crate::best_path::best_path_cmp(a, b))
+                    }) else {
+                        needs_full.insert(*prefix);
+                        continue;
+                    };
+                    // Singleton recompute: the winner is provably the full
+                    // scan's minimum, and `LocRib::recompute` keeps the
+                    // payload-change detection identical to the full path.
+                    if self.loc_rib.recompute(*prefix, std::iter::once(winner)) {
+                        changed.insert(*prefix);
+                        self.publish_best_change_events(*prefix, previous_best);
+                    }
+                }
+            }
+        }
+        changed.extend(self.recompute_best(&needs_full));
+        changed
+    }
+
+    /// Withdraw fast path: the withdrawals (already applied to ONE peer's
+    /// Adj-RIB-In) only *removed* candidates — no payloads changed. If the
+    /// current best's own Adj-RIB-In entry still exists, the minimum of a
+    /// shrunken set that still contains the old minimum is unchanged →
+    /// skip. If the best was withdrawn (or no best exists), full rescan.
+    pub(super) fn recompute_best_after_withdraw(
+        &mut self,
+        affected: &HashSet<Prefix>,
+    ) -> HashSet<Prefix> {
+        let needs_full: HashSet<Prefix> = affected
+            .iter()
+            .filter(|prefix| {
+                let Some(best) = self.loc_rib.get(prefix) else {
+                    return true; // no best: rescan (cheap; re-checks invariant)
+                };
+                self.ribs
+                    .get(&best.peer)
+                    .and_then(|rib| rib.get(prefix, best.path_id))
+                    .is_none() // best itself withdrawn → full rescan
+            })
+            .copied()
+            .collect();
+        self.recompute_best(&needs_full)
+    }
+
     /// Recompute Loc-RIB best path for a set of affected prefixes.
     /// Returns the set of prefixes that actually changed.
     /// Also emits route events to the broadcast channel.
@@ -531,97 +700,131 @@ impl RibManager {
         let mut changed = HashSet::new();
         for prefix in affected {
             let previous_best = self.loc_rib.get(prefix).map(|r| (r.peer, r.path_id));
-            let candidates = self.ribs.values().flat_map(|rib| rib.iter_prefix(prefix));
-            let did_change = self.loc_rib.recompute(*prefix, candidates);
+            // Inner scope: `candidates` borrows the Adj-RIB-Ins and must be
+            // dropped before the `&mut self` event publication below.
+            let did_change = {
+                // One probe pass over the announcing-peers reverse index does
+                // double duty: collect the candidates AND lazily prune peers
+                // whose Adj-RIB-In no longer holds this prefix (withdraw,
+                // session down, GR/LLGR sweep, ... — removal seams have no
+                // eager hook by design, see the `UnicastPrefixPeers` contract).
+                let mut candidates: smallvec::SmallVec<[&crate::route::Route; 8]> =
+                    smallvec::SmallVec::new();
+                if let Some(peers) = self.unicast_prefix_peers.get_mut(prefix) {
+                    let ribs = &self.ribs;
+                    peers.retain(|peer| {
+                        let before = candidates.len();
+                        if let Some(rib) = ribs.get(peer) {
+                            candidates.extend(rib.iter_prefix(prefix));
+                        }
+                        candidates.len() > before
+                    });
+                    if peers.is_empty() {
+                        self.unicast_prefix_peers.remove(prefix);
+                    }
+                }
+                let did_change = self.loc_rib.recompute(*prefix, candidates.iter().copied());
+                if did_change {
+                    // RFC 9069 Loc-RIB tap: any change to the best is a
+                    // Route Monitoring announce of the new best (BGP
+                    // implicit withdraw covers replacement); a best that
+                    // disappeared is an explicit withdraw. Timestamp = the
+                    // Loc-RIB install time, i.e. now. Best-unchanged
+                    // prefixes never reach this branch.
+                    if self.bmp_tx.is_some() {
+                        let (pdu, path_status) = match self.loc_rib.get(prefix) {
+                            Some(best) => {
+                                // Path Marking reason = the decisive step
+                                // versus the runner-up (the closest
+                                // competitor), re-derived here from the
+                                // explain ladder — the hot-path comparator
+                                // records nothing, and a sole candidate
+                                // carries no reason (nothing was compared).
+                                let runner_up = candidates
+                                    .iter()
+                                    .copied()
+                                    .filter(|c| !(c.peer == best.peer && c.path_id == best.path_id))
+                                    .min_by(|a, b| crate::best_path::best_path_cmp(a, b));
+                                let reason = runner_up.map(|r| {
+                                    crate::best_path::best_path_cmp_with_reason(best, r).1
+                                });
+                                let status = crate::bmp_sync::loc_rib_path_status(
+                                    best.is_stale || best.is_llgr_stale,
+                                    reason,
+                                );
+                                (
+                                    crate::bmp_sync::synthesize_unicast_announce(best),
+                                    Some(status),
+                                )
+                            }
+                            None => (crate::bmp_sync::synthesize_unicast_withdraw(*prefix), None),
+                        };
+                        self.emit_bmp_loc_rib(pdu, path_status, std::time::SystemTime::now());
+                    }
+                }
+                did_change
+            };
             if did_change {
                 changed.insert(*prefix);
-                let current_best = self.loc_rib.get(prefix);
-                // RFC 9069 Loc-RIB tap: any change to the best is a
-                // Route Monitoring announce of the new best (BGP
-                // implicit withdraw covers replacement); a best that
-                // disappeared is an explicit withdraw. Timestamp = the
-                // Loc-RIB install time, i.e. now. Best-unchanged
-                // prefixes never reach this branch.
-                if self.bmp_tx.is_some() {
-                    let (pdu, path_status) = match current_best {
-                        Some(best) => {
-                            // Path Marking reason = the decisive step
-                            // versus the runner-up (the closest
-                            // competitor), re-derived here from the
-                            // explain ladder — the hot-path comparator
-                            // records nothing, and a sole candidate
-                            // carries no reason (nothing was compared).
-                            let runner_up = self
-                                .ribs
-                                .values()
-                                .flat_map(|rib| rib.iter_prefix(prefix))
-                                .filter(|c| !(c.peer == best.peer && c.path_id == best.path_id))
-                                .min_by(|a, b| crate::best_path::best_path_cmp(a, b));
-                            let reason = runner_up
-                                .map(|r| crate::best_path::best_path_cmp_with_reason(best, r).1);
-                            let status = crate::bmp_sync::loc_rib_path_status(
-                                best.is_stale || best.is_llgr_stale,
-                                reason,
-                            );
-                            (
-                                crate::bmp_sync::synthesize_unicast_announce(best),
-                                Some(status),
-                            )
-                        }
-                        None => (crate::bmp_sync::synthesize_unicast_withdraw(*prefix), None),
-                    };
-                    self.emit_bmp_loc_rib(pdu, path_status, std::time::SystemTime::now());
-                }
-                match (previous_best, current_best) {
-                    (None, Some(best)) => {
-                        debug!(%prefix, peer = %best.peer, "best path added");
-                        self.publish_route_event(RouteEvent {
-                            event_id: 0,
-                            event_type: RouteEventType::Added,
-                            prefix: *prefix,
-                            peer: Some(best.peer),
-                            previous_peer: None,
-                            target_peer: None,
-                            timestamp: crate::event::unix_timestamp_now(),
-                            path_id: best.path_id,
-                            reason: String::new(),
-                        });
-                    }
-                    (Some((old_peer, old_path_id)), None) => {
-                        debug!(%prefix, "best path removed");
-                        self.publish_route_event(RouteEvent {
-                            event_id: 0,
-                            event_type: RouteEventType::Withdrawn,
-                            prefix: *prefix,
-                            peer: None,
-                            previous_peer: Some(old_peer),
-                            target_peer: None,
-                            timestamp: crate::event::unix_timestamp_now(),
-                            path_id: old_path_id,
-                            reason: String::new(),
-                        });
-                    }
-                    (Some((old_peer, _old_path_id)), Some(best)) => {
-                        debug!(%prefix, peer = %best.peer, "best path changed");
-                        self.publish_route_event(RouteEvent {
-                            event_id: 0,
-                            event_type: RouteEventType::BestChanged,
-                            prefix: *prefix,
-                            peer: Some(best.peer),
-                            previous_peer: Some(old_peer),
-                            target_peer: None,
-                            timestamp: crate::event::unix_timestamp_now(),
-                            path_id: best.path_id,
-                            reason: String::new(),
-                        });
-                    }
-                    (None, None) => {}
-                }
+                self.publish_best_change_events(*prefix, previous_best);
             }
         }
         self.metrics
             .set_loc_rib_prefixes("all", gauge_val(self.loc_rib.len()));
         changed
+    }
+
+    /// Emit the route event for a Loc-RIB best change already applied
+    /// (added / withdrawn / replaced), diffing `previous_best` against the
+    /// freshly installed state. Shared by the full rescan and the announce
+    /// fast path's direct install.
+    fn publish_best_change_events(&mut self, prefix: Prefix, previous_best: Option<(IpAddr, u32)>) {
+        let current_best = self.loc_rib.get(&prefix).map(|r| (r.peer, r.path_id));
+        match (previous_best, current_best) {
+            (None, Some((peer, path_id))) => {
+                debug!(%prefix, %peer, "best path added");
+                self.publish_route_event(RouteEvent {
+                    event_id: 0,
+                    event_type: RouteEventType::Added,
+                    prefix,
+                    peer: Some(peer),
+                    previous_peer: None,
+                    target_peer: None,
+                    timestamp: crate::event::unix_timestamp_now(),
+                    path_id,
+                    reason: String::new(),
+                });
+            }
+            (Some((old_peer, old_path_id)), None) => {
+                debug!(%prefix, "best path removed");
+                self.publish_route_event(RouteEvent {
+                    event_id: 0,
+                    event_type: RouteEventType::Withdrawn,
+                    prefix,
+                    peer: None,
+                    previous_peer: Some(old_peer),
+                    target_peer: None,
+                    timestamp: crate::event::unix_timestamp_now(),
+                    path_id: old_path_id,
+                    reason: String::new(),
+                });
+            }
+            (Some((old_peer, _old_path_id)), Some((peer, path_id))) => {
+                debug!(%prefix, %peer, "best path changed");
+                self.publish_route_event(RouteEvent {
+                    event_id: 0,
+                    event_type: RouteEventType::BestChanged,
+                    prefix,
+                    peer: Some(peer),
+                    previous_peer: Some(old_peer),
+                    target_peer: None,
+                    timestamp: crate::event::unix_timestamp_now(),
+                    path_id,
+                    reason: String::new(),
+                });
+            }
+            (None, None) => {}
+        }
     }
 
     /// Distribute Loc-RIB changes to all registered outbound peers.
@@ -923,6 +1126,7 @@ impl RibManager {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
+                        &self.unicast_prefix_peers,
                         rib_out,
                         &self.peer_is_rr_client,
                         prefix,
@@ -954,6 +1158,7 @@ impl RibManager {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_orr_best_prefix(
                         &self.ribs,
+                        &self.unicast_prefix_peers,
                         rib_out,
                         &self.peer_is_rr_client,
                         orr_topology,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -2,17 +2,25 @@ use super::{
     AdjRibIn, AdjRibOut, Afi, Arc, BgpMetrics, ExplainAdvertisedRoute, ExplainDecision,
     ExplainReason, HashMap, HashSet, IpAddr, Ipv4Addr, LOCAL_PEER, LocRib, NeighborPolicyStats,
     PolicyAction, PolicyChain, PolicyFilteredRouteKey, Prefix, RibCommandError, RibManager,
-    RouteContext, Safi, VrpTable, debug, evaluate_chain_with_attribution, gauge_val, prefix_family,
-    record_export_policy_eval, route_type, route_type_label, route_type_message, routes_equal,
-    should_suppress_ibgp_inner, validate_route_aspa, validate_route_rpki,
+    RouteContext, Safi, UnicastPrefixPeers, VrpTable, debug, evaluate_chain_with_attribution,
+    gauge_val, prefix_family, record_export_policy_eval, route_type, route_type_label,
+    route_type_message, routes_equal, should_suppress_ibgp_inner, validate_route_aspa,
+    validate_route_rpki,
 };
 
 /// Candidate paths for `prefix` visible to `target_peer` under RFC 9107
 /// ORR: every Adj-RIB-In entry that survives split horizon and the
 /// iBGP / RFC 4456 reflection rules. Shared by the ORR distribution and
-/// explain paths so both rank the exact same set.
+/// explain paths so both rank the exact same set. Collection goes through
+/// the announcing-peers reverse index so only peers that actually hold the
+/// prefix are probed.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "candidate collection mirrors the per-target reflection filter inputs"
+)]
 fn orr_candidates<'a>(
     ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    prefix_peers: &'a UnicastPrefixPeers,
     peer_is_rr_client: &'a HashMap<IpAddr, bool>,
     prefix: &'a Prefix,
     target_peer: IpAddr,
@@ -20,22 +28,20 @@ fn orr_candidates<'a>(
     target_is_rr_client: bool,
     cluster_id: Option<Ipv4Addr>,
 ) -> impl Iterator<Item = &'a crate::route::Route> {
-    ribs.values()
-        .flat_map(move |rib| rib.iter_prefix(prefix))
-        .filter(move |route| {
-            // Split horizon: exclude routes from the target peer
-            if route.peer == target_peer {
-                return false;
-            }
-            // iBGP split-horizon / RFC 4456 reflection
-            !should_suppress_ibgp_inner(
-                route,
-                target_is_ebgp,
-                target_is_rr_client,
-                cluster_id,
-                peer_is_rr_client,
-            )
-        })
+    RibManager::unicast_candidates(ribs, prefix_peers, prefix).filter(move |route| {
+        // Split horizon: exclude routes from the target peer
+        if route.peer == target_peer {
+            return false;
+        }
+        // iBGP split-horizon / RFC 4456 reflection
+        !should_suppress_ibgp_inner(
+            route,
+            target_is_ebgp,
+            target_is_rr_client,
+            cluster_id,
+            peer_is_rr_client,
+        )
+    })
 }
 
 impl RibManager {
@@ -47,6 +53,7 @@ impl RibManager {
     pub(in crate::manager) fn explain_single_best_prefix(
         loc_rib: &LocRib,
         ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         prefix: Prefix,
         target_peer: IpAddr,
@@ -88,6 +95,7 @@ impl RibManager {
             explain.orr_vantage = Some(vantage);
             let mut ranked: Vec<&crate::route::Route> = orr_candidates(
                 ribs,
+                prefix_peers,
                 peer_is_rr_client,
                 &prefix,
                 target_peer,
@@ -366,7 +374,9 @@ impl RibManager {
             // partial-progress queries stay live mid-batch — but accumulate
             // the distribution and flush it once when the batch drains, so a
             // multi-chunk flood coalesces into one outbound pass per peer.
-            let changed = self.recompute_best(&affected);
+            // The withdraw fast path skips prefixes whose best provably
+            // survived (only candidates were removed).
+            let changed = self.recompute_best_after_withdraw(&affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
             if let Some(rib) = self.ribs.get_mut(&peer) {
@@ -430,11 +440,19 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
+            // Every inserted prefix registers in the announcing-peers
+            // reverse index BEFORE recompute — the index must never
+            // under-count (see the `UnicastPrefixPeers` contract).
+            for prefix in &affected {
+                self.register_unicast_announcer(peer, *prefix);
+            }
             // Recompute Loc-RIB now — best-path, route events, and
             // partial-progress queries stay live mid-batch — but accumulate
             // the distribution and flush it once when the batch drains, so a
             // multi-chunk flood coalesces into one outbound pass per peer.
-            let changed = self.recompute_best(&affected);
+            // The announce fast path skips prefixes where every candidate
+            // of this peer provably loses to the current best.
+            let changed = self.recompute_best_after_announce(peer, &affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
             if any_replaced && let Some(rib) = self.ribs.get_mut(&peer) {
@@ -455,8 +473,10 @@ impl RibManager {
             .or_insert_with(|| AdjRibIn::new(LOCAL_PEER));
         let replaced = rib.insert(route);
         debug!(%prefix, "injected local route");
+        let rib_len = rib.len();
+        self.register_unicast_announcer(LOCAL_PEER, prefix);
         self.metrics
-            .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib.len()));
+            .set_rib_prefixes(&LOCAL_PEER.to_string(), "all", gauge_val(rib_len));
 
         let mut affected = HashSet::new();
         affected.insert(prefix);
@@ -510,6 +530,7 @@ impl RibManager {
     )]
     pub(in crate::manager) fn distribute_multipath_prefix(
         ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         prefix: &Prefix,
@@ -559,40 +580,40 @@ impl RibManager {
             return;
         }
 
-        // Collect all candidates across all Adj-RIB-In entries
-        let mut candidates: Vec<&crate::route::Route> = ribs
-            .values()
-            .flat_map(|rib| rib.iter_prefix(prefix))
-            .filter(|route| {
-                // Split horizon: exclude routes from the target peer
-                if route.peer == target_peer {
-                    return false;
-                }
-                // iBGP split-horizon / RFC 4456 reflection
-                if should_suppress_ibgp_inner(
-                    route,
-                    target_is_ebgp,
-                    target_is_rr_client,
-                    cluster_id,
-                    peer_is_rr_client,
-                ) {
-                    return false;
-                }
-                // RFC 9494 §4.4: each staged candidate is gated
-                // individually — a stale candidate must not occupy an
-                // Add-Path rank toward a non-LLGR eBGP peer.
-                if super::llgr_stale_export_suppressed(
-                    route.is_llgr_stale,
-                    route.communities(),
-                    family,
-                    target_is_ebgp,
-                    llgr,
-                ) {
-                    return false;
-                }
-                true
-            })
-            .collect();
+        // Collect all candidates across the announcing peers' Adj-RIB-Ins
+        // (reverse-index probe, not an all-peers scan).
+        let mut candidates: Vec<&crate::route::Route> =
+            Self::unicast_candidates(ribs, prefix_peers, prefix)
+                .filter(|route| {
+                    // Split horizon: exclude routes from the target peer
+                    if route.peer == target_peer {
+                        return false;
+                    }
+                    // iBGP split-horizon / RFC 4456 reflection
+                    if should_suppress_ibgp_inner(
+                        route,
+                        target_is_ebgp,
+                        target_is_rr_client,
+                        cluster_id,
+                        peer_is_rr_client,
+                    ) {
+                        return false;
+                    }
+                    // RFC 9494 §4.4: each staged candidate is gated
+                    // individually — a stale candidate must not occupy an
+                    // Add-Path rank toward a non-LLGR eBGP peer.
+                    if super::llgr_stale_export_suppressed(
+                        route.is_llgr_stale,
+                        route.communities(),
+                        family,
+                        target_is_ebgp,
+                        llgr,
+                    ) {
+                        return false;
+                    }
+                    true
+                })
+                .collect();
 
         // Sort by best-path preference (best first). A target bound to a
         // resolved ORR vantage ranks by the vantage's interior cost to
@@ -871,10 +892,12 @@ impl RibManager {
     /// cache.
     #[expect(
         clippy::too_many_arguments,
+        clippy::too_many_lines,
         reason = "ORR export keeps peer, policy, and Adj-RIB-Out diff state together"
     )]
     pub(in crate::manager) fn distribute_orr_best_prefix(
         ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         orr_topology: &crate::orr::OrrTopology,
@@ -928,6 +951,7 @@ impl RibManager {
         // so explain ranks exactly what distribution ranks.
         let candidates = orr_candidates(
             ribs,
+            prefix_peers,
             peer_is_rr_client,
             prefix,
             target_peer,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -33,6 +33,23 @@ use crate::update::{
 
 use helpers::{DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, prefix_family};
 
+/// Reverse index of unicast announcing peers: prefix → the peers whose
+/// Adj-RIB-In currently holds at least one route for it. `FxHash` +
+/// peer-fed keys: same deliberate `HashDoS` tradeoff as the route maps (see the
+/// rationale block at the top of `adj_rib_in.rs`).
+///
+/// Maintenance contract (load-bearing): the index may OVER-count but must
+/// never UNDER-count — `recompute_best` collects candidates only from the
+/// indexed peers, so a missing entry would silently drop a live candidate
+/// from best-path selection. Every seam that inserts a unicast route into
+/// an Adj-RIB-In must call [`RibManager::register_unicast_announcer`]
+/// (announce chunks, local injection, bench seeding — the only three
+/// insert sites). Removal seams (withdraw, session down, GR/LLGR sweeps,
+/// `EoR` clears, max-prefix teardown) need no hook: a peer that no longer
+/// holds the prefix is pruned lazily by the next `recompute_best` probe,
+/// costing one wasted Adj-RIB-In lookup until then.
+type UnicastPrefixPeers = rustc_hash::FxHashMap<Prefix, smallvec::SmallVec<[IpAddr; 1]>>;
+
 #[cfg(test)]
 use helpers::{ERR_REFRESH_TIMEOUT, LOCAL_PEER, validate_route_rpki};
 
@@ -69,6 +86,8 @@ impl RtcMembership {
 /// No `Arc<RwLock>` — all state is owned by this task.
 pub struct RibManager {
     ribs: HashMap<IpAddr, AdjRibIn>,
+    /// See [`UnicastPrefixPeers`] for the maintenance contract.
+    unicast_prefix_peers: UnicastPrefixPeers,
     loc_rib: LocRib,
     adj_ribs_out: HashMap<IpAddr, AdjRibOut>,
     outbound_peers: HashMap<IpAddr, mpsc::Sender<OutboundRouteUpdate>>,
@@ -570,6 +589,7 @@ impl RibManager {
         }
         Self {
             ribs: HashMap::new(),
+            unicast_prefix_peers: UnicastPrefixPeers::default(),
             loc_rib: LocRib::new(),
             adj_ribs_out: HashMap::new(),
             outbound_peers: HashMap::new(),
@@ -1393,6 +1413,7 @@ impl RibManager {
         let explanation = Self::explain_single_best_prefix(
             &self.loc_rib,
             &self.ribs,
+            &self.unicast_prefix_peers,
             &self.peer_is_rr_client,
             prefix,
             peer,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -851,6 +851,7 @@ impl RibManager {
                 let mut policy_filtered = Vec::new();
                 Self::distribute_multipath_prefix(
                     &self.ribs,
+                    &self.unicast_prefix_peers,
                     &initial_view,
                     &self.peer_is_rr_client,
                     prefix,
@@ -884,6 +885,7 @@ impl RibManager {
                 let mut policy_filtered = Vec::new();
                 Self::distribute_orr_best_prefix(
                     &self.ribs,
+                    &self.unicast_prefix_peers,
                     &initial_view,
                     &self.peer_is_rr_client,
                     orr_topology,

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -883,6 +883,7 @@ impl RibManager {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_multipath_prefix(
                         &self.ribs,
+                        &self.unicast_prefix_peers,
                         &refresh_view,
                         &self.peer_is_rr_client,
                         prefix,
@@ -914,6 +915,7 @@ impl RibManager {
                     let mut policy_filtered = Vec::new();
                     Self::distribute_orr_best_prefix(
                         &self.ribs,
+                        &self.unicast_prefix_peers,
                         &refresh_view,
                         &self.peer_is_rr_client,
                         orr_topology,

--- a/crates/rib/src/manager/tests/incremental_best.rs
+++ b/crates/rib/src/manager/tests/incremental_best.rs
@@ -1,0 +1,258 @@
+//! Differential proof for the incremental best-path recompute and the
+//! announcing-peers reverse index (`UnicastPrefixPeers`).
+//!
+//! Random operation sequences — announces (incl. same-peer attr changes,
+//! Add-Path ties, refresh-style replays), withdrawals, session teardown,
+//! GR stale marking, LLGR promotion, and `EoR` sweeps/clears — are applied
+//! through the same seams production uses. After every step:
+//!
+//! 1. the Loc-RIB best for every prefix must be IDENTICAL to a
+//!    from-scratch full-scan recompute over every peer's Adj-RIB-In (the
+//!    pre-index reference semantics), and
+//! 2. the reverse index must satisfy its never-under-count contract:
+//!    every (prefix, peer) pair present in an Adj-RIB-In is indexed
+//!    (over-counting is allowed — stale entries are pruned lazily).
+
+use std::time::Instant;
+
+use proptest::prelude::*;
+
+use super::*;
+use crate::loc_rib::LocRib;
+use crate::route::RouteOrigin;
+
+const FAMILY: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
+const PEERS: u8 = 4;
+const PREFIXES: u8 = 6;
+
+fn peer_addr(peer: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10 + peer))
+}
+
+fn prefix_of(index: u8) -> Prefix {
+    Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 100 + index, 0, 0), 16))
+}
+
+/// Deterministic route for (peer, prefix, `path_id`, variant). `variant`
+/// selects the attribute payload; it deliberately does NOT depend on
+/// `path_id`, so one peer announcing the same variant on two path IDs
+/// produces full-tie candidates (`best_path_cmp` Equal) — the case the
+/// announce fast path must hand to the full rescan.
+fn build_route(peer: u8, prefix: u8, path_id: u8, variant: u8, received_at: Instant) -> Route {
+    Route {
+        prefix: prefix_of(prefix),
+        next_hop: peer_addr(peer),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: peer_addr(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::LocalPref(100 + u32::from(variant % 2) * 10),
+            PathAttribute::Med(u32::from(variant)),
+        ]),
+        received_at,
+        origin_type: if peer < 2 {
+            RouteOrigin::Ebgp
+        } else {
+            RouteOrigin::Ibgp
+        },
+        peer_router_id: Ipv4Addr::new(192, 0, 2, peer),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: u32::from(path_id),
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Op {
+    /// Real announce path: `enqueue_routes_received` → chunk drain →
+    /// `recompute_best_after_announce`. Re-announcing an existing
+    /// (prefix, `path_id`) with a new variant is the same-peer attr-change /
+    /// refresh-replay case.
+    Announce { peer: u8, routes: Vec<(u8, u8, u8)> },
+    /// Real withdraw path → `recompute_best_after_withdraw`.
+    Withdraw { peer: u8, keys: Vec<(u8, u8)> },
+    /// Session teardown seam: Adj-RIB-In dropped whole, then a full
+    /// recompute of its prefixes (`clear_peer_adj_rib_in` shape).
+    SessionDown { peer: u8 },
+    /// RFC 4724 GR entry seam: mark the family stale (consecutive-restart
+    /// re-mark deletes already-stale routes), then recompute.
+    MarkStale { peer: u8 },
+    /// RFC 9494 promotion seam: GR-stale → LLGR-stale with in-place
+    /// `LLGR_STALE` community injection, then recompute.
+    PromoteLlgr { peer: u8 },
+    /// `EoR` seam: sweep still-stale + still-LLGR-stale routes, clear flags
+    /// on the retained ones, then recompute retained ∪ swept.
+    EorClear { peer: u8 },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    let route = (0..PREFIXES, 0u8..2, 0u8..3);
+    prop_oneof![
+        5 => (0..PEERS, proptest::collection::vec(route, 1..5))
+            .prop_map(|(peer, routes)| Op::Announce { peer, routes }),
+        3 => (0..PEERS, proptest::collection::vec((0..PREFIXES, 0u8..2), 1..5))
+            .prop_map(|(peer, keys)| Op::Withdraw { peer, keys }),
+        1 => (0..PEERS).prop_map(|peer| Op::SessionDown { peer }),
+        1 => (0..PEERS).prop_map(|peer| Op::MarkStale { peer }),
+        1 => (0..PEERS).prop_map(|peer| Op::PromoteLlgr { peer }),
+        1 => (0..PEERS).prop_map(|peer| Op::EorClear { peer }),
+    ]
+}
+
+fn apply(manager: &mut RibManager, op: &Op, received_at: Instant) {
+    match op {
+        Op::Announce { peer, routes } => {
+            let announced = routes
+                .iter()
+                .map(|&(prefix, path_id, variant)| {
+                    build_route(*peer, prefix, path_id, variant, received_at)
+                })
+                .collect();
+            manager.enqueue_routes_received(
+                peer_addr(*peer),
+                announced,
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+            );
+            drain_route_chunks(manager);
+        }
+        Op::Withdraw { peer, keys } => {
+            let withdrawn = keys
+                .iter()
+                .map(|&(prefix, path_id)| (prefix_of(prefix), u32::from(path_id)))
+                .collect();
+            manager.enqueue_routes_received(
+                peer_addr(*peer),
+                vec![],
+                withdrawn,
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+            );
+            drain_route_chunks(manager);
+        }
+        Op::SessionDown { peer } => {
+            if let Some(rib) = manager.ribs.remove(&peer_addr(*peer)) {
+                let affected: HashSet<Prefix> = rib.iter().map(|r| r.prefix).collect();
+                manager.recompute_best(&affected);
+            }
+        }
+        Op::MarkStale { peer } => {
+            if let Some(rib) = manager.ribs.get_mut(&peer_addr(*peer)) {
+                let mut affected: HashSet<Prefix> = rib.iter().map(|r| r.prefix).collect();
+                affected.extend(rib.mark_stale(FAMILY));
+                manager.recompute_best(&affected);
+            }
+        }
+        Op::PromoteLlgr { peer } => {
+            if let Some(rib) = manager.ribs.get_mut(&peer_addr(*peer)) {
+                let affected: HashSet<Prefix> =
+                    rib.promote_to_llgr_stale(FAMILY).into_iter().collect();
+                manager.recompute_best(&affected);
+            }
+        }
+        Op::EorClear { peer } => {
+            if let Some(rib) = manager.ribs.get_mut(&peer_addr(*peer)) {
+                let mut swept = rib.sweep_stale_family(FAMILY);
+                swept.extend(rib.sweep_llgr_stale_family(FAMILY));
+                rib.clear_stale(FAMILY);
+                let mut affected: HashSet<Prefix> = rib.iter().map(|r| r.prefix).collect();
+                affected.extend(swept);
+                manager.recompute_best(&affected);
+            }
+        }
+    }
+}
+
+/// Payload-identity comparison mirroring everything `LocRib::recompute`'s
+/// change detection can observe, minus `received_at` (an unchanged best is
+/// deliberately not reinstalled, so its clone keeps the older timestamp).
+fn same_route(a: &Route, b: &Route) -> bool {
+    a.prefix == b.prefix
+        && a.peer == b.peer
+        && a.path_id == b.path_id
+        && a.next_hop == b.next_hop
+        && a.link_local_next_hop == b.link_local_next_hop
+        && a.next_hop_scope == b.next_hop_scope
+        && a.peer_router_id == b.peer_router_id
+        && a.is_stale == b.is_stale
+        && a.is_llgr_stale == b.is_llgr_stale
+        && a.origin_type == b.origin_type
+        && a.validation_state == b.validation_state
+        && a.aspa_state == b.aspa_state
+        && a.attributes == b.attributes
+}
+
+fn check_invariants(manager: &RibManager, step: usize) {
+    // Index contract: never under-count. Every (prefix, peer) actually
+    // present in an Adj-RIB-In must be indexed.
+    for (peer, rib) in &manager.ribs {
+        for route in rib.iter() {
+            assert!(
+                manager
+                    .unicast_prefix_peers
+                    .get(&route.prefix)
+                    .is_some_and(|peers| peers.contains(peer)),
+                "step {step}: index under-counts: peer {peer} holds {} but is not indexed",
+                route.prefix,
+            );
+        }
+    }
+
+    // Loc-RIB equivalence: from-scratch full scan over every peer's
+    // Adj-RIB-In (the pre-index reference collection) must select a best
+    // identical to what the incremental/indexed path installed.
+    let mut reference = LocRib::new();
+    for index in 0..PREFIXES {
+        let prefix = prefix_of(index);
+        reference.recompute(
+            prefix,
+            manager
+                .ribs
+                .values()
+                .flat_map(|rib| rib.iter_prefix(&prefix)),
+        );
+        match (reference.get(&prefix), manager.loc_rib.get(&prefix)) {
+            (None, None) => {}
+            (Some(expected), Some(actual)) => assert!(
+                same_route(expected, actual),
+                "step {step}: best mismatch for {prefix}:\n expected {expected:?}\n actual {actual:?}",
+            ),
+            (expected, actual) => panic!(
+                "step {step}: best presence mismatch for {prefix}: \
+                 expected {expected:?}, actual {actual:?}",
+            ),
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 128,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn incremental_best_path_matches_full_rescan(
+        ops in proptest::collection::vec(op_strategy(), 1..80)
+    ) {
+        let (_tx, rx) = mpsc::channel(8);
+        let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+        let received_at = Instant::now();
+        for (step, op) in ops.iter().enumerate() {
+            apply(&mut manager, op, received_at);
+            check_invariants(&manager, step);
+        }
+    }
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -894,6 +894,7 @@ mod evpn;
 mod explain_mrt;
 mod flowspec;
 mod gr_llgr;
+mod incremental_best;
 mod labeled;
 mod lifecycle;
 mod llgr_families;


### PR DESCRIPTION
Flamegraph-proven fix for the #2 CPU sink: `recompute_best` probed every peer's Adj-RIB-In per affected prefix (40.7%→45.2% of churn CPU at 64→256 peers), and `LocRib::recompute` did a full candidate rescan even for plain announces.

## What

- **Announcing-peers reverse index**: `Prefix → SmallVec<[IpAddr; 1]>` on the manager (SmallVec precedent from #306). Insert seams: the only three unicast Adj-RIB-In insert sites in the tree. Removal needs no eager hooks — the index may over-count but never under-count, and stale entries are pruned lazily inside `recompute_best`'s probe pass (same pass that collects candidates; the BMP runner-up scan reuses the buffer, deleting its former second full scan). The index also drives multipath/ORR/explain/refresh/initial-dump collectors (6 call sites).
- **Incremental cases on announce** (enumerated in the doc comment): challenger strictly loses to the rib-resident best → skip (provably no change); strictly wins → singleton install, sound because `best_path_cmp` tiebreaks on peer address so cross-peer ties are impossible (total order) — gated on BMP-off since path-marking needs runner-up enumeration. Everything else (announcer owns the best, ties, missing entries, BMP on, withdraw of the best) falls back to the full **indexed** rescan — correctness over cleverness.

## Proof

- Proptest differential suite: 128 cases × ≤80 random ops (announce/withdraw/attr-change/Add-Path ties/session-down/GR marks/LLGR promote/EoR sweeps) through the real seams; after every step, Loc-RIB ≡ a from-scratch full-scan reference and the index never under-counts. **Mutation-validated**: four injected bugs each fail the suite; the one surviving mutant is proven equivalent (unreachable tie arm, recorded in a comment). Failure seeds checked into proptest-regressions.
- Full workspace suites green; fmt/clippy/doc/clippy-reasons clean; rebased over #674.

## Measured (rrharness, sequential same-host runs)

| churn-256 | before | after |
|---|---|---|
| recompute share of RR CPU | 46.9% | **0.5%** |
| churn waves / 20s | 46 | **82 (1.8×)** |
| flood-256 100k convergence | 15.2s | 15.1s (no regression) |

Post-fix churn CPU is 77.9% per-peer staging + 19.4% prepare/encode — the update-groups target, as predicted.