### PR TITLE
feat(evpn): decompose mixed runtime edits into sequential primitive generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the system0 address). Receive/reflect proof only — bundle-mode
   origination and dataplane remain future ADR-0092 tranches.
 
+- **Mixed EVPN runtime edits now hot-apply on SIGHUP via a plan
+  decomposer ([#268](https://github.com/lance0/rustbgpd/issues/268)).**
+  A candidate combining EVPN changes the ADR-0063 converger dispatch
+  rejects as a single shape (e.g. an Ethernet Segment delete + its
+  member L2VNI's redefine + a new L2VNI add in one edit) is now split
+  into an ordered sequence of already-supported primitive plans —
+  deletes → redefines → `ip_vrf` relink → adds — each applied through
+  the unchanged converge path and each committing **its own runtime
+  generation** (one SIGHUP / `ApplyEvpnRuntime` = N generations,
+  visible in runtime snapshots and logs). Every step is validated up
+  front, before anything commits; candidates the fixed order cannot
+  express (relink away from a deleted IP-VRF, relink onto an added
+  IP-VRF, an ES left memberless mid-sequence) and IP-VRF
+  L3VNI/device/table identity redefines fail closed naming the
+  offending step. A residual mid-sequence convergence failure is
+  fail-stop: earlier generations stay committed (no cross-step
+  rollback), the model pins, and re-SIGHUP after fixing converges only
+  the remainder. `rustbgpd --diff` classifies decomposable mixed edits
+  as reload-applied ("decomposed: N steps"). IP-VRF identity redefines
+  stay restart-required by design (kernel VRF identity lifecycle); the
+  rationale is recorded in the ADR-0063 amendment and
+  docs/reload-matrix.md.
 - **Export-side explain: "why did/didn't route X go to peer Y?" now
   gets a full, truthful gate-ladder answer.** `ExplainAdvertisedRoute`
   (and `rbgp rib advertised <peer> --explain --prefix X`) now reports

--- a/docs/adr/0063-evpn-runtime-instance-mutation.md
+++ b/docs/adr/0063-evpn-runtime-instance-mutation.md
@@ -262,25 +262,45 @@ must pin the runtime snapshot to the committed model and keep surfacing drift.
   build-up also permits an existing ES row to expand `member_vnis` only when
   every new member VNI is added by the same candidate; ES member removal, ES
   non-member field changes, and existing-VNI membership expansion still fail
-  closed. The two shape families that remain non-live are by design:
-  **L3VNI/device/table IP-VRF identity changes** stay restart-required (a kernel
-  VRF lifecycle operation — a runtime drain/recreate would risk a dual-state
-  window; `router_mac` is still live-redefinable), and **broader ES/IP-VRF mixed
-  edits** fail closed with an operator-actionable "split the request or apply
-  the L2VNI-only change separately" error, pending a generalized
-  converge-to-candidate follow-up ([#268](https://github.com/lance0/rustbgpd/issues/268)).
-- Issue #133 (design) is resolved and closed; the remaining implementation is
-  tracked in #268.
+  closed *as single-shot shapes* but are covered by the plan decomposer below.
+- **Amendment (#268, plan decomposer).** A mixed candidate the dispatch
+  rejects now decomposes into an ordered sequence of already-supported
+  primitive plans — deletes → redefines (L2VNI batch, then per-IP-VRF, then
+  per-ES) → `ip_vrf` relink → adds — each applied through the unchanged
+  converge path and each committing **its own runtime generation**: operators
+  see N generations for one SIGHUP / `ApplyEvpnRuntime`. Every step is
+  validated as a supported primitive shape up front, before anything commits;
+  a candidate with an unsupported step (or a shape the fixed phase order
+  cannot express, e.g. relink-away-then-delete-IP-VRF, relink onto an IP-VRF
+  added in the same candidate, or an ES left memberless mid-sequence) fails
+  closed naming the offending step. A residual mid-sequence converge failure
+  is **fail-stop**: earlier generations stay committed (no cross-step
+  rollback), the coordinator pins the last good model, and a re-SIGHUP after
+  fixing the config replans from the committed model and converges only the
+  remainder. See the `src/evpn_plan_decomposer.rs` module doc for the full
+  ordering contract.
+- **L3VNI/device/table IP-VRF identity changes stay restart-required by
+  design** — this closes the #268 identity-redefine bullet with a rationale
+  rather than code: the L3VNI, VRF device, L3VXLAN device, and table id are
+  the IP-VRF's *kernel-object identity*; changing one is a VRF lifecycle
+  operation (destroy + recreate the kernel VRF), and a runtime
+  drain/recreate would risk a dual-state window where the kernel still holds
+  the old identity while the Type 5 originator publishes the new one.
+  `router_mac` is not identity and remains live-redefinable. The decomposer
+  deliberately refuses to "help" here: a candidate mixing an identity
+  redefine fails closed before any step commits.
+- Issue #133 (design) is resolved and closed; #268 is closed by the plan
+  decomposer plus the documented identity-redefine rationale above.
 
 ## Non-goals
 
 - No per-instance `AddEvpnInstance` / `DeleteEvpnInstance` protobuf surface;
   mutation is a whole-model apply via `EvpnService.ApplyEvpnRuntime`.
-- No hot SIGHUP apply outside the ADR-0063 supported shape set. In particular,
-  L3VNI/device/table IP-VRF identity changes, ES/IP-VRF row mixed edits beyond
-  additive ES member expansion and the supported L2VNI-only composer, and
-  runtime applies on daemons without the required EVPN actors remain
-  fail-closed.
+- No hot SIGHUP apply outside the ADR-0063 supported shape set and its #268
+  primitive decomposition. In particular, L3VNI/device/table IP-VRF identity
+  changes, mixed candidates whose decomposition would need a different phase
+  order (see the amendment above), and runtime applies on daemons without
+  the required EVPN actors remain fail-closed.
 - No automatic Linux bridge, VXLAN, VRF, or Ethernet Segment netdev
   creation.
 - No change to EVPN dataplane defaults such as `apply_bum_enforcement` or

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -235,21 +235,37 @@ live shapes as `EvpnService.ApplyEvpnRuntime`: single L2VNI/IP-VRF/ES
 add/delete/redefine within the documented identity bounds, atomic tenant
 teardown, `ip_vrf` relink, additive build-up, and standalone L2VNI swaps that
 only combine L2VNI adds with standalone L2VNI deletes, plus L2VNI-only batch
-redefines that do not relink IP-VRF membership. The runtime snapshot advances
-only after the coordinator and daemon actor converger accept the
-candidate. Unsupported shapes, missing EVPN actors, or actor convergence
-failure are pinned back to the committed runtime model and logged at `ERROR`,
-so repeated SIGHUPs keep surfacing the drift. Static `rustbgpd --diff` is
-shape-aware: it lists coordinator-supported EVPN edits under reload-applied and
-keeps unsupported mixed edits or restart-only identity changes in
-restart-required. The static diff still cannot predict live actor availability
-or a later convergence failure; those remain runtime SIGHUP outcomes.
+redefines that do not relink IP-VRF membership. Mixed edits beyond those
+shapes now hot-apply through the **#268 plan decomposer**: the candidate is
+split into an ordered sequence of already-supported primitive plans (deletes
+→ redefines → `ip_vrf` relink → adds), each committing **its own runtime
+generation** — one SIGHUP produces N generations in `rbgp`/gRPC runtime
+snapshots and logs, one per step. Every step is validated up front, before
+anything commits; a candidate with an unsupported step (an IP-VRF
+L3VNI/device/table identity redefine, or a shape the fixed phase order
+cannot express — relink away from an IP-VRF deleted in the same candidate,
+relink onto an IP-VRF added in the same candidate, an ES left memberless
+mid-sequence) fails closed naming the offending step. A residual
+mid-sequence convergence failure is fail-stop: generations committed by
+earlier steps stay committed (no cross-step rollback), the model pins, and a
+re-SIGHUP after fixing the config converges only the remainder. The runtime
+snapshot advances only after the coordinator and daemon actor converger
+accept the candidate. Unsupported shapes, missing EVPN actors, or actor
+convergence failure are pinned back to the committed runtime model and
+logged at `ERROR`, so repeated SIGHUPs keep surfacing the drift. Static
+`rustbgpd --diff` is shape-aware: it lists coordinator-supported EVPN edits
+under reload-applied — a decomposable mixed edit shows as "hot-applied
+through the ADR-0063 coordinator (decomposed: N steps, one runtime
+generation each)" — and keeps undecomposable mixed edits or restart-only
+identity changes in restart-required. The static diff still cannot predict
+live actor availability or a later convergence failure; those remain runtime
+SIGHUP outcomes.
 
 | Section | Class | Notes |
 |---|---|---|
-| `[[evpn_instances]]` | coordinator-gated | Supported ADR-0063 L2VNI shapes hot-apply, including standalone L2VNI swaps and L2VNI-only batch redefines; unsupported mixed edits, missing actors, or convergence failure pin/log. |
-| `[[evpn_ip_vrfs]]` | coordinator-gated | Supported IP-VRF add/delete/redefine and `ip_vrf` relink hot-apply; L3VNI/device/table identity changes stay restart-required. |
-| `[[ethernet_segments]]` | coordinator-gated | Supported ES add/delete/redefine and atomic tenant teardown hot-apply when the segment actor can converge. |
+| `[[evpn_instances]]` | coordinator-gated | Supported ADR-0063 L2VNI shapes hot-apply, including standalone L2VNI swaps and L2VNI-only batch redefines; mixed edits decompose into ordered primitive steps (#268), one committed generation per step; undecomposable shapes, missing actors, or convergence failure pin/log. |
+| `[[evpn_ip_vrfs]]` | coordinator-gated | Supported IP-VRF add/delete/redefine and `ip_vrf` relink hot-apply, including decomposed mixed edits (#268); L3VNI/device/table identity changes stay restart-required by design — kernel VRF identity lifecycle (destroy + recreate); a runtime drain/recreate risks a dual-state window (see the ADR-0063 amendment). |
+| `[[ethernet_segments]]` | coordinator-gated | Supported ES add/delete/redefine and atomic tenant teardown hot-apply when the segment actor can converge; mixed edits decompose (#268) with ES redefines applied one segment per generation. |
 | `[managed_netdevs]` | restart-required | ADR-0091 bridge, fixed-VNI VXLAN, SVD / collect-metadata VXLAN, VLAN upper, VRF, and L3VXLAN lifecycle is resolved at startup and reconciled by the dataplane actor (create, stamp, restart adoption, same-owner orphan reap). Managed netdevs are not live-mutable in this tranche. |
 
 ## `[[fib_tables]]` and FIB runtime

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1880,6 +1880,11 @@ pub enum EvpnRuntimeChangeClass {
     /// can hot-apply on SIGHUP, subject to the live actor being
     /// present and accepting the candidate.
     ReloadApplied,
+    /// The edit is a mixed shape the #268 plan decomposer splits into
+    /// `steps` ordered primitive plans, each committed by SIGHUP as its
+    /// own runtime generation (operators see `steps` generations for
+    /// one reload).
+    ReloadAppliedDecomposed { steps: usize },
     /// The edit is a generic/mixed/identity shape the current
     /// runtime coordinator rejects, or the diff could not resolve a
     /// typed EVPN model defensively. A restart is required.
@@ -1888,7 +1893,19 @@ pub enum EvpnRuntimeChangeClass {
 
 impl EvpnRuntimeChangeClass {
     const fn is_reload_applied(self) -> bool {
-        matches!(self, Self::ReloadApplied)
+        matches!(
+            self,
+            Self::ReloadApplied | Self::ReloadAppliedDecomposed { .. }
+        )
+    }
+
+    /// Number of decomposed primitive steps when the edit hot-applies
+    /// via the #268 plan decomposer.
+    const fn decomposed_steps(self) -> Option<usize> {
+        match self {
+            Self::ReloadAppliedDecomposed { steps } => Some(steps),
+            _ => None,
+        }
     }
 
     const fn is_restart_required(self) -> bool {
@@ -2682,7 +2699,14 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
                 style.change_marker
             );
         }
-        if diff.evpn_runtime_change_class.is_reload_applied() {
+        if let Some(steps) = diff.evpn_runtime_change_class.decomposed_steps() {
+            let _ = writeln!(
+                out,
+                "  {} EVPN runtime model hot-applied through the ADR-0063 coordinator \
+                 (decomposed: {steps} steps, one runtime generation each)",
+                style.change_marker
+            );
+        } else if diff.evpn_runtime_change_class.is_reload_applied() {
             let _ = writeln!(
                 out,
                 "  {} EVPN runtime model hot-applied through the ADR-0063 coordinator",
@@ -2878,6 +2902,13 @@ fn classify_evpn_runtime_change(old: &Config, new: &Config) -> EvpnRuntimeChange
     let plan = current.plan_candidate(&candidate);
     if evpn_runtime_plan_is_reload_applied(&current, &candidate, &plan) {
         EvpnRuntimeChangeClass::ReloadApplied
+    } else if let Ok(steps) =
+        crate::evpn_plan_decomposer::decompose_evpn_runtime_candidate(&current, &candidate, &plan)
+    {
+        // #268: a mixed shape the coordinator dispatch rejects may still
+        // converge on SIGHUP as an ordered sequence of primitive steps,
+        // each committing its own runtime generation.
+        EvpnRuntimeChangeClass::ReloadAppliedDecomposed { steps: steps.len() }
     } else {
         EvpnRuntimeChangeClass::RestartRequired
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5956,7 +5956,7 @@ bridge_vlan = 10
 }
 
 #[test]
-fn evpn_instance_swap_with_es_member_delete_stays_restart_required() {
+fn evpn_instance_swap_with_es_member_delete_decomposes_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"
 [[evpn_instances]]
@@ -5998,12 +5998,14 @@ local_vtep_ip = "10.0.0.100"
 
     assert!(diff.evpn_instances_changed);
     assert!(diff.ethernet_segments_changed);
+    // #268: the ES-member delete decomposes into an atomic-teardown step
+    // (L2VNI 100 + its ES) followed by the L2VNI 300 add step.
     assert_eq!(
         diff.evpn_runtime_change_class,
-        EvpnRuntimeChangeClass::RestartRequired
+        EvpnRuntimeChangeClass::ReloadAppliedDecomposed { steps: 2 }
     );
-    assert!(!diff.has_reload_applied_changes());
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
 }
 
 #[test]
@@ -6061,7 +6063,7 @@ originator_ip = "10.0.0.100"
 }
 
 #[test]
-fn evpn_instance_add_existing_es_field_change_stays_restart_required() {
+fn evpn_instance_add_existing_es_field_change_decomposes_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"
 [[evpn_instances]]
@@ -6102,12 +6104,14 @@ originator_ip = "10.0.0.101"
     let diff = diff_config(&old, &new);
     assert!(diff.evpn_instances_changed);
     assert!(diff.ethernet_segments_changed);
+    // #268: the ES field change + add-only build-up decomposes into an ES
+    // redefine step followed by the add step, each its own generation.
     assert_eq!(
         diff.evpn_runtime_change_class,
-        EvpnRuntimeChangeClass::RestartRequired
+        EvpnRuntimeChangeClass::ReloadAppliedDecomposed { steps: 2 }
     );
-    assert!(!diff.has_reload_applied_changes());
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
 }
 
 #[test]
@@ -6310,7 +6314,7 @@ local_vtep_ip = "10.0.0.100"
 }
 
 #[test]
-fn evpn_instance_multi_redefine_relink_stays_restart_required() {
+fn evpn_instance_multi_redefine_relink_decomposes_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"
 [[evpn_instances]]
@@ -6371,20 +6375,24 @@ table_id = 5000
     let diff = diff_config(&old, &new);
 
     assert!(diff.evpn_instances_changed);
+    // #268: decomposes into a batch L2VNI redefine step and a pure relink step.
     assert_eq!(
         diff.evpn_runtime_change_class,
-        EvpnRuntimeChangeClass::RestartRequired
+        EvpnRuntimeChangeClass::ReloadAppliedDecomposed { steps: 2 }
     );
-    assert!(!diff.has_reload_applied_changes());
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
     let json = config_diff_json_value(&diff);
-    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
-    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
-    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+    assert_eq!(
+        json["evpn_runtime_change_class"]["reload_applied_decomposed"]["steps"],
+        2
+    );
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
 }
 
 #[test]
-fn evpn_instance_mixed_redefine_relink_stays_restart_required() {
+fn evpn_instance_mixed_redefine_relink_decomposes_reload_applied() {
     let old = parse(&evpn_toml_with(
         r#"
 [[evpn_instances]]
@@ -6445,16 +6453,20 @@ table_id = 5000
     let diff = diff_config(&old, &new);
 
     assert!(diff.evpn_instances_changed);
+    // #268: decomposes into deletes, L2VNI redefine, relink, and add steps.
     assert_eq!(
         diff.evpn_runtime_change_class,
-        EvpnRuntimeChangeClass::RestartRequired
+        EvpnRuntimeChangeClass::ReloadAppliedDecomposed { steps: 4 }
     );
-    assert!(!diff.has_reload_applied_changes());
-    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert!(!diff.has_restart_required_changes());
     let json = config_diff_json_value(&diff);
-    assert_eq!(json["evpn_runtime_change_class"], "restart_required");
-    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], false);
-    assert_eq!(json["restart_required"]["evpn_instances_changed"], true);
+    assert_eq!(
+        json["evpn_runtime_change_class"]["reload_applied_decomposed"]["steps"],
+        4
+    );
+    assert_eq!(json["reload_applied"]["evpn_runtime_changed"], true);
+    assert_eq!(json["restart_required"]["evpn_instances_changed"], false);
 }
 
 #[test]

--- a/src/evpn_plan_decomposer.rs
+++ b/src/evpn_plan_decomposer.rs
@@ -1,0 +1,965 @@
+//! EVPN runtime plan decomposer (#268, ADR-0063).
+//!
+//! Turns a *mixed* EVPN runtime candidate — one the converger dispatch
+//! rejects as an unsupported composition — into an ordered sequence of
+//! already-supported primitive plans. Each step is applied through the
+//! unchanged converge path (its own validation, its own generation
+//! commit), so one SIGHUP / `ApplyEvpnRuntime` produces **N committed
+//! runtime generations**, one per step.
+//!
+//! # Ordering contract
+//!
+//! Steps are emitted in a fixed phase order:
+//!
+//! 1. **deletes** — every deleted L2VNI / IP-VRF / Ethernet Segment in
+//!    one step (routing to the existing single-delete or atomic
+//!    tenant-teardown shapes). Surviving Ethernet Segments are
+//!    member-shrunk by exactly the deleted VNIs.
+//! 2. **redefines** — one batch step for L2VNI redefines, then one step
+//!    per redefined IP-VRF, then one step per redefined Ethernet
+//!    Segment (each primitive validator accepts exactly one). ES
+//!    redefines at this phase carry the candidate row with any
+//!    *newly added* member VNIs held back for the add step.
+//! 3. **relink** — one pure `ip_vrf` relink step moving every surviving
+//!    L2VNI's link to its candidate target.
+//! 4. **adds** — everything remaining, as one additive build-up (or
+//!    single-add) step whose candidate is the operator's candidate
+//!    verbatim.
+//!
+//! Deletes-first frees identities (VNIs, VRF names, table ids, ESIs,
+//! ES-member slots) that later adds may reuse; adds-last guarantees
+//! every earlier step references only rows that already exist.
+//!
+//! # Shapes where the fixed order is WRONG (fail closed, no reordering)
+//!
+//! - **Relink away from a deleted IP-VRF**: the delete step runs before
+//!   the relink step, so the surviving L2VNI's link would dangle.
+//!   Apply the relink first, then delete the IP-VRF (two changes).
+//! - **Relink of an existing L2VNI onto a newly added IP-VRF**: the
+//!   relink step runs before the add step, so the target VRF does not
+//!   exist yet. Add the IP-VRF first, then relink (two changes).
+//! - **Ethernet Segment left memberless mid-sequence**: deleting all of
+//!   an ES's current member VNIs while re-membering it with VNIs that
+//!   only appear in the add step (or redefining away every
+//!   pre-existing member) would leave the ES empty between steps.
+//! - Any step that fails its primitive validator (notably an IP-VRF
+//!   **L3VNI / device / table identity redefine**, which is
+//!   restart-required by design) fails the whole candidate closed with
+//!   that validator's error, naming the offending step, before any
+//!   step commits.
+//!
+//! # Failure semantics
+//!
+//! The precondition simulation below validates every step against the
+//! model it would see, *before anything commits*. A residual
+//! mid-sequence failure (actor gone, publish failure) is **fail-stop**:
+//! generations committed by earlier steps stay committed (no
+//! cross-step rollback), the coordinator pins the last good model, and
+//! the operator fixes the config and re-SIGHUPs / re-applies — the
+//! next attempt replans from the committed model and converges only
+//! the remainder.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rustbgpd_evpn::{
+    EthernetSegment, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, EvpnRuntimeCandidate,
+    EvpnRuntimeModel, EvpnRuntimePlan, IpVrf, IpVrfTable,
+};
+use rustbgpd_wire::EthernetSegmentIdentifier;
+
+use crate::evpn_runtime_converger::validate_supported_plan_shape;
+
+/// One primitive step of a decomposed mixed candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DecomposedStep {
+    /// Operator-facing summary of what this step changes.
+    pub(crate) description: String,
+    /// Full-model candidate for this step; applied through the
+    /// existing converge path and committed as its own generation.
+    pub(crate) candidate: EvpnRuntimeCandidate,
+}
+
+/// Why a candidate did not decompose.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EvpnDecomposeError {
+    /// The plan is already a supported primitive shape (or a no-op);
+    /// decomposition does not apply and the caller's original outcome
+    /// stands.
+    AlreadyPrimitive,
+    /// The candidate cannot decompose into supported primitive steps;
+    /// the message names the offending step and embeds the primitive
+    /// validator's error. Nothing was committed.
+    Unsupported(String),
+}
+
+fn unsupported(message: impl Into<String>) -> EvpnDecomposeError {
+    EvpnDecomposeError::Unsupported(message.into())
+}
+
+fn parse_vnis(raw: &[u32]) -> Result<BTreeSet<EvpnInstanceId>, EvpnDecomposeError> {
+    raw.iter()
+        .map(|&raw| {
+            EvpnInstanceId::new(raw)
+                .map_err(|err| unsupported(format!("invalid planned L2VNI {raw}: {err}")))
+        })
+        .collect()
+}
+
+fn build_candidate(
+    instances: &BTreeMap<EvpnInstanceId, EvpnInstance>,
+    vrfs: &BTreeMap<String, IpVrf>,
+    links: &BTreeMap<EvpnInstanceId, String>,
+    segments: &BTreeMap<EthernetSegmentIdentifier, EthernetSegment>,
+) -> Result<EvpnRuntimeCandidate, EvpnDecomposeError> {
+    let mut instance_table = EvpnInstanceTable::new();
+    for instance in instances.values() {
+        instance_table.insert(instance.clone()).map_err(|err| {
+            unsupported(format!(
+                "cannot decompose: intermediate L2VNI table invalid: {err}"
+            ))
+        })?;
+    }
+    let mut vrf_table = IpVrfTable::new();
+    for vrf in vrfs.values() {
+        vrf_table.insert(vrf.clone()).map_err(|err| {
+            unsupported(format!(
+                "cannot decompose: intermediate IP-VRF table invalid: {err}"
+            ))
+        })?;
+    }
+    for (vni, name) in links {
+        vrf_table.mark_referenced_by_l2vni(name.clone(), *vni);
+    }
+    Ok(EvpnRuntimeCandidate::new(
+        instance_table,
+        vrf_table,
+        segments.values().cloned().collect(),
+    ))
+}
+
+/// Decompose a mixed EVPN runtime candidate into ordered primitive
+/// steps (deletes → redefines → relink → adds). See the module doc for
+/// the ordering contract and the fail-closed wrong-order shapes.
+///
+/// # Errors
+/// [`EvpnDecomposeError::AlreadyPrimitive`] when the plan is a no-op or
+/// already a supported single shape; [`EvpnDecomposeError::Unsupported`]
+/// when a wrong-order shape or an unsupported step (e.g. an IP-VRF
+/// identity redefine) makes the whole candidate fail closed.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the phase-ordered synthesis reads clearest as one sequence mirroring the module-doc ordering contract"
+)]
+pub(crate) fn decompose_evpn_runtime_candidate(
+    current: &EvpnRuntimeModel,
+    candidate: &EvpnRuntimeCandidate,
+    plan: &EvpnRuntimePlan,
+) -> Result<Vec<DecomposedStep>, EvpnDecomposeError> {
+    if plan.is_noop() || validate_supported_plan_shape(current, candidate, plan).is_ok() {
+        return Err(EvpnDecomposeError::AlreadyPrimitive);
+    }
+
+    let deleted_vnis = parse_vnis(&plan.evpn_instances.deleted)?;
+    let added_vnis = parse_vnis(&plan.evpn_instances.added)?;
+    let redefined_vnis = parse_vnis(&plan.evpn_instances.redefined)?;
+    let deleted_vrfs: BTreeSet<&String> = plan.ip_vrfs.deleted.iter().collect();
+    let added_vrfs: BTreeSet<&String> = plan.ip_vrfs.added.iter().collect();
+
+    let cur_links = current.ip_vrfs().l2vni_link_map();
+    let cand_links = candidate.ip_vrfs().l2vni_link_map();
+
+    // Wrong-order guard: a surviving L2VNI still linked (in the committed
+    // model) to an IP-VRF this candidate deletes would dangle when the
+    // delete step (ordered first) runs.
+    for (vni, vrf_name) in &cur_links {
+        if !deleted_vnis.contains(vni) && deleted_vrfs.contains(vrf_name) {
+            return Err(unsupported(format!(
+                "cannot decompose: IP-VRF {vrf_name:?} is deleted while surviving L2VNI {vni} \
+                 still links to it when the delete step (ordered first) runs; apply the \
+                 relink/unlink as its own change first, then delete the IP-VRF"
+            )));
+        }
+    }
+    // Wrong-order guard: an existing L2VNI relinking onto an IP-VRF this
+    // candidate adds would target a VRF that does not exist until the add
+    // step (ordered last).
+    for (vni, vrf_name) in &cand_links {
+        if !added_vnis.contains(vni) && added_vrfs.contains(vrf_name) {
+            return Err(unsupported(format!(
+                "cannot decompose: L2VNI {vni} links to IP-VRF {vrf_name:?}, which is added \
+                 only in the final add step (relinks are ordered before adds); add the IP-VRF \
+                 as its own change first, then relink"
+            )));
+        }
+    }
+
+    // Working state, advanced phase by phase from the committed model.
+    let mut instances: BTreeMap<EvpnInstanceId, EvpnInstance> = current
+        .instances()
+        .iter()
+        .map(|instance| (instance.id, instance.clone()))
+        .collect();
+    let mut vrfs: BTreeMap<String, IpVrf> = current
+        .ip_vrfs()
+        .iter()
+        .map(|vrf| (vrf.name.clone(), vrf.clone()))
+        .collect();
+    let mut links = cur_links;
+    let mut segments: BTreeMap<EthernetSegmentIdentifier, EthernetSegment> = current
+        .ethernet_segments()
+        .iter()
+        .map(|segment| (segment.esi, segment.clone()))
+        .collect();
+
+    let mut steps: Vec<DecomposedStep> = Vec::new();
+
+    // Phase 1: deletes (one step; routes to single-delete or tenant teardown).
+    if !deleted_vnis.is_empty()
+        || !plan.ip_vrfs.deleted.is_empty()
+        || !plan.ethernet_segments.deleted.is_empty()
+    {
+        for vni in &deleted_vnis {
+            instances.remove(vni);
+            links.remove(vni);
+        }
+        for name in &plan.ip_vrfs.deleted {
+            vrfs.remove(name);
+        }
+        for esi in &plan.ethernet_segments.deleted {
+            segments.remove(esi);
+        }
+        for segment in segments.values_mut() {
+            let shrunk: BTreeSet<EvpnInstanceId> = segment
+                .member_vnis
+                .iter()
+                .filter(|vni| !deleted_vnis.contains(vni))
+                .copied()
+                .collect();
+            if shrunk.len() != segment.member_vnis.len() {
+                if shrunk.is_empty() {
+                    return Err(unsupported(format!(
+                        "cannot decompose: deleting its current member VNIs would leave \
+                         Ethernet Segment {} with no members at the delete step (ordered \
+                         first); replace the segment's membership in its own change instead",
+                        segment.esi
+                    )));
+                }
+                segment.member_vnis = shrunk;
+            }
+        }
+        steps.push(DecomposedStep {
+            description: format!(
+                "deletes ({} L2VNI, {} IP-VRF, {} Ethernet Segment)",
+                deleted_vnis.len(),
+                plan.ip_vrfs.deleted.len(),
+                plan.ethernet_segments.deleted.len()
+            ),
+            candidate: build_candidate(&instances, &vrfs, &links, &segments)?,
+        });
+    }
+
+    // Phase 2a: L2VNI redefines (one batch step; single and batch are both
+    // supported primitive shapes).
+    if !redefined_vnis.is_empty() {
+        for vni in &redefined_vnis {
+            let row = candidate.instances().get(*vni).ok_or_else(|| {
+                unsupported(format!(
+                    "candidate is missing planned redefined L2VNI {vni}"
+                ))
+            })?;
+            instances.insert(*vni, row.clone());
+        }
+        steps.push(DecomposedStep {
+            description: format!("L2VNI redefine ({} instance(s))", redefined_vnis.len()),
+            candidate: build_candidate(&instances, &vrfs, &links, &segments)?,
+        });
+    }
+
+    // Phase 2b: IP-VRF redefines (one step per VRF; the primitive validator
+    // accepts exactly one, and rejects identity redefines fail-closed).
+    let mut redefined_vrfs = plan.ip_vrfs.redefined.clone();
+    redefined_vrfs.sort();
+    for name in &redefined_vrfs {
+        let row = candidate.ip_vrfs().get(name).ok_or_else(|| {
+            unsupported(format!(
+                "candidate is missing planned redefined IP-VRF {name:?}"
+            ))
+        })?;
+        vrfs.insert(name.clone(), row.clone());
+        steps.push(DecomposedStep {
+            description: format!("IP-VRF {name:?} redefine"),
+            candidate: build_candidate(&instances, &vrfs, &links, &segments)?,
+        });
+    }
+
+    // Phase 2c: Ethernet Segment redefines (one step per ES). Newly added
+    // member VNIs are held back for the add step (additive member
+    // expansion); a redefine whose only delta is that expansion needs no
+    // step here.
+    let mut redefined_esis = plan.ethernet_segments.redefined.clone();
+    redefined_esis.sort();
+    for esi in &redefined_esis {
+        let cand_row = candidate
+            .ethernet_segments()
+            .iter()
+            .find(|segment| segment.esi == *esi)
+            .ok_or_else(|| {
+                unsupported(format!(
+                    "candidate is missing planned redefined Ethernet Segment {esi}"
+                ))
+            })?;
+        let working = segments.get(esi).ok_or_else(|| {
+            unsupported(format!(
+                "planned redefined Ethernet Segment {esi} is not committed"
+            ))
+        })?;
+        let mut target = cand_row.clone();
+        target.member_vnis = cand_row
+            .member_vnis
+            .iter()
+            .filter(|vni| !added_vnis.contains(vni))
+            .copied()
+            .collect();
+        if target == *working {
+            continue;
+        }
+        if target.member_vnis.is_empty() {
+            return Err(unsupported(format!(
+                "cannot decompose: every candidate member VNI of Ethernet Segment {esi} is \
+                 newly added, so the redefine step (ordered before adds) would leave the \
+                 segment with no members; add the member VNIs first, then redefine the segment"
+            )));
+        }
+        segments.insert(*esi, target);
+        steps.push(DecomposedStep {
+            description: format!("Ethernet Segment {esi} redefine"),
+            candidate: build_candidate(&instances, &vrfs, &links, &segments)?,
+        });
+    }
+
+    // Phase 3: pure ip_vrf relink for surviving L2VNIs.
+    let desired_links: BTreeMap<EvpnInstanceId, String> = cand_links
+        .iter()
+        .filter(|(vni, _)| instances.contains_key(vni))
+        .map(|(vni, name)| (*vni, name.clone()))
+        .collect();
+    if desired_links != links {
+        links = desired_links;
+        steps.push(DecomposedStep {
+            description: "ip_vrf relink".to_string(),
+            candidate: build_candidate(&instances, &vrfs, &links, &segments)?,
+        });
+    }
+
+    // Phase 4: adds — the final step is the operator's candidate verbatim.
+    let working = build_candidate(&instances, &vrfs, &links, &segments)?;
+    if working != *candidate {
+        steps.push(DecomposedStep {
+            description: format!(
+                "adds ({} L2VNI, {} IP-VRF, {} Ethernet Segment)",
+                added_vnis.len(),
+                plan.ip_vrfs.added.len(),
+                plan.ethernet_segments.added.len()
+            ),
+            candidate: candidate.clone(),
+        });
+    }
+
+    if steps.len() < 2 {
+        // A single-step "decomposition" is the original plan; the caller's
+        // original outcome (today's fail-closed error) stands.
+        return Err(EvpnDecomposeError::AlreadyPrimitive);
+    }
+
+    // Precondition: simulate the sequence and validate every step as a
+    // supported primitive shape BEFORE anything commits. A failure here
+    // fails the whole candidate closed, naming the offending step.
+    let total = steps.len();
+    let mut model = current.clone();
+    for (index, step) in steps.iter().enumerate() {
+        let step_plan = model.plan_candidate(&step.candidate);
+        validate_supported_plan_shape(&model, &step.candidate, &step_plan).map_err(|err| {
+            unsupported(format!(
+                "mixed EVPN runtime candidate does not decompose into supported primitive \
+                 steps: step {}/{} ({}) fails validation: {}",
+                index + 1,
+                total,
+                step.description,
+                err.message()
+            ))
+        })?;
+        model = EvpnRuntimeModel::startup(
+            step.candidate.instances().clone(),
+            step.candidate.ip_vrfs().clone(),
+            step.candidate.ethernet_segments().to_vec(),
+        );
+    }
+
+    Ok(steps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn candidate_from_toml(toml: &str) -> EvpnRuntimeCandidate {
+        let config = Config::load_toml_with_diagnostics(toml, "decomposer test config").unwrap();
+        EvpnRuntimeCandidate::new(
+            config.resolve_evpn_instances().unwrap(),
+            config.resolve_evpn_ip_vrfs().unwrap(),
+            config.resolve_ethernet_segments().unwrap(),
+        )
+    }
+
+    fn model_from_toml(toml: &str) -> EvpnRuntimeModel {
+        let candidate = candidate_from_toml(toml);
+        EvpnRuntimeModel::startup(
+            candidate.instances().clone(),
+            candidate.ip_vrfs().clone(),
+            candidate.ethernet_segments().to_vec(),
+        )
+    }
+
+    fn decompose(
+        current_toml: &str,
+        candidate_toml: &str,
+    ) -> Result<Vec<DecomposedStep>, EvpnDecomposeError> {
+        let current = model_from_toml(current_toml);
+        let candidate = candidate_from_toml(candidate_toml);
+        let plan = current.plan_candidate(&candidate);
+        decompose_evpn_runtime_candidate(&current, &candidate, &plan)
+    }
+
+    const HEADER: &str = r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+"#;
+
+    fn with_header(body: &str) -> String {
+        format!("{HEADER}{body}")
+    }
+
+    fn vni(raw: u32) -> EvpnInstanceId {
+        EvpnInstanceId::new(raw).unwrap()
+    }
+
+    // The maintainer's #268 example shape: delete an ES, redefine its
+    // (surviving) member L2VNI, and add a new L2VNI — one candidate.
+    fn maintainer_example() -> (String, String) {
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.1"
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:101"
+route_targets = ["65000:101"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+        (current, candidate)
+    }
+
+    #[test]
+    fn maintainer_example_decomposes_deletes_then_redefine_then_add() {
+        let (current, candidate) = maintainer_example();
+        let steps = decompose(&current, &candidate).unwrap();
+        assert_eq!(
+            steps.len(),
+            3,
+            "expected deletes, redefine, add: {steps:#?}"
+        );
+
+        // Step 1: ES delete only; VNI 100 keeps its committed definition.
+        assert!(steps[0].description.starts_with("deletes"));
+        assert!(steps[0].candidate.ethernet_segments().is_empty());
+        assert_eq!(
+            steps[0]
+                .candidate
+                .instances()
+                .get(vni(100))
+                .unwrap()
+                .rd
+                .to_string(),
+            "65000:100"
+        );
+        assert!(steps[0].candidate.instances().get(vni(200)).is_none());
+
+        // Step 2: L2VNI 100 redefined; 200 still absent.
+        assert!(steps[1].description.starts_with("L2VNI redefine"));
+        assert_eq!(
+            steps[1]
+                .candidate
+                .instances()
+                .get(vni(100))
+                .unwrap()
+                .rd
+                .to_string(),
+            "65000:101"
+        );
+        assert!(steps[1].candidate.instances().get(vni(200)).is_none());
+
+        // Step 3: the add; final candidate verbatim.
+        assert!(steps[2].description.starts_with("adds"));
+        assert!(steps[2].candidate.instances().get(vni(200)).is_some());
+    }
+
+    #[test]
+    fn supported_single_shape_is_already_primitive() {
+        let current = with_header("");
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+        assert_eq!(
+            decompose(&current, &candidate),
+            Err(EvpnDecomposeError::AlreadyPrimitive)
+        );
+    }
+
+    #[test]
+    fn noop_is_already_primitive() {
+        let current = with_header("");
+        assert_eq!(
+            decompose(&current, &current.clone()),
+            Err(EvpnDecomposeError::AlreadyPrimitive)
+        );
+    }
+
+    #[test]
+    fn ip_vrf_identity_redefine_fails_closed_naming_the_step() {
+        // Mixed: L2VNI add + IP-VRF l3vni (identity) redefine. The whole
+        // candidate must fail closed with the identity validator's error,
+        // naming the offending step, before anything commits.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5001
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+"#,
+        );
+        let Err(EvpnDecomposeError::Unsupported(message)) = decompose(&current, &candidate) else {
+            panic!("identity redefine must fail closed");
+        };
+        assert!(
+            message.contains("step 1/2"),
+            "step naming missing: {message}"
+        );
+        assert!(
+            message.contains("restart-required by design"),
+            "must carry today's identity-redefine error: {message}"
+        );
+    }
+
+    #[test]
+    fn relink_away_from_deleted_ip_vrf_fails_closed() {
+        // VNI 100 linked to tenant-blue; candidate deletes tenant-blue and
+        // relinks 100 to tenant-green. Deletes-first would dangle the link.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-blue"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-green"
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let Err(EvpnDecomposeError::Unsupported(message)) = decompose(&current, &candidate) else {
+            panic!("relink-away-from-deleted-vrf must fail closed");
+        };
+        assert!(
+            message.contains("apply the relink/unlink as its own change first"),
+            "wrong-order error expected: {message}"
+        );
+    }
+
+    #[test]
+    fn relink_onto_added_ip_vrf_fails_closed() {
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+        // Deleting VNI 200 makes this a mixed (delete + relink-onto-added-vrf)
+        // candidate; the relink of existing VNI 100 onto the added VRF must
+        // fail closed.
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-green"
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let Err(EvpnDecomposeError::Unsupported(message)) = decompose(&current, &candidate) else {
+            panic!("relink-onto-added-vrf must fail closed");
+        };
+        assert!(
+            message.contains("add the IP-VRF as its own change first"),
+            "wrong-order error expected: {message}"
+        );
+    }
+
+    #[test]
+    fn es_membership_replacement_fails_closed_when_memberless_mid_sequence() {
+        // ES keeps existing but its only member is deleted and replaced by a
+        // newly added VNI — the segment would be memberless between the
+        // delete step and the add step.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.1"
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [200]
+originator_ip = "10.0.0.1"
+"#,
+        );
+        let Err(EvpnDecomposeError::Unsupported(message)) = decompose(&current, &candidate) else {
+            panic!("memberless-mid-sequence ES must fail closed");
+        };
+        assert!(
+            message.contains("no members at the delete step"),
+            "wrong-order error expected: {message}"
+        );
+    }
+
+    #[test]
+    fn per_phase_grouping_splits_ip_vrf_redefines_and_batches_l2vni_redefines() {
+        // Two L2VNI redefines (one batch step) + two IP-VRF non-identity
+        // redefines (one step each) + one add (final step) = 4 steps.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:110"
+route_targets = ["65000:110"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:210"
+route_targets = ["65000:210"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5100"
+route_targets = ["65000:5100"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5101"
+route_targets = ["65000:5101"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let steps = decompose(&current, &candidate).unwrap();
+        let descriptions: Vec<&str> = steps.iter().map(|s| s.description.as_str()).collect();
+        assert_eq!(steps.len(), 4, "{descriptions:?}");
+        assert!(
+            descriptions[0].starts_with("L2VNI redefine (2"),
+            "{descriptions:?}"
+        );
+        assert!(descriptions[1].contains("tenant-blue"), "{descriptions:?}");
+        assert!(descriptions[2].contains("tenant-green"), "{descriptions:?}");
+        assert!(descriptions[3].starts_with("adds"), "{descriptions:?}");
+    }
+
+    #[test]
+    fn delete_plus_relink_of_surviving_vni_orders_delete_then_relink() {
+        // Delete VNI 200 and relink surviving VNI 100 between existing VRFs:
+        // deletes step, then a pure relink step.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-blue"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+ip_vrf = "tenant-green"
+
+[[evpn_ip_vrfs]]
+name = "tenant-blue"
+vni = 5000
+rd = "65000:5000"
+route_targets = ["65000:5000"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:00"
+vrf_device = "vrf-blue"
+l3vxlan_device = "vxlan5000"
+table_id = 100
+
+[[evpn_ip_vrfs]]
+name = "tenant-green"
+vni = 5001
+rd = "65000:5001"
+route_targets = ["65000:5001"]
+local_vtep_ip = "10.0.0.1"
+router_mac = "02:00:00:00:50:01"
+vrf_device = "vrf-green"
+l3vxlan_device = "vxlan5001"
+table_id = 101
+"#,
+        );
+        let steps = decompose(&current, &candidate).unwrap();
+        assert_eq!(steps.len(), 2, "{steps:#?}");
+        assert!(steps[0].description.starts_with("deletes"));
+        assert_eq!(steps[1].description, "ip_vrf relink");
+        assert!(
+            steps[1]
+                .candidate
+                .ip_vrfs()
+                .referenced_l2vnis("tenant-green")
+                .is_some_and(|vnis| vnis.contains(&vni(100)))
+        );
+    }
+}

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -56,7 +56,7 @@ impl DaemonEvpnRuntimeConvergeError {
         Self::Failed(rustbgpd_evpn::EvpnRuntimeConvergeError::new(message))
     }
 
-    fn message(&self) -> &str {
+    pub(crate) fn message(&self) -> &str {
         match self {
             Self::Unsupported(message) => message,
             Self::Failed(source) => source.message(),
@@ -2081,6 +2081,84 @@ fn redefine_imet_failure(
     }
 }
 
+/// Pure shape gate mirroring [`EvpnRuntimeActorConverger::converge`]'s
+/// dispatch: routes `plan` to the same shape detector + validator the
+/// dispatch would pick, without any actor side effects. Used by the
+/// #268 plan decomposer (`crate::evpn_plan_decomposer`) to prove — up
+/// front, before any step commits — that every decomposed step is an
+/// already-supported primitive shape, and to recognize a plan that is
+/// already primitive. Keep the routing here and in `converge` in sync.
+///
+/// # Errors
+/// The routed validator's error when the plan is not a supported shape.
+pub(crate) fn validate_supported_plan_shape(
+    current: &rustbgpd_evpn::EvpnRuntimeModel,
+    candidate: &rustbgpd_evpn::EvpnRuntimeCandidate,
+    plan: &rustbgpd_evpn::EvpnRuntimePlan,
+) -> Result<(), DaemonEvpnRuntimeConvergeError> {
+    if is_tenant_teardown_plan(plan, current) {
+        return validate_tenant_teardown(current, candidate, plan).map(drop);
+    }
+    if is_ip_vrf_relink_plan(plan) {
+        return validate_ip_vrf_relink(current, candidate, plan);
+    }
+    if is_additive_build_up_plan(plan) {
+        return validate_additive_build_up(current, candidate, plan).map(drop);
+    }
+    if is_l2vni_mixed_plan(plan) {
+        return validate_l2vni_mixed(current, candidate, plan).map(drop);
+    }
+    validate_no_unexpected_relink(current, candidate, plan)?;
+    if plan.evpn_instances.has_changes() {
+        if plan.evpn_instances.added.is_empty()
+            && !plan.evpn_instances.deleted.is_empty()
+            && plan.evpn_instances.redefined.is_empty()
+        {
+            return validate_single_l2vni_delete(current, candidate, plan).map(drop);
+        }
+        if plan.evpn_instances.added.is_empty()
+            && plan.evpn_instances.deleted.is_empty()
+            && !plan.evpn_instances.redefined.is_empty()
+        {
+            return validate_single_l2vni_redefine(current, candidate, plan).map(drop);
+        }
+        return validate_single_l2vni_add(current, candidate, plan).map(drop);
+    }
+    if plan.ip_vrfs.has_changes() {
+        if plan.ip_vrfs.added.is_empty()
+            && !plan.ip_vrfs.deleted.is_empty()
+            && plan.ip_vrfs.redefined.is_empty()
+        {
+            return validate_single_ip_vrf_delete(current, candidate, plan).map(drop);
+        }
+        if plan.ip_vrfs.added.is_empty()
+            && plan.ip_vrfs.deleted.is_empty()
+            && !plan.ip_vrfs.redefined.is_empty()
+        {
+            return validate_single_ip_vrf_redefine(current, candidate, plan).map(drop);
+        }
+        return validate_single_ip_vrf_add(plan).map(drop);
+    }
+    if plan.ethernet_segments.has_changes() {
+        if plan.ethernet_segments.added.is_empty()
+            && !plan.ethernet_segments.deleted.is_empty()
+            && plan.ethernet_segments.redefined.is_empty()
+        {
+            return validate_single_ethernet_segment_delete(current, candidate, plan).map(drop);
+        }
+        if plan.ethernet_segments.added.is_empty()
+            && plan.ethernet_segments.deleted.is_empty()
+            && !plan.ethernet_segments.redefined.is_empty()
+        {
+            return validate_single_ethernet_segment_redefine(current, candidate, plan).map(drop);
+        }
+        return validate_single_ethernet_segment_add(current, candidate, plan).map(drop);
+    }
+    Err(DaemonEvpnRuntimeConvergeError::unsupported(
+        "ApplyEvpnRuntime has no supported changes in this candidate",
+    ))
+}
+
 impl DaemonEvpnRuntimeConverger for EvpnRuntimeActorConverger {
     fn converge<'a>(
         &'a self,
@@ -2089,6 +2167,9 @@ impl DaemonEvpnRuntimeConverger for EvpnRuntimeActorConverger {
         plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
     ) -> DaemonEvpnRuntimeConvergeFuture<'a> {
         Box::pin(async move {
+            // NOTE: `validate_supported_plan_shape` above mirrors this
+            // dispatch for the #268 plan decomposer — keep the routing in
+            // sync when adding or reshaping converge paths.
             // Atomic tenant teardown (delete-only multi-element / cross-resource)
             // is routed first; single-element deletes fall through to the
             // single-shape converters below.
@@ -3455,6 +3536,37 @@ where
     }
 
     if let Err(error) = converger.converge(&current, &candidate, &plan).await {
+        // #268: a candidate the dispatch rejects as an unsupported *mixed*
+        // composition may still converge as an ordered sequence of
+        // already-supported primitive steps, each committing its own
+        // generation. Only `Unsupported` triggers the attempt — a `Failed`
+        // converge had side effects and must pin, exactly as before.
+        if matches!(error, DaemonEvpnRuntimeConvergeError::Unsupported(_)) {
+            match crate::evpn_plan_decomposer::decompose_evpn_runtime_candidate(
+                &current, &candidate, &plan,
+            ) {
+                Ok(steps) => {
+                    return apply_decomposed_evpn_runtime_steps(
+                        steps,
+                        &plan,
+                        coordinator,
+                        converger,
+                    )
+                    .await;
+                }
+                // The plan is already primitive (e.g. a supported shape that
+                // failed on a missing actor): today's error stands verbatim.
+                Err(crate::evpn_plan_decomposer::EvpnDecomposeError::AlreadyPrimitive) => {}
+                // Fail the whole candidate closed, naming the offending
+                // step, before any step commits.
+                Err(crate::evpn_plan_decomposer::EvpnDecomposeError::Unsupported(message)) => {
+                    return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                        "EVPN runtime mutation failed: {message}; generation {} remains committed",
+                        snapshot.generation.as_u64()
+                    )));
+                }
+            }
+        }
         if let DaemonEvpnRuntimeConvergeError::Failed(source) = error.clone() {
             let mut coordinator = coordinator.lock().map_err(|_| {
                 GrpcEvpnRuntimeApplyError::Internal(
@@ -3486,6 +3598,114 @@ where
         message: format!(
             "candidate EVPN runtime model committed as generation {}",
             report.committed_generation.as_u64()
+        ),
+    })
+}
+
+/// Apply the #268-decomposed primitive steps of a mixed candidate in
+/// order, each through the unchanged converge path and each committing
+/// its own runtime generation (operators see N generations for one
+/// SIGHUP / apply). A mid-sequence failure is **fail-stop**: earlier
+/// generations stay committed (no cross-step rollback), a `Failed`
+/// converge pins the coordinator exactly like the single-shot path, and
+/// the error + `ERROR` log name the completed generations, the failed
+/// step, and the re-SIGHUP recovery. The caller holds the apply lock.
+async fn apply_decomposed_evpn_runtime_steps<C>(
+    steps: Vec<crate::evpn_plan_decomposer::DecomposedStep>,
+    overall_plan: &rustbgpd_evpn::EvpnRuntimePlan,
+    coordinator: &Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>,
+    converger: &C,
+) -> Result<proto::ApplyEvpnRuntimeResponse, GrpcEvpnRuntimeApplyError>
+where
+    C: DaemonEvpnRuntimeConverger + ?Sized,
+{
+    let lock_coordinator = || {
+        coordinator.lock().map_err(|_| {
+            GrpcEvpnRuntimeApplyError::Internal(
+                "EVPN runtime coordinator lock poisoned".to_string(),
+            )
+        })
+    };
+    let total = steps.len();
+    tracing::info!(
+        total_steps = total,
+        "mixed EVPN runtime candidate decomposed into {total} primitive steps; \
+         each step commits its own runtime generation ({total} generations for one apply/SIGHUP)"
+    );
+    let mut committed_generations: Vec<u64> = Vec::new();
+    for (index, step) in steps.into_iter().enumerate() {
+        let step_number = index + 1;
+        let (step_current, step_plan) = {
+            let coordinator = lock_coordinator()?;
+            (
+                coordinator.model().clone(),
+                coordinator.plan_candidate(&step.candidate),
+            )
+        };
+        if step_plan.is_noop() {
+            continue;
+        }
+        if let Err(error) = converger
+            .converge(&step_current, &step.candidate, &step_plan)
+            .await
+        {
+            if let DaemonEvpnRuntimeConvergeError::Failed(source) = error.clone() {
+                let mut coordinator = lock_coordinator()?;
+                let mut failed = FailedRuntimeConverger { source };
+                let _ = coordinator.apply_candidate(step.candidate.clone(), &mut failed);
+            }
+            let committed_summary = if committed_generations.is_empty() {
+                "no earlier step committed".to_string()
+            } else {
+                format!(
+                    "earlier steps committed generations {committed_generations:?}, which remain \
+                     committed (fail-stop: no cross-step rollback)"
+                )
+            };
+            tracing::error!(
+                step = step_number,
+                total_steps = total,
+                description = %step.description,
+                error = %error.message(),
+                "decomposed EVPN runtime apply failed mid-sequence; {committed_summary}; fix the \
+                 candidate config and re-SIGHUP / re-apply — the next attempt replans from the \
+                 committed model and converges only the remainder"
+            );
+            return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                "EVPN runtime mutation failed at decomposed step {step_number}/{total} ({}): {}; \
+                 {committed_summary}; fix the config and re-SIGHUP / re-apply to converge the \
+                 remainder",
+                step.description,
+                error.message(),
+            )));
+        }
+        let report = {
+            let mut coordinator = lock_coordinator()?;
+            let mut preconverged = PreconvergedRuntimeConverger;
+            coordinator
+                .apply_candidate(step.candidate, &mut preconverged)
+                .map_err(|err| GrpcEvpnRuntimeApplyError::FailedPrecondition(err.to_string()))?
+        };
+        tracing::info!(
+            step = step_number,
+            total_steps = total,
+            generation = report.committed_generation.as_u64(),
+            description = %step.description,
+            "decomposed EVPN runtime step committed"
+        );
+        committed_generations.push(report.committed_generation.as_u64());
+    }
+    let snapshot = lock_coordinator()?.snapshot();
+    let generations_summary = match (committed_generations.first(), committed_generations.last()) {
+        (Some(first), Some(last)) => format!(" as generations {first}..={last}"),
+        _ => String::new(),
+    };
+    Ok(proto::ApplyEvpnRuntimeResponse {
+        outcome: runtime_apply_outcome_to_proto(rustbgpd_evpn::EvpnRuntimeApplyOutcome::Committed),
+        runtime: Some(runtime_snapshot_to_proto(&snapshot)),
+        plan: Some(runtime_plan_to_proto(overall_plan)),
+        message: format!(
+            "candidate EVPN runtime model committed via {total} decomposed steps{generations_summary}"
         ),
     })
 }
@@ -10935,5 +11155,339 @@ table_id = 6000
         );
 
         dataplane_handle.shutdown().await;
+    }
+
+    // ---- #268 mixed-candidate decomposition (apply-level) ----
+
+    /// Behaves like the real dispatch's validation without actor side
+    /// effects: accepts exactly the supported primitive shapes (via
+    /// `validate_supported_plan_shape`), rejects everything else as
+    /// `Unsupported`, records each accepted plan, and can be scripted to
+    /// fail the Nth accepted converge with a `Failed` error.
+    struct ShapeCheckingConverger {
+        accepted_plans: Arc<std::sync::Mutex<Vec<rustbgpd_evpn::EvpnRuntimePlan>>>,
+        fail_on_accepted_call: Option<usize>,
+    }
+
+    impl ShapeCheckingConverger {
+        fn new() -> Self {
+            Self {
+                accepted_plans: Arc::new(std::sync::Mutex::new(Vec::new())),
+                fail_on_accepted_call: None,
+            }
+        }
+
+        fn failing_on(call: usize) -> Self {
+            Self {
+                fail_on_accepted_call: Some(call),
+                ..Self::new()
+            }
+        }
+    }
+
+    impl DaemonEvpnRuntimeConverger for ShapeCheckingConverger {
+        fn converge<'a>(
+            &'a self,
+            current: &'a rustbgpd_evpn::EvpnRuntimeModel,
+            candidate: &'a rustbgpd_evpn::EvpnRuntimeCandidate,
+            plan: &'a rustbgpd_evpn::EvpnRuntimePlan,
+        ) -> DaemonEvpnRuntimeConvergeFuture<'a> {
+            Box::pin(async move {
+                validate_supported_plan_shape(current, candidate, plan)?;
+                let call_number = {
+                    let mut accepted = self.accepted_plans.lock().unwrap();
+                    accepted.push(plan.clone());
+                    accepted.len()
+                };
+                if self.fail_on_accepted_call == Some(call_number) {
+                    return Err(DaemonEvpnRuntimeConvergeError::failed(
+                        "injected decomposed-step failure",
+                    ));
+                }
+                Ok(())
+            })
+        }
+    }
+
+    // The #268 maintainer example candidate on top of the committed
+    // `l2vni_one_es_runtime_candidate_toml()` model: delete the ES,
+    // redefine its (surviving) member L2VNI 100, and add L2VNI 200.
+    fn decomposer_mixed_candidate_toml() -> &'static str {
+        r#"
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:101"
+route_targets = ["65000:101"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#
+    }
+
+    fn one_es_coordinator() -> Arc<Mutex<rustbgpd_evpn::EvpnRuntimeCoordinator>> {
+        let current = runtime_candidate_from_toml(l2vni_one_es_runtime_candidate_toml());
+        Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            current.instances().clone(),
+            current.ip_vrfs().clone(),
+            current.ethernet_segments().to_vec(),
+        )))
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_mixed_candidate_decomposes_across_generations() {
+        let coordinator = one_es_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = ShapeCheckingConverger::new();
+
+        let response = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: decomposer_mixed_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.outcome,
+            proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+        );
+        assert!(
+            response.message.contains("3 decomposed steps"),
+            "message must surface the decomposition: {}",
+            response.message
+        );
+        assert!(
+            response.message.contains("generations 2..=4"),
+            "message must name the N committed generations: {}",
+            response.message
+        );
+        assert_eq!(response.runtime.unwrap().generation, 4);
+
+        // The converger saw the mixed whole (rejected, not recorded) and
+        // then exactly the ordered primitive steps: deletes, redefine, add.
+        let accepted = converger.accepted_plans.lock().unwrap();
+        assert_eq!(accepted.len(), 3, "three primitive converges expected");
+        assert_eq!(accepted[0].ethernet_segments.deleted.len(), 1);
+        assert!(!accepted[0].evpn_instances.has_changes());
+        assert_eq!(accepted[1].evpn_instances.redefined, vec![100]);
+        assert!(accepted[1].evpn_instances.added.is_empty());
+        assert_eq!(accepted[2].evpn_instances.added, vec![200]);
+        assert!(accepted[2].evpn_instances.redefined.is_empty());
+
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(guard.model().generation().as_u64(), 4);
+        assert_eq!(
+            guard.model().mutation_state(),
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle
+        );
+        assert!(guard.model().ethernet_segments().is_empty());
+        assert_eq!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                .unwrap()
+                .rd
+                .to_string(),
+            "65000:101"
+        );
+        assert!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_decomposed_mid_sequence_failure_is_fail_stop_and_recoverable() {
+        let coordinator = one_es_coordinator();
+        let apply_lock = tokio::sync::Mutex::new(());
+        // Accepted call 2 = decomposed step 2 (the L2VNI redefine).
+        let converger = ShapeCheckingConverger::failing_on(2);
+
+        let error = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: decomposer_mixed_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap_err();
+
+        let GrpcEvpnRuntimeApplyError::FailedPrecondition(message) = error else {
+            panic!("expected FailedPrecondition, got: {error:?}");
+        };
+        assert!(
+            message.contains("decomposed step 2/3"),
+            "must name the failed step: {message}"
+        );
+        assert!(
+            message.contains("generations [2]"),
+            "must name the generations committed by earlier steps: {message}"
+        );
+        assert!(
+            message.contains("no cross-step rollback"),
+            "must state fail-stop semantics: {message}"
+        );
+        assert!(
+            message.contains("re-SIGHUP"),
+            "must carry the recovery instruction: {message}"
+        );
+
+        {
+            let guard = coordinator.lock().unwrap();
+            // Step 1 (the ES delete) committed generation 2 and stays
+            // committed; the failed step pins the model.
+            assert_eq!(guard.model().generation().as_u64(), 2);
+            assert!(guard.model().ethernet_segments().is_empty());
+            assert_eq!(
+                guard.model().mutation_state(),
+                rustbgpd_evpn::EvpnRuntimeMutationState::Failed
+            );
+            assert_eq!(
+                guard.model().lifecycle(),
+                rustbgpd_evpn::EvpnRuntimeLifecycle::Degraded
+            );
+            // The redefine never published: VNI 100 keeps the committed RD.
+            assert_eq!(
+                guard
+                    .model()
+                    .instances()
+                    .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                    .unwrap()
+                    .rd
+                    .to_string(),
+                "65000:100"
+            );
+        }
+
+        // Recovery: re-apply the same candidate with a healthy converger —
+        // the remainder replans from the committed model (redefine + add is
+        // a supported L2VNI-mixed shape) and converges.
+        let healthy = ShapeCheckingConverger::new();
+        let response = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: decomposer_mixed_candidate_toml().to_string(),
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &healthy,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            response.outcome,
+            proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyCommitted as i32
+        );
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(guard.model().generation().as_u64(), 3);
+        assert_eq!(
+            guard.model().mutation_state(),
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle
+        );
+        assert_eq!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                .unwrap()
+                .rd
+                .to_string(),
+            "65000:101"
+        );
+        assert!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_undecomposable_mixed_fails_closed_without_commit() {
+        // L2VNI add mixed with an IP-VRF identity (L3VNI) redefine: the
+        // precondition must fail the whole candidate closed, naming the
+        // offending step, with no generation advance and no pinning.
+        let current = runtime_candidate_from_toml(ip_vrf_runtime_candidate_toml());
+        let coordinator = Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            current.instances().clone(),
+            current.ip_vrfs().clone(),
+            current.ethernet_segments().to_vec(),
+        )));
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = ShapeCheckingConverger::new();
+
+        let mut candidate_toml = ip_vrf_redefined_l3vni_runtime_candidate_toml().to_string();
+        candidate_toml.push_str(
+            r#"
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+
+        let error = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml,
+                validate_only: false,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap_err();
+
+        let GrpcEvpnRuntimeApplyError::FailedPrecondition(message) = error else {
+            panic!("expected FailedPrecondition, got: {error:?}");
+        };
+        assert!(
+            message.contains("does not decompose"),
+            "must fail as a decomposition precondition: {message}"
+        );
+        assert!(
+            message.contains("restart-required by design"),
+            "must carry today's identity-redefine error: {message}"
+        );
+        assert!(
+            message.contains("generation 1 remains committed"),
+            "nothing may commit: {message}"
+        );
+
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(guard.model().generation().as_u64(), 1);
+        assert_eq!(
+            guard.model().mutation_state(),
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+            "an unsupported candidate must not pin/degrade the runtime"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod evpn_es_link_drain;
 mod evpn_imet;
 mod evpn_l3_originator;
 mod evpn_originator;
+mod evpn_plan_decomposer;
 mod evpn_runtime_converger;
 mod evpn_segment;
 mod evpn_svi;

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -2368,6 +2368,131 @@ originator_ip = "10.0.0.1"
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "reload hot-apply test keeps initial/candidate EVPN TOML fixtures inline"
+    )]
+    async fn reload_decomposes_mixed_evpn_runtime_edit_across_generations() {
+        // #268: an ES delete + its (surviving) member L2VNI redefine + a new
+        // L2VNI add in ONE SIGHUP. The converge of the mixed whole rejects it
+        // (scripted `Unsupported`, as the real dispatch would), and the
+        // decomposer then applies deletes → redefine → add as three
+        // primitive steps — three committed generations for one SIGHUP.
+        let path = unique_temp_path("reload-evpn-decomposed-mixed");
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+        let (apply, coordinator) = evpn_reload_apply_sequence(
+            &initial,
+            vec![
+                Err(
+                    crate::evpn_runtime_converger::DaemonEvpnRuntimeConvergeError::Unsupported(
+                        "mixed shape rejected by the dispatch".to_string(),
+                    ),
+                ),
+                Ok(()),
+                Ok(()),
+                Ok(()),
+            ],
+        );
+
+        std::fs::write(
+            &path,
+            r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[evpn_instances]]
+vni = 100
+rd = "65000:101"
+route_targets = ["65000:101"]
+local_vtep_ip = "10.0.0.1"
+
+[[evpn_instances]]
+vni = 200
+rd = "65000:200"
+route_targets = ["65000:200"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        )
+        .unwrap();
+
+        let (peer_mgr_tx, _peer_mgr_rx) = mpsc::channel(8);
+        let returned = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            Some(&apply),
+        )
+        .await
+        .expect("reload should hot-apply the decomposed mixed EVPN edit");
+
+        assert_eq!(
+            returned.evpn_instances.len(),
+            2,
+            "the reload snapshot must advance to the mixed candidate"
+        );
+        assert!(returned.ethernet_segments.is_empty());
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(
+            guard.model().generation().as_u64(),
+            4,
+            "one SIGHUP must commit three generations (deletes, redefine, add)"
+        );
+        assert!(guard.model().ethernet_segments().is_empty());
+        assert_eq!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(100).unwrap())
+                .unwrap()
+                .rd
+                .to_string(),
+            "65000:101"
+        );
+        assert!(
+            guard
+                .model()
+                .instances()
+                .get(rustbgpd_evpn::EvpnInstanceId::new(200).unwrap())
+                .is_some()
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
     async fn reload_retains_hot_applied_evpn_runtime_with_later_steps() {
         let path = unique_temp_path("reload-evpn-hot-apply-plus-honor");
         std::fs::write(


### PR DESCRIPTION
Closes #268.

Mixed EVPN runtime edits composed of already-safe primitives no longer fail closed — they decompose into an ordered primitive sequence, each step applied through the *unchanged* converge path, each committing its own generation. Maintainer-blessed semantics verbatim: fail-stop between steps (pinned model + ERROR naming completed generations + failed step + re-SIGHUP recovery), no cross-step rollback; the N-generations-per-SIGHUP visibility is documented in reload-matrix.

Safety shape: triggers ONLY on candidates today's dispatch rejects as Unsupported (all 108 pre-existing converger tests untouched); whole-candidate precondition before any commit — IP-VRF identity redefines fail the entire candidate closed before step 1 with today's restart-required-by-design error (the #268 bullet closed by documentation: ADR-0063 amendment + reload-matrix rationale); ordering contract deletes → redefines → relinks → adds with the wrong-order shapes enumerated and failing closed precisely (relink-from-deleted-VRF, relink-onto-added-VRF, memberless-ES mid-sequence).

Evidence: mid-sequence failure injection (step 2/3 fails → generation 2 committed, pinned, precise error; re-SIGHUP completes); one reload → three generations for the maintainer's example shape (ES delete + member-L2VNI redefine + L2VNI add); `--diff` renders `ReloadAppliedDecomposed { steps: N }` in human + JSON, verified against the built binary.

Gates: workspace build/test (66 suites, 13 new tests), fmt, clippy -D warnings, cargo doc, clippy-reasons — green; rebased over #691 (additive CHANGELOG conflict, both kept).