### PR TITLE
test(cli): raise rbgp CLI coverage — Status mapping, ORR JSON, connect failure (LAN-87)

### DIFF
--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -173,4 +173,48 @@ mod tests {
         .unwrap();
         print_orr_status(&ListOrrStatusResponse::default(), false).unwrap();
     }
+
+    // The ORR JSON output is produced by hand-rolled `Serialize` impls
+    // (JsonOrrStatus / JsonVantages / JsonVantageRef), which is exactly
+    // where a field can be silently dropped, renamed, or reordered
+    // without any compiler help. Pin the whole shape so that regression
+    // class is caught. `node_key` is emitted verbatim in JSON (unlike the
+    // shortened table label), which operator tooling depends on.
+    #[test]
+    fn orr_status_json_shape_is_stable() {
+        let resp = ListOrrStatusResponse {
+            vantages: vec![OrrVantageStatusEntry {
+                vantage: "10.0.8.1".to_string(),
+                resolved: true,
+                node_key: "0200000000000000000000fc00020000".to_string(),
+                asn: 64512,
+                bgp_ls_id: 7,
+                router_id: "000000000001".to_string(),
+                reachable_nodes: 4,
+                peers: vec!["192.0.2.1".to_string(), "192.0.2.2".to_string()],
+            }],
+            topology_nodes: 4,
+            topology_links: 6,
+        };
+
+        let value = serde_json::to_value(JsonOrrStatus(&resp)).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "vantages": [{
+                    "vantage": "10.0.8.1",
+                    "resolved": true,
+                    "node_key": "0200000000000000000000fc00020000",
+                    "asn": 64512,
+                    "bgp_ls_id": 7,
+                    "router_id": "000000000001",
+                    "reachable_nodes": 4,
+                    "peers": ["192.0.2.1", "192.0.2.2"],
+                }],
+                "topology_nodes": 4,
+                "topology_links": 6,
+            })
+        );
+    }
 }

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -245,4 +245,24 @@ mod tests {
             format!("token file is empty: {}", path.display())
         );
     }
+
+    // Connecting to a socket nothing is listening on must surface the
+    // friendly "daemon is not running or unreachable" message rather than
+    // leak a raw transport/io error. A nonexistent UDS path fails
+    // immediately (ENOENT) so this stays fast and deterministic — no
+    // dependence on the 5s connect timeout.
+    #[tokio::test]
+    async fn connect_to_absent_socket_reports_daemon_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("not-listening.sock");
+        let addr = format!("unix://{}", absent.display());
+
+        // `Connection` is not `Debug`, so match instead of `expect_err`.
+        let err = match connect(&addr, None).await {
+            Ok(_) => panic!("connecting to an unbound socket must fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.to_string(), "daemon is not running or unreachable");
+    }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -57,3 +57,57 @@ impl From<serde_json::Error> for CliError {
         CliError::Json(e)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Status;
+
+    // Every gRPC command routes its `Status` errors through
+    // `From<Status>` via `?`, so this mapping is the CLI's single
+    // operator-facing error contract. These pin the three distinct arms
+    // so a regression (reordering the match, dropping a special case, or
+    // changing a prefix) is caught centrally rather than per command.
+
+    #[test]
+    fn unavailable_is_reported_as_generic_unreachable() {
+        // The raw transport detail is intentionally suppressed: an
+        // operator seeing UNAVAILABLE almost always just means the daemon
+        // is down, so we never leak the noisy inner message.
+        let err = CliError::from(Status::unavailable("connection reset by peer"));
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(err.to_string(), "daemon is not running or unreachable");
+    }
+
+    #[test]
+    fn not_found_gets_friendly_prefix_and_keeps_message() {
+        let err = CliError::from(Status::not_found("no IP-VRF named \"blue\""));
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(err.to_string(), "not found: no IP-VRF named \"blue\"");
+    }
+
+    #[test]
+    fn invalid_argument_falls_through_with_code_and_message() {
+        // INVALID_ARGUMENT is not special-cased: it must surface via the
+        // generic "{code}: {message}" arm so operators see both.
+        let err = CliError::from(Status::invalid_argument("prefix length 33 exceeds 32"));
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(
+            err.to_string(),
+            "Client specified an invalid argument: prefix length 33 exceeds 32"
+        );
+    }
+
+    #[test]
+    fn already_exists_falls_through_with_code_and_message() {
+        let err = CliError::from(Status::already_exists(
+            "neighbor 10.0.0.2 already configured",
+        ));
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(
+            err.to_string(),
+            "Some entity that we attempted to create already exists: \
+             neighbor 10.0.0.2 already configured"
+        );
+    }
+}


### PR DESCRIPTION
## LAN-87 — Raise rbgp CLI test coverage

Test-only. Fills the highest-value gaps in the `crates/cli` test surface with three focused, mock-free additions, following the PR #588 harness pattern. **No production CLI behavior changes.**

### Command groups / modules covered

| Area | Test(s) | Realistic regression class guarded |
|------|---------|-----------------------------------|
| **gRPC `Status` → user-facing error mapping** (`error.rs`) | `unavailable_is_reported_as_generic_unreachable`, `not_found_gets_friendly_prefix_and_keeps_message`, `invalid_argument_falls_through_with_code_and_message`, `already_exists_falls_through_with_code_and_message` | `From<tonic::Status> for CliError` is the single error contract **every** gRPC command routes through via `?`, yet had no tests. Pins the three distinct arms: UNAVAILABLE (raw transport detail suppressed to the generic "daemon unreachable"), NOT_FOUND (friendly `not found:` prefix), and the `{code}: {message}` catch-all exercised by INVALID_ARGUMENT / ALREADY_EXISTS. Catches: reordering the match, dropping a special case, or changing a prefix — silently changing every command's error UX. |
| **ORR JSON output stability** (`commands/orr.rs`) | `orr_status_json_shape_is_stable` | ORR JSON is built by **hand-rolled `Serialize` impls** (`JsonOrrStatus`/`JsonVantages`/`JsonVantageRef`) — exactly where a field gets silently dropped, renamed, or reordered with no compiler help. Golden-equivalence test pins the full shape, incl. `node_key` being emitted verbatim (not the shortened table label). The prior test only rendered the plain table. |
| **Connection failure** (`connection.rs`) | `connect_to_absent_socket_reports_daemon_unreachable` | `connect()` to an unbound socket must surface the friendly `daemon is not running or unreachable` message, not a raw transport/io error. Uses a nonexistent UDS path (immediate ENOENT) so it stays fast and deterministic — no dependence on the 5s connect timeout. |

Covers both success and error paths across the selected surface: success (existing ORR/BFD/etc. tests) plus error paths (NOT_FOUND, INVALID_ARGUMENT, ALREADY_EXISTS, UNAVAILABLE, and a real connection failure). Reuses the existing mock/harness patterns — no parallel harness introduced. `+118` lines, all test code.

### Gate results (all exit 0)

| Gate | exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test -p rustbgpctl --all-targets` | 0 (258 passed, 0 failed) |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |