### PR TITLE
feat(config): durable commit-confirm — boot-time revert journal (NETCONF §8.4 crash story)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Durable commit-confirm: a restart inside the confirm window now
+  reverts at boot instead of making the unconfirmed config permanent
+  (ADR-0076 Decision 6 amendment).** Before a confirmed transaction
+  commits, the daemon atomically journals the pre-commit config
+  snapshot, confirm handle, and deadline to
+  `<runtime_state_dir>/commit-confirm-journal.json`
+  (write-tmp+fsync+rename+fsync-dir); confirm, abort, and timeout
+  auto-revert consume the journal, and a failed rollback deliberately
+  retains it. At startup, an unconfirmed journal triggers a boot-time
+  revert BEFORE the on-disk config is adopted — regardless of remaining
+  confirm time, per NETCONF (RFC 6241 §8.4) cancel-on-session-loss
+  semantics — restoring the pre-transaction config to the config file,
+  saving the unconfirmed candidate aside as `<config>.unconfirmed`, and
+  logging a loud ERROR + banner notice
+  (`config_transaction_lifecycle{operation="boot_revert"}` metric). A
+  torn/unreadable journal or an unusable embedded config refuses boot
+  naming both files (fail closed). Applies to both the gRPC
+  `ApplyConfigTransaction` and gNMI commit-confirmed paths (shared
+  controller). Proven by real-binary SIGKILL-mid-window integration
+  tests (`tests/commit_confirm_binary.rs`); closes the KNOWN_ISSUES
+  "commit-confirmed does not survive a daemon restart" row.
+
 - **Per-client best-path for route-server clients (RFC 7947 §2.3.2
   path-hiding mitigation, the BIRD-`secondary` equivalent).** New
   per-neighbor / per-peer-group knob `per_client_best = true` (requires

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -97,6 +97,20 @@ resolved.
   M33 1h soak: 0 drops, 0 flaps, memory flat at 83 MB, slope 0.50 MB/h
   under sustained 1k rps EVPN churn.
 
+- **Commit-confirmed config transactions now survive a daemon restart
+  (resolved).** The confirm timer and the pre-commit rollback snapshot used to
+  be held in memory only, so a restart inside the confirm window left the
+  already-committed candidate live (confirmed-by-restart) and the auto-revert
+  never fired. The daemon now journals the pre-commit config snapshot to
+  `<runtime_state_dir>/commit-confirm-journal.json` (atomic write) before the
+  candidate commits; a restart that finds an unconfirmed journal reverts to
+  the journaled config at boot — regardless of remaining confirm time, since
+  the confirming session died with the old process (NETCONF RFC 6241 §8.4
+  cancel-on-session-loss semantics) — saving the unconfirmed candidate aside
+  as `<config>.unconfirmed`. A torn or unusable journal refuses boot naming
+  both files. Proven by SIGKILL-mid-window real-binary tests
+  (`tests/commit_confirm_binary.rs`). See ADR-0076 Decision 6 amendment.
+
 ## Limitations (by design, not bugs)
 
 - **RFC 9687 send hold timer is a per-write deadline, not the RFC's
@@ -146,16 +160,6 @@ resolved.
   (`bmp_collector_drops_total`); a collector that saturates its own
   channel diverges until its next reconnect, which per RFC 7854
   discards all state and replays PeerUp — alert on that counter.
-
-- **Commit-confirmed config transactions do not survive a daemon restart.**
-  The confirm timer and the captured pre-commit rollback snapshot are held in
-  memory only. A restart inside the confirm window leaves the already-committed
-  candidate live (effectively confirmed-by-restart) and the auto-revert never
-  fires. Commit-confirmed therefore guards against a bad-but-*running* config
-  (push a change, lose management reachability, and the timer rolls it back) —
-  not against a daemon crash. Validate with `rustbgpd --check` or
-  `PlanConfigTransaction` before applying a change that could itself prevent
-  recovery. See ADR-0076 Decision 6.
 
 - **RFC 8326 receiver gating doesn't yet know about confederations.**
   When `[global] honor_graceful_shutdown = true`, the implicit chain-

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1965,11 +1965,15 @@ impl BgpMetrics {
     /// Record a confirmed config transaction lifecycle transition.
     ///
     /// Labels are deliberately bounded:
-    /// - `operation`: `"confirm"`, `"abort"`, or `"auto_revert"`.
+    /// - `operation`: `"confirm"`, `"abort"`, `"auto_revert"`, or
+    ///   `"boot_revert"` (unconfirmed journal reverted at daemon startup).
     /// - `outcome`: `"success"` or `"failure"`.
     pub fn record_config_transaction_lifecycle(&self, operation: &str, outcome: &str) {
         debug_assert!(
-            matches!(operation, "confirm" | "abort" | "auto_revert"),
+            matches!(
+                operation,
+                "confirm" | "abort" | "auto_revert" | "boot_revert"
+            ),
             "unbounded config-transaction lifecycle operation label: {operation:?}"
         );
         debug_assert!(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2175,6 +2175,13 @@ Confirm handles are operator-chosen correlation IDs. They must be non-empty, at
 most 128 characters, and free of control characters; the CLI validates those
 constraints before reading the candidate file or calling the daemon.
 
+The confirm window is durable: the daemon journals the pre-commit config
+snapshot to `<runtime_state_dir>/commit-confirm-journal.json` before the
+candidate commits, and a restart that finds an unconfirmed journal reverts to
+the journaled config at boot, saving the unconfirmed candidate aside as
+`<config>.unconfirmed`. See `docs/OPERATIONS.md` (config transactions) for the
+boot-revert semantics.
+
 ```console
 $ rbgp fib-table set edge --table-id 1000 --metric 200 \
     --families ipv4_unicast,ipv6_unicast --max-routes 50000

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -132,11 +132,20 @@ snapshot was re-applied), or one of the two rollback-failure terminal states,
 the pre-commit snapshot, the fence has been cleared, and the running config
 needs manual correction.
 
-The confirm timer is in-memory: a daemon restart inside the confirm window
-leaves the already-committed candidate live (effectively confirmed-by-restart)
-and the auto-revert never fires. Commit-confirmed guards a bad-but-running
-config, not a crash — validate with `rustbgpd --check` or `config plan` before
-applying anything that could itself prevent recovery.
+Commit-confirmed also survives a daemon restart or crash inside the confirm
+window. Before the candidate commits, the daemon journals the pre-commit config
+snapshot to `<runtime_state_dir>/commit-confirm-journal.json` (atomic
+write-tmp+rename+fsync); confirm, abort, and timeout auto-revert consume the
+journal. If the daemon starts and finds an unconfirmed journal, it reverts at
+boot — before adopting the on-disk config, and regardless of how much confirm
+time was left, because the operator's confirming session died with the old
+process (the NETCONF RFC 6241 §8.4 rule: session loss cancels a confirmed
+commit). The unconfirmed candidate config file is saved aside as
+`<config>.unconfirmed` and the boot banner + an ERROR log name the transaction
+and that file; re-plan and re-apply to retry it. A torn or unreadable journal,
+or one whose embedded config no longer parses, refuses boot with a message
+naming both the journal and the config file — delete the journal manually only
+if you are sure the on-disk config is the one you want.
 
 For a static-neighbor edit, change the neighbor in the candidate file (for
 example `hold_time`, `max_prefixes`, policy-chain refs, or ORF receive), run

--- a/docs/adr/0076-config-transaction-model.md
+++ b/docs/adr/0076-config-transaction-model.md
@@ -130,10 +130,11 @@ section executors behind that public contract.
    later ad hoc config write. Pending confirmed state is not persisted across
    daemon restart; after restart, clients must re-plan and re-apply. The confirm
    timer is
-   in-memory, so a restart during the confirm window leaves the already-committed
-   candidate live (effectively confirmed-by-restart) and the auto-revert never
-   fires: the timer is a safety net against a bad-but-running config, not against
-   a daemon crash.
+   in-memory, so a restart during the confirm window originally left the
+   already-committed candidate live (effectively confirmed-by-restart) and the
+   auto-revert never fired. *Superseded by the 2026-07-03 amendment below: a
+   restart inside the confirm window now reverts at boot via an on-disk
+   journal.*
 7. **gNMI Set is an adapter, not a second commit model.** gNMI mutation must
    map to this transaction model rather than invent a parallel commit path. The
    gNMI service can normalize Set requests, redact Set audit summaries, and
@@ -205,3 +206,50 @@ section executors behind that public contract.
 See also ADR-0043 (config persistence and SIGHUP reload), ADR-0061 (unicast FIB
 integration), ADR-0064 (gRPC authorization), ADR-0074 (FIB-table CRUD tier), and
 `docs/GNMI.md` for the current gNMI Set supported-path matrix.
+
+## Amendment (2026-07-03): durable commit-confirm — boot-time revert journal
+
+Decision 6 originally held the confirm timer and the pre-commit rollback
+snapshot in memory only, so a daemon restart inside the confirm window made the
+unconfirmed candidate permanent (confirmed-by-restart) — the exact config a
+commit-confirmed deploy exists to protect against (one bad enough to take the
+daemon down) was the one the mechanism could not revert. That hole is closed:
+
+- **Journal at commit.** Before the confirmed candidate commits, the daemon
+  atomically persists (write temp file, fsync, rename, fsync directory) a
+  revert journal — `confirm_id`, deadline, and the full pre-commit config TOML
+  snapshot — to `<runtime_state_dir>/commit-confirm-journal.json`. If the
+  journal cannot be written, the confirmed apply is refused up front; a
+  confirm window never runs unprotected. Confirm deletes the journal (and the
+  confirm fails, keeping the fence and timer armed, if deletion fails — a
+  leftover journal must never boot-revert an explicitly confirmed config).
+  Abort and timeout auto-revert delete it after a successful rollback; a
+  FAILED rollback deliberately retains it so the next boot repairs what the
+  running process could not.
+- **Boot-time revert, unconditionally.** Before adopting the on-disk config,
+  startup checks for the journal. If an unconfirmed journal exists, the daemon
+  boots from the journal's pre-transaction config, restores it to the config
+  file, saves the unconfirmed candidate aside as `<config>.unconfirmed`, and
+  logs a loud ERROR plus a startup-banner notice. The revert fires regardless
+  of how much confirm time remained: the operator's confirming session and the
+  in-memory timer died with the old process, and resuming a half-elapsed timer
+  in a fresh process invites split-brain between the operator's view and the
+  daemon's. This matches NETCONF (RFC 6241 §8.4) semantics, where loss of the
+  session that issued a confirmed commit cancels it.
+- **Fail closed on a damaged journal.** Any journal that exists is treated as
+  an unconfirmed window that must be reverted. If the journal is torn or
+  unreadable, or its embedded previous config is unusable, that revert cannot
+  be completed — the daemon then refuses to boot with a message naming both
+  the journal and the config file, and touches neither. It never silently
+  proceeds with a possibly-unconfirmed candidate. (The atomic
+  write-then-rename makes a torn journal a should-not-happen case: a crash
+  during the write leaves either no journal or a complete one.)
+- **Config-plane only.** No RIB manager involvement; the boot revert happens
+  in `main` before the runtime starts, and the journal lives entirely in the
+  transaction controller (`src/confirm_journal.rs`).
+
+Proven by real-binary SIGKILL tests in `tests/commit_confirm_binary.rs`:
+SIGKILL mid-window then restart boots the previous config with the candidate
+saved aside; confirm-then-SIGKILL retains the new config with no journal;
+in-process timeout auto-revert consumes the journal; a torn journal refuses
+boot naming both files.

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -332,17 +332,50 @@ impl ConfigTransactionController {
                 "failed to serialize confirmed transaction rollback snapshot: {error}"
             ))
         })?;
-        let mut response = apply_config_transaction_locked(&self.deps, request).await?;
-        if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
-            return Ok(response);
-        }
 
         let timeout = Duration::from_secs(u64::from(confirmed.timeout_seconds));
-        let deadline = tokio::time::Instant::now() + timeout;
         let deadline_unix_seconds = SystemTime::now()
             .checked_add(timeout)
             .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
             .map_or(0, |duration| duration.as_secs());
+
+        // Durable commit-confirm (ADR-0076 Decision 6): journal the revert
+        // state BEFORE the candidate commits, so a crash at any later point
+        // inside the confirm window is repaired by the boot-time revert. If
+        // the journal cannot be written, refuse the confirmed apply up front
+        // (nothing has committed yet) rather than run an unprotected window.
+        if let Some(journal_path) = &self.deps.confirm_journal_path {
+            crate::confirm_journal::write(
+                journal_path,
+                &crate::confirm_journal::ConfirmJournal {
+                    confirm_id: confirmed.confirm_id.clone(),
+                    deadline_unix_seconds,
+                    rollback_toml: rollback_toml.clone(),
+                },
+            )
+            .map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "refusing confirmed apply: failed to persist the commit-confirm revert journal {}: {error}",
+                    journal_path.display()
+                ))
+            })?;
+        }
+
+        let mut response = match apply_config_transaction_locked(&self.deps, request).await {
+            Ok(response) => response,
+            Err(error) => {
+                // Nothing committed — a stale journal would only trigger a
+                // harmless same-content boot revert, but clean it up anyway.
+                self.remove_confirm_journal_best_effort("confirmed apply failed");
+                return Err(error);
+            }
+        };
+        if response.status != proto::ConfigTransactionPlanStatus::Committable as i32 {
+            self.remove_confirm_journal_best_effort("confirmed apply did not commit");
+            return Ok(response);
+        }
+
+        let deadline = tokio::time::Instant::now() + timeout;
         let pending = PendingConfirmedTransaction {
             confirm_id: confirmed.confirm_id.clone(),
             rollback_toml,
@@ -386,6 +419,21 @@ impl ConfigTransactionController {
         &self,
         confirm_id: String,
     ) -> Result<proto::ConfirmConfigTransactionResponse, ConfigTransactionApplyError> {
+        // Validate the handle against the pending transaction before touching
+        // the journal, then delete the journal BEFORE clearing the pending
+        // state: if deletion fails the confirm must fail while the fence and
+        // timer stay armed — a leftover journal would boot-revert a config
+        // the operator explicitly confirmed.
+        let _ = self.matching_pending(&confirm_id).await?;
+        if let Some(journal_path) = &self.deps.confirm_journal_path {
+            crate::confirm_journal::remove(journal_path).map_err(|error| {
+                ConfigTransactionApplyError::Internal(format!(
+                    "confirm not recorded: failed to remove the commit-confirm revert journal {}: {error}; \
+                     the transaction is still pending and will roll back on timeout",
+                    journal_path.display()
+                ))
+            })?;
+        }
         let pending = self.take_matching_pending(&confirm_id).await?;
         let record = ConfirmedTransactionRecord {
             confirm_id: pending.confirm_id,
@@ -468,6 +516,9 @@ impl ConfigTransactionController {
         confirm_id: String,
         timeout_seconds: u32,
     ) -> Result<(), ConfigTransactionApplyError> {
+        // The revert journal is NOT rewritten here: its deadline field is
+        // informational only — boot revert fires on any unconfirmed journal
+        // regardless of remaining time (see `confirm_journal` module docs).
         let timeout = Duration::from_secs(u64::from(timeout_seconds));
         let deadline = tokio::time::Instant::now() + timeout;
         let deadline_unix_seconds = SystemTime::now()
@@ -768,6 +819,24 @@ impl ConfigTransactionController {
         }
     }
 
+    /// Best-effort journal removal for paths where a leftover journal is
+    /// harmless-but-noisy rather than dangerous: after a successful abort or
+    /// auto-revert rollback the persisted config already equals the journaled
+    /// snapshot, so a boot revert from a stale journal restores identical
+    /// content. Log loudly so the operator can delete it.
+    fn remove_confirm_journal_best_effort(&self, context: &'static str) {
+        if let Some(journal_path) = &self.deps.confirm_journal_path
+            && let Err(error) = crate::confirm_journal::remove(journal_path)
+        {
+            error!(
+                journal = %journal_path.display(),
+                error = %error,
+                context,
+                "failed to remove the commit-confirm revert journal; delete it manually or the next daemon boot will re-run the revert"
+            );
+        }
+    }
+
     async fn remove_pending_after_rollback(
         &self,
         confirm_id: &str,
@@ -776,6 +845,18 @@ impl ConfigTransactionController {
         human_text: &'static str,
         abort_timer: bool,
     ) {
+        // Journal disposition mirrors the rollback outcome: a successful
+        // rollback re-persisted the pre-transaction config, so the journal is
+        // consumed. A FAILED rollback leaves the unconfirmed candidate
+        // running AND persisted — the journal is deliberately retained so the
+        // next daemon boot repairs what the running process could not.
+        if matches!(
+            status,
+            proto::ConfigTransactionConfirmationStatus::Aborted
+                | proto::ConfigTransactionConfirmationStatus::AutoReverted
+        ) {
+            self.remove_confirm_journal_best_effort("post-rollback cleanup");
+        }
         let mut state = self.state.lock().await;
         let Some(pending) = state.pending.take() else {
             return;
@@ -3346,6 +3427,7 @@ peer_group = "{group}"
             lock: Arc::new(Mutex::new(())),
             config_mutation_gate: None,
             startup_tables,
+            confirm_journal_path: None,
         }
     }
 
@@ -3523,6 +3605,18 @@ remote_asn = 65010
         Arc<Mutex<String>>,
         tokio::task::JoinHandle<()>,
     ) {
+        confirmed_dynamic_controller_with_journal(previous_toml, candidate_toml, None).await
+    }
+
+    async fn confirmed_dynamic_controller_with_journal(
+        previous_toml: String,
+        candidate_toml: String,
+        confirm_journal_path: Option<std::path::PathBuf>,
+    ) -> (
+        ConfigTransactionController,
+        Arc<Mutex<String>>,
+        tokio::task::JoinHandle<()>,
+    ) {
         let snapshot_toml = Arc::new(Mutex::new(previous_toml));
         let peers = Arc::new(Mutex::new(Vec::new()));
         let (peer_tx, peer_rx) = mpsc::channel(8);
@@ -3538,7 +3632,10 @@ remote_asn = 65010
         let (config_tx, config_rx) = mpsc::channel(8);
         let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
         let controller = ConfigTransactionController::new(
-            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            FibTableControlDeps {
+                confirm_journal_path,
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
             BgpMetrics::new(),
         );
 
@@ -3576,6 +3673,238 @@ remote_asn = 65010
             Config::load_toml_with_diagnostics(expected_toml, "expected runtime snapshot")
                 .expect("expected snapshot must parse");
         assert_eq!(snapshot, expected);
+    }
+
+    fn dynamic_candidate_toml() -> String {
+        base_toml(
+            r#"
+[peer_groups.ix-members]
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#,
+        )
+    }
+
+    fn read_journal(path: &std::path::Path) -> crate::confirm_journal::ConfirmJournal {
+        serde_json::from_str(&std::fs::read_to_string(path).expect("journal must be readable"))
+            .expect("journal must parse")
+    }
+
+    #[tokio::test]
+    async fn confirmed_apply_writes_revert_journal_and_confirm_consumes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("commit-confirm-journal.json");
+        let previous_toml = base_toml("");
+        let (controller, _snapshot_toml, ack_task) = confirmed_dynamic_controller_with_journal(
+            previous_toml.clone(),
+            dynamic_candidate_toml(),
+            Some(journal_path.clone()),
+        )
+        .await;
+
+        // Pending window: the journal holds the pre-commit snapshot.
+        let journal = read_journal(&journal_path);
+        assert_eq!(journal.confirm_id, "deploy-1");
+        assert!(journal.deadline_unix_seconds > 0);
+        assert_snapshot_matches_config(&journal.rollback_toml, &previous_toml);
+
+        controller
+            .clone()
+            .confirm(proto::ConfirmConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect("confirm must succeed");
+        assert!(
+            !journal_path.exists(),
+            "confirm must consume the revert journal"
+        );
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn confirmed_abort_consumes_revert_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("commit-confirm-journal.json");
+        let (controller, _snapshot_toml, ack_task) = confirmed_dynamic_controller_with_journal(
+            base_toml(""),
+            dynamic_candidate_toml(),
+            Some(journal_path.clone()),
+        )
+        .await;
+        assert!(journal_path.exists());
+
+        controller
+            .clone()
+            .abort(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect("abort must succeed");
+        assert!(
+            !journal_path.exists(),
+            "successful abort rollback must consume the revert journal"
+        );
+        ack_task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn confirmed_timeout_auto_revert_consumes_revert_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("commit-confirm-journal.json");
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml.clone()));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal_path.clone()),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+        );
+
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                dynamic_candidate_toml(),
+                "deploy-1",
+                1,
+            ))
+            .await
+            .expect("confirmed apply must succeed");
+        assert!(journal_path.exists());
+
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+        let status = controller.status().await.expect("status must succeed");
+        assert_eq!(
+            status.confirmation.unwrap().status,
+            proto::ConfigTransactionConfirmationStatus::AutoReverted as i32
+        );
+        assert!(
+            !journal_path.exists(),
+            "successful timeout auto-revert must consume the revert journal"
+        );
+        assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn failed_abort_rollback_retains_revert_journal_for_boot_repair() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("commit-confirm-journal.json");
+        let previous_toml = base_toml("");
+        let snapshot_toml = Arc::new(Mutex::new(previous_toml));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        // First stage (confirmed apply) succeeds; second (abort rollback) fails,
+        // leaving the unconfirmed candidate running.
+        let stage_results = Arc::new(Mutex::new(VecDeque::from([
+            Ok(()),
+            Err(StageConfigSnapshotError::InvalidCandidate(
+                "stage rollback failed".to_string(),
+            )),
+        ])));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager_with_stage_results(
+            peer_rx,
+            plan(
+                RuntimeConfigTransactionStatus::Committable,
+                vec!["[[dynamic_neighbors]]".to_string()],
+            ),
+            snapshot_toml.clone(),
+            peers,
+            stage_results,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal_path.clone()),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+        );
+
+        controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                dynamic_candidate_toml(),
+                "deploy-1",
+                60,
+            ))
+            .await
+            .expect("confirmed apply must succeed");
+
+        controller
+            .clone()
+            .abort(proto::AbortConfigTransactionRequest {
+                confirm_id: "deploy-1".to_string(),
+            })
+            .await
+            .expect_err("abort rollback failure must be reported");
+        assert!(
+            journal_path.exists(),
+            "a failed rollback must retain the journal so the next boot repairs it"
+        );
+        ack_task.abort();
+    }
+
+    #[tokio::test]
+    async fn rejected_confirmed_apply_leaves_no_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal_path = dir.path().join("commit-confirm-journal.json");
+        let snapshot_toml = Arc::new(Mutex::new(base_toml("")));
+        let peers = Arc::new(Mutex::new(Vec::new()));
+        let (peer_tx, peer_rx) = mpsc::channel(8);
+        tokio::spawn(fake_snapshot_peer_manager(
+            peer_rx,
+            plan(RuntimeConfigTransactionStatus::Rejected, Vec::new()),
+            snapshot_toml.clone(),
+            peers,
+        ));
+        let (config_tx, config_rx) = mpsc::channel(8);
+        let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let controller = ConfigTransactionController::new(
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal_path.clone()),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
+            BgpMetrics::new(),
+        );
+
+        let response = controller
+            .clone()
+            .apply(confirmed_dynamic_request(
+                dynamic_candidate_toml(),
+                "deploy-1",
+                60,
+            ))
+            .await
+            .expect("apply must return a rejected plan, not an error");
+        assert_eq!(
+            response.status,
+            proto::ConfigTransactionPlanStatus::Rejected as i32
+        );
+        assert!(
+            !journal_path.exists(),
+            "a rejected confirmed apply must not leave a journal behind"
+        );
+        ack_task.abort();
     }
 
     #[tokio::test]

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -1,0 +1,383 @@
+//! Durable commit-confirm revert journal (ADR-0076 Decision 6).
+//!
+//! A commit-confirmed config transaction persists the candidate to the config
+//! file at commit time, so without on-disk revert state a daemon restart inside
+//! the confirm window would silently make the unconfirmed candidate permanent
+//! ("confirmed-by-restart") — defeating the whole point of commit-confirmed for
+//! a config bad enough to crash the daemon. This module journals the pre-commit
+//! config snapshot to `<runtime_state_dir>/commit-confirm-journal.json` BEFORE
+//! the candidate commits, and boot ([`boot_revert_check`]) reverts to that
+//! snapshot whenever an unconfirmed journal is found.
+//!
+//! Boot reverts on ANY unconfirmed journal regardless of remaining confirm
+//! time: a restart mid-window means the operator's confirming session and the
+//! in-memory timer are gone, and resuming a half-elapsed timer in a fresh
+//! process invites split-brain between the operator's view and the daemon's.
+//! This matches NETCONF (RFC 6241 §8.4) cancellation of a confirmed commit on
+//! session loss.
+
+#![deny(unsafe_code)]
+
+use std::fs::{self, File};
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+
+/// Journal file name under `runtime_state_dir`.
+pub const JOURNAL_FILE_NAME: &str = "commit-confirm-journal.json";
+
+/// On-disk revert state for one pending commit-confirmed transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfirmJournal {
+    /// Operator-chosen confirm handle, for the boot-revert log line.
+    pub confirm_id: String,
+    /// Informational only — boot revert ignores it (see module docs).
+    pub deadline_unix_seconds: u64,
+    /// TOML snapshot of the running config captured before the candidate
+    /// committed; this is what boot restores.
+    pub rollback_toml: String,
+}
+
+/// Boot-revert outcome consumed by `main`.
+#[derive(Debug)]
+pub struct BootRevert {
+    /// The parsed pre-transaction config the daemon must boot from.
+    pub config: Box<Config>,
+    pub notice: BootRevertNotice,
+}
+
+/// The operator-facing facts of a boot revert (for the banner, log, metric).
+#[derive(Debug, Clone)]
+pub struct BootRevertNotice {
+    pub confirm_id: String,
+    /// Where the unconfirmed candidate was saved aside.
+    pub backup_path: PathBuf,
+}
+
+#[must_use]
+pub fn journal_path(runtime_state_dir: &Path) -> PathBuf {
+    runtime_state_dir.join(JOURNAL_FILE_NAME)
+}
+
+/// Atomically persist the journal: write temp file, fsync it, rename over the
+/// journal path, fsync the directory. Called BEFORE the candidate commits, so
+/// a crash at any point either leaves no journal (nothing committed yet) or a
+/// complete journal.
+pub fn write(path: &Path, journal: &ConfirmJournal) -> io::Result<()> {
+    let parent = parent_dir(path)?;
+    fs::create_dir_all(parent)?;
+    let encoded = serde_json::to_vec_pretty(journal).map_err(io::Error::other)?;
+    write_atomic(path, &encoded)
+}
+
+/// Remove the journal and fsync the directory. A missing journal is success
+/// (confirm after a boot revert already consumed it, or none was written).
+pub fn remove(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => fsync_dir(parent_dir(path)?),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// Boot-time check, run BEFORE the daemon adopts the on-disk config.
+///
+/// - No journal → `Ok(None)`: normal boot.
+/// - Readable journal with a usable embedded previous config → revert: the
+///   unconfirmed candidate config file is saved aside to
+///   `<config_path>.unconfirmed`, the previous config is restored to
+///   `config_path` (atomic write), the journal is removed, and the parsed
+///   previous config is returned for the daemon to boot from.
+/// - Journal present but unreadable/torn, or its embedded previous config is
+///   unusable, or the revert writes fail → `Err`: boot must REFUSE with the
+///   returned message (fail closed — never silently proceed with the
+///   unconfirmed candidate).
+pub fn boot_revert_check(
+    journal_path: &Path,
+    config_path: &Path,
+) -> Result<Option<BootRevert>, String> {
+    let raw = match fs::read_to_string(journal_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(refuse_message(
+                journal_path,
+                config_path,
+                &format!("the journal cannot be read: {error}"),
+            ));
+        }
+    };
+    let journal: ConfirmJournal = serde_json::from_str(&raw).map_err(|error| {
+        refuse_message(
+            journal_path,
+            config_path,
+            &format!("the journal is torn or corrupt: {error}"),
+        )
+    })?;
+    let config =
+        Config::load_toml_with_diagnostics(&journal.rollback_toml, "commit-confirm revert journal")
+            .map_err(|diagnostic| {
+                refuse_message(
+                    journal_path,
+                    config_path,
+                    &format!("the journaled pre-transaction config is unusable:\n{diagnostic}"),
+                )
+            })?;
+
+    // Save the unconfirmed candidate aside for the operator, then restore the
+    // previous config atomically. Order matters: the rename preserves the
+    // candidate bytes before anything overwrites them.
+    let backup_path = unconfirmed_backup_path(config_path);
+    match fs::rename(config_path, &backup_path) {
+        Ok(()) => {}
+        // A missing config file is unexpected mid-revert but not a reason to
+        // refuse restoring a known-good config.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(refuse_message(
+                journal_path,
+                config_path,
+                &format!(
+                    "failed to save the unconfirmed candidate aside to {}: {error}",
+                    backup_path.display()
+                ),
+            ));
+        }
+    }
+    write_atomic(config_path, journal.rollback_toml.as_bytes()).map_err(|error| {
+        refuse_message(
+            journal_path,
+            config_path,
+            &format!("failed to restore the pre-transaction config: {error}"),
+        )
+    })?;
+    remove(journal_path).map_err(|error| {
+        refuse_message(
+            journal_path,
+            config_path,
+            &format!(
+                "the config file was reverted, but the journal could not be removed: {error}; \
+                 delete the journal manually before restarting"
+            ),
+        )
+    })?;
+    Ok(Some(BootRevert {
+        config: Box::new(config),
+        notice: BootRevertNotice {
+            confirm_id: journal.confirm_id,
+            backup_path,
+        },
+    }))
+}
+
+/// `<config_path>.unconfirmed` — one well-known slot, overwritten by a later
+/// boot revert; the loud boot log names it each time.
+fn unconfirmed_backup_path(config_path: &Path) -> PathBuf {
+    let mut name = config_path.as_os_str().to_os_string();
+    name.push(".unconfirmed");
+    PathBuf::from(name)
+}
+
+fn refuse_message(journal_path: &Path, config_path: &Path, detail: &str) -> String {
+    format!(
+        "refusing to boot: a commit-confirmed config transaction revert journal exists at {journal} \
+         (meaning the last run stopped inside a confirm window, so the on-disk config {config} may be \
+         an unconfirmed candidate), but {detail}. Inspect {journal} and {config}; to boot the current \
+         on-disk config anyway, delete the journal.",
+        journal = journal_path.display(),
+        config = config_path.display(),
+    )
+}
+
+/// Write temp file + fsync + rename + fsync dir.
+fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = parent_dir(path)?;
+    let mut tmp = path.as_os_str().to_os_string();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    let mut file = File::create(&tmp)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    drop(file);
+    fs::rename(&tmp, path)?;
+    fsync_dir(parent)
+}
+
+fn parent_dir(path: &Path) -> io::Result<&Path> {
+    path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path {} has no parent directory", path.display()),
+        )
+    })
+}
+
+fn fsync_dir(dir: &Path) -> io::Result<()> {
+    File::open(dir)?.sync_all()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PREVIOUS_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+"#;
+
+    fn journal() -> ConfirmJournal {
+        ConfirmJournal {
+            confirm_id: "deploy-1".to_string(),
+            deadline_unix_seconds: 1234,
+            rollback_toml: PREVIOUS_TOML.to_string(),
+        }
+    }
+
+    #[test]
+    fn write_read_roundtrip_and_remove() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+        let read: ConfirmJournal =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(read, journal());
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "temp file must not linger"
+        );
+        remove(&path).unwrap();
+        assert!(!path.exists());
+        // Removing an absent journal is success.
+        remove(&path).unwrap();
+    }
+
+    #[test]
+    fn write_creates_missing_state_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = journal_path(&dir.path().join("nested/runtime"));
+        write(&path, &journal()).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn boot_check_without_journal_is_normal_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let outcome = boot_revert_check(&journal_path(dir.path()), &config_path).unwrap();
+        assert!(outcome.is_none());
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
+    }
+
+    #[test]
+    fn boot_check_reverts_unconfirmed_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "unconfirmed candidate bytes").unwrap();
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+
+        let revert = boot_revert_check(&path, &config_path)
+            .unwrap()
+            .expect("journal must trigger revert");
+        assert_eq!(revert.notice.confirm_id, "deploy-1");
+        assert_eq!(revert.config.global.asn, 65001);
+        // Config file restored to the journaled previous config.
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        // Unconfirmed candidate saved aside verbatim.
+        assert_eq!(
+            fs::read_to_string(&revert.notice.backup_path).unwrap(),
+            "unconfirmed candidate bytes"
+        );
+        // Journal consumed — the next boot is normal.
+        assert!(!path.exists());
+        assert!(
+            boot_revert_check(&path, &config_path).unwrap().is_none(),
+            "second boot must not revert again"
+        );
+    }
+
+    #[test]
+    fn boot_check_reverts_regardless_of_deadline_remaining() {
+        // Deadline far in the future — revert must fire anyway (the
+        // confirming session died with the old process).
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let path = journal_path(dir.path());
+        write(
+            &path,
+            &ConfirmJournal {
+                deadline_unix_seconds: u64::MAX,
+                ..journal()
+            },
+        )
+        .unwrap();
+        assert!(boot_revert_check(&path, &config_path).unwrap().is_some());
+    }
+
+    #[test]
+    fn boot_check_refuses_on_torn_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let path = journal_path(dir.path());
+        fs::create_dir_all(dir.path()).unwrap();
+        // Truncated mid-JSON.
+        fs::write(&path, "{\"confirm_id\": \"deploy-1\", \"dead").unwrap();
+
+        let message = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message.contains("refusing to boot"), "{message}");
+        assert!(message.contains(&*path.to_string_lossy()), "{message}");
+        assert!(
+            message.contains(&*config_path.to_string_lossy()),
+            "{message}"
+        );
+        // Fail closed: nothing touched.
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn boot_check_refuses_on_unusable_embedded_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let path = journal_path(dir.path());
+        write(
+            &path,
+            &ConfirmJournal {
+                rollback_toml: "this is not a valid config".to_string(),
+                ..journal()
+            },
+        )
+        .unwrap();
+
+        let message = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message.contains("refusing to boot"), "{message}");
+        assert!(message.contains("unusable"), "{message}");
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn boot_check_reverts_even_if_candidate_config_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+
+        let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert!(!revert.notice.backup_path.exists());
+    }
+}

--- a/src/fib_table_control.rs
+++ b/src/fib_table_control.rs
@@ -67,6 +67,11 @@ pub struct FibTableControlDeps {
     /// static while the reconciler is absent (mutations are rejected and SIGHUP
     /// can't hot-apply), so it stays accurate.
     pub startup_tables: Vec<FibTableConfig>,
+    /// Commit-confirm revert journal path (ADR-0076 Decision 6 durability):
+    /// `<runtime_state_dir>/commit-confirm-journal.json`. Only the config
+    /// transaction controller uses it; `None` disables journaling (unit tests
+    /// and non-transaction consumers of these deps).
+    pub confirm_journal_path: Option<std::path::PathBuf>,
 }
 
 /// Build the `FibTableControlFn` the RIB service calls for FIB-table CRUD.
@@ -567,6 +572,7 @@ mod tests {
             lock: Arc::new(Mutex::new(())),
             config_mutation_gate: None,
             startup_tables: vec![original.clone()],
+            confirm_journal_path: None,
         });
         let err = mutate(deps, Mutation::Upsert(table("core", 1001)))
             .await
@@ -635,6 +641,7 @@ mod tests {
             lock: Arc::new(Mutex::new(())),
             config_mutation_gate: None,
             startup_tables: vec![original.clone()],
+            confirm_journal_path: None,
         });
         let err = mutate(deps, Mutation::Upsert(table("core", 1001)))
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod blackhole;
 mod config;
 mod config_persister;
 mod config_transaction_control;
+mod confirm_journal;
 mod evpn_dataplane;
 mod evpn_es_drain;
 mod evpn_es_link_drain;
@@ -967,7 +968,7 @@ fn main() {
         process::exit(1);
     }
 
-    let config = match Config::load_with_diagnostics(&config_path) {
+    let mut config = match Config::load_with_diagnostics(&config_path) {
         Ok(c) => c,
         Err(diagnostic) => {
             eprintln!("{diagnostic}");
@@ -1004,6 +1005,29 @@ fn main() {
         process::exit(i32::from(diff.has_actionable_changes()));
     }
 
+    // Durable commit-confirm (ADR-0076 Decision 6): if the last run stopped
+    // inside a commit-confirmed window, an unconfirmed revert journal exists
+    // and the on-disk config is the unconfirmed candidate. Revert BEFORE the
+    // daemon adopts it — otherwise a config bad enough to crash the daemon
+    // would become permanent via the crash ("confirmed-by-restart"). A
+    // journal that exists but cannot drive a revert refuses boot (fail
+    // closed). Runs only for real daemon startup: --check/--diff returned
+    // above and must never mutate config files.
+    let boot_revert_notice = match confirm_journal::boot_revert_check(
+        &confirm_journal::journal_path(&config.runtime_state_dir()),
+        Path::new(&config_path),
+    ) {
+        Ok(None) => None,
+        Ok(Some(revert)) => {
+            config = *revert.config;
+            Some(revert.notice)
+        }
+        Err(message) => {
+            eprintln!("error: {message}");
+            process::exit(1);
+        }
+    };
+
     let log_directives = config.per_peer_log_directives();
     if let Err(e) = init_logging(&log_directives) {
         eprintln!("error: failed to initialize logging: {e}");
@@ -1026,7 +1050,7 @@ fn main() {
         .enable_all()
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
-    rt.block_on(run(config, profiler));
+    rt.block_on(run(config, boot_revert_notice, profiler));
 }
 
 /// Default tokio worker-thread cap when neither env nor config specifies one.
@@ -1129,7 +1153,11 @@ fn resolve_rib_channel_capacity_from(env: Option<&str>) -> usize {
 }
 
 #[expect(clippy::too_many_lines)]
-async fn run<T>(mut config: Config, profiler: Option<T>) {
+async fn run<T>(
+    mut config: Config,
+    boot_revert_notice: Option<confirm_journal::BootRevertNotice>,
+    profiler: Option<T>,
+) {
     // Snapshot the gRPC listener config as it was at process start.
     // The live TCP/UDS listeners bind once and are not rebuilt on
     // SIGHUP; this snapshot is what they're actually serving. Reload
@@ -1220,6 +1248,25 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
 
     // Startup banner — human-friendly topology summary on stderr.
     print_startup_banner(&config, &grpc_listeners);
+    if let Some(notice) = &boot_revert_notice {
+        // Boot-time revert of an unconfirmed commit-confirmed transaction
+        // (ADR-0076 Decision 6). Loud on purpose: the operator's last change
+        // was undone and its candidate saved aside.
+        error!(
+            confirm_id = %notice.confirm_id,
+            unconfirmed_candidate = %notice.backup_path.display(),
+            "commit-confirmed transaction was never confirmed before the last shutdown — reverted to the pre-transaction config at boot; the unconfirmed candidate config was saved aside"
+        );
+        eprintln!(
+            "!! commit-confirm boot revert: transaction {:?} was never confirmed before the last shutdown.",
+            notice.confirm_id
+        );
+        eprintln!(
+            "!! Booted from the pre-transaction config; the unconfirmed candidate was saved to {}.",
+            notice.backup_path.display()
+        );
+        metrics.record_config_transaction_lifecycle("boot_revert", "success");
+    }
     let router_id: Ipv4Addr = config.global.router_id.parse().unwrap_or_else(|e| {
         error!(
             router_id = %config.global.router_id,
@@ -2340,6 +2387,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 lock: runtime_config_lock.clone(),
                 config_mutation_gate: None,
                 startup_tables: config.fib_tables.clone(),
+                confirm_journal_path: Some(confirm_journal::journal_path(
+                    &config.runtime_state_dir(),
+                )),
             },
             metrics.clone(),
         );
@@ -2513,6 +2563,9 @@ async fn run<T>(mut config: Config, profiler: Option<T>) {
                 lock: runtime_config_lock.clone(),
                 config_mutation_gate: Some(config_mutation_gate.clone()),
                 startup_tables: config.fib_tables.clone(),
+                // FIB CRUD never journals; only the transaction controller
+                // above owns commit-confirm durability.
+                confirm_journal_path: None,
             },
         )),
         gnmi_set: Some(config_transaction_controller.gnmi_set_fn()),

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -1,0 +1,390 @@
+//! Real-binary proof of durable commit-confirm (ADR-0076 Decision 6).
+//!
+//! Each scenario drives the actual `rustbgpd` binary through `rbgp` over the
+//! default runtime-dir UDS listener, then SIGKILLs the daemon to prove the
+//! boot-time revert journal closes the "confirmed-by-restart" hole:
+//!
+//! - unconfirmed window + SIGKILL → restart boots the PREVIOUS config, saves
+//!   the unconfirmed candidate aside, consumes the journal, and prints the
+//!   loud banner;
+//! - confirm + SIGKILL → the new config is retained and no journal remains;
+//! - in-process timeout auto-revert → the journal is consumed;
+//! - torn journal on disk → boot refuses, naming both files.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const JOURNAL_FILE_NAME: &str = "commit-confirm-journal.json";
+
+struct Daemon {
+    child: Child,
+    stderr_path: PathBuf,
+}
+
+impl Daemon {
+    fn spawn(config_path: &Path, stderr_path: PathBuf) -> Self {
+        let stderr = File::create(&stderr_path).expect("failed to create daemon stderr log");
+        let child = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+            .arg(config_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .expect("failed to spawn rustbgpd binary");
+        Self { child, stderr_path }
+    }
+
+    fn assert_still_running(&mut self) {
+        match self.child.try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => panic!(
+                "rustbgpd exited before test completed: {status}\nstderr:\n{}",
+                self.stderr()
+            ),
+            Err(e) => panic!("failed to query rustbgpd child status: {e}"),
+        }
+    }
+
+    fn stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_path).unwrap_or_else(|e| {
+            format!(
+                "<failed to read daemon stderr {}: {e}>",
+                self.stderr_path.display()
+            )
+        })
+    }
+
+    /// SIGKILL — no shutdown coordination, simulating a crash inside the
+    /// confirm window.
+    fn sigkill(mut self) {
+        self.child.kill().expect("failed to SIGKILL rustbgpd");
+        self.child.wait().expect("failed to reap rustbgpd");
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rbgp") {
+        let mut cmd = Command::new(path);
+        cmd.arg("--addr").arg(grpc_addr).args(args).output()
+    } else {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let mut cmd = Command::new(cargo);
+        cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
+            .arg("--addr")
+            .arg(grpc_addr)
+            .args(args)
+            .output()
+    }
+    .expect("failed to spawn rbgp subprocess")
+}
+
+fn rbgp_json(grpc_addr: &str, args: &[&str]) -> serde_json::Value {
+    let output = rbgp(grpc_addr, args);
+    assert!(
+        output.status.success(),
+        "rbgp {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("rbgp JSON output must parse")
+}
+
+fn wait_until_serving(grpc_addr: &str, daemon: &mut Daemon) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if rbgp(grpc_addr, &["--json", "config", "status"])
+            .status
+            .success()
+        {
+            return;
+        }
+        daemon.assert_still_running();
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "rustbgpd gRPC never became ready\ndaemon stderr:\n{}",
+        daemon.stderr()
+    );
+}
+
+struct Lab {
+    config_path: PathBuf,
+    candidate_path: PathBuf,
+    journal_path: PathBuf,
+    grpc_addr: String,
+    dir: PathBuf,
+}
+
+fn base_toml(runtime_dir: &Path, extra: &str) -> String {
+    format!(
+        r#"
+[security.grpc]
+enforcement = "legacy"
+
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 0
+runtime_state_dir = "{runtime_dir}"
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.ix-members]
+{extra}
+"#,
+        runtime_dir = runtime_dir.display()
+    )
+}
+
+const DYNAMIC_NEIGHBOR_EXTRA: &str = r#"
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "ix-members"
+remote_asn = 65010
+"#;
+
+/// Set up config + candidate files in `dir` and return the paths.
+fn lab(dir: &Path) -> Lab {
+    let runtime_dir = dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("failed to create runtime dir");
+    let config_path = dir.join("rustbgpd.toml");
+    std::fs::write(&config_path, base_toml(&runtime_dir, "")).expect("failed to write config");
+    let candidate_path = dir.join("candidate.toml");
+    std::fs::write(
+        &candidate_path,
+        base_toml(&runtime_dir, DYNAMIC_NEIGHBOR_EXTRA),
+    )
+    .expect("failed to write candidate");
+    Lab {
+        config_path,
+        candidate_path,
+        journal_path: runtime_dir.join(JOURNAL_FILE_NAME),
+        grpc_addr: format!("unix://{}", runtime_dir.join("grpc.sock").display()),
+        dir: dir.to_path_buf(),
+    }
+}
+
+impl Lab {
+    fn spawn(&self, stderr_name: &str) -> Daemon {
+        let mut daemon = Daemon::spawn(&self.config_path, self.dir.join(stderr_name));
+        wait_until_serving(&self.grpc_addr, &mut daemon);
+        daemon
+    }
+
+    /// Plan + confirmed-apply the dynamic-neighbor candidate; asserts the
+    /// transaction commits and enters the pending confirm window.
+    fn apply_confirmed(&self, confirm_id: &str, timeout_seconds: &str) {
+        let plan = rbgp_json(
+            &self.grpc_addr,
+            &[
+                "--json",
+                "config",
+                "plan",
+                "--from-file",
+                self.candidate_path.to_str().unwrap(),
+            ],
+        );
+        assert_eq!(plan["status"], "committable", "plan: {plan}");
+        let token = plan["runtime_snapshot_token"]
+            .as_str()
+            .expect("plan must return a runtime snapshot token");
+
+        let apply = rbgp_json(
+            &self.grpc_addr,
+            &[
+                "--json",
+                "config",
+                "apply",
+                "--from-file",
+                self.candidate_path.to_str().unwrap(),
+                "--expected-runtime-snapshot-token",
+                token,
+                "--confirm-id",
+                confirm_id,
+                "--confirm-timeout",
+                timeout_seconds,
+            ],
+        );
+        assert_eq!(apply["status"], "committable", "apply: {apply}");
+        assert_eq!(apply["confirmation"]["status"], "pending", "apply: {apply}");
+
+        // Commit persisted the (unconfirmed) candidate to the config file and
+        // journaled the revert state.
+        let on_disk = std::fs::read_to_string(&self.config_path).unwrap();
+        assert!(
+            on_disk.contains("192.0.2.0/24"),
+            "commit must persist the candidate:\n{on_disk}"
+        );
+        assert!(
+            self.journal_path.exists(),
+            "confirmed apply must write the revert journal"
+        );
+    }
+}
+
+#[test]
+fn sigkill_in_confirm_window_boots_previous_config_and_saves_candidate_aside() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+
+    let daemon = lab.spawn("first.stderr.log");
+    lab.apply_confirmed("kill-window", "600");
+    daemon.sigkill();
+
+    // Restart: boot must revert BEFORE adopting the on-disk (unconfirmed)
+    // candidate — regardless of the 600s deadline still having time left.
+    let mut daemon = lab.spawn("second.stderr.log");
+    let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
+    assert!(
+        !on_disk.contains("192.0.2.0/24"),
+        "boot must restore the pre-transaction config:\n{on_disk}"
+    );
+    let backup_path = lab.dir.join("rustbgpd.toml.unconfirmed");
+    let saved_aside = std::fs::read_to_string(&backup_path)
+        .expect("the unconfirmed candidate must be saved aside");
+    assert!(
+        saved_aside.contains("192.0.2.0/24"),
+        "saved-aside file must hold the unconfirmed candidate:\n{saved_aside}"
+    );
+    assert!(
+        !lab.journal_path.exists(),
+        "boot revert must consume the journal"
+    );
+    let stderr = daemon.stderr();
+    assert!(
+        stderr.contains("commit-confirm boot revert")
+            && stderr.contains("kill-window")
+            && stderr.contains("rustbgpd.toml.unconfirmed"),
+        "boot banner must name the transaction and the saved-aside file:\n{stderr}"
+    );
+
+    // The reverted daemon is running the previous config.
+    let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
+    assert_eq!(
+        ranges.as_array().map(Vec::len),
+        Some(0),
+        "reverted daemon must not run the candidate's dynamic neighbors: {ranges}"
+    );
+    daemon.assert_still_running();
+}
+
+#[test]
+fn confirm_then_sigkill_retains_new_config_and_leaves_no_journal() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+
+    let daemon = lab.spawn("first.stderr.log");
+    lab.apply_confirmed("kill-confirmed", "600");
+    let confirm = rbgp_json(
+        &lab.grpc_addr,
+        &["--json", "config", "confirm", "kill-confirmed"],
+    );
+    assert_eq!(confirm["confirmation"]["status"], "confirmed", "{confirm}");
+    assert!(
+        !lab.journal_path.exists(),
+        "confirm must consume the revert journal"
+    );
+    daemon.sigkill();
+
+    let mut daemon = lab.spawn("second.stderr.log");
+    let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
+    assert!(
+        on_disk.contains("192.0.2.0/24"),
+        "the confirmed config must survive the restart:\n{on_disk}"
+    );
+    assert!(!daemon.stderr().contains("commit-confirm boot revert"));
+    let ranges = rbgp_json(&lab.grpc_addr, &["--json", "dynamic-neighbor", "list"]);
+    assert_eq!(
+        ranges.as_array().map(Vec::len),
+        Some(1),
+        "confirmed daemon must run the new config: {ranges}"
+    );
+    daemon.assert_still_running();
+}
+
+#[test]
+fn in_process_timeout_auto_revert_consumes_journal() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+
+    let mut daemon = lab.spawn("daemon.stderr.log");
+    lab.apply_confirmed("timeout-revert", "2");
+
+    // Poll for the auto-revert (2s timer + rollback work).
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = rbgp_json(&lab.grpc_addr, &["--json", "config", "status"]);
+        match status["confirmation"]["status"].as_str() {
+            Some("pending") => {}
+            Some("auto_reverted") => break,
+            other => panic!("unexpected confirmation status {other:?}: {status}"),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "auto-revert did not happen in time\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        daemon.assert_still_running();
+        thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        !lab.journal_path.exists(),
+        "timeout auto-revert must consume the revert journal"
+    );
+    let on_disk = std::fs::read_to_string(&lab.config_path).unwrap();
+    assert!(
+        !on_disk.contains("192.0.2.0/24"),
+        "auto-revert must restore the pre-transaction config:\n{on_disk}"
+    );
+    daemon.assert_still_running();
+}
+
+#[test]
+fn torn_journal_refuses_boot_naming_both_files() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let lab = lab(temp.path());
+    // Truncated mid-JSON, as a crash during a non-atomic write would leave.
+    std::fs::write(&lab.journal_path, "{\"confirm_id\": \"deploy-1\", \"dead")
+        .expect("failed to write torn journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustbgpd"))
+        .arg(&lab.config_path)
+        .output()
+        .expect("failed to spawn rustbgpd binary");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "daemon must refuse to boot on a torn journal"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for needle in [
+        "refusing to boot",
+        &*lab.journal_path.to_string_lossy(),
+        &*lab.config_path.to_string_lossy(),
+    ] {
+        assert!(
+            stderr.contains(needle),
+            "refusal must mention {needle:?}:\n{stderr}"
+        );
+    }
+    // Fail closed: nothing touched.
+    assert!(lab.journal_path.exists());
+    assert!(
+        std::fs::read_to_string(&lab.config_path)
+            .unwrap()
+            .contains("[peer_groups.ix-members]")
+    );
+}


### PR DESCRIPTION
Closes the documented ADR-0076 Decision 6 caveat: the confirm timer was in-memory, so a restart inside the confirm window made a bad-but-unconfirmed config permanent ("confirmed-by-restart").

## Semantics (recorded in the ADR amendment)

- Journal (JSON: confirm_id + deadline + full pre-commit config snapshot) written atomically (tmp+fsync+rename+fsync-dir) **before** the candidate commits — a journal write failure refuses the confirmed apply, so there is no unprotected window. Confirm deletes it; timeout/abort delete after successful rollback; a failed rollback retains it for boot repair.
- **Boot-time revert on any unconfirmed journal regardless of remaining deadline**: the confirming session and timer died with the process; resuming a half-elapsed timer invites split-brain — NETCONF RFC 6241 §8.4 cancel-on-session-loss semantics. Config file restored to the pre-transaction snapshot; the unconfirmed candidate saved aside; loud banner.
- Torn/unreadable journal → **refuse to boot** naming both files (the rollback config lives inside the JSON, so nothing is recoverable; the atomic write makes this a should-not-happen case — recorded honestly rather than pretending to revert).
- Config-plane only; both gRPC and gNMI commit-confirm paths route through the same journal-aware helpers.

## Proof

Four real-binary tests (real rustbgpd + rbgp over UDS), each passing three consecutive runs: SIGKILL-mid-window → previous config boots + candidate saved aside; confirm → SIGKILL → new config retained; in-process timeout auto-revert; torn journal → exit 1 naming both paths. Plus 13 unit tests.

## Found while proving

`record_config_transaction_lifecycle("boot_revert", ...)` tripped the telemetry label allowlist debug_assert — the daemon panicked at boot immediately after a successful revert in debug builds. Label added.

Gates: workspace build/test, fmt, clippy -D warnings, cargo doc, clippy-reasons — green.