### PR TITLE
fix(rib): preserve GR/LLGR-stale routes across enhanced route-refresh purges (LAN-187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,6 +577,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **An enhanced route refresh no longer purges GR/LLGR-stale routes
+  awaiting End-of-RIB (LAN-187).** RFC 7313's end-of-refresh sweep
+  removes routes not re-advertised inside the BoRR..EoRR window — but a
+  refresh window opened while a peer was re-established under graceful
+  restart (End-of-RIB still pending) also snapshotted the GR-stale and
+  LLGR-stale routes RFC 4724 §4.1 / RFC 9494 §4.2 deliberately retain,
+  so an EoRR (or refresh timeout) from the still-converging restarter
+  deleted exactly the paths GR preserves. GR/LLGR-stale routes are now
+  excluded from the refresh snapshot: a re-advertisement inside the
+  window still refreshes them, and End-of-RIB or the GR/LLGR timers
+  remain their only removal points. Manager tests pin the joint
+  GR+refresh and LLGR+refresh lifecycles across all seven route
+  families' snapshot arms.
+
 - **Label-stack withdraws no longer reset labeled-unicast and VPN
   sessions (caught live by the M79 lab).** RFC 8277 §2.4 says a withdraw
   carries a single ignored 3-octet compatibility field in the label

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -473,12 +473,34 @@ impl RibManager {
             (peer, afi, safi),
             tokio::time::Instant::now() + ERR_REFRESH_TIMEOUT,
         );
+        // RFC 7313 §4 refresh-stale snapshot, joint with GR/LLGR retention
+        // (LAN-187). A route can be inside a refresh window AND GR/LLGR-stale
+        // at once: the peer re-established under GR (or during the LLGR
+        // phase), its End-of-RIB is still pending, and a refresh window
+        // opened. The four combinations at EoRR:
+        //   1. snapshotted, not GR/LLGR-stale, not re-advertised → purged
+        //      (RFC 7313 §4: not re-advertised between BoRR and EoRR).
+        //   2. re-advertised inside the window → kept; the insert removed
+        //      the snapshot key and cleared any GR/LLGR staleness
+        //      (implicit-replace, RFC 4724 §4.1).
+        //   3. GR/LLGR-stale at BoRR, not re-advertised → NOT snapshotted
+        //      below, so EoRR does not purge it: a restarting peer's replay
+        //      is not authoritative while it is still converging. RFC 4724
+        //      §4.1 retains stale paths until End-of-RIB or the restart
+        //      timer, and RFC 9494 §4.2 retains LLGR-stale paths until the
+        //      LLGR timer — those owners sweep the route later.
+        //   4. GR/LLGR-stale acquired DURING the window: unreachable — GR
+        //      entry is session-down, which drops every refresh window for
+        //      the peer (`clear_peer_refresh_state`).
         let mut stale_count = 0usize;
         if let Some(rib) = self.ribs.get(&peer) {
             if safi == Safi::FlowSpec {
                 let stale = self.refresh_stale_flowspec.entry(peer).or_default();
                 stale.retain(|(stale_afi, _, _)| *stale_afi != afi);
-                for route in rib.iter_flowspec().filter(|route| route.afi == afi) {
+                for route in rib
+                    .iter_flowspec()
+                    .filter(|route| route.afi == afi && !route.is_stale && !route.is_llgr_stale)
+                {
                     if stale.insert((route.afi, route.rule.clone(), route.path_id)) {
                         stale_count += 1;
                     }
@@ -486,10 +508,9 @@ impl RibManager {
             } else if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
                 let stale = self.refresh_stale_bgpls.entry(peer).or_default();
                 stale.retain(|key| key.family != bgpls_family);
-                for route in rib
-                    .iter_bgpls()
-                    .filter(|route| route.family == bgpls_family)
-                {
+                for route in rib.iter_bgpls().filter(|route| {
+                    route.family == bgpls_family && !route.is_stale && !route.is_llgr_stale
+                }) {
                     if stale.insert(route.key()) {
                         stale_count += 1;
                     }
@@ -497,10 +518,9 @@ impl RibManager {
             } else if safi == Safi::MplsVpn {
                 let stale = self.refresh_stale_vpn.entry(peer).or_default();
                 stale.retain(|key| key.afi_safi() != (afi, safi));
-                for route in rib
-                    .iter_vpn()
-                    .filter(|route| route.afi_safi() == (afi, safi))
-                {
+                for route in rib.iter_vpn().filter(|route| {
+                    route.afi_safi() == (afi, safi) && !route.is_stale && !route.is_llgr_stale
+                }) {
                     if stale.insert(route.key()) {
                         stale_count += 1;
                     }
@@ -508,10 +528,9 @@ impl RibManager {
             } else if safi == Safi::LabeledUnicast {
                 let stale = self.refresh_stale_labeled.entry(peer).or_default();
                 stale.retain(|key| key.afi_safi() != (afi, safi));
-                for route in rib
-                    .iter_labeled()
-                    .filter(|route| route.afi_safi() == (afi, safi))
-                {
+                for route in rib.iter_labeled().filter(|route| {
+                    route.afi_safi() == (afi, safi) && !route.is_stale && !route.is_llgr_stale
+                }) {
                     if stale.insert(route.key()) {
                         stale_count += 1;
                     }
@@ -519,7 +538,10 @@ impl RibManager {
             } else if (afi, safi) == (Afi::L2Vpn, Safi::Evpn) {
                 let stale = self.refresh_stale_evpn.entry(peer).or_default();
                 stale.clear();
-                for route in rib.iter_evpn() {
+                for route in rib
+                    .iter_evpn()
+                    .filter(|route| !route.is_stale && !route.is_llgr_stale)
+                {
                     if stale.insert(route.key()) {
                         stale_count += 1;
                     }
@@ -529,7 +551,10 @@ impl RibManager {
                 // per-peer set is safe — the EVPN pattern, not the VPN one.
                 let stale = self.refresh_stale_rtc.entry(peer).or_default();
                 stale.clear();
-                for route in rib.iter_rtc() {
+                for route in rib
+                    .iter_rtc()
+                    .filter(|route| !route.is_stale && !route.is_llgr_stale)
+                {
                     if stale.insert(route.key()) {
                         stale_count += 1;
                     }
@@ -537,10 +562,11 @@ impl RibManager {
             } else {
                 let stale = self.refresh_stale_routes.entry(peer).or_default();
                 stale.retain(|(prefix, _)| prefix_family(prefix) != (afi, safi));
-                for route in rib
-                    .iter()
-                    .filter(|route| prefix_family(&route.prefix) == (afi, safi))
-                {
+                for route in rib.iter().filter(|route| {
+                    prefix_family(&route.prefix) == (afi, safi)
+                        && !route.is_stale
+                        && !route.is_llgr_stale
+                }) {
                     if stale.insert((route.prefix, route.path_id)) {
                         stale_count += 1;
                     }

--- a/crates/rib/src/manager/tests/refresh.rs
+++ b/crates/rib/src/manager/tests/refresh.rs
@@ -798,3 +798,290 @@ async fn enhanced_route_refresh_vpn_eorr_reflects_withdrawal_to_peer() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// LAN-187: an enhanced-refresh window completing while the peer is inside
+/// its GR window (re-established, End-of-RIB pending) must not purge the
+/// GR-stale routes RFC 4724 §4.1 retains until End-of-RIB — the restarting
+/// peer's replay is not authoritative while it is still converging.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one end-to-end GR + refresh-window walk: down, re-establish, BoRR..EoRR, End-of-RIB"
+)]
+#[tokio::test]
+async fn eorr_preserves_gr_stale_routes_awaiting_eor() {
+    let (tx, rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let retained_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![
+            make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_route(retained_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    // Peer re-establishes — still awaiting End-of-RIB, routes GR-stale.
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: source,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    // A refresh window opens mid-GR: GR-stale routes are owned by the GR
+    // machinery and must not enter the refresh snapshot.
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryLocRibCount { reply: reply_tx })
+        .await
+        .unwrap();
+    reply_rx.await.unwrap();
+    assert_refresh_metrics(&metrics, "10.0.0.1", "ipv4_unicast", 1.0, 0.0);
+
+    // Only `kept_prefix` is re-advertised inside the window.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+
+    // EoRR must NOT purge the GR-stale route: End-of-RIB (or the GR
+    // timer) resolves it, not the refresh sweep.
+    let mut received = query_received_routes(&tx, source).await;
+    received.sort_by_key(|r| r.prefix.to_string());
+    assert_eq!(
+        received.len(),
+        2,
+        "GR-stale route must survive the EoRR sweep until End-of-RIB"
+    );
+    assert!(!received[0].is_stale, "re-advertised route is fresh");
+    assert!(
+        received[1].is_stale,
+        "non-readvertised route stays GR-stale after EoRR"
+    );
+
+    // End-of-RIB then performs the RFC 4724 §4.1 removal as usual.
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let received = query_received_routes(&tx, source).await;
+    assert_eq!(received.len(), 1);
+    assert_eq!(received[0].prefix, Prefix::V4(kept_prefix));
+    assert!(!received[0].is_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-187 (LLGR arm): a route promoted to LLGR-stale (RFC 9494) whose peer
+/// re-established during the LLGR phase must equally survive an `EoRR` sweep
+/// — RFC 9494 §4.2 retains it until re-advertisement, End-of-RIB, or the
+/// LLGR timer.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one end-to-end LLGR + refresh-window walk: down, GR expiry, re-establish, BoRR..EoRR, End-of-RIB"
+)]
+#[tokio::test]
+async fn eorr_preserves_llgr_stale_routes_awaiting_eor() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let kept_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let retained_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![
+            make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_route(retained_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+        ],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 2,
+        stale_routes_time: 3600,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![rustbgpd_wire::LlgrFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            forwarding_preserved: false,
+            stale_time: 3600,
+        }],
+        llgr_stale_time: 3600,
+    })
+    .await
+    .unwrap();
+    let best = query_best_routes(&tx).await;
+    assert!(best.iter().all(|r| r.is_stale));
+
+    // GR timer expires → LLGR promotion.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    let best = query_best_routes(&tx).await;
+    assert!(best.iter().all(|r| r.is_llgr_stale));
+
+    // Peer re-establishes during LLGR (moves back to the GR wait-for-EoR
+    // phase, routes keep their LLGR-stale flag).
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        session_id: 0,
+        peer: source,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(kept_prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndRouteRefresh {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+
+    let mut received = query_received_routes(&tx, source).await;
+    received.sort_by_key(|r| r.prefix.to_string());
+    assert_eq!(
+        received.len(),
+        2,
+        "LLGR-stale route must survive the EoRR sweep until End-of-RIB"
+    );
+    assert!(!received[0].is_llgr_stale, "re-advertised route is fresh");
+    assert!(
+        received[1].is_llgr_stale,
+        "non-readvertised route stays LLGR-stale after EoRR"
+    );
+
+    // End-of-RIB then removes it (RFC 4724 §4.1 via RFC 9494 §4.2).
+    tx.send(RibUpdate::EndOfRib {
+        session_id: 0,
+        peer: source,
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+    })
+    .await
+    .unwrap();
+    let received = query_received_routes(&tx, source).await;
+    assert_eq!(received.len(), 1);
+    assert_eq!(received[0].prefix, Prefix::V4(kept_prefix));
+    assert!(!received[0].is_llgr_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -468,6 +468,16 @@ implemented per ADR-0040.
   unreplaced routes. 5-minute timeout on the refresh window.
 - Outbound: Enhanced peers get BoRR → routes → EoRR; legacy peers get
   routes → EoR.
+- Joint behavior with GR/LLGR retention (LAN-187): routes flagged
+  GR-stale or LLGR-stale are NOT snapshotted at BoRR, so EoRR (or the
+  window timeout) never purges them. A restarting peer's refresh replay
+  is not authoritative while it is still converging — RFC 4724 §4.1
+  retains stale paths until End-of-RIB or the restart timer, RFC 9494
+  §4.2 until the LLGR timer; those remain the only removal points. A
+  re-advertisement inside the window still clears both staleness kinds
+  via implicit replace. The reverse ordering (GR entry during an open
+  window) is a session-down, which drops all refresh windows for the
+  peer. Combination matrix in `handle_begin_route_refresh`.
 - See ADR-0038.
 
 ---


### PR DESCRIPTION
LAN-187. A real correctness bug, confirmed failing-first.

## The bug

`handle_begin_route_refresh` snapshotted every Adj-RIB-In route of the refreshed family at BoRR — including `is_stale`/`is_llgr_stale` entries. A refresh window opening while a GR-restarting peer was still converging meant EoRR (or the refresh timeout drain) withdrew every non-re-advertised snapshot entry — deleting exactly the paths RFC 4724 §4.1 / RFC 9494 §4.2 retain until EoR or the timers. A still-converging restarter's BoRR..EoRR replay is not authoritative for stale paths; this was the GR blackout the retention machinery exists to prevent. No flag collision was involved — the bug was purely snapshot scope.

## The joint-behavior matrix (documented in code + RFC_NOTES)

1. Snapshotted, not stale, not re-advertised → purge (RFC 7313 §4).
2. Re-advertised in-window → keep (implicit replace clears staleness + snapshot key).
3. GR/LLGR-stale at BoRR, not re-advertised → **preserve** (the fix — EoR/GR-timer/LLGR-timer remain the only removal points). Was: purged.
4. Stale acquired mid-window → unreachable (session-down drops all refresh windows) — verified, not fixed.

## Evidence + fix

Two manager-level tests fail on unfixed HEAD (stale route deleted at EoRR) and pass after; both also pin that the post-EoRR EoR still performs the §4.1 sweep, so GR resolution is unchanged. Fix: filter stale flags in the seven family snapshot arms — one seam drained by both EoRR and the timeout path.

Gates: workspace build/test (66 suites, rib 656), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.