### PR TITLE
fix(rib): pass the per_client_best argument in bench_support's handle_peer_up

### DIFF
--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -62,6 +62,7 @@ impl RibManager {
                 false, // is_ebgp = false (iBGP / route-reflector scenario)
                 is_rr_client,
                 None,       // no ORR vantage
+                false,      // no per-client best (RS mode)
                 Vec::new(), // no Add-Path send
                 0,
                 Vec::new(), // no negotiated receive-side ORF


### PR DESCRIPTION
The feature-gated bench surface missed #696's new parameter — exactly
the failure class the bench-internals CI check exists to catch.
