### PR TITLE
fix: canonicalize rpol_files paths before read (LAN-218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`rpol_files` policy entries are canonicalized before they are read
+  (LAN-218).** Each `[policy] rpol_files` path is now `canonicalize()`d
+  immediately before `read_to_string`, so the file that is opened is the
+  file that was resolved — closing a symlink TOCTOU window between path
+  resolution and open. A path that cannot be canonicalized (missing or
+  unreadable) surfaces the same `failed to read` config error as before.
+  Robustness hardening; path resolution stays deliberately unconfined to
+  the config directory. Regression-tested via
+  `rpol_symlinked_file_canonicalizes_and_loads`.
 - **Update-groups: a second policy-driven regroup while a member's prior
   regroup resync is still un-drained no longer leaks stale routes.** A
   grouped member keeps no per-family Adj-RIB-Out record of its unicast/VPN

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -88,9 +88,12 @@ impl Config {
     /// absolute paths (`/etc/rbgp/policies/common.rpol`) and
     /// parent-relative references into a shared policy library are
     /// legitimate and expected. There is therefore no `..`/symlink
-    /// confinement or canonicalization step; a `base.join(entry)` that
-    /// escapes `base_dir` is intended behavior, not a traversal to
-    /// reject. (Untrusted candidate configs arrive via
+    /// *confinement*: a `base.join(entry)` that escapes `base_dir` is
+    /// intended behavior, not a traversal to reject. Each entry is,
+    /// however, `canonicalize()`d immediately before it is read
+    /// (LAN-218), closing the symlink TOCTOU window between path
+    /// resolution and open — canonicalization resolves the target, it
+    /// does not confine it. (Untrusted candidate configs arrive via
     /// `load_toml_with_diagnostics` with `base_dir = None`, so relative
     /// entries resolve against the process CWD and never against a
     /// caller-influenced base.)
@@ -106,6 +109,17 @@ impl Config {
                 path = base.join(path);
             }
             let display = path.display().to_string();
+            // Canonicalize before reading (LAN-218): resolve symlinks and
+            // `..` once, then read that resolved path so the file we open is
+            // the file we resolved (closes a symlink TOCTOU window).
+            // canonicalize() also errors on a missing/unreadable path — we
+            // surface that identically to a read failure.
+            let path = path
+                .canonicalize()
+                .map_err(|e| ConfigError::InvalidRpolFile {
+                    path: display.clone(),
+                    reason: format!("failed to read: {e}"),
+                })?;
             let source =
                 std::fs::read_to_string(&path).map_err(|e| ConfigError::InvalidRpolFile {
                     path: display.clone(),

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11791,6 +11791,32 @@ fn rpol_missing_file_fails_config_load() {
     assert!(error.contains("failed to read"), "{error}");
 }
 
+/// LAN-218: entries are `canonicalize()`d before reading, so an
+/// `rpol_files` path that points through a symlink still resolves to and
+/// loads the real file's content.
+#[cfg(unix)]
+#[test]
+fn rpol_symlinked_file_canonicalizes_and_loads() {
+    let dir = rpol_config_dir(RPOL_SOURCE, r#""bogon-filter""#);
+    std::os::unix::fs::symlink(
+        dir.path().join("policies/core.rpol"),
+        dir.path().join("policies/link.rpol"),
+    )
+    .unwrap();
+    let toml_path = dir.path().join("config.toml");
+    let toml = fs::read_to_string(&toml_path).unwrap().replace(
+        r#"rpol_files = ["policies/core.rpol"]"#,
+        r#"rpol_files = ["policies/link.rpol"]"#,
+    );
+    fs::write(&toml_path, toml).unwrap();
+
+    let config = load_dir(&dir).expect("symlinked rpol file loads");
+    // Content read through the symlink: both policies registered.
+    assert_eq!(config.policy.rpol.policies.len(), 2);
+    assert!(config.policy.rpol.policies.contains_key("bogon-filter"));
+    assert!(config.policy.rpol.policies.contains_key("customer-in"));
+}
+
 #[test]
 fn rpol_name_collision_with_toml_definition_fails() {
     let dir = rpol_config_dir("policy toml-pass { term t { reject } }", r#""toml-pass""#);


### PR DESCRIPTION
## Problem

`Config::load_rpol_files` (src/config/mod.rs) resolved each `[policy] rpol_files` entry to a path and then `read_to_string`d it directly. Between resolving the path and opening it, a symlink at that path could be swapped — a small TOCTOU window (robustness hardening, not a security requirement per the issue).

## Fix

Canonicalize each entry with `path.canonicalize()` immediately before reading, and read the canonicalized path, so the file that is opened is the file that was resolved. `canonicalize()` also fails on a missing/unreadable path; that is surfaced as the same `failed to read` `ConfigError::InvalidRpolFile` the loader already reports for read failures (no signature or error-type change). Path resolution stays deliberately unconfined to the config directory — canonicalization resolves the target, it does not reject `..`/absolute escapes.

## Test

Added `rpol_symlinked_file_canonicalizes_and_loads` (unix): references an rpol policy file through a symlink and asserts the real file's content loads (both policies registered). The existing `rpol_missing_file_fails_config_load` continues to assert a missing path yields the `failed to read` error, now via the canonicalize path.

Closes LAN-218