### PR TITLE
fix+feat: per-peer log_level was a boot-crash; make it live and guard the inert-knob class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -789,6 +789,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   originator, SVI) under the same feature gate, and CI gained a
   `cargo check -p rustbgpd --all-features --lib` step so the
   bench-internals lib surface can no longer regress unnoticed.
+- **Per-peer `log_level` is now genuinely live on SIGHUP — and no longer
+  aborts boot.** Two bugs closed. (1) The generated filter directive used
+  the unbracketed span form `peer{peer_addr=X}=level`, which the
+  `EnvFilter` parser rejects (`error parsing level filter`); `init_logging`
+  surfaced that as an error and the daemon `exit(1)`-ed, so any config that
+  set a per-peer `log_level` failed to boot. The directive is now the
+  correct bracketed `[peer{peer_addr=X}]=level`, guarded by a test that
+  parses every emitted directive. (2) The reload matrix and deployment docs
+  already classed `[[neighbors]] log_level` (and the peer-group
+  equivalent) as live, but the tracing subscriber was installed once at
+  startup with no reload handle, so an edited per-peer level never took
+  effect without a restart. The subscriber's `EnvFilter`
+  now sits behind a `tracing_subscriber::reload` handle (stored in a
+  process-global `OnceLock` in the telemetry crate, matching the
+  subscriber's own global scope); after a validated config reload the
+  SIGHUP path recomputes `per_peer_log_directives` and swaps in a freshly
+  rebuilt filter (`RUST_LOG` base level plus every current per-peer
+  directive — the base always survives). Reapplying identical directives
+  is a no-op and a malformed directive leaves the live filter untouched.
+  The global base level stays restart-required (read once from
+  `RUST_LOG`). Formatting/output are unchanged. Also adds a class-guard
+  unit test (`build_transport_config_reflects_every_transport_field`) that
+  fails at compile time when a new `PeerManagerNeighborConfig` transport
+  field is added without a copy into `TransportConfig`, and at run time
+  when an existing copy is dropped — the same seam that silently lost
+  `per_client_best` (#702); plus a reload-matrix test that pins the
+  live/restart-required class column so a docs-vs-reality drift fails CI.
 
 - **BMP monitoring can no longer diverge silently from the wire under
   saturation.** Two per-peer holes closed in the PeerSession→BmpManager

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -17,6 +17,6 @@ pub mod logging;
 pub mod metrics;
 pub mod reason_labels;
 
-pub use logging::{LoggingError, init_logging};
+pub use logging::{LoggingError, init_logging, reload_per_peer_directives};
 pub use metrics::BgpMetrics;
 pub use reason_labels::{OtcBlockReason, RrLoopReason};

--- a/crates/telemetry/src/logging.rs
+++ b/crates/telemetry/src/logging.rs
@@ -1,7 +1,47 @@
 //! Structured JSON logging via `tracing`.
 
+use std::sync::OnceLock;
+
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
+
+/// Reloads the live `EnvFilter` in place. Boxed so the caller never has to
+/// name the `reload::Handle`'s formatter type parameter — the concrete
+/// subscriber type produced by the fmt builder is a mouthful and is
+/// irrelevant here; only the ability to swap the filter matters.
+type ReloadFn = Box<dyn Fn(EnvFilter) -> Result<(), String> + Send + Sync>;
+
+/// The live filter reload hook, installed by [`init_logging`] once the
+/// global subscriber is set. Process-global to match the tracing subscriber
+/// itself — threading the handle from startup down to the SIGHUP reload task
+/// would touch every struct in between for no benefit.
+static RELOAD_HANDLE: OnceLock<ReloadFn> = OnceLock::new();
+
+/// Base filter from `RUST_LOG` (or `info` when unset) with the given
+/// per-peer directives appended. Rebuilt in full on every reload so the
+/// base level always survives — dropping it would silence everything not
+/// covered by a per-peer directive.
+fn build_filter(extra_directives: &[String]) -> Result<EnvFilter, LoggingError> {
+    let base = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    append_directives(base, extra_directives)
+}
+
+/// Append per-peer directives onto a base filter. Split out from
+/// [`build_filter`] so tests can pin the base deterministically instead of
+/// depending on the ambient `RUST_LOG`.
+fn append_directives(
+    mut filter: EnvFilter,
+    extra_directives: &[String],
+) -> Result<EnvFilter, LoggingError> {
+    for directive in extra_directives {
+        filter = filter.add_directive(
+            directive
+                .parse()
+                .map_err(|e| LoggingError::InvalidDirective(format!("{directive}: {e}")))?,
+        );
+    }
+    Ok(filter)
+}
 
 /// Initialize the global tracing subscriber with JSON output and
 /// `RUST_LOG` env-filter.
@@ -10,31 +50,73 @@ use tracing_subscriber::fmt;
 /// set.
 ///
 /// `extra_directives` are appended to the filter and can include
-/// per-peer span filters such as `peer{peer_addr=10.0.0.1}=debug`.
+/// per-peer span filters such as `[peer{peer_addr=10.0.0.1}]=debug` (the
+/// span directive MUST be bracketed — see `per_peer_log_directives`).
+///
+/// The filter is installed behind a [`tracing_subscriber::reload`] handle
+/// so per-peer levels can be re-applied at runtime via
+/// [`reload_per_peer_directives`] (SIGHUP) without a restart. The global
+/// base level is fixed at startup from `RUST_LOG`.
 ///
 /// # Errors
 ///
 /// Returns a [`LoggingError`] if the global subscriber has already been
 /// set (e.g., called twice or a test already installed one).
 pub fn init_logging(extra_directives: &[String]) -> Result<(), LoggingError> {
-    let mut filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = build_filter(extra_directives)?;
 
-    for directive in extra_directives {
-        filter = filter.add_directive(
-            directive
-                .parse()
-                .map_err(|e| LoggingError::InvalidDirective(format!("{directive}: {e}")))?,
-        );
-    }
-
-    fmt()
+    let builder = fmt()
         .json()
         .with_env_filter(filter)
         .with_target(true)
         .with_thread_ids(false)
         .with_thread_names(false)
+        .with_filter_reloading();
+    let handle = builder.reload_handle();
+    builder
         .try_init()
-        .map_err(|e| LoggingError::AlreadyInitialized(e.to_string()))
+        .map_err(|e| LoggingError::AlreadyInitialized(e.to_string()))?;
+
+    // Only publish the reload hook after the subscriber actually installed,
+    // so a failed double-init never overwrites a live handle. `set` failing
+    // means init_logging ran twice — the first handle stays authoritative.
+    let _ = RELOAD_HANDLE.set(Box::new(move |filter| {
+        handle.reload(filter).map_err(|e| e.to_string())
+    }));
+    Ok(())
+}
+
+/// Re-apply per-peer log directives to the live subscriber (SIGHUP path).
+///
+/// Rebuilds the full filter (base level from `RUST_LOG` + all current
+/// per-peer directives) and swaps it into the running subscriber, so
+/// `log_level` edits take effect without a restart. Reapplying identical
+/// directives is a harmless no-op.
+///
+/// Defensive by construction: a malformed directive is rejected here (the
+/// filter is rebuilt into a local before the swap), so the live filter is
+/// never taken down — the old one keeps running. Config validation already
+/// gates the values; this is belt-and-suspenders.
+///
+/// # Errors
+///
+/// Returns [`LoggingError::InvalidDirective`] if a directive fails to parse
+/// (the live filter is left untouched), or [`LoggingError::ReloadFailed`]
+/// if the subscriber was dropped. When no reloadable subscriber is
+/// installed (e.g. a test set its own, or `init_logging` was never called),
+/// this logs a warning and returns `Ok(())` — a reload with nowhere to go
+/// is a no-op, not a failure.
+pub fn reload_per_peer_directives(directives: &[String]) -> Result<(), LoggingError> {
+    let filter = build_filter(directives)?;
+    if let Some(reload) = RELOAD_HANDLE.get() {
+        reload(filter).map_err(LoggingError::ReloadFailed)
+    } else {
+        tracing::warn!(
+            "per-peer log_level reload requested but no reloadable logging \
+             subscriber is installed; live filter unchanged"
+        );
+        Ok(())
+    }
 }
 
 /// Errors from logging initialization.
@@ -46,11 +128,19 @@ pub enum LoggingError {
     /// A per-peer log filter directive was malformed.
     #[error("invalid log filter directive: {0}")]
     InvalidDirective(String),
+    /// Swapping the live filter failed (the subscriber was dropped).
+    #[error("failed to reload log filter: {0}")]
+    ReloadFailed(String),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::reload;
 
     #[test]
     fn init_logging_returns_result() {
@@ -60,5 +150,104 @@ mod tests {
         let result = init_logging(&[]);
         // Either Ok (first call) or Err (already set) — neither should panic.
         assert!(result.is_ok() || result.is_err());
+    }
+
+    /// Layer that counts events that pass the filter — a probe for whether
+    /// the `reload::Handle` + `EnvFilter` actually enable/disable a span level.
+    struct CountLayer(Arc<AtomicUsize>);
+    impl<S: tracing::Subscriber> Layer<S> for CountLayer {
+        fn on_event(&self, _event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Behavior proof (not just compile): per-peer `log_level` genuinely
+    /// updates the live filter, and the global base survives every reload.
+    ///
+    /// Tests the `reload::Handle` + `EnvFilter` directly (thread-local
+    /// `set_default`, no global install) so it is independent of whatever
+    /// other tests installed the process-global subscriber. The reloaded
+    /// filter is built with the exact `[peer{peer_addr=X}]=level` directive
+    /// `per_peer_log_directives` emits, against the exact
+    /// `info_span!("peer", peer_addr=...)` span the transport layer creates
+    /// — so this pins the string format that actually flips a real span.
+    /// (The unbracketed `peer{...}=level` form does NOT parse — that latent
+    /// boot-abort bug is exactly what this test would have caught.)
+    #[test]
+    fn per_peer_directive_reload_flips_span_level_and_keeps_base() {
+        let base = EnvFilter::new("info");
+        let (filter_layer, handle) = reload::Layer::new(base);
+        let count = Arc::new(AtomicUsize::new(0));
+        let subscriber = tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(CountLayer(count.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let debug_in_peer_span = || {
+            let span = tracing::info_span!("peer", peer_addr = "10.0.0.9");
+            let _e = span.enter();
+            tracing::debug!("probe");
+        };
+        let info_in_peer_span = || {
+            let span = tracing::info_span!("peer", peer_addr = "10.0.0.9");
+            let _e = span.enter();
+            tracing::info!("base-probe");
+        };
+
+        // Base is info: debug inside the peer span is filtered out.
+        debug_in_peer_span();
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "debug disabled at base info"
+        );
+        // ...but the base info level itself is enabled.
+        info_in_peer_span();
+        assert_eq!(count.load(Ordering::SeqCst), 1, "info enabled at base");
+
+        // Reload with the real directive format for this peer at debug.
+        let reloaded = append_directives(
+            EnvFilter::new("info"),
+            &["[peer{peer_addr=10.0.0.9}]=debug".to_string()],
+        )
+        .expect("directive parses");
+        handle.reload(reloaded).expect("reload succeeds");
+
+        // Debug now reaches the layer for this peer span — live update.
+        debug_in_peer_span();
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            2,
+            "debug enabled for the peer span after reload"
+        );
+        // Base info still enabled — the reload did not drop the base level.
+        info_in_peer_span();
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            3,
+            "base info survives the reload"
+        );
+
+        // Revert to base-only: debug is filtered out again.
+        handle
+            .reload(EnvFilter::new("info"))
+            .expect("revert reload succeeds");
+        debug_in_peer_span();
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            3,
+            "debug disabled again after reverting the directive"
+        );
+    }
+
+    /// A malformed directive is rejected without a subscriber installed,
+    /// and `build_filter` surfaces the parse error rather than panicking —
+    /// the reload path can then leave the live filter untouched. The bad
+    /// level (`notalevel`) is the same failure class the unbracketed
+    /// span-directive form trips into.
+    #[test]
+    fn malformed_directive_is_a_clean_error() {
+        let err = build_filter(&["target=notalevel".to_string()]);
+        assert!(matches!(err, Err(LoggingError::InvalidDirective(_))));
     }
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -594,8 +594,10 @@ short version for first deployment:
 For deeper investigation, raise the daemon log level globally via
 `[global.telemetry] log_format = "json"` and per-peer via
 `[[neighbors]] log_level = "debug"`. Restart required for the global
-setting; per-peer log_level is **live** (see the
-[reload matrix](reload-matrix.md)).
+setting; per-peer log_level is **live** — re-applied on SIGHUP via a
+tracing reload handle that rebuilds the filter (base level plus every
+per-peer directive), so a level edit takes effect without a restart (see
+the [reload matrix](reload-matrix.md)).
 
 ## Related
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -97,7 +97,7 @@ the old neighbor is torn down, the new one starts fresh.
 | `disable_ipv4_unicast` | live (effective next session) | IPv6-only peering: drops IPv4 unicast from the advertised MultiProtocol capability and suppresses the RFC 4760 §8 implicit-IPv4 fallback — both OPEN-time properties, so a toggle takes effect on the next session. Rejected at load when the effective `families` resolve to `ipv4_unicast` only. |
 | `remove_private_as` | live | Applied to every outbound advertisement; the next distribution pass picks up the new value. |
 | `add_path` | live (effective next session) | RFC 7911 Add-Path send/receive modes are negotiated in OPEN. Mid-session changes are no-ops until renegotiation. |
-| `log_level` | live | Per-peer tracing filter; takes effect on next log emission. |
+| `log_level` | live | Per-peer tracing filter, re-applied on SIGHUP via the tracing [`reload`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/reload/index.html) handle: the reload rebuilds the full `EnvFilter` (the `RUST_LOG` base level plus every per-peer directive) and swaps it into the running subscriber, so a level edit takes effect without a restart. The global base level stays restart-required (read once from `RUST_LOG`). |
 | `import_policy` | live | Inline import statements; re-evaluated against all received routes on reconcile. |
 | `export_policy` | live | Inline export statements; re-evaluated against the Adj-RIB-Out on next distribution. |
 | `import_policy_chain` | live | Named-chain reference; same re-evaluation behavior. |
@@ -135,7 +135,7 @@ dynamic-neighbor TCP-AO needs a separate wildcard-MKT design.
 | `disable_ipv4_unicast` | live (effective next session) | Group-level IPv6-only toggle; same OPEN-time semantics as the neighbor field, effective on the inheriting peer's next session. |
 | `remove_private_as` | live | |
 | `add_path` | live (effective next session) | |
-| `log_level` | live | |
+| `log_level` | live | Same as neighbor — inherited per-peer tracing filter, re-applied on SIGHUP via the tracing reload handle. |
 | `import_policy` | live | Inline import statements inherited by peers that do not set their own import policy / chain. |
 | `export_policy` | live | Inline export statements inherited by peers that do not set their own export policy / chain. |
 | `import_policy_chain` | live | Named-chain reference inherited by peers that do not set their own import policy / chain. |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1420,8 +1420,12 @@ impl Config {
     }
     /// Build `tracing` filter directives for per-peer log level overrides.
     ///
-    /// Returns directives like `peer{peer_addr=10.0.0.1}=debug` that can be
-    /// appended to an `EnvFilter`.
+    /// Returns directives like `[peer{peer_addr=10.0.0.1}]=debug` that can
+    /// be appended to an `EnvFilter`. The span directive MUST be wrapped in
+    /// square brackets — `peer{...}=level` (no brackets) is rejected by the
+    /// `EnvFilter` directive parser (`error parsing level filter`), which
+    /// would make `init_logging` fail and abort daemon boot the moment any
+    /// neighbor set a `log_level`.
     pub fn per_peer_log_directives(&self) -> Vec<String> {
         let mut directives = Vec::new();
         for neighbor in &self.neighbors {
@@ -1434,7 +1438,7 @@ impl Config {
             });
             if let Some(level) = level {
                 directives.push(format!(
-                    "peer{{peer_addr={addr}}}={level}",
+                    "[peer{{peer_addr={addr}}}]={level}",
                     addr = neighbor.address
                 ));
             }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -10800,6 +10800,84 @@ fn reload_matrix_documents_every_peer_group_field() {
     }
 }
 
+/// All table rows in the reload matrix whose first cell is exactly the
+/// backtick-wrapped field name. Returns every match — some knobs (e.g.
+/// `log_level`) appear in both the `[[neighbors]]` and `[peer_groups]`
+/// sections and must be classed consistently. Matching the exact
+/// leading table-cell prefix avoids matching prose or compound cells
+/// (such as the `tcp_ao mandatory fields` validation row).
+fn reload_matrix_rows_for<'a>(matrix: &'a str, field: &str) -> Vec<&'a str> {
+    let cell = format!("| `{field}` |");
+    matrix
+        .lines()
+        .filter(|line| line.starts_with(&cell))
+        .collect()
+}
+
+/// The name-coverage tests above only prove a field *appears* in the
+/// matrix. This one pins the CLASS column (live vs restart-required) for
+/// the knobs where the class is load-bearing — a docs-vs-reality drift on
+/// these actively misleads an operator about whether a SIGHUP suffices.
+///
+/// `log_level` is now genuinely live (re-applied on SIGHUP via the
+/// telemetry tracing reload handle), so the doc claim is finally true; if
+/// someone regresses it back to inert and re-marks the row restart-required
+/// (or vice versa) this fails. `tcp_ao` and `bfd` pin the restart-required
+/// side so a blanket "mark everything live" edit also fails.
+#[test]
+fn reload_matrix_pins_load_bearing_field_classes() {
+    let matrix = load_reload_matrix();
+    for (field, class_cell) in [
+        ("log_level", "| live |"),
+        ("tcp_ao", "| restart-required |"),
+        ("bfd", "| restart-required |"),
+    ] {
+        let rows = reload_matrix_rows_for(&matrix, field);
+        assert!(
+            !rows.is_empty(),
+            "no reload-matrix table row found for `{field}`"
+        );
+        for row in rows {
+            assert!(
+                row.contains(class_cell),
+                "reload-matrix class drift: the row for `{field}` must be \
+                 classed `{class_cell}` (load-bearing: it tells operators \
+                 whether SIGHUP is enough). Row reads: {row}"
+            );
+        }
+    }
+}
+
+/// Regression guard for the directive format itself: every string
+/// `per_peer_log_directives` emits must actually parse as an `EnvFilter`
+/// directive. The original `peer{peer_addr=X}=level` form (no brackets)
+/// did NOT parse — `init_logging` rejected it and aborted daemon boot the
+/// moment any neighbor set a `log_level`, so the per-peer knob was inert
+/// *and* boot-fatal. The bracketed `[peer{peer_addr=X}]=level` form parses;
+/// this pins it so the format can't silently regress into a boot-abort.
+#[test]
+fn per_peer_log_directives_parse_as_env_filter() {
+    use tracing_subscriber::filter::Directive;
+
+    // Appends `log_level` onto the fixture's single 10.0.0.2 neighbor.
+    let config = parse(&format!("{}log_level = \"debug\"\n", valid_toml())).unwrap();
+    let directives = config.per_peer_log_directives();
+    assert_eq!(directives.len(), 1, "one neighbor carries a log_level");
+    assert!(
+        directives[0].starts_with("[peer{"),
+        "span directive must be bracketed, got {:?}",
+        directives[0]
+    );
+    for directive in &directives {
+        directive.parse::<Directive>().unwrap_or_else(|e| {
+            panic!(
+                "per_peer_log_directives emitted {directive:?} which EnvFilter \
+                 rejects ({e}) — init_logging would abort daemon boot"
+            )
+        });
+    }
+}
+
 #[test]
 fn managed_netdevs_default_empty_and_resolve_stamps() {
     let config = parse(&format!(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3528,6 +3528,197 @@ fn build_transport_config_preserves_local_role_for_otc() {
     );
 }
 
+/// Class guard for the "config knob parsed/validated/displayed but never
+/// reaches its runtime consumer" bug (#702, `per_client_best` dropped in
+/// `build_transport_config`; caught only by the M83 real-stack lab because
+/// the RIB/CLI unit layers are wired above this seam). This pins the
+/// `PeerManagerNeighborConfig` → `TransportConfig` seam as a whole so a
+/// future dropped copy fails a unit test, not a lab.
+///
+/// Two guards, deliberately layered:
+///
+/// 1. **Compile-time (new field):** the destructure below names EVERY
+///    field with NO `..`. Add a field to `PeerManagerNeighborConfig` and
+///    THIS test stops compiling — forcing an explicit decision: transport
+///    field (assert it) or one of the three non-transport fields
+///    (`description`, `import_policy`, `export_policy` — RIB/label side,
+///    not a session property; add it to the `_`-bound exclusions).
+///
+/// 2. **Run-time (dropped copy of an existing field):** every transport
+///    field is set to a non-default sentinel and asserted against the
+///    resulting `TransportConfig`. A field left at `TransportConfig::new`'s
+///    default would pass a weaker test even with the copy missing, so the
+///    sentinels are chosen to differ from those defaults.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn build_transport_config_reflects_every_transport_field() {
+    let (_, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+
+    let config = PeerManagerNeighborConfig {
+        address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        interface: Some("test-if".to_string()),
+        scope_id: Some(7),
+        remote_asn: 65002,
+        description: "sentinel-description".to_string(),
+        peer_group: Some("rr-clients".to_string()),
+        hold_time: Some(240),
+        send_hold_time: Some(600),
+        max_prefixes: Some(1000),
+        md5_password: Some("hunter2".to_string()),
+        tcp_ao: Some(rustbgpd_transport::TcpAoConfig {
+            key: "ao-secret".to_string(),
+            send_id: 11,
+            recv_id: 22,
+            algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+            preferred: true,
+            deprecated: false,
+        }),
+        ttl_security: true,
+        families: vec![(Afi::Ipv6, Safi::Unicast)],
+        graceful_restart: true,
+        gr_restart_time: 300,
+        gr_stale_routes_time: 720,
+        llgr_stale_time: 3600,
+        gr_restart_eligible: false,
+        local_ipv6_nexthop: Some("2001:db8::1".parse().unwrap()),
+        route_reflector_client: true,
+        orr_vantage: Some(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9))),
+        route_server_client: true,
+        per_client_best: true,
+        remove_private_as: rustbgpd_transport::RemovePrivateAs::All,
+        add_path_receive: true,
+        add_path_send: true,
+        add_path_send_max: 4,
+        local_role: Some(rustbgpd_wire::BgpRole::RouteServer),
+        strict_role: true,
+        prefix_orf_receive: true,
+        disable_ipv4_unicast: true,
+        import_policy: None,
+        export_policy: None,
+    };
+
+    // Destructure with NO `..`: a new field breaks compilation here.
+    let PeerManagerNeighborConfig {
+        address,
+        interface,
+        scope_id,
+        remote_asn,
+        description: _description, // NON-TRANSPORT: operator label only.
+        peer_group,
+        hold_time,
+        send_hold_time,
+        max_prefixes,
+        md5_password,
+        tcp_ao,
+        ttl_security,
+        families,
+        graceful_restart,
+        gr_restart_time,
+        gr_stale_routes_time,
+        llgr_stale_time,
+        gr_restart_eligible,
+        local_ipv6_nexthop,
+        route_reflector_client,
+        orr_vantage,
+        route_server_client,
+        per_client_best,
+        remove_private_as,
+        add_path_receive,
+        add_path_send,
+        add_path_send_max,
+        local_role,
+        strict_role,
+        prefix_orf_receive,
+        disable_ipv4_unicast,
+        import_policy: _import_policy, // NON-TRANSPORT: RIB-side policy chain.
+        export_policy: _export_policy, // NON-TRANSPORT: RIB-side policy chain.
+    } = &config;
+
+    let t = mgr.build_transport_config(&config);
+
+    assert_eq!(t.remote_addr.ip(), *address, "address");
+    assert_eq!(t.peer_interface, *interface, "interface");
+    assert_eq!(t.peer_scope_id, *scope_id, "scope_id");
+    assert_eq!(t.peer.remote_asn, *remote_asn, "remote_asn");
+    assert_eq!(t.peer_group, *peer_group, "peer_group");
+    assert_eq!(t.peer.hold_time, hold_time.unwrap(), "hold_time");
+    assert_eq!(
+        t.peer.send_hold_time,
+        send_hold_time.unwrap(),
+        "send_hold_time"
+    );
+    assert_eq!(t.max_prefixes, *max_prefixes, "max_prefixes");
+    assert_eq!(t.md5_password, *md5_password, "md5_password");
+    assert_eq!(t.tcp_ao, *tcp_ao, "tcp_ao");
+    assert_eq!(t.ttl_security, *ttl_security, "ttl_security");
+    assert_eq!(t.peer.families, *families, "families");
+    assert_eq!(
+        t.peer.graceful_restart, *graceful_restart,
+        "graceful_restart"
+    );
+    assert_eq!(t.peer.gr_restart_time, *gr_restart_time, "gr_restart_time");
+    assert_eq!(
+        t.gr_stale_routes_time, *gr_stale_routes_time,
+        "gr_stale_routes_time"
+    );
+    assert_eq!(t.llgr_stale_time, *llgr_stale_time, "llgr_stale_time");
+    // `gr_restart_eligible` only opens the restart window when the manager
+    // holds a live `local_gr_restart_until` deadline (none here), so it
+    // resolves to `None`. The window→Some path has its own dedicated test
+    // (`build_transport_config_sets_restart_window_for_eligible_static_peer`);
+    // here we just keep the field named/consumed and pin the disabled outcome.
+    assert!(!*gr_restart_eligible);
+    assert!(t.gr_restart_until.is_none(), "gr_restart_until");
+    assert_eq!(
+        t.local_ipv6_nexthop, *local_ipv6_nexthop,
+        "local_ipv6_nexthop"
+    );
+    assert_eq!(
+        t.route_reflector_client, *route_reflector_client,
+        "route_reflector_client"
+    );
+    assert_eq!(t.orr_vantage, *orr_vantage, "orr_vantage");
+    assert_eq!(
+        t.route_server_client, *route_server_client,
+        "route_server_client"
+    );
+    // The #702 field: this is the exact assertion the class of tests exists
+    // to make impossible to lose again.
+    assert_eq!(t.per_client_best, *per_client_best, "per_client_best");
+    assert_eq!(t.remove_private_as, *remove_private_as, "remove_private_as");
+    assert_eq!(
+        t.peer.add_path_receive, *add_path_receive,
+        "add_path_receive"
+    );
+    assert_eq!(t.peer.add_path_send, *add_path_send, "add_path_send");
+    assert_eq!(
+        t.peer.add_path_send_max, *add_path_send_max,
+        "add_path_send_max"
+    );
+    assert_eq!(t.peer.local_role, *local_role, "local_role");
+    assert_eq!(t.peer.strict_role, *strict_role, "strict_role");
+    assert_eq!(
+        t.peer.prefix_orf_receive, *prefix_orf_receive,
+        "prefix_orf_receive"
+    );
+    assert_eq!(
+        t.peer.disable_ipv4_unicast, *disable_ipv4_unicast,
+        "disable_ipv4_unicast"
+    );
+}
+
 #[tokio::test]
 async fn policy_events_publish_successful_policy_mutations() {
     use rustbgpd_api::peer_types::{NamedPolicyDefinition, PolicyStatementDefinition};

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -428,6 +428,24 @@ pub(crate) async fn apply_reload_outcome(
     {
         return Err("config_bridge");
     }
+
+    // Per-peer `log_level` is a LIVE field (reload matrix): re-apply the
+    // tracing filter so level edits take effect without a restart. This is
+    // the single choke point every successful reload flows through, so it
+    // catches a log_level change regardless of which diff bucket carried it.
+    // Directives come from the operator's on-disk `desired` config (the
+    // live intent for this live field); the telemetry layer rebuilds the
+    // full filter (RUST_LOG base + all per-peer directives), so the global
+    // base level always survives. Reapplying identical directives is a
+    // no-op; a malformed directive leaves the live filter untouched. A
+    // failure here is non-fatal — the config is already committed — so warn
+    // rather than unwind the reload.
+    if let Err(error) =
+        rustbgpd_telemetry::reload_per_peer_directives(&reloaded.desired.per_peer_log_directives())
+    {
+        warn!(error = %error, "failed to re-apply per-peer log_level filter on config reload");
+    }
+
     Ok(reloaded.runtime)
 }
 


### PR DESCRIPTION
Started as "make per-peer log_level live" (the docs claim it, the code didn't). Auditing the seam surfaced something worse.

## The latent bug (severity: boot crash)

`per_peer_log_directives` emitted `peer{peer_addr=X}=level` — **invalid `EnvFilter` syntax**; a span directive must be bracketed `[peer{peer_addr=X}]=level`. So `init_logging` `.parse()` returned `Err`, and `main.rs` did `process::exit(1)`. Net: **any neighbor or peer-group config that set `log_level` aborted daemon boot.** It shipped because no test ever parsed the directive end-to-end and no example/test config set a per-peer `log_level`. This is the inert-knob class at its worst — not silently ignored, silently *fatal*.

Fixed at source (`config/mod.rs`), guarded by a test that parses every emitted directive as a real `EnvFilter` directive.

## Making it actually live (the original ask)

- `init_logging` now installs the `EnvFilter` behind `tracing_subscriber`'s `.with_filter_reloading()`; the `reload::Handle` is captured (boxed, to avoid naming the formatter type) into a process-global `OnceLock` in the telemetry crate — matching the subscriber's own process-global scope, and avoiding threading a handle through every struct between init and the SIGHUP task.
- `apply_reload_outcome` (`reload.rs`, the single choke point every successful reload flows through) recomputes the per-peer directives after a validated reload commits and re-applies the **full** filter (RUST_LOG base + all directives, so the base level always survives). Non-fatal on error (config already committed → warn), idempotent, no-op on malformed input. Global base level stays startup-fixed.
- Behavior test: a `peer{peer_addr=X}` debug event is filtered at base `info` → enabled after reloading `[peer{...}]=debug` → disabled after reverting, with base `info` passing throughout.

## Guarding the whole class

- `build_transport_config_reflects_every_transport_field`: destructures `PeerManagerNeighborConfig` with **no `..`** (a new field breaks the build, forcing a transport-vs-excluded decision) *and* sets every transport field to a sentinel asserted against the result. Proven to catch a drop — temporarily removing the `per_client_best` copy (#702) failed it.
- The reload-matrix test now asserts the **class column** (`log_level` → live, `tcp_ao`/`bfd` → restart-required), so docs-vs-reality class drift fails CI.

Docs (reload-matrix, deployment) note the SIGHUP reload handle; CHANGELOG Fixed entries for both bugs. Gates: build/test (67 suites), clippy -D warnings, fmt, doc, clippy-reasons — green; rebased over #706.