### PR TITLE
feat(rib): RT-aware VPN update-group emit with the membership-delta path (v2 slice 2)

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1082,8 +1082,8 @@ impl RibManager {
             // Adj-RIB-Out: its advertised VPN state is the group table
             // (plus pending withdraw residue), so the resync enumeration
             // synthesizes from those — mirroring the unicast synthesis
-            // above. RTC-negotiated groups don't stage VPN (slice-1
-            // gate), so their members keep the per-peer enumeration.
+            // above. (RTC members' Φ is applied by the resync assembly,
+            // not the enumeration — over-enumeration is harmless.)
             let vpn_grouped = self.vpn_grouped_member_of(peer);
             let effective_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = if resync {
                 let mut all: HashSet<rustbgpd_wire::VpnRouteKey> = self
@@ -1209,6 +1209,11 @@ impl RibManager {
             // Non-unicast families ride the per-peer path below
             // unchanged, in the same OutboundRouteUpdate.
             if let Some(gid) = member_of {
+                // The member's Φ: the VPN resync assembles under the
+                // CURRENT filter — the member may have gone dirty across
+                // a Φ change, which is why the membership-delta path
+                // defers to this (design §2.4).
+                let member_filter = self.member_rt_filter(peer);
                 if let Some(group) = self.group_ribs.get(&gid) {
                     if resync {
                         Self::assemble_group_resync(
@@ -1227,13 +1232,14 @@ impl RibManager {
                             &mut nh_override_flags,
                         );
                         // VPN portion of the resync, from the group's VPN
-                        // maps (only staged for non-RTC groups); the
-                        // per-peer VPN staging below is skipped for these
-                        // members (`vpn_grouped` gate).
+                        // maps under the member's Φ; the per-peer VPN
+                        // staging below is skipped for these members
+                        // (`vpn_grouped` gate).
                         if group.stages_vpn() {
                             Self::assemble_group_vpn_resync(
                                 group,
                                 peer,
+                                member_filter.as_ref(),
                                 is_dirty,
                                 is_force,
                                 self.pending_regroup_baseline

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -66,9 +66,9 @@ impl RibManager {
     /// the group table as `rib_out`, split horizon lifted to member emit,
     /// peer-context `RouteContext` fields `None`, and evaluations
     /// accumulated for per-member counter replay. Group targets never
-    /// carry `rtc_filter` (RTC-negotiated groups don't stage VPN in this
-    /// slice; slice 2 applies Φ at member emit), `orr_ctx`, or Add-Path —
-    /// all three disqualify from grouping.
+    /// carry `rtc_filter` (the RFC 4684 filter `Φ_m` is per-member and
+    /// applied at emit by the RT-pass matrix), `orr_ctx`, or Add-Path —
+    /// the latter two disqualify from grouping.
     ///
     /// When the target negotiated Add-Path send for the key's family (RFC
     /// 7911; RFC 9107 requires it between RRs), up to `add_path_send_max`
@@ -521,9 +521,9 @@ impl RibManager {
         // Update-group shared VPN staging: ONE export-tail pass per
         // (VPN-staging group, changed identity), committed to the group
         // tables. The per-peer loop below emits the deltas per member via
-        // the VPN source-flip matrix; RTC-negotiated groups don't stage
-        // VPN (slice-1 gate), so their members — and all ungrouped peers —
-        // take the per-peer staging path exactly as before.
+        // the RT-pass source-flip matrix (Φ applied at emit for RTC
+        // groups); ungrouped peers take the per-peer staging path exactly
+        // as before.
         let vpn_group_stage = self.stage_vpn_update_groups(&changed_keys);
 
         let peers: Vec<IpAddr> = self.outbound_peers.keys().copied().collect();
@@ -533,18 +533,32 @@ impl RibManager {
                     continue;
                 };
                 // Per-member export-policy counters from the group
-                // verdict — integer adds, `totals − own-sourced`.
+                // verdict — integer adds, `totals − own-sourced`. RTC
+                // note: the per-peer path's RT gate precedes its policy
+                // eval, but group staging defers the gate to emit, so
+                // the accumulator holds one eval per key regardless of
+                // Φ — the per-key deviation for Φ-failing keys is the
+                // documented ADR carve-out (counters are aggregates,
+                // never compared by the oracle).
                 self.apply_group_policy_counters(peer, &stage.evals);
+                let member_filter = self.member_rt_filter(peer);
                 let mut vpn_announce = Vec::new();
                 let mut vpn_withdraw = Vec::new();
-                crate::manager::update_groups::emit_vpn_group_deltas_for_member(
+                let count_delta = crate::manager::update_groups::emit_vpn_group_deltas_for_member(
                     &stage.deltas,
                     peer,
+                    member_filter.as_ref(),
                     &mut vpn_announce,
                     &mut vpn_withdraw,
                 );
                 if vpn_announce.is_empty() && vpn_withdraw.is_empty() {
                     continue;
+                }
+                // Optimistic per-member count maintenance (RTC groups
+                // only): a failed send below marks the member dirty and
+                // the resync recompute restores exactness.
+                if let Some(group) = self.group_ribs.get_mut(&gid) {
+                    group.apply_vpn_member_count_delta(peer, count_delta);
                 }
                 if !self.try_send_and_commit_outbound_update(
                     peer,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1035,6 +1035,10 @@ impl RibManager {
             RibUpdate::QueryPeerUpdateGroup { peer, reply } => {
                 self.handle_query_peer_update_group(peer, reply);
             }
+            #[cfg(test)]
+            RibUpdate::TestQueryVpnAdvertised { peer, reply } => {
+                self.handle_test_query_vpn_advertised(peer, reply);
+            }
             RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
                 self.handle_query_export_policy_term_hits(peer, reply);
             }
@@ -2245,18 +2249,55 @@ impl RibManager {
     }
 
     /// Rebuild `peer`'s RT-Constrain membership from its Adj-RIB-In (all
-    /// paths) and, when it changed, mark the peer dirty and run a resync so
-    /// the VPN Adj-RIB-Out restages under the new filter (the
-    /// `handle_replace_peer_export_policy` precedent — the Adj-RIB-Out
-    /// equality machinery yields the RFC 4684 minimal update set, no
-    /// session reset). An unchanged membership skips the restage entirely.
+    /// paths) and route the result through [`Self::set_rt_membership`] —
+    /// the corrective emit (grouped delta walk or per-peer restage) fires
+    /// there iff the membership actually changed.
     fn rebuild_rtc_membership_and_restage_vpn(&mut self, peer: IpAddr) {
         let membership = self.rtc_membership_from_rib(peer);
-        if self.peer_rt_membership.get(&peer) == Some(&membership) {
+        self.set_rt_membership(peer, Some(membership));
+    }
+
+    /// THE single Φ-write function (design §2.3 / risk 1): EVERY mutation
+    /// of `peer_rt_membership` routes through here, so a membership
+    /// change can never be split from its corrective emit. Sites:
+    ///
+    /// - `rebuild_rtc_membership_and_restage_vpn` (RTC routes received,
+    ///   RFC 7313 stale sweeps, GR/LLGR sweeps) → `Some(derived)`;
+    /// - `register_active_session` at `PeerUp` → `Some` (empty-strict,
+    ///   or GR-re-derived) / `None` (family not negotiated) — both run
+    ///   BEFORE the outbound registration, so no corrective emit fires
+    ///   and the Φ-filtered initial-dump replay covers delivery;
+    /// - `clear_outbound_peer_state` teardown → `None` (the outbound
+    ///   registration is going away; nothing to correct).
+    ///
+    /// Corrective emit for a changed Φ on a live registration: a member
+    /// of a VPN-staging group takes the membership-delta table walk
+    /// (zero policy evals, table untouched — design §2.3); everyone else
+    /// keeps the per-peer dirty restage (the Adj-RIB-Out equality
+    /// machinery yields the RFC 4684 minimal update set, no session
+    /// reset). An unchanged membership is a strict no-op.
+    fn set_rt_membership(&mut self, peer: IpAddr, membership: Option<RtcMembership>) {
+        // Capture BEFORE the write (design §2.3): under the invariant
+        // adv(m) = Φ-filtered group table, `old` is the true prior
+        // advertised state.
+        let old = self.peer_rt_membership.get(&peer).cloned();
+        if old == membership {
             return;
         }
-        self.peer_rt_membership.insert(peer, membership);
-        if self.outbound_peers.contains_key(&peer) {
+        let Some(new) = membership else {
+            self.peer_rt_membership.remove(&peer);
+            return;
+        };
+        self.peer_rt_membership.insert(peer, new.clone());
+        if !self.outbound_peers.contains_key(&peer) {
+            return;
+        }
+        if let Some(gid) = self.vpn_grouped_member_of(peer) {
+            // Absent prior membership on a live RTC registration
+            // resolves to strict empty — the `rtc_vpn_filter` rule.
+            let old = old.unwrap_or_default();
+            self.apply_rtc_membership_delta_to_grouped_member(peer, gid, &old, &new);
+        } else {
             self.mark_outbound_dirty(peer);
             self.distribute_changes(&HashSet::new(), &HashSet::new());
         }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -431,8 +431,10 @@ impl RibManager {
         // derive from the session's Adj-RIB-In): `handle_peer_up` re-creates
         // it when the new session negotiates the family — empty-strict
         // normally, or re-derived from the GR-preserved (stale) RTC routes
-        // on a graceful-restart re-establish.
-        self.peer_rt_membership.remove(&peer);
+        // on a graceful-restart re-establish. Routed through the single
+        // Φ-write function (design risk 1); no corrective emit — the
+        // registration is being torn down.
+        self.set_rt_membership(peer, None);
         // The GR-deferred EoR is per-session too: the deferral pairs with
         // THIS session's §6 gate; a new session re-derives it on `PeerUp`.
         self.gr_deferred_eor.remove(&peer);
@@ -633,11 +635,13 @@ impl RibManager {
             } else {
                 super::RtcMembership::default()
             };
-            self.peer_rt_membership.insert(peer, membership);
+            // Single Φ-write function (design risk 1); pre-registration,
+            // so no corrective emit — the initial dump replays under Φ.
+            self.set_rt_membership(peer, Some(membership));
         } else {
             // A replacement session that dropped the family must not
             // inherit its predecessor's filter (not-negotiated ⇒ unfiltered).
-            self.peer_rt_membership.remove(&peer);
+            self.set_rt_membership(peer, None);
         }
 
         debug!(%peer, "peer up — registering for outbound updates");
@@ -827,14 +831,17 @@ impl RibManager {
                 nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
                 announce.push(route.clone());
             }
-            // VPN join replay (non-RTC groups): table minus own-sourced,
-            // export tail already paid when the table was staged. An RTC
-            // group never stages VPN — its members take the per-peer VPN
-            // staging below, where the RFC 4684 RT filter applies.
+            // VPN join replay: table minus own-sourced, filtered by the
+            // joining member's Φ (the RFC 4684 gate the per-peer dump
+            // would have applied; strict-empty membership replays
+            // nothing). Export tail already paid when the table was
+            // staged.
             if group.stages_vpn() {
                 vpn_group_replayed = true;
                 for route in group.table.iter_vpn() {
-                    if route.peer == peer {
+                    if route.peer == peer
+                        || !super::update_groups::rt_passes(rtc_filter.as_ref(), route)
+                    {
                         continue;
                     }
                     vpn_announce.push(route.clone());

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -744,15 +744,19 @@ impl RibManager {
             }
         } else if safi == Safi::MplsVpn {
             // A member of a VPN-staging group replays the refreshed
-            // family from the group table — own-sourced excluded, NO
-            // policy re-evaluation (same shape as the unicast grouped
-            // arm below). RTC-negotiated groups don't stage VPN, so
-            // their members keep the per-peer staging (RT filter applies
-            // there).
+            // family from the group table — own-sourced excluded,
+            // Φ-filtered (the RFC 4684 gate the per-peer refresh would
+            // have applied; RFC 7313 refresh under heterogeneous
+            // memberships stays per-member exact), NO policy
+            // re-evaluation (same shape as the unicast grouped arm
+            // below).
             if let Some(gid) = vpn_member_of {
                 if let Some(group) = self.group_ribs.get(&gid) {
                     for route in group.table.iter_vpn() {
-                        if route.peer == peer || route.afi_safi() != family {
+                        if route.peer == peer
+                            || route.afi_safi() != family
+                            || !super::update_groups::rt_passes(rtc_filter.as_ref(), route)
+                        {
                             continue;
                         }
                         vpn_announce.push(route.clone());

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -332,6 +332,10 @@ struct Oracle {
     tx: mpsc::Sender<RibUpdate>,
     outs: BTreeMap<IpAddr, mpsc::Receiver<OutboundRouteUpdate>>,
     handle: tokio::task::JoinHandle<()>,
+    /// Messages drained so far (incremental collection so the VPN
+    /// invariant checker can fold mid-scenario); `finish` drains the
+    /// remainder into it and returns the whole stream set.
+    collected: Streams,
 }
 
 impl Oracle {
@@ -345,6 +349,7 @@ impl Oracle {
             tx,
             outs: BTreeMap::new(),
             handle,
+            collected: Streams::new(),
         }
     }
 
@@ -396,7 +401,15 @@ impl Oracle {
             })
             .await
             .unwrap();
-        self.outs.insert(IpAddr::V4(peer), out_rx);
+        // A re-registration (e.g. GR re-establish) replaces the
+        // receiver; drain the predecessor first so its messages stay in
+        // the collected stream.
+        if let Some(mut old_rx) = self.outs.insert(IpAddr::V4(peer), out_rx) {
+            let msgs = self.collected.entry(IpAddr::V4(peer)).or_default();
+            while let Ok(update) = old_rx.try_recv() {
+                msgs.push(normalize(&update));
+            }
+        }
         self.quiesce().await;
     }
 
@@ -449,8 +462,33 @@ impl Oracle {
     /// RFC 4684 RT-Constrain advertisement from a peer — rebuilds the
     /// peer's RT membership (the per-peer VPN filter).
     async fn rtc_routes(&mut self, from: Ipv4Addr, announce: Vec<RtcRibRoute>) {
+        self.rtc_routes_full(from, announce, vec![]).await;
+        self.quiesce().await;
+    }
+
+    /// RTC announce + withdraw, WITHOUT quiescing — racing scenarios
+    /// queue this back-to-back with route updates.
+    async fn rtc_routes_full(
+        &mut self,
+        from: Ipv4Addr,
+        announce: Vec<RtcRibRoute>,
+        withdraw: Vec<crate::route::RtcRibRouteKey>,
+    ) {
         self.tx
             .send(RibUpdate::RtcRoutesReceived {
+                peer: IpAddr::V4(from),
+                session_id: SESSION,
+                announced: announce,
+                withdrawn: withdraw,
+            })
+            .await
+            .unwrap();
+    }
+
+    /// VPN announce WITHOUT quiescing (racing scenarios).
+    async fn vpn_routes_no_quiesce(&mut self, from: Ipv4Addr, announce: Vec<VpnRibRoute>) {
+        self.tx
+            .send(RibUpdate::VpnRoutesReceived {
                 peer: IpAddr::V4(from),
                 session_id: SESSION,
                 announced: announce,
@@ -458,7 +496,87 @@ impl Oracle {
             })
             .await
             .unwrap();
+    }
+
+    /// RFC 4724 graceful restart: routes (SAFI-132 interest included)
+    /// are preserved stale for the returning session.
+    async fn graceful_restart(&mut self, peer: Ipv4Addr) {
+        self.tx
+            .send(RibUpdate::PeerGracefulRestart {
+                peer: IpAddr::V4(peer),
+                session_id: SESSION,
+                restart_time: 120,
+                stale_routes_time: 300,
+                gr_families: vpn_rtc_sendable(),
+                peer_llgr_capable: false,
+                peer_llgr_families: vec![],
+                llgr_stale_time: 0,
+            })
+            .await
+            .unwrap();
         self.quiesce().await;
+    }
+
+    /// Total export-policy evaluations recorded by every installed
+    /// chain since install (ADR-0096 live counters) — the zero-eval
+    /// assertion's window.
+    async fn export_policy_evals(&mut self) -> u64 {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::QueryExportPolicyTermHits {
+                peer: None,
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap().iter().map(|row| row.evals).sum()
+    }
+
+    /// Drain every receiver into the collected streams (no await — only
+    /// messages already sent).
+    fn drain_collected(&mut self) {
+        for (peer, rx) in &mut self.outs {
+            let msgs = self.collected.entry(*peer).or_default();
+            while let Ok(update) = rx.try_recv() {
+                msgs.push(normalize(&update));
+            }
+        }
+    }
+
+    /// The design §5 invariant checker: recompute `adv(m)` from manager
+    /// state (`{ e ∈ group table : e.peer ≠ m ∧ pass_m(e) }` for a
+    /// VPN-grouped member, the per-peer Adj-RIB-Out otherwise) for every
+    /// peer and compare against the folded emitted VPN state.
+    async fn check_vpn_invariant(&mut self, label: &str) {
+        self.quiesce().await;
+        self.drain_collected();
+        let folded = fold_vpn(&self.collected);
+        let peers: Vec<IpAddr> = self.outs.keys().copied().collect();
+        for peer in peers {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.tx
+                .send(RibUpdate::TestQueryVpnAdvertised {
+                    peer,
+                    reply: reply_tx,
+                })
+                .await
+                .unwrap();
+            let advertised = reply_rx.await.unwrap();
+            let adv: BTreeMap<String, IpAddr> = advertised.into_iter().collect();
+            let fold: BTreeMap<String, IpAddr> = folded
+                .get(&peer)
+                .map(|table| {
+                    table
+                        .iter()
+                        .map(|(key, (_, _, src, _))| (key.clone(), *src))
+                        .collect()
+                })
+                .unwrap_or_default();
+            assert_eq!(
+                adv, fold,
+                "VPN invariant adv(m) != folded emitted state for {peer} at step: {label}"
+            );
+        }
     }
 
     /// The peer's update-group membership label (`group:N` or the
@@ -529,32 +647,35 @@ impl Oracle {
     }
 
     /// Drain one pending message from a peer's channel (channel-fill
-    /// scenarios).
+    /// scenarios). The message stays in the collected stream so folded
+    /// comparisons and the VPN invariant checker see the whole history.
     async fn drain_one(&mut self, peer: Ipv4Addr) -> OutboundRouteUpdate {
-        self.outs
+        let update = self
+            .outs
             .get_mut(&IpAddr::V4(peer))
             .expect("peer registered")
             .recv()
             .await
-            .expect("message pending")
+            .expect("message pending");
+        self.collected
+            .entry(IpAddr::V4(peer))
+            .or_default()
+            .push(normalize(&update));
+        update
     }
 
-    /// Collect every message every peer has received so far. Messages
-    /// drained early via `drain_one` are NOT re-collected — scenarios
-    /// that pre-drain must compare folded state, not streams.
+    /// Collect every message every peer has received so far, including
+    /// those drained mid-scenario by `drain_one` and the invariant
+    /// checker — the returned streams are the complete emission history.
     async fn finish(mut self) -> Streams {
         self.quiesce().await;
-        let mut streams = Streams::new();
-        for (peer, rx) in &mut self.outs {
-            let mut msgs = Vec::new();
-            while let Ok(update) = rx.try_recv() {
-                msgs.push(normalize(&update));
-            }
-            streams.insert(*peer, msgs);
+        self.drain_collected();
+        for peer in self.outs.keys() {
+            self.collected.entry(*peer).or_default();
         }
         drop(self.tx);
         self.handle.await.unwrap();
-        streams
+        self.collected
     }
 }
 
@@ -944,15 +1065,15 @@ async fn oracle_vpn_dirty_resync_converges_to_identical_state() {
     );
 }
 
-/// The slice-1 RTC gate: peers that negotiated RT-Constrain still group
-/// for unicast, but their VPN families ride the per-peer path where the
-/// RFC 4684 RT membership filter applies. A wildcard-interest member
-/// receives the VPN table; a strict-empty-membership member receives
-/// nothing — byte-identically on both paths (if VPN were wrongly
-/// group-staged, the filterless group table would leak routes to the
-/// empty-membership peer and the streams would diverge).
+/// RTC-negotiated peers group AND stage VPN (v2 slice 2), with the RFC
+/// 4684 RT membership filter `Φ_m` applied per member at emit. A
+/// wildcard-interest member receives the VPN table; a strict-empty-
+/// membership member receives nothing — byte-identically to the
+/// per-peer path (if Φ were dropped at any emit seam, the group table
+/// would leak routes to the empty-membership peer and the streams
+/// would diverge).
 #[tokio::test]
-async fn oracle_rtc_negotiated_vpn_rides_per_peer() {
+async fn oracle_rtc_negotiated_vpn_filtered_at_emit() {
     let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
     let scenario = async |o: &mut Oracle| {
         // Source peer: VPN-capable, no RTC (its group DOES stage VPN).
@@ -985,7 +1106,7 @@ async fn oracle_rtc_negotiated_vpn_rides_per_peer() {
     let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
     assert_eq!(
         grouped, ungrouped,
-        "RTC-negotiated peers' VPN streams must ride the per-peer path unchanged"
+        "RTC-negotiated peers' Φ-filtered group emit must match the per-peer path"
     );
     let vpn_count = |streams: &Streams, peer: Ipv4Addr| {
         streams[&IpAddr::V4(peer)]
@@ -1035,4 +1156,387 @@ async fn oracle_plain_ibgp_split_horizon_identical() {
     };
     let (grouped, ungrouped) = run_grouped_and_ungrouped(None, scenario).await;
     assert_eq!(grouped, ungrouped);
+}
+
+// ---------------------------------------------------------------------
+// RTC churn (update-groups v2 slice 2): the RT-pass emit dimension.
+// ---------------------------------------------------------------------
+
+/// RT extended community `65000:n` (two-octet-AS route target).
+const fn rt_ec(n: u64) -> u64 {
+    0x0002_FDE8_0000_0000 | n
+}
+
+/// RTC interest NLRI covering exactly RT `65000:n` (full /96 prefix).
+fn rtc_nlri_for(n: u64) -> RtcNlri {
+    RtcNlri::new(65000, rt_ec(n), 96).unwrap()
+}
+
+fn rtc_key_for(n: u64) -> crate::route::RtcRibRouteKey {
+    crate::route::RtcRibRouteKey {
+        nlri: rtc_nlri_for(n),
+        path_id: 0,
+    }
+}
+
+/// A SAFI-132 advertisement of interest in RT `65000:n` from a peer.
+fn rtc_interest(src: Ipv4Addr, n: u64) -> RtcRibRoute {
+    RtcRibRoute {
+        nlri: rtc_nlri_for(n),
+        ..rtc_default(src)
+    }
+}
+
+/// The RTC-churn kitchen sink (design §5): membership widen / narrow /
+/// default add+remove / strict-empty, RT flip via route attr change,
+/// RFC 7313 refresh under heterogeneous memberships, GR re-establish
+/// with preserved SAFI-132 state, membership change racing a source
+/// flip in the same manager queue, and a regroup join with pre-existing
+/// membership — exact per-peer streams grouped vs forced-ungrouped,
+/// with the adv(m) invariant checked after every step.
+#[tokio::test]
+async fn oracle_rtc_churn_streams_identical() {
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let modifying_chain = || {
+        permit_all_with(RouteModifications {
+            set_med: Some(42),
+            ..RouteModifications::default()
+        })
+    };
+    let scenario = async |o: &mut Oracle| {
+        // A: VPN source (no RTC). B/C/D: RTC RR clients, one group.
+        // E: RTC RR client with a modifying chain — its own group.
+        o.peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(B, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.peer_up_families(C, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.peer_up_families(D, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.peer_up_families(
+            E,
+            false,
+            true,
+            Some(modifying_chain()),
+            64,
+            vpn_rtc_sendable(),
+        )
+        .await;
+
+        // Memberships: B{RT1}, C{default}, D strict-empty, E{RT2}.
+        o.rtc_routes(B, vec![rtc_interest(B, 1)]).await;
+        o.rtc_routes(C, vec![rtc_default(C)]).await;
+        o.rtc_routes(E, vec![rtc_interest(E, 2)]).await;
+        o.check_vpn_invariant("memberships installed").await;
+
+        // Flood: identities across the RT pool (incl. RT-less id 4,
+        // which only the default membership may receive).
+        o.vpn_routes(
+            A,
+            vec![
+                vpn_route(vpn_nlri(1, 100), A, 100, vec![rt_ec(1)]),
+                vpn_route(vpn_nlri(2, 200), A, 100, vec![rt_ec(2)]),
+                vpn_route(vpn_nlri(3, 300), A, 100, vec![rt_ec(1), rt_ec(2)]),
+                vpn_route(vpn_nlri(4, 400), A, 100, vec![]),
+                vpn_route(vpn_nlri(5, 500), A, 100, vec![rt_ec(3)]),
+            ],
+            vec![],
+        )
+        .await;
+        o.check_vpn_invariant("initial flood").await;
+
+        // Membership widen: B += RT2 (id 2 newly passes; id 3 already
+        // held via RT1 — no re-announce).
+        o.rtc_routes(B, vec![rtc_interest(B, 2)]).await;
+        o.check_vpn_invariant("widen B += RT2").await;
+
+        // Membership narrow: B −= RT1 (id 1 withdrawn; id 3 retained
+        // via RT2).
+        o.rtc_routes_full(B, vec![], vec![rtc_key_for(1)]).await;
+        o.quiesce().await;
+        o.check_vpn_invariant("narrow B -= RT1").await;
+
+        // RT flip via route attr change: id 1 moves RT1 → RT2 (into
+        // Φ_B/Φ_E, C re-announces the changed attrs, D silent); id 5
+        // moves RT3 → RT1 (out of everyone's Φ but C's default).
+        o.vpn_routes(
+            A,
+            vec![
+                vpn_route(vpn_nlri(1, 100), A, 100, vec![rt_ec(2)]),
+                vpn_route(vpn_nlri(5, 500), A, 100, vec![rt_ec(1)]),
+            ],
+            vec![],
+        )
+        .await;
+        o.check_vpn_invariant("RT flip via attr change").await;
+
+        // Default-NLRI remove: C collapses to strict empty (withdraws
+        // everything), then re-declares interest in RT2.
+        o.rtc_routes_full(
+            C,
+            vec![],
+            vec![crate::route::RtcRibRouteKey {
+                nlri: RtcNlri::DEFAULT,
+                path_id: 0,
+            }],
+        )
+        .await;
+        o.quiesce().await;
+        o.check_vpn_invariant("default removed from C").await;
+        o.rtc_routes(C, vec![rtc_interest(C, 2)]).await;
+        o.check_vpn_invariant("C += RT2").await;
+
+        // RFC 7313 refresh under heterogeneous memberships.
+        o.route_refresh(B, Afi::Ipv4, Safi::MplsVpn).await;
+        o.route_refresh(C, Afi::Ipv4, Safi::MplsVpn).await;
+        o.route_refresh(D, Afi::Ipv4, Safi::MplsVpn).await;
+        o.check_vpn_invariant("heterogeneous VPN refresh").await;
+
+        // GR re-establish: B's SAFI-132 interest survives as stale and
+        // the re-derived Φ gates the initial-dump replay.
+        o.graceful_restart(B).await;
+        o.peer_up_families(B, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        o.check_vpn_invariant("GR re-establish of B").await;
+
+        // Membership change racing a source flip in the same queue
+        // (FIFO-deterministic; no quiesce between).
+        o.rtc_routes_full(D, vec![rtc_interest(D, 2)], vec![]).await;
+        o.vpn_routes_no_quiesce(A, vec![vpn_route(vpn_nlri(2, 201), A, 150, vec![rt_ec(2)])])
+            .await;
+        o.quiesce().await;
+        o.check_vpn_invariant("membership racing source flip").await;
+
+        // Regroup join with pre-existing membership: E's chain reverts
+        // to the group default — the one-shot diff runs under Φ_E.
+        o.replace_policy(E, None).await;
+        o.check_vpn_invariant("E regroups with pre-existing membership")
+            .await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        grouped, ungrouped,
+        "grouped Φ-filtered emit and per-peer RTC streams must be identical"
+    );
+    assert!(
+        grouped
+            .values()
+            .any(|msgs| msgs.iter().any(|m| !m.vpn_announce.is_empty())),
+        "scenario must exercise VPN outbound traffic"
+    );
+}
+
+/// Membership change WHILE dirty (design §2.3): the grouped path skips
+/// the delta walk (Φ updated; the pending resync emits against current
+/// Φ, over-withdrawing Φ-failing keys — the backstop term). Streams
+/// legitimately differ; the folded final VPN state must converge, the
+/// Φ-failing key must be withdrawn, and the jammed announce recovered.
+#[tokio::test]
+async fn oracle_rtc_membership_change_while_dirty_converges() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up_families(A, false, true, None, 64, vpn_sendable())
+            .await;
+        o.peer_up_families(B, false, true, None, 64, vpn_rtc_sendable())
+            .await;
+        // C: capacity-2 channel — the RTC-capable initial dump takes
+        // two messages (the default-RTC dump, then the EoR), so two
+        // slots keep C clean until the deliberate jam below.
+        o.peer_up_families(C, false, true, None, 2, vpn_rtc_sendable())
+            .await;
+        let dump = o.drain_one(C).await;
+        assert!(dump.vpn_announce.is_empty(), "got {:?}", normalize(&dump));
+        let eor = o.drain_one(C).await;
+        assert!(!eor.end_of_rib.is_empty(), "got {:?}", normalize(&eor));
+        // C interested in RT1 + RT2 (no VPN routes yet — no emission).
+        o.rtc_routes(C, vec![rtc_interest(C, 1), rtc_interest(C, 2)])
+            .await;
+        o.rtc_routes(B, vec![rtc_default(B)]).await;
+
+        // id 1 + id 2 land in C's channel; id 3 fills the second slot.
+        o.vpn_routes(
+            A,
+            vec![
+                vpn_route(vpn_nlri(1, 100), A, 100, vec![rt_ec(1)]),
+                vpn_route(vpn_nlri(2, 200), A, 100, vec![rt_ec(2)]),
+            ],
+            vec![],
+        )
+        .await;
+        o.vpn_routes(
+            A,
+            vec![vpn_route(vpn_nlri(3, 300), A, 100, vec![rt_ec(1)])],
+            vec![],
+        )
+        .await;
+        // id 4 announce fails for C → C goes dirty.
+        o.vpn_routes(
+            A,
+            vec![vpn_route(vpn_nlri(4, 400), A, 100, vec![rt_ec(1)])],
+            vec![],
+        )
+        .await;
+        // Membership narrows WHILE dirty: C −= RT2 (id 2 must not
+        // survive the resync).
+        o.rtc_routes_full(C, vec![], vec![rtc_key_for(2)]).await;
+        o.quiesce().await;
+
+        // Free the channel and let the resync timer fire.
+        let first = o.drain_one(C).await;
+        assert_eq!(
+            first.vpn_announce.len(),
+            2,
+            "ids 1+2 were delivered before the jam"
+        );
+        let second = o.drain_one(C).await;
+        assert_eq!(second.vpn_announce.len(), 1, "id 3 was delivered too");
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+        o.check_vpn_invariant("post-resync").await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold_vpn(&grouped),
+        fold_vpn(&ungrouped),
+        "final advertised VPN state must converge on both paths"
+    );
+    let c_final = fold_vpn(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    let key = |n: u8, label: u32| format!("{:?}", vpn_nlri(n, label).key());
+    assert!(
+        c_final.contains_key(&key(1, 100)),
+        "Φ-passing id 1 must survive"
+    );
+    assert!(
+        !c_final.contains_key(&key(2, 200)),
+        "the key that left Φ while dirty must be withdrawn by the resync backstop"
+    );
+    assert!(c_final.contains_key(&key(3, 300)), "id 3 must survive");
+    assert!(
+        c_final.contains_key(&key(4, 400)),
+        "the update lost to the full channel must be recovered by the resync"
+    );
+}
+
+/// Kill criterion (b), design §6.2: a single member's membership flip
+/// at 100k staged VPN routes emits ONLY the minimal RFC 4684 delta —
+/// one message, announce-only on widen / withdraw-only on narrow, with
+/// ZERO export-policy evaluations (the ADR-0096 live eval counters of
+/// every installed chain are unchanged) and the group table untouched.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "synthetic RD/prefix bytes are deliberate low-byte extractions"
+)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rtc_membership_flip_at_scale_emits_delta_only_zero_evals() {
+    const N: u32 = 100_000;
+    const RT_POOL: u64 = 64;
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let chain = || permit_all_with(RouteModifications::default());
+    let mut o = Oracle::spawn(false, cluster);
+    o.peer_up_families(A, false, true, None, 512, vpn_sendable())
+        .await;
+    // B (default interest) and C ({RT1}) group together: content-equal
+    // chains, same sendable set.
+    o.peer_up_families(B, false, true, Some(chain()), 512, vpn_rtc_sendable())
+        .await;
+    o.peer_up_families(C, false, true, Some(chain()), 512, vpn_rtc_sendable())
+        .await;
+    o.rtc_routes(B, vec![rtc_default(B)]).await;
+    o.rtc_routes(C, vec![rtc_interest(C, 1)]).await;
+
+    // Flood N identities over an RT pool of 64, in chunks.
+    let mut i = 0u32;
+    while i < N {
+        let hi = (i + 512).min(N);
+        let batch: Vec<VpnRibRoute> = (i..hi)
+            .map(|k| {
+                vpn_route(
+                    VpnNlri {
+                        labels: vec![MplsLabelEntry::try_new(16 + (k % 1000), 0, true).unwrap()],
+                        route_distinguisher: RouteDistinguisher([
+                            0,
+                            0,
+                            0xFD,
+                            0xE8,
+                            (k >> 24) as u8,
+                            (k >> 16) as u8,
+                            (k >> 8) as u8,
+                            k as u8,
+                        ]),
+                        prefix: VpnPrefix::v4(
+                            Ipv4Addr::new(
+                                10u8.wrapping_add((k >> 16) as u8),
+                                (k >> 8) as u8,
+                                k as u8,
+                                0,
+                            ),
+                            24,
+                        )
+                        .unwrap(),
+                    },
+                    A,
+                    100,
+                    vec![rt_ec(u64::from(k) % RT_POOL)],
+                )
+            })
+            .collect();
+        i = hi;
+        o.vpn_routes_no_quiesce(A, batch).await;
+    }
+    o.quiesce().await;
+    o.drain_collected();
+    let msgs_before = o.collected.get(&IpAddr::V4(C)).map_or(0, Vec::len);
+    let evals_before = o.export_policy_evals().await;
+    assert!(evals_before > 0, "the flood must have evaluated the chain");
+
+    let per_rt = |n: u64| (0..N).filter(|k| u64::from(*k) % RT_POOL == n).count();
+
+    // Widen: C += RT2 → exactly one announce-only message of the RT2
+    // share, zero evals.
+    o.rtc_routes(C, vec![rtc_interest(C, 2)]).await;
+    o.quiesce().await;
+    o.drain_collected();
+    let c_msgs = &o.collected[&IpAddr::V4(C)];
+    assert_eq!(
+        c_msgs.len(),
+        msgs_before + 1,
+        "membership widen must emit exactly one message"
+    );
+    let widen = &c_msgs[msgs_before];
+    assert_eq!(widen.vpn_announce.len(), per_rt(2), "announce-only delta");
+    assert!(widen.vpn_withdraw.is_empty(), "widen must not withdraw");
+    // The VPN membership delta itself runs ZERO evaluations. The +1 is
+    // the SAFI-132 route itself: C's new interest NLRI reflects to B
+    // (one RTC staging eval) — identical on the per-peer path, and not
+    // a VPN restage.
+    assert_eq!(
+        o.export_policy_evals().await,
+        evals_before + 1,
+        "membership widen must add only the SAFI-132 reflection eval, zero VPN evals"
+    );
+
+    // Narrow: C −= RT1 → exactly one withdraw-only message.
+    o.rtc_routes_full(C, vec![], vec![rtc_key_for(1)]).await;
+    o.quiesce().await;
+    o.drain_collected();
+    let c_msgs = &o.collected[&IpAddr::V4(C)];
+    assert_eq!(c_msgs.len(), msgs_before + 2);
+    let narrow = &c_msgs[msgs_before + 1];
+    assert!(narrow.vpn_announce.is_empty(), "narrow must not announce");
+    assert_eq!(narrow.vpn_withdraw.len(), per_rt(1), "withdraw-only delta");
+    // A SAFI-132 withdraw stages no eval (withdraw-if-present precedes
+    // the policy check), so the narrow is exactly zero evals.
+    assert_eq!(
+        o.export_policy_evals().await,
+        evals_before + 1,
+        "membership narrow must run ZERO export-policy evaluations"
+    );
+
+    o.check_vpn_invariant("post narrow").await;
+    drop(o.finish().await);
 }

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -35,12 +35,13 @@ use std::net::IpAddr;
 use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation};
 use rustbgpd_wire::{Afi, Prefix, Safi};
 use rustc_hash::FxHashMap;
+use tracing::warn;
 
 use super::helpers::{LOCAL_PEER, routes_equal, vpn_routes_equal};
-use super::{PolicyFilteredRouteKey, RibManager};
+use super::{PolicyFilteredRouteKey, RibManager, RtcMembership};
 use crate::adj_rib_out::AdjRibOut;
 use crate::route::{Route, VpnRibRoute, VpnRibRouteKey};
-use rustbgpd_wire::{VpnAddressFamily, VpnRouteKey};
+use rustbgpd_wire::{ExtendedCommunity, VpnAddressFamily, VpnRouteKey};
 
 /// Fingerprint of every RIB-staging input that makes per-peer staged
 /// output differ (design §1). Per-peer wire preparation (next-hop
@@ -70,10 +71,12 @@ pub(super) struct GroupKey {
     sendable_vpnv4: bool,
     /// Sendable `VPNv6` (SAFI 128).
     sendable_vpnv6: bool,
-    /// RT-Constrain negotiated (sendable ∋ `(Ipv4, RtConstrain)`). Slice 1
-    /// gate: groups with `rtc_negotiated` are EXCLUDED from VPN group
-    /// staging — their VPN families ride the per-peer path (where the RFC
-    /// 4684 RT filter applies); unicast grouping continues normally.
+    /// RT-Constrain negotiated (sendable ∋ `(Ipv4, RtConstrain)`). Stays
+    /// in the key (RTC groups must not mix with non-RTC groups: filter
+    /// *presence* is group-uniform by construction); the RFC 4684 RT
+    /// filter itself (`Φ_m`) is per-member state applied at emit — never
+    /// part of the key, so a PE fleet with distinct RT sets still shares
+    /// one group (design §2, option b).
     rtc_negotiated: bool,
     /// Exact set of families the peer advertised LLGR for (RFC 9494
     /// export-restriction input), sorted raw `(afi, safi)` values.
@@ -354,11 +357,15 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
     }
 }
 
+/// A persistent group-verdict VPN denial: (source peer, denying policy
+/// label, the denied route's extended communities — the Φ gate input
+/// for an RTC member's join-time counter replay).
+type VpnDenialRecord = (IpAddr, Option<String>, Vec<ExtendedCommunity>);
+
 /// One entry of a shared group VPN staging pass. Unlike the unicast
 /// [`GroupDelta`] this carries the full displaced route (`old`), not just
-/// its source: slice 2's RT-pass matrix needs the displaced entry's
-/// extended communities to decide `had` per member (design §2.1). Slice 1
-/// only reads `old.peer` (`pass ≡ true` degenerate case). `path_id` is
+/// its source: the RT-pass matrix needs the displaced entry's extended
+/// communities to decide `had` per member (design §2.1). `path_id` is
 /// fixed at 0 — Add-Path send disqualifies from grouping.
 #[derive(Debug, Clone)]
 pub(in crate::manager) struct VpnGroupDelta {
@@ -386,33 +393,62 @@ pub(in crate::manager) struct VpnGroupStageOutput {
     pub(in crate::manager) evals: GroupEvalAccumulator,
 }
 
+/// Whether a staged VPN route passes a member's RFC 4684 RT filter:
+/// no filter (SAFI 132 not negotiated — group-uniform via the key), or
+/// any of the route's extended communities falls inside the membership.
+/// REUSES [`RtcMembership::matches_any`] — the one implementation of
+/// RTC matching semantics (design §2.2: there is no second copy of the
+/// 96-bit covering-prefix core to drift).
+pub(in crate::manager) fn rt_passes(filter: Option<&RtcMembership>, route: &VpnRibRoute) -> bool {
+    filter.is_none_or(|membership| membership.matches_any(route.extended_communities()))
+}
+
 /// Per-member VPN emit for one shared staging pass — the design §2.2
-/// matrix with the slice-1 degenerate `pass ≡ true` (RTC-negotiated
-/// groups never stage VPN, so no RT filter exists here; slice 2 plugs
-/// `Φ_m` into `had`/`gets`):
+/// RT-pass source-flip matrix (`pass_m` = no filter ∨
+/// `Φ_m.matches_any`; a non-RTC group passes `None` = the slice-1
+/// degenerate `pass ≡ true` case):
 ///
-/// - `had`  = `old` exists ∧ `old.peer ≠ member`
-/// - `gets` = `new` exists ∧ `new.peer ≠ member`
+/// - `had`  = `old` exists ∧ `old.peer ≠ member` ∧ `pass_m(old)`
+/// - `gets` = `new` exists ∧ `new.peer ≠ member` ∧ `pass_m(new)`
 /// - emit: `gets` → announce `new`; `had ∧ ¬gets` → withdraw `(key, 0)`;
 ///   else skip.
+///
+/// Returns the member's net advertised-count delta per VPN family slot
+/// `[vpnv4, vpnv6]` (`gets ∧ ¬had` = +1, `had ∧ ¬gets` = −1) — the
+/// incremental input for the per-member counters an RT filter makes
+/// non-derivable from the group's source counts (design §2.4).
 pub(in crate::manager) fn emit_vpn_group_deltas_for_member(
     deltas: &[VpnGroupDelta],
     member: IpAddr,
+    filter: Option<&RtcMembership>,
     vpn_announce: &mut Vec<VpnRibRoute>,
     vpn_withdraw: &mut Vec<VpnRibRouteKey>,
-) {
+) -> [i64; 2] {
+    let mut count_delta = [0i64; 2];
     for delta in deltas {
-        let had = delta.old.as_ref().is_some_and(|old| old.peer != member);
-        let gets = delta.new.as_ref().is_some_and(|new| new.peer != member);
+        let had = delta
+            .old
+            .as_ref()
+            .is_some_and(|old| old.peer != member && rt_passes(filter, old));
+        let gets = delta
+            .new
+            .as_ref()
+            .is_some_and(|new| new.peer != member && rt_passes(filter, new));
+        let slot = GroupRibOut::vpn_count_slot(&delta.key) - 2;
         if gets {
             vpn_announce.push(delta.new.clone().expect("gets implies new exists"));
+            if !had {
+                count_delta[slot] += 1;
+            }
         } else if had {
             vpn_withdraw.push(VpnRibRouteKey {
                 nlri_key: delta.key,
                 path_id: 0,
             });
+            count_delta[slot] -= 1;
         }
     }
+    count_delta
 }
 
 /// A regrouped member's previously-advertised view, held until its
@@ -472,12 +508,22 @@ pub(in crate::manager) struct GroupRibOut {
     /// VPN sibling of `staged_labels`, keyed by RD+prefix identity.
     vpn_staged_labels: FxHashMap<VpnRouteKey, Option<String>>,
     /// Persistent group-verdict VPN export-policy denials: denied key →
-    /// (source peer, denying policy label). The per-peer VPN path keeps
-    /// no denial *records* (unlike unicast `policy_filtered` — VPN has
-    /// no denied-routes query), but it DOES record a deny eval per
-    /// denied key at every staging pass, so join-time counter replay
-    /// needs this residue for parity.
-    vpn_policy_denied: FxHashMap<VpnRouteKey, (IpAddr, Option<String>)>,
+    /// (source peer, denying policy label, the denied route's extended
+    /// communities). The per-peer VPN path keeps no denial *records*
+    /// (unlike unicast `policy_filtered` — VPN has no denied-routes
+    /// query), but it DOES record a deny eval per denied key at every
+    /// staging pass, so join-time counter replay needs this residue for
+    /// parity. The extended communities let an RTC member's replay skip
+    /// denials its Φ would have RT-gated before the eval (the per-peer
+    /// path's RT gate precedes the policy evaluation).
+    vpn_policy_denied: FxHashMap<VpnRouteKey, VpnDenialRecord>,
+    /// Per-member advertised VPN counts `[vpnv4, vpnv6]`, maintained
+    /// ONLY for RTC-negotiated groups (Φ makes the counts non-derivable
+    /// from `source_counts`; design §2.4) at the emit seams: staging
+    /// emit, membership delta, join, and resync recompute-by-walk. A
+    /// dirty window may drift them; the member's resync recompute
+    /// restores exactness. Non-RTC groups keep the O(1) synthesis.
+    vpn_member_counts: FxHashMap<IpAddr, [i64; 2]>,
     // Group-uniform staging inputs, snapshot at group creation from the
     // first member (all members are key-equal by construction; a key
     // change moves peers to a different group, so these never mutate).
@@ -514,6 +560,7 @@ impl GroupRibOut {
             staged_labels: FxHashMap::default(),
             vpn_staged_labels: FxHashMap::default(),
             vpn_policy_denied: FxHashMap::default(),
+            vpn_member_counts: FxHashMap::default(),
             export_chain,
             is_ebgp,
             is_rr_client,
@@ -522,14 +569,22 @@ impl GroupRibOut {
         }
     }
 
-    /// Whether this group stages VPN routes (design §6 slice 1): `VPNv4`
-    /// or `VPNv6` sendable AND RT-Constrain NOT negotiated. RTC groups'
-    /// VPN families ride the per-peer path where the RFC 4684 filter
-    /// applies (the RT dimension is slice 2). Group-uniform — all three
-    /// inputs are in the [`GroupKey`].
+    /// Whether this group stages VPN routes: `VPNv4` or `VPNv6`
+    /// sendable. RTC-negotiated groups stage too (v2 slice 2) — the RFC
+    /// 4684 filter `Φ_m` is applied per member at emit by the RT-pass
+    /// matrix, never at staging. Group-uniform — the input is in the
+    /// [`GroupKey`].
     pub(in crate::manager) fn stages_vpn(&self) -> bool {
-        !self.sendable.contains(&(Afi::Ipv4, Safi::RtConstrain))
-            && self.sendable.iter().any(|&(_, safi)| safi == Safi::MplsVpn)
+        self.sendable.iter().any(|&(_, safi)| safi == Safi::MplsVpn)
+    }
+
+    /// Whether this group's members negotiated RT-Constrain — filter
+    /// *presence* is group-uniform (`rtc_negotiated` is in the key), so
+    /// this decides between the per-member RT-pass emit + maintained
+    /// counters (RTC) and the shared unfiltered emit + O(1) count
+    /// synthesis (non-RTC).
+    pub(in crate::manager) fn rtc_negotiated(&self) -> bool {
+        self.sendable.contains(&(Afi::Ipv4, Safi::RtConstrain))
     }
 
     fn count_slot(prefix: &Prefix) -> usize {
@@ -633,14 +688,71 @@ impl GroupRibOut {
         self.table.len().saturating_sub(own)
     }
 
-    /// Number of VPN routes `member` currently has advertised: the group
-    /// VPN table minus the member's own-sourced entries. O(1).
+    /// Number of VPN routes `member` currently has advertised. Non-RTC
+    /// group: the group VPN table minus the member's own-sourced entries,
+    /// O(1). RTC group: the maintained per-member counter (Φ makes the
+    /// count non-derivable from `source_counts`).
     pub(in crate::manager) fn vpn_advertised_count_for(&self, member: IpAddr) -> usize {
+        if self.rtc_negotiated() {
+            return self
+                .vpn_member_counts
+                .get(&member)
+                .map_or(0, |counts| counts.iter().sum::<i64>().max(0))
+                .try_into()
+                .unwrap_or(0);
+        }
         let own = self
             .source_counts
             .get(&member)
             .map_or(0, |counts| counts[2] + counts[3]);
         self.table.vpn_len().saturating_sub(own)
+    }
+
+    /// Recompute (and store) a member's advertised VPN counts from the
+    /// group table under its current Φ — the resync/join seam that makes
+    /// the incremental counters exact again after a dirty window. O(VPN
+    /// table); resyncs and joins are rare. No-op for non-RTC groups.
+    pub(in crate::manager) fn recompute_vpn_member_counts(
+        &mut self,
+        member: IpAddr,
+        filter: Option<&RtcMembership>,
+    ) {
+        if !self.rtc_negotiated() {
+            return;
+        }
+        let counts = self.vpn_member_counts_from_table(member, filter);
+        self.vpn_member_counts.insert(member, counts);
+    }
+
+    /// A member's advertised VPN counts recomputed from the table (the
+    /// invariant reference the incremental counters are checked against).
+    pub(in crate::manager) fn vpn_member_counts_from_table(
+        &self,
+        member: IpAddr,
+        filter: Option<&RtcMembership>,
+    ) -> [i64; 2] {
+        let mut counts = [0i64; 2];
+        for route in self.table.iter_vpn() {
+            if route.peer != member && rt_passes(filter, route) {
+                counts[Self::vpn_count_slot(&route.nlri.key()) - 2] += 1;
+            }
+        }
+        counts
+    }
+
+    /// Apply an incremental per-member count delta (an emit seam's
+    /// matrix output). No-op for non-RTC groups (O(1) synthesis).
+    pub(in crate::manager) fn apply_vpn_member_count_delta(
+        &mut self,
+        member: IpAddr,
+        delta: [i64; 2],
+    ) {
+        if !self.rtc_negotiated() || delta == [0, 0] {
+            return;
+        }
+        let counts = self.vpn_member_counts.entry(member).or_default();
+        counts[0] += delta[0];
+        counts[1] += delta[1];
     }
 
     /// Per-family synthesized advertised counts for a member (BMP RFC
@@ -659,11 +771,22 @@ impl GroupRibOut {
             }
         }
         let own = self.source_counts.get(&member).copied().unwrap_or_default();
+        // RTC group: the VPN slots come from the maintained per-member
+        // counters (Φ-filtered), not the table synthesis.
+        let rtc_vpn = self.rtc_negotiated().then(|| {
+            self.vpn_member_counts
+                .get(&member)
+                .copied()
+                .unwrap_or([0; 2])
+        });
         FAMILIES
             .iter()
             .enumerate()
             .filter_map(|(slot, &family)| {
-                let count = totals[slot].saturating_sub(own[slot]) as u64;
+                let count = match (slot, rtc_vpn) {
+                    (2 | 3, Some(counts)) => counts[slot - 2].max(0).unsigned_abs(),
+                    _ => totals[slot].saturating_sub(own[slot]) as u64,
+                };
                 (count > 0).then_some((family, count))
             })
             .collect()
@@ -679,12 +802,18 @@ impl GroupRibOut {
             .collect()
     }
 
-    /// VPN sibling of [`Self::member_view_snapshot`]. Empty when the
-    /// group does not stage VPN (the substrate's VPN maps stay unused).
-    fn member_vpn_view_snapshot(&self, member: IpAddr) -> FxHashMap<VpnRouteKey, VpnRibRoute> {
+    /// VPN sibling of [`Self::member_view_snapshot`], filtered by the
+    /// member's Φ at snapshot time — the true advertised set (design
+    /// §2.4). Empty when the group does not stage VPN (the substrate's
+    /// VPN maps stay unused).
+    fn member_vpn_view_snapshot(
+        &self,
+        member: IpAddr,
+        filter: Option<&RtcMembership>,
+    ) -> FxHashMap<VpnRouteKey, VpnRibRoute> {
         self.table
             .iter_vpn()
-            .filter(|route| route.peer != member)
+            .filter(|route| route.peer != member && rt_passes(filter, route))
             .map(|route| (route.nlri.key(), route.clone()))
             .collect()
     }
@@ -751,9 +880,15 @@ impl RibManager {
     pub(in crate::manager) fn clear_grouped_member_synced(&mut self, peer: IpAddr) {
         self.pending_regroup_baseline.remove(&peer);
         self.pending_extra_withdraws.remove(&peer);
+        // A completed resync leaves the member advertising exactly the
+        // Φ-filtered table — the seam where the incremental per-member
+        // VPN counters (which may have drifted across the dirty window)
+        // are made exact again.
+        let filter = self.member_rt_filter(peer);
         if let Some(gid) = self.grouped_member_of(peer)
             && let Some(group) = self.group_ribs.get_mut(&gid)
         {
+            group.recompute_vpn_member_counts(peer, filter.as_ref());
             group.dirty_members.remove(&peer);
             if group.dirty_members.is_empty() {
                 group.tombstones.clear();
@@ -763,9 +898,8 @@ impl RibManager {
     }
 
     /// Whether `peer` is a grouped member whose VPN advertised state is
-    /// group-owned (member of a group that stages VPN). RTC-negotiated
-    /// groups return `None`: their members' VPN families ride the
-    /// per-peer path (slice-1 gate — the RT dimension is slice 2).
+    /// group-owned (member of a group that stages VPN — RTC groups
+    /// included since v2 slice 2).
     pub(in crate::manager) fn vpn_grouped_member_of(&self, peer: IpAddr) -> Option<usize> {
         let gid = self.grouped_member_of(peer)?;
         self.group_ribs
@@ -775,17 +909,20 @@ impl RibManager {
     }
 
     /// Whether `peer`'s VPN advertised state is group-owned *whenever
-    /// the peer is grouped*: VPN sendable and RT-Constrain not
-    /// negotiated. Pure function of the session's (fixed) sendable set,
-    /// so it answers membership-transition seams before the destination
-    /// group exists.
+    /// the peer is grouped*: VPN sendable. Pure function of the
+    /// session's (fixed) sendable set, so it answers
+    /// membership-transition seams before the destination group exists.
     fn peer_vpn_groupable(&self, peer: IpAddr) -> bool {
         self.peer_sendable_families
             .get(&peer)
-            .is_some_and(|families| {
-                !families.contains(&(Afi::Ipv4, Safi::RtConstrain))
-                    && families.iter().any(|&(_, safi)| safi == Safi::MplsVpn)
-            })
+            .is_some_and(|families| families.iter().any(|&(_, safi)| safi == Safi::MplsVpn))
+    }
+
+    /// A grouped member's Φ — the RFC 4684 VPN filter resolved from its
+    /// RT membership (`Some` iff the peer negotiated SAFI 132, absent
+    /// membership ⇒ strict empty; the [`Self::rtc_vpn_filter`] rule).
+    pub(in crate::manager) fn member_rt_filter(&self, peer: IpAddr) -> Option<RtcMembership> {
+        self.rtc_vpn_filter(peer, self.peer_sendable_families.get(&peer))
     }
 
     /// Run the shared staging pass for every live group over the pass's
@@ -907,8 +1044,8 @@ impl RibManager {
     /// Run the shared VPN staging pass for every VPN-staging group over
     /// the pass's changed RD+prefix identities. Deltas are committed to
     /// the group tables here; `recompute_and_distribute_vpn` emits them
-    /// per member via the VPN source-flip matrix. RTC-negotiated groups
-    /// are skipped by construction ([`GroupRibOut::stages_vpn`]).
+    /// per member via the RT-pass source-flip matrix (Φ applied at emit
+    /// for RTC-negotiated groups).
     pub(in crate::manager) fn stage_vpn_update_groups(
         &mut self,
         changed: &HashSet<VpnRouteKey>,
@@ -941,7 +1078,7 @@ impl RibManager {
         keys: &HashSet<VpnRouteKey>,
     ) -> VpnGroupStageOutput {
         let mut out = VpnGroupStageOutput::default();
-        let mut denials: Vec<(VpnRouteKey, (IpAddr, Option<String>))> = Vec::new();
+        let mut denials: Vec<(VpnRouteKey, VpnDenialRecord)> = Vec::new();
         {
             let Some(group) = self.group_ribs.get(&gid) else {
                 return out;
@@ -972,9 +1109,9 @@ impl RibManager {
                     self.cluster_id,
                     Some(&group.sendable),
                     Some(&group.llgr),
-                    // RT gate deferred by structure: slice 1 never stages
-                    // VPN for RTC groups, slice 2 plugs Φ in at emit (the
-                    // delta carries `old` for exactly that).
+                    // RT gate deferred to member emit: Φ is per-member
+                    // state, applied by the RT-pass matrix (the delta
+                    // carries `old` for exactly that).
                     None,
                     None, // ORR disqualifies from grouping
                     0,    // Add-Path send disqualifies from grouping
@@ -993,7 +1130,15 @@ impl RibManager {
                     _ => None,
                 };
                 if let Some((label, PolicyAction::Deny, source)) = last {
-                    denials.push((*key, (source, label)));
+                    // The evaluated route is the Loc-RIB best (group
+                    // targets never carry ORR); its RTs let an RTC
+                    // member's join replay Φ-gate the denial.
+                    let rts = self
+                        .loc_rib
+                        .get_vpn(key)
+                        .map(|best| best.extended_communities().to_vec())
+                        .unwrap_or_default();
+                    denials.push((*key, (source, label, rts)));
                 }
                 if announce.is_empty() && withdraw.is_empty() {
                     continue;
@@ -1110,8 +1255,17 @@ impl RibManager {
     /// VPN portion of a grouped member's resync update — the VPN sibling
     /// of [`Self::assemble_group_resync`], same three shapes (plain
     /// dirty / regroup one-shot diff / force), assembled from the group
-    /// table's VPN maps with NO policy re-evaluation. Only called for
-    /// groups that stage VPN.
+    /// table's VPN maps with NO policy re-evaluation, under the member's
+    /// CURRENT Φ (`filter`). Only called for groups that stage VPN.
+    ///
+    /// The Φ dimension (design §2.4): announce = table entries passing
+    /// `pass_m`, and retention is Φ-aware (a staged key failing Φ is
+    /// NOT retained). A membership delta missed while dirty is healed
+    /// through `extras`: the Φ-write seam records the keys leaving Φ as
+    /// extra (over-)withdraws — exact, instead of the design's blanket
+    /// failing-Φ withdraw term, which would put spurious withdraws on
+    /// clean regroup diffs too (spurious withdraws are RFC 4271 no-ops,
+    /// but the regroup one-shot diff is held to exact-stream parity).
     #[expect(
         clippy::too_many_arguments,
         reason = "the resync assembly takes the member's full pending-withdraw context"
@@ -1119,6 +1273,7 @@ impl RibManager {
     pub(in crate::manager) fn assemble_group_vpn_resync(
         group: &GroupRibOut,
         member: IpAddr,
+        filter: Option<&RtcMembership>,
         is_dirty: bool,
         is_force: bool,
         baseline: Option<&FxHashMap<VpnRouteKey, VpnRibRoute>>,
@@ -1127,7 +1282,7 @@ impl RibManager {
         vpn_withdraw: &mut Vec<VpnRibRouteKey>,
     ) {
         for route in group.table.iter_vpn() {
-            if route.peer == member {
+            if route.peer == member || !rt_passes(filter, route) {
                 continue;
             }
             if !is_force
@@ -1147,7 +1302,7 @@ impl RibManager {
                     nlri_key: *key,
                     path_id: 0,
                 })
-                .is_some_and(|route| route.peer != member)
+                .is_some_and(|route| route.peer != member && rt_passes(filter, route))
         };
         let mut keys: HashSet<VpnRouteKey> = HashSet::new();
         if let Some(base) = baseline {
@@ -1168,6 +1323,127 @@ impl RibManager {
             nlri_key: key,
             path_id: 0,
         }));
+    }
+
+    /// The membership-delta path for a grouped VPN member whose Φ
+    /// changed (design §2.3, the RTC hard part): ONE walk of the group
+    /// VPN table — old-Φ vs new-Φ per entry — emitting a member-scoped
+    /// announce/withdraw delta. ZERO policy evaluations, the table
+    /// untouched (it is a pure function of (Loc-RIB, group key); Φ is
+    /// member state and cannot touch it by construction). Wire-
+    /// equivalent to the per-peer dirty restage, computed directly.
+    ///
+    /// Called ONLY from [`RibManager::set_rt_membership`] — the single
+    /// Φ-write function (design risk 1).
+    pub(in crate::manager) fn apply_rtc_membership_delta_to_grouped_member(
+        &mut self,
+        peer: IpAddr,
+        gid: usize,
+        old: &RtcMembership,
+        new: &RtcMembership,
+    ) {
+        let mut vpn_announce: Vec<VpnRibRoute> = Vec::new();
+        let mut vpn_withdraw: Vec<VpnRibRouteKey> = Vec::new();
+        let mut count_delta = [0i64; 2];
+        let mut permit_rows: Vec<(Option<String>, PolicyAction, u64)> = Vec::new();
+        // A dirty member cannot take the wire delta (its advertised
+        // state is behind); its pending resync announces the Φ-passing
+        // table under CURRENT Φ, so only the keys LEAVING Φ need a
+        // record — they ride the existing extra-(over-)withdraw residue
+        // (exact heal, no blanket over-withdraw; the resync's
+        // `member_retains` guard drops any key that re-enters Φ before
+        // it runs).
+        let is_dirty = self
+            .group_ribs
+            .get(&gid)
+            .is_some_and(|group| group.dirty_members.contains(&peer));
+        {
+            let Some(group) = self.group_ribs.get(&gid) else {
+                return;
+            };
+            for route in group.table.iter_vpn() {
+                if route.peer == peer {
+                    continue;
+                }
+                let rts = route.extended_communities();
+                match (old.matches_any(rts), new.matches_any(rts)) {
+                    (false, true) if !is_dirty => {
+                        // Newly passing: announce the staged route
+                        // verbatim; the per-peer restage would record a
+                        // permit eval for it — replay from the staged
+                        // label (the join-replay trick; still-passing
+                        // keys deliberately record nothing, the
+                        // documented counter deviation).
+                        let key = route.nlri.key();
+                        count_delta[GroupRibOut::vpn_count_slot(&key) - 2] += 1;
+                        let label = group.vpn_staged_labels.get(&key).cloned().unwrap_or(None);
+                        bump_eval_row(&mut permit_rows, label.as_ref(), PolicyAction::Permit);
+                        vpn_announce.push(route.clone());
+                    }
+                    (true, false) => {
+                        let key = route.nlri.key();
+                        count_delta[GroupRibOut::vpn_count_slot(&key) - 2] -= 1;
+                        vpn_withdraw.push(VpnRibRouteKey {
+                            nlri_key: key,
+                            path_id: 0,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if is_dirty {
+            if !vpn_withdraw.is_empty() {
+                self.pending_extra_withdraws
+                    .entry(peer)
+                    .or_default()
+                    .vpn
+                    .extend(vpn_withdraw.iter().map(|key| key.nlri_key));
+            }
+            return;
+        }
+        if vpn_announce.is_empty() && vpn_withdraw.is_empty() {
+            return;
+        }
+        if let Some(group) = self.group_ribs.get_mut(&gid) {
+            // Optimistic: a failed send marks the member dirty and the
+            // resync recompute restores exactness.
+            group.apply_vpn_member_count_delta(peer, count_delta);
+        }
+        let withdraw_keys: Vec<VpnRouteKey> = vpn_withdraw.iter().map(|key| key.nlri_key).collect();
+        if self.try_send_and_commit_outbound_update(
+            peer,
+            vec![].into(),
+            vec![].into(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vpn_announce,
+            vpn_withdraw,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ) {
+            self.bump_export_counters(peer, &permit_rows);
+        } else {
+            warn!(%peer, "outbound channel full — RTC membership delta deferred to resync");
+            // The v1 dirty machinery takes over: the member's resync
+            // announces the Φ-passing table; the narrow's withdraws
+            // ride the extra-withdraw residue.
+            self.mark_outbound_dirty(peer);
+            self.pending_extra_withdraws
+                .entry(peer)
+                .or_default()
+                .vpn
+                .extend(withdraw_keys);
+        }
     }
 
     /// Bump a member's export-policy counters by the group verdict:
@@ -1215,6 +1491,10 @@ impl RibManager {
         gid: usize,
         family: Option<(Afi, Safi)>,
     ) {
+        // The member's Φ: the per-peer path's RT gate precedes the policy
+        // evaluation, so an RT-failed entry records NO eval — the replay
+        // must count only Φ-passing permits and denials (design §2.4).
+        let vpn_filter = self.rtc_vpn_filter(peer, self.peer_sendable_families.get(&peer));
         let mut rows: Vec<(Option<String>, PolicyAction, u64)> = Vec::new();
         {
             let Some(group) = self.group_ribs.get(&gid) else {
@@ -1263,7 +1543,10 @@ impl RibManager {
                 })
             };
             for route in group.table.iter_vpn() {
-                if route.peer == peer || !in_vpn_family(&route.nlri.key()) {
+                if route.peer == peer
+                    || !in_vpn_family(&route.nlri.key())
+                    || !rt_passes(vpn_filter.as_ref(), route)
+                {
                     continue;
                 }
                 let label = group
@@ -1273,8 +1556,11 @@ impl RibManager {
                     .unwrap_or(None);
                 bump(&label, PolicyAction::Permit);
             }
-            for (key, (source, label)) in &group.vpn_policy_denied {
-                if *source == peer || !in_vpn_family(key) {
+            for (key, (source, label, rts)) in &group.vpn_policy_denied {
+                if *source == peer
+                    || !in_vpn_family(key)
+                    || !vpn_filter.as_ref().is_none_or(|m| m.matches_any(rts))
+                {
                     continue;
                 }
                 bump(label, PolicyAction::Deny);
@@ -1380,12 +1666,15 @@ impl RibManager {
             // changes reach the wire (design §4 one-shot diff). First
             // registration has no view — the initial dump replays the
             // destination group table.
+            // The member's Φ at snapshot time (a regroup never changes
+            // Φ — it is keyed by peer, not group).
+            let rt_filter = self.member_rt_filter(peer);
             let baseline: Option<RegroupBaseline> = match prev_gid {
                 Some(gid) => {
                     let group = self.group_ribs.get(&gid);
                     let base = group.map(|g| RegroupBaseline {
                         unicast: g.member_view_snapshot(peer),
-                        vpn: g.member_vpn_view_snapshot(peer),
+                        vpn: g.member_vpn_view_snapshot(peer, rt_filter.as_ref()),
                     });
                     // A member that leaves while dirty may have missed
                     // withdrawals; carry the group tombstones along as
@@ -1508,8 +1797,12 @@ impl RibManager {
                 }
             }
         }
+        // The joining member's advertised-count seed (RTC groups only):
+        // the O(table) walk rides the join replay's existing cost.
+        let filter = self.member_rt_filter(peer);
         if let Some(group) = self.group_ribs.get_mut(&gid) {
             group.members.insert(peer);
+            group.recompute_vpn_member_counts(peer, filter.as_ref());
         }
     }
 
@@ -1518,6 +1811,7 @@ impl RibManager {
             return;
         };
         group.members.remove(&peer);
+        group.vpn_member_counts.remove(&peer);
         group.dirty_members.remove(&peer);
         if group.dirty_members.is_empty() {
             group.tombstones.clear();
@@ -1633,6 +1927,61 @@ impl RibManager {
                 None => self.metrics.remove_update_group_members(&id.to_string()),
             }
         }
+    }
+
+    /// TEST ONLY: answer `RibUpdate::TestQueryVpnAdvertised` — the
+    /// peer's advertised VPN view recomputed from manager state, the
+    /// oracle invariant checker's window (design §5): for a VPN-grouped
+    /// member, `adv(m) = { e ∈ group table : e.peer ≠ m ∧ pass_m(e) }`
+    /// under the member's CURRENT Φ; for everyone else, the per-peer
+    /// Adj-RIB-Out VPN entries. Also cross-checks the incrementally
+    /// maintained per-member VPN counters against the table recompute
+    /// (the design §2.4 debug assertion).
+    #[cfg(test)]
+    pub(super) fn handle_test_query_vpn_advertised(
+        &mut self,
+        peer: IpAddr,
+        reply: tokio::sync::oneshot::Sender<Vec<(String, IpAddr)>>,
+    ) {
+        let filter = self.member_rt_filter(peer);
+        let view: Vec<(String, IpAddr)> = match self
+            .vpn_grouped_member_of(peer)
+            .and_then(|gid| self.group_ribs.get(&gid))
+        {
+            Some(group) => {
+                // Counter invariant: incremental == recompute-from-table
+                // whenever the member is in sync (a dirty window may
+                // legitimately drift until its resync recompute).
+                if group.rtc_negotiated() && !group.dirty_members.contains(&peer) {
+                    debug_assert_eq!(
+                        group
+                            .vpn_member_counts
+                            .get(&peer)
+                            .copied()
+                            .unwrap_or_default(),
+                        group.vpn_member_counts_from_table(peer, filter.as_ref()),
+                        "per-member VPN counters drifted from the table for {peer}"
+                    );
+                }
+                group
+                    .table
+                    .iter_vpn()
+                    .filter(|route| route.peer != peer && rt_passes(filter.as_ref(), route))
+                    .map(|route| (format!("{:?}", route.nlri.key()), route.peer))
+                    .collect()
+            }
+            None => self
+                .adj_ribs_out
+                .get(&peer)
+                .map(|rib_out| {
+                    rib_out
+                        .iter_vpn()
+                        .map(|route| (format!("{:?}", route.nlri.key()), route.peer))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+        let _ = reply.send(view);
     }
 
     /// Answer `RibUpdate::QueryPeerUpdateGroup`: the membership label
@@ -1968,9 +2317,10 @@ mod tests {
                 };
                 let mut announce = Vec::new();
                 let mut withdraw = Vec::new();
-                emit_vpn_group_deltas_for_member(
+                let count_delta = emit_vpn_group_deltas_for_member(
                     std::slice::from_ref(&delta),
                     MEMBER,
+                    None,
                     &mut announce,
                     &mut withdraw,
                 );
@@ -1986,6 +2336,11 @@ mod tests {
                     withdraw.len(),
                     usize::from(member_had && !member_gets),
                     "withdraw mismatch for old={old:?} new={new:?}"
+                );
+                assert_eq!(
+                    count_delta[0],
+                    i64::from(member_gets && !member_had) - i64::from(member_had && !member_gets),
+                    "count delta mismatch for old={old:?} new={new:?}"
                 );
                 if member_gets {
                     assert_eq!(announce[0].peer, new.unwrap());
@@ -2016,6 +2371,7 @@ mod tests {
         RibManager::assemble_group_vpn_resync(
             &group,
             MEMBER,
+            None,
             true,
             false,
             None,
@@ -2042,6 +2398,7 @@ mod tests {
         RibManager::assemble_group_vpn_resync(
             &group,
             MEMBER,
+            None,
             true,
             false,
             Some(&baseline),
@@ -2059,6 +2416,7 @@ mod tests {
         RibManager::assemble_group_vpn_resync(
             &group,
             MEMBER,
+            None,
             false,
             true,
             Some(&baseline),
@@ -2098,7 +2456,7 @@ mod tests {
                 ((Afi::Ipv4, Safi::MplsVpn), 1)
             ]
         );
-        let view = group.member_vpn_view_snapshot(MEMBER);
+        let view = group.member_vpn_view_snapshot(MEMBER, None);
         assert_eq!(view.len(), 1);
         assert!(view.contains_key(&vpn_key(1)));
 
@@ -2113,7 +2471,8 @@ mod tests {
         assert_eq!(group.table.vpn_len(), 1);
         assert!(!group.vpn_staged_labels.contains_key(&vpn_key(1)));
 
-        // An RTC-negotiated sendable set never stages VPN (slice-1 gate).
+        // An RTC-negotiated sendable set stages VPN too (v2 slice 2):
+        // Φ is applied per member at emit, not by a staging gate.
         let rtc_group = GroupRibOut::new(
             None,
             false,
@@ -2126,7 +2485,202 @@ mod tests {
             vec![],
             0,
         );
-        assert!(!rtc_group.stages_vpn());
+        assert!(rtc_group.stages_vpn());
+        assert!(rtc_group.rtc_negotiated());
+    }
+
+    /// An RTC membership over a specific Route Target (full 96-bit
+    /// origin-AS + RT prefix).
+    fn membership(rts: &[u64]) -> RtcMembership {
+        let mut entries: Vec<rustbgpd_wire::RtcNlri> = rts
+            .iter()
+            .map(|&rt| {
+                let global_admin = (rt >> 32) & 0xFFFF;
+                rustbgpd_wire::RtcNlri::new(global_admin as u32, rt, 96).unwrap()
+            })
+            .collect();
+        entries.sort_unstable();
+        entries.dedup();
+        RtcMembership {
+            has_default: false,
+            entries,
+        }
+    }
+
+    /// RT extended community `65000:n` (two-octet-AS route target).
+    const fn rt(n: u64) -> u64 {
+        0x0002_FDE8_0000_0000 | n
+    }
+
+    fn vpn_route_with_rts(n: u8, src: IpAddr, rts: &[u64]) -> VpnRibRoute {
+        let mut route = vpn_route(n, src);
+        route.attributes = std::sync::Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::ExtendedCommunities(
+                rts.iter().copied().map(ExtendedCommunity::new).collect(),
+            ),
+        ]);
+        route
+    }
+
+    /// The Φ dimension of the emit matrix (design §2.2): `had`/`gets`
+    /// consult `pass_m` via the REUSED `RtcMembership::matches_any` —
+    /// route-mutates-out-of-Φ withdraws, into-Φ announces without a
+    /// spurious withdraw, strict-empty membership receives nothing and
+    /// withdraws nothing (`had` = false for entries it never had).
+    #[test]
+    fn vpn_matrix_rt_filter_dimension() {
+        let phi1 = membership(&[rt(1)]);
+        let empty = RtcMembership::default();
+        let old_r1 = vpn_route_with_rts(1, OTHER1, &[rt(1)]);
+        let new_r2 = vpn_route_with_rts(1, OTHER1, &[rt(2)]);
+
+        // Attr change flips the RT out of Φ: had ∧ ¬gets → withdraw.
+        let delta = VpnGroupDelta {
+            key: vpn_key(1),
+            new: Some(new_r2.clone()),
+            old: Some(old_r1.clone()),
+            policy_label: None,
+        };
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let d = emit_vpn_group_deltas_for_member(
+            std::slice::from_ref(&delta),
+            MEMBER,
+            Some(&phi1),
+            &mut announce,
+            &mut withdraw,
+        );
+        assert!(announce.is_empty());
+        assert_eq!(withdraw.len(), 1);
+        assert_eq!(d, [-1, 0]);
+
+        // The reverse mutation (into Φ): ¬had ∧ gets → announce only.
+        let delta = VpnGroupDelta {
+            key: vpn_key(1),
+            new: Some(old_r1.clone()),
+            old: Some(new_r2.clone()),
+            policy_label: None,
+        };
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        let d = emit_vpn_group_deltas_for_member(
+            std::slice::from_ref(&delta),
+            MEMBER,
+            Some(&phi1),
+            &mut announce,
+            &mut withdraw,
+        );
+        assert_eq!(announce.len(), 1);
+        assert!(withdraw.is_empty());
+        assert_eq!(d, [1, 0]);
+
+        // Strict-empty membership: silent for both directions.
+        for delta in [
+            VpnGroupDelta {
+                key: vpn_key(1),
+                new: Some(old_r1.clone()),
+                old: None,
+                policy_label: None,
+            },
+            VpnGroupDelta {
+                key: vpn_key(1),
+                new: None,
+                old: Some(old_r1.clone()),
+                policy_label: None,
+            },
+        ] {
+            let mut announce = Vec::new();
+            let mut withdraw = Vec::new();
+            let d = emit_vpn_group_deltas_for_member(
+                std::slice::from_ref(&delta),
+                MEMBER,
+                Some(&empty),
+                &mut announce,
+                &mut withdraw,
+            );
+            assert!(announce.is_empty() && withdraw.is_empty());
+            assert_eq!(d, [0, 0]);
+        }
+    }
+
+    /// The Φ dimension of the dirty resync (design §2.4): announce only
+    /// Φ-passing entries; the failing-retention backstop (over-)withdraws
+    /// table keys outside Φ (healing a membership delta missed while
+    /// dirty); the snapshot is Φ-filtered.
+    #[test]
+    fn vpn_dirty_resync_rt_filter_dimension() {
+        let phi1 = membership(&[rt(1)]);
+        let mut group = GroupRibOut::new(
+            None,
+            false,
+            true,
+            vec![
+                (Afi::Ipv4, Safi::Unicast),
+                (Afi::Ipv4, Safi::MplsVpn),
+                (Afi::Ipv4, Safi::RtConstrain),
+            ],
+            vec![],
+            0,
+        );
+        let in_phi = vpn_route_with_rts(1, OTHER1, &[rt(1)]);
+        let out_phi = vpn_route_with_rts(2, OTHER1, &[rt(2)]);
+        group.apply_vpn_delta(&VpnGroupDelta {
+            key: in_phi.nlri.key(),
+            new: Some(in_phi.clone()),
+            old: None,
+            policy_label: None,
+        });
+        group.apply_vpn_delta(&VpnGroupDelta {
+            key: out_phi.nlri.key(),
+            new: Some(out_phi.clone()),
+            old: None,
+            policy_label: None,
+        });
+
+        // A membership narrow missed while dirty lands the leaving key
+        // in the extra-withdraw residue; the resync announces only the
+        // Φ-passing table and withdraws the residue (Φ-aware retention:
+        // a staged-but-Φ-failing key is NOT retained).
+        let extras: HashSet<VpnRouteKey> = HashSet::from([out_phi.nlri.key()]);
+        let mut announce = Vec::new();
+        let mut withdraw = Vec::new();
+        RibManager::assemble_group_vpn_resync(
+            &group,
+            MEMBER,
+            Some(&phi1),
+            true,
+            false,
+            None,
+            Some(&extras),
+            &mut announce,
+            &mut withdraw,
+        );
+        let announced: HashSet<VpnRouteKey> = announce.iter().map(|r| r.nlri.key()).collect();
+        assert_eq!(announced, HashSet::from([in_phi.nlri.key()]));
+        let withdrawn: HashSet<VpnRouteKey> = withdraw.iter().map(|k| k.nlri_key).collect();
+        assert_eq!(
+            withdrawn,
+            HashSet::from([out_phi.nlri.key()]),
+            "a staged key failing Φ is not retained — the extras withdraw must emit"
+        );
+
+        // Snapshot under Φ = the true advertised set.
+        let view = group.member_vpn_view_snapshot(MEMBER, Some(&phi1));
+        assert_eq!(view.len(), 1);
+        assert!(view.contains_key(&in_phi.nlri.key()));
+
+        // Count recompute-from-table under Φ.
+        assert_eq!(
+            group.vpn_member_counts_from_table(MEMBER, Some(&phi1)),
+            [1, 0]
+        );
+        group.recompute_vpn_member_counts(MEMBER, Some(&phi1));
+        assert_eq!(group.vpn_advertised_count_for(MEMBER), 1);
+        assert_eq!(
+            group.family_counts_for(MEMBER),
+            vec![((Afi::Ipv4, Safi::MplsVpn), 1)]
+        );
     }
 
     /// The join replay dimension: a joining member's view is the table

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -654,6 +654,18 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<String>,
     },
+    /// TEST ONLY: a peer's advertised VPN view recomputed from manager
+    /// state — the Φ-filtered group table for a VPN-grouped member, the
+    /// per-peer Adj-RIB-Out otherwise. The update-groups oracle's
+    /// invariant checker (design §5) compares this against the folded
+    /// emitted stream after every scenario step.
+    #[cfg(test)]
+    TestQueryVpnAdvertised {
+        /// The target peer.
+        peer: IpAddr,
+        /// Response channel: `(Debug-formatted VpnRouteKey, source peer)`.
+        reply: oneshot::Sender<Vec<(String, IpAddr)>>,
+    },
     /// Query: snapshot the live per-term guard-hit counters of the
     /// installed export chains (ADR-0096 Decision 3.3). Counters
     /// accumulate since a chain instance was installed and reset when


### PR DESCRIPTION
Update-groups v2 slice 2: RTC-negotiated groups now get VPN group staging, with the RT filter applied per member at emit time — the design's Φ matrix over the invariant adv(m) = { e ∈ group table : e.peer ≠ m ∧ pass_m(e) }.

## Measured (rrharness vpnfloodhet: 256 clients, 100k VPNv4, each member's Φ matching ~10% of the RT pool; 3-run medians)

- Convergence **3.21s → 1.10s (~2.9×)**, RSS **1481 → 482 MiB (~3.1×)** vs the per-peer baseline — kill criterion cleared, no option-(c) fallback.
- Per-peer `stage_vpn_routes` 50% → 3.0% of samples; the `matches_any` emit walk is ~17% of a 3× smaller profile.
- **Zero-policy-eval membership flip pinned at 100k staged routes**: a widen/narrow emits exactly one announce-only/withdraw-only member-scoped message with zero export-policy evaluations (asserted via the live ADR-0096 eval counters).

## The two load-bearing structures

- **Single-Φ-write-function**: every `peer_rt_membership` mutation routes through `set_rt_membership` — complete site census in the commit (RTC receive + refresh/GR sweeps; PeerUp registration; teardown). The membership-delta path replaces the per-peer full dirty-restage for grouped members with one group-table walk (old-Φ vs new-Φ per entry), table untouched — strictly cheaper than today's restage while producing the same minimal RFC 4684 wire delta. RTC semantics are REUSED (`RtcMembership::matches_any` / the 96-bit covering-prefix core) — no second implementation to drift.
- **Φ-aware seams**: emit matrix, dirty resync retention, regroup snapshots at snapshot-time Φ, join/refresh replay, counter parity (RT gate precedes eval; denial residue carries RTs), per-member advertised counters with a debug-assert table recompute.

## Deviation from the design (tighter, documented)

The §2.4 blanket failing-Φ withdraw term on dirty resyncs put spurious withdraws on clean regroup diffs; instead the Φ-write seam records exactly the keys leaving Φ into `pending_extra_withdraws`, with re-entry dropped by the retention guard. Same self-healing guarantee, exact-stream parity preserved.

## Found (pre-existing, slice-1 scope, follow-up queued)

A source-flip member-scoped withdraw lost to a full channel isn't recorded for the resync (tombstones only track table withdrawals) — rare (channel-full exactly on a flip), fix is the same pending_extra_withdraws mechanism; queued as the next slice's first item with a test.

## Oracle + invariant

RTC-churn scenario set (widen/narrow/RT-flip-via-attr/default add+remove/strict-empty/heterogeneous refresh/GR re-establish with preserved SAFI-132/racing source flip/join with pre-existing Φ) with exact per-peer stream equality; while-dirty converges folded; the adv(m) invariant checker runs after every oracle step. All slice-1 and M75-pinned behaviors green.

Gates: workspace build/test (652 rib lib tests), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.