### PR TITLE
Publish the rpol registry only after a reload commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   status, and the operator resolves it by retrying the abort, confirming the
   candidate, or restarting. Previously a second mutation accepted after such a
   failure could be silently clobbered by the retained journal's boot revert.
+- **A rejected `.rpol` reload no longer publishes the candidate registry to
+  the runtime snapshot.** When a SIGHUP/apply reload carried `.rpol` changes
+  and the peer manager rejected the sync (e.g. a chain failed to re-resolve
+  mid-apply), the reload's returned snapshot already carried the candidate
+  registry — so sessions created after the failed reload resolved policies
+  against the REJECTED registry while existing sessions kept the old one
+  (split-brain). The runtime snapshot now adopts the candidate only after the
+  peer manager commits it; on rejection every session — existing and new —
+  keeps resolving against the last-successfully-applied registry, and the
+  operator's `.rpol` files survive on disk as intent for the next successful
+  reload. (LAN-284)
 - **Outbound saturation teardown: Cease is the final frame, and cleanup runs
   from the run loop.** When a peer stopped draining and the bounded writer
   queue filled (`Cease/8` Out-of-Resources teardown), the writer drained the

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -3950,6 +3950,124 @@ async fn sync_rpol_policies_reresolves_chains_and_rejects_shadowing() {
     rib_drainer.await.unwrap();
 }
 
+/// LAN-284: a rejected `sync_rpol_policies` (mid-apply chain resolution
+/// failure) must leave BOTH policy surfaces on the old registry — the
+/// live peer's chain (existing sessions) and `current_config` (what a
+/// session created afterwards resolves against). Asserted at decision
+/// level: the live chain still evaluates the OLD local-pref.
+#[tokio::test]
+async fn sync_rpol_policies_rejection_keeps_old_registry_for_live_and_new_sessions() {
+    use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry, RpolPolicySet};
+
+    fn registry(name: &str, source: &str) -> RpolPolicySet {
+        let file = std::sync::Arc::new(RpolFile::parse(source).expect("clean rpol"));
+        let mut set = RpolPolicySet::default();
+        set.policies.insert(
+            name.to_string(),
+            RpolPolicyEntry {
+                file,
+                params: 0,
+                path: "policies/core.rpol".to_string(),
+            },
+        );
+        set
+    }
+
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut mgr,
+        peer,
+        acking_counted_policy_handle(peer, counters.clone()),
+        false,
+    );
+    let mut neighbor = config_neighbor(peer, 65002);
+    neighbor.import_policy_chain = vec!["edge-in".to_string()];
+    mgr.current_config.neighbors = vec![neighbor];
+    mgr.current_config.policy.rpol = registry(
+        "edge-in",
+        "policy edge-in { term all { set local-pref 150; accept } }",
+    );
+    // Materialize the live chain from the OLD registry.
+    mgr.sync_rpol_policies(vec!["policies/core.rpol".to_string()], {
+        registry(
+            "edge-in",
+            "policy edge-in { term all { set local-pref 150; accept } }",
+        )
+    })
+    .await
+    .expect("baseline sync succeeds");
+
+    // Candidate registry renames the policy, so the static peer's
+    // `import_policy_chain = ["edge-in"]` no longer resolves: the sync
+    // is rejected mid-apply with zero peers touched.
+    mgr.sync_rpol_policies(
+        vec!["policies/core.rpol".to_string()],
+        registry(
+            "edge-in-renamed",
+            "policy edge-in-renamed { term all { set local-pref 250; accept } }",
+        ),
+    )
+    .await
+    .expect_err("chain resolution failure must reject the sync");
+
+    // Existing session: the live chain still evaluates the OLD decision.
+    let managed = mgr.peers.values().next().expect("peer present");
+    let chain = managed.import_policy.as_ref().expect("import chain set");
+    let ctx = rustbgpd_policy::RouteContext {
+        prefix: None,
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 0,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+    assert_eq!(chain.evaluate(&ctx).modifications.set_local_pref, Some(150));
+
+    // New session source: chains for a session created AFTER the
+    // rejection resolve from `current_config`, which must still carry
+    // the old registry — and evaluate the OLD decision.
+    let neighbor = mgr.current_config.neighbors[0].clone();
+    let (import, _export) = mgr
+        .current_config
+        .effective_policy_chains_for_neighbor(&neighbor)
+        .expect("new-session chains resolve against the old registry");
+    let chain = import.expect("import chain configured");
+    assert_eq!(chain.evaluate(&ctx).modifications.set_local_pref, Some(150));
+
+    drop(mgr);
+    rib_drainer.await.unwrap();
+}
+
 /// Like `acking_policy_handle`, but counting `QueryState` and Route Refresh
 /// sends so policy fan-out coverage can be asserted per peer.
 fn acking_counted_policy_handle(peer_addr: IpAddr, counters: Arc<FakePeerCounters>) -> PeerHandle {

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -803,11 +803,6 @@ pub(crate) async fn reload_config(
     // materially changed ones, so an rpol-content-only reload is fully
     // applied by this single step.
     if policy_diff.rpol_changed {
-        working_config
-            .policy
-            .rpol_files
-            .clone_from(&new_config.policy.rpol_files);
-        working_config.policy.rpol = new_config.policy.rpol.clone();
         let (ack_tx, ack_rx) = oneshot::channel();
         let send_failed = peer_mgr_tx
             .send(PeerManagerCommand::SyncRpolPolicies {
@@ -827,7 +822,24 @@ pub(crate) async fn reload_config(
             }
         };
         match result {
-            Ok(()) => info!("reload: rpol policy registry synced"),
+            // LAN-284: adopt the candidate registry into the runtime
+            // snapshot ONLY after the peer manager committed it. The
+            // manager's own sync is two-phase (a rejected sync leaves
+            // its `current_config` and every live chain on the old
+            // registry), so absorbing the candidate before the ack
+            // would ship the REJECTED registry to the runtime snapshot
+            // via halt_partial → ReplaceConfigSnapshot — new sessions
+            // would then resolve against a registry no live session
+            // runs. On failure the candidate survives only as on-disk
+            // `.rpol` intent; the next successful reload adopts it.
+            Ok(()) => {
+                working_config
+                    .policy
+                    .rpol_files
+                    .clone_from(&new_config.policy.rpol_files);
+                working_config.policy.rpol = new_config.policy.rpol.clone();
+                info!("reload: rpol policy registry synced");
+            }
             Err(error) => {
                 return halt_partial(
                     working_config,
@@ -3910,6 +3922,138 @@ hold_time = 90
         };
         let result = chain.evaluate(&ctx);
         assert_eq!(result.modifications.set_local_pref, Some(250));
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(&rpol_path).ok();
+    }
+
+    /// LAN-284: a REJECTED rpol sync must not publish the candidate
+    /// registry to the runtime snapshot. Sessions created after the
+    /// failed reload resolve chains from that snapshot, so it has to
+    /// keep evaluating the OLD policy decision; the candidate survives
+    /// only as on-disk intent and a subsequent successful reload adopts
+    /// it. Asserted at decision level (evaluated local-pref), not
+    /// registry-pointer level.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one scenario drives two full reload rounds (rejected, then adopted) end to end"
+    )]
+    #[tokio::test]
+    async fn reload_rpol_sync_failure_keeps_old_registry_until_a_successful_retry() {
+        let rpol_path = unique_temp_path("reload-rpol-fail-file");
+        std::fs::write(
+            &rpol_path,
+            "policy edge-in { term all { set local-pref 150; accept } }",
+        )
+        .unwrap();
+        let toml = format!(
+            "{}\n[policy]\nrpol_files = [{:?}]\nimport_chain = [\"edge-in\"]\n",
+            baseline_toml(),
+            rpol_path.to_str().unwrap(),
+        );
+        let path = unique_temp_path("reload-rpol-fail-config");
+        std::fs::write(&path, &toml).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+
+        // Operator edits ONLY the .rpol file; the TOML is unchanged.
+        std::fs::write(
+            &rpol_path,
+            "policy edge-in { term all { set local-pref 250; accept } }",
+        )
+        .unwrap();
+
+        let ctx = rustbgpd_policy::RouteContext {
+            prefix: None,
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[],
+            large_communities: &[],
+            as_path_str: "",
+            as_path_len: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        };
+
+        // Reload 1: the peer manager REJECTS the sync (its own two-phase
+        // apply rolled back, so live sessions keep the old chains).
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+        let mock = tokio::spawn(async move {
+            while let Some(cmd) = peer_mgr_rx.recv().await {
+                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
+                    let _ = reply.send(Err(CatalogMutationError::internal(
+                        "mid-apply chain resolution failed",
+                    )));
+                }
+            }
+        });
+        let rejected = reload_config(
+            path.to_str().unwrap(),
+            &initial,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            None,
+        )
+        .await
+        .expect("halted reload still returns the honest partial snapshot");
+        drop(peer_mgr_tx);
+        mock.await.unwrap();
+
+        // The runtime snapshot — what a session created after the failed
+        // reload resolves against — still evaluates the OLD decision.
+        let chain = rejected
+            .import_chain()
+            .expect("chain resolves")
+            .expect("chain configured");
+        assert_eq!(chain.evaluate(&ctx).modifications.set_local_pref, Some(150));
+
+        // Reload 2 (operator retries; peer manager now accepts): the
+        // diff re-detects the on-disk candidate against the reverted
+        // runtime snapshot and adopts it for everyone.
+        let current: Config = (*rejected).clone();
+        let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+        let mock = tokio::spawn(async move {
+            let mut synced = 0_u32;
+            while let Some(cmd) = peer_mgr_rx.recv().await {
+                if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
+                    synced += 1;
+                    let _ = reply.send(Ok(()));
+                }
+            }
+            synced
+        });
+        let adopted = reload_config(
+            path.to_str().unwrap(),
+            &current,
+            live_grpc_tcp.as_ref(),
+            live_grpc_uds.as_ref(),
+            &peer_mgr_tx,
+            None,
+            None,
+        )
+        .await
+        .expect("retry reload completes");
+        drop(peer_mgr_tx);
+        assert_eq!(
+            mock.await.unwrap(),
+            1,
+            "retry must re-detect the rpol change and sync it"
+        );
+        let chain = adopted
+            .import_chain()
+            .expect("chain resolves")
+            .expect("chain configured");
+        assert_eq!(chain.evaluate(&ctx).modifications.set_local_pref, Some(250));
 
         std::fs::remove_file(&path).ok();
         std::fs::remove_file(&rpol_path).ok();


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 1 (LAN-284).

## Problem

In `reload_config`, the runtime snapshot absorbed the candidate `.rpol` registry **before** sending `SyncRpolPolicies` and awaiting the ack. The peer manager's own sync is two-phase and rolls back correctly on rejection — but the rejected reload's `halt_partial` still returned the candidate-carrying snapshot, which `ReplaceConfigSnapshot` installed as `current_config`. Result: live sessions evaluated the old registry while sessions created after the failed reload resolved against the rejected one (split-brain).

## Fix

The snapshot adopts the candidate registry only inside the sync ack's `Ok` arm — i.e. after the peer manager commits it. On rejection, the snapshot keeps the last-successfully-applied registry (matching the live sessions), and the operator's `.rpol` files survive on disk as intent; the next successful reload adopts them. Single publish site verified — no other path ships the candidate.

## Tests (decision-level, not pointer-level)

- `reload_rpol_sync_failure_keeps_old_registry_until_a_successful_retry`: rejected sync → returned snapshot's resolved import chain still evaluates local-pref 150 (old policy); a subsequent accepted reload re-detects the on-disk change and evaluates 250. Fails under the pre-fix code (250 on the first assertion).
- `sync_rpol_policies_rejection_keeps_old_registry_for_live_and_new_sessions`: real `PeerManager`, live peer; mid-apply chain-resolution failure rejects the sync; both the live peer's chain and `effective_policy_chains_for_neighbor` (the new-session source) still evaluate 150.

## Gates

fmt / clippy `-D warnings` / policy crate (206) / full workspace (5030, 0 failed) / doc / `cargo +nightly fuzz build` — all green.