### PR TITLE
fix: BMP peer-state lifecycle across TCP flap (LAN-200, LAN-201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,6 +776,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **BMP peer-state lifecycle no longer emits spurious or mis-ordered
+  events across a TCP flap (LAN-200).** Two gaps closed. (1) A pending
+  BMP divergence repair (the synthetic RFC 7854 PeerDown/PeerUp forced
+  after a RouteMonitoring drop) is now abandoned when the TCP session
+  tears down: `close_tcp` / `handle_tcp_disconnect` clear the divergence
+  latch and disarm the `bmp_repair_timer`, so the run loop's repair arm
+  can no longer fire a synthetic PeerDown/PeerUp for a dead session that
+  a reconnect would then stack a real PeerUp on top of. (2) A live
+  Loc-RIB PeerUp (RFC 9069) dropped on a full collector channel at
+  connect now suppresses that collector's subsequent live Loc-RIB Route
+  Monitoring until a later reconnect lands the PeerUp — a collector can
+  no longer see Loc-RIB RM with no preceding Loc-RIB PeerUp. The
+  connect-time Loc-RIB dump path was already safe (it skips the dump on
+  a dropped PeerUp).
 - **The library target now builds under `--all-features` (LAN-198).**
   The lib exposes `pub mod config` only under `bench-internals`, and
   `config`'s reload-diff logic (`classify_evpn_runtime_change`) reaches

--- a/crates/bmp/src/manager.rs
+++ b/crates/bmp/src/manager.rs
@@ -49,6 +49,12 @@ pub struct BmpManager {
     /// Loc-RIB table-dump request channel toward the RIB manager, used
     /// on collector (re)connect to synthesize the initial table sync.
     dump_tx: Option<mpsc::Sender<BmpDumpRequest>>,
+    /// Collector indices whose most recent connect-time Loc-RIB `PeerUp`
+    /// was dropped on a full channel (LAN-200). Live Loc-RIB Route
+    /// Monitoring is suppressed for these collectors so none ever sees an
+    /// RFC 9069 RM without a preceding Loc-RIB `PeerUp`. Cleared when a
+    /// later reconnect's [`Self::start_loc_rib_sync`] lands the `PeerUp`.
+    loc_rib_suppressed: std::collections::HashSet<usize>,
     metrics: BgpMetrics,
 }
 
@@ -73,6 +79,7 @@ impl BmpManager {
             peer_up_cache: std::collections::HashMap::new(),
             loc_rib: None,
             dump_tx: None,
+            loc_rib_suppressed: std::collections::HashSet::new(),
             metrics,
         }
     }
@@ -202,7 +209,10 @@ impl BmpManager {
         }
         let now = std::time::SystemTime::now();
         self.fan_out_filtered(
-            |f| f.loc_rib,
+            // Suppress live RM for any collector whose connect-time
+            // Loc-RIB PeerUp was dropped (LAN-200) — RFC 9069 RM must
+            // never precede the Loc-RIB PeerUp on the wire.
+            |idx, f| f.loc_rib && !self.loc_rib_suppressed.contains(&idx),
             |version| match event {
                 BmpEvent::LocRibRouteMonitoring {
                     update_pdu,
@@ -267,7 +277,7 @@ impl BmpManager {
             BmpEvent::RouteMonitoring { peer_info, .. } => {
                 let rib_out = peer_info.is_rib_out;
                 self.fan_out_filtered(
-                    |f| {
+                    |_, f| {
                         if rib_out {
                             f.rib_out_post
                         } else {
@@ -318,7 +328,7 @@ impl BmpManager {
                 if let Some(ref cfg) = self.loc_rib {
                     let now = std::time::SystemTime::now();
                     self.fan_out_filtered(
-                        |f| f.loc_rib,
+                        |_, f| f.loc_rib,
                         |version| codec::encode_loc_rib_peer_down(cfg, now, version),
                     );
                 }
@@ -375,7 +385,7 @@ impl BmpManager {
     /// blocks on a slow collector; live Loc-RIB events keep fanning out
     /// concurrently and may overlap the dump (the standard BMP
     /// dump-vs-live race — collectors reconcile by prefix).
-    fn start_loc_rib_sync(&self, collector_id: usize) {
+    fn start_loc_rib_sync(&mut self, collector_id: usize) {
         let Some(ref cfg) = self.loc_rib else {
             return;
         };
@@ -388,24 +398,34 @@ impl BmpManager {
 
         let addr_label = addr.to_string();
         let version = *version;
-        let peer_up = codec::encode_loc_rib_peer_up(cfg, std::time::SystemTime::now(), version);
+        // Clone out of `self` up front so the mutable `loc_rib_suppressed`
+        // bookkeeping below doesn't collide with the collector/config
+        // borrows.
+        let cfg = cfg.clone();
+        let collector_tx = collector_tx.clone();
+        let peer_up = codec::encode_loc_rib_peer_up(&cfg, std::time::SystemTime::now(), version);
         if let Err(e) = collector_tx.try_send(peer_up) {
             let reason = trysend_reason(&e);
             self.metrics
                 .record_bmp_collector_drop(&addr_label, "loc_rib_dump", reason, 1);
             warn!(
-                collector = %addr,
+                collector = %addr_label,
                 error = %e,
-                "BMP collector channel full or closed for Loc-RIB PeerUp; skipping dump"
+                "BMP collector channel full or closed for Loc-RIB PeerUp; skipping dump \
+                 and suppressing live Loc-RIB RM until reconnect"
             );
+            // A dropped PeerUp must not be followed by live RM (LAN-200):
+            // gate live Loc-RIB fan-out for this collector until a later
+            // reconnect lands the PeerUp.
+            self.loc_rib_suppressed.insert(collector_id);
             return;
         }
+        // PeerUp is on the wire ahead of any RM — live fan-out may resume.
+        self.loc_rib_suppressed.remove(&collector_id);
 
         let Some(ref dump_tx) = self.dump_tx else {
             return;
         };
-        let cfg = cfg.clone();
-        let collector_tx = collector_tx.clone();
         let metrics = self.metrics.clone();
         tokio::spawn(forward_loc_rib_dump(
             dump_tx.clone(),
@@ -418,19 +438,20 @@ impl BmpManager {
     }
 
     fn fan_out(&self, encode: impl Fn(BmpVersion) -> Bytes) {
-        self.fan_out_filtered(|_| true, encode);
+        self.fan_out_filtered(|_, _| true, encode);
     }
 
-    /// Fan out one event, framing per collector version. `encode` is
-    /// called at most once per BMP version in use (two-slot memo).
+    /// Fan out one event, framing per collector version. `want` receives
+    /// the collector index and filter; `encode` is called at most once
+    /// per BMP version in use (two-slot memo).
     fn fan_out_filtered(
         &self,
-        want: impl Fn(&BmpMonitorFilter) -> bool,
+        want: impl Fn(usize, &BmpMonitorFilter) -> bool,
         encode: impl Fn(BmpVersion) -> Bytes,
     ) {
         let mut memo: [Option<Bytes>; 2] = [None, None];
-        for (addr, tx, filter, version) in &self.collectors {
-            if !want(filter) {
+        for (idx, (addr, tx, filter, version)) in self.collectors.iter().enumerate() {
+            if !want(idx, filter) {
                 continue;
             }
             let msg = memo[version.idx()]
@@ -1629,6 +1650,71 @@ mod tests {
         drop(event_tx);
         drop(control_tx);
         handle.await.unwrap();
+    }
+
+    /// LAN-200: a Loc-RIB `PeerUp` dropped on a full channel at connect
+    /// suppresses subsequent live Loc-RIB Route Monitoring for that
+    /// collector, so it never sees an RFC 9069 RM without a preceding
+    /// Loc-RIB `PeerUp`. A later reconnect (channel drained) heals it.
+    #[tokio::test]
+    async fn dropped_loc_rib_peer_up_suppresses_live_route_monitoring() {
+        let (_event_tx, event_rx) = mpsc::channel(16);
+        let (_control_tx, control_rx) = mpsc::channel(16);
+        // Capacity-1 collector channel so a single backlog message fills
+        // it and the connect-time Loc-RIB PeerUp cannot enqueue.
+        let (c_tx, mut c_rx) = mpsc::channel(1);
+        let (dump_tx, _dump_rx) = mpsc::channel(4);
+
+        let mut mgr = BmpManager::new(
+            event_rx,
+            control_rx,
+            vec![(
+                collector_addr(0),
+                c_tx.clone(),
+                loc_rib_filter(),
+                BmpVersion::V3,
+            )],
+            BgpMetrics::new(),
+        )
+        .with_loc_rib(loc_rib_config(), dump_tx);
+
+        let live_rm = BmpEvent::LocRibRouteMonitoring {
+            update_pdu: Bytes::from_static(&[0xCC; 23]),
+            timestamp: UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            path_status: None,
+        };
+
+        // Saturate the channel, then connect: the PeerUp try_send hits
+        // Full and is dropped → this collector is suppressed.
+        c_tx.try_send(Bytes::from_static(b"backlog")).unwrap();
+        mgr.handle_control(BmpControlEvent::CollectorConnected {
+            collector_id: 0,
+            collector_addr: collector_addr(0),
+        });
+        mgr.handle_event(&live_rm);
+
+        // Only the pre-existing backlog is queued — no PeerUp, no RM.
+        assert_eq!(c_rx.try_recv().unwrap(), Bytes::from_static(b"backlog"));
+        assert!(
+            c_rx.try_recv().is_err(),
+            "suppressed: no live Loc-RIB RM without a preceding PeerUp"
+        );
+
+        // Reconnect with the channel drained heals it: PeerUp lands, then
+        // live RM flows again.
+        mgr.handle_control(BmpControlEvent::CollectorConnected {
+            collector_id: 0,
+            collector_addr: collector_addr(0),
+        });
+        let peer_up = c_rx.try_recv().unwrap();
+        assert_eq!(
+            peer_up[6], 3,
+            "Loc-RIB PeerUp (peer type 3) delivered on reconnect"
+        );
+        mgr.handle_event(&live_rm);
+        let rm = c_rx.try_recv().unwrap();
+        assert_eq!(rm[5], 0, "route monitoring type");
+        assert_eq!(rm[6], 3, "live Loc-RIB RM resumes after the PeerUp");
     }
 
     /// Shutdown sends the Loc-RIB Peer Down (reason 6 + table-name TLV)

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -300,6 +300,7 @@ impl PeerSession {
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
         self.read_buf.clear();
+        self.clear_bmp_stream_repair();
     }
 
     /// Clear TCP state after disconnect or error. Same writer-channel
@@ -314,6 +315,19 @@ impl PeerSession {
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
         self.read_buf.clear();
+        self.clear_bmp_stream_repair();
+    }
+
+    /// Abandon any pending BMP divergence repair (LAN-200). Once the TCP
+    /// session is gone the repair is meaningless: the reconnect re-floods
+    /// both views and the FSM's `SessionDown` emits the collector-visible
+    /// `PeerDown`. Clearing the latch and disarming its retry timer here
+    /// keeps the run loop's `bmp_repair_timer` arm from firing a spurious
+    /// synthetic `PeerDown`/`PeerUp` for a dead session (which a reconnect
+    /// would then stack a real `PeerUp` on top of).
+    fn clear_bmp_stream_repair(&mut self) {
+        self.bmp_stream_diverged = false;
+        self.bmp_repair_timer = None;
     }
 
     /// Drain complete messages from the read buffer and feed to FSM.

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -925,6 +925,112 @@ async fn bmp_peer_down_survives_full_channel() {
         "PeerDown must be delivered even when the channel was full"
     );
 }
+/// LAN-200: a TCP disconnect abandons any pending BMP divergence repair.
+/// Otherwise the run loop's `bmp_repair_timer` arm could fire after the
+/// socket died and emit a synthetic `PeerDown`/`PeerUp` for a dead session
+/// — which the reconnect would then stack a real `PeerUp` on top of.
+#[tokio::test]
+async fn tcp_disconnect_clears_bmp_repair_latch() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    // Latch divergence + arm the repair timer via a dropped RM on a full
+    // channel.
+    let tx = session.bmp_tx.clone().unwrap();
+    for _ in 0..16 {
+        tx.try_send(BmpEvent::StatsReport {
+            peer_info: session.build_bmp_peer_info(),
+            adj_rib_in_routes: 0,
+            adj_rib_out_post: None,
+        })
+        .unwrap();
+    }
+    session.emit_bmp_event(BmpEvent::RouteMonitoring {
+        peer_info: session.build_bmp_peer_info(),
+        update_pdu: Bytes::from_static(&[0xde, 0xad]),
+    });
+    assert!(session.bmp_stream_diverged);
+    assert!(session.bmp_repair_timer.is_some());
+    // Drain so a stray repair *could* succeed if it fired.
+    for _ in 0..16 {
+        bmp_rx.try_recv().unwrap();
+    }
+    // TCP disconnect must abandon the repair outright.
+    session.handle_tcp_disconnect();
+    assert!(
+        !session.bmp_stream_diverged,
+        "disconnect clears the divergence latch"
+    );
+    assert!(
+        session.bmp_repair_timer.is_none(),
+        "disconnect disarms the repair timer"
+    );
+    // A late repair-timer fire on the dead session must emit nothing.
+    session.retry_bmp_stream_repair();
+    assert!(
+        bmp_rx.try_recv().is_err(),
+        "no synthetic PeerDown/PeerUp for a dead session"
+    );
+}
+/// LAN-201: a partial repair attempt — `PeerDown` enqueued, `PeerUp` hits
+/// a full channel — leaves the latch set and retries. The collector-visible
+/// sequence carries a duplicate `PeerDown`, which is acceptable: RFC 7854
+/// `PeerDown` is idempotent (the collector has already discarded peer state
+/// from the first one), and the pair still ends in exactly one `PeerUp`.
+#[tokio::test]
+async fn repair_partial_enqueue_duplicate_peer_down_is_acceptable() {
+    let (mut session, _rib_rx, mut bmp_rx) = make_test_session_with_rib_and_bmp(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    let tx = session.bmp_tx.clone().unwrap();
+    // Leave exactly one free slot in the 16-deep channel: PeerDown will
+    // enqueue, the following PeerUp hits Full.
+    for _ in 0..15 {
+        tx.try_send(BmpEvent::StatsReport {
+            peer_info: session.build_bmp_peer_info(),
+            adj_rib_in_routes: 0,
+            adj_rib_out_post: None,
+        })
+        .unwrap();
+    }
+    session.bmp_stream_diverged = true;
+    // Partial attempt: PeerDown enqueues, PeerUp returns Full → incomplete.
+    assert!(
+        !session.repair_bmp_stream(&tx),
+        "PeerUp Full leaves the repair incomplete"
+    );
+    assert!(
+        session.bmp_stream_diverged,
+        "latch stays set after a partial attempt"
+    );
+    // Drain the 15 fillers; the 16th queued item is the partial PeerDown.
+    for _ in 0..15 {
+        assert!(matches!(
+            bmp_rx.try_recv().unwrap(),
+            BmpEvent::StatsReport { .. }
+        ));
+    }
+    assert!(
+        matches!(bmp_rx.try_recv().unwrap(), BmpEvent::PeerDown { .. }),
+        "partial attempt enqueued a PeerDown"
+    );
+    // Channel now empty → the retry completes the reset: PeerDown, PeerUp.
+    assert!(
+        session.repair_bmp_stream(&tx),
+        "retry completes once the channel drains"
+    );
+    assert!(!session.bmp_stream_diverged);
+    assert!(matches!(
+        bmp_rx.try_recv().unwrap(),
+        BmpEvent::PeerDown { .. }
+    ));
+    assert!(matches!(
+        bmp_rx.try_recv().unwrap(),
+        BmpEvent::PeerUp { .. }
+    ));
+    assert!(
+        bmp_rx.try_recv().is_err(),
+        "the completed reset ends in exactly one PeerUp"
+    );
+}
 #[test]
 fn ebgp_prepends_asn() {
     let session = make_test_session(65001, 65002);


### PR DESCRIPTION
## Issues

- **LAN-200 (P1)** — BMP repair timer survives TCP disconnect → spurious PeerDown/PeerUp; plus a live Loc-RIB `PeerUp` dropped on a saturated collector channel could be followed by live Loc-RIB Route Monitoring with no preceding `PeerUp`.
- **LAN-201 (P2)** — `repair_bmp_stream` sends PeerDown/PeerUp non-atomically; the harm is by-design harmless (RFC 7854 PeerDown is idempotent), so the deliverable is a regression test locking the acceptable sequence.

## Approach

**LAN-200 (transport, `session/io.rs`).** `close_tcp` / `handle_tcp_disconnect` now clear the `bmp_stream_diverged` latch and disarm `bmp_repair_timer` via a small `clear_bmp_stream_repair` helper. Teardown is now authoritative over the repair machinery: because `handle_tcp_disconnect` runs before `drive_fsm(TcpConnectionFails)` in every disconnect arm, the run loop's `bmp_repair_timer` arm can no longer fire a synthetic PeerDown/PeerUp for a dead session (which a reconnect would then stack a real `PeerUp` on top of). The legitimate collector-visible `PeerDown` still comes from the FSM `SessionDown` action, unchanged.

**LAN-200 (bmp, `manager.rs`).** The only per-collector Loc-RIB `PeerUp` is the connect-time `try_send` in `start_loc_rib_sync`; on a full channel it skips the dump (already safe) but the collector stayed registered, so live Loc-RIB RM via `handle_loc_rib_event` still reached it. Added a `loc_rib_suppressed` set: `start_loc_rib_sync` inserts on a dropped `PeerUp` and removes on a delivered one; live Loc-RIB RM fan-out now excludes suppressed collectors (`fan_out_filtered` gained the collector index). Self-heals on the next reconnect whose `PeerUp` lands. The connect-time dump path is untouched.

**LAN-201 (transport).** No code change — the duplicate `PeerDown` on a partial retry is documented harmless. Added a regression test locking the acceptable collector-visible sequence.

## Tests

- `tcp_disconnect_clears_bmp_repair_latch` — after `handle_tcp_disconnect`, latch cleared, timer disarmed, and a stray `retry_bmp_stream_repair` emits nothing.
- `repair_partial_enqueue_duplicate_peer_down_is_acceptable` — PeerDown enqueued, PeerUp Full → retry; asserts the collector-visible sequence (duplicate PeerDown, ending in exactly one PeerUp).
- `dropped_loc_rib_peer_up_suppresses_live_route_monitoring` — dropped connect-time Loc-RIB PeerUp suppresses subsequent live RM; reconnect heals it.

## Gate exit codes (all 0)

| Gate | Exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |
