### PR TITLE
fix(policy): close the absent-`!=` class #714 opened for next-hop (prefix / route-type / evpn-route-type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -793,6 +793,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   guards that, like `==`, require the attribute present, so an absent
   next-hop matches neither. `!= peer.address` still reads peer identity
   (disqualifies update-group sharing).
+- **`.rpol` `route.prefix != …`, `route.route-type != …`, and
+  `route.evpn-route-type != …` no longer match a route missing that
+  attribute — closes the absent-`!=` class LAN-209 opened for
+  next-hop.** The same `!= → Not(<X>Eq)` lowering that flipped next-hop
+  affected every field whose `==` is false-on-absent: `route.prefix`
+  matched every prefixless route (BGP-LS / RTC NLRIs), `route.route-type`
+  matched when the source class was absent, and — the highest-impact
+  case — `route.evpn-route-type != N` matched **every non-EVPN route**
+  (they all carry no EVPN route type), silently rejecting normal unicast
+  traffic. Each now lowers to a dedicated `PrefixNe` / `RouteTypeNe` /
+  `EvpnRouteTypeNe` guard that, like `==`, requires the attribute
+  present, so an absent attribute matches neither operator. A class-guard
+  test asserts every absent-able comparable field matches neither `==`
+  nor `!=` when its attribute is absent, so a future field cannot
+  reintroduce the flip. (Fields with RFC 4271 implicit defaults —
+  `local-pref` / `med` — and the total-enum `rpki` / `aspa` states were
+  audited and are correctly unaffected.)
 - **Policy hit-counter attribution no longer risks a panic on a stale
   counter set (LAN-192).** `evaluate_with_attribution_counting` indexed
   the per-policy and per-term counter arrays directly; a counter set

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -570,6 +570,16 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
             }
             out
         }
+        MatchExpr::PrefixNe { prefix, ge, le } => {
+            let mut out = format!("route.prefix != {prefix}");
+            if let Some(ge) = ge {
+                let _ = write!(out, " ge {ge}");
+            }
+            if let Some(le) = le {
+                let _ = write!(out, " le {le}");
+            }
+            out
+        }
         MatchExpr::CommunityContains(cm) => {
             format!(
                 "{} has {}",
@@ -622,8 +632,14 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
         MatchExpr::RouteTypeIs(route_type) => {
             format!("route.route-type == {}", route_type_label(*route_type))
         }
+        MatchExpr::RouteTypeNe(route_type) => {
+            format!("route.route-type != {}", route_type_label(*route_type))
+        }
         MatchExpr::EvpnRouteTypeIs(evpn_type) => {
             format!("route.evpn-route-type == {evpn_type}")
+        }
+        MatchExpr::EvpnRouteTypeNe(evpn_type) => {
+            format!("route.evpn-route-type != {evpn_type}")
         }
         MatchExpr::RpkiIs(state) => format!(
             "route.rpki == {}",

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -335,6 +335,12 @@ impl CompiledChain {
             MatchExpr::PrefixEq { prefix, ge, le } => ctx
                 .prefix
                 .is_some_and(|candidate| prefix_entry_matches(*prefix, *ge, *le, candidate)),
+            // `!=` mirrors `==`: a prefixless route (BGP-LS / RTC NLRIs)
+            // matches neither, so require the prefix present before
+            // testing non-containment.
+            MatchExpr::PrefixNe { prefix, ge, le } => ctx
+                .prefix
+                .is_some_and(|candidate| !prefix_entry_matches(*prefix, *ge, *le, candidate)),
             MatchExpr::PrefixInSet(id) => ctx
                 .prefix
                 .is_some_and(|candidate| self.prefix_sets[id.0 as usize].matches(candidate)),
@@ -368,7 +374,14 @@ impl CompiledChain {
                 set.matches(ctx.peer_address, ctx.peer_asn, ctx.peer_group)
             }
             MatchExpr::RouteTypeIs(route_type) => ctx.route_type == Some(*route_type),
+            // `!=` mirrors `==`: an absent route-type matches neither.
+            MatchExpr::RouteTypeNe(route_type) => ctx.route_type.is_some_and(|t| t != *route_type),
             MatchExpr::EvpnRouteTypeIs(evpn_type) => ctx.evpn_route_type == Some(*evpn_type),
+            // `!=` mirrors `==`: a non-EVPN route (absent
+            // evpn-route-type) matches neither.
+            MatchExpr::EvpnRouteTypeNe(evpn_type) => {
+                ctx.evpn_route_type.is_some_and(|t| t != *evpn_type)
+            }
             MatchExpr::RpkiIs(state) => ctx.validation_state == *state,
             MatchExpr::AspaIs(state) => ctx.aspa_state == *state,
         }

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -54,12 +54,14 @@ pub enum Cmp {
 /// matcher exactly (pinned by the golden corpus in
 /// `engine/tests/ir_parity.rs`):
 ///
-/// - Prefix nodes never match a prefixless route (e.g. BGP-LS NLRIs).
+/// - Prefix nodes (`PrefixEq` / `PrefixNe` / `PrefixInSet`) never match
+///   a prefixless route (e.g. BGP-LS / RTC NLRIs) — `!=` mirrors `==`.
 /// - [`Cmp`] on `LocalPref` / `Med` sees the RFC 4271 implicit defaults
 ///   (`LOCAL_PREF` 100, `MED` 0) when the attribute is absent.
-/// - `RouteTypeIs` / `EvpnRouteTypeIs` / `NextHopEq` / `NextHopNe`
-///   never match when the corresponding context field is `None` (`!=`
-///   mirrors `==`: an absent attribute satisfies neither).
+/// - `RouteTypeIs` / `EvpnRouteTypeIs` / `NextHopEq` and their `Ne`
+///   siblings (`RouteTypeNe` / `EvpnRouteTypeNe` / `NextHopNe`) never
+///   match when the corresponding context field is `None` (`!=` mirrors
+///   `==`: an absent attribute satisfies neither).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchExpr {
     /// Always matches (an unconditional term).
@@ -70,6 +72,18 @@ pub enum MatchExpr {
     /// (see [`crate::sets::prefix_entry_matches`]). Single-prefix
     /// matches stay inline rather than paying a set indirection.
     PrefixEq {
+        /// The covering prefix; candidates are masked at its length.
+        prefix: Prefix,
+        /// Minimum candidate prefix length (inclusive).
+        ge: Option<u8>,
+        /// Maximum candidate prefix length (inclusive).
+        le: Option<u8>,
+    },
+    /// The route's prefix does **not** match this `(prefix, ge, le)`
+    /// triple. Unlike `Not(PrefixEq{…})`, this never matches a
+    /// prefixless route (BGP-LS / RTC NLRIs): `!=` mirrors `==`, so an
+    /// absent prefix satisfies neither.
+    PrefixNe {
         /// The covering prefix; candidates are masked at its length.
         prefix: Prefix,
         /// Minimum candidate prefix length (inclusive).
@@ -117,8 +131,16 @@ pub enum MatchExpr {
     NeighborIn(Box<NeighborSetMatch>),
     /// The route's source class equals this type.
     RouteTypeIs(RouteType),
+    /// The route's source class differs from this type. Unlike
+    /// `Not(RouteTypeIs(_))`, this never matches when the route-type is
+    /// absent — `!=` mirrors `==`.
+    RouteTypeNe(RouteType),
     /// The route is an EVPN NLRI of this route type (RFC 7432 §7).
     EvpnRouteTypeIs(u8),
+    /// The route is an EVPN NLRI whose route type differs from this one.
+    /// Unlike `Not(EvpnRouteTypeIs(_))`, this never matches a non-EVPN
+    /// (absent evpn-route-type) route — `!=` mirrors `==`.
+    EvpnRouteTypeNe(u8),
     /// RPKI origin validation state equals this state (RFC 6811).
     RpkiIs(RpkiValidation),
     /// ASPA path verification state equals this state.
@@ -149,10 +171,14 @@ impl MatchExpr {
             | MatchExpr::NextHopNe(_)
             | MatchExpr::NextHopNePeer
             | MatchExpr::RouteTypeIs(_)
+            | MatchExpr::RouteTypeNe(_)
             | MatchExpr::EvpnRouteTypeIs(_)
+            | MatchExpr::EvpnRouteTypeNe(_)
             | MatchExpr::RpkiIs(_)
             | MatchExpr::AspaIs(_) => 0,
-            MatchExpr::PrefixInSet(_) | MatchExpr::PrefixEq { .. } => 1,
+            MatchExpr::PrefixInSet(_) | MatchExpr::PrefixEq { .. } | MatchExpr::PrefixNe { .. } => {
+                1
+            }
             MatchExpr::NeighborIn(_) => 2,
             MatchExpr::CommunityContains(_) | MatchExpr::CommunityInSet(_) => 3,
             MatchExpr::AsPathMatches(_) => 4,

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -362,6 +362,7 @@ impl<'a> Lowerer<'a> {
     }
 }
 
+#[expect(clippy::too_many_lines, reason = "one arm per comparable policy field")]
 fn lower_cmp(
     field: &super::ast::FieldPath,
     op: CmpOp,
@@ -373,12 +374,20 @@ fn lower_cmp(
         Field::LocalPref => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::LocalPref),
         Field::Med => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::Med),
         Field::AsPathLen => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::AsPathLen),
+        // `!=` gets a dedicated Ne node rather than `Not(Eq)`: a
+        // non-EVPN route (absent evpn-route-type) must match neither `==`
+        // nor `!=` (LAN-209 class), and `Not(EvpnRouteTypeIs)` would
+        // wrongly match every non-EVPN route.
         Field::EvpnRouteType => {
             let Rhs::Int(value, _) = rhs else {
                 unreachable!("typechecked: evpn-route-type takes an integer literal")
             };
-            let node = MatchExpr::EvpnRouteTypeIs(u8::try_from(*value).expect("typechecked range"));
-            negate_if(op == CmpOp::Ne, node)
+            let evpn_type = u8::try_from(*value).expect("typechecked range");
+            if op == CmpOp::Ne {
+                MatchExpr::EvpnRouteTypeNe(evpn_type)
+            } else {
+                MatchExpr::EvpnRouteTypeIs(evpn_type)
+            }
         }
         Field::Rpki => {
             let node = MatchExpr::RpkiIs(match rhs_ident(rhs) {
@@ -396,13 +405,20 @@ fn lower_cmp(
             });
             negate_if(op == CmpOp::Ne, node)
         }
+        // `!=` gets a dedicated Ne node rather than `Not(Eq)`: an absent
+        // route-type must match neither `==` nor `!=` (LAN-209 class),
+        // and `Not(RouteTypeIs)` would wrongly match when it is absent.
         Field::RouteType => {
-            let node = MatchExpr::RouteTypeIs(match rhs_ident(rhs) {
+            let route_type = match rhs_ident(rhs) {
                 "local" => crate::engine::RouteType::Local,
                 "internal" => crate::engine::RouteType::Internal,
                 _ => crate::engine::RouteType::External,
-            });
-            negate_if(op == CmpOp::Ne, node)
+            };
+            if op == CmpOp::Ne {
+                MatchExpr::RouteTypeNe(route_type)
+            } else {
+                MatchExpr::RouteTypeIs(route_type)
+            }
         }
         // `!=` gets a dedicated Ne node rather than `Not(Eq)`: an absent
         // next-hop must match neither `==` nor `!=` (LAN-209), and
@@ -454,16 +470,27 @@ fn lower_cmp(
             }));
             negate_if(op == CmpOp::Ne, node)
         }
+        // `!=` gets a dedicated Ne node rather than `Not(Eq)`: a
+        // prefixless route (BGP-LS / RTC NLRIs) must match neither `==`
+        // nor `!=` (LAN-209 class), and `Not(PrefixEq)` would wrongly
+        // match when the prefix is absent.
         Field::Prefix => {
             let Rhs::Prefix(prefix, _) = rhs else {
                 unreachable!("typechecked: prefix compares a prefix")
             };
-            let node = MatchExpr::PrefixEq {
-                prefix: *prefix,
-                ge: None,
-                le: None,
-            };
-            negate_if(op == CmpOp::Ne, node)
+            if op == CmpOp::Ne {
+                MatchExpr::PrefixNe {
+                    prefix: *prefix,
+                    ge: None,
+                    le: None,
+                }
+            } else {
+                MatchExpr::PrefixEq {
+                    prefix: *prefix,
+                    ge: None,
+                    le: None,
+                }
+            }
         }
         Field::Communities | Field::LargeCommunities | Field::ExtCommunities | Field::AsPath => {
             unreachable!("typechecked: no direct comparison on lists")

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -920,3 +920,161 @@ fn evpn_route_type_enforces_rfc7432_range() {
         );
     }
 }
+
+/// A route context with every optional attribute absent — the shape a
+/// BGP-LS / RTC / non-EVPN NLRI presents to a policy.
+fn absent_ctx() -> RouteContext<'static> {
+    RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    }
+}
+
+/// Compile `if route.<expr> { reject }` guarded by `everything-else:
+/// accept`, so a matching guard yields `Deny` and a non-matching one
+/// falls through to `Permit`.
+fn reject_if(guard: &str) -> crate::ir::CompiledChain {
+    compile_ok(&format!(
+        "policy guard {{ term t {{ if {guard} {{ reject }} }} term rest {{ accept }} }}"
+    ))
+}
+
+/// LAN-209 class guard: for EVERY structurally-absent route attribute
+/// that supports `==`/`!=`, an absent attribute must match **neither**
+/// operator (mirroring the next-hop fix). This fails loudly if any
+/// field's `!=` ever lowers back to `Not(<X>Eq)` (which matches on
+/// absent) — a future comparable field cannot silently reintroduce the
+/// bug without tripping this table.
+///
+/// `local-pref`/`med` are deliberately excluded: they carry RFC 4271
+/// implicit defaults (100/0), so their "absent" is a real value that
+/// legitimately compares — they are not part of the absent-`!=` class.
+#[test]
+fn absent_route_attribute_matches_neither_eq_nor_ne() {
+    // (field expression, a literal it compares against)
+    let fields = [
+        ("route.next-hop", "192.0.2.1"),
+        ("route.prefix", "10.0.0.0/24"),
+        ("route.route-type", "external"),
+        ("route.evpn-route-type", "3"),
+    ];
+    let absent = absent_ctx();
+    for (field, literal) in fields {
+        for op in ["==", "!="] {
+            let chain = reject_if(&format!("{field} {op} {literal}"));
+            assert_eq!(
+                chain.evaluate(&absent).action,
+                PolicyAction::Permit,
+                "absent `{field}` must not match `{field} {op} {literal}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn evpn_route_type_ne_absent_does_not_match() {
+    // A non-EVPN route (absent evpn-route-type) must match neither `==`
+    // nor `!=` — `Not(EvpnRouteTypeIs)` used to match every such route.
+    let chain = reject_if("route.evpn-route-type != 3");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::EvpnRouteTypeNe(3)
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        evpn_route_type: Some(2),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        evpn_route_type: Some(3),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "absent evpn-route-type must not match `!= 3`"
+    );
+}
+
+#[test]
+fn prefix_ne_absent_does_not_match() {
+    // A prefixless route (BGP-LS / RTC NLRIs) must match neither `==`
+    // nor `!=` — `Not(PrefixEq)` used to match every prefixless route.
+    let chain = reject_if("route.prefix != 10.0.0.0/24");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::PrefixNe {
+            prefix: v4(10, 0, 0, 0, 24),
+            ge: None,
+            le: None,
+        }
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        prefix: Some(v4(198, 51, 100, 0, 24)),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        prefix: Some(v4(10, 0, 0, 0, 24)),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "absent prefix must not match `!= 10.0.0.0/24`"
+    );
+}
+
+#[test]
+fn route_type_ne_absent_does_not_match() {
+    // A route with no source class must match neither `==` nor `!=` —
+    // `Not(RouteTypeIs)` used to match when the route-type was absent.
+    let chain = reject_if("route.route-type != external");
+    assert_eq!(
+        chain.policies[0].terms[0].guard,
+        MatchExpr::RouteTypeNe(crate::engine::RouteType::External)
+    );
+    let base = absent_ctx();
+    // Present and differing → matches → reject.
+    let differing = RouteContext {
+        route_type: Some(crate::engine::RouteType::Local),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&differing).action, PolicyAction::Deny);
+    // Present and equal → no match → accept.
+    let equal = RouteContext {
+        route_type: Some(crate::engine::RouteType::External),
+        ..base
+    };
+    assert_eq!(chain.evaluate(&equal).action, PolicyAction::Permit);
+    // Absent → must NOT match → accept (this was the bug).
+    assert_eq!(
+        chain.evaluate(&base).action,
+        PolicyAction::Permit,
+        "absent route-type must not match `!= external`"
+    );
+}

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -507,19 +507,20 @@ impl Checker<'_> {
     }
 
     /// `route.evpn-route-type` compares against a 1-5 integer literal
-    /// (the RFC 7432 §7 route types rustbgpd emits); 0 and 6-255 are
-    /// rejected as dead policies.
+    /// (RFC 7432 §7 defines types 1-4; RFC 9136 adds the type 5 IP
+    /// Prefix route); 0 and 6-255 are rejected as dead policies.
     fn check_evpn_route_type_rhs(&mut self, field: &FieldPath, rhs: &Rhs) {
         match rhs {
             // rustbgpd emits EVPN NLRIs of route types 1-5 only
-            // (RFC 7432 §7). A comparison against 0 or 6-255 can never
-            // match a real route, so reject it as a dead policy rather
-            // than let it silently never fire.
+            // (RFC 7432 §7 types 1-4 plus the RFC 9136 type 5 IP Prefix
+            // route). A comparison against 0 or 6-255 can never match a
+            // real route, so reject it as a dead policy rather than let
+            // it silently never fire.
             Rhs::Int(value, span) if !(1..=5).contains(value) => {
                 self.diags.push(Diagnostic::new(
                     *span,
                     format!("EVPN route type {value} out of range"),
-                    "must be 1-5 (RFC 7432 §7 route types)",
+                    "must be 1-5 (RFC 7432 §7 types 1-4, RFC 9136 type 5)",
                 ));
             }
             Rhs::Int(..) => {}


### PR DESCRIPTION
## Summary

PR #714 fixed `route.next-hop != …` matching a route with **no** next-hop
by adding dedicated `NextHopNe` / `NextHopNePeer` IR nodes that — like
`==` — require the attribute present, instead of lowering `!=` to
`Not(NextHopEq)` (which matches when the attribute is `None`). An outside
review found the **same class** of bug on every other field whose `!=`
lowered to `Not(<X>Eq)` where `<X>Eq` is false-on-absent.

This PR closes the class. I audited every `!=` lowering in `lower.rs`
against its matcher in `eval.rs`; the reachable-or-latent instances are
exactly three (no 4th):

| Field | Old lowering | Bug | Fix |
|-------|--------------|-----|-----|
| `route.evpn-route-type != N` | `Not(EvpnRouteTypeIs)` | matched **every non-EVPN route** (all carry `evpn_route_type: None`) — silently rejected normal traffic (high-frequency, reachable) | `EvpnRouteTypeNe(u8)` |
| `route.prefix != P` | `Not(PrefixEq)` | matched every prefixless route (BGP-LS / RTC NLRIs) (reachable) | `PrefixNe { prefix, ge, le }` |
| `route.route-type != external` | `Not(RouteTypeIs)` | matched when the source class was absent (latent) | `RouteTypeNe(RouteType)` |

Each new node requires the attribute present before comparing, so an
absent attribute matches **neither** `==` nor `!=`. Wired exactly like
`NextHopNe`: IR variant (`ir.rs`) + eval arm (`eval.rs`) + lowering
(`lower.rs`) + explain render (`engine/explain.rs`) + cost class. They
read route attributes (not peer identity), so they do **not** count
toward `requires_peer_context`.

### Fields audited and correctly NOT part of the class

- `local-pref` / `med` — RFC 4271 implicit defaults (100 / 0): "absent"
  is a real value that legitimately compares.
- `rpki` / `aspa` — total enums (`NotFound` / `Unknown` are real states).
- `as-path.len` — `usize`, `0` for an empty path.
- `peer.address` / `peer.asn` / `peer.group` (via `NeighborIn`) — peer
  identity is always present in production eval, and "peer has no
  group/asn" is a meaningful `!=` match (not a can't-compare hole).

Set-membership `in` has no `!=`/negated operator form (only the explicit
`!` operator negates it, which is user-controlled and out of the class),
so it is unaffected.

## Tests

All at the `.rpol` frontend level (end-to-end lower + eval):

- **`absent_route_attribute_matches_neither_eq_nor_ne`** — class guard:
  iterates every absent-able comparable route field and asserts an absent
  attribute matches neither `==` nor `!=`. Fails loudly if any field's
  `!=` ever lowers back to `Not(<X>Eq)`, so a future comparable field
  cannot silently reintroduce the flip.
- Per-instance absent-`!=` regressions for `evpn-route-type`, `prefix`,
  and `route-type` (IR-node shape + present-differing / present-equal /
  absent verdicts).

## Also

- Corrected the EVPN route-type RFC attribution in
  `check_evpn_route_type_rhs`: RFC 7432 §7 defines types 1-4; the type 5
  IP Prefix route is RFC 9136 (the valid 1-5 range is unchanged).

## Gates (all green)

| Gate | Exit |
|------|------|
| `cargo build --workspace` | 0 |
| `cargo test -p rustbgpd-policy` | 0 |
| `cargo test --bin rustbgpd` | 0 |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |
| `cd crates/policy/fuzz && cargo +nightly fuzz build` | 0 |

Scope: `crates/policy/**` + `CHANGELOG.md` only.