### PR TITLE
Bound rpol apply expansion and drop the hot-path name allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   truncate at 100 rows; they now paginate transparently until the listing
   completes. Canceled on-demand MRT dump requests are likewise skipped
   before the RIB snapshot, encode, and file write. (LAN-288)
+- **rpol `apply` composition is bounded before lowering, and the
+  non-attributed evaluation path no longer clones policy names.** LAN-184
+  bounded parser recursion; `apply` inlining was the remaining unbounded
+  surface — a legal apply DAG (no cycles) can still multiply the inlined
+  predicate exponentially, so a SIGHUP-supplied file could pin the compiler
+  or overflow the lowering stack. The typechecker now rejects compositions
+  deeper than 8 `apply` levels or expanding past 100k IR nodes, with one
+  root-cause diagnostic per offending policy (dependents don't cascade);
+  evaluation stays flat — `apply` is compile-time inlining, never a runtime
+  call. Separately, every chain evaluation cloned the terminal policy's
+  name for attribution even on the hot per-route path that discards it; the
+  non-attributed path now skips that allocation entirely. (LAN-290)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1074,10 +1074,14 @@ impl PolicyChain {
         self.compiled().requires_peer_context()
     }
 
-    /// Evaluate a route against this chain of policies.
+    /// Evaluate a route against this chain of policies. Hit counters
+    /// still bump; unlike
+    /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
+    /// this never clones a policy name — attribution is telemetry-only
+    /// and this is the per-route hot path.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {
-        self.evaluate_with_attribution(ctx).0
+        self.compiled().evaluate_counting(ctx, self.hit_counters())
     }
 
     /// Evaluate plus attribution — for telemetry / explain surfaces

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -11,7 +11,9 @@
 //! The no-match / no-modification path allocates nothing: guard
 //! evaluation is all borrows, modifications are cloned only when a
 //! matched permit term actually carries some, and the attribution name
-//! is cloned only for a named terminal policy (exactly as before).
+//! is cloned only when the caller actually asked for attribution
+//! (the `ATTR` const generic) — the plain [`CompiledChain::evaluate`]
+//! path never touches it.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -92,7 +94,7 @@ impl CompiledChain {
     /// without the attribution.
     #[must_use]
     pub fn evaluate(&self, ctx: &RouteContext<'_>) -> PolicyResult {
-        self.evaluate_with_attribution(ctx).0
+        self.evaluate_attributed::<false, false>(ctx, None).0
     }
 
     /// Evaluate a route against this chain with attribution to the
@@ -104,7 +106,20 @@ impl CompiledChain {
         &self,
         ctx: &RouteContext<'_>,
     ) -> (PolicyResult, PolicyEvaluation) {
-        self.evaluate_attributed::<false>(ctx, None)
+        self.evaluate_attributed::<false, true>(ctx, None)
+    }
+
+    /// Evaluate with live hit counting but without attribution — the
+    /// non-attributed hot path (`PolicyChain::evaluate`). Skips the
+    /// terminal policy-name clone that attribution pays per call.
+    #[must_use]
+    pub fn evaluate_counting(
+        &self,
+        ctx: &RouteContext<'_>,
+        hits: &PolicyHitCounters,
+    ) -> PolicyResult {
+        hits.evals.fetch_add(1, Ordering::Relaxed);
+        self.evaluate_attributed::<true, false>(ctx, Some(hits)).0
     }
 
     /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
@@ -122,14 +137,18 @@ impl CompiledChain {
         hits: &PolicyHitCounters,
     ) -> (PolicyResult, PolicyEvaluation) {
         hits.evals.fetch_add(1, Ordering::Relaxed);
-        self.evaluate_attributed::<true>(ctx, Some(hits))
+        self.evaluate_attributed::<true, true>(ctx, Some(hits))
     }
 
     /// `COUNT` monomorphizes the walk: the non-counting instantiation
     /// compiles the counter plumbing away entirely, so the plain
     /// [`evaluate_with_attribution`](Self::evaluate_with_attribution)
-    /// path costs exactly what it did before counters existed.
-    fn evaluate_attributed<const COUNT: bool>(
+    /// path costs exactly what it did before counters existed. `ATTR`
+    /// does the same for attribution: the `false` instantiation never
+    /// clones a policy name, so [`evaluate`](Self::evaluate) and
+    /// [`evaluate_counting`](Self::evaluate_counting) allocate nothing
+    /// for the discarded `PolicyEvaluation`.
+    fn evaluate_attributed<const COUNT: bool, const ATTR: bool>(
         &self,
         ctx: &RouteContext<'_>,
         hits: Option<&PolicyHitCounters>,
@@ -153,7 +172,7 @@ impl CompiledChain {
                         PolicyResult::deny(),
                         PolicyEvaluation {
                             action: PolicyAction::Deny,
-                            matched_policy: policy.name.clone(),
+                            matched_policy: if ATTR { policy.name.clone() } else { None },
                         },
                     );
                 }
@@ -171,7 +190,11 @@ impl CompiledChain {
         // All policies permitted (including an empty chain). Attribute
         // to the last policy in the chain since chain evaluation
         // completes only after every policy permits.
-        let matched_policy = self.policies.last().and_then(|p| p.name.clone());
+        let matched_policy = if ATTR {
+            self.policies.last().and_then(|p| p.name.clone())
+        } else {
+            None
+        };
         (
             PolicyResult {
                 action: PolicyAction::Permit,
@@ -325,7 +348,12 @@ impl CompiledChain {
 
     /// Evaluate one guard node. Pure and allocation-free; set/regex
     /// ids index this chain's tables directly (out-of-range ids are a
-    /// compiler bug, not reachable from operator input).
+    /// compiler bug, not reachable from operator input). Evaluation is
+    /// flat: rpol `apply` is inlined into the guard tree at lower time
+    /// (never a runtime call into another policy), and the tree's depth
+    /// is capped by the frontend (`MAX_EXPR_DEPTH` at parse,
+    /// `MAX_APPLY_DEPTH`/`MAX_APPLY_EXPANSION` at typecheck — LAN-184 /
+    /// LAN-290), so this recursion is statically bounded.
     fn eval_expr(&self, expr: &MatchExpr, ctx: &RouteContext<'_>) -> bool {
         match expr {
             MatchExpr::True => true,

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -42,7 +42,10 @@
 //! `Or(over permit-terms i: guard_i && !guard_1..i-1) || (default
 //! Permit && no guard matched)`; `Continue` terms don't decide and are
 //! skipped. Quadratic in the applied policy's term count — fine for
-//! human-written policies, and the DAG check bounds the depth.
+//! human-written policies; the typechecker bounds the composition
+//! (apply DAG plus `MAX_APPLY_DEPTH` / `MAX_APPLY_EXPANSION`,
+//! LAN-290), so the recursive inlining below is statically bounded in
+//! both stack depth and total nodes before lowering ever runs.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -336,6 +339,11 @@ impl<'a> Lowerer<'a> {
                 MatchExpr::AsPathMatches(self.intern_regex(&format!("_{asn}_"), store))
             }
             Expr::Apply { policy, args, .. } => {
+                // Recursion bounded at typecheck (LAN-290): the apply
+                // graph is a DAG no deeper than MAX_APPLY_DEPTH and the
+                // inlined predicate no larger than MAX_APPLY_EXPANSION
+                // nodes, so this cannot overflow or explode (lowering
+                // only ever sees typechecked ASTs).
                 let args: Vec<u32> = args.iter().map(|arg| resolve_u32(arg, env)).collect();
                 let def = self
                     .file

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -676,6 +676,78 @@ fn reasonable_nesting_stays_clean() {
     assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
 }
 
+// ── LAN-290: apply-DAG expansion/depth bounds ───────────────────────
+
+/// `p0` plus `levels` policies each guarding on `apply` of the
+/// previous one, `applies_per_level` times (`||`-joined).
+fn apply_chain(levels: u32, applies_per_level: u32) -> String {
+    use std::fmt::Write;
+
+    let mut src = String::from("policy p0 { term t { if route.med == 0 { accept } } }\n");
+    for i in 1..=levels {
+        let guard = (0..applies_per_level)
+            .map(|_| format!("apply(p{})", i - 1))
+            .collect::<Vec<_>>()
+            .join(" || ");
+        writeln!(
+            src,
+            "policy p{i} {{ term t {{ if {guard} {{ accept }} }} }}"
+        )
+        .expect("string io");
+    }
+    src
+}
+
+#[test]
+fn exponential_apply_dag_is_a_diagnostic_not_an_explosion() {
+    // p_{i+1} applies p_i four times: unbounded lowering would
+    // multiply the inlined predicate ~8× per level (each apply inlines
+    // the target's predicate, which itself embeds each guard twice).
+    let report = check_on_small_stack(apply_chain(40, 4));
+    let rendered = format!("{:?}", report.diagnostics);
+    assert!(
+        rendered.contains("expands past"),
+        "want an expansion diagnostic, got: {rendered:.300}"
+    );
+    // Poisoning: one root-cause diagnostic, not one per dependent.
+    assert_eq!(report.diagnostics.0.len(), 1, "{rendered:.500}");
+}
+
+#[test]
+fn deep_apply_chain_is_a_depth_diagnostic() {
+    // A linear apply chain past MAX_APPLY_DEPTH: a legal DAG, but the
+    // lowering recursion (and the inlined guard tree) would nest one
+    // more level per policy.
+    let report = check_on_small_stack(apply_chain(10, 1));
+    let rendered = format!("{:?}", report.diagnostics);
+    assert!(
+        rendered.contains("nests policies more than"),
+        "want a depth diagnostic, got: {rendered:.300}"
+    );
+    assert_eq!(report.diagnostics.0.len(), 1, "{rendered:.500}");
+}
+
+#[test]
+fn reasonable_apply_composition_stays_clean_and_evaluates_flat() {
+    // A max-depth-legal linear chain compiles and evaluates on a small
+    // stack: `apply` is inlined at lower time (no runtime recursion
+    // into applied policies), so evaluation walks a statically bounded
+    // guard tree.
+    let src = apply_chain(8, 1);
+    let report = check_on_small_stack(src.clone());
+    assert!(report.diagnostics.is_empty(), "{:?}", report.diagnostics);
+    std::thread::Builder::new()
+        .stack_size(1024 * 1024)
+        .spawn(move || {
+            let mut store = SetStore::new();
+            let chain = compile_rpol(&src, &mut store).expect("within bounds");
+            assert_eq!(chain.evaluate(&absent_ctx()).action, PolicyAction::Permit);
+        })
+        .expect("spawn")
+        .join()
+        .expect("bounded compile + flat evaluation must not overflow");
+}
+
 // ── RFC 8097 origin-validation-state well-known names (OV_*) ──────
 
 #[test]

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -10,7 +10,7 @@
 //! strings (regexes, peer groups). Inference is trivial by design —
 //! every field has a known type and every operator a fixed signature.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::engine::AsPathRegex;
 
@@ -61,6 +61,27 @@ const PEER_FIELDS: &[(&str, Field)] = &[
     ("asn", Field::PeerAsn),
     ("group", Field::PeerGroup),
 ];
+
+/// Maximum `apply` composition depth (LAN-290). The DAG check rules
+/// out recursion, but a linear chain of applies still nests: lowering
+/// inlines each `apply` recursively, and every level embeds the
+/// applied policy's predicate at least twice (once positive, once
+/// negated for the default-permit arm), so inlined size doubles per
+/// level and useful compositions are intrinsically shallow — 8 already
+/// allows a 256× multiplier, generous for human-written policy stacks
+/// (typical depth 2–3). rpol files arrive via SIGHUP overlay at
+/// runtime, so an unbounded chain is a config-triggered stack overflow
+/// in the lowering recursion.
+const MAX_APPLY_DEPTH: u32 = 8;
+
+/// Maximum IR guard nodes one policy may expand to through `apply`
+/// inlining (LAN-290). `apply(p)` inlines `p`'s decision as a
+/// predicate at every use site (quadratic in `p`'s decision-term
+/// count — see `lower::accept_predicate`), so a wide apply DAG
+/// multiplies nodes exponentially even within the depth limit. Bounds
+/// compile-time work and compiled-chain memory; a typical
+/// human-written guard is under ten nodes.
+const MAX_APPLY_EXPANSION: u64 = 100_000;
 
 /// Enum members per enum-typed field, in language spelling.
 pub(super) const RPKI_MEMBERS: &[&str] = &["valid", "invalid", "not-found"];
@@ -113,6 +134,7 @@ pub fn typecheck(file: &SourceFile) -> Vec<Diagnostic> {
         checker.check_policy(policy);
     }
     checker.check_apply_dag();
+    checker.check_apply_bounds();
     checker.check_tests();
     checker.diags
 }
@@ -695,18 +717,7 @@ impl Checker<'_> {
     /// Policies referenced through `apply` must form a DAG. Reports one
     /// diagnostic per cycle, naming the full path.
     fn check_apply_dag(&mut self) {
-        let mut edges: HashMap<&str, Vec<(&str, Span)>> = HashMap::new();
-        for policy in &self.file.policies {
-            let mut targets = Vec::new();
-            for term in &policy.terms {
-                for stmt in &term.stmts {
-                    if let Stmt::If(if_stmt) = stmt {
-                        collect_applies(&if_stmt.cond, &mut targets);
-                    }
-                }
-            }
-            edges.insert(&policy.name.node, targets);
-        }
+        let edges = apply_edges(self.file);
         let mut done: HashSet<&str> = HashSet::new();
         for policy in &self.file.policies {
             let name = policy.name.node.as_str();
@@ -723,6 +734,70 @@ impl Checker<'_> {
                     )
                     .with_note("policy composition must form a DAG (no recursion)"),
                 );
+            }
+        }
+    }
+
+    /// Bound `apply` composition depth and worst-case inlined size
+    /// (LAN-290; [`MAX_APPLY_DEPTH`] / [`MAX_APPLY_EXPANSION`]).
+    /// Lowering inlines applies recursively and trusts the
+    /// typechecker, so both bounds are enforced here, before any
+    /// lowering runs. Costs are parameter-independent (arguments are
+    /// `u32` constants), so one analysis covers every monomorphization.
+    /// The walk is iterative (Kahn topological order) — the checker
+    /// itself cannot overflow on a deep chain — and policies on an
+    /// `apply` cycle (diagnosed by [`Self::check_apply_dag`]) never
+    /// become ready and are skipped. A policy over a limit gets one
+    /// diagnostic and poisons its dependents (their costs clamp to
+    /// trivial), so a single root cause does not cascade.
+    fn check_apply_bounds(&mut self) {
+        let file = self.file;
+        let edges = apply_edges(file);
+        // Kahn scaffolding: a policy is ready once every *known* apply
+        // target (unknown names are diagnosed elsewhere) is processed.
+        let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+        let mut pending: HashMap<&str, usize> = HashMap::new();
+        let mut ready: VecDeque<&str> = VecDeque::new();
+        for policy in &file.policies {
+            let name = policy.name.node.as_str();
+            let known: Vec<&str> = edges[name]
+                .iter()
+                .map(|&(target, _)| target)
+                .filter(|target| edges.contains_key(target))
+                .collect();
+            if known.is_empty() {
+                ready.push_back(name);
+            } else {
+                pending.insert(name, known.len());
+                for target in known {
+                    dependents.entry(target).or_default().push(name);
+                }
+            }
+        }
+        let defs: HashMap<&str, &PolicyDef> = file
+            .policies
+            .iter()
+            .map(|p| (p.name.node.as_str(), p))
+            .collect();
+        let mut depth: HashMap<&str, u32> = HashMap::new();
+        let mut pred_cost: HashMap<&str, u64> = HashMap::new();
+        let mut poisoned: HashSet<&str> = HashSet::new();
+        while let Some(name) = ready.pop_front() {
+            if let Some(diag) = bound_policy(
+                defs[name],
+                &edges[name],
+                &mut depth,
+                &mut pred_cost,
+                &mut poisoned,
+            ) {
+                self.diags.push(diag);
+            }
+            for &dependent in dependents.get(name).into_iter().flatten() {
+                let left = pending.get_mut(dependent).expect("counted above");
+                *left -= 1;
+                if *left == 0 {
+                    ready.push_back(dependent);
+                }
             }
         }
     }
@@ -856,6 +931,141 @@ impl Checker<'_> {
                 );
             }
         }
+    }
+}
+
+/// `apply` edges per policy: name → (target, span of the apply), in
+/// source order, duplicates kept.
+fn apply_edges(file: &SourceFile) -> HashMap<&str, Vec<(&str, Span)>> {
+    let mut edges: HashMap<&str, Vec<(&str, Span)>> = HashMap::new();
+    for policy in &file.policies {
+        let mut targets = Vec::new();
+        for term in &policy.terms {
+            for stmt in &term.stmts {
+                if let Stmt::If(if_stmt) = stmt {
+                    collect_applies(&if_stmt.cond, &mut targets);
+                }
+            }
+        }
+        edges.insert(&policy.name.node, targets);
+    }
+    edges
+}
+
+/// One policy's LAN-290 bound check (see
+/// [`Checker::check_apply_bounds`]): update the `depth` / `pred_cost`
+/// memo tables (its apply targets are already present — Kahn order)
+/// and return the diagnostic if the policy breaks a limit. An
+/// over-limit or poisoned policy records trivial costs so dependents
+/// don't repeat the diagnosis.
+fn bound_policy<'a>(
+    def: &'a PolicyDef,
+    targets: &[(&'a str, Span)],
+    depth: &mut HashMap<&'a str, u32>,
+    pred_cost: &mut HashMap<&'a str, u64>,
+    poisoned: &mut HashSet<&'a str>,
+) -> Option<Diagnostic> {
+    let name = def.name.node.as_str();
+    if targets.iter().any(|(target, _)| poisoned.contains(target)) {
+        poisoned.insert(name);
+        depth.insert(name, 0);
+        pred_cost.insert(name, 1);
+        return None;
+    }
+    // Composition depth: one past the deepest apply target (unknown
+    // targets have no entry and are diagnosed elsewhere).
+    let deepest = targets
+        .iter()
+        .filter_map(|&(target, span)| depth.get(target).map(|&d| (d + 1, span)))
+        .max_by_key(|&(d, _)| d);
+    if let Some((d, span)) = deepest {
+        if d > MAX_APPLY_DEPTH {
+            poisoned.insert(name);
+            depth.insert(name, 0);
+            pred_cost.insert(name, 1);
+            return Some(
+                Diagnostic::new(
+                    span,
+                    format!("`apply` chain nests policies more than {MAX_APPLY_DEPTH} deep"),
+                    "this `apply` exceeds the composition depth limit",
+                )
+                .with_note(
+                    "every apply level inlines (and at least doubles) the applied policy's \
+                     predicate; flatten the composition",
+                ),
+            );
+        }
+        depth.insert(name, d);
+    } else {
+        depth.insert(name, 0);
+    }
+    // Expansion: per-arm guard costs in decision order (upper bound:
+    // every `if` decides; an `else` adds a negated arm; a bare action
+    // run lowers to one `True`-guarded term).
+    let mut arms: Vec<u64> = Vec::new();
+    for term in &def.terms {
+        for stmt in &term.stmts {
+            match stmt {
+                Stmt::If(if_stmt) => {
+                    let cost = guard_cost(&if_stmt.cond, pred_cost);
+                    arms.push(cost);
+                    if if_stmt.else_actions.is_some() {
+                        arms.push(cost.saturating_add(1));
+                    }
+                }
+                Stmt::Action(_) => arms.push(1),
+            }
+        }
+    }
+    let lowered: u64 = arms.iter().fold(0u64, |acc, &g| acc.saturating_add(g));
+    if lowered > MAX_APPLY_EXPANSION {
+        poisoned.insert(name);
+        depth.insert(name, 0);
+        pred_cost.insert(name, 1);
+        return Some(
+            Diagnostic::new(
+                def.name.span,
+                format!(
+                    "policy `{name}` expands past {MAX_APPLY_EXPANSION} IR nodes \
+                     through `apply` inlining"
+                ),
+                "compiled size limit exceeded",
+            )
+            .with_note(
+                "apply(p) inlines p's decision predicate at every use site; \
+                 split or flatten the composition",
+            ),
+        );
+    }
+    // Cost of applying this policy elsewhere: `accept_predicate` is
+    // first-match-faithful — arm i carries every prior decision arm's
+    // guard negated — so it is a quadratic prefix sum over arm costs
+    // (the trailing `prior` is the default-permit arm).
+    let mut prior: u64 = 0;
+    let mut total: u64 = 1; // the Or node
+    for &g in &arms {
+        total = total.saturating_add(prior).saturating_add(g);
+        prior = prior.saturating_add(g).saturating_add(1);
+    }
+    pred_cost.insert(name, total.saturating_add(prior));
+    None
+}
+
+/// Upper bound on the IR nodes `expr` lowers to, given the predicate
+/// costs of already-processed `apply` targets (a missing entry —
+/// unknown name or on a diagnosed cycle — counts as trivial; the file
+/// has errors and will never lower). Recursion depth is capped by the
+/// parser's `MAX_EXPR_DEPTH` (LAN-184).
+fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>) -> u64 {
+    match expr {
+        Expr::And(lhs, rhs) | Expr::Or(lhs, rhs) => 1u64
+            .saturating_add(guard_cost(lhs, pred_cost))
+            .saturating_add(guard_cost(rhs, pred_cost)),
+        Expr::Not(inner, _) => 1u64.saturating_add(guard_cost(inner, pred_cost)),
+        // `==`/`!=` on u32 fields lower widest: `Not(And(Ge, Le))`.
+        Expr::Cmp { .. } => 4,
+        Expr::Apply { policy, .. } => pred_cost.get(policy.node.as_str()).copied().unwrap_or(1),
+        _ => 1,
     }
 }
 


### PR DESCRIPTION
Post-v0.50 audit hardening (LAN-290, rpol-bounds item).

- `apply` chain bounds land in the typechecker (one static analysis covers every instantiation path; lowering stays infallible): depth ≤ 8 (each level at least doubles the inlined predicate) and ≤ 100k expanded IR nodes per policy, computed by an iterative topological cost DP — an offender gets one root-cause ariadne diagnostic and poisons dependents (no cascade).
- Evaluation proven flat (apply is compile-time inlining, never a runtime call) — pinned by a max-depth-legal chain compiled and evaluated on a 1 MiB stack; documented at the lower/eval seams instead of adding dead guards.
- `PolicyChain::evaluate` (the per-route daemon hot path) no longer clones the terminal policy name on every evaluation: `evaluate_attributed` is monomorphized over `ATTR` so the clones compile away on the non-attributed path; attribution/explain surfaces unchanged.

Tests: exponential 40-level ×4 DAG (~2^80 nodes if lowered) → one diagnostic, no hang; deep legal chain → depth diagnostic on a small stack; golden decision-parity corpus green. Gates: fmt / clippy -D warnings / policy 209 / workspace / nightly fuzz build / doc — all 0.