### PR TITLE
docs: restore consolidated supported-standards table after README slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -799,6 +799,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Restored the consolidated "supported standards at a glance" table.** The
+  README slim replaced the old protocol-coverage row with a pointer to
+  `docs/RFC_NOTES.md`/`INTEROP.md`/`RECEIPTS.md`, but none of those carried a
+  single at-a-glance list of the supported RFCs/SAFIs. `docs/RFC_NOTES.md` now
+  opens with that table and the README "Protocol coverage" row links to it.
 - **EVPN decomposed-apply response disambiguates committed vs planned
   steps.** When no-op steps are skipped mid-sequence the `ApplyEvpnRuntime`
   message now appends `(N of M planned steps committed)` so an API consumer

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ and more explicit internal architecture.
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
 | Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 3.37.0–4.6.0 across labs and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
-| Protocol coverage | Protocol details and conformance notes live in [docs/RFC_NOTES.md](docs/RFC_NOTES.md), [docs/INTEROP.md](docs/INTEROP.md), and [docs/RECEIPTS.md](docs/RECEIPTS.md). |
+| Protocol coverage | [Supported standards at a glance](docs/RFC_NOTES.md#supported-standards-at-a-glance) plus per-RFC conformance notes in [docs/RFC_NOTES.md](docs/RFC_NOTES.md); interop matrix in [docs/INTEROP.md](docs/INTEROP.md) and receipts in [docs/RECEIPTS.md](docs/RECEIPTS.md). |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |
 
 ```bash

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -5,6 +5,33 @@ implementation choices made during development.
 
 ---
 
+## Supported standards at a glance
+
+Consolidated map of the RFCs, SAFIs, and features rustbgpd implements. The
+per-RFC sections below carry the conformance detail, interpretations, and
+deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
+[docs/RECEIPTS.md](RECEIPTS.md) the receipts index, and
+[docs/LIMITATIONS.md](LIMITATIONS.md) the boundaries and non-goals.
+
+| Area | Standards | Scope |
+|------|-----------|-------|
+| Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
+| MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
+| Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
+| Communities | RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove |
+| Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
+| Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
+| VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |
+| EVPN (Linux/VXLAN alpha) | RFC 7432, RFC 9135/9136 (symmetric IRB), RFC 9012/8365 (VXLAN encap) | Route types 1-5; RR + VTEP + multi-homing building blocks |
+| Origin / path security | RFC 6811 + RFC 8210 (RPKI/RTR), ASPA, RFC 9234 (Roles + OTC, ADR-0071) | Origin validation, AS-path verification, leak prevention |
+| Transport security | RFC 5925 (TCP-AO), TCP MD5, RFC 5082 (GTSM) | TCP-AO: static-neighbor startup keys on Linux only |
+| FlowSpec / blackhole | RFC 8955/8956 (FlowSpec, SAFI 133), RFC 7999 (BLACKHOLE) | Receiver scoping + opt-in Linux FIB discard |
+| Liveness | RFC 5880/5881/5882 (BFD), RFC 9687 (Send Hold Timer) | Single-hop async BFD for static neighbors |
+| Maintenance | RFC 8326 (Graceful Shutdown), RFC 8203 (Admin Shutdown Communication) | Receiver gating + initiator toggle |
+| Monitoring | RFC 7854/8671/9069 (BMP trio), RFC 6396 (MRT TABLE_DUMP_V2), RFC 7951 (gNMI/OpenConfig JSON) | Pre-policy / post-policy / Loc-RIB BMP views |
+
+---
+
 ## Milestone 0 — RFC 4271 Sections
 
 ### §4.2 — OPEN Message


### PR DESCRIPTION
## What

Documentation-cohesion pass after the README slim (50a0d9d7).

The slim replaced the README "Testing and correctness" **Protocol coverage** row (which used to enumerate every supported RFC/SAFI/feature) with a pointer to `docs/RFC_NOTES.md`, `docs/INTEROP.md`, and `docs/RECEIPTS.md`. But none of those three carried a single **at-a-glance** list: `RFC_NOTES.md` is deep per-RFC prose keyed to milestones, `INTEROP.md` is a test matrix, `RECEIPTS.md` is a receipts index. Several standards (BFD RFC 5880/5881, TCP-AO RFC 5925) didn't appear in any of them at all.

This restores a compact "Supported standards at a glance" table at the top of `docs/RFC_NOTES.md` and repoints the README row at it. No README re-bloat — the detail lives in the doc, not the landing page.

## Also verified (no changes needed)

- **LIMITATIONS.md vs KNOWN_ISSUES.md** — consistent on every shared topic (EVPN Linux/VXLAN alpha + L3VNI-restart-required, TCP-AO static-neighbor-keys-only, VPNv4/v6 RR/controller-feed only, BFD single-hop async, Confederation not implemented, FIB opt-in/scoped). No contradiction to reconcile.
- **Dangling links** — the only `README.md#` anchor link in the docs tree (`OPERATIONAL_PROOF.md` -> `#testing-and-correctness`) still resolves; no links point at removed Quick-start subsections or the old Current-limitations bullets.

## Gate

- `cargo fmt --all -- --check` -> exit 0

Docs-only change.