### PR TITLE
feat(api): close the deferred gRPC gaps — route receive time and send_hold_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   stay restart-required by design (kernel VRF identity lifecycle); the
   rationale is recorded in the ADR-0063 amendment and
   docs/reload-matrix.md.
+- **Routes served over gRPC now carry their receive time.** The
+  `Route` message gains `received_at_epoch_seconds` (wall clock,
+  recovered at query time from the monotonic RIB receive instant — the
+  same recovery the RFC 9069 BMP Loc-RIB dump uses), populated by
+  `ListReceivedRoutes` / `ListBestRoutes` / `ListAdvertisedRoutes` and
+  the explain RPCs that embed `Route`. The birdwatcher adapter
+  (`examples/birdwatcher-adapter`) now serves a real per-route `age`
+  from it, closing its last field-level gap vs the deprecated
+  in-daemon looking glass; the smoke test drives a live BGP session
+  and pins non-empty age equality between the two servers.
+- **`send_hold_time` (RFC 9687) is now settable over gRPC.**
+  `AddNeighbor`'s `NeighborConfig` and `PeerGroupDefinition` gain an
+  optional `send_hold_time` field with config-path validation parity
+  (0 = disabled; non-zero must exceed the effective hold time; unset =
+  the RFC 9687 §6 derived default), persisted like the config knob.
+  `ListNeighbors` reports the effective value, `rbgp neighbor <addr>
+  add` gains `--send-hold-time`, and `rbgp neighbor show` /
+  `peer-group show` render it.
+
 - **Export-side explain: "why did/didn't route X go to peer Y?" now
   gets a full, truthful gate-ladder answer.** `ExplainAdvertisedRoute`
   (and `rbgp rib advertised <peer> --explain --prefix X`) now reports

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -22,6 +22,11 @@ use rustbgpd_rib::RibUpdate;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Default hold time applied by the peer manager when `hold_time` is
+/// unset — mirrored here (same value as the daemon config default) for
+/// send-hold-time validation parity with the config path.
+const DEFAULT_HOLD_TIME: u16 = 90;
+
 fn is_ipv6_link_local(address: IpAddr) -> bool {
     match address {
         IpAddr::V6(v6) => v6.segments()[0] & 0xffc0 == 0xfe80,
@@ -384,6 +389,9 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
         remote_asn: info.remote_asn,
         description: info.description.clone(),
         hold_time: info.hold_time.map_or(0, u32::from),
+        // Effective value (configured or the RFC 9687 §6 derived
+        // default); 0 = disabled.
+        send_hold_time: Some(info.send_hold_time),
         max_prefixes: info.max_prefixes.unwrap_or(0),
         families,
         remove_private_as: remove_private_as_to_string(info.remove_private_as),
@@ -482,6 +490,26 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         if config.hold_time > 0 && config.hold_time < 3 {
             return Err(Status::invalid_argument("hold_time must be 0 or >= 3"));
         }
+        // RFC 9687 §4.4 parity with the config path: a non-zero send
+        // hold time must exceed the effective hold time (0 = disabled,
+        // unset = derived default). hold_time 0 here means "use the
+        // default" (see the Some/None mapping below), so validate
+        // against what the peer manager will actually apply.
+        if let Some(value) = config.send_hold_time
+            && value != 0
+        {
+            let effective_hold_time = if config.hold_time > 0 {
+                config.hold_time
+            } else {
+                u32::from(DEFAULT_HOLD_TIME)
+            };
+            if value <= effective_hold_time {
+                return Err(Status::invalid_argument(format!(
+                    "invalid send_hold_time {value}: must be 0 (disabled) or greater than \
+                     hold_time {effective_hold_time} (RFC 9687 §4.4)"
+                )));
+            }
+        }
         let interface = (!config.interface.trim().is_empty()).then(|| config.interface.clone());
         match (is_ipv6_link_local(address), interface.as_ref()) {
             (true, None) => {
@@ -541,9 +569,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             } else {
                 None
             },
-            // Not exposed over gRPC AddNeighbor yet: derive the
-            // RFC 9687 §6 default from the hold time.
-            send_hold_time: None,
+            send_hold_time: config.send_hold_time,
             max_prefixes: if config.max_prefixes > 0 {
                 Some(config.max_prefixes)
             } else {
@@ -1199,6 +1225,61 @@ mod tests {
         let err = svc.add_neighbor(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("hold_time"));
+    }
+
+    /// RFC 9687 §4.4 parity with the config path: a non-zero
+    /// `send_hold_time` must exceed the effective hold time — both when
+    /// `hold_time` is explicit and when it is the daemon default (90).
+    #[tokio::test]
+    async fn add_neighbor_rejects_send_hold_time_not_above_hold_time() {
+        let svc = make_service();
+        for (hold_time, send_hold_time) in [(90, 90), (0, 90), (120, 100)] {
+            let req = Request::new(proto::AddNeighborRequest {
+                config: Some(proto::NeighborConfig {
+                    address: "10.0.0.2".into(),
+                    remote_asn: 65002,
+                    hold_time,
+                    send_hold_time: Some(send_hold_time),
+                    ..Default::default()
+                }),
+            });
+            let err = svc.add_neighbor(req).await.unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+            assert!(
+                err.message().contains("send_hold_time"),
+                "hold {hold_time} / send-hold {send_hold_time}: {}",
+                err.message()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn add_neighbor_forwards_send_hold_time() {
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel(16);
+        let (rib_tx, _rib_rx) = mpsc::channel(16);
+        let svc = NeighborService::new(65001, AccessMode::ReadWrite, peer_mgr_tx, rib_tx, None);
+
+        let call = tokio::spawn(async move {
+            svc.add_neighbor(Request::new(proto::AddNeighborRequest {
+                config: Some(proto::NeighborConfig {
+                    address: "10.0.0.2".into(),
+                    remote_asn: 65002,
+                    hold_time: 90,
+                    // 0 = disabled is also valid (config-path parity).
+                    send_hold_time: Some(0),
+                    ..Default::default()
+                }),
+            }))
+            .await
+        });
+        match peer_mgr_rx.recv().await.unwrap() {
+            PeerManagerCommand::AddPeer { config, reply, .. } => {
+                assert_eq!(config.send_hold_time, Some(0));
+                reply.send(Ok(())).unwrap();
+            }
+            _ => panic!("expected AddPeer"),
+        }
+        call.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -112,6 +112,7 @@ fn proto_definition_to_input(
 
     Ok(PeerGroupDefinition {
         hold_time,
+        send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
         md5_password: definition.md5_password,
         ttl_security: definition.ttl_security,
@@ -153,6 +154,7 @@ fn proto_definition_to_input(
 fn input_definition_to_proto(definition: &PeerGroupDefinition) -> proto::PeerGroupDefinition {
     proto::PeerGroupDefinition {
         hold_time: definition.hold_time.map(u32::from),
+        send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
         // Read RPCs expose the group shape, not credential material.
         md5_password: None,
@@ -671,6 +673,19 @@ mod tests {
         let err = proto_definition_to_input(invalid).unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("orr_vantage"));
+    }
+
+    /// RFC 9687 `send_hold_time` round-trips proto -> input -> proto.
+    /// (The `>hold_time` / 0=disabled rule is enforced by the config
+    /// validation the `SetPeerGroup` apply path re-runs.)
+    #[test]
+    fn send_hold_time_round_trips() {
+        let mut definition = sample_definition();
+        definition.send_hold_time = Some(500);
+        let input = proto_definition_to_input(definition).unwrap();
+        assert_eq!(input.send_hold_time, Some(500));
+        let back = input_definition_to_proto(&input);
+        assert_eq!(back.send_hold_time, Some(500));
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1294,6 +1294,9 @@ pub struct NamedPolicySnapshot {
 pub struct PeerGroupDefinition {
     /// Override hold time.
     pub hold_time: Option<u16>,
+    /// Override RFC 9687 send hold time in seconds; 0 disables (None =
+    /// derive the RFC 9687 §6 default from the hold time).
+    pub send_hold_time: Option<u32>,
     /// Override max prefixes.
     pub max_prefixes: Option<u32>,
     /// Optional TCP MD5 password.
@@ -1673,6 +1676,8 @@ pub struct PeerInfo {
     pub prefix_count: usize,
     /// Configured hold time override (None = default).
     pub hold_time: Option<u16>,
+    /// Effective RFC 9687 send hold time in seconds (0 = disabled).
+    pub send_hold_time: u32,
     /// Maximum prefix limit (None = unlimited).
     pub max_prefixes: Option<u32>,
     /// Configured address families.

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1050,6 +1050,13 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
         // tagged route (otherwise local_pref=0 is ambiguous between
         // "policy set it" and "no LOCAL_PREF on EBGP wire").
         local_pref_attr: route.local_pref_attr(),
+        // Receive wall time recovered from the monotonic receive
+        // instant, the same recovery the BMP Loc-RIB dump uses for its
+        // RFC 9069 per-peer header timestamp.
+        received_at_epoch_seconds: std::time::SystemTime::now()
+            .checked_sub(route.received_at.elapsed())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs()),
     }
 }
 

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -38,6 +38,7 @@ pub(crate) fn peer_info(address: IpAddr) -> PeerInfo {
         enabled: true,
         prefix_count: 0,
         hold_time: None,
+        send_hold_time: 0,
         max_prefixes: None,
         families: Vec::new(),
         remove_private_as: RemovePrivateAs::Disabled,

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -82,6 +82,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             last_error: n.last_error.clone(),
             description: cfg.map(|c| c.description.clone()).unwrap_or_default(),
             hold_time: cfg.map(|c| c.hold_time).unwrap_or(0),
+            send_hold_time: cfg.and_then(|c| c.send_hold_time).unwrap_or(0),
             families: cfg.map(|c| c.families.clone()).unwrap_or_default(),
             peer_group: cfg.map(|c| c.peer_group.clone()).unwrap_or_default(),
             route_server_client: cfg.map(|c| c.route_server_client).unwrap_or(false),
@@ -120,6 +121,10 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         println!(
             "Hold Time:             {}",
             cfg.map(|c| c.hold_time).unwrap_or(0)
+        );
+        println!(
+            "Send Hold Time:        {}",
+            cfg.and_then(|c| c.send_hold_time).unwrap_or(0)
         );
         println!(
             "Families:              {}",
@@ -202,6 +207,7 @@ pub struct AddNeighborOpts {
     pub asn: u32,
     pub description: Option<String>,
     pub hold_time: Option<u32>,
+    pub send_hold_time: Option<u32>,
     pub max_prefixes: Option<u32>,
     pub families: Vec<String>,
     pub route_server_client: bool,
@@ -229,6 +235,7 @@ pub async fn add(
                 remote_asn: opts.asn,
                 description: opts.description.unwrap_or_default(),
                 hold_time: opts.hold_time.unwrap_or(0),
+                send_hold_time: opts.send_hold_time,
                 max_prefixes: opts.max_prefixes.unwrap_or(0),
                 families: opts.families,
                 peer_group: String::new(),
@@ -382,6 +389,7 @@ mod tests {
                 asn: 65002,
                 description: Some("peer-2".to_string()),
                 hold_time: Some(90),
+                send_hold_time: Some(480),
                 max_prefixes: Some(1000),
                 families: vec!["ipv4_unicast".to_string(), "ipv6_unicast".to_string()],
                 route_server_client: true,

--- a/crates/cli/src/commands/peer_group.rs
+++ b/crates/cli/src/commands/peer_group.rs
@@ -34,6 +34,8 @@ struct JsonPeerGroupDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     hold_time: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    send_hold_time: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_prefixes: Option<u32>,
     has_md5_password: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -128,6 +130,7 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
         let detail = JsonPeerGroupDetail {
             name: resp.name.clone(),
             hold_time: def.hold_time,
+            send_hold_time: def.send_hold_time,
             max_prefixes: def.max_prefixes,
             has_md5_password: def.has_md5_password.unwrap_or(false),
             ttl_security: def.ttl_security,
@@ -154,6 +157,9 @@ pub async fn get(connection: Connection, name: &str, json: bool) -> Result<(), C
         println!("Name:                  {}", resp.name);
         if let Some(h) = def.hold_time {
             println!("Hold Time:             {h}");
+        }
+        if let Some(h) = def.send_hold_time {
+            println!("Send Hold Time:        {h}");
         }
         if let Some(m) = def.max_prefixes {
             println!("Max Prefixes:          {m}");

--- a/crates/cli/src/commands/policy_input.rs
+++ b/crates/cli/src/commands/policy_input.rs
@@ -158,6 +158,8 @@ pub struct JsonPeerGroupDefinition {
     #[serde(default)]
     pub hold_time: Option<u32>,
     #[serde(default)]
+    pub send_hold_time: Option<u32>,
+    #[serde(default)]
     pub max_prefixes: Option<u32>,
     #[serde(default)]
     pub md5_password: Option<String>,
@@ -208,6 +210,7 @@ impl From<JsonPeerGroupDefinition> for proto::PeerGroupDefinition {
             .or_else(|| j.md5_password.as_ref().map(|_| true));
         proto::PeerGroupDefinition {
             hold_time: j.hold_time,
+            send_hold_time: j.send_hold_time,
             max_prefixes: j.max_prefixes,
             md5_password: j.md5_password,
             ttl_security: j.ttl_security,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -593,6 +593,10 @@ enum NeighborAction {
         /// Hold time in seconds
         #[arg(long)]
         hold_time: Option<u32>,
+        /// RFC 9687 send hold time in seconds (0 disables; must exceed
+        /// the hold time; default: max(480, 2 x hold time))
+        #[arg(long)]
+        send_hold_time: Option<u32>,
         /// Max prefix limit
         #[arg(long)]
         max_prefixes: Option<u32>,
@@ -1298,6 +1302,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     asn,
                     description,
                     hold_time,
+                    send_hold_time,
                     max_prefixes,
                     families,
                     route_server_client,
@@ -1315,6 +1320,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                         asn,
                         description,
                         hold_time,
+                        send_hold_time,
                         max_prefixes,
                         families,
                         route_server_client,

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -232,6 +232,8 @@ pub struct JsonNeighborDetail {
     pub last_error: String,
     pub description: String,
     pub hold_time: u32,
+    /// Effective RFC 9687 send hold time in seconds (0 = disabled).
+    pub send_hold_time: u32,
     pub families: Vec<String>,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub peer_group: String,
@@ -781,6 +783,7 @@ mod tests {
             last_error: String::new(),
             description: "peer-2".to_string(),
             hold_time: 90,
+            send_hold_time: 480,
             families: vec!["ipv4_unicast".to_string()],
             peer_group: "rs-clients".to_string(),
             route_server_client: true,

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -597,6 +597,7 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
                 remote_asn: 65002,
                 description: "peer-2".to_string(),
                 hold_time: 90,
+                send_hold_time: Some(480),
                 max_prefixes: 0,
                 families: vec!["ipv4_unicast".to_string()],
                 remove_private_as: String::new(),

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -700,6 +700,8 @@ implemented per ADR-0040.
   max(negotiated hold time, 90 s) (not configurable). Per-neighbor +
   peer-group `send_hold_time` knob (§6 MAY); 0 disables; non-zero
   values ≤ the effective hold time are rejected at config load (§4.4).
+  Also settable over gRPC (`AddNeighbor` / `PeerGroupDefinition`, same
+  validation) and via `rbgp neighbor <addr> add --send-hold-time`.
 
 ---
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -45,13 +45,14 @@ every RPC the adapter calls is a read.
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 
 Every endpoint of the in-daemon server is fully servable over today's
-gRPC API — there are no 501 endpoints.
+gRPC API — there are no 501 endpoints. Route `age` is served from the
+`Route.received_at_epoch_seconds` proto field (RIB receive time), the
+same source the in-daemon server reads.
 
 ### Field-level gaps
 
 | Field                  | In-daemon server                  | Adapter                              |
 |------------------------|-----------------------------------|--------------------------------------|
-| route `age`            | derived from RIB receive time     | `""` — the gRPC `Route` message carries no received-at timestamp; Alice-LG parses empty as zero time (benign) |
 | status `last_reconfig` | `""` (not tracked)                | `""` (unchanged)                     |
 
 Error behavior differs only on failure: when the daemon is unreachable

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -15,12 +15,6 @@
 //! Response shapes match birdwatcher field names so Alice-LG can parse
 //! them without adapter code. Fields that have no rustbgpd equivalent
 //! are present but empty/zero.
-//!
-//! Known field-level gap vs the in-daemon server: the gRPC `Route`
-//! message carries no received-at timestamp, so the per-route `age`
-//! field is an empty string (Alice-LG parses that as zero time, the
-//! same benign fallback the in-daemon server already uses for
-//! `last_reconfig`). See the README gap table.
 
 use std::net::{IpAddr, SocketAddr};
 
@@ -299,15 +293,22 @@ fn route_to_birdwatcher(route: &proto::Route) -> Value {
 
     let from_protocol = format!("bgp_{}", route.peer_address).replace(':', "_");
 
+    // Receive wall time, same source and format as the in-daemon
+    // server's `age`. 0 (unknown) renders as the empty string, which
+    // Alice-LG parses as zero time (benign).
+    let age = if route.received_at_epoch_seconds > 0 {
+        format_epoch_secs(route.received_at_epoch_seconds)
+    } else {
+        String::new()
+    };
+
     serde_json::json!({
         "network": format!("{}/{}", route.prefix, route.prefix_length),
         "gateway": route.next_hop,
         "from_protocol": from_protocol,
         "interface": "",
         "metric": 0,
-        // Gap: the gRPC Route message carries no received-at timestamp.
-        // Empty string parses as zero time in Alice-LG (benign).
-        "age": "",
+        "age": age,
         "type": ["BGP", "unicast", "univ"],
         "primary": false,
         "learnt_from": route.peer_address,
@@ -383,6 +384,8 @@ mod tests {
             med: 50,
             communities: vec![(65001 << 16) | 100],
             large_communities: vec!["65001:1:2".to_string()],
+            // 2026-01-02 03:04:05 UTC
+            received_at_epoch_seconds: 1_767_323_045,
             ..Default::default()
         };
         let json = route_to_birdwatcher(&route);
@@ -391,7 +394,7 @@ mod tests {
         assert_eq!(json["gateway"], "192.0.2.1");
         assert_eq!(json["from_protocol"], "bgp_192.0.2.1");
         assert_eq!(json["learnt_from"], "192.0.2.1");
-        assert_eq!(json["age"], "");
+        assert_eq!(json["age"], "2026-01-02 03:04:05");
         assert_eq!(json["primary"], false);
         assert_eq!(json["type"], serde_json::json!(["BGP", "unicast", "univ"]));
         assert_eq!(json["bgp"]["origin"], "Incomplete");
@@ -420,6 +423,8 @@ mod tests {
         };
         let json = route_to_birdwatcher(&route);
         assert_eq!(json["network"], "2001:db8::/32");
+        // No receive timestamp → empty age (Alice-LG zero-time fallback).
+        assert_eq!(json["age"], "");
         assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
         assert_eq!(json["learnt_from"], "2001:db8::1");
         assert_eq!(json["bgp"]["origin"], "IGP");

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -326,6 +326,12 @@ message NeighborConfig {
   string role = 14;
   // Require the peer to advertise a compatible BGP Role capability.
   bool strict_role = 15;
+  // RFC 9687 send hold timer in seconds: tear the session down when the
+  // peer stops draining its TCP socket for this long. 0 disables; a
+  // non-zero value must be greater than the effective hold time
+  // (RFC 9687 §4.4). Unset = the RFC 9687 §6 default,
+  // max(480, 2 × hold_time).
+  optional uint32 send_hold_time = 16;
 }
 
 message NeighborState {
@@ -584,6 +590,10 @@ message PeerGroupDefinition {
   // in this group: an IP address identifying the clients' IGP location as a
   // BGP-LS topology node. Requires route_reflector_client = true.
   optional string orr_vantage = 22;
+  // RFC 9687 send hold timer in seconds inherited by neighbors in this
+  // group. 0 disables; non-zero must be greater than the effective hold
+  // time (RFC 9687 §4.4). Unset = the RFC 9687 §6 default.
+  optional uint32 send_hold_time = 23;
 }
 
 message NamedPeerGroup {
@@ -1640,6 +1650,11 @@ message Route {
   // attribute". Used by the M35 interop test to assert the implicit
   // honor rule actually fired on a tagged route.
   optional uint32 local_pref_attr = 16;
+  // Wall-clock time this route was received, in Unix epoch seconds,
+  // recovered at query time from the monotonic receive instant (the
+  // same recovery the RFC 9069 BMP Loc-RIB dump uses for its per-peer
+  // header timestamp). 0 = unknown.
+  uint64 received_at_epoch_seconds = 17;
 }
 
 message WatchRoutesRequest {

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -31,6 +31,7 @@ fn build_peer_info(
         enabled: managed.enabled,
         prefix_count: session_state.map_or(0, |s| s.prefix_count),
         hold_time: managed.hold_time,
+        send_hold_time: managed.transport_config.peer.send_hold_time,
         max_prefixes: managed.max_prefixes,
         families: managed.transport_config.peer.families.clone(),
         remove_private_as: managed.transport_config.remove_private_as,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1713,6 +1713,7 @@ peer_group = "edge"
             name: "edge".to_string(),
             definition: rustbgpd_api::peer_types::PeerGroupDefinition {
                 hold_time: Some(45),
+                send_hold_time: None,
                 max_prefixes: None,
                 md5_password: None,
                 ttl_security: None,
@@ -1747,6 +1748,7 @@ peer_group = "edge"
 fn edge_group_definition(hold_time: Option<u16>) -> rustbgpd_api::peer_types::PeerGroupDefinition {
     rustbgpd_api::peer_types::PeerGroupDefinition {
         hold_time,
+        send_hold_time: None,
         max_prefixes: None,
         md5_password: None,
         ttl_security: None,

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -169,8 +169,7 @@ fn config_neighbor_set_to_api(definition: &NeighborSetConfig) -> NeighborSetDefi
 pub(crate) fn api_peer_group_to_config(definition: PeerGroupDefinition) -> PeerGroupConfig {
     PeerGroupConfig {
         hold_time: definition.hold_time,
-        send_hold_time: None,
-        // Not exposed over the gRPC peer-group definition yet.
+        send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
         md5_password: definition.md5_password,
         ttl_security: definition.ttl_security,
@@ -209,6 +208,7 @@ pub(crate) fn api_peer_group_to_config(definition: PeerGroupDefinition) -> PeerG
 pub(crate) fn config_peer_group_to_api(definition: &PeerGroupConfig) -> PeerGroupDefinition {
     PeerGroupDefinition {
         hold_time: definition.hold_time,
+        send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
         md5_password: definition.md5_password.clone(),
         ttl_security: definition.ttl_security,

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -7,8 +7,14 @@
 //! fetches `/status`, `/protocols/bgp`, and `/routes/peer/{peer}`
 //! from both and asserts structural equality after blanking the
 //! clock-dependent fields (`current_server`, `last_reboot`,
-//! `state_changed`, `state` — the configured peer has no live
-//! counterpart, so its FSM state cycles).
+//! `state_changed`, `state` — the configured 192.0.2.10 peer has no
+//! live counterpart, so its FSM state cycles).
+//!
+//! A second neighbor (127.0.0.1) is driven by a minimal in-test BGP
+//! speaker that establishes a real session and announces one route, so
+//! the per-route `age` field is exercised end-to-end: both servers
+//! must render a non-empty receive timestamp for the same route, equal
+//! within clock-recovery jitter.
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -100,7 +106,7 @@ fn wait_for_http(port: u16, path: &str, proc_: &mut Proc) {
     );
 }
 
-fn write_config(dir: &Path, grpc_port: u16, lg_port: u16) -> PathBuf {
+fn write_config(dir: &Path, grpc_port: u16, lg_port: u16, bgp_port: u16) -> PathBuf {
     let runtime_dir = dir.join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
     let config_path = dir.join("rustbgpd.toml");
@@ -112,7 +118,7 @@ enforcement = "legacy"
 [global]
 asn = 65001
 router_id = "10.0.0.1"
-listen_port = 0
+listen_port = {bgp_port}
 runtime_state_dir = "{runtime_dir}"
 
 [global.telemetry]
@@ -128,11 +134,86 @@ addr = "127.0.0.1:{lg_port}"
 address = "192.0.2.10"
 remote_asn = 65010
 description = "smoke peer"
+
+[[neighbors]]
+address = "127.0.0.1"
+remote_asn = 65020
+description = "live peer"
 "#,
         runtime_dir = runtime_dir.display()
     );
     std::fs::write(&config_path, config).expect("write test config");
     config_path
+}
+
+/// Minimal BGP speaker: connect to the daemon's listen port, complete
+/// the OPEN/KEEPALIVE handshake as legacy AS 65020 (no capabilities —
+/// implicit IPv4 unicast), and announce one route. The returned stream
+/// must stay alive for the session to survive; the daemon's own
+/// messages are left unread (a handful of bytes, well within the
+/// socket buffer for the test's lifetime).
+fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
+    use rustbgpd_wire::attribute::{AsPath, AsPathSegment, Origin, PathAttribute};
+    use rustbgpd_wire::message::{Message, encode_message};
+    use rustbgpd_wire::open::OpenMessage;
+    use rustbgpd_wire::update::UpdateMessage;
+
+    let mut stream = TcpStream::connect(("127.0.0.1", bgp_port)).expect("connect to BGP port");
+    let open = Message::Open(OpenMessage {
+        version: 4,
+        my_as: 65020,
+        hold_time: 90,
+        bgp_identifier: "10.0.0.2".parse().unwrap(),
+        capabilities: Vec::new(),
+    });
+    let mut attrs = Vec::new();
+    rustbgpd_wire::attribute::encode_path_attributes(
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65020])],
+            }),
+            // Non-loopback: the daemon's UPDATE validation rejects a
+            // loopback NEXT_HOP (subcode 8).
+            PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
+        ],
+        &mut attrs,
+        false,
+        false,
+    )
+    .expect("encode path attributes");
+    let update = Message::Update(UpdateMessage {
+        withdrawn_routes: bytes::Bytes::new(),
+        path_attributes: attrs.into(),
+        // 10.99.0.0/24
+        nlri: bytes::Bytes::from_static(&[24, 10, 99, 0]),
+    });
+    for msg in [&open, &Message::Keepalive, &update] {
+        let encoded = encode_message(msg).expect("encode BGP message");
+        stream.write_all(&encoded).expect("write BGP message");
+    }
+    stream
+}
+
+/// Inverse of the servers' `format_epoch_secs` (`"YYYY-MM-DD HH:MM:SS"`
+/// → Unix epoch seconds) so two `age` renderings can be compared with
+/// clock-recovery jitter tolerance. Howard Hinnant's `days_from_civil`.
+fn epoch_from_timestamp(s: &str) -> u64 {
+    let parts: Vec<u64> = s
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|p| !p.is_empty())
+        .map(|p| p.parse().expect("numeric timestamp field"))
+        .collect();
+    let [y, m, d, h, mi, se] = parts[..] else {
+        panic!("unexpected timestamp shape: {s:?}");
+    };
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    days * 86_400 + h * 3_600 + mi * 60 + se
 }
 
 /// Blank the clock-dependent fields so the two responses (taken at
@@ -165,7 +246,8 @@ fn adapter_matches_in_daemon_looking_glass() {
     let grpc_port = free_port();
     let lg_port = free_port();
     let adapter_port = free_port();
-    let config_path = write_config(temp.path(), grpc_port, lg_port);
+    let bgp_port = free_port();
+    let config_path = write_config(temp.path(), grpc_port, lg_port, bgp_port);
 
     // Spawn the daemon (serves both gRPC and the in-daemon looking
     // glass). Structured logs go to stdout, the banner to stderr.
@@ -245,4 +327,47 @@ fn adapter_matches_in_daemon_looking_glass() {
     let core = get_json(lg_port, "/routes/protocol/bgp_192.0.2.10", "in-daemon");
     let ext = get_json(adapter_port, "/routes/protocol/bgp_192.0.2.10", "adapter");
     assert_eq!(core, ext, "/routes/protocol must match exactly");
+
+    // Establish a real session from the in-test BGP speaker and
+    // announce one route, then compare the non-empty route sets —
+    // including the `age` receive timestamp both servers must now
+    // derive from the same RIB receive instant.
+    let _bgp_session = establish_bgp_and_announce(bgp_port);
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let (mut core, mut ext) = loop {
+        let core = get_json(lg_port, "/routes/peer/127.0.0.1", "in-daemon");
+        let ext = get_json(adapter_port, "/routes/peer/127.0.0.1", "adapter");
+        if core["routes"].as_array().is_some_and(|r| r.len() == 1)
+            && ext["routes"].as_array().is_some_and(|r| r.len() == 1)
+        {
+            break (core, ext);
+        }
+        assert!(
+            Instant::now() < deadline,
+            "announced route did not appear on both servers\nin-daemon: {core}\nadapter: {ext}\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        thread::sleep(Duration::from_millis(200));
+    };
+
+    // Non-empty age on both sides, equal within clock-recovery jitter
+    // (each server independently truncates `now - elapsed` to seconds).
+    let core_age = core["routes"][0]["age"].as_str().unwrap_or_default();
+    let ext_age = ext["routes"][0]["age"].as_str().unwrap_or_default();
+    assert!(!core_age.is_empty(), "in-daemon age must be populated");
+    assert!(!ext_age.is_empty(), "adapter age must be populated");
+    let delta = epoch_from_timestamp(core_age).abs_diff(epoch_from_timestamp(ext_age));
+    assert!(
+        delta <= 2,
+        "age must agree within jitter: in-daemon {core_age:?} vs adapter {ext_age:?}"
+    );
+
+    // With age blanked, the live-route responses must match exactly.
+    core["routes"][0]["age"] = "".into();
+    ext["routes"][0]["age"] = "".into();
+    assert_eq!(core, ext, "/routes/peer for the live peer must match");
+    assert_eq!(
+        core["routes"][0]["network"], "10.99.0.0/24",
+        "announced route must be served"
+    );
 }


### PR DESCRIPTION
The loose-threads sweep ending the tranche's API day.

## Closed

- **Route received-at over gRPC** (the #684 adapter's one field gap): additive `received_at_epoch_seconds` on `Route`, recovered via the BMP install-time pattern, flowing through all route-listing + explain RPCs. The birdwatcher adapter now serves real `age`; its README gap table row is gone; the smoke test grew a minimal raw-wire BGP speaker announcing a real route and asserts age on both servers with byte-exact equality after blanking only the ±1s-jitter field.
- **`send_hold_time` over gRPC** (the #681 deferral): additive on NeighborConfig + PeerGroupDefinition, AddNeighbor validation with config-path parity (0=disabled; must exceed effective hold time incl. the default-90 case) — the downstream plumbing already existed, only the API layer dropped it. Read-back via PeerInfo effective value; CLI add flag + show rendering. Rejection-matrix tests.

## Skipped with honest scope

- **#658 import-stats read relay**: verified — import chains live inside each session task and `PolicyChain::clone()` deliberately resets counters, so a read path needs a PeerCommand + PeerHandle timeout method + fan-out + partial-result semantics (~200 lines, 5 files, plus counter-reset semantic decisions). Over the sweep's bar; ExplainImportPolicy is the exemplar when picked up. docs/API.md note updated.
- AddNeighbor ORR/ORF/RR-client knobs (deliberate TOML-only scoping, each needs its own validation surface), the four `ponytail:` scale-gated ceilings, the M81 stale-bit lab item.

## Sweep verdicts

The #684 proptest flake and the #686 source-flip follow-up were confirmed already fixed on main (#685 rider / #687); the #681+#679 dashboard panel already landed via #687.

Gates: workspace build/test (4895 passed), fmt, clippy -D warnings, cargo doc, clippy-reasons — green; rebased over #692.