### PR TITLE
Gate release publication fail-closed and ship licenses in artifacts

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,40 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  verify-tag-version:
+    # Fail-closed publication gate: the pushed tag `vX.Y.Z` must equal
+    # the workspace `[workspace.package] version` (X.Y.Z). A mismatch
+    # means the tag points at a commit that was never version-bumped
+    # for this release — no image may be published from it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert tag matches workspace version
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml","rb"))["workspace"]["package"]["version"])')"
+          if [ "$tag_version" != "$manifest_version" ]; then
+            echo "::error file=Cargo.toml::tag ${GITHUB_REF_NAME} does not match [workspace.package] version ${manifest_version}; refusing to publish"
+            exit 1
+          fi
+          echo "tag ${GITHUB_REF_NAME} matches workspace version ${manifest_version}"
+
+  test:
+    # Fail-closed publication gate: `build-and-push` `needs:` this, so
+    # the image cannot ship from a tagged commit whose tests did not
+    # run and pass in this exact workflow run.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/install-protobuf
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
   build-and-push:
+    needs: [verify-tag-version, test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,6 +66,22 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build image for verification
+        # Build (without pushing) into the local image store so artifact
+        # content can be asserted before anything reaches the registry.
+        # The push step below reuses these layers.
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: rustbgpd:verify
+
+      - name: Assert license files present in image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint /bin/sh rustbgpd:verify -c \
+            'test -f /LICENSE-MIT && test -f /LICENSE-APACHE'
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,40 @@ permissions:
   contents: write
 
 jobs:
+  verify-tag-version:
+    # Fail-closed publication gate: the pushed tag `vX.Y.Z` must equal
+    # the workspace `[workspace.package] version` (X.Y.Z). A mismatch
+    # means the tag points at a commit that was never version-bumped
+    # for this release — nothing may be built or published from it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert tag matches workspace version
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml","rb"))["workspace"]["package"]["version"])')"
+          if [ "$tag_version" != "$manifest_version" ]; then
+            echo "::error file=Cargo.toml::tag ${GITHUB_REF_NAME} does not match [workspace.package] version ${manifest_version}; refusing to publish"
+            exit 1
+          fi
+          echo "tag ${GITHUB_REF_NAME} matches workspace version ${manifest_version}"
+
+  test:
+    # Fail-closed publication gate: the `release` job `needs:` this,
+    # so no artifact can ship from a tagged commit whose tests did
+    # not run and pass in this exact workflow run.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/install-protobuf
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
   build:
+    needs: verify-tag-version
     strategy:
       matrix:
         include:
@@ -57,9 +90,22 @@ jobs:
           mkdir -p dist staging
           cp target/${{ matrix.target }}/release/rustbgpd staging/
           cp target/${{ matrix.target }}/release/rbgp staging/
-          tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz rustbgpd rbgp
+          cp LICENSE-MIT LICENSE-APACHE staging/
+          tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz \
+            rustbgpd rbgp LICENSE-MIT LICENSE-APACHE
           cd dist
           sha256sum rustbgpd-${SUFFIX}.tar.gz > checksums-${SUFFIX}.txt
+
+      - name: Assert tarball contains license files
+        run: |
+          set -euo pipefail
+          SUFFIX=${{ matrix.suffix }}
+          for f in LICENSE-MIT LICENSE-APACHE; do
+            if ! tar -tzf "dist/rustbgpd-${SUFFIX}.tar.gz" | grep -qx "$f"; then
+              echo "::error::${f} missing from dist/rustbgpd-${SUFFIX}.tar.gz"
+              exit 1
+            fi
+          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -68,7 +114,9 @@ jobs:
           path: dist/
 
   release:
-    needs: build
+    # Publication is impossible unless the tag/version gate, the test
+    # gate, and both package builds all succeeded for this commit.
+    needs: [verify-tag-version, test, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every Adj-RIB-In intern mutation site (GC, injection/withdraw, and announce
   growth) so the series tracks the live intern table under churn.
 
+### Changed
+
+- **Release publication is now fail-closed.** The binary-release and
+  container-image workflows refuse to publish unless the pushed tag
+  `vX.Y.Z` equals the workspace `[workspace.package]` version and
+  `cargo test --workspace` passed for the tagged commit in the same
+  run. Release tarballs and the runtime container image now ship
+  `LICENSE-MIT` and `LICENSE-APACHE`, with workflow assertions that
+  fail the build if either file is missing from an artifact. (LAN-278)
+
 ## [0.50.0] — 2026-07-05
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /out/rustbgpd /usr/local/bin/rustbgpd
 COPY --from=builder /out/rbgp /usr/local/bin/rbgp
+COPY LICENSE-MIT LICENSE-APACHE /
 
 USER rustbgpd
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -518,7 +518,14 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
    here): `git tag -a vX.Y.Z -m "vX.Y.Z — <one-line headline>"`
 7. Push: `git push origin main && git push origin vX.Y.Z`
 8. Verify CI passes on the tag (build matrix x86_64 + aarch64, doc, GHCR
-   push, release.yml binary build + GitHub Release creation)
+   push, release.yml binary build + GitHub Release creation). Both
+   publication workflows are fail-closed: `release.yml` and
+   `container.yml` each gate publication on a `verify-tag-version` job
+   (tag `vX.Y.Z` must equal the workspace `[workspace.package]`
+   version) and a `test` job (`cargo test --workspace` on the tagged
+   commit). If you tagged a commit without the version bump, the tag
+   build fails and publishes nothing — fix the bump, delete the tag,
+   and re-tag.
 9. **Verify container image published to GHCR** via `docker/metadata-action`'s
    semver pattern:
    - `ghcr.io/lance0/rustbgpd:X.Y.Z` (exact, immutable)
@@ -532,6 +539,9 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
     [GitHub Releases](https://github.com/lance0/rustbgpd/releases) — each
     tag should publish version-less `rustbgpd-linux-amd64.tar.gz` and
     `rustbgpd-linux-arm64.tar.gz` plus per-arch `checksums-<arch>.txt`.
+    Each tarball contains `rustbgpd`, `rbgp`, `LICENSE-MIT`, and
+    `LICENSE-APACHE` (license presence is asserted by the workflow;
+    the runtime image likewise ships both licenses at `/`).
     The version-less filenames are what powers the static
     `releases/latest/download/` URLs in `docs/deployment.md`; if the
     filenames drift, deployment.md silently breaks for new operators.


### PR DESCRIPTION
Post-v0.50 audit release blocker (LAN-278).

## Problem

- `container.yml` published the GHCR image from a tag push with **no gates at all** — no test dependency, no version check.
- `release.yml` published binaries with no tag/version equality check and no test dependency.
- Release tarballs and the runtime image shipped without `LICENSE-MIT` / `LICENSE-APACHE`.

## Changes

- **`verify-tag-version` job** in both publish workflows: the pushed tag `vX.Y.Z` must equal `[workspace.package] version`; mismatch fails before anything builds.
- **`test` job** (`cargo test --workspace` on the tagged commit) in both workflows; publication jobs `needs:` it, so nothing ships from a commit whose tests didn't pass in the same run.
- **Licenses in artifacts:** tarballs now include both license files with a `tar -tzf` assertion per file; the runtime image ships them at `/` and `container.yml` builds locally (`load: true`) and asserts their presence in the image **before** the push step.
- `docs/RELEASE_CHECKLIST.md` documents the gates + the re-tag fix path.

## Validation

- YAML parse green for all three workflows; `bash -n` clean on all edited run steps.
- Version gate exercised both directions (match → exit 0, mismatch → exit 1 with `::error`).
- Tarball assertion exercised positive and negative.
- `docker build --check` clean; license COPY sources exist and are not dockerignored.