### PR TITLE
docs: README palatability pass + doc accuracy (birdwatcher, TCP-AO)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -324,10 +324,12 @@ resolved.
 - **Route Refresh is unconditional.** The ROUTE-REFRESH capability
   (code 2) is always advertised. Inbound route refresh requests check
   peer capability, but there is no config option to disable the feature.
-- **TCP-AO not supported for RTR connections.** RPKI cache server
-  connections use plain TCP. TCP-AO (RFC 5925) is not supported for
-  either BGP or RTR sessions. Use network-level access controls or
-  SSH tunnels for RTR transport security.
+- **TCP-AO not supported for RTR connections.** RPKI cache (RTR) server
+  connections use plain TCP; TCP-AO (RFC 5925) is not available for the
+  RTR transport. Use network-level access controls or SSH tunnels for RTR
+  transport security. (TCP-AO *is* supported for BGP static-neighbor
+  startup keys on Linux — see the dynamic-neighbor / runtime-rotation
+  follow-ups in the limitations list.)
 - **Non-negotiated Add-Path NLRI is not detected.** If a peer violates
   negotiation and sends Add-Path-encoded NLRI for a family where Add-Path
   was not negotiated, the wire format is ambiguous — the 4-byte path ID

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ file bootstraps initial state; after startup, gRPC owns the truth. No restarts
 to add peers, change policy, or inject routes.
 
 **Status: public alpha.** Feature-complete for the initial programmable
-control-plane target and expanding toward cloud / AI-scale data-center fabric
-use. Dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA path
-verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN alpha, and full gRPC/CLI
-management are implemented. Default-off Linux FIB integration exists for RFC
-7999 discard routes and configured unicast FIB tables, including ECMP and
-weighted multipath; broader routing-suite features remain future work.
-Validated with a workspace test suite, fuzz targets, and an automated interop
-suite — primarily against FRR 10.3.1, plus GoBGP 3.37.0–4.6.0 across labs and
-StayRTR-backed RTR coverage; BIRD 2.0.12 has documented M0 validation and
-BIRD 3.2.1 backs the
-TCP-AO smoke. A foundation tier runs on every PR, and the privileged Linux
-dataplane smokes run in hosted kernel-dataplane CI; longer soaks and platform
-diversity scripts remain local / manual gates. See
-`docs/INTEROP.md` for the full matrix.
+control-plane target and expanding toward cloud / AI-scale data-center
+fabric use.
+
+- **Implemented:** dual-stack BGP/MP-BGP, Add-Path, GR/LLGR, RPKI/RTR, ASPA
+  path verification, FlowSpec, BMP, MRT, BFD, EVPN/VXLAN (alpha), and full
+  gRPC/CLI management. Linux FIB integration is default-off and scoped to
+  RFC 7999 discard routes and configured unicast tables (including ECMP and
+  weighted multipath); broader routing-suite features remain future work.
+- **Validated** with a workspace test suite, fuzz targets, and an automated
+  interop suite — primarily against FRR 10.3.1, plus GoBGP 3.37.0–4.6.0 and
+  StayRTR-backed RTR coverage, with BIRD 2.0.12 (M0) and BIRD 3.2.1 (TCP-AO
+  smoke). A foundation tier runs on every PR and the privileged Linux
+  dataplane smokes run in hosted CI; longer soaks and platform-diversity
+  scripts remain local. Full matrix: [`docs/INTEROP.md`](docs/INTEROP.md).
 
 > **Alpha expectations:** The config format and gRPC API are not yet frozen.
 > Breaking changes are possible between minor versions. The daemon runs on
@@ -55,7 +55,7 @@ diversity scripts remain local / manual gates. See
 - **Hosting provider prefix management** — API-driven customer prefix announcements
 - **Internet exchange route servers** — transparent mode, Add-Path, per-client best-path (RFC 7947 path-hiding mitigation), RPKI, Prefix ORF, per-member policy
 - **SDN / network automation controllers** — programmable BGP control plane
-- **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP, birdwatcher-compatible REST API
+- **Route collectors and looking glasses** — structured data via gRPC, MRT, BMP, plus a birdwatcher-compatible looking glass via the external `examples/birdwatcher-adapter`
 - **Lab and test environments** — clean API, structured logs, containerlab interop
 
 BGP-LS receive/reflection/API export (RFC 9552), VPNv4/VPNv6 L3VPN


### PR DESCRIPTION
Readability and accuracy pass over the README, plus one KNOWN_ISSUES correction.

## Changes
- **README — opening `Status` block.** Reflow the single 15-line paragraph into a scannable *Implemented* / *Validated* pair. No claims added or removed; `docs/INTEROP.md` is now linked inline.
- **README — "Good fit" bullet.** The in-daemon birdwatcher looking glass is deprecated; the bullet now references the external `examples/birdwatcher-adapter` rather than describing it as a first-class REST API (consistent with the operational-visibility bullet updated in #727).
- **KNOWN_ISSUES.md — TCP-AO.** The note stated TCP-AO was unsupported for both BGP and RTR. TCP-AO is supported for BGP static-neighbor startup keys on Linux; only the RTR transport lacks it. Corrected accordingly. Closes LAN-106.

## Not included
Further trimming of the dense "Why rustbgpd" bullets (operational visibility, update-group fanout) and the EVPN "Current limitations" section — those involve cutting technical detail and are left to a separate editorial pass.