### PR TITLE
fix(policy): rpol next-hop != absent, defensive hardening, apply_community_mods panic (LAN-209, LAN-192, LAN-175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -715,6 +715,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **`.rpol` `route.evpn-route-type` now accepts only 1-5 (LAN-192).**
+  rustbgpd emits EVPN NLRIs of route types 1-5 (RFC 7432 §7), so a
+  comparison against `0` or `6`-`255` could never match a real route.
+  The typechecker previously accepted `0`-`255` and silently compiled a
+  dead policy; out-of-range literals are now a compile-time diagnostic.
 - **The default container image is now a lean production runtime.**
   `docker build .` (and the GHCR release image) ships only the daemon
   and the `rbgp` CLI, runs as a nonroot `rustbgpd` user, and carries no
@@ -776,6 +781,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`.rpol` `route.next-hop != …` no longer matches a route with no
+  next-hop (LAN-209).** `!=` (both `route.next-hop != <ip>` and
+  `route.next-hop != peer.address`) lowered to `Not(NextHopEq…)`, which
+  matched whenever the attribute was absent — the opposite of the
+  documented rule that next-hop predicates never match a route without a
+  next-hop. `!=` now lowers to dedicated `NextHopNe` / `NextHopNePeer`
+  guards that, like `==`, require the attribute present, so an absent
+  next-hop matches neither. `!= peer.address` still reads peer identity
+  (disqualifies update-group sharing).
+- **Policy hit-counter attribution no longer risks a panic on a stale
+  counter set (LAN-192).** `evaluate_with_attribution_counting` indexed
+  the per-policy and per-term counter arrays directly; a counter set
+  shorter than the chain (a hot-reload leftover) would panic on the
+  production evaluation path. It now degrades to skipped increments via
+  bounds-checked access. (The counters live on the owning chain and are
+  replaced with it, so a short set is a construction impossibility today
+  — this is defense-in-depth.)
+- **`apply_community_mods` can no longer panic (LAN-175).** The private
+  helper paired a match predicate with a separate value extractor joined
+  by `.expect("… agree")`; a caller mismatch would have panicked the
+  daemon on the export path. Predicate and extractor are merged into one
+  `Fn(&PathAttribute) -> Option<Vec<_>>` closure that matches and
+  extracts together, so disagreement — and the `expect` — are gone.
 - **`ApplyEvpnRuntime` with `validate_only` now rejects what a real apply
   would reject (LAN-214 #9).** The dry-run path returned
   `EvpnRuntimeApplyValidated` immediately after the (pure, rejection-free)

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1256,10 +1256,9 @@ pub fn apply_modifications(
         &mods.communities_add,
         &mods.communities_remove,
         |a| match a {
-            PathAttribute::Communities(c) => Some(c),
+            PathAttribute::Communities(c) => Some(c.clone()),
             _ => None,
         },
-        |a| matches!(a, PathAttribute::Communities(_)),
         PathAttribute::Communities,
     );
 
@@ -1276,10 +1275,9 @@ pub fn apply_modifications(
         &mods.large_communities_add,
         &mods.large_communities_remove,
         |a| match a {
-            PathAttribute::LargeCommunities(c) => Some(c),
+            PathAttribute::LargeCommunities(c) => Some(c.clone()),
             _ => None,
         },
-        |a| matches!(a, PathAttribute::LargeCommunities(_)),
         PathAttribute::LargeCommunities,
     );
 
@@ -1314,12 +1312,17 @@ fn upsert_attr(
 }
 
 /// Add/remove community-style attributes (standard, extended, large).
+///
+/// `extract` both matches and extracts in one shot — `Some(items)` for
+/// the community kind this call operates on, `None` otherwise — so a
+/// matching predicate can never be paired with a non-yielding extractor
+/// (the disagreement a separate predicate/extractor pair could panic
+/// on).
 fn apply_community_mods<T: Clone + Eq + Hash>(
     attrs: &mut Vec<PathAttribute>,
     add: &[T],
     remove: &[T],
-    extract: impl Fn(PathAttribute) -> Option<Vec<T>>,
-    predicate: impl Fn(&PathAttribute) -> bool,
+    extract: impl Fn(&PathAttribute) -> Option<Vec<T>>,
     wrap: impl Fn(Vec<T>) -> PathAttribute,
 ) {
     if add.is_empty() && remove.is_empty() {
@@ -1330,10 +1333,10 @@ fn apply_community_mods<T: Clone + Eq + Hash>(
     let mut found = false;
     let mut index = 0;
     while index < attrs.len() {
-        if predicate(&attrs[index]) {
-            let attr = attrs.remove(index);
+        if let Some(extracted) = extract(&attrs[index]) {
+            attrs.remove(index);
             if !found {
-                items = extract(attr).expect("community attribute predicate and extractor agree");
+                items = extracted;
                 found = true;
             }
         } else {

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -598,7 +598,9 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
         MatchExpr::LocalPref(cmp) => render_cmp("route.local-pref", *cmp),
         MatchExpr::Med(cmp) => render_cmp("route.med", *cmp),
         MatchExpr::NextHopEq(addr) => format!("route.next-hop == {addr}"),
+        MatchExpr::NextHopNe(addr) => format!("route.next-hop != {addr}"),
         MatchExpr::NextHopEqPeer => "route.next-hop == peer.address".to_string(),
+        MatchExpr::NextHopNePeer => "route.next-hop != peer.address".to_string(),
         MatchExpr::NeighborIn(set) => {
             let mut parts: Vec<String> = Vec::new();
             for addr in &set.addresses {

--- a/crates/policy/src/engine/tests/modifications.rs
+++ b/crates/policy/src/engine/tests/modifications.rs
@@ -156,6 +156,39 @@ fn apply_community_add_remove_preserves_order_and_legacy_attr_position() {
 }
 
 #[test]
+fn apply_community_mods_collapses_duplicate_attributes() {
+    // A route carrying two Communities attributes (malformed but
+    // wire-reachable): the merged match+extract closure removes every
+    // matching attribute and keeps the first's values, with no panic
+    // from a predicate/extractor disagreement (LAN-175).
+    let c1 = (65001u32 << 16) | 0x0064;
+    let c2 = (65001u32 << 16) | 0x00C8;
+    let c3 = (65001u32 << 16) | 0x012C;
+    let mut attrs = vec![
+        PathAttribute::Communities(vec![c1]),
+        PathAttribute::Communities(vec![c2]),
+    ];
+    let mods = RouteModifications {
+        communities_add: vec![c3],
+        ..Default::default()
+    };
+
+    apply_modifications(&mut attrs, &mods);
+
+    let comms: Vec<&Vec<u32>> = attrs
+        .iter()
+        .filter_map(|a| match a {
+            PathAttribute::Communities(c) => Some(c),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(comms.len(), 1, "duplicate community attributes collapsed");
+    // First attribute's value survives (first-attr-wins), plus the add;
+    // the second attribute's value is dropped.
+    assert_eq!(comms[0], &vec![c1, c3]);
+}
+
+#[test]
 fn merge_exact_community_lists_preserves_later_wins_order() {
     let c1 = (65001u32 << 16) | 0x0064;
     let c2 = (65001u32 << 16) | 0x00C8;

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -111,9 +111,10 @@ impl CompiledChain {
     /// plus live hit counting: every matched guard bumps its term's
     /// counter (relaxed; `Continue` terms included, terms after the
     /// decider are never evaluated and never count) and the chain-level
-    /// evaluation count increments once. `hits` must have been built
-    /// from this chain ([`PolicyHitCounters::for_chain`]); a mismatched
-    /// shape is a caller bug (the increment indexes directly).
+    /// evaluation count increments once. `hits` is expected to have
+    /// been built from this chain ([`PolicyHitCounters::for_chain`]); a
+    /// set shorter than the chain (e.g. a stale hot-reload leftover)
+    /// degrades to skipped increments rather than a panic.
     #[must_use]
     pub fn evaluate_with_attribution_counting(
         &self,
@@ -136,7 +137,13 @@ impl CompiledChain {
         let mut accumulated = RouteModifications::default();
         for (policy_index, policy) in self.policies.iter().enumerate() {
             let policy_hits = if COUNT {
-                hits.map(|h| h.policies[policy_index].as_slice())
+                // Counters are shaped for — and live on — the chain they
+                // were built from (they are replaced together), so a set
+                // shorter than the chain is a construction impossibility.
+                // `get` rather than `[]` keeps that invariant a
+                // stat-undercount rather than a daemon panic if a future
+                // refactor ever breaks it on this production path.
+                hits.and_then(|h| h.policies.get(policy_index).map(Vec::as_slice))
             } else {
                 None
             };
@@ -273,7 +280,13 @@ impl CompiledChain {
         for (term_index, term) in policy.terms.iter().enumerate() {
             if self.eval_expr(&term.guard, ctx) {
                 if COUNT && let Some(hits) = hits {
-                    hits[term_index].fetch_add(1, Ordering::Relaxed);
+                    // Same shape invariant as the per-policy slice: a
+                    // term row shorter than the policy is impossible by
+                    // construction, but `get` degrades to a skipped
+                    // increment instead of a panic if it ever isn't.
+                    if let Some(counter) = hits.get(term_index) {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
                 match &term.action {
                     TermAction::Permit(mods) => {
@@ -336,10 +349,19 @@ impl CompiledChain {
             }
             MatchExpr::Med(cmp) => cmp_value(*cmp, ctx.med.unwrap_or(IMPLICIT_MED)),
             MatchExpr::NextHopEq(next_hop) => ctx.next_hop == Some(*next_hop),
+            // `!=` mirrors `==`: an absent next-hop matches neither, so
+            // require the attribute to be present before comparing.
+            MatchExpr::NextHopNe(next_hop) => ctx.next_hop.is_some_and(|nh| nh != *next_hop),
             // Strict next-hop: both sides must be known; two unknowns
             // are not a match.
             MatchExpr::NextHopEqPeer => match (ctx.next_hop, ctx.peer_address) {
                 (Some(next_hop), Some(peer)) => next_hop == peer,
+                _ => false,
+            },
+            // Strict next-hop `!=`: like `==`, both sides must be known;
+            // an absent next-hop or peer never matches.
+            MatchExpr::NextHopNePeer => match (ctx.next_hop, ctx.peer_address) {
+                (Some(next_hop), Some(peer)) => next_hop != peer,
                 _ => false,
             },
             MatchExpr::NeighborIn(set) => {
@@ -556,5 +578,59 @@ mod tests {
         // A prefixless route (e.g. BGP-LS) never matches prefix nodes.
         let (result, _) = chain.evaluate_with_attribution(&ctx(None));
         assert_eq!(result.action, PolicyAction::Deny);
+    }
+
+    /// LAN-192: a counter set shorter than the chain (a stale hot-reload
+    /// leftover) must degrade to skipped increments, not an index panic
+    /// on the production evaluation path.
+    #[test]
+    fn stale_short_counter_set_does_not_panic() {
+        use super::PolicyHitCounters;
+
+        // Counters shaped for a 1-policy / 1-term chain…
+        let small = single_term_chain(MatchExpr::True, Vec::new());
+        let counters = PolicyHitCounters::for_chain(&small);
+
+        // …applied to a larger chain: policy 0 visits two terms (the
+        // second is out of the 1-term counter row) and policy 1 is out
+        // of the 1-policy counter set entirely.
+        let big = CompiledChain {
+            policies: vec![
+                CompiledPolicy {
+                    name: Some("p0".to_string()),
+                    terms: vec![
+                        Term {
+                            name: None,
+                            guard: MatchExpr::True,
+                            action: TermAction::Continue(RouteModifications::default()),
+                        },
+                        Term {
+                            name: None,
+                            guard: MatchExpr::True,
+                            action: TermAction::Permit(RouteModifications::default()),
+                        },
+                    ],
+                    default_action: PolicyAction::Deny,
+                    source: PolicySource::Toml,
+                },
+                CompiledPolicy {
+                    name: Some("p1".to_string()),
+                    terms: vec![Term {
+                        name: None,
+                        guard: MatchExpr::True,
+                        action: TermAction::Permit(RouteModifications::default()),
+                    }],
+                    default_action: PolicyAction::Deny,
+                    source: PolicySource::Toml,
+                },
+            ],
+            ..CompiledChain::empty()
+        };
+
+        let (result, _) = big.evaluate_with_attribution_counting(&ctx(None), &counters);
+        assert_eq!(result.action, PolicyAction::Permit);
+        // In-range term still counted; out-of-range slots skipped.
+        assert_eq!(counters.snapshot(), vec![vec![1]]);
+        assert_eq!(counters.evals(), 1);
     }
 }

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -57,8 +57,9 @@ pub enum Cmp {
 /// - Prefix nodes never match a prefixless route (e.g. BGP-LS NLRIs).
 /// - [`Cmp`] on `LocalPref` / `Med` sees the RFC 4271 implicit defaults
 ///   (`LOCAL_PREF` 100, `MED` 0) when the attribute is absent.
-/// - `RouteTypeIs` / `EvpnRouteTypeIs` / `NextHopEq` never match when
-///   the corresponding context field is `None`.
+/// - `RouteTypeIs` / `EvpnRouteTypeIs` / `NextHopEq` / `NextHopNe`
+///   never match when the corresponding context field is `None` (`!=`
+///   mirrors `==`: an absent attribute satisfies neither).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchExpr {
     /// Always matches (an unconditional term).
@@ -97,6 +98,17 @@ pub enum MatchExpr {
     /// on an export chain the verdict is per-target-peer and the peer
     /// must not join an update group.
     NextHopEqPeer,
+    /// The route's next-hop differs from this address. Unlike
+    /// `Not(NextHopEq(_))`, this never matches when the next-hop is
+    /// absent — `!=` mirrors `==`, so an absent attribute satisfies
+    /// neither.
+    NextHopNe(IpAddr),
+    /// The route's next-hop differs from the evaluation peer's address
+    /// (strict next-hop `!=`, `.rpol` `route.next-hop != peer.address`).
+    /// Never matches when either side is unknown. Like
+    /// [`NextHopEqPeer`](Self::NextHopEqPeer) it reads peer identity, so
+    /// it counts toward [`CompiledChain::requires_peer_context`].
+    NextHopNePeer,
     /// The evaluation peer matches a neighbor set (address, ASN, or
     /// peer-group membership — OR within the set). Boxed: the set is
     /// three `Vec`s (72 bytes) and would otherwise dominate every
@@ -134,6 +146,8 @@ impl MatchExpr {
             | MatchExpr::Med(_)
             | MatchExpr::NextHopEq(_)
             | MatchExpr::NextHopEqPeer
+            | MatchExpr::NextHopNe(_)
+            | MatchExpr::NextHopNePeer
             | MatchExpr::RouteTypeIs(_)
             | MatchExpr::EvpnRouteTypeIs(_)
             | MatchExpr::RpkiIs(_)
@@ -309,7 +323,8 @@ impl CompiledChain {
     /// Whether evaluating this chain depends on the evaluation peer's
     /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
     /// ASN, or peer-group matching — or a strict-next-hop
-    /// [`MatchExpr::NextHopEqPeer`] node). Content-equal chains with
+    /// [`MatchExpr::NextHopEqPeer`] / [`MatchExpr::NextHopNePeer`]
+    /// node). Content-equal chains with
     /// such a guard can still yield peer-different verdicts, so
     /// update-group fingerprinting must not group peers that share one.
     /// Import chains are evaluated per-session and are unaffected by
@@ -317,7 +332,10 @@ impl CompiledChain {
     #[must_use]
     pub fn requires_peer_context(&self) -> bool {
         self.any_guard_node(&|expr| {
-            matches!(expr, MatchExpr::NeighborIn(_) | MatchExpr::NextHopEqPeer)
+            matches!(
+                expr,
+                MatchExpr::NeighborIn(_) | MatchExpr::NextHopEqPeer | MatchExpr::NextHopNePeer
+            )
         })
     }
 

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -404,11 +404,27 @@ fn lower_cmp(
             });
             negate_if(op == CmpOp::Ne, node)
         }
+        // `!=` gets a dedicated Ne node rather than `Not(Eq)`: an absent
+        // next-hop must match neither `==` nor `!=` (LAN-209), and
+        // `Not(NextHopEq)` would wrongly match when the attribute is
+        // absent.
         Field::NextHop => match rhs {
-            Rhs::Ip(addr, _) => negate_if(op == CmpOp::Ne, MatchExpr::NextHopEq(*addr)),
+            Rhs::Ip(addr, _) => {
+                if op == CmpOp::Ne {
+                    MatchExpr::NextHopNe(*addr)
+                } else {
+                    MatchExpr::NextHopEq(*addr)
+                }
+            }
             // Strict next-hop (`route.next-hop == peer.address`); the
             // typechecker only lets `peer.address` through here.
-            Rhs::Field(_) => negate_if(op == CmpOp::Ne, MatchExpr::NextHopEqPeer),
+            Rhs::Field(_) => {
+                if op == CmpOp::Ne {
+                    MatchExpr::NextHopNePeer
+                } else {
+                    MatchExpr::NextHopEqPeer
+                }
+            }
             _ => unreachable!("typechecked: next-hop compares an IP or peer.address"),
         },
         Field::PeerAddress => {

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -643,7 +643,11 @@ fn deep_bang_and_operator_chains_are_diagnostics_too() {
         "!".repeat(100_000),
     );
     let report = check_on_small_stack(src);
-    assert!(!report.diagnostics.is_empty());
+    let rendered = format!("{:?}", report.diagnostics);
+    assert!(
+        rendered.contains("nesting exceeds"),
+        "want a depth diagnostic, got: {rendered:.300}"
+    );
 
     // Chained binary ops build a left-leaning AST whose depth the
     // downstream recursive passes (typeck, lower, Drop) consume.
@@ -801,6 +805,13 @@ fn strict_next_hop_negated_form() {
              term rest { accept }
          }",
     );
+    // `!=` lowers to a dedicated Ne node (not `Not(NextHopEqPeer)`) so
+    // that an absent next-hop matches neither `==` nor `!=` (LAN-209).
+    assert_eq!(chain.policies[0].terms[0].guard, MatchExpr::NextHopNePeer);
+    assert!(
+        chain.requires_peer_context(),
+        "strict next-hop `!=` still reads peer identity"
+    );
     let peer = std::net::IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
     let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
     let matching = RouteContext {
@@ -815,6 +826,58 @@ fn strict_next_hop_negated_form() {
         ..base
     };
     assert_eq!(chain.evaluate(&mismatched).action, PolicyAction::Deny);
+    // LAN-209: an absent next-hop must NOT match `!=` — the `reroute`
+    // term must not fire, so the route falls through to `accept`.
+    let absent = RouteContext {
+        next_hop: None,
+        peer_address: Some(peer),
+        ..base
+    };
+    assert_eq!(
+        chain.evaluate(&absent).action,
+        PolicyAction::Permit,
+        "absent next-hop must not match `route.next-hop != peer.address`"
+    );
+}
+
+#[test]
+fn next_hop_ne_literal_absent_does_not_match() {
+    // LAN-209: `route.next-hop != <ip>` must never match when the
+    // next-hop attribute is absent (mirroring `==`), rather than
+    // matching via `Not(NextHopEq)`.
+    let chain = compile_ok(
+        "policy drop-non-blackhole {
+             term reject-others { if route.next-hop != 192.0.2.1 { reject } }
+             term rest { accept }
+         }",
+    );
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::NextHopNe(std::net::IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)))
+    );
+    let base = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        next_hop: Some(std::net::IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7))),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        next_hop: Some(std::net::IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    let absent = RouteContext {
+        next_hop: None,
+        ..base
+    };
+    assert_eq!(
+        chain.evaluate(&absent).action,
+        PolicyAction::Permit,
+        "absent next-hop must not match `route.next-hop != <ip>`"
+    );
 }
 
 #[test]
@@ -834,4 +897,26 @@ fn strict_next_hop_rejects_other_field_comparisons() {
     let (_, rendered) =
         diagnostics_of("policy p { term t { if peer.address == route.next-hop { accept } } }");
     assert!(rendered.contains("field reference"), "{rendered}");
+}
+
+#[test]
+fn evpn_route_type_enforces_rfc7432_range() {
+    // LAN-192: rustbgpd only emits EVPN route types 1-5 (RFC 7432 §7),
+    // so those compile…
+    for t in 1..=5 {
+        compile_ok(&format!(
+            "policy p {{ term t {{ if route.evpn-route-type == {t} {{ accept }} }} }}"
+        ));
+    }
+    // …while 0 and 6-255 can never match a real route and are rejected
+    // as dead policies rather than silently never firing.
+    for t in [0u32, 6, 255, 256] {
+        let (_, rendered) = diagnostics_of(&format!(
+            "policy p {{ term t {{ if route.evpn-route-type == {t} {{ accept }} }} }}"
+        ));
+        assert!(
+            rendered.contains("out of range"),
+            "evpn-route-type {t} must be rejected, got: {rendered}"
+        );
+    }
 }

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -506,15 +506,20 @@ impl Checker<'_> {
         }
     }
 
-    /// `route.evpn-route-type` compares against a 0-255 integer
-    /// literal (RFC 7432 route types are 1-5).
+    /// `route.evpn-route-type` compares against a 1-5 integer literal
+    /// (the RFC 7432 §7 route types rustbgpd emits); 0 and 6-255 are
+    /// rejected as dead policies.
     fn check_evpn_route_type_rhs(&mut self, field: &FieldPath, rhs: &Rhs) {
         match rhs {
-            Rhs::Int(value, span) if *value > 255 => {
+            // rustbgpd emits EVPN NLRIs of route types 1-5 only
+            // (RFC 7432 §7). A comparison against 0 or 6-255 can never
+            // match a real route, so reject it as a dead policy rather
+            // than let it silently never fire.
+            Rhs::Int(value, span) if !(1..=5).contains(value) => {
                 self.diags.push(Diagnostic::new(
                     *span,
                     format!("EVPN route type {value} out of range"),
-                    "must be 0-255 (RFC 7432 route types are 1-5)",
+                    "must be 1-5 (RFC 7432 §7 route types)",
                 ));
             }
             Rhs::Int(..) => {}

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -221,7 +221,7 @@ group. Comparisons: `==`, `!=`, `>=`, `<=`.
 | `route.rpki == invalid` | RPKI origin validation state |
 | `route.aspa == unknown` | ASPA verification state |
 | `route.route-type == external` | route source class |
-| `route.evpn-route-type == 2` | EVPN route type (integer literal 0–255; `==`/`!=` only) |
+| `route.evpn-route-type == 2` | EVPN route type (integer literal 1–5, RFC 7432 §7; `==`/`!=` only) |
 | `peer.address == 192.0.2.1` | evaluation-peer address |
 | `peer.asn == 65010` | evaluation-peer ASN (`==`/`!=` only) |
 | `peer.group == "leaf"` | evaluation-peer group name |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -80,6 +80,20 @@ impl Config {
     /// file's directory when known, the process working directory
     /// otherwise). Name collisions — with `[policy.definitions]` or
     /// across `.rpol` files — are load errors naming both sources.
+    ///
+    /// Path resolution is deliberately **not** confined to `base_dir`.
+    /// `rpol_files` is an operator-authored include directive — the same
+    /// trust model as an nginx `include` or a systemd drop-in: whoever
+    /// writes the on-disk config is the trusted host operator, and
+    /// absolute paths (`/etc/rbgp/policies/common.rpol`) and
+    /// parent-relative references into a shared policy library are
+    /// legitimate and expected. There is therefore no `..`/symlink
+    /// confinement or canonicalization step; a `base.join(entry)` that
+    /// escapes `base_dir` is intended behavior, not a traversal to
+    /// reject. (Untrusted candidate configs arrive via
+    /// `load_toml_with_diagnostics` with `base_dir = None`, so relative
+    /// entries resolve against the process CWD and never against a
+    /// caller-influenced base.)
     fn load_rpol_files(&mut self, base_dir: Option<&std::path::Path>) -> Result<(), ConfigError> {
         use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry};
 


### PR DESCRIPTION
Fixes three verified P3 rpol issues. Root-cause fixes, each with a named regression test.

## LAN-209 — `!=` next-hop matches when the attribute is absent
`route.next-hop != <ip>` and `route.next-hop != peer.address` lowered to `Not(NextHopEq…)`, so the negation **matched** when the next-hop was absent — contradicting the documented rule that next-hop predicates never match a route without a next-hop.

**Fix:** dedicated `NextHopNe` / `NextHopNePeer` IR nodes that, like `==`, require the attribute present (absent → no match). `!= peer.address` still reads peer identity, so it counts toward `requires_peer_context` (disqualifies update-group sharing). Explain renders the new nodes as `route.next-hop != …`.
Tests: `next_hop_ne_literal_absent_does_not_match`, extended `strict_next_hop_negated_form` (adds the absent case + guard-shape assertion).

## LAN-192 — defensive hardening bucket
1. **Attribution counter bounds.** `evaluate_with_attribution_counting` indexed per-policy/per-term counter arrays directly; a stale (shorter) counter set would panic on the production path. Now bounds-checked (`get`), degrading to skipped increments. The counters live on the owning chain (replaced together), so a short set is a construction impossibility today — this is defense-in-depth, so no `debug_assert` (it would fire in the regression test). Test: `stale_short_counter_set_does_not_panic`.
2. **`evpn-route-type` range.** The typechecker accepted `0` and `6`-`255` though rustbgpd only emits RFC 7432 §7 route types `1`-`5`, silently compiling dead policies. Now rejected with a diagnostic (verified against `EvpnRoute::route_type()`, which only returns 1-5). Behavior change → `### Changed`. Test: `evpn_route_type_enforces_rfc7432_range`.
3. **`load_rpol_files` path confinement — PRODUCT DECISION (see below).** Documented the trust model instead of confining.
4. **Test tightening.** `deep_bang_and_operator_chains_are_diagnostics_too` now asserts the rendered `"nesting exceeds"` diagnostic for the `!`-chain case, matching the `&&`-chain case.

## LAN-175 — panic-prone `expect` in `apply_community_mods`
The private helper paired a match `predicate` with a separate value `extractor` joined by `.expect("… agree")`; a caller mismatch would panic the daemon on the export path.

**Fix (preferred option):** merge predicate + extract into one `Fn(&PathAttribute) -> Option<Vec<T>>` closure that matches and extracts together, removing the possibility of disagreement and the `expect`. Test: `apply_community_mods_collapses_duplicate_attributes`.

## Flagged product decision (LAN-192.3)
`load_rpol_files` path-joins `rpol_files` entries to the config directory without confine-to-base. I **did not** implement confinement. `rpol_files` is an operator-authored include directive (same trust model as an nginx `include` / systemd drop-in): the on-disk load path (`base_dir = Some`) is written by the trusted host operator, and absolute paths (`/etc/rbgp/policies/common.rpol`) and parent-relative references into a shared policy library are legitimate and expected — no established config-include tool confines them. Untrusted candidate configs arrive via `load_toml_with_diagnostics` with `base_dir = None` (relative → CWD, never a caller-influenced base). Per the ticket's escape hatch, I documented this explicitly in the function doc and flag it here for review. (A test would live in `src/config/tests.rs`, outside this change's scope fence, and the mandated canonicalization test is tied to the confinement option I declined.)

## Gates — all exit 0
- `cargo build --workspace` — 0
- `cargo test -p rustbgpd-policy` — 0 (202 passed)
- `cargo test --bin rustbgpd` — 0 (1300 passed)
- `cargo test --workspace` — 0 (0 failures)
- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo doc --workspace --no-deps` — 0
- `cargo check -p rustbgpd --all-features --lib` — 0
- `cd crates/policy/fuzz && cargo +nightly fuzz build` — 0