### PR TITLE
feat(policy): RFC 8097 origin-validation communities and strict next-hop matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tests (`tests/commit_confirm_binary.rs`); closes the KNOWN_ISSUES
   "commit-confirmed does not survive a daemon restart" row.
 
+- **RFC 8097 origin-validation-state extended communities as policy
+  well-knowns.** `OV_VALID` / `OV_NOT_FOUND` / `OV_INVALID` (RFC 8097:
+  non-transitive opaque, type `0x43` sub-type `0x00`, validation state
+  in the last octet) are accepted everywhere community names are: TOML
+  `match_community` / `set_community_add` / `set_community_remove` and
+  `.rpol` `has` / `in` (community sets) / `add ext-community` /
+  `remove ext-community`, with matching and removal by exact wire
+  value. The route-server example's `hygiene.rpol` now tags routes
+  with their RPKI outcome so clients can act on it (the missing
+  arouteserver-essentials piece from ADR-0101).
+- **Strict next-hop matching in `.rpol`:** `route.next-hop ==
+  peer.address` (and `!=`) — the policy-language form of the classic
+  IXP next-hop-hygiene check. It is the language's only field-vs-field
+  comparison; anything else on the right-hand side is a compile-time
+  diagnostic. Reads peer identity, so an export chain using it makes
+  the peer ineligible for update-group sharing
+  (`policy_peer_context`), exactly like `peer.*` matches; import-chain
+  use is grouping-irrelevant. Never matches when either side is
+  unknown.
 - **Per-client best-path for route-server clients (RFC 7947 §2.3.2
   path-hiding mitigation, the BIRD-`secondary` equivalent).** New
   per-neighbor / per-peer-group knob `per_client_best = true` (requires

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -321,6 +321,12 @@ pub enum CommunityMatch {
         /// Second local data part.
         local_data2: u32,
     },
+    /// Match an extended community by its exact raw 8-byte value.
+    /// Used by well-known non-RT/RO extended communities such as the
+    /// RFC 8097 origin-validation states (`OV_VALID` / `OV_NOT_FOUND` /
+    /// `OV_INVALID`); unlike RT/RO matching there is no
+    /// encoding-agnostic decode — the wire value *is* the identity.
+    ExactExt(u64),
 }
 
 impl CommunityMatch {
@@ -334,6 +340,7 @@ impl CommunityMatch {
             CommunityMatch::RouteOrigin { global, local } => {
                 ec.route_origin() == Some((*global, *local))
             }
+            CommunityMatch::ExactExt(raw) => ec.as_u64() == *raw,
             CommunityMatch::Standard { .. } | CommunityMatch::LargeCommunity { .. } => false,
         }
     }
@@ -367,7 +374,9 @@ impl CommunityMatch {
     #[inline]
     pub(crate) fn matches_route_communities(&self, ctx: &RouteContext<'_>) -> bool {
         match self {
-            CommunityMatch::RouteTarget { .. } | CommunityMatch::RouteOrigin { .. } => ctx
+            CommunityMatch::RouteTarget { .. }
+            | CommunityMatch::RouteOrigin { .. }
+            | CommunityMatch::ExactExt(_) => ctx
                 .extended_communities
                 .iter()
                 .any(|ec| self.matches_ec(ec)),
@@ -389,6 +398,9 @@ impl CommunityMatch {
 /// - Well-known names: `"NO_EXPORT"`, `"NO_ADVERTISE"`, `"NO_EXPORT_SUBCONFED"`,
 ///   `"BLACKHOLE"` (RFC 7999 §5, `0xFFFF_029A`), `"GRACEFUL_SHUTDOWN"`
 ///   (RFC 8326 §3, `0xFFFF_0000`)
+/// - Well-known extended-community names: `"OV_VALID"`, `"OV_NOT_FOUND"`,
+///   `"OV_INVALID"` (RFC 8097 origin-validation state, type `0x43`
+///   sub-type `0x00`)
 ///
 /// # Errors
 ///
@@ -396,6 +408,9 @@ impl CommunityMatch {
 pub fn parse_community_match(s: &str) -> Result<CommunityMatch, String> {
     if let Some(value) = well_known_community_value(s) {
         return Ok(CommunityMatch::Standard { value });
+    }
+    if let Some(ec) = well_known_ext_community_value(s) {
+        return Ok(CommunityMatch::ExactExt(ec.as_u64()));
     }
 
     // Check for LC: prefix first (4 parts with LC: prefix)
@@ -496,6 +511,19 @@ fn well_known_community_value(s: &str) -> Option<u32> {
         "NO_EXPORT_SUBCONFED" => Some(rustbgpd_wire::COMMUNITY_NO_EXPORT_SUBCONFED),
         "BLACKHOLE" => Some(rustbgpd_wire::COMMUNITY_BLACKHOLE),
         "GRACEFUL_SHUTDOWN" => Some(rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN),
+        _ => None,
+    }
+}
+
+/// Resolve well-known extended-community aliases (RFC 8097
+/// origin-validation states). Same alias surface as the standard
+/// well-knowns: usable in match and set positions in both the TOML and
+/// `.rpol` frontends.
+fn well_known_ext_community_value(s: &str) -> Option<ExtendedCommunity> {
+    match s {
+        "OV_VALID" => Some(ExtendedCommunity::ORIGIN_VALIDATION_VALID),
+        "OV_NOT_FOUND" => Some(ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND),
+        "OV_INVALID" => Some(ExtendedCommunity::ORIGIN_VALIDATION_INVALID),
         _ => None,
     }
 }

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -212,6 +212,9 @@ fn fmt_community_match(cm: &CommunityMatch) -> String {
             local_data1,
             local_data2,
         } => format!("LC:{global_admin}:{local_data1}:{local_data2}"),
+        // Well-known values (e.g. the RFC 8097 OV_* states) render by
+        // name via the wire Display impl; unknown raws render as hex.
+        CommunityMatch::ExactExt(raw) => rustbgpd_wire::ExtendedCommunity::new(*raw).to_string(),
     }
 }
 
@@ -595,6 +598,7 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
         MatchExpr::LocalPref(cmp) => render_cmp("route.local-pref", *cmp),
         MatchExpr::Med(cmp) => render_cmp("route.med", *cmp),
         MatchExpr::NextHopEq(addr) => format!("route.next-hop == {addr}"),
+        MatchExpr::NextHopEqPeer => "route.next-hop == peer.address".to_string(),
         MatchExpr::NeighborIn(set) => {
             let mut parts: Vec<String> = Vec::new();
             for addr in &set.addresses {
@@ -686,9 +690,9 @@ fn community_field(criteria: &[CommunityMatch]) -> &'static str {
     let mut fields = criteria.iter().map(|cm| match cm {
         CommunityMatch::Standard { .. } => "route.communities",
         CommunityMatch::LargeCommunity { .. } => "route.large-communities",
-        CommunityMatch::RouteTarget { .. } | CommunityMatch::RouteOrigin { .. } => {
-            "route.ext-communities"
-        }
+        CommunityMatch::RouteTarget { .. }
+        | CommunityMatch::RouteOrigin { .. }
+        | CommunityMatch::ExactExt(_) => "route.ext-communities",
     });
     let Some(first) = fields.next() else {
         return "route.communities";

--- a/crates/policy/src/engine/tests/community.rs
+++ b/crates/policy/src/engine/tests/community.rs
@@ -384,3 +384,30 @@ fn community_match_route_origin() {
         PolicyAction::Deny
     );
 }
+
+// -----------------------------------------------------------------------
+// RFC 8097 origin-validation-state well-known names (OV_*)
+// -----------------------------------------------------------------------
+
+#[test]
+fn parse_community_match_ov_well_known_names() {
+    for (name, ec) in [
+        ("OV_VALID", ExtendedCommunity::ORIGIN_VALIDATION_VALID),
+        (
+            "OV_NOT_FOUND",
+            ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND,
+        ),
+        ("OV_INVALID", ExtendedCommunity::ORIGIN_VALIDATION_INVALID),
+    ] {
+        let cm = parse_community_match(name).unwrap();
+        assert_eq!(cm, CommunityMatch::ExactExt(ec.as_u64()), "{name}");
+        // Exact raw-value semantics: matches its own state only.
+        assert!(cm.matches_ec(&ec));
+    }
+    let invalid = parse_community_match("OV_INVALID").unwrap();
+    assert!(!invalid.matches_ec(&ExtendedCommunity::ORIGIN_VALIDATION_VALID));
+    // An RT does not match an exact-ext criterion and vice versa.
+    assert!(!invalid.matches_ec(&make_rt(65001, 100)));
+    let rt = parse_community_match("RT:65001:100").unwrap();
+    assert!(!rt.matches_ec(&ExtendedCommunity::ORIGIN_VALIDATION_INVALID));
+}

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -336,6 +336,12 @@ impl CompiledChain {
             }
             MatchExpr::Med(cmp) => cmp_value(*cmp, ctx.med.unwrap_or(IMPLICIT_MED)),
             MatchExpr::NextHopEq(next_hop) => ctx.next_hop == Some(*next_hop),
+            // Strict next-hop: both sides must be known; two unknowns
+            // are not a match.
+            MatchExpr::NextHopEqPeer => match (ctx.next_hop, ctx.peer_address) {
+                (Some(next_hop), Some(peer)) => next_hop == peer,
+                _ => false,
+            },
             MatchExpr::NeighborIn(set) => {
                 set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
             }

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -90,6 +90,13 @@ pub enum MatchExpr {
     Med(Cmp),
     /// The route's next-hop equals this address.
     NextHopEq(IpAddr),
+    /// The route's next-hop equals the evaluation peer's address
+    /// (strict next-hop, `.rpol` `route.next-hop == peer.address`).
+    /// Never matches when either side is unknown. Reads peer identity,
+    /// so it counts toward [`CompiledChain::requires_peer_context`]:
+    /// on an export chain the verdict is per-target-peer and the peer
+    /// must not join an update group.
+    NextHopEqPeer,
     /// The evaluation peer matches a neighbor set (address, ASN, or
     /// peer-group membership — OR within the set). Boxed: the set is
     /// three `Vec`s (72 bytes) and would otherwise dominate every
@@ -126,6 +133,7 @@ impl MatchExpr {
             | MatchExpr::LocalPref(_)
             | MatchExpr::Med(_)
             | MatchExpr::NextHopEq(_)
+            | MatchExpr::NextHopEqPeer
             | MatchExpr::RouteTypeIs(_)
             | MatchExpr::EvpnRouteTypeIs(_)
             | MatchExpr::RpkiIs(_)
@@ -300,12 +308,17 @@ impl CompiledChain {
 
     /// Whether evaluating this chain depends on the evaluation peer's
     /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
-    /// ASN, or peer-group matching). Content-equal chains with such a
-    /// guard can still yield peer-different verdicts, so update-group
-    /// fingerprinting must not group peers that share one.
+    /// ASN, or peer-group matching — or a strict-next-hop
+    /// [`MatchExpr::NextHopEqPeer`] node). Content-equal chains with
+    /// such a guard can still yield peer-different verdicts, so
+    /// update-group fingerprinting must not group peers that share one.
+    /// Import chains are evaluated per-session and are unaffected by
+    /// this flag.
     #[must_use]
     pub fn requires_peer_context(&self) -> bool {
-        self.any_guard_node(&|expr| matches!(expr, MatchExpr::NeighborIn(_)))
+        self.any_guard_node(&|expr| {
+            matches!(expr, MatchExpr::NeighborIn(_) | MatchExpr::NextHopEqPeer)
+        })
     }
 
     /// Does any guard node across all policies satisfy `pred`?

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -75,6 +75,11 @@ pub enum CommunityLit {
         /// IPv4 address (selects the type 0x01 wire encoding).
         ipv4_admin: bool,
     },
+    /// A well-known extended community by raw 8-byte value —
+    /// `OV_VALID` / `OV_NOT_FOUND` / `OV_INVALID` (RFC 8097
+    /// origin-validation state). The name is resolved at parse time;
+    /// matching and add/remove operate on the exact wire value.
+    ExtRaw(u64),
 }
 
 /// The community kind named by an action or fixture keyword
@@ -96,7 +101,7 @@ impl CommunityLit {
         match self {
             CommunityLit::Standard(_) => CommunityKind::Standard,
             CommunityLit::Large(_) => CommunityKind::Large,
-            CommunityLit::Ext { .. } => CommunityKind::Ext,
+            CommunityLit::Ext { .. } | CommunityLit::ExtRaw(_) => CommunityKind::Ext,
         }
     }
 
@@ -122,6 +127,7 @@ impl CommunityLit {
                 local,
                 ..
             } => CommunityMatch::RouteOrigin { global, local },
+            CommunityLit::ExtRaw(raw) => CommunityMatch::ExactExt(raw),
         }
     }
 }
@@ -319,6 +325,11 @@ pub enum Rhs {
     /// Community literal (never valid in a comparison — accepted so
     /// the typechecker can point at `has`/`in` instead).
     Community(Spanned<CommunityLit>),
+    /// A field path on the right-hand side. The only accepted
+    /// field-vs-field comparison is strict next-hop
+    /// (`route.next-hop == peer.address`); the typechecker rejects
+    /// everything else with a spanned diagnostic.
+    Field(FieldPath),
 }
 
 impl Rhs {
@@ -329,6 +340,7 @@ impl Rhs {
             Rhs::Int(_, span) | Rhs::Ip(_, span) | Rhs::Prefix(_, span) => *span,
             Rhs::Ident(s) | Rhs::Str(s) => s.span,
             Rhs::Community(lit) => lit.span,
+            Rhs::Field(path) => path.span,
         }
     }
 
@@ -342,6 +354,7 @@ impl Rhs {
             Rhs::Prefix(..) => "prefix",
             Rhs::Str(_) => "string",
             Rhs::Community(_) => "community literal",
+            Rhs::Field(_) => "field reference",
         }
     }
 }

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -404,12 +404,13 @@ fn lower_cmp(
             });
             negate_if(op == CmpOp::Ne, node)
         }
-        Field::NextHop => {
-            let Rhs::Ip(addr, _) = rhs else {
-                unreachable!("typechecked: next-hop compares an IP")
-            };
-            negate_if(op == CmpOp::Ne, MatchExpr::NextHopEq(*addr))
-        }
+        Field::NextHop => match rhs {
+            Rhs::Ip(addr, _) => negate_if(op == CmpOp::Ne, MatchExpr::NextHopEq(*addr)),
+            // Strict next-hop (`route.next-hop == peer.address`); the
+            // typechecker only lets `peer.address` through here.
+            Rhs::Field(_) => negate_if(op == CmpOp::Ne, MatchExpr::NextHopEqPeer),
+            _ => unreachable!("typechecked: next-hop compares an IP or peer.address"),
+        },
         Field::PeerAddress => {
             let Rhs::Ip(addr, _) = rhs else {
                 unreachable!("typechecked: peer.address compares an IP")
@@ -508,6 +509,16 @@ fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMa
                 ipv4_admin,
             } => {
                 let value = ext_community_value(route_target, global, local, ipv4_admin);
+                if *add {
+                    mods.extended_communities_add.push(value);
+                } else {
+                    mods.extended_communities_remove.push(value);
+                }
+            }
+            // Well-known extended communities (RFC 8097 OV_* states):
+            // add/remove by exact raw wire value.
+            CommunityLit::ExtRaw(raw) => {
+                let value = ExtendedCommunity::new(raw);
                 if *add {
                     mods.extended_communities_add.push(value);
                 } else {

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -294,18 +294,22 @@ impl Parser<'_> {
                 self.ext_community_lit(&text, span)?
             }
             Tok::Ident => {
-                // Well-known standard community names share the TOML
-                // frontend's alias table via `parse_community_match`.
+                // Well-known community names (standard and extended)
+                // share the TOML frontend's alias table via
+                // `parse_community_match`.
+                let well_known_shape = text.chars().all(|c| c.is_ascii_uppercase() || c == '_');
                 match parse_community_match(&text) {
-                    Ok(CommunityMatch::Standard { value })
-                        if text.chars().all(|c| c.is_ascii_uppercase() || c == '_') =>
-                    {
+                    Ok(CommunityMatch::Standard { value }) if well_known_shape => {
                         self.bump();
                         CommunityLit::Standard(value)
                     }
+                    Ok(CommunityMatch::ExactExt(raw)) if well_known_shape => {
+                        self.bump();
+                        CommunityLit::ExtRaw(raw)
+                    }
                     _ => {
                         return Err(self.error_expected(
-                            "a community literal (`65000:100`, `65000:1:2`, `RT:65001:100`, or a well-known name like `NO_EXPORT`)",
+                            "a community literal (`65000:100`, `65000:1:2`, `RT:65001:100`, or a well-known name like `NO_EXPORT` or `OV_INVALID`)",
                         ));
                     }
                 }
@@ -821,6 +825,10 @@ impl Parser<'_> {
             Tok::StdCommunityLit | Tok::LargeCommunityLit | Tok::ExtCommunityLit => {
                 Ok(Rhs::Community(self.community_lit()?))
             }
+            // Field-vs-field comparison (`route.next-hop ==
+            // peer.address`); the typechecker restricts which pairs
+            // are legal.
+            Tok::RouteKw | Tok::PeerKw => Ok(Rhs::Field(self.field_path()?)),
             _ => Err(self.error_expected(
                 "a comparison operand (integer, identifier, IP, prefix, or string)",
             )),

--- a/crates/policy/src/rpol/testing.rs
+++ b/crates/policy/src/rpol/testing.rs
@@ -97,19 +97,22 @@ impl Fixture {
                 }
                 RouteField::ExtCommunities(lits, _) => {
                     for lit in lits {
-                        if let CommunityLit::Ext {
-                            route_target,
-                            global,
-                            local,
-                            ipv4_admin,
-                        } = lit.node
-                        {
-                            fixture.extended_communities.push(ext_community_value(
+                        match lit.node {
+                            CommunityLit::Ext {
                                 route_target,
                                 global,
                                 local,
                                 ipv4_admin,
-                            ));
+                            } => fixture.extended_communities.push(ext_community_value(
+                                route_target,
+                                global,
+                                local,
+                                ipv4_admin,
+                            )),
+                            CommunityLit::ExtRaw(raw) => fixture
+                                .extended_communities
+                                .push(ExtendedCommunity::new(raw)),
+                            CommunityLit::Standard(_) | CommunityLit::Large(_) => {}
                         }
                     }
                 }
@@ -282,6 +285,9 @@ fn check_assertion(
                     local,
                     ipv4_admin,
                 )),
+                CommunityLit::ExtRaw(raw) => mods
+                    .extended_communities_add
+                    .contains(&ExtendedCommunity::new(raw)),
             };
             (!present).then(|| "expected community was not added".to_string())
         }

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -671,3 +671,167 @@ fn reasonable_nesting_stays_clean() {
     let report = check_on_small_stack(src);
     assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
 }
+
+// ── RFC 8097 origin-validation-state well-known names (OV_*) ──────
+
+#[test]
+fn ov_names_match_add_remove_and_evaluate() {
+    use rustbgpd_wire::ExtendedCommunity;
+
+    let chain = compile_ok(
+        r"policy ov {
+             term drop-invalid { if route.ext-communities has OV_INVALID { reject } }
+             term tag {
+                 add ext-community OV_VALID;
+                 remove ext-community OV_NOT_FOUND;
+                 accept
+             }
+         }",
+    );
+    let TermAction::Permit(mods) = &chain.policies[0].terms[1].action else {
+        panic!("expected permit")
+    };
+    assert_eq!(
+        mods.extended_communities_add,
+        vec![ExtendedCommunity::ORIGIN_VALIDATION_VALID]
+    );
+    assert_eq!(
+        mods.extended_communities_remove,
+        vec![ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND]
+    );
+
+    let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    let invalid_ecs = [ExtendedCommunity::ORIGIN_VALIDATION_INVALID];
+    assert_eq!(
+        chain
+            .evaluate(&RouteContext {
+                extended_communities: &invalid_ecs,
+                ..base
+            })
+            .action,
+        PolicyAction::Deny
+    );
+    // Exact raw-value match: a different OV state does not trip it.
+    let valid_ecs = [ExtendedCommunity::ORIGIN_VALIDATION_VALID];
+    assert_eq!(
+        chain
+            .evaluate(&RouteContext {
+                extended_communities: &valid_ecs,
+                ..base
+            })
+            .action,
+        PolicyAction::Permit
+    );
+}
+
+#[test]
+fn ov_names_in_test_fixtures_and_with_assertions() {
+    // End-to-end tag-on-import + match through the in-language runner:
+    // one policy tags, a second matches what the first added.
+    let source = r"
+policy tag-ov { term tag { add ext-community OV_INVALID; accept } }
+policy drop-ov-invalid {
+    term drop { if route.ext-communities has OV_INVALID { reject } }
+    term rest { accept }
+}
+
+test tagging-asserts-the-added-ov-state {
+    route { prefix 10.0.0.0/24 }
+    expect tag-ov == accept with ext-community OV_INVALID
+}
+
+test tagged-route-is-dropped-on-rematch {
+    route { prefix 10.0.0.0/24; ext-communities [OV_INVALID] }
+    expect drop-ov-invalid == reject
+}
+
+test untagged-route-passes {
+    route { prefix 10.0.0.0/24; ext-communities [OV_VALID, RT:65001:100] }
+    expect drop-ov-invalid == accept
+}
+";
+    let report = run_rpol_tests(source).expect("compiles");
+    assert!(report.all_passed(), "{:?}", report.failures);
+}
+
+// ── strict next-hop (`route.next-hop == peer.address`) ────────────
+
+#[test]
+fn strict_next_hop_lowers_and_evaluates_both_ways() {
+    let chain = compile_ok(
+        "policy strict-nh {
+             term ok { if route.next-hop == peer.address { accept } }
+             term rest { reject }
+         }",
+    );
+    assert_eq!(chain.policies[0].terms[0].guard, MatchExpr::NextHopEqPeer);
+    assert!(
+        chain.requires_peer_context(),
+        "strict next-hop reads peer identity — must disqualify grouping"
+    );
+
+    let peer = std::net::IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    let matching = RouteContext {
+        next_hop: Some(peer),
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&matching).action, PolicyAction::Permit);
+    let mismatched = RouteContext {
+        next_hop: Some(std::net::IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7))),
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&mismatched).action, PolicyAction::Deny);
+    // Unknown next-hop never matches (both sides must be known).
+    let unknown = RouteContext {
+        next_hop: None,
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&unknown).action, PolicyAction::Deny);
+}
+
+#[test]
+fn strict_next_hop_negated_form() {
+    let chain = compile_ok(
+        "policy not-self {
+             term reroute { if route.next-hop != peer.address { reject } }
+             term rest { accept }
+         }",
+    );
+    let peer = std::net::IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    let matching = RouteContext {
+        next_hop: Some(peer),
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&matching).action, PolicyAction::Permit);
+    let mismatched = RouteContext {
+        next_hop: Some(std::net::IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7))),
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&mismatched).action, PolicyAction::Deny);
+}
+
+#[test]
+fn strict_next_hop_rejects_other_field_comparisons() {
+    // The one legal field-vs-field pair is next-hop vs peer.address.
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if route.next-hop == peer.asn { accept } } }");
+    assert!(
+        rendered.contains("only `peer.address` is allowed here"),
+        "{rendered}"
+    );
+    // Field references are not valid operands for other fields.
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if route.local-pref == peer.address { accept } } }");
+    assert!(rendered.contains("field reference"), "{rendered}");
+    // And peer.address still only compares against an IP literal.
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { if peer.address == route.next-hop { accept } } }");
+    assert!(rendered.contains("field reference"), "{rendered}");
+}

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -439,20 +439,7 @@ impl Checker<'_> {
             }
             Field::EvpnRouteType => {
                 eq_only(self);
-                match rhs {
-                    Rhs::Int(value, span) if *value > 255 => {
-                        self.diags.push(Diagnostic::new(
-                            *span,
-                            format!("EVPN route type {value} out of range"),
-                            "must be 0-255 (RFC 7432 route types are 1-5)",
-                        ));
-                    }
-                    Rhs::Int(..) => {}
-                    other => {
-                        self.diags
-                            .push(type_mismatch(field, "an integer EVPN route type", other));
-                    }
-                }
+                self.check_evpn_route_type_rhs(field, rhs);
             }
             Field::Rpki => {
                 eq_only(self);
@@ -466,7 +453,11 @@ impl Checker<'_> {
                 eq_only(self);
                 self.expect_enum_rhs(field, rhs, ROUTE_TYPE_MEMBERS, params);
             }
-            Field::NextHop | Field::PeerAddress => {
+            Field::NextHop => {
+                eq_only(self);
+                self.check_next_hop_rhs(field, rhs);
+            }
+            Field::PeerAddress => {
                 eq_only(self);
                 if !matches!(rhs, Rhs::Ip(..)) {
                     self.diags.push(type_mismatch(field, "an IP address", rhs));
@@ -512,6 +503,56 @@ impl Checker<'_> {
                     ),
                 );
             }
+        }
+    }
+
+    /// `route.evpn-route-type` compares against a 0-255 integer
+    /// literal (RFC 7432 route types are 1-5).
+    fn check_evpn_route_type_rhs(&mut self, field: &FieldPath, rhs: &Rhs) {
+        match rhs {
+            Rhs::Int(value, span) if *value > 255 => {
+                self.diags.push(Diagnostic::new(
+                    *span,
+                    format!("EVPN route type {value} out of range"),
+                    "must be 0-255 (RFC 7432 route types are 1-5)",
+                ));
+            }
+            Rhs::Int(..) => {}
+            other => {
+                self.diags
+                    .push(type_mismatch(field, "an integer EVPN route type", other));
+            }
+        }
+    }
+
+    /// `route.next-hop` compares against an IP literal or — the one
+    /// legal field-vs-field comparison (strict next-hop) —
+    /// `peer.address`.
+    fn check_next_hop_rhs(&mut self, field: &FieldPath, rhs: &Rhs) {
+        match rhs {
+            Rhs::Ip(..) => {}
+            Rhs::Field(path) => match resolve_field(path) {
+                Ok(Field::PeerAddress) => {}
+                Ok(_) => self.diags.push(
+                    Diagnostic::new(
+                        path.span,
+                        format!(
+                            "`route.next-hop` cannot be compared against `{}`",
+                            path.render()
+                        ),
+                        "only `peer.address` is allowed here",
+                    )
+                    .with_note(
+                        "strict next-hop is `route.next-hop == peer.address`; other fields have no next-hop comparison",
+                    ),
+                ),
+                Err(diag) => self.diags.push(diag),
+            },
+            other => self.diags.push(type_mismatch(
+                field,
+                "an IP address or `peer.address`",
+                other,
+            )),
         }
     }
 

--- a/crates/policy/src/sets.rs
+++ b/crates/policy/src/sets.rs
@@ -261,6 +261,7 @@ pub struct CommunitySet {
     route_targets: FxHashSet<(u32, u32)>,
     route_origins: FxHashSet<(u32, u32)>,
     large: FxHashSet<(u32, u32, u32)>,
+    exact_ext: FxHashSet<u64>,
 }
 
 impl CommunitySet {
@@ -295,6 +296,9 @@ impl CommunitySet {
                 } => {
                     set.large.insert((global_admin, local_data1, local_data2));
                 }
+                CommunityMatch::ExactExt(raw) => {
+                    set.exact_ext.insert(raw);
+                }
             }
         }
         set
@@ -309,13 +313,16 @@ impl CommunitySet {
         if !self.standard.is_empty() && ctx.communities.iter().any(|c| self.standard.contains(c)) {
             return true;
         }
-        if (!self.route_targets.is_empty() || !self.route_origins.is_empty())
+        if (!self.route_targets.is_empty()
+            || !self.route_origins.is_empty()
+            || !self.exact_ext.is_empty())
             && ctx.extended_communities.iter().any(|ec| {
                 ec.route_target()
                     .is_some_and(|key| self.route_targets.contains(&key))
                     || ec
                         .route_origin()
                         .is_some_and(|key| self.route_origins.contains(&key))
+                    || self.exact_ext.contains(&ec.as_u64())
             })
         {
             return true;
@@ -353,6 +360,11 @@ fn community_key(cm: CommunityMatch) -> CommunityKey {
             local_data1,
             local_data2,
         } => (3, global_admin, local_data1, local_data2),
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deliberate split of the raw u64 into two key halves"
+        )]
+        CommunityMatch::ExactExt(raw) => (4, (raw >> 32) as u32, raw as u32, 0),
     }
 }
 

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -468,3 +468,75 @@ async fn content_identical_policy_replace_is_key_stable() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// Strict next-hop (`route.next-hop == peer.address`, rpol) reads peer
+/// identity, so an EXPORT chain carrying it must disqualify the peer
+/// from update-group membership (`policy_peer_context`). The other
+/// direction of the matrix — the same policy on an IMPORT chain — is
+/// grouping-irrelevant by construction: import chains are applied at
+/// session ingress and never enter the fingerprint (`PeerUp` carries
+/// only `export_policy`), so a peer whose import policy uses strict
+/// next-hop still groups normally.
+#[tokio::test]
+async fn strict_next_hop_export_chain_disqualifies_grouping() {
+    use std::sync::Arc;
+
+    use rustbgpd_policy::NamedPolicy;
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::SetStore;
+
+    fn rpol_chain(source: &str, name: &str) -> PolicyChain {
+        let mut store = SetStore::new();
+        let compiled = RpolFile::parse(source)
+            .expect("clean rpol")
+            .compile_policy(name, &[], &mut store)
+            .expect("policy exists");
+        PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+            name.to_string(),
+            Arc::new(compiled),
+        )])
+    }
+
+    let strict_nh = "policy strict-nh {
+        term nh { if route.next-hop == peer.address { reject } }
+        term rest { accept }
+    }";
+    let plain = "policy plain {
+        term nh { if route.next-hop == 192.0.2.99 { reject } }
+        term rest { accept }
+    }";
+
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let strict_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let plain_a = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let plain_b = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 3));
+
+    let mut spec = PeerUpSpec::ibgp(strict_peer);
+    spec.export_policy = Some(rpol_chain(strict_nh, "strict-nh"));
+    let _rx1 = peer_up(&tx, spec).await;
+
+    // Content-equal non-strict chains group together.
+    for peer in [plain_a, plain_b] {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.export_policy = Some(rpol_chain(plain, "plain"));
+        let _rx = peer_up(&tx, spec).await;
+    }
+
+    assert_eq!(
+        query_update_group(&tx, strict_peer).await,
+        "policy_peer_context"
+    );
+    let group_a = query_update_group(&tx, plain_a).await;
+    assert!(
+        group_a.starts_with("group:"),
+        "plain peer must group: {group_a}"
+    );
+    assert_eq!(query_update_group(&tx, plain_b).await, group_a);
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -285,6 +285,17 @@ pub struct DfElectionExtendedCommunity {
     pub preference: Option<u16>,
 }
 impl ExtendedCommunity {
+    /// RFC 8097 BGP Origin Validation State Extended Community,
+    /// state `valid` (0). Non-transitive opaque: type `0x43`
+    /// (opaque `0x03` with the non-transitive bit `0x40` set),
+    /// sub-type `0x00`, five reserved zero bytes, and the validation
+    /// state in the last octet (RFC 8097 §2).
+    pub const ORIGIN_VALIDATION_VALID: Self = Self(0x4300_0000_0000_0000);
+    /// RFC 8097 Origin Validation State, state `not found` (1).
+    pub const ORIGIN_VALIDATION_NOT_FOUND: Self = Self(0x4300_0000_0000_0001);
+    /// RFC 8097 Origin Validation State, state `invalid` (2).
+    pub const ORIGIN_VALIDATION_INVALID: Self = Self(0x4300_0000_0000_0002);
+
     /// Create from a raw 8-byte value.
     #[must_use]
     pub fn new(raw: u64) -> Self {
@@ -579,6 +590,14 @@ impl ExtendedCommunity {
 }
 impl fmt::Display for ExtendedCommunity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // RFC 8097 origin-validation states render by their well-known
+        // names (the same aliases the policy frontends parse).
+        match *self {
+            Self::ORIGIN_VALIDATION_VALID => return write!(f, "OV_VALID"),
+            Self::ORIGIN_VALIDATION_NOT_FOUND => return write!(f, "OV_NOT_FOUND"),
+            Self::ORIGIN_VALIDATION_INVALID => return write!(f, "OV_INVALID"),
+            _ => {}
+        }
         let is_ipv4 = self.type_byte() & 0x3F == 0x01;
         if let Some((g, l)) = self.route_target() {
             if is_ipv4 {
@@ -2906,6 +2925,46 @@ mod tests {
         assert!(matches!(err, DecodeError::MalformedField { .. }));
     }
     // ---- EVPN extended community typed accessors (RFC 7432 / 8365 / 9135) ---
+    #[test]
+    fn ext_comm_rfc8097_origin_validation_state_encoding() {
+        // RFC 8097 §2: high-order octet 0x43 (non-transitive), low-order
+        // 0x00, five reserved zero bytes, state in the last octet
+        // (0 = valid, 1 = not found, 2 = invalid).
+        for (ec, state) in [
+            (ExtendedCommunity::ORIGIN_VALIDATION_VALID, 0u8),
+            (ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND, 1),
+            (ExtendedCommunity::ORIGIN_VALIDATION_INVALID, 2),
+        ] {
+            assert_eq!(
+                ec.as_u64().to_be_bytes(),
+                [0x43, 0x00, 0, 0, 0, 0, 0, state]
+            );
+            assert_eq!(ec.type_byte(), 0x43);
+            assert_eq!(ec.subtype(), 0x00);
+            assert!(!ec.is_transitive(), "RFC 8097 is non-transitive");
+            assert_eq!(
+                ExtendedCommunity::new(u64::from_be_bytes([0x43, 0x00, 0, 0, 0, 0, 0, state])),
+                ec,
+                "decode roundtrip"
+            );
+            // Not an RT/RO — the two-part decoders must not claim it.
+            assert_eq!(ec.route_target(), None);
+            assert_eq!(ec.route_origin(), None);
+        }
+        assert_eq!(
+            ExtendedCommunity::ORIGIN_VALIDATION_INVALID.to_string(),
+            "OV_INVALID"
+        );
+        assert_eq!(
+            ExtendedCommunity::ORIGIN_VALIDATION_VALID.to_string(),
+            "OV_VALID"
+        );
+        assert_eq!(
+            ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND.to_string(),
+            "OV_NOT_FOUND"
+        );
+    }
+
     #[test]
     fn ext_comm_bgp_encapsulation_vxlan() {
         let c = ExtendedCommunity::bgp_encapsulation(8); // VXLAN

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1591,6 +1591,7 @@ accept these formats:
 | Well-known name | `"NO_EXPORT"`, `"NO_ADVERTISE"`, `"NO_EXPORT_SUBCONFED"`, `"BLACKHOLE"`, `"GRACEFUL_SHUTDOWN"` | Standard community |
 | `RT:ASN:VALUE` | `"RT:65001:100"` | Extended community (route target) |
 | `RO:ASN:VALUE` | `"RO:65001:200"` | Extended community (route origin) |
+| Well-known name | `"OV_VALID"`, `"OV_NOT_FOUND"`, `"OV_INVALID"` | Extended community (RFC 8097 origin-validation state; matched/added/removed by exact wire value) |
 | `LC:G:L1:L2` | `"LC:65001:100:200"` | Large community (RFC 8092) |
 
 ### AS_PATH regex

--- a/docs/adr/0101-route-server-profile.md
+++ b/docs/adr/0101-route-server-profile.md
@@ -150,11 +150,14 @@ Add-Path send, so mitigation (b) existed; the gap was (a).
   peer-parameterized policy matchers — rejected (superseded by the v2
   filter); default-on mitigation — deferred pending soak history;
   RFC 8097 validation-state extended-community tagging on import —
-  deferred small slice (rpol can add ext-communities on match today;
-  the well-known encoding constants deserve their own slice; on the
-  arouteserver-target critical path). ARouteServer target — deferred
+  **delivered** (the deferred small slice landed: `OV_VALID` /
+  `OV_NOT_FOUND` / `OV_INVALID` well-known extended-community names in
+  TOML and `.rpol` match/add/remove positions, exact-wire-value
+  semantics, RFC 8097 encoding pinned by wire tests; the RS example's
+  `hygiene.rpol` tags RPKI outcomes on import). ARouteServer target — deferred
   per ROADMAP until a pilot is credible; noted: arouteserver supports
   only BIRD and OpenBGPD (7.5+) today, adding a target is a Jinja2
   contribution on their side, and after this arc rustbgpd covers the
-  generated-config essentials except RFC 8097 tagging and RTT-based
-  communities (no RTT source — likely permanent-reject).
+  generated-config essentials except RTT-based
+  communities (no RTT source — likely permanent-reject); the RFC 8097
+  tagging gap has since been closed (see above).

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -92,7 +92,11 @@ report.
   - Extended community (Route Target / Route Origin):
     `RT:65001:100`, `RO:65001:100`, `RT:192.0.2.1:5` (IPv4 admin),
     `RT:200000:100` (4-octet-AS admin). IPv4 and 4-octet-AS admins
-    take a u16 local part (RFC 4360 encodings).
+    take a u16 local part (RFC 4360 encodings). Well-known names:
+    `OV_VALID`, `OV_NOT_FOUND`, `OV_INVALID` — the RFC 8097
+    origin-validation states (non-transitive opaque, type `0x43`
+    sub-type `0x00`, state in the last octet), matched and
+    added/removed by exact wire value.
   - Strings (AS-path regexes, peer-group names): `"..."` with `\"`
     and `\\` escapes.
 - **Statement separators**: `;` between statements is conventional
@@ -213,6 +217,7 @@ group. Comparisons: `==`, `!=`, `>=`, `<=`.
 | `route.as-path matches "^65010"` | Cisco/Quagga-style regex; `_` is a boundary anchor |
 | `route.local-pref >= 200`, `route.med <= 50` | u32 comparisons; `==`/`!=` also allowed |
 | `route.next-hop == 10.0.0.1` | next-hop equality (`==`/`!=` only) |
+| `route.next-hop == peer.address` | strict next-hop — the one field-vs-field comparison; reads peer identity, so an export chain using it makes the peer ineligible for update-group sharing (`policy_peer_context`) |
 | `route.rpki == invalid` | RPKI origin validation state |
 | `route.aspa == unknown` | ASPA verification state |
 | `route.route-type == external` | route source class |
@@ -259,7 +264,7 @@ Two consequences worth internalizing:
 | `set next-hop <ip>` / `set next-hop self` | override `NEXT_HOP` |
 | `add community 65001:999` / `remove community ...` | standard communities |
 | `add large-community 65000:1:2` / `remove ...` | large communities |
-| `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO) |
+| `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO, or well-known: `add ext-community OV_INVALID`) |
 | `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
 
 The kind keyword must match the literal's kind (`add community

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -7,7 +7,7 @@ with OTC, RPKI origin validation, and both path-hiding mitigations.
 | File | Purpose |
 |---|---|
 | `config.toml` | Daemon config: two members, RPKI, policy chain |
-| `hygiene.rpol` | Import hygiene in the rpol policy language: reject AS_SET, reject ASPA-invalid — with in-language tests |
+| `hygiene.rpol` | Import hygiene in the rpol policy language: reject AS_SET, reject ASPA-invalid, tag RPKI outcomes as RFC 8097 `OV_*` extended communities — with in-language tests |
 
 ## Path-hiding (RFC 7947 §2.3), both mitigations
 

--- a/examples/route-server/hygiene.rpol
+++ b/examples/route-server/hygiene.rpol
@@ -18,6 +18,21 @@ policy ixp-hygiene {
     term reject-aspa-invalid {
         if route.aspa == invalid { reject }
     }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid {
+        if route.rpki == valid { add ext-community OV_VALID }
+    }
+    term tag-ov-not-found {
+        if route.rpki == not-found { add ext-community OV_NOT_FOUND }
+    }
+    term tag-ov-invalid {
+        if route.rpki == invalid { add ext-community OV_INVALID }
+    }
 }
 
 test as-set-is-rejected {
@@ -33,4 +48,14 @@ test aspa-invalid-is-rejected {
 test clean-route-falls-through {
     route { prefix 203.0.113.0/24; as-path "64501 64510" }
     expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
 }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -541,6 +541,9 @@ fn parse_community_values(strings: &[String]) -> Result<CommunityValues, ConfigE
             } => {
                 large.push(LargeCommunity::new(global_admin, local_data1, local_data2));
             }
+            // Well-known extended communities (RFC 8097 OV_* states):
+            // the exact raw wire value is the identity.
+            CommunityMatch::ExactExt(raw) => extended.push(ExtendedCommunity::new(raw)),
         }
     }
     Ok(CommunityValues {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2607,6 +2607,37 @@ fn set_community_ro_4byte_asn_rejected() {
 }
 
 #[test]
+fn ov_well_known_ext_community_names_in_toml_policy() {
+    // RFC 8097 origin-validation states ride the well-known-name path
+    // in match and set positions.
+    let toml = community_toml(
+        r#"action = "permit"
+            match_community = ["OV_INVALID"]
+            set_community_add = ["OV_VALID"]
+            set_community_remove = ["OV_NOT_FOUND"]"#,
+    );
+    let cfg = parse(&toml).unwrap();
+    let neighbor = &cfg.neighbors[0];
+    let (import, _export) = cfg.effective_policy_chains_for_neighbor(neighbor).unwrap();
+    let chain = import.expect("import chain configured");
+    let stmt = &chain.policies[0].entries[0];
+    assert_eq!(
+        stmt.match_community,
+        vec![rustbgpd_policy::CommunityMatch::ExactExt(
+            rustbgpd_wire::ExtendedCommunity::ORIGIN_VALIDATION_INVALID.as_u64()
+        )]
+    );
+    assert_eq!(
+        stmt.modifications.extended_communities_add,
+        vec![rustbgpd_wire::ExtendedCommunity::ORIGIN_VALIDATION_VALID]
+    );
+    assert_eq!(
+        stmt.modifications.extended_communities_remove,
+        vec![rustbgpd_wire::ExtendedCommunity::ORIGIN_VALIDATION_NOT_FOUND]
+    );
+}
+
+#[test]
 fn set_community_rt_2byte_asn_accepted() {
     let toml = community_toml(
         r#"action = "permit"


### PR DESCRIPTION
The demand-indicted rpol slice from the gap recon — both items on the arouteserver critical path.

## RFC 8097 origin-validation extended communities

`OV_VALID` / `OV_NOT_FOUND` / `OV_INVALID` as well-known names in rpol (`has`, community-sets, `add|remove ext-community`) and TOML (match/add/remove), rendered by name in displays. Encoding independently verified against RFC 8097 §2 + the IANA registry (non-transitive 0x43, sub-type 0x00, five reserved zero bytes, state octet) with byte-asserting wire tests including non-transitivity and that the RT/RO decoders don't claim it. The RS example's hygiene.rpol now tags all three ROV outcomes (`rbgp policy check`: 5/5).

## Strict next-hop (`route.next-hop == peer.address`)

arouteserver's default NEXT_HOP policy, previously inexpressible. Exactly one field-vs-field Rhs (any other field gets a spanned "only peer.address is allowed here" diagnostic), lowering to `MatchExpr::NextHopEqPeer`. The update-groups interaction is pinned both directions: an export chain using it trips `requires_peer_context` and disqualifies the peer (`policy_peer_context` reason, rib-level test), while import use is grouping-irrelevant by construction (documented + asserted).

Inherited a non-compiling draft; finished lowering/testing/TOML plumbing/docs. ADR-0101's register marks 8097 delivered.

Gates: workspace build/test, fmt, clippy -D warnings, cargo doc, clippy-reasons, policy fuzz build — green.