### PR TITLE
feat(rib): update-group shared staging with delta fanout (slice 2)

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -139,6 +139,16 @@ impl AdjRibOut {
             .map_or(&[], SmallVec::as_slice)
     }
 
+    /// Remove only the unicast routes and their secondary prefix index,
+    /// leaving every other family untouched. Used when a peer moves onto
+    /// the update-group path: its unicast advertised state becomes
+    /// group-owned while non-unicast families keep riding this per-peer
+    /// table.
+    pub fn clear_unicast(&mut self) {
+        self.routes.clear();
+        self.prefix_path_ids.clear();
+    }
+
     /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS,
     /// VPN, labeled-unicast, and RTC — and the secondary prefix index.
     pub fn clear(&mut self) {

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -270,7 +270,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — BGP-LS update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -482,7 +482,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — EVPN update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -396,7 +396,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — FlowSpec update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -563,7 +563,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — labeled update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -94,6 +94,78 @@ fn route_type_message(route_type: RouteType) -> &'static str {
     }
 }
 
+/// The consumer identity for the shared single-best export tail
+/// ([`RibManager::distribute_single_best_prefix`]): a concrete peer
+/// (today's per-peer path — split horizon against the peer,
+/// peer-context policy fields, direct per-peer counter recording) or a
+/// whole update group (shared staging — split horizon deferred to
+/// member emit via the source-flip matrix, peer-context-free chain by
+/// group eligibility, evaluations accumulated once and replayed per
+/// member as integer adds). ONE body serves both paths: the per-peer
+/// path stays the correctness oracle for the group path forever
+/// (design risk 1 — parameterized, never copied).
+pub(in crate::manager) enum ExportTarget<'a> {
+    Peer {
+        peer: IpAddr,
+        peer_asn: Option<u32>,
+        peer_group: Option<&'a str>,
+        metrics: &'a BgpMetrics,
+        policy_stats: &'a mut NeighborPolicyStats,
+        peer_label: &'a str,
+    },
+    Group {
+        evals: &'a mut super::update_groups::GroupEvalAccumulator,
+    },
+}
+
+impl ExportTarget<'_> {
+    /// The peer to apply split horizon against; `None` for group
+    /// staging (lifted out — applied per member at emit time).
+    fn split_horizon_peer(&self) -> Option<IpAddr> {
+        match self {
+            Self::Peer { peer, .. } => Some(*peer),
+            Self::Group { .. } => None,
+        }
+    }
+
+    /// Peer-context fields for the policy `RouteContext`. Group-staged
+    /// chains never read them (`requires_peer_context` disqualifies).
+    fn ctx_peer(&self) -> (Option<IpAddr>, Option<u32>, Option<&str>) {
+        match self {
+            Self::Peer {
+                peer,
+                peer_asn,
+                peer_group,
+                ..
+            } => (Some(*peer), *peer_asn, *peer_group),
+            Self::Group { .. } => (None, None, None),
+        }
+    }
+
+    /// Record one export-chain evaluation: directly per peer, or into
+    /// the group accumulator for per-member replay.
+    fn record_eval(&mut self, evaluation: &PolicyEvaluation, source: IpAddr) {
+        match self {
+            Self::Peer {
+                metrics,
+                policy_stats,
+                peer_label,
+                ..
+            } => record_export_policy_eval(metrics, policy_stats, peer_label, evaluation),
+            Self::Group { evals } => evals.record(evaluation, source),
+        }
+    }
+
+    /// Target stamped on policy-denial records; group records carry the
+    /// `LOCAL_PEER` placeholder and are restamped per member.
+    fn policy_filtered_target(&self) -> IpAddr {
+        match self {
+            Self::Peer { peer, .. } => *peer,
+            Self::Group { .. } => LOCAL_PEER,
+        }
+    }
+}
+
 fn record_export_policy_eval(
     metrics: &BgpMetrics,
     stats: &mut NeighborPolicyStats,
@@ -149,6 +221,12 @@ impl RibManager {
             return false;
         };
 
+        // A grouped member's unicast advertised state is group-owned
+        // (design §2: NO per-peer unicast storage) — skip the per-peer
+        // unicast commit and synthesize its gauge from the group table.
+        // Non-unicast families always commit per peer.
+        let grouped_unicast_count = self.grouped_advertised_count(peer);
+
         if !announce.is_empty()
             || !withdraw.is_empty()
             || !flowspec_announce.is_empty()
@@ -169,11 +247,13 @@ impl RibManager {
                 .adj_ribs_out
                 .entry(peer)
                 .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
-            for route in &announce {
-                rib_out.insert(route.clone());
-            }
-            for (prefix, path_id) in &withdraw {
-                rib_out.withdraw(prefix, *path_id);
+            if grouped_unicast_count.is_none() {
+                for route in &announce {
+                    rib_out.insert(route.clone());
+                }
+                for (prefix, path_id) in &withdraw {
+                    rib_out.withdraw(prefix, *path_id);
+                }
             }
             for route in &flowspec_announce {
                 rib_out.insert_flowspec(route.clone());
@@ -214,7 +294,7 @@ impl RibManager {
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
                 "all",
-                gauge_val(rib_out.len()),
+                gauge_val(grouped_unicast_count.unwrap_or_else(|| rib_out.len())),
             );
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
@@ -285,13 +365,22 @@ impl RibManager {
         }
 
         self.peer_export_policies.insert(peer, export_policy);
-        // Shadow-mode update-group fingerprint: recompute on the policy
-        // replacement seam (per-peer gRPC edits, ADR-0076 live-impact
-        // txns, and SIGHUP rpol overlays all funnel through this
-        // handler). Content-equality keying makes a reinstall of an
-        // identical chain key-stable — no regroup is recorded.
+        // Update-group membership recompute on the policy replacement
+        // seam (per-peer gRPC edits, ADR-0076 live-impact txns, and
+        // SIGHUP rpol overlays all funnel through this handler).
+        // Content-equality keying makes a reinstall of an identical
+        // chain key-stable — no regroup, and (key-stable fast path) NO
+        // resync either: a grouped member's staged output is a pure
+        // function of the key, so re-emitting would be a no-op flood.
+        // Everything else — regrouped members (one-shot baseline diff)
+        // and ungrouped peers (per-peer equality-suppressed diff) —
+        // takes the dirty resync exactly as before.
+        let before = self.grouped_member_of(peer);
         self.recompute_update_group(peer);
-        self.dirty_peers.insert(peer);
+        let key_stable = before.is_some() && before == self.grouped_member_of(peer);
+        if !key_stable {
+            self.mark_outbound_dirty(peer);
+        }
         self.distribute_changes(&HashSet::new(), &HashSet::new());
         let _ = reply.send(Ok(()));
     }
@@ -412,7 +501,7 @@ impl RibManager {
                     self.gr_deferred_eor.remove(&peer);
                 }
                 self.pending_eor.entry(peer).or_default().insert(family);
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
             self.force_outbound_peers.insert(peer);
             self.distribute_changes(&HashSet::new(), &HashSet::new());
@@ -863,7 +952,14 @@ impl RibManager {
         // this outlives the per-peer iteration deliberately, since the
         // win is identical modified attrs across peers sharing a chain.
         let mut export_memo = ExportMemo::default();
+        // Update-group shared staging: ONE export-tail pass per (group,
+        // changed prefix), committed to the group tables. The per-peer
+        // loop below emits the deltas per member via the source-flip
+        // matrix; disqualified peers take the per-peer staging path
+        // exactly as before.
+        let group_stage = self.stage_update_groups(best_changed, &mut export_memo);
         for peer in peers {
+            let member_of = self.grouped_member_of(peer);
             // For dirty peers, compute full prefix set from Loc-RIB + AdjRibOut
             let is_dirty = self.dirty_peers.contains(&peer);
             // `is_force` peers are dirty-equivalent for prefix enumeration AND
@@ -874,16 +970,34 @@ impl RibManager {
             let resync = is_dirty || is_force;
             let effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
                 let mut all: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
-                // For multi-path dirty resync, also include all Adj-RIB-In prefixes
-                if self.peer_has_any_add_path_send(peer) {
-                    for rib in self.ribs.values() {
-                        all.extend(rib.iter().map(|r| r.prefix));
+                if let Some(gid) = member_of {
+                    // A grouped member's advertised state is the group
+                    // table (plus any pending withdraw residue); the
+                    // per-peer Adj-RIB-Out holds no unicast for it.
+                    if let Some(group) = self.group_ribs.get(&gid) {
+                        all.extend(group.table.iter().map(|r| r.prefix));
+                        all.extend(group.tombstones.iter().map(|(p, _)| *p));
+                    }
+                    if let Some(base) = self.pending_regroup_baseline.get(&peer) {
+                        all.extend(base.keys().map(|(p, _)| *p));
+                    }
+                } else {
+                    // For multi-path dirty resync, also include all Adj-RIB-In prefixes
+                    if self.peer_has_any_add_path_send(peer) {
+                        for rib in self.ribs.values() {
+                            all.extend(rib.iter().map(|r| r.prefix));
+                        }
+                    }
+                    if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
+                        all.extend(rib_out.iter().map(|r| r.prefix));
                     }
                 }
-                if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter().map(|r| r.prefix));
-                }
                 Cow::Owned(all)
+            } else if member_of.is_some() {
+                // Grouped peers have no ORR / Add-Path extras (both are
+                // grouping disqualifiers): the group deltas cover
+                // exactly the best-changed set.
+                Cow::Borrowed(best_changed)
             } else {
                 // An RFC 9107 ORR peer selects from the per-target
                 // candidate set, not the Loc-RIB best — a candidate
@@ -1031,6 +1145,9 @@ impl RibManager {
                 // semantics. Same shape for `dirty_peers` for symmetry.
                 if is_dirty {
                     self.dirty_peers.remove(&peer);
+                    if member_of.is_some() {
+                        self.clear_grouped_member_synced(peer);
+                    }
                 }
                 if is_force {
                     self.force_outbound_peers.remove(&peer);
@@ -1055,6 +1172,46 @@ impl RibManager {
             let mut rtc_withdraw = Vec::new();
             let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> =
                 HashSet::new();
+
+            // Grouped member: the unicast portion comes from the group —
+            // source-flip matrix over this pass's deltas for a clean
+            // member, full-table replay (tombstone withdraws / regroup
+            // one-shot diff) for a resyncing one. No per-prefix staging,
+            // no policy eval: the shared group pass already ran once.
+            // Non-unicast families ride the per-peer path below
+            // unchanged, in the same OutboundRouteUpdate.
+            if let Some(gid) = member_of {
+                if let Some(group) = self.group_ribs.get(&gid) {
+                    if resync {
+                        Self::assemble_group_resync(
+                            group,
+                            peer,
+                            is_dirty,
+                            is_force,
+                            self.pending_regroup_baseline.get(&peer),
+                            self.pending_extra_withdraws.get(&peer),
+                            &mut announce,
+                            &mut withdraw,
+                            &mut nh_override_flags,
+                        );
+                    } else if let Some(stage) = group_stage.get(&gid) {
+                        super::update_groups::emit_group_deltas_for_member(
+                            &stage.deltas,
+                            peer,
+                            &mut announce,
+                            &mut withdraw,
+                            &mut nh_override_flags,
+                        );
+                    }
+                    current_policy_filtered_routes
+                        .extend(group.policy_filtered_for_member(peer, &effective_prefixes));
+                }
+                // Per-member export-policy counters from the group
+                // verdict — integer adds, no per-(prefix × peer) work.
+                if !resync && let Some(stage) = group_stage.get(&gid) {
+                    self.apply_group_policy_counters(peer, &stage.evals);
+                }
+            }
 
             // Resolve export policy, sendable families, and RR state before
             // borrowing rib_out (which holds a &mut to self.adj_ribs_out).
@@ -1105,8 +1262,16 @@ impl RibManager {
                 .entry(peer)
                 .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
 
-            // Stage: compute delta without mutating AdjRibOut
-            for prefix in &*effective_prefixes {
+            // Stage: compute delta without mutating AdjRibOut. Grouped
+            // members skip the per-prefix staging wholesale — their
+            // unicast update was assembled from the group table above.
+            let empty_prefixes: HashSet<Prefix> = HashSet::new();
+            let staging_prefixes: &HashSet<Prefix> = if member_of.is_none() {
+                &effective_prefixes
+            } else {
+                &empty_prefixes
+            };
+            for prefix in staging_prefixes {
                 let family = prefix_family(prefix);
                 // RFC 5291 §6 gate: suppress this family's advertisement (incl.
                 // ongoing churn) until the peer's first ROUTE-REFRESH lifts it.
@@ -1187,14 +1352,20 @@ impl RibManager {
                     current_policy_filtered_routes.extend(policy_filtered);
                 } else {
                     let mut policy_filtered = Vec::new();
+                    let mut target = ExportTarget::Peer {
+                        peer,
+                        peer_asn: target_peer_asn,
+                        peer_group: target_peer_group,
+                        metrics: &metrics,
+                        policy_stats: &mut *policy_stats,
+                        peer_label: &target_peer_label,
+                    };
                     Self::distribute_single_best_prefix(
                         loc_rib,
                         rib_out,
                         &self.peer_is_rr_client,
                         prefix,
-                        peer,
-                        target_peer_asn,
-                        target_peer_group,
+                        &mut target,
                         target_is_ebgp,
                         target_is_rr_client,
                         cluster_id,
@@ -1203,9 +1374,6 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf,
                         &mut export_memo,
-                        &metrics,
-                        policy_stats,
-                        &target_peer_label,
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
@@ -1436,6 +1604,9 @@ impl RibManager {
                         );
                         if is_dirty {
                             self.dirty_peers.remove(&peer);
+                            if member_of.is_some() {
+                                self.clear_grouped_member_synced(peer);
+                            }
                             if pending_eor.is_empty() {
                                 self.flush_pending_eor(peer);
                             } else {
@@ -1453,7 +1624,17 @@ impl RibManager {
                 } else {
                     warn!(%peer, "outbound channel full or closed — marking dirty for resync");
                     self.metrics.record_outbound_route_drop(&peer.to_string());
-                    self.dirty_peers.insert(peer);
+                    self.mark_outbound_dirty(peer);
+                    // A grouped member that just went dirty missed this
+                    // pass's withdrawals: record them as tombstones so
+                    // its resync can (over-)withdraw them.
+                    if let Some(gid) = member_of
+                        && let Some(stage) = group_stage.get(&gid)
+                        && let Some(group) = self.group_ribs.get_mut(&gid)
+                    {
+                        let withdrawn: Vec<(Prefix, u32)> = stage.withdrawn_keys().collect();
+                        group.tombstones.extend(withdrawn);
+                    }
                 }
             } else {
                 self.update_policy_filtered_routes_for_prefixes(
@@ -1466,6 +1647,9 @@ impl RibManager {
                     debug!(%peer, "outbound routes unchanged after resync");
                     if is_dirty {
                         self.dirty_peers.remove(&peer);
+                        if member_of.is_some() {
+                            self.clear_grouped_member_synced(peer);
+                        }
                         self.flush_pending_eor(peer);
                         self.retry_pending_refresh(peer);
                     }

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -290,7 +290,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — RTC update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -705,19 +705,23 @@ impl RibManager {
         }
     }
 
+    /// Single-best export tail for one prefix. `target` selects the
+    /// consumer: a concrete peer (per-peer path) or an update group
+    /// (shared staging with `rib_out` = the group table and split
+    /// horizon lifted out to member-emit time). ONE body serves both —
+    /// the per-peer path is the group path's correctness oracle
+    /// (design risk 1: parameterized, never copied).
     #[expect(
         clippy::too_many_arguments,
         clippy::too_many_lines,
-        reason = "single-best export keeps peer, policy, and Adj-RIB-Out diff state together"
+        reason = "single-best export keeps target, policy, and Adj-RIB-Out diff state together"
     )]
     pub(in crate::manager) fn distribute_single_best_prefix(
         loc_rib: &LocRib,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         prefix: &Prefix,
-        target_peer: IpAddr,
-        target_peer_asn: Option<u32>,
-        target_peer_group: Option<&str>,
+        target: &mut super::ExportTarget<'_>,
         target_is_ebgp: bool,
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
@@ -726,9 +730,6 @@ impl RibManager {
         export_pol: Option<&PolicyChain>,
         orf_filter: Option<&crate::orf::OrfFilterSet>,
         memo: &mut super::ExportMemo,
-        metrics: &BgpMetrics,
-        policy_stats: &mut NeighborPolicyStats,
-        target_peer_label: &str,
         announce: &mut Vec<crate::route::Route>,
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<rustbgpd_policy::NextHopAction>>,
@@ -744,8 +745,10 @@ impl RibManager {
             return;
         };
 
-        // Split horizon: don't send route back to its source
-        if best.peer == target_peer {
+        // Split horizon: don't send route back to its source. Group
+        // staging has no single target — the source-flip matrix applies
+        // this per member at emit time.
+        if target.split_horizon_peer() == Some(best.peer) {
             for &path_id in existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
@@ -801,11 +804,15 @@ impl RibManager {
             return;
         }
 
-        // Export policy check
+        // Export policy check. Group staging passes no peer-context
+        // fields: a chain that reads them disqualifies its peers from
+        // grouping (`requires_peer_context`), so the verdict here is
+        // target-independent by construction.
         let aspath_str = export_pol
             .is_some_and(PolicyChain::requires_as_path_string)
             .then(|| memo.aspath_str(best));
         let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+        let (peer_address, peer_asn, peer_group) = target.ctx_peer();
         let ctx = RouteContext {
             prefix: Some(*prefix),
             next_hop: Some(best.next_hop),
@@ -816,19 +823,19 @@ impl RibManager {
             as_path_len: aspath_len,
             validation_state: best.validation_state,
             aspa_state: best.aspa_state,
-            peer_address: Some(target_peer),
-            peer_asn: target_peer_asn,
-            peer_group: target_peer_group,
+            peer_address,
+            peer_asn,
+            peer_group,
             route_type: Some(route_type(best.origin_type)),
             evpn_route_type: None,
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
         let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
-        record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+        target.record_eval(&evaluation, best.peer);
         if result.action != PolicyAction::Permit {
             policy_filtered.push(PolicyFilteredRouteKey {
-                target_peer,
+                target_peer: target.policy_filtered_target(),
                 source_peer: best.peer,
                 prefix: *prefix,
                 path_id: best.path_id,

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -615,7 +615,7 @@ impl RibManager {
                 )
             {
                 warn!(%peer, "outbound channel full — VPN update deferred");
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -310,10 +310,33 @@ pub struct RibManager {
     /// re-arm) becomes deterministically observable. `None` in
     /// production — the only cost when unset is an `is_some()` check.
     test_ingest_stall: Option<std::time::Duration>,
-    /// Update-group fingerprint registry (shadow mode, slice 1):
-    /// records which peers *could* share staged output and why the
-    /// rest can't. Distribution never reads it yet.
+    /// Update-group fingerprint registry (slice 1): membership (group
+    /// id or ungrouped reason) per registered peer. Since slice 2 the
+    /// distribution path reads it: grouped peers share the staged
+    /// tables in `group_ribs`; ungrouped peers keep the per-peer path.
     update_groups: update_groups::UpdateGroupRegistry,
+    /// Group-owned staged outbound tables, keyed by group id. One per
+    /// non-empty group; created (and built with a single shared staging
+    /// pass) at the first member's join, dropped at the last member's
+    /// leave. See [`update_groups::GroupRibOut`].
+    group_ribs: HashMap<usize, update_groups::GroupRibOut>,
+    /// A regrouped member's previously-advertised unicast view (old
+    /// group table minus own-sourced, or the per-peer Adj-RIB-Out),
+    /// held until its one-shot resync diff succeeds. Transient —
+    /// regroups are config-time events.
+    pending_regroup_baseline:
+        HashMap<IpAddr, rustc_hash::FxHashMap<(Prefix, u32), crate::route::Route>>,
+    /// Extra (over-)withdraw keys a member must emit on its next
+    /// resync: tombstones carried across a regroup by a member that was
+    /// dirty when it moved (its missed withdrawals are unknown —
+    /// over-withdraw is the safe direction). Cleared on resync success.
+    pending_extra_withdraws: HashMap<IpAddr, HashSet<(Prefix, u32)>>,
+    /// Differential-oracle test hook: disqualify every peer from
+    /// grouping so identical scenarios can be driven through the
+    /// per-peer path (the correctness oracle) and compared against a
+    /// grouped run.
+    #[cfg(test)]
+    test_force_ungrouped: bool,
 }
 
 /// Bound on `live_sessions` entries per peer address. The RFC 4271 §6.8
@@ -634,6 +657,11 @@ impl RibManager {
             peer_group: HashMap::new(),
             peer_bgp_id: HashMap::new(),
             update_groups: update_groups::UpdateGroupRegistry::default(),
+            group_ribs: HashMap::new(),
+            pending_regroup_baseline: HashMap::new(),
+            pending_extra_withdraws: HashMap::new(),
+            #[cfg(test)]
+            test_force_ungrouped: false,
             vrp_table: None,
             aspa_table: None,
             route_events_tx,
@@ -1378,11 +1406,14 @@ impl RibManager {
         peer: IpAddr,
         reply: tokio::sync::oneshot::Sender<Vec<crate::route::Route>>,
     ) {
-        let routes: Vec<_> = self
-            .adj_ribs_out
-            .get(&peer)
-            .map(|rib| rib.iter().cloned().collect())
-            .unwrap_or_default();
+        // A grouped member holds no per-peer unicast Adj-RIB-Out; its
+        // advertised set is synthesized: group table − own-sourced.
+        let routes: Vec<_> = self.grouped_advertised_routes(peer).unwrap_or_else(|| {
+            self.adj_ribs_out
+                .get(&peer)
+                .map(|rib| rib.iter().cloned().collect())
+                .unwrap_or_default()
+        });
 
         if reply.send(routes).is_err() {
             warn!("query caller dropped before receiving response");
@@ -1877,7 +1908,10 @@ impl RibManager {
         peer: IpAddr,
         reply: tokio::sync::oneshot::Sender<usize>,
     ) {
-        let count = self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len);
+        // Grouped members synthesize: group table len − own-sourced.
+        let count = self
+            .grouped_advertised_count(peer)
+            .unwrap_or_else(|| self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len));
         let _ = reply.send(count);
     }
 
@@ -1885,11 +1919,27 @@ impl RibManager {
         &mut self,
         reply: tokio::sync::oneshot::Sender<crate::update::AdjRibOutCounts>,
     ) {
-        let counts = self
+        let mut counts: crate::update::AdjRibOutCounts = self
             .adj_ribs_out
             .iter()
             .map(|(peer, rib)| (*peer, rib.family_counts()))
             .collect();
+        // Grouped members hold no per-peer unicast entries: synthesize
+        // their unicast family counts from the group tables (BMP RFC
+        // 8671 stat type 17 must not report zero for them).
+        for (&peer, membership) in &self.update_groups.members {
+            let update_groups::GroupMembership::Grouped(gid) = membership else {
+                continue;
+            };
+            let Some(group) = self.group_ribs.get(gid) else {
+                continue;
+            };
+            let synthesized = group.family_counts_for(peer);
+            if synthesized.is_empty() {
+                continue;
+            }
+            counts.entry(peer).or_default().extend(synthesized);
+        }
         let _ = reply.send(counts);
     }
 
@@ -2208,7 +2258,7 @@ impl RibManager {
         }
         self.peer_rt_membership.insert(peer, membership);
         if self.outbound_peers.contains_key(&peer) {
-            self.dirty_peers.insert(peer);
+            self.mark_outbound_dirty(peer);
             self.distribute_changes(&HashSet::new(), &HashSet::new());
         }
     }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -466,6 +466,8 @@ impl RibManager {
         // totals can subtract Prometheus snapshots
         // (`bgp_policy_routes_total` is monotonic per process).
         self.export_policy_stats.remove(&peer);
+        self.pending_regroup_baseline.remove(&peer);
+        self.pending_extra_withdraws.remove(&peer);
         self.remove_update_group_member(peer);
         self.clear_peer_refresh_state(peer);
     }
@@ -801,7 +803,8 @@ impl RibManager {
         let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
         let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
         let target_peer_asn = self.peer_asn.get(&peer).copied();
-        let target_peer_group = self.peer_group.get(&peer).map(String::as_str);
+        // Owned so no `&self` borrow spans the join-counters call below.
+        let target_peer_group = self.peer_group.get(&peer).cloned();
         let cluster_id = self.cluster_id;
         let peer_add_path_send_max = self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0);
         let peer_add_path_send_families = self
@@ -809,19 +812,8 @@ impl RibManager {
             .get(&peer)
             .cloned()
             .unwrap_or_default();
-        // RFC 9107 ORR: a late-joining peer bound to a resolved vantage
-        // gets the per-vantage best in its initial dump (the SPF was
-        // seeded at PeerUp); an unresolved vantage falls back to the
-        // standard single-best.
-        let orr_ctx = self
-            .peer_orr_vantage
-            .get(&peer)
-            .and_then(|vantage| self.orr.spf.get(vantage))
-            .map(|spf| (&self.orr.topology, spf));
-        let loc_rib = &self.loc_rib;
         let target_peer_label = peer.to_string();
         let metrics = self.metrics.clone();
-        let policy_stats = self.export_policy_stats.entry(peer).or_default();
 
         let mut all_prefixes: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
         for rib in self.ribs.values() {
@@ -836,7 +828,48 @@ impl RibManager {
         // set share the post-modification attributes across this dump.
         let mut export_memo = super::distribution::ExportMemo::default();
 
-        for prefix in &all_prefixes {
+        // A grouped member's initial unicast dump is a replay of the
+        // group table minus its own-sourced entries — the export tail
+        // already ran when the table was built (design §4: join pays no
+        // per-prefix staging walk). The loop below is the ungrouped
+        // path; grouped peers skip it (empty staging set).
+        let member_of = self.grouped_member_of(peer);
+        if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {
+            for route in group.table.iter() {
+                if route.peer == peer {
+                    continue;
+                }
+                nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
+                announce.push(route.clone());
+            }
+            current_policy_filtered_routes
+                .extend(group.policy_filtered_for_member(peer, &all_prefixes));
+        }
+        if let Some(gid) = member_of {
+            // Export counters for the join, reconstructed from the
+            // group's staged residue (per-peer initial-dump parity).
+            self.apply_group_join_counters(peer, gid);
+        }
+        let empty_prefixes: HashSet<Prefix> = HashSet::new();
+        let staging_prefixes = if member_of.is_none() {
+            &all_prefixes
+        } else {
+            &empty_prefixes
+        };
+        // RFC 9107 ORR: a late-joining peer bound to a resolved vantage
+        // gets the per-vantage best in its initial dump (the SPF was
+        // seeded at PeerUp); an unresolved vantage falls back to the
+        // standard single-best. Resolved after the group-join counter
+        // replay above (which needs `&mut self`; ORR peers are never
+        // grouped, so ordering is free).
+        let orr_ctx = self
+            .peer_orr_vantage
+            .get(&peer)
+            .and_then(|vantage| self.orr.spf.get(vantage))
+            .map(|spf| (&self.orr.topology, spf));
+        let loc_rib = &self.loc_rib;
+        let policy_stats = self.export_policy_stats.entry(peer).or_default();
+        for prefix in staging_prefixes {
             if orf_gated.contains(&prefix_family(prefix)) {
                 continue;
             }
@@ -857,7 +890,7 @@ impl RibManager {
                     prefix,
                     peer,
                     target_peer_asn,
-                    target_peer_group,
+                    target_peer_group.as_deref(),
                     prefix_send_max,
                     target_is_ebgp,
                     target_is_rr_client,
@@ -893,7 +926,7 @@ impl RibManager {
                     prefix,
                     peer,
                     target_peer_asn,
-                    target_peer_group,
+                    target_peer_group.as_deref(),
                     target_is_ebgp,
                     target_is_rr_client,
                     cluster_id,
@@ -916,14 +949,20 @@ impl RibManager {
                 current_policy_filtered_routes.extend(policy_filtered);
             } else {
                 let mut policy_filtered = Vec::new();
+                let mut target = super::distribution::ExportTarget::Peer {
+                    peer,
+                    peer_asn: target_peer_asn,
+                    peer_group: target_peer_group.as_deref(),
+                    metrics: &metrics,
+                    policy_stats: &mut *policy_stats,
+                    peer_label: &target_peer_label,
+                };
                 Self::distribute_single_best_prefix(
                     loc_rib,
                     &initial_view,
                     &self.peer_is_rr_client,
                     prefix,
-                    peer,
-                    target_peer_asn,
-                    target_peer_group,
+                    &mut target,
                     target_is_ebgp,
                     target_is_rr_client,
                     cluster_id,
@@ -934,9 +973,6 @@ impl RibManager {
                     // has no installed filter during the initial dump.
                     None,
                     &mut export_memo,
-                    &metrics,
-                    policy_stats,
-                    &target_peer_label,
                     &mut announce,
                     &mut withdraw,
                     &mut nh_override_flags,
@@ -960,7 +996,7 @@ impl RibManager {
                 &all_flowspec_rules,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -992,7 +1028,7 @@ impl RibManager {
                 &all_evpn_keys,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1021,7 +1057,7 @@ impl RibManager {
                 &all_bgpls_keys,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1064,7 +1100,7 @@ impl RibManager {
                 &all_l3vpn_keys,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1111,7 +1147,7 @@ impl RibManager {
                 &all_labeled_keys,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1146,7 +1182,7 @@ impl RibManager {
                 &all_rtc_keys,
                 peer,
                 target_peer_asn,
-                target_peer_group,
+                target_peer_group.as_deref(),
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1234,7 +1270,7 @@ impl RibManager {
             for f in &eor_families {
                 self.pending_eor.entry(peer).or_default().insert(*f);
             }
-            self.dirty_peers.insert(peer);
+            self.mark_outbound_dirty(peer);
             return;
         }
         self.update_policy_filtered_routes_for_prefixes(
@@ -1272,7 +1308,7 @@ impl RibManager {
                 for f in &eor_families {
                     self.pending_eor.entry(peer).or_default().insert(*f);
                 }
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
             }
         }
     }

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -944,14 +944,20 @@ impl RibManager {
                     current_policy_filtered_routes.extend(policy_filtered);
                 } else {
                     let mut policy_filtered = Vec::new();
+                    let mut target = super::distribution::ExportTarget::Peer {
+                        peer,
+                        peer_asn: target_peer_asn,
+                        peer_group: target_peer_group,
+                        metrics: &metrics,
+                        policy_stats: &mut *policy_stats,
+                        peer_label: &target_peer_label,
+                    };
                     Self::distribute_single_best_prefix(
                         loc_rib,
                         &refresh_view,
                         &self.peer_is_rr_client,
                         prefix,
-                        peer,
-                        target_peer_asn,
-                        target_peer_group,
+                        &mut target,
                         target_is_ebgp,
                         target_is_rr_client,
                         cluster_id,
@@ -960,9 +966,6 @@ impl RibManager {
                         export_pol.as_ref(),
                         orf_filter.as_ref(),
                         &mut export_memo,
-                        &metrics,
-                        policy_stats,
-                        &target_peer_label,
                         &mut announce,
                         &mut withdraw,
                         &mut nh_override_flags,
@@ -1016,7 +1019,7 @@ impl RibManager {
                 warn!(%peer, ?family, "outbound channel full during route refresh response");
                 self.metrics.record_outbound_route_drop(&peer.to_string());
                 self.pending_refresh.entry(peer).or_default().insert(family);
-                self.dirty_peers.insert(peer);
+                self.mark_outbound_dirty(peer);
                 return;
             }
             self.update_policy_filtered_routes_for_prefixes(
@@ -1086,7 +1089,7 @@ impl RibManager {
         if tx.try_send(eor).is_err() {
             warn!(%peer, "outbound channel full — `EoR` still deferred");
             self.pending_eor.insert(peer, families);
-            self.dirty_peers.insert(peer);
+            self.mark_outbound_dirty(peer);
         }
     }
 

--- a/crates/rib/src/manager/tests/lifecycle.rs
+++ b/crates/rib/src/manager/tests/lifecycle.rs
@@ -9,7 +9,12 @@ async fn channel_full_marks_dirty_and_resyncs() {
     tokio::time::pause();
 
     let (tx, rx) = mpsc::channel(64);
-    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // Pin the PER-PEER path: commit-after-send is a per-peer AdjRibOut
+    // discipline (a grouped member's advertised view is synthesized from
+    // the group table, which advances at staging time and heals via the
+    // dirty resync — covered by the update-group differential tests).
+    manager.test_force_ungrouped = true;
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
@@ -296,7 +301,12 @@ async fn dirty_resync_not_starved_by_query_traffic() {
 #[tokio::test]
 async fn initial_dump_failure_leaves_adjribout_empty() {
     let (tx, rx) = mpsc::channel(64);
-    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // Pin the PER-PEER path: commit-after-send is a per-peer AdjRibOut
+    // discipline (a grouped member's advertised view is synthesized from
+    // the group table, which advances at staging time and heals via the
+    // dirty resync — covered by the update-group differential tests).
+    manager.test_force_ungrouped = true;
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
@@ -363,7 +373,12 @@ async fn initial_dump_failure_resyncs_via_timer() {
     tokio::time::pause();
 
     let (tx, rx) = mpsc::channel(64);
-    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // Pin the PER-PEER path: commit-after-send is a per-peer AdjRibOut
+    // discipline (a grouped member's advertised view is synthesized from
+    // the group table, which advances at staging time and heals via the
+    // dirty resync — covered by the update-group differential tests).
+    manager.test_force_ungrouped = true;
     let handle = tokio::spawn(manager.run());
 
     let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -907,4 +907,5 @@ mod rpki;
 mod rtc;
 mod unicast;
 mod update_groups;
+mod update_groups_oracle;
 mod vpn;

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -1,0 +1,572 @@
+//! Differential oracle for update-group staging (design risk 1).
+//!
+//! Every scenario runs twice through the REAL manager task: once with
+//! grouping live and once with the `test_force_ungrouped` hook putting
+//! every peer on the per-peer path — the correctness oracle. The
+//! per-peer outbound streams must be IDENTICAL message for message
+//! (announces normalized by sort; intra-message ordering is `HashSet`
+//! iteration order and deliberately not part of the contract).
+//!
+//! The one scenario compared by FINAL ADVERTISED STATE instead of exact
+//! streams is the dirty-member resync: a grouped member keeps no
+//! per-peer advertised record, so its resync deliberately over-emits
+//! (full-table announce + tombstone over-withdraw — the safe
+//! direction) where the per-peer path diffs against Adj-RIB-Out. The
+//! folded end state must still be identical.
+
+use std::collections::BTreeMap;
+
+use rustbgpd_policy::{
+    NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+};
+
+use super::*;
+use crate::route::RouteOrigin;
+
+const SESSION: u64 = 1;
+
+/// An iBGP-learned route fixture: `LOCAL_PREF` ranks it, optional
+/// communities ride along (e.g. `COMMUNITY_LLGR_STALE`).
+fn ibgp_route(prefix: Ipv4Prefix, src: Ipv4Addr, local_pref: u32, communities: Vec<u32>) -> Route {
+    let mut attributes = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        PathAttribute::LocalPref(local_pref),
+    ];
+    if !communities.is_empty() {
+        attributes.push(PathAttribute::Communities(communities));
+    }
+    Route {
+        prefix: Prefix::V4(prefix),
+        next_hop: IpAddr::V4(src),
+        link_local_next_hop: None,
+        next_hop_scope: None,
+        peer: IpAddr::V4(src),
+        attributes: Arc::new(attributes),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+    }
+}
+
+fn pfx(a: u8, b: u8) -> Ipv4Prefix {
+    Ipv4Prefix::new(Ipv4Addr::new(10, 200, a, b), 24)
+}
+
+fn permit_all_with(modifications: RouteModifications) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications,
+        }],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+fn deny_prefix_chain(prefix: Ipv4Prefix) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: Some(Prefix::V4(prefix)),
+            ge: None,
+            le: None,
+            action: PolicyAction::Deny,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications::default(),
+        }],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+/// One outbound message, normalized: announces carry everything the
+/// wire path consumes (route identity, next hop, source, attributes,
+/// aligned next-hop-override flag), sorted so intra-message iteration
+/// order is not compared.
+/// (prefix, path id, next hop, source peer, attributes, nh-override).
+type NormAnnounce = (
+    Prefix,
+    u32,
+    IpAddr,
+    IpAddr,
+    Vec<PathAttribute>,
+    Option<NextHopAction>,
+);
+
+#[derive(Debug, PartialEq, Clone)]
+struct NormMsg {
+    announce: Vec<NormAnnounce>,
+    withdraw: Vec<(Prefix, u32)>,
+    end_of_rib: Vec<(Afi, Safi)>,
+}
+
+fn normalize(update: &OutboundRouteUpdate) -> NormMsg {
+    let mut announce: Vec<_> = update
+        .announce
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            (
+                r.prefix,
+                r.path_id,
+                r.next_hop,
+                r.peer,
+                (*r.attributes).clone(),
+                update.next_hop_override.get(i).cloned().flatten(),
+            )
+        })
+        .collect();
+    // `Prefix`/`Afi`/`Safi` don't implement `Ord` — sort textually
+    // (comparison stability is all that matters here).
+    announce.sort_by_key(|entry| (entry.0.to_string(), entry.1));
+    let mut withdraw = update.withdraw.clone();
+    withdraw.sort_by_key(|(prefix, path_id)| (prefix.to_string(), *path_id));
+    let mut end_of_rib = update.end_of_rib.clone();
+    end_of_rib.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+    NormMsg {
+        announce,
+        withdraw,
+        end_of_rib,
+    }
+}
+
+type Streams = BTreeMap<IpAddr, Vec<NormMsg>>;
+
+/// Fold a stream into the final advertised state (announce replaces,
+/// withdraw removes; unknown withdraws are RFC 4271 no-ops).
+/// (next hop, source peer, attributes, nh-override).
+type FoldedEntry = (IpAddr, IpAddr, Vec<PathAttribute>, Option<NextHopAction>);
+type FoldedState = BTreeMap<IpAddr, HashMap<(Prefix, u32), FoldedEntry>>;
+
+fn fold(streams: &Streams) -> FoldedState {
+    let mut state = FoldedState::new();
+    for (peer, msgs) in streams {
+        let table = state.entry(*peer).or_default();
+        for msg in msgs {
+            for (prefix, path_id) in &msg.withdraw {
+                table.remove(&(*prefix, *path_id));
+            }
+            for (prefix, path_id, nh, src, attrs, nh_override) in &msg.announce {
+                table.insert(
+                    (*prefix, *path_id),
+                    (*nh, *src, attrs.clone(), nh_override.clone()),
+                );
+            }
+        }
+    }
+    state
+}
+
+struct Oracle {
+    tx: mpsc::Sender<RibUpdate>,
+    outs: BTreeMap<IpAddr, mpsc::Receiver<OutboundRouteUpdate>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Oracle {
+    fn spawn(force_ungrouped: bool, cluster_id: Option<Ipv4Addr>) -> Self {
+        let (tx, rx) = mpsc::channel(512);
+        let mut manager =
+            RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
+        manager.test_force_ungrouped = force_ungrouped;
+        let handle = tokio::spawn(manager.run());
+        Self {
+            tx,
+            outs: BTreeMap::new(),
+            handle,
+        }
+    }
+
+    async fn peer_up(
+        &mut self,
+        peer: Ipv4Addr,
+        is_ebgp: bool,
+        route_reflector_client: bool,
+        export_policy: Option<PolicyChain>,
+        capacity: usize,
+    ) {
+        let (out_tx, out_rx) = mpsc::channel(capacity);
+        self.tx
+            .send(RibUpdate::PeerUp {
+                session_id: SESSION,
+                peer: IpAddr::V4(peer),
+                peer_asn: if is_ebgp { 65010 } else { 65000 },
+                peer_router_id: peer,
+                outbound_tx: out_tx,
+                export_policy,
+                sendable_families: ipv4_sendable(),
+                is_ebgp,
+                route_reflector_client,
+                orr_vantage: None,
+                add_path_send_families: vec![],
+                add_path_send_max: 0,
+                negotiated_orf_recv: Vec::new(),
+                negotiated_llgr_families: Vec::new(),
+            })
+            .await
+            .unwrap();
+        self.outs.insert(IpAddr::V4(peer), out_rx);
+        self.quiesce().await;
+    }
+
+    async fn peer_down(&mut self, peer: Ipv4Addr) {
+        self.tx
+            .send(RibUpdate::PeerDown {
+                peer: IpAddr::V4(peer),
+                session_id: SESSION,
+            })
+            .await
+            .unwrap();
+        self.quiesce().await;
+    }
+
+    async fn routes(&mut self, from: Ipv4Addr, announce: Vec<Route>, withdraw: Vec<Ipv4Prefix>) {
+        self.tx
+            .send(RibUpdate::RoutesReceived {
+                session_id: SESSION,
+                peer: IpAddr::V4(from),
+                announced: announce,
+                withdrawn: withdraw.into_iter().map(|p| (Prefix::V4(p), 0)).collect(),
+                flowspec_announced: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            })
+            .await
+            .unwrap();
+        self.quiesce().await;
+    }
+
+    async fn replace_policy(&mut self, peer: Ipv4Addr, export_policy: Option<PolicyChain>) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::ReplacePeerExportPolicy {
+                peer: IpAddr::V4(peer),
+                export_policy,
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap().unwrap();
+    }
+
+    async fn refresh_outbound(&mut self, peer: Ipv4Addr) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::RefreshPeerOutbound {
+                peer: IpAddr::V4(peer),
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap().unwrap();
+    }
+
+    /// Round-trip a query on the primary channel: the run loop only
+    /// handles it after every prior update (and its route chunks) has
+    /// been fully processed, so all resulting outbound sends have
+    /// happened by the time the reply arrives.
+    async fn quiesce(&mut self) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::QueryBestRoutes { reply: reply_tx })
+            .await
+            .unwrap();
+        let _ = reply_rx.await.unwrap();
+    }
+
+    /// Drain one pending message from a peer's channel (channel-fill
+    /// scenarios).
+    async fn drain_one(&mut self, peer: Ipv4Addr) -> OutboundRouteUpdate {
+        self.outs
+            .get_mut(&IpAddr::V4(peer))
+            .expect("peer registered")
+            .recv()
+            .await
+            .expect("message pending")
+    }
+
+    /// Collect every message every peer has received so far. Messages
+    /// drained early via `drain_one` are NOT re-collected — scenarios
+    /// that pre-drain must compare folded state, not streams.
+    async fn finish(mut self) -> Streams {
+        self.quiesce().await;
+        let mut streams = Streams::new();
+        for (peer, rx) in &mut self.outs {
+            let mut msgs = Vec::new();
+            while let Ok(update) = rx.try_recv() {
+                msgs.push(normalize(&update));
+            }
+            streams.insert(*peer, msgs);
+        }
+        drop(self.tx);
+        self.handle.await.unwrap();
+        streams
+    }
+}
+
+const A: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+const B: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
+const C: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 3);
+const D: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 4);
+const E: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 5);
+const F: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 6);
+
+async fn run_grouped_and_ungrouped<S>(
+    cluster_id: Option<Ipv4Addr>,
+    scenario: S,
+) -> (Streams, Streams)
+where
+    S: AsyncFn(&mut Oracle),
+{
+    let mut grouped = Oracle::spawn(false, cluster_id);
+    scenario(&mut grouped).await;
+    let grouped = grouped.finish().await;
+    let mut ungrouped = Oracle::spawn(true, cluster_id);
+    scenario(&mut ungrouped).await;
+    let ungrouped = ungrouped.finish().await;
+    (grouped, ungrouped)
+}
+
+/// The kitchen-sink exact-stream scenario: initial dump, best change,
+/// best withdraw, split horizon (source inside the group), source-flip
+/// X→Y→X, policy-modified attributes, next-hop-override flags,
+/// RR-client vs non-client groups, eBGP LLGR suppression, member join
+/// mid-stream, leave, regroup on policy change (content-equal reinstall
+/// AND a genuine change), and a GShut-style forced refresh.
+#[tokio::test]
+async fn oracle_streams_identical_across_rr_mix() {
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let modifying_chain = || {
+        permit_all_with(RouteModifications {
+            set_med: Some(77),
+            communities_add: vec![0xFDE8_0001],
+            set_next_hop: Some(NextHopAction::Specific(IpAddr::V4(Ipv4Addr::new(
+                198, 51, 100, 99,
+            )))),
+            ..RouteModifications::default()
+        })
+    };
+    let scenario = async |o: &mut Oracle| {
+        // Three RR clients (one group), a non-client (second group), an
+        // eBGP peer with an attribute-modifying chain (third group).
+        o.peer_up(A, false, true, None, 64).await;
+        o.peer_up(B, false, true, None, 64).await;
+        o.peer_up(C, false, true, None, 64).await;
+        o.peer_up(D, false, false, None, 64).await;
+        o.peer_up(E, true, false, Some(modifying_chain()), 64).await;
+
+        // Initial announces from a member: split horizon inside the group.
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+
+        // Source flip X→Y (B takes over p1 with higher LOCAL_PREF)...
+        o.routes(B, vec![ibgp_route(pfx(1, 0), B, 200, vec![])], vec![])
+            .await;
+        // ... and flip back Y→X (B withdraws its path).
+        o.routes(B, vec![], vec![pfx(1, 0)]).await;
+
+        // Attribute change on the standing best (same source).
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 150, vec![])], vec![])
+            .await;
+
+        // LLGR-stale-tagged route: suppressed toward the eBGP peer
+        // (no LLGR capability), advertised to iBGP members.
+        o.routes(
+            B,
+            vec![ibgp_route(
+                pfx(3, 0),
+                B,
+                100,
+                vec![rustbgpd_wire::COMMUNITY_LLGR_STALE],
+            )],
+            vec![],
+        )
+        .await;
+
+        // Late joiner into the client group: replay, not restage.
+        o.peer_up(F, false, true, None, 64).await;
+
+        // Best withdraw: p1 goes away entirely.
+        o.routes(A, vec![], vec![pfx(1, 0)]).await;
+
+        // Member leaves (its p3 route falls out of the Loc-RIB too).
+        o.peer_down(B).await;
+
+        // Regroup fast path: a content-equal chain reinstall on E must
+        // emit nothing on either path.
+        o.replace_policy(E, Some(modifying_chain())).await;
+
+        // Genuine regroup: C moves to a deny-p2 group — one-shot diff
+        // withdraws p2 and leaves everything else untouched.
+        o.replace_policy(C, Some(deny_prefix_chain(pfx(2, 0))))
+            .await;
+
+        // GShut-style forced re-emission (RefreshPeerOutbound).
+        o.refresh_outbound(D).await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        grouped, ungrouped,
+        "grouped and per-peer outbound streams must be identical"
+    );
+    // Sanity: the scenario actually produced traffic.
+    assert!(
+        grouped.values().any(|msgs| !msgs.is_empty()),
+        "scenario must exercise outbound traffic"
+    );
+}
+
+/// Dirty-member resync (channel-full → tombstones → timer resync).
+/// Streams intentionally differ (the grouped resync over-emits — the
+/// safe direction); the folded final advertised state must be
+/// identical, and the withdraw of the prefix that went away while
+/// dirty must reach the wire on both paths.
+#[tokio::test]
+async fn oracle_dirty_resync_converges_to_identical_state() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        o.peer_up(B, false, true, None, 64).await;
+        // C gets a capacity-1 channel so a second update fails try_reserve.
+        o.peer_up(C, false, true, None, 1).await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // p1 lands in C's channel (fills it).
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        // p2 announce fails for C → C goes dirty.
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+        // p1 withdrawn WHILE C is dirty → tombstone; C's channel still full.
+        o.routes(A, vec![], vec![pfx(1, 0)]).await;
+
+        // Free the channel and let the resync timer fire.
+        let first = o.drain_one(C).await;
+        assert_eq!(first.announce.len(), 1, "p1 was delivered before the jam");
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    // The dirty member must have (over-)withdrawn the tombstoned p1 on
+    // the grouped path: its folded table must not contain p1 (fold
+    // starts after the pre-drained p1 announce, so a leftover p1 key
+    // could only come from a resync bug).
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)),
+        "tombstoned prefix must not survive the grouped resync"
+    );
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
+        "the update lost to the full channel must be recovered by the resync"
+    );
+}
+
+/// A second peer joining an existing group whose chain sets a next-hop
+/// override: the join replay must reproduce the override flags without
+/// re-running policy (they ride the group table residue).
+#[tokio::test]
+async fn oracle_nh_override_survives_group_join_replay() {
+    let chain = || {
+        permit_all_with(RouteModifications {
+            set_next_hop: Some(NextHopAction::Specific(IpAddr::V4(Ipv4Addr::new(
+                198, 51, 100, 42,
+            )))),
+            ..RouteModifications::default()
+        })
+    };
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        o.peer_up(D, true, false, Some(chain()), 64).await;
+        o.routes(A, vec![ibgp_route(pfx(9, 0), A, 100, vec![])], vec![])
+            .await;
+        // E joins D's group (same eBGP + content-equal chain): its
+        // initial dump replays the staged route WITH the nh override.
+        o.peer_up(E, true, false, Some(chain()), 64).await;
+    };
+    let (grouped, ungrouped) =
+        run_grouped_and_ungrouped(Some(Ipv4Addr::new(192, 0, 2, 1)), scenario).await;
+    assert_eq!(grouped, ungrouped);
+    // Belt and braces: E's dump carries the override flag on both paths.
+    let e_msgs = &grouped[&IpAddr::V4(E)];
+    let announced_with_flag = e_msgs.iter().flat_map(|m| &m.announce).any(|entry| {
+        entry.5
+            == Some(NextHopAction::Specific(IpAddr::V4(Ipv4Addr::new(
+                198, 51, 100, 42,
+            ))))
+    });
+    assert!(
+        announced_with_flag,
+        "join replay must reproduce the next-hop-override flag"
+    );
+}
+
+/// iBGP full mesh (no cluster id): plain split horizon suppresses
+/// iBGP-learned routes toward every iBGP peer; locally-injected and
+/// eBGP-origin routes still flow. Exercises the no-RR key shape.
+#[tokio::test]
+async fn oracle_plain_ibgp_split_horizon_identical() {
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, false, None, 64).await;
+        o.peer_up(B, false, false, None, 64).await;
+        o.peer_up(E, true, false, None, 64).await;
+        // iBGP-learned: suppressed toward A/B (split horizon, no RR),
+        // advertised to the eBGP peer.
+        o.routes(A, vec![ibgp_route(pfx(4, 0), A, 100, vec![])], vec![])
+            .await;
+        // An eBGP-origin route from E flows to the iBGP peers.
+        let mut ebgp = ibgp_route(pfx(5, 0), E, 100, vec![]);
+        ebgp.origin_type = RouteOrigin::Ebgp;
+        o.routes(E, vec![ebgp], vec![]).await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(None, scenario).await;
+    assert_eq!(grouped, ungrouped);
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1,27 +1,45 @@
-//! Update-group fingerprint registry — SHADOW MODE (slice 1 of the
-//! update-groups arc).
+//! Update groups: shared outbound staging for peers whose staged routes
+//! are identical (slice 2 of the update-groups arc).
 //!
-//! Peers whose staged outbound routes would be identical share a
-//! [`GroupKey`]; peers hitting a v1 disqualifier fall back to the
-//! per-peer path with a recorded reason. In this slice the registry is
-//! purely observational: membership is computed at session
-//! registration, recomputed on export-policy replacement, and removed
-//! on teardown — but **nothing reads it for distribution decisions**.
-//! Every peer stays on today's per-peer distribution path.
+//! Slice 1 introduced the [`GroupKey`] fingerprint registry in shadow
+//! mode. This slice makes membership REAL for grouped peers: each group
+//! owns ONE staged outbound table ([`GroupRibOut`]), the export tail
+//! runs once per (group, changed prefix) instead of once per (peer,
+//! prefix), and per-member updates are derived from the shared delta by
+//! the source-flip matrix ([`emit_group_deltas_for_member`]). Peers
+//! hitting a v1 disqualifier keep today's per-peer path entirely — the
+//! fallback is structural, and the per-peer path remains the
+//! correctness oracle (design risk 1).
 //!
-//! The one load-bearing property proven here: the export-chain
-//! component is keyed by chain **content** (interned via `PolicyChain`
-//! `PartialEq`), never by `Arc`/instance identity — so a SIGHUP / rpol
+//! Group-owned state (design §2): the staged table (post-policy routes
+//! with source peer preserved — the equality-suppression baseline),
+//! next-hop-override residue, withdrawal tombstones maintained only
+//! while ≥1 member is dirty, and the persistent group-verdict
+//! policy-denial set. Per-member state is O(1): membership id, dirty
+//! flag, and (transiently, across a regroup) a baseline snapshot of the
+//! member's previously advertised view. **No per-peer advertised
+//! unicast storage exists for grouped peers** — a member's advertised
+//! set is `group table − own-sourced entries`.
+//!
+//! The one load-bearing registry property from slice 1 still holds: the
+//! export-chain key component is chain **content** (interned via
+//! `PolicyChain` `PartialEq`), never `Arc` identity — a SIGHUP / rpol
 //! overlay / ADR-0076 txn that reinstalls a content-identical chain
-//! keeps the key stable and does not count as a regroup.
+//! keeps the key stable, does not count as a regroup, and (new in this
+//! slice) skips the resync entirely: the staged output is a pure
+//! function of the key.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 
-use rustbgpd_policy::PolicyChain;
-use rustbgpd_wire::{Afi, Safi};
+use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation};
+use rustbgpd_wire::{Afi, Prefix, Safi};
+use rustc_hash::FxHashMap;
 
-use super::RibManager;
+use super::helpers::{LOCAL_PEER, routes_equal};
+use super::{PolicyFilteredRouteKey, RibManager};
+use crate::adj_rib_out::AdjRibOut;
+use crate::route::Route;
 
 /// Fingerprint of every RIB-staging input that makes per-peer staged
 /// output differ (design §1). Per-peer wire preparation (next-hop
@@ -86,9 +104,9 @@ impl GroupMembership {
     }
 }
 
-/// The shadow-mode registry: interned chain contents, group keys, and
-/// per-peer membership. Owned by the [`RibManager`] task like all other
-/// RIB state — no locking.
+/// The registry: interned chain contents, group keys, and per-peer
+/// membership. Owned by the [`RibManager`] task like all other RIB
+/// state — no locking.
 #[derive(Debug, Default)]
 pub(super) struct UpdateGroupRegistry {
     /// Interned export-chain contents; a [`GroupKey::chain`] indexes
@@ -101,7 +119,7 @@ pub(super) struct UpdateGroupRegistry {
     /// emptied group's slot is kept and reused when its key recurs.
     groups: Vec<GroupKey>,
     /// Membership (group id or ungrouped reason) per registered peer.
-    members: HashMap<IpAddr, GroupMembership>,
+    pub(super) members: HashMap<IpAddr, GroupMembership>,
 }
 
 impl UpdateGroupRegistry {
@@ -129,30 +147,864 @@ impl UpdateGroupRegistry {
     }
 }
 
+/// One entry of a shared group staging pass: the new staged route (or a
+/// withdrawal) for a `(prefix, path_id)` key, plus the source peer of
+/// the entry it replaced — everything the source-flip matrix needs.
+#[derive(Debug, Clone)]
+pub(in crate::manager) struct GroupDelta {
+    pub(in crate::manager) prefix: Prefix,
+    pub(in crate::manager) path_id: u32,
+    /// Newly staged post-policy route + its next-hop-override flag, or
+    /// `None` for a withdrawal.
+    pub(in crate::manager) new: Option<(Route, Option<NextHopAction>)>,
+    /// Source peer of the group-table entry this delta replaces, read
+    /// BEFORE commit. `None` = the key was not previously staged.
+    pub(in crate::manager) old_source: Option<IpAddr>,
+    /// Terminal policy of the permitting evaluation (`None` = inline /
+    /// no chain). Retained on the staged entry so a later join can
+    /// replay the member's export counters without re-running policy.
+    pub(in crate::manager) policy_label: Option<String>,
+}
+
+/// Result of one shared staging pass over a group: the deltas (already
+/// committed to the group table) and the accumulated export-policy
+/// verdicts for per-member counter replay.
+#[derive(Default)]
+pub(in crate::manager) struct GroupStageOutput {
+    pub(in crate::manager) deltas: Vec<GroupDelta>,
+    pub(in crate::manager) evals: GroupEvalAccumulator,
+}
+
+impl GroupStageOutput {
+    /// Keys withdrawn by this pass — the tombstone contribution when a
+    /// member is (or goes) dirty.
+    pub(in crate::manager) fn withdrawn_keys(&self) -> impl Iterator<Item = (Prefix, u32)> + '_ {
+        self.deltas
+            .iter()
+            .filter(|d| d.new.is_none())
+            .map(|d| (d.prefix, d.path_id))
+    }
+}
+
+/// Export-policy verdicts of one shared staging pass, aggregated by
+/// (terminal policy, action) with a per-source-peer breakdown so each
+/// member can be bumped by `totals − own-sourced` — exactly what the
+/// per-peer path would have recorded (split horizon skips the eval for
+/// the route's own source). Integer adds only; no per-(prefix × peer)
+/// prometheus lookups (design §6).
+#[derive(Default)]
+pub(in crate::manager) struct GroupEvalAccumulator {
+    totals: Vec<(Option<String>, PolicyAction, u64)>,
+    per_source: FxHashMap<IpAddr, Vec<(Option<String>, PolicyAction, u64)>>,
+    /// Verdict of the most recent evaluation, consumed per prefix by
+    /// the staging loop to label the staged entry / denial residue
+    /// (single-best stages at most one eval per prefix).
+    last: Option<(Option<String>, PolicyAction)>,
+}
+
+fn bump_eval_row(
+    rows: &mut Vec<(Option<String>, PolicyAction, u64)>,
+    policy: Option<&String>,
+    action: PolicyAction,
+) {
+    if let Some((_, _, n)) = rows
+        .iter_mut()
+        .find(|(p, a, _)| *a == action && p.as_ref() == policy)
+    {
+        *n += 1;
+    } else {
+        rows.push((policy.cloned(), action, 1));
+    }
+}
+
+impl GroupEvalAccumulator {
+    /// Record one chain evaluation for the route sourced by `source`.
+    pub(in crate::manager) fn record(&mut self, evaluation: &PolicyEvaluation, source: IpAddr) {
+        bump_eval_row(
+            &mut self.totals,
+            evaluation.matched_policy.as_ref(),
+            evaluation.action,
+        );
+        bump_eval_row(
+            self.per_source.entry(source).or_default(),
+            evaluation.matched_policy.as_ref(),
+            evaluation.action,
+        );
+        self.last = Some((evaluation.matched_policy.clone(), evaluation.action));
+    }
+
+    /// Take (and clear) the last recorded verdict — the staging loop's
+    /// per-prefix label hook.
+    fn take_last(&mut self) -> Option<(Option<String>, PolicyAction)> {
+        self.last.take()
+    }
+}
+
+/// Per-member emit for one shared staging pass — the source-flip matrix
+/// (design §3). Announce / withdraw / skip is decided per delta entry
+/// from `(member == new source, member == old source)` alone:
+///
+/// | entry             | member == `new.peer`                                      | member == `old_source`                       | else     |
+/// |-------------------|-----------------------------------------------------------|----------------------------------------------|----------|
+/// | announce (`Some`) | old exists ∧ `old_source` ≠ member → withdraw; else skip  | announce (member was excluded, now eligible) | announce |
+/// | withdraw (`None`) | —                                                          | skip (member never had it)                   | withdraw |
+///
+/// `nh_override_flags` stays aligned with `announce` by pushing in the
+/// same arm. A free function so the risk-2 unit matrix can drive it
+/// directly.
+pub(in crate::manager) fn emit_group_deltas_for_member(
+    deltas: &[GroupDelta],
+    member: IpAddr,
+    announce: &mut Vec<Route>,
+    withdraw: &mut Vec<(Prefix, u32)>,
+    nh_override_flags: &mut Vec<Option<NextHopAction>>,
+) {
+    for delta in deltas {
+        match &delta.new {
+            Some((route, nh)) => {
+                if route.peer == member {
+                    // Split horizon applied at emit: the new best is the
+                    // member's own route. If the member previously held a
+                    // different source's advertisement for this key it
+                    // must be withdrawn (per-peer semantics: best ==
+                    // target ⇒ withdraw existing); if the old entry was
+                    // also member-sourced (or absent) the member never
+                    // had it — skip.
+                    if delta.old_source.is_some_and(|source| source != member) {
+                        withdraw.push((delta.prefix, delta.path_id));
+                    }
+                } else {
+                    nh_override_flags.push(nh.clone());
+                    announce.push(route.clone());
+                }
+            }
+            None => {
+                // A member never receives its own-sourced entries, so a
+                // withdrawal of one is a no-op for it (and a withdraw
+                // delta with no old entry — unreachable by construction
+                // — would be a no-op for everyone).
+                if delta.old_source.is_some_and(|source| source != member) {
+                    withdraw.push((delta.prefix, delta.path_id));
+                }
+            }
+        }
+    }
+}
+
+/// The group-owned staged outbound table (design §2): the unicast
+/// portion of an [`AdjRibOut`] reused as substrate, plus the group's
+/// membership/dirty bookkeeping and the group-uniform staging inputs
+/// snapshot. One instance per non-empty group; dropped when the last
+/// member leaves.
+pub(in crate::manager) struct GroupRibOut {
+    /// Post-policy staged routes, source peer preserved (needed by the
+    /// source-flip matrix). Only the unicast maps of the substrate are
+    /// used. This IS the equality-suppression baseline: `routes_equal`
+    /// runs once per group against it.
+    pub(in crate::manager) table: AdjRibOut,
+    /// Next-hop-override flags for staged entries (`Some` values only)
+    /// so joins/replays don't re-run policy to recover them.
+    nh_overrides: FxHashMap<(Prefix, u32), NextHopAction>,
+    /// Staged-entry count per source peer — O(1) per-member advertised
+    /// count synthesis (`table.len() − own`), split (v4, v6) for the
+    /// BMP stat-17 family counts.
+    source_counts: FxHashMap<IpAddr, (usize, usize)>,
+    /// Keys withdrawn from the table since the first member went dirty;
+    /// empty (and unmaintained) while no member is dirty. A dirty
+    /// member's resync withdraws `tombstones ∖ still-staged` — spurious
+    /// withdraws of never-advertised prefixes are RFC 4271 no-ops
+    /// (over-withdraw is the safe direction).
+    pub(in crate::manager) tombstones: HashSet<(Prefix, u32)>,
+    pub(in crate::manager) members: HashSet<IpAddr>,
+    pub(in crate::manager) dirty_members: HashSet<IpAddr>,
+    /// Persistent group-verdict export-policy denials (target stamped
+    /// with [`GROUP_FILTERED_PLACEHOLDER`], restamped per member) with
+    /// the denying policy's label for join-time counter replay.
+    policy_filtered: FxHashMap<PolicyFilteredRouteKey, Option<String>>,
+    /// Terminal policy label per staged entry (`None` = inline) —
+    /// join-time counter replay residue.
+    staged_labels: FxHashMap<(Prefix, u32), Option<String>>,
+    // Group-uniform staging inputs, snapshot at group creation from the
+    // first member (all members are key-equal by construction; a key
+    // change moves peers to a different group, so these never mutate).
+    pub(in crate::manager) export_chain: Option<PolicyChain>,
+    pub(in crate::manager) is_ebgp: bool,
+    pub(in crate::manager) is_rr_client: bool,
+    pub(in crate::manager) sendable: Vec<(Afi, Safi)>,
+    pub(in crate::manager) llgr: Vec<(Afi, Safi)>,
+}
+
+/// Placeholder target for group-level policy-denial records; restamped
+/// with the concrete member at emit time. `LOCAL_PEER` can never be an
+/// outbound target.
+const GROUP_FILTERED_PLACEHOLDER: IpAddr = LOCAL_PEER;
+
+impl GroupRibOut {
+    fn new(
+        export_chain: Option<PolicyChain>,
+        is_ebgp: bool,
+        is_rr_client: bool,
+        sendable: Vec<(Afi, Safi)>,
+        llgr: Vec<(Afi, Safi)>,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            table: AdjRibOut::with_capacity(GROUP_FILTERED_PLACEHOLDER, capacity),
+            nh_overrides: FxHashMap::default(),
+            source_counts: FxHashMap::default(),
+            tombstones: HashSet::new(),
+            members: HashSet::new(),
+            dirty_members: HashSet::new(),
+            policy_filtered: FxHashMap::default(),
+            staged_labels: FxHashMap::default(),
+            export_chain,
+            is_ebgp,
+            is_rr_client,
+            sendable,
+            llgr,
+        }
+    }
+
+    fn count_slot(prefix: &Prefix) -> usize {
+        match prefix {
+            Prefix::V4(_) => 0,
+            Prefix::V6(_) => 1,
+        }
+    }
+
+    fn dec_source(&mut self, peer: IpAddr, prefix: &Prefix) {
+        if let Some(counts) = self.source_counts.get_mut(&peer) {
+            let slot = if Self::count_slot(prefix) == 0 {
+                &mut counts.0
+            } else {
+                &mut counts.1
+            };
+            *slot = slot.saturating_sub(1);
+            if counts.0 == 0 && counts.1 == 0 {
+                self.source_counts.remove(&peer);
+            }
+        }
+    }
+
+    fn inc_source(&mut self, peer: IpAddr, prefix: &Prefix) {
+        let counts = self.source_counts.entry(peer).or_default();
+        if Self::count_slot(prefix) == 0 {
+            counts.0 += 1;
+        } else {
+            counts.1 += 1;
+        }
+    }
+
+    /// Commit one staged delta into the group table, keeping the
+    /// source-count and next-hop-override residue in sync.
+    fn apply_delta(&mut self, delta: &GroupDelta) {
+        let key = (delta.prefix, delta.path_id);
+        if let Some(old) = self.table.get(&delta.prefix, delta.path_id) {
+            let old_peer = old.peer;
+            self.dec_source(old_peer, &delta.prefix);
+        }
+        if let Some((route, nh)) = &delta.new {
+            self.inc_source(route.peer, &delta.prefix);
+            match nh {
+                Some(action) => {
+                    self.nh_overrides.insert(key, action.clone());
+                }
+                None => {
+                    self.nh_overrides.remove(&key);
+                }
+            }
+            self.staged_labels.insert(key, delta.policy_label.clone());
+            self.table.insert(route.clone());
+        } else {
+            self.table.withdraw(&delta.prefix, delta.path_id);
+            self.nh_overrides.remove(&key);
+            self.staged_labels.remove(&key);
+        }
+    }
+
+    /// The next-hop-override flag staged for a table entry.
+    pub(in crate::manager) fn nh_override(&self, key: (Prefix, u32)) -> Option<NextHopAction> {
+        self.nh_overrides.get(&key).cloned()
+    }
+
+    /// Number of routes `member` currently has advertised: the group
+    /// table minus the member's own-sourced entries. O(1).
+    pub(in crate::manager) fn advertised_count_for(&self, member: IpAddr) -> usize {
+        let own = self
+            .source_counts
+            .get(&member)
+            .map_or(0, |(v4, v6)| v4 + v6);
+        self.table.len().saturating_sub(own)
+    }
+
+    /// Per-family synthesized unicast advertised counts for a member
+    /// (BMP RFC 8671 stat type 17 input). Zero-count families omitted.
+    pub(in crate::manager) fn family_counts_for(&self, member: IpAddr) -> Vec<((Afi, Safi), u64)> {
+        let (mut v4, mut v6) = (0usize, 0usize);
+        for (a, b) in self.source_counts.values() {
+            v4 += a;
+            v6 += b;
+        }
+        let own = self.source_counts.get(&member).copied().unwrap_or((0, 0));
+        let v4 = v4.saturating_sub(own.0) as u64;
+        let v6 = v6.saturating_sub(own.1) as u64;
+        let mut counts = Vec::new();
+        if v4 > 0 {
+            counts.push(((Afi::Ipv4, Safi::Unicast), v4));
+        }
+        if v6 > 0 {
+            counts.push(((Afi::Ipv6, Safi::Unicast), v6));
+        }
+        counts
+    }
+
+    /// Snapshot of `member`'s advertised view (table minus own-sourced)
+    /// — the baseline for a regroup's one-shot diff.
+    fn member_view_snapshot(&self, member: IpAddr) -> FxHashMap<(Prefix, u32), Route> {
+        self.table
+            .iter()
+            .filter(|route| route.peer != member)
+            .map(|route| ((route.prefix, route.path_id), route.clone()))
+            .collect()
+    }
+
+    /// Refresh the persistent group-verdict denial set for one staging
+    /// pass: entries for staged prefixes are replaced by the pass's
+    /// denials (same transition scope as the per-peer path's
+    /// `update_policy_filtered_routes_for_prefixes`).
+    fn record_policy_filtered(
+        &mut self,
+        staged: &HashSet<Prefix>,
+        current: &[(PolicyFilteredRouteKey, Option<String>)],
+    ) {
+        self.policy_filtered
+            .retain(|key, _| !staged.contains(&key.prefix));
+        self.policy_filtered.extend(current.iter().cloned());
+    }
+
+    /// The member's view of the group-verdict denial set, restamped
+    /// with the member as target and restricted to `prefixes` (the
+    /// pass's evaluation scope). The member's own-sourced denials are
+    /// excluded — the per-peer path's split horizon returns before the
+    /// policy evaluation for those.
+    pub(in crate::manager) fn policy_filtered_for_member<'a>(
+        &'a self,
+        member: IpAddr,
+        prefixes: &'a HashSet<Prefix>,
+    ) -> impl Iterator<Item = PolicyFilteredRouteKey> + 'a {
+        self.policy_filtered
+            .keys()
+            .filter(move |key| key.source_peer != member && prefixes.contains(&key.prefix))
+            .map(move |key| PolicyFilteredRouteKey {
+                target_peer: member,
+                ..*key
+            })
+    }
+}
+
 impl RibManager {
+    /// The group id a registered peer is a member of, if any.
+    pub(in crate::manager) fn grouped_member_of(&self, peer: IpAddr) -> Option<usize> {
+        match self.update_groups.members.get(&peer) {
+            Some(GroupMembership::Grouped(id)) => Some(*id),
+            _ => None,
+        }
+    }
+
+    /// Mark a peer's outbound channel dirty for the resync timer, and —
+    /// for a grouped member — flag it in its group so tombstone
+    /// maintenance starts. Every `dirty_peers` insertion site routes
+    /// through here.
+    pub(in crate::manager) fn mark_outbound_dirty(&mut self, peer: IpAddr) {
+        self.dirty_peers.insert(peer);
+        if let Some(gid) = self.grouped_member_of(peer)
+            && let Some(group) = self.group_ribs.get_mut(&gid)
+        {
+            group.dirty_members.insert(peer);
+        }
+    }
+
+    /// A grouped member's resync succeeded (or had nothing to send):
+    /// drop its regroup residue and its group dirty flag; the last
+    /// dirty member syncing clears the tombstones.
+    pub(in crate::manager) fn clear_grouped_member_synced(&mut self, peer: IpAddr) {
+        self.pending_regroup_baseline.remove(&peer);
+        self.pending_extra_withdraws.remove(&peer);
+        if let Some(gid) = self.grouped_member_of(peer)
+            && let Some(group) = self.group_ribs.get_mut(&gid)
+        {
+            group.dirty_members.remove(&peer);
+            if group.dirty_members.is_empty() {
+                group.tombstones.clear();
+            }
+        }
+    }
+
+    /// Run the shared staging pass for every live group over the pass's
+    /// changed prefixes. Deltas are committed to the group tables here;
+    /// the per-peer loop emits them per member via the source-flip
+    /// matrix. `memo` is the pass-scoped export memo shared with the
+    /// ungrouped fallback staging.
+    pub(in crate::manager) fn stage_update_groups(
+        &mut self,
+        best_changed: &HashSet<Prefix>,
+        memo: &mut super::distribution::ExportMemo,
+    ) -> HashMap<usize, GroupStageOutput> {
+        let mut staged = HashMap::new();
+        if best_changed.is_empty() || self.group_ribs.is_empty() {
+            return staged;
+        }
+        let gids: Vec<usize> = self.group_ribs.keys().copied().collect();
+        for gid in gids {
+            staged.insert(gid, self.stage_group_prefixes(gid, best_changed, memo));
+        }
+        staged
+    }
+
+    /// One shared export-tail pass for `gid` over `prefixes`, reusing
+    /// `distribute_single_best_prefix` with split horizon lifted out
+    /// (`ExportTarget::Group`) and the group table as the diff baseline
+    /// — the SAME body as the per-peer path, parameterized, never
+    /// copied (design risk 1). Deltas are committed before returning;
+    /// tombstones extend when a member is already dirty.
+    fn stage_group_prefixes(
+        &mut self,
+        gid: usize,
+        prefixes: &HashSet<Prefix>,
+        memo: &mut super::distribution::ExportMemo,
+    ) -> GroupStageOutput {
+        let mut out = GroupStageOutput::default();
+        let mut labeled_filtered: Vec<(PolicyFilteredRouteKey, Option<String>)> = Vec::new();
+        {
+            let Some(group) = self.group_ribs.get(&gid) else {
+                return out;
+            };
+            // `share()`, not `clone()`: evaluations through the group
+            // handle must land in the installed chain's ADR-0096 term
+            // hit counters, exactly like the per-peer path's handle.
+            let chain = group.export_chain.as_ref().map(PolicyChain::share);
+            let mut announce: Vec<Route> = Vec::new();
+            let mut withdraw: Vec<(Prefix, u32)> = Vec::new();
+            let mut nh_flags: Vec<Option<NextHopAction>> = Vec::new();
+            let mut filtered: Vec<PolicyFilteredRouteKey> = Vec::new();
+            for prefix in prefixes {
+                let old_source = group.table.get(prefix, 0).map(|r| r.peer);
+                let mut target = super::distribution::ExportTarget::Group {
+                    evals: &mut out.evals,
+                };
+                Self::distribute_single_best_prefix(
+                    &self.loc_rib,
+                    &group.table,
+                    &self.peer_is_rr_client,
+                    prefix,
+                    &mut target,
+                    group.is_ebgp,
+                    group.is_rr_client,
+                    self.cluster_id,
+                    Some(&group.sendable),
+                    Some(&group.llgr),
+                    chain.as_ref(),
+                    None, // ORF disqualifies from grouping — never present here
+                    memo,
+                    &mut announce,
+                    &mut withdraw,
+                    &mut nh_flags,
+                    &mut filtered,
+                    false,
+                );
+                // Single-best stages at most one evaluation per prefix;
+                // its terminal-policy label tags the staged entry (or
+                // the denial residue) for join-time counter replay.
+                let label = out.evals.take_last().and_then(|(label, _)| label);
+                for (route, nh) in announce.drain(..).zip(nh_flags.drain(..)) {
+                    out.deltas.push(GroupDelta {
+                        prefix: *prefix,
+                        path_id: route.path_id,
+                        new: Some((route, nh)),
+                        old_source,
+                        policy_label: label.clone(),
+                    });
+                }
+                for (p, path_id) in withdraw.drain(..) {
+                    out.deltas.push(GroupDelta {
+                        prefix: p,
+                        path_id,
+                        new: None,
+                        old_source,
+                        policy_label: None,
+                    });
+                }
+                labeled_filtered.extend(filtered.drain(..).map(|key| (key, label.clone())));
+            }
+        }
+        let group = self
+            .group_ribs
+            .get_mut(&gid)
+            .expect("group staged above still exists");
+        for delta in &out.deltas {
+            group.apply_delta(delta);
+        }
+        group.record_policy_filtered(prefixes, &labeled_filtered);
+        if !group.dirty_members.is_empty() {
+            let withdrawn: Vec<(Prefix, u32)> = out.withdrawn_keys().collect();
+            group.tombstones.extend(withdrawn);
+        }
+        out
+    }
+
+    /// Unicast portion of a grouped member's resync update, assembled
+    /// from the group table with NO policy re-evaluation:
+    ///
+    /// - plain dirty: announce the full table minus own-sourced,
+    ///   withdraw `tombstones ∖ still-retained` (over-withdraw is the
+    ///   safe direction — the member's missed sends are unknown);
+    /// - regroup (baseline present): one-shot diff — announce entries
+    ///   not `routes_equal` to the baseline, withdraw baseline keys the
+    ///   member no longer retains;
+    /// - force-only (RFC 8326 `GShut` refresh): re-announce everything,
+    ///   bypassing the equality diff, withdraw nothing.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the resync assembly takes the member's full pending-withdraw context"
+    )]
+    pub(in crate::manager) fn assemble_group_resync(
+        group: &GroupRibOut,
+        member: IpAddr,
+        is_dirty: bool,
+        is_force: bool,
+        baseline: Option<&FxHashMap<(Prefix, u32), Route>>,
+        extras: Option<&HashSet<(Prefix, u32)>>,
+        announce: &mut Vec<Route>,
+        withdraw: &mut Vec<(Prefix, u32)>,
+        nh_override_flags: &mut Vec<Option<NextHopAction>>,
+    ) {
+        for route in group.table.iter() {
+            if route.peer == member {
+                continue;
+            }
+            let key = (route.prefix, route.path_id);
+            if !is_force
+                && let Some(base) = baseline
+                && base.get(&key).is_some_and(|old| routes_equal(old, route))
+            {
+                continue;
+            }
+            nh_override_flags.push(group.nh_override(key));
+            announce.push(route.clone());
+        }
+        // A key the member still retains (staged, not own-sourced) must
+        // not be withdrawn — everything else in the candidate sets is a
+        // safe (possibly spurious) withdraw.
+        let member_retains = |key: &(Prefix, u32)| {
+            group
+                .table
+                .get(&key.0, key.1)
+                .is_some_and(|route| route.peer != member)
+        };
+        let mut keys: HashSet<(Prefix, u32)> = HashSet::new();
+        if let Some(base) = baseline {
+            keys.extend(base.keys().filter(|key| !member_retains(key)));
+        }
+        if is_dirty {
+            keys.extend(group.tombstones.iter().filter(|key| !member_retains(key)));
+        }
+        if let Some(extra) = extras {
+            keys.extend(extra.iter().filter(|key| !member_retains(key)));
+        }
+        withdraw.extend(keys);
+    }
+
+    /// Bump a member's export-policy counters by the group verdict:
+    /// `totals − own-sourced` per (policy, action), as integer adds —
+    /// identical totals to the per-peer path, which skips the eval for
+    /// routes the target itself sourced (split horizon precedes the
+    /// policy check).
+    pub(in crate::manager) fn apply_group_policy_counters(
+        &mut self,
+        peer: IpAddr,
+        evals: &GroupEvalAccumulator,
+    ) {
+        if evals.totals.is_empty() {
+            return;
+        }
+        let own = evals.per_source.get(&peer);
+        let rows: Vec<(Option<String>, PolicyAction, u64)> = evals
+            .totals
+            .iter()
+            .map(|(policy, action, total)| {
+                let own_n = own
+                    .and_then(|rows| {
+                        rows.iter()
+                            .find(|(p, a, _)| a == action && p == policy)
+                            .map(|(_, _, n)| *n)
+                    })
+                    .unwrap_or(0);
+                (policy.clone(), *action, total.saturating_sub(own_n))
+            })
+            .collect();
+        self.bump_export_counters(peer, &rows);
+    }
+
+    /// Reconstruct a joining member's export counters from the group's
+    /// staged residue: one permit per replayed table entry (labelled by
+    /// its retained terminal policy), one deny per persistent denial —
+    /// own-sourced entries excluded on both sides, exactly what the
+    /// per-peer initial-dump staging would have recorded, without
+    /// re-running policy.
+    pub(in crate::manager) fn apply_group_join_counters(&mut self, peer: IpAddr, gid: usize) {
+        let mut rows: Vec<(Option<String>, PolicyAction, u64)> = Vec::new();
+        {
+            let Some(group) = self.group_ribs.get(&gid) else {
+                return;
+            };
+            let mut bump = |policy: &Option<String>, action: PolicyAction| {
+                if let Some((_, _, n)) = rows
+                    .iter_mut()
+                    .find(|(p, a, _)| *a == action && p == policy)
+                {
+                    *n += 1;
+                } else {
+                    rows.push((policy.clone(), action, 1));
+                }
+            };
+            for route in group.table.iter() {
+                if route.peer == peer {
+                    continue;
+                }
+                let label = group
+                    .staged_labels
+                    .get(&(route.prefix, route.path_id))
+                    .cloned()
+                    .unwrap_or(None);
+                bump(&label, PolicyAction::Permit);
+            }
+            for (key, label) in &group.policy_filtered {
+                if key.source_peer == peer {
+                    continue;
+                }
+                bump(label, PolicyAction::Deny);
+            }
+        }
+        self.bump_export_counters(peer, &rows);
+    }
+
+    /// Apply aggregated export-policy verdict rows to a peer's counters
+    /// (integer adds — no per-(prefix × peer) prometheus lookups).
+    fn bump_export_counters(&mut self, peer: IpAddr, rows: &[(Option<String>, PolicyAction, u64)]) {
+        let stats = self.export_policy_stats.entry(peer).or_default();
+        let peer_label = peer.to_string();
+        for (policy, action, n) in rows {
+            if *n == 0 {
+                continue;
+            }
+            let action_label = match action {
+                PolicyAction::Permit => {
+                    stats.export_policy_routes_permitted =
+                        stats.export_policy_routes_permitted.saturating_add(*n);
+                    "permit"
+                }
+                PolicyAction::Deny => {
+                    stats.export_policy_routes_denied =
+                        stats.export_policy_routes_denied.saturating_add(*n);
+                    "deny"
+                }
+            };
+            self.metrics.record_policy_routes_by(
+                &peer_label,
+                policy.as_deref().unwrap_or("inline"),
+                "export",
+                action_label,
+                *n,
+            );
+        }
+    }
+
+    /// Synthesized advertised-route list for a grouped peer (group
+    /// table minus own-sourced); `None` for ungrouped peers.
+    pub(in crate::manager) fn grouped_advertised_routes(&self, peer: IpAddr) -> Option<Vec<Route>> {
+        let group = self.group_ribs.get(&self.grouped_member_of(peer)?)?;
+        Some(
+            group
+                .table
+                .iter()
+                .filter(|route| route.peer != peer)
+                .cloned()
+                .collect(),
+        )
+    }
+
+    /// Synthesized advertised-route count for a grouped peer; `None`
+    /// for ungrouped peers.
+    pub(in crate::manager) fn grouped_advertised_count(&self, peer: IpAddr) -> Option<usize> {
+        self.group_ribs
+            .get(&self.grouped_member_of(peer)?)
+            .map(|group| group.advertised_count_for(peer))
+    }
+
     /// Compute (or recompute) a registered peer's update-group
-    /// membership from the fingerprint inputs already in hand, record
-    /// it, and refresh the observability gauges. Called at the session
-    /// registration seam and the export-policy replacement seam (which
-    /// is also where SIGHUP rpol overlays and ADR-0076 live-impact txns
-    /// land). Shadow mode: distribution never reads the result.
+    /// membership from the fingerprint inputs already in hand, and run
+    /// the membership lifecycle (design §4): join = lookup-or-create
+    /// the group (building its table with one shared staging pass when
+    /// new); leave = drop membership (last member drops the table);
+    /// regroup = leave + join with a baseline snapshot of the member's
+    /// old advertised view for the one-shot resync diff. Called at the
+    /// session registration seam and the export-policy replacement seam
+    /// (per-peer gRPC edits, ADR-0076 live-impact txns, SIGHUP rpol
+    /// overlays). A key-stable recompute (content-equal chain
+    /// reinstall) is a strict no-op.
     pub(super) fn recompute_update_group(&mut self, peer: IpAddr) {
         let membership = self.compute_update_group_membership(peer);
-        let previous = self.update_groups.members.insert(peer, membership.clone());
+        let previous = self.update_groups.members.get(&peer).cloned();
+        if previous.as_ref() == Some(&membership) {
+            // Key-stable fast path: nothing moved, no regroup counted —
+            // this is what keeps a 1000-peer txn installing
+            // content-identical chains from shattering anything.
+            return;
+        }
+        let prev_gid = match previous {
+            Some(GroupMembership::Grouped(id)) => Some(id),
+            _ => None,
+        };
+        let new_gid = match membership {
+            GroupMembership::Grouped(id) => Some(id),
+            _ => None,
+        };
+        self.update_groups.members.insert(peer, membership);
         // A regroup is an already-registered peer whose membership
-        // moved; first registration and content-identical policy
-        // reinstalls (same interned index ⇒ same key) don't count.
-        if previous.is_some_and(|prev| prev != membership) {
+        // moved; first registration doesn't count.
+        if previous.is_some() {
             self.metrics.record_update_group_regroup();
+        }
+        if prev_gid != new_gid {
+            // Snapshot the member's currently-advertised unicast view
+            // before the move: the destination side diffs against it so
+            // only genuine changes reach the wire (design §4 one-shot
+            // diff). First registration has no view — the initial dump
+            // replays the destination group table.
+            let baseline: Option<FxHashMap<(Prefix, u32), Route>> = match prev_gid {
+                Some(gid) => {
+                    let group = self.group_ribs.get(&gid);
+                    let base = group.map(|g| g.member_view_snapshot(peer));
+                    // A member that leaves while dirty may have missed
+                    // withdrawals; carry the group tombstones along as
+                    // extra (over-)withdraws for the destination resync.
+                    if let Some(g) = group
+                        && g.dirty_members.contains(&peer)
+                        && !g.tombstones.is_empty()
+                    {
+                        self.pending_extra_withdraws
+                            .entry(peer)
+                            .or_default()
+                            .extend(g.tombstones.iter().copied());
+                    }
+                    base
+                }
+                None if previous.is_some() => Some(
+                    self.adj_ribs_out
+                        .get(&peer)
+                        .map(|rib_out| {
+                            rib_out
+                                .iter()
+                                .map(|route| ((route.prefix, route.path_id), route.clone()))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                ),
+                None => None,
+            };
+            if let Some(gid) = prev_gid {
+                self.leave_group(gid, peer);
+            } else if previous.is_some() {
+                // Moving off the per-peer path: the unicast advertised
+                // state becomes group-owned (captured in the baseline);
+                // non-unicast families stay per-peer.
+                if let Some(rib_out) = self.adj_ribs_out.get_mut(&peer) {
+                    rib_out.clear_unicast();
+                }
+            }
+            if let Some(gid) = new_gid {
+                self.join_group(gid, peer);
+            }
+            match (baseline, new_gid) {
+                (Some(base), Some(_)) => {
+                    self.pending_regroup_baseline.insert(peer, base);
+                }
+                (Some(base), None) => {
+                    // Back on the per-peer path: seed Adj-RIB-Out with
+                    // the old advertised view so the dirty resync diffs
+                    // against it instead of re-flooding the table.
+                    let loc_rib_len = self.loc_rib.len();
+                    let rib_out = self
+                        .adj_ribs_out
+                        .entry(peer)
+                        .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
+                    for route in base.into_values() {
+                        rib_out.insert(route);
+                    }
+                }
+                (None, _) => {}
+            }
         }
         self.refresh_update_group_gauges();
     }
 
-    /// Drop a departing peer's membership (the
+    /// Add a member; a group seen for the first time snapshots its
+    /// group-uniform staging inputs from the joining peer (all members
+    /// are key-equal) and builds the shared table with one staging pass
+    /// — the policy work every subsequent join replays for free.
+    fn join_group(&mut self, gid: usize, peer: IpAddr) {
+        if !self.group_ribs.contains_key(&gid) {
+            let group = GroupRibOut::new(
+                // `share()`, not `clone()`: the snapshot must keep
+                // feeding the installed chain's ADR-0096 hit counters.
+                self.export_policy_for(peer).map(PolicyChain::share),
+                self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
+                self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),
+                self.peer_sendable_families
+                    .get(&peer)
+                    .cloned()
+                    .unwrap_or_default(),
+                self.peer_advertised_llgr_families
+                    .get(&peer)
+                    .cloned()
+                    .unwrap_or_default(),
+                self.loc_rib.len(),
+            );
+            self.group_ribs.insert(gid, group);
+            let prefixes: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
+            let mut memo = super::distribution::ExportMemo::default();
+            // Deltas of the build pass are discarded: there are no
+            // members yet, and the joining member replays the whole
+            // table anyway.
+            let _ = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+        }
+        if let Some(group) = self.group_ribs.get_mut(&gid) {
+            group.members.insert(peer);
+        }
+    }
+
+    fn leave_group(&mut self, gid: usize, peer: IpAddr) {
+        let Some(group) = self.group_ribs.get_mut(&gid) else {
+            return;
+        };
+        group.members.remove(&peer);
+        group.dirty_members.remove(&peer);
+        if group.dirty_members.is_empty() {
+            group.tombstones.clear();
+        }
+        if group.members.is_empty() {
+            self.group_ribs.remove(&gid);
+        }
+    }
+
+    /// Drop a departing peer's membership and group state (the
     /// `clear_outbound_peer_state` seam — `PeerDown`, `PeerDeleted`, GR
     /// teardown, and collision replacement all route through it).
     pub(super) fn remove_update_group_member(&mut self, peer: IpAddr) {
-        if self.update_groups.members.remove(&peer).is_some() {
+        if let Some(membership) = self.update_groups.members.remove(&peer) {
+            if let GroupMembership::Grouped(gid) = membership {
+                self.leave_group(gid, peer);
+            }
             self.refresh_update_group_gauges();
         }
     }
@@ -160,6 +1012,13 @@ impl RibManager {
     /// The fingerprint itself: disqualifiers first (design §1), then
     /// the group key from RIB-staging inputs.
     fn compute_update_group_membership(&mut self, peer: IpAddr) -> GroupMembership {
+        // Differential-oracle hook: force every peer onto the per-peer
+        // fallback path so identical scenarios can be compared grouped
+        // vs ungrouped. Reuses the policy-peer-context reason label.
+        #[cfg(test)]
+        if self.test_force_ungrouped {
+            return GroupMembership::PolicyPeerContext;
+        }
         if self
             .export_policy_for(peer)
             .is_some_and(PolicyChain::requires_peer_context)
@@ -256,5 +1115,286 @@ impl RibManager {
             .map(GroupMembership::label)
             .unwrap_or_default();
         let _ = reply.send(label);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use rustbgpd_wire::Ipv4Prefix;
+
+    use super::*;
+    use crate::test_support::make_route;
+
+    const MEMBER: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1));
+    const OTHER1: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 2));
+    const OTHER2: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 3));
+
+    fn prefix(n: u8) -> Prefix {
+        Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 100, n, 0), 24))
+    }
+
+    fn route(p: Prefix, src: IpAddr) -> Route {
+        let Prefix::V4(v4) = p else { unreachable!() };
+        let IpAddr::V4(src4) = src else {
+            unreachable!()
+        };
+        let mut route = make_route(v4, src4);
+        route.peer = src;
+        route
+    }
+
+    fn empty_group() -> GroupRibOut {
+        GroupRibOut::new(
+            None,
+            false,
+            true,
+            vec![(Afi::Ipv4, Safi::Unicast)],
+            vec![],
+            0,
+        )
+    }
+
+    fn announce_delta(p: Prefix, src: IpAddr, old: Option<IpAddr>) -> GroupDelta {
+        GroupDelta {
+            prefix: p,
+            path_id: 0,
+            new: Some((route(p, src), None)),
+            old_source: old,
+            policy_label: None,
+        }
+    }
+
+    fn withdraw_delta(p: Prefix, old: Option<IpAddr>) -> GroupDelta {
+        GroupDelta {
+            prefix: p,
+            path_id: 0,
+            new: None,
+            old_source: old,
+            policy_label: None,
+        }
+    }
+
+    /// Risk-2 exhaustive source-flip matrix: every combination of
+    /// `{old_source} × {new source | withdraw}` for a fixed member,
+    /// asserted against the per-peer-path reference semantics:
+    ///
+    /// - the member HAD the key iff an old entry existed with a source
+    ///   other than the member (split horizon excluded own-sourced);
+    /// - the member GETS the key iff the new entry exists with a source
+    ///   other than the member;
+    /// - expected announce ⇔ GETS; expected withdraw ⇔ HAD ∧ ¬GETS
+    ///   (announce-replaces is BGP implicit withdraw).
+    #[test]
+    fn source_flip_matrix_exhaustive() {
+        let old_sources = [None, Some(MEMBER), Some(OTHER1), Some(OTHER2)];
+        // `None` = withdraw delta; `Some(src)` = announce sourced by src.
+        let new_sources = [None, Some(MEMBER), Some(OTHER1), Some(OTHER2)];
+        for old in old_sources {
+            for new in new_sources {
+                if new.is_none() && old.is_none() {
+                    // A withdraw delta always has an old entry (the
+                    // staging body only withdraws existing keys).
+                    continue;
+                }
+                let p = prefix(1);
+                let delta = match new {
+                    Some(src) => announce_delta(p, src, old),
+                    None => withdraw_delta(p, old),
+                };
+                let mut announce = Vec::new();
+                let mut withdraw = Vec::new();
+                let mut nh_flags = Vec::new();
+                emit_group_deltas_for_member(
+                    std::slice::from_ref(&delta),
+                    MEMBER,
+                    &mut announce,
+                    &mut withdraw,
+                    &mut nh_flags,
+                );
+
+                let member_had = old.is_some_and(|s| s != MEMBER);
+                let member_gets = new.is_some_and(|s| s != MEMBER);
+                let expect_announce = usize::from(member_gets);
+                let expect_withdraw = usize::from(member_had && !member_gets);
+                assert_eq!(
+                    announce.len(),
+                    expect_announce,
+                    "announce mismatch for old={old:?} new={new:?}"
+                );
+                assert_eq!(
+                    withdraw.len(),
+                    expect_withdraw,
+                    "withdraw mismatch for old={old:?} new={new:?}"
+                );
+                assert_eq!(
+                    nh_flags.len(),
+                    announce.len(),
+                    "nh flags must stay aligned with announces"
+                );
+                if member_gets {
+                    assert_eq!(announce[0].peer, new.unwrap());
+                }
+            }
+        }
+    }
+
+    /// Dirty-member resync: full-table announce minus own-sourced;
+    /// tombstones withdraw unless the member still retains the key
+    /// (staged by another source). Over-withdrawing keys now staged by
+    /// the member itself is the deliberate safe direction.
+    #[test]
+    fn dirty_resync_replays_table_and_tombstones() {
+        let mut group = empty_group();
+        let (k1, k2, k3, k4) = (prefix(1), prefix(2), prefix(3), prefix(4));
+        group.apply_delta(&announce_delta(k1, OTHER1, None));
+        group.apply_delta(&announce_delta(k2, MEMBER, None));
+        group.apply_delta(&announce_delta(k4, MEMBER, None));
+        group.tombstones.insert((k1, 0)); // retained via OTHER1 — no withdraw
+        group.tombstones.insert((k3, 0)); // gone — withdraw
+        group.tombstones.insert((k4, 0)); // member-sourced now — safe over-withdraw
+
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let mut nh_flags = Vec::new();
+        RibManager::assemble_group_resync(
+            &group,
+            MEMBER,
+            true,
+            false,
+            None,
+            None,
+            &mut announce,
+            &mut withdraw,
+            &mut nh_flags,
+        );
+        let announced: HashSet<Prefix> = announce.iter().map(|r| r.prefix).collect();
+        assert_eq!(
+            announced,
+            HashSet::from([k1]),
+            "own-sourced entries excluded"
+        );
+        let withdrawn: HashSet<(Prefix, u32)> = withdraw.into_iter().collect();
+        assert_eq!(withdrawn, HashSet::from([(k3, 0), (k4, 0)]));
+        assert_eq!(nh_flags.len(), announce.len());
+    }
+
+    /// Regroup one-shot diff: entries `routes_equal` to the baseline
+    /// are suppressed, changed entries announce, baseline keys no
+    /// longer retained withdraw — and `force` bypasses only the
+    /// equality suppression.
+    #[test]
+    fn regroup_baseline_diff_and_force() {
+        let mut group = empty_group();
+        let (k1, k5, k6) = (prefix(1), prefix(5), prefix(6));
+        group.apply_delta(&announce_delta(k1, OTHER1, None));
+        group.apply_delta(&announce_delta(k6, OTHER2, None));
+
+        let mut baseline: FxHashMap<(Prefix, u32), Route> = FxHashMap::default();
+        baseline.insert((k1, 0), route(k1, OTHER1)); // unchanged — suppressed
+        baseline.insert((k5, 0), route(k5, OTHER1)); // gone — withdraw
+        baseline.insert((k6, 0), route(k6, OTHER1)); // source flipped — announce
+
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let mut nh_flags = Vec::new();
+        RibManager::assemble_group_resync(
+            &group,
+            MEMBER,
+            true,
+            false,
+            Some(&baseline),
+            None,
+            &mut announce,
+            &mut withdraw,
+            &mut nh_flags,
+        );
+        let announced: HashSet<Prefix> = announce.iter().map(|r| r.prefix).collect();
+        assert_eq!(announced, HashSet::from([k6]));
+        let withdrawn: HashSet<(Prefix, u32)> = withdraw.into_iter().collect();
+        assert_eq!(withdrawn, HashSet::from([(k5, 0)]));
+
+        // Force (GShut refresh): every retained entry re-announces.
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let mut nh_flags = Vec::new();
+        RibManager::assemble_group_resync(
+            &group,
+            MEMBER,
+            false,
+            true,
+            Some(&baseline),
+            None,
+            &mut announce,
+            &mut withdraw,
+            &mut nh_flags,
+        );
+        let announced: HashSet<Prefix> = announce.iter().map(|r| r.prefix).collect();
+        assert_eq!(announced, HashSet::from([k1, k6]));
+        let withdrawn: HashSet<(Prefix, u32)> = withdraw.into_iter().collect();
+        assert_eq!(withdrawn, HashSet::from([(k5, 0)]));
+    }
+
+    /// Carried-over extra withdraws (a dirty member regrouping) emit
+    /// unless the member retains the key in the new group.
+    #[test]
+    fn extra_withdraws_respect_retained_keys() {
+        let mut group = empty_group();
+        let (k1, k7) = (prefix(1), prefix(7));
+        group.apply_delta(&announce_delta(k1, OTHER1, None));
+        let extras: HashSet<(Prefix, u32)> = HashSet::from([(k1, 0), (k7, 0)]);
+
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let mut nh_flags = Vec::new();
+        RibManager::assemble_group_resync(
+            &group,
+            MEMBER,
+            true,
+            false,
+            None,
+            Some(&extras),
+            &mut announce,
+            &mut withdraw,
+            &mut nh_flags,
+        );
+        let withdrawn: HashSet<(Prefix, u32)> = withdraw.into_iter().collect();
+        assert_eq!(
+            withdrawn,
+            HashSet::from([(k7, 0)]),
+            "a key still retained (k1 via OTHER1) must not be withdrawn"
+        );
+    }
+
+    /// The join replay dimension: a joining member's view is the table
+    /// minus its own-sourced entries, with O(1) count synthesis kept in
+    /// lockstep by `apply_delta` (announce, replace, withdraw).
+    #[test]
+    fn join_view_and_count_synthesis_track_deltas() {
+        let mut group = empty_group();
+        let (k1, k2) = (prefix(1), prefix(2));
+        group.apply_delta(&announce_delta(k1, OTHER1, None));
+        group.apply_delta(&announce_delta(k2, MEMBER, None));
+        assert_eq!(group.advertised_count_for(MEMBER), 1);
+        assert_eq!(group.advertised_count_for(OTHER1), 1);
+        assert_eq!(group.advertised_count_for(OTHER2), 2);
+        assert_eq!(
+            group.family_counts_for(MEMBER),
+            vec![((Afi::Ipv4, Safi::Unicast), 1)]
+        );
+        let view = group.member_view_snapshot(MEMBER);
+        assert_eq!(view.len(), 1);
+        assert!(view.contains_key(&(k1, 0)));
+
+        // Source flip k1 OTHER1 → MEMBER keeps counts exact.
+        group.apply_delta(&announce_delta(k1, MEMBER, Some(OTHER1)));
+        assert_eq!(group.advertised_count_for(MEMBER), 0);
+        assert_eq!(group.advertised_count_for(OTHER1), 2);
+
+        // Withdraw drops the entry and its residue.
+        group.apply_delta(&withdraw_delta(k1, Some(MEMBER)));
+        assert_eq!(group.advertised_count_for(OTHER1), 1);
+        assert_eq!(group.table.len(), 1);
     }
 }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2276,6 +2276,28 @@ impl BgpMetrics {
         });
     }
 
+    /// Bulk variant of [`Self::record_policy_routes`]: add `n` evaluations
+    /// in one call. Used by the update-group fanout, which evaluates the
+    /// export chain once per (group, prefix) and replays the verdict to
+    /// each member as an integer add instead of per-(prefix × peer)
+    /// counter lookups. Totals and label sets are identical to calling
+    /// `record_policy_routes` `n` times.
+    pub fn record_policy_routes_by(
+        &self,
+        peer: &str,
+        policy: &str,
+        direction: &str,
+        action: &str,
+        n: u64,
+    ) {
+        if n == 0 {
+            return;
+        }
+        self.policy_routes
+            .with_label_values(&[peer, policy, direction, action])
+            .inc_by(n);
+    }
+
     /// Set the GR active flag for a peer (1 = in GR, 0 = not).
     pub fn set_gr_active(&self, peer: &str, active: bool) {
         self.gr_active_peers


### PR DESCRIPTION
Update-groups slice 2 — the centerpiece: grouped peers share ONE export-staging pass per changed prefix; per-member work drops to a source-flip delta emit. **Kill criterion passed: 100k-route convergence at 256 peers 15.1s → 1.41s (~10.7×).**

## Shared body, not forked (design risk 1)

`distribute_single_best_prefix` is the one staging body for both paths, parameterized by `ExportTarget`: `Peer{..}` is today's path verbatim; `Group{evals}` lifts split horizon out (applied per member at emit), passes `None` peer-context (sound — `requires_peer_context` chains are disqualified from grouping), and accumulates evaluations for per-member counter replay. The per-peer path remains the correctness oracle forever.

## GroupRibOut + source-flip matrix

One staged table per group (existing AdjRibOut substrate, source peer preserved); `routes_equal` suppression runs once per group. No per-peer advertised storage for grouped members — advertised set = table − own-sourced. Per-member emit implements the design's source-flip matrix; proven by an exhaustive unit matrix over {old_source} × {announce source, withdraw} against the per-peer reference formula (HAD/GETS).

## Lifecycle

Join replays table−own-sourced (policy work already done); leave drops the table with the last member; regroup = leave+join with a one-shot routes_equal diff in both directions (grouped↔ungrouped); content-equal chain reinstall stays key-stable and skips resync. Dirty members: group-level withdrawal tombstones (maintained only while ≥1 member dirty), resync = withdraw tombstones∖retained + full-table announce (over-withdraw is the safe direction); `pending_extra_withdraws` closes the dirty-member-regroups-while-tombstoned hole the design missed.

## Differential oracle (risk 1)

Every scenario runs twice through the real manager — grouped vs a forced-ungrouped hook — with per-peer streams asserted identical (attributes + nh-override flags included): initial dump, best change/withdraw, policy-modified attrs, split horizon, source-flip X→Y→X, mid-stream join, leave, both regroup flavors, RR-client vs non-client, eBGP LLGR suppression, GShut refresh, plain-iBGP split horizon. Dirty-resync compares folded final state (the grouped path deliberately over-emits; inherent to abolishing per-peer advertised storage) plus recovery assertions.

## Measured (rrharness flood-256)

- Convergence 15.1s → **1.41s (~10.7×)**; sustained ~1.46s per 100k block.
- staging+AdjRibOut bucket 81.9% → 28.5% (target <20% near-missed): the old trie-insert/Route-memcpy lines are gone; the residual is the per-member `Vec<Route>` fanout clone + SipHash `PreparedAttrCacheKey` — both reserved for slice 4 (Arc payload, FxHash).

## Semantics notes

- Grouped advertised-routes queries report intended state (table−own) rather than last-successfully-sent; per-peer commit-after-send pins now run under the forced-ungrouped hook.
- Export evaluations genuinely happen once per group: clean-pass/join counters replay group verdicts; grouped dirty/regroup resyncs don't re-evaluate. ADR-0096 term-hit counters keep working via chain share().
- Minimal query synthesis (advertised routes/count, BMP stat-17) pulled forward from slice 3 so grouped peers never return wrong answers.

Gates: workspace build/test (641 rib tests, 64 suites), fmt, clippy -D warnings, cargo doc, clippy-reasons, bench-internals check — all green.