### PR TITLE
feat(rib): per-client-best explain arm, RS profile polish, and ADR-0101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   --per-client-best` + show/JSON, config persistence, reload matrix
   (live, effective next session).
 
+- **Route-server profile polish (ADR-0101): truthful explain for
+  per-client best-path, distribution-mode display, and the refreshed
+  IXP example.** `ExplainAdvertisedRoute` for a `per_client_best`
+  member now dry-runs the same filtered-best candidate walk live
+  staging performs — ranked candidate ladder with one verdict per
+  denied candidate naming the deciding policy term ("candidate 1 of 2
+  denied by export policy \"no-tagged:block-tagged\"") and the
+  advertised runner-up, instead of the false "denied" the single-best
+  dry-run could report. `rbgp neighbor show` names the unicast
+  distribution mode (`single-best` / `add-path` / `orr` /
+  `per-client-best`, also in JSON). `examples/route-server/` now shows
+  both RFC 7947 §2.3.2 mitigations (member-alpha: Add-Path;
+  member-beta: `per_client_best`), sets `role = "route_server"` on
+  members (RFC 9234 OTC — dynamic/gRPC-added peers confirmed by test),
+  and adds `hygiene.rpol` (reject-AS_SET via `route.as-path matches
+  "\\{"`, reject-ASPA-invalid) with in-language tests runnable via
+  `rbgp policy check`.
+
 - **M82 interop receipt: EVPN VLAN-Aware Bundle (non-zero Ethernet
   Tag) route reflection — including rustbgpd's FIRST vendor-NOS interop
   leg (Nokia SR Linux 25.10).** The ADR-0092 Decision 6 proof ladder,

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ diversity scripts remain local / manual gates. See
 - **Cloud / AI-scale data-center fabrics** — API-first BGP control, BFD, ECMP,
   EVPN/VXLAN alpha, and whitebox-friendly interop surfaces
 - **Hosting provider prefix management** — API-driven customer prefix announcements
-- **Internet exchange route servers** — transparent mode, Add-Path, RPKI, Prefix ORF, per-member policy
+- **Internet exchange route servers** — transparent mode, Add-Path, per-client best-path (RFC 7947 path-hiding mitigation), RPKI, Prefix ORF, per-member policy
 - **SDN / network automation controllers** — programmable BGP control plane
 - **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP, birdwatcher-compatible REST API
 - **Lab and test environments** — clean API, structured logs, containerlab interop
@@ -310,7 +310,7 @@ and more explicit internal architecture.
 |---------|-------------|
 | [`examples/docker-compose/`](examples/docker-compose/) | Quick-start with Docker Compose — rustbgpd + FRR peer with sample routes |
 | [`examples/minimal/`](examples/minimal/) | Smallest working config — single eBGP peer |
-| [`examples/route-server/`](examples/route-server/) | IXP route server with RPKI, Add-Path, policy chains |
+| [`examples/route-server/`](examples/route-server/) | IXP route server with RPKI, Add-Path + per-client best-path, rpol hygiene policy |
 | [`examples/ddos-mitigation/`](examples/ddos-mitigation/) | FlowSpec + RTBH for automated DDoS mitigation |
 | [`examples/hosting-provider/`](examples/hosting-provider/) | iBGP route injector for customer prefix management |
 | [`examples/linux-edge-fib/`](examples/linux-edge-fib/) | Linux edge host with explicit ADR-0061 `[[fib_tables]]` unicast FIB programming |

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -64,6 +64,19 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         .into_inner();
 
     let cfg = n.config.as_ref();
+    // Unicast distribution mode, mirroring the RIB's mode ladder
+    // (negotiated Add-Path send outranks the per-client-best fallback).
+    // An ORR vantage is not on the runtime NeighborConfig surface, so
+    // it is recognized via the update-group ungrouped reason.
+    let distribution_mode = if cfg.map(|c| c.add_path_send).unwrap_or(false) {
+        "add-path"
+    } else if cfg.map(|c| c.per_client_best).unwrap_or(false) {
+        "per-client-best"
+    } else if n.update_group == "orr_vantage" {
+        "orr"
+    } else {
+        "single-best"
+    };
     if json {
         let out = JsonNeighborDetail {
             address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
@@ -87,6 +100,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             peer_group: cfg.map(|c| c.peer_group.clone()).unwrap_or_default(),
             route_server_client: cfg.map(|c| c.route_server_client).unwrap_or(false),
             per_client_best: cfg.map(|c| c.per_client_best).unwrap_or(false),
+            distribution_mode: distribution_mode.to_string(),
             add_path_receive: cfg.map(|c| c.add_path_receive).unwrap_or(false),
             add_path_send: cfg.map(|c| c.add_path_send).unwrap_or(false),
             add_path_send_max: cfg.map(|c| c.add_path_send_max).unwrap_or(0),
@@ -142,6 +156,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         if cfg.map(|c| c.per_client_best).unwrap_or(false) {
             println!("Per-Client Best:       true");
         }
+        println!("Distribution Mode:     {distribution_mode}");
         let role = cfg.map(|c| c.role.as_str()).unwrap_or("");
         if !role.is_empty() {
             println!("BGP Role:              {role}");

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -240,6 +240,9 @@ pub struct JsonNeighborDetail {
     pub route_server_client: bool,
     #[serde(skip_serializing_if = "is_false")]
     pub per_client_best: bool,
+    /// Unicast distribution mode: `single-best`, `add-path`, `orr`, or
+    /// `per-client-best`.
+    pub distribution_mode: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub role: String,
     pub strict_role: bool,
@@ -790,6 +793,7 @@ mod tests {
             peer_group: "rs-clients".to_string(),
             route_server_client: true,
             per_client_best: false,
+            distribution_mode: "add-path".to_string(),
             role: "rs".to_string(),
             strict_role: true,
             remote_role: "rs-client".to_string(),

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -44,18 +44,74 @@ fn orr_candidates<'a>(
     })
 }
 
+/// Candidate paths for `prefix` visible to `target_peer` in the live
+/// multipath / per-client-best collector: [`orr_candidates`]'
+/// split-horizon and RFC 4456 reflection filter plus the per-candidate
+/// RFC 9494 §4.4 LLGR export gate. Shared by
+/// `distribute_multipath_prefix` and the per-client-best explain arm so
+/// explain walks exactly the candidate set live staging walks.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "candidate collection mirrors the per-target reflection filter inputs"
+)]
+fn multipath_candidates<'a>(
+    ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    prefix_peers: &'a UnicastPrefixPeers,
+    peer_is_rr_client: &'a HashMap<IpAddr, bool>,
+    prefix: &'a Prefix,
+    target_peer: IpAddr,
+    target_is_ebgp: bool,
+    target_is_rr_client: bool,
+    cluster_id: Option<Ipv4Addr>,
+    family: (Afi, Safi),
+    llgr: Option<&'a Vec<(Afi, Safi)>>,
+) -> impl Iterator<Item = &'a crate::route::Route> {
+    orr_candidates(
+        ribs,
+        prefix_peers,
+        peer_is_rr_client,
+        prefix,
+        target_peer,
+        target_is_ebgp,
+        target_is_rr_client,
+        cluster_id,
+    )
+    .filter(move |route| {
+        // RFC 9494 §4.4: each staged candidate is gated individually —
+        // a stale candidate must not occupy an Add-Path rank (or the
+        // filtered-best slot) toward a non-LLGR eBGP peer.
+        !super::llgr_stale_export_suppressed(
+            route.is_llgr_stale,
+            route.communities(),
+            family,
+            target_is_ebgp,
+            llgr,
+        )
+    })
+}
+
 impl RibManager {
-    /// Explain the single-best export ladder for an RFC 9107 ORR peer
-    /// or an Add-Path-send peer — the two per-target selection shapes
+    /// Explain the single-best export ladder for an RFC 9107 ORR peer,
+    /// an Add-Path-send peer, or an RFC 7947 §2.3.2 per-client-best
+    /// peer — the per-target selection shapes
     /// the [`super::ExportTarget::Explain`] dry run of
     /// `distribute_single_best_prefix` cannot serve (their best is not
     /// the Loc-RIB best / their staging is multipath). Candidate
-    /// collection is shared with live distribution (`orr_candidates`),
-    /// and every gate reuses the same helper the live bodies call
-    /// (`llgr_stale_export_suppressed`, `OrfFilterSet::permits`,
-    /// `rr_suppression_reason`, `routes_equal`), in the live bodies'
-    /// evaluation order (family → ORF → selection → LLGR → policy →
-    /// Adj-RIB-Out diff).
+    /// collection is shared with live distribution (`orr_candidates` /
+    /// `multipath_candidates`), and every gate reuses the same helper
+    /// the live bodies call (`llgr_stale_export_suppressed`,
+    /// `OrfFilterSet::permits`, `rr_suppression_reason`,
+    /// `routes_equal`), in the live bodies' evaluation order (family →
+    /// ORF → selection → LLGR → policy → Adj-RIB-Out diff).
+    ///
+    /// `per_client_best` selects the RFC 7947 §2.3.2 arm: rank the live
+    /// collector's candidate set with the Loc-RIB comparator and take
+    /// the first export-policy-permitted candidate, recording one
+    /// reason per denied candidate — the same walk
+    /// `distribute_multipath_prefix(send_max = 1, stage_path_id_zero)`
+    /// performs live. Ignored when Add-Path send is negotiated for the
+    /// prefix's family (a negotiated capability outranks the fallback,
+    /// exactly like the live mode ladder).
     #[expect(
         clippy::too_many_arguments,
         clippy::too_many_lines,
@@ -80,6 +136,7 @@ impl RibManager {
         add_path_send_max: u32,
         export_pol: Option<&PolicyChain>,
         orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult, IpAddr)>,
+        per_client_best: bool,
     ) -> ExplainAdvertisedRoute {
         use crate::best_path::{
             BestPathReason, best_path_cmp_orr, best_path_cmp_orr_with_reason,
@@ -269,6 +326,143 @@ impl RibManager {
                     message: format!("selected over runner-up: {detail}"),
                 });
             }
+            winner
+        } else if per_client_best && add_path_send_max == 0 {
+            // RFC 7947 §2.3.2 per-client best-path: rank the exact
+            // candidate set the live filtered-best collector walks
+            // (`multipath_candidates` — split horizon, RFC 4456
+            // reflection, per-candidate LLGR) with the Loc-RIB
+            // comparator, then take the first export-policy-permitted
+            // candidate — the same walk
+            // `distribute_multipath_prefix(send_max = 1)` performs
+            // live, with one recorded verdict per denied candidate.
+            let mut ranked: Vec<&crate::route::Route> = multipath_candidates(
+                ribs,
+                prefix_peers,
+                peer_is_rr_client,
+                &prefix,
+                target_peer,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                family,
+                llgr,
+            )
+            .collect();
+            ranked.sort_by(|a, b| crate::best_path::best_path_cmp(a, b));
+            if ranked.is_empty() {
+                let message = "no candidate for this prefix survives split-horizon / \
+                               reflection / LLGR filtering for this per-client best-path \
+                               peer"
+                    .to_string();
+                gate(
+                    &mut explain.gates,
+                    "best_route",
+                    "no_per_client_candidate",
+                    Stop,
+                    message.clone(),
+                );
+                explain.reasons.push(ExplainReason {
+                    code: "no_per_client_candidate",
+                    message,
+                });
+                return explain;
+            }
+            let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
+            let total = ranked.len();
+            let mut winner = None;
+            for (index, &candidate) in ranked.iter().enumerate() {
+                // Per-candidate export-policy verdict — the same
+                // context the live per-candidate walk builds, evaluated
+                // without counters (explain is a one-shot query; see
+                // the tail's non-counting rationale).
+                let aspath_str = if needs_as_path_string {
+                    candidate
+                        .as_path()
+                        .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
+                } else {
+                    String::new()
+                };
+                let ctx = RouteContext {
+                    prefix: Some(prefix),
+                    next_hop: Some(candidate.next_hop),
+                    extended_communities: candidate.extended_communities(),
+                    communities: candidate.communities(),
+                    large_communities: candidate.large_communities(),
+                    as_path_str: &aspath_str,
+                    as_path_len: candidate.as_path().map_or(0, rustbgpd_wire::AsPath::len),
+                    validation_state: candidate.validation_state,
+                    aspa_state: candidate.aspa_state,
+                    peer_address: Some(target_peer),
+                    peer_asn: target_peer_asn,
+                    peer_group: target_peer_group,
+                    route_type: Some(route_type(candidate.origin_type)),
+                    evpn_route_type: None,
+                    local_pref: candidate.local_pref_attr(),
+                    med: candidate.med_attr(),
+                };
+                let permitted = match export_pol {
+                    Some(chain) => {
+                        let (result, evaluation) = chain.compiled().evaluate_with_attribution(&ctx);
+                        if result.action == PolicyAction::Permit {
+                            true
+                        } else {
+                            let label = super::policy_label_with_term(
+                                export_pol,
+                                &ctx,
+                                evaluation.matched_policy.as_deref(),
+                            );
+                            explain.reasons.push(ExplainReason {
+                                code: "per_client_candidate_denied",
+                                message: format!(
+                                    "candidate {rank} of {total} (from {peer}, next hop \
+                                     {next_hop}) denied by export policy {label:?}",
+                                    rank = index + 1,
+                                    peer = candidate.peer,
+                                    next_hop = candidate.next_hop,
+                                ),
+                            });
+                            false
+                        }
+                    }
+                    None => true,
+                };
+                if permitted {
+                    winner = Some((index, candidate));
+                    break;
+                }
+            }
+            let Some((rank, winner)) = winner else {
+                explain.decision = ExplainDecision::Deny;
+                let message = format!(
+                    "all {total} candidate(s) denied by export policy — per-client \
+                     best-path (RFC 7947 §2.3.2) advertises nothing"
+                );
+                gate(
+                    &mut explain.gates,
+                    "best_route",
+                    "per_client_all_denied",
+                    Stop,
+                    message.clone(),
+                );
+                explain.reasons.push(ExplainReason {
+                    code: "per_client_all_denied",
+                    message,
+                });
+                return explain;
+            };
+            gate(
+                &mut explain.gates,
+                "best_route",
+                "per_client_best",
+                Pass,
+                format!(
+                    "per-client best-path (RFC 7947 §2.3.2): candidate {} of {total} \
+                     from {} is the first export-policy-permitted candidate",
+                    rank + 1,
+                    winner.peer
+                ),
+            );
             winner
         } else {
             let Some(best) = loc_rib.get(&prefix) else {
@@ -820,39 +1014,22 @@ impl RibManager {
         }
 
         // Collect all candidates across the announcing peers' Adj-RIB-Ins
-        // (reverse-index probe, not an all-peers scan).
-        let mut candidates: Vec<&crate::route::Route> =
-            Self::unicast_candidates(ribs, prefix_peers, prefix)
-                .filter(|route| {
-                    // Split horizon: exclude routes from the target peer
-                    if route.peer == target_peer {
-                        return false;
-                    }
-                    // iBGP split-horizon / RFC 4456 reflection
-                    if should_suppress_ibgp_inner(
-                        route,
-                        target_is_ebgp,
-                        target_is_rr_client,
-                        cluster_id,
-                        peer_is_rr_client,
-                    ) {
-                        return false;
-                    }
-                    // RFC 9494 §4.4: each staged candidate is gated
-                    // individually — a stale candidate must not occupy an
-                    // Add-Path rank toward a non-LLGR eBGP peer.
-                    if super::llgr_stale_export_suppressed(
-                        route.is_llgr_stale,
-                        route.communities(),
-                        family,
-                        target_is_ebgp,
-                        llgr,
-                    ) {
-                        return false;
-                    }
-                    true
-                })
-                .collect();
+        // (reverse-index probe, not an all-peers scan) — the collector is
+        // shared with the per-client-best explain arm so explain walks
+        // exactly this set.
+        let mut candidates: Vec<&crate::route::Route> = multipath_candidates(
+            ribs,
+            prefix_peers,
+            peer_is_rr_client,
+            prefix,
+            target_peer,
+            target_is_ebgp,
+            target_is_rr_client,
+            cluster_id,
+            family,
+            llgr,
+        )
+        .collect();
 
         // Sort by best-path preference (best first). A target bound to a
         // resolved ORR vantage ranks by the vantage's interior cost to

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1483,10 +1483,13 @@ impl RibManager {
     /// counts nothing; a grouped member is explained against its group
     /// table (its real advertised state) with split horizon applied
     /// against the member, exactly like the source-flip matrix does at
-    /// emit time. ORR-vantage and Add-Path-send peers (never grouped —
-    /// both disqualify) take the dedicated explain that shares its
-    /// candidate collection and gate helpers with the live
-    /// ORR/multipath bodies.
+    /// emit time. ORR-vantage, Add-Path-send, and per-client-best peers
+    /// (never grouped — all three disqualify) take the dedicated explain
+    /// that shares its candidate collection and gate helpers with the
+    /// live ORR/multipath bodies — a per-client-best peer's explain
+    /// ranks the same filtered-best candidate walk live staging
+    /// performs, so it reports the advertised runner-up (not a false
+    /// "denied") when the Loc-RIB best is policy-denied.
     fn explain_unicast_export(&mut self, peer: IpAddr, prefix: Prefix) -> ExplainAdvertisedRoute {
         let family = prefix_family(&prefix);
         if self
@@ -1518,8 +1521,9 @@ impl RibManager {
                 .map(|spf| (&self.orr.topology, spf, *vantage))
         });
         let add_path_send_max = self.add_path_send_max_for_prefix(peer, &prefix);
+        let per_client_best = self.peer_per_client_best.contains(&peer);
 
-        if orr_ctx.is_some() || add_path_send_max > 0 {
+        if orr_ctx.is_some() || add_path_send_max > 0 || per_client_best {
             return Self::explain_single_best_prefix(
                 &self.loc_rib,
                 &self.ribs,
@@ -1539,6 +1543,7 @@ impl RibManager {
                 add_path_send_max,
                 self.export_policy_for(peer),
                 orr_ctx,
+                per_client_best,
             );
         }
 

--- a/crates/rib/src/manager/tests/per_client_best.rs
+++ b/crates/rib/src/manager/tests/per_client_best.rs
@@ -388,6 +388,175 @@ async fn route_refresh_replays_filtered_best() {
     handle.await.unwrap();
 }
 
+/// An rpol chain with a named term denying `65000:99`-tagged routes —
+/// the explain tests assert the term label surfaces per candidate.
+fn rpol_deny_tagged_chain() -> PolicyChain {
+    const RPOL: &str = r"
+policy no-tagged {
+    term block-tagged {
+        if route.communities has 65000:99 { reject }
+    }
+}
+";
+    let file = rustbgpd_policy::rpol::RpolFile::parse(RPOL).expect("clean rpol");
+    let mut store = rustbgpd_policy::sets::SetStore::new();
+    let compiled = file
+        .compile_policy("no-tagged", &[], &mut store)
+        .expect("policy exists");
+    PolicyChain::from_named(vec![rustbgpd_policy::NamedPolicy::from_rpol(
+        "no-tagged".to_string(),
+        Arc::new(compiled),
+    )])
+}
+
+/// The slice-1 known gap, fixed: `ExplainAdvertisedRoute` for a
+/// per-client-best peer dry-runs the filtered-best walk live staging
+/// performs — when the Loc-RIB best is policy-denied it explains the
+/// advertised runner-up (candidate ladder with per-candidate term
+/// labels), not a false "denied". A single-best sibling with the same
+/// chain keeps its truthful Deny.
+#[tokio::test]
+async fn explain_names_runner_up_selection_with_term_labels() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    announce_from(&tx, SOURCE_A, vec![best_route()]).await;
+    announce_from(&tx, SOURCE_B, vec![runner_up_route()]).await;
+
+    let mitigated = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut mitigated_rx =
+        client_peer_up(&tx, mitigated, Some(rpol_deny_tagged_chain()), true).await;
+    let dump = mitigated_rx.recv().await.unwrap();
+    assert_eq!(dump.announce.len(), 1, "live sends the runner-up");
+    assert_eq!(dump.announce[0].peer, IpAddr::V4(SOURCE_B));
+
+    let hidden = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let mut hidden_rx = client_peer_up(&tx, hidden, Some(rpol_deny_tagged_chain()), false).await;
+    drain_eor(&mut hidden_rx).await;
+
+    // Per-client-best explain: agrees with the wire — the runner-up IS
+    // advertised, with the denied best named per candidate.
+    let explain = query_explain_advertised_route(&tx, mitigated, Prefix::V4(prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Advertise);
+    assert_eq!(explain.route_peer, Some(IpAddr::V4(SOURCE_B)));
+    assert_eq!(explain.next_hop, Some(IpAddr::V4(SOURCE_B)));
+    assert!(
+        explain.already_advertised,
+        "live already advertised the filtered best — explain must report in-sync"
+    );
+    let selection = explain
+        .gates
+        .iter()
+        .find(|step| step.code == "per_client_best")
+        .expect("per-client selection gate present");
+    assert_eq!(selection.gate, "best_route");
+    assert!(
+        selection.detail.contains("candidate 2 of 2"),
+        "selection names the ladder position, got {:?}",
+        selection.detail
+    );
+    let denial = explain
+        .reasons
+        .iter()
+        .find(|reason| reason.code == "per_client_candidate_denied")
+        .expect("denied candidate recorded");
+    assert!(
+        denial.message.contains("no-tagged:block-tagged"),
+        "per-candidate verdict names the rpol term, got {:?}",
+        denial.message
+    );
+    assert!(
+        denial.message.contains("candidate 1 of 2"),
+        "denial names the rank, got {:?}",
+        denial.message
+    );
+    // The winner's own policy gate passed with the chain named.
+    assert!(
+        explain
+            .gates
+            .iter()
+            .any(|step| step.code == "policy_permitted"),
+        "winner passes the export-policy rung"
+    );
+
+    // Single-best sibling: same chain, truthful Deny (path hiding).
+    let hidden_explain = query_explain_advertised_route(&tx, hidden, Prefix::V4(prefix())).await;
+    assert_eq!(
+        hidden_explain.decision,
+        crate::update::ExplainDecision::Deny
+    );
+    assert!(
+        hidden_explain
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "policy_denied"),
+        "single-best explain unchanged"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Every candidate denied: the explain ladder stops at selection with
+/// one recorded verdict per candidate — mirroring the live walk, which
+/// stages nothing.
+#[tokio::test]
+async fn explain_reports_every_denied_candidate_when_nothing_is_advertised() {
+    const RPOL: &str = r"
+policy deny-all {
+    term block-everything { reject }
+}
+";
+    let file = rustbgpd_policy::rpol::RpolFile::parse(RPOL).expect("clean rpol");
+    let mut store = rustbgpd_policy::sets::SetStore::new();
+    let compiled = file
+        .compile_policy("deny-all", &[], &mut store)
+        .expect("policy exists");
+    let chain = PolicyChain::from_named(vec![rustbgpd_policy::NamedPolicy::from_rpol(
+        "deny-all".to_string(),
+        Arc::new(compiled),
+    )]);
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    announce_from(&tx, SOURCE_A, vec![best_route()]).await;
+    announce_from(&tx, SOURCE_B, vec![runner_up_route()]).await;
+
+    let client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut client_rx = client_peer_up(&tx, client, Some(chain), true).await;
+    drain_eor(&mut client_rx).await; // nothing staged: EoR only
+
+    let explain = query_explain_advertised_route(&tx, client, Prefix::V4(prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    let stop = explain
+        .gates
+        .iter()
+        .find(|step| step.verdict == crate::update::ExportGateVerdict::Stop)
+        .expect("ladder stops");
+    assert_eq!(
+        (stop.gate, stop.code),
+        ("best_route", "per_client_all_denied")
+    );
+    let denials: Vec<_> = explain
+        .reasons
+        .iter()
+        .filter(|reason| reason.code == "per_client_candidate_denied")
+        .collect();
+    assert_eq!(denials.len(), 2, "one verdict per candidate");
+    assert!(
+        denials
+            .iter()
+            .all(|reason| reason.message.contains("deny-all:block-everything")),
+        "each verdict names the term"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// With no denying chain, per-client-best selects the same route
 /// single-best would — the modes agree on the common path (differential
 /// pin against mode drift, design risk 4).

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -188,6 +188,12 @@ IXP member C (AS 64503) ──┘
   peer directly via the exchange fabric)
 - **Add-Path send** — members see all candidate paths, not just the best,
   enabling their own best-path selection
+- **Per-client best-path** (`per_client_best`, RFC 7947 §2.3.2) — the
+  path-hiding mitigation for members that cannot do Add-Path: when a
+  member's export policy denies the best path, it receives the best
+  *permitted* candidate instead of nothing (the BIRD-`secondary`
+  equivalent), and `rbgp rib advertised --explain` shows the per-candidate
+  verdict ladder
 - **RPKI validation** — drop RPKI-invalid routes, prefer valid over not-found
 - **Receive-side Prefix ORF** — let members push prefix filters that constrain
   what the route server advertises back to them

--- a/docs/adr/0101-route-server-profile.md
+++ b/docs/adr/0101-route-server-profile.md
@@ -1,0 +1,153 @@
+# ADR-0101: IXP route-server profile — per-client best-path (RFC 7947 §2.3.2)
+
+**Status:** Accepted — per-client best-path shipped in #696; explain arm,
+profile polish, and this record in the follow-up slice. The M83
+multi-stack interop receipt is the remaining slice.
+**Date:** 2026-07-03
+
+## Context
+
+The ROADMAP's route-server item named one load-bearing gap versus
+BIRD/OpenBGPd at an IXP: **RFC 7948 path-hiding mitigation for members
+that cannot do Add-Path**. A design pass over main verified that the
+transparency core of RFC 7947 §2.2 had already shipped in ADR-0039
+(`route_server_client`, FRR interop receipt M19) — at the transport seam
+(`crates/transport/src/session/outbound.rs`, `prepare_outbound_attributes`):
+
+| Attribute | RFC 7947 §2.2 | rustbgpd |
+|---|---|---|
+| AS_PATH no self-prepend | SHOULD NOT | prepend arm gated `is_ebgp && !route_server_client`, replicated in every per-family variant |
+| NEXT_HOP unmodified | MUST | next-hop-self gated the same way; explicit policy `NextHopAction` remains ADR-0039's documented escape hatch; RFC 8950 covered |
+| MED propagated | SHOULD | by pass-through — no MED arm exists in the attribute prep |
+| Communities untouched | SHOULD NOT modify | catch-all pass-through (standard, large, extended) |
+| LOCAL_PREF | n/a (eBGP) | stripped |
+
+Dynamic peers can set `route_server_client` and `local_role` via gRPC
+(closing ADR-0039's recorded negative); `local_role = "route_server"`
+attaches OTC (RFC 9234) at the same seam — confirmed by test, not new
+code. The "profile" is therefore what ADR-0039 chose: a per-neighbor /
+per-peer-group flag plus a curated example (`examples/route-server/`),
+**not** a new config mechanism — a peer group with
+`route_server_client = true` IS the profile, matching how BIRD/OpenBGPd
+operators and arouteserver think.
+
+What the incumbents do about path hiding: BIRD offers `secondary`
+(first filter-accepted route from the sorted table; arouteserver
+defaults it on); OpenBGPd offers `rde evaluate all` (arouteserver does
+NOT default it on, citing documented stability bugs — spurious 2nd-best
+withdrawals/re-announcements, openbgpd-portable#21); Add-Path per
+RFC 7948 is the alternative both support. rustbgpd already shipped
+Add-Path send, so mitigation (b) existed; the gap was (a).
+
+## Decisions
+
+1. **Per-client best-path as an opt-in per-neighbor/per-group knob
+   (`per_client_best`, requires `route_server_client`), with Add-Path
+   remaining the recommended mitigation where members support it.** A
+   negotiated capability outranks the fallback: families with Add-Path
+   send negotiated use Add-Path, per family, no error. Opt-in — not
+   default-on — until the churn class (the OpenBGPd bug family) has
+   soak history; arouteserver defaults it on for BIRD but off for
+   OpenBGPd for exactly this reason. Earn the default.
+
+2. **Distribution-time selection through the existing multipath body —
+   no per-client Loc-RIBs.** `distribute_multipath_prefix` already did
+   filtered-best-N (collect per-target candidates, sort by
+   `best_path_cmp`, take the first `send_max` export-policy-permitted);
+   per-client best is that body with `send_max = 1` plus
+   `stage_path_id_zero` — the winner stages at `path_id 0` so
+   Adj-RIB-Out, BMP RIB-Out, and `ListAdvertisedRoutes` present the
+   single-best shape and the filtered-best flip is an implicit replace.
+   The wire is already path-id-free (Add-Path not negotiated). The
+   shadow-table alternative (BIRD's multi-table model) is **rejected
+   permanently**: memory multiplies by client count, and the
+   distribution-time pattern was already proven twice (Add-Path send,
+   ORR — ADR-0095 Decision 4's reasoning transfers verbatim). ORR and
+   per-client-best are mutually exclusive by validation (vantage ⇒ iBGP
+   RR client; per_client_best ⇒ eBGP RS client), pinned by debug_assert.
+
+3. **Per-client-best peers disqualify from update groups
+   (ADR-0098 Decision 2 structural fallback).** The member sourcing the
+   Loc-RIB best receives the runner-up, so no shared staged winner
+   exists — same shape as the Add-Path and ORR disqualifiers. Reason
+   string `per_client_best` on `NeighborState.update_group`, counted by
+   `bgp_update_group_fallback_peers`. The grouping claims verified
+   during design: transparent RS clients sharing a chain with plain
+   eBGP peers grouping legally is TRUE by construction
+   (`route_server_client` acts in transport, below the staging
+   boundary; it is not in `GroupKey` and does not need to be), pinned
+   by a mixed-group differential test. "Distinct chains → distinct
+   groups keeps heterogeneous member policy fast" is TRUE with an
+   honest asterisk: arouteserver-style community steering
+   ("do-not-announce-to-AS-X") written as per-member literal chains
+   makes every chain distinct → groups of one → per-peer cost. rpol has
+   no peer-parameterized community matcher, and adding one would trip
+   `requires_peer_context` and disqualify anyway. The scalable answer
+   is the ADR-0099 Decision-2 pattern — steering as a per-member
+   **emit-time filter** `pass_m(route)` = f(route communities, member
+   ASN), presence bit in the key, exactly like the VPN RT filter, which
+   keeps the whole steering fleet in one group — **deferred to v2**
+   with this sketch recorded; un-defer trigger: a real >100-member
+   deployment where steering chains measurably shatter grouping.
+
+4. **RPKI/ASPA enforcement stays in policy — no hard-coded RS gate.**
+   Validation state is computed at import; enforcement is rpol/TOML
+   matchers (`rpki invalid`, `aspa invalid`) in the import chain, which
+   composes with explain (the deny term is named in the trace,
+   answering "why isn't my prefix at the IXP?") and matches
+   arouteserver's reject-or-tag configurability. Reject-AS_SET needed
+   zero code: AS_SETs render as `{...}` in the AS_PATH string, so an
+   rpol `route.as-path matches "\\{"` term works (the `_` boundary
+   expansion already includes `[{}]`); it ships in the example's
+   `hygiene.rpol` with in-language tests.
+
+5. **Explain dry-runs the live filtered-best walk — the #690
+   truthfulness principle.** `ExplainAdvertisedRoute` for a
+   per-client-best peer ranks the exact candidate set live staging
+   walks (`multipath_candidates`, shared collector: split horizon,
+   RFC 4456 reflection, per-candidate LLGR) with the Loc-RIB comparator
+   and records one verdict per denied candidate — "candidate k of N
+   denied by export policy `<chain:term>`; candidate k+1 advertised".
+   This fixes the slice-1 known gap where a per-client-best peer's
+   explain dry-ran the single-best body and could report "denied" while
+   live sent the runner-up. Grouped transparent members need nothing:
+   grouped-vs-ungrouped verdict equality is already test-pinned, and
+   transparency is transport-side, below explain's remit (explain
+   describes what is staged; M83 verifies the bytes). `rbgp neighbor
+   show` names the distribution mode
+   (single-best / add-path / orr / per-client-best).
+
+## Consequences
+
+- The §2.3 scenario both ways is test-pinned: without the knob the
+  member whose chain denies the best gets nothing (documented path
+  hiding); with it, the runner-up — including the source member of the
+  best. The OpenBGPd `rde evaluate all` bug class is pinned negative:
+  candidate churn that doesn't flip the filtered best emits nothing;
+  a filtered-best flip is announce-only implicit replace; content-equal
+  policy reload emits nothing.
+- Honest costs, documented: per-client-best peers are ungrouped (an
+  all-members-enabled IXP pays per-peer staging again — recommend
+  Add-Path first; the planned 1000-peer RS scale receipt should run the
+  realistic mix), and each such peer pays O(candidates) export-policy
+  evaluations per changed prefix — the same cost BIRD pays in filter
+  runs.
+- Three per-target selection modes now flow through
+  `distribute_multipath_prefix` (Add-Path, per-client-best; ORR via its
+  comparator-swapped sibling). The mode-agreement and differential
+  tests are the drift guard; any new export-tail feature must land in
+  the shared body or disqualify (the ADR-0098 Decision-3 rule extends
+  to modes).
+- Deferral register: per-client Loc-RIBs — rejected permanently;
+  community-steering emit-time filter — v2, sketch in Decision 3;
+  peer-parameterized policy matchers — rejected (superseded by the v2
+  filter); default-on mitigation — deferred pending soak history;
+  RFC 8097 validation-state extended-community tagging on import —
+  deferred small slice (rpol can add ext-communities on match today;
+  the well-known encoding constants deserve their own slice; on the
+  arouteserver-target critical path). ARouteServer target — deferred
+  per ROADMAP until a pilot is credible; noted: arouteserver supports
+  only BIRD and OpenBGPD (7.5+) today, adding a target is a Jinja2
+  contribution on their side, and after this arc rustbgpd covers the
+  generated-config essentials except RFC 8097 tagging and RTT-based
+  communities (no RTT source — likely permanent-reject).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -109,6 +109,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0098](0098-update-groups.md) | RIB-level update groups — shared outbound staging | Accepted | 2026-07-03 |
 | [0099](0099-update-groups-v2.md) | Update groups v2 — per-family keying and RT-aware VPN emit | Accepted | 2026-07-03 |
 | [0100](0100-parallel-rib-manager.md) | Parallelizing the RibManager (research blueprint) | Proposed | 2026-07-03 |
+| [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 |
 
 ## Template
 

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -1,0 +1,42 @@
+# IXP route server
+
+rustbgpd as an Internet-exchange route server (RFC 7947/7948): transparent
+mode for every member (NEXT_HOP preserved, no AS prepend), RFC 9234 roles
+with OTC, RPKI origin validation, and both path-hiding mitigations.
+
+| File | Purpose |
+|---|---|
+| `config.toml` | Daemon config: two members, RPKI, policy chain |
+| `hygiene.rpol` | Import hygiene in the rpol policy language: reject AS_SET, reject ASPA-invalid — with in-language tests |
+
+## Path-hiding (RFC 7947 §2.3), both mitigations
+
+- **member-alpha** negotiates **Add-Path send**: it receives all candidate
+  paths and runs its own best-path selection. Preferred where the member
+  edge supports Add-Path receive — these peers stay update-group-shareable.
+- **member-beta** cannot do Add-Path, so it sets **`per_client_best = true`**
+  (requires `route_server_client`): when its export policy denies the best
+  path, the route server advertises the best *permitted* candidate instead
+  of hiding the prefix — the BIRD-`secondary` equivalent. Trade-off: such
+  peers are excluded from update-group sharing (visible as the
+  `per_client_best` reason in `rbgp neighbor show`).
+
+## Try it
+
+```bash
+# Validate the config and the rpol policy (both offline):
+rustbgpd --check config.toml
+rbgp policy check hygiene.rpol
+
+# Run, then inspect a member:
+rbgp neighbor 198.51.100.3                 # Distribution Mode: per-client-best
+rbgp rib advertised 198.51.100.3 --explain --prefix 203.0.113.0/24
+```
+
+The explain output for a per-client-best member shows the ranked candidate
+ladder with per-candidate export-policy verdicts (which candidates were
+denied by which policy term, and which one was advertised).
+
+Members are managed dynamically via gRPC as they join and leave — see
+`rbgp neighbor <addr> add --asn <asn> --route-server-client \
+--per-client-best --role rs`.

--- a/examples/route-server/config.toml
+++ b/examples/route-server/config.toml
@@ -1,10 +1,20 @@
 # IXP route server configuration
 #
-# rustbgpd as an IX route server with two members. Each member gets:
+# rustbgpd as an IX route server with two members. Every member gets:
 # - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
-# - Add-Path send (members see all candidate paths, not just the best)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
 # - dual-stack (IPv4 + IPv6 unicast)
-# - RPKI origin validation (drop invalid, prefer valid)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, reject ASPA-invalid — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees all candidate paths
+#   and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
 #
 # Add more [[neighbors]] blocks for additional IXP members, or manage
 # them dynamically via gRPC at runtime.
@@ -92,8 +102,12 @@ action = "permit"
 set_local_pref = 100
 
 [policy]
+# ixp-hygiene (reject AS_SET, reject ASPA-invalid) lives in hygiene.rpol;
+# rpol and TOML policies share one namespace and compose in one chain.
+rpol_files = ["hygiene.rpol"]
 import_chain = [
     "reject-rpki-invalid",
+    "ixp-hygiene",
     "reject-bogon-prefixes",
     "reject-long-prefixes",
     "prefer-rpki-valid",
@@ -101,6 +115,8 @@ import_chain = [
 
 # --- IXP member peers ---
 
+# Add-Path-capable member: sees all candidate paths (preferred
+# path-hiding mitigation) and stays update-group-shareable.
 [[neighbors]]
 address = "198.51.100.2"
 remote_asn = 64501
@@ -108,12 +124,16 @@ description = "member-alpha"
 hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 route_server_client = true
+role = "route_server"
 max_prefixes = 50000
 
 [neighbors.add_path]
 send = true
 send_max = 8
 
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
 [[neighbors]]
 address = "198.51.100.3"
 remote_asn = 64502
@@ -121,8 +141,6 @@ description = "member-beta"
 hold_time = 90
 families = ["ipv4_unicast", "ipv6_unicast"]
 route_server_client = true
+per_client_best = true
+role = "route_server"
 max_prefixes = 50000
-
-[neighbors.add_path]
-send = true
-send_max = 8

--- a/examples/route-server/hygiene.rpol
+++ b/examples/route-server/hygiene.rpol
@@ -1,0 +1,36 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set {
+        if route.as-path matches "\\{" { reject }
+    }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid {
+        if route.aspa == invalid { reject }
+    }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -115,14 +115,23 @@ fn config_examples_parse() {
         let source = fs::read_to_string(&path).unwrap_or_else(|err| {
             panic!("failed to read example config {label}: {err}");
         });
-        // parse_strict (not parse) so every shipped example is validated under
-        // the production v0.24.0 `enforcement = "tier"` default. parse() would
-        // auto-inject `enforcement = "legacy"` for configs lacking a
-        // [security.grpc] block, masking examples that cannot actually start
-        // under defaults — the gap that shipped all examples unstartable until
-        // the v0.33.0 fixup. This guard fails closed if a new example omits the
-        // gRPC authorization config.
-        parse_strict(&source).unwrap_or_else(|err| {
+        // Strict parse (not the legacy-injecting `parse`) so every shipped
+        // example is validated under the production v0.24.0
+        // `enforcement = "tier"` default. Injection would mask examples that
+        // cannot actually start under defaults — the gap that shipped all
+        // examples unstartable until the v0.33.0 fixup. This guard fails
+        // closed if a new example omits the gRPC authorization config.
+        // Referenced .rpol files compile against the example's directory,
+        // exactly like the production load path, so chains resolve against
+        // the combined TOML + rpol namespace (e.g. route-server's
+        // hygiene.rpol).
+        let mut config: Config = toml::from_str(&source).unwrap_or_else(|err| {
+            panic!("example config {label} failed to parse: {err}");
+        });
+        config.load_rpol_files(path.parent()).unwrap_or_else(|err| {
+            panic!("example config {label} failed to load rpol files: {err}");
+        });
+        config.validate().unwrap_or_else(|err| {
             panic!("example config {label} failed validation under the tier default: {err}");
         });
     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3466,6 +3466,39 @@ fn build_transport_config_preserves_route_server_client() {
     assert!(transport.route_server_client);
 }
 
+/// RFC 9234 OTC for dynamic/gRPC-added peers: `local_role` set on a
+/// runtime `PeerConfig` (the `AddNeighbor` / dynamic-range path) reaches
+/// the transport session config verbatim — transport attaches OTC on
+/// eBGP egress for `Provider`/`Peer`/`RouteServer` roles from exactly
+/// this field (`otc_egress_adds_local_asn_for_provider_peer_and_route_server`
+/// in the transport crate pins the attach itself).
+#[test]
+fn build_transport_config_preserves_local_role_for_otc() {
+    let (_, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let mut config = make_config(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 65002);
+    config.route_server_client = true;
+    config.local_role = Some(rustbgpd_wire::BgpRole::RouteServer);
+
+    let transport = mgr.build_transport_config(&config);
+    assert_eq!(
+        transport.peer.local_role,
+        Some(rustbgpd_wire::BgpRole::RouteServer)
+    );
+}
+
 #[tokio::test]
 async fn policy_events_publish_successful_policy_mutations() {
     use rustbgpd_api::peer_types::{NamedPolicyDefinition, PolicyStatementDefinition};


### PR DESCRIPTION
Route-server profile slice 2 — closes the truthfulness gap flagged in #696 and records the profile's decisions.

## The explain arm (the #690 principle upheld)

The live multipath body's candidate filter was factored into a shared `multipath_candidates` collector that `distribute_multipath_prefix` now uses verbatim — so a per-client-best peer's explain provably walks the exact candidate set live staging walks, ranked by `best_path_cmp`, with a non-counting per-candidate policy walk. Output: "candidate k of N from X is the first export-policy-permitted candidate" plus one denied-candidate reason per rung with the deciding term label — the sentence no other route-server daemon can print. The #696 gap is pinned directly: the denied-best scenario now explains Advertise + runner-up while a single-best sibling keeps its truthful Deny.

## Also

- `rbgp neighbor` gains `Distribution Mode: single-best|add-path|orr|per-client-best`.
- OTC on dynamic peers confirmed already-working with a threading test (zero product code).
- Example refresh: one member on Add-Path, one on `per_client_best`, both `role = "route_server"` (RFC 9234); new `hygiene.rpol` with reject-AS_SET (escape semantics verified against the rpol lexer) + ASPA-invalid deny; validated with --check, a clean boot, and `rbgp policy check` (3/3). Side fix: `config_examples_parse` now compiles example rpol files like the production loader.
- **ADR-0101 "IXP route-server profile — per-client best-path"**: transparency verification table, the path-hiding decision with per-client Loc-RIBs rejected permanently, enforcement-in-policy, the update-groups verdict with the community-steering asterisk + the v2 emit-filter sketch and its un-defer trigger, and the deferral register (RFC 8097 tagging, arouteserver notes, RTT permanent-reject).

Gates: workspace build/test (66 suites), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.