### PR TITLE
fix: VPNv6 link-local next-hop survives reflection (LAN-217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -779,6 +779,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **VPNv6 reflection no longer drops the link-local next-hop (LAN-217).**
+  `VpnRibRoute` stored only a single global next-hop, so a VPNv6 route
+  received with an RFC 4659 §3.2.1.1 two-address next-hop (48-byte: RD +
+  global, RD + link-local) was reflected with a 24-byte single-address
+  next-hop — the link-local half was silently discarded. Mirroring the
+  labeled-IPv6 fix (LAN-190), the route data model now carries
+  `link_local_next_hop` alongside the global next-hop; the receive path
+  populates it and the reflected `MP_REACH_NLRI` re-emits the 48-byte
+  form verbatim, so VPNv6 link-local forwarding survives reflection. A
+  change confined to the link-local half now correctly re-advertises.
+  (The wire codec already round-tripped the 48-byte two-address VPN
+  next-hop; the gap was purely the RIB/transport plumbing.)
 - **CLI/API consistency cleanup (LAN-211).** The default hold time (90s)
   is now a single `rustbgpd_fsm::DEFAULT_HOLD_TIME` constant reused by the
   gRPC neighbor service's send-hold-time validation instead of a duplicated

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -2537,6 +2537,7 @@ mod tests {
                 prefix: VpnPrefix::v4(Ipv4Addr::new(10, 1, 0, 0), 24).unwrap(),
             },
             next_hop: Ipv4Addr::new(192, 0, 2, 1).into(),
+            link_local_next_hop: None,
             peer: Ipv4Addr::new(192, 0, 2, 2).into(),
             attributes: Arc::new(vec![
                 PathAttribute::AsPath(AsPath {

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -2272,6 +2272,7 @@ mod tests {
         VpnRibRoute {
             nlri,
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: Instant::now(),

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -546,6 +546,7 @@ mod tests {
         VpnRibRoute {
             nlri,
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: Instant::now(),

--- a/crates/rib/src/bmp_sync.rs
+++ b/crates/rib/src/bmp_sync.rs
@@ -434,6 +434,7 @@ mod tests {
         VpnRibRoute {
             nlri: vpn_nlri(),
             next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9)),
+            link_local_next_hop: None,
             peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             attributes: Arc::new(base_attrs()),
             received_at: Instant::now(),

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -1317,6 +1317,7 @@ mod tests {
         VpnRibRoute {
             nlri,
             next_hop: peer,
+            link_local_next_hop: None,
             peer,
             attributes: Arc::new(vec![
                 PathAttribute::Origin(Origin::Igp),

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -85,6 +85,9 @@ pub(super) fn vpn_routes_equal(
 ) -> bool {
     a.nlri == b.nlri
         && a.next_hop == b.next_hop
+        // A change confined to the IPv6 link-local half of the next-hop
+        // (RFC 4659 two-address form) must still re-advertise (LAN-217).
+        && a.link_local_next_hop == b.link_local_next_hop
         && a.peer == b.peer
         && a.path_id == b.path_id
         && (Arc::ptr_eq(&a.attributes, &b.attributes) || a.attributes == b.attributes)

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -185,6 +185,7 @@ fn make_vpn_rib_route(
     VpnRibRoute {
         nlri,
         next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
         peer: IpAddr::V4(peer),
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),
@@ -653,6 +654,7 @@ fn make_vpn6_rib_route_with_rts(
     VpnRibRoute {
         nlri,
         next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
         peer: IpAddr::V4(peer),
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -102,6 +102,7 @@ fn vpn_route(
     VpnRibRoute {
         nlri,
         next_hop: IpAddr::V4(src),
+        link_local_next_hop: None,
         peer: IpAddr::V4(src),
         attributes: Arc::new(attributes),
         received_at: Instant::now(),

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2341,6 +2341,7 @@ mod tests {
                 prefix: key.prefix,
             },
             next_hop: src,
+            link_local_next_hop: None,
             peer: src,
             attributes: std::sync::Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: std::time::Instant::now(),

--- a/crates/rib/src/route.rs
+++ b/crates/rib/src/route.rs
@@ -495,8 +495,14 @@ impl VpnRibRouteKey {
 pub struct VpnRibRoute {
     /// Full NLRI: RD + prefix + MPLS label stack (preserved verbatim).
     pub nlri: VpnNlri,
-    /// VPN next-hop from `MP_REACH_NLRI` (Route-Distinguisher-stripped).
+    /// Global VPN next-hop from `MP_REACH_NLRI` (Route-Distinguisher-stripped).
     pub next_hop: IpAddr,
+    /// IPv6 link-local next-hop carried alongside the global one (RFC 4659
+    /// §3.2.1.1 48-byte two-address form), populated when the received
+    /// `VPNv6` `MP_REACH_NLRI` had a 48-byte next-hop. Reflected verbatim so
+    /// `VPNv6` link-local forwarding survives reflection (LAN-217); `None`
+    /// for `VPNv4` or single-address `VPNv6` next-hops.
+    pub link_local_next_hop: Option<Ipv6Addr>,
     /// The peer that advertised this route.
     pub peer: IpAddr,
     /// BGP path attributes. Route Targets ride here as extended communities.
@@ -1314,6 +1320,7 @@ mod tests {
         VpnRibRoute {
             nlri,
             next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
             peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
             attributes: Arc::new(vec![PathAttribute::Origin(Origin::Igp)]),
             received_at: Instant::now(),

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1588,6 +1588,10 @@ impl PeerSession {
                                 vpn_announced.push(VpnRibRoute {
                                     nlri: entry.nlri.clone(),
                                     next_hop: mp.next_hop,
+                                    // Carry the RFC 4659 two-address IPv6
+                                    // link-local half so VPNv6 reflection
+                                    // re-emits it (LAN-217).
+                                    link_local_next_hop: mp.link_local_next_hop,
                                     peer: self.peer_ip,
                                     attributes: attrs,
                                     received_at: now,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1164,6 +1164,7 @@ impl PeerSession {
             let mut vpn_groups: Vec<(
                 (Afi, Safi),
                 IpAddr,
+                Option<Ipv6Addr>,
                 Vec<PathAttribute>,
                 Vec<rustbgpd_wire::VpnNlriEntry>,
             )> = Vec::new();
@@ -1174,20 +1175,28 @@ impl PeerSession {
                 }
                 let attrs = self.prepare_outbound_attributes_vpn(vpn_route, is_ebgp);
                 let nh = vpn_route.next_hop;
+                // RFC 4659 two-address IPv6 next-hop: the link-local half
+                // is grouped alongside the global next-hop so it survives
+                // reflection (LAN-217).
+                let ll = vpn_route.link_local_next_hop;
                 let entry = rustbgpd_wire::VpnNlriEntry {
                     path_id: vpn_route.path_id,
                     nlri: vpn_route.nlri.clone(),
                 };
-                if let Some(group) = vpn_groups.iter_mut().find(|(g_family, g_nh, g_attrs, _)| {
-                    *g_family == family && *g_nh == nh && *g_attrs == attrs
-                }) {
-                    group.3.push(entry);
+                if let Some(group) =
+                    vpn_groups
+                        .iter_mut()
+                        .find(|(g_family, g_nh, g_ll, g_attrs, _)| {
+                            *g_family == family && *g_nh == nh && *g_ll == ll && *g_attrs == attrs
+                        })
+                {
+                    group.4.push(entry);
                 } else {
-                    vpn_groups.push((family, nh, attrs, vec![entry]));
+                    vpn_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
             let max_len = usize::from(self.max_message_len());
-            for ((afi, _), next_hop, attrs, routes) in vpn_groups {
+            for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in vpn_groups {
                 let add_path = match afi {
                     Afi::Ipv4 => add_path_vpnv4_send,
                     _ => add_path_vpnv6_send,
@@ -1195,6 +1204,7 @@ impl PeerSession {
                 if !self.send_vpn_reach_chunked(
                     afi,
                     next_hop,
+                    link_local_next_hop,
                     &attrs,
                     &routes,
                     four_octet_as,
@@ -1690,6 +1700,7 @@ impl PeerSession {
         &mut self,
         afi: Afi,
         next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::VpnNlriEntry],
         four_octet_as: bool,
@@ -1705,7 +1716,7 @@ impl PeerSession {
                 afi,
                 safi: Safi::MplsVpn,
                 next_hop,
-                link_local_next_hop: None,
+                link_local_next_hop,
                 announced: vec![],
                 flowspec_announced: vec![],
                 evpn_announced: vec![],

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1535,6 +1535,7 @@ fn make_vpn_rib_route(label: u32) -> rustbgpd_rib::VpnRibRoute {
             prefix: VpnPrefix::v4(Ipv4Addr::new(10, 0, 1, 0), 24).unwrap(),
         },
         next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+        link_local_next_hop: None,
         peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
         attributes: Arc::new(vec![
             PathAttribute::Origin(Origin::Igp),
@@ -1772,6 +1773,92 @@ async fn send_route_update_reflects_labeled_v6_link_local_next_hop() {
         mp.link_local_next_hop,
         Some(link_local),
         "labeled IPv6 link-local next-hop must survive reflection (LAN-190)"
+    );
+}
+/// LAN-217: a `VPNv6` route carrying an RFC 4659 §3.2.1.1 48-byte two-address
+/// next-hop (global + link-local) reflects the link-local half — the emitted
+/// `MP_REACH` uses the 48-byte next-hop form, not the 24-byte single-address
+/// form.
+/// Without this, `VPNv6` link-local forwarding breaks on reflection.
+#[tokio::test]
+async fn send_route_update_reflects_vpnv6_link_local_next_hop() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::MplsVpn)];
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+    let route = rustbgpd_rib::VpnRibRoute {
+        nlri: VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 1]),
+            prefix: VpnPrefix::v6("2001:db8:100::".parse().unwrap(), 48).unwrap(),
+        },
+        next_hop: IpAddr::V6(global),
+        link_local_next_hop: Some(link_local),
+        peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]),
+        received_at: Instant::now(),
+        origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    };
+    session.send_route_update(OutboundRouteUpdate {
+        announce: vec![].into(),
+        withdraw: vec![],
+        end_of_rib: vec![],
+        refresh_markers: vec![],
+        next_hop_override: vec![].into(),
+        flowspec_announce: vec![],
+        flowspec_withdraw: vec![],
+        evpn_announce: vec![],
+        evpn_withdraw: vec![],
+        bgpls_announce: vec![],
+        bgpls_withdraw: vec![],
+        vpn_announce: vec![route.clone()],
+        labeled_announce: vec![],
+        rtc_announce: vec![],
+        vpn_withdraw: vec![],
+        labeled_withdraw: vec![],
+        rtc_withdraw: vec![],
+        request_refresh_all_negotiated: false,
+    });
+    let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
+        panic!("expected VPN MP_REACH UPDATE");
+    };
+    let parsed = msg.parse(true, false, &[]).unwrap();
+    let mp = parsed
+        .attributes
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::MpReachNlri(mp) => Some(mp),
+            _ => None,
+        })
+        .expect("VPN announcement must use MP_REACH");
+    assert_eq!(mp.afi, Afi::Ipv6);
+    assert_eq!(mp.safi, Safi::MplsVpn);
+    assert_eq!(
+        mp.next_hop,
+        IpAddr::V6(global),
+        "VPN global next-hop must pass through reflection unchanged"
+    );
+    assert_eq!(
+        mp.link_local_next_hop,
+        Some(link_local),
+        "VPNv6 link-local next-hop must survive reflection (LAN-217)"
     );
 }
 /// RFC 7911 labeled outbound: with Add-Path send negotiated for (IPv4, SAFI

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -2701,6 +2701,46 @@ mod tests {
         );
         assert!(decoded_mp.announced.is_empty());
     }
+    /// LAN-217: a `VPNv6` `MP_REACH` carrying an RFC 4659 §3.2.1.1 48-byte
+    /// two-address next-hop (RD + global, RD + link-local) must emit the
+    /// 48-byte form and round-trip the link-local half, so a route reflector
+    /// re-advertising the route preserves `VPNv6` link-local forwarding.
+    #[test]
+    fn mp_reach_vpnv6_link_local_next_hop_roundtrip() {
+        let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+        let route = vpnv6_nlri(100);
+        let mp = MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::MplsVpn,
+            next_hop: IpAddr::V6(global),
+            link_local_next_hop: Some(link_local),
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![vpn_entry(0, route.clone())],
+            rtc_announced: vec![],
+        };
+        let attr = PathAttribute::MpReachNlri(mp.clone());
+        let mut buf = Vec::new();
+        encode_path_attributes(std::slice::from_ref(&attr), &mut buf, true, false).unwrap();
+        // Value layout after the 3-byte attribute header: AFI(2) SAFI(1)
+        // NH-Len(1); NH-Len must be 48 (RD + global, RD + link-local), not 24.
+        assert_eq!(buf[6], 48, "VPNv6 two-address next-hop must be 48 bytes");
+        let decoded = decode_path_attributes(&buf, true, &[]).expect("decode VPNv6 MP_REACH");
+        let PathAttribute::MpReachNlri(decoded_mp) = &decoded[0] else {
+            panic!("not MP_REACH after decode");
+        };
+        assert_eq!(decoded_mp.next_hop, IpAddr::V6(global));
+        assert_eq!(
+            decoded_mp.link_local_next_hop,
+            Some(link_local),
+            "VPNv6 link-local next-hop must survive encode/decode"
+        );
+        assert_eq!(decoded, vec![PathAttribute::MpReachNlri(mp)]);
+    }
     #[test]
     fn mp_unreach_vpnv6_attribute_roundtrip() {
         // RFC 8277 §2.4: a withdrawn VPN NLRI carries a 3-octet compatibility


### PR DESCRIPTION
## Problem

`VpnRibRoute` stored only a single global `next_hop`, so a VPNv6 route received with an RFC 4659 §3.2.1.1 two-address next-hop (48 bytes: RD + global, RD + link-local) was reflected with a 24-byte single-address next-hop — the IPv6 link-local half was silently dropped, breaking VPNv6 link-local forwarding on reflection.

## Mirror of #715 (LAN-190)

This is the same single-next-hop limitation already fixed for labeled-IPv6 unicast in #715, mirrored faithfully onto `VpnRibRoute`:

- Add `link_local_next_hop: Option<Ipv6Addr>` to `VpnRibRoute`.
- The transport receive path populates it from the decoded `MP_REACH` (`mp.link_local_next_hop`).
- The reflected `MP_REACH_NLRI` re-emits the 48-byte two-address form verbatim (grouped alongside the global next-hop in the outbound batcher, plumbed through `send_vpn_reach_chunked`).
- `vpn_routes_equal` compares the link-local half, so a change confined to it re-advertises.

Plumbing-only: the wire 48-byte two-address VPN next-hop codec already round-trips; it is unchanged. All construction sites (`crates/api`, `crates/bmp`, RIB, transport) default the new field to `None` where a link-local isn't applicable.

## Tests

- `mp_reach_vpnv6_link_local_next_hop_roundtrip` (wire): a VPNv6 `MP_REACH` with global + link-local next-hop emits the 48-byte form and round-trips both addresses through encode→decode.
- `send_route_update_reflects_vpnv6_link_local_next_hop` (transport): a learned VPNv6 route with a link-local next-hop is reflected with the link-local preserved (mirror of the #715 labeled-IPv6 reflection test).

Closes LAN-217