### PR TITLE
Track LLGR stale deadlines per AFI/SAFI and preserve original LLST across resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `evpn_foreign_deletes_skipped_total`, and
   `evpn_foreign_owned_relinquished_total` counters. (LAN-283)
 
+- **LLGR lifecycle is now per-AFI/SAFI and honors the original Long-Lived
+  Stale Time through reconnects (RFC 9494).** LLGR stale deadlines are
+  tracked per (peer, AFI, SAFI) instead of one peer-wide minimum, so a
+  family with a longer negotiated stale time is no longer purged when a
+  shorter-lived family's timer fires; each family sweeps on its own
+  deadline. A family's deadline is stamped once when it enters the LLGR
+  stale phase and survives re-establishment while routes remain
+  LLGR-stale: a peer that reconnects during LLGR and goes down again
+  re-uses the surviving deadline instead of restarting the timer, and
+  LLGR-stale routes are retained (not purged) across consecutive resets
+  until that original deadline expires — End-of-RIB for the family retires
+  it. Also documented and pinned two deliberate LLGR export behaviors:
+  transport's LLGR-stale export form detects staleness by the `LLGR_STALE`
+  community (superset of the flag — it also catches upstream-tagged
+  routes) with a regression test proving flag/community coupling across
+  the Adj-RIB-In mutation paths, and EVPN GR-stale routes intentionally
+  continue to be exported during the GR window (RFC 4724) rather than
+  triggering VXLAN flood-and-relearn churn. (LAN-282, LAN-191)
 - **Outbound saturation teardown: Cease is the final frame, and cleanup runs
   from the run loop.** When a peer stopped draining and the bounded writer
   queue filled (`Cease/8` Out-of-Resources teardown), the writer drained the

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -296,16 +296,20 @@ impl AdjRibIn {
     /// Mark all routes matching the given address family as stale
     /// (RFC 4724 §4.1 helper retention on session drop).
     ///
-    /// A route that is *already* stale (GR or LLGR) when a new mark arrives
-    /// survived a previous restart without ever being refreshed and is deleted
-    /// instead of re-marked (RFC 4724 §4.1: stale routes must not be retained
-    /// across consecutive restarts). Returns the deleted prefixes so the
-    /// caller can withdraw them downstream.
+    /// A route that is already *GR*-stale when a new mark arrives survived a
+    /// previous restart without ever being refreshed and is deleted instead
+    /// of re-marked (RFC 4724 §4.1: stale routes must not be retained across
+    /// consecutive restarts). An *LLGR*-stale route is the RFC 9494
+    /// exception: it is retained as-is across consecutive resets — neither
+    /// deleted nor demoted back to GR-stale — until its original per-family
+    /// Long-Lived Stale Time deadline (held by the manager) expires.
+    /// Returns the deleted prefixes so the caller can withdraw them
+    /// downstream.
     pub fn mark_stale(&mut self, family: (Afi, Safi)) -> Vec<Prefix> {
         let already_stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && route_matches_family(r, family))
+            .filter(|(_, r)| r.is_stale && route_matches_family(r, family))
             .map(|(k, _)| *k)
             .collect();
         let mut deleted = Vec::new();
@@ -316,7 +320,7 @@ impl AdjRibIn {
             self.remove_from_prefix_index(&key.0, key.1);
         }
         for route in self.routes.values_mut() {
-            if route_matches_family(route, family) {
+            if route_matches_family(route, family) && !route.is_llgr_stale {
                 route.is_stale = true;
             }
         }
@@ -621,15 +625,19 @@ impl AdjRibIn {
         let already_stale: Vec<EvpnRouteKey> = self
             .evpn_routes
             .iter()
-            .filter(|(_, r)| r.is_stale || r.is_llgr_stale)
+            .filter(|(_, r)| r.is_stale)
             .map(|(k, _)| *k)
             .collect();
         for key in &already_stale {
             self.evpn_llgr_stale_local_tags.remove(key);
             self.evpn_routes.remove(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.evpn_routes.values_mut() {
-            route.is_stale = true;
+            if !route.is_llgr_stale {
+                route.is_stale = true;
+            }
         }
         already_stale
     }
@@ -854,15 +862,17 @@ impl AdjRibIn {
         let already_stale: Vec<BgpLsRouteKey> = self
             .bgpls_routes
             .iter()
-            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.family == fam)
+            .filter(|(_, r)| r.is_stale && r.family == fam)
             .map(|(k, _)| k.clone())
             .collect();
         for key in &already_stale {
             self.bgpls_llgr_stale_local_tags.remove(key);
             self.bgpls_routes.remove(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.bgpls_routes.values_mut() {
-            if route.family == fam {
+            if route.family == fam && !route.is_llgr_stale {
                 route.is_stale = true;
             }
         }
@@ -1159,14 +1169,16 @@ impl AdjRibIn {
         let already_stale: Vec<VpnRibRouteKey> = self
             .vpn_routes
             .iter()
-            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.afi_safi() == family)
+            .filter(|(_, r)| r.is_stale && r.afi_safi() == family)
             .map(|(k, _)| k.clone())
             .collect();
         for key in &already_stale {
             self.remove_vpn_entry(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.vpn_routes.values_mut() {
-            if route.afi_safi() == family {
+            if route.afi_safi() == family && !route.is_llgr_stale {
                 route.is_stale = true;
             }
         }
@@ -1456,14 +1468,16 @@ impl AdjRibIn {
         let already_stale: Vec<LabeledRibRouteKey> = self
             .labeled_routes
             .iter()
-            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.afi_safi() == family)
+            .filter(|(_, r)| r.is_stale && r.afi_safi() == family)
             .map(|(k, _)| *k)
             .collect();
         for key in &already_stale {
             self.remove_labeled_entry(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.labeled_routes.values_mut() {
-            if route.afi_safi() == family {
+            if route.afi_safi() == family && !route.is_llgr_stale {
                 route.is_stale = true;
             }
         }
@@ -1721,15 +1735,19 @@ impl AdjRibIn {
         let already_stale: Vec<RtcRibRouteKey> = self
             .rtc_routes
             .iter()
-            .filter(|(_, r)| r.is_stale || r.is_llgr_stale)
+            .filter(|(_, r)| r.is_stale)
             .map(|(k, _)| k.clone())
             .collect();
         for key in &already_stale {
             self.rtc_llgr_stale_local_tags.remove(key);
             self.rtc_routes.remove(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.rtc_routes.values_mut() {
-            route.is_stale = true;
+            if !route.is_llgr_stale {
+                route.is_stale = true;
+            }
         }
         already_stale
     }
@@ -1902,7 +1920,7 @@ impl AdjRibIn {
         let already_stale: Vec<(FlowSpecRule, u32)> = self
             .flowspec_routes
             .iter()
-            .filter(|(_, r)| (r.is_stale || r.is_llgr_stale) && r.afi == family.0)
+            .filter(|(_, r)| r.is_stale && r.afi == family.0)
             .map(|(k, _)| k.clone())
             .collect();
         let mut deleted = Vec::new();
@@ -1911,8 +1929,10 @@ impl AdjRibIn {
             self.flowspec_llgr_stale_local_tags.remove(key);
             self.flowspec_routes.remove(key);
         }
+        // LLGR-stale routes are retained as-is (RFC 9494: consecutive resets
+        // neither delete nor re-mark them; the original deadline governs).
         for route in self.flowspec_routes.values_mut() {
-            if route.afi == family.0 {
+            if route.afi == family.0 && !route.is_llgr_stale {
                 route.is_stale = true;
             }
         }
@@ -2698,33 +2718,102 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
         let gr_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
         let llgr_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
-        rib.insert(make_route(gr_prefix, Ipv4Addr::new(10, 0, 0, 1)));
+
+        // First cycle: one route goes GR-stale, then GR expiry promotes it
+        // to LLGR-stale (real promotion path — injects the community).
         rib.insert(make_route(llgr_prefix, Ipv4Addr::new(10, 0, 0, 1)));
-
-        // First session drop: both routes go GR-stale; one then enters LLGR.
         rib.mark_stale((Afi::Ipv4, Safi::Unicast));
-        let llgr_route = rib.routes.get_mut(&(Prefix::V4(llgr_prefix), 0)).unwrap();
-        llgr_route.is_stale = false;
-        llgr_route.is_llgr_stale = true;
+        rib.promote_to_llgr_stale((Afi::Ipv4, Safi::Unicast));
 
-        // Second session drop before any refresh: both already-stale routes
-        // (GR-stale and LLGR-stale) are deleted, not re-marked
-        // (RFC 4724 §4.1: no retention across consecutive restarts).
-        let mut deleted = rib.mark_stale((Afi::Ipv4, Safi::Unicast));
-        deleted.sort_by_key(std::string::ToString::to_string);
-        assert_eq!(
-            deleted,
-            vec![Prefix::V4(gr_prefix), Prefix::V4(llgr_prefix)]
-        );
-        assert_eq!(rib.len(), 0);
+        // Reconnect re-advertises a second prefix (not the first); the
+        // session drops again, marking the fresh route GR-stale.
+        rib.insert(make_route(gr_prefix, Ipv4Addr::new(10, 0, 0, 1)));
+        assert!(rib.mark_stale((Afi::Ipv4, Safi::Unicast)).is_empty());
+
+        // Third drop before any refresh: the GR-stale route is deleted
+        // (RFC 4724 §4.1: no retention across consecutive restarts) but the
+        // LLGR-stale route is retained unchanged (RFC 9494: its original
+        // stale-time deadline governs), keeping flag and community coupled.
+        let deleted = rib.mark_stale((Afi::Ipv4, Safi::Unicast));
+        assert_eq!(deleted, vec![Prefix::V4(gr_prefix)]);
+        assert_eq!(rib.len(), 1);
         // The secondary prefix index is maintained through the deletion.
         assert_eq!(rib.iter_prefix(&Prefix::V4(gr_prefix)).count(), 0);
-        assert_eq!(rib.iter_prefix(&Prefix::V4(llgr_prefix)).count(), 0);
+        let retained = rib.routes.get(&(Prefix::V4(llgr_prefix), 0)).unwrap();
+        assert!(retained.is_llgr_stale);
+        assert!(!retained.is_stale, "LLGR-stale must not be re-marked");
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+            "retained LLGR-stale route keeps its LLGR_STALE community"
+        );
+    }
+
+    /// Transport's `apply_llgr_stale_export_form` detects LLGR staleness by
+    /// scanning for the `LLGR_STALE` community (the superset — it also
+    /// catches routes tagged by an upstream helper). That is only safe for
+    /// locally promoted routes if every mutation path keeps the
+    /// `is_llgr_stale` flag and the community coupled: flag set ⇒ community
+    /// present. This walks the full lifecycle and asserts the invariant
+    /// after every step (LAN-191).
+    #[test]
+    fn llgr_stale_flag_implies_community_across_mutations() {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let mut rib = AdjRibIn::new(peer);
+        let family = (Afi::Ipv4, Safi::Unicast);
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+
+        let assert_coupled = |rib: &AdjRibIn, step: &str| {
+            for route in rib.iter() {
+                assert!(
+                    !route.is_llgr_stale
+                        || route
+                            .communities()
+                            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+                    "flag set without LLGR_STALE community after {step}"
+                );
+            }
+        };
+
+        rib.insert(make_route(prefix, Ipv4Addr::new(10, 0, 0, 1)));
+        assert_coupled(&rib, "insert");
+
+        rib.mark_stale(family); // session drop
+        assert_coupled(&rib, "mark_stale");
+
+        rib.promote_to_llgr_stale(family); // GR timer expiry
+        assert_coupled(&rib, "promote_to_llgr_stale");
+        assert!(rib.iter().any(|r| r.is_llgr_stale));
+
+        rib.mark_stale(family); // consecutive reset: LLGR-stale retained
+        assert_coupled(&rib, "mark_stale on LLGR-stale");
+        assert!(rib.iter().any(|r| r.is_llgr_stale));
+
+        // Re-advertisement replaces the entry, clearing the flag with the
+        // (locally added) community gone from the fresh attributes.
+        rib.insert(make_route(prefix, Ipv4Addr::new(10, 0, 0, 1)));
+        assert_coupled(&rib, "re-advertisement insert");
+        assert!(rib.iter().all(|r| !r.is_llgr_stale));
+
+        // Second cycle ending in End-of-RIB hygiene: both clear paths drop
+        // the flag together with the locally injected community.
+        rib.mark_stale(family);
+        rib.promote_to_llgr_stale(family);
+        rib.clear_llgr_stale(family);
+        assert_coupled(&rib, "clear_llgr_stale");
+        assert!(rib.iter().all(|r| !r.is_llgr_stale));
+
+        rib.mark_stale(family);
+        rib.promote_to_llgr_stale(family);
+        rib.clear_stale(family);
+        assert_coupled(&rib, "clear_stale");
+        assert!(rib.iter().all(|r| !r.is_llgr_stale));
     }
 
     #[test]
@@ -2926,23 +3015,43 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_flowspec_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_flowspec_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
-        let route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
-        let rule = route.rule.clone();
-        rib.insert_flowspec(route);
+        let llgr_route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+        let llgr_rule = llgr_route.rule.clone();
+        let mut gr_route = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+        gr_route.rule = FlowSpecRule {
+            components: vec![rustbgpd_wire::FlowSpecComponent::DestinationPrefix(
+                rustbgpd_wire::FlowSpecPrefix::V4(Ipv4Prefix::new(
+                    Ipv4Addr::new(198, 51, 100, 0),
+                    24,
+                )),
+            )],
+        };
+        let gr_rule = gr_route.rule.clone();
 
-        // First session drop marks the rule stale; a second drop before any
-        // refresh deletes it (RFC 4724 §4.1: no retention across
-        // consecutive restarts).
+        // First cycle: rule goes GR-stale, then promotes to LLGR-stale.
+        rib.insert_flowspec(llgr_route);
+        rib.mark_stale_flowspec((Afi::Ipv4, Safi::FlowSpec));
+        rib.promote_to_llgr_stale_flowspec((Afi::Ipv4, Safi::FlowSpec));
+
+        // Reconnect advertises a second rule; two more drops follow.
+        rib.insert_flowspec(gr_route);
         assert!(
             rib.mark_stale_flowspec((Afi::Ipv4, Safi::FlowSpec))
                 .is_empty()
         );
         let deleted = rib.mark_stale_flowspec((Afi::Ipv4, Safi::FlowSpec));
-        assert_eq!(deleted, vec![rule]);
-        assert_eq!(rib.flowspec_len(), 0);
+        assert_eq!(deleted, vec![gr_rule]);
+        assert_eq!(rib.flowspec_len(), 1);
+        let retained = rib.flowspec_routes.get(&(llgr_rule, 0)).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]
@@ -3162,26 +3271,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_evpn_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_evpn_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer_ip);
-        let gr_key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+
+        // First cycle: one route goes GR-stale, then promotes to LLGR-stale.
         let llgr_key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 200, vec![]);
-
-        // First session drop: both routes go GR-stale; one then enters LLGR.
         rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
-        let llgr_route = rib.evpn_routes.get_mut(&llgr_key).unwrap();
-        llgr_route.is_stale = false;
-        llgr_route.is_llgr_stale = true;
+        rib.promote_to_llgr_stale_evpn((Afi::L2Vpn, Safi::Evpn));
 
-        // Second session drop before any refresh: both already-stale routes
-        // (GR-stale and LLGR-stale) are deleted, not re-marked
-        // (RFC 4724 §4.1: no retention across consecutive restarts).
+        // Reconnect advertises a second route; two more drops follow. The
+        // GR-stale route is deleted (RFC 4724 §4.1), the LLGR-stale one is
+        // retained unchanged (RFC 9494: original deadline governs).
+        let gr_key = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
+        assert!(rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn)).is_empty());
         let deleted = rib.mark_stale_evpn((Afi::L2Vpn, Safi::Evpn));
-        assert_eq!(deleted.len(), 2);
-        assert!(deleted.contains(&gr_key));
-        assert!(deleted.contains(&llgr_key));
-        assert_eq!(rib.evpn_len(), 0);
+        assert_eq!(deleted, vec![gr_key]);
+        assert_eq!(rib.evpn_len(), 1);
+        let retained = rib.evpn_routes.get(&llgr_key).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]
@@ -3452,23 +3565,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_vpn_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_vpn_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
-        let gr_key = insert_vpn_with(&mut rib, vpn_nlri([10, 0, 1, 0], 24, 100), vec![]);
-        let llgr_key = insert_vpn_with(&mut rib, vpn_nlri([10, 0, 2, 0], 24, 200), vec![]);
 
-        // First session drop: both routes go GR-stale; one then enters LLGR.
+        // First cycle: one route goes GR-stale, then promotes to LLGR-stale.
+        let llgr_key = insert_vpn_with(&mut rib, vpn_nlri([10, 0, 2, 0], 24, 200), vec![]);
         rib.mark_stale_vpn(VPN_V4);
-        let llgr_route = rib.vpn_routes.get_mut(&llgr_key).unwrap();
-        llgr_route.is_stale = false;
-        llgr_route.is_llgr_stale = true;
-        // Second session drop before any refresh: both already-stale routes
-        // (GR-stale and LLGR-stale) are deleted, not re-marked.
-        let mut deleted = rib.mark_stale_vpn(VPN_V4);
-        deleted.sort_by_key(|k| k.nlri_key.prefix.to_string());
-        assert_eq!(deleted, vec![gr_key, llgr_key]);
-        assert_eq!(rib.vpn_len(), 0);
+        rib.promote_to_llgr_stale_vpn(VPN_V4);
+
+        // Reconnect advertises a second route; two more drops follow. The
+        // GR-stale route is deleted (RFC 4724 §4.1), the LLGR-stale one is
+        // retained unchanged (RFC 9494: original deadline governs).
+        let gr_key = insert_vpn_with(&mut rib, vpn_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        assert!(rib.mark_stale_vpn(VPN_V4).is_empty());
+        let deleted = rib.mark_stale_vpn(VPN_V4);
+        assert_eq!(deleted, vec![gr_key]);
+        assert_eq!(rib.vpn_len(), 1);
+        let retained = rib.vpn_routes.get(&llgr_key).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]
@@ -3838,23 +3958,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_labeled_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_labeled_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
-        let gr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
-        let llgr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 2, 0], 24, 200), vec![]);
 
-        // First session drop: both routes go GR-stale; one then enters LLGR.
+        // First cycle: one route goes GR-stale, then promotes to LLGR-stale.
+        let llgr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 2, 0], 24, 200), vec![]);
         rib.mark_stale_labeled(LU_V4);
-        let llgr_route = rib.labeled_routes.get_mut(&llgr_key).unwrap();
-        llgr_route.is_stale = false;
-        llgr_route.is_llgr_stale = true;
-        // Second session drop before any refresh: both already-stale routes
-        // (GR-stale and LLGR-stale) are deleted, not re-marked.
-        let mut deleted = rib.mark_stale_labeled(LU_V4);
-        deleted.sort_by_key(|k| k.prefix.to_string());
-        assert_eq!(deleted, vec![gr_key, llgr_key]);
-        assert_eq!(rib.labeled_len(), 0);
+        rib.promote_to_llgr_stale_labeled(LU_V4);
+
+        // Reconnect advertises a second route; two more drops follow. The
+        // GR-stale route is deleted (RFC 4724 §4.1), the LLGR-stale one is
+        // retained unchanged (RFC 9494: original deadline governs).
+        let gr_key = insert_labeled_with(&mut rib, labeled_nlri([10, 0, 1, 0], 24, 100), vec![]);
+        assert!(rib.mark_stale_labeled(LU_V4).is_empty());
+        let deleted = rib.mark_stale_labeled(LU_V4);
+        assert_eq!(deleted, vec![gr_key]);
+        assert_eq!(rib.labeled_len(), 1);
+        let retained = rib.labeled_routes.get(&llgr_key).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]
@@ -4048,15 +4175,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_bgpls_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_bgpls_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
-        let key = insert_bgpls_with(&mut rib, BgpLsFamily::LinkState, bgpls_nlri(1), vec![]);
 
+        // First cycle: one route goes GR-stale, then promotes to LLGR-stale.
+        let llgr_key = insert_bgpls_with(&mut rib, BgpLsFamily::LinkState, bgpls_nlri(2), vec![]);
         rib.mark_stale_bgpls(LS_BASE);
+        rib.promote_to_llgr_stale_bgpls(LS_BASE);
+
+        // Reconnect advertises a second route; two more drops follow. The
+        // GR-stale route is deleted (RFC 4724 §4.1), the LLGR-stale one is
+        // retained unchanged (RFC 9494: original deadline governs).
+        let gr_key = insert_bgpls_with(&mut rib, BgpLsFamily::LinkState, bgpls_nlri(1), vec![]);
+        assert!(rib.mark_stale_bgpls(LS_BASE).is_empty());
         let deleted = rib.mark_stale_bgpls(LS_BASE);
-        assert_eq!(deleted, vec![key]);
-        assert_eq!(rib.bgpls_len(), 0);
+        assert_eq!(deleted, vec![gr_key]);
+        assert_eq!(rib.bgpls_len(), 1);
+        let retained = rib.bgpls_routes.get(&llgr_key).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]
@@ -4224,15 +4366,30 @@ mod tests {
     }
 
     #[test]
-    fn mark_stale_rtc_deletes_already_stale_routes_on_consecutive_restart() {
+    fn mark_stale_rtc_consecutive_restart_deletes_gr_stale_and_retains_llgr_stale() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
-        let key = insert_rtc_with(&mut rib, rtc_nlri(100), vec![]);
 
+        // First cycle: one route goes GR-stale, then promotes to LLGR-stale.
+        let llgr_key = insert_rtc_with(&mut rib, rtc_nlri(200), vec![]);
         rib.mark_stale_rtc(RTC_FAM);
+        rib.promote_to_llgr_stale_rtc(RTC_FAM);
+
+        // Reconnect advertises a second route; two more drops follow. The
+        // GR-stale route is deleted (RFC 4724 §4.1), the LLGR-stale one is
+        // retained unchanged (RFC 9494: original deadline governs).
+        let gr_key = insert_rtc_with(&mut rib, rtc_nlri(100), vec![]);
+        assert!(rib.mark_stale_rtc(RTC_FAM).is_empty());
         let deleted = rib.mark_stale_rtc(RTC_FAM);
-        assert_eq!(deleted, vec![key]);
-        assert_eq!(rib.rtc_len(), 0);
+        assert_eq!(deleted, vec![gr_key]);
+        assert_eq!(rib.rtc_len(), 1);
+        let retained = rib.rtc_routes.get(&llgr_key).unwrap();
+        assert!(retained.is_llgr_stale && !retained.is_stale);
+        assert!(
+            retained
+                .communities()
+                .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+        );
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -212,6 +212,16 @@ impl RibManager {
 
             // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
             // suppressed. See `llgr_stale_export_suppressed`.
+            //
+            // GR-stale (`is_stale`) EVPN routes are deliberately NOT gated
+            // here: RFC 4724 permits advertising stale paths during the
+            // restart window, and withdrawing them would tear down remote
+            // VXLAN forwarding state (MAC/IP bindings, flood lists) for a
+            // peer expected back within the restart time — flood-and-relearn
+            // churn that usually costs more than briefly forwarding toward a
+            // stale VTEP. Operators who cannot tolerate stale MAC/IP
+            // forwarding should shorten `stale_routes_time`. Pinned by
+            // `evpn_gr_stale_routes_keep_exporting_during_gr_window`.
             if super::llgr_stale_export_suppressed(
                 best.is_llgr_stale,
                 best.communities(),

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -67,13 +67,16 @@ impl RibManager {
         if let Some(rib) = self.ribs.get_mut(&peer) {
             // RFC 4724 helper retention: mark GR-covered families stale.
             // Every mark helper returns the keys of routes that were
-            // ALREADY stale from a previous restart and were deleted
+            // ALREADY GR-stale from a previous restart and were deleted
             // (RFC 4724 §4.1: no retention across consecutive restarts) —
             // collect them so the recompute below withdraws them
-            // downstream. Each helper is a family-scoped no-op for
-            // non-matching tuples. EVPN has a single family tuple, so its
-            // mark call is hoisted out of the loop and made once when
-            // (L2Vpn, Evpn) is among the GR-preserved families.
+            // downstream. LLGR-stale routes are the RFC 9494 exception:
+            // the helpers retain them unchanged across consecutive resets,
+            // bounded by their surviving per-family original-LLST deadline
+            // in `llgr_stale_deadlines`. Each helper is a family-scoped
+            // no-op for non-matching tuples. EVPN has a single family
+            // tuple, so its mark call is hoisted out of the loop and made
+            // once when (L2Vpn, Evpn) is among the GR-preserved families.
             for &family in &gr_families {
                 affected.extend(rib.mark_stale(family));
                 fs_affected.extend(rib.mark_stale_flowspec(family));
@@ -433,16 +436,6 @@ impl RibManager {
                 .filter(|f| !llgr_family_set.contains(f))
                 .collect();
 
-            // Compute effective stale time: min(local, peer per-family minimum)
-            let peer_min_stale = llgr_config
-                .peer_llgr_families
-                .iter()
-                .filter(|f| llgr_families.contains(&(f.afi, f.safi)))
-                .map(|f| f.stale_time)
-                .min()
-                .unwrap_or(llgr_config.local_llgr_stale_time);
-            let effective_stale_time = peer_min_stale.min(llgr_config.local_llgr_stale_time);
-
             let mut affected = HashSet::new();
             let mut fs_affected = HashSet::new();
             let mut evpn_affected: HashSet<EvpnRouteKey> = HashSet::new();
@@ -568,10 +561,26 @@ impl RibManager {
             self.metrics
                 .set_rib_prefixes(&peer_label, "evpn", gauge_val(evpn_len));
 
-            // Set LLGR timer
-            let deadline = tokio::time::Instant::now()
-                + std::time::Duration::from_secs(u64::from(effective_stale_time));
-            self.llgr_stale_deadlines.insert(peer, deadline);
+            // Set the LLGR timer per family (RFC 9494 §4.3: stale time is
+            // negotiated per AFI/SAFI): min(local config, the peer's
+            // advertised stale time for that family). `or_insert` is the
+            // original-LLST rule — a deadline that survived a
+            // reconnect-then-down is re-used, never restarted, so total
+            // retention stays bounded by the FIRST promotion's deadline.
+            let now = tokio::time::Instant::now();
+            for &(afi, safi) in &llgr_families {
+                let peer_family_stale = llgr_config
+                    .peer_llgr_families
+                    .iter()
+                    .filter(|f| (f.afi, f.safi) == (afi, safi))
+                    .map(|f| f.stale_time)
+                    .min()
+                    .unwrap_or(llgr_config.local_llgr_stale_time);
+                let effective = peer_family_stale.min(llgr_config.local_llgr_stale_time);
+                self.llgr_stale_deadlines
+                    .entry((peer, afi, safi))
+                    .or_insert(now + std::time::Duration::from_secs(u64::from(effective)));
+            }
             self.llgr_peers
                 .insert(peer, llgr_families.into_iter().collect());
             // GR remains "active" for metrics until LLGR completes
@@ -583,8 +592,15 @@ impl RibManager {
         // so this is defensive — but the map must not outlive GR).
         self.llgr_peer_config.remove(&peer);
         info!(%peer, "graceful restart timer expired — sweeping stale routes");
-        self.metrics.set_gr_active(&peer_label, false);
-        self.metrics.set_gr_stale_routes(&peer_label, 0);
+        // LLGR-stale routes from a PREVIOUS retention cycle (their original
+        // per-family deadlines survive reconnects) are not touched by the
+        // GR-stale sweeps below; they stay until those deadlines fire, so
+        // retention accounting stays active while any remain.
+        let llgr_retention_remains = self.llgr_stale_deadlines.keys().any(|&(p, _, _)| p == peer);
+        if !llgr_retention_remains {
+            self.metrics.set_gr_active(&peer_label, false);
+            self.metrics.set_gr_stale_routes(&peer_label, 0);
+        }
 
         let mut swept = Vec::new();
         let mut fs_swept = Vec::new();
@@ -676,20 +692,42 @@ impl RibManager {
             self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
 
-        self.release_peer_state_if_departed(peer);
+        if !llgr_retention_remains {
+            self.release_peer_state_if_departed(peer);
+        }
     }
 
-    /// Sweep LLGR-stale routes for a peer whose LLGR timer has expired.
-    pub(super) fn sweep_llgr_stale(&mut self, peer: IpAddr) {
-        info!(%peer, "LLGR timer expired — sweeping LLGR-stale routes");
-        self.llgr_peers.remove(&peer);
-        self.llgr_stale_deadlines.remove(&peer);
-        // LLGR is the last retention phase — the per-peer LLGR config has
-        // no further reader once the stale routes are swept.
-        self.llgr_peer_config.remove(&peer);
+    /// Sweep every (peer, AFI, SAFI) whose LLGR stale deadline has expired,
+    /// grouped per peer. Called from the manager run loop's LLGR timer arm.
+    pub(super) fn sweep_expired_llgr_stale(&mut self) {
+        let now = tokio::time::Instant::now();
+        let mut expired: std::collections::HashMap<IpAddr, Vec<(Afi, Safi)>> =
+            std::collections::HashMap::new();
+        for (&(peer, afi, safi), &deadline) in &self.llgr_stale_deadlines {
+            if deadline <= now {
+                expired.entry(peer).or_default().push((afi, safi));
+            }
+        }
+        for (peer, families) in expired {
+            self.sweep_llgr_stale(peer, &families);
+        }
+    }
+
+    /// Sweep LLGR-stale routes for the given families of a peer whose LLGR
+    /// stale deadlines have expired (RFC 9494 §4.3: the stale time — and so
+    /// the sweep — is per AFI/SAFI; longer-lived families keep their routes).
+    ///
+    /// Deadlines survive re-establishment while routes remain LLGR-stale,
+    /// so this can fire for a peer that is back up and awaiting End-of-RIB
+    /// (`gr_peers`): the original Long-Lived Stale Time bounds retention
+    /// regardless — routes the peer has not re-advertised by then are purged.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "family-scoped sweeps and recomputes across all seven route tables"
+    )]
+    pub(super) fn sweep_llgr_stale(&mut self, peer: IpAddr, families: &[(Afi, Safi)]) {
+        info!(%peer, ?families, "LLGR timer expired — sweeping LLGR-stale routes");
         let peer_label = peer.to_string();
-        self.metrics.set_gr_active(&peer_label, false);
-        self.metrics.set_gr_stale_routes(&peer_label, 0);
 
         let mut swept = Vec::new();
         let mut fs_swept = Vec::new();
@@ -700,19 +738,36 @@ impl RibManager {
         let mut rtc_swept = Vec::new();
         let mut rib_len = 0;
         let mut evpn_len = 0;
+        let mut llgr_stale_remaining = 0;
+        for &(afi, safi) in families {
+            self.llgr_stale_deadlines.remove(&(peer, afi, safi));
+            if let Some(awaiting) = self.llgr_peers.get_mut(&peer) {
+                awaiting.remove(&(afi, safi));
+            }
+        }
         if let Some(rib) = self.ribs.get_mut(&peer) {
-            swept = rib.sweep_llgr_stale();
-            fs_swept = rib.sweep_llgr_stale_flowspec();
-            evpn_swept = rib.sweep_llgr_stale_evpn();
-            bgpls_swept = rib.sweep_llgr_stale_bgpls();
-            l3vpn_swept = rib.sweep_llgr_stale_vpn();
-            labeled_swept = rib.sweep_llgr_stale_labeled();
-            rtc_swept = rib.sweep_llgr_stale_rtc();
+            // Each helper is a family-scoped no-op for non-matching tuples.
+            for &family in families {
+                swept.extend(rib.sweep_llgr_stale_family(family));
+                fs_swept.extend(rib.sweep_llgr_stale_flowspec_family(family));
+                evpn_swept.extend(rib.sweep_llgr_stale_family_evpn(family));
+                bgpls_swept.extend(rib.sweep_llgr_stale_family_bgpls(family));
+                l3vpn_swept.extend(rib.sweep_llgr_stale_family_vpn(family));
+                labeled_swept.extend(rib.sweep_llgr_stale_family_labeled(family));
+                rtc_swept.extend(rib.sweep_llgr_stale_family_rtc(family));
+            }
             rib.gc_intern_table();
             self.metrics
                 .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
+            llgr_stale_remaining = rib.iter().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_flowspec().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_evpn().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_vpn().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_labeled().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_bgpls().filter(|r| r.is_llgr_stale).count()
+                + rib.iter_rtc().filter(|r| r.is_llgr_stale).count();
         }
         let had_swept = !swept.is_empty();
         let had_fs_swept = !fs_swept.is_empty();
@@ -783,6 +838,27 @@ impl RibManager {
             self.rebuild_rtc_membership_and_restage_vpn(peer);
         }
 
+        // Terminal only when no family retains an LLGR deadline: other
+        // families with longer stale times keep their retention (and the
+        // peer's config, needed for a later re-promotion) alive.
+        if self.llgr_stale_deadlines.keys().any(|&(p, _, _)| p == peer) {
+            self.metrics
+                .set_gr_stale_routes(&peer_label, gauge_val(llgr_stale_remaining));
+            return;
+        }
+        self.llgr_peers.remove(&peer);
+        if self.gr_peers.contains_key(&peer) {
+            // Re-established and awaiting End-of-RIB: the GR machinery owns
+            // the remaining lifecycle (and still reads `llgr_peer_config`).
+            self.metrics
+                .set_gr_stale_routes(&peer_label, gauge_val(llgr_stale_remaining));
+            return;
+        }
+        // LLGR is the last retention phase — the per-peer LLGR config has
+        // no further reader once the stale routes are swept.
+        self.llgr_peer_config.remove(&peer);
+        self.metrics.set_gr_active(&peer_label, false);
+        self.metrics.set_gr_stale_routes(&peer_label, 0);
         self.release_peer_state_if_departed(peer);
     }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -187,8 +187,13 @@ pub struct RibManager {
     /// Peers currently in LLGR stale phase (RFC 9494), keyed by peer address.
     /// Value is the set of (AFI, SAFI) families in LLGR.
     llgr_peers: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
-    /// Deadlines for sweeping LLGR-stale routes per peer.
-    llgr_stale_deadlines: HashMap<IpAddr, tokio::time::Instant>,
+    /// Deadlines for sweeping LLGR-stale routes, per (peer, AFI, SAFI) —
+    /// RFC 9494 §4.3 stale time is negotiated per family. An entry is
+    /// stamped ONCE when the family enters the LLGR stale phase and
+    /// deliberately survives re-establishment while routes remain
+    /// LLGR-stale: the ORIGINAL Long-Lived Stale Time bounds total
+    /// retention, so a reconnect-then-down never restarts the timer.
+    llgr_stale_deadlines: HashMap<(IpAddr, Afi, Safi), tokio::time::Instant>,
     /// Configured per-peer LLGR parameters, stored on `PeerGracefulRestart`.
     llgr_peer_config: HashMap<IpAddr, LlgrPeerConfig>,
     /// Maximum Add-Path paths per prefix per peer (0 = single-best only).
@@ -3013,15 +3018,7 @@ impl RibManager {
                 if self.drain_ready_updates() {
                     continue;
                 }
-                let expired: Vec<IpAddr> = self
-                    .llgr_stale_deadlines
-                    .iter()
-                    .filter(|&(_, &deadline)| deadline <= now)
-                    .map(|(&peer, _)| peer)
-                    .collect();
-                for peer in expired {
-                    self.sweep_llgr_stale(peer);
-                }
+                self.sweep_expired_llgr_stale();
                 continue;
             }
             if has_refresh_timers && refresh_sleep.deadline() <= now {
@@ -3091,17 +3088,7 @@ impl RibManager {
                         if self.drain_ready_updates() {
                             continue;
                         }
-                        // Find all peers whose LLGR deadline has expired
-                        let now = tokio::time::Instant::now();
-                        let expired: Vec<IpAddr> = self
-                            .llgr_stale_deadlines
-                            .iter()
-                            .filter(|&(_, &deadline)| deadline <= now)
-                            .map(|(&peer, _)| peer)
-                            .collect();
-                        for peer in expired {
-                            self.sweep_llgr_stale(peer);
-                        }
+                        self.sweep_expired_llgr_stale();
                     }
                     () = refresh_sleep.as_mut(), if has_refresh_timers => {
                         if self.drain_ready_updates() {

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -271,7 +271,6 @@ impl RibManager {
         }
 
         if self.llgr_peers.remove(&peer).is_some() {
-            self.llgr_stale_deadlines.remove(&peer);
             // The LLGR config survives GR→LLGR promotion (handle_peer_up
             // reads it on re-establishment), so an LLGR abort must drop it
             // here — the GR arm above won't fire for a peer already
@@ -282,6 +281,10 @@ impl RibManager {
             self.metrics.set_gr_active(&peer_label, false);
             self.metrics.set_gr_stale_routes(&peer_label, 0);
         }
+        // Per-family LLGR deadlines can outlive both maps above (they
+        // survive re-establishment while routes remain LLGR-stale); a full
+        // teardown ends retention outright.
+        self.llgr_stale_deadlines.retain(|&(p, _, _), _| p != peer);
 
         self.clear_peer_adj_rib_in(peer);
 
@@ -599,7 +602,13 @@ impl RibManager {
         } else if self.llgr_peers.contains_key(&peer)
             && let Some(llgr_families) = self.llgr_peers.remove(&peer)
         {
-            self.llgr_stale_deadlines.remove(&peer);
+            // The per-family LLGR deadlines are deliberately NOT cleared:
+            // routes stay LLGR-stale until End-of-RIB, and RFC 9494 bounds
+            // total retention by the ORIGINAL Long-Lived Stale Time — if a
+            // deadline fires before this session's End-of-RIB (or the peer
+            // flaps again), the family's unrefreshed routes are purged on
+            // the original schedule. End-of-RIB removes the deadline once
+            // the family is refreshed.
             let srt = self
                 .llgr_peer_config
                 .get(&peer)

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -219,6 +219,11 @@ impl RibManager {
                 rtc_swept |= !rib.sweep_llgr_stale_family_rtc((afi, safi)).is_empty();
                 rib.clear_stale_rtc((afi, safi));
             }
+            // End-of-RIB resolves this family's LLGR retention (routes were
+            // either re-advertised or swept just above), so its surviving
+            // original-LLST deadline — kept across the re-establishment —
+            // is retired here.
+            self.llgr_stale_deadlines.remove(&(peer, afi, safi));
 
             // FlowSpec/EVPN affected keys were collected BEFORE the sweep,
             // so removed keys are already in their sets; the unicast set is
@@ -393,6 +398,8 @@ impl RibManager {
                 rtc_swept = !rib.sweep_llgr_stale_family_rtc((afi, safi)).is_empty();
                 rib.clear_llgr_stale_rtc((afi, safi));
             }
+            // This family's LLGR retention is resolved — retire its deadline.
+            self.llgr_stale_deadlines.remove(&(peer, afi, safi));
 
             // Same shape as the GR arm: FlowSpec/EVPN affected keys already
             // include the swept ones (collected pre-sweep); join the swept
@@ -452,7 +459,6 @@ impl RibManager {
             if all_done {
                 info!(%peer, "LLGR complete — all End-of-RIB received");
                 self.llgr_peers.remove(&peer);
-                self.llgr_stale_deadlines.remove(&peer);
                 // The LLGR config outlives GR→LLGR promotion; LLGR
                 // completion is a terminal point, mirror the GR arm above.
                 self.llgr_peer_config.remove(&peer);

--- a/crates/rib/src/manager/tests/gr_llgr.rs
+++ b/crates/rib/src/manager/tests/gr_llgr.rs
@@ -1204,7 +1204,7 @@ async fn llgr_expiry_sweep_drops_llgr_peer_config() {
     );
 
     // LLGR expires with the peer still gone — the config must not leak.
-    manager.sweep_llgr_stale(peer);
+    manager.sweep_llgr_stale(peer, &[(Afi::Ipv4, Safi::Unicast)]);
     assert!(
         !manager.llgr_peer_config.contains_key(&peer),
         "LLGR expiry must drop the per-peer LLGR config"
@@ -1313,7 +1313,7 @@ async fn llgr_expiry_without_reestablish_releases_peer_state() {
     assert!(manager.ribs.contains_key(&peer), "LLGR retains the rib");
 
     // LLGR expires with the peer still gone.
-    manager.sweep_llgr_stale(peer);
+    manager.sweep_llgr_stale(peer, &[(Afi::Ipv4, Safi::Unicast)]);
 
     assert!(
         !manager.ribs.contains_key(&peer),
@@ -1396,3 +1396,496 @@ async fn gr_expiry_sweep_spares_reestablished_peer_awaiting_eor() {
 }
 
 // --- Route Reflector tests ---
+
+// --- Per-family LLGR lifecycle (LAN-282) + LLGR export coupling (LAN-191) ---
+
+/// Re-establish `peer` through the run loop as an iBGP RR client with the
+/// given sendable families.
+async fn channel_peer_up(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    sendable: Vec<(Afi, Safi)>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: sendable,
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    out_rx
+}
+
+async fn send_eor(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr, afi: Afi, safi: Safi) {
+    tx.send(RibUpdate::EndOfRib {
+        peer,
+        session_id: 0,
+        afi,
+        safi,
+    })
+    .await
+    .unwrap();
+}
+
+/// RFC 9494 §4.3: the stale time is per AFI/SAFI. Two families with
+/// different peer-advertised stale times must be swept on their OWN
+/// deadlines — the shorter one first, the longer one retained until its
+/// own timer expires (the old peer-wide min purged both at the shorter).
+#[tokio::test]
+async fn llgr_mixed_stale_times_sweep_per_family() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_vpn_rib_route(Ipv4Addr::new(10, 0, 0, 1), 31, 100, 100)],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // GR with per-family LLGR stale times: unicast 10 s, VPN 60 s.
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 2,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)],
+        peer_llgr_capable: true,
+        peer_llgr_families: vec![
+            rustbgpd_wire::LlgrFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                forwarding_preserved: false,
+                stale_time: 10,
+            },
+            rustbgpd_wire::LlgrFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::MplsVpn,
+                forwarding_preserved: false,
+                stale_time: 60,
+            },
+        ],
+        llgr_stale_time: 3600,
+    })
+    .await
+    .unwrap();
+    assert!(query_best_routes(&tx).await[0].is_stale);
+
+    // Past the GR timer: both families promote to LLGR-stale.
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_best_routes(&tx).await[0].is_llgr_stale);
+    assert!(query_vpn_routes(&tx).await[0].is_llgr_stale);
+
+    // Past the unicast stale time only: unicast swept, VPN retained.
+    tokio::time::advance(Duration::from_secs(11)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_best_routes(&tx).await.is_empty(),
+        "shorter-stale-time family must be swept on its own deadline"
+    );
+    let vpn = query_vpn_routes(&tx).await;
+    assert_eq!(
+        vpn.len(),
+        1,
+        "longer-stale-time family must survive the shorter family's sweep"
+    );
+    assert!(vpn[0].is_llgr_stale);
+
+    // Past the VPN stale time: the remaining family is swept.
+    tokio::time::advance(Duration::from_secs(50)).await;
+    tokio::task::yield_now().await;
+    assert!(query_vpn_routes(&tx).await.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RFC 9494: the ORIGINAL Long-Lived Stale Time bounds total retention.
+/// A peer that re-establishes during LLGR and goes down again must not
+/// restart the timer — the surviving deadline is re-used, and the
+/// LLGR-stale routes are retained (not purged) across the second reset.
+#[tokio::test]
+async fn llgr_reconnect_and_second_down_preserve_original_deadline() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let family = vec![(Afi::Ipv4, Safi::Unicast)];
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    // GR down with a 20 s LLST; promotion happens ~t=3, deadline ~t=23.
+    tx.send(gr_with_llgr(source, 2, family.clone(), family.clone(), 20))
+        .await
+        .unwrap();
+    assert!(query_best_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(query_best_routes(&tx).await[0].is_llgr_stale);
+
+    // ~t=13: re-establish during LLGR, then drop again WITHOUT refreshing.
+    // A restarted timer would push the sweep out to ~t=33.
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::task::yield_now().await;
+    let _out_rx = channel_peer_up(&tx, source, ipv4_sendable()).await;
+    tx.send(gr_with_llgr(source, 100, family.clone(), family, 20))
+        .await
+        .unwrap();
+
+    // The LLGR-stale route survives the second reset (RFC 9494 retention —
+    // the old purge-on-second-reset would have deleted it here)...
+    let best = query_best_routes(&tx).await;
+    assert_eq!(
+        best.len(),
+        1,
+        "LLGR-stale route must be retained across consecutive resets"
+    );
+    assert!(best[0].is_llgr_stale);
+    assert!(!best[0].is_stale, "must not be demoted back to GR-stale");
+
+    // ...but only until the ORIGINAL deadline (~t=23): at ~t=25 it is gone,
+    // long before both the restarted-timer horizon (~t=33) and the second
+    // session's GR window (~t=113).
+    tokio::time::advance(Duration::from_secs(12)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        query_best_routes(&tx).await.is_empty(),
+        "original LLST must bound total retention through reconnects"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LLGR→GR re-establishment carries the `LLGR_STALE` state: routes stay
+/// LLGR-stale (flag + community) through the new session until End-of-RIB,
+/// which retires both the staleness and the family's surviving original
+/// deadline — a refreshed table must NOT be swept at the old LLST horizon.
+#[tokio::test]
+async fn llgr_reestablish_carries_llgr_stale_until_eor() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let family = vec![(Afi::Ipv4, Safi::Unicast)];
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    tx.send(gr_with_llgr(source, 2, family.clone(), family, 60))
+        .await
+        .unwrap();
+    assert!(query_best_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    // Re-establish during LLGR: the unrefreshed route keeps its LLGR-stale
+    // flag and community while the session waits for End-of-RIB.
+    let _out_rx = channel_peer_up(&tx, source, ipv4_sendable()).await;
+    let best = query_best_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert!(
+        best[0].is_llgr_stale,
+        "LLGR_STALE state must carry through re-establishment until EoR"
+    );
+    assert!(
+        best[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE)
+    );
+
+    // The peer re-advertises the route and completes with End-of-RIB.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    send_eor(&tx, source, Afi::Ipv4, Safi::Unicast).await;
+    let best = query_best_routes(&tx).await;
+    assert_eq!(best.len(), 1);
+    assert!(!best[0].is_stale && !best[0].is_llgr_stale);
+    assert!(
+        !best[0]
+            .communities()
+            .contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE),
+        "locally injected LLGR_STALE community must be stripped after EoR"
+    );
+
+    // Past the original 60 s LLST: the refreshed route must survive — EoR
+    // retired the family's deadline.
+    tokio::time::advance(Duration::from_secs(70)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        query_best_routes(&tx).await.len(),
+        1,
+        "EoR must retire the surviving original deadline for the family"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Reconnect-before-expiry across every LLGR-capable family on one peer
+/// (unicast, VPN, labeled, EVPN, RTC): promotion marks all five families
+/// LLGR-stale; the peer re-establishes, re-advertises everything, and
+/// sends per-family End-of-RIB — every route survives past the original
+/// LLST fresh.
+#[expect(
+    clippy::too_many_lines,
+    reason = "announce + assert across five address families"
+)]
+#[tokio::test]
+async fn llgr_reconnect_before_expiry_across_families() {
+    tokio::time::pause();
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let src_v4 = Ipv4Addr::new(10, 0, 0, 1);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let families = vec![
+        (Afi::Ipv4, Safi::Unicast),
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::LabeledUnicast),
+        (Afi::L2Vpn, Safi::Evpn),
+        (Afi::Ipv4, Safi::RtConstrain),
+    ];
+
+    let announce_all = |tx: mpsc::Sender<RibUpdate>| async move {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![make_route(prefix, src_v4)],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![make_evpn_imet(src_v4, 100)],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        tx.send(RibUpdate::VpnRoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![make_vpn_rib_route(src_v4, 31, 100, 100)],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        tx.send(RibUpdate::LabeledRoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![make_labeled_rib_route(src_v4, 41, 100, 100)],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        tx.send(RibUpdate::RtcRoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![make_rtc_rib_route(src_v4, 7, 100)],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    };
+    announce_all(tx.clone()).await;
+
+    tx.send(gr_with_llgr(
+        source,
+        2,
+        families.clone(),
+        families.clone(),
+        30,
+    ))
+    .await
+    .unwrap();
+    // Sync: the GR entry must be processed before time advances.
+    assert!(query_best_routes(&tx).await[0].is_stale);
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+
+    assert!(query_best_routes(&tx).await[0].is_llgr_stale);
+    assert!(query_vpn_routes(&tx).await[0].is_llgr_stale);
+    assert!(query_labeled_routes(&tx).await[0].is_llgr_stale);
+    assert!(query_evpn_routes(&tx).await[0].is_llgr_stale);
+    assert!(query_rtc_routes(&tx).await[0].is_llgr_stale);
+
+    // Re-establish before expiry, re-advertise everything, EoR per family.
+    let _out_rx = channel_peer_up(&tx, source, families.clone()).await;
+    announce_all(tx.clone()).await;
+    for &(afi, safi) in &families {
+        send_eor(&tx, source, afi, safi).await;
+    }
+
+    // Past the original 30 s LLST: every family survived, fresh.
+    tokio::time::advance(Duration::from_secs(35)).await;
+    tokio::task::yield_now().await;
+    let best = query_best_routes(&tx).await;
+    assert_eq!(
+        best.len(),
+        1,
+        "unicast must survive reconnect-before-expiry"
+    );
+    assert!(!best[0].is_stale && !best[0].is_llgr_stale);
+    let vpn = query_vpn_routes(&tx).await;
+    assert_eq!(vpn.len(), 1, "VPN must survive reconnect-before-expiry");
+    assert!(!vpn[0].is_stale && !vpn[0].is_llgr_stale);
+    let labeled = query_labeled_routes(&tx).await;
+    assert_eq!(
+        labeled.len(),
+        1,
+        "labeled must survive reconnect-before-expiry"
+    );
+    assert!(!labeled[0].is_stale && !labeled[0].is_llgr_stale);
+    let evpn = query_evpn_routes(&tx).await;
+    assert_eq!(evpn.len(), 1, "EVPN must survive reconnect-before-expiry");
+    assert!(!evpn[0].is_stale && !evpn[0].is_llgr_stale);
+    // The RTC-capable re-establishment also self-originates the default
+    // wildcard RTC NLRI — pick out the peer's own route.
+    let rtc = query_rtc_routes(&tx).await;
+    let peer_rtc: Vec<_> = rtc.iter().filter(|r| r.peer == source).collect();
+    assert_eq!(
+        peer_rtc.len(),
+        1,
+        "RTC must survive reconnect-before-expiry"
+    );
+    assert!(!peer_rtc[0].is_stale && !peer_rtc[0].is_llgr_stale);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-191: EVPN GR-stale routes deliberately continue to be exported
+/// during the GR window (RFC 4724 permits advertising stale paths) — the
+/// operational tradeoff is documented at the EVPN staging gate. A GR entry
+/// must not withdraw the already-advertised EVPN route from other peers.
+#[tokio::test]
+async fn evpn_gr_stale_routes_keep_exporting_during_gr_window() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    // eBGP target: iBGP targets would be split-horizon-suppressed without
+    // an RR cluster-id, and GR-stale export is not eBGP-gated (only
+    // LLGR-stale toward a non-LLGR eBGP peer is).
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let mut out_rx = llgr_gate_peer_up(&tx, target, evpn_sendable(), true, vec![], None).await;
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let imet = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
+    let key = imet.key();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![imet],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let first = out_rx.recv().await.unwrap();
+    assert_eq!(first.evpn_announce.len(), 1);
+
+    // Source enters GR covering EVPN (no LLGR).
+    tx.send(RibUpdate::PeerGracefulRestart {
+        session_id: 0,
+        peer: source,
+        restart_time: 120,
+        stale_routes_time: 360,
+        gr_families: vec![(Afi::L2Vpn, Safi::Evpn)],
+        peer_llgr_capable: false,
+        peer_llgr_families: vec![],
+        llgr_stale_time: 0,
+    })
+    .await
+    .unwrap();
+
+    let evpn = query_evpn_routes(&tx).await;
+    assert_eq!(evpn.len(), 1);
+    assert!(evpn[0].is_stale, "route must be GR-stale during the window");
+
+    // The stale route stays exported: no withdraw toward the target.
+    while let Ok(update) = out_rx.try_recv() {
+        assert!(
+            !update.evpn_withdraw.contains(&key),
+            "GR-stale EVPN route must keep exporting during the GR window"
+        );
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -133,6 +133,16 @@ impl PeerSession {
     /// LLGR peers too). This lives beside the other per-peer attribute
     /// rewrites (eBGP `LOCAL_PREF` strip, `ORIGINATOR_ID`/`CLUSTER_LIST`,
     /// `GShut` attach) rather than at RIB staging.
+    ///
+    /// Detection is by the `LLGR_STALE` community rather than the RIB's
+    /// `is_llgr_stale` flag — deliberately: the community is the superset.
+    /// A route *received* already tagged by an upstream LLGR helper carries
+    /// only the community (the local flag is never set for it), yet §4.6
+    /// applies to it all the same. For locally promoted routes the flag and
+    /// community are coupled by construction (promotion injects the
+    /// community; the flag is never set anywhere else), and that coupling
+    /// is pinned by `llgr_stale_flag_implies_community_across_mutations` in
+    /// `rustbgpd-rib::adj_rib_in`.
     fn apply_llgr_stale_export_form(
         &self,
         attrs: &mut Vec<PathAttribute>,


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 1 (LAN-282), folding in the remaining LAN-191 GR/LLGR conformance items. Restores the GR/LLGR roadmap row toward Shipped.

## Problem

- LLGR stale deadlines were per-peer: `sweep_gr_stale` promoted with one `min`-over-families stale time, so a 60s family was purged when a 10s family expired (RFC 9494 §4.3 defines stale time per AFI/SAFI).
- Reconnect deleted the deadline and a second down restarted timers from scratch, extending retention beyond the original Long-Lived Stale Time.
- Every `mark_stale*` helper deleted LLGR-stale routes on a consecutive reset, applying RFC 4724 §4.1 to exactly what RFC 9494 exempts.

## Changes

- Deadline map keyed `(peer, afi, safi)`, stamped once per family at LLGR entry (min of local config and that family's peer-advertised stale time) and preserved through reconnects; EoR retires the family's deadline; sweeps are per-family. `next_llgr_deadline()` signature unchanged (min over the map).
- All seven family `mark_stale*` helpers retain LLGR-stale routes as-is across consecutive resets until the original deadline expires; GR-stale still deletes per RFC 4724 §4.1.
- LAN-191 items: LLGR-stale export detection keeps the community scan (superset of the flag — catches upstream-tagged routes) with a rationale comment plus a regression test proving flag/community coupling across insert → mark → promote → re-reset → re-advertise → clear; EVPN GR-stale export during the GR window is now an explicitly documented + tested operator tradeoff; LLGR→GR re-establish carrying LLGR_STALE is lifecycle-tested.

## Tests

`llgr_mixed_stale_times_sweep_per_family` (10s unicast swept, 60s VPN survives — old code purged both), `llgr_reconnect_and_second_down_preserve_original_deadline`, `llgr_reestablish_carries_llgr_stale_until_eor`, reconnect-before-expiry across unicast/VPN/labeled/EVPN/RTC, and seven per-family consecutive-reset unit tests. rib suite 694 passed; full workspace 5034 passed / 0 failed; fmt / clippy `-D warnings` / bench-internals check / doc all green.