### PR TITLE
docs: add the deployment cookbook, quickstart hardening, and embedder-surface notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ rbgp completions bash > /etc/bash_completion.d/rbgp
 # Or use pre-generated: examples/completions/
 ```
 
+**Next steps:** the [cookbook](docs/cookbook/README.md) has complete
+recipes — receipt-proven config, verification commands, metrics, and
+failure-mode debugging — for the common deployment shapes: iBGP route
+reflector at scale, L3VPN (VPNv4/VPNv6 + RT-Constrain) reflection,
+a BMP/event/MRT monitoring feed, an EVPN fabric RR, and the `.rpol`
+policy workflow.
+
 gRPC defaults to a local Unix domain socket. For remote access, configure
 native mTLS on the TCP listener (`tls_cert_file` / `tls_key_file` /
 `tls_client_ca_file` — all three required together; partial config is
@@ -434,6 +441,7 @@ evolving API.**
 
 | Document | Content |
 |----------|---------|
+| [docs/cookbook/](docs/cookbook/README.md) | Scenario recipes with receipt-proven configs: RR at scale, L3VPN RR, monitoring feed, EVPN fabric RR, policy quickstart |
 | [docs/USE_CASES.md](docs/USE_CASES.md) | Deployment scenarios: DDoS, hosting, IX, SDN, collector |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Crate graph, runtime model, ownership, data flow |
 | [docs/DESIGN.md](docs/DESIGN.md) | Tradeoffs, protocol scope, rationale |

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -389,3 +389,60 @@ To be the de facto Rust BGP codec, the concrete gaps:
       (the embedding proof).
 - [ ] `.github/workflows/ci.yml` — gate `cargo semver-checks` on
       `crates/wire/**` and `crates/fsm/**` path changes.
+
+---
+
+## 8. The Shape-A (gRPC) embedder surface — recent additions
+
+Shape A (§3.4) — a separate process driving the daemon over gRPC — is
+the recommended production embedding, and its surface grew. What a
+gRPC consumer gains from the recent proto additions
+(`proto/rustbgpd.proto`; all additive):
+
+- **`Route.received_at_epoch_seconds`** — every `Route` served by
+  `ListReceivedRoutes` / `ListBestRoutes` / `ListAdvertisedRoutes`
+  (and the explain RPCs that embed `Route`) now carries its receive
+  time, recovered from the monotonic RIB receive instant. Consumers
+  no longer need to track route age themselves by diffing streams.
+- **`RibService.ExplainAdvertisedRoute`** — the export decision as
+  data: the full gate ladder (`split_horizon`, `rr_reflection`,
+  `family`, `llgr`, `orf`, `rt_membership`, `export_policy`,
+  `adj_rib_out`) with per-gate verdict + detail, produced by a dry
+  run of the same staging body live distribution executes. A
+  controller can answer "why isn't prefix X on peer Y" without
+  screen-scraping. The response's `update_group_id` and
+  `NeighborState.update_group` expose ADR-0098 group membership for
+  fleet-level diagnostics.
+- **`send_hold_time` (RFC 9687)** — settable in `AddNeighbor`'s
+  `NeighborConfig` and in `PeerGroupDefinition`, with the same
+  validation as the config path; `ListNeighbors` reports the
+  effective value. Automation that provisions peers can now manage
+  the wedged-peer teardown timer instead of inheriting the default.
+
+**The event-replay contract** (`EventService.SubscribeFromEvent`,
+ADR-0072) is the durable half of the event surface and the one an
+integration should build on: events carry a monotonic `event_id`;
+the consumer persists the last id it processed and resumes with
+`from_event_id` after either side restarts. It requires
+`[event_history].enabled = true` on the daemon and returns
+`FAILED_PRECONDITION` otherwise — treat that as "replay not
+provisioned", not an error to retry. The live `WatchEvents` stream
+emits `stream_lagged` warnings when a bounded source dropped events;
+that is the signal to fall back to the durable cursor.
+
+**Reference consumers in-tree:** `examples/event-bridge/` (gRPC →
+JSON-lines event bridge, the minimal Shape-A skeleton) and
+`examples/birdwatcher-adapter/` (a complete REST service — the
+birdwatcher/Alice-LG contract — sourced entirely from the public gRPC
+API, including per-route `age` from `received_at_epoch_seconds`). The
+adapter is the honest template: if the public API is missing a field
+an external tool needs, the fix is an additive proto field, not a
+daemon-internal shortcut — that is how `received_at_epoch_seconds`
+landed.
+
+**Stability posture:** the daemon is alpha and the proto is versioned
+by convention, not frozen — but the working convention is additive
+evolution (new fields and RPCs; `optional` scalars for new knobs),
+with any breaking change called out in `CHANGELOG.md`. Generated
+client code should tolerate unknown fields (protobuf's default) and
+gate features on field presence, not daemon version.

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -20,6 +20,20 @@ Numbering note: M0–M4 and M10 onward are interop labs. M5–M9 were
 development-phase build milestones (wire/RIB/API hardening) and are documented
 in [`milestones.md`](milestones.md), not here.
 
+## Receipts → deployment recipes
+
+Several receipt clusters back a copy-paste deployment recipe in
+[`cookbook/`](cookbook/README.md) — the receipt proves the behavior,
+the recipe is the config + runbook it enables:
+
+| Receipts | Recipe |
+|----------|--------|
+| M14, M76, M77, 1000-peer scale receipt | [iBGP route reflector at scale](cookbook/route-reflector.md) |
+| M74, M75, M77, VPN scale receipt | [L3VPN route reflector](cookbook/l3vpn-route-reflector.md) |
+| M24, M81 | [Controller / monitoring feed](cookbook/monitoring-feed.md) |
+| M29, M30, M31, M32, M33, M82 | [EVPN fabric route reflector](cookbook/evpn-fabric-rr.md) |
+| M34, M80 | [Policy quickstart (`.rpol`)](cookbook/policy-quickstart.md) |
+
 ## Interop labs — PR-gated (`interop.yml`)
 
 These run on every pull request via

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,0 +1,31 @@
+# Cookbook — scenario-driven deployment recipes
+
+Each recipe here is a complete deployment shape: a working config, the
+verification commands with the output shape to expect, the metrics to
+watch, and the failure modes with the explain commands that debug them.
+The configs are derived from the interop fixtures under
+[`tests/interop/configs/`](../../tests/interop/configs/) that the
+M-series receipts run against real peer stacks — every recipe cites the
+receipts that prove its scenario ([`RECEIPTS.md`](../RECEIPTS.md)).
+
+| Recipe | When this is you | Proven by |
+|--------|------------------|-----------|
+| [iBGP route reflector at scale](route-reflector.md) | Replacing an iBGP full mesh; tens to 1,000 clients | M14, M76, M77, [1000-peer scale receipt](../perf/scale-receipt-2026-07.md) |
+| [L3VPN route reflector](l3vpn-route-reflector.md) | VPNv4/VPNv6 reflection for a PE fleet, RT-Constrain filtered | M74, M75, M77, [VPN scale receipt](../perf/scale-receipt-2026-07.md) |
+| [Controller / monitoring feed](monitoring-feed.md) | Streaming BMP, durable events, and MRT into a controller or collector stack | M24, M81 |
+| [EVPN fabric route reflector](evpn-fabric-rr.md) | Control-plane-only RR for a VXLAN-EVPN leaf/spine fabric | M29, M30, M82, M33 |
+| [Policy quickstart (`.rpol`)](policy-quickstart.md) | First typed policy: tests, dry-run, hot swap, explain | M80, M34 |
+
+Conventions:
+
+- Addresses are examples (RFC 5737 / private ranges) — substitute your
+  own. No config here references a hostname.
+- Every config in this directory's recipes loads through the real
+  config loader: validated with `rustbgpd --check` and a daemon
+  startup on the same commit that shipped them.
+- gRPC in the recipes stays on the default local Unix socket with tier
+  authorization ([ADR-0064](../adr/0064-grpc-authorization.md)). For
+  remote access, see the mTLS guidance in [`SECURITY.md`](../SECURITY.md).
+- Start here if you haven't run the daemon at all yet: the README
+  [quick start](../../README.md#quick-start-bare-metal), then come
+  back for your scenario.

--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -1,0 +1,150 @@
+# EVPN fabric route reflector (control-plane only)
+
+**When this is you:** a VXLAN-EVPN leaf/spine fabric where the VTEPs
+(FRR, SR Linux, GoBGP, or rustbgpd leaves) do the dataplane and you
+want a lean, API-first reflector distributing the RFC 7432 routes
+between them. Scope, stated up front: **this recipe is the RR role.**
+The RR holds no EVI state, learns no MACs, and forwards no packets —
+it reflects all five EVPN route types verbatim between clients.
+rustbgpd also has a bidirectional VTEP mode (alpha, Linux/VXLAN-only,
+with IRB and multi-homing — see
+[`evpn-enablement.md`](../evpn-enablement.md)); that is a different
+deployment and not this document.
+
+**Proven by:** [M29](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
+(EVPN RR capability + `ListEvpnRoutes` vs FRR), M30 (Type 2 MAC
+reflection end-to-end between kernel VXLAN VTEPs), M31 (MAC mobility +
+sticky preservation), M32 (multi-homing Type 1 EAD / Type 4 ES
+reflection), M82 (VLAN-aware-bundle reflection with non-zero Ethernet
+Tags — including rustbgpd's first vendor-NOS leg, Nokia SR Linux
+25.10), and the M33 scale gate (50k reflected Type 2 routes + 60 s of
+1,000-rps churn). The config below is
+[`examples/rr-evpn-fabric/config.toml`](../../examples/rr-evpn-fabric/config.toml).
+
+## Config
+
+```toml
+[global]
+asn = 65000
+router_id = "10.0.0.100"
+listen_port = 179
+cluster_id = "10.0.0.100"
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# All VTEPs are iBGP RR clients on the l2vpn_evpn family. Empty
+# [[evpn_instances]] (none configured) selects pure RR mode: no local
+# EVI state, no kernel programming, reflection only.
+[[neighbors]]
+address = "10.0.0.1"
+remote_asn = 65000
+description = "vtep-leaf-01"
+hold_time = 180
+families = ["l2vpn_evpn"]
+route_reflector_client = true
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65000
+description = "vtep-leaf-02"
+hold_time = 180
+families = ["l2vpn_evpn"]
+route_reflector_client = true
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65000
+description = "vtep-leaf-03"
+hold_time = 180
+families = ["l2vpn_evpn"]
+route_reflector_client = true
+```
+
+For larger fabrics, template the leaves with a peer group and an
+auto-accept range over the VTEP loopback subnet — the
+[unicast RR recipe](route-reflector.md#config) shows the
+`[peer_groups]` + `[[dynamic_neighbors]]` shape; swap the families for
+`["l2vpn_evpn"]`.
+
+## Verify
+
+```console
+$ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
+$ rbgp neighbor                      # every leaf Established, l2vpn_evpn negotiated
+$ rbgp evpn                          # all reflected EVPN routes
+$ rbgp evpn --route-type 2           # MAC/IP advertisements only
+$ rbgp evpn --route-type 3           # IMET (BUM flooding) entries
+$ rbgp evpn --rd 65000:100           # one EVI's view
+$ rbgp evpn --peer 10.0.0.1          # what leaf-01 contributed
+```
+
+Expected shape: one row per (RD, route-type, key) with the originating
+peer; after two leaves come up with the same L2VNI you should see each
+leaf's Type 3 IMET route reflected to the other, then Type 2 rows
+appearing as MACs are learned.
+
+Two things that look odd but are correct:
+
+- **The same MAC under two Ethernet Tags is two routes.** In
+  VLAN-aware-bundle service the non-zero Ethernet Tag is part of the
+  route identity ([ADR-0092](../adr/0092-evpn-vlan-aware-bundle-service.md));
+  the RR keys and reflects them separately, tag-verbatim, and a
+  single-tag withdraw removes exactly that entry (M82).
+- **Attributes pass through untouched.** RD, label/VNI, next-hop, RTs,
+  MAC-mobility sequence numbers, ESI — the RR adds ORIGINATOR_ID and
+  CLUSTER_LIST per RFC 4456 and changes nothing else. DF election,
+  ARP/ND suppression, and mobility sequencing are the VTEPs' business.
+
+## Watch
+
+The [Grafana overview](../GRAFANA.md) session and RIB-scale rows apply
+as-is (`bgp_session_state_transitions_total`,
+`bgp_rib_outbound_registered_peers`, update-group gauges). Per-VNI
+EVPN metric families (`evpn_*`) are VTEP-mode surface and stay empty
+in the RR role — deliberately not on the overview dashboard.
+
+Route churn is the fabric health signal on an EVPN RR: watch
+`rbgp events watch --category route` (or the route-event history,
+`rbgp events --limit 200`) during rollouts. MAC-mobility wars show up
+as a tight add/withdraw loop on one MAC key with a climbing sequence
+number.
+
+## Failure modes
+
+**A leaf's routes aren't reaching another leaf.** (The
+`rbgp rib advertised --explain` gate ladder covers the unicast and
+VPN families, not EVPN — for EVPN, walk the gates by hand; they fail
+in this order.) First `rbgp evpn --peer 10.0.0.1` — did the RR accept
+the routes from the source leaf at all? Then the two common
+reflection stops: *family* — the quiet leaf didn't negotiate
+`l2vpn_evpn` (check its row in `rbgp neighbor`; an FRR leaf missing
+`neighbor X activate` under `address-family l2vpn evpn` establishes
+happily and receives nothing — the M29 lesson) — and *RR rules* — the
+leaf isn't marked `route_reflector_client`, so client→non-client
+reflection rules apply.
+
+**Vendor NOS quirks.** From the M82 SR Linux leg: SR Linux enforces
+one EVI per mac-vrf (bundle identity = shared RT + Ethernet Tag,
+per-BD RDs) and needs an explicit `transport local-address` on the BGP
+group, or it sources the session from its system0 address and the RR's
+neighbor stanza never matches. Recorded in
+[`upstream-findings.md`](../upstream-findings.md) and the M82 lab
+fixtures.
+
+**Reflected state survives leaf restarts?** Add GR to the neighbor
+stanzas (`graceful_restart = true` and friends, as in the
+[unicast recipe](route-reflector.md#config)) if your leaves support
+GR for EVPN; without it, a leaf bounce withdraws its routes
+fabric-wide and they re-learn on re-establish.

--- a/docs/cookbook/l3vpn-route-reflector.md
+++ b/docs/cookbook/l3vpn-route-reflector.md
@@ -1,0 +1,174 @@
+# L3VPN route reflector (VPNv4/VPNv6 + RT-Constrain)
+
+**When this is you:** you have a PE fleet exchanging VPNv4/VPNv6
+routes (SAFI 128) and want the reflector out of the vendor-appliance
+business — reflect with RD, MPLS label stack, next-hop, and Route
+Targets preserved verbatim, and only send each PE the routes whose RTs
+it actually imports (RFC 4684 RT-Constrain). Scope honesty up front:
+this is the **route-reflector / controller-feed slice only**
+([ADR-0077](../adr/0077-mpls-vpn-bgpls-address-family-boundary.md)).
+rustbgpd does no VRF import, no MPLS label forwarding, no CE-facing
+attachment circuits — the PEs keep their dataplane; the RR moves
+routes.
+
+**Proven by:** [M74](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
+(VPNv4 reflection, RD/label/RT/next-hop field-equal on the sink's
+re-decoded NLRI, vs GoBGP), M75 (RT-Constrain filtering: strict
+empty-membership, widen/narrow without session reset, and the
+non-RTC-peer full-table rule), M77 (GR/LLGR stale preservation for the
+VPN and RTC families — RTC membership survives a PE restart, so no
+VPN blackout at re-establish), and the
+[VPN scale receipt](../perf/scale-receipt-2026-07.md) (Scenario E):
+100k VPNv4 to 1,000 clients in 12.6 s uniform / 3.9 s with
+heterogeneous ~10 % RT memberships, and a single member's
+RT-membership flip at 100k staged routes hitting the wire in ~15 ms
+with zero policy evaluations. Config shape derived from
+[`tests/interop/configs/rustbgpd-m75-rtc-rr.toml`](../../tests/interop/configs/rustbgpd-m75-rtc-rr.toml)
+and [`rustbgpd-m77-gr-rr.toml`](../../tests/interop/configs/rustbgpd-m77-gr-rr.toml).
+
+## Config
+
+```toml
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+cluster_id = "10.0.0.1"
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# PE clients: VPN families plus "rtc" (RFC 4684, AFI 1 / SAFI 132).
+# Each PE advertises its RT membership as RTC NLRIs; the RR filters
+# its VPN reflection per peer accordingly. Semantics are strict: an
+# RTC-negotiated peer with an empty advertised membership receives
+# NO VPN routes (fail closed) until its first RTC announce arrives.
+#
+# GR/LLGR on the VPN + RTC families keeps both the VPN routes AND the
+# peer's RTC membership across a PE restart — without membership
+# retention, a restarting PE would blackhole its VPNs until it
+# re-advertised every RT (M77 proves the retention).
+[peer_groups.pe-clients]
+hold_time = 90
+families = ["l3vpn_ipv4_unicast", "l3vpn_ipv6_unicast", "rtc"]
+route_reflector_client = true
+graceful_restart = true
+gr_stale_routes_time = 120
+llgr_stale_time = 300
+
+[[neighbors]]
+address = "10.0.0.11"
+remote_asn = 65000
+description = "pe-1"
+peer_group = "pe-clients"
+
+[[neighbors]]
+address = "10.0.0.12"
+remote_asn = 65000
+description = "pe-2"
+peer_group = "pe-clients"
+
+# A consumer WITHOUT "rtc" on purpose: a peer that has not negotiated
+# SAFI 132 must receive the full unfiltered VPN table (RFC 4684 rule;
+# M75 pins it). This is the controller/analytics-feed shape.
+[[neighbors]]
+address = "10.0.0.100"
+remote_asn = 65000
+description = "controller-feed"
+hold_time = 90
+route_reflector_client = true
+families = ["l3vpn_ipv4_unicast", "l3vpn_ipv6_unicast"]
+```
+
+## Verify
+
+```console
+$ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
+$ rbgp neighbor
+```
+
+All PEs `Established`. Note the update-group column: since
+[ADR-0099](../adr/0099-update-groups-v2.md), RTC negotiation is part
+of the group key, **not** a per-peer fallback — PEs with entirely
+different RT memberships still share one group and one staging pass;
+the RFC 4684 filter is applied per member at emit time.
+
+The VPN table and the membership driving the filter:
+
+```console
+$ rbgp rib vpn                          # VPNv4/VPNv6: RD, prefix, label, RTs
+$ rbgp rib vpn -a vpnv6                 # VPNv6 only
+$ rbgp rib rtc                          # RT-Constrain NLRIs per peer
+$ rbgp rib rtc --peer 10.0.0.11         # what pe-1 says it imports
+$ rbgp rib advertised 10.0.0.12 -a l3vpn_ipv4_unicast   # what pe-2 gets
+```
+
+Expected shape: `rbgp rib advertised` toward an RTC peer shows only
+routes whose RTs intersect that peer's membership;
+toward `controller-feed` it shows every VPN route.
+
+Refresh a PE's VPN view without touching the session (the stale
+lifecycle is BoRR/EoRR-bounded per RFC 7313):
+
+```console
+$ rbgp neighbor 10.0.0.11 softreset --family l3vpn_ipv4_unicast
+```
+
+## Watch
+
+Same dashboard rows as the
+[unicast RR recipe](route-reflector.md#watch) — the update-group
+gauges (`bgp_update_groups`, `bgp_update_group_members{group}`,
+`bgp_update_group_fallback_peers`) cover the VPN groups too
+(ADR-0099), and `bgp_session_state_transitions_total` catches PE
+flaps. RIB scale panels in the [Grafana overview](../GRAFANA.md)
+track table growth as VPNs are provisioned.
+
+## Failure modes
+
+**A PE gets no VPN routes although its session is Established.**
+First suspect: empty RTC membership — strict fail-closed is the
+designed behavior, not a bug. Check what the PE has advertised:
+
+```console
+$ rbgp rib rtc --peer 10.0.0.11
+```
+
+Empty output = the PE negotiated SAFI 132 but announced no RT
+membership; fix the PE's VRF import config (or its RTC default-route
+origination). Confirm with the VPN export ladder, which includes the
+RT-membership gate:
+
+```console
+$ rbgp rib advertised 10.0.0.11 --explain --prefix 10.1.0.0/24 --rd 65000:1
+```
+
+A STOP at `rt_membership` names exactly this condition; the ladder
+otherwise mirrors the unicast one
+(`best_route → … → rt_membership → export_policy → adj_rib_out`).
+
+**The controller feed receives "too much".** By design: no SAFI 132
+negotiated → full table. If the consumer should be filtered, negotiate
+`rtc` on that peer and advertise membership from its side.
+
+**Stale VPN routes after a PE restart.** Bounded by the GR window then
+`llgr_stale_time`, same as unicast — and deliberately so: the RTC
+membership is preserved through the same mechanism, so reflection
+resumes without a blackout when the PE returns (M77). If a PE never
+returns, both the routes and its membership expire with LLGR.
+
+**A VRF is torn down on a PE but its routes linger on other PEs.**
+Check the withdraw actually arrived: `rbgp events --prefix <pfx>`
+shows the per-prefix route-event history, and `rbgp rib vpn --peer
+<pe>` shows what the RR still holds from that PE.

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -1,0 +1,188 @@
+# Controller / monitoring feed (BMP trio, events, MRT)
+
+**When this is you:** a controller, analytics pipeline, or NOC stack
+needs to see what this daemon sees — pre-policy, post-policy, and
+Loc-RIB route streams into BMP collectors, a durable event feed your
+bridge can replay after a restart, periodic MRT table archives, and a
+Grafana dashboard on top. rustbgpd exports the full BMP monitoring
+trio on one exporter (RFC 7854 Adj-RIB-In, RFC 8671 Adj-RIB-Out as
+byte-exact wire PDUs, RFC 9069 Loc-RIB), selectable per collector.
+
+**Proven by:** [M24](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
+(BMP Initiation / PeerUp / RouteMonitoring ordering vs a BMP receiver)
+and M81 (the trio plus BMPv4, validated against three independent
+decoders at once: pmacct, gobmp, and tshark). Config shape derived
+from
+[`tests/interop/configs/rustbgpd-m81-bmp-rr.toml`](../../tests/interop/configs/rustbgpd-m81-bmp-rr.toml)
+and [`examples/route-collector/`](../../examples/route-collector/).
+
+## Config
+
+The example is an RR that also feeds the monitoring stack; the same
+`[bmp]` / `[event_history]` / `[mrt]` blocks bolt onto any of the
+other recipes unchanged.
+
+```toml
+[global]
+asn = 65000
+router_id = "10.255.0.1"
+listen_port = 179
+cluster_id = "10.255.0.1"
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# Durable event outbox (ADR-0072): restart-safe replay cursor for
+# SubscribeFromEvent. Opt-in — it costs memory/CPU at scale, which is
+# why it is off by default. Enable it here because replay is the
+# point of this deployment.
+[event_history]
+enabled = true
+
+# Periodic MRT TABLE_DUMP_V2 snapshots — readable by bgpdump, BGPKIT,
+# and the RouteViews/RIPE RIS toolchains.
+[mrt]
+output_dir = "/var/lib/rustbgpd/mrt"
+dump_interval = 3600
+compress = true
+file_prefix = "feed"
+
+[bmp]
+sys_name = "rustbgpd-feed"
+sys_descr = "fabric RR monitoring feed"
+
+# Production collector: BMP v3 (the default), all three RIB views.
+# When a collector connects it receives a chunked dump of the current
+# table state followed by End-of-RIB, then deltas (RFC 9069 §"on
+# connect" behavior — no daemon restart needed to attach a collector).
+[[bmp.collectors]]
+address = "10.20.0.10:1790"
+reconnect_interval = 5
+monitor = ["rib_in_pre", "rib_out_post", "loc_rib"]
+
+# Optional second collector with BMPv4 TLV framing + the Path Marking
+# TLV. Caveat, stated plainly: BMPv4 code points are pre-IANA drafts
+# (draft-ietf-grow-bmp-tlv / draft-ietf-grow-bmp-path-marking-tlv) and
+# may renumber; current pmacct releases discard tlv-20-framed v4 Route
+# Monitoring messages. Keep production collectors on v3 (the default);
+# point v4 only at tooling that tracks the drafts (M81 validated the
+# v4 bytes with tshark 4.4).
+#[[bmp.collectors]]
+#address = "10.20.0.11:1790"
+#reconnect_interval = 5
+#version = 4
+#monitor = ["rib_in_pre", "rib_out_post", "loc_rib"]
+
+[[neighbors]]
+address = "10.0.0.11"
+remote_asn = 65000
+description = "pe-1"
+hold_time = 90
+route_reflector_client = true
+families = ["ipv4_unicast", "ipv6_unicast", "l3vpn_ipv4_unicast"]
+
+[[neighbors]]
+address = "10.0.1.2"
+remote_asn = 65000
+description = "pe-2"
+hold_time = 90
+route_reflector_client = true
+families = ["ipv4_unicast", "ipv6_unicast", "l3vpn_ipv4_unicast"]
+```
+
+## Verify
+
+```console
+$ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
+$ rbgp health
+$ rbgp neighbor
+```
+
+**BMP:** on the collector you should see Initiation, one PeerUp per
+established peer per view, the chunked table dump, End-of-RIB, then
+live RouteMonitoring deltas. From the daemon side the collector
+connection state is visible in the logs (`log_format = "json"`) and
+the BMP metrics below.
+
+**Event replay (the bridge contract):** live tail plus durable replay
+from a cursor. `--from-event-id 0` replays everything retained, then
+tails; your bridge persists the last `event_id` it processed and
+resumes from there after either side restarts:
+
+```console
+$ rbgp events watch --from-event-id 0
+$ rbgp events watch --category route,session --from-event-id 41236
+```
+
+The same contract over raw gRPC is
+`EventService.SubscribeFromEvent` — see
+[`examples/event-bridge/`](../../examples/event-bridge/) for a
+complete bridge (gRPC → JSON lines) you can pipe into Kafka, NATS,
+or Vector. rustbgpd deliberately is not an event bus; the outbox is
+a bounded SQLite WAL store with a monotonic cursor
+([ADR-0072](../adr/0072-durable-event-history.md)).
+
+**MRT:** force a dump and inspect it with your usual tooling:
+
+```console
+$ rbgp mrt-dump
+$ ls /var/lib/rustbgpd/mrt/
+feed.20260703.120001.123456789.mrt.gz
+```
+
+**Looking glass (optional):** for an Alice-LG-style frontend, run the
+[`examples/birdwatcher-adapter/`](../../examples/birdwatcher-adapter/)
+against a gRPC TCP listener — the in-daemon
+`[global.telemetry.looking_glass]` is deprecated in favor of it.
+
+## Watch
+
+Import the overview dashboard per [`GRAFANA.md`](../GRAFANA.md); the
+BMP / event-outbox row is populated once the features above are
+configured. Key series:
+
+| Metric | Meaning |
+|--------|---------|
+| `bgp_event_outbox_degraded` | 1 = outbox DB failed and was quarantined; replay unavailable until operator restart |
+| `bmp_collector_drops_total` | messages dropped toward a slow/disconnected collector |
+| `bmp_source_drops_total` | route-monitoring events dropped at the source tap under backpressure |
+| `bmp_replay_attempts_total` | PeerUp-cache replays on collector reconnect |
+| `bgp_rib_outbound_registered_peers` | feed coverage: peers whose routes the views carry |
+
+## Failure modes
+
+**`SubscribeFromEvent` / `rbgp events watch --from-event-id` returns
+`FAILED_PRECONDITION`.** The daemon is running with
+`[event_history].enabled = false` (the default). Enable it and
+restart — the outbox fields are restart-required.
+
+**The bridge missed events during a burst.** Live streams emit
+`stream_lagged` warnings when a bounded source dropped events for a
+slow consumer. That is the signal to resume via the durable cursor
+(`--from-event-id <last-processed>`) rather than the live ring.
+
+**A BMP collector shows nothing after a network blip.** The daemon
+redials every `reconnect_interval` seconds and replays the full state
+dump on reconnect; check the collector-side listener first, then the
+daemon log for the collector's connection state transitions.
+
+**pmacct rejects the v4 stream (`BMPv4 BGP PDU TLV != 1`).** Known and
+expected — see the caveat in the config above. Move that collector to
+`version = 3` (or drop the `version` key; 3 is the default).
+
+**The events DB was corrupted by a crash.** The bad file is renamed
+`events.db.stale`, the daemon continues (pass-through) unless
+`[event_history].required = true`, and `bgp_event_outbox_degraded`
+latches to 1 until an operator restart. Details:
+[`CONFIGURATION.md` §event_history](../CONFIGURATION.md#event_history).

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -1,0 +1,244 @@
+# Policy quickstart (`.rpol`)
+
+**When this is you:** you're about to write your first real routing
+policy on rustbgpd and want the workflow that keeps it honest — a
+typed, compiled policy file with its unit tests *in the file*, checked
+before it ever touches the daemon, dry-run against the live RIB before
+it's attached, hot-swapped under traffic with SIGHUP, and explainable
+per term afterwards. Full language reference:
+[`rpol-language.md`](../rpol-language.md)
+([ADR-0096](../adr/0096-policy-language.md)).
+
+**Proven by:** [M80](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
+(route-for-route parity against FRR route-maps, `rbgp policy check`
+gating, and a SIGHUP hot-apply under traffic that refreshes only the
+peers whose chains changed) and M34 (SIGHUP policy soft-reset
+auto-fire). The fixture this quickstart is modeled on:
+[`tests/interop/configs/rustbgpd-m80-policy.rpol`](../../tests/interop/configs/rustbgpd-m80-policy.rpol).
+
+## 1. Write the policy — `edge.rpol`
+
+An eBGP edge shape: bogon and transit-leak guards, a customer
+prefix-set with per-peer local-pref, community bookkeeping, and tests.
+
+```rpol
+prefix-set bogons {
+    10.0.0.0/8 le 32, 172.16.0.0/12 le 32, 192.168.0.0/16 le 32,
+    100.64.0.0/10 le 32, 0.0.0.0/8 le 32
+}
+prefix-set customers { 203.0.113.0/24 ge 25 le 28, 198.51.100.0/24 }
+community-set scrub-marks { 65000:666 }
+
+# Predicate policy: decides both ways so `apply()` is meaningful.
+policy bogon-filter {
+    term drop-bogons {
+        if route.prefix in bogons { reject }
+    }
+    term clean { accept }
+}
+
+# Parameterized import template: each peer instantiates its own
+# local-pref. peer.group matching keeps one policy for the whole
+# customer fleet — note the update-group consequence in §6.
+policy customer-in(peer_lp: u32) {
+    term bogon-guard {
+        if !apply(bogon-filter) { reject }
+    }
+    term transit-guard {
+        # A customer must never send us a path through our transit.
+        if route.as-path matches "_64620_" { reject }
+    }
+    term scrub {
+        # Modify-and-continue: no verdict, keep walking.
+        if route.communities in scrub-marks {
+            remove community 65000:666;
+            set med 0
+        }
+    }
+    term customer-routes {
+        if route.prefix in customers && peer.group == "customers" {
+            set local-pref peer_lp;
+            add community 65000:100;
+            accept
+        }
+    }
+    term default-reject { reject }
+}
+
+policy edge-out {
+    term no-internal-leak {
+        if route.communities has 65000:900 { reject }
+    }
+    term tag { add community 65000:200; accept }
+}
+
+# Tests live with the policy and run offline (`rbgp policy check`).
+test accepts-customer-prefix-with-lp {
+    route { prefix 203.0.113.0/26; communities [65000:666]; med 300 }
+    peer { group "customers" }
+    expect customer-in(150) == accept with local-pref 150, med 0, community 65000:100
+}
+
+test rejects-customer-prefix-from-wrong-group {
+    route { prefix 203.0.113.0/26 }
+    peer { group "transit" }
+    expect customer-in(150) == reject
+}
+
+test rejects-bogon {
+    route { prefix 10.1.0.0/16 }
+    expect customer-in(150) == reject
+}
+
+test rejects-transit-aspath {
+    route { prefix 203.0.113.0/26; as-path "65010 64620 3356" }
+    expect customer-in(150) == reject
+}
+
+test export-blocks-internal {
+    route { prefix 198.51.100.0/24; communities [65000:900] }
+    expect edge-out == reject
+}
+```
+
+Note the `peer { ... }` fixture blocks: a policy that matches on
+`peer.group` (or `peer.address` / `peer.asn`) needs the test to say
+which peer it is evaluating as — an omitted peer block means an empty
+peer context and those predicates never match.
+
+## 2. Check it — no daemon needed
+
+```console
+$ rbgp policy check edge.rpol
+```
+
+Parse, typecheck, and every `test` block — exit 0 clean, 1 for
+diagnostics (rendered with source spans), 2 for test failures. Put
+this in CI next to the config lint; M80 gates on it.
+
+## 3. Wire it into the config
+
+```toml
+[global]
+asn = 65000
+router_id = "192.0.2.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+[policy]
+rpol_files = ["policies/edge.rpol"]   # relative to this config file
+
+[peer_groups.customers]
+hold_time = 90
+families = ["ipv4_unicast"]
+
+[[neighbors]]
+address = "192.0.2.10"
+remote_asn = 64500
+description = "customer-a"
+peer_group = "customers"
+import_policy_chain = ["customer-in(150)"]
+export_policy_chain = ["edge-out"]
+
+[[neighbors]]
+address = "192.0.2.20"
+remote_asn = 64501
+description = "customer-b"
+peer_group = "customers"
+import_policy_chain = ["customer-in(200)"]   # same template, higher LP
+export_policy_chain = ["edge-out"]
+```
+
+`rustbgpd --check config.toml` validates the whole thing — including
+compiling the `.rpol` file — before you restart or reload anything.
+
+Before attaching a *candidate* policy on a running daemon, dry-run it
+against the live RIB — read-only, no route state or session touched:
+
+```console
+$ rbgp policy test edge.rpol --policy "customer-in(150)" \
+    --direction import --peer 192.0.2.10
+```
+
+Output: accept/reject counts, per-term hit counters, and before/after
+attribute diffs for the first N modified routes.
+
+## 4. Hot-swap under traffic
+
+Edit `edge.rpol`, re-run `rbgp policy check`, then:
+
+```console
+$ kill -HUP $(pidof rustbgpd)
+```
+
+The planner diffs policy *content*: only peers whose effective chains
+changed get a route refresh / re-evaluation (M80 asserts exactly one
+peer refreshes when one peer's policy changes; M34 proves the
+soft-reset auto-fire). Peers on unchanged chains are untouched.
+
+## 5. Explain it afterwards — the trilogy
+
+```console
+# Import: why was this prefix permitted/denied from this peer?
+# Per-term trace for .rpol members; backed by the per-session
+# decision cache ([policy.explain], on by default — ADR-0073).
+$ rbgp policy explain --neighbor 192.0.2.10 --prefix 203.0.113.0/26
+
+# Export: the full gate ladder toward a peer; the export_policy rung
+# names the deciding policy:term.
+$ rbgp rib advertised 192.0.2.20 --explain --prefix 203.0.113.0/26
+
+# Best path: why this candidate won in the Loc-RIB.
+$ rbgp rib --prefix 203.0.113.0/26 --explain
+```
+
+And the live counters — which terms are actually doing work since the
+chain was installed (counters reset on chain replace):
+
+```console
+$ rbgp policy stats --peer 192.0.2.20
+```
+
+## 6. The update-group footnote
+
+`peer.group` / `peer.address` / `peer.asn` matches make a policy's
+verdict peer-dependent, so any peer whose **export** chain uses them
+drops to the per-peer staging path (`policy_peer_context` in
+`rbgp neighbor <address>`, [reason table](../CONFIGURATION.md#update-groups-automatic)).
+Identical semantics, less sharing. Import chains don't affect
+grouping, and parameterized instantiations like `customer-in(150)` vs
+`customer-in(200)` on the *import* side are free. Keep peer-context
+matches out of widely shared export chains on a big reflector.
+
+## Failure modes
+
+**`--check` fails after an `.rpol` edit but the daemon is still
+running the old policy.** That is the designed order — compile errors
+never reach the live daemon. On SIGHUP with a broken file, the reload
+is rejected as a unit and the running config stays; fix and re-signal.
+
+**A route you expected `accept`ed is missing.** `rbgp policy explain`
+first: `not_seen` means it never arrived (look upstream), a term-named
+denial means your policy did it. A denied route keeps no
+modifications — a `set` executed before a later `reject` is discarded
+by design.
+
+**A test passes but the live daemon disagrees.** Usually chain
+composition — another member of the effective chain rejected first —
+or a peer-context mismatch between the test's `peer` fixture and the
+real neighbor. `rbgp policy chain show --neighbor <addr>` prints the
+effective chain order; `rbgp policy test` with `--peer` reproduces
+the live evaluation against the real peer context.

--- a/docs/cookbook/route-reflector.md
+++ b/docs/cookbook/route-reflector.md
@@ -1,0 +1,210 @@
+# iBGP route reflector at scale
+
+**When this is you:** you run (or are about to run) an iBGP full mesh
+that no longer scales, and you want a dedicated route reflector —
+tens to a thousand clients, fast convergence without per-peer tuning,
+stale-route protection across client restarts, and per-client optimal
+paths if your clients sit in different corners of the IGP. rustbgpd's
+RR path needs no fanout configuration: peers whose staged output is
+provably identical share one update group automatically.
+
+**Proven by:** [M14](../RECEIPTS.md#interop-labs--pr-gated-interopyml)
+(RFC 4456 reflection vs FRR), M76 (RFC 9107 Optimal Route Reflection),
+M77 (GR/LLGR stale preservation), and the
+[1000-peer scale receipt](../perf/scale-receipt-2026-07.md): 100k
+routes to 1,000 real transport sessions converge on the wire in 1.8 s
+at 419 MiB RSS, driven by the ADR-0098 update-group fanout (~28×
+faster than per-peer staging at 256 uniform clients). Config shape
+derived from
+[`tests/interop/configs/rustbgpd-m76-orr-rr.toml`](../../tests/interop/configs/rustbgpd-m76-orr-rr.toml)
+and [`rustbgpd-m77-gr-rr.toml`](../../tests/interop/configs/rustbgpd-m77-gr-rr.toml).
+
+## Config
+
+```toml
+[global]
+asn = 65000
+router_id = "10.0.0.1"
+listen_port = 179
+cluster_id = "10.0.0.1"        # RFC 4456 cluster identifier
+dynamic_neighbor_limit = 1024  # cap for the auto-accept range below
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# One template for the whole client fleet. Uniform clients group
+# automatically (ADR-0098) — there is no update-group knob.
+#
+# GR/LLGR: the RR is a receiving-speaker helper. On client restart it
+# keeps the client's routes for the peer-advertised restart window
+# (RFC 4724), then — because llgr_stale_time > 0 — demotes them to
+# LLGR_STALE (RFC 9494) instead of purging, up to
+# min(local llgr_stale_time, peer's per-family time).
+#
+# send_hold_time (RFC 9687) is on by default at max(480, 2 × hold_time):
+# a client that stops draining its TCP socket is torn down instead of
+# silently wedging the shared writer.
+[peer_groups.rr-clients]
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_reflector_client = true
+graceful_restart = true
+gr_stale_routes_time = 120
+llgr_stale_time = 300
+
+[[neighbors]]
+address = "10.0.0.11"
+remote_asn = 65000
+description = "client-1"
+peer_group = "rr-clients"
+
+[[neighbors]]
+address = "10.0.0.12"
+remote_asn = 65000
+description = "client-2"
+peer_group = "rr-clients"
+
+# The rest of the fleet auto-accepts from the loopback range — no
+# per-client stanza needed. Dynamic peers inherit rr-clients.
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "rr-clients"
+remote_asn = 65000
+description = "rr client fleet"
+```
+
+### Optional: per-client optimal paths (ORR, RFC 9107)
+
+If clients in different IGP regions should each get *their* closest
+exit (not the RR's), add a BGP-LS topology source and pin clients to
+vantages. Per-vantage best paths are computed via SPF over the
+BGP-LS-sourced topology ([ADR-0095](../adr/0095-optimal-route-reflection.md))
+— a capability no other open-source BGP daemon ships. M76 proves
+divergent per-vantage bests and a topology-driven flip against GoBGP.
+
+```toml
+# An IGP node exporting the topology over BGP-LS (e.g. a router or a
+# controller speaking AFI 16388 / SAFI 71).
+[[neighbors]]
+address = "10.0.0.250"
+remote_asn = 65000
+description = "igp-topology-source"
+hold_time = 90
+route_reflector_client = true
+families = ["linkstate"]
+
+# A client whose best paths should be computed from node 10.0.8.1's
+# position in the IGP. An unresolved vantage falls back silently to
+# the standard best — check `rbgp orr` after enabling.
+[[neighbors]]
+address = "10.0.0.13"
+remote_asn = 65000
+description = "client-region-b"
+peer_group = "rr-clients"
+orr_vantage = "10.0.8.1"
+```
+
+## Verify
+
+```console
+$ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
+$ rbgp neighbor
+```
+
+Expect one row per client in `Established`. The per-peer detail view
+carries the update-group membership: uniform clients share a
+`group:N` id; a peer on the per-peer fallback shows its reason
+instead:
+
+```console
+$ rbgp neighbor 10.0.0.11
+...
+Send Hold Time:        480
+...
+Update Group:          group:0
+```
+
+Routes and reflection:
+
+```console
+$ rbgp rib                                 # Loc-RIB best routes
+$ rbgp rib received 10.0.0.11              # what a client sent us
+$ rbgp rib advertised 10.0.0.12            # what we reflect to a client
+$ rbgp rib --prefix 203.0.113.0/24 --explain   # why this best won
+```
+
+ORR (if configured):
+
+```console
+$ rbgp topology nodes        # BGP-LS-sourced graph is populated
+$ rbgp orr                   # each vantage: resolved, SPF reach, bound peers
+```
+
+An unresolved vantage row means that client is silently getting the
+standard best — fix the BGP-LS feed, not the client.
+
+## Watch
+
+Prometheus (`prometheus_addr`, `/metrics`; dashboard import in
+[`GRAFANA.md`](../GRAFANA.md) — the churn/distribution row carries the
+update-group gauges):
+
+| Metric | Healthy shape |
+|--------|---------------|
+| `bgp_update_groups` | small and stable (1 for a uniform fleet) |
+| `bgp_update_group_members{group}` | ≈ fleet size in one group |
+| `bgp_update_group_fallback_peers` | 0 unless you expect fallbacks (table below) |
+| `bgp_update_group_regroups_total` | flat outside config/policy changes |
+| `bgp_rib_outbound_registered_peers` | = established client count |
+| `bgp_session_state_transitions_total` | flat outside maintenance |
+
+## Failure modes
+
+**A client is not grouped (`rbgp neighbor <address>` prints a reason, not
+`group:N`).** Grouping is purely an optimization — semantics are
+identical on the per-peer path — but at fleet scale you want to know
+why. The reasons ([full table](../CONFIGURATION.md#update-groups-automatic)):
+`policy_peer_context` (its export chain matches on peer
+address/ASN/group), `add_path_send`, `orr_vantage`, `orf_installed`.
+The first is the one you can usually fix: rewrite the chain so the
+peer-dependent match lives in a per-neighbor chain instead of a shared
+one.
+
+**A route isn't reaching a client.** Run the export gate ladder — a
+read-only dry run of the same staging body live distribution executes,
+update groups included:
+
+```console
+$ rbgp rib advertised 10.0.0.12 --explain --prefix 203.0.113.0/24
+```
+
+Each rung reports pass / STOP / n/a in live evaluation order
+(`best_route → split_horizon → rr_reflection → family → llgr → orf →
+export_policy → adj_rib_out`); a STOP names the gate holding the route
+back. `rr_reflection` STOPs are the classic RR misconfigurations:
+non-client → non-client reflection, or the client's own cluster id in
+CLUSTER_LIST.
+
+**Stale routes after a client restart.** Expected, and bounded: routes
+stay for the peer's advertised GR restart time, then carry
+`LLGR_STALE` until `llgr_stale_time` expires (during LLGR they are
+export-restricted per RFC 9494). If routes vanish immediately instead,
+the client didn't advertise GR — check `rbgp neighbor <address>` capability
+output. Legacy-family edge cases are documented in
+[`KNOWN_ISSUES.md`](../../KNOWN_ISSUES.md).
+
+**A client session drops with a send-hold NOTIFICATION.** The client
+stopped reading its socket for `send_hold_time` seconds (RFC 9687) —
+that is the protection working; investigate the client. Tune per peer
+group if your clients legitimately stall longer.


### PR DESCRIPTION
The adoption kit — the "first 15 minutes" for an evaluating operator. Docs-only, +1,076 lines.

## docs/cookbook/ — five scenario recipes

Each: "when this is you" → complete config → rbgp verification with expected shapes → metrics/dashboard rows → failure modes with the explain command that debugs each. Scenarios: RR at scale (update-groups + ORR + GR/LLGR + send-hold; cites the 1000-peer receipt), L3VPN RR (RTC strict-empty semantics, RT-aware grouping, --rd export explain), monitoring feed (BMP trio + the pre-IANA v4 caveat with pmacct reality, event replay, MRT, Grafana), EVPN fabric RR (RR-role-scoped explicitly; cites M82 incl. SR Linux quirks), policy quickstart (full rpol workflow through the explain trilogy; its 5 in-file tests pass live).

**Every config validated against the real binary**: extracted verbatim from the doc, `rustbgpd --check`, then booted live with rbgp probes. The validation caught and fixed two doc errors before they shipped (update-group renders on the neighbor detail view, not the list; export explain has no EVPN ladder).

## Quickstart + embedding

README quick-start commands verified against the built binary; "Next steps" now points at the cookbook (no separate QUICKSTART.md — it would be a third overlap). EMBEDDING.md extended in its existing voice with §8: the week's gRPC surface additions (received_at, export explain + group fields, settable send_hold_time), the SubscribeFromEvent replay contract, and the additive-proto stability posture.

Cross-links: README docs table, RECEIPTS.md receipts→recipes mapping. Link check: 0 problems across all touched files; no hostnames.