### PR TITLE
fix: labeled IPv6 link-local next-hop survives reflection + VPN/RTC/labeled test sweep (LAN-190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Labeled IPv6 reflection no longer drops the link-local next-hop
+  (LAN-190).** `LabeledRibRoute` stored only a single global next-hop, so
+  a labeled-unicast (SAFI 4) IPv6 route received with an RFC 8950 §4 /
+  RFC 2545 §3 two-address next-hop (32-byte: global + link-local) was
+  reflected with a 16-byte single-address next-hop — the link-local half
+  was silently discarded. The route data model now carries
+  `link_local_next_hop` alongside the global next-hop; the receive path
+  populates it and the reflected `MP_REACH_NLRI` re-emits the 32-byte
+  form verbatim, so labeled IPv6 link-local forwarding survives
+  reflection. A change confined to the link-local half now correctly
+  re-advertises. (The VPNv6 reflection path shares the same
+  single-next-hop limitation on `VpnRibRoute`; that mirror is deferred as
+  a follow-up — the wire codec already round-trips the RFC 4659 48-byte
+  two-address VPN next-hop.)
 - **`.rpol` `route.next-hop != …` no longer matches a route with no
   next-hop (LAN-209).** `!=` (both `route.next-hop != <ip>` and
   `route.next-hop != peer.address`) lowered to `Not(NextHopEq…)`, which

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -3632,6 +3632,7 @@ mod tests {
         LabeledRibRoute {
             nlri,
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: Instant::now(),

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -593,6 +593,7 @@ mod tests {
                 prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::from(addr), len)),
             },
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: Instant::now(),

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -1497,6 +1497,7 @@ mod tests {
         LabeledRibRoute {
             nlri,
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![
                 PathAttribute::Origin(Origin::Igp),

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -100,6 +100,9 @@ pub(super) fn labeled_routes_equal(
 ) -> bool {
     a.nlri == b.nlri
         && a.next_hop == b.next_hop
+        // A change confined to the IPv6 link-local half of the next-hop
+        // (RFC 8950 two-address form) must still re-advertise (LAN-190).
+        && a.link_local_next_hop == b.link_local_next_hop
         && a.peer == b.peer
         && a.path_id == b.path_id
         && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -695,8 +695,15 @@ impl RibManager {
 
     /// Insert the local default RT-Constrain NLRI into the `LOCAL_PEER`
     /// Adj-RIB-In (lazy + idempotent) and run the RTC recompute so it flows
-    /// to any already-established RTC peers. Never withdrawn — harmless if
-    /// no RTC peer remains. No config knob by design.
+    /// to any already-established RTC peers. No config knob by design.
+    ///
+    /// Intentionally never withdrawn (LAN-190 §B). The default lives in the
+    /// synthetic `LOCAL_PEER` Adj-RIB-In, which no session teardown touches
+    /// (`clear_peer_adj_rib_in` only removes the departed *peer's* RIB), so
+    /// it survives the last RTC peer going down as a local, inert entry and
+    /// is re-advertised for free when an RTC peer returns. This is correct,
+    /// not a leak: adding a withdraw would only churn the RIB with nothing
+    /// downstream to receive it.
     fn ensure_default_rtc_originated(&mut self) {
         use rustbgpd_wire::{AsPath, Origin, PathAttribute, RtcNlri};
 

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -122,6 +122,7 @@ fn make_labeled_rib_route(
     crate::route::LabeledRibRoute {
         nlri,
         next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
         peer: IpAddr::V4(peer),
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),

--- a/crates/rib/src/manager/tests/rtc.rs
+++ b/crates/rib/src/manager/tests/rtc.rs
@@ -374,6 +374,49 @@ async fn default_rtc_origination_idempotent_across_peer_ups() {
     handle.await.unwrap();
 }
 
+/// LAN-190 §B: the locally-originated default RTC NLRI is intentionally
+/// retained when the LAST RTC peer drops — it lives in the synthetic
+/// `LOCAL_PEER` RIB, which peer teardown never touches — and is
+/// re-advertised for free when an RTC peer returns. No withdraw is emitted.
+#[tokio::test]
+async fn default_rtc_retained_after_last_rtc_peer_drops_and_readvertised_on_return() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    // The only RTC peer comes up: default is originated and advertised.
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = rtc_peer_up(&tx, peer, true, false).await;
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    // The last (and only) RTC peer drops.
+    tx.send(RibUpdate::PeerDown {
+        peer,
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+
+    // The default RTC NLRI is retained, not withdrawn: still originated with
+    // no RTC peer remaining.
+    let stored = query_rtc_routes(&tx).await;
+    assert_eq!(stored.len(), 1, "default RTC NLRI must be retained");
+    assert!(stored[0].nlri.is_default());
+    assert_eq!(stored[0].origin_type, crate::route::RouteOrigin::Local);
+
+    // An RTC peer returns: the retained default is re-advertised in its
+    // initial dump — no re-origination churn, the entry was never dropped.
+    let mut return_rx = rtc_peer_up(&tx, peer, true, false).await;
+    let dump = return_rx.recv().await.unwrap();
+    assert!(
+        dump.rtc_announce.iter().any(|r| r.nlri.is_default()),
+        "returning RTC peer must receive the retained default NLRI"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Peer teardown removes the departed peer's RTC routes and withdraws them
 /// from remaining peers.
 #[tokio::test]
@@ -821,6 +864,45 @@ async fn vpn_not_advertised_to_rtc_peer_with_empty_membership() {
 
     drop(tx);
     handle.await.unwrap();
+}
+
+/// LAN-190 §E: `rtc_vpn_filter` resolves the RFC 4684 VPN outbound filter
+/// directly. Two contracts pinned: (1) an RTC-negotiated peer with no
+/// membership recorded resolves to the STRICT EMPTY filter (advertise
+/// nothing), never fail-open; (2) the filter keys off the `sendable`
+/// ARGUMENT, so a stale `peer_sendable_families` entry is harmless — a
+/// sendable set lacking RTC resolves to `None` (unfiltered) even when a
+/// membership is still recorded for the peer.
+#[test]
+fn rtc_vpn_filter_strict_empty_and_argument_driven() {
+    let (_tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let sendable_rtc = vec![crate::route::RtcRibRouteKey::afi_safi()];
+    let sendable_no_rtc = vec![(Afi::Ipv4, Safi::Unicast)];
+
+    // (1) RTC negotiated, no membership recorded → strict empty, not fail-open.
+    assert_eq!(
+        manager.rtc_vpn_filter(peer, Some(&sendable_rtc)),
+        Some(RtcMembership::default()),
+        "no membership must resolve to strict empty, not fail-open"
+    );
+
+    // A recorded membership is returned verbatim.
+    let membership = RtcMembership {
+        has_default: true,
+        entries: vec![],
+    };
+    manager.peer_rt_membership.insert(peer, membership.clone());
+    assert_eq!(
+        manager.rtc_vpn_filter(peer, Some(&sendable_rtc)),
+        Some(membership)
+    );
+
+    // (2) Argument-driven: a sendable set lacking RTC (or absent) resolves
+    // to None even though a membership is still recorded for the peer.
+    assert_eq!(manager.rtc_vpn_filter(peer, Some(&sendable_no_rtc)), None);
+    assert_eq!(manager.rtc_vpn_filter(peer, None), None);
 }
 
 /// When a matching RTC NLRI arrives, the withheld VPN route is announced as a

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -669,8 +669,14 @@ impl LabeledRibRouteKey {
 pub struct LabeledRibRoute {
     /// Full NLRI: prefix + MPLS label stack (preserved verbatim).
     pub nlri: LabeledNlri,
-    /// Next-hop from `MP_REACH_NLRI`.
+    /// Global next-hop from `MP_REACH_NLRI`.
     pub next_hop: IpAddr,
+    /// IPv6 link-local next-hop carried alongside the global one (RFC 8950 §4
+    /// / RFC 2545 §3 two-address form), populated when the received labeled
+    /// `MP_REACH_NLRI` had a 32-byte next-hop. Reflected verbatim so labeled
+    /// IPv6 link-local forwarding survives reflection (LAN-190); `None` for
+    /// IPv4 or single-address IPv6 next-hops.
+    pub link_local_next_hop: Option<Ipv6Addr>,
     /// The peer that advertised this route.
     pub peer: IpAddr,
     /// BGP path attributes.

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1630,6 +1630,10 @@ impl PeerSession {
                                 labeled_announced.push(LabeledRibRoute {
                                     nlri: entry.nlri.clone(),
                                     next_hop: mp.next_hop,
+                                    // Carry the RFC 8950 two-address IPv6
+                                    // link-local half so labeled IPv6
+                                    // reflection re-emits it (LAN-190).
+                                    link_local_next_hop: mp.link_local_next_hop,
                                     peer: self.peer_ip,
                                     attributes: attrs,
                                     received_at: now,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1217,6 +1217,7 @@ impl PeerSession {
             let mut labeled_groups: Vec<(
                 (Afi, Safi),
                 IpAddr,
+                Option<Ipv6Addr>,
                 Vec<PathAttribute>,
                 Vec<rustbgpd_wire::LabeledNlriEntry>,
             )> = Vec::new();
@@ -1227,6 +1228,10 @@ impl PeerSession {
                 }
                 let attrs = self.prepare_outbound_attributes_labeled(labeled_route, is_ebgp);
                 let nh = labeled_route.next_hop;
+                // RFC 8950 two-address IPv6 next-hop: the link-local half
+                // is grouped alongside the global next-hop so it survives
+                // reflection (LAN-190).
+                let ll = labeled_route.link_local_next_hop;
                 let entry = rustbgpd_wire::LabeledNlriEntry {
                     path_id: labeled_route.path_id,
                     nlri: labeled_route.nlri.clone(),
@@ -1234,17 +1239,17 @@ impl PeerSession {
                 if let Some(group) =
                     labeled_groups
                         .iter_mut()
-                        .find(|(g_family, g_nh, g_attrs, _)| {
-                            *g_family == family && *g_nh == nh && *g_attrs == attrs
+                        .find(|(g_family, g_nh, g_ll, g_attrs, _)| {
+                            *g_family == family && *g_nh == nh && *g_ll == ll && *g_attrs == attrs
                         })
                 {
-                    group.3.push(entry);
+                    group.4.push(entry);
                 } else {
-                    labeled_groups.push((family, nh, attrs, vec![entry]));
+                    labeled_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
             let max_len = usize::from(self.max_message_len());
-            for ((afi, _), next_hop, attrs, routes) in labeled_groups {
+            for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in labeled_groups {
                 let add_path = match afi {
                     Afi::Ipv4 => add_path_labeled_v4_send,
                     _ => add_path_labeled_v6_send,
@@ -1252,6 +1257,7 @@ impl PeerSession {
                 if !self.send_labeled_reach_chunked(
                     afi,
                     next_hop,
+                    link_local_next_hop,
                     &attrs,
                     &routes,
                     four_octet_as,
@@ -1812,6 +1818,7 @@ impl PeerSession {
         &mut self,
         afi: Afi,
         next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::LabeledNlriEntry],
         four_octet_as: bool,
@@ -1827,7 +1834,7 @@ impl PeerSession {
                 afi,
                 safi: Safi::LabeledUnicast,
                 next_hop,
-                link_local_next_hop: None,
+                link_local_next_hop,
                 announced: vec![],
                 flowspec_announced: vec![],
                 evpn_announced: vec![],

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1560,6 +1560,7 @@ fn make_labeled_rib_route(label: u32) -> rustbgpd_rib::LabeledRibRoute {
             )),
         },
         next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+        link_local_next_hop: None,
         peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1686,6 +1687,91 @@ async fn send_route_update_emits_labeled_reach_and_unreach() {
             }
         }],
         "withdraw-mode NLRI carries no label stack (RFC 8277 §2.4 compatibility field)"
+    );
+}
+/// LAN-190: a labeled IPv6 route carrying an RFC 8950 two-address next-hop
+/// (global + link-local) reflects the link-local half — the emitted
+/// `MP_REACH` uses the 32-byte next-hop form, not the 16-byte single-address
+/// form.
+/// Without this, labeled IPv6 link-local forwarding breaks on reflection.
+#[tokio::test]
+async fn send_route_update_reflects_labeled_v6_link_local_next_hop() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::LabeledUnicast)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+    let route = rustbgpd_rib::LabeledRibRoute {
+        nlri: rustbgpd_wire::LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+            prefix: Prefix::V6(Ipv6Prefix::new("2001:db8:100::".parse().unwrap(), 48)),
+        },
+        next_hop: IpAddr::V6(global),
+        link_local_next_hop: Some(link_local),
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    };
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![].into(),
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![].into(),
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![],
+        labeled_announce: vec![route.clone()],
+        rtc_announce: vec![],
+        vpn_withdraw: vec![],
+        labeled_withdraw: vec![],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected labeled MP_REACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &[]).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("labeled announcement must use MP_REACH");
+    assert_eq!(mp.afi, Afi::Ipv6);
+    assert_eq!(mp.safi, Safi::LabeledUnicast);
+    assert_eq!(
+        mp.next_hop,
+        IpAddr::V6(global),
+        "labeled global next-hop must pass through reflection unchanged"
+    );
+    assert_eq!(
+        mp.link_local_next_hop,
+        Some(link_local),
+        "labeled IPv6 link-local next-hop must survive reflection (LAN-190)"
     );
 }
 /// RFC 7911 labeled outbound: with Add-Path send negotiated for (IPv4, SAFI

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -4453,6 +4453,50 @@ mod tests {
         assert!(decoded_mp.announced.is_empty());
     }
 
+    /// LAN-190: an IPv6 labeled-unicast `MP_REACH` carrying an RFC 8950 §4 /
+    /// RFC 2545 §3 two-address next-hop (global + link-local) must emit the
+    /// 32-byte form and round-trip the link-local half, so a route reflector
+    /// re-advertising the route preserves labeled IPv6 link-local forwarding.
+    #[test]
+    fn mp_reach_labeled_v6_link_local_next_hop_roundtrip() {
+        let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+        let nlri = labeled_v6_nlri(100);
+        let mp = MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::LabeledUnicast,
+            next_hop: IpAddr::V6(global),
+            link_local_next_hop: Some(link_local),
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            vpn_announced: vec![],
+            labeled_announced: vec![labeled_entry(0, nlri.clone())],
+            rtc_announced: vec![],
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        // Value layout after the 3-byte attribute header: AFI(2) SAFI(1)
+        // NH-Len(1); NH-Len must be 32 (global + link-local), not 16.
+        assert_eq!(
+            buf[6], 32,
+            "labeled IPv6 two-address next-hop must be 32 bytes"
+        );
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode labeled v6 MP_REACH");
+        let PathAttribute::MpReachNlri(decoded_mp) = &decoded[0] else {
+            panic!("not MP_REACH after decode");
+        };
+        assert_eq!(decoded_mp.next_hop, IpAddr::V6(global));
+        assert_eq!(
+            decoded_mp.link_local_next_hop,
+            Some(link_local),
+            "labeled IPv6 link-local next-hop must survive encode/decode"
+        );
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+    }
+
     /// RFC 8277 §2.4: a labeled-unicast withdraw carries one ignored
     /// 3-octet compatibility field, not a label stack — the decoded entry
     /// has empty `labels` and re-encode emits 0x800000.

--- a/crates/wire/src/labeled.rs
+++ b/crates/wire/src/labeled.rs
@@ -1007,6 +1007,34 @@ mod tests {
         );
     }
 
+    /// LAN-190 §C: RFC 7911 reserves `path_id` 0 for "no Add-Path", but the
+    /// Add-Path decoder deliberately *accepts* a received `path_id` of 0
+    /// rather than rejecting it (some peers emit it). Pin the permissive
+    /// acceptance so a future change can't silently tighten it into a reject.
+    #[test]
+    fn addpath_labeled_decode_accepts_path_id_zero() {
+        let entry = LabeledNlriEntry {
+            path_id: 0,
+            nlri: LabeledNlri {
+                labels: vec![label(100, true)],
+                prefix: v4([10, 0, 1, 0], 24),
+            },
+        };
+        let mut buf = Vec::new();
+        encode_labeled_nlri_addpath(
+            std::slice::from_ref(&entry),
+            LabeledAddressFamily::V4,
+            &mut buf,
+        )
+        .unwrap();
+        let decoded = decode_labeled_nlri_addpath(&buf, LabeledAddressFamily::V4).unwrap();
+        assert_eq!(decoded, vec![entry]);
+        assert_eq!(
+            decoded[0].path_id, 0,
+            "path_id 0 must be accepted, not rejected"
+        );
+    }
+
     #[test]
     fn addpath_labeled_v6_withdraw_roundtrip() {
         let entry = LabeledNlriEntry {

--- a/crates/wire/src/rtc.rs
+++ b/crates/wire/src/rtc.rs
@@ -455,6 +455,26 @@ mod tests {
     }
 
     #[test]
+    fn prefix_32_matches_origin_as_only() {
+        // LAN-190 §D: a /32 NLRI covers only the origin-AS field. Every RT
+        // bit below it — the RT type/sub-type byte included — is outside the
+        // prefix and ignored, so interest in AS 65001 matches that AS's RTs
+        // regardless of RT sub-type encoding or local admin.
+        let entry = nlri(65001, 0, 32);
+        // 2-octet-AS RT:65001:100 (type 0x00) — global admin 65001.
+        assert!(entry.matches(ExtendedCommunity::new(RT_65001_100)));
+        // Same global admin 65001 but a DIFFERENT RT sub-type encoding
+        // (4-octet AS, type 0x02, RT:65001:999) — still a hit; /32
+        // discriminates on origin-AS alone, not the RT sub-type.
+        assert!(entry.matches(ExtendedCommunity::new(0x0202_0000_FDE9_03E7)));
+        // A different global admin (65002) misses.
+        assert!(!entry.matches(ExtendedCommunity::new(0x0002_FDEA_0000_0064)));
+        // A non-RT community (Route Origin, sub-type 0x03) never matches,
+        // even when its global admin equals the origin AS.
+        assert!(!entry.matches(ExtendedCommunity::new(0x0003_FDE9_0000_0064)));
+    }
+
+    #[test]
     fn origin_as_mismatch_at_96_misses() {
         // The RT bytes are identical, but the candidate's high 32 bits come
         // from the RT's global administrator (65001), not the NLRI's origin

--- a/crates/wire/src/vpn.rs
+++ b/crates/wire/src/vpn.rs
@@ -1299,6 +1299,31 @@ mod tests {
         );
     }
 
+    /// LAN-190 §C: RFC 7911 reserves `path_id` 0 for "no Add-Path", but the
+    /// VPN Add-Path decoder deliberately *accepts* a received `path_id` of 0
+    /// rather than rejecting it (some peers emit it). Pin the permissive
+    /// acceptance so a future change can't silently tighten it into a reject.
+    #[test]
+    fn addpath_vpn_decode_accepts_path_id_zero() {
+        let entry = VpnNlriEntry {
+            path_id: 0,
+            nlri: VpnNlri {
+                labels: vec![label(200, true)],
+                route_distinguisher: rd(),
+                prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
+            },
+        };
+        let mut buf = Vec::new();
+        encode_vpn_nlri_addpath(std::slice::from_ref(&entry), VpnAddressFamily::V4, &mut buf)
+            .unwrap();
+        let decoded = decode_vpn_nlri_addpath(&buf, VpnAddressFamily::V4).unwrap();
+        assert_eq!(decoded, vec![entry]);
+        assert_eq!(
+            decoded[0].path_id, 0,
+            "path_id 0 must be accepted, not rejected"
+        );
+    }
+
     #[test]
     fn addpath_vpnv6_roundtrip() {
         let entry = VpnNlriEntry {


### PR DESCRIPTION
## LAN-190 (P3) — VPN/RTC/labeled-unicast sweep

Maintainer decisions implemented exactly: (A) is the real fix; (B)-(E) are KEEP-as-is, covered with regression tests + a documenting comment.

### (A) FIX — labeled IPv6 link-local next-hop dropped on reflection

**Data-model change, call out explicitly:** `LabeledRibRoute` grew a
`link_local_next_hop: Option<Ipv6Addr>` field alongside the global `next_hop`.

Before: a labeled-unicast (SAFI 4) IPv6 route received with an RFC 8950 §4 /
RFC 2545 §3 two-address next-hop (32 bytes: global + link-local) was reflected
with a 16-byte single-address next-hop — the link-local half was silently
discarded, breaking labeled IPv6 link-local forwarding on the reflected path.

Now:
- The transport **receive** path populates `link_local_next_hop` from the
  decoded `MP_REACH` (`inbound.rs`).
- The transport **send** path groups on and re-emits the link-local, so the
  reflected `MP_REACH` uses the 32-byte two-address form verbatim
  (`outbound.rs`).
- `labeled_routes_equal` compares the link-local half, so a change confined to
  it correctly re-advertises.

The **wire codec already round-tripped** the labeled two-address next-hop
(`encode_plain_mp_next_hop` / `decode_mp_reach_nlri`) — the bug was purely the
RIB/transport plumbing. Adding the field fans out to the transport
receive/encode sites by compile necessity (that is where labeled routes are
decoded/encoded), so this PR necessarily touches `crates/transport` in addition
to `crates/rib` + `crates/wire`.

**VPNv6 mirror: DEFERRED (flagged).** `VpnRibRoute` has the same single-next-hop
limitation but is a different struct with far more construction sites (incl.
`crates/api`, `crates/bmp`), so mirroring it there would balloon the change past
the LAN-190 item. Per the maintainer's guidance, labeled IPv6 is done correctly
and VPNv6 is called out as a follow-up. Its wire 48-byte two-address VPN
next-hop codec already round-trips, so the follow-up is plumbing-only.

Tests: wire labeled IPv6 32-byte next-hop encode/decode round-trip
(`mp_reach_labeled_v6_link_local_next_hop_roundtrip`); transport end-to-end
reflection asserting the emitted `MP_REACH` keeps the link-local
(`send_route_update_reflects_labeled_v6_link_local_next_hop`).

### (B) Default RTC retention — KEEP (documented)
The locally-originated default RTC NLRI lives in the synthetic `LOCAL_PEER`
RIB, which peer teardown never touches, so it is intentionally retained when the
last RTC peer drops and re-advertised on return. Added a documenting comment on
`ensure_default_rtc_originated` and a regression test
(`default_rtc_retained_after_last_rtc_peer_drops_and_readvertised_on_return`).
No withdraw added.

### (C) Add-Path `path_id = 0` on receive — KEEP permissive
The VPN and labeled Add-Path decoders accept a received `path_id` of 0. Added
`addpath_labeled_decode_accepts_path_id_zero` / `addpath_vpn_decode_accepts_path_id_zero`
pinning the permissive acceptance so a future change can't silently tighten it.

### (D) `RtcNlri::matches` coverage
Added `prefix_32_matches_origin_as_only` (/32 matches on origin AS regardless of
RT sub-type; misses a differing global admin or a non-RT community). The
RFC 4684-correct /96 behavior and the documented GoBGP divergence stay covered
by the existing tests. Matching semantics unchanged.

### (E) `rtc_vpn_filter` empty-membership coverage
Added `rtc_vpn_filter_strict_empty_and_argument_driven`: RTC negotiated + no
membership => strict empty (never fail-open), and the filter keys off the
passed `sendable` argument so a stale `peer_sendable_families` entry is harmless.

## Gates (all exit 0)
| gate | exit |
|---|---|
| `cargo build --workspace` | 0 |
| `cargo test -p rustbgpd-rib` | 0 |
| `cargo test -p rustbgpd-wire` | 0 |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |
| `cargo check -p rustbgpd-rib --features bench-internals --benches` | 0 |