### PR TITLE
fix: boot-revert fails closed on journal-cleanup failure (LAN-219/220/221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -887,30 +887,43 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   write-tmp+fsync+rename+fsync-dir primitive the commit-confirm journal
   uses (`confirm_journal::write_atomic`).
 
-- **Boot revert can no longer leave the config file missing (LAN-207).**
+- **Boot revert can no longer leave the config file missing, and its
+  refusal messages are state-aware (LAN-207, LAN-220).**
   `boot_revert_check` renames the on-disk candidate to
   `<config>.unconfirmed` before writing the restored pre-transaction
   config; if that write failed, the config file was gone and boot
   refused with nothing left to load. The candidate is now put back on a
-  restore-write failure, and the refusal message names the
-  `<config>.unconfirmed` backup slot and an explicit `rm <journal>`
-  recovery command.
+  restore-write failure. The refusal message now detects whether the
+  config file exists: when it is missing it no longer tells the operator
+  to `rm <journal>` and boot the on-disk config (there is none) — it
+  points them at the pre-transaction config embedded in the journal and
+  the `<config>.unconfirmed` candidate to restore instead. The revert is
+  idempotent across a crash mid-revert (config missing + live journal
+  resumes cleanly).
 
-- **A journal-removal failure at boot no longer loops and clobbers the
-  saved-aside candidate (LAN-208).** After a successful restore, if the
-  journal could not be removed, `boot_revert_check` returned `Err`;
-  under systemd `Restart=` that looped boot, and each iteration renamed
-  the already-reverted config over the real `<config>.unconfirmed`
-  candidate, destroying it. Boot now proceeds from the restored config,
-  surfaces the retained journal
-  (`config_transaction_lifecycle{operation="boot_revert",outcome="failure"}`
-  metric + loud ERROR/banner telling the operator to delete it) instead
-  of looping.
+- **A journal-removal failure at boot now FAILS STARTUP instead of
+  booting anyway, and never clobbers the saved-aside candidate
+  (LAN-219; supersedes the earlier LAN-208 boot-anyway behavior).**
+  After the revert is written, if the journal cannot be removed
+  `boot_revert_check` returns `Err` and the daemon refuses to start: a
+  daemon that cannot prove the revert intent was consumed would
+  otherwise silently re-revert every config the operator applies on each
+  restart. The reverted config is still written to disk and the
+  unconfirmed candidate is preserved at `<config>.unconfirmed`; the
+  refusal message states exactly this and tells the operator to preserve
+  the candidate, then fix the journal's permissions or `rm` it and
+  restart. The `.unconfirmed` recovery copy is written once and is never
+  overwritten with different bytes on a subsequent boot, so a restart
+  loop can no longer destroy the real saved candidate.
 
-- **Oversized commit-confirm journals are rejected before parse
-  (LAN-204).** A corrupt journal with a huge `rollback_toml` could OOM
-  during boot deserialization; boot now refuses (fail closed) any
-  journal larger than 10 MB before reading it.
+- **Oversized and non-regular-file commit-confirm journals are rejected
+  before read (LAN-204, LAN-221).** A corrupt journal with a huge
+  `rollback_toml` could OOM during boot deserialization; boot refuses
+  (fail closed) any journal larger than 10 MB. The size guard trusted
+  `metadata().len()`, which a FIFO/socket/device reports as 0 (bypassing
+  it) before a read blocks or runs unbounded — boot now also refuses any
+  journal path that is not a regular file, and reads the journal through
+  a hard byte cap as defense-in-depth.
 
 - **The library target now builds under `--all-features` (LAN-198).**
   The lib exposes `pub mod config` only under `bench-internals`, and

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -19,7 +19,7 @@
 #![deny(unsafe_code)]
 
 use std::fs::{self, File};
-use std::io::{self, Write as _};
+use std::io::{self, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -56,17 +56,15 @@ pub struct BootRevert {
 }
 
 /// The operator-facing facts of a boot revert (for the banner, log, metric).
+///
+/// A `BootRevert` is only produced when the revert fully succeeded — config
+/// restored AND journal consumed. A journal-cleanup failure fails startup
+/// (LAN-219), so there is no "booted anyway" residual state to carry here.
 #[derive(Debug, Clone)]
 pub struct BootRevertNotice {
     pub confirm_id: String,
     /// Where the unconfirmed candidate was saved aside.
     pub backup_path: PathBuf,
-    /// The config was restored, but the journal could not be removed. The boot
-    /// still proceeds from the restored config (rather than looping under
-    /// systemd `Restart=` and clobbering the saved-aside candidate — LAN-208);
-    /// `main` records a durable failure metric and tells the operator to delete
-    /// the stale journal.
-    pub journal_retained: bool,
 }
 
 #[must_use]
@@ -100,31 +98,29 @@ pub fn remove(path: &Path) -> io::Result<()> {
 /// - No journal → `Ok(None)`: normal boot.
 /// - Readable journal with a usable embedded previous config → revert: the
 ///   unconfirmed candidate config file is saved aside to
-///   `<config_path>.unconfirmed`, the previous config is restored to
-///   `config_path` (atomic write), the journal is removed, and the parsed
-///   previous config is returned for the daemon to boot from.
-/// - Journal present but unreadable/torn, or its embedded previous config is
-///   unusable, or the revert writes fail → `Err`: boot must REFUSE with the
-///   returned message (fail closed — never silently proceed with the
-///   unconfirmed candidate).
+///   `<config_path>.unconfirmed` (never overwriting an existing one), the
+///   previous config is restored to `config_path` (atomic write), the journal
+///   is removed, and the parsed previous config is returned to boot from.
+/// - Journal present but not a regular file, unreadable/torn/oversized, its
+///   embedded previous config is unusable, or the revert write fails → `Err`:
+///   boot REFUSES (fail closed — never silently proceed with the unconfirmed
+///   candidate).
+/// - Revert write SUCCEEDED but the journal cannot then be removed → `Err`
+///   (LAN-219): boot REFUSES rather than proceeding, because a daemon that
+///   cannot prove the revert intent was consumed would silently re-revert every
+///   config the operator applies on each restart. The recovery copy at
+///   `<config_path>.unconfirmed` is preserved; the next boot fails identically
+///   until the operator removes/fixes the journal.
 pub fn boot_revert_check(
     journal_path: &Path,
     config_path: &Path,
 ) -> Result<Option<BootRevert>, String> {
-    // Size guard BEFORE read (LAN-204): a corrupt journal with a giant
-    // `rollback_toml` must not OOM `read_to_string`/deserialize at boot.
-    match fs::metadata(journal_path) {
-        Ok(meta) if meta.len() > MAX_JOURNAL_BYTES => {
-            return Err(refuse_message(
-                journal_path,
-                config_path,
-                &format!(
-                    "the journal is {} bytes, exceeding the {MAX_JOURNAL_BYTES}-byte sanity limit — refusing to load a journal this large",
-                    meta.len()
-                ),
-            ));
-        }
-        Ok(_) => {}
+    // LAN-221: the journal must be a regular file. A FIFO/socket/device reports
+    // `len() == 0` (silently bypassing the size guard) and then blocks or reads
+    // unbounded; a directory is nonsense. Reject anything non-regular before
+    // opening it.
+    let meta = match fs::metadata(journal_path) {
+        Ok(meta) => meta,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(refuse_message(
@@ -133,8 +129,29 @@ pub fn boot_revert_check(
                 &format!("the journal cannot be read: {error}"),
             ));
         }
+    };
+    if !meta.is_file() {
+        return Err(refuse_message(
+            journal_path,
+            config_path,
+            "the journal is not a regular file (a directory, FIFO, socket, or device) — refusing to read it",
+        ));
     }
-    let raw = match fs::read_to_string(journal_path) {
+    // Size guard BEFORE read (LAN-204): a corrupt journal with a giant
+    // `rollback_toml` must not OOM deserialize at boot.
+    if meta.len() > MAX_JOURNAL_BYTES {
+        return Err(refuse_message(
+            journal_path,
+            config_path,
+            &format!(
+                "the journal is {} bytes, exceeding the {MAX_JOURNAL_BYTES}-byte sanity limit — refusing to load a journal this large",
+                meta.len()
+            ),
+        ));
+    }
+    // Bounded read (LAN-221 defense-in-depth): even if `metadata().len()` lied
+    // or the file grew after the size guard, never buffer more than the cap.
+    let raw = match read_journal_bounded(journal_path) {
         Ok(raw) => raw,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
@@ -162,32 +179,16 @@ pub fn boot_revert_check(
                 )
             })?;
 
-    // Save the unconfirmed candidate aside for the operator, then restore the
-    // previous config atomically. Order matters: the rename preserves the
-    // candidate bytes before anything overwrites them.
+    // Preserve the unconfirmed candidate for the operator, then restore the
+    // previous config. `candidate_saved` is true only when THIS call moved the
+    // config aside, so the write-failure path below knows it may put it back.
     let backup_path = unconfirmed_backup_path(config_path);
-    let candidate_saved = match fs::rename(config_path, &backup_path) {
-        Ok(()) => true,
-        // A missing config file is unexpected mid-revert but not a reason to
-        // refuse restoring a known-good config.
-        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
-        Err(error) => {
-            return Err(refuse_message(
-                journal_path,
-                config_path,
-                &format!(
-                    "failed to save the unconfirmed candidate aside to {}: {error}",
-                    backup_path.display()
-                ),
-            ));
-        }
-    };
+    let candidate_saved = save_candidate_aside(config_path, &backup_path, journal_path)?;
     if let Err(error) = write_atomic(config_path, journal.rollback_toml.as_bytes()) {
-        // The candidate was already renamed aside; if we bail now the config
-        // file is GONE and the next boot has nothing to load (LAN-207). Put the
-        // candidate back so the on-disk state is exactly what it was before this
-        // attempt — the journal is still present, so a retry runs the same
-        // (idempotent) revert.
+        // The write failed. If we moved the config aside this call, put it back
+        // so `config_path` is not left missing (LAN-207) — moving back only our
+        // own fresh backup, never a pre-existing `.unconfirmed`. The refusal
+        // message is state-aware about whether the config survived (LAN-220).
         if candidate_saved {
             let _ = fs::rename(&backup_path, config_path);
         }
@@ -197,41 +198,145 @@ pub fn boot_revert_check(
             &format!("failed to restore the pre-transaction config: {error}"),
         ));
     }
-    // The config is now restored on disk. If the journal cannot be removed we
-    // must NOT return Err: under systemd `Restart=` that loops boot, and the
-    // next iteration renames the (already-reverted) config over the real
-    // `.unconfirmed` candidate, destroying it (LAN-208). Boot from the restored
-    // config and surface the retained journal so `main` records a durable
-    // metric and tells the operator to delete it.
-    let journal_retained = remove(journal_path).is_err();
+    // Config restored on disk. LAN-219: we must PROVE the revert intent was
+    // consumed. If the journal cannot be removed, FAIL CLOSED — booting anyway
+    // turns a filesystem fault into silent, repeated reverting of every config
+    // the operator applies. The recovery copy already exists idempotently (moved
+    // aside above, or preserved from a prior attempt), so refuse without
+    // touching it; the next boot fails the same way until the journal is fixed.
+    if let Err(error) = remove(journal_path) {
+        return Err(refuse_after_revert_message(
+            journal_path,
+            config_path,
+            &backup_path,
+            &error,
+        ));
+    }
     Ok(Some(BootRevert {
         config: Box::new(config),
         notice: BootRevertNotice {
             confirm_id: journal.confirm_id,
             backup_path,
-            journal_retained,
         },
     }))
 }
 
-/// `<config_path>.unconfirmed` — one well-known slot, overwritten by a later
-/// boot revert; the loud boot log names it each time.
+/// Read the journal with a hard byte cap (LAN-221). Even if `metadata().len()`
+/// under-reports (a lying special file slipped past `is_file`, or the file grew
+/// after the size guard), never buffer more than the sanity cap.
+fn read_journal_bounded(path: &Path) -> io::Result<String> {
+    let mut reader = File::open(path)?.take(MAX_JOURNAL_BYTES + 1);
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf)?;
+    if buf.len() as u64 > MAX_JOURNAL_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("the journal exceeds the {MAX_JOURNAL_BYTES}-byte sanity limit"),
+        ));
+    }
+    Ok(buf)
+}
+
+/// Move the current on-disk config aside to `backup_path` so the operator keeps
+/// the unconfirmed candidate, then let the caller overwrite the config with the
+/// rollback. IDEMPOTENCY INVARIANT (LAN-208/LAN-219): never overwrite an
+/// existing `.unconfirmed` — on a restart loop it already holds the REAL saved
+/// candidate, and the config file is about to be overwritten anyway. Returns
+/// whether THIS call moved the config aside (so the caller may move it back on a
+/// write failure — it, and only it, created that backup).
+fn save_candidate_aside(
+    config_path: &Path,
+    backup_path: &Path,
+    journal_path: &Path,
+) -> Result<bool, String> {
+    let backup_exists = backup_path.try_exists().map_err(|error| {
+        refuse_message(
+            journal_path,
+            config_path,
+            &format!(
+                "failed to check the recovery copy at {}: {error}",
+                backup_path.display()
+            ),
+        )
+    })?;
+    if backup_exists {
+        return Ok(false);
+    }
+    match fs::rename(config_path, backup_path) {
+        Ok(()) => Ok(true),
+        // Config missing mid-revert (crash resume): nothing to save aside — the
+        // recovery copy, if one was ever made, is already at backup.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(refuse_message(
+            journal_path,
+            config_path,
+            &format!(
+                "failed to save the unconfirmed candidate aside to {}: {error}",
+                backup_path.display()
+            ),
+        )),
+    }
+}
+
+/// `<config_path>.unconfirmed` — one well-known slot, written once and preserved
+/// across restarts (never overwritten once it holds a candidate — LAN-208); the
+/// loud boot log names it.
 fn unconfirmed_backup_path(config_path: &Path) -> PathBuf {
     let mut name = config_path.as_os_str().to_os_string();
     name.push(".unconfirmed");
     PathBuf::from(name)
 }
 
+/// Refusal for a journal that could NOT be fully applied (not a regular file,
+/// torn/oversized/unusable, or a failed save-aside/restore). State-aware on
+/// whether the config file survived (LAN-220): advising the operator to `rm`
+/// the journal and boot the on-disk config is wrong when that file is missing.
 fn refuse_message(journal_path: &Path, config_path: &Path, detail: &str) -> String {
+    let journal = journal_path.display();
+    let config = config_path.display();
+    let backup = unconfirmed_backup_path(config_path);
+    let backup = backup.display();
+    // Treat an errored existence check as "missing": the safe assumption is to
+    // NOT advise booting a file we cannot confirm is present.
+    if config_path.try_exists().unwrap_or(false) {
+        format!(
+            "refusing to boot: a commit-confirmed config transaction revert journal exists at {journal} \
+             (meaning the last run stopped inside a confirm window, so the on-disk config {config} may be \
+             an unconfirmed candidate), but {detail}. If a candidate was saved aside during the revert it \
+             is at {backup}. Inspect {journal} and {config}; to boot the current on-disk config anyway, \
+             run `rm {journal}` and restart."
+        )
+    } else {
+        format!(
+            "refusing to boot: a commit-confirmed config transaction revert journal exists at {journal} \
+             (meaning the last run stopped inside a confirm window), but {detail}. The config file {config} \
+             is MISSING, so there is nothing to boot — do NOT just `rm {journal}`. The pre-transaction config \
+             is embedded in {journal} and the unconfirmed candidate, if one was saved, is at {backup}; \
+             restore one of them to {config} before restarting."
+        )
+    }
+}
+
+/// Refusal after the revert WAS applied but the journal could not be cleaned up
+/// (LAN-219 fail-closed). Distinct from [`refuse_message`]: the config on disk
+/// is now the reverted pre-transaction config and the candidate is preserved, so
+/// the recovery instructions differ — the operator must clear the journal, not
+/// restore the config.
+fn refuse_after_revert_message(
+    journal_path: &Path,
+    config_path: &Path,
+    backup_path: &Path,
+    error: &io::Error,
+) -> String {
     format!(
-        "refusing to boot: a commit-confirmed config transaction revert journal exists at {journal} \
-         (meaning the last run stopped inside a confirm window, so the on-disk config {config} may be \
-         an unconfirmed candidate), but {detail}. If a candidate was saved aside during the revert it \
-         is at {backup}. Inspect {journal} and {config}; to boot the current on-disk config anyway, \
-         run `rm {journal}` and restart.",
-        journal = journal_path.display(),
+        "refusing to boot: the commit-confirmed revert WAS applied — the pre-transaction config was written \
+         to {config} — but the revert journal at {journal} could not be removed ({error}). The unconfirmed \
+         candidate is preserved at {backup}. Refusing to start to avoid repeatedly reverting any config you \
+         apply: until the journal is gone, every boot re-runs this revert. To recover, inspect and preserve \
+         {backup}, then fix the journal's permissions or `rm {journal}`, and restart.",
         config = config_path.display(),
-        backup = unconfirmed_backup_path(config_path).display(),
+        journal = journal_path.display(),
+        backup = backup_path.display(),
     )
 }
 
@@ -422,8 +527,8 @@ log_format = "json"
 
         let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
         assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        // No candidate existed, so nothing was saved aside.
         assert!(!revert.notice.backup_path.exists());
-        assert!(!revert.notice.journal_retained);
     }
 
     #[test]
@@ -478,11 +583,14 @@ log_format = "json"
 
     #[cfg(unix)]
     #[test]
-    fn boot_check_retains_journal_instead_of_looping_when_removal_fails() {
-        // LAN-208: a journal-removal failure after a successful restore must NOT
-        // be fatal (returning Err loops boot under systemd Restart= and, on the
-        // next iteration, renames the reverted config over the real .unconfirmed
-        // candidate). Boot from the restored config with journal_retained set.
+    fn boot_check_fails_closed_without_clobbering_candidate_when_journal_removal_fails() {
+        // LAN-219 (SUPERSEDES LAN-208's boot-anyway): a journal-removal failure
+        // AFTER a successful restore must FAIL STARTUP (return Err), not boot
+        // anyway. Booting anyway lets a filesystem fault silently re-revert every
+        // config the operator applies. The revert is still written to disk and
+        // the real candidate is preserved at `.unconfirmed` — and, crucially, a
+        // second boot (with a different on-disk config, as if the operator
+        // re-applied) must STILL fail and must NOT clobber that candidate.
         use std::os::unix::fs::PermissionsExt;
 
         let base = tempfile::tempdir().unwrap();
@@ -504,22 +612,126 @@ log_format = "json"
             return;
         }
 
-        let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
-        assert!(
-            revert.notice.journal_retained,
-            "a removal failure must surface as journal_retained, not a fatal Err"
-        );
-        // Config restored despite the removal failure.
+        // First boot: revert is written, journal removal fails → fail closed.
+        let message = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message.contains("refusing to boot"), "{message}");
+        assert!(message.contains("WAS applied"), "{message}");
+        // The revert WAS written despite the refusal.
         assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
         // The real candidate is preserved in the backup slot.
+        let backup = unconfirmed_backup_path(&config_path);
         assert_eq!(
-            fs::read_to_string(&revert.notice.backup_path).unwrap(),
+            fs::read_to_string(&backup).unwrap(),
             "unconfirmed candidate bytes"
         );
-        // Journal still present (couldn't be removed) but boot succeeded.
-        assert!(path.exists());
+        assert!(path.exists(), "journal preserved for the next boot");
+
+        // Second boot, simulating an operator who applied a DIFFERENT config in
+        // the meantime: it must STILL fail closed and must NOT overwrite the
+        // preserved candidate with those different bytes (the LAN-208 clobber).
+        fs::write(&config_path, "operator re-applied different bytes").unwrap();
+        let message2 = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message2.contains("refusing to boot"), "{message2}");
+        // Candidate is byte-for-byte unchanged — no clobber.
+        assert_eq!(
+            fs::read_to_string(&backup).unwrap(),
+            "unconfirmed candidate bytes",
+            "the saved candidate must never be overwritten by a restart loop"
+        );
 
         // Restore perms so tempdir cleanup works.
         fs::set_permissions(&journal_dir, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[test]
+    fn boot_check_never_overwrites_existing_unconfirmed_candidate() {
+        // LAN-219 invariant: a pre-existing `.unconfirmed` (the real saved
+        // candidate) is never overwritten, even on a normal successful revert.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "current on-disk config").unwrap();
+        let backup = unconfirmed_backup_path(&config_path);
+        fs::write(&backup, "the real preserved candidate").unwrap();
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+
+        let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
+        // Revert still applied.
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        // The pre-existing candidate is untouched — NOT overwritten with the
+        // current on-disk config.
+        assert_eq!(
+            fs::read_to_string(&revert.notice.backup_path).unwrap(),
+            "the real preserved candidate"
+        );
+        assert!(!path.exists(), "journal consumed on success");
+    }
+
+    #[test]
+    fn boot_check_resumes_revert_after_crash_without_overwriting_candidate() {
+        // LAN-220 idempotency: crash mid-revert leaves config_path missing (it
+        // was already renamed to `.unconfirmed`) with a live journal. Resume must
+        // write the rollback and NOT overwrite the preserved candidate.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        // config_path intentionally absent (renamed aside by the crashed run).
+        let backup = unconfirmed_backup_path(&config_path);
+        fs::write(&backup, "candidate from the crashed run").unwrap();
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+
+        let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+        assert_eq!(
+            fs::read_to_string(&revert.notice.backup_path).unwrap(),
+            "candidate from the crashed run",
+            "the candidate preserved before the crash must survive the resume"
+        );
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn boot_check_refuse_message_is_state_aware_when_config_missing() {
+        // LAN-220: when config_path does not exist, the refusal must NOT tell the
+        // operator to `rm` the journal and boot the on-disk config (there is
+        // none). It must name the journal and the `.unconfirmed` candidate.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml"); // absent
+        let path = journal_path(dir.path());
+        // Torn journal so the revert cannot apply, forcing a refusal.
+        fs::write(&path, "{\"confirm_id\": \"deploy-1\", \"dead").unwrap();
+
+        let message = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message.contains("refusing to boot"), "{message}");
+        assert!(message.contains("MISSING"), "{message}");
+        assert!(
+            message.contains(&*path.to_string_lossy()),
+            "must name the journal: {message}"
+        );
+        assert!(
+            message.contains(&*unconfirmed_backup_path(&config_path).to_string_lossy()),
+            "must name the .unconfirmed candidate: {message}"
+        );
+        assert!(
+            !message.contains("boot the current on-disk config"),
+            "must not advise booting a missing config: {message}"
+        );
+    }
+
+    #[test]
+    fn boot_check_refuses_non_regular_file_journal() {
+        // LAN-221: a journal path that is a directory (or any non-regular file,
+        // e.g. a FIFO reporting len()==0) must be refused, never read/hung.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let path = journal_path(dir.path());
+        fs::create_dir(&path).unwrap();
+
+        let message = boot_revert_check(&path, &config_path).unwrap_err();
+        assert!(message.contains("refusing to boot"), "{message}");
+        assert!(message.contains("not a regular file"), "{message}");
+        // Fail closed: config untouched.
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1265,24 +1265,10 @@ async fn run<T>(
             "!! Booted from the pre-transaction config; the unconfirmed candidate was saved to {}.",
             notice.backup_path.display()
         );
-        if notice.journal_retained {
-            // Config was restored, but the revert journal could not be removed.
-            // Booting anyway (rather than looping and clobbering the saved-aside
-            // candidate — LAN-208); the operator must delete the journal, and a
-            // durable failure metric makes the residual state diagnosable.
-            error!(
-                journal = %confirm_journal::journal_path(&config.runtime_state_dir()).display(),
-                "commit-confirm boot revert could not remove the journal after restoring the config; \
-                 delete it manually or the next boot re-runs the revert and overwrites the saved-aside candidate"
-            );
-            eprintln!(
-                "!! WARNING: the revert journal could not be removed. Delete {} before the next restart.",
-                confirm_journal::journal_path(&config.runtime_state_dir()).display()
-            );
-            metrics.record_config_transaction_lifecycle("boot_revert", "failure");
-        } else {
-            metrics.record_config_transaction_lifecycle("boot_revert", "success");
-        }
+        // A `BootRevertNotice` only exists when the revert fully succeeded
+        // (config restored AND journal consumed); a journal-cleanup failure
+        // fails startup upstream (LAN-219), so there is no failure branch here.
+        metrics.record_config_transaction_lifecycle("boot_revert", "success");
     }
     let router_id: Ipv4Addr = config.global.router_id.parse().unwrap_or_else(|e| {
         error!(


### PR DESCRIPTION
Round-2 durability fixes for the commit-confirm boot-revert path (`src/confirm_journal.rs::boot_revert_check`), found by an outside review of #708. **This SUPERSEDES the LAN-208 boot-anyway behavior: the daemon now fails closed.**

## LAN-219 — fail closed on journal-cleanup failure (core)
After the revert config is written to `config_path`, if the journal cannot then be removed, boot now **FAILS STARTUP** (returns `Err`) instead of booting anyway. Rationale: a daemon that cannot prove the rollback intent was consumed must not run — booting anyway turns a filesystem fault into silent, repeated reverting of every config the operator applies on each restart. The reverted config is still written; the unconfirmed candidate is preserved at `<config>.unconfirmed`; the refusal message states exactly this and gives operator recovery (preserve `.unconfirmed`, fix permissions or `rm` the journal, restart). The next boot fails identically until the journal is fixed.

**No-clobber invariant** (fixes the original LAN-208 clobber): `.unconfirmed` is written once and is **never overwritten with different bytes** on a subsequent boot, so a restart loop can no longer destroy the real saved candidate.

Removed the now-unreachable `BootRevertNotice::journal_retained` field, its `main.rs` branch, and the `config_transaction_lifecycle{operation="boot_revert",outcome="failure"}` metric emission (the loud pre-refusal message is the signal now). The metric definition stays — it is still used by confirm/abort/auto_revert.

## LAN-220 — state-aware refusal + idempotent resume
The restore-on-write-failure refusal messages now detect whether `config_path` exists: when it is missing they no longer advise `rm <journal>` and booting the on-disk config (there is none) — they point at the journal's embedded pre-transaction config and the `.unconfirmed` candidate. The revert is idempotent across a crash mid-revert (config missing + live journal resumes without overwriting the preserved candidate).

## LAN-221 — reject non-regular-file journals + bounded read
The size guard trusted `metadata().len()`, which a FIFO/special file reports as `0` (bypassing it) before `read` blocks or reads unbounded. Boot now refuses any journal path that is not a regular file, and reads the journal through a hard byte cap (`take(MAX+1)`) as defense-in-depth.

## Tests
- `boot_check_fails_closed_without_clobbering_candidate_when_journal_removal_fails` — **the no-clobber regression test** (rewrites the obsolete #708 `boot_check_retains_journal_instead_of_looping_when_removal_fails`): first boot fails closed with the revert written + candidate preserved; a second boot with a *different* on-disk config still fails closed and leaves `.unconfirmed` byte-for-byte unchanged.
- `boot_check_never_overwrites_existing_unconfirmed_candidate` — pre-existing `.unconfirmed` never overwritten even on a successful revert.
- `boot_check_resumes_revert_after_crash_without_overwriting_candidate` — config missing + live journal + preserved candidate → resumes cleanly.
- `boot_check_refuse_message_is_state_aware_when_config_missing` — missing-config refusal names journal + `.unconfirmed`, does not say "boot the on-disk config".
- `boot_check_refuses_non_regular_file_journal` — directory/special-file journal refused, not hung.
- Happy path + existing LAN-204/207 refusal tests unchanged and green.

## Gates (all exit 0)
| gate | exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test --bin rustbgpd` | 0 (1304 passed) |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |

Scope: `src/confirm_journal.rs`, `src/main.rs`, `CHANGELOG.md` only.