### PR TITLE
Update crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Dev-dependency-only lockfile bump (`criterion` → `rayon` → `crossbeam-deque` → `crossbeam-epoch`). Restores a clean `cargo audit` with no ignore entries. No production dependency changes.

Verified locally: `cargo update -p crossbeam-epoch` (0.9.18 → 0.9.20), `cargo audit` exit 0, `cargo check --workspace` green.