### PR TITLE
fix(config): reject degenerate ORR vantage IP (LAN-216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **ORR vantage config validation now rejects a degenerate vantage IP
+  (LAN-216).** An `orr_vantage` (RFC 9107) equal to the neighbor's own
+  peering address or the reflector's `router_id` degenerates to the
+  reflector's own viewpoint (plain non-ORR reflection) and is a
+  copy-paste misconfiguration. Config load/validate now fails closed on
+  either case with a diagnostic naming the field and offending address,
+  alongside the existing iBGP / `route_reflector_client` checks, rather
+  than silently accepting it.
 - **Update-groups: a second policy-driven regroup while a member's prior
   regroup resync is still un-drained no longer leaks stale routes.** A
   grouped member keeps no per-family Adj-RIB-Out record of its unicast/VPN

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2201,6 +2201,41 @@ orr_vantage = "192.0.2.7"
 }
 
 #[test]
+fn orr_vantage_rejected_when_equal_to_neighbor_or_local_address() {
+    // Vantage == the neighbor's own peering address (10.0.0.2).
+    let toml = orr_toml(
+        "route_reflector_client = true\norr_vantage = \"10.0.0.2\"",
+        "",
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidRrConfig { .. }));
+    assert!(
+        err.to_string().contains("orr_vantage")
+            && err.to_string().contains("neighbor's own address"),
+        "diagnostic names the field and offending address: {err}"
+    );
+
+    // Vantage == the reflector's own router_id (10.0.0.1).
+    let toml = orr_toml(
+        "route_reflector_client = true\norr_vantage = \"10.0.0.1\"",
+        "",
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidRrConfig { .. }));
+    assert!(
+        err.to_string().contains("orr_vantage") && err.to_string().contains("router_id"),
+        "diagnostic names the field and offending address: {err}"
+    );
+
+    // A distinct vantage is still accepted.
+    let toml = orr_toml(
+        "route_reflector_client = true\norr_vantage = \"192.0.2.7\"",
+        "",
+    );
+    assert!(parse(&toml).is_ok(), "distinct vantage passes validation");
+}
+
+#[test]
 fn orr_vantage_warns_without_linkstate_family() {
     // The warning condition (pure helper backing the load-time warn):
     // vantage set, no linkstate family anywhere → true.

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -408,7 +408,7 @@ impl Config {
             let orr_vantage = neighbor
                 .orr_vantage
                 .or_else(|| group.and_then(|g| g.orr_vantage));
-            if orr_vantage.is_some() {
+            if let Some(vantage) = orr_vantage {
                 if neighbor.remote_asn != self.global.asn {
                     return Err(ConfigError::InvalidRrConfig {
                         reason: format!(
@@ -422,6 +422,33 @@ impl Config {
                         reason: format!(
                             "orr_vantage on neighbor {} requires route_reflector_client = true",
                             neighbor.address
+                        ),
+                    });
+                }
+                // RFC 9107: the vantage must identify a *distinct* BGP-LS
+                // topology node. Equal to the client's own peering address
+                // or the reflector's router_id it degenerates to the
+                // reflector's own viewpoint (plain non-ORR reflection) — a
+                // copy-paste misconfiguration. Fail closed at config load.
+                if let Ok(peer_addr) = neighbor.address.parse::<IpAddr>()
+                    && vantage == peer_addr
+                {
+                    return Err(ConfigError::InvalidRrConfig {
+                        reason: format!(
+                            "orr_vantage {vantage} on neighbor {} must not equal the \
+                             neighbor's own address",
+                            neighbor.address
+                        ),
+                    });
+                }
+                if let Ok(local_addr) = self.global.router_id.parse::<IpAddr>()
+                    && vantage == local_addr
+                {
+                    return Err(ConfigError::InvalidRrConfig {
+                        reason: format!(
+                            "orr_vantage {vantage} on neighbor {} must not equal the \
+                             reflector's local router_id {}",
+                            neighbor.address, self.global.router_id
                         ),
                     });
                 }


### PR DESCRIPTION
## Problem

Optimal Route Reflection (RFC 9107) lets a neighbor carry an `orr_vantage` IP (the client's IGP location as a BGP-LS topology node). Config validation rejected a vantage on eBGP or without `route_reflector_client`, but did **not** reject a vantage IP equal to the neighbor's own peering address or the reflector's own `router_id`. Both degenerate to the reflector's own viewpoint (plain non-ORR reflection) and are copy-paste misconfigurations that should fail closed at config load, not silently take effect.

## Fix

In the static-TOML neighbor validation (`src/config/validation.rs`, the same block that already enforces the iBGP / `route_reflector_client` requirements), reject an `orr_vantage` that equals:
- the neighbor's own address, or
- the reflector's local `router_id`.

Each returns the existing `ConfigError::InvalidRrConfig` with a diagnostic naming the field and the offending address. This is the correct layer — `RibManager` only sees an already-validated vantage via a runtime `PeerUp`, and rejecting there would tear down a live session.

## Test

`orr_vantage_rejected_when_equal_to_neighbor_or_local_address` (`src/config/tests.rs`): vantage == neighbor address is rejected, vantage == `router_id` is rejected, and a distinct valid vantage still passes.

Closes LAN-216