### PR TITLE
Preflight and revalidate ownership before replacing or deleting dataplane state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RTR transaction is bounded by a wall-clock deadline plus record and byte
   budgets so a broken or malicious cache cannot wedge or OOM the client.
   (LAN-281)
+- **EVPN Linux dataplane: foreign-state ownership preflight and revalidation.**
+  The reconciler could `replace` over — or delete — a same-key kernel row it
+  did not own: an operator/other-agent FDB row, VRF route, L3 neighbor, or
+  L3VXLAN FDB row that occupied (or took over) an exact key rustbgpd wanted.
+  Every L2/L3 write path now fails closed when a foreign row holds the key
+  (level-triggered: the install resumes once the foreign row goes away),
+  ownership is relinquished when a live snapshot shows a foreign writer
+  replaced an owned row (no "repair" back over it), and deletes during
+  withdrawal, `NotReady` drain, and shutdown are revalidated against a live
+  snapshot so foreign rows always survive rustbgpd's teardown. Observability:
+  warn-once transition logs plus new `evpn_foreign_replaces_blocked_total`,
+  `evpn_foreign_deletes_skipped_total`, and
+  `evpn_foreign_owned_relinquished_total` counters. (LAN-283)
+
 - **Outbound saturation teardown: Cease is the final frame, and cleanup runs
   from the run loop.** When a peer stopped draining and the bounded writer
   queue filled (`Cease/8` Out-of-Resources teardown), the writer drained the

--- a/crates/evpn-linux/src/diff.rs
+++ b/crates/evpn-linux/src/diff.rs
@@ -66,6 +66,17 @@ pub struct Plan {
     /// set against the previous pass to suppress steady-state spam.
     /// Empty when no entries fall back.
     pub ipv6_alias_fallback_keys: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    /// `(VNI, MAC)` keys whose operation was withheld this pass
+    /// because a same-key FOREIGN kernel row (not `extern_learn` /
+    /// not ours) occupies the slot — a netlink `replace` would
+    /// silently adopt-and-overwrite another agent's state, and a
+    /// delete would tear down a row we no longer own. Fail closed:
+    /// nothing is emitted for these keys; the reconcile actor logs a
+    /// warning on the transition into blocked, bumps the
+    /// foreign-state counters, and relinquishes stale ownership.
+    /// Level-triggered: once the foreign row goes away the next pass
+    /// emits normally.
+    pub foreign_blocked_keys: BTreeSet<(EvpnInstanceId, MacAddress)>,
 }
 
 impl Plan {
@@ -140,6 +151,10 @@ pub fn compute_diff(
     // back.
     let mut ipv6_alias_fallback_keys: BTreeSet<(EvpnInstanceId, MacAddress)> = BTreeSet::new();
 
+    // LAN-283: keys withheld because a foreign kernel row occupies
+    // the exact slot. See `Plan::foreign_blocked_keys`.
+    let mut foreign_blocked: BTreeSet<(EvpnInstanceId, MacAddress)> = BTreeSet::new();
+
     // Pass 1 + 1b — creates / updates. Scoped to Ready instances;
     // entries for NotReady / Unbound instances contribute zero ops.
     for (&(vni, mac), entry) in desired.iter() {
@@ -191,6 +206,7 @@ pub fn compute_diff(
                     &mut creates,
                     &mut updates,
                     &mut conversions,
+                    &mut foreign_blocked,
                 );
             }
             (Some(_), false, true) => {
@@ -223,6 +239,7 @@ pub fn compute_diff(
                     &mut creates,
                     &mut updates,
                     &mut conversions,
+                    &mut foreign_blocked,
                 );
             }
             _ => {
@@ -250,6 +267,7 @@ pub fn compute_diff(
                     &mut creates,
                     &mut updates,
                     &mut conversions,
+                    &mut foreign_blocked,
                 );
             }
         }
@@ -270,30 +288,45 @@ pub fn compute_diff(
             OwnedEntryKind::SingleDst { .. } => {
                 // Existing single-dst delete: check kernel snapshot,
                 // emit RemoveRemoteFdb only if the kernel still has
-                // it. Interface flap / manual `bridge fdb del` is a
-                // no-op for this pass — the actor's OwnedSet drift
-                // self-heals on the next successful reconcile.
-                if snapshot.find_fdb_in_vlan(vni, mac, owned.vlan).is_some() {
-                    deletes.push(DataplaneOp::RemoveRemoteFdb {
-                        vni,
-                        mac,
-                        vlan: owned.vlan,
-                    });
+                // *our* row. Interface flap / manual `bridge fdb del`
+                // is a no-op for this pass — the actor's OwnedSet
+                // drift self-heals on the next successful reconcile.
+                // A same-key row that is NOT extern_learned means a
+                // foreign writer replaced ours (LAN-283): never emit
+                // the delete — the foreign row must survive our
+                // withdrawal / NotReady drain.
+                match snapshot.find_fdb_in_vlan(vni, mac, owned.vlan) {
+                    Some(kernel) if kernel.is_extern_learned() => {
+                        deletes.push(DataplaneOp::RemoveRemoteFdb {
+                            vni,
+                            mac,
+                            vlan: owned.vlan,
+                        });
+                    }
+                    Some(_) => {
+                        foreign_blocked.insert((vni, mac));
+                    }
+                    None => {}
                 }
             }
             OwnedEntryKind::FdbNhg { group_key } => {
-                // FDB-NHG delete: always emit. The coordinator is
-                // idempotent (slice 3a `apply_remove_fdb_nhg_row`
-                // uses `classify_remove_apply_error` → ENOENT-as-ACK).
-                // We don't gate on kernel snapshot because nhid-row
-                // drift detection from RTNLGRP_NEIGH is incomplete
-                // per research §8.
-                deletes.push(DataplaneOp::RemoveFdbNhg {
-                    vni,
-                    mac,
-                    vlan: owned.vlan,
-                    group_key,
-                });
+                // FDB-NHG delete: emit even when the snapshot has no
+                // row (the coordinator is idempotent — slice 3a
+                // `apply_remove_fdb_nhg_row` uses
+                // `classify_remove_apply_error` → ENOENT-as-ACK, and
+                // nhid-row drift detection from RTNLGRP_NEIGH is
+                // incomplete per research §8) — but never when the
+                // row present at the key is foreign (LAN-283).
+                if foreign_row_at(snapshot, vni, mac, owned.vlan) {
+                    foreign_blocked.insert((vni, mac));
+                } else {
+                    deletes.push(DataplaneOp::RemoveFdbNhg {
+                        vni,
+                        mac,
+                        vlan: owned.vlan,
+                        group_key,
+                    });
+                }
             }
         }
     }
@@ -340,7 +373,23 @@ pub fn compute_diff(
     Plan {
         ops,
         ipv6_alias_fallback_keys,
+        foreign_blocked_keys: foreign_blocked,
     }
+}
+
+/// `true` when the kernel snapshot holds a row at `(vni, vlan, mac)`
+/// that is provably not ours (no `extern_learn` marker, or a foreign
+/// `NDA_PROTOCOL` stamp). LAN-283 fail-closed predicate: no create /
+/// update / conversion / delete may target such a key.
+fn foreign_row_at(
+    snapshot: &KernelSnapshot,
+    vni: EvpnInstanceId,
+    mac: MacAddress,
+    vlan: Option<u16>,
+) -> bool {
+    snapshot
+        .find_fdb_in_vlan(vni, mac, vlan)
+        .is_some_and(|k| !k.is_extern_learned())
 }
 
 /// `true` when `entry.remote_vtep_ip` and every `alias_vtep_ips`
@@ -379,10 +428,21 @@ fn emit_single_dst_pass(
     creates: &mut Vec<DataplaneOp>,
     updates: &mut Vec<DataplaneOp>,
     conversions: &mut Vec<DataplaneOp>,
+    foreign_blocked: &mut BTreeSet<(EvpnInstanceId, MacAddress)>,
 ) {
     if let Some(owned) = last_applied.get(vni, mac)
         && owned.vlan != vlan
     {
+        // LAN-283: the conversion pair below deletes the row at the
+        // owned VLAN and adds at the desired VLAN without consulting
+        // the snapshot. If a foreign row sits at either key, emitting
+        // would clobber it — fail closed for this MAC instead.
+        if foreign_row_at(snapshot, vni, mac, owned.vlan)
+            || foreign_row_at(snapshot, vni, mac, vlan)
+        {
+            foreign_blocked.insert((vni, mac));
+            return;
+        }
         match owned.kind {
             OwnedEntryKind::SingleDst { .. } => conversions.push(DataplaneOp::RemoveRemoteFdb {
                 vni,
@@ -420,6 +480,13 @@ fn emit_single_dst_pass(
     if let Some(owned) = last_applied.get(vni, mac)
         && let OwnedEntryKind::FdbNhg { group_key } = owned.kind
     {
+        // LAN-283: the Remove half of this conversion pair deletes
+        // whatever row sits at the key — never emit it over a
+        // foreign row.
+        if foreign_row_at(snapshot, vni, mac, vlan) {
+            foreign_blocked.insert((vni, mac));
+            return;
+        }
         conversions.push(DataplaneOp::RemoveFdbNhg {
             vni,
             mac,
@@ -454,6 +521,7 @@ fn emit_single_dst_pass(
                 last_applied,
                 updates,
                 conversions,
+                foreign_blocked,
             );
         }
     }
@@ -478,7 +546,35 @@ fn emit_fdb_nhg_pass(
     creates: &mut Vec<DataplaneOp>,
     updates: &mut Vec<DataplaneOp>,
     conversions: &mut Vec<DataplaneOp>,
+    foreign_blocked: &mut BTreeSet<(EvpnInstanceId, MacAddress)>,
 ) {
+    // LAN-283 fail-closed gate: a foreign row at the desired key (or
+    // at the previously-owned VLAN key for the conversion arm) blocks
+    // every per-MAC emission below — Install with `convert_from_dst`,
+    // the group-key-drift Remove→Install pair, and the drift-repair
+    // re-Install would all replace or delete another agent's row.
+    // Foreign-entry preservation for the fresh-install arm used to
+    // live in a local `fdb_nhg_install_safe` check; this gate
+    // subsumes it and extends it to the owned arms. Group-level
+    // `UpdateFdbNhgMembers` is not gated — it targets our kernel
+    // nexthop objects, not the FDB row.
+    if foreign_row_at(snapshot, vni, mac, vlan) {
+        foreign_blocked.insert((vni, mac));
+        tracing::trace!(
+            ?vni,
+            mac = %mac,
+            "FDB-NHG emission skipped: foreign kernel row at this (vni, mac)"
+        );
+        return;
+    }
+    if let Some(owned) = last_applied.get(vni, mac)
+        && owned.vlan != vlan
+        && foreign_row_at(snapshot, vni, mac, owned.vlan)
+    {
+        foreign_blocked.insert((vni, mac));
+        return;
+    }
+
     let canonical = group_members(entry);
     let standby = entry.single_active_backup_vtep_ip;
 
@@ -523,26 +619,20 @@ fn emit_fdb_nhg_pass(
             //     rides `convert_from_dst` because the in-place
             //     REPLACE would be rejected with -EOPNOTSUPP and end
             //     up permanently suppressed.
-            // Operator-static / kernel-learned rows are skipped here
-            // the same way `handle_existing_kernel_entry` does for the
-            // single-dst path.
-            if fdb_nhg_install_safe(snapshot, vni, mac, vlan) {
-                creates.push(DataplaneOp::InstallFdbNhg {
-                    vni,
-                    mac,
-                    vlan,
-                    group_key: linux_key,
-                    members: canonical,
-                    standby,
-                    convert_from_dst: kernel_dst_row,
-                });
-            } else {
-                tracing::trace!(
-                    ?vni,
-                    mac = %mac,
-                    "FDB-NHG install skipped: foreign kernel row at this (vni, mac)"
-                );
-            }
+            // Operator-static / kernel-learned rows are skipped by
+            // the LAN-283 foreign gate at the top of this function,
+            // the same way `handle_existing_kernel_entry` does for
+            // the single-dst path — so any row still present here is
+            // ours (restart marker) or absent.
+            creates.push(DataplaneOp::InstallFdbNhg {
+                vni,
+                mac,
+                vlan,
+                group_key: linux_key,
+                members: canonical,
+                standby,
+                convert_from_dst: kernel_dst_row,
+            });
         }
         Some(OwnedEntryKind::SingleDst { .. }) => {
             // Single-dst → FDB-NHG transition. The old dst row must
@@ -684,18 +774,6 @@ fn emit_fdb_nhg_vlan_conversion(
     true
 }
 
-fn fdb_nhg_install_safe(
-    snapshot: &KernelSnapshot,
-    vni: EvpnInstanceId,
-    mac: MacAddress,
-    vlan: Option<u16>,
-) -> bool {
-    match snapshot.find_fdb_in_vlan(vni, mac, vlan) {
-        None => true,
-        Some(k) => k.is_extern_learned(),
-    }
-}
-
 /// Decide what to do when `desired` wants `(vni, mac) -> dst` and the
 /// kernel already has *some* entry there. Splits the six interesting
 /// cases:
@@ -735,6 +813,7 @@ fn handle_existing_kernel_entry(
     last_applied: &OwnedSet,
     updates: &mut Vec<DataplaneOp>,
     conversions: &mut Vec<DataplaneOp>,
+    foreign_blocked: &mut BTreeSet<(EvpnInstanceId, MacAddress)>,
 ) {
     if kernel_entry.is_extern_learned() {
         // Case 4: nhid-shaped marker row, dst-shaped desire. The
@@ -803,8 +882,13 @@ fn handle_existing_kernel_entry(
         return;
     }
 
-    // Operator-static / `self` / non-extern_learn entry. Skip silently;
-    // the operator owns this entry.
+    // Operator-static / `self` / non-extern_learn entry. Skip and
+    // record the key as foreign-blocked (LAN-283: the actor logs the
+    // transition + bumps the foreign-state counter); the operator
+    // owns this entry. The kernel-learned-local case above stays out
+    // of the blocked set — that's the expected RFC 7432 §15 mobility
+    // race, resolved at the domain layer, not a foreign takeover.
+    foreign_blocked.insert((vni, mac));
     tracing::trace!(
         ?vni,
         mac = %mac,
@@ -1227,6 +1311,137 @@ mod tests {
             "should not overwrite foreign static, got {:?}",
             plan.ops
         );
+        assert!(
+            plan.foreign_blocked_keys.contains(&(vni(100), mac(1))),
+            "blocked key must be reported for observability (LAN-283)"
+        );
+    }
+
+    // LAN-283 rule 3: an owned single-dst key that is no longer
+    // desired, whose kernel row was REPLACED by a foreign permanent
+    // entry, must NOT get a RemoveRemoteFdb — the foreign row has to
+    // survive our withdrawal.
+    #[test]
+    fn withdraw_spares_foreign_replaced_single_dst_row() {
+        let desired = RemoteMacTable::new();
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                vlan: None,
+                dst: Some(ip("10.9.9.9")),
+                nh_id: None,
+                protocol: None,
+                flags: KernelFdbFlags {
+                    permanent: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let applied = applied_one(vni(100), mac(1), "10.0.0.2", None);
+        let probes = ready_probes(&[vni(100)]);
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert!(
+            plan.is_noop(),
+            "withdrawal must spare the foreign row, got {:?}",
+            plan.ops
+        );
+        assert!(plan.foreign_blocked_keys.contains(&(vni(100), mac(1))));
+    }
+
+    // LAN-283 rule 3, NotReady variant: the instance-drain path is
+    // the same Pass 2 — a foreign same-key row survives it too.
+    #[test]
+    fn not_ready_drain_spares_foreign_replaced_row() {
+        let desired = desired_one(vni(100), mac(1), entry("10.0.0.2", None));
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                vlan: None,
+                dst: Some(ip("10.9.9.9")),
+                nh_id: None,
+                protocol: None,
+                flags: KernelFdbFlags {
+                    permanent: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let applied = applied_one(vni(100), mac(1), "10.0.0.2", None);
+        let mut probes = InstanceProbes::new();
+        probes.insert(
+            vni(100),
+            InstanceProbe::NotReady {
+                reason: "bridge gone".into(),
+            },
+        );
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert!(
+            plan.is_noop(),
+            "NotReady drain must spare the foreign row, got {:?}",
+            plan.ops
+        );
+        assert!(plan.foreign_blocked_keys.contains(&(vni(100), mac(1))));
+    }
+
+    // LAN-283 rule 3, FDB-NHG variant: the "always emit RemoveFdbNhg"
+    // bookkeeping rule must not fire when the row at the key is
+    // foreign.
+    #[test]
+    fn withdraw_spares_foreign_replaced_fdb_nhg_row() {
+        let desired = RemoteMacTable::new();
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                vlan: None,
+                dst: Some(ip("10.9.9.9")),
+                nh_id: None,
+                protocol: None,
+                flags: KernelFdbFlags {
+                    permanent: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 0x11)));
+        let probes = ready_probes(&[vni(100)]);
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &probes,
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert!(
+            plan.is_noop(),
+            "FDB-NHG withdrawal must spare the foreign row, got {:?}",
+            plan.ops
+        );
+        assert!(plan.foreign_blocked_keys.contains(&(vni(100), mac(1))));
     }
 
     #[test]
@@ -1610,6 +1825,51 @@ mod tests {
 
     fn linux_key(v: u32, seg: u8) -> AliasGroupKey {
         AliasGroupKey::new(vni(v), esi(seg), EthernetTagId(0))
+    }
+
+    // LAN-283 rule 1, FDB-NHG drift-repair variant: an owned FdbNhg
+    // key whose kernel row was replaced by a foreign permanent dst
+    // row must NOT re-Install (`convert_from_dst` would delete→add
+    // over the foreign row — a silent adopt-and-overwrite).
+    #[test]
+    fn foreign_takeover_blocks_fdb_nhg_reinstall() {
+        let desired = desired_one(
+            vni(100),
+            mac(1),
+            entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+        );
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_fdb(
+            vni(100),
+            KernelFdbEntry {
+                mac: mac(1),
+                vlan: None,
+                dst: Some(ip("10.9.9.9")),
+                nh_id: None,
+                protocol: None,
+                flags: KernelFdbFlags {
+                    permanent: true,
+                    master: true,
+                    ..Default::default()
+                },
+            },
+        );
+        let mut applied = OwnedSet::new();
+        applied.record_applied(vni(100), mac(1), OwnedEntry::fdb_nhg(linux_key(100, 7)));
+        let plan = compute_diff(
+            &desired,
+            &snapshot,
+            &applied,
+            &ready_probes(&[vni(100)]),
+            &GroupOwnedMap::new(),
+            &EvpnInstanceTable::new(),
+        );
+        assert!(
+            plan.is_noop(),
+            "foreign row must block the FDB-NHG re-install, got {:?}",
+            plan.ops
+        );
+        assert!(plan.foreign_blocked_keys.contains(&(vni(100), mac(1))));
     }
 
     #[test]

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -1030,12 +1030,15 @@ impl InMemoryDataplane {
 
         let mut out = L3AdoptionDump::default();
         for (&(table_id, prefix), row) in &state.l3_routes {
-            if !row.marked {
-                continue;
-            }
             let Some(vrf_id) = tables.get(&table_id).copied() else {
                 continue;
             };
+            if !row.marked {
+                // LAN-283: unmarked row in a configured table —
+                // foreign state the actor must fail closed on.
+                out.foreign_routes.insert((vrf_id, prefix));
+                continue;
+            }
             out.routes.insert(
                 (vrf_id, prefix),
                 AdoptedL3Route {
@@ -1050,21 +1053,23 @@ impl InMemoryDataplane {
             );
         }
         for (&(ifindex, next_hop), row) in &state.l3_neighbors {
-            if !row.marked {
-                continue;
-            }
             let Some(vrf_id) = managed.get(&ifindex).copied() else {
                 continue;
             };
+            if !row.marked {
+                out.foreign_neighbors.insert((ifindex, next_hop));
+                continue;
+            }
             out.neighbors.insert((ifindex, next_hop), vrf_id);
         }
         for (&(ifindex, router_mac), row) in &state.l3_vxlan_fdb {
-            if !row.marked {
-                continue;
-            }
             let Some(vrf_id) = managed.get(&ifindex).copied() else {
                 continue;
             };
+            if !row.marked {
+                out.foreign_fdb.insert((ifindex, router_mac));
+                continue;
+            }
             let target = match row.target {
                 InMemoryL3VxlanFdbTarget::SingleDst { .. } => AdoptedL3VxlanFdbTarget::SingleDst,
                 InMemoryL3VxlanFdbTarget::Nhg { nh_id } => {

--- a/crates/evpn-linux/src/l3_adoption.rs
+++ b/crates/evpn-linux/src/l3_adoption.rs
@@ -24,7 +24,7 @@
 //! the re-install *is* the claim), and reaps whatever stays unclaimed
 //! after the deferral.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
 use rustbgpd_evpn::{EvpnIpPrefixValue, IpVrfId, MacAddress};
@@ -86,11 +86,29 @@ pub struct L3AdoptionDump {
     pub neighbors: BTreeMap<(u32, IpAddr), IpVrfId>,
     /// `(l3vxlan_ifindex, router_mac)` → adopted FDB row identity.
     pub l3vxlan_fdb: BTreeMap<(u32, MacAddress), AdoptedL3VxlanFdb>,
+    /// LAN-283 foreign-state visibility: `(vrf_id, prefix)` keys in a
+    /// configured IP-VRF table whose route row does NOT carry our
+    /// marker pair — another writer's state. The reconcile actor
+    /// blocks replaces over these keys and never deletes them.
+    pub foreign_routes: BTreeSet<(IpVrfId, EvpnIpPrefixValue)>,
+    /// Foreign `(l3vxlan_ifindex, next_hop)` neighbor keys on managed
+    /// L3VXLAN devices: rows programmed by another agent (permanent /
+    /// noarp state without our markers, or a non-BGP `NDA_PROTOCOL`
+    /// stamp). Transient kernel-dynamic ARP/ND cache entries are NOT
+    /// classified foreign — our control-plane replace of a volatile
+    /// cache entry is normal operation.
+    pub foreign_neighbors: BTreeSet<(u32, IpAddr)>,
+    /// Foreign `(l3vxlan_ifindex, router_mac)` FDB keys on managed
+    /// L3VXLAN devices — any row that is not marker-matching (managed
+    /// L3VXLANs run `nolearning`, so every row was programmed by
+    /// someone).
+    pub foreign_fdb: BTreeSet<(u32, MacAddress)>,
 }
 
 impl L3AdoptionDump {
     /// True when no marker rows were observed in any of the three
-    /// kernel surfaces.
+    /// kernel surfaces (foreign rows do not count — they are never
+    /// adoption candidates).
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.routes.is_empty() && self.neighbors.is_empty() && self.l3vxlan_fdb.is_empty()

--- a/crates/evpn-linux/src/linux/l3_adoption.rs
+++ b/crates/evpn-linux/src/linux/l3_adoption.rs
@@ -69,6 +69,10 @@ use super::routes::{
 /// constant in `super::l3` (the write side); both halves of the
 /// marker must read the same bit.
 const NUD_PERMANENT: u16 = 0x80;
+/// `NUD_NOARP` — programmed pseudo-state, never subject to
+/// reachability probing. Read alongside `NUD_PERMANENT` by the
+/// LAN-283 foreign-neighbor classifier.
+const NUD_NOARP: u16 = 0x40;
 /// `NDA_NH_ID` (kind = 13). `netlink-packet-route 0.30` exposes it
 /// through `NeighbourAttribute::Other(DefaultNla)`.
 const NDA_NH_ID: u16 = 13;
@@ -171,6 +175,30 @@ fn extract_route_targets(msg: &RouteMessage) -> Option<(Vec<IpAddr>, u32)> {
     Some((out, ifindex?))
 }
 
+/// LAN-283 foreign-route classifier: a row in a *configured* IP-VRF
+/// table that fails the ADR-0079 marker pair (`RTPROT_BGP` + onlink)
+/// is another writer's state at a key we could be asked to program —
+/// surface its `(vrf_id, prefix)` so the reconcile actor can fail
+/// closed instead of `RTM_NEWROUTE`-replacing or deleting it.
+/// Marker-matching rows (including `MarkedButUnusable`) are never
+/// foreign; rows without a parseable destination cannot be keyed and
+/// are skipped.
+#[must_use]
+pub(crate) fn classify_foreign_route(
+    msg: &RouteMessage,
+    tables: &HashMap<u32, IpVrfId>,
+) -> Option<(IpVrfId, EvpnIpPrefixValue)> {
+    let table_id = extract_table_id(msg);
+    let vrf_id = tables.get(&table_id).copied()?;
+    if msg.header.protocol == netlink_packet_route::route::RouteProtocol::Bgp
+        && msg.header.flags.contains(RouteFlags::Onlink)
+    {
+        return None; // marker pair — ours (or marked-but-unusable)
+    }
+    let prefix = extract_prefix(msg)?;
+    Some((vrf_id, prefix))
+}
+
 /// Pure L3-neighbor classifier: keep rows on a managed L3VXLAN
 /// ifindex whose state carries `NUD_PERMANENT` and whose flags carry
 /// `NTF_EXT_LEARNED` — exactly what `super::l3::apply_add_l3_neighbor`
@@ -209,6 +237,65 @@ pub(crate) fn classify_adoption_neighbor(
         _ => None,
     })?;
     Some(((ifindex, next_hop), vrf_id))
+}
+
+/// LAN-283 foreign-neighbor classifier: a row on a managed L3VXLAN
+/// ifindex that is *programmed state* (permanent / noarp) or carries
+/// a non-BGP `NDA_PROTOCOL` stamp, but is not marker-matching ours —
+/// another agent's entry at a key our `AddL3Neighbor` replace would
+/// clobber. Transient kernel-dynamic cache entries (REACHABLE /
+/// STALE / ...) are not foreign: replacing a volatile ARP/ND cache
+/// row with control-plane state is normal operation, and blocking on
+/// it would flap.
+///
+/// Call only for rows [`classify_adoption_neighbor`] rejected — this
+/// function does not re-check ours-ness beyond the marker halves.
+#[must_use]
+pub(crate) fn classify_foreign_neighbor(
+    msg: &NeighbourMessage,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+) -> Option<(u32, IpAddr)> {
+    let ifindex = msg.header.ifindex;
+    managed_l3vxlan.get(&ifindex)?;
+    let programmed = state_has_permanent(msg.header.state) || state_has_noarp(msg.header.state);
+    let foreign_stamp = extract_protocol(msg).is_some_and(|p| p != RouteProtocol::Bgp);
+    if !programmed && !foreign_stamp {
+        return None;
+    }
+    let next_hop = msg.attributes.iter().find_map(|attr| match attr {
+        NeighbourAttribute::Destination(NeighbourAddress::Inet(v4)) => Some(IpAddr::V4(*v4)),
+        NeighbourAttribute::Destination(NeighbourAddress::Inet6(v6)) => Some(IpAddr::V6(*v6)),
+        _ => None,
+    })?;
+    Some((ifindex, next_hop))
+}
+
+/// LAN-283 foreign L3VXLAN-FDB classifier: any `AF_BRIDGE` row on a
+/// managed L3VXLAN ifindex that [`classify_adoption_l3vxlan_fdb`]
+/// rejected. Managed L3VXLANs run `nolearning`, so every row in
+/// their FDB was programmed by someone — a non-marker row is another
+/// agent's state at a key our FDB replace / delete would clobber.
+///
+/// Call only for rows [`classify_adoption_l3vxlan_fdb`] rejected.
+#[must_use]
+pub(crate) fn classify_foreign_l3vxlan_fdb(
+    msg: &NeighbourMessage,
+    managed_l3vxlan: &HashMap<u32, IpVrfId>,
+) -> Option<(u32, MacAddress)> {
+    if msg.header.family != AddressFamily::Bridge {
+        return None;
+    }
+    let ifindex = msg.header.ifindex;
+    managed_l3vxlan.get(&ifindex)?;
+    let router_mac = msg.attributes.iter().find_map(|attr| match attr {
+        NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
+            let mut arr = [0u8; 6];
+            arr.copy_from_slice(bytes);
+            Some(MacAddress::new(arr))
+        }
+        _ => None,
+    })?;
+    Some((ifindex, router_mac))
 }
 
 /// Pure L3VXLAN-FDB classifier: keep `AF_BRIDGE` rows on a managed
@@ -296,6 +383,18 @@ fn state_has_permanent(state: NeighbourState) -> bool {
     match state {
         NeighbourState::Permanent => true,
         NeighbourState::Other(bits) => bits & NUD_PERMANENT != 0,
+        _ => false,
+    }
+}
+
+/// `true` when the `ndm_state` bitmask includes `NUD_NOARP` — the
+/// other "programmed, never aged" state bit (`ip neigh add ...
+/// nud noarp`, and half of the combined `NUD_NOARP | NUD_PERMANENT`
+/// FDB shape).
+fn state_has_noarp(state: NeighbourState) -> bool {
+    match state {
+        NeighbourState::Noarp => true,
+        NeighbourState::Other(bits) => bits & NUD_NOARP != 0,
         _ => false,
     }
 }
@@ -394,7 +493,14 @@ async fn dump_routes_one_family(
                     "L3 adoption: marker route missing gateway/oif/dst; skipping"
                 );
             }
-            RouteAdoptionVerdict::NotOurs => {}
+            RouteAdoptionVerdict::NotOurs => {
+                // LAN-283: surface foreign same-table route keys so
+                // the reconcile actor can fail closed on exact-key
+                // collisions instead of replacing / deleting them.
+                if let Some(key) = classify_foreign_route(&route_msg, tables) {
+                    out.foreign_routes.insert(key);
+                }
+            }
         }
     }
     Ok(())
@@ -414,6 +520,8 @@ async fn dump_neighbors_one_family(
     })? {
         if let Some((key, vrf_id)) = classify_adoption_neighbor(&msg, managed_l3vxlan) {
             out.neighbors.insert(key, vrf_id);
+        } else if let Some(key) = classify_foreign_neighbor(&msg, managed_l3vxlan) {
+            out.foreign_neighbors.insert(key);
         }
     }
     Ok(())
@@ -434,6 +542,8 @@ async fn dump_l3vxlan_fdb(
     {
         if let Some((key, row)) = classify_adoption_l3vxlan_fdb(&msg, managed_l3vxlan) {
             out.l3vxlan_fdb.insert(key, row);
+        } else if let Some(key) = classify_foreign_l3vxlan_fdb(&msg, managed_l3vxlan) {
+            out.foreign_fdb.insert(key);
         }
     }
     Ok(())
@@ -648,6 +758,155 @@ mod tests {
         assert_eq!(
             classify_adoption_route(&not_bgp, &tables(&[(201, 101)])),
             RouteAdoptionVerdict::NotOurs,
+        );
+    }
+
+    // ── LAN-283 foreign classifiers ──
+
+    #[test]
+    fn foreign_route_in_configured_table_is_keyed() {
+        let msg = route_msg(
+            201,
+            RouteProtocol::Static,
+            false,
+            Some(Ipv4Addr::new(203, 0, 113, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 99)),
+            Some(42),
+        );
+        assert_eq!(
+            classify_foreign_route(&msg, &tables(&[(201, 101)])),
+            Some((
+                vrf_id(101),
+                EvpnIpPrefixValue::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+            )),
+        );
+    }
+
+    #[test]
+    fn marker_route_is_never_foreign() {
+        let msg = route_msg(
+            201,
+            RouteProtocol::Bgp,
+            true,
+            Some(Ipv4Addr::new(198, 51, 100, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some(42),
+        );
+        assert_eq!(classify_foreign_route(&msg, &tables(&[(201, 101)])), None);
+    }
+
+    #[test]
+    fn foreign_route_outside_configured_tables_is_skipped() {
+        let msg = route_msg(
+            999,
+            RouteProtocol::Static,
+            false,
+            Some(Ipv4Addr::new(203, 0, 113, 0)),
+            Some(Ipv4Addr::new(10, 0, 0, 99)),
+            Some(42),
+        );
+        assert_eq!(classify_foreign_route(&msg, &tables(&[(201, 101)])), None);
+    }
+
+    #[test]
+    fn foreign_neighbor_permanent_without_our_markers_is_keyed() {
+        // Operator `ip neigh add ... nud permanent` — no extern_learn.
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Permanent,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+        );
+        assert_eq!(
+            classify_foreign_neighbor(&msg, &managed(&[(42, 101)])),
+            Some((42, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)))),
+        );
+    }
+
+    #[test]
+    fn foreign_neighbor_with_zebra_stamp_is_keyed() {
+        let msg = with_protocol(
+            neigh_msg(
+                AddressFamily::Inet,
+                42,
+                NeighbourState::Reachable,
+                NeighbourFlags::empty(),
+                Some(Ipv4Addr::new(10, 0, 0, 2)),
+                Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+            ),
+            RouteProtocol::Zebra,
+        );
+        assert_eq!(
+            classify_foreign_neighbor(&msg, &managed(&[(42, 101)])),
+            Some((42, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)))),
+        );
+    }
+
+    #[test]
+    fn dynamic_kernel_neighbor_is_not_foreign() {
+        // A volatile kernel ARP/ND cache row must not block installs.
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            42,
+            NeighbourState::Reachable,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+        );
+        assert_eq!(
+            classify_foreign_neighbor(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+
+    #[test]
+    fn foreign_neighbor_on_unmanaged_ifindex_is_skipped() {
+        let msg = neigh_msg(
+            AddressFamily::Inet,
+            7,
+            NeighbourState::Permanent,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 2)),
+            Some([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
+        );
+        assert_eq!(
+            classify_foreign_neighbor(&msg, &managed(&[(42, 101)])),
+            None
+        );
+    }
+
+    #[test]
+    fn foreign_l3vxlan_fdb_row_is_keyed() {
+        // `bridge fdb add ... self permanent` without extern_learn.
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            42,
+            NeighbourState::Permanent,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 99)),
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_foreign_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            Some((42, MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]))),
+        );
+    }
+
+    #[test]
+    fn foreign_l3vxlan_fdb_on_unmanaged_ifindex_is_skipped() {
+        let msg = neigh_msg(
+            AddressFamily::Bridge,
+            7,
+            NeighbourState::Permanent,
+            NeighbourFlags::empty(),
+            Some(Ipv4Addr::new(10, 0, 0, 99)),
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+        );
+        assert_eq!(
+            classify_foreign_l3vxlan_fdb(&msg, &managed(&[(42, 101)])),
+            None,
         );
     }
 

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -39,11 +39,11 @@ use std::time::Duration;
 use rustbgpd_evpn::{
     AppliedOp, DataplaneIntent, DataplaneOpKind, DataplaneReport, EvpnInstanceTable, FailedOp,
     FdbNexthopDataplaneStatus, FdbNexthopGroupStatus, FdbNexthopMemberStatus, FdbNhgDriftCounters,
-    InstanceDataplaneStatus, InstanceState, L3AdoptionCounters, ManagedBridgeNetdev,
-    ManagedL3VxlanNetdev, ManagedNetdevClass, ManagedNetdevState, ManagedNetdevStatus,
-    ManagedNetdevTable, ManagedSvdVxlanBinding, ManagedSvdVxlanNetdev, ManagedVlanUpperNetdev,
-    ManagedVrfNetdev, ManagedVxlanNetdev, RemoteMacTable, SingleActiveCounters,
-    parse_ownership_stamp,
+    ForeignStateCounters, InstanceDataplaneStatus, InstanceState, L3AdoptionCounters,
+    ManagedBridgeNetdev, ManagedL3VxlanNetdev, ManagedNetdevClass, ManagedNetdevState,
+    ManagedNetdevStatus, ManagedNetdevTable, ManagedSvdVxlanBinding, ManagedSvdVxlanNetdev,
+    ManagedVlanUpperNetdev, ManagedVrfNetdev, ManagedVxlanNetdev, RemoteMacTable,
+    SingleActiveCounters, parse_ownership_stamp,
 };
 use tokio::sync::{mpsc, watch};
 use tokio::time::{Instant, MissedTickBehavior, sleep_until};
@@ -315,6 +315,21 @@ struct ActorState {
     /// was withdrawn) are also pruned so a future re-entry produces
     /// a fresh warn.
     warned_ipv6_fallback: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    /// LAN-283: `(VNI, MAC)` keys currently withheld because a
+    /// foreign kernel FDB row occupies the exact key. Same warn-once
+    /// discipline as `warned_ipv6_fallback` — warn (and count) when a
+    /// key enters the blocked set, prune when it leaves so a later
+    /// re-block warns fresh.
+    warned_foreign_fdb: BTreeSet<(EvpnInstanceId, MacAddress)>,
+    /// LAN-283: L3 op keys currently withheld because a foreign
+    /// kernel row occupies the exact key (route / neighbor / L3VXLAN
+    /// FDB). Same warn-once discipline as `warned_foreign_fdb`.
+    warned_foreign_l3: BTreeSet<L3OpKey>,
+    /// LAN-283 foreign-state deltas (replaces blocked, deletes
+    /// skipped, ownership relinquished) accumulated since the last
+    /// [`DataplaneReport`]. Same drain-into-Prometheus contract as
+    /// `fdb_nhg_drift_since_report`.
+    foreign_since_report: ForeignStateCounters,
     /// Managed-netdev rows we've already warned about for the current
     /// fail-closed condition. Pruned when the row becomes safe or
     /// disappears, so a later re-entry warns again.
@@ -508,6 +523,9 @@ impl ActorState {
             managed_permanent_failures: BTreeMap::new(),
             pending_deletes: BTreeSet::new(),
             warned_ipv6_fallback: BTreeSet::new(),
+            warned_foreign_fdb: BTreeSet::new(),
+            warned_foreign_l3: BTreeSet::new(),
+            foreign_since_report: ForeignStateCounters::default(),
             warned_managed_netdevs: BTreeSet::new(),
             last_intent_generation: 0,
             reconcile_generation: 0,
@@ -940,6 +958,15 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             }
         }
 
+        // LAN-283 rule 2 (relinquish on foreign replacement): a key
+        // we own whose live kernel row is no longer extern_learned
+        // was replaced by another writer. Stop claiming it BEFORE the
+        // diff runs — the withdraw pass must not delete the foreign
+        // row, and the install pass must not "repair" ours back over
+        // it (the diff's own foreign gates then fail closed for the
+        // key while the foreign row persists).
+        self.relinquish_foreign_l2(&snapshot).await;
+
         let mut plan = compute_diff(
             intent.remote_macs.as_ref(),
             &snapshot,
@@ -949,6 +976,26 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             intent.instances.as_ref(),
         );
         self.prune_stale_fdb_permanent_failures(intent.remote_macs.as_ref());
+
+        // LAN-283 rule 1 observability: warn once per key entering
+        // the foreign-blocked set (same transition discipline as the
+        // IPv6-fallback warn below) and bump the counter; keys that
+        // left the set are pruned so a later re-block warns fresh.
+        for key in plan
+            .foreign_blocked_keys
+            .difference(&self.state.warned_foreign_fdb)
+        {
+            self.state.foreign_since_report.replaces_blocked += 1;
+            tracing::warn!(
+                vni = ?key.0,
+                mac = %key.1,
+                "foreign kernel FDB row at this (vni, mac); operation withheld until the \
+                 foreign row goes away (LAN-283 fail-closed)"
+            );
+        }
+        self.state
+            .warned_foreign_fdb
+            .clone_from(&plan.foreign_blocked_keys);
 
         // ADR-0059 mixed-family alias fallback warn: log only for
         // `(VNI, MAC)` keys that newly entered the fallback this pass.
@@ -1320,12 +1367,40 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             // first pass that sees it. A failed dump leaves the latch
             // unset so the next pass retries; never sweep a partial
             // kernel view.
-            if self.state.l3_adoption_reap_after.is_none() && !intent.ip_vrfs.is_empty() {
-                match self
-                    .dataplane
+            // LAN-283 live ownership guard: one marker/foreign dump
+            // per pass scopes every L3 mutation below — foreign rows
+            // at exact keys block replaces (rule 1), takeovers of
+            // owned keys relinquish ownership (rule 2), and deletes
+            // are revalidated so foreign rows survive withdrawal /
+            // NotReady / config-removal teardown (rule 3). With an
+            // empty `[[evpn_ip_vrfs]]` table the markers are not
+            // recognizable (same reasoning as the reap's empty-config
+            // guard), so the drain-everything path proceeds unguarded.
+            // On a failed dump the entire L3 apply phase is skipped —
+            // fail closed, never mutate off an unknown ownership view.
+            // ponytail: this adds one netlink dump set per pass with
+            // L3 config; gate on non-empty plans if it ever shows up
+            // in profiles.
+            let l3_live: Option<crate::l3_adoption::L3AdoptionDump> = if intent.ip_vrfs.is_empty() {
+                None
+            } else {
+                self.dataplane
                     .dump_l3_adoption_candidates(intent.ip_vrfs.as_ref())
                     .await
-                {
+            };
+            let l3_guard_failed = !intent.ip_vrfs.is_empty() && l3_live.is_none();
+            if l3_guard_failed {
+                tracing::warn!(
+                    "L3 ownership guard dump failed; skipping all L3 kernel mutations this \
+                     pass (fail closed, LAN-283)"
+                );
+            }
+            if let Some(live) = &l3_live {
+                self.relinquish_foreign_l3(live);
+            }
+
+            if self.state.l3_adoption_reap_after.is_none() && !intent.ip_vrfs.is_empty() {
+                match &l3_live {
                     Some(dump) => {
                         self.state.l3_adoption_reap_after =
                             Some(Instant::now() + self.config.l3_adoption_reap_deferral);
@@ -1439,8 +1514,90 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             // non-converged pass is the known traffic-gap failure
             // mode (same gate as the slice-2 FDB reap).
             let mut l3_pass_had_failures = false;
-            for op in &l3_plan.ops {
+            // LAN-283: L3 op keys blocked by a foreign row this pass,
+            // for the warn-once transition sync below.
+            let mut blocked_l3_now: BTreeSet<L3OpKey> = BTreeSet::new();
+            let l3_ops_to_apply: &[crate::dataplane::DataplaneOp] = if l3_guard_failed {
+                // Fail closed: an unknown ownership view must not be
+                // mutated. Marking the pass failed also blocks the
+                // ADR-0079 reap below.
+                l3_pass_had_failures = true;
+                &[]
+            } else {
+                &l3_plan.ops
+            };
+            for op in l3_ops_to_apply {
                 let l3_key = l3_op_key(op);
+                // LAN-283 foreign-state guard against the live
+                // ownership dump fetched above.
+                let mut spare_foreign_nhg_row = false;
+                if let Some(live) = &l3_live {
+                    match l3_foreign_disposition(op, live) {
+                        Some(L3ForeignDisposition::BlockReplace) => {
+                            // Rule 1: an exact-key foreign row means a
+                            // netlink replace would silently adopt-and-
+                            // overwrite another agent's state. Withheld;
+                            // dependent route adds in this pass are
+                            // fail-stopped through the prerequisite
+                            // sets, and the reap is blocked.
+                            if let Some(key) = l3_key.clone() {
+                                if !self.state.warned_foreign_l3.contains(&key) {
+                                    self.state.foreign_since_report.replaces_blocked += 1;
+                                    tracing::warn!(
+                                        ?op,
+                                        "foreign kernel row at this L3 key; install withheld \
+                                         until the foreign row goes away (LAN-283 fail-closed)"
+                                    );
+                                }
+                                blocked_l3_now.insert(key);
+                            }
+                            record_l3_prerequisite_failure(
+                                op,
+                                &mut failed_neighbor_keys,
+                                &mut failed_fdb_keys,
+                                &mut failed_l3_group_keys,
+                            );
+                            l3_pass_had_failures = true;
+                            continue;
+                        }
+                        Some(L3ForeignDisposition::SkipDelete) => {
+                            // Rule 3: the row under this key is now a
+                            // foreign writer's — it must survive our
+                            // withdrawal / NotReady / shutdown. Record
+                            // the op as logically complete so the owned
+                            // state drops the key (rule 2 relinquish
+                            // for the withdraw path).
+                            self.state.foreign_since_report.deletes_skipped += 1;
+                            tracing::warn!(
+                                ?op,
+                                "live row under this L3 key is foreign; delete skipped and \
+                                 ownership relinquished (LAN-283)"
+                            );
+                            crate::l3_diff::record_l3_success(
+                                &mut self.state.l3_owned,
+                                op,
+                                &ready_l3vxlan_ifindex,
+                                intent.ip_vrfs.as_ref(),
+                                intent.remote_ip_prefixes.as_ref(),
+                            );
+                            continue;
+                        }
+                        Some(L3ForeignDisposition::SpareNhgRow) => {
+                            // RemoveL3FdbNhg where the kernel row was
+                            // foreign-replaced: run the group refcount
+                            // teardown (the tagged NHID objects are
+                            // still ours) but never delete the row.
+                            self.state.foreign_since_report.deletes_skipped += 1;
+                            tracing::warn!(
+                                ?op,
+                                "L3VXLAN FDB row under this key is foreign; row delete \
+                                 skipped, group objects GC'd (LAN-283)"
+                            );
+                            spare_foreign_nhg_row = true;
+                        }
+                        None => {}
+                    }
+                }
                 if let Some(key) = l3_key.as_ref()
                     && check_permanent_suppression(
                         &mut self.state.l3_permanent_failures,
@@ -1511,7 +1668,13 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 let res = match op {
                     crate::dataplane::DataplaneOp::InstallL3FdbNhg { .. }
                     | crate::dataplane::DataplaneOp::RemoveL3FdbNhg { .. } => {
-                        apply_l3_nhg_op(&mut self.dataplane, &mut self.state, op).await
+                        apply_l3_nhg_op(
+                            &mut self.dataplane,
+                            &mut self.state,
+                            op,
+                            spare_foreign_nhg_row,
+                        )
+                        .await
                     }
                     _ => self.dataplane.apply(op).await,
                 };
@@ -1593,6 +1756,14 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                         }
                     }
                 }
+            }
+
+            // LAN-283 warn-once sync: keys that left the blocked set
+            // are pruned so a later re-block warns fresh. Only when
+            // the guard actually ran — a failed / unscoped pass must
+            // not clear the record.
+            if !l3_guard_failed && l3_live.is_some() {
+                self.state.warned_foreign_l3 = blocked_l3_now;
             }
 
             // ADR-0079 L3 sweep: drop claimed keys from the adopted
@@ -2817,6 +2988,123 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
     /// table are skipped (kept tracked, never removed): rows of
     /// unmanaged VNIs are out of scope, same rationale as the L3
     /// reap's empty-config guard.
+    /// LAN-283 rule 2 for the Gate 9 L3 surfaces: drop owned route /
+    /// neighbor / scalar-FDB keys whose live dump shows a FOREIGN row
+    /// under the key and no marker row of ours — another writer took
+    /// the slot. The foreign row is never touched; a still-desired
+    /// key re-emits an Add on the next diff, which the foreign guard
+    /// then fails closed until the foreign row goes away. L3 FDB-NHG
+    /// rows are guarded at op level instead (`SpareNhgRow`) — their
+    /// group bookkeeping lives in `l3_groups`, and the takeover
+    /// disposition runs the refcount teardown there.
+    fn relinquish_foreign_l3(&mut self, live: &crate::l3_adoption::L3AdoptionDump) {
+        let taken_routes: Vec<(IpVrfId, EvpnIpPrefixValue)> = self
+            .state
+            .l3_owned
+            .installs
+            .keys()
+            .filter(|key| live.foreign_routes.contains(key) && !live.routes.contains_key(key))
+            .copied()
+            .collect();
+        for key in taken_routes {
+            self.state.l3_owned.record_remove(&key);
+            self.state.foreign_since_report.owned_relinquished += 1;
+            tracing::warn!(
+                vrf_id = key.0.as_u32(),
+                prefix = ?key.1,
+                "owned VRF route was replaced by a foreign entry; relinquishing ownership \
+                 (foreign row preserved, LAN-283)"
+            );
+        }
+        let taken_neighbors: Vec<(u32, IpAddr)> = self
+            .state
+            .l3_owned
+            .kernel_neighbors
+            .keys()
+            .filter(|key| live.foreign_neighbors.contains(key) && !live.neighbors.contains_key(key))
+            .copied()
+            .collect();
+        for key in taken_neighbors {
+            self.state.l3_owned.kernel_neighbors.remove(&key);
+            self.state.foreign_since_report.owned_relinquished += 1;
+            tracing::warn!(
+                l3vxlan_ifindex = key.0,
+                next_hop = %key.1,
+                "owned L3 neighbor was replaced by a foreign entry; relinquishing ownership \
+                 (foreign row preserved, LAN-283)"
+            );
+        }
+        let taken_fdb: Vec<(u32, MacAddress)> = self
+            .state
+            .l3_owned
+            .kernel_fdb
+            .keys()
+            .filter(|key| live.foreign_fdb.contains(key) && !live.l3vxlan_fdb.contains_key(key))
+            .copied()
+            .collect();
+        for key in taken_fdb {
+            self.state.l3_owned.kernel_fdb.remove(&key);
+            self.state.foreign_since_report.owned_relinquished += 1;
+            tracing::warn!(
+                l3vxlan_ifindex = key.0,
+                router_mac = %key.1,
+                "owned L3VXLAN FDB row was replaced by a foreign entry; relinquishing \
+                 ownership (foreign row preserved, LAN-283)"
+            );
+        }
+    }
+
+    /// LAN-283 rule 2 for the L2 FDB surface: drop every owned
+    /// `(VNI, MAC)` whose live snapshot row exists but is not ours
+    /// (`extern_learn` missing, or a foreign `NDA_PROTOCOL` stamp) —
+    /// another writer replaced our row. The foreign row is never
+    /// touched; `FdbNhg` entries release their group reference so the
+    /// tagged kernel nexthop objects (still ours) are GC'd when this
+    /// MAC was the last referrer. A missing row is NOT a takeover
+    /// (interface flap self-heals through the normal diff).
+    async fn relinquish_foreign_l2(&mut self, snapshot: &KernelSnapshot) {
+        let takeovers: Vec<(EvpnInstanceId, MacAddress, Option<u16>, OwnedEntryKind)> = self
+            .state
+            .owned
+            .iter()
+            .filter(|entry| {
+                let (&(vni, mac), owned) = *entry;
+                snapshot
+                    .find_fdb_in_vlan(vni, mac, owned.vlan)
+                    .is_some_and(|k| !k.is_extern_learned())
+            })
+            .map(|(&(vni, mac), owned)| (vni, mac, owned.vlan, owned.kind.clone()))
+            .collect();
+        for (vni, mac, vlan, kind) in takeovers {
+            self.state.owned.record_withdrawn(vni, mac);
+            self.state.retry.record_success((vni, mac));
+            if let OwnedEntryKind::FdbNhg { group_key } = kind {
+                // Bookkeeping-only unref: the FDB row is foreign now,
+                // but the group / member NHIDs are still rustbgpd's
+                // tagged objects. GC failures land in
+                // `pending_deletes` via `try_del_and_release_alloc`
+                // and retry next pass, so the Err is already
+                // handled internally.
+                let _ = release_fdb_nhg_group_refs(
+                    &mut self.dataplane,
+                    &mut self.state,
+                    vni,
+                    mac,
+                    group_key,
+                )
+                .await;
+            }
+            self.state.foreign_since_report.owned_relinquished += 1;
+            tracing::warn!(
+                ?vni,
+                %mac,
+                ?vlan,
+                "owned FDB row was replaced by a foreign entry; relinquishing ownership \
+                 (foreign row preserved, LAN-283)"
+            );
+        }
+    }
+
     async fn reap_adopted_fdb(
         &mut self,
         snapshot: &KernelSnapshot,
@@ -3480,6 +3768,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         let fdb_nhg_drift_counters = std::mem::take(&mut self.state.fdb_nhg_drift_since_report);
         let l3_adoption_counters = std::mem::take(&mut self.state.l3_adoption_since_report);
         let single_active_counters = std::mem::take(&mut self.state.single_active_since_report);
+        let foreign_state_counters = std::mem::take(&mut self.state.foreign_since_report);
         let report = DataplaneReport {
             intent_generation: self.state.last_intent_generation,
             reconcile_generation: self.state.reconcile_generation,
@@ -3496,6 +3785,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             fdb_nhg_drift_counters,
             l3_adoption_counters,
             single_active_counters,
+            foreign_state_counters,
         };
         if let Err(e) = self.report_tx.send(report).await {
             tracing::trace!(error = %e, "report receiver gone; report dropped");
@@ -3640,6 +3930,25 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 }
             }
 
+            // LAN-283 rule 3 (revalidate before delete): re-dump the
+            // kernel FDB so shutdown only deletes rows that are still
+            // ours — a foreign row that replaced ours after the last
+            // reconcile pass must survive the daemon's exit. On dump
+            // failure, fail closed: skip the FDB drain entirely (the
+            // rows carry our durable extern_learn marker, so the next
+            // startup's adoption sweep owns the cleanup).
+            let drain_snapshot = match self.dataplane.dump_snapshot().await {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "shutdown snapshot dump failed; skipping owned-FDB drain (fail \
+                         closed, LAN-283) — next startup adopts the marker rows"
+                    );
+                    None
+                }
+            };
+
             // Snapshot the owned set with kind info — for FdbNhg
             // entries we route through `apply_nhg_op` (so the FDB
             // row → group → members teardown sequence runs and the
@@ -3648,13 +3957,36 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             // `RemoveRemoteFdb` for FdbNhg-owned MACs — which
             // `Dataplane::apply` rejects with `InvalidArgument` and
             // the kernel group/members stay orphaned across restart.
-            let owned_drain: Vec<(EvpnInstanceId, MacAddress, Option<u16>, OwnedEntryKind)> = self
-                .state
-                .owned
-                .iter()
-                .map(|(&(vni, mac), entry)| (vni, mac, entry.vlan, entry.kind.clone()))
-                .collect();
+            let owned_drain: Vec<(EvpnInstanceId, MacAddress, Option<u16>, OwnedEntryKind)> =
+                if drain_snapshot.is_some() {
+                    self.state
+                        .owned
+                        .iter()
+                        .map(|(&(vni, mac), entry)| (vni, mac, entry.vlan, entry.kind.clone()))
+                        .collect()
+                } else {
+                    Vec::new()
+                };
             for (vni, mac, vlan, kind) in owned_drain {
+                if drain_snapshot.as_ref().is_some_and(|snap| {
+                    snap.find_fdb_in_vlan(vni, mac, vlan)
+                        .is_some_and(|k| !k.is_extern_learned())
+                }) {
+                    // A foreign writer replaced our row since the
+                    // last pass — spare it and relinquish. For FdbNhg
+                    // entries the tagged group objects stay for the
+                    // next startup's adoption sweep (drain is
+                    // time-bounded; no bookkeeping GC here).
+                    self.state.owned.record_withdrawn(vni, mac);
+                    self.state.foreign_since_report.deletes_skipped += 1;
+                    tracing::warn!(
+                        ?vni,
+                        %mac,
+                        "foreign FDB row under owned key at shutdown; drain skips it \
+                         (LAN-283)"
+                    );
+                    continue;
+                }
                 let op = match kind {
                     OwnedEntryKind::SingleDst { .. } => {
                         DataplaneOp::RemoveRemoteFdb { vni, mac, vlan }
@@ -3688,7 +4020,70 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             // + tear down the kernel resolution rows. Failed ops are
             // best-effort like the L2 path; the next startup's diff
             // re-converges against whatever the kernel still has.
-            for op in &l3_drain_plan.ops {
+            // LAN-283 rule 3: revalidate against a live ownership
+            // dump first — a key whose row is now foreign is skipped
+            // (and dropped from owned state); on dump failure skip
+            // the whole L3 drain (fail closed — everything we wrote
+            // carries durable markers for the next startup). With no
+            // configured IP-VRFs the markers are unrecognizable, so
+            // that (config-removed) path drains unguarded, as before.
+            let l3_drain_live: Option<crate::l3_adoption::L3AdoptionDump> =
+                if l3_drain_plan.ops.is_empty() || l3_ip_vrfs.is_empty() {
+                    None
+                } else {
+                    self.dataplane
+                        .dump_l3_adoption_candidates(l3_ip_vrfs.as_ref())
+                        .await
+                };
+            let l3_drain_guard_failed =
+                !l3_drain_plan.ops.is_empty() && !l3_ip_vrfs.is_empty() && l3_drain_live.is_none();
+            if l3_drain_guard_failed {
+                tracing::warn!(
+                    "shutdown L3 ownership dump failed; skipping L3 drain (fail closed, \
+                     LAN-283) — next startup adopts the marker rows"
+                );
+            }
+            let l3_drain_ops: &[DataplaneOp] = if l3_drain_guard_failed {
+                &[]
+            } else {
+                &l3_drain_plan.ops
+            };
+            for op in l3_drain_ops {
+                if let Some(live) = &l3_drain_live
+                    && let Some(disposition) = l3_foreign_disposition(op, live)
+                {
+                    match disposition {
+                        L3ForeignDisposition::SkipDelete => {
+                            self.state.foreign_since_report.deletes_skipped += 1;
+                            tracing::warn!(
+                                ?op,
+                                "foreign row under owned L3 key at shutdown; drain skips \
+                                 it (LAN-283)"
+                            );
+                            crate::l3_diff::record_l3_success(
+                                &mut self.state.l3_owned,
+                                op,
+                                &ready_l3vxlan_empty,
+                                l3_ip_vrfs.as_ref(),
+                                l3_intent.as_ref(),
+                            );
+                            continue;
+                        }
+                        L3ForeignDisposition::SpareNhgRow | L3ForeignDisposition::BlockReplace => {
+                            // Drain plans are remove-only; the NHG-row
+                            // spare leaves the tagged nexthop objects
+                            // for the next startup's adoption sweep
+                            // (drain is time-bounded, no GC here).
+                            self.state.foreign_since_report.deletes_skipped += 1;
+                            tracing::warn!(
+                                ?op,
+                                "foreign row under owned L3 key at shutdown; drain skips \
+                                 it (LAN-283)"
+                            );
+                            continue;
+                        }
+                    }
+                }
                 if let Err(e) = self.dataplane.apply(op).await {
                     tracing::debug!(error = %e, ?op, "L3 drain op failed");
                 } else {
@@ -5791,6 +6186,7 @@ async fn apply_l3_nhg_op<D>(
     dataplane: &mut D,
     state: &mut ActorState,
     op: &DataplaneOp,
+    spare_foreign_nhg_row: bool,
 ) -> Result<(), crate::error::DataplaneError>
 where
     D: crate::dataplane::NexthopOps,
@@ -5829,6 +6225,7 @@ where
                 *group_key,
                 *router_mac,
                 *l3vxlan_ifindex,
+                spare_foreign_nhg_row,
             )
             .await
         }
@@ -5943,6 +6340,7 @@ where
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_remove_l3_fdb_nhg<D>(
     dataplane: &mut D,
     state: &mut ActorState,
@@ -5950,6 +6348,7 @@ async fn apply_remove_l3_fdb_nhg<D>(
     group_key: crate::group_state::L3NhgKey,
     router_mac: rustbgpd_evpn::MacAddress,
     l3vxlan_ifindex: u32,
+    spare_foreign_row: bool,
 ) -> Result<(), crate::error::DataplaneError>
 where
     D: crate::dataplane::NexthopOps,
@@ -5968,9 +6367,14 @@ where
         return Ok(());
     }
 
-    dataplane
-        .remove_l3_fdb_nhg_row(l3vxlan_ifindex, router_mac)
-        .await?;
+    if !spare_foreign_row {
+        // LAN-283: when a foreign writer replaced the kernel FDB row
+        // under this key, the row is not ours to delete — only the
+        // tagged nexthop objects below are.
+        dataplane
+            .remove_l3_fdb_nhg_row(l3vxlan_ifindex, router_mac)
+            .await?;
+    }
     dataplane.del_nexthop(group.id).await?;
     state.nh_id_alloc.release_l3(group.id);
     let delta = state
@@ -6345,10 +6749,29 @@ async fn apply_remove_fdb_nhg<D>(
 where
     D: crate::dataplane::NexthopOps,
 {
-    use crate::group_state::RefDelta;
-
     // FDB row first (ADR §5 invariant 2).
     dataplane.remove_fdb_nhg_row(vni, mac, vlan).await?;
+    release_fdb_nhg_group_refs(dataplane, state, vni, mac, group_key).await
+}
+
+/// Drop one MAC's reference on its FDB nexthop group and GC the
+/// group / member / standby kernel nexthop objects when it was the
+/// last referrer — WITHOUT touching the kernel FDB row. Shared by
+/// [`apply_remove_fdb_nhg`] (which deletes the row first) and the
+/// LAN-283 foreign-takeover relinquish path (where the row is no
+/// longer ours to delete but the tagged NHID objects still are).
+async fn release_fdb_nhg_group_refs<D>(
+    dataplane: &mut D,
+    state: &mut ActorState,
+    vni: rustbgpd_evpn::EvpnInstanceId,
+    mac: rustbgpd_evpn::MacAddress,
+    group_key: crate::group_state::AliasGroupKey,
+) -> Result<(), crate::error::DataplaneError>
+where
+    D: crate::dataplane::NexthopOps,
+{
+    use crate::group_state::RefDelta;
+
     match state.groups.record_mac_unref(group_key, vni, mac) {
         RefDelta::GroupStillReferenced => Ok(()),
         RefDelta::GroupShouldDelete {
@@ -6422,6 +6845,95 @@ fn check_permanent_suppression<K: Ord>(
         );
         map.remove(key);
         false
+    }
+}
+
+/// What the LAN-283 foreign-state guard decided for one L3 op against
+/// the pass's live ownership dump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum L3ForeignDisposition {
+    /// An exact-key foreign row exists — the install / replace must
+    /// not run (rule 1, fail closed).
+    BlockReplace,
+    /// The row under the key is foreign and no marker row of ours
+    /// remains — the delete must not run; record the op as logically
+    /// complete so the owned state drops the key (rules 2 + 3).
+    SkipDelete,
+    /// `RemoveL3FdbNhg` variant of [`Self::SkipDelete`]: run the group
+    /// refcount teardown (the tagged NHID objects are still ours) but
+    /// spare the foreign kernel FDB row. A foreign row that itself
+    /// references a rustbgpd NHID is LAN-290 (NHID authority)
+    /// territory, out of scope here.
+    SpareNhgRow,
+}
+
+/// Classify one L3 op against the live ownership dump. `None` means
+/// no foreign row is involved and the op proceeds normally.
+fn l3_foreign_disposition(
+    op: &DataplaneOp,
+    live: &crate::l3_adoption::L3AdoptionDump,
+) -> Option<L3ForeignDisposition> {
+    match op {
+        DataplaneOp::AddRemoteIpRoute { vrf_id, prefix, .. }
+        | DataplaneOp::AddRemoteIpRouteEcmp { vrf_id, prefix, .. } => live
+            .foreign_routes
+            .contains(&(*vrf_id, *prefix))
+            .then_some(L3ForeignDisposition::BlockReplace),
+        DataplaneOp::AddL3Neighbor {
+            l3vxlan_ifindex,
+            next_hop,
+            ..
+        } => live
+            .foreign_neighbors
+            .contains(&(*l3vxlan_ifindex, *next_hop))
+            .then_some(L3ForeignDisposition::BlockReplace),
+        DataplaneOp::AddL3VxlanFdb {
+            l3vxlan_ifindex,
+            router_mac,
+            ..
+        }
+        | DataplaneOp::InstallL3FdbNhg {
+            l3vxlan_ifindex,
+            router_mac,
+            ..
+        } => live
+            .foreign_fdb
+            .contains(&(*l3vxlan_ifindex, *router_mac))
+            .then_some(L3ForeignDisposition::BlockReplace),
+        DataplaneOp::RemoveRemoteIpRoute { vrf_id, prefix, .. }
+        | DataplaneOp::RemoveRemoteIpRouteEcmp { vrf_id, prefix, .. } => {
+            let key = (*vrf_id, *prefix);
+            (live.foreign_routes.contains(&key) && !live.routes.contains_key(&key))
+                .then_some(L3ForeignDisposition::SkipDelete)
+        }
+        DataplaneOp::RemoveL3Neighbor {
+            l3vxlan_ifindex,
+            next_hop,
+            ..
+        } => {
+            let key = (*l3vxlan_ifindex, *next_hop);
+            (live.foreign_neighbors.contains(&key) && !live.neighbors.contains_key(&key))
+                .then_some(L3ForeignDisposition::SkipDelete)
+        }
+        DataplaneOp::RemoveL3VxlanFdb {
+            l3vxlan_ifindex,
+            router_mac,
+            ..
+        } => {
+            let key = (*l3vxlan_ifindex, *router_mac);
+            (live.foreign_fdb.contains(&key) && !live.l3vxlan_fdb.contains_key(&key))
+                .then_some(L3ForeignDisposition::SkipDelete)
+        }
+        DataplaneOp::RemoveL3FdbNhg {
+            l3vxlan_ifindex,
+            router_mac,
+            ..
+        } => {
+            let key = (*l3vxlan_ifindex, *router_mac);
+            (live.foreign_fdb.contains(&key) && !live.l3vxlan_fdb.contains_key(&key))
+                .then_some(L3ForeignDisposition::SpareNhgRow)
+        }
+        _ => None,
     }
 }
 

--- a/crates/evpn-linux/tests/netns_foreign_state.rs
+++ b/crates/evpn-linux/tests/netns_foreign_state.rs
@@ -1,0 +1,589 @@
+//! Privileged netns integration tests for LAN-283 foreign-state
+//! ownership protection.
+//!
+//! Drives the real [`ReconcileActor`] + `LinuxDataplane` inside an
+//! isolated network namespace and pins, against a real kernel, that:
+//!
+//! 1. a foreign same-key row that REPLACES a rustbgpd-owned row is
+//!    never "repaired" back over (ownership is relinquished), and
+//! 2. the foreign row survives rustbgpd's withdrawal and shutdown
+//!    drain — for the L2 bridge FDB row and for the Gate 9 L3 triple
+//!    (VRF route, L3 neighbor, L3VXLAN FDB row).
+//!
+//! The in-memory equivalents live in `tests/reconcile_actor.rs`; this
+//! file validates that the netlink dump surfaces (FDB flags for L2,
+//! the ADR-0079 marker/foreign classification for L3) really carry
+//! the ownership signals the actor's guards key on.
+//!
+//! ## Why gated
+//!
+//! Creating a netns + bridge / VRF / VXLAN devices requires
+//! `CAP_NET_ADMIN`. PR-CI runners don't have it, so these tests are
+//! gated by the `EVPN_LINUX_NETNS=1` environment variable and skip
+//! cleanly without it.
+//!
+//! ```bash
+//! sudo -E env EVPN_LINUX_NETNS=1 \
+//!   cargo test -p rustbgpd-evpn-linux --test netns_foreign_state
+//! ```
+
+#![cfg(target_os = "linux")]
+
+use std::net::IpAddr;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustbgpd_evpn::ip_vrf::{RemoteIpPrefixEntry, RemoteIpPrefixTable};
+use rustbgpd_evpn::{
+    BumEnforcementTable, DataplaneIntent, EvpnInstance, EvpnInstanceId, EvpnInstanceTable, IpVrf,
+    IpVrfId, IpVrfTable, Ipv4Prefix, MacAddress, RemoteMacEntry, RemoteMacSource, RemoteMacTable,
+    RouteDistinguisher, RouteTarget,
+};
+use rustbgpd_evpn_linux::{LinuxDataplane, ReconcileActor, ReconcileActorConfig};
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+fn netns_gate() -> bool {
+    std::env::var("EVPN_LINUX_NETNS").as_deref() == Ok("1")
+}
+
+fn run(cmd: &str, args: &[&str]) -> std::process::Output {
+    let out = Command::new(cmd).args(args).output().expect("spawn");
+    if !out.status.success() {
+        panic!(
+            "{cmd} {args:?} failed: status={} stdout={} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+    out
+}
+
+fn try_run(cmd: &str, args: &[&str]) {
+    let _ = Command::new(cmd).args(args).output();
+}
+
+/// Run a command in the current (inner) netns context and capture
+/// stdout.
+fn shell(cmd: &str, args: &[&str]) -> String {
+    String::from_utf8_lossy(&run(cmd, args).stdout).into_owned()
+}
+
+struct NetnsFixture {
+    name: String,
+}
+
+impl NetnsFixture {
+    fn create(test_name: &str) -> Self {
+        let name = format!("rustbgpd-foreign-{test_name}-{}", std::process::id());
+        try_run("ip", &["netns", "delete", &name]);
+        run("ip", &["netns", "add", &name]);
+        run("ip", &["-n", &name, "link", "set", "lo", "up"]);
+        Self { name }
+    }
+
+    fn exec(&self, cmd: &str, args: &[&str]) -> String {
+        let mut full = vec!["netns", "exec", self.name.as_str(), cmd];
+        full.extend(args);
+        String::from_utf8_lossy(&run("ip", &full).stdout).into_owned()
+    }
+}
+
+impl Drop for NetnsFixture {
+    fn drop(&mut self) {
+        try_run("ip", &["netns", "delete", &self.name]);
+    }
+}
+
+/// Re-exec the named test inside the netns; the inner invocation
+/// opens the netlink socket in the netns context.
+fn run_inner(ns: &NetnsFixture, test_name: &str) {
+    let exe = std::env::current_exe().expect("self-exe");
+    let status = Command::new("ip")
+        .args(["netns", "exec", &ns.name])
+        .arg(&exe)
+        .args(["--exact", "--nocapture", test_name])
+        .env("RUSTBGPD_NETNS_INNER", "1")
+        .env("EVPN_LINUX_NETNS", "1")
+        .status()
+        .expect("spawn inner");
+    assert!(status.success(), "inner test invocation failed");
+}
+
+fn is_inner() -> bool {
+    std::env::var("RUSTBGPD_NETNS_INNER").is_ok()
+}
+
+async fn spawn_reconcile_actor() -> (
+    watch::Sender<Arc<DataplaneIntent>>,
+    mpsc::Receiver<rustbgpd_evpn::DataplaneReport>,
+    CancellationToken,
+    tokio::task::JoinHandle<()>,
+) {
+    let dataplane = LinuxDataplane::connect()
+        .await
+        .expect("netlink connect inside netns");
+    let (intent_tx, intent_rx) = watch::channel(Arc::new(DataplaneIntent::empty()));
+    let (report_tx, report_rx) = mpsc::channel(16);
+    let shutdown = CancellationToken::new();
+    let actor = ReconcileActor::new(
+        ReconcileActorConfig::for_tests(),
+        dataplane,
+        intent_rx,
+        report_tx,
+        shutdown.clone(),
+    );
+    let actor_join = tokio::spawn(actor.run());
+    (intent_tx, report_rx, shutdown, actor_join)
+}
+
+async fn wait_for_report_generation(
+    report_rx: &mut mpsc::Receiver<rustbgpd_evpn::DataplaneReport>,
+    generation: u64,
+) -> rustbgpd_evpn::DataplaneReport {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let report = report_rx.recv().await.expect("dataplane report channel");
+            if report.intent_generation >= generation {
+                return report;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for dataplane report")
+}
+
+fn mac_str(m: MacAddress) -> String {
+    let o = m.octets();
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        o[0], o[1], o[2], o[3], o[4], o[5]
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────
+// L2: bridge FDB
+// ─────────────────────────────────────────────────────────────────
+
+const L2_VNI: u32 = 100;
+const L2_LOCAL_IP: &str = "10.0.0.1";
+
+fn l2_mac() -> MacAddress {
+    MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x33])
+}
+
+fn l2_rd() -> RouteDistinguisher {
+    let mut bytes = [0u8; 8];
+    bytes[2..4].copy_from_slice(&65001u16.to_be_bytes());
+    bytes[4..8].copy_from_slice(&L2_VNI.to_be_bytes());
+    RouteDistinguisher::new(bytes)
+}
+
+fn l2_instances() -> EvpnInstanceTable {
+    let mut table = EvpnInstanceTable::new();
+    table
+        .insert(
+            EvpnInstance::new(
+                EvpnInstanceId::new(L2_VNI).unwrap(),
+                l2_rd(),
+                vec![RouteTarget::TwoOctetAs {
+                    asn: 65001,
+                    value: L2_VNI,
+                }],
+                L2_LOCAL_IP.parse::<IpAddr>().unwrap(),
+                Some("br100".to_string()),
+                false,
+            )
+            .expect("EvpnInstance"),
+        )
+        .expect("insert");
+    table
+}
+
+fn l2_macs(desired: bool) -> RemoteMacTable {
+    let mut builder = RemoteMacTable::builder();
+    if desired {
+        builder
+            .insert(
+                EvpnInstanceId::new(L2_VNI).unwrap(),
+                l2_mac(),
+                RemoteMacEntry {
+                    remote_vtep_ip: "10.0.0.2".parse().unwrap(),
+                    mobility_sequence: None,
+                    alias_vtep_ips: Vec::new(),
+                    alias_group_key: None,
+                    single_active_backup_vtep_ip: None,
+                    source: RemoteMacSource::EvpnRibBestPath,
+                },
+            )
+            .unwrap();
+    }
+    builder.build()
+}
+
+fn l2_intent(generation: u64, desired: bool) -> Arc<DataplaneIntent> {
+    Arc::new(DataplaneIntent {
+        generation,
+        instances: Arc::new(l2_instances()),
+        remote_macs: Arc::new(l2_macs(desired)),
+        bum_enforcement: Arc::new(BumEnforcementTable::new()),
+        ip_vrfs: Arc::new(IpVrfTable::new()),
+        remote_ip_prefixes: Arc::new(RemoteIpPrefixTable::new()),
+        managed_netdevs: Arc::new(rustbgpd_evpn::ManagedNetdevTable::new()),
+    })
+}
+
+fn setup_l2_topology(ns: &NetnsFixture) {
+    ns.exec(
+        "ip",
+        &["addr", "add", &format!("{L2_LOCAL_IP}/32"), "dev", "lo"],
+    );
+    ns.exec("ip", &["link", "add", "name", "br100", "type", "bridge"]);
+    ns.exec("ip", &["link", "set", "br100", "up"]);
+    ns.exec(
+        "ip",
+        &[
+            "link",
+            "add",
+            "name",
+            "vxlan100",
+            "type",
+            "vxlan",
+            "id",
+            "100",
+            "local",
+            L2_LOCAL_IP,
+            "dstport",
+            "4789",
+            "nolearning",
+        ],
+    );
+    ns.exec("ip", &["link", "set", "vxlan100", "master", "br100"]);
+    ns.exec("ip", &["link", "set", "vxlan100", "up"]);
+}
+
+fn l2_fdb_line(dump: &str, mac: &str) -> Option<String> {
+    dump.lines()
+        .find(|line| line.contains(mac) && !line.contains("dst"))
+        .map(str::to_owned)
+        .or_else(|| {
+            dump.lines()
+                .find(|line| line.contains(mac))
+                .map(str::to_owned)
+        })
+}
+
+/// LAN-283 L2: a foreign `static` FDB row that replaces the owned row
+/// under the same `(vni, mac)` blocks repair, survives withdrawal,
+/// and survives the shutdown drain.
+#[tokio::test]
+async fn l2_foreign_takeover_row_survives_withdrawal_and_shutdown() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged foreign-state test");
+        return;
+    }
+    if !is_inner() {
+        let ns = NetnsFixture::create("l2");
+        setup_l2_topology(&ns);
+        run_inner(
+            &ns,
+            "l2_foreign_takeover_row_survives_withdrawal_and_shutdown",
+        );
+        return;
+    }
+
+    // ── inner: actor runs inside the netns ──
+    let (intent_tx, mut report_rx, shutdown, actor_join) = spawn_reconcile_actor().await;
+    let mac = mac_str(l2_mac());
+
+    // 1. Install the remote MAC through the normal reconcile path.
+    intent_tx.send(l2_intent(1, true)).unwrap();
+    let report = wait_for_report_generation(&mut report_rx, 1).await;
+    assert!(report.failed.is_empty(), "install: {:?}", report.failed);
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(
+        dump.lines()
+            .any(|l| l.contains(&mac) && l.contains("extern_learn")),
+        "owned row missing:\n{dump}"
+    );
+
+    // 2. Foreign takeover: operator replaces the row (permanent, no
+    //    extern_learn) under the same key.
+    run(
+        "bridge",
+        &[
+            "fdb", "replace", &mac, "dev", "vxlan100", "master", "static",
+        ],
+    );
+
+    // 3. Re-reconcile with the MAC still desired — rustbgpd must NOT
+    //    repair its row back over the foreign one.
+    intent_tx.send(l2_intent(2, true)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 2).await;
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    let line = l2_fdb_line(&dump, &mac).expect("foreign row present");
+    assert!(
+        !line.contains("extern_learn"),
+        "foreign row must not be replaced by an extern_learn repair:\n{dump}"
+    );
+
+    // 4. Withdraw the MAC — the foreign row must survive.
+    intent_tx.send(l2_intent(3, false)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 3).await;
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(
+        l2_fdb_line(&dump, &mac).is_some(),
+        "foreign row must survive withdrawal:\n{dump}"
+    );
+
+    // 5. Shutdown drain — the foreign row must survive that too.
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), actor_join).await;
+    let dump = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(
+        l2_fdb_line(&dump, &mac).is_some(),
+        "foreign row must survive the shutdown drain:\n{dump}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// L3: VRF route + L3 neighbor + L3VXLAN FDB
+// ─────────────────────────────────────────────────────────────────
+
+const L3_TABLE_ID: u32 = 200;
+const L3_VNI: u32 = 101;
+const L3_LOCAL_IP: &str = "10.0.0.1";
+const L3_PREFIX: &str = "198.51.100.0/24";
+
+fn l3_router_mac() -> MacAddress {
+    MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x01, 0xaa])
+}
+
+fn l3_local_mac() -> MacAddress {
+    MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x01, 0x10])
+}
+
+fn l3_prefix() -> rustbgpd_evpn::EvpnIpPrefixValue {
+    rustbgpd_evpn::EvpnIpPrefixValue::V4(Ipv4Prefix::new("198.51.100.0".parse().unwrap(), 24))
+}
+
+fn l3_ip_vrfs() -> IpVrfTable {
+    let mut table = IpVrfTable::new();
+    table
+        .insert(
+            IpVrf::new(
+                "vrf-test".to_string(),
+                IpVrfId::new(L3_VNI).unwrap(),
+                RouteDistinguisher::new([0, 0, 0xfd, 0xe8, 0, 0, 0, 101]),
+                vec!["65000:101".parse::<RouteTarget>().unwrap()],
+                L3_LOCAL_IP.parse().unwrap(),
+                l3_local_mac(),
+                "vrf-test".to_string(),
+                "l3vxlan-test".to_string(),
+                L3_TABLE_ID,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    table
+}
+
+fn l3_prefixes(desired: bool) -> RemoteIpPrefixTable {
+    let mut table = RemoteIpPrefixTable::new();
+    if desired {
+        table.insert_resolved(
+            IpVrfId::new(L3_VNI).unwrap(),
+            RemoteIpPrefixEntry::single(
+                l3_prefix(),
+                "10.0.0.2".parse().unwrap(),
+                L3_VNI,
+                l3_router_mac(),
+            ),
+        );
+    }
+    table
+}
+
+fn l3_intent(generation: u64, desired: bool) -> Arc<DataplaneIntent> {
+    Arc::new(DataplaneIntent {
+        generation,
+        instances: Arc::new(EvpnInstanceTable::new()),
+        remote_macs: Arc::new(RemoteMacTable::new()),
+        bum_enforcement: Arc::new(BumEnforcementTable::new()),
+        ip_vrfs: Arc::new(l3_ip_vrfs()),
+        remote_ip_prefixes: Arc::new(l3_prefixes(desired)),
+        managed_netdevs: Arc::new(rustbgpd_evpn::ManagedNetdevTable::new()),
+    })
+}
+
+fn setup_l3_topology(ns: &NetnsFixture) {
+    let mac = mac_str(l3_router_mac());
+    ns.exec(
+        "ip",
+        &["addr", "add", &format!("{L3_LOCAL_IP}/32"), "dev", "lo"],
+    );
+    ns.exec(
+        "ip",
+        &[
+            "link",
+            "add",
+            "vrf-test",
+            "type",
+            "vrf",
+            "table",
+            &L3_TABLE_ID.to_string(),
+        ],
+    );
+    ns.exec("ip", &["link", "set", "vrf-test", "up"]);
+    ns.exec(
+        "ip",
+        &[
+            "link",
+            "add",
+            "name",
+            "l3vxlan-test",
+            "address",
+            &mac,
+            "type",
+            "vxlan",
+            "id",
+            &L3_VNI.to_string(),
+            "local",
+            L3_LOCAL_IP,
+            "dstport",
+            "4789",
+            "nolearning",
+        ],
+    );
+    ns.exec("ip", &["link", "set", "l3vxlan-test", "master", "vrf-test"]);
+    ns.exec("ip", &["link", "set", "l3vxlan-test", "up"]);
+}
+
+fn assert_foreign_l3_triple_present(context: &str) {
+    let routes = shell("ip", &["route", "show", "table", &L3_TABLE_ID.to_string()]);
+    let route_line = routes
+        .lines()
+        .find(|l| l.contains(L3_PREFIX))
+        .unwrap_or_else(|| panic!("{context}: foreign route missing:\n{routes}"));
+    assert!(
+        route_line.contains("static") && route_line.contains("10.0.0.9"),
+        "{context}: foreign route must keep its proto static identity:\n{routes}"
+    );
+
+    let neigh = shell("ip", &["neigh", "show", "dev", "l3vxlan-test"]);
+    let neigh_line = neigh
+        .lines()
+        .find(|l| l.starts_with("10.0.0.2"))
+        .unwrap_or_else(|| panic!("{context}: foreign neighbor missing:\n{neigh}"));
+    assert!(
+        neigh_line.contains("de:ad:be:ef:00:01") && !neigh_line.contains("extern_learn"),
+        "{context}: foreign neighbor must keep its identity:\n{neigh}"
+    );
+
+    let fdb = shell("bridge", &["fdb", "show", "dev", "l3vxlan-test"]);
+    let mac = mac_str(l3_router_mac());
+    let fdb_line = fdb
+        .lines()
+        .find(|l| l.contains(&mac))
+        .unwrap_or_else(|| panic!("{context}: foreign FDB row missing:\n{fdb}"));
+    assert!(
+        fdb_line.contains("10.0.0.9") && !fdb_line.contains("extern_learn"),
+        "{context}: foreign FDB row must keep its identity:\n{fdb}"
+    );
+}
+
+/// LAN-283 L3: foreign rows that replace the owned route / neighbor /
+/// L3VXLAN-FDB triple under the same keys block repair, survive
+/// withdrawal, and survive the shutdown drain.
+#[tokio::test]
+async fn l3_foreign_takeover_triple_survives_withdrawal_and_shutdown() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged foreign-state test");
+        return;
+    }
+    if !is_inner() {
+        let ns = NetnsFixture::create("l3");
+        setup_l3_topology(&ns);
+        run_inner(
+            &ns,
+            "l3_foreign_takeover_triple_survives_withdrawal_and_shutdown",
+        );
+        return;
+    }
+
+    // ── inner: actor runs inside the netns ──
+    let (intent_tx, mut report_rx, shutdown, actor_join) = spawn_reconcile_actor().await;
+    let mac = mac_str(l3_router_mac());
+
+    // 1. Install the L3 triple through the normal reconcile path.
+    intent_tx.send(l3_intent(1, true)).unwrap();
+    let report = wait_for_report_generation(&mut report_rx, 1).await;
+    assert!(report.failed.is_empty(), "install: {:?}", report.failed);
+    let routes = shell("ip", &["route", "show", "table", &L3_TABLE_ID.to_string()]);
+    assert!(routes.contains(L3_PREFIX), "owned route missing:\n{routes}");
+
+    // 2. Foreign takeover of all three rows under the same keys.
+    run(
+        "ip",
+        &[
+            "route",
+            "replace",
+            L3_PREFIX,
+            "via",
+            "10.0.0.9",
+            "dev",
+            "l3vxlan-test",
+            "table",
+            &L3_TABLE_ID.to_string(),
+            "proto",
+            "static",
+            "onlink",
+        ],
+    );
+    run(
+        "ip",
+        &[
+            "neigh",
+            "replace",
+            "10.0.0.2",
+            "lladdr",
+            "de:ad:be:ef:00:01",
+            "dev",
+            "l3vxlan-test",
+            "nud",
+            "permanent",
+        ],
+    );
+    run(
+        "bridge",
+        &[
+            "fdb",
+            "replace",
+            &mac,
+            "dev",
+            "l3vxlan-test",
+            "self",
+            "static",
+            "dst",
+            "10.0.0.9",
+        ],
+    );
+
+    // 3. Re-reconcile with the prefix still desired — no repair over
+    //    the foreign rows.
+    intent_tx.send(l3_intent(2, true)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 2).await;
+    assert_foreign_l3_triple_present("after re-reconcile");
+
+    // 4. Withdraw the prefix — every foreign row must survive.
+    intent_tx.send(l3_intent(3, false)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 3).await;
+    assert_foreign_l3_triple_present("after withdrawal");
+
+    // 5. Shutdown drain — the foreign triple must survive that too.
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), actor_join).await;
+    assert_foreign_l3_triple_present("after shutdown drain");
+}

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -5032,3 +5032,319 @@ async fn shutdown_restores_ac_gate_even_without_owned_fdb_entries() {
         "shutdown drain must restore the gate-blocked AC port to forwarding"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────
+// LAN-283 foreign-state ownership: preflight, relinquish, revalidate
+// ─────────────────────────────────────────────────────────────────
+
+/// A same-key foreign L2 FDB row (operator `bridge fdb add ...
+/// permanent` shape — no `extern_learn`).
+fn foreign_fdb_entry(m: MacAddress, dst: &str) -> KernelFdbEntry {
+    KernelFdbEntry {
+        mac: m,
+        vlan: None,
+        dst: Some(ipa(dst)),
+        nh_id: None,
+        protocol: None,
+        flags: KernelFdbFlags {
+            permanent: true,
+            master: true,
+            ..Default::default()
+        },
+    }
+}
+
+fn sum_foreign_counters(
+    reports: &[rustbgpd_evpn::DataplaneReport],
+) -> rustbgpd_evpn::ForeignStateCounters {
+    reports.iter().fold(
+        rustbgpd_evpn::ForeignStateCounters::default(),
+        |mut acc, r| {
+            acc.replaces_blocked += r.foreign_state_counters.replaces_blocked;
+            acc.deletes_skipped += r.foreign_state_counters.deletes_skipped;
+            acc.owned_relinquished += r.foreign_state_counters.owned_relinquished;
+            acc
+        },
+    )
+}
+
+// Rule 1: a pre-existing foreign row at the exact desired key blocks
+// the install — the kernel row keeps the foreign destination and the
+// report carries the blocked counter.
+#[tokio::test]
+async fn foreign_fdb_row_blocks_desired_install() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    h.handle
+        .pre_load_fdb(vni(100), foreign_fdb_entry(mac(1), "10.9.9.9"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    h.intent_tx
+        .send(intent(
+            1,
+            one_instance_table(instance(100, Some("br100"), "10.0.0.1")),
+            macs.build(),
+        ))
+        .unwrap();
+
+    let mut reports = vec![wait_for_generation(&mut h, 1).await];
+    let snap = h.handle.kernel_snapshot();
+    let row = snap.find_fdb(vni(100), mac(1)).expect("row must survive");
+    assert_eq!(
+        row.dst,
+        Some(ipa("10.9.9.9")),
+        "foreign row must not be replaced"
+    );
+    assert!(row.flags.permanent, "foreign flags must be preserved");
+    reports.extend(h.shutdown().await);
+    let counters = sum_foreign_counters(&reports);
+    assert_eq!(counters.replaces_blocked, 1, "warn-once counter");
+}
+
+// Rule 2 + 3: a foreign writer replaces an owned row → ownership is
+// relinquished (no repair back over it), and a later withdrawal
+// leaves the foreign row in place.
+#[tokio::test]
+async fn foreign_takeover_relinquishes_ownership_and_withdrawal_spares_row() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.build()))
+        .unwrap();
+    let mut reports = vec![wait_for_generation(&mut h, 1).await];
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(1)));
+
+    // Foreign takeover: operator replaces our row under the same key.
+    h.handle
+        .pre_load_fdb(vni(100), foreign_fdb_entry(mac(1), "10.9.9.9"));
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    h.intent_tx
+        .send(intent(2, inst.clone(), macs.build()))
+        .unwrap();
+    reports.push(wait_for_generation(&mut h, 2).await);
+
+    // No repair over the foreign row while it persists.
+    let snap = h.handle.kernel_snapshot();
+    assert_eq!(
+        snap.find_fdb(vni(100), mac(1)).and_then(|e| e.dst),
+        Some(ipa("10.9.9.9")),
+        "relinquished key must not be repaired back over the foreign row"
+    );
+
+    // Withdrawal: the foreign row must survive.
+    h.intent_tx
+        .send(intent(3, inst, RemoteMacTable::new()))
+        .unwrap();
+    reports.push(wait_for_generation(&mut h, 3).await);
+    let snap = h.handle.kernel_snapshot();
+    let row = snap
+        .find_fdb(vni(100), mac(1))
+        .expect("foreign row must survive withdrawal");
+    assert_eq!(row.dst, Some(ipa("10.9.9.9")));
+
+    reports.extend(h.shutdown().await);
+    let counters = sum_foreign_counters(&reports);
+    assert_eq!(counters.owned_relinquished, 1);
+}
+
+// Rule 3, NotReady variant: the instance drain must spare a same-key
+// foreign row.
+#[tokio::test]
+async fn not_ready_transition_spares_foreign_row() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    let macs = macs.build();
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.clone()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+
+    h.handle
+        .pre_load_fdb(vni(100), foreign_fdb_entry(mac(1), "10.9.9.9"));
+    h.handle.set_probe(
+        vni(100),
+        InstanceProbe::NotReady {
+            reason: "bridge gone".into(),
+        },
+    );
+    h.intent_tx.send(intent(2, inst, macs)).unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+
+    let snap = h.handle.kernel_snapshot();
+    assert_eq!(
+        snap.find_fdb(vni(100), mac(1)).and_then(|e| e.dst),
+        Some(ipa("10.9.9.9")),
+        "NotReady drain must spare the foreign row"
+    );
+    h.shutdown().await;
+}
+
+// Rule 3, shutdown variant: the drain revalidates against a fresh
+// snapshot and spares a foreign row that replaced an owned one.
+#[tokio::test]
+async fn shutdown_drain_spares_foreign_row() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(vni(100), mac(1), entry("10.0.0.2", None))
+        .unwrap();
+    h.intent_tx
+        .send(intent(
+            1,
+            one_instance_table(instance(100, Some("br100"), "10.0.0.1")),
+            macs.build(),
+        ))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+    assert!(h.handle.kernel_has_fdb(vni(100), mac(1)));
+
+    // Foreign takeover after the last reconcile pass; the drain's
+    // fresh dump is the only chance to notice.
+    h.handle
+        .pre_load_fdb(vni(100), foreign_fdb_entry(mac(1), "10.9.9.9"));
+
+    let handle = h.handle.clone();
+    h.shutdown().await;
+    let snap = handle.kernel_snapshot();
+    let row = snap
+        .find_fdb(vni(100), mac(1))
+        .expect("foreign row must survive shutdown drain");
+    assert_eq!(row.dst, Some(ipa("10.9.9.9")));
+    assert!(row.flags.permanent);
+}
+
+// L3 rule 1: a foreign route at the exact (table, prefix) key blocks
+// the route install; the foreign row keeps its identity.
+#[tokio::test]
+async fn l3_foreign_route_blocks_install() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+    // Operator/foreign route at the exact key (no ADR-0079 markers).
+    h.handle
+        .pre_load_l3_route(L3_TABLE_ID, l3_prefix(), L3_IFINDEX, ipa("10.9.9.9"), false);
+
+    let ip_vrfs = l3_ip_vrfs();
+    let prefixes = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(1, ip_vrfs, prefixes)).unwrap();
+    let mut reports = vec![wait_for_generation(&mut h, 1).await];
+
+    let route = h
+        .handle
+        .l3_routes()
+        .remove(&(L3_TABLE_ID, l3_prefix()))
+        .expect("foreign route must survive");
+    assert!(!route.marked, "foreign route must not be replaced");
+    assert_eq!(route.next_hop, ipa("10.9.9.9"));
+
+    reports.extend(h.shutdown().await);
+    let counters = sum_foreign_counters(&reports);
+    assert_eq!(counters.replaces_blocked, 1, "warn-once counter");
+}
+
+// L3 rules 2 + 3: foreign rows replace the owned route / neighbor /
+// L3VXLAN FDB triple → ownership relinquished, and withdrawal leaves
+// every foreign row in the kernel.
+#[tokio::test]
+async fn l3_foreign_takeover_relinquishes_and_withdrawal_spares_rows() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+
+    let ip_vrfs = l3_ip_vrfs();
+    let prefixes = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx
+        .send(l3_intent(1, ip_vrfs.clone(), prefixes.clone()))
+        .unwrap();
+    let report = wait_for_generation(&mut h, 1).await;
+    assert!(report.failed.is_empty(), "install: {:?}", report.failed);
+    assert!(h.handle.kernel_has_l3_route(L3_TABLE_ID, l3_prefix()));
+
+    // Foreign takeover of all three kernel rows.
+    let foreign_mac = MacAddress::new([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]);
+    h.handle
+        .pre_load_l3_route(L3_TABLE_ID, l3_prefix(), L3_IFINDEX, ipa("10.9.9.9"), false);
+    h.handle
+        .pre_load_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2"), foreign_mac, false);
+    h.handle
+        .pre_load_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac(), ipa("10.9.9.9"), false);
+
+    // Withdraw the prefix — every foreign row must survive.
+    h.intent_tx
+        .send(l3_intent(2, ip_vrfs, RemoteIpPrefixTable::new()))
+        .unwrap();
+    let mut reports = vec![wait_for_generation(&mut h, 2).await];
+
+    let route = h
+        .handle
+        .l3_routes()
+        .remove(&(L3_TABLE_ID, l3_prefix()))
+        .expect("foreign route must survive withdrawal");
+    assert!(!route.marked);
+    assert!(
+        h.handle.kernel_has_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2")),
+        "foreign neighbor must survive withdrawal"
+    );
+    assert!(
+        h.handle
+            .kernel_has_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac()),
+        "foreign L3VXLAN FDB row must survive withdrawal"
+    );
+
+    reports.extend(h.shutdown().await);
+    let counters = sum_foreign_counters(&reports);
+    assert_eq!(
+        counters.owned_relinquished, 3,
+        "route + neighbor + FDB takeover must each relinquish"
+    );
+}
+
+// L3 rule 3, shutdown variant: the drain revalidates against a fresh
+// ownership dump and spares the foreign triple.
+#[tokio::test]
+async fn shutdown_drain_spares_foreign_l3_rows() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_ip_vrf_status(l3_vrf_id(), l3_ready_status());
+    h.handle.set_l3vxlan_ifindex(l3_vrf_id(), L3_IFINDEX);
+
+    let ip_vrfs = l3_ip_vrfs();
+    let prefixes = l3_desired_prefixes(&ip_vrfs);
+    h.intent_tx.send(l3_intent(1, ip_vrfs, prefixes)).unwrap();
+    let report = wait_for_generation(&mut h, 1).await;
+    assert!(report.failed.is_empty(), "install: {:?}", report.failed);
+
+    // Takeover after the last pass; drain must notice via its dump.
+    let foreign_mac = MacAddress::new([0xde, 0xad, 0xbe, 0xef, 0x00, 0x02]);
+    h.handle
+        .pre_load_l3_route(L3_TABLE_ID, l3_prefix(), L3_IFINDEX, ipa("10.9.9.9"), false);
+    h.handle
+        .pre_load_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2"), foreign_mac, false);
+    h.handle
+        .pre_load_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac(), ipa("10.9.9.9"), false);
+
+    let handle = h.handle.clone();
+    h.shutdown().await;
+
+    let route = handle
+        .l3_routes()
+        .remove(&(L3_TABLE_ID, l3_prefix()))
+        .expect("foreign route must survive shutdown drain");
+    assert!(!route.marked);
+    assert!(handle.kernel_has_l3_neighbor(L3_IFINDEX, ipa("10.0.0.2")));
+    assert!(handle.kernel_has_l3_vxlan_fdb(L3_IFINDEX, l3_router_mac()));
+}

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -502,6 +502,13 @@ pub struct DataplaneReport {
     /// failover events (group swaps + ordered teardowns). Same
     /// drain-into-Prometheus contract as `fdb_nhg_drift_counters`.
     pub single_active_counters: SingleActiveCounters,
+    /// Per-report deltas for foreign-state ownership protection:
+    /// replaces blocked because a foreign row holds the exact key,
+    /// deletes skipped because the live row is no longer ours, and
+    /// owned keys relinquished after a foreign writer took them over.
+    /// Same drain-into-Prometheus contract as
+    /// `fdb_nhg_drift_counters`.
+    pub foreign_state_counters: ForeignStateCounters,
     /// ADR-0091 managed-netdev desired/observed status rows. Rows are
     /// produced only when `[managed_netdevs]` is configured (a desired
     /// bridge row, or an owner token under which observed rustbgpd
@@ -554,6 +561,26 @@ pub struct L3AdoptionCounters {
     pub l3vxlan_fdb_adopted: u64,
     /// Adopted L3VXLAN FDB rows reaped after the deferral.
     pub l3vxlan_fdb_reaped: u64,
+}
+
+/// Per-report deltas for foreign-state ownership protection on the
+/// L2 FDB and Gate 9 L3 write paths (routes / neighbors / L3VXLAN
+/// FDB): the reconciler must never `replace` over — or delete — a
+/// same-key kernel row it does not own, and must stop claiming a key
+/// another writer took over.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ForeignStateCounters {
+    /// Install / replace operations withheld because an exact-key
+    /// foreign kernel row exists (fail closed; retried level-triggered
+    /// once the foreign row goes away).
+    pub replaces_blocked: u64,
+    /// Delete operations skipped during withdrawal / `NotReady` drain /
+    /// shutdown because the live kernel row under the key is no
+    /// longer ours (a foreign row must survive our teardown).
+    pub deletes_skipped: u64,
+    /// Owned keys dropped from the in-memory owned state because a
+    /// live snapshot showed a foreign row had replaced ours.
+    pub owned_relinquished: u64,
 }
 
 /// Per-report deltas for ADR-0083 single-active backup-path failover

--- a/crates/evpn/src/lib.rs
+++ b/crates/evpn/src/lib.rs
@@ -118,9 +118,9 @@ pub use dataplane::{
     AcGateEntry, AcGateState, AppliedOp, BumEnforcementEntry, BumEnforcementKey,
     BumEnforcementReadiness, BumEnforcementStatus, BumEnforcementTable, BumForwardingAction,
     DataplaneIntent, DataplaneOpKind, DataplaneReport, FailedOp, FdbNexthopDataplaneStatus,
-    FdbNexthopGroupStatus, FdbNexthopMemberStatus, FdbNhgDriftCounters, InstanceDataplaneStatus,
-    InstanceState, IpVrfDataplaneStatus, L3AdoptionCounters, SameEsiBiasTable,
-    SingleActiveCounters,
+    FdbNexthopGroupStatus, FdbNexthopMemberStatus, FdbNhgDriftCounters, ForeignStateCounters,
+    InstanceDataplaneStatus, InstanceState, IpVrfDataplaneStatus, L3AdoptionCounters,
+    SameEsiBiasTable, SingleActiveCounters,
 };
 pub use df_election::{DfCandidate, DfElection, DfElectionError};
 pub use duplicate_mac::{

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -204,6 +204,9 @@ pub struct BgpMetrics {
     evpn_single_active_backup_swaps: IntCounter,
     evpn_single_active_teardowns: IntCounter,
     evpn_single_active_backup_active: IntGauge,
+    evpn_foreign_replaces_blocked: IntCounter,
+    evpn_foreign_deletes_skipped: IntCounter,
+    evpn_foreign_owned_relinquished: IntCounter,
 
     // ── EVPN runtime apply (ADR-0063, #268 decomposition) ──────────
     evpn_runtime_decomposed_fail_stops: IntCounter,
@@ -1120,6 +1123,24 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_foreign_replaces_blocked = IntCounter::new(
+            "evpn_foreign_replaces_blocked_total",
+            "EVPN dataplane installs/replaces withheld because an exact-key foreign kernel row exists (LAN-283 fail-closed).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_foreign_deletes_skipped = IntCounter::new(
+            "evpn_foreign_deletes_skipped_total",
+            "EVPN dataplane deletes skipped during withdrawal/NotReady/shutdown because the live kernel row is no longer rustbgpd's (LAN-283).",
+        )
+        .expect("valid metric definition");
+
+        let evpn_foreign_owned_relinquished = IntCounter::new(
+            "evpn_foreign_owned_relinquished_total",
+            "EVPN dataplane owned keys relinquished after a live snapshot showed a foreign writer replaced the row (LAN-283).",
+        )
+        .expect("valid metric definition");
+
         let evpn_single_active_backup_active = IntGauge::new(
             "evpn_single_active_backup_active",
             "Number of (ESI, EthernetTag) single-active groups currently retargeted at \
@@ -1538,6 +1559,15 @@ impl BgpMetrics {
             .register(Box::new(evpn_single_active_teardowns.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_foreign_replaces_blocked.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_foreign_deletes_skipped.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(evpn_foreign_owned_relinquished.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(evpn_single_active_backup_active.clone()))
             .expect("metric not already registered");
         registry
@@ -1685,6 +1715,9 @@ impl BgpMetrics {
             evpn_single_active_backup_swaps,
             evpn_single_active_teardowns,
             evpn_single_active_backup_active,
+            evpn_foreign_replaces_blocked,
+            evpn_foreign_deletes_skipped,
+            evpn_foreign_owned_relinquished,
             evpn_runtime_decomposed_fail_stops,
             bmp_source_drops,
             bmp_collector_drops,
@@ -2782,6 +2815,30 @@ impl BgpMetrics {
         self.evpn_single_active_teardowns.inc_by(delta);
     }
 
+    /// Increment the LAN-283 foreign-blocked replace counter.
+    pub fn add_evpn_foreign_replaces_blocked(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_foreign_replaces_blocked.inc_by(delta);
+    }
+
+    /// Increment the LAN-283 foreign-spared delete counter.
+    pub fn add_evpn_foreign_deletes_skipped(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_foreign_deletes_skipped.inc_by(delta);
+    }
+
+    /// Increment the LAN-283 foreign-takeover relinquish counter.
+    pub fn add_evpn_foreign_owned_relinquished(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_foreign_owned_relinquished.inc_by(delta);
+    }
+
     /// Increment the #268 decomposed-apply fail-stop counter: a
     /// mid-sequence decomposed step pinned the coordinator
     /// (`mutation_state=Failed`), leaving earlier generations committed.
@@ -3735,6 +3792,23 @@ mod tests {
         assert!(text.contains("evpn_l3_neighbor_reaped_total 4"));
         assert!(text.contains("evpn_l3vxlan_fdb_adopted_total 5"));
         assert!(text.contains("evpn_l3vxlan_fdb_reaped_total 6"));
+    }
+
+    #[test]
+    fn evpn_foreign_state_counters_are_exported() {
+        let m = BgpMetrics::new();
+        m.add_evpn_foreign_replaces_blocked(1);
+        m.add_evpn_foreign_deletes_skipped(2);
+        m.add_evpn_foreign_owned_relinquished(3);
+
+        assert_eq!(m.evpn_foreign_replaces_blocked.get(), 1);
+        assert_eq!(m.evpn_foreign_deletes_skipped.get(), 2);
+        assert_eq!(m.evpn_foreign_owned_relinquished.get(), 3);
+
+        let text = gather_text(&m);
+        assert!(text.contains("evpn_foreign_replaces_blocked_total 1"));
+        assert!(text.contains("evpn_foreign_deletes_skipped_total 2"));
+        assert!(text.contains("evpn_foreign_owned_relinquished_total 3"));
     }
 
     #[test]

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -551,6 +551,7 @@ where
                 record_fdb_nhg_drift_metrics(&metrics, report.fdb_nhg_drift_counters);
                 record_l3_adoption_metrics(&metrics, report.l3_adoption_counters);
                 record_single_active_metrics(&metrics, report.single_active_counters);
+                record_foreign_state_metrics(&metrics, report.foreign_state_counters);
                 record_remote_prefix_install_drop_metrics(
                     &metrics,
                     &mut last_ip_prefix_install_drop_counts,
@@ -632,6 +633,15 @@ fn record_single_active_metrics(
 ) {
     metrics.add_evpn_single_active_backup_swaps(counters.backup_swaps);
     metrics.add_evpn_single_active_teardowns(counters.teardowns);
+}
+
+fn record_foreign_state_metrics(
+    metrics: &BgpMetrics,
+    counters: rustbgpd_evpn::ForeignStateCounters,
+) {
+    metrics.add_evpn_foreign_replaces_blocked(counters.replaces_blocked);
+    metrics.add_evpn_foreign_deletes_skipped(counters.deletes_skipped);
+    metrics.add_evpn_foreign_owned_relinquished(counters.owned_relinquished);
 }
 
 fn record_l3_adoption_metrics(metrics: &BgpMetrics, counters: L3AdoptionCounters) {

--- a/src/evpn_runtime_converger.rs
+++ b/src/evpn_runtime_converger.rs
@@ -10597,6 +10597,7 @@ local_vtep_ip = "10.0.0.1"
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
             l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
             single_active_counters: rustbgpd_evpn::SingleActiveCounters::default(),
+            foreign_state_counters: rustbgpd_evpn::ForeignStateCounters::default(),
         }
     }
 

--- a/src/evpn_svi.rs
+++ b/src/evpn_svi.rs
@@ -532,6 +532,7 @@ mod tests {
             fdb_nhg_drift_counters: rustbgpd_evpn::FdbNhgDriftCounters::default(),
             l3_adoption_counters: rustbgpd_evpn::L3AdoptionCounters::default(),
             single_active_counters: rustbgpd_evpn::SingleActiveCounters::default(),
+            foreign_state_counters: rustbgpd_evpn::ForeignStateCounters::default(),
         }
     }
 


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 1 (LAN-283).

## Problem

The EVPN Linux dataplane could clobber or delete state it does not own: netlink `replace` silently adopts-and-overwrites another agent's same-key FDB/route/neighbor rows; a foreign takeover of a previously-owned key was "repaired" back over; and withdrawal / NotReady / shutdown deletion removed same-key rows without checking they were still ours.

## Changes

Per-class foreign classification (L2 FDB: `extern_learn`/`NDA_PROTOCOL`; VRF routes: `RTPROT_BGP`+`RTNH_F_ONLINK`; L3 neighbors: `NUD_PERMANENT`+`extern_learn`+BGP stamp — volatile kernel ARP/ND is deliberately not foreign; L3VXLAN FDB: marker rows on managed devices), then three rules:

1. **Preflight**: a foreign row at the exact key blocks `replace` — fail-closed per key (`Plan.foreign_blocked_keys`, L3 `BlockReplace` disposition into the existing fail-stop prerequisite machinery).
2. **Relinquish**: a live snapshot showing a foreign replacement of an owned key drops it from owned state (and releases FDB-NHG group refs) — no repair over the foreign row.
3. **Revalidate before delete**: withdrawal, NotReady, and shutdown drain re-check ownership and spare foreign rows; shutdown fails closed (skips the drain phase) if the revalidation dump fails.

Observability: `evpn_foreign_{replaces_blocked,deletes_skipped,owned_relinquished}_total` counters + warn-once transition logs. NHID write-authority is out of scope here (tracked separately).

Documented accepted gap: with an empty `[[evpn_ip_vrfs]]` table the L3 markers are unrecognizable, so the config-removed drain-everything path proceeds unguarded, as before.

## Tests

5 pure-diff + 7 in-memory actor tests (blocked replace, takeover relinquish, withdrawal/NotReady/shutdown sparing for L2 and the L3 route/neighbor/FDB triple), 8 classifier units, and 2 env-gated netns tests (compile and skip cleanly ungated; not executed here — they run under the privileged kernel-dataplane harness).

## Gates

fmt / clippy `-D warnings` / evpn+evpn-linux suites (343 + 560) / full workspace (5051, 0 failed) / doc — all green.