### PR TITLE
docs: add the Grafana overview dashboard and the receipts index

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ evolving API.**
 | [docs/SECURITY.md](docs/SECURITY.md) | Security posture, firewall guidance, deployment tiers |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Wire codec and RIB performance numbers, scaling analysis |
 | [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md) | Consolidated operational proof receipts: CI interop, dataplane, benchmarks, memory, soak |
+| [docs/RECEIPTS.md](docs/RECEIPTS.md) | Full receipts index: every M-series interop lab, perf/scale receipt, archived soak, and CI schedule |
+| [docs/GRAFANA.md](docs/GRAFANA.md) | Grafana overview dashboard: import instructions and Prometheus scrape config |
 | [docs/COMPARISON.md](docs/COMPARISON.md) | Feature comparison with FRR, BIRD, GoBGP, OpenBGPd |
 | [docs/INTEROP.md](docs/INTEROP.md) | Interop test coverage and results |
 | [docs/evpn-enablement.md](docs/evpn-enablement.md) | EVPN Phase 1-9 gate ladder: what each gate unlocks, work per gate, priority |

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -1,0 +1,64 @@
+# Grafana Dashboard
+
+A ready-to-import overview dashboard lives at
+[`grafana/rustbgpd-overview.json`](grafana/rustbgpd-overview.json)
+(uid `rustbgpd-overview`). It covers session health, RIB scale,
+churn/distribution (including the ADR-0098 update-group gauges), policy
+decisions, BMP/event-outbox health, and RPKI/ASPA state. Every panel
+references metrics the daemon actually exports from
+`crates/telemetry/src/metrics.rs` — no speculative series.
+
+## Enable the metrics endpoint
+
+Metrics are served by the daemon's built-in Prometheus listener,
+configured in [`CONFIGURATION.md`](CONFIGURATION.md#globaltelemetry):
+
+```toml
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+```
+
+The same listener serves `/metrics`, `/livez`, and `/readyz`. Omit
+`prometheus_addr` to disable it.
+
+## Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: rustbgpd
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["127.0.0.1:9179"]
+```
+
+## Import the dashboard
+
+1. Grafana → **Dashboards → New → Import**.
+2. Upload `docs/grafana/rustbgpd-overview.json` (or paste its contents).
+3. Pick your Prometheus data source when prompted (the dashboard uses a
+   `datasource` template variable, so it binds at import time).
+
+Template variables:
+
+- **Instance** — Prometheus `instance` label, populated from
+  `bgp_rib_outbound_registered_peers` (always exported, even at zero).
+- **Peer** — the daemon's `peer` label (neighbor address), multi-select
+  with an All option. Per-peer series are reaped when a peer is deleted,
+  so stale neighbors age out of the picker on the next scrape.
+
+## Reading notes
+
+- Counters are plotted with `rate(...[$__rate_interval])`; gauges are
+  plotted raw. Single-stats use last-not-null.
+- "Peers registered for distribution" is
+  `bgp_rib_outbound_registered_peers` — the closest exported gauge to
+  "currently Established peers". The daemon does not export a per-peer
+  session-state gauge; state history is available via
+  `bgp_session_state_transitions_total`.
+- Panels for optional subsystems (BFD, BMP, RPKI/ASPA, update groups,
+  event outbox) stay empty until the corresponding feature is configured;
+  vector metrics only emit series once a label combination is touched.
+- EVPN metrics (the `evpn_*` families) are intentionally not on this
+  overview dashboard; they are VTEP-alpha surface with per-VNI/MAC/ESI
+  cardinality better served by a dedicated dashboard.

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -1,0 +1,167 @@
+# Receipts Index
+
+rustbgpd's development rule is simple: **every wire-behavior claim has a lab
+that proves it, and every performance claim has a measured receipt.** A
+feature is not "done" when the code merges — it is done when a containerlab
+topology against a real peer implementation (FRR, BIRD, GoBGP), a real kernel
+dataplane, or a documented same-host measurement demonstrates the claimed
+behavior, and that evidence is checked in. This page is the single index of
+those receipts: the M-series interop labs, the performance and scale
+measurements, the archived long-running soaks, and the CI schedules that keep
+re-proving all of it. The operator-facing roll-up (what has been proved, in
+prose) is [`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md); detailed procedures
+and per-test assertions live in [`INTEROP.md`](INTEROP.md). Receipts must
+satisfy the [M-series proof quality
+contract](INTEROP.md#m-series-proof-quality-contract): target-scoped
+assertions, kernel evidence for kernel claims, rerunnable cleanup-safe
+drivers, and a non-vacuity sentinel.
+
+Numbering note: M0–M4 and M10 onward are interop labs. M5–M9 were
+development-phase build milestones (wire/RIB/API hardening) and are documented
+in [`milestones.md`](milestones.md), not here.
+
+## Interop labs — PR-gated (`interop.yml`)
+
+These run on every pull request via
+[`.github/workflows/interop.yml`](../.github/workflows/interop.yml); the job
+id matches the milestone. Full procedures: [`INTEROP.md`](INTEROP.md).
+
+| Receipt | Proves | Peer stack |
+|---------|--------|------------|
+| M1 | Basic session + UPDATE receive into the RIB | FRR 10.3.1 |
+| M10 | IPv6 dual-stack MP-BGP (MP_REACH_NLRI) | FRR 10.3.1 |
+| M13 | Policy engine: import chains, export deny/MED/prepend (3-node) | FRR 10.3.1 |
+| M14 | Route reflector (RFC 4456): ORIGINATOR_ID, CLUSTER_LIST, reflection | FRR 10.3.1 |
+| M15 | Route Refresh (RFC 2918) via gRPC SoftResetIn | FRR 10.3.1 |
+| M17 | Add-Path (RFC 7911) multi-path send with distinct path ids | FRR 10.3.1 |
+| M22 | FlowSpec inject + distribute + withdraw | FRR 10.3.1 |
+| M24 | BMP Initiation, PeerUp, RouteMonitoring ordering | FRR + BMP receiver |
+| M25 | TCP MD5 authentication + GTSM/TTL security | FRR 10.3.1 ×2 |
+| M29 | EVPN RR capability sanity (RFC 7432) + `ListEvpnRoutes` | FRR 10.3.1 |
+| M30 | EVPN Type 2 MAC reflection end-to-end with kernel VXLAN VTEPs | FRR 10.3.1 ×2 |
+| M34 | SIGHUP policy soft-reset auto-fire | FRR 10.3.1 |
+| M35 / M35b / M35c | RFC 8326 Graceful Shutdown: receiver + initiator legs across unicast, FlowSpec, and EVPN | FRR 10.3.1 |
+| M41 | RFC 7999 BLACKHOLE receiver scoping + opt-in kernel FIB discard | FRR 10.3.1 |
+| M44 | ADR-0064 gRPC tier authorization over native mTLS | grpcurl |
+| M45 | EVPN Type 5 control-plane injection via gRPC (RFC 9136) | FRR 10.3.1 |
+| M54 | ADR-0070 gNMI / OpenConfig telemetry + Set over mTLS | gnmic 0.46.0 |
+| M55 | BGP Roles + Only-to-Customer leak prevention (RFC 9234) | FRR 10.3.1 ×5 |
+| M56 | gNMI `Subscribe ON_CHANGE` session-state stream | gnmic + FRR |
+| M57 | Receive-side Address-Prefix ORF (RFC 5291/5292) | FRR 10.3.1 |
+| M63 | ADR-0078 inbound backpressure: hold-timer survival under a stalled RIB | FRR 10.3.1 |
+| M64 | IPv6-only peering (`disable_ipv4_unicast`) | FRR 10.3.1 |
+| M73 | BGP-LS route reflection: source → RR → sink, attributes verbatim | GoBGP 4.6.0 ×2 |
+| M74 | VPNv4 (SAFI 128) reflection: RD/label/RT/next-hop preserved verbatim | GoBGP 3.37.0 ×2 |
+| M75 | RT-Constrain (RFC 4684) VPNv4 reflection filtering, widen/narrow without reset | GoBGP 3.37.0 ×3 |
+| M76 | RFC 9107 Optimal Route Reflection: divergent per-vantage best paths, topology-driven flip | GoBGP 4.6.0 ×5 |
+| M77 | GR/LLGR stale preservation for the RR families (RFC 4724 + RFC 9494) | GoBGP 4.6.0 ×3 |
+| M78 | Multi-cluster ORR + inter-RR Add-Path | GoBGP 4.6.0 ×5 + rustbgpd ×2 |
+| M79 | RFC 8277 labeled-unicast (SAFI 4) reflection + GR | GoBGP 4.6.0 ×2 |
+| M80 | ADR-0096 `.rpol` policy parity vs FRR route-maps, hot-apply under traffic | FRR 10.3.1 ×3 |
+| M81 | BMP trio (rib-in, rib-out, loc-rib) + BMPv4 against three independent decoders | GoBGP ×2 + pmacct + gobmp + tshark |
+
+## Interop labs — kernel dataplane, PR + nightly (`kernel-dataplane.yml`)
+
+Privileged containerlab/netns receipts on hosted runners via
+[`.github/workflows/kernel-dataplane.yml`](../.github/workflows/kernel-dataplane.yml)
+(PRs, pushes to `main`, nightly 07:00 UTC, manual dispatch). Kernel claims are
+proved with kernel evidence (routes, FDB rows, nexthop groups, netdev state).
+
+| Receipt | Proves | Peer stack |
+|---------|--------|------------|
+| M36 | EVPN VTEP receive-side Linux FDB programming | FRR 10.3.1 |
+| M37 / M37+IP | EVPN local MAC (+MAC/IP) Type 2/Type 3 origination from kernel observation | FRR 10.3.1 |
+| M38 | EVPN multi-homing DF election + Type 1/4 origination | rustbgpd ×2 |
+| M39 | EVPN symmetric Interface-less IRB (Type 5 / L3VNI) bidirectional | FRR 10.3.1 |
+| M39b | Auto-derived Route Targets cross-vendor (RFC 8365 `AS:VNI`) | FRR 10.3.1 |
+| M40 | ADR-0059 EVPN aliasing dataplane ECMP via FDB nexthop groups | FRR EVPN-MH |
+| M42 | ADR-0061 opt-in general unicast Linux FIB runtime | FRR 10.3.1 |
+| M43 | ADR-0062 TCP-AO protected session (probed; skips only if the runner kernel lacks TCP-AO) | BIRD 3.2.1 |
+| M46 | RFC 8584 Highest Random Weight DF election | rustbgpd ×2 |
+| M47 / M48 | ADR-0063 runtime EVPN tenant teardown (control plane / kernel L3 datapath) | FRR 10.3.1 |
+| M49 / M69 | RFC 9785 Highest-Preference DF election (rustbgpd↔rustbgpd and cross-vendor) | rustbgpd ×2 / FRR |
+| M50 / M52 | ADR-0066 unicast multipath ECMP FIB install + multipath-relax | FRR 10.3.1 ×2 |
+| M51 | ADR-0067 single-hop BFD + RFC 5882 BGP coupling | FRR 10.3.1 |
+| M53 | ADR-0069 BGP unnumbered / IPv6 link-local peering + scoped FIB | FRR 10.3.1 ×2 |
+| M58 | ADR-0061 runtime `[[fib_tables]]` CRUD over gRPC/CLI | FRR 10.3.1 |
+| M60 / M61 / M62 | ADR-0079 adoption sweeps: kill-and-restart reaping/re-adoption for FDB, EVPN L3, and BLACKHOLE state | FRR 10.3.1 |
+| M65 | ADR-0083 single-active failover blackout measurement | GoBGP 3.x ×2 |
+| M66 / M67 | ADR-0084/0085 Ethernet Segment drain: operator handover and link-driven failover | rustbgpd ×3 |
+| M68 | ADR-0087 native GW-IP overlay-index Type 5, FRR consume-side recursion | FRR 10.3.1 |
+| M70 | ADR-0089 VLAN-aware bridge FDB attribution | FRR 10.3.1 |
+| M71 / M72 | RFC 9136 §4.3 ESI overlay-index Type 5 receive: single-active and all-active recursion | GoBGP 3.x |
+| netns selectors | Docker-harness privileged selectors (`fdb_nhg`, `fib_runtime`, `bfd_runtime`, `svd_fdb_vni`, managed-netdev lifecycle, L3 multipath/writer, …) | Linux kernel |
+
+## Interop labs — manual / local gates
+
+Documented drivers that stay off PR CI (long wall clock, extra fixtures, or
+covered by later CI receipts). Procedures and results:
+[`INTEROP.md`](INTEROP.md).
+
+| Receipt | Proves | Peer stack |
+|---------|--------|------------|
+| M0 | Session establishment, restart/reset recovery, 30-min soak | FRR 10.3.1 and BIRD 2.0.12 |
+| M2 | Best-path selection + `ListBestRoutes` pagination | FRR 10.3.1 |
+| M3 | Redistribution, split horizon, injection, withdrawal propagation | FRR 10.3.1 ×2 |
+| M4 | Route-server mode: 10-peer static + dynamic neighbor management | FRR 10.3.1 |
+| M11 | Graceful Restart (RFC 4724): stale marking, EoR, timer sweep | FRR 10.3.1 |
+| M12 | Extended Communities (RFC 4360) receive + inject | FRR 10.3.1 |
+| M16 | LLGR (RFC 9494): GR→LLGR transition, stale clearing | FRR 10.3.1 |
+| M18 | Extended Next-Hop (RFC 8950): IPv6 next hop for IPv4 NLRI | FRR 10.3.1 |
+| M19 | Transparent route server: no ASN prepend, NH preservation | FRR 10.3.1 |
+| M20 | Private AS removal (remove/all/replace) | FRR 10.3.1 |
+| M21 | RPKI origin validation via RTR | FRR + StayRTR |
+| M23 | Bidirectional route exchange with GoBGP | GoBGP 4.3.0 |
+| M26 | Cease/Max-Prefixes (subcode 1) teardown + re-establish | FRR 10.3.1 |
+| M27 / M59 | ASPA via RTR v2: validation states, best-path preference, role-aware downstream verification | FRR + RTR v2 mock |
+| M28 | Dynamic prefix-based neighbors: auto-accept, auto-remove | FRR 10.3.1 |
+| M30b | EVPN Type 5 IP-prefix origination (RFC 9136) with kernel VRF/L3VNI | FRR 10.3.1 |
+| M31 | EVPN MAC mobility + sticky preservation (RFC 7432 §15.1/§7.7) | FRR 10.3.1 ×3 |
+| M32 / M32b | EVPN multi-homing Type 1 EAD + Type 4 ES reflection (kernel bond / synthetic ESI) | FRR 10.3.1 ×3 |
+| M33 | EVPN RR scale: 50k Type 2 routes + 60 s of 1000/s churn | in-tree `bench/evpn-load` |
+
+## Performance and scale receipts
+
+| Receipt | What it measures | Source |
+|---------|------------------|--------|
+| 1000-peer RR scale receipt | Real `RibManager` + 1000 real transport sessions over loopback: 100k-route cold convergence, policy-on, mixed-fleet, and churn, with the profile-to-fix storyline behind the ADR-0098 update-groups arc | [`perf/scale-receipt-2026-07.md`](perf/scale-receipt-2026-07.md) |
+| RIB operations (Criterion) | Ingest, best-path, distribution microbenchmarks with pinned A/B compare methodology | [`BENCHMARKS.md`](BENCHMARKS.md#rib-operations) |
+| End-to-end bgperf2 | Same-host convergence/CPU/RSS comparison vs BIRD and GoBGP | [`BENCHMARKS.md`](BENCHMARKS.md#end-to-end-system-benchmarks) |
+| High-N RIB memory | Structural memory at 100k/500k/900k prefixes; A/B via `bench/compare-rib-memory.sh` under the shared host lock | [`BENCHMARKS.md`](BENCHMARKS.md#memory-footprint), [`../bench/README.md`](../bench/README.md) |
+| EVPN M33 load gate | 50k reflected Type 2 routes + 60 s of 1k-rps churn | [`BENCHMARKS.md`](BENCHMARKS.md#evpn-rr-scale-m33) |
+
+## Soak receipts
+
+Archived long-running runs with pass/fail gates, RSS slopes, and git-tracked
+artifacts under [`artifacts/soak/`](artifacts/soak/). Harnesses live in
+[`../tests/soak/`](../tests/soak/README.md).
+
+| Receipt | Duration | What it proves |
+|---------|----------|----------------|
+| [Gate 8b BUM-state](soak-gate8b-24h-bum-state.md) | 24 h | BUM-port flag triplet survives 71 DF-flip cycles; flat RSS |
+| [Gate 8b MAC-churn dry run](soak-gate8b-mac-churn-1h.md) | 1 h | Dry run gating the 24 h MAC-churn soak |
+| [Gate 8b MAC-churn](soak-gate8b-mac-churn-24h.md) | 24 h | 69 post-flip reconverges under MAC churn; zero WARN/FATAL; ~0.08 MB/h envelope |
+| [Gate 8b MAC-churn leak A/B](soak-gate8b-mac-churn-10h-leak.md) | ~10 h | EVPN attribute-intern table bounded under churn across DF flips (MAC-mobility leak fix, churn axis) |
+| [Gate 9 symmetric IRB](soak-gate9-slice6-24h-symmetric-irb.md) | 24 h | 703 Type 5 churn cycles; zero session or installed-route violations |
+| [M33 EVPN scale leak A/B](soak-m33-evpn-scale-10h-leak.md) | ~10 h | Attribute-intern table bounded at 50k Type 2 routes + churn (leak fix, scale axis) |
+| [M37 local-origination churn](soak-m37-local-origination-churn-24h.md) | 24 h | 430,400 injects balanced by 430,400 withdraws; zero flaps |
+| [M67 link-drain MAC-mobility](soak-m67-link-drain-24h-evpn-leak.md) | 24 h | 960 link-drain failover cycles with live MAC-mobility churn; all six RSS gates flat; blackout ≤ 300 ms |
+
+## Continuous verification — CI schedules
+
+| Workflow | Trigger | What it re-proves |
+|----------|---------|-------------------|
+| [`ci.yml`](../.github/workflows/ci.yml) | every PR / push | fmt, clippy (warnings denied), workspace tests, rustdoc, kernel-primitive gate |
+| [`interop.yml`](../.github/workflows/interop.yml) | every PR / push | The PR-gated M-series table above, one containerlab job per milestone |
+| [`kernel-dataplane.yml`](../.github/workflows/kernel-dataplane.yml) | PR, push, nightly 07:00 UTC | Privileged EVPN/FIB/BFD/TCP-AO dataplane receipts + netns selectors |
+| [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC + PR smoke | libFuzzer wire-decode harnesses |
+| [`bench-nightly.yml`](../.github/workflows/bench-nightly.yml) | nightly 05:00 UTC | Benchmark tracking on the bench runner |
+| [`audit.yml`](../.github/workflows/audit.yml) | daily 06:00 UTC | `cargo audit` / dependency advisories |
+| [`privileged-interop.yml`](../.github/workflows/privileged-interop.yml) | manual dispatch | Direct-`cargo` privileged netns suites |
+
+## Adding a receipt
+
+Write the detailed source document first (interop procedure in
+[`INTEROP.md`](INTEROP.md), soak postmortem as `docs/soak-*.md` with artifacts
+under `docs/artifacts/soak/<run-id>/`, perf receipt under `docs/perf/`), then
+add the row here and in [`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md).

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -1,0 +1,1819 @@
+{
+  "uid": "rustbgpd-overview",
+  "title": "rustbgpd Overview",
+  "description": "Session health, RIB scale, churn/distribution, policy, BMP, and RPKI/ASPA overview for rustbgpd. Every panel references metrics exported by the daemon's Prometheus endpoint ([telemetry].prometheus_addr).",
+  "tags": [
+    "rustbgpd",
+    "bgp"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "timezone": "",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(bgp_rib_outbound_registered_peers, instance)",
+        "current": {},
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "peer",
+        "label": "Peer",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": "label_values(bgp_session_state_transitions_total{instance=~\"$instance\"}, peer)",
+        "current": {},
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Peers registered for distribution",
+      "description": "bgp_rib_outbound_registered_peers: peers currently registered with the RIB manager for outbound distribution \u2014 the closest exported gauge to 'currently Established peers'. An Established session missing here has a wedged advertisement path.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(bgp_rib_outbound_registered_peers{instance=~\"$instance\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Loc-RIB routes (all families)",
+      "description": "Sum of bgp_rib_loc_prefixes across every AFI/SAFI.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(bgp_rib_loc_prefixes{instance=~\"$instance\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Update groups",
+      "description": "bgp_update_groups: update groups with at least one member peer (ADR-0098).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(bgp_update_groups{instance=~\"$instance\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Ungrouped (fallback) peers",
+      "description": "bgp_update_group_fallback_peers: peers on the per-peer distribution path because a v1 disqualifier (peer-context policy, Add-Path send, ORR vantage, negotiated ORF) applies.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(bgp_update_group_fallback_peers{instance=~\"$instance\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Session flaps (1h)",
+      "description": "increase(bgp_session_flaps_total[1h]) summed over selected peers.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(bgp_session_flaps_total{instance=~\"$instance\",peer=~\"$peer\"}[1h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Event outbox health",
+      "description": "bgp_event_outbox_degraded: 1 after any outbox drop or open failure since process start (does not auto-clear).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OK",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "DEGRADED",
+                  "color": "red"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(bgp_event_outbox_degraded{instance=~\"$instance\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Session health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Session establishments / flaps",
+      "description": "Counters bgp_session_established_total and bgp_session_flaps_total as rates.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_session_established_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "established {{peer}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_session_flaps_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "flap {{peer}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "FSM state transitions",
+      "description": "bgp_session_state_transitions_total by destination state.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, to) (rate(bgp_session_state_transitions_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "{{peer}} \u2192 {{to}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "NOTIFICATIONs by code/subcode",
+      "description": "bgp_notifications_sent_total / bgp_notifications_received_total.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (code, subcode) (rate(bgp_notifications_sent_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "sent {{code}}/{{subcode}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (code, subcode) (rate(bgp_notifications_received_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "recv {{code}}/{{subcode}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Hold-timer re-arms / stale timer events",
+      "description": "bgp_hold_timer_rearmed_pending_input_total: hold-timer expiries converted to re-arms because the local daemon was the bottleneck (ADR-0078). bgp_fsm_stale_timer_events_total: timer events in a state where that timer should not run (daemon-side timer bug indicator).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_hold_timer_rearmed_pending_input_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "hold re-arm {{peer}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, timer) (rate(bgp_fsm_stale_timer_events_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "stale {{timer}} {{peer}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "BFD sessions",
+      "description": "bfd_session_up gauge (1 = Up) and bfd_session_flaps_total rate. Empty unless BFD is enabled (ADR-0067).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bfd_session_up{instance=~\"$instance\",peer=~\"$peer\"}",
+          "legendFormat": "up {{peer}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bfd_session_flaps_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "flaps {{peer}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "row",
+      "title": "RIB scale",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": []
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Loc-RIB prefixes by family",
+      "description": "bgp_rib_loc_prefixes per AFI/SAFI.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_rib_loc_prefixes{instance=~\"$instance\"}",
+          "legendFormat": "{{afi_safi}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Adj-RIB-In prefixes by family",
+      "description": "bgp_rib_prefixes summed over selected peers per AFI/SAFI.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (afi_safi) (bgp_rib_prefixes{instance=~\"$instance\",peer=~\"$peer\"})",
+          "legendFormat": "{{afi_safi}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Adj-RIB-In prefixes per peer",
+      "description": "bgp_rib_prefixes summed over families per peer.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (bgp_rib_prefixes{instance=~\"$instance\",peer=~\"$peer\"})",
+          "legendFormat": "{{peer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Adj-RIB-Out prefixes per peer",
+      "description": "bgp_rib_adj_out_prefixes summed over families per peer.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (bgp_rib_adj_out_prefixes{instance=~\"$instance\",peer=~\"$peer\"})",
+          "legendFormat": "{{peer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "row",
+      "title": "Churn and distribution",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "panels": []
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "UPDATE rate in / out",
+      "description": "bgp_messages_received_total / bgp_messages_sent_total filtered to type=\"update\".",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(bgp_messages_received_total{instance=~\"$instance\",peer=~\"$peer\",type=\"update\"}[$__rate_interval]))",
+          "legendFormat": "UPDATEs in",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(bgp_messages_sent_total{instance=~\"$instance\",peer=~\"$peer\",type=\"update\"}[$__rate_interval]))",
+          "legendFormat": "UPDATEs out",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Message rate by type",
+      "description": "All BGP message types (open, update, keepalive, notification, route_refresh).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(bgp_messages_sent_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "sent {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (type) (rate(bgp_messages_received_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "recv {{type}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Update-group membership (ADR-0098)",
+      "description": "bgp_update_group_members per group id; bgp_update_group_regroups_total as a rate (membership churn \u2014 should be quiet in steady state).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 47
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_update_group_members{instance=~\"$instance\"}",
+          "legendFormat": "group {{group}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(bgp_update_group_regroups_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "regroups/s",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "RIB ingest pressure",
+      "description": "bgp_rib_ingest_channel_depth (queued RibUpdates; pegged at capacity = producers parked), bgp_inbound_rib_backpressure_total and bgp_outbound_route_drops_total rates.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 47
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_rib_ingest_channel_depth{instance=~\"$instance\"}",
+          "legendFormat": "ingest depth",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_inbound_rib_backpressure_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "inbound blocked {{peer}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_outbound_route_drops_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "outbound drops {{peer}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Route-refresh windows / dirty resync",
+      "description": "bgp_route_refresh_in_progress and bgp_route_refresh_stale_entries (RFC 7313 enhanced refresh), plus bgp_rib_dirty_resync_total by outcome.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 47
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, afi_safi) (bgp_route_refresh_in_progress{instance=~\"$instance\",peer=~\"$peer\"})",
+          "legendFormat": "refresh {{peer}} {{afi_safi}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, afi_safi) (bgp_route_refresh_stale_entries{instance=~\"$instance\",peer=~\"$peer\"})",
+          "legendFormat": "stale {{peer}} {{afi_safi}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (outcome) (rate(bgp_rib_dirty_resync_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "resync {{outcome}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "row",
+      "title": "Policy",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "panels": []
+    },
+    {
+      "id": 25,
+      "type": "timeseries",
+      "title": "Policy decisions by direction/action",
+      "description": "bgp_policy_routes_total: routes evaluated through a policy chain, attributed to the terminal-decision policy.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 56
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (direction, action) (rate(bgp_policy_routes_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "{{direction}}/{{action}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "Top policies by evaluated routes",
+      "description": "topk(10) over bgp_policy_routes_total by terminal policy name (\"inline\" = anonymous chain).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 56
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (policy) (rate(bgp_policy_routes_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval])))",
+          "legendFormat": "{{policy}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Protection rejections",
+      "description": "Max-prefix teardowns, AS_PATH / RR loop rejections, RFC 9234 OTC blocks and role mismatches.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 56
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_max_prefix_exceeded_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "max-prefix {{peer}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_as_path_loop_detected_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "as-path loop {{peer}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_rr_loop_detected_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "rr loop {{peer}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, reason) (rate(bgp_otc_routes_blocked_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "otc {{reason}} {{peer}}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer) (rate(bgp_role_mismatch_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "role mismatch {{peer}}",
+          "refId": "E"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "type": "row",
+      "title": "BMP and event streaming",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "panels": []
+    },
+    {
+      "id": 29,
+      "type": "timeseries",
+      "title": "BMP drops",
+      "description": "bmp_source_drops_total (session\u2192manager), bmp_collector_drops_total (manager\u2192collector, by phase), bmp_control_event_drops_total. Any non-zero rate means the BMP feed is lossy.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 65
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (peer, reason) (rate(bmp_source_drops_total{instance=~\"$instance\",peer=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "source {{reason}} {{peer}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (collector, phase, reason) (rate(bmp_collector_drops_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{collector}} {{phase}} {{reason}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (collector, kind, reason) (rate(bmp_control_event_drops_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "ctl {{collector}} {{kind}} {{reason}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "BMP collector replays",
+      "description": "bmp_replay_attempts_total: PeerUp-cache replays triggered by collector reconnects.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 65
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (collector) (rate(bmp_replay_attempts_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{collector}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Event outbox (ADR-0072)",
+      "description": "Producer queue depth per category (climbs before drops start), drop rate, and on-disk size of events.db + WAL.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 65
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (category) (bgp_event_outbox_queue_depth{instance=~\"$instance\"})",
+          "legendFormat": "queue {{category}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (category, reason) (rate(bgp_event_outbox_dropped_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "dropped {{category}} {{reason}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_event_outbox_db_size_bytes{instance=~\"$instance\"}",
+          "legendFormat": "db bytes",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "row",
+      "title": "RPKI and ASPA",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "panels": []
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "RPKI VRPs by address family",
+      "description": "bgp_rpki_vrp_count: validated ROA payloads currently loaded from the RTR cache.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 74
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_rpki_vrp_count{instance=~\"$instance\"}",
+          "legendFormat": "{{af}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "ASPA records",
+      "description": "bgp_aspa_records_total: ASPA customer records in the merged table.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 74
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "bgp_aspa_records_total{instance=~\"$instance\"}",
+          "legendFormat": "records",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 35,
+      "type": "timeseries",
+      "title": "Validation-cache import refreshes",
+      "description": "bgp_validation_import_refreshes_total: inbound Route Refresh work triggered by RPKI/ASPA cache updates, by dependency and outcome.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 74
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (dependency, outcome) (rate(bgp_validation_import_refreshes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{dependency}} {{outcome}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -3,7 +3,9 @@
 Archived build orders, exit criteria, and design choices from the
 initial development phase. For the current feature roadmap, see
 [ROADMAP.md](../ROADMAP.md). For a full changelog, see
-[CHANGELOG.md](../CHANGELOG.md).
+[CHANGELOG.md](../CHANGELOG.md). For the index of every M-series
+interop receipt (and the perf/soak/CI receipts alongside them), see
+[RECEIPTS.md](RECEIPTS.md).
 
 All milestones below shipped as **v0.1.0** (2026-02-28).
 


### PR DESCRIPTION
Two trust-sweep legibility artifacts. Docs/JSON only.

## Grafana overview dashboard (docs/grafana/rustbgpd-overview.json + docs/GRAFANA.md)

All 103 exported metric families inventoried from crates/telemetry/src/metrics.rs; every panel expression uses a verified real metric name + labels. 6 stat panels + 23 timeseries across session health, RIB scale, churn/distribution (incl. the #674 update-group gauges and backpressure counters), policy + protections, BMP/monitoring, RPKI/ASPA. Template variables ($datasource/$instance/$peer), rate() on counters with $__rate_interval, stable uid. GRAFANA.md carries import steps and a scrape config matching the real prometheus_addr endpoint.

A "wanted but not exported" list is recorded (per-peer state gauge, best-path-change counter, send-hold expirations, BMP emit counters, per-term policy hits) — honest gaps, no Rust added.

## Receipts index (docs/RECEIPTS.md)

The receipts philosophy made legible: every wire-behavior claim has a lab, every perf claim a measurement. Indexed: 33 PR-gated interop milestone rows (M1→M81), 22 kernel-dataplane lab rows, 19 manual/local labs, 5 perf/scale receipts, 8 soak receipts, 7 scheduled CI workflows with cron times. Numbering gaps explained. README docs table + milestones.md header pointers added.

Gates: JSON parses; scripted link check verifies every relative target and #anchor against actual headings — all pass; no hostnames.