### PR TITLE
docs: add an optional docs site (static, searchable, agent-native), preview inside

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Trim generated artifacts and internal logs from the docs build copy
         run: |
-          rm -rf docs/artifacts docs/images docs/perf
+          rm -rf docs/artifacts docs/images docs/perf docs/adr
           rm -f docs/soak-*.md docs/RECEIPTS.md docs/OPERATIONAL_PROOF.md docs/evpn-alpha-soak.md \
                 docs/milestones.md docs/upstream-findings.md docs/RELEASE_CHECKLIST.md docs/FUZZING.md
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: docs
+
+# Docs-as-code: kura.toml + this workflow render docs/ into a searchable, agent-native static site via
+# the kurajs/pages action, deployed to GitHub Pages. The repo's docs/ also holds generated soak-test
+# artifacts and dated postmortems; those are pruned from the build copy here (the repo itself is never
+# modified) so the site stays focused on the reference docs.
+
+on:
+  push:
+    branches: [main, master, docs/kura-site]
+    paths:
+      - "docs/**"
+      - "kura.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Trim generated artifacts and internal logs from the docs build copy
+        run: |
+          rm -rf docs/artifacts docs/images docs/perf
+          rm -f docs/soak-*.md docs/RECEIPTS.md docs/OPERATIONAL_PROOF.md docs/evpn-alpha-soak.md \
+                docs/milestones.md docs/upstream-findings.md docs/RELEASE_CHECKLIST.md docs/FUZZING.md
+
+      - uses: kurajs/pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Trim generated artifacts and internal logs from the docs build copy
         run: |
-          rm -rf docs/artifacts docs/images docs/perf docs/adr
+          rm -rf docs/artifacts docs/images docs/perf
           rm -f docs/soak-*.md docs/RECEIPTS.md docs/OPERATIONAL_PROOF.md docs/evpn-alpha-soak.md \
                 docs/milestones.md docs/upstream-findings.md docs/RELEASE_CHECKLIST.md docs/FUZZING.md
 

--- a/kura.toml
+++ b/kura.toml
@@ -21,7 +21,7 @@ title  = "Cookbook"
 groups = ["cookbook"]
 [[nav.tabs]]
 title  = "Internals"
-groups = ["design", "adr"]
+groups = ["design"]
 [nav.groups.guide]
 title = "Guide"
 pages = [
@@ -52,5 +52,3 @@ pages = [
   { slug = "INTEROP", title = "Interop results" }, { slug = "RFC_NOTES", title = "RFC notes" },
   { slug = "reload-matrix", title = "Reload matrix" }, { slug = "kernel-dataplane-runner", title = "Kernel dataplane runner" },
 ]
-[nav.groups.adr]
-title = "Design records (ADR)"

--- a/kura.toml
+++ b/kura.toml
@@ -21,7 +21,7 @@ title  = "Cookbook"
 groups = ["cookbook"]
 [[nav.tabs]]
 title  = "Internals"
-groups = ["design"]
+groups = ["design", "adr"]
 [nav.groups.guide]
 title = "Guide"
 pages = [
@@ -52,3 +52,5 @@ pages = [
   { slug = "INTEROP", title = "Interop results" }, { slug = "RFC_NOTES", title = "RFC notes" },
   { slug = "reload-matrix", title = "Reload matrix" }, { slug = "kernel-dataplane-runner", title = "Kernel dataplane runner" },
 ]
+[nav.groups.adr]
+title = "Design records (ADR)"

--- a/kura.toml
+++ b/kura.toml
@@ -1,0 +1,56 @@
+# rustbgpd docs site — the ONLY config. The kurajs/pages action reads this + renders docs/ into the
+# site. The repo is Rust, so nothing at the root is touched. Deployed by .github/workflows/docs.yml.
+
+markdown  = "commonmark"
+base_path = ""
+[site]
+name        = "rustbgpd"
+description = "An API-first BGP daemon in Rust for programmable route-server and control-plane use cases."
+[deploy]
+target = "github-pages"
+[content]
+sources = []
+[[nav.tabs]]
+title  = "Guide"
+groups = ["guide"]
+[[nav.tabs]]
+title  = "Reference"
+groups = ["api", "evpn"]
+[[nav.tabs]]
+title  = "Cookbook"
+groups = ["cookbook"]
+[[nav.tabs]]
+title  = "Internals"
+groups = ["design", "adr"]
+[nav.groups.guide]
+title = "Guide"
+pages = [
+  { slug = "deployment", title = "Deployment" }, { slug = "CONFIGURATION", title = "Configuration" },
+  { slug = "OPERATIONS", title = "Operations" }, { slug = "USE_CASES", title = "Use cases" },
+  { slug = "SECURITY", title = "Security posture" }, { slug = "EMBEDDING", title = "Embedding (library map)" },
+]
+[nav.groups.api]
+title = "API & telemetry"
+pages = [
+  { slug = "API", title = "gRPC API reference" }, { slug = "rpol-language", title = "Policy language (.rpol)" },
+  { slug = "grpc-method-inventory", title = "gRPC method inventory" }, { slug = "GNMI", title = "gNMI / OpenConfig" },
+  { slug = "GRAFANA", title = "Grafana dashboard" },
+]
+[nav.groups.evpn]
+title = "EVPN"
+pages = [
+  { slug = "evpn-vtep-setup", title = "VTEP setup" }, { slug = "evpn-vtep-troubleshooting", title = "VTEP troubleshooting" },
+  { slug = "evpn-enablement", title = "Enablement roadmap" },
+]
+[nav.groups.cookbook]
+title = "Cookbook"
+[nav.groups.design]
+title = "Design & comparisons"
+pages = [
+  { slug = "DESIGN", title = "Design document" }, { slug = "COMPARISON", title = "BGP comparison" },
+  { slug = "gobgp-parity", title = "GoBGP parity" }, { slug = "BENCHMARKS", title = "Benchmarks" },
+  { slug = "INTEROP", title = "Interop results" }, { slug = "RFC_NOTES", title = "RFC notes" },
+  { slug = "reload-matrix", title = "Reload matrix" }, { slug = "kernel-dataplane-runner", title = "Kernel dataplane runner" },
+]
+[nav.groups.adr]
+title = "Design records (ADR)"


### PR DESCRIPTION
Hi @lance0 👋 rustbgpd caught my eye (an API-first BGP daemon for programmable route servers is a genuinely fresh take). You have a deep set of docs in `docs/` already (the gRPC API reference, the configuration reference, the EVPN runbooks, the cookbook), but they only live on GitHub right now, so I built a docs-generation tool called Kura and, on a whim, forked rustbgpd and rendered them into a searchable docs site to see how it'd look.

**Live preview: https://linyiru.github.io/rustbgpd/**

The nav groups them as Guide / Reference (API + EVPN) / Cookbook / Internals (design docs, comparisons, and the 103 ADRs). A few things it does:

- **Docs-as-code**: it renders the Markdown already in `docs/` into a fully static HTML site. Your writing flow doesn't change at all. You edit the same `.md` files and the site rebuilds itself.
- **Built-in search**: client-side, instant, no server. Try searching "route reflector" or "gRPC".
- **GitHub Pages**: fully static, so hosting is free.
- **Dead-simple config**: one `kura.toml` at the root (nav plus which folder holds the docs), and a GitHub Actions workflow that deploys on every docs change.
- **Agent-friendly**: every page is also served as `.md` for AI/agents, plus a built-in `/llms.txt` whole-site map (fitting for a daemon whose whole point is a programmable API).
- **No dead links**: docs that link to repo files (`../RECEIPTS.md`, test configs like `tests/interop/configs/*.toml`, `KNOWN_ISSUES.md`) automatically point at the file on GitHub at the exact built commit, so nothing 404s.

**Minimal intrusion:** this PR adds only **2 files**, `kura.toml` and `.github/workflows/docs.yml`. rustbgpd is Rust, so nothing at the repo root is touched.

One honest note on curation: your `docs/` also holds generated soak artifacts and dated postmortems. The workflow prunes those from the BUILD COPY only (the repo itself is never modified), so the site stays focused on the reference docs, and thanks to the repo-link fallback above, any doc that references a pruned file still links to it on GitHub. Easy to include them instead if you prefer.

**What you get once this is merged:** the same site at `https://lance0.github.io/rustbgpd/` automatically (that URL goes live after merge, not before). GitHub Pages hosts it for free, and you can point a custom domain at it anytime. From then on it just tracks your `docs/`, with no extra maintenance.

Totally optional. Mostly I'd love your feedback: does this make rustbgpd easier to explore and adopt? Happy to adjust anything (nav grouping, which docs are included, theme) or close it if it's not a fit.
