### PR TITLE
feat(rib): extend update-groups to VPN staging for non-RTC groups (v2 slice 1)

### DIFF
--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -149,6 +149,15 @@ impl AdjRibOut {
         self.prefix_path_ids.clear();
     }
 
+    /// Remove only the VPN routes and their secondary key index, leaving
+    /// every other family untouched. The VPN sibling of
+    /// [`Self::clear_unicast`]: used when a peer's VPN advertised state
+    /// moves onto the update-group path.
+    pub fn clear_vpn(&mut self) {
+        self.vpn_routes.clear();
+        self.vpn_key_path_ids.clear();
+    }
+
     /// Remove every advertised route — unicast, `FlowSpec`, EVPN, BGP-LS,
     /// VPN, labeled-unicast, and RTC — and the secondary prefix index.
     pub fn clear(&mut self) {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -224,8 +224,13 @@ impl RibManager {
         // A grouped member's unicast advertised state is group-owned
         // (design §2: NO per-peer unicast storage) — skip the per-peer
         // unicast commit and synthesize its gauge from the group table.
-        // Non-unicast families always commit per peer.
+        // Same for VPN when the member's group stages VPN (non-RTC
+        // groups, v2 slice 1). Other families always commit per peer.
         let grouped_unicast_count = self.grouped_advertised_count(peer);
+        let grouped_vpn_count = self
+            .vpn_grouped_member_of(peer)
+            .and_then(|gid| self.group_ribs.get(&gid))
+            .map(|group| group.vpn_advertised_count_for(peer));
 
         if !announce.is_empty()
             || !withdraw.is_empty()
@@ -273,11 +278,13 @@ impl RibManager {
             for key in &bgpls_withdraw {
                 rib_out.remove_bgpls(key);
             }
-            for route in &vpn_announce {
-                rib_out.insert_vpn(route.clone());
-            }
-            for key in &vpn_withdraw {
-                rib_out.remove_vpn(key);
+            if grouped_vpn_count.is_none() {
+                for route in &vpn_announce {
+                    rib_out.insert_vpn(route.clone());
+                }
+                for key in &vpn_withdraw {
+                    rib_out.remove_vpn(key);
+                }
             }
             for route in &labeled_announce {
                 rib_out.insert_labeled(route.clone());
@@ -314,7 +321,7 @@ impl RibManager {
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
                 "vpn",
-                gauge_val(rib_out.vpn_len()),
+                gauge_val(grouped_vpn_count.unwrap_or_else(|| rib_out.vpn_len())),
             );
             self.metrics.set_adj_rib_out_prefixes(
                 &peer.to_string(),
@@ -979,7 +986,7 @@ impl RibManager {
                         all.extend(group.tombstones.iter().map(|(p, _)| *p));
                     }
                     if let Some(base) = self.pending_regroup_baseline.get(&peer) {
-                        all.extend(base.keys().map(|(p, _)| *p));
+                        all.extend(base.unicast.keys().map(|(p, _)| *p));
                     }
                 } else {
                     // For multi-path dirty resync, also include all Adj-RIB-In prefixes
@@ -1071,21 +1078,38 @@ impl RibManager {
                 HashSet::new()
             };
 
+            // A member of a VPN-staging group holds no per-peer VPN
+            // Adj-RIB-Out: its advertised VPN state is the group table
+            // (plus pending withdraw residue), so the resync enumeration
+            // synthesizes from those — mirroring the unicast synthesis
+            // above. RTC-negotiated groups don't stage VPN (slice-1
+            // gate), so their members keep the per-peer enumeration.
+            let vpn_grouped = self.vpn_grouped_member_of(peer);
             let effective_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = if resync {
                 let mut all: HashSet<rustbgpd_wire::VpnRouteKey> = self
                     .loc_rib
                     .iter_vpn()
                     .map(|route| route.nlri.key())
                     .collect();
-                // For a VPN Add-Path-send resync, the staged top-N draws from
-                // every Adj-RIB-In identity, not just the Loc-RIB bests.
-                if self.peer_vpn_add_path_send(peer) {
-                    for rib in self.ribs.values() {
-                        all.extend(rib.iter_vpn().map(|route| route.nlri.key()));
+                if let Some(gid) = vpn_grouped {
+                    if let Some(group) = self.group_ribs.get(&gid) {
+                        all.extend(group.table.iter_vpn().map(|route| route.nlri.key()));
+                        all.extend(group.vpn_tombstones.iter().copied());
                     }
-                }
-                if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_vpn().map(|route| route.nlri.key()));
+                    if let Some(base) = self.pending_regroup_baseline.get(&peer) {
+                        all.extend(base.vpn.keys().copied());
+                    }
+                } else {
+                    // For a VPN Add-Path-send resync, the staged top-N draws from
+                    // every Adj-RIB-In identity, not just the Loc-RIB bests.
+                    if self.peer_vpn_add_path_send(peer) {
+                        for rib in self.ribs.values() {
+                            all.extend(rib.iter_vpn().map(|route| route.nlri.key()));
+                        }
+                    }
+                    if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
+                        all.extend(rib_out.iter_vpn().map(|route| route.nlri.key()));
+                    }
                 }
                 all
             } else {
@@ -1192,12 +1216,36 @@ impl RibManager {
                             peer,
                             is_dirty,
                             is_force,
-                            self.pending_regroup_baseline.get(&peer),
-                            self.pending_extra_withdraws.get(&peer),
+                            self.pending_regroup_baseline
+                                .get(&peer)
+                                .map(|base| &base.unicast),
+                            self.pending_extra_withdraws
+                                .get(&peer)
+                                .map(|extras| &extras.unicast),
                             &mut announce,
                             &mut withdraw,
                             &mut nh_override_flags,
                         );
+                        // VPN portion of the resync, from the group's VPN
+                        // maps (only staged for non-RTC groups); the
+                        // per-peer VPN staging below is skipped for these
+                        // members (`vpn_grouped` gate).
+                        if group.stages_vpn() {
+                            Self::assemble_group_vpn_resync(
+                                group,
+                                peer,
+                                is_dirty,
+                                is_force,
+                                self.pending_regroup_baseline
+                                    .get(&peer)
+                                    .map(|base| &base.vpn),
+                                self.pending_extra_withdraws
+                                    .get(&peer)
+                                    .map(|extras| &extras.vpn),
+                                &mut vpn_announce,
+                                &mut vpn_withdraw,
+                            );
+                        }
                     } else if let Some(stage) = group_stage.get(&gid) {
                         if stage.shared_applies_to(peer) {
                             // Common case: this member's matrix output IS
@@ -1467,16 +1515,25 @@ impl RibManager {
                 );
             }
 
-            if resync && !effective_l3vpn_keys.is_empty() {
+            // A VPN-staging group member's VPN resync was assembled from
+            // the group table above — no per-peer staging, no policy
+            // re-evaluation.
+            if resync && vpn_grouped.is_none() && !effective_l3vpn_keys.is_empty() {
+                let mut target = ExportTarget::Peer {
+                    peer,
+                    peer_asn: target_peer_asn,
+                    peer_group: target_peer_group,
+                    metrics: &metrics,
+                    policy_stats: &mut *policy_stats,
+                    peer_label: &target_peer_label,
+                };
                 Self::stage_vpn_routes(
                     loc_rib,
                     &self.ribs,
                     rib_out,
                     &self.peer_is_rr_client,
                     &effective_l3vpn_keys,
-                    peer,
-                    target_peer_asn,
-                    target_peer_group,
+                    &mut target,
                     target_is_ebgp,
                     target_is_rr_client,
                     cluster_id,
@@ -1487,9 +1544,6 @@ impl RibManager {
                     peer_add_path_send_max,
                     &peer_add_path_send_families,
                     export_pol.as_ref(),
-                    &metrics,
-                    policy_stats,
-                    &target_peer_label,
                     &mut vpn_announce,
                     &mut vpn_withdraw,
                     is_force,

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -1,7 +1,6 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib,
-    NeighborPolicyStats, PolicyChain, RibManager, RouteContext, Safi, gauge_val,
-    record_export_policy_eval, route_type, should_suppress_ibgp_inner, vpn_routes_equal, warn,
+    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, PolicyChain, RibManager,
+    RouteContext, Safi, gauge_val, route_type, should_suppress_ibgp_inner, vpn_routes_equal, warn,
 };
 use crate::loc_rib::vpn_tiebreak_orr;
 use crate::route::{VpnRibRoute, VpnRibRouteKey};
@@ -61,6 +60,16 @@ impl RibManager {
     /// (honest, unlike the prefixless BGP-LS placeholder) plus communities,
     /// large communities, `AS_PATH`, peer, and route type.
     ///
+    /// `target` selects the consumer (the unicast `ExportTarget` pattern —
+    /// ONE body, never copied; the per-peer path stays the group path's
+    /// correctness oracle): a concrete peer, or a whole update group with
+    /// the group table as `rib_out`, split horizon lifted to member emit,
+    /// peer-context `RouteContext` fields `None`, and evaluations
+    /// accumulated for per-member counter replay. Group targets never
+    /// carry `rtc_filter` (RTC-negotiated groups don't stage VPN in this
+    /// slice; slice 2 applies Φ at member emit), `orr_ctx`, or Add-Path —
+    /// all three disqualify from grouping.
+    ///
     /// When the target negotiated Add-Path send for the key's family (RFC
     /// 7911; RFC 9107 requires it between RRs), up to `add_path_send_max`
     /// candidates per key are ranked — with the ORR vantage comparator when
@@ -77,9 +86,7 @@ impl RibManager {
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         keys: &HashSet<VpnRouteKey>,
-        target_peer: IpAddr,
-        target_peer_asn: Option<u32>,
-        target_peer_group: Option<&str>,
+        target: &mut super::ExportTarget<'_>,
         target_is_ebgp: bool,
         target_is_rr_client: bool,
         cluster_id: Option<Ipv4Addr>,
@@ -90,14 +97,14 @@ impl RibManager {
         add_path_send_max: u32,
         add_path_send_families: &[(Afi, Safi)],
         export_pol: Option<&PolicyChain>,
-        metrics: &BgpMetrics,
-        policy_stats: &mut NeighborPolicyStats,
-        target_peer_label: &str,
         vpn_announce: &mut Vec<VpnRibRoute>,
         vpn_withdraw: &mut Vec<VpnRibRouteKey>,
         force: bool,
     ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
+        // `None` for group staging: split horizon is applied per member
+        // at emit time by the VPN source-flip matrix.
+        let split_horizon_peer = target.split_horizon_peer();
         for key in keys {
             let family = vpn_afi_safi(key);
             // Path IDs currently advertised for this identity — the diff
@@ -133,7 +140,7 @@ impl RibManager {
                     .values()
                     .flat_map(|rib| rib.iter_vpn_for_nlri(key))
                     .filter(|candidate| {
-                        candidate.peer != target_peer
+                        split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &vpn_suppression_probe(candidate),
                                 target_is_ebgp,
@@ -199,6 +206,7 @@ impl RibManager {
                         String::new()
                     };
                     let aspath_len = candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+                    let (peer_address, peer_asn, peer_group) = target.ctx_peer();
                     let ctx = RouteContext {
                         prefix: Some(candidate.inner_prefix()),
                         next_hop: Some(candidate.next_hop),
@@ -209,9 +217,9 @@ impl RibManager {
                         as_path_len: aspath_len,
                         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-                        peer_address: Some(target_peer),
-                        peer_asn: target_peer_asn,
-                        peer_group: target_peer_group,
+                        peer_address,
+                        peer_asn,
+                        peer_group,
                         route_type: Some(route_type(candidate.origin_type)),
                         evpn_route_type: None,
                         local_pref: candidate.local_pref_attr(),
@@ -219,12 +227,7 @@ impl RibManager {
                     };
                     let (result, evaluation) =
                         rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
-                    record_export_policy_eval(
-                        metrics,
-                        policy_stats,
-                        target_peer_label,
-                        &evaluation,
-                    );
+                    target.record_eval(&evaluation, candidate.peer);
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
                         continue;
                     }
@@ -280,7 +283,7 @@ impl RibManager {
                     .values()
                     .flat_map(|rib| rib.iter_vpn_for_nlri(key))
                     .filter(|candidate| {
-                        candidate.peer != target_peer
+                        split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &vpn_suppression_probe(candidate),
                                 target_is_ebgp,
@@ -341,8 +344,10 @@ impl RibManager {
 
             // The two suppression checks below are no-ops for an ORR
             // winner (its candidate set is pre-filtered above); they
-            // decide only for the Loc-RIB best of a plain peer.
-            if best.peer == target_peer {
+            // decide only for the Loc-RIB best of a plain peer. Group
+            // staging has no single target — the VPN source-flip matrix
+            // applies split horizon per member at emit time.
+            if split_horizon_peer == Some(best.peer) {
                 withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
             }
@@ -365,6 +370,10 @@ impl RibManager {
                 String::new()
             };
             let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
+            // Group staging passes no peer-context fields: a chain that
+            // reads them disqualifies its peers from grouping, so the
+            // verdict is target-independent by construction.
+            let (peer_address, peer_asn, peer_group) = target.ctx_peer();
             let ctx = RouteContext {
                 prefix: Some(best.inner_prefix()),
                 next_hop: Some(best.next_hop),
@@ -375,9 +384,9 @@ impl RibManager {
                 as_path_len: aspath_len,
                 validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                 aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-                peer_address: Some(target_peer),
-                peer_asn: target_peer_asn,
-                peer_group: target_peer_group,
+                peer_address,
+                peer_asn,
+                peer_group,
                 route_type: Some(route_type(best.origin_type)),
                 evpn_route_type: None,
                 local_pref: best.local_pref_attr(),
@@ -385,7 +394,7 @@ impl RibManager {
             };
             let (result, evaluation) =
                 rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
-            record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+            target.record_eval(&evaluation, best.peer);
             if result.action != rustbgpd_policy::PolicyAction::Permit {
                 withdraw_existing(vpn_withdraw, existing_path_ids);
                 continue;
@@ -509,8 +518,71 @@ impl RibManager {
                 .set_loc_rib_prefixes("vpn", gauge_val(self.loc_rib.vpn_len()));
         }
 
+        // Update-group shared VPN staging: ONE export-tail pass per
+        // (VPN-staging group, changed identity), committed to the group
+        // tables. The per-peer loop below emits the deltas per member via
+        // the VPN source-flip matrix; RTC-negotiated groups don't stage
+        // VPN (slice-1 gate), so their members — and all ungrouped peers —
+        // take the per-peer staging path exactly as before.
+        let vpn_group_stage = self.stage_vpn_update_groups(&changed_keys);
+
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
         for peer in peers {
+            if let Some(gid) = self.vpn_grouped_member_of(peer) {
+                let Some(stage) = vpn_group_stage.get(&gid) else {
+                    continue;
+                };
+                // Per-member export-policy counters from the group
+                // verdict — integer adds, `totals − own-sourced`.
+                self.apply_group_policy_counters(peer, &stage.evals);
+                let mut vpn_announce = Vec::new();
+                let mut vpn_withdraw = Vec::new();
+                crate::manager::update_groups::emit_vpn_group_deltas_for_member(
+                    &stage.deltas,
+                    peer,
+                    &mut vpn_announce,
+                    &mut vpn_withdraw,
+                );
+                if vpn_announce.is_empty() && vpn_withdraw.is_empty() {
+                    continue;
+                }
+                if !self.try_send_and_commit_outbound_update(
+                    peer,
+                    vec![].into(),
+                    vec![].into(),
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                    vpn_announce,
+                    vpn_withdraw,
+                    vec![],
+                    vec![],
+                    vec![],
+                    vec![],
+                ) {
+                    warn!(%peer, "outbound channel full — VPN update deferred");
+                    self.mark_outbound_dirty(peer);
+                    // The member missed this pass's withdrawals: record
+                    // them as VPN tombstones so its resync can
+                    // (over-)withdraw them.
+                    if let Some(group) = self.group_ribs.get_mut(&gid) {
+                        group.vpn_tombstones.extend(
+                            stage
+                                .deltas
+                                .iter()
+                                .filter(|d| d.new.is_none())
+                                .map(|d| d.key),
+                        );
+                    }
+                }
+                continue;
+            }
             // A peer bound to a vantage that resolved this pass takes the
             // per-vantage best; an unresolved vantage silently falls back
             // to the standard Loc-RIB best (same shape as unicast).
@@ -565,15 +637,21 @@ impl RibManager {
 
             let mut vpn_announce = Vec::new();
             let mut vpn_withdraw = Vec::new();
+            let mut target = super::ExportTarget::Peer {
+                peer,
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group,
+                metrics: &metrics,
+                policy_stats: &mut *policy_stats,
+                peer_label: &target_peer_label,
+            };
             Self::stage_vpn_routes(
                 &self.loc_rib,
                 &self.ribs,
                 rib_out,
                 &self.peer_is_rr_client,
                 staged_keys,
-                peer,
-                target_peer_asn,
-                target_peer_group,
+                &mut target,
                 target_is_ebgp,
                 target_is_rr_client,
                 self.cluster_id,
@@ -584,9 +662,6 @@ impl RibManager {
                 add_path_send_max,
                 &add_path_send_families,
                 export_pol.as_ref(),
-                &metrics,
-                policy_stats,
-                &target_peer_label,
                 &mut vpn_announce,
                 &mut vpn_withdraw,
                 false,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -320,17 +320,16 @@ pub struct RibManager {
     /// pass) at the first member's join, dropped at the last member's
     /// leave. See [`update_groups::GroupRibOut`].
     group_ribs: HashMap<usize, update_groups::GroupRibOut>,
-    /// A regrouped member's previously-advertised unicast view (old
-    /// group table minus own-sourced, or the per-peer Adj-RIB-Out),
-    /// held until its one-shot resync diff succeeds. Transient —
-    /// regroups are config-time events.
-    pending_regroup_baseline:
-        HashMap<IpAddr, rustc_hash::FxHashMap<(Prefix, u32), crate::route::Route>>,
+    /// A regrouped member's previously-advertised view (old group table
+    /// minus own-sourced, or the per-peer Adj-RIB-Out) — unicast plus
+    /// group-owned VPN — held until its one-shot resync diff succeeds.
+    /// Transient — regroups are config-time events.
+    pending_regroup_baseline: HashMap<IpAddr, update_groups::RegroupBaseline>,
     /// Extra (over-)withdraw keys a member must emit on its next
     /// resync: tombstones carried across a regroup by a member that was
     /// dirty when it moved (its missed withdrawals are unknown —
     /// over-withdraw is the safe direction). Cleared on resync success.
-    pending_extra_withdraws: HashMap<IpAddr, HashSet<(Prefix, u32)>>,
+    pending_extra_withdraws: HashMap<IpAddr, update_groups::ExtraWithdraws>,
     /// Differential-oracle test hook: disqualify every peer from
     /// grouping so identical scenarios can be driven through the
     /// per-peer path (the correctness oracle) and compared against a

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -818,6 +818,7 @@ impl RibManager {
         // per-prefix staging walk). The loop below is the ungrouped
         // path; grouped peers skip it (empty staging set).
         let member_of = self.grouped_member_of(peer);
+        let mut vpn_group_replayed = false;
         if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {
             for route in group.table.iter() {
                 if route.peer == peer {
@@ -825,6 +826,19 @@ impl RibManager {
                 }
                 nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
                 announce.push(route.clone());
+            }
+            // VPN join replay (non-RTC groups): table minus own-sourced,
+            // export tail already paid when the table was staged. An RTC
+            // group never stages VPN — its members take the per-peer VPN
+            // staging below, where the RFC 4684 RT filter applies.
+            if group.stages_vpn() {
+                vpn_group_replayed = true;
+                for route in group.table.iter_vpn() {
+                    if route.peer == peer {
+                        continue;
+                    }
+                    vpn_announce.push(route.clone());
+                }
             }
             current_policy_filtered_routes
                 .extend(group.policy_filtered_for_member(peer, &all_prefixes));
@@ -1075,16 +1089,25 @@ impl RibManager {
                 all_l3vpn_keys.extend(rib.iter_vpn().map(|route| route.nlri.key()));
             }
         }
-        if !all_l3vpn_keys.is_empty() {
+        // Skipped when the VPN dump was replayed from the group table
+        // above (VPN-staging group member — design §4: join pays no
+        // per-key staging walk).
+        if !all_l3vpn_keys.is_empty() && !vpn_group_replayed {
+            let mut target = super::distribution::ExportTarget::Peer {
+                peer,
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group.as_deref(),
+                metrics: &metrics,
+                policy_stats: &mut *policy_stats,
+                peer_label: &target_peer_label,
+            };
             Self::stage_vpn_routes(
                 loc_rib,
                 &self.ribs,
                 &initial_view,
                 &self.peer_is_rr_client,
                 &all_l3vpn_keys,
-                peer,
-                target_peer_asn,
-                target_peer_group.as_deref(),
+                &mut target,
                 target_is_ebgp,
                 target_is_rr_client,
                 cluster_id,
@@ -1095,9 +1118,6 @@ impl RibManager {
                 peer_add_path_send_max,
                 &peer_add_path_send_families,
                 export_pol.as_ref(),
-                &metrics,
-                policy_stats,
-                &target_peer_label,
                 &mut vpn_announce,
                 &mut vpn_withdraw,
                 false, // initial dump — equality check is correct

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -629,6 +629,9 @@ impl RibManager {
         let target_peer_label = peer.to_string();
         let metrics = self.metrics.clone();
         let member_of = self.grouped_member_of(peer);
+        // Resolved before the `policy_stats` borrow below (whole-`self`
+        // method call).
+        let vpn_member_of = self.vpn_grouped_member_of(peer);
         let policy_stats = self.export_policy_stats.entry(peer).or_default();
 
         let mut all_prefixes: HashSet<Prefix> = self
@@ -740,54 +743,78 @@ impl RibManager {
                 );
             }
         } else if safi == Safi::MplsVpn {
-            let mut vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = self
-                .loc_rib
-                .iter_vpn()
-                .filter(|route| route.afi_safi() == family)
-                .map(|route| route.nlri.key())
-                .collect();
-            // An Add-Path-send refresh re-emits the staged top-N, which
-            // draws from every Adj-RIB-In identity of the family.
-            if peer_add_path_send_max > 0
-                && peer_add_path_send_families
-                    .iter()
-                    .any(|(_, safi)| *safi == Safi::MplsVpn)
-            {
-                for rib in self.ribs.values() {
-                    vpn_keys.extend(
-                        rib.iter_vpn()
-                            .filter(|route| route.afi_safi() == family)
-                            .map(|route| route.nlri.key()),
+            // A member of a VPN-staging group replays the refreshed
+            // family from the group table — own-sourced excluded, NO
+            // policy re-evaluation (same shape as the unicast grouped
+            // arm below). RTC-negotiated groups don't stage VPN, so
+            // their members keep the per-peer staging (RT filter applies
+            // there).
+            if let Some(gid) = vpn_member_of {
+                if let Some(group) = self.group_ribs.get(&gid) {
+                    for route in group.table.iter_vpn() {
+                        if route.peer == peer || route.afi_safi() != family {
+                            continue;
+                        }
+                        vpn_announce.push(route.clone());
+                    }
+                }
+                // Export counters for the replayed family, from the
+                // group's staged residue (per-peer refresh re-eval
+                // parity).
+                self.apply_group_join_counters(peer, gid, Some(family));
+            } else {
+                let mut vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = self
+                    .loc_rib
+                    .iter_vpn()
+                    .filter(|route| route.afi_safi() == family)
+                    .map(|route| route.nlri.key())
+                    .collect();
+                // An Add-Path-send refresh re-emits the staged top-N, which
+                // draws from every Adj-RIB-In identity of the family.
+                if peer_add_path_send_max > 0
+                    && peer_add_path_send_families
+                        .iter()
+                        .any(|(_, safi)| *safi == Safi::MplsVpn)
+                {
+                    for rib in self.ribs.values() {
+                        vpn_keys.extend(
+                            rib.iter_vpn()
+                                .filter(|route| route.afi_safi() == family)
+                                .map(|route| route.nlri.key()),
+                        );
+                    }
+                }
+                if !vpn_keys.is_empty() {
+                    let mut target = super::distribution::ExportTarget::Peer {
+                        peer,
+                        peer_asn: target_peer_asn,
+                        peer_group: target_peer_group,
+                        metrics: &metrics,
+                        policy_stats: &mut *policy_stats,
+                        peer_label: &target_peer_label,
+                    };
+                    Self::stage_vpn_routes(
+                        loc_rib,
+                        &self.ribs,
+                        &refresh_view,
+                        &self.peer_is_rr_client,
+                        &vpn_keys,
+                        &mut target,
+                        target_is_ebgp,
+                        target_is_rr_client,
+                        cluster_id,
+                        sendable.as_ref(),
+                        llgr.as_ref(),
+                        rtc_filter.as_ref(),
+                        orr_ctx,
+                        peer_add_path_send_max,
+                        &peer_add_path_send_families,
+                        export_pol.as_ref(),
+                        &mut vpn_announce,
+                        &mut vpn_withdraw,
+                        false, // route refresh re-emits via empty refresh_view
                     );
                 }
-            }
-            if !vpn_keys.is_empty() {
-                Self::stage_vpn_routes(
-                    loc_rib,
-                    &self.ribs,
-                    &refresh_view,
-                    &self.peer_is_rr_client,
-                    &vpn_keys,
-                    peer,
-                    target_peer_asn,
-                    target_peer_group,
-                    target_is_ebgp,
-                    target_is_rr_client,
-                    cluster_id,
-                    sendable.as_ref(),
-                    llgr.as_ref(),
-                    rtc_filter.as_ref(),
-                    orr_ctx,
-                    peer_add_path_send_max,
-                    &peer_add_path_send_families,
-                    export_pol.as_ref(),
-                    &metrics,
-                    policy_stats,
-                    &target_peer_label,
-                    &mut vpn_announce,
-                    &mut vpn_withdraw,
-                    false, // route refresh re-emits via empty refresh_view
-                );
             }
         } else if safi == Safi::LabeledUnicast {
             let mut labeled_keys: HashSet<Prefix> = self

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -19,9 +19,10 @@ use std::collections::BTreeMap;
 use rustbgpd_policy::{
     NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
 };
+use rustbgpd_wire::RtcNlri;
 
 use super::*;
-use crate::route::RouteOrigin;
+use crate::route::{RouteOrigin, RtcRibRoute, VpnRibRouteKey};
 
 const SESSION: u64 = 1;
 
@@ -57,6 +58,91 @@ fn ibgp_route(prefix: Ipv4Prefix, src: Ipv4Addr, local_pref: u32, communities: V
 
 fn pfx(a: u8, b: u8) -> Ipv4Prefix {
     Ipv4Prefix::new(Ipv4Addr::new(10, 200, a, b), 24)
+}
+
+/// A `VPNv4` NLRI fixture: RD 65000:n, inner prefix 10.210.n.0/24, one
+/// BOS label. The label is route *data* (not key), so a relabel of the
+/// same `n` is the ADR-0077 same-peer-relabel re-advertise case.
+fn vpn_nlri(n: u8, label: u32) -> VpnNlri {
+    VpnNlri {
+        labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
+        route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, n]),
+        prefix: VpnPrefix::v4(Ipv4Addr::new(10, 210, n, 0), 24).unwrap(),
+    }
+}
+
+fn vpn_key(n: u8, label: u32) -> VpnRibRouteKey {
+    VpnRibRouteKey {
+        nlri_key: vpn_nlri(n, label).key(),
+        path_id: 0,
+    }
+}
+
+/// An iBGP-learned VPN route fixture; `LOCAL_PREF` ranks it in the VPN
+/// selection chain, extended communities (RTs) ride along when given.
+fn vpn_route(
+    nlri: VpnNlri,
+    src: Ipv4Addr,
+    local_pref: u32,
+    extended_communities: Vec<u64>,
+) -> VpnRibRoute {
+    let mut attributes = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath { segments: vec![] }),
+        PathAttribute::LocalPref(local_pref),
+    ];
+    if !extended_communities.is_empty() {
+        attributes.push(PathAttribute::ExtendedCommunities(
+            extended_communities
+                .into_iter()
+                .map(ExtendedCommunity::new)
+                .collect(),
+        ));
+    }
+    VpnRibRoute {
+        nlri,
+        next_hop: IpAddr::V4(src),
+        peer: IpAddr::V4(src),
+        attributes: Arc::new(attributes),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: src,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+/// RT-Constrain default-NLRI advertisement from a peer (RFC 4684
+/// wildcard interest — membership passes every RT).
+fn rtc_default(src: Ipv4Addr) -> RtcRibRoute {
+    RtcRibRoute {
+        nlri: RtcNlri::DEFAULT,
+        next_hop: IpAddr::V4(src),
+        peer: IpAddr::V4(src),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath { segments: vec![] }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: src,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+fn vpn_sendable() -> Vec<(Afi, Safi)> {
+    vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)]
+}
+
+fn vpn_rtc_sendable() -> Vec<(Afi, Safi)> {
+    vec![
+        (Afi::Ipv4, Safi::Unicast),
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::RtConstrain),
+    ]
 }
 
 fn permit_all_with(modifications: RouteModifications) -> PolicyChain {
@@ -127,11 +213,19 @@ type NormAnnounce = (
     Option<NextHopAction>,
 );
 
+/// One normalized VPN announce: (RD+prefix key, full NLRI incl. label
+/// stack, next hop, source peer, attributes). Keys/NLRI are `Debug`
+/// strings — `VpnRouteKey` has no `Display` and only sort stability
+/// matters here.
+type NormVpnAnnounce = (String, String, IpAddr, IpAddr, Vec<PathAttribute>);
+
 #[derive(Debug, PartialEq, Clone)]
 struct NormMsg {
     announce: Vec<NormAnnounce>,
     withdraw: Vec<(Prefix, u32)>,
     end_of_rib: Vec<(Afi, Safi)>,
+    vpn_announce: Vec<NormVpnAnnounce>,
+    vpn_withdraw: Vec<(String, u32)>,
 }
 
 fn normalize(update: &OutboundRouteUpdate) -> NormMsg {
@@ -157,10 +251,32 @@ fn normalize(update: &OutboundRouteUpdate) -> NormMsg {
     withdraw.sort_by_key(|(prefix, path_id)| (prefix.to_string(), *path_id));
     let mut end_of_rib = update.end_of_rib.clone();
     end_of_rib.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+    let mut vpn_announce: Vec<NormVpnAnnounce> = update
+        .vpn_announce
+        .iter()
+        .map(|r| {
+            (
+                format!("{:?}", r.nlri.key()),
+                format!("{:?}", r.nlri),
+                r.next_hop,
+                r.peer,
+                (*r.attributes).clone(),
+            )
+        })
+        .collect();
+    vpn_announce.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut vpn_withdraw: Vec<(String, u32)> = update
+        .vpn_withdraw
+        .iter()
+        .map(|key| (format!("{:?}", key.nlri_key), key.path_id))
+        .collect();
+    vpn_withdraw.sort();
     NormMsg {
         announce,
         withdraw,
         end_of_rib,
+        vpn_announce,
+        vpn_withdraw,
     }
 }
 
@@ -185,6 +301,27 @@ fn fold(streams: &Streams) -> FoldedState {
                     (*prefix, *path_id),
                     (*nh, *src, attrs.clone(), nh_override.clone()),
                 );
+            }
+        }
+    }
+    state
+}
+
+/// VPN counterpart of [`fold`]: final advertised VPN state per peer,
+/// keyed by RD+prefix identity (`path_id` 0 only in these scenarios).
+type FoldedVpnState =
+    BTreeMap<IpAddr, HashMap<String, (String, IpAddr, IpAddr, Vec<PathAttribute>)>>;
+
+fn fold_vpn(streams: &Streams) -> FoldedVpnState {
+    let mut state = FoldedVpnState::new();
+    for (peer, msgs) in streams {
+        let table = state.entry(*peer).or_default();
+        for msg in msgs {
+            for (key, _) in &msg.vpn_withdraw {
+                table.remove(key);
+            }
+            for (key, nlri, nh, src, attrs) in &msg.vpn_announce {
+                table.insert(key.clone(), (nlri.clone(), *nh, *src, attrs.clone()));
             }
         }
     }
@@ -219,6 +356,26 @@ impl Oracle {
         export_policy: Option<PolicyChain>,
         capacity: usize,
     ) {
+        self.peer_up_families(
+            peer,
+            is_ebgp,
+            route_reflector_client,
+            export_policy,
+            capacity,
+            ipv4_sendable(),
+        )
+        .await;
+    }
+
+    async fn peer_up_families(
+        &mut self,
+        peer: Ipv4Addr,
+        is_ebgp: bool,
+        route_reflector_client: bool,
+        export_policy: Option<PolicyChain>,
+        capacity: usize,
+        sendable_families: Vec<(Afi, Safi)>,
+    ) {
         let (out_tx, out_rx) = mpsc::channel(capacity);
         self.tx
             .send(RibUpdate::PeerUp {
@@ -228,7 +385,7 @@ impl Oracle {
                 peer_router_id: peer,
                 outbound_tx: out_tx,
                 export_policy,
-                sendable_families: ipv4_sendable(),
+                sendable_families,
                 is_ebgp,
                 route_reflector_client,
                 orr_vantage: None,
@@ -269,6 +426,53 @@ impl Oracle {
             .await
             .unwrap();
         self.quiesce().await;
+    }
+
+    async fn vpn_routes(
+        &mut self,
+        from: Ipv4Addr,
+        announce: Vec<VpnRibRoute>,
+        withdraw: Vec<VpnRibRouteKey>,
+    ) {
+        self.tx
+            .send(RibUpdate::VpnRoutesReceived {
+                peer: IpAddr::V4(from),
+                session_id: SESSION,
+                announced: announce,
+                withdrawn: withdraw,
+            })
+            .await
+            .unwrap();
+        self.quiesce().await;
+    }
+
+    /// RFC 4684 RT-Constrain advertisement from a peer — rebuilds the
+    /// peer's RT membership (the per-peer VPN filter).
+    async fn rtc_routes(&mut self, from: Ipv4Addr, announce: Vec<RtcRibRoute>) {
+        self.tx
+            .send(RibUpdate::RtcRoutesReceived {
+                peer: IpAddr::V4(from),
+                session_id: SESSION,
+                announced: announce,
+                withdrawn: vec![],
+            })
+            .await
+            .unwrap();
+        self.quiesce().await;
+    }
+
+    /// The peer's update-group membership label (`group:N` or the
+    /// ungrouped reason).
+    async fn group_label(&mut self, peer: Ipv4Addr) -> String {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::QueryPeerUpdateGroup {
+                peer: IpAddr::V4(peer),
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap()
     }
 
     async fn replace_policy(&mut self, peer: Ipv4Addr, export_policy: Option<PolicyChain>) {
@@ -570,6 +774,245 @@ async fn oracle_nh_override_survives_group_join_replay() {
         announced_with_flag,
         "join replay must reproduce the next-hop-override flag"
     );
+}
+
+/// The VPN kitchen-sink exact-stream scenario (update-groups v2 slice
+/// 1): initial VPN dump, flood, source-flip X→Y→X, same-peer relabel
+/// (ADR-0077 re-advertise), attr mutate, withdraw, split horizon
+/// (source inside the group), late joiner replay, RFC 7313 VPN route
+/// refresh, member leave, regroup on policy change (content-equal
+/// reinstall AND a genuine deny), and a GShut-style forced refresh —
+/// grouped vs forced-ungrouped per-peer VPN streams must be identical.
+#[tokio::test]
+async fn oracle_vpn_streams_identical_across_group_lifecycle() {
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let modifying_chain = || {
+        permit_all_with(RouteModifications {
+            set_med: Some(77),
+            communities_add: vec![0xFDE8_0001],
+            ..RouteModifications::default()
+        })
+    };
+    let scenario = async |o: &mut Oracle| {
+        // Three RR clients (one group), a non-client (second group), an
+        // iBGP peer with an attribute-modifying chain (third group) —
+        // all VPN-capable, none RTC.
+        o.peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(B, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(C, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(D, false, false, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(E, false, true, Some(modifying_chain()), 64, vpn_sendable())
+            .await;
+
+        // Flood from a member: split horizon inside the group.
+        o.vpn_routes(
+            A,
+            vec![
+                vpn_route(vpn_nlri(1, 100), A, 100, vec![]),
+                vpn_route(vpn_nlri(2, 200), A, 100, vec![]),
+            ],
+            vec![],
+        )
+        .await;
+
+        // Source flip X→Y (B takes over identity 1 with higher LP)...
+        o.vpn_routes(B, vec![vpn_route(vpn_nlri(1, 100), B, 200, vec![])], vec![])
+            .await;
+        // ... and flip back Y→X (B withdraws its path).
+        o.vpn_routes(B, vec![], vec![vpn_key(1, 100)]).await;
+
+        // Same-peer relabel: identity 2 keeps its key, the label stack
+        // changes — must re-advertise (label is data, not key).
+        o.vpn_routes(A, vec![vpn_route(vpn_nlri(2, 999), A, 100, vec![])], vec![])
+            .await;
+
+        // Attribute change on the standing best (same source).
+        o.vpn_routes(A, vec![vpn_route(vpn_nlri(2, 999), A, 150, vec![])], vec![])
+            .await;
+
+        // Late joiner into the client group: replay, not restage.
+        o.peer_up_families(F, false, true, None, 64, vpn_sendable())
+            .await;
+
+        // RFC 7313 VPN route refresh, both group shapes: a grouped RR
+        // client with own-sourced entries (split-horizon exclusion in
+        // the replay) and the modified-chain peer (the replay must
+        // reproduce the modified attributes from the staged residue
+        // without re-running policy).
+        o.route_refresh(A, Afi::Ipv4, Safi::MplsVpn).await;
+        o.route_refresh(E, Afi::Ipv4, Safi::MplsVpn).await;
+
+        // Withdraw identity 1 entirely.
+        o.vpn_routes(A, vec![], vec![vpn_key(1, 100)]).await;
+
+        // Member leaves (its VPN paths fall out of the Loc-RIB too).
+        o.peer_down(B).await;
+
+        // Regroup fast path: content-equal chain reinstall — no emission.
+        o.replace_policy(E, Some(modifying_chain())).await;
+
+        // Genuine regroup: C moves to a group whose chain denies the
+        // identity-2 inner prefix — the one-shot diff withdraws it.
+        o.replace_policy(
+            C,
+            Some(deny_prefix_chain(Ipv4Prefix::new(
+                Ipv4Addr::new(10, 210, 2, 0),
+                24,
+            ))),
+        )
+        .await;
+
+        // GShut-style forced re-emission (RefreshPeerOutbound).
+        o.refresh_outbound(D).await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        grouped, ungrouped,
+        "grouped and per-peer outbound VPN streams must be identical"
+    );
+    assert!(
+        grouped
+            .values()
+            .any(|msgs| msgs.iter().any(|m| !m.vpn_announce.is_empty())),
+        "scenario must exercise VPN outbound traffic"
+    );
+}
+
+/// VPN dirty-member resync (channel-full → VPN tombstones → timer
+/// resync): streams intentionally differ (the grouped resync over-emits
+/// — the safe direction); the folded final advertised VPN state must be
+/// identical, the withdraw of the identity that went away while dirty
+/// must reach the wire, and the jammed announce must be recovered.
+#[tokio::test]
+async fn oracle_vpn_dirty_resync_converges_to_identical_state() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(B, false, true, None, 64, vpn_sendable())
+            .await;
+        // C gets a capacity-1 channel so a second update fails try_reserve.
+        o.peer_up_families(C, false, true, None, 1, vpn_sendable())
+            .await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.vpn_announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Identity 1 lands in C's channel (fills it).
+        o.vpn_routes(A, vec![vpn_route(vpn_nlri(1, 100), A, 100, vec![])], vec![])
+            .await;
+        // Identity 2 announce fails for C → C goes dirty.
+        o.vpn_routes(A, vec![vpn_route(vpn_nlri(2, 200), A, 100, vec![])], vec![])
+            .await;
+        // Identity 1 withdrawn WHILE C is dirty → VPN tombstone.
+        o.vpn_routes(A, vec![], vec![vpn_key(1, 100)]).await;
+
+        // Free the channel and let the resync timer fire.
+        let first = o.drain_one(C).await;
+        assert_eq!(
+            first.vpn_announce.len(),
+            1,
+            "identity 1 was delivered before the jam"
+        );
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold_vpn(&grouped),
+        fold_vpn(&ungrouped),
+        "final advertised VPN state must converge on both paths"
+    );
+    let c_final = fold_vpn(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    let key1 = format!("{:?}", vpn_nlri(1, 100).key());
+    let key2 = format!("{:?}", vpn_nlri(2, 200).key());
+    assert!(
+        !c_final.contains_key(&key1),
+        "tombstoned VPN identity must not survive the grouped resync"
+    );
+    assert!(
+        c_final.contains_key(&key2),
+        "the update lost to the full channel must be recovered by the resync"
+    );
+}
+
+/// The slice-1 RTC gate: peers that negotiated RT-Constrain still group
+/// for unicast, but their VPN families ride the per-peer path where the
+/// RFC 4684 RT membership filter applies. A wildcard-interest member
+/// receives the VPN table; a strict-empty-membership member receives
+/// nothing — byte-identically on both paths (if VPN were wrongly
+/// group-staged, the filterless group table would leak routes to the
+/// empty-membership peer and the streams would diverge).
+#[tokio::test]
+async fn oracle_rtc_negotiated_vpn_rides_per_peer() {
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        // Source peer: VPN-capable, no RTC (its group DOES stage VPN).
+        o.peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        // Two RTC-negotiated RR clients: B advertises wildcard interest,
+        // C advertises nothing (strict empty membership).
+        o.peer_up_families(B, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.peer_up_families(C, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.rtc_routes(B, vec![rtc_default(B)]).await;
+
+        // VPN flood with an RT extended community + a unicast route
+        // (the unicast dimension must keep grouping for RTC peers).
+        o.vpn_routes(
+            A,
+            vec![vpn_route(
+                vpn_nlri(7, 700),
+                A,
+                100,
+                vec![0x0002_FDE8_0000_002A],
+            )],
+            vec![],
+        )
+        .await;
+        o.routes(A, vec![ibgp_route(pfx(7, 0), A, 100, vec![])], vec![])
+            .await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        grouped, ungrouped,
+        "RTC-negotiated peers' VPN streams must ride the per-peer path unchanged"
+    );
+    let vpn_count = |streams: &Streams, peer: Ipv4Addr| {
+        streams[&IpAddr::V4(peer)]
+            .iter()
+            .map(|m| m.vpn_announce.len())
+            .sum::<usize>()
+    };
+    assert!(
+        vpn_count(&grouped, B) > 0,
+        "wildcard-interest RTC peer receives the VPN route"
+    );
+    assert_eq!(
+        vpn_count(&grouped, C),
+        0,
+        "strict-empty-membership RTC peer receives no VPN routes"
+    );
+    // And the unicast dimension still groups the RTC peers (the gate is
+    // VPN-staging-only, not a membership disqualifier).
+    let mut grouped_oracle = Oracle::spawn(false, cluster);
+    scenario(&mut grouped_oracle).await;
+    let label_b = grouped_oracle.group_label(B).await;
+    let label_c = grouped_oracle.group_label(C).await;
+    assert!(
+        label_b.starts_with("group:") && label_b == label_c,
+        "RTC peers must still share a unicast update group (got {label_b} / {label_c})"
+    );
+    drop(grouped_oracle.finish().await);
 }
 
 /// iBGP full mesh (no cluster id): plain split horizon suppresses

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -36,10 +36,11 @@ use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation
 use rustbgpd_wire::{Afi, Prefix, Safi};
 use rustc_hash::FxHashMap;
 
-use super::helpers::{LOCAL_PEER, routes_equal};
+use super::helpers::{LOCAL_PEER, routes_equal, vpn_routes_equal};
 use super::{PolicyFilteredRouteKey, RibManager};
 use crate::adj_rib_out::AdjRibOut;
-use crate::route::Route;
+use crate::route::{Route, VpnRibRoute, VpnRibRouteKey};
+use rustbgpd_wire::{VpnAddressFamily, VpnRouteKey};
 
 /// Fingerprint of every RIB-staging input that makes per-peer staged
 /// output differ (design §1). Per-peer wire preparation (next-hop
@@ -65,6 +66,15 @@ pub(super) struct GroupKey {
     sendable_ipv4_unicast: bool,
     /// Sendable IPv6-unicast.
     sendable_ipv6_unicast: bool,
+    /// Sendable `VPNv4` (SAFI 128) — the v2 VPN-staging key dimension.
+    sendable_vpnv4: bool,
+    /// Sendable `VPNv6` (SAFI 128).
+    sendable_vpnv6: bool,
+    /// RT-Constrain negotiated (sendable ∋ `(Ipv4, RtConstrain)`). Slice 1
+    /// gate: groups with `rtc_negotiated` are EXCLUDED from VPN group
+    /// staging — their VPN families ride the per-peer path (where the RFC
+    /// 4684 RT filter applies); unicast grouping continues normally.
+    rtc_negotiated: bool,
     /// Exact set of families the peer advertised LLGR for (RFC 9494
     /// export-restriction input), sorted raw `(afi, safi)` values.
     llgr_families: Vec<(u16, u8)>,
@@ -249,10 +259,10 @@ impl GroupStageOutput {
 pub(in crate::manager) struct GroupEvalAccumulator {
     totals: Vec<(Option<String>, PolicyAction, u64)>,
     per_source: FxHashMap<IpAddr, Vec<(Option<String>, PolicyAction, u64)>>,
-    /// Verdict of the most recent evaluation, consumed per prefix by
-    /// the staging loop to label the staged entry / denial residue
-    /// (single-best stages at most one eval per prefix).
-    last: Option<(Option<String>, PolicyAction)>,
+    /// Verdict (and source peer) of the most recent evaluation, consumed
+    /// per key by the staging loops to label the staged entry / denial
+    /// residue (single-best stages at most one eval per key).
+    last: Option<(Option<String>, PolicyAction, IpAddr)>,
 }
 
 fn bump_eval_row(
@@ -283,12 +293,12 @@ impl GroupEvalAccumulator {
             evaluation.matched_policy.as_ref(),
             evaluation.action,
         );
-        self.last = Some((evaluation.matched_policy.clone(), evaluation.action));
+        self.last = Some((evaluation.matched_policy.clone(), evaluation.action, source));
     }
 
     /// Take (and clear) the last recorded verdict — the staging loop's
-    /// per-prefix label hook.
-    fn take_last(&mut self) -> Option<(Option<String>, PolicyAction)> {
+    /// per-key label / denial-residue hook.
+    fn take_last(&mut self) -> Option<(Option<String>, PolicyAction, IpAddr)> {
         self.last.take()
     }
 }
@@ -344,6 +354,85 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
     }
 }
 
+/// One entry of a shared group VPN staging pass. Unlike the unicast
+/// [`GroupDelta`] this carries the full displaced route (`old`), not just
+/// its source: slice 2's RT-pass matrix needs the displaced entry's
+/// extended communities to decide `had` per member (design §2.1). Slice 1
+/// only reads `old.peer` (`pass ≡ true` degenerate case). `path_id` is
+/// fixed at 0 — Add-Path send disqualifies from grouping.
+#[derive(Debug, Clone)]
+pub(in crate::manager) struct VpnGroupDelta {
+    pub(in crate::manager) key: VpnRouteKey,
+    /// Newly staged post-policy route (source-faithful, ADR-0077 §6), or
+    /// `None` for a withdrawal.
+    pub(in crate::manager) new: Option<VpnRibRoute>,
+    /// Prior staged entry for the key, cloned before commit (one clone
+    /// per delta, total). `None` = the key was not previously staged.
+    pub(in crate::manager) old: Option<VpnRibRoute>,
+    /// Terminal policy of the permitting evaluation — join-time counter
+    /// replay residue, exactly like [`GroupDelta::policy_label`].
+    pub(in crate::manager) policy_label: Option<String>,
+}
+
+/// Result of one shared VPN staging pass over a group: deltas (already
+/// committed to the group table) plus the accumulated export-policy
+/// verdicts for per-member counter replay. No shared-`Arc` payload — the
+/// outbound envelope's VPN queue is a `Vec`, so members clone per route
+/// either way; the receipt-proven win is collapsing the *staging* (policy
+/// eval + suppression per peer), not the emit clones.
+#[derive(Default)]
+pub(in crate::manager) struct VpnGroupStageOutput {
+    pub(in crate::manager) deltas: Vec<VpnGroupDelta>,
+    pub(in crate::manager) evals: GroupEvalAccumulator,
+}
+
+/// Per-member VPN emit for one shared staging pass — the design §2.2
+/// matrix with the slice-1 degenerate `pass ≡ true` (RTC-negotiated
+/// groups never stage VPN, so no RT filter exists here; slice 2 plugs
+/// `Φ_m` into `had`/`gets`):
+///
+/// - `had`  = `old` exists ∧ `old.peer ≠ member`
+/// - `gets` = `new` exists ∧ `new.peer ≠ member`
+/// - emit: `gets` → announce `new`; `had ∧ ¬gets` → withdraw `(key, 0)`;
+///   else skip.
+pub(in crate::manager) fn emit_vpn_group_deltas_for_member(
+    deltas: &[VpnGroupDelta],
+    member: IpAddr,
+    vpn_announce: &mut Vec<VpnRibRoute>,
+    vpn_withdraw: &mut Vec<VpnRibRouteKey>,
+) {
+    for delta in deltas {
+        let had = delta.old.as_ref().is_some_and(|old| old.peer != member);
+        let gets = delta.new.as_ref().is_some_and(|new| new.peer != member);
+        if gets {
+            vpn_announce.push(delta.new.clone().expect("gets implies new exists"));
+        } else if had {
+            vpn_withdraw.push(VpnRibRouteKey {
+                nlri_key: delta.key,
+                path_id: 0,
+            });
+        }
+    }
+}
+
+/// A regrouped member's previously-advertised view, held until its
+/// one-shot resync diff succeeds (design §4): the unicast table plus —
+/// for a member whose VPN state is group-owned — the VPN view.
+#[derive(Debug, Default)]
+pub(in crate::manager) struct RegroupBaseline {
+    pub(in crate::manager) unicast: FxHashMap<(Prefix, u32), Route>,
+    pub(in crate::manager) vpn: FxHashMap<VpnRouteKey, VpnRibRoute>,
+}
+
+/// Extra (over-)withdraw keys a member must emit on its next resync:
+/// tombstones carried across a regroup by a member that was dirty when
+/// it moved. Over-withdraw is the safe direction.
+#[derive(Debug, Default)]
+pub(in crate::manager) struct ExtraWithdraws {
+    pub(in crate::manager) unicast: HashSet<(Prefix, u32)>,
+    pub(in crate::manager) vpn: HashSet<VpnRouteKey>,
+}
+
 /// The group-owned staged outbound table (design §2): the unicast
 /// portion of an [`AdjRibOut`] reused as substrate, plus the group's
 /// membership/dirty bookkeeping and the group-uniform staging inputs
@@ -359,15 +448,18 @@ pub(in crate::manager) struct GroupRibOut {
     /// so joins/replays don't re-run policy to recover them.
     nh_overrides: FxHashMap<(Prefix, u32), NextHopAction>,
     /// Staged-entry count per source peer — O(1) per-member advertised
-    /// count synthesis (`table.len() − own`), split (v4, v6) for the
-    /// BMP stat-17 family counts.
-    source_counts: FxHashMap<IpAddr, (usize, usize)>,
+    /// count synthesis (`len − own`), one slot per staged family
+    /// (v4-unicast, v6-unicast, vpnv4, vpnv6) for the BMP stat-17
+    /// family counts.
+    source_counts: FxHashMap<IpAddr, [usize; 4]>,
     /// Keys withdrawn from the table since the first member went dirty;
     /// empty (and unmaintained) while no member is dirty. A dirty
     /// member's resync withdraws `tombstones ∖ still-staged` — spurious
     /// withdraws of never-advertised prefixes are RFC 4271 no-ops
     /// (over-withdraw is the safe direction).
     pub(in crate::manager) tombstones: HashSet<(Prefix, u32)>,
+    /// VPN sibling of `tombstones` (`path_id` fixed at 0).
+    pub(in crate::manager) vpn_tombstones: HashSet<VpnRouteKey>,
     pub(in crate::manager) members: HashSet<IpAddr>,
     pub(in crate::manager) dirty_members: HashSet<IpAddr>,
     /// Persistent group-verdict export-policy denials (target stamped
@@ -377,6 +469,15 @@ pub(in crate::manager) struct GroupRibOut {
     /// Terminal policy label per staged entry (`None` = inline) —
     /// join-time counter replay residue.
     staged_labels: FxHashMap<(Prefix, u32), Option<String>>,
+    /// VPN sibling of `staged_labels`, keyed by RD+prefix identity.
+    vpn_staged_labels: FxHashMap<VpnRouteKey, Option<String>>,
+    /// Persistent group-verdict VPN export-policy denials: denied key →
+    /// (source peer, denying policy label). The per-peer VPN path keeps
+    /// no denial *records* (unlike unicast `policy_filtered` — VPN has
+    /// no denied-routes query), but it DOES record a deny eval per
+    /// denied key at every staging pass, so join-time counter replay
+    /// needs this residue for parity.
+    vpn_policy_denied: FxHashMap<VpnRouteKey, (IpAddr, Option<String>)>,
     // Group-uniform staging inputs, snapshot at group creation from the
     // first member (all members are key-equal by construction; a key
     // change moves peers to a different group, so these never mutate).
@@ -406,16 +507,29 @@ impl GroupRibOut {
             nh_overrides: FxHashMap::default(),
             source_counts: FxHashMap::default(),
             tombstones: HashSet::new(),
+            vpn_tombstones: HashSet::new(),
             members: HashSet::new(),
             dirty_members: HashSet::new(),
             policy_filtered: FxHashMap::default(),
             staged_labels: FxHashMap::default(),
+            vpn_staged_labels: FxHashMap::default(),
+            vpn_policy_denied: FxHashMap::default(),
             export_chain,
             is_ebgp,
             is_rr_client,
             sendable,
             llgr,
         }
+    }
+
+    /// Whether this group stages VPN routes (design §6 slice 1): `VPNv4`
+    /// or `VPNv6` sendable AND RT-Constrain NOT negotiated. RTC groups'
+    /// VPN families ride the per-peer path where the RFC 4684 filter
+    /// applies (the RT dimension is slice 2). Group-uniform — all three
+    /// inputs are in the [`GroupKey`].
+    pub(in crate::manager) fn stages_vpn(&self) -> bool {
+        !self.sendable.contains(&(Afi::Ipv4, Safi::RtConstrain))
+            && self.sendable.iter().any(|&(_, safi)| safi == Safi::MplsVpn)
     }
 
     fn count_slot(prefix: &Prefix) -> usize {
@@ -425,27 +539,32 @@ impl GroupRibOut {
         }
     }
 
-    fn dec_source(&mut self, peer: IpAddr, prefix: &Prefix) {
+    fn vpn_count_slot(key: &VpnRouteKey) -> usize {
+        match key.prefix.family() {
+            VpnAddressFamily::V4 => 2,
+            VpnAddressFamily::V6 => 3,
+        }
+    }
+
+    fn dec_source_slot(&mut self, peer: IpAddr, slot: usize) {
         if let Some(counts) = self.source_counts.get_mut(&peer) {
-            let slot = if Self::count_slot(prefix) == 0 {
-                &mut counts.0
-            } else {
-                &mut counts.1
-            };
-            *slot = slot.saturating_sub(1);
-            if counts.0 == 0 && counts.1 == 0 {
+            counts[slot] = counts[slot].saturating_sub(1);
+            if counts.iter().all(|&n| n == 0) {
                 self.source_counts.remove(&peer);
             }
         }
     }
 
+    fn inc_source_slot(&mut self, peer: IpAddr, slot: usize) {
+        self.source_counts.entry(peer).or_default()[slot] += 1;
+    }
+
+    fn dec_source(&mut self, peer: IpAddr, prefix: &Prefix) {
+        self.dec_source_slot(peer, Self::count_slot(prefix));
+    }
+
     fn inc_source(&mut self, peer: IpAddr, prefix: &Prefix) {
-        let counts = self.source_counts.entry(peer).or_default();
-        if Self::count_slot(prefix) == 0 {
-            counts.0 += 1;
-        } else {
-            counts.1 += 1;
-        }
+        self.inc_source_slot(peer, Self::count_slot(prefix));
     }
 
     /// Commit one staged delta into the group table, keeping the
@@ -475,49 +594,98 @@ impl GroupRibOut {
         }
     }
 
+    /// Commit one staged VPN delta into the group table's VPN maps,
+    /// keeping the source counts and label residue in sync. The VPN
+    /// sibling of [`Self::apply_delta`]; `path_id` fixed at 0.
+    fn apply_vpn_delta(&mut self, delta: &VpnGroupDelta) {
+        let rib_key = VpnRibRouteKey {
+            nlri_key: delta.key,
+            path_id: 0,
+        };
+        let slot = Self::vpn_count_slot(&delta.key);
+        if let Some(old) = self.table.get_vpn(&rib_key) {
+            let old_peer = old.peer;
+            self.dec_source_slot(old_peer, slot);
+        }
+        if let Some(route) = &delta.new {
+            self.inc_source_slot(route.peer, slot);
+            self.vpn_staged_labels
+                .insert(delta.key, delta.policy_label.clone());
+            self.table.insert_vpn(route.clone());
+        } else {
+            self.table.remove_vpn(&rib_key);
+            self.vpn_staged_labels.remove(&delta.key);
+        }
+    }
+
     /// The next-hop-override flag staged for a table entry.
     pub(in crate::manager) fn nh_override(&self, key: (Prefix, u32)) -> Option<NextHopAction> {
         self.nh_overrides.get(&key).cloned()
     }
 
-    /// Number of routes `member` currently has advertised: the group
-    /// table minus the member's own-sourced entries. O(1).
+    /// Number of unicast routes `member` currently has advertised: the
+    /// group table minus the member's own-sourced entries. O(1).
     pub(in crate::manager) fn advertised_count_for(&self, member: IpAddr) -> usize {
         let own = self
             .source_counts
             .get(&member)
-            .map_or(0, |(v4, v6)| v4 + v6);
+            .map_or(0, |counts| counts[0] + counts[1]);
         self.table.len().saturating_sub(own)
     }
 
-    /// Per-family synthesized unicast advertised counts for a member
-    /// (BMP RFC 8671 stat type 17 input). Zero-count families omitted.
-    pub(in crate::manager) fn family_counts_for(&self, member: IpAddr) -> Vec<((Afi, Safi), u64)> {
-        let (mut v4, mut v6) = (0usize, 0usize);
-        for (a, b) in self.source_counts.values() {
-            v4 += a;
-            v6 += b;
-        }
-        let own = self.source_counts.get(&member).copied().unwrap_or((0, 0));
-        let v4 = v4.saturating_sub(own.0) as u64;
-        let v6 = v6.saturating_sub(own.1) as u64;
-        let mut counts = Vec::new();
-        if v4 > 0 {
-            counts.push(((Afi::Ipv4, Safi::Unicast), v4));
-        }
-        if v6 > 0 {
-            counts.push(((Afi::Ipv6, Safi::Unicast), v6));
-        }
-        counts
+    /// Number of VPN routes `member` currently has advertised: the group
+    /// VPN table minus the member's own-sourced entries. O(1).
+    pub(in crate::manager) fn vpn_advertised_count_for(&self, member: IpAddr) -> usize {
+        let own = self
+            .source_counts
+            .get(&member)
+            .map_or(0, |counts| counts[2] + counts[3]);
+        self.table.vpn_len().saturating_sub(own)
     }
 
-    /// Snapshot of `member`'s advertised view (table minus own-sourced)
-    /// — the baseline for a regroup's one-shot diff.
+    /// Per-family synthesized advertised counts for a member (BMP RFC
+    /// 8671 stat type 17 input). Zero-count families omitted.
+    pub(in crate::manager) fn family_counts_for(&self, member: IpAddr) -> Vec<((Afi, Safi), u64)> {
+        const FAMILIES: [(Afi, Safi); 4] = [
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv6, Safi::Unicast),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv6, Safi::MplsVpn),
+        ];
+        let mut totals = [0usize; 4];
+        for counts in self.source_counts.values() {
+            for (total, n) in totals.iter_mut().zip(counts) {
+                *total += n;
+            }
+        }
+        let own = self.source_counts.get(&member).copied().unwrap_or_default();
+        FAMILIES
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, &family)| {
+                let count = totals[slot].saturating_sub(own[slot]) as u64;
+                (count > 0).then_some((family, count))
+            })
+            .collect()
+    }
+
+    /// Snapshot of `member`'s advertised unicast view (table minus
+    /// own-sourced) — the baseline for a regroup's one-shot diff.
     fn member_view_snapshot(&self, member: IpAddr) -> FxHashMap<(Prefix, u32), Route> {
         self.table
             .iter()
             .filter(|route| route.peer != member)
             .map(|route| ((route.prefix, route.path_id), route.clone()))
+            .collect()
+    }
+
+    /// VPN sibling of [`Self::member_view_snapshot`]. Empty when the
+    /// group does not stage VPN (the substrate's VPN maps stay unused).
+    fn member_vpn_view_snapshot(&self, member: IpAddr) -> FxHashMap<VpnRouteKey, VpnRibRoute> {
+        self.table
+            .iter_vpn()
+            .filter(|route| route.peer != member)
+            .map(|route| (route.nlri.key(), route.clone()))
             .collect()
     }
 
@@ -589,8 +757,35 @@ impl RibManager {
             group.dirty_members.remove(&peer);
             if group.dirty_members.is_empty() {
                 group.tombstones.clear();
+                group.vpn_tombstones.clear();
             }
         }
+    }
+
+    /// Whether `peer` is a grouped member whose VPN advertised state is
+    /// group-owned (member of a group that stages VPN). RTC-negotiated
+    /// groups return `None`: their members' VPN families ride the
+    /// per-peer path (slice-1 gate — the RT dimension is slice 2).
+    pub(in crate::manager) fn vpn_grouped_member_of(&self, peer: IpAddr) -> Option<usize> {
+        let gid = self.grouped_member_of(peer)?;
+        self.group_ribs
+            .get(&gid)
+            .is_some_and(GroupRibOut::stages_vpn)
+            .then_some(gid)
+    }
+
+    /// Whether `peer`'s VPN advertised state is group-owned *whenever
+    /// the peer is grouped*: VPN sendable and RT-Constrain not
+    /// negotiated. Pure function of the session's (fixed) sendable set,
+    /// so it answers membership-transition seams before the destination
+    /// group exists.
+    fn peer_vpn_groupable(&self, peer: IpAddr) -> bool {
+        self.peer_sendable_families
+            .get(&peer)
+            .is_some_and(|families| {
+                !families.contains(&(Afi::Ipv4, Safi::RtConstrain))
+                    && families.iter().any(|&(_, safi)| safi == Safi::MplsVpn)
+            })
     }
 
     /// Run the shared staging pass for every live group over the pass's
@@ -672,7 +867,7 @@ impl RibManager {
                 // Single-best stages at most one evaluation per prefix;
                 // its terminal-policy label tags the staged entry (or
                 // the denial residue) for join-time counter replay.
-                let label = out.evals.take_last().and_then(|(label, _)| label);
+                let label = out.evals.take_last().and_then(|(label, _, _)| label);
                 for (route, nh) in announce.drain(..).zip(nh_flags.drain(..)) {
                     out.deltas.push(GroupDelta {
                         prefix: *prefix,
@@ -705,6 +900,147 @@ impl RibManager {
         if !group.dirty_members.is_empty() {
             let withdrawn: Vec<(Prefix, u32)> = out.withdrawn_keys().collect();
             group.tombstones.extend(withdrawn);
+        }
+        out
+    }
+
+    /// Run the shared VPN staging pass for every VPN-staging group over
+    /// the pass's changed RD+prefix identities. Deltas are committed to
+    /// the group tables here; `recompute_and_distribute_vpn` emits them
+    /// per member via the VPN source-flip matrix. RTC-negotiated groups
+    /// are skipped by construction ([`GroupRibOut::stages_vpn`]).
+    pub(in crate::manager) fn stage_vpn_update_groups(
+        &mut self,
+        changed: &HashSet<VpnRouteKey>,
+    ) -> HashMap<usize, VpnGroupStageOutput> {
+        let mut staged = HashMap::new();
+        if changed.is_empty() || self.group_ribs.is_empty() {
+            return staged;
+        }
+        let gids: Vec<usize> = self
+            .group_ribs
+            .iter()
+            .filter(|(_, group)| group.stages_vpn())
+            .map(|(gid, _)| *gid)
+            .collect();
+        for gid in gids {
+            staged.insert(gid, self.stage_group_vpn_keys(gid, changed));
+        }
+        staged
+    }
+
+    /// One shared VPN export-tail pass for `gid` over `keys`, reusing
+    /// `stage_vpn_routes`'s single-best body with split horizon lifted
+    /// out (`ExportTarget::Group`) and the group table's VPN maps as the
+    /// diff baseline — the SAME body as the per-peer path, parameterized,
+    /// never copied (design risk 1). Deltas are committed before
+    /// returning; VPN tombstones extend when a member is already dirty.
+    fn stage_group_vpn_keys(
+        &mut self,
+        gid: usize,
+        keys: &HashSet<VpnRouteKey>,
+    ) -> VpnGroupStageOutput {
+        let mut out = VpnGroupStageOutput::default();
+        let mut denials: Vec<(VpnRouteKey, (IpAddr, Option<String>))> = Vec::new();
+        {
+            let Some(group) = self.group_ribs.get(&gid) else {
+                return out;
+            };
+            // `share()`, not `clone()` — ADR-0096 term hit counters, as
+            // in `stage_group_prefixes`.
+            let chain = group.export_chain.as_ref().map(PolicyChain::share);
+            let mut announce: Vec<VpnRibRoute> = Vec::new();
+            let mut withdraw: Vec<VpnRibRouteKey> = Vec::new();
+            // Reused single-key set: the staging body iterates a key set,
+            // but the delta needs per-key `old` capture and eval labels.
+            let mut key_set: HashSet<VpnRouteKey> = HashSet::with_capacity(1);
+            for key in keys {
+                key_set.clear();
+                key_set.insert(*key);
+                let mut target = super::distribution::ExportTarget::Group {
+                    evals: &mut out.evals,
+                };
+                Self::stage_vpn_routes(
+                    &self.loc_rib,
+                    &self.ribs,
+                    &group.table,
+                    &self.peer_is_rr_client,
+                    &key_set,
+                    &mut target,
+                    group.is_ebgp,
+                    group.is_rr_client,
+                    self.cluster_id,
+                    Some(&group.sendable),
+                    Some(&group.llgr),
+                    // RT gate deferred by structure: slice 1 never stages
+                    // VPN for RTC groups, slice 2 plugs Φ in at emit (the
+                    // delta carries `old` for exactly that).
+                    None,
+                    None, // ORR disqualifies from grouping
+                    0,    // Add-Path send disqualifies from grouping
+                    &[],
+                    chain.as_ref(),
+                    &mut announce,
+                    &mut withdraw,
+                    false,
+                );
+                // Single-best stages at most one eval per key: a Permit
+                // labels the staged entry; a Deny lands in the persistent
+                // denial residue (join-time counter replay).
+                let last = out.evals.take_last();
+                let label = match &last {
+                    Some((label, PolicyAction::Permit, _)) => label.clone(),
+                    _ => None,
+                };
+                if let Some((label, PolicyAction::Deny, source)) = last {
+                    denials.push((*key, (source, label)));
+                }
+                if announce.is_empty() && withdraw.is_empty() {
+                    continue;
+                }
+                // Prior staged entry, cloned before commit — one clone
+                // per delta, total (slice 2's Φ(old) input).
+                let old = group
+                    .table
+                    .get_vpn(&VpnRibRouteKey {
+                        nlri_key: *key,
+                        path_id: 0,
+                    })
+                    .cloned();
+                for route in announce.drain(..) {
+                    out.deltas.push(VpnGroupDelta {
+                        key: *key,
+                        new: Some(route),
+                        old: old.clone(),
+                        policy_label: label.clone(),
+                    });
+                }
+                for rib_key in withdraw.drain(..) {
+                    debug_assert_eq!(rib_key.path_id, 0, "group table stages path 0 only");
+                    out.deltas.push(VpnGroupDelta {
+                        key: *key,
+                        new: None,
+                        old: old.clone(),
+                        policy_label: None,
+                    });
+                }
+            }
+        }
+        let group = self
+            .group_ribs
+            .get_mut(&gid)
+            .expect("group staged above still exists");
+        for delta in &out.deltas {
+            group.apply_vpn_delta(delta);
+        }
+        // Denial-residue transition scope: this pass's keys replace their
+        // prior records (the `record_policy_filtered` shape).
+        group.vpn_policy_denied.retain(|key, _| !keys.contains(key));
+        group.vpn_policy_denied.extend(denials);
+        if !group.dirty_members.is_empty() {
+            group
+                .vpn_tombstones
+                .extend(out.deltas.iter().filter(|d| d.new.is_none()).map(|d| d.key));
         }
         out
     }
@@ -769,6 +1105,69 @@ impl RibManager {
             keys.extend(extra.iter().filter(|key| !member_retains(key)));
         }
         withdraw.extend(keys);
+    }
+
+    /// VPN portion of a grouped member's resync update — the VPN sibling
+    /// of [`Self::assemble_group_resync`], same three shapes (plain
+    /// dirty / regroup one-shot diff / force), assembled from the group
+    /// table's VPN maps with NO policy re-evaluation. Only called for
+    /// groups that stage VPN.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the resync assembly takes the member's full pending-withdraw context"
+    )]
+    pub(in crate::manager) fn assemble_group_vpn_resync(
+        group: &GroupRibOut,
+        member: IpAddr,
+        is_dirty: bool,
+        is_force: bool,
+        baseline: Option<&FxHashMap<VpnRouteKey, VpnRibRoute>>,
+        extras: Option<&HashSet<VpnRouteKey>>,
+        vpn_announce: &mut Vec<VpnRibRoute>,
+        vpn_withdraw: &mut Vec<VpnRibRouteKey>,
+    ) {
+        for route in group.table.iter_vpn() {
+            if route.peer == member {
+                continue;
+            }
+            if !is_force
+                && let Some(base) = baseline
+                && base
+                    .get(&route.nlri.key())
+                    .is_some_and(|old| vpn_routes_equal(old, route))
+            {
+                continue;
+            }
+            vpn_announce.push(route.clone());
+        }
+        let member_retains = |key: &VpnRouteKey| {
+            group
+                .table
+                .get_vpn(&VpnRibRouteKey {
+                    nlri_key: *key,
+                    path_id: 0,
+                })
+                .is_some_and(|route| route.peer != member)
+        };
+        let mut keys: HashSet<VpnRouteKey> = HashSet::new();
+        if let Some(base) = baseline {
+            keys.extend(base.keys().filter(|key| !member_retains(key)));
+        }
+        if is_dirty {
+            keys.extend(
+                group
+                    .vpn_tombstones
+                    .iter()
+                    .filter(|key| !member_retains(key)),
+            );
+        }
+        if let Some(extra) = extras {
+            keys.extend(extra.iter().filter(|key| !member_retains(key)));
+        }
+        vpn_withdraw.extend(keys.into_iter().map(|key| VpnRibRouteKey {
+            nlri_key: key,
+            path_id: 0,
+        }));
     }
 
     /// Bump a member's export-policy counters by the group verdict:
@@ -846,6 +1245,36 @@ impl RibManager {
             }
             for (key, label) in &group.policy_filtered {
                 if key.source_peer == peer || !in_family(&key.prefix) {
+                    continue;
+                }
+                bump(label, PolicyAction::Deny);
+            }
+            // VPN dimension (only staged for non-RTC groups): permits
+            // from the staged labels, denies from the denial residue —
+            // own-sourced excluded on both sides (the per-peer path's
+            // split horizon returns before the policy evaluation).
+            let in_vpn_family = |key: &VpnRouteKey| {
+                family.is_none_or(|f| {
+                    let afi = match key.prefix.family() {
+                        VpnAddressFamily::V4 => Afi::Ipv4,
+                        VpnAddressFamily::V6 => Afi::Ipv6,
+                    };
+                    (afi, Safi::MplsVpn) == f
+                })
+            };
+            for route in group.table.iter_vpn() {
+                if route.peer == peer || !in_vpn_family(&route.nlri.key()) {
+                    continue;
+                }
+                let label = group
+                    .vpn_staged_labels
+                    .get(&route.nlri.key())
+                    .cloned()
+                    .unwrap_or(None);
+                bump(&label, PolicyAction::Permit);
+            }
+            for (key, (source, label)) in &group.vpn_policy_denied {
+                if *source == peer || !in_vpn_family(key) {
                     continue;
                 }
                 bump(label, PolicyAction::Deny);
@@ -942,37 +1371,54 @@ impl RibManager {
             self.metrics.record_update_group_regroup();
         }
         if prev_gid != new_gid {
-            // Snapshot the member's currently-advertised unicast view
-            // before the move: the destination side diffs against it so
-            // only genuine changes reach the wire (design §4 one-shot
-            // diff). First registration has no view — the initial dump
-            // replays the destination group table.
-            let baseline: Option<FxHashMap<(Prefix, u32), Route>> = match prev_gid {
+            // Whether the peer's VPN advertised state is group-owned
+            // whenever it is grouped. Sendable families are fixed per
+            // session, so this answers for source AND destination.
+            let vpn_groupable = self.peer_vpn_groupable(peer);
+            // Snapshot the member's currently-advertised view before the
+            // move: the destination side diffs against it so only genuine
+            // changes reach the wire (design §4 one-shot diff). First
+            // registration has no view — the initial dump replays the
+            // destination group table.
+            let baseline: Option<RegroupBaseline> = match prev_gid {
                 Some(gid) => {
                     let group = self.group_ribs.get(&gid);
-                    let base = group.map(|g| g.member_view_snapshot(peer));
+                    let base = group.map(|g| RegroupBaseline {
+                        unicast: g.member_view_snapshot(peer),
+                        vpn: g.member_vpn_view_snapshot(peer),
+                    });
                     // A member that leaves while dirty may have missed
                     // withdrawals; carry the group tombstones along as
                     // extra (over-)withdraws for the destination resync.
                     if let Some(g) = group
                         && g.dirty_members.contains(&peer)
-                        && !g.tombstones.is_empty()
+                        && (!g.tombstones.is_empty() || !g.vpn_tombstones.is_empty())
                     {
-                        self.pending_extra_withdraws
-                            .entry(peer)
-                            .or_default()
-                            .extend(g.tombstones.iter().copied());
+                        let extras = self.pending_extra_withdraws.entry(peer).or_default();
+                        extras.unicast.extend(g.tombstones.iter().copied());
+                        extras.vpn.extend(g.vpn_tombstones.iter().copied());
                     }
                     base
                 }
                 None if previous.is_some() => Some(
                     self.adj_ribs_out
                         .get(&peer)
-                        .map(|rib_out| {
-                            rib_out
+                        .map(|rib_out| RegroupBaseline {
+                            unicast: rib_out
                                 .iter()
                                 .map(|route| ((route.prefix, route.path_id), route.clone()))
-                                .collect()
+                                .collect(),
+                            // VPN moves to group ownership only for a
+                            // VPN-groupable peer; an RTC peer's VPN state
+                            // stays per-peer and must not be captured.
+                            vpn: if vpn_groupable {
+                                rib_out
+                                    .iter_vpn()
+                                    .map(|route| (route.nlri.key(), route.clone()))
+                                    .collect()
+                            } else {
+                                FxHashMap::default()
+                            },
                         })
                         .unwrap_or_default(),
                 ),
@@ -981,11 +1427,15 @@ impl RibManager {
             if let Some(gid) = prev_gid {
                 self.leave_group(gid, peer);
             } else if previous.is_some() {
-                // Moving off the per-peer path: the unicast advertised
-                // state becomes group-owned (captured in the baseline);
-                // non-unicast families stay per-peer.
+                // Moving off the per-peer path: the unicast (and, for a
+                // VPN-groupable peer, VPN) advertised state becomes
+                // group-owned (captured in the baseline); other families
+                // stay per-peer.
                 if let Some(rib_out) = self.adj_ribs_out.get_mut(&peer) {
                     rib_out.clear_unicast();
+                    if vpn_groupable {
+                        rib_out.clear_vpn();
+                    }
                 }
             }
             if let Some(gid) = new_gid {
@@ -1004,8 +1454,11 @@ impl RibManager {
                         .adj_ribs_out
                         .entry(peer)
                         .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
-                    for route in base.into_values() {
+                    for route in base.unicast.into_values() {
                         rib_out.insert(route);
+                    }
+                    for route in base.vpn.into_values() {
+                        rib_out.insert_vpn(route);
                     }
                 }
                 (None, _) => {}
@@ -1039,10 +1492,21 @@ impl RibManager {
             self.group_ribs.insert(gid, group);
             let prefixes: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
             let mut memo = super::distribution::ExportMemo::default();
-            // Deltas of the build pass are discarded: there are no
+            // Deltas of the build passes are discarded: there are no
             // members yet, and the joining member replays the whole
             // table anyway.
             let _ = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+            if self
+                .group_ribs
+                .get(&gid)
+                .is_some_and(GroupRibOut::stages_vpn)
+            {
+                let keys: HashSet<VpnRouteKey> =
+                    self.loc_rib.iter_vpn().map(|r| r.nlri.key()).collect();
+                if !keys.is_empty() {
+                    let _ = self.stage_group_vpn_keys(gid, &keys);
+                }
+            }
         }
         if let Some(group) = self.group_ribs.get_mut(&gid) {
             group.members.insert(peer);
@@ -1057,6 +1521,7 @@ impl RibManager {
         group.dirty_members.remove(&peer);
         if group.dirty_members.is_empty() {
             group.tombstones.clear();
+            group.vpn_tombstones.clear();
         }
         if group.members.is_empty() {
             self.group_ribs.remove(&gid);
@@ -1136,6 +1601,9 @@ impl RibManager {
             target_is_rr_client: self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),
             sendable_ipv4_unicast: contains((Afi::Ipv4, Safi::Unicast)),
             sendable_ipv6_unicast: contains((Afi::Ipv6, Safi::Unicast)),
+            sendable_vpnv4: contains((Afi::Ipv4, Safi::MplsVpn)),
+            sendable_vpnv6: contains((Afi::Ipv6, Safi::MplsVpn)),
+            rtc_negotiated: contains((Afi::Ipv4, Safi::RtConstrain)),
             llgr_families,
         };
         GroupMembership::Grouped(self.update_groups.group_for(key))
@@ -1188,7 +1656,9 @@ impl RibManager {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use rustbgpd_wire::Ipv4Prefix;
+    use rustbgpd_wire::{
+        Ipv4Prefix, MplsLabelEntry, Origin, PathAttribute, RouteDistinguisher, VpnNlri, VpnPrefix,
+    };
 
     use super::*;
     use crate::test_support::make_route;
@@ -1431,6 +1901,232 @@ mod tests {
             HashSet::from([(k7, 0)]),
             "a key still retained (k1 via OTHER1) must not be withdrawn"
         );
+    }
+
+    fn vpn_key(n: u8) -> VpnRouteKey {
+        VpnRouteKey {
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, n]),
+            prefix: VpnPrefix::v4(Ipv4Addr::new(10, 210, n, 0), 24).unwrap(),
+        }
+    }
+
+    fn vpn_route(n: u8, src: IpAddr) -> VpnRibRoute {
+        let key = vpn_key(n);
+        VpnRibRoute {
+            nlri: VpnNlri {
+                labels: vec![MplsLabelEntry::try_new(100, 0, true).unwrap()],
+                route_distinguisher: key.route_distinguisher,
+                prefix: key.prefix,
+            },
+            next_hop: src,
+            peer: src,
+            attributes: std::sync::Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
+            received_at: std::time::Instant::now(),
+            origin_type: crate::route::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        }
+    }
+
+    fn vpn_announce_delta(n: u8, src: IpAddr, old: Option<IpAddr>) -> VpnGroupDelta {
+        VpnGroupDelta {
+            key: vpn_key(n),
+            new: Some(vpn_route(n, src)),
+            old: old.map(|peer| vpn_route(n, peer)),
+            policy_label: None,
+        }
+    }
+
+    fn vpn_withdraw_delta(n: u8, old: Option<IpAddr>) -> VpnGroupDelta {
+        VpnGroupDelta {
+            key: vpn_key(n),
+            new: None,
+            old: old.map(|peer| vpn_route(n, peer)),
+            policy_label: None,
+        }
+    }
+
+    /// Risk-2 exhaustive VPN source-flip matrix: every combination of
+    /// `{old source} × {new source | withdraw}` for a fixed member,
+    /// asserted against the per-peer-path reference semantics (design
+    /// §2.2, `pass ≡ true`): announce ⇔ GETS; withdraw ⇔ HAD ∧ ¬GETS.
+    #[test]
+    fn vpn_source_flip_matrix_exhaustive() {
+        let old_sources = [None, Some(MEMBER), Some(OTHER1), Some(OTHER2)];
+        let new_sources = [None, Some(MEMBER), Some(OTHER1), Some(OTHER2)];
+        for old in old_sources {
+            for new in new_sources {
+                if new.is_none() && old.is_none() {
+                    // A withdraw delta always has an old entry.
+                    continue;
+                }
+                let delta = match new {
+                    Some(src) => vpn_announce_delta(1, src, old),
+                    None => vpn_withdraw_delta(1, old),
+                };
+                let mut announce = Vec::new();
+                let mut withdraw = Vec::new();
+                emit_vpn_group_deltas_for_member(
+                    std::slice::from_ref(&delta),
+                    MEMBER,
+                    &mut announce,
+                    &mut withdraw,
+                );
+
+                let member_had = old.is_some_and(|s| s != MEMBER);
+                let member_gets = new.is_some_and(|s| s != MEMBER);
+                assert_eq!(
+                    announce.len(),
+                    usize::from(member_gets),
+                    "announce mismatch for old={old:?} new={new:?}"
+                );
+                assert_eq!(
+                    withdraw.len(),
+                    usize::from(member_had && !member_gets),
+                    "withdraw mismatch for old={old:?} new={new:?}"
+                );
+                if member_gets {
+                    assert_eq!(announce[0].peer, new.unwrap());
+                }
+                if member_had && !member_gets {
+                    assert_eq!(withdraw[0].nlri_key, vpn_key(1));
+                    assert_eq!(withdraw[0].path_id, 0);
+                }
+            }
+        }
+    }
+
+    /// VPN dirty-member resync: full-VPN-table announce minus
+    /// own-sourced; VPN tombstones withdraw unless the member still
+    /// retains the key via another source; own-sourced tombstones are a
+    /// safe over-withdraw. Force bypasses only the equality suppression.
+    #[test]
+    fn vpn_dirty_resync_replays_table_and_tombstones() {
+        let mut group = empty_group();
+        group.apply_vpn_delta(&vpn_announce_delta(1, OTHER1, None));
+        group.apply_vpn_delta(&vpn_announce_delta(2, MEMBER, None));
+        group.vpn_tombstones.insert(vpn_key(1)); // retained via OTHER1 — no withdraw
+        group.vpn_tombstones.insert(vpn_key(3)); // gone — withdraw
+        group.vpn_tombstones.insert(vpn_key(2)); // member-sourced — safe over-withdraw
+
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        RibManager::assemble_group_vpn_resync(
+            &group,
+            MEMBER,
+            true,
+            false,
+            None,
+            None,
+            &mut announce,
+            &mut withdraw,
+        );
+        let announced: HashSet<VpnRouteKey> = announce.iter().map(|r| r.nlri.key()).collect();
+        assert_eq!(
+            announced,
+            HashSet::from([vpn_key(1)]),
+            "own-sourced entries excluded"
+        );
+        let withdrawn: HashSet<VpnRouteKey> = withdraw.iter().map(|k| k.nlri_key).collect();
+        assert_eq!(withdrawn, HashSet::from([vpn_key(2), vpn_key(3)]));
+
+        // Regroup one-shot diff: unchanged baseline entry suppressed,
+        // baseline key no longer retained withdrawn.
+        let mut baseline: FxHashMap<VpnRouteKey, VpnRibRoute> = FxHashMap::default();
+        baseline.insert(vpn_key(1), vpn_route(1, OTHER1)); // unchanged — suppressed
+        baseline.insert(vpn_key(5), vpn_route(5, OTHER1)); // gone — withdraw
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        RibManager::assemble_group_vpn_resync(
+            &group,
+            MEMBER,
+            true,
+            false,
+            Some(&baseline),
+            None,
+            &mut announce,
+            &mut withdraw,
+        );
+        assert!(announce.is_empty(), "baseline-equal entries suppressed");
+        let withdrawn: HashSet<VpnRouteKey> = withdraw.iter().map(|k| k.nlri_key).collect();
+        assert!(withdrawn.contains(&vpn_key(5)));
+
+        // Force re-announces every retained entry.
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        RibManager::assemble_group_vpn_resync(
+            &group,
+            MEMBER,
+            false,
+            true,
+            Some(&baseline),
+            None,
+            &mut announce,
+            &mut withdraw,
+        );
+        let announced: HashSet<VpnRouteKey> = announce.iter().map(|r| r.nlri.key()).collect();
+        assert_eq!(announced, HashSet::from([vpn_key(1)]));
+    }
+
+    /// VPN count synthesis tracks `apply_vpn_delta` (announce, source
+    /// flip, withdraw), and `family_counts_for` buckets VPN by family.
+    #[test]
+    fn vpn_counts_and_family_synthesis_track_deltas() {
+        let mut group = GroupRibOut::new(
+            None,
+            false,
+            true,
+            vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)],
+            vec![],
+            0,
+        );
+        assert!(group.stages_vpn());
+        group.apply_delta(&announce_delta(prefix(1), OTHER1, None));
+        group.apply_vpn_delta(&vpn_announce_delta(1, OTHER1, None));
+        group.apply_vpn_delta(&vpn_announce_delta(2, MEMBER, None));
+        assert_eq!(group.vpn_advertised_count_for(MEMBER), 1);
+        assert_eq!(group.vpn_advertised_count_for(OTHER1), 1);
+        assert_eq!(group.vpn_advertised_count_for(OTHER2), 2);
+        // Unicast count synthesis is untouched by the VPN entries.
+        assert_eq!(group.advertised_count_for(MEMBER), 1);
+        assert_eq!(
+            group.family_counts_for(MEMBER),
+            vec![
+                ((Afi::Ipv4, Safi::Unicast), 1),
+                ((Afi::Ipv4, Safi::MplsVpn), 1)
+            ]
+        );
+        let view = group.member_vpn_view_snapshot(MEMBER);
+        assert_eq!(view.len(), 1);
+        assert!(view.contains_key(&vpn_key(1)));
+
+        // Source flip key 1 OTHER1 → MEMBER keeps counts exact.
+        group.apply_vpn_delta(&vpn_announce_delta(1, MEMBER, Some(OTHER1)));
+        assert_eq!(group.vpn_advertised_count_for(MEMBER), 0);
+        assert_eq!(group.vpn_advertised_count_for(OTHER1), 2);
+
+        // Withdraw drops the entry and its label residue.
+        group.apply_vpn_delta(&vpn_withdraw_delta(1, Some(MEMBER)));
+        assert_eq!(group.vpn_advertised_count_for(OTHER1), 1);
+        assert_eq!(group.table.vpn_len(), 1);
+        assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
+
+        // An RTC-negotiated sendable set never stages VPN (slice-1 gate).
+        let rtc_group = GroupRibOut::new(
+            None,
+            false,
+            true,
+            vec![
+                (Afi::Ipv4, Safi::Unicast),
+                (Afi::Ipv4, Safi::MplsVpn),
+                (Afi::Ipv4, Safi::RtConstrain),
+            ],
+            vec![],
+            0,
+        );
+        assert!(!rtc_group.stages_vpn());
     }
 
     /// The join replay dimension: a joining member's view is the table

--- a/crates/wire/tests/proptest_roundtrip.proptest-regressions
+++ b/crates/wire/tests/proptest_roundtrip.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 380602e1bc19093003f4bd403f959bf39a3121de55c0a311d456942c37b8f6e9 # shrinks to notif = NotificationMessage { code: Unknown(8), subcode: 0, data: b"" }

--- a/crates/wire/tests/proptest_roundtrip.rs
+++ b/crates/wire/tests/proptest_roundtrip.rs
@@ -24,8 +24,11 @@ fn arb_notification_code() -> impl Strategy<Value = NotificationCode> {
         Just(NotificationCode::HoldTimerExpired),
         Just(NotificationCode::FsmError),
         Just(NotificationCode::Cease),
-        // Unknown codes: 0 and 7–255 (outside the RFC 4271 range)
-        prop_oneof![Just(0u8), 7..=255u8].prop_map(NotificationCode::Unknown),
+        Just(NotificationCode::SendHoldTimerExpired),
+        // Unknown codes: 0, 7, and 9–255 (outside the assigned range —
+        // 8 became RFC 9687 Send Hold Timer Expired, so `Unknown(8)`
+        // no longer round-trips).
+        prop_oneof![Just(0u8), Just(7u8), 9..=255u8].prop_map(NotificationCode::Unknown),
     ]
 }
 


### PR DESCRIPTION
Update-groups v2 slice 1: VPNv4/v6 group staging + delta emit for groups without RT-Constrain, per the v2 design (single GroupKey extended with family bools; RT dimension = slice 2).

## Measured (rrharness vpnflood, 256 iBGP RR clients × 100k VPNv4, no RTC; baseline measured first at the pre-slice commit)

- Convergence median **18.66s → 3.75s (4.98×** — the ≥5× bar within run noise; best pairing 5.08×).
- **RSS 8227 MiB → 492 MiB (16.7×)** — the per-member VPN Adj-RIB-Out is structurally gone.
- Staging bucket 27.3% → **3.4%** (bar <20%); the residual wall is the shared wire pipeline, not staging.
- Unicast non-regression: 0.748s → 0.622s (improved).

## Shape

- `stage_vpn_routes` parameterized by the v1 `ExportTarget` — ONE body; the four per-peer call sites remain the correctness oracle; multipath/ORR branches untouched (both disqualify).
- `VpnGroupDelta { key, new, old, policy_label }` carries the displaced route so slice 2's Φ filter plugs in at emit with no reshape; emit matrix = the design's pass≡true degenerate case.
- Slice gate: `stages_vpn()` = VPN sendable ∧ ¬RTC-negotiated (all in the key). RTC peers' VPN families ride the per-peer path byte-identically (oracle-pinned) while still sharing unicast groups.
- Lifecycle: join replay, dirty resync with VPN tombstones, regroup baselines carrying unicast+VPN, RFC 7313 VPN refresh from the group table, `effective_l3vpn_keys` synthesis, stat-17 vpnv4/v6 slots, counter parity incl. a VPN denial residue (per-peer records deny evals; join/refresh parity needs it).

## Oracle

Grouped vs forced-ungrouped through the real manager: flood, source-flip X→Y→X, same-peer relabel, attr-mutate, withdraw, split horizon, late joiner, VPN refresh (plain + modified-chain), leave, content-equal reinstall no-op, deny regroup, GShut force — exact per-peer streams; dirty resync folded-state equality; RTC-negotiated per-peer-path pin. Exhaustive VPN source-flip unit matrix.

## Rider

Fixes the seed-dependent `roundtrip_notification` flake #681 introduced (generator produced `Unknown(8)`, now a named code) — 2-line strategy fix + checked-in regression seed. Flagged independently by two agents today.

Gates: workspace build/test (64 suites; rib 647), fmt, clippy -D warnings, cargo doc, clippy-reasons — green; rebased over #682-#684.