### PR TITLE
chore: lean production image, unprivileged systemd default, and global-inline-policy deprecation

### DIFF
--- a/.github/actions/setup-dataplane-host/action.yml
+++ b/.github/actions/setup-dataplane-host/action.yml
@@ -101,6 +101,7 @@ runs:
         context: .
         load: true
         tags: rustbgpd:dev
+        target: dev
         cache-from: type=gha
         # ignore-error: a flaking GHA cache backend ("error writing
         # layer blob: not_found") must cost the NEXT build its cache

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -162,6 +162,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -196,6 +197,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -233,6 +235,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -267,6 +270,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -301,6 +305,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -335,6 +340,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -369,6 +375,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -404,6 +411,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -442,6 +450,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -480,6 +489,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -518,6 +528,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -556,6 +567,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -594,6 +606,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -632,6 +645,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -673,6 +687,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -707,6 +722,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -743,6 +759,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -786,6 +803,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -829,6 +847,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -869,6 +888,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -906,6 +926,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -943,6 +964,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -980,6 +1002,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1016,6 +1039,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1054,6 +1078,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1088,6 +1113,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1132,6 +1158,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1172,6 +1199,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1209,6 +1237,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1247,6 +1276,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1284,6 +1314,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1322,6 +1353,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
@@ -1360,6 +1392,7 @@ jobs:
           context: .
           load: true
           tags: rustbgpd:dev
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Deprecated
+
+- **Global inline policy (`[[policy.import]]` / `[[policy.export]]`)
+  is deprecated and will be removed in a future release.** It is the
+  legacy pre-chain fallback: restart-required on change (no SIGHUP
+  hot-apply) and invisible to config transactions and the impact
+  planner. The daemon now logs a loud deprecation warning at startup,
+  in the startup banner, and on every reload while it is present.
+  Migrate to named policy chains (`[policy.definitions]` +
+  `import_chain` / `export_chain`) or `.rpol` files
+  (`policy.rpol_files`); see docs/CONFIGURATION.md "Inline policy
+  (deprecated)". Per-neighbor inline policy is unaffected.
+
+### Changed
+
+- **The default container image is now a lean production runtime.**
+  `docker build .` (and the GHCR release image) ships only the daemon
+  and the `rbgp` CLI, runs as a nonroot `rustbgpd` user, and carries no
+  dev/test/bench helpers. The previous all-in image (adds
+  `evpn-tester` / `evpn-monitor`, `iproute2`, the interop start
+  script; runs as root) is now the `dev` build target:
+  `docker build --target dev -t rustbgpd:dev .` — CI interop/soak
+  workflows are pinned to it.
+- **systemd packaging split into an unprivileged base unit + opt-in
+  dataplane drop-in.** `examples/systemd/rustbgpd.service` now runs as
+  a dedicated `rustbgpd` user with `CAP_NET_BIND_SERVICE` only
+  (`CAP_NET_RAW` dropped from the bounding set — nothing in the daemon
+  needs it; kernel programming was never possible under the old unit
+  either, which lacked `CAP_NET_ADMIN`). Kernel-dataplane deployments
+  ([[fib_tables]], blackhole install, EVPN VTEP/IRB) opt in via the
+  new `examples/systemd/rustbgpd-dataplane.conf` drop-in, which adds
+  `CAP_NET_ADMIN`. See docs/deployment.md "systemd".
+
 ### Added
 
 - **RFC 9687 Send Hold Timer: a peer that stops draining its TCP socket

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 # syntax=docker/dockerfile:1.7
 
-# rustbgpd:dev — interop / CI / dev container.
+# rustbgpd container image.
+#
+# Two consumable stages:
+#
+#   runtime (DEFAULT) — lean production image: the daemon + the `rbgp`
+#     CLI, nonroot user, nothing else. This is what the GHCR release
+#     image publishes (.github/workflows/container.yml builds the
+#     default target).
+#   dev — interop / CI / lab image: adds the EVPN load-gen helpers
+#     (evpn-tester / evpn-monitor), the interop start script, and
+#     iproute2/ping for containerlab topologies.
 #
 # Multi-stage build with cargo-chef separating dep compilation from
 # workspace compilation. Builds the `ci` profile (release-shaped but
@@ -13,7 +23,8 @@
 #   - mold linker: parallel final link, faster than the default GNU ld
 #
 # Build:
-#   docker build -t rustbgpd:dev .
+#   docker build -t rustbgpd:latest .                    # lean runtime
+#   docker build --target dev -t rustbgpd:dev .          # dev / interop
 #
 # BuildKit is required for the `RUN --mount=type=cache` directives
 # below; the legacy Docker builder rejects them with a parse error.
@@ -59,7 +70,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp target/ci/evpn-tester /out/ && \
     cp target/ci/evpn-monitor /out/
 
-FROM debian:bookworm-slim
+# ── dev: interop / CI / lab image ────────────────────────────────────
+# Ships the daemon + CLI plus the development-only helpers the
+# containerlab topologies and soak harnesses expect. Runs as root so
+# labs can program links/netns freely.
+FROM debian:bookworm-slim AS dev
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
@@ -78,4 +93,30 @@ EXPOSE 179 9179
 
 # Default: run daemon with config at /etc/rustbgpd/config.toml
 # Interop tests override with: docker run ... sleep infinity
+CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]
+
+# ── runtime: lean production image (DEFAULT target) ──────────────────
+# Daemon + rbgp only — no dev/test/bench helpers. Runs as a nonroot
+# user; Docker's default net.ipv4.ip_unprivileged_port_start=0 lets it
+# bind port 179 (grant CAP_NET_BIND_SERVICE explicitly on runtimes
+# that don't, e.g. some Kubernetes setups). Kernel-dataplane features
+# (Linux FIB / EVPN VTEP) additionally need CAP_NET_ADMIN — see
+# docs/deployment.md.
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --user-group --home-dir /var/lib/rustbgpd \
+       --shell /usr/sbin/nologin rustbgpd \
+    && mkdir -p /var/lib/rustbgpd \
+    && chown rustbgpd:rustbgpd /var/lib/rustbgpd
+
+COPY --from=builder /out/rustbgpd /usr/local/bin/rustbgpd
+COPY --from=builder /out/rbgp /usr/local/bin/rbgp
+
+USER rustbgpd
+
+EXPOSE 179 9179
+
 CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Press `q` to exit the TUI. When you're done: `docker compose down`.
 ```bash
 # Prerequisites: Rust 1.95+, protobuf-compiler
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
-cargo build --workspace --release
+cargo build --release -p rustbgpd -p rustbgpctl
 
 # Binaries are at target/release/rustbgpd and target/release/rbgp
 ```
@@ -139,7 +139,8 @@ cargo build --workspace --release
 ### Docker
 
 ```bash
-docker build -t rustbgpd .
+docker build -t rustbgpd .                    # lean runtime: daemon + rbgp, nonroot
+docker build --target dev -t rustbgpd:dev .   # dev/interop image (lab helpers, root)
 ```
 
 ## Quick start (bare metal)

--- a/bench/README.md
+++ b/bench/README.md
@@ -2,6 +2,21 @@
 
 This directory contains local tooling for repeatable performance checks.
 
+**Development tooling only.** Nothing in this directory is production
+surface: it is excluded from the default `cargo build`, the release
+binary tarballs, and the default (runtime) container image. The
+`evpn-load` crate's `evpn-tester` / `evpn-monitor` binaries are built
+only with `--workspace` and ship only in the `dev` image target used
+by the interop/soak labs.
+
+## evpn-load
+
+`evpn-load/` is the EVPN scale load generator — a deliberately minimal
+iBGP tester (`evpn-tester`) + convergence monitor (`evpn-monitor`) for
+RR benchmarking and the soak gates. It is not a BGP implementation and
+not an operator tool; see the crate docs in `evpn-load/src/lib.rs` for
+scope.
+
 ## Criterion compare
 
 `compare-criterion.sh` runs the same Criterion bench target at two git refs,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1269,7 +1269,19 @@ See [ADR-0034](adr/0034-rpki-origin-validation.md) for design details.
 Optional. Defines global import and export policy that applies to all neighbors
 that do not declare their own per-neighbor policy.
 
-### Inline policy (original syntax)
+### Inline policy (deprecated)
+
+> **DEPRECATED.** The global inline fallback (`[[policy.import]]` /
+> `[[policy.export]]`) predates the current policy architecture and
+> will be **removed in a future release**. It is restart-required on
+> change (no SIGHUP hot-apply), and it is invisible to config
+> transactions and the impact planner. The daemon logs a loud
+> deprecation warning at startup and on every reload while it is
+> present. Migrate to [named policy definitions](#named-policy-definitions)
+> plus `import_chain` / `export_chain`, or to
+> [`.rpol` policy files](rpol-language.md) via `policy.rpol_files`.
+> Per-neighbor inline policy (`[[neighbors.import_policy]]` /
+> `[[neighbors.export_policy]]`) is **not** deprecated.
 
 ```toml
 [[policy.import]]
@@ -1613,7 +1625,9 @@ For each neighbor, import and export policies are resolved independently:
    or `[[neighbors.export_policy]]`), those are wrapped in a single-element chain.
 3. Otherwise, the global **chain** (`import_chain` / `export_chain`) is used.
 4. Otherwise, the global **inline policy** (`[[policy.import]]` / `[[policy.export]]`)
-   is wrapped in a single-element chain.
+   is wrapped in a single-element chain. *(Deprecated — see
+   [Inline policy (deprecated)](#inline-policy-deprecated); will be removed
+   in a future release.)*
 5. If none of the above exist, all routes are permitted (no filtering).
 
 Per-neighbor policy completely replaces the global policy for that direction --

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -188,7 +188,7 @@ the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
 
 - Docker installed and running
 - containerlab installed
-- `rustbgpd:dev` Docker image built: `docker build -t rustbgpd:dev .`
+- `rustbgpd:dev` Docker image built: `docker build --target dev -t rustbgpd:dev .`
 - `bird:2-bookworm` Docker image built: `docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop/`
 - `bird:3.2.1-tcpao` Docker image built for M43:
   `docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/`
@@ -248,7 +248,7 @@ Linux kernel with `CONFIG_TCP_AO=y`:
 
 ```sh
 docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
 bash tests/interop/scripts/test-m43-tcp-ao-bird.sh
 containerlab destroy -t tests/interop/m43-tcp-ao-bird.clab.yml --cleanup

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -261,7 +261,7 @@ test -s docs/adr/0064-threat-model.md
 Run at least one from each category:
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 
 # Basic eBGP + RIB
 containerlab deploy -t tests/interop/m4-frr.clab.yml
@@ -331,7 +331,7 @@ can be reproduced manually the same way. M36 and M37 run in the hosted
 
 ```bash
 # Build the daemon image (bidirectional VTEP needs CAP_NET_ADMIN)
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 
 # M36 — Gate 7b downward path: rustbgpd-as-VTEP, FRR-as-originator
 containerlab deploy -t tests/interop/m36-evpn-vtep-smoke.clab.yml
@@ -410,7 +410,7 @@ reproduction:
 
 ```bash
 # M42 — ADR-0061 configured-table unicast Linux FIB runtime
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m42-fib-runtime-frr.clab.yml
 bash tests/interop/scripts/test-m42-fib-runtime-frr.sh
 containerlab destroy -t tests/interop/m42-fib-runtime-frr.clab.yml
@@ -433,7 +433,7 @@ Manual reproduction:
 
 ```bash
 # M51 — single-hop BFD + RFC 5882 coupling against FRR bfdd
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m51-bfd-frr.clab.yml
 bash tests/interop/scripts/test-m51-bfd-frr.sh
 containerlab destroy -t tests/interop/m51-bfd-frr.clab.yml
@@ -477,7 +477,7 @@ containerlab destroy -t tests/interop/m23-gobgp.clab.yml
 ### Docker smoke
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 
 # Verify shipped binaries are present
 docker run --rm --entrypoint sh rustbgpd:dev -c \

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -259,13 +259,15 @@ setcap cap_net_admin=eip /usr/local/bin/rustbgpd
 getcap /usr/local/bin/rustbgpd  # verify
 ```
 
-Or under systemd:
+Or under systemd, install the shipped drop-in
+[`examples/systemd/rustbgpd-dataplane.conf`](../examples/systemd/rustbgpd-dataplane.conf)
+on top of the unprivileged base unit (see
+[deployment.md](deployment.md#kernel-dataplane-opt-in-privilege-drop-in)):
 
 ```ini
 [Service]
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
-NoNewPrivileges=true
 ```
 
 This privilege scope is the minimum required for Linux EVPN VTEP

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,7 +72,9 @@ rbgp --version
 sudo apt-get install -y protobuf-compiler   # Debian/Ubuntu
 git clone https://github.com/lance0/rustbgpd
 cd rustbgpd
-cargo build --workspace --release
+# Builds exactly what a deployment ships: the daemon + the rbgp CLI.
+# (`--workspace` would also build dev/bench helpers you don't need.)
+cargo build --release -p rustbgpd -p rustbgpctl
 sudo install -m 0755 \
   target/release/rustbgpd target/release/rbgp \
   /usr/local/bin/
@@ -98,79 +100,92 @@ releases but pins against minor-version churn:
 docker pull ghcr.io/lance0/rustbgpd:0.30
 ```
 
-If you'd rather build locally:
+The published image is the Dockerfile's default `runtime` target:
+lean, daemon + `rbgp` only, running as a nonroot `rustbgpd` user. No
+dev/test/bench helpers are included. If you'd rather build it locally:
 
 ```sh
-docker build -t rustbgpd:dev .
+docker build -t rustbgpd:latest .
 ```
 
-The local image is what the M-series interop suite runs against; it's
-the canonical *development* image.
+The *development* image — adds `evpn-tester` / `evpn-monitor`,
+`iproute2`, and the interop start script, and runs as root for lab
+plumbing — is the `dev` target. It's what the M-series interop suite
+and the soak harnesses run against:
+
+```sh
+docker build --target dev -t rustbgpd:dev .
+```
 
 ## systemd
 
 A hardened unit lives at
-[`examples/systemd/rustbgpd.service`](../examples/systemd/rustbgpd.service):
-
-```ini
-[Unit]
-Description=rustbgpd BGP daemon
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/rustbgpd /etc/rustbgpd/config.toml
-ExecReload=/bin/kill -HUP $MAINPID
-StateDirectory=rustbgpd
-RuntimeDirectory=rustbgpd
-NoNewPrivileges=yes
-ProtectSystem=strict
-ProtectHome=yes
-ReadWritePaths=/var/lib/rustbgpd /etc/rustbgpd
-PrivateTmp=yes
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-```
+[`examples/systemd/rustbgpd.service`](../examples/systemd/rustbgpd.service).
+It runs the daemon **unprivileged by default**: a dedicated `rustbgpd`
+system user, the standard sandbox set (`NoNewPrivileges`,
+`ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `StateDirectory` /
+`RuntimeDirectory`), and a capability set of exactly
+`CAP_NET_BIND_SERVICE` (bind port 179 as non-root). That is everything
+a route-reflector / control-plane-only deployment needs.
 
 Notes on the sandbox:
 
 - `CAP_NET_BIND_SERVICE` lets the daemon bind port 179 without running
-  as root. `CAP_NET_RAW` is required for the configured Linux FIB
-  integration (ADR-0061) and for the optional BFD socket setup
-  (ADR-0067).
+  as root. Nothing else is granted by default — in particular **not**
+  `CAP_NET_ADMIN`, so the unprivileged unit cannot program the kernel.
 - `ProtectSystem=strict` + explicit `ReadWritePaths` confines the
   daemon to `/var/lib/rustbgpd` (state) and `/etc/rustbgpd` (config).
 - `ExecReload=kill -HUP` is the supported reload path. See the
   [reload matrix](reload-matrix.md) for which fields hot-apply vs.
   need a restart.
-- **If rustbgpd programs the kernel** (`[[fib_tables]]`,
-  `install_blackhole_discard`, or the EVPN dataplane) on a host that
-  also runs systemd-networkd, set `ManageForeignRoutes=no`,
-  `ManageForeignRoutingPolicyRules=no`, and (where supported)
-  `ManageForeignNextHops=no` in `networkd.conf`. The defaults are
-  `yes`, and networkd will delete routes and next-hop groups it did
-  not create — including rustbgpd's, especially across a daemon
-  restart (ADR-0079). Co-residency with another daemon that claims
-  `proto bgp` kernel state (e.g. FRR zebra) is unsupported for the
-  same reason.
 
 ### Installation
 
 ```sh
+sudo useradd --system --home-dir /var/lib/rustbgpd \
+  --shell /usr/sbin/nologin rustbgpd
 sudo install -m 0644 examples/systemd/rustbgpd.service \
   /etc/systemd/system/rustbgpd.service
 sudo install -d -m 0755 /etc/rustbgpd
 sudo install -m 0640 examples/minimal/config.toml /etc/rustbgpd/config.toml
+sudo chgrp rustbgpd /etc/rustbgpd/config.toml   # readable by the service user
 $EDITOR /etc/rustbgpd/config.toml    # set ASN, router_id, neighbors
 sudo systemctl daemon-reload
 sudo systemctl enable --now rustbgpd
 ```
+
+### Kernel dataplane: opt-in privilege drop-in
+
+If — and only if — the config programs the kernel (`[[fib_tables]]`
+per ADR-0061, `install_blackhole_discard`, or the EVPN VTEP/IRB
+dataplane), the daemon needs `CAP_NET_ADMIN` for rtnetlink route /
+nexthop programming, VXLAN + bridge FDB writes, and the
+`RTNLGRP_NEIGH` subscription behind local-MAC learning. Grant it via
+the shipped drop-in
+[`examples/systemd/rustbgpd-dataplane.conf`](../examples/systemd/rustbgpd-dataplane.conf)
+instead of editing the base unit — systemd merges capability sets, so
+the drop-in *adds* `CAP_NET_ADMIN` on top of the unprivileged default:
+
+```sh
+sudo mkdir -p /etc/systemd/system/rustbgpd.service.d
+sudo install -m 0644 examples/systemd/rustbgpd-dataplane.conf \
+  /etc/systemd/system/rustbgpd.service.d/rustbgpd-dataplane.conf
+sudo systemctl daemon-reload
+sudo systemctl restart rustbgpd
+```
+
+RR-only boxes should **not** install this drop-in — the unprivileged
+default is the point.
+
+Dataplane host caveat: **if rustbgpd programs the kernel** on a host
+that also runs systemd-networkd, set `ManageForeignRoutes=no`,
+`ManageForeignRoutingPolicyRules=no`, and (where supported)
+`ManageForeignNextHops=no` in `networkd.conf`. The defaults are
+`yes`, and networkd will delete routes and next-hop groups it did
+not create — including rustbgpd's, especially across a daemon
+restart (ADR-0079). Co-residency with another daemon that claims
+`proto bgp` kernel state (e.g. FRR zebra) is unsupported for the
+same reason.
 
 ### Operational checks
 
@@ -249,7 +264,7 @@ Bring it up:
 
 ```sh
 # Build the dev image
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 
 # Deploy
 sudo containerlab deploy -t tests/interop/m0-frr.clab.yml

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -321,7 +321,7 @@ The current real-VTEP smokes are M37 (MAC-only origination) and
 M37+IP (MAC+IP origination via ARP/ND suppression):
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 
 # MAC-only path (Gate 7b+1)
 sudo containerlab deploy -t tests/interop/m37-evpn-local-origination.clab.yml

--- a/examples/event-bridge/README.md
+++ b/examples/event-bridge/README.md
@@ -5,7 +5,10 @@ consuming `rustbgpd`'s **durable event outbox** over gRPC and
 forwarding events to an external system (Kafka, NATS, Vector,
 journald, a SIEM ingestion endpoint, etc.).
 
-It is a **reference skeleton**, not a maintained bus connector.
+It is a **reference skeleton**, not a maintained bus connector —
+development/example status only. It is not part of the default
+`cargo build`, the release tarballs, or any container image; it
+builds only with `--workspace` or an explicit `-p event-bridge`.
 Real deployments fork this and replace the stdout writer with the
 operator's preferred sink. The patterns to preserve are:
 

--- a/examples/systemd/rustbgpd-dataplane.conf
+++ b/examples/systemd/rustbgpd-dataplane.conf
@@ -1,0 +1,24 @@
+# Opt-in drop-in for kernel-dataplane deployments.
+#
+# The base rustbgpd.service runs unprivileged (CAP_NET_BIND_SERVICE
+# only) — enough for route-reflector / control-plane-only use. Enable
+# this drop-in ONLY when the config actually programs the kernel:
+# [[fib_tables]] (ADR-0061), install_blackhole_discard, or the EVPN
+# VTEP/IRB dataplane.
+#
+# CAP_NET_ADMIN covers everything the dataplane does: rtnetlink route /
+# nexthop programming, VXLAN + bridge FDB writes, and the RTNLGRP_NEIGH
+# subscription that feeds local-MAC learning.
+#
+# Install:
+#   sudo mkdir -p /etc/systemd/system/rustbgpd.service.d
+#   sudo install -m 0644 rustbgpd-dataplane.conf \
+#     /etc/systemd/system/rustbgpd.service.d/rustbgpd-dataplane.conf
+#   sudo systemctl daemon-reload && sudo systemctl restart rustbgpd
+#
+# systemd merges capability-set assignments, so these lines ADD to the
+# base unit's CAP_NET_BIND_SERVICE rather than replacing it.
+
+[Service]
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN

--- a/examples/systemd/rustbgpd.service
+++ b/examples/systemd/rustbgpd.service
@@ -9,6 +9,11 @@ Type=simple
 ExecStart=/usr/local/bin/rustbgpd /etc/rustbgpd/config.toml
 ExecReload=/bin/kill -HUP $MAINPID
 
+# Unprivileged service user. Create it once:
+#   useradd --system --home-dir /var/lib/rustbgpd --shell /usr/sbin/nologin rustbgpd
+User=rustbgpd
+Group=rustbgpd
+
 # State directory for GR restart markers, gRPC UDS, config persistence
 StateDirectory=rustbgpd
 RuntimeDirectory=rustbgpd
@@ -20,9 +25,14 @@ ProtectHome=yes
 ReadWritePaths=/var/lib/rustbgpd /etc/rustbgpd
 PrivateTmp=yes
 
-# BGP needs CAP_NET_BIND_SERVICE for port 179
+# Unprivileged default: CAP_NET_BIND_SERVICE only (bind port 179 as
+# non-root). This covers route-reflector / control-plane-only
+# deployments. Kernel-dataplane features ([[fib_tables]], blackhole
+# install, EVPN VTEP/IRB) additionally need CAP_NET_ADMIN — enable the
+# rustbgpd-dataplane.conf drop-in shipped next to this unit instead of
+# widening these lines.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Restart on failure, but not on clean shutdown (exit 0) or SIGTERM
 Restart=on-failure

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -332,6 +332,34 @@ impl Config {
         None
     }
 
+    /// True when the deprecated global inline policy fallback
+    /// (`[[policy.import]]` / `[[policy.export]]`) is present.
+    ///
+    /// This is the pre-ADR-0076/0096 legacy surface: evaluated only
+    /// when the global chains are empty, restart-required on change
+    /// (no hot-reload), and invisible to the transaction planner.
+    /// Per-neighbor inline policy is NOT covered — only the global
+    /// fallback is deprecated.
+    pub fn uses_deprecated_global_inline_policy(&self) -> bool {
+        !self.policy.import.is_empty() || !self.policy.export.is_empty()
+    }
+
+    /// Emit the load-time deprecation warning for the global inline
+    /// policy fallback, if present. Called wherever a config enters
+    /// the daemon (startup, SIGHUP reload).
+    pub fn warn_if_deprecated_global_inline_policy(&self) {
+        if self.uses_deprecated_global_inline_policy() {
+            tracing::warn!(
+                "DEPRECATED: global inline [[policy.import]] / [[policy.export]] \
+                 statements are deprecated and will be removed in a future release. \
+                 They are restart-required on change and invisible to config \
+                 transactions. Migrate to named policy chains ([policy.definitions] \
+                 + import_chain/export_chain) or .rpol files (policy.rpol_files) — \
+                 see docs/CONFIGURATION.md, \"Inline policy\"."
+            );
+        }
+    }
+
     /// Resolve the global import policy chain.
     ///
     /// If `import_chain` is set, resolves named policies. Otherwise wraps

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11783,3 +11783,78 @@ fn send_hold_time_change_is_a_runtime_neighbor_change() {
         "{changes:?}"
     );
 }
+
+// ── Global inline policy deprecation (Item: surface reduction) ──────
+
+/// `MakeWriter` capturing tracing output into a shared buffer so the
+/// deprecation-warning tests can assert on emitted (or absent) warns.
+#[derive(Clone, Default)]
+struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn capture_deprecation_warning(config: &Config) -> String {
+    let writer = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        config.warn_if_deprecated_global_inline_policy();
+    });
+    let bytes = writer.0.lock().unwrap().clone();
+    String::from_utf8(bytes).unwrap()
+}
+
+#[test]
+fn global_inline_policy_emits_deprecation_warning() {
+    let toml_str = format!(
+        "{}\n[[policy.import]]\nprefix = \"10.0.0.0/8\"\nge = 8\nle = 24\naction = \"permit\"\n",
+        valid_toml()
+    );
+    let config = parse(&toml_str).unwrap();
+    assert!(config.uses_deprecated_global_inline_policy());
+    let output = capture_deprecation_warning(&config);
+    assert!(
+        output.contains("WARN"),
+        "expected a warn-level log: {output}"
+    );
+    assert!(
+        output.contains("DEPRECATED") && output.contains("[[policy.import]]"),
+        "warning must name the deprecated surface: {output}"
+    );
+    assert!(
+        output.contains("import_chain") && output.contains("rpol"),
+        "warning must point at the migration targets: {output}"
+    );
+}
+
+#[test]
+fn config_without_global_inline_policy_does_not_warn() {
+    // Named definitions + chains and per-neighbor inline policy are
+    // NOT deprecated — only the global inline fallback warns.
+    let toml_str = format!(
+        "{}\nimport_policy = [{{ prefix = \"10.0.0.0/8\", ge = 8, le = 32, action = \"permit\" }}]\n\
+         [policy]\nimport_chain = [\"keep-all\"]\n\
+         [policy.definitions.keep-all]\nstatements = []\n",
+        valid_toml_no_grpc_security()
+    );
+    let config = parse(&toml_str).unwrap();
+    assert!(!config.uses_deprecated_global_inline_policy());
+    let output = capture_deprecation_warning(&config);
+    assert!(output.is_empty(), "no warning expected: {output}");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,6 +664,10 @@ async fn trigger_import_validation_refresh(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "one linear eprintln per banner line; splitting it would scatter the banner's visual order across helpers"
+)]
 fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) {
     let ebgp = config
         .neighbors
@@ -726,6 +730,13 @@ fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) 
             ));
         }
         eprintln!("  |- {}", parts.join(", "));
+    }
+    if config.uses_deprecated_global_inline_policy() {
+        eprintln!(
+            "  |- DEPRECATED: global inline [[policy.import]]/[[policy.export]] — \
+             will be removed in a future release; migrate to named policy chains \
+             or .rpol files (docs/CONFIGURATION.md)"
+        );
     }
 
     // Listeners
@@ -1197,6 +1208,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         neighbors = config.neighbors.len(),
         "starting rustbgpd"
     );
+    config.warn_if_deprecated_global_inline_policy();
 
     let metrics = BgpMetrics::new();
     let grpc_listeners = resolve_grpc_listeners(&config).unwrap_or_else(|e| {

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -472,6 +472,7 @@ pub(crate) async fn reload_config(
             return None;
         }
     };
+    desired_config.warn_if_deprecated_global_inline_policy();
     let mut new_config = desired_config.clone();
 
     let honor_graceful_shutdown_changed =

--- a/tests/interop/m32b-evpn-ead-synthetic.clab.yml
+++ b/tests/interop/m32b-evpn-ead-synthetic.clab.yml
@@ -23,7 +23,7 @@
 # side (the monitor logs received UPDATEs).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m32b-evpn-ead-synthetic.clab.yml
 #   bash tests/interop/scripts/test-m32b-evpn-ead-synthetic.sh
 #   containerlab destroy -t tests/interop/m32b-evpn-ead-synthetic.clab.yml --cleanup

--- a/tests/interop/m33-evpn-scale.clab.yml
+++ b/tests/interop/m33-evpn-scale.clab.yml
@@ -20,7 +20,7 @@
 # repo — no third-party daemon is in the measurement path.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m33-evpn-scale.clab.yml
 #   bash tests/interop/scripts/test-m33-evpn-scale.sh
 #   containerlab destroy -t tests/interop/m33-evpn-scale.clab.yml --cleanup

--- a/tests/interop/m36-evpn-vtep-smoke.clab.yml
+++ b/tests/interop/m36-evpn-vtep-smoke.clab.yml
@@ -30,7 +30,7 @@
 # programming is verified.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m36-evpn-vtep-smoke.clab.yml
 #   bash tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
 #   sudo containerlab destroy -t tests/interop/m36-evpn-vtep-smoke.clab.yml

--- a/tests/interop/m37-evpn-local-origination.clab.yml
+++ b/tests/interop/m37-evpn-local-origination.clab.yml
@@ -37,7 +37,7 @@
 # via `vtysh`, not VXLAN data-plane forwarding).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-evpn-local-origination.clab.yml
 #   bash tests/interop/scripts/test-m37-evpn-local-origination.sh
 #   sudo containerlab destroy -t tests/interop/m37-evpn-local-origination.clab.yml

--- a/tests/interop/m37-evpn-mac-ip-origination.clab.yml
+++ b/tests/interop/m37-evpn-mac-ip-origination.clab.yml
@@ -25,7 +25,7 @@
 # test asserts control-plane Type 2 visibility via `vtysh`.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml
 #   bash tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
 #   sudo containerlab destroy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml

--- a/tests/interop/m37-soak.clab.yml
+++ b/tests/interop/m37-soak.clab.yml
@@ -11,7 +11,7 @@
 # soak harness (tests/soak/run-m37-local-origination-churn-soak.sh).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-soak.clab.yml
 #   bash tests/soak/run-m37-local-origination-churn-soak.sh
 #   sudo containerlab destroy -t tests/interop/m37-soak.clab.yml

--- a/tests/interop/m38-evpn-df-election.clab.yml
+++ b/tests/interop/m38-evpn-df-election.clab.yml
@@ -26,7 +26,7 @@
 # no VXLAN data-plane forwarding.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m38-evpn-df-election.clab.yml
 #   bash tests/interop/scripts/test-m38-evpn-df-election.sh
 #   sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml

--- a/tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
+++ b/tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
@@ -30,7 +30,7 @@
 #   view of both EAD-per-EVI routes is what the test asserts.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml
 #   bash tests/interop/scripts/test-m40-evpn-aliasing-ecmp-frr.sh
 #   containerlab destroy -t tests/interop/m40-evpn-aliasing-ecmp-frr.clab.yml

--- a/tests/interop/m42-fib-runtime-frr.clab.yml
+++ b/tests/interop/m42-fib-runtime-frr.clab.yml
@@ -14,7 +14,7 @@
 #   * A graceful rustbgpd shutdown drains daemon-owned routes.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m42-fib-runtime-frr.clab.yml
 #   bash tests/interop/scripts/test-m42-fib-runtime-frr.sh
 #   containerlab destroy -t tests/interop/m42-fib-runtime-frr.clab.yml --cleanup

--- a/tests/interop/m43-tcp-ao-bird.clab.yml
+++ b/tests/interop/m43-tcp-ao-bird.clab.yml
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
 #   bash tests/interop/scripts/test-m43-tcp-ao-bird.sh
 #   containerlab destroy -t tests/interop/m43-tcp-ao-bird.clab.yml --cleanup

--- a/tests/interop/m44-grpc-tier-authz.clab.yml
+++ b/tests/interop/m44-grpc-tier-authz.clab.yml
@@ -8,7 +8,7 @@
 # ./configs/m44-certs/ before deploy and bind-mounted read-only.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m44-certs.sh
 #   containerlab deploy -t tests/interop/m44-grpc-tier-authz.clab.yml
 #   bash tests/interop/scripts/test-m44-grpc-tier-authz.sh

--- a/tests/interop/m46-evpn-df-hrw.clab.yml
+++ b/tests/interop/m46-evpn-df-hrw.clab.yml
@@ -26,7 +26,7 @@
 # Ready. No VXLAN data-plane forwarding.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m46-evpn-df-hrw.clab.yml
 #   bash tests/interop/scripts/test-m46-evpn-df-hrw.sh
 #   sudo containerlab destroy -t tests/interop/m46-evpn-df-hrw.clab.yml

--- a/tests/interop/m49-evpn-preference-df.clab.yml
+++ b/tests/interop/m49-evpn-preference-df.clab.yml
@@ -32,7 +32,7 @@
 # Ready. No VXLAN data-plane forwarding.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m49-evpn-preference-df.clab.yml
 #   bash tests/interop/scripts/test-m49-evpn-preference-df.sh
 #   sudo containerlab destroy -t tests/interop/m49-evpn-preference-df.clab.yml

--- a/tests/interop/m50-fib-ecmp-frr.clab.yml
+++ b/tests/interop/m50-fib-ecmp-frr.clab.yml
@@ -13,7 +13,7 @@
 #     surviving single next-hop; re-advertising restores the two-way ECMP.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m50-fib-ecmp-frr.clab.yml
 #   bash tests/interop/scripts/test-m50-fib-ecmp-frr.sh
 #   containerlab destroy -t tests/interop/m50-fib-ecmp-frr.clab.yml --cleanup

--- a/tests/interop/m51-bfd-frr.clab.yml
+++ b/tests/interop/m51-bfd-frr.clab.yml
@@ -14,7 +14,7 @@
 #   * Recovery: watchfrr restarts bfdd and the session re-establishes.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m51-bfd-frr.clab.yml
 #   bash tests/interop/scripts/test-m51-bfd-frr.sh
 #   containerlab destroy -t tests/interop/m51-bfd-frr.clab.yml --cleanup

--- a/tests/interop/m52-fib-ecmp-relax-frr.clab.yml
+++ b/tests/interop/m52-fib-ecmp-relax-frr.clab.yml
@@ -15,7 +15,7 @@
 #     re-advertising restores the two-way ECMP.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m52-fib-ecmp-relax-frr.clab.yml
 #   bash tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
 #   containerlab destroy -t tests/interop/m52-fib-ecmp-relax-frr.clab.yml --cleanup

--- a/tests/interop/m53-bgp-unnumbered-frr.clab.yml
+++ b/tests/interop/m53-bgp-unnumbered-frr.clab.yml
@@ -11,7 +11,7 @@
 #     re-advertising restores two-way ECMP.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m53-bgp-unnumbered-frr.clab.yml
 #   bash tests/interop/scripts/test-m53-bgp-unnumbered-frr.sh
 #   containerlab destroy -t tests/interop/m53-bgp-unnumbered-frr.clab.yml --cleanup

--- a/tests/interop/m54-gnmi-openconfig.clab.yml
+++ b/tests/interop/m54-gnmi-openconfig.clab.yml
@@ -13,7 +13,7 @@
 # with EBUSY.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m54-certs.sh
 #   containerlab deploy -t tests/interop/m54-gnmi-openconfig.clab.yml
 #   bash tests/interop/scripts/test-m54-gnmi-openconfig.sh

--- a/tests/interop/m55-bgp-roles-otc-frr.clab.yml
+++ b/tests/interop/m55-bgp-roles-otc-frr.clab.yml
@@ -13,7 +13,7 @@
 #     withdrawals in the same UPDATE still apply.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m55-bgp-roles-otc-frr.clab.yml
 #   bash tests/interop/scripts/test-m55-bgp-roles-otc-frr.sh
 #   containerlab destroy -t tests/interop/m55-bgp-roles-otc-frr.clab.yml --cleanup

--- a/tests/interop/m56-gnmi-onchange-frr.clab.yml
+++ b/tests/interop/m56-gnmi-onchange-frr.clab.yml
@@ -13,7 +13,7 @@
 # disconnected-window transitions.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m54-certs.sh   # reuses M54 certs
 #   containerlab deploy -t tests/interop/m56-gnmi-onchange-frr.clab.yml
 #   bash tests/interop/scripts/test-m56-gnmi-onchange-frr.sh

--- a/tests/interop/m58-fib-table-crud-frr.clab.yml
+++ b/tests/interop/m58-fib-table-crud-frr.clab.yml
@@ -25,7 +25,7 @@
 # config survives and a fresh daemon reads the post-CRUD set.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m58-fib-table-crud-frr.clab.yml
 #   bash tests/interop/scripts/test-m58-fib-table-crud-frr.sh
 #   containerlab destroy -t tests/interop/m58-fib-table-crud-frr.clab.yml --cleanup

--- a/tests/interop/m60-evpn-adoption-sweep.clab.yml
+++ b/tests/interop/m60-evpn-adoption-sweep.clab.yml
@@ -32,7 +32,7 @@
 # the daemon — the test script controls the restart.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m60-evpn-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
 #   sudo containerlab destroy -t tests/interop/m60-evpn-adoption-sweep.clab.yml

--- a/tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
+++ b/tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
@@ -45,7 +45,7 @@
 # M39/M48 — runs on the hosted kernel-dataplane runner (GitHub Actions).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
 #   containerlab destroy -t tests/interop/m61-evpn-l3-adoption-sweep.clab.yml

--- a/tests/interop/m62-blackhole-adoption-sweep.clab.yml
+++ b/tests/interop/m62-blackhole-adoption-sweep.clab.yml
@@ -35,7 +35,7 @@
 # the daemon — the test script controls the restart.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m62-blackhole-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
 #   containerlab destroy -t tests/interop/m62-blackhole-adoption-sweep.clab.yml

--- a/tests/interop/m65-evpn-single-active-failover.clab.yml
+++ b/tests/interop/m65-evpn-single-active-failover.clab.yml
@@ -47,7 +47,7 @@
 # reconcile backstop).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m65-evpn-single-active-failover.clab.yml
 #   bash tests/interop/scripts/test-m65-evpn-single-active-failover.sh

--- a/tests/interop/m66-evpn-es-drain-handover.clab.yml
+++ b/tests/interop/m66-evpn-es-drain-handover.clab.yml
@@ -98,7 +98,7 @@
 # fixture shape.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m66-evpn-es-drain-handover.clab.yml
 #   bash tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
 #   containerlab destroy -t tests/interop/m66-evpn-es-drain-handover.clab.yml

--- a/tests/interop/m67-evpn-link-drain-failover.clab.yml
+++ b/tests/interop/m67-evpn-link-drain-failover.clab.yml
@@ -74,7 +74,7 @@
 # The VTEP keeps the M65/M66 legacy fixture shape.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m67-evpn-link-drain-failover.clab.yml
 #   bash tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
 #   containerlab destroy -t tests/interop/m67-evpn-link-drain-failover.clab.yml

--- a/tests/interop/m69-evpn-preference-df-frr.clab.yml
+++ b/tests/interop/m69-evpn-preference-df-frr.clab.yml
@@ -14,7 +14,7 @@
 #   (10.0.0.2, AS 65000)
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m69-evpn-preference-df-frr.clab.yml
 #   bash tests/interop/scripts/test-m69-evpn-preference-df-frr.sh
 #   sudo containerlab destroy -t tests/interop/m69-evpn-preference-df-frr.clab.yml --cleanup

--- a/tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml
+++ b/tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml
@@ -8,7 +8,7 @@
 # VLAN-scoped FDB row.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml
 #   bash tests/interop/scripts/test-m70-evpn-vlan-aware-bridge-frr.sh
 #   sudo containerlab destroy -t tests/interop/m70-evpn-vlan-aware-bridge-frr.clab.yml --cleanup

--- a/tests/interop/m71-evpn-esi-overlay-type5-receive-gobgp.clab.yml
+++ b/tests/interop/m71-evpn-esi-overlay-type5-receive-gobgp.clab.yml
@@ -30,7 +30,7 @@
 #   4. Withdraw: deleting the Type 5 leaves the VRF clean.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m71-evpn-esi-overlay-type5-receive-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m71-evpn-esi-overlay-type5-receive-gobgp.sh

--- a/tests/interop/m72-evpn-esi-overlay-type5-all-active-gobgp.clab.yml
+++ b/tests/interop/m72-evpn-esi-overlay-type5-all-active-gobgp.clab.yml
@@ -27,7 +27,7 @@
 #   4. Withdraw: deleting the Type 5 leaves vrf1 and L3 NHG state clean.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m72-evpn-esi-overlay-type5-all-active-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m72-evpn-esi-overlay-type5-all-active-gobgp.sh

--- a/tests/interop/m73-bgpls-reflection-gobgp.clab.yml
+++ b/tests/interop/m73-bgpls-reflection-gobgp.clab.yml
@@ -6,7 +6,7 @@
 # opaque BGP-LS Attribute payload, and withdraws it cleanly.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   containerlab deploy -t tests/interop/m73-bgpls-reflection-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m73-bgpls-reflection-gobgp.sh

--- a/tests/interop/m74-vpnv4-reflection-gobgp.clab.yml
+++ b/tests/interop/m74-vpnv4-reflection-gobgp.clab.yml
@@ -8,7 +8,7 @@
 # dataplane.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m74-vpnv4-reflection-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh

--- a/tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml
+++ b/tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml
@@ -12,7 +12,7 @@
 # (gobgp #2427).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh

--- a/tests/interop/m76-orr-divergent-best-gobgp.clab.yml
+++ b/tests/interop/m76-orr-divergent-best-gobgp.clab.yml
@@ -9,7 +9,7 @@
 # to one identical standard best when the topology is withdrawn.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   containerlab deploy -t tests/interop/m76-orr-divergent-best-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh

--- a/tests/interop/m77-gr-llgr-rr-gobgp.clab.yml
+++ b/tests/interop/m77-gr-llgr-rr-gobgp.clab.yml
@@ -32,7 +32,7 @@
 # the very table this receipt asserts on.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   containerlab deploy -t tests/interop/m77-gr-llgr-rr-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh

--- a/tests/interop/m78-multicluster-orr-gobgp.clab.yml
+++ b/tests/interop/m78-multicluster-orr-gobgp.clab.yml
@@ -17,7 +17,7 @@
 # non-client iBGP route is never reflected to another non-client).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   containerlab deploy -t tests/interop/m78-multicluster-orr-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh

--- a/tests/interop/m79-labeled-reflection-gobgp.clab.yml
+++ b/tests/interop/m79-labeled-reflection-gobgp.clab.yml
@@ -16,7 +16,7 @@
 # container.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   containerlab deploy -t tests/interop/m79-labeled-reflection-gobgp.clab.yml
 #   bash tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh

--- a/tests/interop/m81-bmp-trio-gobgp.clab.yml
+++ b/tests/interop/m81-bmp-trio-gobgp.clab.yml
@@ -19,7 +19,7 @@
 #   - sbezverk/gobmp:latest       = master 2026-06-24
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   docker build -t bmpsink:m81 -f tests/interop/Dockerfile.bmpsink tests/interop
 #   containerlab deploy -t tests/interop/m81-bmp-trio-gobgp.clab.yml

--- a/tests/interop/scripts/test-m32b-evpn-ead-synthetic.sh
+++ b/tests/interop/scripts/test-m32b-evpn-ead-synthetic.sh
@@ -19,7 +19,7 @@
 #   4. RR gRPC stays healthy throughout.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m32b-evpn-ead-synthetic.clab.yml
 
 TOPO="m32b-evpn-ead-synthetic"

--- a/tests/interop/scripts/test-m33-evpn-scale.sh
+++ b/tests/interop/scripts/test-m33-evpn-scale.sh
@@ -33,7 +33,7 @@
 # interop tests (M30-M32). Treat M33 as the hot-path scale gate.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .  (must include evpn-tester + evpn-monitor)
+#   - docker build --target dev -t rustbgpd:dev .  (must include evpn-tester + evpn-monitor)
 #   - containerlab deploy -t tests/interop/m33-evpn-scale.clab.yml
 
 TOPO="m33-evpn-scale"

--- a/tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
+++ b/tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
@@ -18,7 +18,7 @@
 #    preservation against a real kernel, not just the fake.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m36-evpn-vtep-smoke.clab.yml
 #   bash tests/interop/scripts/test-m36-evpn-vtep-smoke.sh
 #   sudo containerlab destroy -t tests/interop/m36-evpn-vtep-smoke.clab.yml

--- a/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
@@ -8,7 +8,7 @@
 # run that captures RSS, Prometheus counters, logs, and run metadata.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-evpn-local-origination.clab.yml
 #   M37_CHURN_MACS=1000 M37_CHURN_ROUNDS=60 \
 #     bash tests/interop/scripts/test-m37-evpn-local-origination-churn.sh

--- a/tests/interop/scripts/test-m37-evpn-local-origination.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination.sh
@@ -18,7 +18,7 @@
 #      exits).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-evpn-local-origination.clab.yml
 #   bash tests/interop/scripts/test-m37-evpn-local-origination.sh
 #   sudo containerlab destroy -t tests/interop/m37-evpn-local-origination.clab.yml

--- a/tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
+++ b/tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
@@ -20,7 +20,7 @@
 # the daemon never sees an IpAdded.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml
 #   bash tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
 #   sudo containerlab destroy -t tests/interop/m37-evpn-mac-ip-origination.clab.yml

--- a/tests/interop/scripts/test-m38-evpn-df-election.sh
+++ b/tests/interop/scripts/test-m38-evpn-df-election.sh
@@ -13,7 +13,7 @@
 #      carrying the ESI Label extcomm (RFC 7432 §7.5).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m38-evpn-df-election.clab.yml
 #   bash tests/interop/scripts/test-m38-evpn-df-election.sh
 #   sudo containerlab destroy -t tests/interop/m38-evpn-df-election.clab.yml

--- a/tests/interop/scripts/test-m42-fib-runtime-frr.sh
+++ b/tests/interop/scripts/test-m42-fib-runtime-frr.sh
@@ -2,7 +2,7 @@
 # M42 interop test — ADR-0061 opt-in general unicast FIB runtime.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m42-fib-runtime-frr.clab.yml
 #   - grpcurl + jq installed on the host
 

--- a/tests/interop/scripts/test-m43-tcp-ao-bird.sh
+++ b/tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -10,7 +10,7 @@
 #   - BIRD image built:
 #       docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
 #   - rustbgpd image built:
-#       docker build -t rustbgpd:dev .
+#       docker build --target dev -t rustbgpd:dev .
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
 #

--- a/tests/interop/scripts/test-m44-grpc-tier-authz.sh
+++ b/tests/interop/scripts/test-m44-grpc-tier-authz.sh
@@ -16,7 +16,7 @@
 #      under bounded result labels.
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m44-certs.sh
 #   containerlab deploy -t tests/interop/m44-grpc-tier-authz.clab.yml
 #

--- a/tests/interop/scripts/test-m46-evpn-df-hrw.sh
+++ b/tests/interop/scripts/test-m46-evpn-df-hrw.sh
@@ -18,7 +18,7 @@
 #      `evpn_df_role_changes_total{...,vni="10"}` increments.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m46-evpn-df-hrw.clab.yml
 #   bash tests/interop/scripts/test-m46-evpn-df-hrw.sh
 #   sudo containerlab destroy -t tests/interop/m46-evpn-df-hrw.clab.yml

--- a/tests/interop/scripts/test-m49-evpn-preference-df.sh
+++ b/tests/interop/scripts/test-m49-evpn-preference-df.sh
@@ -25,7 +25,7 @@
 #      `evpn_df_role_changes_total{...,vni="200"}` increments.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m49-evpn-preference-df.clab.yml
 #   bash tests/interop/scripts/test-m49-evpn-preference-df.sh
 #   sudo containerlab destroy -t tests/interop/m49-evpn-preference-df.clab.yml

--- a/tests/interop/scripts/test-m50-fib-ecmp-frr.sh
+++ b/tests/interop/scripts/test-m50-fib-ecmp-frr.sh
@@ -7,7 +7,7 @@
 # the two-way ECMP when it returns.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m50-fib-ecmp-frr.clab.yml
 #   - grpcurl + jq installed on the host
 

--- a/tests/interop/scripts/test-m51-bfd-frr.sh
+++ b/tests/interop/scripts/test-m51-bfd-frr.sh
@@ -12,7 +12,7 @@
 #   3. Recovery: watchfrr restarts bfdd; BFD and BGP re-establish.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m51-bfd-frr.clab.yml
 #   - grpcurl + jq installed on the host
 

--- a/tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
+++ b/tests/interop/scripts/test-m52-fib-ecmp-relax-frr.sh
@@ -9,7 +9,7 @@
 # survivor; re-advertising restores the ECMP.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m52-fib-ecmp-relax-frr.clab.yml
 #   - grpcurl + jq installed on the host
 

--- a/tests/interop/scripts/test-m54-gnmi-openconfig.sh
+++ b/tests/interop/scripts/test-m54-gnmi-openconfig.sh
@@ -17,7 +17,7 @@
 #      OpenConfig leaf.
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m54-certs.sh
 #   containerlab deploy -t tests/interop/m54-gnmi-openconfig.clab.yml
 #

--- a/tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
+++ b/tests/interop/scripts/test-m56-gnmi-onchange-frr.sh
@@ -15,7 +15,7 @@
 #      a replay of the disconnected-window transitions.
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   bash tests/interop/scripts/gen-m54-certs.sh   # certs reused
 #   containerlab deploy -t tests/interop/m56-gnmi-onchange-frr.clab.yml
 #

--- a/tests/interop/scripts/test-m58-fib-table-crud-frr.sh
+++ b/tests/interop/scripts/test-m58-fib-table-crud-frr.sh
@@ -7,7 +7,7 @@
 # Companion to M42, which covers the startup FIB path.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - containerlab deploy -t tests/interop/m58-fib-table-crud-frr.clab.yml
 #   - grpcurl + jq installed on the host
 

--- a/tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
@@ -29,7 +29,7 @@
 #    evpn_fdb_single_dst_reaped_total == 1 for the restarted process.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/interop/m60-evpn-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m60-evpn-adoption-sweep.sh
 #   sudo containerlab destroy -t tests/interop/m60-evpn-adoption-sweep.clab.yml

--- a/tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
@@ -66,7 +66,7 @@
 #    (adopted == 1, reaped == 0).
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m61-evpn-l3-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m61-evpn-l3-adoption-sweep.sh
 #   containerlab destroy -t tests/interop/m61-evpn-l3-adoption-sweep.clab.yml

--- a/tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
+++ b/tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
@@ -36,7 +36,7 @@
 #    process.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m62-blackhole-adoption-sweep.clab.yml
 #   bash tests/interop/scripts/test-m62-blackhole-adoption-sweep.sh
 #   containerlab destroy -t tests/interop/m62-blackhole-adoption-sweep.clab.yml

--- a/tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
+++ b/tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
@@ -47,7 +47,7 @@
 #    == 1 with state Established.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m63-stalled-rib-hold-timer.clab.yml
 #   bash tests/interop/scripts/test-m63-stalled-rib-hold-timer.sh
 #   containerlab destroy -t tests/interop/m63-stalled-rib-hold-timer.clab.yml --cleanup

--- a/tests/interop/scripts/test-m64-ipv6-only.sh
+++ b/tests/interop/scripts/test-m64-ipv6-only.sh
@@ -31,7 +31,7 @@
 #    flag.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m64-ipv6-only.clab.yml
 #   bash tests/interop/scripts/test-m64-ipv6-only.sh
 #   containerlab destroy -t tests/interop/m64-ipv6-only.clab.yml --cleanup

--- a/tests/interop/scripts/test-m65-evpn-single-active-failover.sh
+++ b/tests/interop/scripts/test-m65-evpn-single-active-failover.sh
@@ -61,7 +61,7 @@
 #    driver-planted untagged fdb nexthop survive the whole cycle.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   containerlab deploy -t tests/interop/m65-evpn-single-active-failover.clab.yml
 #   bash tests/interop/scripts/test-m65-evpn-single-active-failover.sh

--- a/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
+++ b/tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
@@ -59,7 +59,7 @@
 #    the static all-zero flood entries survive the whole cycle.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m66-evpn-es-drain-handover.clab.yml
 #   bash tests/interop/scripts/test-m66-evpn-es-drain-handover.sh
 #   containerlab destroy -t tests/interop/m66-evpn-es-drain-handover.clab.yml

--- a/tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
+++ b/tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
@@ -72,7 +72,7 @@
 # BUM-flood-only.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m67-evpn-link-drain-failover.clab.yml
 #   bash tests/interop/scripts/test-m67-evpn-link-drain-failover.sh
 #   containerlab destroy -t tests/interop/m67-evpn-link-drain-failover.clab.yml

--- a/tests/interop/scripts/test-m73-bgpls-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m73-bgpls-reflection-gobgp.sh
@@ -9,7 +9,7 @@
 #   5. Source withdrawal removes it from rustbgpd and from the sink.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m73-bgpls-reflection-gobgp.clab.yml

--- a/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m74-vpnv4-reflection-gobgp.sh
@@ -16,7 +16,7 @@
 #      and no kernel routes derived from the VPN family.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m74-vpnv4-reflection-gobgp.clab.yml

--- a/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
+++ b/tests/interop/scripts/test-m75-rtc-vpnv4-filter-gobgp.sh
@@ -32,7 +32,7 @@
 # (gobgp #2427).
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m75-rtc-vpnv4-filter-gobgp.clab.yml

--- a/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
+++ b/tests/interop/scripts/test-m76-orr-divergent-best-gobgp.sh
@@ -32,7 +32,7 @@
 #      the session ("rf 65537 not available") in a permanent flap loop.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m76-orr-divergent-best-gobgp.clab.yml

--- a/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
+++ b/tests/interop/scripts/test-m77-gr-llgr-rr-gobgp.sh
@@ -50,7 +50,7 @@
 #   8. No dataplane writes on the RR.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m77-gr-llgr-rr-gobgp.clab.yml

--- a/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
+++ b/tests/interop/scripts/test-m78-multicluster-orr-gobgp.sh
@@ -40,7 +40,7 @@
 #   7. Neither RR installed anything into any dataplane.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m78-multicluster-orr-gobgp.clab.yml

--- a/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
+++ b/tests/interop/scripts/test-m79-labeled-reflection-gobgp.sh
@@ -50,7 +50,7 @@
 # no withdraw churn, no flap) is rustbgpd behavior and unaffected.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:bgpls -f tests/interop/Dockerfile.gobgp-bgpls tests/interop
 #   - containerlab deployed:
 #       containerlab deploy -t tests/interop/m79-labeled-reflection-gobgp.clab.yml

--- a/tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
+++ b/tests/interop/scripts/test-m81-bmp-trio-gobgp.sh
@@ -129,7 +129,7 @@
 # level (30/31) instead.
 #
 # Prerequisites:
-#   - docker build -t rustbgpd:dev .
+#   - docker build --target dev -t rustbgpd:dev .
 #   - docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
 #   - docker build -t bmpsink:m81 -f tests/interop/Dockerfile.bmpsink tests/interop
 #   - containerlab deployed:

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -60,7 +60,7 @@ churn."
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m33-evpn-scale.clab.yml
 
 # Full 24h run (default):
@@ -217,7 +217,7 @@ DF flips and FDB programming in flight.
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m37-soak.clab.yml
 
 # 10-minute wiring check:
@@ -319,7 +319,7 @@ whole-AC gate under repeated real carrier transitions.
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/soak/m67-link-drain-soak.clab.yml
 
 # 5-minute wiring check:
@@ -439,7 +439,7 @@ the BUM-suppression rtnetlink path is exercised on every flip.
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 sudo containerlab deploy -t tests/soak/gate8b-soak.clab.yml
 
 # Full 24h run (default):
@@ -540,7 +540,7 @@ pipeline is the path under test, not the gRPC route-inject path.
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 sudo containerlab deploy -t tests/soak/gate8b-soak.clab.yml
 
 # Full 24h run (default):
@@ -734,7 +734,7 @@ oscillation rather than steady state.
 ## Run
 
 ```bash
-docker build -t rustbgpd:dev .
+docker build --target dev -t rustbgpd:dev .
 sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
 
 # Full 24h run (default):

--- a/tests/soak/gate8b-soak.clab.yml
+++ b/tests/soak/gate8b-soak.clab.yml
@@ -16,7 +16,7 @@
 # updates correspondingly.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/soak/gate8b-soak.clab.yml
 #   bash tests/soak/run-gate8b-soak.sh
 #   sudo containerlab destroy -t tests/soak/gate8b-soak.clab.yml --cleanup

--- a/tests/soak/gate9-slice6-soak.clab.yml
+++ b/tests/soak/gate9-slice6-soak.clab.yml
@@ -17,7 +17,7 @@
 # sustained churn.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
 #   bash tests/soak/run-gate9-slice6-soak.sh
 #   sudo containerlab destroy -t tests/soak/gate9-slice6-soak.clab.yml --cleanup

--- a/tests/soak/m67-link-drain-soak.clab.yml
+++ b/tests/soak/m67-link-drain-soak.clab.yml
@@ -74,7 +74,7 @@
 # The VTEP keeps the M65/M66 legacy fixture shape.
 #
 # Usage:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/soak/m67-link-drain-soak.clab.yml
 #   SOAK_SECONDS=600 bash tests/soak/run-m67-link-drain-churn-soak.sh
 #   containerlab destroy -t tests/soak/m67-link-drain-soak.clab.yml

--- a/tests/soak/run-gate8b-mac-churn-soak.sh
+++ b/tests/soak/run-gate8b-mac-churn-soak.sh
@@ -42,7 +42,7 @@
 #   - run.json        run metadata (image SHA, git rev, env at start)
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/soak/gate8b-soak.clab.yml
 #
 # Usage:

--- a/tests/soak/run-gate8b-soak.sh
+++ b/tests/soak/run-gate8b-soak.sh
@@ -20,7 +20,7 @@
 #   - run.json        run metadata (image SHA, git rev, env at start)
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/soak/gate8b-soak.clab.yml
 #
 # Usage:

--- a/tests/soak/run-gate9-slice6-soak.sh
+++ b/tests/soak/run-gate9-slice6-soak.sh
@@ -28,7 +28,7 @@
 #   - run.json        run metadata (image SHA, git rev, env at start)
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   sudo containerlab deploy -t tests/soak/gate9-slice6-soak.clab.yml
 #
 # Usage:

--- a/tests/soak/run-m33-soak.sh
+++ b/tests/soak/run-m33-soak.sh
@@ -14,7 +14,7 @@
 #   - report.json     analyzer verdict (slope, percentiles, gates)
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m33-evpn-scale.clab.yml
 #
 # Usage:

--- a/tests/soak/run-m37-local-origination-churn-soak.sh
+++ b/tests/soak/run-m37-local-origination-churn-soak.sh
@@ -9,7 +9,7 @@
 # and leaves enough metadata for a 1h or 24h postmortem.
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m37-soak.clab.yml
 #
 # The soak uses tests/interop/m37-soak.clab.yml (topology name

--- a/tests/soak/run-m67-link-drain-churn-soak.sh
+++ b/tests/soak/run-m67-link-drain-churn-soak.sh
@@ -9,7 +9,7 @@
 # 24h receipt without claiming one in CI.
 #
 # Prerequisites:
-#   docker build -t rustbgpd:dev .
+#   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/soak/m67-link-drain-soak.clab.yml
 #
 # Usage:


### PR DESCRIPTION
Surface-reduction items 2 and 4 (maintainer-directed).

## Production shape

- **Default Docker target is now a lean `runtime` stage**: `rustbgpd` + `rbgp` only, nonroot (uid 999), ca-certificates, 189 MB. The previous all-in stage (helpers, iproute2, root, 204 MB) is preserved verbatim as the named `dev` target — all 33 interop workflow builds plus the shared dataplane-host action now pin `target: dev`, so lab expectations are intact; ~100 doc occurrences rewritten. The GHCR release image goes lean automatically with no workflow change; release tarballs already shipped exactly the two binaries.
- Verified `cargo build` default artifacts exclude the bench/example helpers (root-package workspace); bench/ and examples/event-bridge READMEs now state development status plainly; source-install docs build `-p rustbgpd -p rustbgpctl`.
- **systemd split** (`examples/systemd/`, the repo's convention): base unit = nonroot user + hardening + `CAP_NET_BIND_SERVICE` **only** (deviation from an empty capability set, justified: port 179 is unbindable without it; `CAP_NET_RAW` dropped entirely after a code sweep found no raw-socket use — BFD is plain UDP, FIB/EVPN is rtnetlink — fixing a stale docs claim). New `rustbgpd-dataplane.conf` drop-in adds `CAP_NET_ADMIN` for the opt-in dataplane role; systemd merges the sets. deployment.md documents "unprivileged RR default, dataplane opt-in"; `systemd-analyze verify` passes both shapes.

## Global inline policy deprecated

Premise verified before acting: `[[policy.import]]/[[policy.export]]` is a pure legacy fallback — consulted only when named chains are empty, restart-required on change, invisible to ADR-0076 transactions and the rpol registry. Now warns loudly at startup, on every SIGHUP reload, and in the startup banner, with migration pointers (named chains / .rpol); behavior unchanged; per-neighbor inline untouched. Tests capture the warning presence and its absence for modern configs; CONFIGURATION.md section marked deprecated with resolution-order notes; CHANGELOG `### Deprecated` + `### Changed` entries.

Gates: workspace build/test, fmt, clippy -D warnings, cargo doc, clippy-reasons, both docker targets built and booted (lean runs nonroot with the example config), systemd-analyze — all green. Rebased over #682.