### PR TITLE
Define MAC mobility sequence policy at the u32 boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   message instead of passing vacuously); the M33 soak analyzer rejects a
   samples CSV whose expected columns are missing instead of silently gating
   on all-zero deltas.
+- **EVPN MAC Mobility sequence numbers saturate at `u32::MAX` instead of
+  wrapping.** RFC 7432 leaves sequence wrap undefined; outbidding a received
+  `u32::MAX` with a naive `+1` would have overflowed (panic in debug builds,
+  wrap to 0 in release — and a wrapped 0 loses every §15 comparison, flapping
+  forever). Every sequence increment in the MAC-only and MAC+IP origination
+  state machines now saturates at `u32::MAX`: a received `u32::MAX` is
+  unbeatable-by-increment, rustbgpd originates at `u32::MAX` too, and the
+  RFC 7432 §7.7 lowest-VTEP-IP tiebreak becomes the standing resolution —
+  the MAX-vs-MAX tie stays quiet instead of re-emitting the same sequence on
+  every remote event. (LAN-287)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/evpn/src/origination.rs
+++ b/crates/evpn/src/origination.rs
@@ -59,6 +59,20 @@
 //!    advertise the MAC, then drops `originated_key`. The state entry
 //!    is **kept** so a subsequent re-Learn preserves the seq ratchet.
 //!
+//! # Sequence saturation at `u32::MAX`
+//!
+//! RFC 7432 does not define what happens when an increment would
+//! exceed `u32::MAX`. Emitting a wrapped 0 would lose every §15
+//! comparison and re-trigger a bump on every subsequent remote event —
+//! a permanent flap. Policy: **every sequence increment saturates at
+//! `u32::MAX`**. A received `u32::MAX` is unbeatable-by-increment; we
+//! originate at `u32::MAX` too and the RFC 7432 §7.7 lowest-VTEP-IP
+//! tiebreaker (implemented in [`crate::projection`]) becomes the
+//! standing resolution. [`LocalMacOriginator::on_remote_changed`] suppresses the
+//! re-Inject when the saturated bump cannot exceed the sequence we
+//! already advertise, so a MAX-vs-MAX tie is quiet, not a churn loop.
+//! [`crate::origination_macip`] follows the same policy.
+//!
 //! # Sticky bit (RFC 7432 §15.4)
 //!
 //! [`OriginationAction::Inject::sticky`] is plumbed through but the
@@ -302,6 +316,9 @@ impl LocalMacOriginator {
         // that was previously advertised, then Aged, must preserve its
         // sequence ratchet on re-Learn (otherwise a peer that still
         // remembers our prior seq could win the contention).
+        // All increments saturate at u32::MAX — see "Sequence
+        // saturation at `u32::MAX`" in the module docs. Never wrap
+        // to 0 (a wrapped 0 loses every comparison and flaps forever).
         let is_first_ever = prior.is_none();
         let new_seq = match new_last_seen {
             None => {
@@ -309,7 +326,7 @@ impl LocalMacOriginator {
                 if is_first_ever {
                     0
                 } else if was_advertising && (port_changed || sticky_changed) {
-                    prior_seq + 1
+                    prior_seq.saturating_add(1)
                 } else {
                     // Idempotent re-Learn or re-Learn after Aged with
                     // unchanged identity — preserve ratchet.
@@ -319,15 +336,15 @@ impl LocalMacOriginator {
             Some(remote_seq) => {
                 // A contender has been observed at some point.
                 if is_first_ever {
-                    remote_seq + 1
+                    remote_seq.saturating_add(1)
                 } else if !was_advertising {
                     // Re-Learn after Aged with contention history —
                     // bump above contender AND above our prior seq.
-                    (remote_seq + 1).max(prior_seq + 1)
+                    remote_seq.max(prior_seq).saturating_add(1)
                 } else if remote_seq >= prior_seq {
-                    remote_seq + 1
+                    remote_seq.saturating_add(1)
                 } else if port_changed || sticky_changed {
-                    prior_seq + 1
+                    prior_seq.saturating_add(1)
                 } else {
                     prior_seq
                 }
@@ -412,7 +429,15 @@ impl LocalMacOriginator {
             return Vec::new();
         }
 
-        let new_seq = remote_seq.max(entry.our_seq) + 1;
+        let new_seq = remote_seq.max(entry.our_seq).saturating_add(1);
+        if new_seq == entry.our_seq {
+            // Only reachable via saturation: both sides sit at
+            // u32::MAX. An increment cannot outbid the contender —
+            // the §7.7 lowest-VTEP-IP tiebreak (crate::projection)
+            // is the standing resolution. Re-emitting the same seq
+            // would just churn; stay quiet. See module docs.
+            return Vec::new();
+        }
         entry.our_seq = new_seq;
         let mobility_seq = entry.rendered_seq();
         let sticky = entry.sticky;
@@ -560,6 +585,85 @@ mod tests {
         let actions = o.on_remote_changed(mac(0xAA), Some(&v));
         assert_eq!(actions.len(), 1);
         assert_inject(&actions[0], Some(101), false);
+    }
+
+    // --- u32::MAX boundary (sequence saturation policy) ---
+
+    #[test]
+    fn first_learned_outbids_remote_at_max_minus_one_with_max() {
+        let mut o = fresh();
+        let v = remote(Some(u32::MAX - 1));
+        let actions = o.on_local_learned(mac(0xAA), 10, false, Some(&v));
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn first_learned_with_remote_at_max_saturates_never_wraps_to_zero() {
+        let mut o = fresh();
+        let v = remote(Some(u32::MAX));
+        let actions = o.on_local_learned(mac(0xAA), 10, false, Some(&v));
+        assert_eq!(actions.len(), 1);
+        // Unbeatable-by-increment: originate at u32::MAX too and let
+        // the §7.7 lowest-VTEP-IP tiebreak stand. A wrapped 0 would
+        // lose every comparison and flap forever.
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn remote_changed_to_max_minus_one_bumps_to_max() {
+        let mut o = fresh();
+        let _ = o.on_local_learned(mac(0xAA), 10, false, None);
+        let v = remote(Some(u32::MAX - 1));
+        let actions = o.on_remote_changed(mac(0xAA), Some(&v));
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn remote_at_max_against_our_max_is_a_quiet_standing_tie() {
+        let mut o = fresh();
+        // Outbid MAX-1 → we advertise u32::MAX.
+        let v = remote(Some(u32::MAX - 1));
+        let _ = o.on_local_learned(mac(0xAA), 10, false, Some(&v));
+
+        // Remote catches up to MAX. An increment can't outbid it —
+        // no wrapped-0 emission, no same-seq re-Inject churn.
+        let vmax = remote(Some(u32::MAX));
+        let actions = o.on_remote_changed(mac(0xAA), Some(&vmax));
+        assert!(actions.is_empty(), "got {actions:?}");
+        // Repeat events stay quiet too — no flap loop.
+        let actions = o.on_remote_changed(mac(0xAA), Some(&vmax));
+        assert!(actions.is_empty(), "got {actions:?}");
+    }
+
+    #[test]
+    fn local_port_move_at_max_saturates_never_wraps_to_zero() {
+        let mut o = fresh();
+        // Outbid MAX-2 → our_seq = MAX-1.
+        let v = remote(Some(u32::MAX - 2));
+        let _ = o.on_local_learned(mac(0xAA), 10, false, Some(&v));
+        // Port move bumps MAX-1 → MAX.
+        let a1 = o.on_local_learned(mac(0xAA), 11, false, None);
+        assert_eq!(a1.len(), 1);
+        assert_inject(&a1[0], Some(u32::MAX), false);
+        // Another move at the ceiling: saturate, don't wrap.
+        let a2 = o.on_local_learned(mac(0xAA), 12, false, None);
+        assert_eq!(a2.len(), 1);
+        assert_inject(&a2[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn relearn_after_aged_with_contender_at_max_saturates() {
+        let mut o = fresh();
+        let v = remote(Some(u32::MAX));
+        let _ = o.on_local_learned(mac(0xAA), 10, false, Some(&v));
+        let _ = o.on_local_aged(mac(0xAA));
+        // Re-Learn after Aged with contention history at the ceiling:
+        // ratchet is preserved at u32::MAX, never wrapped.
+        let actions = o.on_local_learned(mac(0xAA), 10, false, None);
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
     }
 
     #[test]

--- a/crates/evpn/src/origination_macip.rs
+++ b/crates/evpn/src/origination_macip.rs
@@ -275,6 +275,9 @@ impl LocalMacIpOriginator {
         // (MAC, IP) that was previously advertised then withdrawn
         // must preserve its ratchet, otherwise a peer that still
         // remembers our prior seq could win contention on re-Learn.
+        // All increments saturate at u32::MAX — same policy as
+        // MAC-only, see "Sequence saturation at `u32::MAX`" in
+        // `crate::origination`'s module docs. Never wrap to 0.
         let is_first_ever = prior.is_none();
         let new_seq = match new_last_seen {
             None => {
@@ -289,16 +292,16 @@ impl LocalMacIpOriginator {
             }
             Some(remote_seq) => {
                 if is_first_ever {
-                    remote_seq + 1
+                    remote_seq.saturating_add(1)
                 } else if !was_advertising {
                     // Re-Learn after Aged with contention history —
                     // bump above contender AND above our prior seq.
                     // Mirrors MAC-only: a peer that still remembers
                     // our prior advertisement sees a fresh higher
                     // number rather than a tie.
-                    (remote_seq + 1).max(prior_seq + 1)
+                    remote_seq.max(prior_seq).saturating_add(1)
                 } else if remote_seq >= prior_seq {
-                    remote_seq + 1
+                    remote_seq.saturating_add(1)
                 } else {
                     prior_seq
                 }
@@ -410,7 +413,15 @@ impl LocalMacIpOriginator {
             return Vec::new();
         }
 
-        let new_seq = remote_seq.max(entry.our_seq) + 1;
+        let new_seq = remote_seq.max(entry.our_seq).saturating_add(1);
+        if new_seq == entry.our_seq {
+            // Only reachable via saturation: both sides sit at
+            // u32::MAX. An increment cannot outbid the contender —
+            // the §7.7 lowest-VTEP-IP tiebreak (crate::projection)
+            // is the standing resolution. Re-emitting the same seq
+            // would just churn; stay quiet.
+            return Vec::new();
+        }
         entry.our_seq = new_seq;
         let mobility_seq = entry.rendered_seq();
         let sticky = entry.sticky;
@@ -541,6 +552,88 @@ mod tests {
         // No remote contender → seq stays at 0; sticky now true →
         // extcomm is emitted (rendered_seq enables it for sticky=true).
         assert_inject(&actions[0], Some(0), true);
+    }
+
+    // --- u32::MAX boundary (sequence saturation policy) ---
+
+    #[test]
+    fn first_learn_outbids_remote_at_max_minus_one_with_max() {
+        let mut o = fresh();
+        let actions = o.on_local_ip_learned(
+            mac(0xAA),
+            ipa("192.0.2.10"),
+            false,
+            Some(&remote(Some(u32::MAX - 1))),
+        );
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn first_learn_with_remote_at_max_saturates_never_wraps_to_zero() {
+        let mut o = fresh();
+        let actions = o.on_local_ip_learned(
+            mac(0xAA),
+            ipa("192.0.2.10"),
+            false,
+            Some(&remote(Some(u32::MAX))),
+        );
+        assert_eq!(actions.len(), 1);
+        // Unbeatable-by-increment: originate at u32::MAX too and let
+        // the §7.7 lowest-VTEP-IP tiebreak stand. A wrapped 0 would
+        // lose every comparison and flap forever.
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn remote_changed_to_max_minus_one_bumps_to_max() {
+        let mut o = fresh();
+        let _ = o.on_local_ip_learned(mac(0xAA), ipa("192.0.2.10"), false, None);
+        let actions = o.on_remote_ip_changed(
+            mac(0xAA),
+            ipa("192.0.2.10"),
+            Some(&remote(Some(u32::MAX - 1))),
+        );
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
+    }
+
+    #[test]
+    fn remote_at_max_against_our_max_is_a_quiet_standing_tie() {
+        let mut o = fresh();
+        // Outbid MAX-1 → we advertise u32::MAX.
+        let _ = o.on_local_ip_learned(
+            mac(0xAA),
+            ipa("192.0.2.10"),
+            false,
+            Some(&remote(Some(u32::MAX - 1))),
+        );
+
+        // Remote catches up to MAX. An increment can't outbid it —
+        // no wrapped-0 emission, no same-seq re-Inject churn.
+        let vmax = remote(Some(u32::MAX));
+        let actions = o.on_remote_ip_changed(mac(0xAA), ipa("192.0.2.10"), Some(&vmax));
+        assert!(actions.is_empty(), "got {actions:?}");
+        // Repeat events stay quiet too — no flap loop.
+        let actions = o.on_remote_ip_changed(mac(0xAA), ipa("192.0.2.10"), Some(&vmax));
+        assert!(actions.is_empty(), "got {actions:?}");
+    }
+
+    #[test]
+    fn relearn_after_aged_with_contender_at_max_saturates() {
+        let mut o = fresh();
+        let _ = o.on_local_ip_learned(
+            mac(0xAA),
+            ipa("192.0.2.10"),
+            false,
+            Some(&remote(Some(u32::MAX))),
+        );
+        let _ = o.on_local_ip_aged(mac(0xAA), ipa("192.0.2.10"));
+        // Re-Learn after Aged with contention history at the ceiling:
+        // ratchet is preserved at u32::MAX, never wrapped.
+        let actions = o.on_local_ip_learned(mac(0xAA), ipa("192.0.2.10"), false, None);
+        assert_eq!(actions.len(), 1);
+        assert_inject(&actions[0], Some(u32::MAX), false);
     }
 
     // --- on_local_ip_aged ---


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 2 (LAN-287).

## Problem

The MAC-mobility origination paths computed the outbidding sequence with unchecked `+ 1`. A received MAC Mobility sequence of `u32::MAX` would wrap to 0 — a wrapped 0 loses every §7.7 comparison and re-injects forever (permanent flap loop).

## Policy: saturate + RFC 7432 §7.7 tiebreak

Every increment is `saturating_add(1)`. A received `u32::MAX` is unbeatable-by-increment: rustbgpd originates at `u32::MAX` and the existing §7.7 lowest-VTEP-IP tiebreak resolves the standing tie. The anti-flap piece: `on_remote_changed` / `on_remote_ip_changed` return no actions when the saturated bump cannot exceed the current local sequence (reachable only at MAX-vs-MAX), so the tie is quiet instead of a same-sequence re-inject on every remote event. Documented in the `origination.rs` module docs.

All 10 sequence-arithmetic sites across MAC-only and MAC+IP origination converted (the only such sites in the tree); first-learn, contender-update, re-learn-after-Aged, and port/sticky-move paths covered.

## Tests

11 boundary tests at MAX-1/MAX for both MAC-only and MAC+IP: outbidding MAX-1 → MAX, receiving MAX → saturate never wrap, quiet standing tie asserted empty on repeated events, port-move and re-learn saturation. evpn suite 354 passed; full workspace 5084 passed / 0 failed; fmt / clippy `-D warnings` / doc green.