### PR TITLE
fix(bmp): heal silent Adj-RIB-Out divergence under channel pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -701,6 +701,34 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BMP monitoring can no longer diverge silently from the wire under
+  saturation.** Two per-peer holes closed in the PeerSession→BmpManager
+  path: (1) BMP `PeerUp`/`PeerDown` were emitted with the same lossy
+  `try_send` as Route Monitoring, so under a full BMP event channel the
+  one signal that tells collectors to discard a peer's state could be
+  dropped — collectors would trust a stale Adj-RIB-In/Adj-RIB-Out view
+  forever. Lifecycle events now await channel space (bounded: the
+  manager loop always drains and never blocks; a dead manager returns
+  an immediate counted error). (2) When an outbound UPDATE reached the
+  wire but its rib-out Route Monitoring mirror hit a full channel, the
+  event was dropped with only a counter — and the rib-in/rib-out
+  streams being live-only (no dump), the collector's view stayed
+  incomplete until the next real session flap. The session now latches
+  the divergence and forces a synthetic `PeerDown`/`PeerUp` pair (an
+  RFC 7854 peer-state reset, reason 2/FSM code 0) ahead of the next
+  emission — retried on a 1s timer so a session that goes quiet after
+  the drop is still repaired — making the gap collector-detectable
+  instead of silent. The outbound-writer saturation path itself was
+  verified correct and is now regression-pinned: the UPDATE that fails
+  to enqueue is never mirrored (RFC 8671 mirrors what was sent), and
+  the teardown's `PeerDown` — now truthfully reason 1 carrying the
+  `Cease/8` NOTIFICATION we send, rather than the "remote closed"
+  default — is ordered after the last mirrored event on the same
+  channel. `bmp_source_drops_total` still counts every drop; no
+  unbounded queueing anywhere. Per-collector fan-out drops
+  (`bmp_collector_drops_total`) remain the documented lossy layer,
+  healed by the collector's own reconnect (RFC 7854 state discard +
+  PeerUp replay).
 - **An enhanced route refresh no longer purges GR/LLGR-stale routes
   awaiting End-of-RIB (LAN-187).** RFC 7313's end-of-refresh sweep
   removes routes not re-advertised inside the BoRR..EoRR window — but a

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -134,7 +134,18 @@ resolved.
   byte-faithful to what was advertised; pre-policy Adj-RIB-In is
   unreconstructable post-import. Collectors needing those exact views
   should connect before sessions establish (or trigger a route
-  refresh).
+  refresh). Because these streams are live-only, a Route Monitoring
+  event lost to BMP-channel saturation can never be replayed — so the
+  daemon guarantees such a loss is collector-detectable, never silent:
+  per-peer `PeerUp`/`PeerDown` delivery from sessions to the BMP
+  manager is reliable, and a Route Monitoring event dropped on a full
+  session→manager channel (counted in `bmp_source_drops_total`) forces
+  a synthetic `PeerDown`/`PeerUp` peer-state reset on the stream so
+  collectors discard the now-incomplete view and rebuild from live
+  traffic. The per-collector fan-out queue remains lossy by design
+  (`bmp_collector_drops_total`); a collector that saturates its own
+  channel diverges until its next reconnect, which per RFC 7854
+  discards all state and replays PeerUp — alert on that counter.
 
 - **Commit-confirmed config transactions do not survive a daemon restart.**
   The confirm timer and the captured pre-commit rollback snapshot are held in

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -413,28 +413,12 @@ impl PeerSession {
                     self.negotiated = Some(*neg);
                     self.established_at = Some(Instant::now());
 
-                    // Emit BMP Peer Up event
+                    // Emit BMP Peer Up event — reliable (awaited): losing
+                    // it would leave collectors permanently blind to
+                    // this session's monitoring stream.
                     if self.bmp_tx.is_some() {
-                        let (local_addr, local_port, remote_port) = self.read_half.as_ref().map_or(
-                            (IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0),
-                            |h| {
-                                let local = h.local_addr().ok();
-                                let remote = h.peer_addr().ok();
-                                (
-                                    local.map_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED), |a| a.ip()),
-                                    local.map_or(0, |a| a.port()),
-                                    remote.map_or(0, |a| a.port()),
-                                )
-                            },
-                        );
-                        self.emit_bmp_event(BmpEvent::PeerUp {
-                            peer_info: self.build_bmp_peer_info(),
-                            local_open: self.local_open_pdu.clone().unwrap_or_default(),
-                            remote_open: self.remote_open_pdu.clone().unwrap_or_default(),
-                            local_addr,
-                            local_port,
-                            remote_port,
-                        });
+                        let peer_up = self.build_bmp_peer_up_event();
+                        self.emit_bmp_event_reliable(peer_up).await;
                     }
 
                     // Register with RIB manager for outbound updates
@@ -526,16 +510,23 @@ impl PeerSession {
                 Action::SessionDown => {
                     info!(peer = %self.peer_label, "session down");
 
-                    // Emit BMP Peer Down event before clearing state
+                    // Emit BMP Peer Down event before clearing state —
+                    // reliable (awaited): PeerDown is the collectors'
+                    // state-reset signal, and it must not be overtaken
+                    // or dropped after RouteMonitoring events that were
+                    // already emitted on the same channel. It also
+                    // supersedes any pending divergence repair (the
+                    // re-established session re-floods both views).
                     if self.bmp_tx.is_some() && self.established_at.is_some() {
                         let reason = self
                             .last_down_reason
                             .take()
                             .unwrap_or(PeerDownReason::RemoteNoNotification);
-                        self.emit_bmp_event(BmpEvent::PeerDown {
+                        self.emit_bmp_event_reliable(BmpEvent::PeerDown {
                             peer_info: self.build_bmp_peer_info(),
                             reason,
-                        });
+                        })
+                        .await;
                     }
 
                     // Check GR state before clearing negotiated info.

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -163,6 +163,17 @@ impl PeerSession {
         // through here as final wire bytes, so the BMP mirror is
         // byte-exact post-policy. Non-UPDATE bulk traffic (BoRR/EoRR
         // ROUTE-REFRESH markers) is not route monitoring and is skipped.
+        //
+        // Loss semantics under saturation (both directions are covered):
+        // - writer channel Full → the UPDATE never reaches the wire, so
+        //   NOT mirroring it is correct (RFC 8671 mirrors what was
+        //   sent); the saturation teardown below ends in a reliable BMP
+        //   PeerDown ordered after the last mirrored UPDATE, and the
+        //   re-established session re-floods the view.
+        // - wire send Ok but the BMP channel Full → `emit_bmp_event`
+        //   latches `bmp_stream_diverged` and forces a PeerDown/PeerUp
+        //   peer-state reset once the channel drains, so collectors
+        //   never keep a silently incomplete rib-out view.
         let bmp_rib_out_pdu =
             (self.config.bmp_rib_out && self.bmp_tx.is_some() && matches!(msg, Message::Update(_)))
                 .then(|| encoded.clone());
@@ -246,6 +257,14 @@ impl PeerSession {
             cease_subcode::OUT_OF_RESOURCES,
             bytes::Bytes::new(),
         );
+        // Classify the upcoming BMP Peer Down truthfully: reason 1
+        // (local system sent NOTIFICATION) carrying the Cease/8 PDU,
+        // instead of the reason-4 "remote closed" default.
+        if self.bmp_tx.is_some()
+            && let Ok(pdu) = rustbgpd_wire::encode_message(&Message::Notification(notif.clone()))
+        {
+            self.last_down_reason = Some(PeerDownReason::LocalNotification(pdu.freeze()));
+        }
         // Best-effort: the writer's priority channel is unbounded, so
         // this only fails if we already dropped the writer (e.g. a
         // double-trigger race). Either way, proceed with teardown.

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -184,6 +184,21 @@ pub(crate) struct PeerSession {
     session_identity: SessionIdentity,
     /// Optional BMP event sender (None when BMP not configured).
     bmp_tx: Option<mpsc::Sender<BmpEvent>>,
+    /// A `RouteMonitoring` event for this session was dropped on a full
+    /// BMP channel while the mirrored traffic *did* flow (the outbound
+    /// UPDATE reached the writer, or the inbound UPDATE reached the
+    /// RIB): the collectors' view of this peer has silently diverged
+    /// and — rib-in/rib-out being live-only streams with no dump — will
+    /// never self-correct. Repaired by forcing a synthetic
+    /// PeerDown/PeerUp pair ahead of the next BMP event for this peer
+    /// (an RFC 7854 peer-state reset collectors can detect), retried on
+    /// `bmp_repair_timer` so a session that goes quiet right after the
+    /// drop cannot stay diverged indefinitely.
+    bmp_stream_diverged: bool,
+    /// Bounded-latency retry for the forced peer-state reset above.
+    /// Armed whenever `bmp_stream_diverged` is set and the reset could
+    /// not be emitted yet (BMP channel still full).
+    bmp_repair_timer: Option<Pin<Box<Sleep>>>,
     /// RPKI/ASPA validation snapshot for import policy evaluation.
     /// `None` when RPKI not configured or in tests.
     validation_rx: Option<watch::Receiver<rustbgpd_rpki::ValidationSnapshot>>,
@@ -274,6 +289,12 @@ pub(crate) struct PeerSession {
 
 /// Outbound channel buffer size.
 const OUTBOUND_BUFFER: usize = 4096;
+
+/// Retry cadence for the forced BMP peer-state reset after a dropped
+/// `RouteMonitoring` event (see `PeerSession::bmp_stream_diverged`).
+/// Short enough that a diverged-then-quiet session is repaired promptly;
+/// long enough not to spin while the BMP channel stays saturated.
+const BMP_STREAM_REPAIR_RETRY: Duration = Duration::from_secs(1);
 
 /// FSM event code carried in the BMP Peer Down reason-2 body when the
 /// send hold timer expires: Event 29, `SendHoldTimer_Expires` (RFC 9687
@@ -496,6 +517,8 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             bmp_tx,
+            bmp_stream_diverged: false,
+            bmp_repair_timer: None,
             validation_rx,
             local_open_pdu: None,
             remote_open_pdu: None,
@@ -604,6 +627,8 @@ impl PeerSession {
             session_event_tx,
             session_identity,
             bmp_tx,
+            bmp_stream_diverged: false,
+            bmp_repair_timer: None,
             validation_rx,
             local_open_pdu: None,
             remote_open_pdu: None,
@@ -680,10 +705,58 @@ impl PeerSession {
         }
     }
 
-    fn emit_bmp_event(&self, event: BmpEvent) {
-        if let Some(ref tx) = self.bmp_tx
-            && let Err(e) = tx.try_send(event)
-        {
+    /// Build the BMP `PeerUp` event for this session (RFC 7854 §4.10).
+    /// Used at `SessionEstablished` and by the forced peer-state reset
+    /// after a dropped `RouteMonitoring` event.
+    fn build_bmp_peer_up_event(&self) -> BmpEvent {
+        let (local_addr, local_port, remote_port) =
+            self.read_half
+                .as_ref()
+                .map_or((IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0), |h| {
+                    let local = h.local_addr().ok();
+                    let remote = h.peer_addr().ok();
+                    (
+                        local.map_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED), |a| a.ip()),
+                        local.map_or(0, |a| a.port()),
+                        remote.map_or(0, |a| a.port()),
+                    )
+                });
+        BmpEvent::PeerUp {
+            peer_info: self.build_bmp_peer_info(),
+            local_open: self.local_open_pdu.clone().unwrap_or_default(),
+            remote_open: self.remote_open_pdu.clone().unwrap_or_default(),
+            local_addr,
+            local_port,
+            remote_port,
+        }
+    }
+
+    /// Lossy BMP emission for the high-rate mirror events
+    /// (`RouteMonitoring`, `StatsReport`): never blocks and never
+    /// backpressures the session (ADR-0041/0097 posture). A full
+    /// channel drops the event and bumps `bmp_source_drops_total` —
+    /// but a dropped `RouteMonitoring` additionally latches
+    /// `bmp_stream_diverged`, because the mirrored traffic did flow and
+    /// the collectors' live-only rib-in/rib-out views would otherwise
+    /// be silently wrong forever. The pending divergence is repaired
+    /// (forced PeerDown/PeerUp reset) ahead of the next emission, or
+    /// from the run loop's `bmp_repair_timer` arm if the session goes
+    /// quiet first. Lifecycle events must use
+    /// [`Self::emit_bmp_event_reliable`] instead.
+    fn emit_bmp_event(&mut self, event: BmpEvent) {
+        let Some(tx) = self.bmp_tx.clone() else {
+            return;
+        };
+        if self.bmp_stream_diverged && !self.repair_bmp_stream(&tx) {
+            // The channel is still saturated: this event cannot be
+            // emitted ahead of the pending peer-state reset without
+            // presenting the collector a diverged stream as healthy.
+            self.metrics
+                .record_bmp_source_drop(&self.peer_label, "channel_full");
+            return;
+        }
+        let is_route_monitoring = matches!(event, BmpEvent::RouteMonitoring { .. });
+        if let Err(e) = tx.try_send(event) {
             let reason = match e {
                 tokio::sync::mpsc::error::TrySendError::Full(_) => "channel_full",
                 tokio::sync::mpsc::error::TrySendError::Closed(_) => "channel_closed",
@@ -691,6 +764,97 @@ impl PeerSession {
             self.metrics
                 .record_bmp_source_drop(&self.peer_label, reason);
             debug!(peer = %self.peer_label, reason, "BMP event channel full or closed");
+            if is_route_monitoring && matches!(e, tokio::sync::mpsc::error::TrySendError::Full(_)) {
+                self.mark_bmp_stream_diverged();
+            }
+        }
+    }
+
+    /// Reliable BMP emission for the per-peer lifecycle events
+    /// (`PeerUp`, `PeerDown`). These are the collectors' state-reset
+    /// signals — losing one leaves every collector permanently wrong
+    /// about the peer — so instead of the lossy `try_send` this awaits
+    /// channel space. Bounded: the `BmpManager` loop never blocks
+    /// (sync encode + per-collector `try_send`), so the wait is at most
+    /// one channel drain, and a dead manager surfaces as an immediate
+    /// send error (counted, session unaffected).
+    ///
+    /// A real `PeerDown` also supersedes any pending divergence repair:
+    /// it resets collector state, and the re-established session
+    /// re-floods both rib-in (peer resends) and rib-out (initial-table
+    /// walk re-enters the tap).
+    async fn emit_bmp_event_reliable(&mut self, event: BmpEvent) {
+        let Some(tx) = self.bmp_tx.clone() else {
+            return;
+        };
+        if matches!(event, BmpEvent::PeerDown { .. }) {
+            self.bmp_stream_diverged = false;
+            self.bmp_repair_timer = None;
+        }
+        if tx.send(event).await.is_err() {
+            self.metrics
+                .record_bmp_source_drop(&self.peer_label, "channel_closed");
+            debug!(peer = %self.peer_label, "BMP event channel closed");
+        }
+    }
+
+    /// Latch the divergence flag after a dropped `RouteMonitoring` and
+    /// arm the bounded-latency repair timer.
+    fn mark_bmp_stream_diverged(&mut self) {
+        if !self.bmp_stream_diverged {
+            warn!(
+                peer = %self.peer_label,
+                "BMP RouteMonitoring dropped on a full channel while the mirrored \
+                 traffic flowed — collector view diverged; forcing a BMP peer-state \
+                 reset once the channel drains"
+            );
+        }
+        self.bmp_stream_diverged = true;
+        self.bmp_repair_timer = Some(Box::pin(tokio::time::sleep(BMP_STREAM_REPAIR_RETRY)));
+    }
+
+    /// Attempt the pending RFC 7854 peer-state reset: a synthetic
+    /// `PeerDown` (reason 2 — local close, no NOTIFICATION, FSM event
+    /// code 0) followed by a fresh `PeerUp`, making the earlier
+    /// divergence collector-detectable (the collector discards its
+    /// state for this peer and rebuilds from subsequent monitoring).
+    /// Returns `true` when the pair was enqueued and the flag cleared;
+    /// `false` when the channel is still saturated (flag and retry
+    /// timer stay armed; a duplicate `PeerDown` from a partial attempt
+    /// is harmless).
+    fn repair_bmp_stream(&mut self, tx: &mpsc::Sender<BmpEvent>) -> bool {
+        let down = BmpEvent::PeerDown {
+            peer_info: self.build_bmp_peer_info(),
+            reason: PeerDownReason::LocalNoNotification(0),
+        };
+        if tx.try_send(down).is_err() {
+            return false;
+        }
+        if tx.try_send(self.build_bmp_peer_up_event()).is_err() {
+            return false;
+        }
+        self.bmp_stream_diverged = false;
+        self.bmp_repair_timer = None;
+        info!(
+            peer = %self.peer_label,
+            "BMP peer-state reset emitted after earlier RouteMonitoring drop — \
+             collector view resynchronized via PeerDown/PeerUp"
+        );
+        true
+    }
+
+    /// Run-loop timer entry for the deferred divergence repair: retry
+    /// the forced peer-state reset, re-arming the timer while the BMP
+    /// channel remains saturated.
+    fn retry_bmp_stream_repair(&mut self) {
+        if !self.bmp_stream_diverged {
+            return;
+        }
+        let Some(tx) = self.bmp_tx.clone() else {
+            return;
+        };
+        if !self.repair_bmp_stream(&tx) {
+            self.bmp_repair_timer = Some(Box::pin(tokio::time::sleep(BMP_STREAM_REPAIR_RETRY)));
         }
     }
 
@@ -854,6 +1018,7 @@ impl PeerSession {
                 connect_task,
                 outbound_rx,
                 writer_join,
+                bmp_repair_timer,
                 ..
             } = self;
 
@@ -909,6 +1074,16 @@ impl PeerSession {
                     self.reconnect_timer = None;
                     debug!(peer = %self.peer_label, "reconnect timer fired");
                     self.drive_fsm(Event::ManualStart).await;
+                }
+
+                // Deferred BMP peer-state reset after a dropped
+                // RouteMonitoring event (`bmp_stream_diverged`): retry
+                // on a short timer so a session that goes quiet right
+                // after the drop cannot leave collectors silently
+                // diverged until its next update.
+                () = poll_timer(bmp_repair_timer) => {
+                    self.bmp_repair_timer = None;
+                    self.retry_bmp_stream_repair();
                 }
 
                 // In-flight outbound TCP connect completion

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -680,9 +680,12 @@ async fn outbound_evpn_update_emits_rib_out_bmp_byte_exact() {
     let pdu = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
     assert_eq!(pdu.as_ref(), &wire[..]);
 }
-/// The rib-out tap keeps the lossy posture: a full BMP event channel
-/// drops the event and bumps `bmp_source_drops_total` — it never blocks
-/// or tears down the session.
+/// The rib-out tap keeps the non-blocking posture: a full BMP event
+/// channel drops the event and bumps `bmp_source_drops_total` — it
+/// never blocks or tears down the session. But the drop is no longer
+/// silent: the UPDATE did reach the wire, so the session latches the
+/// divergence for the forced peer-state reset (see
+/// `bmp_channel_full_after_wire_send_forces_peer_state_reset`).
 #[tokio::test]
 async fn rib_out_tap_full_channel_increments_source_drop_counter() {
     let (mut session, _rib_rx, _bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
@@ -720,6 +723,207 @@ async fn rib_out_tap_full_channel_increments_source_drop_counter() {
         })
         .sum();
     assert_eq!(drops, 1, "17th event over a 16-deep channel drops once");
+    assert!(
+        session.writer_bulk_tx.is_some(),
+        "a BMP-side drop must never tear down the BGP session"
+    );
+    assert!(
+        session.bmp_stream_diverged,
+        "a dropped rib-out RouteMonitoring must latch the divergence"
+    );
+    assert!(
+        session.bmp_repair_timer.is_some(),
+        "the bounded-latency repair timer must be armed"
+    );
+}
+/// Outbound-writer saturation ordering: the UPDATE that failed to
+/// enqueue is never mirrored to BMP (RFC 8671 mirrors what was actually
+/// sent), and the saturation teardown ends in a BMP `PeerDown` ordered
+/// after the last mirrored `RouteMonitoring` on the same channel — a
+/// collector sees an explicit resync signal (discard peer state; the
+/// re-established session re-floods), never a silent gap.
+#[tokio::test]
+async fn writer_saturation_orders_bmp_peer_down_after_last_mirrored_update() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    match bmp_rx.try_recv().unwrap() {
+        BmpEvent::PeerUp { .. } => {}
+        other => panic!("expected BMP PeerUp, got {other:?}"),
+    }
+    // Swap in a capacity-1 bulk channel that is never drained: the
+    // first UPDATE enqueues (and is mirrored), the second hits Full.
+    let (bulk_tx, _bulk_rx) = mpsc::channel(1);
+    session.writer_bulk_tx = Some(bulk_tx);
+    for lp in [100, 200] {
+        let mut update = empty_outbound_update();
+        update.announce = vec![make_route(lp)].into();
+        update.next_hop_override = vec![None].into();
+        session.send_route_update(update);
+    }
+    assert!(
+        session.writer_bulk_tx.is_none(),
+        "bulk-channel Full must trigger the saturation teardown"
+    );
+    // Run-loop follow-through: the writer exit surfaces as a TCP
+    // disconnect and drives the FSM out of Established.
+    session.drive_fsm(Event::TcpConnectionFails).await;
+    assert_ne!(session.fsm.state(), SessionState::Established);
+    // BMP stream order: the mirrored UPDATE, then PeerDown. Nothing
+    // for the UPDATE that never reached the wire.
+    let _mirrored = expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    match bmp_rx.try_recv().unwrap() {
+        BmpEvent::PeerDown { reason, .. } => match reason {
+            PeerDownReason::LocalNotification(pdu) => {
+                // 19-byte header, then code 6 (Cease) / subcode 8
+                // (Out of Resources).
+                assert_eq!(&pdu[19..21], &[6, 8], "Cease/8 NOTIFICATION PDU");
+            }
+            other => panic!("expected reason 1 (local NOTIFICATION), got {other:?}"),
+        },
+        other => panic!("expected BMP PeerDown after the last mirrored RM, got {other:?}"),
+    }
+    assert!(
+        bmp_rx.try_recv().is_err(),
+        "no RouteMonitoring may be emitted for the UPDATE that never reached the wire"
+    );
+}
+/// The inverse saturation case — the wire send succeeded but the BMP
+/// channel was full: the divergence is repaired by forcing a synthetic
+/// PeerDown/PeerUp pair (RFC 7854 peer-state reset) ahead of the next
+/// emission, so collectors detect the reset instead of keeping a
+/// silently incomplete Adj-RIB-Out view forever.
+#[tokio::test]
+async fn bmp_channel_full_after_wire_send_forces_peer_state_reset() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    session.local_open_pdu = Some(Bytes::from_static(&[1, 2, 3]));
+    session.remote_open_pdu = Some(Bytes::from_static(&[4, 5, 6]));
+    // 16 mirrored UPDATEs fill the channel; the 17th reaches the wire
+    // but its RouteMonitoring is dropped → divergence latched.
+    for _ in 0..17 {
+        let mut update = empty_outbound_update();
+        update.announce = vec![make_route(100)].into();
+        update.next_hop_override = vec![None].into();
+        session.send_route_update(update);
+    }
+    assert!(session.bmp_stream_diverged);
+    for _ in 0..16 {
+        expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    }
+    // Next emission repairs the stream first: PeerDown, PeerUp, then
+    // the new RouteMonitoring — in that order, on the same channel.
+    let mut update = empty_outbound_update();
+    update.announce = vec![make_route(300)].into();
+    update.next_hop_override = vec![None].into();
+    session.send_route_update(update);
+    assert!(!session.bmp_stream_diverged, "repair must clear the latch");
+    assert!(session.bmp_repair_timer.is_none());
+    match bmp_rx.try_recv().unwrap() {
+        BmpEvent::PeerDown { reason, .. } => assert!(
+            matches!(reason, PeerDownReason::LocalNoNotification(0)),
+            "synthetic reset uses reason 2 with FSM event code 0, got {reason:?}"
+        ),
+        other => panic!("expected synthetic BMP PeerDown, got {other:?}"),
+    }
+    match bmp_rx.try_recv().unwrap() {
+        BmpEvent::PeerUp { local_open, .. } => {
+            assert_eq!(local_open.as_ref(), &[1, 2, 3], "cached OPEN replayed");
+        }
+        other => panic!("expected synthetic BMP PeerUp, got {other:?}"),
+    }
+    expect_rib_out_rm(bmp_rx.try_recv().unwrap());
+    assert!(bmp_rx.try_recv().is_err());
+}
+/// A session that goes quiet right after the drop is repaired from the
+/// run loop's `bmp_repair_timer` arm instead of waiting for its next
+/// UPDATE: retry re-arms while the channel is saturated and emits the
+/// PeerDown/PeerUp reset once it drains.
+#[tokio::test]
+async fn bmp_repair_timer_retries_until_channel_drains() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    // Fill the 16-deep channel, then latch divergence with one more RM.
+    let tx = session.bmp_tx.clone().unwrap();
+    for _ in 0..16 {
+        tx.try_send(BmpEvent::StatsReport {
+            peer_info: session.build_bmp_peer_info(),
+            adj_rib_in_routes: 0,
+            adj_rib_out_post: None,
+        })
+        .unwrap();
+    }
+    session.emit_bmp_event(BmpEvent::RouteMonitoring {
+        peer_info: session.build_bmp_peer_info(),
+        update_pdu: Bytes::from_static(&[0xde, 0xad]),
+    });
+    assert!(session.bmp_stream_diverged);
+    // Channel still full: the retry must keep the latch and re-arm.
+    session.bmp_repair_timer = None;
+    session.retry_bmp_stream_repair();
+    assert!(session.bmp_stream_diverged);
+    assert!(session.bmp_repair_timer.is_some(), "retry must re-arm");
+    // Drain, then retry succeeds.
+    for _ in 0..16 {
+        bmp_rx.try_recv().unwrap();
+    }
+    session.retry_bmp_stream_repair();
+    assert!(!session.bmp_stream_diverged);
+    assert!(session.bmp_repair_timer.is_none());
+    assert!(matches!(
+        bmp_rx.try_recv().unwrap(),
+        BmpEvent::PeerDown { .. }
+    ));
+    assert!(matches!(
+        bmp_rx.try_recv().unwrap(),
+        BmpEvent::PeerUp { .. }
+    ));
+}
+/// `PeerDown` is never lost to a full BMP channel: the session awaits
+/// channel space (bounded — the `BmpManager` loop always drains) rather
+/// than dropping the one signal that tells collectors to discard the
+/// peer's state.
+#[tokio::test]
+async fn bmp_peer_down_survives_full_channel() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    session.established_at = Some(Instant::now());
+    session.last_down_reason = Some(PeerDownReason::RemoteNoNotification);
+    let tx = session.bmp_tx.clone().unwrap();
+    for _ in 0..16 {
+        tx.try_send(BmpEvent::StatsReport {
+            peer_info: session.build_bmp_peer_info(),
+            adj_rib_in_routes: 0,
+            adj_rib_out_post: None,
+        })
+        .unwrap();
+    }
+    // Consumer (the BmpManager stand-in) drains concurrently; the
+    // awaited PeerDown send completes once space frees up.
+    let drain = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        while let Some(event) = bmp_rx.recv().await {
+            if matches!(event, BmpEvent::PeerDown { .. }) {
+                return true;
+            }
+        }
+        false
+    });
+    session.execute_actions(vec![Action::SessionDown]).await;
+    drop(session);
+    assert!(
+        drain.await.unwrap(),
+        "PeerDown must be delivered even when the channel was full"
+    );
 }
 #[test]
 fn ebgp_prepends_asn() {

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -591,7 +591,18 @@ implemented per ADR-0040.
 - Live-only (no rib-out table dump): AdjRibOut stores routes
   pre-transport-stamping, so a synthesized dump would not be
   byte-faithful. Pre-policy rib-out deliberately skipped.
-- See ADR-0097 (Decisions 1, 3).
+- Saturation semantics: "mirror what was actually sent" is enforced in
+  both directions. An UPDATE that fails to enqueue on the saturated
+  writer is never mirrored (it never reached the wire; the `Cease/8`
+  teardown ends in a reliably delivered, correctly ordered Peer Down and
+  the re-established session re-floods the view). Conversely, a mirror
+  event dropped on a full BMP channel after the wire send succeeded
+  forces a synthetic Peer Down/Peer Up peer-state reset on the stream
+  (reason 2, FSM code 0) so the divergence is collector-detectable —
+  live-only views can never silently under-report. Per-peer Peer
+  Up/Peer Down delivery to the BMP manager is reliable (never
+  try_send-dropped).
+- See ADR-0097 (Decisions 1, 3 incl. the saturation amendment).
 
 ---
 

--- a/docs/adr/0097-bmp-monitoring.md
+++ b/docs/adr/0097-bmp-monitoring.md
@@ -88,6 +88,28 @@ This ADR records the decisions of that arc as shipped.
    therefore live-only (like rib-in), and the post-policy Loc-RIB dump
    covers what dump consumers want from an RR.
 
+   *Amendment (post-review): live-only loss must be detectable, never
+   silent.* Because there is no dump to resynchronize from, the "lossy
+   try_send, monitoring never backpressures the control plane" posture
+   was refined at the session→manager seam: per-peer `PeerUp`/`PeerDown`
+   are now delivered reliably (awaited send — bounded, since the manager
+   loop only ever does sync encode + per-collector `try_send`), and a
+   `RouteMonitoring` event dropped on a full channel while the mirrored
+   traffic did flow latches a per-session divergence flag that forces a
+   synthetic `PeerDown`/`PeerUp` peer-state reset (RFC 7854 reason 2,
+   FSM code 0) ahead of the next emission, with a 1s retry timer for
+   sessions that go quiet after the drop. Collectors thus either have a
+   correct view or an explicit reset telling them to rebuild from live
+   traffic. The outbound-writer saturation path needs no BMP-side
+   compensation by construction: an UPDATE that fails to enqueue never
+   reaches the wire (not mirroring it is what RFC 8671 requires) and
+   the `Cease/8` teardown ends in an ordered reliable `PeerDown`
+   (truthful reason 1 carrying that NOTIFICATION) followed by a
+   re-establish re-flood. The manager→collector fan-out stays lossy by
+   design — that layer's reset is the collector's own reconnect (state
+   discard + PeerUp replay), and `bmp_collector_drops_total` is its
+   alert signal.
+
 4. **BMPv4 is a per-collector framing decision at fan-out, not an
    internal representation.** Internal `BmpEvent`s stay
    version-agnostic; the manager frames per collector at fan-out with a


### PR DESCRIPTION
Maintainer deep-review finding 2 (#618-#662 review), characterized then fixed. The filed path proved sound; the hunt flushed the real bug one seam over.

## Characterization verdicts

- **Q1 (as filed) — sound, now pinned**: on writer-channel Full the UPDATE never reaches the wire, so not mirroring it is RFC 8671-correct; the saturation teardown's Cease/8 rides the unbounded priority channel and BMP PeerDown is emitted on the same mpsc, i.e. ordered after the last mirrored RouteMonitoring — collectors get a clean state reset. Regression test pins the ordering and the never-sent-UPDATE non-emission (incl. the multi-PDU partial-failure case, Q3). Truthfulness bonus: that PeerDown now carries reason 1 with the actual Cease/8 NOTIFICATION instead of the reason-4 default.
- **Q2 — the real bug, confirmed**: wire send Ok + `bmp_tx` try_send Full = silent divergence with no teardown (rib-in/rib-out are live-only; the view stayed wrong until the next real flap). Fix in the shared `emit_bmp_event` (covers rib-out AND rib-in taps): a dropped RouteMonitoring latches a diverged flag and forces a synthetic PeerDown/PeerUp pair (RFC 7854 peer-state reset) ahead of the next emission, with a 1s repair timer so a quiet session still heals. Order proven by test.
- **Companion hole**: PeerUp/PeerDown themselves used the lossy try_send — losing the state-reset signal is worse than losing an RM. Lifecycle events now use a reliable awaited send (bounded: the BmpManager loop never blocks). Test: PeerDown survives a full channel.

Boundedness: repair enqueues ≤2 events/attempt at 1s cadence; RM stays non-blocking; the manager→collector fan-out remains the documented lossy layer healed by reconnect. Loc-RIB paths untouched.

Gates: workspace build/test (4 new tests), fmt, clippy -D warnings, cargo doc, clippy-reasons — green.