### PR TITLE
fix(evpn): disambiguate committed vs planned steps in decomposed-apply message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -790,6 +790,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EVPN decomposed-apply response disambiguates committed vs planned
+  steps.** When no-op steps are skipped mid-sequence the `ApplyEvpnRuntime`
+  message now appends `(N of M planned steps committed)` so an API consumer
+  does not read the committed count as the planned count. The boot-revert
+  save-aside's hard-link filesystem requirement is now documented in
+  `docs/OPERATIONS.md`.
 - **BMP VPNv6 Adj-RIB-Out mirror preserves the link-local next-hop
   (LAN-217 follow-up).** `synthesize_vpn_announce` now copies the route's
   link-local half into the synthesized `MP_REACH`, mirroring the unicast

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -147,6 +147,17 @@ or one whose embedded config no longer parses, refuses boot with a message
 naming both the journal and the config file — delete the journal manually only
 if you are sure the on-disk config is the one you want.
 
+The boot-revert save-aside moves the unconfirmed candidate to
+`<config>.unconfirmed` with an atomic hard-link + unlink, so it never clobbers
+an existing `.unconfirmed`. That needs the config file and its directory to be
+on a filesystem that supports hard links — every local filesystem does. On a
+filesystem without hard-link support (some FUSE mounts, certain NFS setups),
+the save-aside fails and the daemon **refuses to boot** with the journal left
+intact, rather than risk an unsafe revert. Keep the config and
+`runtime_state_dir` on a local filesystem (the default); this mainly matters
+for containerized deployments that bind-mount the config from an exotic
+backend.
+
 For a static-neighbor edit, change the neighbor in the candidate file (for
 example `hold_time`, `max_prefixes`, policy-chain refs, or ORF receive), run
 `config plan`, then apply with the returned token. The transaction reconfigures

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -3794,6 +3794,12 @@ where
     // Report what actually committed, not `total` (`steps.len()`): no-op
     // steps `continue` without a generation, so `committed` can be < total.
     let committed = committed_generations.len();
+    // #25: no-op steps `continue` without a generation, so committed may be < total.
+    let planned_note = if committed == total {
+        String::new()
+    } else {
+        format!(" ({committed} of {total} planned steps committed)")
+    };
     let generations_summary = match (committed_generations.first(), committed_generations.last()) {
         (Some(first), Some(last)) => format!(" as generations {first}..={last}"),
         _ => String::new(),
@@ -3806,7 +3812,7 @@ where
         // the INFO logs above and in `generations_summary`.
         plan: Some(runtime_plan_to_proto(overall_plan)),
         message: format!(
-            "candidate EVPN runtime model committed via {committed} decomposed steps{generations_summary}"
+            "candidate EVPN runtime model committed via {committed} decomposed steps{planned_note}{generations_summary}"
         ),
     })
 }


### PR DESCRIPTION
Two pre-release polish items from ensemble review.

## Changes
- **EVPN decomposed-apply message.** `ApplyEvpnRuntime` appends `(N of M planned steps committed)` when no-op steps are skipped mid-sequence, so an API consumer does not read the committed count as the planned step count.
- **Boot-revert filesystem requirement (docs).** `docs/OPERATIONS.md` now documents that the save-aside uses an atomic hard-link + unlink; a filesystem without hard-link support fails closed (refuses boot) rather than risk an unsafe revert.

## Not included
A suggested `.rpol` `!=` range-bound (`ge`/`le`) test was investigated and is not applicable: `PrefixNe` is only ever constructed with `ge: None, le: None` (inline `!=` on a bare prefix), and range bounds lower to `PrefixInSet`, not `PrefixNe`. There is no reachable `PrefixNe`-with-range behavior to test; `prefix_ne_absent_does_not_match` already pins the `None`/`None` shape.

## Gates (verified in-tree)
build / policy tests / evpn tests / clippy -D warnings / fmt / doc — all exit 0.