### PR TITLE
feat(cli): add neighbors + recent events to rbgp doctor bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`rbgp doctor` support bundle and familiar CLI aliases.** `rbgp doctor`
   writes a redacted support bundle for issue reports
-  (health/global/metrics/environment/manifest) — it never copies the daemon
-  config file or bearer-token material. New visible aliases match common
+  (health/global/metrics/environment/manifest, plus the neighbor list and a
+  bounded recent slice of session-lifecycle and policy events) — it never
+  copies the daemon config file or bearer-token material. New visible aliases match common
   operator muscle memory: `rbgp summary` (neighbor list), `rbgp rib recv
   <peer>` / `rbgp rib sent <peer>`, and `rbgp policy counters`. A slimmed
   README now links deep first-run/limitations content to `docs/QUICKSTART.md`

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -4,12 +4,27 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
+use crate::commands::watch::bgp_event_json_value;
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output;
+use crate::output::{self, JsonNeighbor};
 use crate::proto::control_service_client::ControlServiceClient;
+use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
-use crate::proto::{GetGlobalRequest, HealthRequest, MetricsRequest};
+use crate::proto::neighbor_service_client::NeighborServiceClient;
+use crate::proto::{
+    GetGlobalRequest, HealthRequest, ListNeighborsRequest, ListPolicyEventsRequest,
+    ListSessionEventsRequest, MetricsRequest,
+};
+
+/// Bounded recent slice pulled from each event history for triage. The
+/// daemon clamps to its own 4096-event ceiling; this keeps the bundle small.
+const EVENT_HISTORY_LIMIT: u32 = 256;
+
+/// Keys in the shipped `BgpEvent` JSON whose values are free text that
+/// could echo operator/peer-supplied strings (e.g. RFC 8203 shutdown
+/// reasons). Redacted the same way `tcp_ao_detail`/metrics are.
+const EVENT_FREE_TEXT_KEYS: &[&str] = &["summary", "reason", "shutdown_reason", "target"];
 
 #[derive(Serialize)]
 struct BundleManifest<'a> {
@@ -45,6 +60,12 @@ struct EnvironmentSnapshot<'a> {
     current_dir: String,
     daemon_address: &'a str,
     token_file_configured: bool,
+}
+
+#[derive(Serialize)]
+struct EventsSnapshot {
+    session: Vec<serde_json::Value>,
+    policy: Vec<serde_json::Value>,
 }
 
 fn now_unix_seconds() -> u64 {
@@ -86,6 +107,20 @@ fn redact_text(input: &str) -> String {
         .join("\n")
 }
 
+/// Redact the free-text leaf fields of one serialized `BgpEvent` in place,
+/// mirroring how `tcp_ao_detail`/metrics are scrubbed. State names, ASNs,
+/// timestamps, and other structured fields are left untouched.
+fn redact_event(mut value: serde_json::Value) -> serde_json::Value {
+    if let Some(object) = value.as_object_mut() {
+        for key in EVENT_FREE_TEXT_KEYS {
+            if let Some(serde_json::Value::String(text)) = object.get_mut(*key) {
+                *text = redact_text(text);
+            }
+        }
+    }
+    value
+}
+
 fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), CliError> {
     let bytes = serde_json::to_vec_pretty(value)?;
     fs::write(path, bytes)?;
@@ -108,10 +143,34 @@ pub async fn run(
         ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
     let mut global =
         GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut neighbor =
+        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut events =
+        EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
 
     let health = control.get_health(HealthRequest {}).await?.into_inner();
     let global_state = global.get_global(GetGlobalRequest {}).await?.into_inner();
     let metrics = control.get_metrics(MetricsRequest {}).await?.into_inner();
+    let neighbors = neighbor
+        .list_neighbors(ListNeighborsRequest {})
+        .await?
+        .into_inner();
+    let session_events = events
+        .list_session_events(ListSessionEventsRequest {
+            neighbor_address: String::new(),
+            event_types: Vec::new(),
+            limit: EVENT_HISTORY_LIMIT,
+        })
+        .await?
+        .into_inner();
+    let policy_events = events
+        .list_policy_events(ListPolicyEventsRequest {
+            neighbor_address: String::new(),
+            event_types: Vec::new(),
+            limit: EVENT_HISTORY_LIMIT,
+        })
+        .await?
+        .into_inner();
 
     write_json(
         &bundle_dir.join("health.json"),
@@ -146,6 +205,40 @@ pub async fn run(
             token_file_configured,
         },
     )?;
+    let neighbor_snapshots: Vec<JsonNeighbor> = neighbors
+        .neighbors
+        .iter()
+        .map(|n| {
+            let cfg = n.config.as_ref();
+            JsonNeighbor {
+                address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
+                interface: cfg.map(|c| c.interface.clone()).unwrap_or_default(),
+                remote_asn: cfg.map(|c| c.remote_asn).unwrap_or(0),
+                state: output::format_state_with_stale(n.state, n.stale).to_string(),
+                stale: n.stale,
+                uptime_seconds: n.uptime_seconds,
+                prefixes_received: n.prefixes_received,
+                prefixes_sent: n.prefixes_sent,
+                description: redact_text(&cfg.map(|c| c.description.clone()).unwrap_or_default()),
+            }
+        })
+        .collect();
+    write_json(&bundle_dir.join("neighbors.json"), &neighbor_snapshots)?;
+    write_json(
+        &bundle_dir.join("events.json"),
+        &EventsSnapshot {
+            session: session_events
+                .events
+                .iter()
+                .map(|e| bgp_event_json_value(e).map(redact_event))
+                .collect::<Result<Vec<_>, _>>()?,
+            policy: policy_events
+                .events
+                .iter()
+                .map(|e| bgp_event_json_value(e).map(redact_event))
+                .collect::<Result<Vec<_>, _>>()?,
+        },
+    )?;
     write_json(
         &bundle_dir.join("manifest.json"),
         &BundleManifest {
@@ -159,6 +252,8 @@ pub async fn run(
                 "global.json",
                 "metrics.prom",
                 "environment.json",
+                "neighbors.json",
+                "events.json",
             ],
             note: "No daemon config file or bearer token material is copied.",
         },
@@ -188,6 +283,21 @@ mod tests {
         assert_eq!(redacted, "ok 1\n[REDACTED]\n[REDACTED]\nok 2");
     }
 
+    #[test]
+    fn redact_event_scrubs_free_text_but_keeps_structured_fields() {
+        let event = serde_json::json!({
+            "event_type": "session_lost",
+            "new_state": "Idle",
+            "reason": "shutdown bearer token leaked here",
+            "summary": "peer down",
+        });
+        let redacted = redact_event(event);
+        assert_eq!(redacted["reason"], "[REDACTED]");
+        assert_eq!(redacted["summary"], "peer down");
+        assert_eq!(redacted["event_type"], "session_lost");
+        assert_eq!(redacted["new_state"], "Idle");
+    }
+
     #[tokio::test]
     async fn doctor_writes_bundle_and_calls_core_rpcs() {
         let server = spawn_mock_server(None).await;
@@ -204,11 +314,27 @@ mod tests {
         assert!(bundle.join("global.json").exists());
         assert!(bundle.join("metrics.prom").exists());
         assert!(bundle.join("environment.json").exists());
+        assert!(bundle.join("neighbors.json").exists());
+        assert!(bundle.join("events.json").exists());
         assert_eq!(server.state.health_calls.load(Ordering::SeqCst), 1);
         assert_eq!(server.state.global_calls.load(Ordering::SeqCst), 1);
         assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(server.state.list_neighbors_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            server
+                .state
+                .list_session_events_calls
+                .load(Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            server.state.list_policy_events_calls.load(Ordering::SeqCst),
+            1
+        );
 
         let manifest = fs::read_to_string(bundle.join("manifest.json")).unwrap();
         assert!(manifest.contains("No daemon config file or bearer token material is copied."));
+        assert!(manifest.contains("neighbors.json"));
+        assert!(manifest.contains("events.json"));
     }
 }

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -580,7 +580,7 @@ impl Serialize for JsonBgpEvent<'_> {
     }
 }
 
-fn bgp_event_json_value(event: &BgpEvent) -> Result<serde_json::Value, CliError> {
+pub(crate) fn bgp_event_json_value(event: &BgpEvent) -> Result<serde_json::Value, CliError> {
     Ok(serde_json::to_value(JsonBgpEvent(event))?)
 }
 

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -15,6 +15,7 @@ use rustbgpd_api::proto as server_proto;
 use rustbgpd_api::proto::bfd_service_server::BfdServiceServer;
 use rustbgpd_api::proto::config_service_server::ConfigServiceServer;
 use rustbgpd_api::proto::control_service_server::ControlServiceServer;
+use rustbgpd_api::proto::event_service_server::EventServiceServer;
 use rustbgpd_api::proto::evpn_service_server::EvpnServiceServer;
 use rustbgpd_api::proto::global_service_server::GlobalServiceServer;
 use rustbgpd_api::proto::neighbor_service_server::NeighborServiceServer;
@@ -28,6 +29,9 @@ pub(crate) struct MockState {
     pub(crate) health_calls: AtomicUsize,
     pub(crate) metrics_calls: AtomicUsize,
     pub(crate) global_calls: AtomicUsize,
+    pub(crate) list_neighbors_calls: AtomicUsize,
+    pub(crate) list_session_events_calls: AtomicUsize,
+    pub(crate) list_policy_events_calls: AtomicUsize,
     pub(crate) config_diff_calls: AtomicUsize,
     pub(crate) config_plan_calls: AtomicUsize,
     pub(crate) config_apply_calls: AtomicUsize,
@@ -163,6 +167,9 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
         state: Arc::clone(&state),
     };
     let evpn = MockEvpnService;
+    let event = MockEventService {
+        state: Arc::clone(&state),
+    };
     let policy = MockPolicyService {
         state: Arc::clone(&state),
     };
@@ -192,6 +199,10 @@ pub(crate) async fn spawn_mock_server(auth_token: Option<&str>) -> MockServerHan
             .add_service(RibServiceServer::with_interceptor(rib, interceptor.clone()))
             .add_service(EvpnServiceServer::with_interceptor(
                 evpn,
+                interceptor.clone(),
+            ))
+            .add_service(EventServiceServer::with_interceptor(
+                event,
                 interceptor.clone(),
             ))
             .add_service(PolicyServiceServer::with_interceptor(
@@ -249,6 +260,9 @@ pub(crate) async fn spawn_mock_uds_server(
         state: Arc::clone(&state),
     };
     let evpn = MockEvpnService;
+    let event = MockEventService {
+        state: Arc::clone(&state),
+    };
     let policy = MockPolicyService {
         state: Arc::clone(&state),
     };
@@ -278,6 +292,10 @@ pub(crate) async fn spawn_mock_uds_server(
             .add_service(RibServiceServer::with_interceptor(rib, interceptor.clone()))
             .add_service(EvpnServiceServer::with_interceptor(
                 evpn,
+                interceptor.clone(),
+            ))
+            .add_service(EventServiceServer::with_interceptor(
+                event,
                 interceptor.clone(),
             ))
             .add_service(PolicyServiceServer::with_interceptor(
@@ -583,6 +601,9 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
         &self,
         _request: Request<server_proto::ListNeighborsRequest>,
     ) -> Result<Response<server_proto::ListNeighborsResponse>, Status> {
+        self.state
+            .list_neighbors_calls
+            .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(server_proto::ListNeighborsResponse {
             neighbors: vec![],
         }))
@@ -894,6 +915,65 @@ impl rustbgpd_api::proto::evpn_service_server::EvpnService for MockEvpnService {
         _request: Request<server_proto::ApplyEvpnRuntimeRequest>,
     ) -> Result<Response<server_proto::ApplyEvpnRuntimeResponse>, Status> {
         Err(Status::unimplemented("not in mock"))
+    }
+}
+
+struct MockEventService {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl rustbgpd_api::proto::event_service_server::EventService for MockEventService {
+    type WatchEventsStream =
+        std::pin::Pin<Box<dyn Stream<Item = Result<server_proto::BgpEvent, Status>> + Send>>;
+    type SubscribeFromEventStream =
+        std::pin::Pin<Box<dyn Stream<Item = Result<server_proto::BgpEvent, Status>> + Send>>;
+
+    async fn watch_events(
+        &self,
+        _request: Request<server_proto::WatchEventsRequest>,
+    ) -> Result<Response<Self::WatchEventsStream>, Status> {
+        Err(Status::unimplemented("not used in CLI tests"))
+    }
+
+    async fn subscribe_from_event(
+        &self,
+        _request: Request<server_proto::SubscribeFromEventRequest>,
+    ) -> Result<Response<Self::SubscribeFromEventStream>, Status> {
+        Err(Status::unimplemented("not used in CLI tests"))
+    }
+
+    async fn list_evpn_events(
+        &self,
+        _request: Request<server_proto::ListEvpnEventsRequest>,
+    ) -> Result<Response<server_proto::ListEvpnEventsResponse>, Status> {
+        Ok(Response::new(server_proto::ListEvpnEventsResponse {
+            events: vec![],
+        }))
+    }
+
+    async fn list_session_events(
+        &self,
+        _request: Request<server_proto::ListSessionEventsRequest>,
+    ) -> Result<Response<server_proto::ListSessionEventsResponse>, Status> {
+        self.state
+            .list_session_events_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(server_proto::ListSessionEventsResponse {
+            events: vec![],
+        }))
+    }
+
+    async fn list_policy_events(
+        &self,
+        _request: Request<server_proto::ListPolicyEventsRequest>,
+    ) -> Result<Response<server_proto::ListPolicyEventsResponse>, Status> {
+        self.state
+            .list_policy_events_calls
+            .fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(server_proto::ListPolicyEventsResponse {
+            events: vec![],
+        }))
     }
 }
 


### PR DESCRIPTION
## What

Extends the `rbgp doctor` redacted support bundle (v2) so bug reports arrive
complete. Two new files join `health.json` / `global.json` / `metrics.prom` /
`environment.json` / `manifest.json`:

- **`neighbors.json`** — the neighbor list from `NeighborService.ListNeighbors`
  (session state, remote ASN, uptime, prefix counts), reusing the `JsonNeighbor`
  shape the `rbgp neighbor` list already surfaces.
- **`events.json`** — a **bounded** recent slice (256, no streaming) of
  `EventService.ListSessionEvents` and `ListPolicyEvents`, i.e. session
  lifecycle + policy mutations, the two histories most useful for triage. Each
  event reuses the shipped `BgpEvent` JSON serializer, keyed under `session` /
  `policy`.

## Redaction / no-secret invariant preserved

- `redact_text` is applied to the neighbor `description` and to event free-text
  fields (`summary`, `reason`, `shutdown_reason`, `target`) — the same scrub
  used for `tcp_ao_detail` and metrics. Structured fields (state names, ASNs,
  timestamps) are left intact.
- The daemon config file and bearer-token material are **still never copied**;
  `token_file_configured` stays a bool. The manifest note remains accurate:
  "No daemon config file or bearer token material is copied." The manifest
  `files` list now includes `neighbors.json` and `events.json`.

## Tests

- Mock server now serves `EventService` and counts `ListNeighbors` /
  `ListSessionEvents` / `ListPolicyEvents`.
- `doctor_writes_bundle_and_calls_core_rpcs` asserts the two new files are
  written, the manifest lists them, and the three new RPCs are each called once.
- New `redact_event_scrubs_free_text_but_keeps_structured_fields` locks the
  event redaction boundary.

Follows up the original `rbgp doctor` support-bundle feature; closes nothing.
