### PR TITLE
fix: library target builds under --all-features (LAN-198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       # bench_support surface; it has silently broken before when a
       # manager API grew an argument.
       - run: cargo check -p rustbgpd-rib --features bench-internals --benches
+      # Same class of gap for the root crate: `bench-internals` exposes
+      # `pub mod config` (and its EVPN reload-diff dependencies) in the
+      # lib, a surface the default `--all-targets` clippy never compiles.
+      # LAN-198: `config` referenced binary-only modules, so the lib
+      # failed to build under `--all-features` while the bin stayed green.
+      - run: cargo check -p rustbgpd --all-features --lib
       - run: cargo test --workspace
       - run: cargo doc --workspace --lib --no-deps
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,6 +776,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The library target now builds under `--all-features` (LAN-198).**
+  The lib exposes `pub mod config` only under `bench-internals`, and
+  `config`'s reload-diff logic (`classify_evpn_runtime_change`) reaches
+  into the EVPN runtime subsystem — modules previously declared only in
+  `main.rs`. With `bench-internals` off (the default) the lib compiled
+  empty, so the gap was invisible; `cargo check -p rustbgpd
+  --all-features --lib` failed with `E0433: cannot find
+  evpn_plan_decomposer in crate` while the binary stayed green. The lib
+  now declares the transitive EVPN module closure (plan decomposer,
+  converger, ES-drain, originator, segment, dataplane, IMET, L3
+  originator, SVI) under the same feature gate, and CI gained a
+  `cargo check -p rustbgpd --all-features --lib` step so the
+  bench-internals lib surface can no longer regress unnoticed.
+
 - **BMP monitoring can no longer diverge silently from the wire under
   saturation.** Two per-peer holes closed in the PeerSession→BmpManager
   path: (1) BMP `PeerUp`/`PeerDown` were emitted with the same lossy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,36 @@ mod fib_common;
 #[cfg(feature = "bench-internals")]
 mod fib;
 
+// `config`'s reload-diff logic (`classify_evpn_runtime_change` inside
+// `diff_config`) reaches into the EVPN runtime subsystem — the plan
+// decomposer, which transitively pulls in the converger, ES-drain
+// modules, originator, L3 originator, segment, SVI, dataplane, and
+// IMET. The bin declares all of these in `main.rs`; the lib needs its
+// own declarations so that when `config` is exposed under this feature
+// the paths resolve. Without them, `cargo check -p rustbgpd
+// --all-features --lib` fails with E0433 on `crate::evpn_plan_decomposer`
+// (LAN-198).
+#[cfg(feature = "bench-internals")]
+mod evpn_dataplane;
+#[cfg(feature = "bench-internals")]
+mod evpn_es_drain;
+#[cfg(feature = "bench-internals")]
+mod evpn_es_link_drain;
+#[cfg(feature = "bench-internals")]
+mod evpn_imet;
+#[cfg(feature = "bench-internals")]
+mod evpn_l3_originator;
+#[cfg(feature = "bench-internals")]
+mod evpn_originator;
+#[cfg(feature = "bench-internals")]
+mod evpn_plan_decomposer;
+#[cfg(feature = "bench-internals")]
+mod evpn_runtime_converger;
+#[cfg(feature = "bench-internals")]
+mod evpn_segment;
+#[cfg(feature = "bench-internals")]
+mod evpn_svi;
+
 // `fib`'s unit tests (the only bench-internals lib module with tests
 // that use the shared builders) reach for `crate::test_support`. The
 // bin declares it in `main.rs`; the lib needs its own declaration so


### PR DESCRIPTION
Closes LAN-198. `cargo check --all-features --lib` (and `cargo clippy --all-features`) failed on the library crate with `E0433: cannot find evpn_plan_decomposer in crate` at `config/mod.rs:2913`.

## Root cause

`lib.rs` exposes `pub mod config` **only under the `bench-internals` feature**. `config`'s reload-diff logic (`classify_evpn_runtime_change` in `diff_config`) references `crate::evpn_plan_decomposer` (added by #692), which is declared **only in `main.rs`**. With `bench-internals` off (default) the lib compiles empty, so the gap was invisible; `--all-features` flips it on, pulls `config` into the lib, and the binary-only module can't resolve. The binary always had the mods in `main.rs`, which is why `cargo build`/`test` passed all along and only the lib target failed.

## Fix

Declare the transitive EVPN module closure (plan decomposer, converger, ES-drain ×2, originator, L3 originator, segment, SVI, dataplane, IMET) in `lib.rs` under the same `bench-internals` gate so the lib resolves them. No behavior change — the decomposer still runs in the daemon via the binary's own declarations (#692 unaffected). Chose this over relocating the call site because it sits in genuine `ConfigDiff` construction logic, not daemon wiring.

## The sweep (the point of the exercise)

The full `cargo clippy --workspace --all-targets --all-features -- -D warnings` — previously unreachable behind this fail-fast, so the `--all-features` lint status of rib/transport/api was unknown — is **clean at exit 0, zero warnings**. No hidden lint debt.

## Recurrence guard

Added `cargo check -p rustbgpd --all-features --lib` to the CI `check` job, next to the sibling `rustbgpd-rib --features bench-internals` guard (same class of root cause: CI never compiled the feature-gated surface).

All gates green: default + `--all-features` clippy, `--all-features --lib`, build/test/fmt/doc/clippy-reasons/bench-internals.