### PR TITLE
Fail proof harnesses closed on errored queries and missing samples (M37/Gate8b/M33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `LICENSE-MIT` and `LICENSE-APACHE`, with workflow assertions that
   fail the build if either file is missing from an artifact. (LAN-278)
 
+### Fixed
+
+- **Proof-harness assertions fail closed on missing/errored inputs.** The M37
+  local-origination harnesses no longer treat a failed/errored FRR query
+  (unreachable vtysh, docker exec error) as evidence of route absence, and
+  the churn soak records `nan` instead of `0` when the consumer query fails;
+  the Gate 8b analyzer's DF-counter monotonicity gate now requires numeric
+  samples to be present (all-missing/non-numeric columns fail with a clear
+  message instead of passing vacuously); the M33 soak analyzer rejects a
+  samples CSV whose expected columns are missing instead of silently gating
+  on all-zero deltas.
+
 ## [0.50.0] — 2026-07-05
 
 ### Added

--- a/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination-churn.sh
@@ -68,11 +68,26 @@ format_mac() {
         $((n & 255))
 }
 
+frr_macip_table() {
+    # Propagates docker/vtysh failure so callers can tell "query errored"
+    # apart from "table validly empty".
+    docker exec "$CONSUMER" vtysh -c "show bgp l2vpn evpn route type macip" 2>/dev/null
+}
+
 frr_has_type2() {
     local mac=${1:?}
-    docker exec "$CONSUMER" vtysh -c "show bgp l2vpn evpn route type macip" 2>/dev/null \
+    frr_macip_table \
         | grep -A1 -iF "$mac" \
         | grep -qF "$RUSTBGPD_IP"
+}
+
+frr_type2_absent() {
+    # Succeeds only when the FRR query itself succeeded AND the route is
+    # missing. An errored/empty query is never evidence of absence.
+    local mac=${1:?}
+    local out
+    out=$(frr_macip_table) || return 1
+    ! printf '%s\n' "$out" | grep -A1 -iF "$mac" | grep -qF "$RUSTBGPD_IP"
 }
 
 rb_fdb_replace() {
@@ -101,7 +116,7 @@ sample_check_absent() {
     local sample
     sample=$(format_mac 1)
     for _ in $(seq 1 15); do
-        if ! frr_has_type2 "$sample"; then
+        if frr_type2_absent "$sample"; then
             return 0
         fi
         sleep 1

--- a/tests/interop/scripts/test-m37-evpn-local-origination.sh
+++ b/tests/interop/scripts/test-m37-evpn-local-origination.sh
@@ -46,6 +46,12 @@ frr_vtysh() {
     docker exec "$CONSUMER" vtysh -c "$1" 2>/dev/null || true
 }
 
+# Strict variant: propagates docker/vtysh failure so absence checks can
+# tell "query errored" apart from "table validly empty".
+frr_vtysh_strict() {
+    docker exec "$CONSUMER" vtysh -c "$1" 2>/dev/null
+}
+
 # Does FRR list a Type 2 macip route for the given MAC originating
 # from rustbgpd?
 #
@@ -71,6 +77,22 @@ frr_has_type2() {
 frr_has_type3() {
     frr_vtysh "show bgp l2vpn evpn route type multicast" \
         | grep -qF "$RUSTBGPD_IP"
+}
+
+# Absence checks succeed only when the FRR query itself succeeded AND the
+# route is missing. An errored/unreachable query is never evidence of
+# absence — that would let the withdraw proofs pass vacuously.
+frr_type2_absent() {
+    local mac=${1:?}
+    local out
+    out=$(frr_vtysh_strict "show bgp l2vpn evpn route type macip") || return 1
+    ! echo "$out" | grep -A1 -iF "$mac" | grep -qF "$RUSTBGPD_IP"
+}
+
+frr_type3_absent() {
+    local out
+    out=$(frr_vtysh_strict "show bgp l2vpn evpn route type multicast") || return 1
+    ! echo "$out" | grep -qF "$RUSTBGPD_IP"
 }
 
 # Inject a static MAC on the rustbgpd container's non-VXLAN bridge
@@ -139,11 +161,11 @@ echo "Removing local MAC $TEST_MAC..."
 rb_fdb_del "$TEST_MAC"
 echo "Waiting up to 15s for Type 2 withdraw..."
 for _ in $(seq 1 15); do
-    if ! frr_has_type2 "$TEST_MAC"; then break; fi
+    if frr_type2_absent "$TEST_MAC"; then break; fi
     sleep 1
 done
 assert "Type 2 withdraw on bridge fdb del" \
-    '! frr_has_type2 "$TEST_MAC"'
+    'frr_type2_absent "$TEST_MAC"'
 
 # 4. Stop rustbgpd; expect IMET to drain within ~15s (graceful
 #    shutdown emits the Withdraw).
@@ -151,11 +173,11 @@ echo "Stopping rustbgpd to validate IMET drain..."
 docker stop -t 5 "$RUSTBGPD" >/dev/null
 echo "Waiting up to 15s for Type 3 IMET withdraw..."
 for _ in $(seq 1 15); do
-    if ! frr_has_type3; then break; fi
+    if frr_type3_absent; then break; fi
     sleep 1
 done
 assert "Type 3 IMET withdraw on shutdown drain" \
-    '! frr_has_type3'
+    'frr_type3_absent'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
+++ b/tests/interop/scripts/test-m37-evpn-mac-ip-origination.sh
@@ -49,6 +49,12 @@ frr_vtysh() {
     docker exec "$CONSUMER" vtysh -c "$1" 2>/dev/null || true
 }
 
+# Strict variant: propagates docker/vtysh failure so absence checks can
+# tell "query errored" apart from "table validly empty".
+frr_vtysh_strict() {
+    docker exec "$CONSUMER" vtysh -c "$1" 2>/dev/null
+}
+
 # Returns 0 if FRR sees a Type 2 for `$mac` with a "no IP" NLRI
 # (MAC-only). FRR 10.3.1 prints macip routes as
 # `[2]:[EthTag]:[MAClen]:[MAC]` for MAC-only and
@@ -68,6 +74,26 @@ frr_has_mac_ip() {
     local mac=${1:?}
     local ip=${2:?}
     frr_vtysh "show bgp l2vpn evpn route type macip" \
+        | grep -qiE "\[2\]:\[[^]]*\]:(\[[^]]*\]:)?\[48\]:\[$mac\]:\[(32|128)\]:\[$ip\]"
+}
+
+# Absence checks succeed only when the FRR query itself succeeded AND the
+# route is missing. An errored/unreachable query is never evidence of
+# absence — that would let the withdraw proofs pass vacuously.
+frr_mac_only_absent() {
+    local mac=${1:?}
+    local out
+    out=$(frr_vtysh_strict "show bgp l2vpn evpn route type macip") || return 1
+    ! echo "$out" \
+        | grep -qiE "\[2\]:\[[^]]*\]:(\[[^]]*\]:)?\[48\]:\[$mac\][[:space:]]*$"
+}
+
+frr_mac_ip_absent() {
+    local mac=${1:?}
+    local ip=${2:?}
+    local out
+    out=$(frr_vtysh_strict "show bgp l2vpn evpn route type macip") || return 1
+    ! echo "$out" \
         | grep -qiE "\[2\]:\[[^]]*\]:(\[[^]]*\]:)?\[48\]:\[$mac\]:\[(32|128)\]:\[$ip\]"
 }
 
@@ -150,15 +176,15 @@ wait_until "MAC+IP Type 2 surfaces on FRR" \
 assert "MAC+IP Type 2 originated after IpAdded" \
     "frr_has_mac_ip \"$TEST_MAC\" \"$TEST_IP\""
 assert "MAC-only Type 2 withdrawn under replace model" \
-    "! frr_has_mac_only \"$TEST_MAC\""
+    "frr_mac_only_absent \"$TEST_MAC\""
 
 # 3. Delete bridge neighbour → MAC+IP withdrawn, MAC-only re-emitted.
 echo "Removing bridge neighbour $TEST_IP..."
 rb_neigh_del "$TEST_IP"
 wait_until "MAC+IP withdrawn after IpRemoved" \
-    "! frr_has_mac_ip \"$TEST_MAC\" \"$TEST_IP\"" 15 || true
+    "frr_mac_ip_absent \"$TEST_MAC\" \"$TEST_IP\"" 15 || true
 assert "MAC+IP Type 2 withdrawn on IpRemoved" \
-    "! frr_has_mac_ip \"$TEST_MAC\" \"$TEST_IP\""
+    "frr_mac_ip_absent \"$TEST_MAC\" \"$TEST_IP\""
 wait_until "MAC-only re-emitted on downgrade" \
     "frr_has_mac_only \"$TEST_MAC\"" 30 || true
 assert "MAC-only Type 2 re-emitted after last IP removed" \
@@ -168,9 +194,9 @@ assert "MAC-only Type 2 re-emitted after last IP removed" \
 echo "Removing static FDB entry $TEST_MAC..."
 rb_fdb_del "$TEST_MAC"
 wait_until "MAC-only Type 2 withdrawn on Aged" \
-    "! frr_has_mac_only \"$TEST_MAC\"" 15 || true
+    "frr_mac_only_absent \"$TEST_MAC\"" 15 || true
 assert "MAC-only Type 2 withdrawn on FDB del" \
-    "! frr_has_mac_only \"$TEST_MAC\""
+    "frr_mac_only_absent \"$TEST_MAC\""
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/soak/analyze-gate8b-soak.py
+++ b/tests/soak/analyze-gate8b-soak.py
@@ -117,20 +117,33 @@ def main():
     pe2_peak = peak(enumerate(rows), "pe2_rss_mb")
 
     # DF transition counter monotonicity. A reset implies daemon
-    # restart inside the run window — that's a fail.
-    def is_monotone(key):
+    # restart inside the run window — that's a fail. The claim is only
+    # meaningful over actual numeric samples: a run whose counter column
+    # is entirely missing/non-numeric (NaN, "unreachable", empty) proves
+    # nothing and must fail, not pass vacuously.
+    def monotone_gate(key):
         prev = None
+        numeric = 0
         for r in rows:
             v = safe_float(r[key])
             if v is None:
                 continue
+            numeric += 1
             if prev is not None and v < prev:
-                return False
+                return False, f"counter reset detected in {key} (daemon restart)"
             prev = v
-        return True
+        if numeric < 2:
+            return False, (
+                f"only {numeric} numeric sample(s) in {key} — samples "
+                "missing/non-numeric, cannot claim monotonicity"
+            )
+        return True, (
+            f"monotone over {numeric} numeric samples "
+            "(no counter reset = no daemon restart)"
+        )
 
-    pe1_mono = is_monotone("pe1_df_changes")
-    pe2_mono = is_monotone("pe2_df_changes")
+    pe1_mono, pe1_mono_detail = monotone_gate("pe1_df_changes")
+    pe2_mono, pe2_mono_detail = monotone_gate("pe2_df_changes")
     pe1_total_changes = next(
         (safe_float(r["pe1_df_changes"]) for r in reversed(rows)
          if safe_float(r["pe1_df_changes"]) is not None),
@@ -163,10 +176,8 @@ def main():
     gate("pe2_peak_memory",
          not math.isnan(pe2_peak) and pe2_peak < args.mem_peak_fail,
          f"{pe2_peak:.1f} MB vs cap {args.mem_peak_fail}")
-    gate("pe1_df_changes_monotone", pe1_mono,
-         "no counter reset = no daemon restart")
-    gate("pe2_df_changes_monotone", pe2_mono,
-         "no counter reset = no daemon restart")
+    gate("pe1_df_changes_monotone", pe1_mono, pe1_mono_detail)
+    gate("pe2_df_changes_monotone", pe2_mono, pe2_mono_detail)
     gate("ran_through_at_least_one_full_flip_cycle",
          pe2_running_samples > 0 and pe2_stopped_samples > 0,
          f"pe2 running={pe2_running_samples} stopped={pe2_stopped_samples}")

--- a/tests/soak/analyze-soak.py
+++ b/tests/soak/analyze-soak.py
@@ -150,9 +150,31 @@ def main() -> int:
 
     try:
         with open(args.csv, newline="") as fh:
-            rows = list(csv.DictReader(fh))
+            reader = csv.DictReader(fh)
+            fieldnames = reader.fieldnames or []
+            rows = list(reader)
     except FileNotFoundError:
         print(f"ERROR: CSV not found: {args.csv}", file=sys.stderr)
+        return 2
+
+    # Every column the gates read must be present in the header. A missing
+    # column would otherwise read as None everywhere and let the gates pass
+    # vacuously (deltas of 0, zero gRPC failures, no restart).
+    expected_columns = (
+        "uptime_sec",
+        "mem_mb",
+        "grpc_ok",
+        "session_flaps_total",
+        "outbound_drops_total",
+        "msgs_sent_total",
+        "msgs_recv_total",
+    )
+    missing = [c for c in expected_columns if c not in fieldnames]
+    if missing:
+        print(
+            f"ERROR: CSV is missing expected column(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
         return 2
 
     if not rows:

--- a/tests/soak/run-m37-local-origination-churn-soak.sh
+++ b/tests/soak/run-m37-local-origination-churn-soak.sh
@@ -193,8 +193,15 @@ rb_local_fdb_count() {
 }
 
 frr_type2_count() {
-    frr_vtysh "show bgp l2vpn evpn route type macip" \
-        | grep -ci '02:37:' || true
+    # A failed/errored FRR query is not "zero routes" — record nan (the
+    # missing-sample convention used for the prom columns) so a postmortem
+    # cannot read an unreachable consumer as a valid route-absence sample.
+    local out
+    if ! out=$(docker exec "$CONSUMER" vtysh -c "show bgp l2vpn evpn route type macip" 2>/dev/null); then
+        echo nan
+        return 0
+    fi
+    printf '%s\n' "$out" | grep -ci '02:37:' || true
 }
 
 write_run_json() {


### PR DESCRIPTION
Post-v0.50 audit release blocker (LAN-279). Three proof harnesses could pass without observing what they claim to gate.

## M37 (interop scripts + soak sampler)
Absence proofs were negated presence greps over error-swallowed queries (`2>/dev/null`, `|| true`): an unreachable FRR produced empty output, the grep failed, and "withdrawn" passed vacuously. Each script now uses strict query helpers whose exit codes propagate, and `*_absent` predicates that succeed only when the query itself succeeded AND the route is missing. The churn-soak sampler records `nan` (its missing-sample convention) on query failure instead of a fabricated `0`.

## Gate 8b analyzer
`is_monotone` skipped non-numeric samples and returned true over an entirely missing/NaN column. The monotonicity gate now requires ≥2 numeric samples, failing with an explicit "samples missing/non-numeric" message otherwise.

## M33 analyzer
Gate reads used `r.get(col)` so a CSV missing an expected column silently gated on zeros. The analyzer now validates the header and exits 2 listing missing columns.

## Verification
- Synthetic negative proofs for all three: docker-fail → absence predicates refuse; NaN DF column → gate fails (old analyzer: passed); missing CSV column → exit 2 (old analyzer: verdict clean, exit 0).
- Happy paths unchanged: old and new analyzers produce identical verdicts on valid input.
- `bash -n` / `py_compile` clean on all touched files. No soaks or containerlab deploys were run.