### PR TITLE
fix: RIB explain modifications only after permit + precision doc nits (LAN-212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Export-explain no longer reports staged modifications for a denied
+  route (LAN-212).** `distribute_single_best_prefix` recorded the export
+  policy's `modifications` into the explain trace before the deny gate,
+  so a policy-denied prefix could surface modifications it would never
+  apply; the assignment now happens only after a Permit, matching the
+  per-client-best explain arm. Regression-tested via
+  `denied_route_explain_has_no_modifications`. Also clarifies two
+  precision limitations in comments/docs: the grouped-member explain
+  dry-run still counts a member's own-sourced (split-horizon-excluded)
+  prefixes in its `already_advertised` gate, and
+  `Route.received_at_epoch_seconds` is recovered from two independent
+  clock reads and so is a display timestamp, not a precise ordering key.
 - **ORR vantage config validation now rejects a degenerate vantage IP
   (LAN-216).** An `orr_vantage` (RFC 9107) equal to the neighbor's own
   peering address or the reflector's `router_id` degenerates to the

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1052,7 +1052,11 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
         local_pref_attr: route.local_pref_attr(),
         // Receive wall time recovered from the monotonic receive
         // instant, the same recovery the BMP Loc-RIB dump uses for its
-        // RFC 9069 per-peer header timestamp.
+        // RFC 9069 per-peer header timestamp. Approximation: `now()` and
+        // `received_at.elapsed()` are two independent clock reads, so a
+        // wall-clock step between them skews the recovered epoch by that
+        // step. Acceptable for a display timestamp; not re-architected
+        // into a single stored wall time.
         received_at_epoch_seconds: std::time::SystemTime::now()
             .checked_sub(route.received_at.elapsed())
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1346,7 +1346,6 @@ impl RibManager {
             trace.policy_label = export_pol.map(|chain| {
                 policy_label_with_term(Some(chain), &ctx, evaluation.matched_policy.as_deref())
             });
-            trace.modifications = result.modifications.clone();
         }
         if result.action != PolicyAction::Permit {
             if let Some(trace) = target.trace() {
@@ -1370,6 +1369,11 @@ impl RibManager {
             return;
         }
         if let Some(trace) = target.trace() {
+            // Record staged modifications only after the Permit above — a
+            // denied route carries no modifications (mirrors the
+            // per-client-best arm, which sets `explain.modifications`
+            // after its own deny early-return).
+            trace.modifications = result.modifications.clone();
             match trace.policy_label.clone() {
                 Some(label) => trace.push(
                     "export_policy",

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1627,6 +1627,13 @@ impl RibManager {
         // Dry run of the live single-best staging body. A grouped
         // member's advertised state is the group table (update-groups
         // design §2: members hold no per-peer unicast Adj-RIB-Out).
+        //
+        // Limitation: the group table still holds routes this member
+        // itself sourced, which split-horizon excludes from the live
+        // emit but which the dry-run's `already_advertised` gate does
+        // not filter. A member-scoped AdjRibOut view (`route.peer !=
+        // peer`) is not synthesized here, so for a member's own-sourced
+        // prefixes the dry-run may show them as already-advertised.
         let member_of = self.grouped_member_of(peer);
         let empty_rib_out;
         let rib_out = if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {

--- a/crates/rib/src/manager/tests/export_explain.rs
+++ b/crates/rib/src/manager/tests/export_explain.rs
@@ -624,6 +624,84 @@ async fn advertised_route_reports_in_sync_and_staged_modifications() {
     handle.await.unwrap();
 }
 
+/// A denied route's explain trace must carry no staged modifications —
+/// `distribute_single_best_prefix` records `trace.modifications` only
+/// after the export policy permits, matching the per-client-best arm. A
+/// permitted route in the same chain still reports its modifications.
+#[tokio::test]
+async fn denied_route_explain_has_no_modifications() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let denied_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let permitted_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+
+    // One chain: deny one prefix (with configured — but dropped — mods,
+    // documenting that a deny carries none), permit + modify the other.
+    let mut denying = statement(denied_prefix, PolicyAction::Deny);
+    denying.modifications.set_med = Some(999);
+    let mut modifying = statement(permitted_prefix, PolicyAction::Permit);
+    modifying.modifications.set_med = Some(750);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![denying, modifying],
+        default_action: PolicyAction::Permit,
+    }]);
+
+    let _rx_s = explain_peer_up(
+        &tx,
+        source,
+        ipv4_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+    let _rx_t = explain_peer_up(
+        &tx,
+        target,
+        ipv4_sendable(),
+        true,
+        false,
+        Some(chain),
+        vec![],
+        vec![],
+    )
+    .await;
+
+    feed_routes(
+        &tx,
+        source,
+        vec![
+            make_route(denied_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+            make_route(permitted_prefix, Ipv4Addr::new(10, 0, 0, 1)),
+        ],
+    )
+    .await;
+
+    let denied = query_explain_advertised_route(&tx, target, Prefix::V4(denied_prefix)).await;
+    assert_eq!(denied.decision, crate::update::ExplainDecision::Deny);
+    assert!(
+        denied.modifications.is_empty(),
+        "denied route must carry no staged modifications, got {:?}",
+        denied.modifications
+    );
+
+    let permitted = query_explain_advertised_route(&tx, target, Prefix::V4(permitted_prefix)).await;
+    assert_eq!(
+        permitted.decision,
+        crate::update::ExplainDecision::Advertise
+    );
+    assert_eq!(permitted.modifications.set_med, Some(750));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// The differential oracle applied to explain: an update-grouped member
 /// and a content-equivalent ungrouped peer (peer-context chain, the
 /// grouping disqualifier) must produce identical gate ladders and

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -404,6 +404,10 @@ gRPC consumer gains from the recent proto additions
   (and the explain RPCs that embed `Route`) now carries its receive
   time, recovered from the monotonic RIB receive instant. Consumers
   no longer need to track route age themselves by diffing streams.
+  Approximation: the recovery reads the wall clock and the monotonic
+  elapsed separately, so a wall-clock step between the two reads skews
+  the reported epoch by that step. It is a display timestamp, not a
+  precise event ordering key — use the monotonic `event_id` for that.
 - **`RibService.ExplainAdvertisedRoute`** — the export decision as
   data: the full gate ladder (`split_horizon`, `rr_reflection`,
   `family`, `llgr`, `orf`, `rt_membership`, `export_policy`,


### PR DESCRIPTION
Addresses three RIB explain / received-at precision nits (LAN-212).

## #18 (fix) — explain modifications populated for denied routes
`distribute_single_best_prefix` (`crates/rib/src/manager/distribution/unicast.rs`) set `trace.modifications` before the export deny gate, so a policy-denied prefix could surface staged modifications it would never apply. Moved the assignment to after the `Permit` check, mirroring the per-client-best explain arm which already sets `explain.modifications` only after its deny early-return. Added regression test `denied_route_explain_has_no_modifications` (`crates/rib/src/manager/tests/export_explain.rs`) proving a denied route's explain trace has empty modifications while a permitted route in the same chain still reports its modifications.

## #19 (document only) — grouped-member explain dry-run own-sourced prefixes
Extended the comment at `crates/rib/src/manager/mod.rs` (grouped-member explain dry-run) to explicitly document that the group table still holds the member's own-sourced routes that split-horizon excludes from the live emit, so the `already_advertised` gate is off for those prefixes. A member-scoped AdjRibOut view (`route.peer != peer`) is not synthesized. No behavior change.

## #20 (document) — received-at two-clock-read skew
`crates/api/src/rib_service.rs` recovers `received_at_epoch_seconds` from two independent clock reads (`SystemTime::now()` and `received_at.elapsed()`), which skew if the wall clock steps between them. Documented the approximation with a code comment at the site and a note in the `received_at_epoch_seconds` bullet of `docs/EMBEDDING.md`. Not re-architected.

Closes LAN-212