### PR TITLE
fix: RIB grouped-peer counters (LAN-210) + ORR determinism (LAN-189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,6 +776,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Grouped peers no longer lose export-policy counters on a dirty
+  resync (LAN-210).** After a full-outbound-channel dirty (or forced)
+  resync, `distribute_changes` replayed a grouped member's table to the
+  wire but never re-recorded its per-member export-policy counters:
+  `apply_group_policy_counters` was `!resync`-gated and the join-style
+  replay only ran from the route-refresh / peer-lifecycle paths, while
+  ungrouped peers re-record every prefix through the per-prefix staging
+  path on every resync. Grouped and ungrouped peers therefore drifted
+  on `bgp_policy_routes_total`. The resync branch now replays
+  `apply_group_join_counters` (full-table permit/deny counts), matching
+  the ungrouped path exactly.
+
+- **ORR next-hop resolution is now deterministic on equal-metric ties
+  (LAN-189).** `OrrTopology::resolve_node` broke equal prefix-metric LPM
+  ties by advertiser `Vec` order, which derives from hasher-dependent
+  Adj-RIB-In iteration, so an ambiguous vantage could resolve to a
+  different node across restarts. Ties now break on the lowest canonical
+  BGP-LS node key. Additionally, an empty BGP-LS batch (a withdraw of a
+  key not held, or an empty announce) no longer triggers a wasted ORR
+  topology rebuild + per-vantage SPF recompute, and the covering-default
+  (`0.0.0.0/0` / `::/0`) Prefix-NLRI LPM semantics are now documented and
+  regression-pinned (a default route yields a finite `distance + metric`
+  cost; least-preferred `None` means no covering Prefix NLRI at all).
+
 - **Config persistence now fsyncs before rename (LAN-206).**
   `ConfigPersister::persist()` wrote the temp config with `fs::write` +
   `fs::rename` and never called `sync_all()` on the temp file or fsynced

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1540,9 +1540,15 @@ impl RibManager {
                     current_policy_filtered_routes
                         .extend(group.policy_filtered_for_member(peer, &effective_prefixes));
                 }
-                // Per-member export-policy counters from the group
-                // verdict — integer adds, no per-(prefix × peer) work.
-                if !resync && let Some(stage) = group_stage.get(&gid) {
+                // Per-member export-policy counters — integer adds, no
+                // per-(prefix × peer) work. A clean pass takes the group
+                // verdict delta; a resync (dirty or force) replays
+                // join-style full-table counters, matching the ungrouped
+                // per-prefix staging path which re-records every Loc-RIB
+                // entry on resync (LAN-210).
+                if resync {
+                    self.apply_group_join_counters(peer, gid, None);
+                } else if let Some(stage) = group_stage.get(&gid) {
                     self.apply_group_policy_counters(peer, &stage.evals);
                 }
             }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2656,6 +2656,16 @@ impl RibManager {
     /// unicast/FlowSpec/EVPN recompute + distribution pattern.
     fn recompute_bgpls_keys(&mut self, affected: &HashSet<crate::route::BgpLsRouteKey>) {
         self.recompute_and_distribute_bgpls(affected);
+        // An empty affected set means no BGP-LS route actually changed
+        // (e.g. a withdraw of a key not held, or an empty batch), so the
+        // Adj-RIB-In topology union is byte-identical and the SPF surface
+        // cannot have moved — skip the topology rebuild + per-vantage SPF
+        // (LAN-189). Vantage-config changes take the direct
+        // `recompute_orr()` path in peer_lifecycle, not this seam, so
+        // they are unaffected by this guard.
+        if affected.is_empty() {
+            return;
+        }
         // Every BGP-LS mutation seam routes through here — receive
         // (`handle_bgpls_routes_received`), the enhanced-refresh EoRR
         // sweep (`finish_route_refresh`), the GR entry sweep

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -226,6 +226,53 @@ async fn no_vantage_configured_skips_topology_rebuild() {
     handle.await.unwrap();
 }
 
+/// LAN-189 sub-item 2: a BGP-LS batch that changes nothing (a withdraw of
+/// a key not held) must not rebuild the topology or re-run SPF — the
+/// `bgp_orr_spf_runs_total` counter stays put even with a resolved vantage
+/// configured.
+#[tokio::test]
+async fn empty_bgpls_batch_skips_orr_recompute() {
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    // Resolve a vantage against the square topology (initial SPF run).
+    let feed = Ipv4Addr::new(10, 9, 9, 9);
+    feed_square_topology(&tx, feed).await;
+    let client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let _out_rx = orr_client_peer_up(&tx, client, Some(vantage_at_node_a())).await;
+    let status = query_orr_status(&tx).await;
+    assert!(status.vantages[0].resolved, "vantage must resolve");
+    let runs_before = counter_metric_value(&metrics, "bgp_orr_spf_runs_total");
+    assert!(runs_before >= 1.0, "initial SPF ran");
+
+    // No-op batch: withdraw a real key from a peer that holds nothing, so
+    // the affected set stays empty.
+    let unheld_key = crate::orr::fixtures::square_topology(feed)
+        .first()
+        .expect("fixture has routes")
+        .key();
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(Ipv4Addr::new(10, 8, 8, 8)),
+        announced: vec![],
+        withdrawn: vec![unheld_key],
+    })
+    .await
+    .unwrap();
+    // Sync point so the no-op batch is fully processed.
+    let _ = query_orr_status(&tx).await;
+    assert!(
+        (counter_metric_value(&metrics, "bgp_orr_spf_runs_total") - runs_before).abs()
+            < f64::EPSILON,
+        "an empty BGP-LS batch must not re-run ORR SPF"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Collect the unicast staging stream (announce prefixes + withdraws per
 /// update) an RR client sees for a fixed scenario, with or without an
 /// ORR vantage configured on it.

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -540,3 +540,115 @@ async fn strict_next_hop_export_chain_disqualifies_grouping() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// LAN-210: a grouped member's export-policy counters must not drift
+/// from an otherwise-identical ungrouped peer's across a dirty resync.
+/// Before the fix the dirty-resync distribution pass replayed the group
+/// table to the wire but never re-recorded the per-member counters
+/// (`apply_group_policy_counters` was `!resync`-gated, and the join
+/// replay only ran from lifecycle/route-refresh paths), while the
+/// ungrouped per-prefix path re-records every entry on resync.
+#[tokio::test]
+async fn grouped_and_ungrouped_export_counters_match_after_dirty_resync() {
+    tokio::time::pause();
+
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let grouped = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let ungrouped = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    // Unresolved ORR vantage: disqualifies grouping but leaves
+    // single-best selection and the permit-all verdict untouched, so the
+    // two peers must report identical counters at every step.
+    let vantage = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let prefix1 = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let prefix2 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+
+    // Capacity-1 channels so the second announce can't fit and drives the
+    // dirty-resync path.
+    let (g_tx, mut g_rx) = mpsc::channel(1);
+    let (u_tx, mut u_rx) = mpsc::channel(1);
+    for (peer, out_tx, vantage) in [(grouped, g_tx, None), (ungrouped, u_tx, Some(vantage))] {
+        tx.send(RibUpdate::PeerUp {
+            per_client_best: false,
+            session_id: 0,
+            peer,
+            peer_asn: 65000,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: None,
+            sendable_families: ipv4_sendable(),
+            is_ebgp: true,
+            route_reflector_client: false,
+            orr_vantage: vantage,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        })
+        .await
+        .unwrap();
+    }
+    drain_eor(&mut g_rx).await;
+    drain_eor(&mut u_rx).await;
+    assert_eq!(query_update_group(&tx, grouped).await, "group:0");
+    assert_eq!(query_update_group(&tx, ungrouped).await, "orr_vantage");
+
+    // First route fits both channels; the second can't, marking both
+    // peers dirty. Neither is drained yet.
+    for prefix in [prefix1, prefix2] {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    // Serialize past both distribution passes.
+    let _ = query_best_routes(&tx).await;
+
+    let pre_grouped = query_neighbor_policy_stats(&tx, grouped).await;
+    let pre_ungrouped = query_neighbor_policy_stats(&tx, ungrouped).await;
+    assert_eq!(
+        pre_grouped.export_policy_routes_permitted, pre_ungrouped.export_policy_routes_permitted,
+        "grouped/ungrouped counters must already agree pre-resync"
+    );
+    assert!(pre_grouped.export_policy_routes_permitted > 0);
+
+    // Drain the stuck first announce so the resync has room, then fire
+    // the dirty-resync timer.
+    let _ = g_rx.recv().await.unwrap();
+    let _ = u_rx.recv().await.unwrap();
+    tokio::time::advance(Duration::from_secs(2)).await;
+    // The resync delivers the previously-dropped prefix2 to both peers.
+    let _ = g_rx.recv().await.unwrap();
+    let _ = u_rx.recv().await.unwrap();
+
+    let post_grouped = query_neighbor_policy_stats(&tx, grouped).await;
+    let post_ungrouped = query_neighbor_policy_stats(&tx, ungrouped).await;
+    assert!(
+        post_ungrouped.export_policy_routes_permitted
+            > pre_ungrouped.export_policy_routes_permitted,
+        "sanity: ungrouped peer must re-record its table on resync"
+    );
+    assert_eq!(
+        post_grouped.export_policy_routes_permitted, post_ungrouped.export_policy_routes_permitted,
+        "grouped peer must re-record export counters on dirty resync (LAN-210)"
+    );
+    assert_eq!(
+        post_grouped.export_policy_routes_denied,
+        post_ungrouped.export_policy_routes_denied,
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/orr.rs
+++ b/crates/rib/src/orr.rs
@@ -342,7 +342,14 @@ impl OrrTopology {
     /// Resolve an IP address to a topology node: (a) exact link
     /// interface/neighbor address hit; (b) longest-prefix match over
     /// Prefix NLRIs, picking the advertising node with the lowest prefix
-    /// metric. `None` when the address is outside the topology.
+    /// metric. `None` when the address matches no exact link address and
+    /// no covering Prefix NLRI (a `0.0.0.0/0` / `::/0` Prefix NLRI, if
+    /// advertised, IS a covering LPM match).
+    ///
+    /// Equal-metric ties break on the lowest canonical node key
+    /// ([`BgpLsNodeKey`] bytes), so an ambiguous vantage resolves the
+    /// same way across restarts regardless of the advertiser insertion
+    /// order (which derives from hasher-dependent Adj-RIB-In iteration).
     #[must_use]
     pub fn resolve_node(&self, ip: IpAddr) -> Option<NodeIx> {
         if let Some(&ix) = self.addr_index.get(&ip) {
@@ -350,7 +357,13 @@ impl OrrTopology {
         }
         self.prefix_lpm(ip)?
             .iter()
-            .min_by_key(|(_, metric)| *metric)
+            .min_by(|(a_ix, a_metric), (b_ix, b_metric)| {
+                a_metric.cmp(b_metric).then_with(|| {
+                    self.node_keys[a_ix.index()]
+                        .as_bytes()
+                        .cmp(self.node_keys[b_ix.index()].as_bytes())
+                })
+            })
             .map(|&(ix, _)| ix)
     }
 
@@ -522,6 +535,13 @@ impl SpfResult {
     /// address hit yields the node distance; (b) longest-prefix match
     /// yields the min over advertisers of distance + prefix metric;
     /// (c) `None` — the caller must rank unknown-cost as least preferred.
+    ///
+    /// A `0.0.0.0/0` / `::/0` Prefix NLRI (an IGP default route carried in
+    /// BGP-LS) is a legitimate covering match under (b): a next-hop with
+    /// no more-specific match resolves to the default's advertiser at
+    /// `distance + default-prefix metric`, exactly as ordinary LPM
+    /// dictates. `None` (least-preferred) therefore means "no covering
+    /// Prefix NLRI at all", not merely "no host/subnet route".
     ///
     /// `topo` must be the topology this SPF was computed over.
     #[must_use]
@@ -1082,6 +1102,62 @@ mod tests {
             spf.cost_to(&topo, IpAddr::V4(Ipv4Addr::new(10, 0, B, X))),
             None
         );
+    }
+
+    #[test]
+    fn resolve_node_breaks_equal_metric_ties_by_lowest_node_key() {
+        // X and Y both advertise 192.0.2.0/24 with the SAME prefix
+        // metric — an ambiguous vantage. The tie must break on the lower
+        // canonical node key, independent of advertiser insertion order
+        // (which derives from hasher-dependent Adj-RIB-In iteration).
+        // LAN-189 sub-item 1.
+        let prefix = Ipv4Addr::new(192, 0, 2, 0);
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 77));
+        assert!(
+            node_key(X).as_bytes() < node_key(Y).as_bytes(),
+            "fixture precondition: X's key sorts below Y's"
+        );
+        let x_first = [
+            prefix_route(PEER1, X, prefix, 24, Some(50)),
+            prefix_route(PEER2, Y, prefix, 24, Some(50)),
+        ];
+        let y_first = [
+            prefix_route(PEER1, Y, prefix, 24, Some(50)),
+            prefix_route(PEER2, X, prefix, 24, Some(50)),
+        ];
+        let topo_x = OrrTopology::build(x_first.iter());
+        let topo_y = OrrTopology::build(y_first.iter());
+        assert_eq!(topo_x.resolve_node(ip), Some(ix(&topo_x, X)));
+        assert_eq!(
+            topo_y.resolve_node(ip),
+            Some(ix(&topo_y, X)),
+            "equal-metric tie must resolve to the lowest node key regardless of insertion order"
+        );
+    }
+
+    #[test]
+    fn default_prefix_nlri_is_a_covering_lpm_match() {
+        // Chosen semantics (LAN-189 sub-item 3): a 0.0.0.0/0 Prefix NLRI
+        // (an IGP default carried in BGP-LS) is a legitimate covering LPM
+        // match. An otherwise out-of-topology next-hop resolves to the
+        // default's advertiser at dist+metric; `None` (least-preferred)
+        // means "no covering Prefix NLRI at all", not "no host route".
+        let outside = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200));
+
+        // Baseline: no default route → the NH is genuinely unknown-cost.
+        let no_default = square();
+        let spf = no_default.spf(ix(&no_default, A));
+        assert_eq!(no_default.resolve_node(outside), None);
+        assert_eq!(spf.cost_to(&no_default, outside), None);
+
+        // Default originated by X (metric 7): the same NH now resolves to
+        // X at dist(A->X)=1 + 7 = 8.
+        let mut routes = square_topology(PEER1);
+        routes.push(prefix_route(PEER1, X, Ipv4Addr::UNSPECIFIED, 0, Some(7)));
+        let topo = OrrTopology::build(routes.iter());
+        let spf = topo.spf(ix(&topo, A));
+        assert_eq!(topo.resolve_node(outside), Some(ix(&topo, X)));
+        assert_eq!(spf.cost_to(&topo, outside), Some(8));
     }
 
     #[test]


### PR DESCRIPTION
Fixes two verified Linear issues in the RIB, both scoped to `crates/rib/`.

## LAN-210 (P3) — Grouped peers lose export-policy counters on dirty resync

**Root cause.** After a full-outbound-channel dirty (or forced) resync,
`distribute_changes` replays a grouped member's group table to the wire
but never re-records the member's export-policy counters:
`apply_group_policy_counters` was `!resync`-gated, and the join-style
counter replay (`apply_group_join_counters`) only ran from the
route-refresh / peer-lifecycle paths — never the dirty-resync
distribution pass. Ungrouped peers, by contrast, re-record every prefix
through the per-prefix staging path on every resync (the `record_eval`
call precedes the AdjRibOut equality/force check). So grouped and
ungrouped peers drifted on `bgp_policy_routes_total`.

**Fix.** The grouped resync branch now replays
`apply_group_join_counters(peer, gid, None)` (full-table permit/deny
counts) instead of skipping counters, matching the ungrouped per-prefix
path exactly. The guard is `resync` (dirty **or** force) because the
ungrouped path re-records on both.

**Regression test.**
`grouped_and_ungrouped_export_counters_match_after_dirty_resync` drives a
grouped peer and an otherwise-identical ungrouped peer (disqualified only
by an unresolved ORR vantage) through a channel-full dirty resync and
asserts identical counters. Verified failing before the fix
(grouped=2, ungrouped=4) and passing after.

## LAN-189 (P3) — ORR determinism & topology-cost edge cleanup

1. **Non-deterministic tie-break (correctness — done).**
   `OrrTopology::resolve_node` broke equal prefix-metric LPM ties by
   advertiser `Vec` order (hasher-dependent Adj-RIB-In iteration), so an
   ambiguous vantage could resolve differently across restarts. Ties now
   break on the lowest canonical BGP-LS node key. Test:
   `resolve_node_breaks_equal_metric_ties_by_lowest_node_key` (verified
   failing before the fix).

2. **Wasted recompute (done).** `recompute_bgpls_keys` rebuilt the
   topology and re-ran per-vantage SPF even when the affected key set was
   empty (e.g. a withdraw of a key not held). It now early-returns on an
   empty affected set. Vantage-config changes take the direct
   `recompute_orr()` path in `peer_lifecycle`, so they are unaffected.
   Test: `empty_bgpls_batch_skips_orr_recompute` asserts
   `bgp_orr_spf_runs_total` stays put (verified failing before the fix).

3. **Default-prefix cost (clarified + pinned).** A `0.0.0.0/0` / `::/0`
   Prefix NLRI (an IGP default carried in BGP-LS) is a legitimate
   covering LPM match. Chosen semantics: it yields a finite
   `distance + metric` cost; `None` (least-preferred) means "no covering
   Prefix NLRI at all", not merely "no host/subnet route". Docs on
   `resolve_node` / `cost_to` updated; test:
   `default_prefix_nlri_is_a_covering_lpm_match`.

### Deferred / flagged for maintainer decision

4. **Theoretical `u32::try_from(node_keys.len()).expect(...)`
   (DEFERRED).** Converting `intern` to a typed error would ripple a
   `Result` through `from_routes` / `add_link` / `add_prefix` for a
   genuinely impossible case (>4 billion BGP-LS nodes). The `expect`
   already carries a clear message. Per the ticket's "OK to defer if
   context is short" — deferred as not worth the builder-wide churn.

5. **Config validation: vantage == neighbor / reflector-local address
   (DEFERRED — out of scope).** The proper rejection point is the config
   layer (`crates/transport/src/config.rs` `NeighborConfig` /
   `crates/api`), which is **outside this PR's `crates/rib/` scope fence**
   and owned by concurrent agents. The `RibManager` only receives the
   already-validated vantage via a runtime `PeerUp` message; rejecting it
   there would be the wrong layer (it would tear down a live session
   rather than reject bad config). Flagged for a follow-up in the config
   crate.

## Gates (all exit 0)

| Gate | Exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test -p rustbgpd-rib` | 0 |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |
| `cargo check -p rustbgpd-rib --features bench-internals --benches` | 0 |
