### PR TITLE
Classify restart-only reloads and surface listener and shutdown truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RFC 7432 §7.7 lowest-VTEP-IP tiebreak becomes the standing resolution —
   the MAX-vs-MAX tie stays quiet instead of re-emitting the same sequence on
   every remote event. (LAN-287)
+- **Reload classification and listener/shutdown truth.** Four daemon-truth
+  fixes: (1) `[security.grpc]`, `[event_history]`, and `[managed_netdevs]`
+  edits are now classified restart-required — SIGHUP/apply pins the runtime
+  snapshot back to the live startup values with an explicit restart-required
+  error (the operator's edit survives in the on-disk config), and the first
+  two now appear in the `--diff` / transaction-plan restart-required buckets
+  alongside `[managed_netdevs]` instead of silently drifting the in-memory
+  snapshot. (2) The two peer-manager→RIB reply awaits on the reload/apply
+  path (per-peer outbound refresh after a graceful-shutdown toggle,
+  export-policy swap) are now bounded by a 5 s deadline that surfaces a clear
+  error instead of hanging the reload forever behind a wedged RIB task.
+  (3) A BGP listener bind failure at startup now turns `/readyz` red with
+  `BGP listener failed to bind` (previously the daemon ran silently
+  unreachable for inbound sessions behind a lone warning). (4) Coordinated
+  shutdown flips the availability gate first: readiness goes red, persisted
+  config mutations are rejected, and new inbound BGP connections are dropped
+  before any teardown begins, instead of admitting work into it. (LAN-286)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/api/src/health_probe.rs
+++ b/crates/api/src/health_probe.rs
@@ -1,6 +1,8 @@
 //! Shared control-plane health/readiness probes.
 
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
@@ -11,6 +13,61 @@ use rustbgpd_rib::RibUpdate;
 
 /// Total deadline for the core actor readiness probe.
 pub const CORE_READINESS_DEADLINE: Duration = Duration::from_millis(200);
+
+/// Process-wide daemon availability gate.
+///
+/// Two one-way transitions, both set from `main.rs` and observed by the
+/// readiness surface:
+///
+/// - **not-ready**: a fatal availability fault (BGP listener failed to
+///   bind, coordinated shutdown started). `/readyz` reports 503 with the
+///   first recorded reason until the process restarts.
+/// - **shutting-down**: coordinated shutdown has begun; admission paths
+///   (inbound BGP connections, persisted config mutations) reject new
+///   work instead of racing the teardown.
+#[derive(Clone, Debug, Default)]
+pub struct DaemonGate {
+    inner: Arc<DaemonGateInner>,
+}
+
+#[derive(Debug, Default)]
+struct DaemonGateInner {
+    not_ready: OnceLock<&'static str>,
+    shutting_down: AtomicBool,
+}
+
+impl DaemonGate {
+    /// Create a gate in the ready, not-shutting-down state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a fatal availability fault. First reason wins; later calls
+    /// are no-ops so the root cause stays visible.
+    pub fn mark_not_ready(&self, reason: &'static str) {
+        let _ = self.inner.not_ready.set(reason);
+    }
+
+    /// Enter coordinated shutdown: readiness goes red and admission
+    /// paths stop accepting new work.
+    pub fn begin_shutdown(&self) {
+        self.inner.shutting_down.store(true, Ordering::Relaxed);
+        self.mark_not_ready("daemon is shutting down");
+    }
+
+    /// The not-ready reason, if any fault has been recorded.
+    #[must_use]
+    pub fn not_ready_reason(&self) -> Option<&'static str> {
+        self.inner.not_ready.get().copied()
+    }
+
+    /// Whether coordinated shutdown has begun.
+    #[must_use]
+    pub fn is_shutting_down(&self) -> bool {
+        self.inner.shutting_down.load(Ordering::Relaxed)
+    }
+}
 
 /// Snapshot returned by a successful core actor probe.
 #[derive(Debug)]
@@ -26,6 +83,7 @@ pub struct CoreHealthSnapshot {
 pub struct CoreReadinessProbe {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
     rib_tx: mpsc::Sender<RibUpdate>,
+    gate: Option<DaemonGate>,
 }
 
 impl CoreReadinessProbe {
@@ -38,7 +96,17 @@ impl CoreReadinessProbe {
         Self {
             peer_mgr_tx,
             rib_tx,
+            gate: None,
         }
+    }
+
+    /// Attach the process-wide [`DaemonGate`]: a recorded fault (bind
+    /// failure, shutdown) makes the probe fail before touching the
+    /// core actors.
+    #[must_use]
+    pub fn with_gate(mut self, gate: DaemonGate) -> Self {
+        self.gate = Some(gate);
+        self
     }
 
     /// Probe `PeerManager` and RIB responsiveness.
@@ -63,6 +131,9 @@ impl CoreReadinessProbe {
     /// drops its reply channel, or does not respond before the readiness
     /// deadline.
     pub async fn snapshot(&self) -> Result<CoreHealthSnapshot, CoreReadinessError> {
+        if let Some(reason) = self.gate.as_ref().and_then(DaemonGate::not_ready_reason) {
+            return Err(CoreReadinessError::DaemonUnavailable(reason));
+        }
         let deadline = Instant::now() + CORE_READINESS_DEADLINE;
         let peers = self.query_peer_manager(deadline).await?;
         let total_routes = self.query_rib(deadline).await?;
@@ -136,6 +207,9 @@ pub enum CoreReadinessError {
     RibTimedOut,
     /// RIB dropped the reply channel.
     RibDroppedReply,
+    /// The daemon recorded a fatal availability fault ([`DaemonGate`]):
+    /// BGP listener bind failure or coordinated shutdown in progress.
+    DaemonUnavailable(&'static str),
 }
 
 impl fmt::Display for CoreReadinessError {
@@ -152,6 +226,7 @@ impl fmt::Display for CoreReadinessError {
                 write!(f, "RIB manager probe timed out ({deadline_ms}ms deadline)")
             }
             Self::RibDroppedReply => f.write_str("RIB manager dropped reply"),
+            Self::DaemonUnavailable(reason) => f.write_str(reason),
         }
     }
 }
@@ -336,6 +411,78 @@ mod tests {
             result.expect_err("dropped RIB reply should fail"),
             CoreReadinessError::RibDroppedReply
         );
+    }
+
+    #[tokio::test]
+    async fn gated_probe_fails_without_touching_core_actors() {
+        // BGP-listener bind failure: readiness must go red even though
+        // both core actors would answer (nothing replies here and the
+        // probe must not need them to).
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let gate = DaemonGate::new();
+        let probe = CoreReadinessProbe::new(peer_tx, rib_tx).with_gate(gate.clone());
+
+        gate.mark_not_ready("BGP listener failed to bind");
+
+        let err = probe
+            .check()
+            .await
+            .expect_err("tripped gate must fail readiness");
+        assert_eq!(
+            err,
+            CoreReadinessError::DaemonUnavailable("BGP listener failed to bind")
+        );
+        assert_eq!(err.to_string(), "BGP listener failed to bind");
+        assert!(
+            !gate.is_shutting_down(),
+            "a bind fault must not flip the shutdown admission gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn begin_shutdown_turns_readiness_red_and_stops_admission() {
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let gate = DaemonGate::new();
+        let probe = CoreReadinessProbe::new(peer_tx, rib_tx).with_gate(gate.clone());
+
+        assert!(!gate.is_shutting_down());
+        gate.begin_shutdown();
+
+        assert!(gate.is_shutting_down());
+        assert_eq!(
+            probe.check().await,
+            Err(CoreReadinessError::DaemonUnavailable(
+                "daemon is shutting down"
+            ))
+        );
+    }
+
+    #[test]
+    fn first_not_ready_reason_wins() {
+        let gate = DaemonGate::new();
+        gate.mark_not_ready("BGP listener failed to bind");
+        gate.begin_shutdown();
+        assert_eq!(
+            gate.not_ready_reason(),
+            Some("BGP listener failed to bind"),
+            "the root-cause fault must stay visible across later transitions"
+        );
+    }
+
+    #[tokio::test]
+    async fn ungated_probe_still_probes_core_actors() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let probe = CoreReadinessProbe::new(peer_tx, rib_tx).with_gate(DaemonGate::new());
+
+        let (result, ()) = tokio::join!(
+            probe.check(),
+            reply_to_core_probe(&mut peer_rx, Vec::new(), &mut rib_rx, 0)
+        );
+
+        result.expect("untripped gate must not affect readiness");
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1851,6 +1851,14 @@ pub struct ConfigDiff {
     /// lifecycle changes are restart-required until the managed-netdev
     /// executor lands.
     pub managed_netdevs_changed: bool,
+    /// `[security.grpc]` (enforcement mode / principal roles) changed.
+    /// The authorization context is built once per listener at startup,
+    /// so edits are restart-required and must remain visible in `--diff`.
+    pub security_grpc_changed: bool,
+    /// `[event_history]` changed. The ADR-0072 durable outbox is
+    /// configured once at startup (all fields are restart-required per
+    /// the reload matrix), so edits must remain visible in `--diff`.
+    pub event_history_changed: bool,
     /// `[[fib_tables]]` blocks added/removed/modified between old and new.
     /// Reload-applied in the common case: the ADR-0061 general-FIB actor
     /// accepts a runtime table-set swap on SIGHUP
@@ -2097,6 +2105,8 @@ impl ConfigDiff {
             || self.policy_explain_changed
             || self.fib_tables_requires_restart
             || self.managed_netdevs_changed
+            || self.security_grpc_changed
+            || self.event_history_changed
     }
 
     /// Changes detected but not applied by current SIGHUP. Empty
@@ -2379,6 +2389,16 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .restart_required_sections
             .push("[managed_netdevs]".to_string());
     }
+    if diff.security_grpc_changed {
+        class
+            .restart_required_sections
+            .push("[security.grpc]".to_string());
+    }
+    if diff.event_history_changed {
+        class
+            .restart_required_sections
+            .push("[event_history]".to_string());
+    }
     if diff.apply_bum_enforcement_changed {
         class
             .restart_required_sections
@@ -2536,6 +2556,8 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "evpn_ip_vrfs_changed": diff.evpn_runtime_change_class.is_restart_required() && diff.evpn_ip_vrfs_changed,
             "ethernet_segments_changed": diff.evpn_runtime_change_class.is_restart_required() && diff.ethernet_segments_changed,
             "managed_netdevs_changed": diff.managed_netdevs_changed,
+            "security_grpc_changed": diff.security_grpc_changed,
+            "event_history_changed": diff.event_history_changed,
             "fib_tables_requires_restart": diff.fib_tables_requires_restart,
             "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
             "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
@@ -2779,6 +2801,12 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     if diff.managed_netdevs_changed {
         restart_sections.push("[managed_netdevs]");
     }
+    if diff.security_grpc_changed {
+        restart_sections.push("[security.grpc]");
+    }
+    if diff.event_history_changed {
+        restart_sections.push("[event_history]");
+    }
     if diff.fib_tables_requires_restart {
         restart_sections.push("[[fib_tables]] (start FIB from an empty config)");
     }
@@ -2910,6 +2938,8 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         evpn_ip_vrfs_changed: old.evpn_ip_vrfs != new.evpn_ip_vrfs,
         ethernet_segments_changed: old.ethernet_segments != new.ethernet_segments,
         managed_netdevs_changed: old.managed_netdevs != new.managed_netdevs,
+        security_grpc_changed: old.security != new.security,
+        event_history_changed: old.event_history != new.event_history,
         fib_tables_changed: old.fib_tables != new.fib_tables,
         fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
         dynamic_neighbors_changed: old.dynamic_neighbors != new.dynamic_neighbors,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4205,6 +4205,73 @@ fn diff_config_no_policy_explain_change_is_clean() {
 }
 
 #[test]
+fn diff_config_flags_security_grpc_as_restart_required() {
+    // LAN-286: `[security.grpc]` is resolved once at startup when the
+    // gRPC listeners are built — an edit must classify as
+    // restart-required, not vanish from the diff.
+    let old = parse(valid_toml()).unwrap();
+    let mut new = old.clone();
+    new.security
+        .grpc
+        .roles
+        .insert("observer-readonly".to_string(), GrpcRoleConfig::Observer);
+
+    let diff = super::diff_config(&old, &new);
+    assert!(diff.security_grpc_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(
+        !diff.has_reload_applied_changes(),
+        "a security-only edit does not hot-apply"
+    );
+
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(json["restart_required"]["security_grpc_changed"], true);
+
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(text.contains("[security.grpc]"), "{text}");
+
+    let sections = super::classify_config_transaction_v1(&diff);
+    assert!(
+        sections
+            .restart_required_sections
+            .contains(&"[security.grpc]".to_string()),
+        "{sections:?}"
+    );
+}
+
+#[test]
+fn diff_config_flags_event_history_as_restart_required() {
+    // LAN-286: every `[event_history]` field is restart-required (the
+    // ADR-0072 outbox is configured once at startup) — an edit must
+    // classify as restart-required, not vanish from the diff.
+    let old = parse(valid_toml()).unwrap();
+    let mut new = old.clone();
+    new.event_history.enabled = !new.event_history.enabled;
+
+    let diff = super::diff_config(&old, &new);
+    assert!(diff.event_history_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(
+        !diff.has_reload_applied_changes(),
+        "an event-history-only edit does not hot-apply"
+    );
+
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(json["restart_required"]["event_history_changed"], true);
+
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(text.contains("[event_history]"), "{text}");
+
+    let sections = super::classify_config_transaction_v1(&diff);
+    assert!(
+        sections
+            .restart_required_sections
+            .contains(&"[event_history]".to_string()),
+        "{sections:?}"
+    );
+}
+
+#[test]
 fn diff_config_pins_entire_neighbor_when_tcp_ao_changes() {
     let mut old = parse(valid_toml()).unwrap();
     old.neighbors[0].hold_time = Some(90);

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,12 +70,13 @@ use crate::peer_manager::PeerManager;
 use crate::reload::{
     apply_reload_outcome, reload_config, run_config_bridge, runtime_config_snapshot,
 };
+use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
 };
 use rustbgpd_api::server::{
-    AccessMode as GrpcServerAccessMode, ListenerConfig as GrpcListenerConfig, ListenerEndpoint,
-    ServeConfig,
+    AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
+    ListenerEndpoint, ServeConfig,
 };
 
 const GR_RESTART_MARKER_VERSION: u8 = 1;
@@ -2395,7 +2396,24 @@ async fn run<T>(
             },
             metrics.clone(),
         );
-    let config_mutation_gate = config_transaction_controller.mutation_gate_fn();
+    // Process-wide availability gate (LAN-286): BGP-listener bind failure
+    // turns readiness red; coordinated shutdown turns readiness red AND
+    // stops admitting persisted config mutations and inbound BGP sessions.
+    let daemon_gate = DaemonGate::new();
+    let config_mutation_gate: ConfigMutationGateFn = {
+        let inner = config_transaction_controller.mutation_gate_fn();
+        let gate = daemon_gate.clone();
+        Arc::new(move |operation| {
+            let inner = inner.clone();
+            let gate = gate.clone();
+            Box::pin(async move {
+                if gate.is_shutting_down() {
+                    return Err(format!("{operation} rejected: daemon is shutting down"));
+                }
+                inner(operation).await
+            })
+        })
+    };
     let serve_config = ServeConfig {
         asn: config.global.asn,
         router_id: config.global.router_id.clone(),
@@ -2630,8 +2648,18 @@ async fn run<T>(
     match BgpListener::bind_with_options(listen_addr, accept_tx, listener_options).await {
         Ok(listener) => {
             let listener_peer_mgr_tx = peer_mgr_tx.clone();
+            let listener_gate = daemon_gate.clone();
             tokio::spawn(async move {
                 while let Some(conn) = accept_rx.recv().await {
+                    // Coordinated shutdown has begun: drop (close) the
+                    // socket instead of admitting a session into teardown.
+                    if listener_gate.is_shutting_down() {
+                        info!(
+                            peer = %conn.peer_addr,
+                            "rejecting inbound BGP connection: daemon is shutting down"
+                        );
+                        continue;
+                    }
                     if let Err(e) = listener_peer_mgr_tx
                         .send(PeerManagerCommand::AcceptInbound {
                             stream: conn.stream,
@@ -2654,7 +2682,16 @@ async fn run<T>(
                 );
                 process::exit(1);
             }
-            warn!(%listen_addr, error = %e, "failed to bind BGP listener");
+            // The daemon can still open outbound sessions, but it is
+            // unreachable for inbound peers — surface that on /readyz
+            // instead of running silently unreachable.
+            error!(
+                %listen_addr,
+                error = %e,
+                "failed to bind BGP listener; inbound BGP sessions cannot be accepted — \
+                 readiness reports not-ready until the daemon is restarted"
+            );
+            daemon_gate.mark_not_ready("BGP listener failed to bind");
         }
     }
 
@@ -2729,7 +2766,8 @@ async fn run<T>(
         let readiness_probe = rustbgpd_api::health_probe::CoreReadinessProbe::new(
             peer_mgr_tx.clone(),
             rib_tx.clone(),
-        );
+        )
+        .with_gate(daemon_gate.clone());
         tokio::spawn(async move {
             metrics_server::serve_metrics(prometheus_addr, metrics_clone, readiness_probe).await;
         });
@@ -2885,7 +2923,11 @@ async fn run<T>(
     drop(profiler);
 
     // Coordinated shutdown:
+    // 0. Flip the availability gate FIRST: readiness goes red, persisted
+    //    config mutations are rejected, and new inbound BGP sessions are
+    //    dropped — nothing new is admitted into the teardown below.
     // 1. Tell PeerManager to shut down (sends NOTIFICATIONs to all peers)
+    daemon_gate.begin_shutdown();
     info!("initiating coordinated shutdown");
     if let Some(restart_time_secs) = max_gr_restart_time_secs(&config) {
         let expires_at = SystemTime::now() + Duration::from_secs(restart_time_secs);

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -284,6 +284,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_readyz_returns_503_when_daemon_gate_is_tripped() {
+        // LAN-286: bind failure / coordinated shutdown trips the daemon
+        // gate — /readyz must go red without consulting the core actors.
+        use rustbgpd_api::health_probe::DaemonGate;
+
+        let (peer_tx, _peer_rx) = mpsc::channel(1);
+        let (rib_tx, _rib_rx) = mpsc::channel(1);
+        let gate = DaemonGate::new();
+        let addr =
+            start_server(CoreReadinessProbe::new(peer_tx, rib_tx).with_gate(gate.clone())).await;
+
+        gate.begin_shutdown();
+
+        let response = request(addr, "/readyz").await;
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.ends_with("not ready: daemon is shutting down\n"));
+    }
+
+    #[tokio::test]
     async fn slow_client_times_out() {
         let addr = start_server(unused_probe()).await;
         let stream = TcpStream::connect(addr).await.unwrap();

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -874,12 +874,21 @@ impl PeerManager {
                 failures.push(format!("{addr}: rib send: {e}"));
                 continue;
             }
-            match reply_rx.await {
+            // Bounded: a wedged RIB task must not park the peer-manager
+            // actor (and the SIGHUP reload driving this toggle) forever.
+            match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
                 Err(_) => {
+                    warn!(%addr, "RIB did not reply to gshut refresh within deadline");
+                    failures.push(format!(
+                        "{addr}: rib reply timed out after {:?}",
+                        super::RIB_REPLY_TIMEOUT
+                    ));
+                }
+                Ok(Err(_)) => {
                     warn!(%addr, "RIB dropped reply for gshut refresh");
                     failures.push(format!("{addr}: rib reply dropped"));
                 }
-                Ok(Err(e)) => {
+                Ok(Ok(Err(e))) => {
                     // "peer X not registered for outbound updates" is
                     // expected for peers not yet Established — log at
                     // debug, not as a failure.
@@ -889,7 +898,7 @@ impl PeerManager {
                          desired state stored, will apply on next PeerUp"
                     );
                 }
-                Ok(Ok(())) => {}
+                Ok(Ok(Ok(()))) => {}
             }
         }
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -68,6 +68,13 @@ const PEER_POLICY_UPDATE_TIMEOUT: Duration = Duration::from_millis(500);
 /// blocking every peer's RPC/reconcile work behind one stalled session.
 const PEER_LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
+/// actor (export-policy swap, per-peer outbound refresh). Generous — the
+/// RIB answers these inline and never legitimately takes seconds — but
+/// bounded so a wedged RIB task cannot park the peer-manager actor (and
+/// therefore SIGHUP reload / gRPC policy apply) forever.
+const RIB_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// ADR-0073: deadline for an `ExplainImportPolicy` round-trip to a
 /// session task. Bounded for the same reason as the policy-update
 /// timeout — a session parked on TCP back-pressure must not park the

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -647,10 +647,17 @@ impl PeerManager {
                 .await;
             let rib_outcome: Result<(), String> = match send_outcome {
                 Err(_) => Err("RIB manager unavailable".to_string()),
-                Ok(()) => match reply_rx.await {
-                    Err(_) => Err("RIB manager dropped reply".to_string()),
-                    Ok(Err(e)) => Err(format!("failed to update export policy: {e}")),
-                    Ok(Ok(())) => Ok(()),
+                // Bounded: a wedged RIB task must not park the
+                // peer-manager actor (and the SIGHUP reload / gRPC
+                // apply driving this policy change) forever.
+                Ok(()) => match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
+                    Err(_) => Err(format!(
+                        "RIB manager did not reply within {:?} while updating export policy",
+                        super::RIB_REPLY_TIMEOUT
+                    )),
+                    Ok(Err(_)) => Err("RIB manager dropped reply".to_string()),
+                    Ok(Ok(Err(e))) => Err(format!("failed to update export policy: {e}")),
+                    Ok(Ok(Ok(()))) => Ok(()),
                 },
             };
             if let Err(error) = rib_outcome {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -5845,6 +5845,140 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
     );
 }
 
+#[tokio::test(start_paused = true)]
+async fn gshut_toggle_times_out_when_rib_reply_wedges() {
+    use rustbgpd_transport::PeerCommand;
+
+    // LAN-286: a wedged RIB (accepts RefreshPeerOutbound but never
+    // replies) must surface as a bounded error — not park the
+    // peer-manager actor (and the reload/apply path driving the
+    // toggle) forever.
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let session_task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            if let PeerCommand::UpdateGracefulShutdown { reply, .. } = cmd {
+                let _ = reply.send(Ok(()));
+            }
+        }
+        Ok(())
+    });
+    let handle = PeerHandle::from_parts(session_tx, session_task);
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(64);
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::RefreshPeerOutbound { reply, .. } = update {
+                // Wedged RIB: hold the reply channel open, never answer.
+                held.push(reply);
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+
+    let err = mgr
+        .set_graceful_shutdown(Some(key(addr)), true)
+        .await
+        .expect_err("wedged RIB reply must fail the toggle, not hang it");
+    assert!(
+        err.to_string().contains("timed out"),
+        "error must name the RIB reply timeout: {err}"
+    );
+}
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test(start_paused = true)]
+async fn export_policy_apply_times_out_when_rib_reply_wedges() {
+    use rustbgpd_transport::PeerCommand;
+
+    // LAN-286: same wedge class as the gshut refresh — the
+    // ReplacePeerExportPolicy reply await must be bounded so a wedged
+    // RIB cannot hang a SIGHUP reload / gRPC policy apply forever.
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let session_task = tokio::spawn(async move {
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::UpdateImportPolicy { reply, .. }
+                | PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: SessionState::Established,
+                        peer_ip: addr,
+                        peer_asn: None,
+                        prefix_count: 0,
+                        negotiated_hold_time: None,
+                        four_octet_as: None,
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 0,
+                        last_error: String::new(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    let handle = PeerHandle::from_parts(session_tx, session_task);
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(64);
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                // Wedged RIB: hold the reply channel open, never answer.
+                held.push(reply);
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+
+    let err = mgr
+        .update_runtime_policies(addr, None, Some(deny_policy_chain()))
+        .await
+        .expect_err("wedged RIB reply must fail the export apply, not hang it");
+    assert!(
+        err.contains("did not reply within"),
+        "error must name the RIB reply timeout: {err}"
+    );
+}
+
 #[tokio::test]
 async fn gshut_not_found_preserves_scoped_peer_label() {
     let (_tx, rx) = mpsc::channel(16);

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -593,6 +593,38 @@ pub(crate) async fn reload_config(
         );
         new_config.apply_bum_enforcement = current.apply_bum_enforcement;
     }
+    // Restart-required sections resolved once at startup: without an
+    // explicit pin, a SIGHUP would silently advance the in-memory
+    // snapshot to the new declared state while the running subsystem
+    // keeps the startup values — the next reload then stops warning
+    // even though nothing was applied. Pin each back to the live
+    // startup snapshot (the operator's edit survives in the desired
+    // on-disk config for the next restart).
+    if new_config.security != current.security {
+        error!(
+            "[security.grpc] changed — gRPC authorization enforcement and roles \
+             are resolved once at startup when listeners are built. Restart \
+             rustbgpd to apply; the live listeners keep their startup \
+             authorization until then."
+        );
+        new_config.security = current.security.clone();
+    }
+    if new_config.event_history != current.event_history {
+        error!(
+            "[event_history] changed — the ADR-0072 durable event outbox is \
+             configured once at startup. Restart rustbgpd to apply; the running \
+             outbox keeps its startup configuration until then."
+        );
+        new_config.event_history = current.event_history.clone();
+    }
+    if new_config.managed_netdevs != current.managed_netdevs {
+        error!(
+            "[managed_netdevs] changed — the ADR-0091 managed-netdev lifecycle \
+             reads this table once at startup. Restart rustbgpd to apply; the \
+             dataplane keeps reconciling the startup netdev set until then."
+        );
+        new_config.managed_netdevs = current.managed_netdevs.clone();
+    }
     // `[[fib_tables]]` is hot-applied to the running FIB reconciler below
     // (after the honor knobs), ack-gated on the actor accepting the new set —
     // see the FIB hot-apply step.
@@ -4169,6 +4201,91 @@ hold_time = 90
             returned.desired.neighbors[0].bfd.as_ref().unwrap().profile,
             "fast",
             "desired TOML must preserve the operator's BFD edit for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_pins_security_grpc_edits_to_startup_snapshot() {
+        // LAN-286: [security.grpc] is resolved once at startup when the
+        // gRPC listeners are built. A SIGHUP must pin the runtime
+        // snapshot back to the startup authorization config — but keep
+        // the operator's edit in the desired TOML for the next restart.
+        let initial = baseline_toml();
+        let new_toml = format!(
+            "{}\n[security.grpc.roles]\n\"observer-readonly\" = \"observer\"\n",
+            baseline_toml()
+        );
+
+        let (returned, tags) = drive_reload(initial, &new_toml).await;
+        let returned = returned.expect("reload should return pinned runtime config");
+
+        assert!(
+            tags.is_empty(),
+            "security-only edits are restart-required and must not reconcile peers: {tags:?}"
+        );
+        assert!(
+            returned.security.grpc.roles.is_empty(),
+            "runtime snapshot must keep the startup gRPC authorization config"
+        );
+        assert_eq!(
+            returned.desired.security.grpc.roles.len(),
+            1,
+            "desired TOML must preserve the operator's edit for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_pins_event_history_edits_to_startup_snapshot() {
+        // LAN-286: every [event_history] field is restart-required (the
+        // ADR-0072 outbox is configured once at startup). A SIGHUP must
+        // pin the runtime snapshot back to the startup outbox config —
+        // but keep the operator's edit in the desired TOML.
+        let initial = baseline_toml();
+        let new_toml = format!("{}\n[event_history]\nenabled = true\n", baseline_toml());
+
+        let (returned, tags) = drive_reload(initial, &new_toml).await;
+        let returned = returned.expect("reload should return pinned runtime config");
+
+        assert!(
+            tags.is_empty(),
+            "event-history-only edits are restart-required and must not reconcile peers: {tags:?}"
+        );
+        assert!(
+            !returned.event_history.enabled,
+            "runtime snapshot must keep the startup (disabled) outbox config"
+        );
+        assert!(
+            returned.desired.event_history.enabled,
+            "desired TOML must preserve the operator's edit for restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_pins_managed_netdevs_edits_to_startup_snapshot() {
+        // LAN-286: [managed_netdevs] is read once at startup by the
+        // ADR-0091 lifecycle. A SIGHUP must pin the runtime snapshot
+        // back to the startup netdev table — but keep the operator's
+        // edit in the desired TOML for the next restart.
+        let initial = baseline_toml();
+        let new_toml = format!(
+            "{}\n[managed_netdevs]\nowner_token = \"leaf-1\"\n",
+            baseline_toml()
+        );
+
+        let (returned, tags) = drive_reload(initial, &new_toml).await;
+        let returned = returned.expect("reload should return pinned runtime config");
+
+        assert!(
+            tags.is_empty(),
+            "managed-netdev-only edits are restart-required and must not reconcile peers: {tags:?}"
+        );
+        assert!(
+            returned.managed_netdevs.owner_token.is_empty(),
+            "runtime snapshot must keep the startup managed-netdev table"
+        );
+        assert_eq!(
+            returned.desired.managed_netdevs.owner_token, "leaf-1",
+            "desired TOML must preserve the operator's edit for restart"
         );
     }
 


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 2 (LAN-286). Four daemon-truth fixes:

1. **Restart-only reload classification.** `[security.grpc]`, `[event_history]`, and `[managed_netdevs]` edits silently advanced the in-memory snapshot on SIGHUP/apply while the running subsystem kept startup values. They now follow the existing pin machinery: error-logged as restart-required, snapshot pinned to live values, the operator's edit surviving on disk as intent. `ConfigDiff` gained `security_grpc_changed` / `event_history_changed` (managed_netdevs was already diff-classified; its gap was the reload pin), wired through `--diff` JSON and the human renderer. `docs/reload-matrix.md` already documented all three as restart-required — the daemon now enforces what the matrix says.
2. **Bounded reply waits.** The two remaining unbounded PeerManager→RIB reply awaits (gshut toggle refresh, export-policy replace) now time out at 5s with named errors — a wedged RIB task can no longer hang a reload forever.
3. **Bind-failure visibility.** A BGP listener bind failure now trips a `DaemonGate`: `/readyz` returns 503 with the reason, before touching core actors (previously a warn log and a silently unreachable daemon).
4. **Shutdown truth.** Coordinated shutdown begins by turning readiness red, rejecting config mutations at the existing mutation-gate choke point, and dropping new inbound BGP connections instead of admitting them into teardown.

## Tests

Three reload-pin tests (one per section), two wedged-reply timeout tests (`start_paused`; hang without the fix), readyz-503 on tripped gate, first-reason-wins, shutdown-red admission stop, ungated-probe control. gRPC authz tier matrix untouched (36 authz tests green).

## Gates

fmt / clippy `-D warnings` / full workspace (5085 passed, 0 failed) / doc — all green.