### PR TITLE
fix(bmp): resumable cursor-based Loc-RIB dump — no full-table materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -729,6 +729,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`bmp_collector_drops_total`) remain the documented lossy layer,
   healed by the collector's own reconnect (RFC 7854 state discard +
   PeerUp replay).
+- **The BMP Loc-RIB collector-connect dump no longer materializes the
+  whole table on the RIB task.** The RFC 9069 dump handler synthesized
+  every Loc-RIB UPDATE PDU into one vector before chunking — an
+  O(table) allocation burst (hundreds of MB transient at full-DFZ
+  scale) during which no other RIB command ran. The dump is now
+  resumable: the BMP dump forwarder requests one 256-message chunk at
+  a time and hands back a key-based cursor ("smallest keys strictly
+  greater than the last emitted"), so per-request allocation is
+  bounded by the chunk size, live route processing and queries
+  interleave between chunks, and the cursor stays valid across
+  mid-dump insertions and withdrawals (surviving routes dump exactly
+  once; a route added behind the cursor reaches the collector on the
+  live stream — the accepted dump/live overlap race, ADR-0097).
+  Peer-up replay → dump → per-family End-of-RIB → live ordering is
+  unchanged and remains test-pinned.
+
 - **An enhanced route refresh no longer purges GR/LLGR-stale routes
   awaiting End-of-RIB (LAN-187).** RFC 7313's end-of-refresh sweep
   removes routes not re-advertised inside the BoRR..EoRR window — but a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ version = "0.45.0"
 dependencies = [
  "bytes",
  "rustbgpd-telemetry",
+ "rustbgpd-wire",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/bmp/Cargo.toml
+++ b/crates/bmp/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 rustbgpd-telemetry.workspace = true
+rustbgpd-wire.workspace = true
 bytes.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/bmp/src/lib.rs
+++ b/crates/bmp/src/lib.rs
@@ -21,7 +21,7 @@ pub mod types;
 pub use client::BmpClient;
 pub use manager::BmpManager;
 pub use types::{
-    BmpClientConfig, BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig,
-    BmpMonitorFilter, BmpPathStatus, BmpPeerInfo, BmpPeerType, BmpVersion, LOC_RIB_TABLE_NAME,
-    PeerDownReason,
+    BmpClientConfig, BmpControlEvent, BmpDumpChunk, BmpDumpCursor, BmpDumpRequest, BmpEvent,
+    BmpLocRibConfig, BmpMonitorFilter, BmpPathStatus, BmpPeerInfo, BmpPeerType, BmpVersion,
+    LOC_RIB_TABLE_NAME, PeerDownReason,
 };

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -17,8 +17,7 @@ use tracing::{debug, info, warn};
 
 use crate::codec;
 use crate::types::{
-    BmpControlEvent, BmpDumpChunk, BmpDumpRequest, BmpEvent, BmpLocRibConfig, BmpMonitorFilter,
-    BmpVersion,
+    BmpControlEvent, BmpDumpRequest, BmpEvent, BmpLocRibConfig, BmpMonitorFilter, BmpVersion,
 };
 
 /// Per-message send timeout for a Loc-RIB dump forwarder. Paces the dump
@@ -405,24 +404,11 @@ impl BmpManager {
         let Some(ref dump_tx) = self.dump_tx else {
             return;
         };
-        let (chunk_tx, chunk_rx) = mpsc::channel::<BmpDumpChunk>(4);
-        if let Err(e) = dump_tx.try_send(BmpDumpRequest { reply: chunk_tx }) {
-            let reason = trysend_reason(&e);
-            self.metrics
-                .record_bmp_collector_drop(&addr_label, "loc_rib_dump", reason, 1);
-            warn!(
-                collector = %addr,
-                error = %e,
-                "Loc-RIB dump request channel full or closed; collector starts live-only"
-            );
-            return;
-        }
-
         let cfg = cfg.clone();
         let collector_tx = collector_tx.clone();
         let metrics = self.metrics.clone();
         tokio::spawn(forward_loc_rib_dump(
-            chunk_rx,
+            dump_tx.clone(),
             collector_tx,
             cfg,
             version,
@@ -464,22 +450,42 @@ impl BmpManager {
     }
 }
 
-/// Forward one Loc-RIB dump — chunks of `(synthesized UPDATE PDU,
-/// install time)` from the RIB manager — to a single collector as
-/// Route Monitoring messages. The bounded collector channel plus a
-/// per-message send timeout pace the dump at the collector's drain
-/// rate; a timeout or closed channel aborts the dump (a fresh one runs
-/// on the next reconnect).
+/// Forward one Loc-RIB dump to a single collector as Route Monitoring
+/// messages, driving the resumable chunk loop against the RIB manager:
+/// request one bounded chunk, forward it, then request the next from
+/// the returned cursor. The RIB manager synthesizes at most one chunk
+/// per request, so live route processing interleaves between chunks
+/// and no full-table dump vector ever materializes.
+///
+/// The bounded collector channel plus a per-message send timeout pace
+/// the dump at the collector's drain rate; a timeout or closed channel
+/// aborts the dump (a fresh one runs on the next reconnect).
 async fn forward_loc_rib_dump(
-    mut chunk_rx: mpsc::Receiver<BmpDumpChunk>,
+    dump_tx: mpsc::Sender<BmpDumpRequest>,
     collector_tx: mpsc::Sender<Bytes>,
     cfg: BmpLocRibConfig,
     version: BmpVersion,
     metrics: BgpMetrics,
     addr_label: String,
 ) {
+    let mut cursor = None;
     let mut sent: u64 = 0;
-    while let Some(chunk) = chunk_rx.recv().await {
+    loop {
+        let (reply, chunk_rx) = tokio::sync::oneshot::channel();
+        if dump_tx
+            .send(BmpDumpRequest { cursor, reply })
+            .await
+            .is_err()
+        {
+            metrics.record_bmp_collector_drop(&addr_label, "loc_rib_dump", "channel_closed", 1);
+            warn!(collector = %addr_label, "Loc-RIB dump request channel closed, aborting dump");
+            return;
+        }
+        let Ok(chunk) = chunk_rx.await else {
+            metrics.record_bmp_collector_drop(&addr_label, "loc_rib_dump", "channel_closed", 1);
+            warn!(collector = %addr_label, "RIB manager dropped Loc-RIB dump chunk reply, aborting dump");
+            return;
+        };
         for (pdu, timestamp, path_status) in chunk.messages {
             let msg = codec::encode_route_monitoring(
                 &cfg.peer_info(timestamp),
@@ -510,6 +516,10 @@ async fn forward_loc_rib_dump(
                     return;
                 }
             }
+        }
+        match chunk.next {
+            Some(next) => cursor = Some(next),
+            None => break,
         }
     }
     debug!(collector = %addr_label, messages = sent, "Loc-RIB dump forwarded");
@@ -1438,13 +1448,21 @@ mod tests {
         assert_eq!(peer_up[6], 3, "peer type 3");
         assert_eq!(&peer_up[peer_up.len() - 6..], b"global");
 
-        // 2. The manager requested a dump; answer with two chunks
-        // playing the RIB manager's role (2 routes + 1 "EoR" PDU).
+        // 2. The manager requested the first dump chunk (fresh cursor);
+        // answer with a resumable chunk playing the RIB manager's role,
+        // then serve the follow-up request from the returned cursor
+        // (1 route + 1 "EoR" PDU) — proving the forwarder drives the
+        // request→forward→request-next loop and round-trips the cursor.
         let request = tokio::time::timeout(std::time::Duration::from_secs(2), dump_rx.recv())
             .await
             .expect("dump requested on connect")
             .expect("dump channel open");
+        assert!(request.cursor.is_none(), "fresh dump starts cursor-less");
         let install = UNIX_EPOCH + std::time::Duration::from_secs(1_600_000_000);
+        let resume = rustbgpd_wire::Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+            std::net::Ipv4Addr::new(10, 2, 0, 0),
+            16,
+        ));
         request
             .reply
             .send(crate::types::BmpDumpChunk {
@@ -1452,17 +1470,26 @@ mod tests {
                     (Bytes::from_static(&[0xD1; 23]), install, None),
                     (Bytes::from_static(&[0xD2; 23]), install, None),
                 ],
+                next: Some(crate::types::BmpDumpCursor::Unicast(resume)),
             })
-            .await
             .unwrap();
+        let request = tokio::time::timeout(std::time::Duration::from_secs(2), dump_rx.recv())
+            .await
+            .expect("follow-up chunk requested")
+            .expect("dump channel open");
+        match request.cursor {
+            Some(crate::types::BmpDumpCursor::Unicast(p)) => {
+                assert_eq!(p, resume, "cursor round-trips verbatim");
+            }
+            other => panic!("expected the returned cursor back, got {other:?}"),
+        }
         request
             .reply
             .send(crate::types::BmpDumpChunk {
                 messages: vec![(Bytes::from_static(&[0xE0; 23]), install, None)],
+                next: None,
             })
-            .await
             .unwrap();
-        drop(request);
 
         for expected in [0xD1u8, 0xD2, 0xE0] {
             let msg = c_rx.recv().await.unwrap();

--- a/crates/bmp/src/types.rs
+++ b/crates/bmp/src/types.rs
@@ -4,7 +4,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::SystemTime;
 
 use bytes::Bytes;
-use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 /// BMP event sent from transport to BMP manager.
 #[derive(Debug)]
@@ -116,16 +116,39 @@ impl BmpLocRibConfig {
     }
 }
 
-/// A Loc-RIB table-dump request from the BMP manager to the RIB manager,
-/// issued when a collector monitoring `loc_rib` (re)connects.
+/// Resume position within a resumable Loc-RIB table dump.
 ///
-/// The RIB manager answers with bounded [`BmpDumpChunk`]s (synthesized
-/// UPDATE PDUs with per-route install timestamps, ending with one
-/// End-of-RIB PDU per dumped AFI/SAFI) and then drops the sender.
+/// Produced by the RIB manager (the last key it emitted per family
+/// phase) and round-tripped verbatim by the BMP dump forwarder on the
+/// next [`BmpDumpRequest`]. Because it names a *key*, not a table
+/// position, it stays valid across route insertions and removals
+/// between chunks: each chunk is "the smallest keys strictly greater
+/// than the cursor", so a surviving route is emitted exactly once and
+/// mutations land on the live stream (the accepted dump-vs-live race).
+#[derive(Debug, Clone, Copy)]
+pub enum BmpDumpCursor {
+    /// Resuming the unicast Loc-RIB walk after this prefix.
+    Unicast(rustbgpd_wire::Prefix),
+    /// Unicast walk done; resuming the VPN walk after this key
+    /// (`None` = VPN walk not yet started).
+    Vpn(Option<rustbgpd_wire::VpnRouteKey>),
+}
+
+/// One bounded Loc-RIB table-dump chunk request from the BMP manager to
+/// the RIB manager: the first is issued when a collector monitoring
+/// `loc_rib` (re)connects (`cursor: None`), follow-ups resume from the
+/// cursor returned in the previous [`BmpDumpChunk`].
+///
+/// The RIB manager answers each request with one bounded chunk
+/// (synthesized UPDATE PDUs with per-route install timestamps; the
+/// final chunk ends with one End-of-RIB PDU per dumped AFI/SAFI) and
+/// yields back to live route processing between requests.
 #[derive(Debug)]
 pub struct BmpDumpRequest {
-    /// Chunk reply channel. Bounded — the dump producer paces on it.
-    pub reply: mpsc::Sender<BmpDumpChunk>,
+    /// Resume position; `None` starts a fresh dump.
+    pub cursor: Option<BmpDumpCursor>,
+    /// Reply channel for this chunk.
+    pub reply: oneshot::Sender<BmpDumpChunk>,
 }
 
 /// One bounded chunk of a Loc-RIB table dump.
@@ -134,6 +157,9 @@ pub struct BmpDumpChunk {
     /// Synthesized UPDATE PDUs with their route install times and the
     /// Path Marking payload (`None` on the End-of-RIB markers).
     pub messages: Vec<(Bytes, SystemTime, Option<BmpPathStatus>)>,
+    /// Where the next request should resume; `None` = dump complete
+    /// (this chunk carries the End-of-RIB markers).
+    pub next: Option<BmpDumpCursor>,
 }
 
 /// Path Marking TLV payload (draft-ietf-grow-bmp-path-marking-tlv-05

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -374,8 +374,35 @@ pub(super) struct LiveSessionRecord {
 }
 
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
-/// Synthesized messages per RFC 9069 Loc-RIB dump chunk.
+/// Synthesized messages per RFC 9069 Loc-RIB dump chunk — the
+/// per-request allocation bound of the resumable dump (the final chunk
+/// additionally carries one End-of-RIB marker per streamed family).
 const BMP_DUMP_CHUNK_SIZE: usize = 256;
+
+/// The `n` smallest keys strictly greater than `after`, ascending,
+/// selected in one pass over an unordered key iterator with a max-heap
+/// capped at `n` — the mutation-robust cursor step of the resumable
+/// BMP Loc-RIB dump. Returns fewer than `n` keys iff the walk past
+/// `after` is exhausted.
+fn smallest_keys_after<K: Ord + Copy>(
+    keys: impl Iterator<Item = K>,
+    after: Option<K>,
+    n: usize,
+) -> Vec<K> {
+    let mut heap = std::collections::BinaryHeap::with_capacity(n + 1);
+    for key in keys {
+        if after.is_some_and(|a| key <= a) {
+            continue;
+        }
+        if heap.len() < n {
+            heap.push(key);
+        } else if heap.peek().is_some_and(|&top| key < top) {
+            heap.pop();
+            heap.push(key);
+        }
+    }
+    heap.into_sorted_vec()
+}
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
@@ -1175,26 +1202,43 @@ impl RibManager {
             }
             RibUpdate::QueryOrrStatus { reply } => self.handle_query_orr_status(reply),
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
-            RibUpdate::QueryBmpLocRibDump { reply } => self.handle_query_bmp_loc_rib_dump(reply),
+            RibUpdate::QueryBmpLocRibDump { cursor, reply } => {
+                self.handle_query_bmp_loc_rib_dump(cursor, reply);
+            }
             RibUpdate::QueryBmpLocRibStats { reply } => {
                 self.handle_query_bmp_loc_rib_stats(reply);
             }
         }
     }
 
-    /// RFC 9069 Loc-RIB table dump: synthesize one UPDATE PDU per
-    /// Loc-RIB best route (unicast + VPN) with its install-time
-    /// timestamp, append one End-of-RIB PDU per streamed family, and
-    /// stream the lot back in bounded chunks from a spawned drain task
-    /// — the RIB task never awaits the (slow-collector-paced) reply
-    /// channel.
+    /// One bounded chunk of the RFC 9069 Loc-RIB table dump: synthesize
+    /// at most [`BMP_DUMP_CHUNK_SIZE`] UPDATE PDUs (unicast bests, then
+    /// VPN bests) resuming after `cursor`, and reply with the next
+    /// resume position. The BMP dump forwarder drives the loop, so the
+    /// full table is never materialized at once and every other RIB
+    /// command interleaves between chunk requests.
     ///
-    /// The whole table is synthesized up front in this handler; that is
-    /// the same O(table) burst the MRT snapshot query already takes.
-    // ponytail: full-table synthesis burst; switch to resumable per-chunk
-    // queries if dump CPU/memory at extreme scale ever bites.
-    fn handle_query_bmp_loc_rib_dump(&self, reply: mpsc::Sender<rustbgpd_bmp::BmpDumpChunk>) {
+    /// Cursor semantics: each chunk is "the `N` smallest keys strictly
+    /// greater than the cursor" in the key's total order, selected in
+    /// one pass over the unordered Loc-RIB map. That makes the cursor
+    /// robust to mutations between chunks — a route that survives the
+    /// dump is emitted exactly once, a removed route simply stops
+    /// matching, and an insertion behind the cursor reaches the
+    /// collector via the live stream (the accepted dump-vs-live race,
+    /// ADR-0097). A phase yielding fewer than `N` keys is exhausted:
+    /// unicast hands over to VPN, VPN closes the dump with one
+    /// End-of-RIB per streamed family (dump→EoR→live ordering).
+    // ponytail: each chunk re-scans the family's key set (O(table) per
+    // chunk, O(table²/N) per dump) — swap the scan for a sorted index
+    // or key snapshot if dump CPU at DFZ scale ever bites; allocation
+    // is already bounded per chunk.
+    fn handle_query_bmp_loc_rib_dump(
+        &self,
+        cursor: Option<rustbgpd_bmp::BmpDumpCursor>,
+        reply: tokio::sync::oneshot::Sender<rustbgpd_bmp::BmpDumpChunk>,
+    ) {
         use crate::bmp_sync;
+        use rustbgpd_bmp::BmpDumpCursor as Cursor;
         let now = std::time::SystemTime::now();
         // Install time ≈ receive wall time, recovered from the monotonic
         // receive instant (RFC 9069 per-peer header timestamp).
@@ -1208,45 +1252,78 @@ impl RibManager {
             bytes::Bytes,
             std::time::SystemTime,
             Option<rustbgpd_bmp::BmpPathStatus>,
-        )> = Vec::with_capacity(
-            self.loc_rib.len() + self.loc_rib.vpn_len() + bmp_sync::LOC_RIB_FAMILIES.len(),
-        );
-        for route in self.loc_rib.iter() {
-            if let Some(pdu) = bmp_sync::synthesize_unicast_announce(route) {
-                let status =
-                    bmp_sync::loc_rib_path_status(route.is_stale || route.is_llgr_stale, None);
-                messages.push((pdu, install_time(route.received_at), Some(status)));
-            }
-        }
-        for route in self.loc_rib.iter_vpn() {
-            if let Some(pdu) = bmp_sync::synthesize_vpn_announce(route) {
-                let status =
-                    bmp_sync::loc_rib_path_status(route.is_stale || route.is_llgr_stale, None);
-                messages.push((pdu, install_time(route.received_at), Some(status)));
-            }
-        }
-        // End-of-RIB per family closes the dump; live emission continues
-        // seamlessly after (dump→EoR→live, with the standard BMP overlap
-        // race accepted). EoR markers announce no path — nothing to mark.
-        for (afi, safi) in bmp_sync::LOC_RIB_FAMILIES {
-            if let Some(pdu) = bmp_sync::synthesize_end_of_rib(afi, safi) {
-                messages.push((pdu, now, None));
-            }
-        }
-        tokio::spawn(async move {
-            let mut iter = messages.into_iter().peekable();
-            while iter.peek().is_some() {
-                let chunk: Vec<_> = iter.by_ref().take(BMP_DUMP_CHUNK_SIZE).collect();
-                if reply
-                    .send(rustbgpd_bmp::BmpDumpChunk { messages: chunk })
-                    .await
-                    .is_err()
-                {
-                    debug!("BMP Loc-RIB dump consumer dropped, aborting dump");
-                    return;
+        )> = Vec::with_capacity(BMP_DUMP_CHUNK_SIZE);
+        let next = match cursor {
+            None | Some(Cursor::Unicast(_)) => {
+                let after = match cursor {
+                    Some(Cursor::Unicast(prefix)) => Some(prefix),
+                    _ => None,
+                };
+                let keys = smallest_keys_after(
+                    self.loc_rib.iter().map(|r| r.prefix),
+                    after,
+                    BMP_DUMP_CHUNK_SIZE,
+                );
+                for key in &keys {
+                    let Some(route) = self.loc_rib.get(key) else {
+                        continue;
+                    };
+                    if let Some(pdu) = bmp_sync::synthesize_unicast_announce(route) {
+                        let status = bmp_sync::loc_rib_path_status(
+                            route.is_stale || route.is_llgr_stale,
+                            None,
+                        );
+                        messages.push((pdu, install_time(route.received_at), Some(status)));
+                    }
+                }
+                match keys.last() {
+                    Some(&last) if keys.len() == BMP_DUMP_CHUNK_SIZE => Some(Cursor::Unicast(last)),
+                    _ => Some(Cursor::Vpn(None)),
                 }
             }
-        });
+            Some(Cursor::Vpn(after)) => {
+                let keys = smallest_keys_after(
+                    self.loc_rib.iter_vpn().map(|r| r.nlri.key()),
+                    after,
+                    BMP_DUMP_CHUNK_SIZE,
+                );
+                for key in &keys {
+                    let Some(route) = self.loc_rib.get_vpn(key) else {
+                        continue;
+                    };
+                    if let Some(pdu) = bmp_sync::synthesize_vpn_announce(route) {
+                        let status = bmp_sync::loc_rib_path_status(
+                            route.is_stale || route.is_llgr_stale,
+                            None,
+                        );
+                        messages.push((pdu, install_time(route.received_at), Some(status)));
+                    }
+                }
+                match keys.last() {
+                    Some(&last) if keys.len() == BMP_DUMP_CHUNK_SIZE => {
+                        Some(Cursor::Vpn(Some(last)))
+                    }
+                    _ => {
+                        // End-of-RIB per family closes the dump; live
+                        // emission continues seamlessly after (dump→EoR→
+                        // live). EoR markers announce no path — nothing
+                        // to mark.
+                        for (afi, safi) in bmp_sync::LOC_RIB_FAMILIES {
+                            if let Some(pdu) = bmp_sync::synthesize_end_of_rib(afi, safi) {
+                                messages.push((pdu, now, None));
+                            }
+                        }
+                        None
+                    }
+                }
+            }
+        };
+        if reply
+            .send(rustbgpd_bmp::BmpDumpChunk { messages, next })
+            .is_err()
+        {
+            debug!("BMP Loc-RIB dump consumer dropped, aborting dump");
+        }
     }
 
     /// Per-AFI/SAFI Loc-RIB route counts for the RFC 9069 BMP stats

--- a/crates/rib/src/manager/tests/bmp.rs
+++ b/crates/rib/src/manager/tests/bmp.rs
@@ -4,7 +4,7 @@
 
 use std::time::SystemTime;
 
-use rustbgpd_bmp::{BmpDumpChunk, BmpEvent, BmpPathStatus, tlv as bmp_tlv};
+use rustbgpd_bmp::{BmpDumpCursor, BmpEvent, BmpPathStatus, tlv as bmp_tlv};
 use rustbgpd_wire::UpdateMessage;
 
 use super::*;
@@ -45,6 +45,62 @@ fn assert_no_event(bmp_rx: &mut mpsc::Receiver<BmpEvent>) {
         Err(mpsc::error::TryRecvError::Empty) => {}
         other => panic!("expected no BMP event, got {other:?}"),
     }
+}
+
+/// Drive the resumable Loc-RIB dump the way the BMP forwarder does —
+/// request one bounded chunk, then the next from the returned cursor —
+/// asserting the per-request allocation bound on every chunk. Returns
+/// the messages in arrival order plus the number of chunk requests.
+async fn drive_loc_rib_dump_from(
+    tx: &mpsc::Sender<RibUpdate>,
+    mut cursor: Option<BmpDumpCursor>,
+) -> (
+    Vec<(bytes::Bytes, SystemTime, Option<BmpPathStatus>)>,
+    usize,
+) {
+    let mut messages = Vec::new();
+    let mut requests = 0usize;
+    loop {
+        let (reply, chunk_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryBmpLocRibDump { cursor, reply })
+            .await
+            .unwrap();
+        let chunk = tokio::time::timeout(Duration::from_secs(2), chunk_rx)
+            .await
+            .expect("dump chunk within timeout")
+            .expect("RIB manager replies to every chunk request");
+        requests += 1;
+        // Per-request allocation bound: chunk size, plus the per-family
+        // End-of-RIB markers on the final chunk only.
+        let bound = if chunk.next.is_some() {
+            BMP_DUMP_CHUNK_SIZE
+        } else {
+            BMP_DUMP_CHUNK_SIZE + crate::bmp_sync::LOC_RIB_FAMILIES.len()
+        };
+        assert!(
+            chunk.messages.len() <= bound,
+            "chunk of {} messages exceeds the per-request bound {bound}",
+            chunk.messages.len()
+        );
+        messages.extend(chunk.messages);
+        match chunk.next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    (messages, requests)
+}
+
+/// Announced unicast prefixes across a slice of dump messages, in dump
+/// order (End-of-RIB and VPN PDUs contribute none).
+fn dumped_unicast_prefixes(
+    messages: &[(bytes::Bytes, SystemTime, Option<BmpPathStatus>)],
+) -> Vec<Ipv4Prefix> {
+    let mut prefixes = Vec::new();
+    for (pdu, _, _) in messages {
+        prefixes.extend(decode_pdu(pdu).announced.iter().map(|e| e.prefix));
+    }
+    prefixes
 }
 
 /// New best → RM announce; better path from another peer → RM announce
@@ -265,10 +321,6 @@ async fn vpn_best_change_emits_loc_rib_route_monitoring() {
 /// The Loc-RIB dump streams every best (unicast + VPN) in chunks and
 /// closes with exactly one End-of-RIB per streamed family; dump-entry
 /// timestamps reflect route install time, not dump time.
-#[expect(
-    clippy::too_many_lines,
-    reason = "one end-to-end dump walk asserting order, timestamps, path status, and EoR set together"
-)]
 #[tokio::test]
 async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
     let (tx, rx) = mpsc::channel(64);
@@ -303,22 +355,11 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
     // Let the routes age so install-time and dump-time are separable.
     tokio::time::sleep(Duration::from_millis(1200)).await;
 
-    let (reply, mut chunk_rx) = mpsc::channel::<BmpDumpChunk>(4);
     let dump_started = SystemTime::now();
-    tx.send(RibUpdate::QueryBmpLocRibDump { reply })
-        .await
-        .unwrap();
-
-    let mut messages: Vec<(bytes::Bytes, SystemTime, Option<BmpPathStatus>)> = Vec::new();
-    while let Some(chunk) = tokio::time::timeout(Duration::from_secs(2), chunk_rx.recv())
-        .await
-        .expect("dump chunk within timeout")
-    {
-        messages.extend(chunk.messages);
-        if chunk_rx.is_closed() && chunk_rx.is_empty() {
-            break;
-        }
-    }
+    let (messages, requests) = drive_loc_rib_dump_from(&tx, None).await;
+    // Two resumable requests: the unicast phase, then the VPN phase
+    // closing with the End-of-RIB markers.
+    assert_eq!(requests, 2, "unicast chunk, then VPN + EoR chunk");
     // 2 unicast + 1 VPN route, then 4 EoRs (v4u, v6u, vpnv4, vpnv6).
     assert_eq!(messages.len(), 3 + 4, "routes then one EoR per family");
 
@@ -380,6 +421,208 @@ async fn query_bmp_loc_rib_dump_streams_routes_then_eor_per_family() {
             (Afi::Ipv6, Safi::Unicast),
             (Afi::Ipv6, Safi::MplsVpn),
         ]
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A table larger than one chunk streams to completion across multiple
+/// bounded chunk requests: every route present exactly once, no chunk
+/// above the per-request allocation bound (asserted in the drive
+/// helper), and the End-of-RIB markers only on the final chunk.
+#[tokio::test]
+async fn loc_rib_dump_chunks_stream_complete_table() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    let total = 2 * BMP_DUMP_CHUNK_SIZE + 88;
+    let prefixes: Vec<Ipv4Prefix> = (0..total)
+        .map(|i| {
+            Ipv4Prefix::new(
+                Ipv4Addr::new(
+                    10,
+                    u8::try_from(i / 256).unwrap(),
+                    u8::try_from(i % 256).unwrap(),
+                    0,
+                ),
+                24,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: prefixes
+            .iter()
+            .map(|&p| make_route_with_lp(p, peer, 100))
+            .collect(),
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let (messages, requests) = drive_loc_rib_dump_from(&tx, None).await;
+    // Three bounded unicast chunks (256 + 256 + 88), then the VPN
+    // phase closing the dump with the four EoR markers.
+    assert_eq!(requests, 4, "dump streams across multiple chunk requests");
+    assert_eq!(
+        messages.len(),
+        total + 4,
+        "every route plus one EoR per family"
+    );
+
+    let mut dumped = dumped_unicast_prefixes(&messages);
+    assert_eq!(
+        dumped.len(),
+        total,
+        "no route lost or duplicated across chunks"
+    );
+    dumped.sort_unstable();
+    assert_eq!(dumped, prefixes, "every route present exactly once");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Live RIB commands interleave between dump chunk requests, and the
+/// key-based cursor is robust to mutations mid-dump: a stats query
+/// fired between chunks is serviced before the dump resumes, a route
+/// inserted behind the cursor stays off the dump (the live stream
+/// covers it — the accepted race), a route inserted ahead of the
+/// cursor is picked up, and a not-yet-dumped route withdrawn between
+/// chunks never appears. The dump still completes with the
+/// End-of-RIB set.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one mid-dump mutation walk: chunk, mutate, live query, resume, membership asserts"
+)]
+#[tokio::test]
+async fn loc_rib_dump_interleaves_live_commands_between_chunks() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = Ipv4Addr::new(10, 0, 0, 1);
+    let total = BMP_DUMP_CHUNK_SIZE + 44;
+    // Ascending insertion order == cursor (key) order for these prefixes.
+    let prefixes: Vec<Ipv4Prefix> = (0..total)
+        .map(|i| {
+            Ipv4Prefix::new(
+                Ipv4Addr::new(
+                    10,
+                    u8::try_from(i / 256).unwrap(),
+                    u8::try_from(i % 256).unwrap(),
+                    0,
+                ),
+                24,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: prefixes
+            .iter()
+            .map(|&p| make_route_with_lp(p, peer, 100))
+            .collect(),
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // First chunk by hand (the forwarder's opening request): exactly
+    // the chunk-size smallest prefixes, with a resume cursor.
+    let (reply, chunk_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibDump {
+        cursor: None,
+        reply,
+    })
+    .await
+    .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(2), chunk_rx)
+        .await
+        .expect("first chunk within timeout")
+        .expect("RIB manager replies");
+    assert_eq!(first.messages.len(), BMP_DUMP_CHUNK_SIZE);
+    let cursor = first.next.expect("table larger than one chunk");
+
+    // Mutate the table between chunk requests: one prefix sorting
+    // before the cursor (dump must skip it), one after (dump must pick
+    // it up), and withdraw a not-yet-dumped prefix.
+    let low = Ipv4Prefix::new(Ipv4Addr::new(1, 0, 0, 0), 24);
+    let high = Ipv4Prefix::new(Ipv4Addr::new(240, 0, 0, 0), 24);
+    let withdrawn_mid = prefixes[BMP_DUMP_CHUNK_SIZE + 10];
+    tx.send(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(peer),
+        session_id: 0,
+        announced: vec![
+            make_route_with_lp(low, peer, 100),
+            make_route_with_lp(high, peer, 100),
+        ],
+        withdrawn: vec![(Prefix::V4(withdrawn_mid), 0)],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // A live query between chunk requests is serviced before the dump
+    // resumes — the dump holds no lock on the manager.
+    let (stats_reply, stats_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBmpLocRibStats { reply: stats_reply })
+        .await
+        .unwrap();
+    let stats = tokio::time::timeout(Duration::from_secs(2), stats_rx)
+        .await
+        .expect("stats reply while the dump is mid-flight")
+        .expect("stats channel open");
+    let v4_count = stats
+        .iter()
+        .find(|&&(afi, safi, _)| afi == Afi::Ipv4 as u16 && safi == Safi::Unicast as u8)
+        .map(|&(_, _, count)| count)
+        .unwrap();
+    assert_eq!(
+        v4_count,
+        u64::try_from(total + 2 - 1).unwrap(),
+        "the mutation batch was applied between dump chunks"
+    );
+
+    // Resume the dump to completion from the first chunk's cursor.
+    let (rest, _) = drive_loc_rib_dump_from(&tx, Some(cursor)).await;
+    let mut messages = first.messages;
+    messages.extend(rest);
+
+    let dumped = dumped_unicast_prefixes(&messages);
+    let mut expected: Vec<Ipv4Prefix> = prefixes
+        .iter()
+        .copied()
+        .filter(|&p| p != withdrawn_mid)
+        .chain(std::iter::once(high))
+        .collect();
+    expected.sort_unstable();
+    let mut sorted = dumped.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        sorted, expected,
+        "surviving + ahead-of-cursor routes exactly once; behind-cursor \
+         insert and mid-dump withdrawal absent"
+    );
+    assert!(
+        !dumped.contains(&low),
+        "insertion behind the cursor is live-stream territory, not dump"
     );
 
     drop(tx);

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -899,16 +899,20 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<MrtSnapshotData>,
     },
-    /// RFC 9069 Loc-RIB table dump for a (re)connected BMP collector:
-    /// synthesize one UPDATE PDU per Loc-RIB best route (unicast + VPN)
-    /// with its install time, ending with an End-of-RIB PDU per dumped
-    /// family, streamed back in bounded chunks. The synthesis runs in
-    /// the handler; the chunk sends are driven by a spawned drain task
-    /// so a slow collector never blocks the RIB task.
+    /// One bounded chunk of an RFC 9069 Loc-RIB table dump for a
+    /// (re)connected BMP collector: synthesize at most one chunk of
+    /// UPDATE PDUs (unicast + VPN bests, resumed from `cursor`) with
+    /// their install times, ending with an End-of-RIB PDU per dumped
+    /// family on the final chunk. The BMP dump forwarder drives the
+    /// chunk loop, so the full table is never materialized at once and
+    /// live route processing interleaves between chunks.
     QueryBmpLocRibDump {
-        /// Bounded chunk reply channel (from the BMP manager's
-        /// `BmpDumpRequest`). Dropped when the dump completes.
-        reply: mpsc::Sender<rustbgpd_bmp::BmpDumpChunk>,
+        /// Resume position from the previous chunk's reply; `None`
+        /// starts a fresh dump.
+        cursor: Option<rustbgpd_bmp::BmpDumpCursor>,
+        /// Reply channel for this chunk (from the BMP manager's
+        /// `BmpDumpRequest`).
+        reply: oneshot::Sender<rustbgpd_bmp::BmpDumpChunk>,
     },
     /// Query per-AFI/SAFI Loc-RIB route counts for the RFC 9069 BMP
     /// statistics report (stat type 10 entries; type 8 is their sum).

--- a/crates/wire/src/nlri.rs
+++ b/crates/wire/src/nlri.rs
@@ -168,7 +168,11 @@ impl fmt::Display for Ipv6Prefix {
 }
 
 /// A prefix that can be either IPv4 or IPv6.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// The derived total order (all V4 before V6, then by address/length)
+/// carries no routing meaning; it exists so stable cursors can be cut
+/// through unordered prefix-keyed tables (e.g. resumable BMP dumps).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Prefix {
     /// IPv4 prefix.
     V4(Ipv4Prefix),

--- a/docs/adr/0097-bmp-monitoring.md
+++ b/docs/adr/0097-bmp-monitoring.md
@@ -80,6 +80,24 @@ This ADR records the decisions of that arc as shipped.
    already handles it; ordering (dump → EoR → live per collector) is
    test-pinned.
 
+   *As-built amendment (post-review):* the dump is **resumable**, not
+   pre-materialized. The original handler synthesized the whole table
+   into one vector on the RIB task before chunking — an O(table)
+   allocation burst that stalled route processing at DFZ scale. Now
+   each `BmpDumpRequest` carries an optional `BmpDumpCursor` and the
+   RIB manager answers with exactly one bounded chunk (unicast phase,
+   then VPN, then the End-of-RIB markers) plus the next cursor; the
+   per-collector forwarder task drives the request→forward→request-next
+   loop. The cursor names a *key* ("smallest keys strictly greater than
+   the last emitted", selected per chunk with a size-capped max-heap
+   over the unordered map), so it stays valid across mid-dump
+   insertions and withdrawals without snapshot isolation — surviving
+   routes are emitted exactly once, and an insertion behind the cursor
+   is covered by the live stream under the same accepted overlap race.
+   Every other RIB command interleaves between chunk requests. Known
+   ceiling: each chunk re-scans the family's key set (O(table) per
+   chunk); a sorted index is the upgrade path if dump CPU ever bites.
+
 3. **Rib-out table dumps were rejected.** AdjRibOut stores routes
    *pre*-transport-stamping — ORIGINATOR_ID/CLUSTER_LIST, GShut, and
    LLGR stripping apply session-side at encode. A dump synthesized from

--- a/src/main.rs
+++ b/src/main.rs
@@ -1376,6 +1376,7 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 while let Some(request) = dump_rx.recv().await {
                     if dump_rib_tx
                         .send(RibUpdate::QueryBmpLocRibDump {
+                            cursor: request.cursor,
                             reply: request.reply,
                         })
                         .await


### PR DESCRIPTION
Maintainer deep-review finding 1 (#618-#662 review): the Loc-RIB BMP dump synthesized the entire table into one Vec synchronously on the single-threaded RIB manager task — hundreds of MB transient at DFZ scale per collector connect, stalling live route processing for the whole walk.

## The protocol

`BmpDumpRequest` carries an optional cursor + oneshot reply; the BMP forwarder drives request→forward→request-next with the existing collector pacing. Cursor = `Unicast(Prefix) → Vpn(Option<VpnRouteKey>)` (phase handover in the enum); each chunk selects "the N smallest keys strictly greater than the cursor" via a size-capped max-heap over the unordered map — **key-based, not positional**, so no snapshot isolation is needed: survivors emit exactly once, deletions stop matching, behind-cursor insertions ride the live stream (the ADR-0097 accepted race). Final chunk appends the per-family EoR markers. `Prefix` gained a derived `Ord`, documented cursor-only.

## Acceptance (all four, test-pinned)

1. Per-request allocation ≤ 256 messages (+4 EoR on the final chunk) — asserted on every chunk.
2. 600 routes across 4 chunk requests: every route exactly once.
3. A stats query is serviced mid-dump; mutations between chunks behave per the race contract (ahead-of-cursor insert dumped, behind-cursor excluded, undumped withdrawal absent).
4. Collector-connect ordering peer-up → multi-chunk dump → EoR-per-family → live pinned at the BMP-manager level; the M81 receipt's pins stay green.

Known ceiling in a `ponytail:` note + the ADR-0097 amendment: O(table) key-scan per chunk; a sorted index is the upgrade path.

Gates: workspace build/test (66 suites), fmt, clippy -D warnings, cargo doc, clippy-reasons, bench-internals check — green; rebased over #699 (additive CHANGELOG conflict, both kept).