### PR TITLE
Make bgp_rib_attr_intern_size per-peer so the intern-slope soak gates observe live data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **`bgp_rib_attr_intern_size` gauge** — total unique interned attribute sets
-  summed across all peers' Adj-RIB-In tables, recorded after each
-  session-lifecycle GC (graceful-restart entry, GR/LLGR stale sweep,
-  End-of-RIB, route-refresh finish) and kept off the per-chunk distribution
-  hot path. Three containerlab soak harnesses (GR-restart intern-GC,
-  hot-reload, inject-churn), each with a topology and a post-hoc analyzer,
-  exercise it and adjacent long-run paths.
+- **`bgp_rib_attr_intern_size{peer}` gauge** — unique interned attribute sets
+  in each peer's Adj-RIB-In table (attribute-memory dedup); sum across peers
+  for the daemon-wide total. Three containerlab soak harnesses (GR-restart
+  intern-GC, hot-reload, inject-churn), each with a topology and a post-hoc
+  analyzer, exercise it and adjacent long-run paths. Recorded O(1) per peer at
+  every Adj-RIB-In intern mutation site (GC, injection/withdraw, and announce
+  growth) so the series tracks the live intern table under churn.
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -46,6 +46,8 @@ impl RibManager {
             self.recompute_and_distribute_evpn(&affected);
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
     }
@@ -91,8 +93,12 @@ impl RibManager {
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
             self.recompute_and_distribute_evpn(&affected);
-            if any_replaced && let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                if any_replaced {
+                    rib.gc_intern_table();
+                }
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
     }
@@ -112,8 +118,12 @@ impl RibManager {
         let mut evpn_affected = HashSet::new();
         evpn_affected.insert(key);
         self.recompute_and_distribute_evpn(&evpn_affected);
-        if replaced && let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-            rib.gc_intern_table();
+        if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+            if replaced {
+                rib.gc_intern_table();
+            }
+            self.metrics
+                .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
         }
         let _ = reply.send(Ok(()));
     }
@@ -134,6 +144,8 @@ impl RibManager {
             self.recompute_and_distribute_evpn(&evpn_affected);
             if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
             }
             let _ = reply.send(Ok(()));
         } else {

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -805,6 +805,8 @@ impl RibManager {
             self.pending_distribute_affected.extend(affected);
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
     }
@@ -879,8 +881,12 @@ impl RibManager {
             let changed = self.recompute_best_after_announce(peer, &affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
-            if any_replaced && let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
+            if let Some(rib) = self.ribs.get_mut(&peer) {
+                if any_replaced {
+                    rib.gc_intern_table();
+                }
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
     }
@@ -906,8 +912,12 @@ impl RibManager {
         affected.insert(prefix);
         let changed = self.recompute_best(&affected);
         self.distribute_changes(&changed, &affected);
-        if replaced && let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-            rib.gc_intern_table();
+        if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
+            if replaced {
+                rib.gc_intern_table();
+            }
+            self.metrics
+                .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
         }
 
         let _ = reply.send(Ok(()));
@@ -933,6 +943,8 @@ impl RibManager {
             self.distribute_changes(&changed, &affected);
             if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
             }
             let _ = reply.send(Ok(()));
         } else {

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -168,6 +168,8 @@ impl RibManager {
             // attribute sets stranded by those removals now rather than
             // waiting for an unrelated future withdraw on this peer.
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
 
         if let Some(rib) = self.ribs.get(&peer) {
@@ -235,6 +237,8 @@ impl RibManager {
             // receive path's recompute-then-gc ordering.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !vpn_affected.is_empty() {
@@ -242,6 +246,8 @@ impl RibManager {
             // Same recompute-then-gc ordering rationale as BGP-LS above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !labeled_affected.is_empty() {
@@ -249,6 +255,8 @@ impl RibManager {
             // Same recompute-then-gc ordering rationale as BGP-LS above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !rtc_affected.is_empty() {
@@ -256,6 +264,8 @@ impl RibManager {
             // Same recompute-then-gc ordering rationale as BGP-LS above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         // No RTC membership rebuild here even when routes were deleted:
@@ -302,27 +312,6 @@ impl RibManager {
         });
         self.metrics
             .set_gr_stale_routes(&peer_label, gauge_val(stale_count));
-        self.record_rib_attr_intern_size();
-    }
-
-    /// Record the total interned attribute-set count, summed across every
-    /// peer's Adj-RIB-In intern table, into `bgp_rib_attr_intern_size`.
-    /// Called at the end of each operation that runs `gc_intern_table`
-    /// (GR entry, GR/LLGR stale sweeps, End-of-RIB, route-refresh finish) so
-    /// the gauge tracks reclamation across the full restart cycle rather than
-    /// flapping to whichever peer was collected last.
-    ///
-    // ponytail: intentionally NOT called on the per-chunk distribution GC
-    // path (process_announce_chunk / distribute_changes) — an O(peers) sum
-    // on the data-plane hot path is the wrong trade; steady-state churn
-    // refreshes this gauge at the next session-lifecycle GC instead.
-    pub(super) fn record_rib_attr_intern_size(&self) {
-        let total: usize = self
-            .ribs
-            .values()
-            .map(crate::adj_rib_in::AdjRibIn::intern_len)
-            .sum();
-        self.metrics.set_rib_attr_intern_size(gauge_val(total));
     }
 
     pub(super) fn handle_rpki_cache_update(&mut self, table: Arc<VrpTable>) {
@@ -521,6 +510,8 @@ impl RibManager {
                 // drops selected-route clones that were still holding old
                 // Arcs alive here.
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             if !non_llgr_families.is_empty() {
                 info!(%peer, families = ?non_llgr_families, "swept stale routes for non-LLGR families");
@@ -559,6 +550,8 @@ impl RibManager {
                 && let Some(rib) = self.ribs.get_mut(&peer)
             {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             if rtc_changed {
                 // A non-LLGR purge (or a NO_LLGR removal during promotion)
@@ -611,6 +604,8 @@ impl RibManager {
             labeled_swept = rib.sweep_stale_labeled();
             rtc_swept = rib.sweep_stale_rtc();
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
         }
@@ -671,6 +666,8 @@ impl RibManager {
             && let Some(rib) = self.ribs.get_mut(&peer)
         {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
         if had_rtc_swept {
             // Same obligation as the LLGR branch: a re-established peer whose
@@ -680,7 +677,6 @@ impl RibManager {
         }
 
         self.release_peer_state_if_departed(peer);
-        self.record_rib_attr_intern_size();
     }
 
     /// Sweep LLGR-stale routes for a peer whose LLGR timer has expired.
@@ -713,6 +709,8 @@ impl RibManager {
             labeled_swept = rib.sweep_llgr_stale_labeled();
             rtc_swept = rib.sweep_llgr_stale_rtc();
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
         }
@@ -774,6 +772,8 @@ impl RibManager {
             && let Some(rib) = self.ribs.get_mut(&peer)
         {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
         if had_rtc_swept {
             // Same obligation as the GR-expiry sweeps: the down peer's
@@ -784,7 +784,6 @@ impl RibManager {
         }
 
         self.release_peer_state_if_departed(peer);
-        self.record_rib_attr_intern_size();
     }
 
     /// Release a departed peer's remaining per-peer state once GR/LLGR

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -31,7 +31,7 @@ use crate::update::{
     NeighborPolicyStats, OutboundRouteUpdate, RibUpdate,
 };
 
-use helpers::{DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, prefix_family};
+use helpers::{DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, gauge_val, prefix_family};
 
 /// Reverse index of unicast announcing peers: prefix → the peers whose
 /// Adj-RIB-In currently holds at least one route for it. `FxHash` +
@@ -2384,6 +2384,8 @@ impl RibManager {
         self.recompute_bgpls_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
     }
 
@@ -2439,6 +2441,8 @@ impl RibManager {
         self.recompute_vpn_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
     }
 
@@ -2504,6 +2508,8 @@ impl RibManager {
         self.recompute_labeled_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
     }
 
@@ -2564,6 +2570,8 @@ impl RibManager {
         self.recompute_rtc_keys(&affected);
         if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
             rib.gc_intern_table();
+            self.metrics
+                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
         self.rebuild_rtc_membership_and_restage_vpn(peer);
     }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2382,8 +2382,12 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_bgpls_keys(&affected);
-        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
-            rib.gc_intern_table();
+        if !affected.is_empty()
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            if needs_intern_gc {
+                rib.gc_intern_table();
+            }
             self.metrics
                 .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
@@ -2439,8 +2443,12 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_vpn_keys(&affected);
-        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
-            rib.gc_intern_table();
+        if !affected.is_empty()
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            if needs_intern_gc {
+                rib.gc_intern_table();
+            }
             self.metrics
                 .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
@@ -2506,8 +2514,12 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_labeled_keys(&affected);
-        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
-            rib.gc_intern_table();
+        if !affected.is_empty()
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            if needs_intern_gc {
+                rib.gc_intern_table();
+            }
             self.metrics
                 .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }
@@ -2568,8 +2580,12 @@ impl RibManager {
         self.decrement_refresh_stale_count(peer, family.0, family.1, removed_stale);
         self.update_peer_refresh_metrics(peer);
         self.recompute_rtc_keys(&affected);
-        if needs_intern_gc && let Some(rib) = self.ribs.get_mut(&peer) {
-            rib.gc_intern_table();
+        if !affected.is_empty()
+            && let Some(rib) = self.ribs.get_mut(&peer)
+        {
+            if needs_intern_gc {
+                rib.gc_intern_table();
+            }
             self.metrics
                 .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
         }

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -252,6 +252,8 @@ impl RibManager {
             }
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             if rtc_swept {
                 // The EoR sweep removed RT interest the peer did not
@@ -423,6 +425,8 @@ impl RibManager {
             }
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             if rtc_swept {
                 // The EoR sweep removed LLGR-stale RT interest the peer did
@@ -456,7 +460,6 @@ impl RibManager {
                 self.metrics.set_gr_stale_routes(&peer_label, 0);
             }
         }
-        self.record_rib_attr_intern_size();
     }
 
     pub(super) fn handle_route_refresh_request(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
@@ -1384,6 +1387,8 @@ impl RibManager {
                 || !rtc_affected.is_empty()
             {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             self.metrics
                 .set_rib_prefixes(&peer.to_string(), "all", gauge_val(rib.len()));
@@ -1491,6 +1496,8 @@ impl RibManager {
             // receive path's recompute-then-gc ordering.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !vpn_affected.is_empty() {
@@ -1500,6 +1507,8 @@ impl RibManager {
             // until recompute_vpn_keys drops it, so gc must run after it.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !labeled_affected.is_empty() {
@@ -1507,18 +1516,21 @@ impl RibManager {
             // Same gc-after-recompute ordering as VPN above.
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
         }
         if !rtc_affected.is_empty() {
             self.recompute_rtc_keys(&rtc_affected);
             if let Some(rib) = self.ribs.get_mut(&peer) {
                 rib.gc_intern_table();
+                self.metrics
+                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             }
             // The sweep just mutated this peer's RTC Adj-RIB-In — its RT
             // membership shrank, so VPN routes no longer covered must be
             // withdrawn from this peer's Adj-RIB-Out.
             self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
-        self.record_rib_attr_intern_size();
     }
 }

--- a/crates/rib/src/manager/tests/attr_intern.rs
+++ b/crates/rib/src/manager/tests/attr_intern.rs
@@ -420,6 +420,39 @@ fn bgpls_withdraw_reclaims_attr_intern_after_loc_rib_recompute() {
 }
 
 #[test]
+fn bgpls_pure_add_records_peer_attr_intern_size() {
+    // Per-peer intern-size telemetry must move on growth, not only on later
+    // replacement/withdraw GC. BGP-LS is representative of the RR-only
+    // families handled in manager/mod.rs: insert_* returns "replaced", so a
+    // first-time route add grows the intern table while `needs_intern_gc`
+    // remains false.
+    let (_tx, rx) = mpsc::channel(8);
+    let metrics = BgpMetrics::new();
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let peer_addr = Ipv4Addr::new(10, 0, 0, 1);
+    let peer = IpAddr::V4(peer_addr);
+    manager.ribs.insert(peer, AdjRibIn::new(peer));
+
+    let route = make_bgpls_route(peer_addr, 24, 100);
+    manager.handle_bgpls_routes_received(peer, vec![route], vec![]);
+
+    assert_eq!(
+        manager.ribs[&peer].intern_len(),
+        1,
+        "the pure add should grow the peer's intern table"
+    );
+    let gauge = gauge_metric_value(
+        &metrics,
+        "bgp_rib_attr_intern_size",
+        &[("peer", &peer.to_string())],
+    );
+    assert!(
+        (gauge - 1.0).abs() < f64::EPSILON,
+        "pure-add growth must be visible in the exported per-peer gauge"
+    );
+}
+
+#[test]
 fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
     // A GR-down that preserves some families keeps the peer Adj-RIB-In shell
     // alive. If EVPN is not preserved, that GR entry prunes EVPN routes through

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -90,7 +90,7 @@ pub struct BgpMetrics {
     rib_prefixes: IntGaugeVec,
     rib_adj_out_prefixes: IntGaugeVec,
     rib_loc_prefixes: IntGaugeVec,
-    rib_attr_intern_size: IntGauge,
+    rib_attr_intern_size: IntGaugeVec,
     route_event_history_depth: IntGauge,
     route_event_history_capacity: IntGauge,
 
@@ -365,9 +365,12 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
-        let rib_attr_intern_size = IntGauge::new(
-            "bgp_rib_attr_intern_size",
-            "Total unique interned attribute sets summed across all peers' Adj-RIB-In intern tables (gc_intern_table reclaims unreferenced entries per peer).",
+        let rib_attr_intern_size = IntGaugeVec::new(
+            Opts::new(
+                "bgp_rib_attr_intern_size",
+                "Unique interned attribute sets in a peer's Adj-RIB-In intern table (gc_intern_table reclaims unreferenced entries). Sum across peers for the daemon-wide total.",
+            ),
+            &["peer"],
         )
         .expect("valid metric definition");
 
@@ -1737,6 +1740,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.messages_sent, peer);
         Self::reap_peer_series_from_vec(&self.messages_received, peer);
         Self::reap_peer_series_from_vec(&self.rib_prefixes, peer);
+        Self::reap_peer_series_from_vec(&self.rib_attr_intern_size, peer);
         Self::reap_peer_series_from_vec(&self.rib_adj_out_prefixes, peer);
         Self::reap_peer_series_from_vec(&self.max_prefix_exceeded, peer);
         Self::reap_peer_series_from_vec(&self.outbound_route_drops, peer);
@@ -1914,11 +1918,14 @@ impl BgpMetrics {
             .set(count);
     }
 
-    /// Set the total number of unique interned attribute sets summed across
-    /// every peer's Adj-RIB-In intern table. Monitors `gc_intern_table`
-    /// reclamation across GR-restart / `EoR` / stale-clear cycles.
-    pub fn set_rib_attr_intern_size(&self, count: i64) {
-        self.rib_attr_intern_size.set(count);
+    /// Set the number of unique interned attribute sets in one peer's
+    /// Adj-RIB-In intern table. O(1); sum across peers for the daemon-wide
+    /// total. Monitors `gc_intern_table` reclamation and live growth under
+    /// injection / route churn.
+    pub fn set_rib_attr_intern_size(&self, peer: &str, count: i64) {
+        self.rib_attr_intern_size
+            .with_label_values(&[peer])
+            .set(count);
     }
 
     /// Set the number of retained events in the bounded route-event
@@ -3488,6 +3495,41 @@ mod tests {
     }
 
     #[test]
+    fn rib_attr_intern_size_gauge_is_per_peer() {
+        let m = BgpMetrics::new();
+        m.set_rib_attr_intern_size("10.0.0.1", 7);
+        m.set_rib_attr_intern_size("10.0.0.2", 3);
+
+        assert_eq!(
+            m.rib_attr_intern_size
+                .with_label_values(&["10.0.0.1"])
+                .get(),
+            7
+        );
+        assert_eq!(
+            m.rib_attr_intern_size
+                .with_label_values(&["10.0.0.2"])
+                .get(),
+            3
+        );
+
+        m.reap_peer_series("10.0.0.1");
+        assert!(
+            !series_for_peer(&m, "10.0.0.1")
+                .iter()
+                .any(|name| name == "bgp_rib_attr_intern_size"),
+            "reaped peer's intern-size series should be gone"
+        );
+        // The other peer's series survives.
+        assert_eq!(
+            m.rib_attr_intern_size
+                .with_label_values(&["10.0.0.2"])
+                .get(),
+            3
+        );
+    }
+
+    #[test]
     fn per_peer_isolation() {
         let m = BgpMetrics::new();
         m.record_state_transition("10.0.0.1", "idle", "connect");
@@ -3994,6 +4036,7 @@ mod tests {
         m.record_message_sent(peer, "keepalive");
         m.record_message_received(peer, "update");
         m.set_rib_prefixes(peer, "ipv4_unicast", 42);
+        m.set_rib_attr_intern_size(peer, 11);
         m.set_adj_rib_out_prefixes(peer, "ipv4_unicast", 7);
         m.record_max_prefix_exceeded(peer);
         m.record_outbound_route_drop(peer);
@@ -4050,8 +4093,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 33 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 34);
+        // 34 peer-labeled families; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 35);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -4061,7 +4104,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 34);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 35);
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -422,6 +422,7 @@ authenticated sensitive-read surface.
 | `bgp_rib_loc_prefixes{afi_safi}` | Loc-RIB size (best paths) per AFI/SAFI |
 | `bgp_rib_prefixes{peer,afi_safi}` | Adj-RIB-In size per peer + AFI/SAFI (received) |
 | `bgp_rib_adj_out_prefixes{peer,afi_safi}` | Adj-RIB-Out size per peer + AFI/SAFI (advertised) |
+| `bgp_rib_attr_intern_size{peer}` | Unique interned attribute sets in a peer's Adj-RIB-In (attribute-memory dedup). Sum across peers for the daemon-wide total; tracks `gc_intern_table` reclamation and growth under churn |
 | `bgp_messages_received_total` | Inbound BGP messages by type |
 | `bgp_messages_sent_total` | Outbound BGP messages by type |
 | `bgp_route_refresh_in_progress{peer,afi_safi}` | Active inbound Enhanced Route Refresh window for a peer/family (1 = active, 0 = inactive) |

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -809,3 +809,15 @@ per-cycle events recorded in `churn.log`.
   or the `evpn_l3_originator` / `evpn_l3_installer` daemon tasks.
 - **Before tagging any release that touches the symmetric IRB
   packet path or the L3 owned-state model.**
+
+# Intern-table / churn soak harnesses
+
+| Harness | Proves | Topology / analyzer |
+|---------|--------|---------------------|
+| `run-soak-gr-restart-intern-gc.sh` | The attribute intern table does not grow across GR-restart → EoR → stale-clear cycles: `sum(bgp_rib_attr_intern_size)` slope `< 1.0`/hr | containerlab topology + post-hoc slope analyzer |
+| `run-soak-hot-reload.sh` | Sustained SIGHUP / live-apply config churn leaks no state | containerlab topology + post-hoc analyzer |
+| `run-soak-inject-churn.sh` | Sustained gRPC AddPath/DeletePath churn holds RSS + intern-table size flat | containerlab topology + post-hoc analyzer |
+
+Each pairs a containerlab topology with a post-hoc analyzer and runs under the
+shared host mutex (see the top-of-file bench-vs-soak section); consult each
+script's header for the deploy step and its env vars.

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -98,6 +98,15 @@ prom_extract_or_zero() {
     '
 }
 
+# Sum all per-peer series of a labeled gauge from a scraped /metrics blob.
+prom_extract_sum() {
+    local prom="$1" name="$2"
+    awk -v n="$name" '
+        $0 ~ "^"n"[{ ]" { s += $NF }
+        END { printf "%d", s+0 }
+    ' <<<"$prom"
+}
+
 container_rss_mb() {
     docker exec "$RUSTBGPD" sh -c '
         pid=$(pidof rustbgpd 2>/dev/null || true)
@@ -192,7 +201,7 @@ sample_row() {
     local prom rss intern_size gr_active established
     prom=$(prom_scrape)
     rss=$(container_rss_mb)
-    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
     gr_active=$(prom_extract_or_zero "$prom" bgp_gr_active_peers)
     if frr_established_seen; then
         established=1

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -99,6 +99,15 @@ prom_extract_or_zero() {
     '
 }
 
+# Sum all per-peer series of a labeled gauge from a scraped /metrics blob.
+prom_extract_sum() {
+    local prom="$1" name="$2"
+    awk -v n="$name" '
+        $0 ~ "^"n"[{ ]" { s += $NF }
+        END { printf "%d", s+0 }
+    ' <<<"$prom"
+}
+
 container_rss_mb() {
     docker exec "$RUSTBGPD" sh -c '
         pid=$(pidof rustbgpd 2>/dev/null || true)
@@ -241,7 +250,7 @@ sample_row() {
     local prom rss intern_size established
     prom=$(prom_scrape)
     rss=$(container_rss_mb)
-    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
     if frr_established_seen; then
         established=1
     else

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -151,6 +151,15 @@ prom_extract_or_zero() {
     '
 }
 
+# Sum all per-peer series of a labeled gauge from a scraped /metrics blob.
+prom_extract_sum() {
+    local prom="$1" name="$2"
+    awk -v n="$name" '
+        $0 ~ "^"n"[{ ]" { s += $NF }
+        END { printf "%d", s+0 }
+    ' <<<"$prom"
+}
+
 prom_sum() {
     local text="$1" metric="$2"
     printf '%s' "$text" | awk -v m="$metric" '
@@ -276,7 +285,7 @@ sample_row() {
     else
         established=0
     fi
-    intern_size=$(prom_extract_or_zero "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
     printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \


### PR DESCRIPTION
## Summary

Refines the `bgp_rib_attr_intern_size` metric (added in #732, unreleased) before its first release.

The metric shipped as a global `IntGauge` refreshed only at session-lifecycle GC (GR entry, stale sweep, EoR, route-refresh). Two of the three soak analyzers that gate on it — `inject-churn` (sustained gRPC `AddPath`/`DeletePath`) and `hot-reload` (config live-apply) — keep sessions established and never hit a lifecycle GC, so the gauge sat flat and their `intern_slope < 1.0/hr` gate could not fail: a real intern-table leak under churn would pass undetected.

This makes the metric **per-peer** (`IntGaugeVec{peer}`, matching `bgp_rib_prefixes`) and records it **O(1)** — one label lookup + one set — at every Adj-RIB-In intern mutation site:

- All ~30 `gc_intern_table()` reclaim sites.
- The injection/announce **growth** paths, set unconditionally past the `if replaced` / `if any_replaced` guards, so a pure add is reflected even when no GC runs.
- Peer series reaped on peer delete via `reap_peer_series_from_vec` (no dead-peer series retained).

The daemon-wide total moves to the query layer (`sum(bgp_rib_attr_intern_size)`), keeping any O(peers) sum off the line-rate distribution path. The three soak scripts now sum the per-peer series; all three intern-slope gates are retained and now observe live data.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo build --bin rustbgpd`, `cargo doc` — all green.
- `cargo test -p rustbgpd-rib` (687) and `-p rustbgpd-telemetry` (58), including a new `rib_attr_intern_size_gauge_is_per_peer` test and the peer-series reap sync-guard.
- `bash -n` on the three soak scripts.