### PR TITLE
feat: extract the birdwatcher looking glass to a gRPC adapter and deprecate the in-daemon server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecated
 
+- **The in-daemon birdwatcher looking glass
+  (`[global.telemetry.looking_glass]`) is deprecated and will be
+  removed in a future release.** Partial compatibility with an external
+  REST contract does not belong in daemon core; the daemon's durable
+  API is gRPC + `rbgp`. The same birdwatcher-compatible REST surface
+  (identical endpoints and response shapes, consumed by Alice-LG and
+  similar frontends) is now served by a maintained external adapter,
+  `examples/birdwatcher-adapter`, which sources everything from the
+  daemon's gRPC API — point it at a gRPC TCP listener and keep the same
+  frontend config. The daemon logs a deprecation warning at startup
+  while the section is present; behavior is otherwise unchanged. An
+  end-to-end smoke test pins adapter-vs-in-daemon response equality.
 - **Global inline policy (`[[policy.import]]` / `[[policy.export]]`)
   is deprecated and will be removed in a future release.** It is the
   legacy pre-chain fallback: restart-required on change (no SIGHUP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "birdwatcher-adapter"
+version = "0.45.0"
+dependencies = [
+ "axum",
+ "clap",
+ "rustbgpd-api",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/event-history",
     "bench/evpn-load",
     "examples/event-bridge",
+    "examples/birdwatcher-adapter",
 ]
 resolver = "2"
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -208,7 +208,15 @@ Required. Configures observability and management endpoints.
 `prometheus_addr`, when present, must be a valid `ip:port` socket address. The
 same listener serves `/metrics`, `/livez`, and `/readyz`.
 
-### `[global.telemetry.looking_glass]`
+### `[global.telemetry.looking_glass]` (deprecated)
+
+> **Deprecated — will be removed in a future release.** The daemon's
+> durable API is gRPC + `rbgp`; the birdwatcher REST surface moved to a
+> maintained external adapter, `examples/birdwatcher-adapter`, which
+> serves the identical endpoints and response shapes from the daemon's
+> gRPC API. Configuring this section logs a deprecation warning at
+> startup; behavior is otherwise unchanged until removal. See the
+> adapter README for the endpoint→gRPC mapping and migration notes.
 
 Optional birdwatcher-compatible HTTP server for looking glass frontends
 (Alice-LG, etc.).

--- a/examples/birdwatcher-adapter/Cargo.toml
+++ b/examples/birdwatcher-adapter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "birdwatcher-adapter"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Birdwatcher-compatible REST looking glass adapter for rustbgpd. Serves the birdwatcher API contract (Alice-LG and similar frontends) from a running daemon over gRPC."
+
+[[bin]]
+name = "birdwatcher-adapter"
+path = "src/main.rs"
+
+[dependencies]
+rustbgpd-api.workspace = true
+tonic.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+axum.workspace = true
+serde_json.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -1,0 +1,66 @@
+# birdwatcher-adapter — external looking glass REST adapter
+
+Standalone HTTP server that exposes rustbgpd through the
+**birdwatcher-compatible REST contract** consumed by
+[Alice-LG](https://github.com/alice-lg/alice-lg) and similar looking
+glass frontends. All data is sourced from a running rustbgpd over
+gRPC; endpoint paths and response shapes are identical to the
+deprecated in-daemon `[global.telemetry.looking_glass]` server this
+adapter replaces.
+
+Rationale: the daemon's durable API identity is **gRPC + `rbgp`**.
+Partial compatibility with someone else's REST API inside daemon core
+is a permanent source of misunderstanding, so the birdwatcher surface
+lives here as a maintained adapter instead. It is a workspace member
+but not part of the default `cargo build`, release tarballs, or
+container images; it builds with `--workspace` or an explicit
+`-p birdwatcher-adapter`.
+
+## Build + run
+
+```sh
+cargo run --release -p birdwatcher-adapter -- \
+    --grpc-addr http://127.0.0.1:50051 \
+    --listen 0.0.0.0:8080
+```
+
+Flags (also settable via env):
+
+| Flag          | Env                             | Default          | Meaning                          |
+|---------------|---------------------------------|------------------|----------------------------------|
+| `--grpc-addr` | `BIRDWATCHER_ADAPTER_GRPC_ADDR` | (required)       | rustbgpd gRPC endpoint (TCP)     |
+| `--listen`    | `BIRDWATCHER_ADAPTER_LISTEN`    | `127.0.0.1:8080` | REST listen address              |
+
+The daemon needs a gRPC TCP listener the adapter can reach
+(`[global.telemetry.grpc_tcp]`); read-only access is sufficient —
+every RPC the adapter calls is a read.
+
+## Endpoint → gRPC mapping
+
+| REST endpoint (birdwatcher)  | Backing gRPC RPC(s)                                            |
+|------------------------------|----------------------------------------------------------------|
+| `GET /status`                | `GlobalService.GetGlobal` + `ControlService.GetHealth`         |
+| `GET /protocols/bgp`         | `NeighborService.ListNeighbors`                                |
+| `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
+| `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
+
+Every endpoint of the in-daemon server is fully servable over today's
+gRPC API — there are no 501 endpoints.
+
+### Field-level gaps
+
+| Field                  | In-daemon server                  | Adapter                              |
+|------------------------|-----------------------------------|--------------------------------------|
+| route `age`            | derived from RIB receive time     | `""` — the gRPC `Route` message carries no received-at timestamp; Alice-LG parses empty as zero time (benign) |
+| status `last_reconfig` | `""` (not tracked)                | `""` (unchanged)                     |
+
+Error behavior differs only on failure: when the daemon is unreachable
+the adapter returns `502 Bad Gateway` (the in-daemon server returned
+`500` when its internal channels failed).
+
+## Testing
+
+- Unit tests: `cargo test -p birdwatcher-adapter`
+- End-to-end smoke test comparing adapter output against the in-daemon
+  server for the same state: `cargo test --test birdwatcher_adapter_smoke`
+  (root package; spawns a real daemon plus this adapter).

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -1,0 +1,437 @@
+//! Birdwatcher-compatible REST looking glass adapter for rustbgpd.
+//!
+//! Standalone HTTP server that serves the birdwatcher API contract
+//! consumed by Alice-LG and similar looking glass frontends, sourcing
+//! all data from a running rustbgpd over gRPC. This replaces the
+//! deprecated in-daemon `[global.telemetry.looking_glass]` server;
+//! endpoint paths and response shapes are identical.
+//!
+//! **Supported endpoints** (single-table mode):
+//! - `GET /status` — daemon status
+//! - `GET /protocols/bgp` — BGP neighbor list
+//! - `GET /routes/protocol/{id}` — received routes by neighbor address
+//! - `GET /routes/peer/{peer}` — received routes by peer IP
+//!
+//! Response shapes match birdwatcher field names so Alice-LG can parse
+//! them without adapter code. Fields that have no rustbgpd equivalent
+//! are present but empty/zero.
+//!
+//! Known field-level gap vs the in-daemon server: the gRPC `Route`
+//! message carries no received-at timestamp, so the per-route `age`
+//! field is an empty string (Alice-LG parses that as zero time, the
+//! same benign fallback the in-daemon server already uses for
+//! `last_reconfig`). See the README gap table.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::{Json, Router, routing::get};
+use clap::Parser;
+use rustbgpd_api::proto;
+use serde_json::Value;
+use tonic::transport::Channel;
+use tracing::{error, info};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "birdwatcher-adapter",
+    about = "Birdwatcher-compatible REST looking glass, served from rustbgpd's gRPC API"
+)]
+struct Args {
+    /// rustbgpd gRPC endpoint, e.g. `http://127.0.0.1:50051`.
+    #[arg(long, env = "BIRDWATCHER_ADAPTER_GRPC_ADDR")]
+    grpc_addr: String,
+
+    /// HTTP listen address for the birdwatcher REST surface.
+    #[arg(
+        long,
+        env = "BIRDWATCHER_ADAPTER_LISTEN",
+        default_value = "127.0.0.1:8080"
+    )]
+    listen: SocketAddr,
+}
+
+/// Shared state: one multiplexed gRPC channel; per-request clients are
+/// cheap clones of it.
+#[derive(Clone)]
+struct AppState {
+    channel: Channel,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+
+    info!(grpc_addr = %args.grpc_addr, "connecting to rustbgpd");
+    // `connect_lazy` so the adapter can start before/independently of
+    // the daemon; requests fail with 502 until the daemon is reachable.
+    let channel = Channel::from_shared(args.grpc_addr.clone())?.connect_lazy();
+    let state = AppState { channel };
+
+    let app = Router::new()
+        .route("/status", get(status))
+        .route("/protocols/bgp", get(protocols_bgp))
+        .route("/routes/protocol/{id}", get(routes_protocol))
+        .route("/routes/peer/{peer}", get(routes_peer))
+        .with_state(state);
+
+    info!(addr = %args.listen, "starting birdwatcher-compatible looking glass");
+    let listener = tokio::net::TcpListener::bind(args.listen).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Map a gRPC error to 502 Bad Gateway — the adapter is healthy, the
+/// upstream daemon call failed.
+fn bad_gateway(context: &str, status: &tonic::Status) -> StatusCode {
+    error!(context, error = %status, "upstream gRPC call failed");
+    StatusCode::BAD_GATEWAY
+}
+
+// ---------------------------------------------------------------------------
+// Birdwatcher-compatible response pieces (shapes match the in-daemon
+// server in `src/looking_glass.rs`, which this adapter supersedes).
+// ---------------------------------------------------------------------------
+
+/// Top-level `api` block included in every birdwatcher response.
+fn api_block() -> Value {
+    serde_json::json!({
+        "Version": format!("rustbgpd {}", env!("CARGO_PKG_VERSION")),
+        "result_from_cache": false,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GET /status  →  GlobalService.GetGlobal + ControlService.GetHealth
+// ---------------------------------------------------------------------------
+
+async fn status(State(state): State<AppState>) -> Result<Json<Value>, StatusCode> {
+    let mut global = proto::global_service_client::GlobalServiceClient::new(state.channel.clone());
+    let g = global
+        .get_global(proto::GetGlobalRequest {})
+        .await
+        .map_err(|e| bad_gateway("GetGlobal", &e))?
+        .into_inner();
+
+    let mut control =
+        proto::control_service_client::ControlServiceClient::new(state.channel.clone());
+    let h = control
+        .get_health(proto::HealthRequest {})
+        .await
+        .map_err(|e| bad_gateway("GetHealth", &e))?
+        .into_inner();
+
+    Ok(Json(serde_json::json!({
+        "api": api_block(),
+        "status": {
+            "router_id": g.router_id,
+            "current_server": format_timestamp_now(),
+            "last_reboot": format_secs_ago(h.uptime_seconds),
+            // Not tracked by the daemon — same empty-string fallback as
+            // the in-daemon server; Alice-LG parses it as zero time.
+            "last_reconfig": "",
+            "message": format!("rustbgpd AS{}", g.asn),
+            "version": format!("rustbgpd {}", env!("CARGO_PKG_VERSION")),
+        }
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// GET /protocols/bgp  →  NeighborService.ListNeighbors
+// ---------------------------------------------------------------------------
+
+async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, StatusCode> {
+    let mut client =
+        proto::neighbor_service_client::NeighborServiceClient::new(state.channel.clone());
+    let resp = client
+        .list_neighbors(proto::ListNeighborsRequest {})
+        .await
+        .map_err(|e| bad_gateway("ListNeighbors", &e))?
+        .into_inner();
+
+    // Birdwatcher returns protocols as a map keyed by protocol name.
+    // Alice-LG iterates this map and reads fields like `neighbor_address`,
+    // `neighbor_as`, `state`, `description`, `routes`, `state_changed`.
+    let mut protocols = serde_json::Map::new();
+    for n in &resp.neighbors {
+        let cfg = n.config.clone().unwrap_or_default();
+        let protocol_id = format!("bgp_{}", cfg.address).replace(':', "_");
+        protocols.insert(
+            protocol_id,
+            serde_json::json!({
+                "bird_protocol": "BGP",
+                "state": format_bird_state(n.state),
+                "neighbor_address": cfg.address,
+                "neighbor_as": cfg.remote_asn,
+                "description": cfg.description,
+                "table": "master",
+                "state_changed": format_secs_ago(n.uptime_seconds),
+                "routes": {
+                    // Same sources the in-daemon server used: current
+                    // Adj-RIB-In count and current advertised count.
+                    "imported": n.prefixes_received,
+                    "filtered": 0,
+                    "exported": n.prefixes_sent,
+                    "preferred": 0
+                }
+            }),
+        );
+    }
+
+    Ok(Json(serde_json::json!({
+        "api": api_block(),
+        "protocols": protocols,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// GET /routes/protocol/{id}  — Alice-LG single-table mode
+// GET /routes/peer/{peer}    — Alice-LG multi-table mode
+//                            →  RibService.ListReceivedRoutes
+// ---------------------------------------------------------------------------
+
+async fn routes_protocol(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    // Protocol IDs are "bgp_<addr>" — extract the address.
+    let addr_str = id.strip_prefix("bgp_").unwrap_or(&id).replace('_', ":");
+    let peer_addr: IpAddr = addr_str.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+    serve_routes_for_peer(&state, peer_addr).await
+}
+
+async fn routes_peer(
+    State(state): State<AppState>,
+    Path(peer): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    let peer_addr: IpAddr = peer.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+    serve_routes_for_peer(&state, peer_addr).await
+}
+
+async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Value>, StatusCode> {
+    let mut client = proto::rib_service_client::RibServiceClient::new(state.channel.clone());
+    let mut routes: Vec<Value> = Vec::new();
+    let mut page_token = String::new();
+    loop {
+        let resp = client
+            .list_received_routes(proto::ListRoutesRequest {
+                neighbor_address: peer.to_string(),
+                // UNSPECIFIED = all unicast families, matching the
+                // in-daemon server's unfiltered per-peer query.
+                afi_safi: proto::AddressFamily::Unspecified as i32,
+                page_size: 1000,
+                page_token,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| bad_gateway("ListReceivedRoutes", &e))?
+            .into_inner();
+        routes.extend(resp.routes.iter().map(route_to_birdwatcher));
+        if resp.next_page_token.is_empty() {
+            break;
+        }
+        page_token = resp.next_page_token;
+    }
+
+    Ok(Json(serde_json::json!({
+        "api": api_block(),
+        "routes": routes,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Format peer state as birdwatcher/BIRD protocol state string.
+/// Alice-LG lowercases this and maps "established" → "up" display.
+fn format_bird_state(state: i32) -> &'static str {
+    match proto::SessionState::try_from(state) {
+        Ok(proto::SessionState::Connect) => "start",
+        Ok(proto::SessionState::Active) => "active",
+        Ok(proto::SessionState::OpenSent) => "opensent",
+        Ok(proto::SessionState::OpenConfirm) => "openconfirm",
+        Ok(proto::SessionState::Established) => "established",
+        // Idle, Unspecified, or unknown enum value.
+        _ => "down",
+    }
+}
+
+/// Convert a gRPC `Route` to the birdwatcher route JSON shape.
+///
+/// Alice-LG reads: `network`, `gateway`, `from_protocol`, `interface`,
+/// `metric`, `age`, `type`, `primary`, `learnt_from`, and `bgp` sub-object
+/// with `origin`, `as_path`, `next_hop`, `local_pref`, `med`, `communities`,
+/// `large_communities`.
+fn route_to_birdwatcher(route: &proto::Route) -> Value {
+    // Wire encoding of the ORIGIN attribute (RFC 4271): 0=IGP, 1=EGP,
+    // 2=INCOMPLETE. Default IGP, matching the in-daemon server.
+    let origin = match route.origin {
+        1 => "EGP",
+        2 => "Incomplete",
+        _ => "IGP",
+    };
+
+    let communities: Vec<Vec<u32>> = route
+        .communities
+        .iter()
+        .map(|c| vec![(*c >> 16) & 0xffff, *c & 0xffff])
+        .collect();
+
+    // gRPC encodes large communities as "global_admin:data1:data2".
+    let large_communities: Vec<Vec<u64>> = route
+        .large_communities
+        .iter()
+        .filter_map(|lc| {
+            let parts: Vec<u64> = lc.split(':').filter_map(|p| p.parse().ok()).collect();
+            (parts.len() == 3).then_some(parts)
+        })
+        .collect();
+
+    let from_protocol = format!("bgp_{}", route.peer_address).replace(':', "_");
+
+    serde_json::json!({
+        "network": format!("{}/{}", route.prefix, route.prefix_length),
+        "gateway": route.next_hop,
+        "from_protocol": from_protocol,
+        "interface": "",
+        "metric": 0,
+        // Gap: the gRPC Route message carries no received-at timestamp.
+        // Empty string parses as zero time in Alice-LG (benign).
+        "age": "",
+        "type": ["BGP", "unicast", "univ"],
+        "primary": false,
+        "learnt_from": route.peer_address,
+        "bgp": {
+            "origin": origin,
+            "as_path": route.as_path,
+            "next_hop": route.next_hop,
+            "local_pref": route.local_pref,
+            "med": route.med,
+            "communities": communities,
+            "large_communities": large_communities,
+        }
+    })
+}
+
+/// Format a "now" timestamp in the layout Alice-LG expects for
+/// `ServerTimeShort`. Birdwatcher uses BIRD's `current_server` format:
+/// `"2025-03-14 12:34:56"`.
+fn format_timestamp_now() -> String {
+    format_secs_ago(0)
+}
+
+/// Produce a timestamp for an event `secs` seconds in the past
+/// (`last_reboot`, `state_changed`).
+fn format_secs_ago(secs: u64) -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format_epoch_secs(now.saturating_sub(secs))
+}
+
+/// Format epoch seconds as `"YYYY-MM-DD HH:MM:SS"` (UTC, no chrono dep).
+fn format_epoch_secs(epoch_secs: u64) -> String {
+    let (days, day_secs) = (epoch_secs / 86400, epoch_secs % 86400);
+    let (hour, rem) = (day_secs / 3600, day_secs % 3600);
+    let (min, sec) = (rem / 60, rem % 60);
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{min:02}:{sec:02}")
+}
+
+/// Convert days since epoch to (year, month, day). Minimal implementation.
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from Howard Hinnant's `civil_from_days`
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_conversion_matches_birdwatcher_shape() {
+        let route = proto::Route {
+            prefix: "10.1.0.0".to_string(),
+            prefix_length: 24,
+            next_hop: "192.0.2.1".to_string(),
+            peer_address: "192.0.2.1".to_string(),
+            origin: 2,
+            as_path: vec![65010, 65020],
+            local_pref: 200,
+            med: 50,
+            communities: vec![(65001 << 16) | 100],
+            large_communities: vec!["65001:1:2".to_string()],
+            ..Default::default()
+        };
+        let json = route_to_birdwatcher(&route);
+
+        assert_eq!(json["network"], "10.1.0.0/24");
+        assert_eq!(json["gateway"], "192.0.2.1");
+        assert_eq!(json["from_protocol"], "bgp_192.0.2.1");
+        assert_eq!(json["learnt_from"], "192.0.2.1");
+        assert_eq!(json["age"], "");
+        assert_eq!(json["primary"], false);
+        assert_eq!(json["type"], serde_json::json!(["BGP", "unicast", "univ"]));
+        assert_eq!(json["bgp"]["origin"], "Incomplete");
+        assert_eq!(json["bgp"]["as_path"], serde_json::json!([65010, 65020]));
+        assert_eq!(json["bgp"]["next_hop"], "192.0.2.1");
+        assert_eq!(json["bgp"]["local_pref"], 200);
+        assert_eq!(json["bgp"]["med"], 50);
+        assert_eq!(
+            json["bgp"]["communities"],
+            serde_json::json!([[65001, 100]])
+        );
+        assert_eq!(
+            json["bgp"]["large_communities"],
+            serde_json::json!([[65001, 1, 2]])
+        );
+    }
+
+    #[test]
+    fn ipv6_peer_protocol_id_uses_underscores() {
+        let route = proto::Route {
+            prefix: "2001:db8::".to_string(),
+            prefix_length: 32,
+            next_hop: "2001:db8::1".to_string(),
+            peer_address: "2001:db8::1".to_string(),
+            ..Default::default()
+        };
+        let json = route_to_birdwatcher(&route);
+        assert_eq!(json["network"], "2001:db8::/32");
+        assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
+        assert_eq!(json["learnt_from"], "2001:db8::1");
+        assert_eq!(json["bgp"]["origin"], "IGP");
+    }
+
+    #[test]
+    fn bird_state_mapping() {
+        assert_eq!(
+            format_bird_state(proto::SessionState::Established as i32),
+            "established"
+        );
+        assert_eq!(format_bird_state(proto::SessionState::Idle as i32), "down");
+        assert_eq!(format_bird_state(999), "down");
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -360,6 +360,27 @@ impl Config {
         }
     }
 
+    /// Emit the startup deprecation warning for the in-daemon
+    /// birdwatcher-compatible looking glass HTTP server, if configured.
+    ///
+    /// The daemon's durable API identity is gRPC + rbgp; the birdwatcher
+    /// REST surface moved to the external `examples/birdwatcher-adapter`
+    /// binary, which serves the identical contract over gRPC. The
+    /// in-daemon server keeps working unchanged until removal.
+    pub fn warn_if_deprecated_looking_glass(&self) {
+        if self.global.telemetry.looking_glass.is_some() {
+            tracing::warn!(
+                "DEPRECATED: the in-daemon looking glass HTTP server \
+                 ([global.telemetry.looking_glass]) is deprecated and will be \
+                 removed in a future release. Run the external adapter instead: \
+                 examples/birdwatcher-adapter serves the same birdwatcher REST \
+                 endpoints from the daemon's gRPC API — see \
+                 docs/CONFIGURATION.md \"[global.telemetry.looking_glass] \
+                 (deprecated)\" and the CHANGELOG Deprecated entry."
+            );
+        }
+    }
+
     /// Resolve the global import policy chain.
     ///
     /// If `import_chain` is set, resolves named policies. Otherwise wraps

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11808,16 +11808,18 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
     }
 }
 
-fn capture_deprecation_warning(config: &Config) -> String {
+fn capture_warnings(f: impl FnOnce()) -> String {
     let writer = CaptureWriter::default();
     let subscriber = tracing_subscriber::fmt()
         .with_writer(writer.clone())
         .finish();
-    tracing::subscriber::with_default(subscriber, || {
-        config.warn_if_deprecated_global_inline_policy();
-    });
+    tracing::subscriber::with_default(subscriber, f);
     let bytes = writer.0.lock().unwrap().clone();
     String::from_utf8(bytes).unwrap()
+}
+
+fn capture_deprecation_warning(config: &Config) -> String {
+    capture_warnings(|| config.warn_if_deprecated_global_inline_policy())
 }
 
 #[test]
@@ -11856,5 +11858,36 @@ fn config_without_global_inline_policy_does_not_warn() {
     let config = parse(&toml_str).unwrap();
     assert!(!config.uses_deprecated_global_inline_policy());
     let output = capture_deprecation_warning(&config);
+    assert!(output.is_empty(), "no warning expected: {output}");
+}
+
+// ── In-daemon looking glass deprecation (Item: surface reduction) ────
+
+#[test]
+fn looking_glass_emits_deprecation_warning() {
+    let toml_str = format!(
+        "{}\n[global.telemetry.looking_glass]\naddr = \"127.0.0.1:8080\"\n",
+        valid_toml()
+    );
+    let config = parse(&toml_str).unwrap();
+    let output = capture_warnings(|| config.warn_if_deprecated_looking_glass());
+    assert!(
+        output.contains("WARN"),
+        "expected a warn-level log: {output}"
+    );
+    assert!(
+        output.contains("DEPRECATED") && output.contains("[global.telemetry.looking_glass]"),
+        "warning must name the deprecated surface: {output}"
+    );
+    assert!(
+        output.contains("birdwatcher-adapter"),
+        "warning must point at the external adapter: {output}"
+    );
+}
+
+#[test]
+fn config_without_looking_glass_does_not_warn() {
+    let config = parse(valid_toml()).unwrap();
+    let output = capture_warnings(|| config.warn_if_deprecated_looking_glass());
     assert!(output.is_empty(), "no warning expected: {output}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1209,6 +1209,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
         "starting rustbgpd"
     );
     config.warn_if_deprecated_global_inline_policy();
+    config.warn_if_deprecated_looking_glass();
 
     let metrics = BgpMetrics::new();
     let grpc_listeners = resolve_grpc_listeners(&config).unwrap_or_else(|e| {

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -1,0 +1,248 @@
+//! Smoke test: the external birdwatcher-adapter must serve the same
+//! birdwatcher REST contract as the deprecated in-daemon looking
+//! glass, for the same daemon state.
+//!
+//! Spawns one rustbgpd (in-daemon looking glass + gRPC TCP enabled)
+//! and one birdwatcher-adapter pointed at that gRPC endpoint, then
+//! fetches `/status`, `/protocols/bgp`, and `/routes/peer/{peer}`
+//! from both and asserts structural equality after blanking the
+//! clock-dependent fields (`current_server`, `last_reboot`,
+//! `state_changed`, `state` — the configured peer has no live
+//! counterpart, so its FSM state cycles).
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct Proc {
+    child: Child,
+    name: &'static str,
+    stderr_path: PathBuf,
+}
+
+impl Proc {
+    fn stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_path)
+            .unwrap_or_else(|e| format!("<failed to read {} stderr: {e}>", self.name))
+    }
+}
+
+impl Drop for Proc {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+/// Grab a free localhost port. Racy in principle, fine for a test.
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind 127.0.0.1:0")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Minimal HTTP/1.1 GET over a raw TcpStream — avoids an HTTP client
+/// dev-dependency for a smoke test.
+fn http_get(port: u16, path: &str) -> Option<(u16, String)> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .ok()?;
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    )
+    .ok()?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    let (head, body) = response.split_once("\r\n\r\n")?;
+    let status: u16 = head.split_whitespace().nth(1)?.parse().ok()?;
+    Some((status, body.to_string()))
+}
+
+fn get_json(port: u16, path: &str, context: &str) -> serde_json::Value {
+    let (status, body) =
+        http_get(port, path).unwrap_or_else(|| panic!("{context}: GET {path} failed"));
+    assert_eq!(
+        status, 200,
+        "{context}: GET {path} returned {status}: {body}"
+    );
+    serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("{context}: GET {path} body is not JSON ({e}): {body}"))
+}
+
+fn wait_for_http(port: u16, path: &str, proc_: &mut Proc) {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if matches!(http_get(port, path), Some((200, _))) {
+            return;
+        }
+        if let Ok(Some(status)) = proc_.child.try_wait() {
+            panic!(
+                "{} exited before serving {path}: {status}\nstderr:\n{}",
+                proc_.name,
+                proc_.stderr()
+            );
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "{} did not serve {path} within timeout\nstderr:\n{}",
+        proc_.name,
+        proc_.stderr()
+    );
+}
+
+fn write_config(dir: &Path, grpc_port: u16, lg_port: u16) -> PathBuf {
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+    let config_path = dir.join("rustbgpd.toml");
+    let config = format!(
+        r#"
+[security.grpc]
+enforcement = "legacy"
+
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 0
+runtime_state_dir = "{runtime_dir}"
+
+[global.telemetry]
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "127.0.0.1:{grpc_port}"
+
+[global.telemetry.looking_glass]
+addr = "127.0.0.1:{lg_port}"
+
+[[neighbors]]
+address = "192.0.2.10"
+remote_asn = 65010
+description = "smoke peer"
+"#,
+        runtime_dir = runtime_dir.display()
+    );
+    std::fs::write(&config_path, config).expect("write test config");
+    config_path
+}
+
+/// Blank the clock-dependent fields so the two responses (taken at
+/// slightly different instants, over different uptime sources) compare
+/// structurally. Every blanked field is first asserted non-empty.
+fn normalize(mut value: serde_json::Value) -> serde_json::Value {
+    if let Some(status) = value.get_mut("status").and_then(|s| s.as_object_mut()) {
+        for key in ["current_server", "last_reboot"] {
+            let v = status.get(key).and_then(|v| v.as_str()).unwrap_or_default();
+            assert!(!v.is_empty(), "status.{key} must be populated");
+            status.insert(key.to_string(), "".into());
+        }
+    }
+    if let Some(protocols) = value.get_mut("protocols").and_then(|p| p.as_object_mut()) {
+        for (id, proto) in protocols.iter_mut() {
+            let obj = proto.as_object_mut().expect("protocol entry is an object");
+            for key in ["state_changed", "state"] {
+                let v = obj.get(key).and_then(|v| v.as_str()).unwrap_or_default();
+                assert!(!v.is_empty(), "protocols.{id}.{key} must be populated");
+                obj.insert(key.to_string(), "".into());
+            }
+        }
+    }
+    value
+}
+
+#[test]
+fn adapter_matches_in_daemon_looking_glass() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let grpc_port = free_port();
+    let lg_port = free_port();
+    let adapter_port = free_port();
+    let config_path = write_config(temp.path(), grpc_port, lg_port);
+
+    // Spawn the daemon (serves both gRPC and the in-daemon looking
+    // glass). Structured logs go to stdout, the banner to stderr.
+    let daemon_stdout = temp.path().join("rustbgpd.stdout.log");
+    let daemon_stderr = temp.path().join("rustbgpd.stderr.log");
+    let mut daemon = Proc {
+        child: Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg(&config_path)
+            .stdout(Stdio::from(
+                std::fs::File::create(&daemon_stdout).expect("daemon stdout log"),
+            ))
+            .stderr(Stdio::from(
+                std::fs::File::create(&daemon_stderr).expect("daemon stderr log"),
+            ))
+            .spawn()
+            .expect("spawn rustbgpd"),
+        name: "rustbgpd",
+        stderr_path: daemon_stderr,
+    };
+    wait_for_http(lg_port, "/status", &mut daemon);
+
+    // The configured looking glass must emit the deprecation warning.
+    let daemon_logs = std::fs::read_to_string(&daemon_stdout).expect("read daemon stdout");
+    assert!(
+        daemon_logs.contains("DEPRECATED") && daemon_logs.contains("birdwatcher-adapter"),
+        "daemon startup must warn that the in-daemon looking glass is deprecated:\n{daemon_logs}"
+    );
+
+    // Spawn the adapter against the daemon's gRPC endpoint. Built via
+    // `cargo run` (same fallback pattern the rbgp test helper uses) —
+    // the workspace build has usually compiled it already.
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let adapter_stderr = temp.path().join("adapter.stderr.log");
+    let mut adapter = Proc {
+        child: Command::new(cargo)
+            .args(["run", "--quiet", "-p", "birdwatcher-adapter", "--"])
+            .arg("--grpc-addr")
+            .arg(format!("http://127.0.0.1:{grpc_port}"))
+            .arg("--listen")
+            .arg(format!("127.0.0.1:{adapter_port}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(
+                std::fs::File::create(&adapter_stderr).expect("adapter stderr log"),
+            ))
+            .spawn()
+            .expect("spawn birdwatcher-adapter"),
+        name: "birdwatcher-adapter",
+        stderr_path: adapter_stderr,
+    };
+    wait_for_http(adapter_port, "/status", &mut adapter);
+
+    // /status — equal after blanking the two clock fields.
+    let core = normalize(get_json(lg_port, "/status", "in-daemon"));
+    let ext = normalize(get_json(adapter_port, "/status", "adapter"));
+    assert_eq!(core, ext, "/status must match");
+
+    // /protocols/bgp — protocol id, neighbor_address, neighbor_as,
+    // description, table, and route counters must match; state and
+    // state_changed are blanked (unconnectable peer cycles its FSM).
+    let core = get_json(lg_port, "/protocols/bgp", "in-daemon");
+    assert!(
+        core["protocols"]["bgp_192.0.2.10"].is_object(),
+        "in-daemon response must contain the configured peer: {core}"
+    );
+    let core = normalize(core);
+    let ext = normalize(get_json(adapter_port, "/protocols/bgp", "adapter"));
+    assert_eq!(core, ext, "/protocols/bgp must match");
+
+    // /routes/peer/{peer} — byte-equivalent JSON (empty route set; the
+    // envelope, api block, and routes array shape must be identical).
+    let core = get_json(lg_port, "/routes/peer/192.0.2.10", "in-daemon");
+    let ext = get_json(adapter_port, "/routes/peer/192.0.2.10", "adapter");
+    assert_eq!(core, ext, "/routes/peer must match exactly");
+
+    // Same via the single-table protocol route (exercises the
+    // "bgp_<addr>" id parsing on both sides).
+    let core = get_json(lg_port, "/routes/protocol/bgp_192.0.2.10", "in-daemon");
+    let ext = get_json(adapter_port, "/routes/protocol/bgp_192.0.2.10", "adapter");
+    assert_eq!(core, ext, "/routes/protocol must match exactly");
+}


### PR DESCRIPTION
Surface-reduction item 3 (maintainer-directed): the daemon's durable API identity is gRPC + rbgp; partial REST compatibility moves out of core. Real extraction, not a drop — looking-glass operators are plausible early adopters.

## The adapter (examples/birdwatcher-adapter, event-bridge precedent — not in default builds/images)

Standalone axum binary serving the same birdwatcher REST endpoints from the daemon's gRPC: /status, /protocols/bgp, /routes/protocol/{id}, /routes/peer/{peer}. Response-shape code carried over verbatim where possible; one multiplexed tonic channel; flags/env config. **Zero 501s** — every endpoint maps to existing RPCs (the neighbor list even improves to one RPC instead of N+1). The only field-level gap: gRPC Route has no received-at timestamp, so route `age` is empty (Alice-LG parses that as the same benign zero-time fallback the servers already use elsewhere) — documented in the README gap table; a proto field is the future fix.

## Deprecation in core

`[global.telemetry.looking_glass]` now logs a startup deprecation warning pointing at the adapter; behavior otherwise unchanged; removal in a future release. Warning-present/absent tests (capture helper factored to be shared with #683's pattern); CONFIGURATION.md marked deprecated; CHANGELOG Deprecated entry.

## Proof

Smoke test spawns a real daemon + adapter and compares live responses: /status and /protocols/bgp structurally equal (volatile fields blanked after asserting populated), route endpoints **exact JSON equality**. Serialization corners (community hi/lo split, large communities, IPv6 underscore ids) unit-covered.

## Found, not fixed here (separate PR follows)

Pre-existing seed-dependent flake on main: #681's `NotificationCode::SendHoldTimerExpired = 8` makes the wire `roundtrip_notification` proptest generator produce `Unknown(8)` which decodes to the named variant — round-trip asserts unequal. Generator needs a one-line exclusion.

Gates: workspace build/test (4861 passed), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.