### PR TITLE
Page RIB reads through bounded resumable actor queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   identical timestamp in both views. The fabricated Loc-RIB OPEN's
   infallible encoding is now backed by an explicit bounded-size test on the
   declared family set instead of an unproven `expect`. (LAN-193)
+- **RIB route listings are bounded, resumable, and never silently
+  truncated.** `ListReceivedRoutes`/`ListBestRoutes`/`ListAdvertisedRoutes`
+  used to materialize the full table out of the RIB task per call and
+  filter/slice it in the API layer with numeric-offset tokens; filtering and
+  pagination now run inside the RIB task as bounded resumable queries
+  (opaque last-key cursor, per-page allocation capped at 1000 rows, the same
+  mutation-robust cursor step as the BMP Loc-RIB dump), and a canceled gRPC
+  request whose page query is already enqueued is skipped before any scan.
+  `rbgp best` / `rbgp rib received` / `rbgp rib advertised` used to silently
+  truncate at 100 rows; they now paginate transparently until the listing
+  completes. Canceled on-demand MRT dump requests are likewise skipped
+  before the RIB snapshot, encode, and file write. (LAN-288)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -15,7 +15,8 @@ use rustbgpd_rib::{
     BgpLsFamily, BgpLsRibRoute, EvpnRibRoute, ExplainAdvertisedRoute, ExplainBestPath,
     ExplainDecision, ExportGateVerdict, FlowSpecRoute, LabeledRibRoute, OrrLinkSnapshot,
     OrrNodeSnapshot, OrrStatusSnapshot, OrrTopologySnapshot, OrrVantageStatus, RibUpdate, Route,
-    RouteEventType, RtcRibRoute, VpnRibRoute,
+    RouteEventType, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, RtcRibRoute,
+    VpnRibRoute, route_query_key,
 };
 use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{
@@ -202,25 +203,26 @@ impl RibService {
             .map_err(|_| Status::internal("RIB manager dropped reply"))
     }
 
-    async fn query_routes(&self, peer: Option<IpAddr>) -> Result<Vec<Route>, Status> {
+    /// One bounded, resumable page from the RIB task. Filtering and
+    /// pagination run inside the actor; the reply channel doubles as
+    /// the cancellation token (dropping this future drops the receiver,
+    /// so an already-enqueued page query is skipped by the actor).
+    async fn query_routes_page(
+        &self,
+        scope: RouteQueryScope,
+        filter: Option<RouteQueryFilter>,
+        after: Option<RouteQueryKey>,
+        page_size: usize,
+    ) -> Result<RoutePage, Status> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.rib_tx
-            .send(RibUpdate::QueryReceivedRoutes {
-                peer,
+            .send(RibUpdate::QueryRoutesPage {
+                scope,
+                filter,
+                after,
+                page_size,
                 reply: reply_tx,
             })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
-        reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))
-    }
-
-    async fn query_best_routes(&self) -> Result<Vec<Route>, Status> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryBestRoutes { reply: reply_tx })
             .await
             .map_err(|_| Status::internal("RIB manager unavailable"))?;
 
@@ -694,87 +696,88 @@ fn prefix_parts(prefix: Prefix) -> (String, u32) {
     }
 }
 
-fn parse_page_params(req: &proto::ListRoutesRequest) -> Result<(usize, usize), &'static str> {
-    let offset: usize = if req.page_token.is_empty() {
-        0
-    } else {
-        req.page_token.parse().map_err(|_| "invalid page_token")?
-    };
+/// Default page size when the request leaves `page_size` at 0.
+const DEFAULT_ROUTE_PAGE_SIZE: usize = 100;
 
+/// Decode the pagination fields of a route-listing request: the resume
+/// cursor (from the opaque `page_token`) and the requested page size.
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for validation helpers"
+)]
+fn parse_route_page_params(
+    req: &proto::ListRoutesRequest,
+) -> Result<(Option<RouteQueryKey>, usize), Status> {
+    let after = if req.page_token.is_empty() {
+        None
+    } else {
+        Some(decode_route_page_token(&req.page_token)?)
+    };
     let page_size = if req.page_size == 0 {
-        100
+        DEFAULT_ROUTE_PAGE_SIZE
     } else {
         req.page_size as usize
     };
-
-    Ok((offset, page_size))
+    Ok((after, page_size))
 }
 
-fn build_filtered_response(
-    routes: Vec<Route>,
-    afi_safi: i32,
-    filters: &RouteFilters,
-    offset: usize,
-    page_size: usize,
-    best: bool,
-) -> proto::ListRoutesResponse {
-    let filters_active = !filters.is_empty();
+/// Encode a resume cursor as the opaque `next_page_token`: the identity
+/// key (`prefix|peer|path_id`) of the last row on the page.
+fn encode_route_page_token(key: &RouteQueryKey) -> String {
+    let (prefix, peer, path_id) = key;
+    let (addr, len) = prefix_parts(*prefix);
+    format!("{addr}/{len}|{peer}|{path_id}")
+}
 
-    // Fast path: when neither the family filter nor the route filters narrow the
-    // snapshot, `total_count` is just the snapshot length and the page is a
-    // plain offset/limit slice — no full scan to count. This preserves the
-    // pre-fusion O(offset + page_size) cost for the common "list, first page"
-    // call instead of walking the whole RIB just to recompute `routes.len()`.
-    if !filters_active && family_filter_is_noop(afi_safi) {
-        let total_count = routes.len();
-        let page: Vec<proto::Route> = routes
-            .iter()
-            .skip(offset)
-            .take(page_size)
-            .map(|r| route_to_proto(r, best))
-            .collect();
-        let next_offset = offset.saturating_add(page.len());
-        let next_page_token = if next_offset < total_count {
-            next_offset.to_string()
-        } else {
-            String::new()
-        };
-        return proto::ListRoutesResponse {
-            routes: page,
-            next_page_token,
-            total_count: u64::try_from(total_count).unwrap_or(u64::MAX),
-        };
+#[allow(
+    clippy::result_large_err,
+    reason = "tonic::Status is the direct gRPC error type for validation helpers"
+)]
+fn decode_route_page_token(token: &str) -> Result<RouteQueryKey, Status> {
+    let invalid = || Status::invalid_argument("invalid page_token");
+    let mut parts = token.split('|');
+    let (Some(prefix), Some(peer), Some(path_id), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return Err(invalid());
+    };
+    let (addr, len) = prefix.split_once('/').ok_or_else(invalid)?;
+    let len: u32 = len.parse().map_err(|_| invalid())?;
+    let prefix = parse_prefix_request(addr, len).map_err(|_| invalid())?;
+    let peer: IpAddr = peer.parse().map_err(|_| invalid())?;
+    let path_id: u32 = path_id.parse().map_err(|_| invalid())?;
+    Ok((prefix, peer, path_id))
+}
+
+/// Build the row filter evaluated inside the RIB task. `None` when
+/// neither the family filter nor the route filters narrow the scope, so
+/// the actor skips per-route predicate calls entirely.
+fn build_route_query_filter(afi_safi: i32, filters: RouteFilters) -> Option<RouteQueryFilter> {
+    if filters.is_empty() && family_filter_is_noop(afi_safi) {
+        return None;
     }
+    Some(Box::new(move |route| {
+        route_matches_family(route, afi_safi) && filters.matches(route)
+    }))
+}
 
-    let mut total_count = 0usize;
-    let mut page = Vec::new();
-
-    for route in routes {
-        if !route_matches_family(&route, afi_safi) {
-            continue;
-        }
-        if filters_active && !filters.matches(&route) {
-            continue;
-        }
-
-        let row_index = total_count;
-        total_count = total_count.saturating_add(1);
-        if row_index >= offset && page.len() < page_size {
-            page.push(route_to_proto(&route, best));
-        }
-    }
-
-    let next_offset = offset.saturating_add(page.len());
-    let next_page_token = if next_offset < total_count {
-        next_offset.to_string()
+fn route_page_to_response(page: &RoutePage, best: bool) -> proto::ListRoutesResponse {
+    let next_page_token = if page.has_more {
+        page.routes
+            .last()
+            .map(|route| encode_route_page_token(&route_query_key(route)))
+            .unwrap_or_default()
     } else {
         String::new()
     };
-
     proto::ListRoutesResponse {
-        routes: page,
+        routes: page
+            .routes
+            .iter()
+            .map(|route| route_to_proto(route, best))
+            .collect(),
         next_page_token,
-        total_count: u64::try_from(total_count).unwrap_or(u64::MAX),
+        total_count: page.total,
     }
 }
 
@@ -1158,16 +1161,16 @@ impl proto::rib_service_server::RibService for RibService {
         };
 
         let filters = RouteFilters::from_request(&req)?;
-        let all_routes = self.query_routes(peer).await?;
-        let (offset, page_size) = parse_page_params(&req).map_err(Status::invalid_argument)?;
-        Ok(Response::new(build_filtered_response(
-            all_routes,
-            req.afi_safi,
-            &filters,
-            offset,
-            page_size,
-            false,
-        )))
+        let (after, page_size) = parse_route_page_params(&req)?;
+        let page = self
+            .query_routes_page(
+                RouteQueryScope::Received { peer },
+                build_route_query_filter(req.afi_safi, filters),
+                after,
+                page_size,
+            )
+            .await?;
+        Ok(Response::new(route_page_to_response(&page, false)))
     }
 
     async fn list_best_routes(
@@ -1177,16 +1180,16 @@ impl proto::rib_service_server::RibService for RibService {
         let req = request.into_inner();
         validate_unicast_afi_safi(req.afi_safi)?;
         let filters = RouteFilters::from_request(&req)?;
-        let all_routes = self.query_best_routes().await?;
-        let (offset, page_size) = parse_page_params(&req).map_err(Status::invalid_argument)?;
-        Ok(Response::new(build_filtered_response(
-            all_routes,
-            req.afi_safi,
-            &filters,
-            offset,
-            page_size,
-            true,
-        )))
+        let (after, page_size) = parse_route_page_params(&req)?;
+        let page = self
+            .query_routes_page(
+                RouteQueryScope::Best,
+                build_route_query_filter(req.afi_safi, filters),
+                after,
+                page_size,
+            )
+            .await?;
+        Ok(Response::new(route_page_to_response(&page, true)))
     }
 
     async fn list_advertised_routes(
@@ -1207,29 +1210,17 @@ impl proto::rib_service_server::RibService for RibService {
             .parse()
             .map_err(|e| Status::invalid_argument(format!("invalid address: {e}")))?;
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.rib_tx
-            .send(RibUpdate::QueryAdvertisedRoutes {
-                peer,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-
         let filters = RouteFilters::from_request(&req)?;
-        let all_routes = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
-
-        let (offset, page_size) = parse_page_params(&req).map_err(Status::invalid_argument)?;
-        Ok(Response::new(build_filtered_response(
-            all_routes,
-            req.afi_safi,
-            &filters,
-            offset,
-            page_size,
-            false,
-        )))
+        let (after, page_size) = parse_route_page_params(&req)?;
+        let page = self
+            .query_routes_page(
+                RouteQueryScope::Advertised { peer },
+                build_route_query_filter(req.afi_safi, filters),
+                after,
+                page_size,
+            )
+            .await?;
+        Ok(Response::new(route_page_to_response(&page, false)))
     }
 
     async fn explain_advertised_route(
@@ -3958,17 +3949,6 @@ mod tests {
         }
     }
 
-    fn empty_route_filters() -> RouteFilters {
-        RouteFilters {
-            prefix: None,
-            longer: false,
-            origin_asn: 0,
-            communities: vec![],
-            large_community_filter_active: false,
-            large_communities: vec![],
-        }
-    }
-
     #[test]
     fn route_filters_exact_prefix() {
         let route = Route {
@@ -4151,79 +4131,100 @@ mod tests {
     }
 
     #[test]
-    fn build_filtered_response_counts_and_paginates_after_family_filtering() {
-        let routes = vec![
-            test_route(
+    fn route_page_token_round_trips() {
+        for key in [
+            (
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
-                vec![],
+                "192.0.2.1".parse::<IpAddr>().unwrap(),
+                0u32,
             ),
-            test_route(
+            (
                 Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
-                vec![],
+                "2001:db8::1".parse::<IpAddr>().unwrap(),
+                7u32,
             ),
-            test_route(
-                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24)),
-                vec![],
-            ),
-        ];
-
-        let first = build_filtered_response(
-            routes.clone(),
-            proto::AddressFamily::Ipv4Unicast as i32,
-            &empty_route_filters(),
-            0,
-            1,
-            true,
-        );
-        assert_eq!(first.total_count, 2);
-        assert_eq!(first.routes.len(), 1);
-        assert_eq!(first.routes[0].prefix, "10.0.0.0");
-        assert!(first.routes[0].best);
-        assert_eq!(first.next_page_token, "1");
-
-        let second = build_filtered_response(
-            routes,
-            proto::AddressFamily::Ipv4Unicast as i32,
-            &empty_route_filters(),
-            1,
-            1,
-            true,
-        );
-        assert_eq!(second.total_count, 2);
-        assert_eq!(second.routes.len(), 1);
-        assert_eq!(second.routes[0].prefix, "10.0.1.0");
-        assert!(second.next_page_token.is_empty());
+        ] {
+            let token = encode_route_page_token(&key);
+            assert_eq!(decode_route_page_token(&token).unwrap(), key);
+        }
     }
 
     #[test]
-    fn build_filtered_response_fast_path_counts_full_snapshot_without_filters() {
-        // No family filter (afi_safi = 0) and no route filters → the fast path
-        // counts the whole snapshot via len() and slices the page, with the
-        // same total_count / pagination as the fused path.
-        let routes = vec![
-            test_route(
+    fn route_page_token_rejects_garbage() {
+        for token in ["", "5", "not-a-token", "10.0.0.0/24|192.0.2.1", "a|b|c|d"] {
+            let err = decode_route_page_token(token).unwrap_err();
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        }
+    }
+
+    #[tokio::test]
+    async fn list_received_routes_pages_through_the_actor() {
+        // The RPC forwards cursor + page size to the actor and turns the
+        // page's last key into the next_page_token when more rows remain.
+        let (tx, mut rx) = mpsc::channel(16);
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        let route = {
+            let mut route = test_route(
                 Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
                 vec![],
-            ),
-            test_route(
-                Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
-                vec![],
-            ),
-            test_route(
-                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24)),
-                vec![],
-            ),
-        ];
+            );
+            route.peer = peer;
+            route
+        };
+        let page_route = route.clone();
+        tokio::spawn(async move {
+            while let Some(update) = rx.recv().await {
+                if let RibUpdate::QueryRoutesPage {
+                    scope,
+                    filter,
+                    after,
+                    page_size,
+                    reply,
+                } = update
+                {
+                    assert_eq!(scope, RouteQueryScope::Received { peer: None });
+                    assert!(filter.is_none(), "unfiltered list sends no predicate");
+                    assert!(after.is_none());
+                    assert_eq!(page_size, 1);
+                    let _ = reply.send(RoutePage {
+                        routes: vec![page_route.clone()],
+                        total: 2,
+                        has_more: true,
+                    });
+                }
+            }
+        });
 
-        let first = build_filtered_response(routes.clone(), 0, &empty_route_filters(), 0, 2, false);
-        assert_eq!(first.total_count, 3, "fast path counts every family");
-        assert_eq!(first.routes.len(), 2);
-        assert_eq!(first.routes[0].prefix, "10.0.0.0");
-        assert_eq!(first.next_page_token, "2");
+        let svc = RibService::new(tx);
+        let resp = svc
+            .list_received_routes(Request::new(proto::ListRoutesRequest {
+                page_size: 1,
+                ..list_routes_request()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
 
-        let last = build_filtered_response(routes, 0, &empty_route_filters(), 2, 2, false);
-        assert_eq!(last.total_count, 3);
-        assert_eq!(last.routes.len(), 1);
-        assert!(last.next_page_token.is_empty());
+        assert_eq!(resp.total_count, 2);
+        assert_eq!(resp.routes.len(), 1);
+        assert_eq!(resp.routes[0].prefix, "10.0.0.0");
+        assert_eq!(
+            resp.next_page_token,
+            encode_route_page_token(&route_query_key(&route))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_received_routes_rejects_invalid_page_token() {
+        let svc = make_service();
+        let err = svc
+            .list_received_routes(Request::new(proto::ListRoutesRequest {
+                page_token: "not-a-token".to_string(),
+                ..list_routes_request()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("page_token"));
     }
 }

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -64,6 +64,49 @@ fn make_route_request(
     })
 }
 
+type RibClient = RibServiceClient<
+    tonic::service::interceptor::InterceptedService<
+        tonic::transport::Channel,
+        crate::connection::AuthInterceptor,
+    >,
+>;
+
+/// Which unicast route-listing RPC [`fetch_all_route_pages`] drives.
+enum RouteListRpc {
+    Best,
+    Received,
+    Advertised,
+}
+
+/// Requested page size for transparent pagination — matches the
+/// server's per-page cap so the loop takes the fewest round trips.
+const ROUTE_PAGE_SIZE: u32 = 1000;
+
+/// Fetch every page of a route listing. The server bounds each page;
+/// the CLI follows `next_page_token` until the listing completes, so
+/// output is never silently truncated.
+async fn fetch_all_route_pages(
+    client: &mut RibClient,
+    rpc: &RouteListRpc,
+    mut req: ListRoutesRequest,
+) -> Result<Vec<Route>, CliError> {
+    req.page_size = ROUTE_PAGE_SIZE;
+    let mut routes = Vec::new();
+    loop {
+        let resp = match rpc {
+            RouteListRpc::Best => client.list_best_routes(req.clone()).await?,
+            RouteListRpc::Received => client.list_received_routes(req.clone()).await?,
+            RouteListRpc::Advertised => client.list_advertised_routes(req.clone()).await?,
+        }
+        .into_inner();
+        routes.extend(resp.routes);
+        if resp.next_page_token.is_empty() {
+            return Ok(routes);
+        }
+        req.page_token = resp.next_page_token;
+    }
+}
+
 fn parse_fib_state(s: &str) -> Result<i32, CliError> {
     match s {
         "installed" => Ok(FibRouteState::Installed as i32),
@@ -1456,11 +1499,13 @@ pub async fn best(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_best_routes(make_route_request(None, family, filters)?)
-        .await?
-        .into_inner();
-    print_routes(&resp.routes, json)
+    let routes = fetch_all_route_pages(
+        &mut client,
+        &RouteListRpc::Best,
+        make_route_request(None, family, filters)?,
+    )
+    .await?;
+    print_routes(&routes, json)
 }
 
 pub async fn blackholes(connection: Connection, json: bool) -> Result<(), CliError> {
@@ -1554,11 +1599,13 @@ pub async fn received(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_received_routes(make_route_request(Some(address), family, filters)?)
-        .await?
-        .into_inner();
-    print_routes(&resp.routes, json)
+    let routes = fetch_all_route_pages(
+        &mut client,
+        &RouteListRpc::Received,
+        make_route_request(Some(address), family, filters)?,
+    )
+    .await?;
+    print_routes(&routes, json)
 }
 
 pub async fn advertised(
@@ -1570,11 +1617,13 @@ pub async fn advertised(
 ) -> Result<(), CliError> {
     let mut client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let resp = client
-        .list_advertised_routes(make_route_request(Some(address), family, filters)?)
-        .await?
-        .into_inner();
-    print_routes(&resp.routes, json)
+    let routes = fetch_all_route_pages(
+        &mut client,
+        &RouteListRpc::Advertised,
+        make_route_request(Some(address), family, filters)?,
+    )
+    .await?;
+    print_routes(&routes, json)
 }
 
 pub async fn explain_advertised(
@@ -2600,5 +2649,72 @@ mod tests {
         assert_eq!(v["best_reason_detail"], "local_pref 200 > 100");
         assert_eq!(v["candidates"][0]["vs_best_detail"], "local_pref 100 < 200");
         assert_eq!(v["candidates"][0]["multipath"], "relax_only");
+    }
+
+    fn no_route_filters() -> RouteFilterOpts {
+        RouteFilterOpts {
+            prefix: None,
+            longer: false,
+            origin_asn: None,
+            community: vec![],
+            large_community: vec![],
+        }
+    }
+
+    fn mock_route_page(
+        prefix: &str,
+        next_page_token: &str,
+    ) -> rustbgpd_api::proto::ListRoutesResponse {
+        rustbgpd_api::proto::ListRoutesResponse {
+            routes: vec![rustbgpd_api::proto::Route {
+                prefix: prefix.to_string(),
+                prefix_length: 24,
+                ..Default::default()
+            }],
+            next_page_token: next_page_token.to_string(),
+            total_count: 2,
+        }
+    }
+
+    /// `rbgp rib received` follows `next_page_token` until the listing
+    /// completes — no silent truncation at the server's page size.
+    #[tokio::test]
+    async fn received_paginates_transparently() {
+        let server = spawn_mock_server(None).await;
+        {
+            let mut pages = server.state.list_route_pages.lock().await;
+            pages.push(mock_route_page("10.0.0.0", "10.0.0.0/24|192.0.2.1|0"));
+            pages.push(mock_route_page("10.0.1.0", ""));
+        }
+
+        let connection = connect(&server.addr, None).await.unwrap();
+        received(connection, "192.0.2.1", None, &no_route_filters(), false)
+            .await
+            .unwrap();
+
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 2, "one RPC per page");
+        assert!(requests[0].page_token.is_empty());
+        assert!(requests[0].page_size > 0, "CLI requests bounded pages");
+        assert_eq!(requests[1].page_token, "10.0.0.0/24|192.0.2.1|0");
+    }
+
+    /// `rbgp best` stops after a single page when the server reports
+    /// the listing complete (empty `next_page_token`).
+    #[tokio::test]
+    async fn best_stops_on_final_page() {
+        let server = spawn_mock_server(None).await;
+        {
+            let mut pages = server.state.list_route_pages.lock().await;
+            pages.push(mock_route_page("10.0.0.0", ""));
+        }
+
+        let connection = connect(&server.addr, None).await.unwrap();
+        best(connection, None, &no_route_filters(), false)
+            .await
+            .unwrap();
+
+        let requests = server.state.list_route_requests.lock().await;
+        assert_eq!(requests.len(), 1);
     }
 }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -53,6 +53,11 @@ pub(crate) struct MockState {
     pub(crate) last_softreset: Mutex<Option<server_proto::SoftResetInRequest>>,
     pub(crate) last_explain_advertised: Mutex<Option<server_proto::ExplainAdvertisedRouteRequest>>,
     pub(crate) last_explain_best_path: Mutex<Option<server_proto::ExplainBestPathRequest>>,
+    // Canned pages served in order by the unicast route-listing RPCs
+    // (received/best/advertised) — drives the CLI pagination loop.
+    // Empty = every call returns an empty final page.
+    pub(crate) list_route_pages: Mutex<Vec<server_proto::ListRoutesResponse>>,
+    pub(crate) list_route_requests: Mutex<Vec<server_proto::ListRoutesRequest>>,
     pub(crate) last_list_bgpls: Mutex<Option<server_proto::ListBgpLsRequest>>,
     pub(crate) last_list_vpn: Mutex<Option<server_proto::ListVpnRoutesRequest>>,
     pub(crate) last_list_labeled: Mutex<Option<server_proto::ListLabeledRoutesRequest>>,
@@ -718,6 +723,27 @@ struct MockRibService {
     state: Arc<MockState>,
 }
 
+impl MockRibService {
+    /// Record the request and serve the next canned route page (an
+    /// empty final page when none are queued).
+    async fn next_route_page(
+        &self,
+        request: server_proto::ListRoutesRequest,
+    ) -> server_proto::ListRoutesResponse {
+        self.state.list_route_requests.lock().await.push(request);
+        let mut pages = self.state.list_route_pages.lock().await;
+        if pages.is_empty() {
+            server_proto::ListRoutesResponse {
+                routes: vec![],
+                next_page_token: String::new(),
+                total_count: 0,
+            }
+        } else {
+            pages.remove(0)
+        }
+    }
+}
+
 struct MockEvpnService;
 
 #[tonic::async_trait]
@@ -986,35 +1012,29 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
 
     async fn list_received_routes(
         &self,
-        _request: Request<server_proto::ListRoutesRequest>,
+        request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
-        Ok(Response::new(server_proto::ListRoutesResponse {
-            routes: vec![],
-            next_page_token: String::new(),
-            total_count: 0,
-        }))
+        Ok(Response::new(
+            self.next_route_page(request.into_inner()).await,
+        ))
     }
 
     async fn list_best_routes(
         &self,
-        _request: Request<server_proto::ListRoutesRequest>,
+        request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
-        Ok(Response::new(server_proto::ListRoutesResponse {
-            routes: vec![],
-            next_page_token: String::new(),
-            total_count: 0,
-        }))
+        Ok(Response::new(
+            self.next_route_page(request.into_inner()).await,
+        ))
     }
 
     async fn list_advertised_routes(
         &self,
-        _request: Request<server_proto::ListRoutesRequest>,
+        request: Request<server_proto::ListRoutesRequest>,
     ) -> Result<Response<server_proto::ListRoutesResponse>, Status> {
-        Ok(Response::new(server_proto::ListRoutesResponse {
-            routes: vec![],
-            next_page_token: String::new(),
-            total_count: 0,
-        }))
+        Ok(Response::new(
+            self.next_route_page(request.into_inner()).await,
+        ))
     }
 
     async fn explain_best_path(

--- a/crates/mrt/src/manager.rs
+++ b/crates/mrt/src/manager.rs
@@ -60,6 +60,14 @@ impl MrtManager {
                 }
                 maybe_reply = self.trigger_rx.recv() => {
                     if let Some(reply) = maybe_reply {
+                        // The reply channel doubles as the cancel token: a
+                        // request whose caller is gone (e.g. a canceled gRPC
+                        // dump request queued behind a slow dump) is skipped
+                        // before the RIB snapshot, encode, and file write.
+                        if reply.is_closed() {
+                            debug!("MRT on-demand dump canceled before start; skipping");
+                            continue;
+                        }
                         debug!("MRT on-demand dump triggered");
                         let result = self.do_dump().await;
                         let _ = reply.send(result);
@@ -190,5 +198,58 @@ mod tests {
         rib_handler.await.unwrap();
         drop(trigger_tx);
         handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn canceled_trigger_skips_dump_before_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = MrtWriterConfig {
+            output_dir: dir.path().to_path_buf(),
+            dump_interval: 86400,
+            compress: false,
+            file_prefix: "rib".to_string(),
+        };
+
+        let (rib_tx, mut rib_rx) = mpsc::channel(16);
+        let (trigger_tx, trigger_rx) = mpsc::channel(16);
+
+        let mgr = MrtManager::new(config, rib_tx, trigger_rx, Ipv4Addr::new(1, 2, 3, 4));
+        let handle = tokio::spawn(mgr.run());
+
+        // Count RIB snapshot queries: the canceled trigger must never
+        // reach the RIB (skip happens before snapshot/encode/write).
+        let rib_handler = tokio::spawn(async move {
+            let mut snapshots = 0usize;
+            while let Some(update) = rib_rx.recv().await {
+                if let RibUpdate::QueryMrtSnapshot { reply } = update {
+                    snapshots += 1;
+                    let _ = reply.send(MrtSnapshotData {
+                        peers: vec![],
+                        routes: vec![],
+                        evpn_routes: vec![],
+                    });
+                }
+            }
+            snapshots
+        });
+
+        // Canceled request: receiver dropped before the manager sees it.
+        let (canceled_tx, canceled_rx) = oneshot::channel();
+        drop(canceled_rx);
+        trigger_tx.send(canceled_tx).await.unwrap();
+
+        // Live request queued behind it still completes.
+        let (reply_tx, reply_rx) = oneshot::channel();
+        trigger_tx.send(reply_tx).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), reply_rx)
+            .await
+            .expect("timeout waiting for MRT dump reply")
+            .expect("reply channel closed")
+            .expect("live MRT dump should succeed");
+
+        drop(trigger_tx);
+        handle.await.unwrap();
+        let snapshots = rib_handler.await.unwrap();
+        assert_eq!(snapshots, 1, "canceled dump must not query the RIB");
     }
 }

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -60,4 +60,5 @@ pub use update::{
     AdjRibOutCounts, BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision,
     ExplainReason, ExportGateStep, ExportGateVerdict, MrtPeerEntry, MrtSnapshotData,
     NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, RibCommandError, RibUpdate,
+    RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, route_query_key,
 };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -28,7 +28,8 @@ use crate::event::{RouteEvent, RouteEventType};
 use crate::loc_rib::LocRib;
 use crate::update::{
     BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, MrtPeerEntry, MrtSnapshotData,
-    NeighborPolicyStats, OutboundRouteUpdate, RibUpdate,
+    NeighborPolicyStats, OutboundRouteUpdate, RibUpdate, RoutePage, RouteQueryFilter,
+    RouteQueryKey, RouteQueryScope, route_query_key,
 };
 
 use helpers::{DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, gauge_val, prefix_family};
@@ -407,6 +408,79 @@ fn smallest_keys_after<K: Ord + Copy>(
         }
     }
     heap.into_sorted_vec()
+}
+
+/// Server-side hard cap on a paged route-query page — bounds per-page
+/// allocation regardless of the client-requested size.
+pub(crate) const ROUTE_QUERY_MAX_PAGE_SIZE: usize = 1000;
+
+/// One bounded page over an unordered route iterator: the filter-matching
+/// routes with the `page_size` smallest identity keys strictly greater
+/// than `after`, ascending, plus the scope's total matching count.
+/// Single pass, O(page) allocation — the same mutation-robust cursor
+/// step as [`smallest_keys_after`], carrying the routes alongside the
+/// keys so no per-key re-lookup is needed.
+fn page_routes<'a>(
+    routes: impl Iterator<Item = &'a crate::route::Route>,
+    filter: Option<&RouteQueryFilter>,
+    after: Option<RouteQueryKey>,
+    page_size: usize,
+) -> RoutePage {
+    /// Max-heap entry ordered by identity key only.
+    struct Entry<'a>(RouteQueryKey, &'a crate::route::Route);
+    impl PartialEq for Entry<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+    impl Eq for Entry<'_> {}
+    impl PartialOrd for Entry<'_> {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+    impl Ord for Entry<'_> {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.0.cmp(&other.0)
+        }
+    }
+
+    let n = page_size.clamp(1, ROUTE_QUERY_MAX_PAGE_SIZE);
+    let mut heap = std::collections::BinaryHeap::with_capacity(n + 1);
+    let mut total: u64 = 0;
+    // Matching routes strictly past the cursor — tells whether routes
+    // remain beyond this page.
+    let mut remaining: u64 = 0;
+    for route in routes {
+        if let Some(filter) = filter
+            && !filter(route)
+        {
+            continue;
+        }
+        total += 1;
+        let key = route_query_key(route);
+        if after.is_some_and(|a| key <= a) {
+            continue;
+        }
+        remaining += 1;
+        if heap.len() < n {
+            heap.push(Entry(key, route));
+        } else if heap.peek().is_some_and(|top| key < top.0) {
+            heap.pop();
+            heap.push(Entry(key, route));
+        }
+    }
+    let routes: Vec<_> = heap
+        .into_sorted_vec()
+        .into_iter()
+        .map(|entry| entry.1.clone())
+        .collect();
+    let has_more = remaining > routes.len() as u64;
+    RoutePage {
+        routes,
+        total,
+        has_more,
+    }
 }
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
@@ -1007,6 +1081,15 @@ impl RibManager {
             RibUpdate::QueryReceivedRoutes { peer, reply } => {
                 self.handle_query_received_routes(peer, reply);
             }
+            RibUpdate::QueryRoutesPage {
+                scope,
+                filter,
+                after,
+                page_size,
+                reply,
+            } => {
+                self.handle_query_routes_page(scope, filter.as_ref(), after, page_size, reply);
+            }
             RibUpdate::QueryBestRoutes { reply } => self.handle_query_best_routes(reply),
             RibUpdate::QueryFibInstallCandidates {
                 max_paths,
@@ -1384,6 +1467,64 @@ impl RibManager {
         };
 
         if reply.send(routes).is_err() {
+            warn!("query caller dropped before receiving response");
+        }
+    }
+
+    /// One bounded page of a resumable route listing. The reply channel
+    /// doubles as the cancellation token: an abandoned caller (dropped
+    /// receiver — e.g. a canceled gRPC request whose page query was
+    /// already enqueued) skips the scan entirely, so abandoned
+    /// pagination stops costing the RIB task anything.
+    // ponytail: each page re-scans the scope (O(table) per page, like
+    // the BMP Loc-RIB dump) — allocation is bounded per page; swap in a
+    // sorted index if paging CPU at DFZ scale ever bites.
+    fn handle_query_routes_page(
+        &mut self,
+        scope: RouteQueryScope,
+        filter: Option<&RouteQueryFilter>,
+        after: Option<RouteQueryKey>,
+        page_size: usize,
+        reply: tokio::sync::oneshot::Sender<RoutePage>,
+    ) {
+        if reply.is_closed() {
+            debug!("route page query canceled before scan; skipping");
+            return;
+        }
+        let page = match scope {
+            RouteQueryScope::Received { peer: Some(peer) } => page_routes(
+                self.ribs.get(&peer).into_iter().flat_map(AdjRibIn::iter),
+                filter,
+                after,
+                page_size,
+            ),
+            RouteQueryScope::Received { peer: None } => page_routes(
+                self.ribs.values().flat_map(AdjRibIn::iter),
+                filter,
+                after,
+                page_size,
+            ),
+            RouteQueryScope::Best => page_routes(self.loc_rib.iter(), filter, after, page_size),
+            RouteQueryScope::Advertised { peer } => {
+                // A grouped member holds no per-peer unicast Adj-RIB-Out;
+                // its advertised set is synthesized (group table − own-
+                // sourced) — materialized by that synthesis, then paged
+                // so the reply stays bounded either way.
+                match self.grouped_advertised_routes(peer) {
+                    Some(routes) => page_routes(routes.iter(), filter, after, page_size),
+                    None => page_routes(
+                        self.adj_ribs_out
+                            .get(&peer)
+                            .into_iter()
+                            .flat_map(AdjRibOut::iter),
+                        filter,
+                        after,
+                        page_size,
+                    ),
+                }
+            }
+        };
+        if reply.send(page).is_err() {
             warn!("query caller dropped before receiving response");
         }
     }

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -929,6 +929,7 @@ mod llgr_families;
 mod multipath_fib;
 mod orf;
 mod orr;
+mod paged_query;
 mod per_client_best;
 mod policy;
 mod refresh;

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -1,0 +1,321 @@
+//! Bounded, resumable paged route queries (`QueryRoutesPage`): page
+//! unions match the single-shot queries across page sizes, filters run
+//! inside the actor, and a canceled query (dropped reply receiver)
+//! skips the scan entirely.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+use crate::update::{RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, route_query_key};
+
+async fn query_page(
+    tx: &mpsc::Sender<RibUpdate>,
+    scope: RouteQueryScope,
+    filter: Option<RouteQueryFilter>,
+    after: Option<RouteQueryKey>,
+    page_size: usize,
+) -> RoutePage {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryRoutesPage {
+        scope,
+        filter,
+        after,
+        page_size,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
+/// Drive the resumable loop: follow `has_more` + last-key cursors until
+/// the listing completes, returning the union of all pages.
+async fn collect_pages(
+    tx: &mpsc::Sender<RibUpdate>,
+    scope: RouteQueryScope,
+    page_size: usize,
+) -> Vec<Route> {
+    let mut out: Vec<Route> = Vec::new();
+    let mut after = None;
+    loop {
+        let page = query_page(tx, scope, None, after, page_size).await;
+        assert!(
+            page.routes.len() <= page_size,
+            "page exceeded requested size"
+        );
+        let has_more = page.has_more;
+        after = page.routes.last().map(route_query_key);
+        out.extend(page.routes);
+        if !has_more {
+            return out;
+        }
+    }
+}
+
+fn keys(routes: &[Route]) -> Vec<RouteQueryKey> {
+    routes.iter().map(route_query_key).collect()
+}
+
+fn sorted_keys(routes: &[Route]) -> Vec<RouteQueryKey> {
+    let mut keys = keys(routes);
+    keys.sort_unstable();
+    keys
+}
+
+/// Seed a running manager with 3 peers × 4 prefixes = 12 received routes
+/// (4 distinct Loc-RIB bests) and register one outbound target peer, so
+/// all three scopes have content.
+async fn seeded_manager() -> (
+    mpsc::Sender<RibUpdate>,
+    IpAddr,
+    mpsc::Receiver<OutboundRouteUpdate>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
+    let (out_tx, out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    for peer_octet in 1..=3u8 {
+        let peer_addr = Ipv4Addr::new(10, 0, 0, peer_octet);
+        let announced = (0..4u8)
+            .map(|p| {
+                make_route(
+                    Ipv4Prefix::new(Ipv4Addr::new(192, 168, p, 0), 24),
+                    peer_addr,
+                )
+            })
+            .collect();
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(peer_addr),
+            announced,
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+
+    (tx, target, out_rx, handle)
+}
+
+#[tokio::test]
+async fn paged_union_matches_single_shot_across_page_sizes() {
+    let (tx, target, _out_rx, handle) = seeded_manager().await;
+
+    // Single-shot references for every scope.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryReceivedRoutes {
+        peer: None,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    let full_received = reply_rx.await.unwrap();
+    assert_eq!(full_received.len(), 12);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
+        .await
+        .unwrap();
+    let full_best = reply_rx.await.unwrap();
+    assert_eq!(full_best.len(), 4);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: target,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    let full_advertised = reply_rx.await.unwrap();
+    assert_eq!(full_advertised.len(), 4);
+
+    let one_peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryReceivedRoutes {
+        peer: Some(one_peer),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    let full_one_peer = reply_rx.await.unwrap();
+    assert_eq!(full_one_peer.len(), 4);
+
+    for page_size in [1, 2, 3, 5, 100] {
+        let scopes: [(RouteQueryScope, &[Route]); 4] = [
+            (RouteQueryScope::Received { peer: None }, &full_received),
+            (
+                RouteQueryScope::Received {
+                    peer: Some(one_peer),
+                },
+                &full_one_peer,
+            ),
+            (RouteQueryScope::Best, &full_best),
+            (
+                RouteQueryScope::Advertised { peer: target },
+                &full_advertised,
+            ),
+        ];
+        for (scope, full) in scopes {
+            let paged = collect_pages(&tx, scope, page_size).await;
+            assert_eq!(
+                keys(&paged),
+                sorted_keys(full),
+                "paged union diverged for {scope:?} at page_size {page_size}"
+            );
+        }
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn paged_query_reports_total_and_has_more() {
+    let (tx, _target, _out_rx, handle) = seeded_manager().await;
+
+    let first = query_page(&tx, RouteQueryScope::Received { peer: None }, None, None, 5).await;
+    assert_eq!(first.total, 12);
+    assert!(first.has_more);
+    assert_eq!(first.routes.len(), 5);
+
+    // Resuming from the final key reports completion.
+    let all = query_page(
+        &tx,
+        RouteQueryScope::Received { peer: None },
+        None,
+        None,
+        100,
+    )
+    .await;
+    assert!(!all.has_more);
+    let last = query_page(
+        &tx,
+        RouteQueryScope::Received { peer: None },
+        None,
+        all.routes.last().map(route_query_key),
+        100,
+    )
+    .await;
+    assert!(last.routes.is_empty());
+    assert!(!last.has_more);
+    assert_eq!(last.total, 12, "total stays cursor-independent");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn paged_query_filters_inside_the_actor() {
+    let (tx, _target, _out_rx, handle) = seeded_manager().await;
+
+    // Keep only one prefix; total and pages both reflect the filter.
+    let wanted = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24));
+    let mut after = None;
+    let mut got = Vec::new();
+    loop {
+        let page = query_page(
+            &tx,
+            RouteQueryScope::Received { peer: None },
+            Some(Box::new(move |route: &Route| route.prefix == wanted)),
+            after,
+            2,
+        )
+        .await;
+        assert_eq!(page.total, 3, "one route per peer matches the filter");
+        let has_more = page.has_more;
+        after = page.routes.last().map(route_query_key);
+        got.extend(page.routes);
+        if !has_more {
+            break;
+        }
+    }
+    assert_eq!(got.len(), 3);
+    assert!(got.iter().all(|route| route.prefix == wanted));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn canceled_paged_query_skips_the_scan() {
+    let (tx, _target, _out_rx, handle) = seeded_manager().await;
+
+    // Probe: the filter runs once per scanned route, so zero calls
+    // proves the actor skipped the scan for the abandoned query.
+    let probe = Arc::new(AtomicUsize::new(0));
+    let probe_in_filter = Arc::clone(&probe);
+    let (reply_tx, reply_rx) = oneshot::channel();
+    drop(reply_rx); // caller gone before the actor dequeues the query
+    tx.send(RibUpdate::QueryRoutesPage {
+        scope: RouteQueryScope::Received { peer: None },
+        filter: Some(Box::new(move |_: &Route| {
+            probe_in_filter.fetch_add(1, Ordering::Relaxed);
+            true
+        })),
+        after: None,
+        page_size: 100,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+
+    // A follow-up live query proves the canceled one was processed
+    // (single actor, in-order) and still answers normally.
+    let live = query_page(
+        &tx,
+        RouteQueryScope::Received { peer: None },
+        None,
+        None,
+        100,
+    )
+    .await;
+    assert_eq!(live.routes.len(), 12);
+    assert_eq!(
+        probe.load(Ordering::Relaxed),
+        0,
+        "canceled query must not scan any route"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn paged_query_page_size_is_capped() {
+    let (tx, _target, _out_rx, handle) = seeded_manager().await;
+
+    // A zero page size is clamped up to 1 rather than looping forever.
+    let page = query_page(&tx, RouteQueryScope::Received { peer: None }, None, None, 0).await;
+    assert_eq!(page.routes.len(), 1);
+    assert!(page.has_more);
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -326,6 +326,50 @@ pub struct BestPathCandidate {
     pub multipath: crate::best_path::MultipathEligibility,
 }
 
+/// Which table a paged route query ([`RibUpdate::QueryRoutesPage`]) reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteQueryScope {
+    /// Adj-RIB-In routes, optionally narrowed to one peer.
+    Received {
+        /// Optional peer filter; `None` reads all peers.
+        peer: Option<IpAddr>,
+    },
+    /// Loc-RIB best routes.
+    Best,
+    /// Routes advertised to a specific peer (Adj-RIB-Out, or the
+    /// synthesized view for an update-grouped member).
+    Advertised {
+        /// The target peer.
+        peer: IpAddr,
+    },
+}
+
+/// Resume cursor for a paged route query: the identity key of the last
+/// route on the previous page. The tuple's derived total order carries
+/// no routing meaning; it exists so stable cursors can be cut through
+/// the unordered route tables (see the `Ord` note on [`Prefix`]).
+pub type RouteQueryKey = (Prefix, IpAddr, u32);
+
+/// Identity key of a route within a paged-query scope.
+#[must_use]
+pub fn route_query_key(route: &Route) -> RouteQueryKey {
+    (route.prefix, route.peer, route.path_id)
+}
+
+/// Row filter evaluated inside the RIB task during a paged route query.
+pub type RouteQueryFilter = Box<dyn Fn(&Route) -> bool + Send + Sync>;
+
+/// One page of a resumable route query.
+#[derive(Debug, Clone, Default)]
+pub struct RoutePage {
+    /// Routes on this page, ascending by identity key.
+    pub routes: Vec<Route>,
+    /// Total filter-matching routes in scope (cursor-independent).
+    pub total: u64,
+    /// Whether matching routes remain beyond this page.
+    pub has_more: bool,
+}
+
 /// Messages sent from peer sessions to the RIB manager.
 pub enum RibUpdate {
     /// Peer session sent us routes.
@@ -530,6 +574,25 @@ pub enum RibUpdate {
         peer: Option<IpAddr>,
         /// Response channel.
         reply: oneshot::Sender<Vec<Route>>,
+    },
+    /// Query: one bounded page of a resumable route listing. Filtering
+    /// and pagination run inside the RIB task with per-page bounded
+    /// allocation (same mutation-robust cursor step as the BMP Loc-RIB
+    /// dump), and the reply channel doubles as the cancellation token:
+    /// an abandoned caller (dropped receiver) skips the scan entirely.
+    QueryRoutesPage {
+        /// Which table to read.
+        scope: RouteQueryScope,
+        /// Optional row filter evaluated inside the RIB task; `None`
+        /// keeps every route in scope.
+        filter: Option<RouteQueryFilter>,
+        /// Resume strictly after this key; `None` starts from the
+        /// beginning.
+        after: Option<RouteQueryKey>,
+        /// Maximum routes on the page (clamped to a server-side cap).
+        page_size: usize,
+        /// Response channel; a dropped receiver cancels the query.
+        reply: oneshot::Sender<RoutePage>,
     },
     /// Query: return best routes from the Loc-RIB.
     QueryBestRoutes {

--- a/docs/API.md
+++ b/docs/API.md
@@ -904,11 +904,16 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   -d '{"page_size": 2}' \
   localhost:50051 rustbgpd.v1.RibService/ListBestRoutes
 
-# Next page
+# Next page (pass the previous response's next_page_token verbatim)
 grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
-  -d '{"page_size": 2, "page_token": "2"}' \
+  -d '{"page_size": 2, "page_token": "<next_page_token>"}' \
   localhost:50051 rustbgpd.v1.RibService/ListBestRoutes
 ```
+
+`page_token` is opaque: always pass the `next_page_token` from the previous
+response (empty = listing complete). Pages are keyed, not offset-based, so a
+listing stays consistent while the RIB mutates underneath it. `page_size` is
+capped server-side at 1000 rows per page (0 = default of 100).
 
 ### Watch route changes (streaming)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -136,13 +136,13 @@ service ControlService {
 
 ### RIB Query Model
 
-**Paginated unary (default).** `ListRoutesRequest` includes a `page_size` (max results per page, capped server-side) and an opaque `page_token` (cursor). The RIB snapshots at the start of the first page request; subsequent pages iterate the same snapshot for consistency. No lock held on the RIB task — the snapshot is a read-only copy.
+**Paginated unary (default).** `ListRoutesRequest` includes a `page_size` (max results per page, capped server-side) and an opaque `page_token` (cursor). Each page is a bounded, resumable query on the RIB task: the cursor is the identity key of the last row on the previous page, and a page returns the next `page_size` rows strictly greater than it in key order — the same mutation-robust cursor step as the BMP Loc-RIB dump. A row that survives the walk is returned exactly once; rows inserted behind the cursor between pages are picked up by the next listing (or the watch stream). Per-page allocation is bounded; the full table is never materialized for a listing.
 
 ```protobuf
 message ListRoutesRequest {
   string neighbor_address = 1;      // filter by peer (empty = all)
   AddressFamily afi_safi = 2;       // address family filter
-  uint32 page_size = 3;             // max results (server-capped at 10000)
+  uint32 page_size = 3;             // max results (server-capped at 1000)
   string page_token = 4;            // opaque cursor for next page
 }
 


### PR DESCRIPTION
Post-v0.50 audit, correctness tranche 2 (LAN-288).

## Problem

RibService list RPCs materialized and filtered whole tables on the single RIB task per request; `rbgp best` / `rbgp rib received` / `rbgp rib advertised` silently truncated at 100 rows; canceled MRT dump requests still paid for snapshot/encode/file creation.

## Changes

- **Bounded resumable actor queries:** opaque `page_token` = route identity key, pages selected via a max-heap capped at page size over one scan — the same mutation-robust cursor step as the resumable BMP Loc-RIB dump (`Prefix: Ord` existed for exactly this). Per-page allocation clamped at 1000 in the actor regardless of the requested size; filtering runs inside the actor.
- **Cancellation:** the oneshot reply channel doubles as the cancel token — the actor checks `is_closed()` before scanning, so abandoned gRPC streams cost nothing.
- **CLI:** the three commands paginate transparently until `next_page_token` is empty — no truncation.
- **MRT:** canceled on-demand dumps are skipped before snapshot/encode/write.
- **Proto: zero changes** — the page-token fields already existed; no new RPCs, authz tier matrix untouched (gate green). Old numeric-offset tokens are rejected with `INVALID_ARGUMENT`. DESIGN/API docs corrected where they described never-implemented snapshot semantics.

Known ceiling noted in-code: each page re-scans the scope O(table) (allocation bounded, CPU O(table²/page) for a full listing) — swap in a sorted index if paging CPU at DFZ scale ever bites.

## Tests

Paged-union == single-shot across page sizes 1/2/3/5/100 for all scope shapes; cancellation probe (zero filter evaluations after receiver drop); page-size clamp; token round-trip + garbage rejection; CLI transparent pagination with token progression asserted; MRT cancel-before-snapshot.

## Gates

fmt / clippy `-D warnings` / rib+api+cli+mrt suites / bench-internals check / authz (36) / full workspace / doc — all green, re-verified after rebasing onto the BMP generation-fence change (rib 701 combined).