### PR TITLE
Add bgp_rib_attr_intern_size gauge and GR/hot-reload/inject-churn soak harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`bgp_rib_attr_intern_size` gauge** — total unique interned attribute sets
+  summed across all peers' Adj-RIB-In tables, recorded after each
+  session-lifecycle GC (graceful-restart entry, GR/LLGR stale sweep,
+  End-of-RIB, route-refresh finish) and kept off the per-chunk distribution
+  hot path. Three containerlab soak harnesses (GR-restart intern-GC,
+  hot-reload, inject-churn), each with a topology and a post-hoc analyzer,
+  exercise it and adjacent long-run paths.
+
 ## [0.50.0] — 2026-07-05
 
 ### Added

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -302,6 +302,27 @@ impl RibManager {
         });
         self.metrics
             .set_gr_stale_routes(&peer_label, gauge_val(stale_count));
+        self.record_rib_attr_intern_size();
+    }
+
+    /// Record the total interned attribute-set count, summed across every
+    /// peer's Adj-RIB-In intern table, into `bgp_rib_attr_intern_size`.
+    /// Called at the end of each operation that runs `gc_intern_table`
+    /// (GR entry, GR/LLGR stale sweeps, End-of-RIB, route-refresh finish) so
+    /// the gauge tracks reclamation across the full restart cycle rather than
+    /// flapping to whichever peer was collected last.
+    ///
+    // ponytail: intentionally NOT called on the per-chunk distribution GC
+    // path (process_announce_chunk / distribute_changes) — an O(peers) sum
+    // on the data-plane hot path is the wrong trade; steady-state churn
+    // refreshes this gauge at the next session-lifecycle GC instead.
+    pub(super) fn record_rib_attr_intern_size(&self) {
+        let total: usize = self
+            .ribs
+            .values()
+            .map(crate::adj_rib_in::AdjRibIn::intern_len)
+            .sum();
+        self.metrics.set_rib_attr_intern_size(gauge_val(total));
     }
 
     pub(super) fn handle_rpki_cache_update(&mut self, table: Arc<VrpTable>) {
@@ -659,6 +680,7 @@ impl RibManager {
         }
 
         self.release_peer_state_if_departed(peer);
+        self.record_rib_attr_intern_size();
     }
 
     /// Sweep LLGR-stale routes for a peer whose LLGR timer has expired.
@@ -762,6 +784,7 @@ impl RibManager {
         }
 
         self.release_peer_state_if_departed(peer);
+        self.record_rib_attr_intern_size();
     }
 
     /// Release a departed peer's remaining per-peer state once GR/LLGR

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -456,6 +456,7 @@ impl RibManager {
                 self.metrics.set_gr_stale_routes(&peer_label, 0);
             }
         }
+        self.record_rib_attr_intern_size();
     }
 
     pub(super) fn handle_route_refresh_request(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
@@ -1518,5 +1519,6 @@ impl RibManager {
             // withdrawn from this peer's Adj-RIB-Out.
             self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
+        self.record_rib_attr_intern_size();
     }
 }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -90,6 +90,7 @@ pub struct BgpMetrics {
     rib_prefixes: IntGaugeVec,
     rib_adj_out_prefixes: IntGaugeVec,
     rib_loc_prefixes: IntGaugeVec,
+    rib_attr_intern_size: IntGauge,
     route_event_history_depth: IntGauge,
     route_event_history_capacity: IntGauge,
 
@@ -361,6 +362,12 @@ impl BgpMetrics {
                 "Number of prefixes in the Loc-RIB per AFI/SAFI",
             ),
             &["afi_safi"],
+        )
+        .expect("valid metric definition");
+
+        let rib_attr_intern_size = IntGauge::new(
+            "bgp_rib_attr_intern_size",
+            "Total unique interned attribute sets summed across all peers' Adj-RIB-In intern tables (gc_intern_table reclaims unreferenced entries per peer).",
         )
         .expect("valid metric definition");
 
@@ -1273,6 +1280,9 @@ impl BgpMetrics {
             .register(Box::new(rib_loc_prefixes.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(rib_attr_intern_size.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(route_event_history_depth.clone()))
             .expect("metric not already registered");
         registry
@@ -1586,6 +1596,7 @@ impl BgpMetrics {
             rib_prefixes,
             rib_adj_out_prefixes,
             rib_loc_prefixes,
+            rib_attr_intern_size,
             route_event_history_depth,
             route_event_history_capacity,
             orr_spf_runs_total,
@@ -1901,6 +1912,13 @@ impl BgpMetrics {
         self.rib_loc_prefixes
             .with_label_values(&[afi_safi])
             .set(count);
+    }
+
+    /// Set the total number of unique interned attribute sets summed across
+    /// every peer's Adj-RIB-In intern table. Monitors `gc_intern_table`
+    /// reclamation across GR-restart / `EoR` / stale-clear cycles.
+    pub fn set_rib_attr_intern_size(&self, count: i64) {
+        self.rib_attr_intern_size.set(count);
     }
 
     /// Set the number of retained events in the bounded route-event

--- a/tests/interop/configs/frr-bgpd-soak-inject-churn.conf
+++ b/tests/interop/configs/frr-bgpd-soak-inject-churn.conf
@@ -1,0 +1,15 @@
+frr version 10.3.1
+frr defaults traditional
+hostname frr-soak-inject
+log stdout informational
+
+router bgp 65002
+ bgp router-id 10.0.0.2
+ no bgp ebgp-requires-policy
+ neighbor 10.0.0.1 remote-as 65001
+ neighbor 10.0.0.1 description rustbgpd-soak-inject
+ neighbor 10.0.0.1 timers 30 90
+ !
+ address-family ipv4 unicast
+ exit-address-family
+!

--- a/tests/interop/configs/rustbgpd-soak-gr-restart.toml
+++ b/tests/interop/configs/rustbgpd-soak-gr-restart.toml
@@ -1,0 +1,28 @@
+# Soak variant of the M16 GR + LLGR config. Mirrors
+# rustbgpd-m16-llgr.toml but lives at a distinct bind path so the
+# soak topology (soak-gr-restart) does not collide with a hosted CI
+# run of the M16 interop smoke.
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+description = "frr-soak-gr-restart"
+hold_time = 30
+graceful_restart = true
+gr_restart_time = 15
+gr_stale_routes_time = 20
+llgr_stale_time = 60
+
+[security.grpc]
+enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-hot-reload.toml
+++ b/tests/interop/configs/rustbgpd-soak-hot-reload.toml
@@ -1,0 +1,25 @@
+# Soak variant for the config live-apply (hot-reload) soak. Single
+# IPv4 eBGP peer (FRR receiver). The soak harness cycles
+# `rbgp config plan` / `config apply` against candidate TOMLs that
+# mutate the neighbor description, exercising the ADR-0063
+# shape-gated live-apply path.
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+description = "frr-soak-hot-reload-cycle-0"
+hold_time = 90
+
+[security.grpc]
+enforcement = "legacy"

--- a/tests/interop/configs/rustbgpd-soak-inject-churn.toml
+++ b/tests/interop/configs/rustbgpd-soak-inject-churn.toml
@@ -1,0 +1,23 @@
+# Soak variant of the M3 injection config. Single IPv4 eBGP peer
+# (FRR receiver). gRPC injection path is exercised by the soak
+# harness via rbgp rib add / rib delete.
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+description = "frr-soak-inject"
+hold_time = 90
+
+[security.grpc]
+enforcement = "legacy"

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Post-hoc analyzer for the GR-restart intern-gc soak.
+
+Reads the CSV emitted by run-soak-gr-restart-intern-gc.sh and emits a
+JSON verdict against the soak-specific gates:
+
+  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
+    (the intern table should not grow across restart cycles; a positive
+    slope indicates gc_intern_table is not reclaiming stranded sets)
+  - RSS slope (steady state, MB/hour) < 1.0
+  - peak RSS < 512 MB
+  - at least one restart cycle recorded
+  - BGP established observed in the final 3 samples (session recovered)
+
+Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
+harness/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Optional
+
+
+def safe_float(value: str | None) -> Optional[float]:
+    if value is None or value in ("", "NaN", "nan"):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def linreg(xs: list[float], ys: list[float]) -> float:
+    if len(xs) < 2:
+        return float("nan")
+    mx = sum(xs) / len(xs)
+    my = sum(ys) / len(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    den = sum((x - mx) ** 2 for x in xs)
+    if den == 0:
+        return float("nan")
+    return num / den
+
+
+def analyze(rows: list[dict[str, str]]) -> dict:
+    elapsed = []
+    rss = []
+    intern = []
+    established_final = []
+    max_cycles = 0
+
+    for row in rows:
+        e = safe_float(row.get("elapsed_sec"))
+        r = safe_float(row.get("rss_mb"))
+        i = safe_float(row.get("intern_size"))
+        if e is not None:
+            elapsed.append(e)
+            if r is not None:
+                rss.append((e, r))
+            if i is not None:
+                intern.append((e, i))
+        c = safe_float(row.get("restart_cycles"))
+        if c is not None:
+            max_cycles = max(max_cycles, int(c))
+        est = row.get("bgp_established")
+        established_final.append(est)
+
+    # Convert to hours for slope-per-hour.
+    rss_slope = linreg([e / 3600 for e, _ in rss], [r for _, r in rss]) if rss else float("nan")
+    intern_slope = (
+        linreg([e / 3600 for e, _ in intern], [v for _, v in intern])
+        if intern
+        else float("nan")
+    )
+
+    peak_rss = max((r for _, r in rss), default=float("nan"))
+
+    # Last 3 samples established?
+    tail = established_final[-3:] if established_final else []
+    final_established = tail.count("1") > 0 if tail else False
+
+    gates = {
+        "intern_slope_per_hour": {
+            "value": intern_slope if not math.isnan(intern_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(intern_slope)) and intern_slope < 1.0,
+        },
+        "rss_slope_per_hour": {
+            "value": rss_slope if not math.isnan(rss_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(rss_slope)) and rss_slope < 1.0,
+        },
+        "peak_rss_mb": {
+            "value": peak_rss if not math.isnan(peak_rss) else None,
+            "limit": 512.0,
+            "pass": (not math.isnan(peak_rss)) and peak_rss < 512.0,
+        },
+        "restart_cycles": {
+            "value": max_cycles,
+            "limit": 1,
+            "pass": max_cycles >= 1,
+        },
+        "final_session_established": {
+            "value": final_established,
+            "pass": final_established,
+        },
+    }
+
+    all_pass = all(g["pass"] for g in gates.values())
+    return {
+        "verdict": "pass" if all_pass else "fail",
+        "restart_cycles": max_cycles,
+        "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
+        "intern_slope_per_hour": intern_slope if not math.isnan(intern_slope) else None,
+        "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
+        "samples": len(rows),
+        "gates": gates,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze GR-restart intern-gc soak")
+    parser.add_argument("run_dir", help="Soak run directory containing samples.csv")
+    parser.add_argument("--output", help="Write verdict JSON to this path")
+    args = parser.parse_args()
+
+    csv_path = f"{args.run_dir}/samples.csv"
+    try:
+        with open(csv_path, newline="") as f:
+            rows = list(csv.DictReader(f))
+    except OSError as e:
+        print(f"error reading {csv_path}: {e}", file=sys.stderr)
+        return 2
+
+    if not rows:
+        print("error: samples.csv is empty", file=sys.stderr)
+        return 2
+
+    result = analyze(rows)
+    out = json.dumps(result, indent=2)
+    print(out)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(out)
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -5,6 +5,7 @@ Reads the CSV emitted by run-soak-hot-reload.sh and emits a JSON
 verdict against the soak-specific gates:
 
   - RSS slope (steady state, MB/hour) < 1.0
+  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap from live-apply)
   - at least one apply cycle recorded
@@ -53,6 +54,7 @@ def linreg(xs: list[float], ys: list[float]) -> float:
 
 def analyze(rows: list[dict[str, str]]) -> dict:
     rss_pts: list[tuple[float, float]] = []
+    intern_pts: list[tuple[float, float]] = []
     established_final: list[str] = []
     max_cycles = 0
     final_ok = 0
@@ -61,8 +63,11 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     for row in rows:
         e = safe_float(row.get("elapsed_sec"))
         r = safe_float(row.get("rss_mb"))
+        i = safe_float(row.get("intern_size"))
         if e is not None and r is not None:
             rss_pts.append((e, r))
+        if e is not None and i is not None:
+            intern_pts.append((e, i))
         c = safe_int(row.get("apply_cycles"))
         if c is not None:
             max_cycles = max(max_cycles, c)
@@ -79,6 +84,11 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         if rss_pts
         else float("nan")
     )
+    intern_slope = (
+        linreg([e / 3600 for e, _ in intern_pts], [i for _, i in intern_pts])
+        if intern_pts
+        else float("nan")
+    )
     peak_rss = max((r for _, r in rss_pts), default=float("nan"))
 
     tail = established_final[-3:] if established_final else []
@@ -88,6 +98,11 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     fail_rate = (final_fail / total_applies) if total_applies > 0 else 1.0
 
     gates = {
+        "intern_slope_per_hour": {
+            "value": intern_slope if not math.isnan(intern_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(intern_slope)) and intern_slope < 1.0,
+        },
         "rss_slope_per_hour": {
             "value": rss_slope if not math.isnan(rss_slope) else None,
             "limit": 1.0,
@@ -121,6 +136,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         "apply_ok": final_ok,
         "apply_fail": final_fail,
         "apply_failure_rate": fail_rate,
+        "intern_slope_per_hour": intern_slope if not math.isnan(intern_slope) else None,
         "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
         "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
         "samples": len(rows),

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Post-hoc analyzer for the config live-apply (hot-reload) soak.
+
+Reads the CSV emitted by run-soak-hot-reload.sh and emits a JSON
+verdict against the soak-specific gates:
+
+  - RSS slope (steady state, MB/hour) < 1.0
+  - peak RSS < 512 MB
+  - session established in final 3 samples (no flap from live-apply)
+  - at least one apply cycle recorded
+  - apply failure rate < 50% (live-apply path must be functional)
+
+Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
+harness/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Optional
+
+
+def safe_float(value: str | None) -> Optional[float]:
+    if value is None or value in ("", "NaN", "nan"):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def safe_int(value: str | None) -> Optional[int]:
+    f = safe_float(value)
+    return int(f) if f is not None else None
+
+
+def linreg(xs: list[float], ys: list[float]) -> float:
+    if len(xs) < 2:
+        return float("nan")
+    mx = sum(xs) / len(xs)
+    my = sum(ys) / len(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    den = sum((x - mx) ** 2 for x in xs)
+    if den == 0:
+        return float("nan")
+    return num / den
+
+
+def analyze(rows: list[dict[str, str]]) -> dict:
+    rss_pts: list[tuple[float, float]] = []
+    established_final: list[str] = []
+    max_cycles = 0
+    final_ok = 0
+    final_fail = 0
+
+    for row in rows:
+        e = safe_float(row.get("elapsed_sec"))
+        r = safe_float(row.get("rss_mb"))
+        if e is not None and r is not None:
+            rss_pts.append((e, r))
+        c = safe_int(row.get("apply_cycles"))
+        if c is not None:
+            max_cycles = max(max_cycles, c)
+        ok = safe_int(row.get("apply_ok"))
+        fail = safe_int(row.get("apply_fail"))
+        if ok is not None:
+            final_ok = ok
+        if fail is not None:
+            final_fail = fail
+        established_final.append(row.get("bgp_established", ""))
+
+    rss_slope = (
+        linreg([e / 3600 for e, _ in rss_pts], [r for _, r in rss_pts])
+        if rss_pts
+        else float("nan")
+    )
+    peak_rss = max((r for _, r in rss_pts), default=float("nan"))
+
+    tail = established_final[-3:] if established_final else []
+    final_established = tail.count("1") > 0 if tail else False
+
+    total_applies = final_ok + final_fail
+    fail_rate = (final_fail / total_applies) if total_applies > 0 else 1.0
+
+    gates = {
+        "rss_slope_per_hour": {
+            "value": rss_slope if not math.isnan(rss_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(rss_slope)) and rss_slope < 1.0,
+        },
+        "peak_rss_mb": {
+            "value": peak_rss if not math.isnan(peak_rss) else None,
+            "limit": 512.0,
+            "pass": (not math.isnan(peak_rss)) and peak_rss < 512.0,
+        },
+        "apply_cycles": {
+            "value": max_cycles,
+            "limit": 1,
+            "pass": max_cycles >= 1,
+        },
+        "final_session_established": {
+            "value": final_established,
+            "pass": final_established,
+        },
+        "apply_failure_rate": {
+            "value": fail_rate,
+            "limit": 0.5,
+            "pass": fail_rate < 0.5,
+        },
+    }
+
+    all_pass = all(g["pass"] for g in gates.values())
+    return {
+        "verdict": "pass" if all_pass else "fail",
+        "apply_cycles": max_cycles,
+        "apply_ok": final_ok,
+        "apply_fail": final_fail,
+        "apply_failure_rate": fail_rate,
+        "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
+        "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
+        "samples": len(rows),
+        "gates": gates,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze hot-reload soak")
+    parser.add_argument("run_dir", help="Soak run directory containing samples.csv")
+    parser.add_argument("--output", help="Write verdict JSON to this path")
+    args = parser.parse_args()
+
+    csv_path = f"{args.run_dir}/samples.csv"
+    try:
+        with open(csv_path, newline="") as f:
+            rows = list(csv.DictReader(f))
+    except OSError as e:
+        print(f"error reading {csv_path}: {e}", file=sys.stderr)
+        return 2
+
+    if not rows:
+        print("error: samples.csv is empty", file=sys.stderr)
+        return 2
+
+    result = analyze(rows)
+    out = json.dumps(result, indent=2)
+    print(out)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(out)
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Post-hoc analyzer for the gRPC inject-churn soak.
+
+Reads the CSV emitted by run-soak-inject-churn.sh and emits a JSON
+verdict against the soak-specific gates:
+
+  - RSS slope (steady state, MB/hour) < 1.0
+  - peak RSS < 512 MB
+  - session established in final 3 samples (no flap)
+  - at least one churn cycle recorded
+
+Stdlib only. Exit code 0 on pass, 1 on any gate failure, 2 on
+harness/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import Optional
+
+
+def safe_float(value: str | None) -> Optional[float]:
+    if value is None or value in ("", "NaN", "nan"):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def linreg(xs: list[float], ys: list[float]) -> float:
+    if len(xs) < 2:
+        return float("nan")
+    mx = sum(xs) / len(xs)
+    my = sum(ys) / len(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    den = sum((x - mx) ** 2 for x in xs)
+    if den == 0:
+        return float("nan")
+    return num / den
+
+
+def analyze(rows: list[dict[str, str]]) -> dict:
+    rss_pts: list[tuple[float, float]] = []
+    established_final: list[str] = []
+    max_cycles = 0
+
+    for row in rows:
+        e = safe_float(row.get("elapsed_sec"))
+        r = safe_float(row.get("rss_mb"))
+        if e is not None and r is not None:
+            rss_pts.append((e, r))
+        c = safe_float(row.get("churn_cycles"))
+        if c is not None:
+            max_cycles = max(max_cycles, int(c))
+        established_final.append(row.get("bgp_established", ""))
+
+    rss_slope = (
+        linreg([e / 3600 for e, _ in rss_pts], [r for _, r in rss_pts])
+        if rss_pts
+        else float("nan")
+    )
+    peak_rss = max((r for _, r in rss_pts), default=float("nan"))
+
+    tail = established_final[-3:] if established_final else []
+    final_established = tail.count("1") > 0 if tail else False
+
+    gates = {
+        "rss_slope_per_hour": {
+            "value": rss_slope if not math.isnan(rss_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(rss_slope)) and rss_slope < 1.0,
+        },
+        "peak_rss_mb": {
+            "value": peak_rss if not math.isnan(peak_rss) else None,
+            "limit": 512.0,
+            "pass": (not math.isnan(peak_rss)) and peak_rss < 512.0,
+        },
+        "churn_cycles": {
+            "value": max_cycles,
+            "limit": 1,
+            "pass": max_cycles >= 1,
+        },
+        "final_session_established": {
+            "value": final_established,
+            "pass": final_established,
+        },
+    }
+
+    all_pass = all(g["pass"] for g in gates.values())
+    return {
+        "verdict": "pass" if all_pass else "fail",
+        "churn_cycles": max_cycles,
+        "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
+        "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
+        "samples": len(rows),
+        "gates": gates,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze inject-churn soak")
+    parser.add_argument("run_dir", help="Soak run directory containing samples.csv")
+    parser.add_argument("--output", help="Write verdict JSON to this path")
+    args = parser.parse_args()
+
+    csv_path = f"{args.run_dir}/samples.csv"
+    try:
+        with open(csv_path, newline="") as f:
+            rows = list(csv.DictReader(f))
+    except OSError as e:
+        print(f"error reading {csv_path}: {e}", file=sys.stderr)
+        return 2
+
+    if not rows:
+        print("error: samples.csv is empty", file=sys.stderr)
+        return 2
+
+    result = analyze(rows)
+    out = json.dumps(result, indent=2)
+    print(out)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(out)
+    return 0 if result["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -5,6 +5,7 @@ Reads the CSV emitted by run-soak-inject-churn.sh and emits a JSON
 verdict against the soak-specific gates:
 
   - RSS slope (steady state, MB/hour) < 1.0
+  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap)
   - at least one churn cycle recorded
@@ -47,14 +48,18 @@ def linreg(xs: list[float], ys: list[float]) -> float:
 
 def analyze(rows: list[dict[str, str]]) -> dict:
     rss_pts: list[tuple[float, float]] = []
+    intern_pts: list[tuple[float, float]] = []
     established_final: list[str] = []
     max_cycles = 0
 
     for row in rows:
         e = safe_float(row.get("elapsed_sec"))
         r = safe_float(row.get("rss_mb"))
+        i = safe_float(row.get("intern_size"))
         if e is not None and r is not None:
             rss_pts.append((e, r))
+        if e is not None and i is not None:
+            intern_pts.append((e, i))
         c = safe_float(row.get("churn_cycles"))
         if c is not None:
             max_cycles = max(max_cycles, int(c))
@@ -65,12 +70,22 @@ def analyze(rows: list[dict[str, str]]) -> dict:
         if rss_pts
         else float("nan")
     )
+    intern_slope = (
+        linreg([e / 3600 for e, _ in intern_pts], [i for _, i in intern_pts])
+        if intern_pts
+        else float("nan")
+    )
     peak_rss = max((r for _, r in rss_pts), default=float("nan"))
 
     tail = established_final[-3:] if established_final else []
     final_established = tail.count("1") > 0 if tail else False
 
     gates = {
+        "intern_slope_per_hour": {
+            "value": intern_slope if not math.isnan(intern_slope) else None,
+            "limit": 1.0,
+            "pass": (not math.isnan(intern_slope)) and intern_slope < 1.0,
+        },
         "rss_slope_per_hour": {
             "value": rss_slope if not math.isnan(rss_slope) else None,
             "limit": 1.0,
@@ -96,6 +111,7 @@ def analyze(rows: list[dict[str, str]]) -> dict:
     return {
         "verdict": "pass" if all_pass else "fail",
         "churn_cycles": max_cycles,
+        "intern_slope_per_hour": intern_slope if not math.isnan(intern_slope) else None,
         "rss_slope_per_hour": rss_slope if not math.isnan(rss_slope) else None,
         "peak_rss_mb": peak_rss if not math.isnan(peak_rss) else None,
         "samples": len(rows),

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Soak: GR-restart → EoR → stale-clear → gc_intern_table cycle.
+#
+# Repeatedly restarts FRR's bgpd to drive rustbgpd through the
+# Graceful Restart state machine: session down → stale-mark →
+# reconnect → EoR → stale-clear → gc_intern_table. Samples RSS and
+# the bgp_rib_attr_intern_size Prometheus gauge each cycle to prove
+# the interned-attribute table does not grow across restart cycles
+# (the leak class fixed in #603 and unsoaked at HEAD until now).
+#
+# Prerequisites:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-gr-restart-intern-gc.clab.yml
+#
+# Usage:
+#   SOAK_SECONDS=600 bash tests/soak/run-soak-gr-restart-intern-gc.sh   # 10-min smoke
+#   SOAK_HOURS=6   bash tests/soak/run-soak-gr-restart-intern-gc.sh     # 6h dry run
+#   bash tests/soak/run-soak-gr-restart-intern-gc.sh                    # 6h default
+#
+# Output: tests/soak/runs/soak-gr-restart-<UTC>/
+#   - samples.csv      one row per sample interval
+#   - soak.log         harness stdout/stderr
+#   - cycles.log       per-restart-cycle log
+#   - rustbgpd.log     rustbgpd daemon log copied from inside the container
+#   - run.json         run metadata
+
+set -euo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-gr-restart-intern-gc.clab.yml}"
+
+SOAK_HOURS="${SOAK_HOURS:-6}"
+SOAK_SECONDS="${SOAK_SECONDS:-$((SOAK_HOURS * 3600))}"
+SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-30}"
+RESTART_INTERVAL_SEC="${RESTART_INTERVAL_SEC:-300}"
+WARMUP_SEC="${WARMUP_SEC:-120}"
+CLEANUP="${CLEANUP:-0}"
+
+TOPO="${TOPO:-soak-gr-restart}"
+RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
+FRR="${FRR:-clab-${TOPO}-frr}"
+RUSTBGPD_IP="${RUSTBGPD_IP:-10.0.0.1}"
+FRR_IP="${FRR_IP:-10.0.0.2}"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-gr-restart-$RUN_ID}"
+mkdir -p "$RUN_DIR"
+
+SAMPLES_CSV="$RUN_DIR/samples.csv"
+SOAK_LOG="$RUN_DIR/soak.log"
+CYCLES_LOG="$RUN_DIR/cycles.log"
+RUN_JSON="$RUN_DIR/run.json"
+RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
+
+exec > >(tee -a "$SOAK_LOG") 2>&1
+
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+cycle_log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$CYCLES_LOG"
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log "ERROR: required tool '$1' not in PATH"
+        exit 2
+    fi
+}
+
+require_container() {
+    if ! docker inspect "$1" >/dev/null 2>&1; then
+        log "ERROR: container '$1' not found; deploy $TOPOLOGY first"
+        exit 2
+    fi
+}
+
+prom_scrape() {
+    local ip
+    ip=$(docker inspect --format \
+        '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+        "$RUSTBGPD" 2>/dev/null | awk '{print $1}')
+    [ -z "$ip" ] && return 0
+    curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
+}
+
+prom_extract_or_zero() {
+    local text="$1" metric="$2"
+    printf '%s' "$text" | awk -v m="$metric" '
+        $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
+        END { if (!found) { print "0" } }
+    '
+}
+
+container_rss_mb() {
+    docker exec "$RUSTBGPD" sh -c '
+        pid=$(pidof rustbgpd 2>/dev/null || true)
+        if [ -n "$pid" ] && [ -r "/proc/$pid/status" ]; then
+            awk "/^VmRSS:/ { printf \"%.3f\", \$2 / 1024.0 }" "/proc/$pid/status"
+        fi
+    ' 2>/dev/null || true
+}
+
+rb_gr_active() {
+    local prom
+    prom=$(prom_scrape)
+    [ -z "$prom" ] && { echo 0; return; }
+    prom_extract_or_zero "$prom" bgp_gr_active_peers
+}
+
+frr_established_seen() {
+    docker exec "$FRR" vtysh -c "show bgp neighbors $RUSTBGPD_IP json" 2>/dev/null \
+        | grep -q '"bgpState":"Established"'
+}
+
+wait_established() {
+    local timeout=${1:-90}
+    log "Waiting for BGP session to reach Established (timeout ${timeout}s)..."
+    for i in $(seq 1 "$timeout"); do
+        if frr_established_seen; then
+            log "BGP session established after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: BGP session did not reach Established within ${timeout}s"
+    return 1
+}
+
+restart_frr_bgpd() {
+    cycle_log "restarting FRR bgpd"
+    # Stop bgpd, wait for rustbgpd to notice the session drop and mark stale.
+    docker exec "$FRR" /usr/lib/frr/frrinit.sh stop >/dev/null 2>&1 || true
+    sleep 5
+    # Start bgpd again; rustbgpd will see reconnect + EoR + stale-clear + gc.
+    docker exec "$FRR" /usr/lib/frr/frrinit.sh start >/dev/null 2>&1 || true
+    cycle_log "FRR bgpd restart initiated"
+}
+
+write_run_json() {
+    {
+        echo "{"
+        printf '  "run_id": "%s",\n' "$RUN_ID"
+        printf '  "git_head": "%s",\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+        printf '  "soak_seconds": %d,\n' "$SOAK_SECONDS"
+        printf '  "sample_interval_sec": %d,\n' "$SAMPLE_INTERVAL"
+        printf '  "restart_interval_sec": %d,\n' "$RESTART_INTERVAL_SEC"
+        printf '  "warmup_sec": %d,\n' "$WARMUP_SEC"
+        printf '  "rustbgpd_container": "%s",\n' "$RUSTBGPD"
+        printf '  "frr_container": "%s",\n' "$FRR"
+        printf '  "topology": "%s"\n' "$TOPOLOGY"
+        echo "}"
+    } >"$RUN_JSON"
+}
+
+start_log_stream() {
+    docker exec "$RUSTBGPD" sh -c \
+        'touch /var/log/rustbgpd.log; tail -n +1 -F /var/log/rustbgpd.log' \
+        >"$RUSTBGPD_LOG" 2>&1 &
+    RUST_LOG_PID=$!
+}
+
+stop_log_stream() {
+    if [ "${RUST_LOG_PID:-}" ]; then
+        kill "$RUST_LOG_PID" 2>/dev/null || true
+        wait "$RUST_LOG_PID" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    local exit_code=$?
+    set +e
+    stop_log_stream
+    if [ "$CLEANUP" = "1" ]; then
+        log "Destroying containerlab topology"
+        containerlab destroy -t "$TOPOLOGY" --cleanup >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM HUP
+
+sample_row() {
+    local elapsed=${1:?}
+    local cycles=${2:?}
+    local prom rss intern_size gr_active established
+    prom=$(prom_scrape)
+    rss=$(container_rss_mb)
+    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
+    gr_active=$(prom_extract_or_zero "$prom" bgp_gr_active_peers)
+    if frr_established_seen; then
+        established=1
+    else
+        established=0
+    fi
+    printf '%s,%s,%s,%s,%s,%s,%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$elapsed" \
+        "${rss:-nan}" \
+        "$intern_size" \
+        "$gr_active" \
+        "$established" \
+        "$cycles" \
+        >>"$SAMPLES_CSV"
+}
+
+main() {
+    require_tool docker
+    require_tool curl
+    require_tool awk
+    require_container "$RUSTBGPD"
+    require_container "$FRR"
+
+    write_run_json
+    start_log_stream
+
+    log "GR-restart intern-gc soak starting"
+    log "  duration:          ${SOAK_SECONDS}s"
+    log "  sample interval:   ${SAMPLE_INTERVAL}s"
+    log "  restart interval:  ${RESTART_INTERVAL_SEC}s"
+    log "  warmup:            ${WARMUP_SEC}s"
+    log "  output:            $RUN_DIR"
+
+    wait_established 90
+
+    log "Warmup: waiting ${WARMUP_SEC}s for initial convergence"
+    sleep "$WARMUP_SEC"
+
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,gr_active_peers,bgp_established,restart_cycles" >"$SAMPLES_CSV"
+
+    local start_epoch end_epoch next_sample next_restart cycles
+    start_epoch=$(date +%s)
+    end_epoch=$((start_epoch + SOAK_SECONDS))
+    next_sample=$start_epoch
+    next_restart=$start_epoch
+    cycles=0
+
+    sample_row 0 "$cycles"
+
+    while [ "$(date +%s)" -lt "$end_epoch" ]; do
+        now=$(date +%s)
+        if [ "$now" -ge "$next_restart" ]; then
+            restart_frr_bgpd
+            cycles=$((cycles + 1))
+            next_restart=$((now + RESTART_INTERVAL_SEC))
+            # Wait for re-establishment so the cycle is well-formed.
+            wait_established 60 || log "WARN: session did not re-establish after cycle $cycles"
+        fi
+        if [ "$now" -ge "$next_sample" ]; then
+            local elapsed=$((now - start_epoch))
+            sample_row "$elapsed" "$cycles"
+            next_sample=$((now + SAMPLE_INTERVAL))
+        fi
+        sleep 1
+    done
+
+    local final_elapsed=$(( $(date +%s) - start_epoch ))
+    sample_row "$final_elapsed" "$cycles"
+    log "soak loop completed; $cycles restart cycles; final samples in $SAMPLES_CSV"
+    log "Run the analyzer: python3 tests/soak/analyze-soak-gr-restart.py $RUN_DIR"
+}
+
+main "$@"

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Soak: config live-apply (hot-reload) churn.
+#
+# Repeatedly runs `rbgp config plan` → `config apply` with a candidate
+# TOML that mutates the neighbor description, exercising the ADR-0063
+# shape-gated live-apply path without restarting the daemon. Proves the
+# live-apply path does not leak and sessions stay established across
+# hundreds of config cycles.
+#
+# Prerequisites:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-hot-reload.clab.yml
+#
+# Usage:
+#   SOAK_SECONDS=600 bash tests/soak/run-soak-hot-reload.sh   # 10-min smoke
+#   SOAK_HOURS=6   bash tests/soak/run-soak-hot-reload.sh     # 6h
+#   bash tests/soak/run-soak-hot-reload.sh                    # 6h default
+#
+# Output: tests/soak/runs/soak-hot-reload-<UTC>/
+#   - samples.csv      one row per sample interval
+#   - soak.log         harness stdout/stderr
+#   - cycles.log       per-apply-cycle log
+#   - rustbgpd.log     rustbgpd daemon log
+#   - run.json         run metadata
+
+set -euo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-hot-reload.clab.yml}"
+
+SOAK_HOURS="${SOAK_HOURS:-6}"
+SOAK_SECONDS="${SOAK_SECONDS:-$((SOAK_HOURS * 3600))}"
+SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-30}"
+APPLY_INTERVAL_SEC="${APPLY_INTERVAL_SEC:-120}"
+WARMUP_SEC="${WARMUP_SEC:-120}"
+CLEANUP="${CLEANUP:-0}"
+
+TOPO="${TOPO:-soak-hot-reload}"
+RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
+FRR="${FRR:-clab-${TOPO}-frr}"
+RUSTBGPD_IP="${RUSTBGPD_IP:-10.0.0.1}"
+FRR_IP="${FRR_IP:-10.0.0.2}"
+GRPC_ADDR="${GRPC_ADDR:-http://127.0.0.1:50051}"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-hot-reload-$RUN_ID}"
+mkdir -p "$RUN_DIR"
+
+SAMPLES_CSV="$RUN_DIR/samples.csv"
+SOAK_LOG="$RUN_DIR/soak.log"
+CYCLES_LOG="$RUN_DIR/cycles.log"
+RUN_JSON="$RUN_DIR/run.json"
+RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
+CANDIDATE_TOML="$RUN_DIR/candidate.toml"
+
+exec > >(tee -a "$SOAK_LOG") 2>&1
+
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+cycle_log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$CYCLES_LOG"
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log "ERROR: required tool '$1' not in PATH"
+        exit 2
+    fi
+}
+
+require_container() {
+    if ! docker inspect "$1" >/dev/null 2>&1; then
+        log "ERROR: container '$1' not found; deploy $TOPOLOGY first"
+        exit 2
+    fi
+}
+
+prom_scrape() {
+    local ip
+    ip=$(docker inspect --format \
+        '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+        "$RUSTBGPD" 2>/dev/null | awk '{print $1}')
+    [ -z "$ip" ] && return 0
+    curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
+}
+
+prom_extract_or_zero() {
+    local text="$1" metric="$2"
+    printf '%s' "$text" | awk -v m="$metric" '
+        $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
+        END { if (!found) { print "0" } }
+    '
+}
+
+container_rss_mb() {
+    docker exec "$RUSTBGPD" sh -c '
+        pid=$(pidof rustbgpd 2>/dev/null || true)
+        if [ -n "$pid" ] && [ -r "/proc/$pid/status" ]; then
+            awk "/^VmRSS:/ { printf \"%.3f\", \$2 / 1024.0 }" "/proc/$pid/status"
+        fi
+    ' 2>/dev/null || true
+}
+
+frr_vtysh() {
+    docker exec "$FRR" vtysh -c "$1" 2>/dev/null || true
+}
+
+frr_established_seen() {
+    frr_vtysh "show bgp neighbors $RUSTBGPD_IP json" \
+        | grep -q '"bgpState":"Established"'
+}
+
+wait_established() {
+    log "Waiting for BGP session to reach Established..."
+    for i in $(seq 1 90); do
+        if frr_established_seen; then
+            log "BGP session established after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: BGP session did not reach Established within 90s"
+    return 1
+}
+
+write_candidate_toml() {
+    local cycle=${1:?}
+    cat >"$CANDIDATE_TOML" <<EOF
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+description = "frr-soak-hot-reload-cycle-${cycle}"
+hold_time = 90
+
+[security.grpc]
+enforcement = "legacy"
+EOF
+}
+
+# Plan a candidate config, extract the runtime_snapshot_token from JSON.
+plan_and_extract_token() {
+    local token
+    token=$(docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config plan \
+        --from-file /tmp/candidate.toml -j 2>/dev/null \
+        | grep -o '"runtime_snapshot_token":"[^"]*"' \
+        | head -1 \
+        | sed 's/"runtime_snapshot_token":"//;s/"//')
+    printf '%s' "$token"
+}
+
+run_apply_cycle() {
+    local cycle=${1:?}
+    write_candidate_toml "$cycle"
+    cycle_log "cycle $cycle: writing candidate TOML"
+    # Copy candidate into the container (rbgp reads from_file locally).
+    docker cp "$CANDIDATE_TOML" "$RUSTBGPD:/tmp/candidate.toml" >/dev/null 2>&1
+    local token
+    token=$(plan_and_extract_token)
+    if [ -z "$token" ]; then
+        cycle_log "cycle $cycle: WARN plan returned no token, skipping apply"
+        return 1
+    fi
+    cycle_log "cycle $cycle: token=$token, applying"
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" config apply \
+        --from-file /tmp/candidate.toml \
+        --expected-runtime-snapshot-token "$token" -j >/dev/null 2>&1 || {
+        cycle_log "cycle $cycle: apply failed"
+        return 1
+    }
+    cycle_log "cycle $cycle: apply OK"
+    return 0
+}
+
+write_run_json() {
+    {
+        echo "{"
+        printf '  "run_id": "%s",\n' "$RUN_ID"
+        printf '  "git_head": "%s",\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+        printf '  "soak_seconds": %d,\n' "$SOAK_SECONDS"
+        printf '  "sample_interval_sec": %d,\n' "$SAMPLE_INTERVAL"
+        printf '  "apply_interval_sec": %d,\n' "$APPLY_INTERVAL_SEC"
+        printf '  "warmup_sec": %d,\n' "$WARMUP_SEC"
+        printf '  "rustbgpd_container": "%s",\n' "$RUSTBGPD"
+        printf '  "frr_container": "%s",\n' "$FRR"
+        printf '  "topology": "%s"\n' "$TOPOLOGY"
+        echo "}"
+    } >"$RUN_JSON"
+}
+
+start_log_stream() {
+    docker exec "$RUSTBGPD" sh -c \
+        'touch /var/log/rustbgpd.log; tail -n +1 -F /var/log/rustbgpd.log' \
+        >"$RUSTBGPD_LOG" 2>&1 &
+    RUST_LOG_PID=$!
+}
+
+stop_log_stream() {
+    if [ "${RUST_LOG_PID:-}" ]; then
+        kill "$RUST_LOG_PID" 2>/dev/null || true
+        wait "$RUST_LOG_PID" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    local exit_code=$?
+    set +e
+    stop_log_stream
+    if [ "$CLEANUP" = "1" ]; then
+        log "Destroying containerlab topology"
+        containerlab destroy -t "$TOPOLOGY" --cleanup >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM HUP
+
+sample_row() {
+    local elapsed=${1:?}
+    local cycles=${2:?}
+    local apply_ok=${3:?}
+    local apply_fail=${4:?}
+    local prom rss established
+    prom=$(prom_scrape)
+    rss=$(container_rss_mb)
+    if frr_established_seen; then
+        established=1
+    else
+        established=0
+    fi
+    printf '%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$elapsed" \
+        "${rss:-nan}" \
+        "$established" \
+        "$cycles" \
+        "$apply_ok" \
+        "$apply_fail" \
+        >>"$SAMPLES_CSV"
+}
+
+main() {
+    require_tool docker
+    require_tool curl
+    require_tool awk
+    require_container "$RUSTBGPD"
+    require_container "$FRR"
+
+    write_run_json
+    start_log_stream
+
+    log "Hot-reload (config live-apply) soak starting"
+    log "  duration:         ${SOAK_SECONDS}s"
+    log "  sample interval:  ${SAMPLE_INTERVAL}s"
+    log "  apply interval:   ${APPLY_INTERVAL_SEC}s"
+    log "  warmup:           ${WARMUP_SEC}s"
+    log "  output:           $RUN_DIR"
+
+    wait_established
+
+    log "Warmup: waiting ${WARMUP_SEC}s"
+    sleep "$WARMUP_SEC"
+
+    echo "timestamp,elapsed_sec,rss_mb,bgp_established,apply_cycles,apply_ok,apply_fail" >"$SAMPLES_CSV"
+
+    local start_epoch end_epoch next_sample next_apply cycles apply_ok apply_fail
+    start_epoch=$(date +%s)
+    end_epoch=$((start_epoch + SOAK_SECONDS))
+    next_sample=$start_epoch
+    next_apply=$start_epoch
+    cycles=0
+    apply_ok=0
+    apply_fail=0
+
+    sample_row 0 "$cycles" "$apply_ok" "$apply_fail"
+
+    while [ "$(date +%s)" -lt "$end_epoch" ]; do
+        now=$(date +%s)
+        if [ "$now" -ge "$next_apply" ]; then
+            cycles=$((cycles + 1))
+            if run_apply_cycle "$cycles"; then
+                apply_ok=$((apply_ok + 1))
+            else
+                apply_fail=$((apply_fail + 1))
+            fi
+            next_apply=$((now + APPLY_INTERVAL_SEC))
+        fi
+        if [ "$now" -ge "$next_sample" ]; then
+            local elapsed=$((now - start_epoch))
+            sample_row "$elapsed" "$cycles" "$apply_ok" "$apply_fail"
+            next_sample=$((now + SAMPLE_INTERVAL))
+        fi
+        sleep 1
+    done
+
+    local final_elapsed=$(( $(date +%s) - start_epoch ))
+    sample_row "$final_elapsed" "$cycles" "$apply_ok" "$apply_fail"
+    log "soak loop completed; $cycles apply cycles ($apply_ok ok, $apply_fail fail); final samples in $SAMPLES_CSV"
+    log "Run the analyzer: python3 tests/soak/analyze-soak-hot-reload.py $RUN_DIR"
+}
+
+main "$@"

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -238,9 +238,10 @@ sample_row() {
     local cycles=${2:?}
     local apply_ok=${3:?}
     local apply_fail=${4:?}
-    local prom rss established
+    local prom rss intern_size established
     prom=$(prom_scrape)
     rss=$(container_rss_mb)
+    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
     if frr_established_seen; then
         established=1
     else
@@ -250,6 +251,7 @@ sample_row() {
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \
         "${rss:-nan}" \
+        "$intern_size" \
         "$established" \
         "$cycles" \
         "$apply_ok" \
@@ -279,7 +281,7 @@ main() {
     log "Warmup: waiting ${WARMUP_SEC}s"
     sleep "$WARMUP_SEC"
 
-    echo "timestamp,elapsed_sec,rss_mb,bgp_established,apply_cycles,apply_ok,apply_fail" >"$SAMPLES_CSV"
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,bgp_established,apply_cycles,apply_ok,apply_fail" >"$SAMPLES_CSV"
 
     local start_epoch end_epoch next_sample next_apply cycles apply_ok apply_fail
     start_epoch=$(date +%s)

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Soak: gRPC route-injection churn (automation-controller beachhead).
+#
+# Drives `InjectionService.AddPath` / `DeletePath` over gRPC at a
+# sustained add/delete rate, proving the controller-injection path
+# (the automation-controller beachhead) does not leak under
+# steady-state churn. Uses `rbgp rib add` / `rbgp rib delete` from
+# inside the rustbgpd container.
+#
+# Prerequisites:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-inject-churn.clab.yml
+#
+# Usage:
+#   SOAK_SECONDS=600 bash tests/soak/run-soak-inject-churn.sh   # 10-min smoke
+#   SOAK_HOURS=24  bash tests/soak/run-soak-inject-churn.sh     # 24h
+#   bash tests/soak/run-soak-inject-churn.sh                    # 24h default
+#
+# Output: tests/soak/runs/soak-inject-churn-<UTC>/
+#   - samples.csv      one row per sample interval
+#   - soak.log         harness stdout/stderr
+#   - churn.log        per-cycle add/delete log
+#   - rustbgpd.log     rustbgpd daemon log copied from inside the container
+#   - run.json         run metadata
+
+set -euo pipefail
+
+SOAK_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SOAK_SCRIPT_DIR/../.." && pwd)"
+TOPOLOGY="${TOPOLOGY:-$REPO_ROOT/tests/soak/soak-inject-churn.clab.yml}"
+
+SOAK_HOURS="${SOAK_HOURS:-24}"
+SOAK_SECONDS="${SOAK_SECONDS:-$((SOAK_HOURS * 3600))}"
+SAMPLE_INTERVAL="${SAMPLE_INTERVAL:-60}"
+CHURN_INTERVAL_SEC="${CHURN_INTERVAL_SEC:-5}"
+CHURN_BATCH="${CHURN_BATCH:-25}"
+PREFIX_POOL_SIZE="${PREFIX_POOL_SIZE:-4096}"
+LIVE_TARGET_PREFIXES="${LIVE_TARGET_PREFIXES:-1024}"
+WARMUP_SEC="${WARMUP_SEC:-120}"
+CLEANUP="${CLEANUP:-0}"
+
+TOPO="${TOPO:-soak-inject-churn}"
+RUSTBGPD="${RUSTBGPD:-clab-${TOPO}-rustbgpd}"
+FRR="${FRR:-clab-${TOPO}-frr}"
+RUSTBGPD_IP="${RUSTBGPD_IP:-10.0.0.1}"
+FRR_IP="${FRR_IP:-10.0.0.2}"
+GRPC_ADDR="${GRPC_ADDR:-http://127.0.0.1:50051}"
+NEXTHOP="${NEXTHOP:-10.0.0.1}"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR_OVERRIDE:-$SOAK_SCRIPT_DIR/runs/soak-inject-churn-$RUN_ID}"
+mkdir -p "$RUN_DIR"
+
+SAMPLES_CSV="$RUN_DIR/samples.csv"
+SOAK_LOG="$RUN_DIR/soak.log"
+CHURN_LOG="$RUN_DIR/churn.log"
+RUN_JSON="$RUN_DIR/run.json"
+RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
+LIVE_SET_FILE="$RUN_DIR/live-prefix-indexes.txt"
+
+exec > >(tee -a "$SOAK_LOG") 2>&1
+
+# shellcheck source=./host-lock.sh
+source "$SOAK_SCRIPT_DIR/host-lock.sh"
+acquire_rustbgpd_host_lock
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+churn_log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$CHURN_LOG"
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        log "ERROR: required tool '$1' not in PATH"
+        exit 2
+    fi
+}
+
+require_container() {
+    if ! docker inspect "$1" >/dev/null 2>&1; then
+        log "ERROR: container '$1' not found; deploy $TOPOLOGY first"
+        exit 2
+    fi
+}
+
+format_prefix() {
+    local n=${1:?}
+    # 10.<high>.<low>.0/24 — unique /24s from the pool index.
+    printf '10.%d.%d.0/24' $(((n >> 8) & 255)) $((n & 255))
+}
+
+wrap_index() {
+    local value=${1:?}
+    if [ "$value" -gt "$PREFIX_POOL_SIZE" ]; then
+        value=1
+    fi
+    printf '%s\n' "$value"
+}
+
+rb_inject_add() {
+    local prefix=${1:?}
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" rib add "$prefix" \
+        --nexthop "$NEXTHOP" >/dev/null 2>&1 || true
+}
+
+rb_inject_del() {
+    local prefix=${1:?}
+    docker exec "$RUSTBGPD" rbgp -s "$GRPC_ADDR" rib delete "$prefix" \
+        >/dev/null 2>&1 || true
+}
+
+frr_vtysh() {
+    docker exec "$FRR" vtysh -c "$1" 2>/dev/null || true
+}
+
+frr_established_seen() {
+    frr_vtysh "show bgp neighbors $RUSTBGPD_IP json" \
+        | grep -q '"bgpState":"Established"'
+}
+
+wait_established() {
+    log "Waiting for BGP session to reach Established..."
+    for i in $(seq 1 90); do
+        if frr_established_seen; then
+            log "BGP session established after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: BGP session did not reach Established within 90s"
+    return 1
+}
+
+prom_scrape() {
+    local ip
+    ip=$(docker inspect --format \
+        '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+        "$RUSTBGPD" 2>/dev/null | awk '{print $1}')
+    [ -z "$ip" ] && return 0
+    curl -sfm 5 "http://${ip}:9179/metrics" 2>/dev/null || true
+}
+
+prom_extract_or_zero() {
+    local text="$1" metric="$2"
+    printf '%s' "$text" | awk -v m="$metric" '
+        $0 ~ "^"m"( |\\{)" { print $NF; found=1; exit }
+        END { if (!found) { print "0" } }
+    '
+}
+
+prom_sum() {
+    local text="$1" metric="$2"
+    printf '%s' "$text" | awk -v m="$metric" '
+        $0 ~ "^"m"( |\\{)" { sum += $NF }
+        END { if (sum == "") { print "0" } else { print sum } }
+    '
+}
+
+container_rss_mb() {
+    docker exec "$RUSTBGPD" sh -c '
+        pid=$(pidof rustbgpd 2>/dev/null || true)
+        if [ -n "$pid" ] && [ -r "/proc/$pid/status" ]; then
+            awk "/^VmRSS:/ { printf \"%.3f\", \$2 / 1024.0 }" "/proc/$pid/status"
+        fi
+    ' 2>/dev/null || true
+}
+
+frr_route_count() {
+    frr_vtysh "show bgp ipv4 unicast" \
+        | grep -c '10\.' || true
+}
+
+write_run_json() {
+    {
+        echo "{"
+        printf '  "run_id": "%s",\n' "$RUN_ID"
+        printf '  "git_head": "%s",\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+        printf '  "soak_seconds": %d,\n' "$SOAK_SECONDS"
+        printf '  "sample_interval_sec": %d,\n' "$SAMPLE_INTERVAL"
+        printf '  "churn_interval_sec": %d,\n' "$CHURN_INTERVAL_SEC"
+        printf '  "churn_batch": %d,\n' "$CHURN_BATCH"
+        printf '  "prefix_pool_size": %d,\n' "$PREFIX_POOL_SIZE"
+        printf '  "live_target_prefixes": %d,\n' "$LIVE_TARGET_PREFIXES"
+        printf '  "warmup_sec": %d,\n' "$WARMUP_SEC"
+        printf '  "rustbgpd_container": "%s",\n' "$RUSTBGPD"
+        printf '  "frr_container": "%s",\n' "$FRR"
+        printf '  "topology": "%s"\n' "$TOPOLOGY"
+        echo "}"
+    } >"$RUN_JSON"
+}
+
+start_log_stream() {
+    docker exec "$RUSTBGPD" sh -c \
+        'touch /var/log/rustbgpd.log; tail -n +1 -F /var/log/rustbgpd.log' \
+        >"$RUSTBGPD_LOG" 2>&1 &
+    RUST_LOG_PID=$!
+}
+
+stop_log_stream() {
+    if [ "${RUST_LOG_PID:-}" ]; then
+        kill "$RUST_LOG_PID" 2>/dev/null || true
+        wait "$RUST_LOG_PID" 2>/dev/null || true
+    fi
+}
+
+drain_live_prefixes() {
+    if [ ! -s "$LIVE_SET_FILE" ]; then
+        return 0
+    fi
+    log "Draining remaining injected prefixes"
+    while IFS= read -r idx; do
+        [ -z "$idx" ] && continue
+        rb_inject_del "$(format_prefix "$idx")"
+    done <"$LIVE_SET_FILE"
+    : >"$LIVE_SET_FILE"
+}
+
+cleanup() {
+    local exit_code=$?
+    set +e
+    drain_live_prefixes
+    stop_log_stream
+    if [ "$CLEANUP" = "1" ]; then
+        log "Destroying containerlab topology"
+        containerlab destroy -t "$TOPOLOGY" --cleanup >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM HUP
+
+validate_config() {
+    if [ "$PREFIX_POOL_SIZE" -le "$LIVE_TARGET_PREFIXES" ]; then
+        log "ERROR: PREFIX_POOL_SIZE must be greater than LIVE_TARGET_PREFIXES"
+        exit 2
+    fi
+    if [ "$CHURN_BATCH" -le 0 ] || [ "$LIVE_TARGET_PREFIXES" -le 0 ]; then
+        log "ERROR: CHURN_BATCH and LIVE_TARGET_PREFIXES must be positive"
+        exit 2
+    fi
+    if [ "$CHURN_BATCH" -gt "$LIVE_TARGET_PREFIXES" ]; then
+        log "ERROR: CHURN_BATCH must not exceed LIVE_TARGET_PREFIXES"
+        exit 2
+    fi
+    local pool_headroom=$((PREFIX_POOL_SIZE - LIVE_TARGET_PREFIXES))
+    if [ "$pool_headroom" -lt "$CHURN_BATCH" ]; then
+        log "ERROR: PREFIX_POOL_SIZE - LIVE_TARGET_PREFIXES must be at least CHURN_BATCH"
+        exit 2
+    fi
+}
+
+prefill_live_set() {
+    : >"$LIVE_SET_FILE"
+    log "Prefilling $LIVE_TARGET_PREFIXES injected prefixes"
+    local idx
+    for idx in $(seq 1 "$LIVE_TARGET_PREFIXES"); do
+        printf '%s\n' "$idx" >>"$LIVE_SET_FILE"
+        rb_inject_add "$(format_prefix "$idx")"
+    done
+}
+
+sample_row() {
+    local elapsed=${1:?}
+    local cycles=${2:?}
+    local add_total=${3:?}
+    local del_total=${4:?}
+    local prom rss frr_count established intern_size
+    prom=$(prom_scrape)
+    rss=$(container_rss_mb)
+    frr_count=$(frr_route_count)
+    if frr_established_seen; then
+        established=1
+    else
+        established=0
+    fi
+    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$elapsed" \
+        "${rss:-nan}" \
+        "$LIVE_TARGET_PREFIXES" \
+        "$frr_count" \
+        "$established" \
+        "$cycles" \
+        "$add_total" \
+        "$del_total" \
+        >>"$SAMPLES_CSV"
+}
+
+run_churn_cycle() {
+    local del_idx_ref=${1:?}
+    local add_idx_ref=${2:?}
+    local del_idx add_idx prefix i
+    del_idx=$(cat "$del_idx_ref")
+    add_idx=$(cat "$add_idx_ref")
+
+    for i in $(seq 1 "$CHURN_BATCH"); do
+        prefix=$(format_prefix "$del_idx")
+        rb_inject_del "$prefix"
+        sed -i "/^${del_idx}$/d" "$LIVE_SET_FILE"
+        churn_log "del $prefix"
+        del_idx=$(wrap_index $((del_idx + 1)))
+    done
+
+    for i in $(seq 1 "$CHURN_BATCH"); do
+        prefix=$(format_prefix "$add_idx")
+        printf '%s\n' "$add_idx" >>"$LIVE_SET_FILE"
+        rb_inject_add "$prefix"
+        churn_log "add $prefix"
+        add_idx=$(wrap_index $((add_idx + 1)))
+    done
+
+    printf '%s\n' "$del_idx" >"$del_idx_ref"
+    printf '%s\n' "$add_idx" >"$add_idx_ref"
+}
+
+main() {
+    require_tool docker
+    require_tool curl
+    require_tool awk
+    require_container "$RUSTBGPD"
+    require_container "$FRR"
+    validate_config
+
+    write_run_json
+    start_log_stream
+
+    log "gRPC inject-churn soak starting"
+    log "  duration: ${SOAK_SECONDS}s"
+    log "  sample:   ${SAMPLE_INTERVAL}s"
+    log "  churn:    ${CHURN_BATCH} del + ${CHURN_BATCH} add every ${CHURN_INTERVAL_SEC}s"
+    log "  pool:     ${PREFIX_POOL_SIZE}, live target: ${LIVE_TARGET_PREFIXES}"
+    log "  output:   $RUN_DIR"
+
+    wait_established
+    prefill_live_set
+
+    echo "timestamp,elapsed_sec,rss_mb,live_target,frr_route_count,bgp_established,churn_cycles,add_total,del_total" >"$SAMPLES_CSV"
+
+    local start_epoch end_epoch next_sample next_churn cycles add_total del_total
+    local del_idx_file add_idx_file now
+    start_epoch=$(date +%s)
+    end_epoch=$((start_epoch + SOAK_SECONDS))
+    next_sample=$start_epoch
+    next_churn=$((start_epoch + WARMUP_SEC))
+    cycles=0
+    add_total=$LIVE_TARGET_PREFIXES
+    del_total=0
+    del_idx_file="$RUN_DIR/next-delete-index"
+    add_idx_file="$RUN_DIR/next-add-index"
+    printf '1\n' >"$del_idx_file"
+    printf '%s\n' "$((LIVE_TARGET_PREFIXES + 1))" >"$add_idx_file"
+
+    sample_row 0 "$cycles" "$add_total" "$del_total"
+
+    while [ "$(date +%s)" -lt "$end_epoch" ]; do
+        now=$(date +%s)
+        if [ "$now" -ge "$next_churn" ]; then
+            run_churn_cycle "$del_idx_file" "$add_idx_file"
+            cycles=$((cycles + 1))
+            add_total=$((add_total + CHURN_BATCH))
+            del_total=$((del_total + CHURN_BATCH))
+            next_churn=$((now + CHURN_INTERVAL_SEC))
+        fi
+        if [ "$now" -ge "$next_sample" ]; then
+            local elapsed=$((now - start_epoch))
+            sample_row "$elapsed" "$cycles" "$add_total" "$del_total"
+            next_sample=$((now + SAMPLE_INTERVAL))
+        fi
+        sleep 1
+    done
+
+    local final_elapsed=$(( $(date +%s) - start_epoch ))
+    sample_row "$final_elapsed" "$cycles" "$add_total" "$del_total"
+    log "soak loop completed; $cycles churn cycles; final samples in $SAMPLES_CSV"
+    log "Run the analyzer: python3 tests/soak/analyze-soak-inject-churn.py $RUN_DIR"
+}
+
+main "$@"

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -277,10 +277,11 @@ sample_row() {
         established=0
     fi
     intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
-    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \
         "${rss:-nan}" \
+        "$intern_size" \
         "$LIVE_TARGET_PREFIXES" \
         "$frr_count" \
         "$established" \
@@ -338,7 +339,7 @@ main() {
     wait_established
     prefill_live_set
 
-    echo "timestamp,elapsed_sec,rss_mb,live_target,frr_route_count,bgp_established,churn_cycles,add_total,del_total" >"$SAMPLES_CSV"
+    echo "timestamp,elapsed_sec,rss_mb,intern_size,live_target,frr_route_count,bgp_established,churn_cycles,add_total,del_total" >"$SAMPLES_CSV"
 
     local start_epoch end_epoch next_sample next_churn cycles add_total del_total
     local del_idx_file add_idx_file now

--- a/tests/soak/soak-gr-restart-intern-gc.clab.yml
+++ b/tests/soak/soak-gr-restart-intern-gc.clab.yml
@@ -1,0 +1,52 @@
+# Containerlab topology: soak variant of M16 (GR + LLGR).
+#
+# Distinct `name:` (`soak-gr-restart`) so a hosted CI run of the M16
+# interop smoke cannot destroy the soak's containers by-name — mirrors
+# the m37-soak / m37 split.
+#
+# FRR advertises 192.168.1.0/24 and 192.168.2.0/24 with GR + LLGR.
+# rustbgpd has gr_restart_time=15, gr_stale_routes_time=20,
+# llgr_stale_time=60. The soak harness cyclically restarts FRR's
+# bgpd to drive the rustbgpd GR-restart → stale-mark → EoR →
+# stale-clear → gc_intern_table path repeatedly, sampling RSS and
+# the bgp_rib_attr_intern_size gauge to prove the intern table
+# does not grow across restart cycles.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-gr-restart-intern-gc.clab.yml
+#   bash tests/soak/run-soak-gr-restart-intern-gc.sh
+#   containerlab destroy -t tests/soak/soak-gr-restart-intern-gc.clab.yml
+
+name: soak-gr-restart
+
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-soak-gr-restart.toml:/etc/rustbgpd/config.toml:ro
+        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+      exec:
+        - ip addr add 10.0.0.1/24 dev eth1
+        - ip link set eth1 up
+      env:
+        RUST_LOG: info
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-m16-llgr.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip addr add 10.0.0.2/24 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]
+
+# rustbgpd: 10.0.0.1, AS 65001 (GR + LLGR helper)
+# FRR:      10.0.0.2, AS 65002 (GR + LLGR enabled, stale-time 30s)

--- a/tests/soak/soak-hot-reload.clab.yml
+++ b/tests/soak/soak-hot-reload.clab.yml
@@ -1,0 +1,50 @@
+# Containerlab topology: soak for config live-apply (hot-reload).
+#
+# Distinct `name:` (`soak-hot-reload`) so a hosted CI run of the M3
+# interop smoke cannot destroy the soak's containers by-name.
+#
+# rustbgpd peers with a single FRR receiver. The soak harness
+# repeatedly runs `rbgp config plan` → `config apply` with a candidate
+# TOML that mutates a non-disruptive neighbor field (description),
+# exercising the ADR-0063 shape-gated live-apply path without
+# restarting the daemon. Proves the live-apply path does not leak
+# and sessions stay established across hundreds of config cycles.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-hot-reload.clab.yml
+#   bash tests/soak/run-soak-hot-reload.sh
+#   containerlab destroy -t tests/soak/soak-hot-reload.clab.yml
+
+name: soak-hot-reload
+
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-soak-hot-reload.toml:/etc/rustbgpd/config.toml:ro
+        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+      exec:
+        - ip addr add 10.0.0.1/24 dev eth1
+        - ip link set eth1 up
+      env:
+        RUST_LOG: info
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip addr add 10.0.0.2/24 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]
+
+# rustbgpd: 10.0.0.1, AS 65001 — live-apply target
+# FRR:      10.0.0.2, AS 65002 — IPv4 receiver (passive)

--- a/tests/soak/soak-inject-churn.clab.yml
+++ b/tests/soak/soak-inject-churn.clab.yml
@@ -1,0 +1,48 @@
+# Containerlab topology: soak variant of M3 (gRPC route injection).
+#
+# Distinct `name:` (`soak-inject-churn`) so a hosted CI run of the M3
+# interop smoke cannot destroy the soak's containers by-name.
+#
+# rustbgpd peers with a single FRR receiver. The soak harness drives
+# `InjectionService.AddPath` / `DeletePath` over gRPC at a sustained
+# churn rate, proving the injection path (the automation-controller
+# beachhead) does not leak under steady-state add/delete cycling.
+#
+# Usage:
+#   docker build -t rustbgpd:dev .
+#   containerlab deploy -t tests/soak/soak-inject-churn.clab.yml
+#   bash tests/soak/run-soak-inject-churn.sh
+#   containerlab destroy -t tests/soak/soak-inject-churn.clab.yml
+
+name: soak-inject-churn
+
+topology:
+  nodes:
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      binds:
+        - ./configs/rustbgpd-soak-inject-churn.toml:/etc/rustbgpd/config.toml:ro
+        - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
+      exec:
+        - ip addr add 10.0.0.1/24 dev eth1
+        - ip link set eth1 up
+      env:
+        RUST_LOG: info
+
+    frr:
+      kind: linux
+      image: quay.io/frrouting/frr:10.3.1
+      binds:
+        - ./configs/frr-daemons:/etc/frr/daemons:ro
+        - ./configs/frr-bgpd-soak-inject-churn.conf:/etc/frr/frr.conf:ro
+      exec:
+        - ip addr add 10.0.0.2/24 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["rustbgpd:eth1", "frr:eth1"]
+
+# rustbgpd: 10.0.0.1, AS 65001 — gRPC route injector
+# FRR:      10.0.0.2, AS 65002 — IPv4 receiver


### PR DESCRIPTION
## Summary

Adds `bgp_rib_attr_intern_size`, an `IntGauge` summing the interned attribute sets across every peer's Adj-RIB-In table. It is recorded at each session-lifecycle GC operation — graceful-restart entry, GR/LLGR stale sweep, End-of-RIB, and route-refresh finish — through a single `record_rib_attr_intern_size()` helper, and deliberately kept off the per-chunk distribution hot path so the gauge tracks reclamation across the full restart cycle without adding an O(peers) sum to the data plane.

Adds three containerlab soak harnesses that exercise the gauge and adjacent long-run paths, each with a topology and a post-hoc analyzer:

- **GR-restart intern-GC** — restart → EoR → stale-clear → gc cycle; asserts the intern table does not grow across restart cycles (slope < 1.0/hour).
- **hot-reload** — sustained SIGHUP config churn.
- **inject-churn** — sustained route churn under RSS watch.

No CI workflow is touched; the harnesses are run manually on the soak host.

## Testing

- `cargo build`, `cargo test -p rustbgpd-rib` (687 pass), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo doc` — all green.
- `bash -n` on the three soak scripts.