### PR TITLE
fix(evpn): enforce validate_only rejection + shape-gate/converge mirror (LAN-214, LAN-203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,6 +776,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`ApplyEvpnRuntime` with `validate_only` now rejects what a real apply
+  would reject (LAN-214 #9).** The dry-run path returned
+  `EvpnRuntimeApplyValidated` immediately after the (pure, rejection-free)
+  `plan_candidate`, so an operator could "validate" a candidate that a
+  real apply then fails closed (e.g. an IP-VRF L3VNI identity redefine, or
+  an undecomposable mixed candidate). Validate-only now runs the same
+  shape acceptance the commit path uses — `validate_supported_plan_shape`
+  plus, for unsupported-but-mixed candidates, the #268 decomposition —
+  without committing or touching any actor, returning the planned step
+  descriptions on success and the real shape rejection on failure.
+- **The EVPN runtime shape gate and converge dispatch are now proven to
+  classify plan shapes identically (LAN-214 #8).**
+  `validate_supported_plan_shape` mirrors `EvpnRuntimeActorConverger::converge`'s
+  if/else routing by hand, previously guarded only by a "keep in sync"
+  comment. Regression tests now drive a representative set of shapes
+  through both routers and assert identical classification — byte-identical
+  rejection messages for unsupported shapes (every `converge_*` runs its
+  `validate_single_*` before any actor, so the comparison is side-effect
+  free) and gate-acceptance of every shape the dispatch commits.
 - **The library target now builds under `--all-features` (LAN-198).**
   The lib exposes `pub mod config` only under `bench-internals`, and
   `config`'s reload-diff logic (`classify_evpn_runtime_change`) reaches

--- a/src/evpn_plan_decomposer.rs
+++ b/src/evpn_plan_decomposer.rs
@@ -532,6 +532,72 @@ local_vtep_ip = "10.0.0.1"
     }
 
     #[test]
+    fn redefined_l2vni_non_identity_change_collapses_to_redefine_not_delete_plus_add() {
+        // LAN-203: the plan diff (`diff_keyed_maps`) partitions every VNI
+        // into exactly one of {deleted, redefined, added} — a VNI can never
+        // land in both `deleted` and `added`. A same-VNI "delete + re-add"
+        // is therefore structurally a *redefine*, so no "reject if in both
+        // lists" guard is reachable. An L2VNI has no restart-required
+        // identity field (unlike an IP-VRF's L3VNI/device/table), so even a
+        // change to its most device-like attribute (`local_vtep_ip`) is a
+        // live redefine — it must decompose to a supported redefine step,
+        // not fail closed.
+        let current = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.1"
+
+[[ethernet_segments]]
+esi = "00:00:00:00:00:00:00:00:00:01"
+member_vnis = [100]
+originator_ip = "10.0.0.1"
+"#,
+        );
+        // Redefine VNI 100's local_vtep_ip AND delete its Ethernet Segment
+        // (cross-domain mix, so the candidate is not a supported primitive
+        // and must decompose).
+        let candidate = with_header(
+            r#"
+[[evpn_instances]]
+vni = 100
+rd = "65000:100"
+route_targets = ["65000:100"]
+local_vtep_ip = "10.0.0.2"
+"#,
+        );
+
+        let current_model = model_from_toml(&current);
+        let candidate_model = candidate_from_toml(&candidate);
+        let plan = current_model.plan_candidate(&candidate_model);
+        // The crux of LAN-203: VNI 100 is redefined, never simultaneously
+        // deleted and added.
+        assert_eq!(plan.evpn_instances.redefined, vec![100]);
+        assert!(!plan.evpn_instances.deleted.contains(&100));
+        assert!(!plan.evpn_instances.added.contains(&100));
+
+        let steps = decompose_evpn_runtime_candidate(&current_model, &candidate_model, &plan)
+            .expect("non-identity L2VNI redefine must decompose, not fail closed");
+        let redefine = steps
+            .iter()
+            .find(|step| step.description.starts_with("L2VNI redefine"))
+            .expect("a supported L2VNI redefine step is expected");
+        assert_eq!(
+            redefine
+                .candidate
+                .instances()
+                .get(vni(100))
+                .unwrap()
+                .local_vtep_ip
+                .to_string(),
+            "10.0.0.2",
+            "the redefine step must carry the changed non-identity attribute"
+        );
+    }
+
+    #[test]
     fn supported_single_shape_is_already_primitive() {
         let current = with_header("");
         let candidate = with_header(

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -2087,7 +2087,9 @@ fn redefine_imet_failure(
 /// #268 plan decomposer (`crate::evpn_plan_decomposer`) to prove — up
 /// front, before any step commits — that every decomposed step is an
 /// already-supported primitive shape, and to recognize a plan that is
-/// already primitive. Keep the routing here and in `converge` in sync.
+/// already primitive. Keep the routing here and in `converge` in sync —
+/// `shape_gate_and_converge_reject_unsupported_shapes_identically` and
+/// `shape_gate_accepts_every_supported_converge_shape` enforce it.
 ///
 /// # Errors
 /// The routed validator's error when the plan is not a supported shape.
@@ -2169,7 +2171,9 @@ impl DaemonEvpnRuntimeConverger for EvpnRuntimeActorConverger {
         Box::pin(async move {
             // NOTE: `validate_supported_plan_shape` above mirrors this
             // dispatch for the #268 plan decomposer — keep the routing in
-            // sync when adding or reshaping converge paths.
+            // sync when adding or reshaping converge paths. The
+            // `shape_gate_*` tests assert both routers classify shapes
+            // identically.
             // Atomic tenant teardown (delete-only multi-element / cross-resource)
             // is routed first; single-element deletes fall through to the
             // single-shape converters below.
@@ -3491,6 +3495,10 @@ where
     apply_evpn_runtime_candidate_locked(candidate, validate_only, coordinator, converger).await
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "the plan/validate-only/converge/decompose/commit sequence reads clearest as one flow"
+)]
 async fn apply_evpn_runtime_candidate_locked<C>(
     candidate: rustbgpd_evpn::EvpnRuntimeCandidate,
     validate_only: bool,
@@ -3516,11 +3524,61 @@ where
     };
 
     if validate_only {
+        // LAN-214 #9: a dry-run must reject exactly what a real apply would
+        // reject. Re-run the same shape acceptance the commit path uses —
+        // supported primitive shape, or a #268 decomposition into supported
+        // steps — WITHOUT committing or touching any actor. (`converge` is
+        // skipped on purpose: it has actor side effects, and its only shape
+        // decision mirrors `validate_supported_plan_shape`.)
+        let message = if plan.is_noop() {
+            "candidate EVPN runtime model validated (no-op: matches the committed generation); \
+             generation not advanced"
+                .to_string()
+        } else {
+            match validate_supported_plan_shape(&current, &candidate, &plan) {
+                Ok(()) => "candidate EVPN runtime model validated as a supported primitive shape; \
+                           generation not advanced"
+                    .to_string(),
+                Err(shape_error) => {
+                    match crate::evpn_plan_decomposer::decompose_evpn_runtime_candidate(
+                        &current, &candidate, &plan,
+                    ) {
+                        Ok(steps) => format!(
+                            "candidate EVPN runtime model validated; a real apply would decompose \
+                             it into {} supported steps ({}); generation not advanced",
+                            steps.len(),
+                            steps
+                                .iter()
+                                .map(|step| step.description.clone())
+                                .collect::<Vec<_>>()
+                                .join("; ")
+                        ),
+                        // Primitive but unsupported: surface the same shape
+                        // rejection the commit path would return.
+                        Err(crate::evpn_plan_decomposer::EvpnDecomposeError::AlreadyPrimitive) => {
+                            return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                                "EVPN runtime candidate rejected: {}; generation {} remains committed",
+                                shape_error.message(),
+                                snapshot.generation.as_u64()
+                            )));
+                        }
+                        Err(crate::evpn_plan_decomposer::EvpnDecomposeError::Unsupported(
+                            reason,
+                        )) => {
+                            return Err(GrpcEvpnRuntimeApplyError::FailedPrecondition(format!(
+                                "EVPN runtime candidate rejected: {reason}; generation {} remains committed",
+                                snapshot.generation.as_u64()
+                            )));
+                        }
+                    }
+                }
+            }
+        };
         return Ok(proto::ApplyEvpnRuntimeResponse {
             outcome: proto::EvpnRuntimeApplyOutcome::EvpnRuntimeApplyValidated as i32,
             runtime: Some(runtime_snapshot_to_proto(&snapshot)),
             plan: Some(runtime_plan_to_proto(&plan)),
-            message: "candidate EVPN runtime model validated; generation not advanced".to_string(),
+            message,
         });
     }
 
@@ -5130,6 +5188,15 @@ table_id = 6000
         evpn_runtime_candidate_from_toml(toml).unwrap()
     }
 
+    fn runtime_model_from_toml(toml: &str) -> rustbgpd_evpn::EvpnRuntimeModel {
+        let candidate = runtime_candidate_from_toml(toml);
+        rustbgpd_evpn::EvpnRuntimeModel::startup(
+            candidate.instances().clone(),
+            candidate.ip_vrfs().clone(),
+            candidate.ethernet_segments().to_vec(),
+        )
+    }
+
     fn runtime_converger_rib_responder(
         mut rib_rx: mpsc::Receiver<RibUpdate>,
         injects: Arc<tokio::sync::Mutex<Vec<rustbgpd_wire::EvpnRouteKey>>>,
@@ -5282,6 +5349,162 @@ table_id = 6000
         assert_eq!(plan.evpn_instances.unwrap().added, vec!["100"]);
         assert_eq!(response.runtime.unwrap().generation, 1);
         assert_eq!(coordinator.lock().unwrap().model().generation().as_u64(), 1);
+    }
+
+    #[tokio::test]
+    async fn apply_evpn_runtime_validate_only_rejects_unsupported_shape() {
+        // LAN-214 #9: a dry-run must reject what a real apply rejects. An
+        // IP-VRF L3VNI (identity) redefine is restart-required by design; a
+        // real apply fails it closed, so validate_only must too — not return
+        // "validated". The converger is scripted to fail if converge is ever
+        // called, proving the dry-run stays side-effect free.
+        let current = runtime_candidate_from_toml(ip_vrf_runtime_candidate_toml());
+        let coordinator = Arc::new(Mutex::new(rustbgpd_evpn::EvpnRuntimeCoordinator::new(
+            current.instances().clone(),
+            current.ip_vrfs().clone(),
+            current.ethernet_segments().to_vec(),
+        )));
+        let apply_lock = tokio::sync::Mutex::new(());
+        let converger = TestRuntimeConverger::failed("validate_only must not converge");
+
+        let error = apply_evpn_runtime_request(
+            &proto::ApplyEvpnRuntimeRequest {
+                candidate_toml: ip_vrf_redefined_l3vni_runtime_candidate_toml().to_string(),
+                validate_only: true,
+            },
+            coordinator.as_ref(),
+            &apply_lock,
+            &converger,
+        )
+        .await
+        .unwrap_err();
+
+        let GrpcEvpnRuntimeApplyError::FailedPrecondition(message) = error else {
+            panic!("expected FailedPrecondition, got: {error:?}");
+        };
+        assert!(
+            message.contains("rejected"),
+            "dry-run must reject, not validate: {message}"
+        );
+        assert!(
+            message.contains("restart-required by design"),
+            "must carry the real shape rejection: {message}"
+        );
+
+        let guard = coordinator.lock().unwrap();
+        assert_eq!(
+            guard.model().generation().as_u64(),
+            1,
+            "a rejected dry-run must not advance the generation"
+        );
+        assert_eq!(
+            guard.model().mutation_state(),
+            rustbgpd_evpn::EvpnRuntimeMutationState::Idle,
+            "a rejected dry-run must not pin/degrade the runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn shape_gate_and_converge_reject_unsupported_shapes_identically() {
+        // LAN-214 #8: `validate_supported_plan_shape` re-implements the
+        // converge dispatch's if/else routing. If the two ladders drift, a
+        // shape one routes to a supported branch the other rejects. Every
+        // `converge_*` method runs its `validate_single_*` before touching
+        // any actor, so an all-None converger reaches the exact same shape
+        // rejection the gate does. Asserting the messages are byte-identical
+        // enforces that both routers classify each shape the same way.
+        let (rib_tx, _rib_rx) = mpsc::channel::<RibUpdate>(8);
+        let converger = EvpnRuntimeActorConverger {
+            rib_tx,
+            imet_controller: Arc::new(
+                tokio::sync::Mutex::new(evpn_imet::EvpnImetController::new()),
+            ),
+            dataplane: None,
+            originator: None,
+            svi: None,
+            l3_originator: None,
+            segment: None,
+            es_drain: crate::evpn_es_drain::EvpnEsDrainState::default(),
+        };
+
+        // L2VNI add mixed with an IP-VRF identity redefine: undecomposable,
+        // routes to the L2VNI-add branch which rejects the IP-VRF change.
+        let mut mixed_candidate = ip_vrf_redefined_l3vni_runtime_candidate_toml().to_string();
+        mixed_candidate.push_str(
+            r#"
+[[evpn_instances]]
+vni = 300
+rd = "65000:300"
+route_targets = ["65000:300"]
+local_vtep_ip = "10.0.0.1"
+"#,
+        );
+
+        let cases: Vec<(
+            &str,
+            rustbgpd_evpn::EvpnRuntimeModel,
+            rustbgpd_evpn::EvpnRuntimeCandidate,
+        )> = vec![
+            (
+                "ip_vrf identity (L3VNI) redefine",
+                runtime_model_from_toml(ip_vrf_runtime_candidate_toml()),
+                runtime_candidate_from_toml(ip_vrf_redefined_l3vni_runtime_candidate_toml()),
+            ),
+            (
+                "l2vni add mixed with ip_vrf identity redefine",
+                runtime_model_from_toml(ip_vrf_runtime_candidate_toml()),
+                runtime_candidate_from_toml(&mixed_candidate),
+            ),
+        ];
+
+        for (name, current, candidate) in &cases {
+            let plan = current.plan_candidate(candidate);
+            let gate_error = validate_supported_plan_shape(current, candidate, &plan)
+                .expect_err(&format!("{name}: shape gate must reject"));
+            let converge_error = converger
+                .converge(current, candidate, &plan)
+                .await
+                .expect_err(&format!("{name}: converge dispatch must reject"));
+            assert_eq!(
+                gate_error.message(),
+                converge_error.message(),
+                "{name}: shape gate and converge dispatch must route to the identical rejection"
+            );
+        }
+    }
+
+    #[test]
+    fn shape_gate_accepts_every_supported_converge_shape() {
+        // LAN-214 #8 (accept side): the shape gate must accept exactly the
+        // shapes the converge dispatch commits. Each shape below has a
+        // dedicated committing test through the real converger (e.g.
+        // `apply_evpn_runtime_ethernet_segment_add_commits_after_convergence`);
+        // this asserts the gate agrees they are supported.
+        let cases: [(&str, rustbgpd_evpn::EvpnRuntimeModel, &str); 3] = [
+            (
+                "single L2VNI add",
+                runtime_model_from_toml(minimal_runtime_candidate_toml()),
+                l2vni_runtime_candidate_toml(),
+            ),
+            (
+                "single IP-VRF add",
+                runtime_model_from_toml(minimal_runtime_candidate_toml()),
+                ip_vrf_runtime_candidate_toml(),
+            ),
+            (
+                "Ethernet Segment add",
+                runtime_model_from_toml(two_l2vni_one_es_runtime_candidate_toml()),
+                two_l2vni_two_es_runtime_candidate_toml(),
+            ),
+        ];
+        for (name, current, candidate_toml) in &cases {
+            let candidate = runtime_candidate_from_toml(candidate_toml);
+            let plan = current.plan_candidate(&candidate);
+            assert!(
+                validate_supported_plan_shape(current, &candidate, &plan).is_ok(),
+                "{name}: shape gate must accept a shape the converge dispatch commits"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Issues

- **LAN-214 #9** — `validate_only` skipped validation.
- **LAN-214 #8** — the EVPN shape gate / converge routing mirror was unenforced.
- **LAN-203** — investigate the alleged missing "VNI in both deleted+added" guard.

## Approach

### LAN-214 #9 (fixed)
`apply_evpn_runtime_candidate_locked` returned `EvpnRuntimeApplyValidated`
immediately after the pure, rejection-free `plan_candidate`, so a dry-run
could "validate" a candidate a real apply then fails closed (e.g. an IP-VRF
L3VNI identity redefine, or an undecomposable mixed candidate). The
validate-only branch now runs the same shape acceptance the commit path uses
— `validate_supported_plan_shape` plus, for unsupported-but-mixed candidates,
the #268 `decompose_evpn_runtime_candidate` — **without committing or touching
any actor**. It returns the planned step descriptions on success and the real
shape rejection (`FailedPrecondition`) on failure. Regression test:
`apply_evpn_runtime_validate_only_rejects_unsupported_shape` (converger scripted
to panic if converge is ever called, proving the dry-run stays side-effect free).

### LAN-214 #8 (enforced by test)
`validate_supported_plan_shape` mirrors `EvpnRuntimeActorConverger::converge`'s
if/else routing by hand, previously guarded only by a "keep in sync" comment.
Two regression tests now drive a representative set of shapes through **both**
routers and assert identical classification:
- `shape_gate_and_converge_reject_unsupported_shapes_identically` — for each
  unsupported shape, both routers must emit the **byte-identical** rejection
  message. This is side-effect free because every `converge_*` method runs its
  `validate_single_*` before any actor interaction, so an all-`None` converger
  reaches the exact same rejection the gate does.
- `shape_gate_accepts_every_supported_converge_shape` — the gate accepts each
  shape the dispatch commits (converge-side acceptance is already proven by the
  existing committing tests).

### LAN-203 (documented — no guard change; concern is subsumed)
Investigated: the plan diff (`diff_keyed_maps`) partitions every VNI into
exactly one of {deleted, redefined, added}, so a VNI can **never** be in both
`deleted` and `added` — a blanket "reject if in both lists" guard would be dead
code. A same-VNI delete+re-add is structurally a *redefine*. The only possible
residual — a non-identity attribute change on a redefined VNI — is handled
correctly: an L2VNI has no restart-required identity field (unlike an IP-VRF's
L3VNI/device/table), so even a change to its most device-like attribute
(`local_vtep_ip`) decomposes into a supported live L2VNI-redefine step, not a
fail-closed case. Documented by
`redefined_l2vni_non_identity_change_collapses_to_redefine_not_delete_plus_add`;
no guard added (redefine routing already subsumes the reported concern).

## Scope

Touches only `src/evpn_runtime_converger.rs`, `src/evpn_plan_decomposer.rs`,
and `CHANGELOG.md`.

## Gate exit codes (all run to completion locally)

| Gate | exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test --bin rustbgpd` | 0 (1296 passed) |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |