### PR TITLE
Close saturated sessions with Cease as the final frame and run-loop-driven cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound saturation teardown: Cease is the final frame, and cleanup runs
+  from the run loop.** When a peer stopped draining and the bounded writer
+  queue filled (`Cease/8` Out-of-Resources teardown), the writer drained the
+  entire queued UPDATE backlog *after* the NOTIFICATION — delaying the close
+  for as long as the peer stayed slow, and sending frames a peer must never
+  see after a NOTIFICATION — and then exited cleanly, so `TcpConnectionFails`
+  was never driven: the FSM stayed Established with no TCP connection and the
+  RIB kept the dead peer registered. The writer now discards the backlog
+  outright, flushes the Cease best-effort within a short bound (racing any
+  wedged in-flight write without ever splicing a frame), hard-closes, and
+  exits with a distinct status that the session run loop maps to
+  `TcpConnectionFails` → FSM `SessionDown` → RIB `PeerDown`/deregistration,
+  exactly like a real TCP failure.
+
 ### Added
 
 - **`bgp_rib_attr_intern_size{peer}` gauge** — unique interned attribute sets

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -236,17 +236,20 @@ impl PeerSession {
     /// Tear the session down because the writer's bulk channel
     /// saturated — the peer hasn't drained `OUTBOUND_BUFFER` BGP
     /// messages, so we send a `Cease` / `Out of Resources` (RFC 4486
-    /// §4 subcode 8) NOTIFICATION on the priority channel ahead of
-    /// any pending bulk traffic, then drop the writer channels.
+    /// §4 subcode 8) NOTIFICATION on the priority channel, signal the
+    /// writer's hard-teardown watch, then drop the writer channels.
     ///
-    /// The writer's biased `select!` picks the priority NOTIFICATION
-    /// before falling through to the `else` arm, so the peer sees a
-    /// clean `Cease/8` if its TCP receive buffer ever drains. The
-    /// session's own writer-exit arm observes the resulting
-    /// `JoinHandle` resolution and drives the FSM through
-    /// `TcpConnectionFails` from there — no need to await an FSM
-    /// transition synchronously here, which keeps the bulk caller
-    /// chain (`send_route_update`) sync.
+    /// The teardown signal makes the writer **discard the queued bulk
+    /// backlog instead of draining it** — the Cease must be the final
+    /// frame the peer ever sees, and flushing a saturated queue would
+    /// delay the close indefinitely — flush the Cease best-effort
+    /// within a short bound (a saturated TCP window may never accept
+    /// it), and exit with `WriterExit::TornDown`. The session's
+    /// writer-exit arm observes that exit and drives the FSM through
+    /// `TcpConnectionFails` (→ `SessionDown` → RIB `PeerDown` /
+    /// deregistration) exactly as a real TCP failure would — no need
+    /// to await an FSM transition synchronously here, which keeps the
+    /// bulk caller chain (`send_route_update`) sync.
     pub(super) fn trigger_outbound_saturation_teardown(&mut self) {
         warn!(
             peer = %self.peer_label,
@@ -278,6 +281,12 @@ impl PeerSession {
         );
         self.metrics
             .record_message_sent(&self.peer_label, "notification");
+        // Signal the hard close BEFORE dropping the senders: the writer
+        // races this watch against any in-flight (wedged) write, so the
+        // teardown is never gated on the peer draining its window.
+        if let Some(tx) = &self.writer_teardown_tx {
+            let _ = tx.send(true);
+        }
         self.handle_tcp_disconnect();
     }
 
@@ -299,6 +308,7 @@ impl PeerSession {
         self.writer_bulk_tx = None;
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
+        self.writer_teardown_tx = None;
         self.read_buf.clear();
         self.clear_bmp_stream_repair();
     }
@@ -314,6 +324,7 @@ impl PeerSession {
         self.writer_bulk_tx = None;
         self.writer_priority_tx = None;
         self.writer_keepalive_tx = None;
+        self.writer_teardown_tx = None;
         self.read_buf.clear();
         self.clear_bmp_stream_repair();
     }

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -80,8 +80,10 @@ pub(crate) struct PeerSession {
     /// - **At teardown**: `read_half` and both writer senders are
     ///   dropped synchronously. `writer_join` is **intentionally
     ///   retained** so the run-loop's writer-exit `select!` arm can
-    ///   observe the writer task draining its priority queue (e.g. a
-    ///   `Cease/8` we just enqueued) and exiting cleanly. The arm body
+    ///   observe the writer task exiting — cleanly after draining its
+    ///   priority queue on ordinary closes, or with
+    ///   `WriterExit::TornDown` after the saturation hard close (bulk
+    ///   backlog discarded, `Cease/8` flushed best-effort). The arm body
     ///   clears `writer_join = None` after `JoinHandle::await` resolves
     ///   exactly once — polling a completed `JoinHandle` again panics.
     /// - **Steady state**: `read_half.is_some() ==
@@ -103,6 +105,13 @@ pub(crate) struct PeerSession {
     /// timer and `None` when it stops it; dropping the sender (TCP
     /// teardown) also stops the cadence.
     writer_keepalive_tx: Option<tokio::sync::watch::Sender<Option<std::time::Duration>>>,
+    /// Hard-teardown signal for the writer task. Signalled (before the
+    /// senders are dropped) by `trigger_outbound_saturation_teardown`
+    /// only: the writer discards its bulk backlog so the `Cease/8` is
+    /// the final frame on the wire, then exits `WriterExit::TornDown`,
+    /// which the writer-exit arm maps to `TcpConnectionFails`. Ordinary
+    /// close paths drop it unsignalled (drain semantics preserved).
+    writer_teardown_tx: Option<watch::Sender<bool>>,
     /// `JoinHandle` of the writer task. Polled by the session's
     /// `select!` so writer-exit (clean shutdown, TCP error, or RFC 9687
     /// send-hold expiry) surfaces as a TCP-disconnect event.
@@ -491,6 +500,7 @@ impl PeerSession {
             writer_bulk_tx: None,
             writer_priority_tx: None,
             writer_keepalive_tx: None,
+            writer_teardown_tx: None,
             writer_join: None,
             read_buf: ReadBuffer::new(),
             timers: Timers::default(),
@@ -601,6 +611,7 @@ impl PeerSession {
             writer_bulk_tx: Some(writer_handle.bulk_tx),
             writer_priority_tx: Some(writer_handle.priority_tx),
             writer_keepalive_tx: Some(writer_handle.keepalive_tx),
+            writer_teardown_tx: Some(writer_handle.teardown_tx),
             writer_join: Some(writer_handle.join),
             read_buf: ReadBuffer::new(),
             timers: Timers::default(),
@@ -947,6 +958,14 @@ impl PeerSession {
                     )),
                 );
             }
+            Ok(Err(writer::WriterExit::TornDown)) => {
+                // Saturation teardown: the writer discarded the bulk
+                // backlog, put the Cease/8 on the wire best-effort, and
+                // hard-closed. Fall through so the FSM sees
+                // `TcpConnectionFails` and the RIB gets its
+                // PeerDown/deregistration from this run-loop path.
+                debug!(peer = %self.peer_label, "writer task hard-closed by saturation teardown");
+            }
             Ok(Err(writer::WriterExit::Io(e))) => {
                 debug!(peer = %self.peer_label, error = %e, "writer task TCP error");
             }
@@ -983,6 +1002,10 @@ impl PeerSession {
     }
 
     /// Main event loop. Runs until Shutdown command or fatal error.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the run loop keeps every select! arm and its state wiring in one place"
+    )]
     pub(crate) async fn run(&mut self) -> Result<(), TransportError> {
         loop {
             // Gate the TCP read arm closed while the FSM is still in `Idle`.
@@ -1109,6 +1132,7 @@ impl PeerSession {
                             self.writer_bulk_tx = Some(handle.bulk_tx);
                             self.writer_priority_tx = Some(handle.priority_tx);
                             self.writer_keepalive_tx = Some(handle.keepalive_tx);
+                            self.writer_teardown_tx = Some(handle.teardown_tx);
                             self.writer_join = Some(handle.join);
                             self.drive_fsm(Event::TcpConnectionConfirmed).await;
                         }
@@ -1164,6 +1188,7 @@ impl PeerSession {
         self.writer_bulk_tx = Some(handle.bulk_tx);
         self.writer_priority_tx = Some(handle.priority_tx);
         self.writer_keepalive_tx = Some(handle.keepalive_tx);
+        self.writer_teardown_tx = Some(handle.teardown_tx);
         self.writer_join = Some(handle.join);
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1525,7 +1525,10 @@ async fn oversized_bgpls_output_tears_down_session() {
         .await
         .expect("writer should exit after oversize-triggered teardown")
         .expect("writer join should not panic");
-    assert!(result.is_ok());
+    assert!(
+        matches!(result, Err(super::writer::WriterExit::TornDown)),
+        "oversize output routes through the saturation hard close, got: {result:?}"
+    );
 }
 fn make_vpn_rib_route(label: u32) -> rustbgpd_rib::VpnRibRoute {
     rustbgpd_rib::VpnRibRoute {
@@ -6736,15 +6739,170 @@ async fn outbound_saturation_teardown_emits_cease_out_of_resources() {
         cease_subcode::OUT_OF_RESOURCES,
         "saturation must surface as Cease/Out-of-Resources, not silent drop"
     );
-    // After the priority message drains and both senders are gone, the
-    // biased select's `else` arm fires and the writer exits Ok.
+    // After flushing the Cease the writer hard-closes with `TornDown`
+    // (never draining any bulk backlog), which is what the run loop's
+    // writer-exit arm maps to `TcpConnectionFails` + FSM/RIB cleanup.
     let result = tokio::time::timeout(Duration::from_secs(2), join)
         .await
-        .expect("writer should exit within 2s of senders dropped")
+        .expect("writer should exit within 2s of the teardown signal")
         .expect("writer task should not panic");
     assert!(
-        result.is_ok(),
-        "writer should exit Ok after clean shutdown, got: {result:?}"
+        matches!(result, Err(super::writer::WriterExit::TornDown)),
+        "writer should exit TornDown after the saturation hard close, got: {result:?}"
+    );
+}
+/// Split a captured wire byte stream into BGP frames as
+/// `(message_type, frame_bytes)` pairs, asserting the stream contains
+/// no truncated trailing frame.
+fn parse_wire_frames(mut wire: &[u8]) -> Vec<(u8, Vec<u8>)> {
+    let mut frames = Vec::new();
+    while !wire.is_empty() {
+        assert!(
+            wire.len() >= 19,
+            "trailing partial BGP header on the wire: {} bytes left",
+            wire.len()
+        );
+        let len = usize::from(u16::from_be_bytes([wire[16], wire[17]]));
+        assert!(
+            (19..=wire.len()).contains(&len),
+            "truncated BGP frame: declared {len}, {} bytes left",
+            wire.len()
+        );
+        frames.push((wire[18], wire[..len].to_vec()));
+        wire = &wire[len..];
+    }
+    frames
+}
+/// LAN-280 end-to-end regression: outbound saturation detected on the
+/// REAL run-loop path — a peer draining too slowly while outbound
+/// updates flood in through the RIB channel — must:
+///
+/// 1. put the `Cease/8` NOTIFICATION on the wire as the FINAL frame:
+///    the queued UPDATE backlog is discarded, never drained after the
+///    NOTIFICATION;
+/// 2. deregister the peer from the RIB (`PeerDown`) via the
+///    writer-exit → `TcpConnectionFails` wiring, with **no manually
+///    injected FSM events** (the vacuity this test exists to prevent);
+/// 3. leave the session task alive and responsive afterwards.
+#[tokio::test]
+async fn saturation_teardown_from_run_loop_ceases_closes_and_deregisters() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    // The harness drops its command sender, which would end `run()`
+    // immediately — install a live command channel instead.
+    let (cmd_tx, cmd_rx) = mpsc::channel(8);
+    session.commands = cmd_rx;
+    // Small socket buffers so the writer wedges in `write_all` after a
+    // few KiB and the bounded bulk queue actually fills.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connect = tokio::spawn(async move {
+        let socket = tokio::net::TcpSocket::new_v4().unwrap();
+        socket.set_recv_buffer_size(4096).unwrap();
+        socket.connect(addr).await.unwrap()
+    });
+    let (server, _) = listener.accept().await.unwrap();
+    socket2::SockRef::from(&server)
+        .set_send_buffer_size(4096)
+        .unwrap();
+    let peer = connect.await.unwrap();
+    session.test_install_stream(server);
+    establish_test_session(&mut session, 65002).await;
+    match rib_rx.recv().await.unwrap() {
+        RibUpdate::PeerUp { .. } => {}
+        _ => panic!("expected RIB PeerUp after establishment"),
+    }
+    let outbound_tx = session.outbound_tx.clone();
+    let session_task = tokio::spawn(async move { session.run().await });
+    // Slow reader: trickles just enough that the writer stays wedged
+    // while the flood fills the bulk queue, but keeps draining so the
+    // in-flight frame completes within the teardown linger and the
+    // whole wire (including the final Cease) is observable to EOF.
+    let reader = tokio::spawn(async move {
+        let mut peer = peer;
+        let mut collected = Vec::new();
+        let mut buf = [0u8; 1024];
+        loop {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            match peer.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => collected.extend_from_slice(&buf[..n]),
+            }
+        }
+        collected
+    });
+    // Flood through the REAL outbound path (outbound channel → run
+    // loop → send_route_update → enqueue_bulk). 3× the writer queue
+    // depth guarantees `try_send` hits `Full` and the production
+    // saturation detection fires. No `trigger_outbound_saturation_-
+    // teardown` call, no injected FSM events.
+    let flood_total = 3 * OUTBOUND_BUFFER;
+    for _ in 0..flood_total {
+        let mut update = empty_outbound_update();
+        update.announce = vec![make_route(100)].into();
+        update.next_hop_override = vec![None].into();
+        if outbound_tx.send(update).await.is_err() {
+            // SessionDown already recreated the outbound channel.
+            break;
+        }
+    }
+    // (2) Production wiring: the RIB observes the PeerDown without any
+    // manually injected `TcpConnectionFails`. Skip other session-up
+    // messages (e.g. `SetPeerPolicyContext`) on the way.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let msg = tokio::time::timeout_at(deadline, rib_rx.recv())
+            .await
+            .expect("RIB must observe the saturation teardown (writer-exit → TcpConnectionFails)")
+            .expect("rib channel must stay open");
+        match msg {
+            RibUpdate::PeerDown { peer, .. } => {
+                assert_eq!(peer, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+                break;
+            }
+            RibUpdate::PeerGracefulRestart { .. } => {
+                panic!("saturation teardown must deregister via PeerDown, not GR-preserve")
+            }
+            _ => {}
+        }
+    }
+    // (3) The session task survived the teardown and terminates
+    // cleanly on command.
+    cmd_tx.send(PeerCommand::Shutdown).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(5), session_task)
+        .await
+        .expect("session task must terminate on Shutdown")
+        .expect("session task must not panic")
+        .expect("run() must return Ok");
+    // (1) The wire: the writer hard-closed, so the peer reaches EOF;
+    // the Cease/8 is the FINAL frame and no UPDATE follows it.
+    let wire = tokio::time::timeout(Duration::from_secs(15), reader)
+        .await
+        .expect("peer must observe EOF after the hard close")
+        .unwrap();
+    let frames = parse_wire_frames(&wire);
+    let notif_idx = frames
+        .iter()
+        .position(|(msg_type, _)| *msg_type == 3)
+        .expect("the Cease NOTIFICATION must reach the wire");
+    assert_eq!(
+        &frames[notif_idx].1[19..21],
+        &[6, 8],
+        "NOTIFICATION must be Cease/Out of Resources"
+    );
+    assert_eq!(
+        notif_idx,
+        frames.len() - 1,
+        "the NOTIFICATION must be the final frame — the saturated backlog \
+         must be discarded, never drained after the Cease"
+    );
+    let updates_on_wire = frames.iter().filter(|(t, _)| *t == 2).count();
+    assert!(
+        updates_on_wire > 0,
+        "sanity: UPDATEs must have flowed before saturation"
+    );
+    assert!(
+        updates_on_wire < flood_total,
+        "sanity: the flood must have outrun the wire"
     );
 }
 // ── Inbound ORF ROUTE-REFRESH handling (RFC 5291/5292) ──────────────────

--- a/crates/transport/src/session/writer.rs
+++ b/crates/transport/src/session/writer.rs
@@ -26,10 +26,17 @@
 //! Saturation policy lives in the session task, not here:
 //! `bulk_tx.try_send` failing with `Full` means the peer hasn't drained
 //! 4096 BGP messages, the session emits a `Cease/8` (Out of Resources,
-//! RFC 4486 §4 subcode 8) through `priority_tx`, then drops both
-//! senders so this task exits cleanly. Wiring lives in
+//! RFC 4486 §4 subcode 8) through `priority_tx`, signals `teardown_tx`,
+//! and drops the senders. The teardown signal makes this task **discard
+//! the queued bulk backlog instead of draining it** — the Cease must be
+//! the final frame the peer sees, and flushing a saturated queue would
+//! delay the close indefinitely — flush the already-enqueued priority
+//! frames best-effort within [`TEARDOWN_LINGER`], and exit with
+//! [`WriterExit::TornDown`] so the session's writer-exit arm drives
+//! `TcpConnectionFails` + FSM/RIB cleanup exactly like a real TCP
+//! failure. Wiring lives in
 //! `PeerSession::trigger_outbound_saturation_teardown`; this module
-//! just provides the channels and the pipe.
+//! owns the discard/flush/close mechanics.
 //!
 //! # Send hold timer (RFC 9687)
 //!
@@ -76,7 +83,20 @@ pub(super) enum WriterExit {
         /// The configured `SendHoldTime` that elapsed.
         limit: Duration,
     },
+    /// Session-requested hard close (outbound saturation `Cease/8`):
+    /// the queued bulk backlog was discarded — never drained — the
+    /// Cease was flushed best-effort within [`TEARDOWN_LINGER`], and
+    /// the socket closed. The session's writer-exit arm maps this to
+    /// `TcpConnectionFails` so FSM/RIB cleanup runs from the run loop.
+    TornDown,
 }
+
+/// Best-effort bound on teardown writes: how long the writer will wait
+/// for an in-flight frame to reach a frame boundary and for the Cease
+/// NOTIFICATION to reach the wire before hard-closing anyway. A
+/// saturated TCP window may never accept the Cease; the close must not
+/// wait on it.
+const TEARDOWN_LINGER: Duration = Duration::from_secs(2);
 
 /// Channel handles + a [`JoinHandle`] held by the session task.
 ///
@@ -100,6 +120,15 @@ pub(super) struct WriterHandle {
     /// retimes the writer-owned periodic KEEPALIVE, `None` stops it.
     /// Dropping the sender also stops it.
     pub(super) keepalive_tx: watch::Sender<Option<Duration>>,
+    /// Hard-teardown signal (saturation `Cease/8`): sending `true`
+    /// makes the writer discard the bulk backlog, flush pending
+    /// priority frames within [`TEARDOWN_LINGER`], and exit with
+    /// [`WriterExit::TornDown`]. Racing an in-flight write is part of
+    /// the contract — a writer wedged in `write_all` observes the
+    /// signal without waiting for the write to complete. Dropping the
+    /// sender without signalling is the ordinary close path and keeps
+    /// today's drain semantics.
+    pub(super) teardown_tx: watch::Sender<bool>,
     /// Resolves when the writer exits: `Ok(())` on clean shutdown,
     /// `Err(WriterExit)` on TCP write/flush failure or send-hold expiry.
     pub(super) join: JoinHandle<Result<(), WriterExit>>,
@@ -131,11 +160,13 @@ pub(super) fn spawn(
     let (bulk_tx, bulk_rx) = mpsc::channel::<Bytes>(bulk_buffer);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel::<Bytes>();
     let (keepalive_tx, keepalive_rx) = watch::channel(None);
+    let (teardown_tx, teardown_rx) = watch::channel(false);
     let task = WriterTask {
         write_half,
         bulk_rx,
         priority_rx,
         keepalive_rx,
+        teardown_rx,
         metrics,
         peer_label,
         send_hold_time,
@@ -145,6 +176,7 @@ pub(super) fn spawn(
         bulk_tx,
         priority_tx,
         keepalive_tx,
+        teardown_tx,
         join,
     }
 }
@@ -154,9 +186,34 @@ struct WriterTask {
     bulk_rx: mpsc::Receiver<Bytes>,
     priority_rx: mpsc::UnboundedReceiver<Bytes>,
     keepalive_rx: watch::Receiver<Option<Duration>>,
+    teardown_rx: watch::Receiver<bool>,
     metrics: BgpMetrics,
     peer_label: String,
     send_hold_time: Option<Duration>,
+}
+
+/// Resolve once the session has signalled hard teardown. Pends forever
+/// otherwise — including when the sender is dropped *without*
+/// signalling, which is the ordinary (non-saturation) close path and
+/// must keep the writer's drain-then-exit semantics.
+async fn teardown_requested(rx: &mut watch::Receiver<bool>) {
+    while !*rx.borrow_and_update() {
+        if rx.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// Apply the RFC 9687 send-hold bound to a write when configured.
+/// `Err(limit)` means the timer expired.
+async fn with_send_hold(
+    write: impl Future<Output = std::io::Result<()>>,
+    send_hold_time: Option<Duration>,
+) -> Result<std::io::Result<()>, Duration> {
+    match send_hold_time {
+        Some(limit) => tokio::time::timeout(limit, write).await.map_err(|_| limit),
+        None => Ok(write.await),
+    }
 }
 
 impl WriterTask {
@@ -164,9 +221,17 @@ impl WriterTask {
         let mut bulk_open = true;
         let mut priority_open = true;
         let mut cadence_open = true;
+        let mut teardown_open = true;
         let mut cadence: Option<Duration> = *self.keepalive_rx.borrow();
         let mut next_keepalive = cadence.map(|interval| tokio::time::Instant::now() + interval);
         loop {
+            // Hard teardown (saturation Cease/8): discard the bulk
+            // backlog, flush the pending priority frames best-effort,
+            // close. Checked at the top of every iteration so no bulk
+            // frame can slip out between the signal and the close.
+            if *self.teardown_rx.borrow() {
+                return self.teardown_close().await;
+            }
             // Exit only when both message channels have closed — the
             // cadence alone must not keep a writer alive for a session
             // that already tore down its senders.
@@ -179,6 +244,15 @@ impl WriterTask {
             // `Cease/8` reaches the wire before any further bulk work.
             let bytes = tokio::select! {
                 biased;
+                changed = self.teardown_rx.changed(), if teardown_open => {
+                    if changed.is_err() {
+                        // Sender dropped without signalling: ordinary
+                        // close path, keep drain semantics and never
+                        // poll this arm again.
+                        teardown_open = false;
+                    }
+                    continue;
+                }
                 changed = self.keepalive_rx.changed(), if cadence_open => {
                     if changed.is_ok() {
                         cadence = *self.keepalive_rx.borrow();
@@ -225,31 +299,91 @@ impl WriterTask {
     }
 
     /// `write_all + flush` one message, bounded by the RFC 9687 send
-    /// hold timer when configured.
+    /// hold timer when configured, and raced against the session's
+    /// hard-teardown signal — a writer wedged mid-write on a saturated
+    /// TCP window must not delay the teardown indefinitely.
     async fn write_message(&mut self, bytes: &Bytes) -> Result<(), WriterExit> {
+        let Self {
+            write_half,
+            teardown_rx,
+            send_hold_time,
+            peer_label,
+            ..
+        } = self;
         let write = async {
-            self.write_half.write_all(bytes).await?;
-            self.write_half.flush().await
+            write_half.write_all(bytes).await?;
+            write_half.flush().await
         };
-        let result = match self.send_hold_time {
-            Some(limit) => match tokio::time::timeout(limit, write).await {
-                Ok(result) => result,
-                Err(_elapsed) => {
-                    warn!(
-                        peer = %self.peer_label,
-                        send_hold_time = ?limit,
-                        "send hold timer expired: peer stopped draining our TCP output \
-                         (RFC 9687); terminating session without NOTIFICATION"
-                    );
-                    return Err(WriterExit::SendHoldExpired { limit });
+        tokio::pin!(write);
+        let outcome = tokio::select! {
+            biased;
+            result = with_send_hold(write.as_mut(), *send_hold_time) => Some(result),
+            () = teardown_requested(teardown_rx) => None,
+        };
+        let result = match outcome {
+            Some(Ok(result)) => result,
+            Some(Err(limit)) => {
+                warn!(
+                    peer = %peer_label,
+                    send_hold_time = ?limit,
+                    "send hold timer expired: peer stopped draining our TCP output \
+                     (RFC 9687); terminating session without NOTIFICATION"
+                );
+                return Err(WriterExit::SendHoldExpired { limit });
+            }
+            None => {
+                // Hard teardown while this frame is in flight: give the
+                // write a short linger to reach a frame boundary (so
+                // the Cease can still follow it intact), then abandon —
+                // a `write_all` cancelled mid-frame may have left a
+                // partial PDU on the wire, so nothing (not even the
+                // Cease) may be written after an abandoned write. On
+                // completion the run loop's top-of-iteration check
+                // routes into `teardown_close`.
+                match tokio::time::timeout(TEARDOWN_LINGER, write.as_mut()).await {
+                    Ok(result) => result,
+                    Err(_elapsed) => {
+                        debug!(
+                            peer = %peer_label,
+                            "teardown: abandoned in-flight write after linger; hard close"
+                        );
+                        return Err(WriterExit::TornDown);
+                    }
                 }
-            },
-            None => write.await,
+            }
         };
         result.map_err(|e| {
             warn!(error = %e, "writer: write/flush failed");
             WriterExit::Io(e)
         })
+    }
+
+    /// Session-requested hard close: drop the queued bulk backlog on
+    /// the floor — the `Cease/8` already enqueued on the priority
+    /// channel must be the FINAL frame the peer sees, and draining a
+    /// saturated queue could take unbounded time — then flush the
+    /// pending priority frames best-effort within [`TEARDOWN_LINGER`]
+    /// and exit. Returning drops the write half, which closes the
+    /// socket without draining.
+    async fn teardown_close(mut self) -> Result<(), WriterExit> {
+        let deadline = tokio::time::Instant::now() + TEARDOWN_LINGER;
+        // The session enqueues the Cease before signalling teardown and
+        // then drops its senders, so `try_recv` yields exactly the
+        // still-buffered priority frames (normally just the Cease/8).
+        while let Ok(bytes) = self.priority_rx.try_recv() {
+            let write = async {
+                self.write_half.write_all(&bytes).await?;
+                self.write_half.flush().await
+            };
+            match tokio::time::timeout_at(deadline, write).await {
+                Ok(Ok(())) => {}
+                // Best-effort: a saturated TCP window may never accept
+                // the Cease. Do not delay the close for it.
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        debug!(peer = %self.peer_label, "writer: hard close after saturation teardown");
+        Err(WriterExit::TornDown)
     }
 }
 


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 1 (LAN-280).

## Problem

When a peer's bounded writer queue saturated (Cease/8 teardown):
1. The writer drained the entire buffered bulk backlog **after** writing the Cease — the peer could receive UPDATE frames after the NOTIFICATION, and draining a saturated queue delayed the close indefinitely (a wedged in-flight write was never interrupted).
2. The drained writer exited `Ok(())`, which `handle_writer_exit` early-returns on — `TcpConnectionFails` was never driven, leaving the FSM Established with no TCP and the RIB holding a dead peer registration (silent zombie session).
3. The existing test injected `TcpConnectionFails` manually, masking the missing production wiring.

## Fix

- New writer hard-teardown watch + `WriterExit::TornDown`: on saturation the writer discards the bulk backlog (never drained), flushes the buffered priority frames (the Cease) best-effort within a 2s linger — a wedged write gets the linger to reach a frame boundary, else it is abandoned so no frame is spliced — then hard-closes.
- `handle_writer_exit` maps `TornDown` through the common teardown: `handle_tcp_disconnect` + `drive_fsm(TcpConnectionFails)` → `SessionDown` → RIB `PeerDown`, driven from the real run loop.
- Ordinary close paths drop the watch unsignalled; drain semantics and ADR-0078 writer-owned keepalives unchanged.

## Regression test

`saturation_teardown_from_run_loop_ceases_closes_and_deregisters`: 4KB socket buffers + trickle reader, 12k updates through the real `outbound_tx → run loop → enqueue_bulk` path; injects no FSM event and never calls the teardown trigger directly. Asserts Cease/8 is the final wire frame (parsed to EOF), RIB receives PeerDown (not GR-preserve), and the session terminates. Non-vacuity: with the watch signal reverted, the test fails at the PeerDown timeout.

## Gates

fmt / clippy `-D warnings` / transport tests (213 lib + 14 integration) / full workspace tests / doc / `--all-features` check — all green; regression test stable across repeated runs.