### PR TITLE
fix(rib): union regroup baseline on second regroup while dirty (stale-route leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Update-groups: a second policy-driven regroup while a member's prior
+  regroup resync is still un-drained no longer leaks stale routes.** A
+  grouped member keeps no per-family Adj-RIB-Out record of its unicast/VPN
+  wire state, so its `pending_regroup_baseline` is the *only* record of
+  what is on its wire. When a regroup resync send failed (outbound channel
+  full) the member stayed dirty with that baseline retained; a second
+  regroup before it drained *overwrote* the baseline with a fresh
+  group-view snapshot of a table the member was never advertised. Keys on
+  the wire but absent from both the new snapshot and the new group's table
+  then fell out of the withdraw candidate set and were never withdrawn,
+  stranding stale routes on the peer. The second regroup now *unions* the
+  new snapshot onto the retained baseline (existing/wire values win on
+  conflict) for both unicast and VPN, so every wire key stays a withdraw
+  candidate; `member_retains` still suppresses withdrawing keys present in
+  the new group's table. Regression-tested against the per-peer oracle
+  (`oracle_second_regroup_while_dirty_unions_baseline_no_leak`).
 - **Labeled IPv6 reflection no longer drops the link-local next-hop
   (LAN-190).** `LabeledRibRoute` stored only a single global next-hop, so
   a labeled-unicast (SAFI 4) IPv6 route received with an RFC 8950 §4 /

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -199,6 +199,39 @@ fn deny_prefix_chain(prefix: Ipv4Prefix) -> PolicyChain {
     }])
 }
 
+/// Deny several prefixes, permit the rest — a multi-statement variant of
+/// [`deny_prefix_chain`] so a second regroup lands on a *different* chain
+/// (a content-equal reinstall is key-stable and would not regroup).
+fn deny_prefixes_chain(prefixes: &[Ipv4Prefix]) -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: prefixes
+            .iter()
+            .map(|prefix| PolicyStatement {
+                prefix: Some(Prefix::V4(*prefix)),
+                ge: None,
+                le: None,
+                action: PolicyAction::Deny,
+                match_community: vec![],
+                match_as_path: None,
+                match_neighbor_set: None,
+                match_route_type: None,
+                match_evpn_route_type: None,
+                match_rpki_validation: None,
+                match_aspa_validation: None,
+                match_as_path_length_ge: None,
+                match_as_path_length_le: None,
+                match_local_pref_ge: None,
+                match_local_pref_le: None,
+                match_med_ge: None,
+                match_med_le: None,
+                match_next_hop: None,
+                modifications: RouteModifications::default(),
+            })
+            .collect(),
+        default_action: PolicyAction::Permit,
+    }])
+}
+
 /// One outbound message, normalized: announces carry everything the
 /// wire path consumes (route identity, next hop, source, attributes,
 /// aligned next-hop-override flag), sorted so intra-message iteration
@@ -906,6 +939,86 @@ async fn oracle_source_flip_withdraw_lost_to_full_channel_recovers() {
     assert!(
         !c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)),
         "the source-flip withdraw lost to the full channel must be recovered by the resync"
+    );
+}
+
+/// Regression (stale-route leak): a grouped member whose regroup resync
+/// SEND FAILS is dirty with `pending_regroup_baseline` holding the ONLY
+/// record of its true wire state (a grouped member keeps no per-family
+/// Adj-RIB-Out). A SECOND regroup before it drains must UNION the fresh
+/// group-view snapshot onto that baseline, not overwrite it — a blind
+/// overwrite drops wire keys absent from BOTH the new snapshot and the
+/// new group's table, so they are never withdrawn and leak.
+///
+/// Sequence: C in sync on wire {p1,p2} → jam its cap-1 channel with p3 →
+/// regroup A→B (policy denies p1; resync send fails → C dirty, baseline
+/// = {p1,p2,p3}) → regroup B→C (policy denies p1,p3) before C drains →
+/// drain + fire the resync timer. p1 is in the first baseline, absent
+/// from the second group view (denied by B) AND from group C's table
+/// (denied by C) — it MUST be withdrawn, not stranded on C's wire.
+#[tokio::test]
+async fn oracle_second_regroup_while_dirty_unions_baseline_no_leak() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await; // route source
+        o.peer_up(C, false, true, None, 1).await; // observed, cap-1 channel
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Sync C to wire {p1,p2}: each lands and is drained, so the
+        // channel empties between sends and C never goes dirty here.
+        for n in 1..=2u8 {
+            o.routes(A, vec![ibgp_route(pfx(n, 0), A, 100, vec![])], vec![])
+                .await;
+            o.drain_one(C).await;
+        }
+
+        // Jam: p3 (a distinct prefix) lands in the cap-1 channel and is
+        // NOT drained, so the next resync send fails against a full queue.
+        o.routes(A, vec![ibgp_route(pfx(3, 0), A, 100, vec![])], vec![])
+            .await;
+
+        // Regroup A→B (deny p1): baseline captures wire {p1,p2,p3}; the
+        // resync send fails against the full channel → C stays dirty.
+        o.replace_policy(C, Some(deny_prefixes_chain(&[pfx(1, 0)])))
+            .await;
+        // Regroup B→C (deny p1,p3) BEFORE C drains: must UNION onto the
+        // retained {p1,p2,p3} baseline, not overwrite with {p2,p3}.
+        o.replace_policy(C, Some(deny_prefixes_chain(&[pfx(1, 0), pfx(3, 0)])))
+            .await;
+
+        // Free the channel and let the resync timer fire.
+        o.drain_one(C).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    // The leak: p1 was on C's wire, is absent from group C's table, and
+    // is absent from the second group-view snapshot. A baseline overwrite
+    // never withdraws it (it never reaches the withdraw candidate set);
+    // the union does.
+    assert!(
+        !c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)),
+        "stale-route leak: p1 was never withdrawn — the second regroup \
+         overwrote the wire baseline instead of unioning it"
+    );
+    // member_retains must keep a route still in group C's table advertised.
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
+        "p2 (still in group C's table) must stay advertised"
+    );
+    // And the whole grouped end state must converge with the per-peer
+    // oracle, which tracks wire state in Adj-RIB-Out and cannot leak.
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "grouped final advertised state must converge with the per-peer oracle"
     );
 }
 

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1783,7 +1783,25 @@ impl RibManager {
                 self.join_group(gid, peer);
             }
             match (baseline, new_gid) {
-                (Some(base), Some(_)) => {
+                (Some(mut base), Some(_)) => {
+                    // A grouped member keeps no per-family record of its
+                    // unicast/VPN wire state in `adj_ribs_out` (join clears
+                    // it), so its `pending_regroup_baseline` entry is the
+                    // ONLY record of what is on its wire. If the member's
+                    // prior resync never committed (still dirty), that entry
+                    // is the true wire state, while `base` is a snapshot of a
+                    // group view the member was never advertised — UNION them
+                    // (existing/wire values win on conflict) rather than blind
+                    // overwrite. A blind overwrite drops wire keys absent from
+                    // BOTH the new snapshot and the new group's table: they
+                    // would never be withdrawn and leak as stale routes. One
+                    // baseline covers unicast AND VPN, so this covers both.
+                    if self.dirty_peers.contains(&peer)
+                        && let Some(prev) = self.pending_regroup_baseline.remove(&peer)
+                    {
+                        base.unicast.extend(prev.unicast);
+                        base.vpn.extend(prev.vpn);
+                    }
                     self.pending_regroup_baseline.insert(peer, base);
                 }
                 (Some(base), None) => {


### PR DESCRIPTION
## The bug (confirmed correctness defect)

A grouped update-group member keeps **no** per-family Adj-RIB-Out record of its unicast/VPN wire state — `join_group` clears it — so its `pending_regroup_baseline` entry is the **only** record of what is on that member's wire.

`recompute_update_group` did an **unconditional** `pending_regroup_baseline.insert(peer, base)`. Leak sequence:

1. Peer `P` grouped in group **A**, in sync (wire = `table_A − own`).
2. Policy edit **A→B**: captures `base_A`, moves P, `pending_regroup_baseline[P] = base_A`; marks P dirty; distributes.
3. P's resync **send fails** (outbound channel full) → `clear_grouped_member_synced` is *not* called → `base_A` retained, P dirty, nothing on the wire changed.
4. Policy edit **B→C** before P drains: recompute snapshots `base_B = table_B − own` and **blindly overwrites** `pending_regroup_baseline[P] = base_B`. P was never advertised `base_B`.
5. P drains → `assemble_group_resync(C, baseline = base_B)`; withdraw set = `base_B.keys() ∖ member_retains`. Keys in `base_A` but absent from **both** `base_B` and `table_C` are never withdrawn → **stale routes leak on P**.

## The fix

`recompute_update_group` now **unions** the fresh group-view snapshot onto the retained baseline (existing/wire values win on conflict) whenever the member is still dirty with a pending baseline, instead of overwriting. One `RegroupBaseline` holds both unicast and VPN, so the single guard covers **both** families (`base.unicast.extend(prev.unicast)` / `base.vpn.extend(prev.vpn)`).

Verified properties:
- `member_retains` still suppresses withdrawing keys present in the new group's table, so legitimately-advertised routes are not withdrawn by the enlarged baseline.
- Over-withdrawing a unioned key that was never actually on the wire is an RFC 4271 no-op.
- The baseline is still dropped on a successful resync (`clear_grouped_member_synced`) and on peer teardown (`peer_lifecycle.rs`), so the union cannot grow unbounded.
- The grouped→ungrouped→grouped (Adj-RIB-Out-seeded) path is unaffected — its baseline derives from Adj-RIB-Out with no pending entry present, so the guard is a no-op there; set-union keys cannot double-count.

## Regression test

`oracle_second_regroup_while_dirty_unions_baseline_no_leak` reproduces the exact leak against the differential per-peer oracle (which tracks wire state in Adj-RIB-Out and cannot leak). **Confirmed it fails before the fix** (`stale-route leak: p1 was never withdrawn`) and passes after.

## Gates (all exit 0)

| gate | rc |
|---|---|
| `cargo build --workspace` | 0 |
| `cargo test -p rustbgpd-rib` | 0 |
| `cargo test --workspace` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo doc --workspace --no-deps` | 0 |
| `cargo check -p rustbgpd --all-features --lib` | 0 |
| `cargo check -p rustbgpd-rib --features bench-internals --benches` | 0 |