### PR TITLE
fix: deduplicate hold-time default and CLI/API consistency nits (LAN-211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,6 +770,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **CLI/API consistency cleanup (LAN-211).** The default hold time (90s)
+  is now a single `rustbgpd_fsm::DEFAULT_HOLD_TIME` constant reused by the
+  gRPC neighbor service's send-hold-time validation instead of a duplicated
+  literal, added a `per_client_best` proto round-trip test for peer groups,
+  and documented the deliberate export-gate-verdict label duplication across
+  the client/server type boundary.
 - **ORR vantage config validation now rejects a degenerate vantage IP
   (LAN-216).** An `orr_vantage` (RFC 9107) equal to the neighbor's own
   peering address or the reflector's `router_id` degenerates to the

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -22,11 +22,6 @@ use rustbgpd_rib::RibUpdate;
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Default hold time applied by the peer manager when `hold_time` is
-/// unset — mirrored here (same value as the daemon config default) for
-/// send-hold-time validation parity with the config path.
-const DEFAULT_HOLD_TIME: u16 = 90;
-
 fn is_ipv6_link_local(address: IpAddr) -> bool {
     match address {
         IpAddr::V6(v6) => v6.segments()[0] & 0xffc0 == 0xfe80,
@@ -499,10 +494,12 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         if let Some(value) = config.send_hold_time
             && value != 0
         {
+            // Unset hold_time falls back to the daemon default the peer
+            // manager applies (single source of truth in the fsm crate).
             let effective_hold_time = if config.hold_time > 0 {
                 config.hold_time
             } else {
-                u32::from(DEFAULT_HOLD_TIME)
+                u32::from(rustbgpd_fsm::DEFAULT_HOLD_TIME)
             };
             if value <= effective_hold_time {
                 return Err(Status::invalid_argument(format!(

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -690,6 +690,17 @@ mod tests {
         assert_eq!(back.send_hold_time, Some(500));
     }
 
+    /// `per_client_best` round-trips proto -> input -> proto.
+    #[test]
+    fn per_client_best_round_trips() {
+        let mut definition = sample_definition();
+        definition.per_client_best = Some(true);
+        let input = proto_definition_to_input(definition).unwrap();
+        assert_eq!(input.per_client_best, Some(true));
+        let back = input_definition_to_proto(&input);
+        assert_eq!(back.per_client_best, Some(true));
+    }
+
     #[tokio::test]
     async fn read_peer_group_responses_redact_md5_password() {
         let definition = proto_definition_to_input(sample_definition()).unwrap();

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -68,6 +68,13 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
     // (negotiated Add-Path send outranks the per-client-best fallback).
     // An ORR vantage is not on the runtime NeighborConfig surface, so
     // it is recognized via the update-group ungrouped reason.
+    //
+    // LAN-211 #6: this reads the *configured* add_path_send/per_client_best
+    // bits echoed on NeighborConfig, so a peer that configured Add-Path but
+    // never negotiated it still prints "add-path". A negotiated/effective
+    // mode is not surfaced on NeighborState (update_group is a shadow-mode
+    // grouping string, "group:N" when grouped), so fixing this needs new
+    // plumbing; deferred.
     let distribution_mode = if cfg.map(|c| c.add_path_send).unwrap_or(false) {
         "add-path"
     } else if cfg.map(|c| c.per_client_best).unwrap_or(false) {

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1022,6 +1022,11 @@ fn explain_to_json(
 }
 
 /// Render an export gate verdict for text/JSON output.
+///
+/// This maps the *proto* `ExportGateVerdict` (which has an extra
+/// `Unspecified` variant crossing the client/server boundary), so it can't
+/// reuse `rustbgpd_rib::ExportGateVerdict::label()` directly. These labels
+/// must stay in sync with that server-side `label()`.
 fn gate_verdict_label(verdict: i32) -> &'static str {
     match ExportGateVerdict::try_from(verdict).unwrap_or(ExportGateVerdict::Unspecified) {
         ExportGateVerdict::Pass => "pass",

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -28,6 +28,12 @@ pub(crate) fn graceful_restart_preserves_family((afi, safi): (Afi, Safi)) -> boo
     )
 }
 
+/// Default proposed hold time in seconds (RFC 4271 §4.2 suggested value).
+/// Single source of truth for the daemon default — other crates (e.g. the
+/// gRPC neighbor service's send-hold-time validation) reuse this rather
+/// than re-hardcoding 90.
+pub const DEFAULT_HOLD_TIME: u16 = 90;
+
 /// Minimum default `SendHoldTime` in seconds: 8 minutes (RFC 9687 §6).
 pub const MIN_DEFAULT_SEND_HOLD_TIME: u32 = 480;
 
@@ -113,8 +119,8 @@ impl Default for PeerConfig {
             local_asn: 0,
             remote_asn: 0,
             local_router_id: Ipv4Addr::UNSPECIFIED,
-            hold_time: 90,
-            send_hold_time: default_send_hold_time(90),
+            hold_time: DEFAULT_HOLD_TIME,
+            send_hold_time: default_send_hold_time(DEFAULT_HOLD_TIME),
             connect_retry_secs: 120,
             families: Vec::new(),
             graceful_restart: false,

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -38,7 +38,7 @@ pub mod session;
 pub mod state;
 
 pub use action::{Action, NegotiatedSession, TimerType};
-pub use config::{PeerConfig, default_send_hold_time};
+pub use config::{DEFAULT_HOLD_TIME, PeerConfig, default_send_hold_time};
 pub use event::Event;
 pub use session::Session;
 pub use state::SessionState;

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -206,6 +206,10 @@ pub enum ExportGateVerdict {
 
 impl ExportGateVerdict {
     /// Stable lowercase label used by the API/CLI surfaces.
+    ///
+    /// The CLI's `gate_verdict_label` maps the proto enum (which adds an
+    /// `Unspecified` variant) rather than reusing this across the
+    /// client/server boundary — keep the two label sets in sync.
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {


### PR DESCRIPTION
Addresses the four LAN-211 CLI/API consistency nits, scoped exactly.

### #5 (FIX) deduplicate the hold-time default
- Added `pub const DEFAULT_HOLD_TIME: u16 = 90;` in `crates/fsm/src/config.rs` (alongside `MIN_DEFAULT_SEND_HOLD_TIME`), re-exported from `crates/fsm/src/lib.rs`.
- `PeerConfig::default()` now uses it for both `hold_time` and `default_send_hold_time(..)`.
- `crates/api/src/neighbor_service.rs` dropped its duplicated `const DEFAULT_HOLD_TIME` and now uses `rustbgpd_fsm::DEFAULT_HOLD_TIME` (the api crate already depends on the fsm crate).
- Only the genuine production default was replaced; `test_config()` fixtures and numeric `negotiate_hold_time`/`default_send_hold_time` assertions that happen to use `90` were left untouched. Value stays 90 (pure refactor).

### #22 (FIX) add missing `per_client_best` round-trip test
- Added `per_client_best_round_trips` in `crates/api/src/peer_group_service.rs`, mirroring `send_hold_time_round_trips` (the field is `Option<bool>`, so it round-trips `Some(true)` through the proto conversion).

### #21 (DOCUMENT ONLY)
- Added a sync-note comment at both label sites: `gate_verdict_label` in `crates/cli/src/commands/rib.rs` (proto enum with the extra `Unspecified`) and `ExportGateVerdict::label()` in `crates/rib/src/update.rs`. No code change — the duplication is intentional (client/server type boundary).

### #6 (DEFERRED)
- CLI `distribution_mode` derives from the *configured* `add_path_send`/`per_client_best` bits echoed on `NeighborConfig`, so a peer that configured but never negotiated Add-Path still prints "add-path". `NeighborState` exposes no negotiated/effective mode (`update_group` is a shadow-mode grouping string, `"group:N"` when grouped), so a correct fix needs new proto/RIB plumbing. Deferred with a `// LAN-211 #6:` comment at the site in `crates/cli/src/commands/neighbor.rs`.

### Gates (all green)
- `cargo build --workspace` — 0
- `cargo test --workspace` — 0 (new `per_client_best_round_trips` passes)
- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo doc --workspace --no-deps` — 0

Closes LAN-211
