### PR TITLE
docs: fix verified doc drift (LAN-111/136/195/213)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,10 +19,10 @@ telemetry      (no internal deps)
 event-history  ──► telemetry
 evpn           ──► wire
 evpn-linux     ──► evpn
-rib            ──► wire, policy, telemetry, rpki
+rib            ──► wire, policy, telemetry, rpki, bmp
 transport      ──► wire, fsm, rib, policy, rpki, telemetry, bmp
 api            ──► wire, fsm, rib, policy, transport, telemetry, evpn, event-history
-cli            ──► wire        (dev tests also use api, evpn)
+cli            ──► wire, policy    (dev tests also use api, evpn)
 ```
 
 The daemon binary (`src/`) depends on every crate above; it wires them
@@ -45,7 +45,7 @@ unicast Linux FIB, the BFD socket actor, and the EVPN dataplane glue).
 | `rustbgpd-event-history` | Durable local event outbox (ADR-0072): SQLite WAL store with monotonic `event_id`, `EventHistoryManager` actor + storage thread, in-process `subscribe_live()` broadcast, retention by count + bytes, payload-opaque (producer-encoded bytes are persisted and broadcast byte-identically). Producers (RIB, EVPN, PeerManager session lifecycle, policy, BFD bridge, dataplane FIB / blackhole) enqueue prost-encoded `BgpEvent` envelopes; the gRPC `SubscribeFromEvent` cursor in `api` does the replay → live handoff. |
 | `rustbgpd-evpn` | EVPN local VTEP domain model: `EvpnInstance` / `EvpnInstanceTable` / `RouteTarget` / `IpVrf` / `IpVrfTable` (RFC 7432 / RFC 8365 / RFC 9136). Includes the `LocalMacOriginator` / `LocalMacIpOriginator` / `LocalEsOriginator` / `LocalEadPerEs*` state machines (RFC 7432 §15.1 mobility + §8 multi-homing), the `DataplaneIntent` / `RemoteMacTable` snapshot types with `RemoteMacEntry::alias_group_key` for ADR-0059 aliasing-ECMP wire intent, the IP-VRF readiness probe (Gate 9), and the pure-logic Type 5 origination + projection helpers (RFC 9136 §4.4.2 Interface-less IRB). Aliasing module (`aliasing::group_members`) produces the canonical alias VTEP set for a multi-homed Type 2. Domain-only, kernel-free. See ADR-0052, ADR-0054, ADR-0055, ADR-0057, ADR-0058, ADR-0059. |
 | `rustbgpd-evpn-linux` | Linux kernel dataplane for EVPN VTEP mode (`cfg(target_os = "linux")`). Reconciles remote-MAC FDB programming via rtnetlink, surfaces local-MAC observations from `RTNLGRP_NEIGH` upward (plus `RTNLGRP_IPV4_ROUTE` / `RTNLGRP_IPV6_ROUTE` for slice 6a sub-second IP-VRF route observation), supplies Linux rtnetlink dumps for VRF / L3VXLAN inventory (Gate 9), implements the `Dataplane::probe_ip_vrfs` IRB readiness call, and programs FDB nexthop groups via `NDA_NH_ID` / `NHA_FDB` for aliasing-ECMP receive paths (ADR-0059). `linux::nexthop_raw` is the raw-netlink primitive (rtnetlink 0.21 has no nexthop API); `linux::fdb_nhg` is the apply primitive with the CVE-2025-39851 guard; `group_state` + `nh_id_alloc` carry the refcount + NHID-tagging state the reconcile coordinator uses. Consumes domain types from `rustbgpd-evpn`; never imports `rib` or `transport`. See ADR-0054, ADR-0055, ADR-0058, ADR-0059. |
-| `rustbgpd-api` | gRPC server (tonic). Eleven services, proto codegen at build time. |
+| `rustbgpd-api` | gRPC server (tonic). Twelve services (eleven native, plus the vendored OpenConfig `gnmi.gNMI` service — Capabilities/Get/Set/Subscribe), proto codegen at build time. |
 | `rustbgpd-telemetry` | Prometheus metrics + structured tracing. |
 | `rbgp` | CLI tool. Client-only generated gRPC stubs; depends on `wire` for shared route/address-family parsing and formatting. Dev tests use `api` and `evpn` mock surfaces. |
 
@@ -214,7 +214,7 @@ gRPC request
 | FlowSpec NLRI | `crates/wire/src/flowspec.rs` |
 | FSM state transitions | `crates/fsm/src/lib.rs` |
 | Capability negotiation | `crates/fsm/src/negotiation.rs` |
-| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`) |
+| Peer session runtime | `crates/transport/src/session/` (split into `mod.rs`, `fsm.rs`, `inbound.rs`, `outbound.rs`, `io.rs`, `commands.rs`, `writer.rs`, `import_decision_cache.rs`, `tests.rs`) |
 | Outbound UPDATE construction | `crates/transport/src/session/outbound.rs` — `prepare_outbound_attributes()` |
 | Policy evaluation | `crates/policy/src/engine.rs` |
 | Best-path selection | `crates/rib/src/best_path.rs` — `best_path_cmp` / `best_path_cmp_with_reason` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,17 +115,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the script header (FRR: per-neighbor `no enforce-first-as`; BIRD:
   `enforce first as off`; GoBGP: no enforcement exists).
 
-- **Fixed: `per_client_best` never reached live sessions.** The knob
-  (RFC 7947 §2.3.2 per-client best-path, #696) parsed, validated,
-  survived SIGHUP diffs, and displayed in the docs/reload matrix — but
-  `PeerManager::build_transport_config` never copied it into the
-  transport session config, so every configured peer silently
-  registered single-best and `rbgp neighbor` reported `Distribution
-  Mode: single-best` regardless of config. Caught live by the M83 lab
-  (the RIB- and CLI-layer tests from #696/#698 sit above the dropped
-  seam); fixed with a one-line copy plus a
-  `build_transport_config_preserves_per_client_best` unit pin.
-
 - **M82 interop receipt: EVPN VLAN-Aware Bundle (non-zero Ethernet
   Tag) route reflection — including rustbgpd's FIRST vendor-NOS interop
   leg (Nokia SR Linux 25.10).** The ADR-0092 Decision 6 proof ladder,
@@ -775,6 +764,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   "Crash-restart adoption across upgrades (ADR-0082)".
 
 ### Fixed
+
+- **`per_client_best` never reached live sessions.** The knob
+  (RFC 7947 §2.3.2 per-client best-path, #696) parsed, validated,
+  survived SIGHUP diffs, and displayed in the docs/reload matrix — but
+  `PeerManager::build_transport_config` never copied it into the
+  transport session config, so every configured peer silently
+  registered single-best and `rbgp neighbor` reported `Distribution
+  Mode: single-best` regardless of config. Caught live by the M83 lab
+  (the RIB- and CLI-layer tests from #696/#698 sit above the dropped
+  seam); fixed with a one-line copy plus a
+  `build_transport_config_preserves_per_client_best` unit pin.
 
 - **`ApplyEvpnRuntime` with `validate_only` now rejects what a real apply
   would reject (LAN-214 #9).** The dry-run path returned

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ rbgp completions bash > /etc/bash_completion.d/rbgp
 recipes — receipt-proven config, verification commands, metrics, and
 failure-mode debugging — for the common deployment shapes: iBGP route
 reflector at scale, L3VPN (VPNv4/VPNv6 + RT-Constrain) reflection,
-a BMP/event/MRT monitoring feed, an EVPN fabric RR, and the `.rpol`
-policy workflow.
+an IXP route server, a BMP/event/MRT monitoring feed, an EVPN fabric RR,
+and the `.rpol` policy workflow.
 
 gRPC defaults to a local Unix domain socket. For remote access, configure
 native mTLS on the TCP listener (`tls_cert_file` / `tls_key_file` /
@@ -444,7 +444,7 @@ evolving API.**
 
 | Document | Content |
 |----------|---------|
-| [docs/cookbook/](docs/cookbook/README.md) | Scenario recipes with receipt-proven configs: RR at scale, L3VPN RR, monitoring feed, EVPN fabric RR, policy quickstart |
+| [docs/cookbook/](docs/cookbook/README.md) | Scenario recipes with receipt-proven configs: RR at scale, L3VPN RR, IXP route server, monitoring feed, EVPN fabric RR, policy quickstart |
 | [docs/USE_CASES.md](docs/USE_CASES.md) | Deployment scenarios: DDoS, hosting, IX, SDN, collector |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Crate graph, runtime model, ownership, data flow |
 | [docs/DESIGN.md](docs/DESIGN.md) | Tradeoffs, protocol scope, rationale |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -226,7 +226,8 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   hit counters). M80 proves route-for-route parity against FRR
   route-maps expressing the same intent, plus refresh-scoping on an
   `.rpol` edit under traffic. Follow-up: an import-side read surface for
-  the (already-accumulating) import hit counters. — per-client best paths
+  the (already-accumulating) import hit counters.
+- **Optimal Route Reflection (RFC 9107)** — per-client best paths
   via SPF over the BGP-LS-sourced topology; typed topology accessors, graph +
   hand-rolled Dijkstra + NH-cost resolution, `orr_vantage` config, the
   interior-cost tiebreak at RFC 4271's step-(e) slot, `rbgp topology`/`rbgp

--- a/docs/adr/0101-route-server-profile.md
+++ b/docs/adr/0101-route-server-profile.md
@@ -15,8 +15,8 @@ layers testing green) — fixed in the M83 change with a unit pin.
 ## Context
 
 The ROADMAP's route-server item named one load-bearing gap versus
-BIRD/OpenBGPd at an IXP: **RFC 7948 path-hiding mitigation for members
-that cannot do Add-Path**. A design pass over main verified that the
+BIRD/OpenBGPd at an IXP: **RFC 7947 §2.3.2 path-hiding mitigation for
+members that cannot do Add-Path**. A design pass over main verified that the
 transparency core of RFC 7947 §2.2 had already shipped in ADR-0039
 (`route_server_client`, FRR interop receipt M19) — at the transport seam
 (`crates/transport/src/session/outbound.rs`, `prepare_outbound_attributes`):

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -12,6 +12,7 @@ receipts that prove its scenario ([`RECEIPTS.md`](../RECEIPTS.md)).
 |--------|------------------|-----------|
 | [iBGP route reflector at scale](route-reflector.md) | Replacing an iBGP full mesh; tens to 1,000 clients | M14, M76, M77, [1000-peer scale receipt](../perf/scale-receipt-2026-07.md) |
 | [L3VPN route reflector](l3vpn-route-reflector.md) | VPNv4/VPNv6 reflection for a PE fleet, RT-Constrain filtered | M74, M75, M77, [VPN scale receipt](../perf/scale-receipt-2026-07.md) |
+| [IXP route server](route-server.md) | Transparent redistribution among exchange members: RPKI, RFC 9234 roles, Add-Path + per-client best-path | M19, M83 |
 | [Controller / monitoring feed](monitoring-feed.md) | Streaming BMP, durable events, and MRT into a controller or collector stack | M24, M81 |
 | [EVPN fabric route reflector](evpn-fabric-rr.md) | Control-plane-only RR for a VXLAN-EVPN leaf/spine fabric | M29, M30, M82, M33 |
 | [Policy quickstart (`.rpol`)](policy-quickstart.md) | First typed policy: tests, dry-run, hot swap, explain | M80, M34 |

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -1,0 +1,203 @@
+# IXP route server
+
+**When this is you:** you run (or are about to run) an Internet-exchange
+route server — one BGP speaker that redistributes routes among member
+networks so they don't need a full mesh of bilateral sessions. You want
+transparent redistribution (the members' own NEXT_HOP and AS_PATH, not
+yours), RPKI origin validation and import hygiene at the door, RFC 9234
+roles so a member can't leak transit back through the fabric, and a path
+that doesn't hide a prefix from a member just because that member's own
+policy rejected the single best path.
+
+**Proven by:**
+[M83](../RECEIPTS.md#interop-labs--pr-gated-interopyml) (RFC 7947
+route-server profile against BIRD 2.0.12 + GoBGP 3.37.0 + FRR 10.3.1 +
+StayRTR, [ADR-0101](../adr/0101-route-server-profile.md)): byte-level
+transparency on the wire (tshark on the RS↔BIRD link — no route-server
+ASN in any AS_PATH segment, NEXT_HOP = originator, MED and communities
+verbatim), RFC 9234 OTC toward members, per-member export views, ROV
+reject-at-import with `rbgp policy explain`, and the §2.3 path-hiding
+contrast live (single-best hides / per-client-best advertises the
+runner-up / Add-Path carries both). Also
+[M19](../RECEIPTS.md#interop-labs--manual--local-gates) (transparent
+route server vs FRR: no ASN prepend, NEXT_HOP preservation). Config
+shape derived from
+[`examples/route-server/`](../../examples/route-server/) — the same
+config the M83 lab runs.
+
+## Config
+
+Two members, dual-stack, RPKI, and a hygiene chain. `member-alpha` can do
+Add-Path; `member-beta` can't, so it opts into per-client best-path. Add
+more `[[neighbors]]` for additional members, or manage them dynamically
+over gRPC as they join and leave the fabric.
+
+```toml
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+principal = "operator"
+
+[security.grpc]
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# --- RPKI origin validation ---
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, StayRTR, etc.
+
+# --- Import hygiene, applied to every member ---
+# reject-rpki-invalid and prefer-rpki-valid are TOML policies; ixp-hygiene
+# (reject AS_SET, reject ASPA-invalid, tag routes with their RFC 8097
+# OV_* extended community) lives in hygiene.rpol. rpol and TOML policies
+# share one namespace and compose in one chain — see
+# examples/route-server/ for the full policy set.
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+[policy]
+rpol_files = ["hygiene.rpol"]
+import_chain = ["reject-rpki-invalid", "ixp-hygiene", "prefer-rpki-valid"]
+
+# --- Members ---
+
+# Add-Path-capable member: receives every candidate path and runs its own
+# best-path selection (the preferred path-hiding mitigation). These peers
+# stay update-group-shareable.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true     # transparent: no AS prepend, NEXT_HOP preserved
+role = "route_server"          # RFC 9234: attach OTC on egress
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied (RFC
+# 7947 §2.3.2 per-client best-path, the BIRD-`secondary` equivalent).
+# Requires route_server_client; excludes the peer from update-group sharing.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000
+```
+
+## Verify
+
+```console
+$ rustbgpd --check config.toml          # config + rpol validate offline
+$ rbgp policy check hygiene.rpol         # rpol in-language tests
+$ export RUSTBGPD_ADDR=unix:///var/lib/rustbgpd/grpc.sock
+$ rbgp neighbor                          # both members Established
+```
+
+Distribution mode per member — the mitigation each one uses is visible in
+the detail view (`single-best` / `add-path` / `per-client-best`):
+
+```console
+$ rbgp neighbor 198.51.100.2             # Distribution Mode: add-path
+$ rbgp neighbor 198.51.100.3             # Distribution Mode: per-client-best
+```
+
+Transparency and per-member views:
+
+```console
+$ rbgp rib received 198.51.100.2         # what a member sent us
+$ rbgp rib advertised 198.51.100.3       # what that member sees back
+$ rbgp rib advertised 198.51.100.3 --explain --prefix 203.0.113.0/24
+```
+
+For a `per-client-best` member the explain output is a ranked candidate
+ladder: each denied candidate names the export-policy term that dropped
+it, followed by the runner-up actually advertised — instead of the false
+"denied" a single-best dry run would report.
+
+Members can be added and removed at runtime:
+
+```console
+$ rbgp neighbor 198.51.100.4 add --asn 64503 \
+    --route-server-client --per-client-best --role rs
+```
+
+## Watch
+
+Prometheus (`prometheus_addr`, `/metrics`; dashboards in
+[`GRAFANA.md`](../GRAFANA.md)):
+
+| Metric | Healthy shape |
+|--------|---------------|
+| `bgp_session_state_transitions_total` | flat outside member churn |
+| `bgp_rpki_vrp_total` | non-zero once the RTR cache syncs |
+| `bgp_update_group_fallback_peers` | ≥ your `per_client_best` member count (they never group) |
+| `bgp_rib_outbound_registered_peers` | = established member count |
+
+## Failure modes
+
+**A member's routes never appear (`rbgp rib received <addr>` is empty
+but the session is Established).** Import hygiene dropped them. Run the
+import decision cache explain:
+
+```console
+$ rbgp rib received 198.51.100.2 --explain --prefix 203.0.113.0/24
+```
+
+It names the deciding term — typically `reject-rpki-invalid` (fix the
+member's ROA or your RTR feed) or an `ixp-hygiene` rule (AS_SET or
+ASPA-invalid in the announcement).
+
+**A prefix is hidden from one member but present in the Loc-RIB.** That
+member's own export policy denies the single best path. In `single-best`
+mode this is correct RFC 7947 behavior — the prefix is legitimately
+withheld. If the member can't do Add-Path and you want it to see the
+next-best permitted candidate instead, set `per_client_best = true` on
+it (it drops out of update-group sharing, shown as the `per_client_best`
+fallback reason).
+
+**A member's AS or your route-server ASN shows up in an AS_PATH.**
+Transparency broke. Confirm `route_server_client = true` on the member —
+without it, the route server prepends its own ASN and rewrites NEXT_HOP
+like an ordinary eBGP speaker. Some stacks also reject the transparent
+first-AS (the neighbor AS isn't first in the path); disable first-AS
+enforcement on the *member* side (FRR `no enforce-first-as`, BIRD
+`enforce first as off`).
+
+**A member leaks transit routes back into the fabric.** The RFC 9234
+role guards this: with `role = "route_server"` the route server attaches
+OTC on egress and a conforming member drops OTC-marked routes it would
+otherwise re-advertise. A member that ignores roles still needs its own
+outbound filter — roles are defense in depth, not a substitute for it.


### PR DESCRIPTION
Documentation-only drift fixes verified against HEAD code. No `.rs` changes.

## LAN-111 + LAN-136 — `ARCHITECTURE.md`
- **Service count:** crate summary said "Eleven services". Actual is twelve: 11 native services in `proto/rustbgpd.proto` (`grep -cE '^service ' proto/rustbgpd.proto` = 11) **plus** the vendored OpenConfig `gnmi.gNMI` service (`crates/api/src/gnmi_service.rs`, wired in `server.rs`). Changed to "Twelve services (eleven native, plus the vendored OpenConfig `gnmi.gNMI` service — Capabilities/Get/Set/Subscribe)", matching README's framing.
- **Session file list:** the "Where to Change X" peer-session row omitted `import_decision_cache.rs` (ADR-0073), a production module imported by `inbound.rs` (`super::import_decision_cache::...`). Added it (and `tests.rs`).

## LAN-195 — `ARCHITECTURE.md` crate dependency graph
- `rib` line missing `bmp` — `crates/rib/Cargo.toml` has `rustbgpd-bmp.workspace = true`. Now `rib ──► wire, policy, telemetry, rpki, bmp`.
- `cli` line missing runtime `policy` — `crates/cli/Cargo.toml` `[dependencies]` has `rustbgpd-policy` and `rustbgpd-wire`; `rustbgpd-api`/`rustbgpd-evpn` are dev-deps only. Now `cli ──► wire, policy    (dev tests also use api, evpn)`.

## LAN-213 — docs bucket
- **`docs/adr/0101-route-server-profile.md`:** the §Context path-hiding gap cited "RFC 7948" where it should be "RFC 7947 §2.3.2" (the title and §2.2 table already cite 7947; the later RFC 7948 Add-Path reference is correct and left alone).
- **`ROADMAP.md`:** the Optimal Route Reflection (RFC 9107) item was fused onto the preceding `.rpol` bullet via an em-dash with no list marker. Split into its own `- **Optimal Route Reflection (RFC 9107)** — …` list item.
- **`CHANGELOG.md`:** moved the "`per_client_best` never reached live sessions" fix out of the Unreleased `### Added` section into the Unreleased `### Fixed` section (pure move; dropped the redundant "Fixed:" lead-in to match sibling style). No new entries; Send Hold Timer bullets untouched.
- **`docs/cookbook/route-server.md` (new):** IXP route-server recipe following the house recipe structure, derived from `examples/route-server/`, proven by M19/M83. Listed in the cookbook index (`docs/cookbook/README.md`) and the README cookbook + next-steps lists.

## Gates
- `cargo build --workspace` — exit 0
- `cargo fmt --all -- --check` — exit 0
- No markdown/link linter in `scripts/` or `.github/workflows/` (docs-audit runs via local cron, not a repo script) — none to run.
