### PR TITLE
Correct Extended Message directionality and align CI/fuzz claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       # bench_support surface; it has silently broken before when a
       # manager API grew an argument.
       - run: cargo check -p rustbgpd-rib --features bench-internals --benches
+      # Transport has the same feature-gated `bench-internals` bench surface.
+      - run: cargo check -p rustbgpd-transport --features bench-internals --benches
       # Same class of gap for the root crate: `bench-internals` exposes
       # `pub mod config` (and its EVPN reload-diff dependencies) in the
       # lib, a surface the default `--all-targets` clippy never compiles.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,14 @@ jobs:
       - name: Fuzz wire decoders (2 minutes per target)
         run: |
           cd crates/wire
-          for t in $(cargo +nightly fuzz list); do
+          # `$(cargo fuzz list)` inline would let an errored or empty
+          # enumeration silently run zero targets — fail loudly instead.
+          targets=$(cargo +nightly fuzz list)
+          if [ -z "$targets" ]; then
+            echo "fuzz-target enumeration returned no targets" >&2
+            exit 1
+          fi
+          for t in $targets; do
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
@@ -28,7 +35,14 @@ jobs:
       - name: Fuzz rpol policy frontend (2 minutes per target)
         run: |
           cd crates/policy
-          for t in $(cargo +nightly fuzz list); do
+          # `$(cargo fuzz list)` inline would let an errored or empty
+          # enumeration silently run zero targets — fail loudly instead.
+          targets=$(cargo +nightly fuzz list)
+          if [ -z "$targets" ]; then
+            echo "fuzz-target enumeration returned no targets" >&2
+            exit 1
+          fi
+          for t in $targets; do
             mkdir -p "fuzz/corpus/$t"
             seeds=""
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   call. Separately, every chain evaluation cloned the terminal policy's
   name for attribution even on the hot per-route path that discards it; the
   non-attributed path now skips that allocation entirely. (LAN-290)
+- **Extended Message (RFC 8654) directionality and per-type size limits.**
+  The framing layer only accepted inbound messages over 4096 bytes when the
+  PEER advertised the Extended Message capability — inverted: RFC 8654 §2
+  ties inbound acceptance to OUR advertised capability (always sent), and
+  the peer's capability only governs what we may send, which is now the sole
+  thing it gates. NOTIFICATION and ROUTE-REFRESH size limits now follow the
+  negotiated maximum in both directions (§3: extended messages apply to
+  every type except OPEN and KEEPALIVE): an extended NOTIFICATION no longer
+  fails to encode toward an extended-message peer, and a ROUTE-REFRESH with
+  a large ORF section can no longer exceed 4096 bytes toward a peer that
+  never advertised the capability. (LAN-290)
 
 ## [0.50.0] — 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ and more explicit internal architecture.
 | Evidence | Details |
 |----------|---------|
 | Workspace tests | Unit, integration, and property tests (`cargo test --workspace`) |
-| Wire fuzzing | libFuzzer harnesses on message and attribute decoders, CI smoke + nightly extended |
+| Wire fuzzing | libFuzzer harnesses on message and attribute decoders, run nightly in CI |
 | Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 3.37.0–4.6.0 across labs and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
 | Protocol coverage | [Supported standards at a glance](docs/RFC_NOTES.md#supported-standards-at-a-glance) plus per-RFC conformance notes in [docs/RFC_NOTES.md](docs/RFC_NOTES.md); interop matrix in [docs/INTEROP.md](docs/INTEROP.md) and receipts in [docs/RECEIPTS.md](docs/RECEIPTS.md). |

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -379,12 +379,14 @@ impl PeerSession {
                     if unnumbered_ipv4_without_enhe {
                         sendable_families.retain(|family| *family != (Afi::Ipv4, Safi::Unicast));
                     }
-                    // If Extended Messages was negotiated, increase the
-                    // framing buffer limit from 4096 to 65535 (RFC 8654).
-                    if neg.peer_extended_message {
-                        self.read_buf
-                            .set_max_message_len(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN);
-                    }
+                    // RFC 8654 §2: OUR advertised Extended Message capability
+                    // governs what we accept INBOUND; the peer's capability
+                    // (neg.peer_extended_message) only governs what we may
+                    // SEND (see outbound_max_message_len). FsmConfig::
+                    // capabilities() always advertises Extended Message, so
+                    // raise the framing limit to 65535 unconditionally.
+                    self.read_buf
+                        .set_max_message_len(rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN);
 
                     // Compute the families for which we may send Add-Path.
                     // The wire layer handles Add-Path per family; the RIB

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -355,10 +355,12 @@ impl PeerSession {
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => Err(()),
         }
     }
-    /// Check whether a prefix's address family is among the negotiated families.
-    /// Negotiated maximum message length: 65535 if Extended Messages was
-    /// negotiated, otherwise 4096.
-    pub(super) fn max_message_len(&self) -> u16 {
+    /// Maximum message length we may SEND to this peer: 65535 if the PEER
+    /// advertised Extended Messages, otherwise 4096 (RFC 8654 §2 — the
+    /// peer's capability governs our outbound sizes). The inbound limit is
+    /// governed by OUR advertised capability and lives on the framing
+    /// buffer (see the `SessionEstablished` arm in fsm.rs).
+    pub(super) fn outbound_max_message_len(&self) -> u16 {
         if self
             .negotiated
             .as_ref()
@@ -369,6 +371,7 @@ impl PeerSession {
             rustbgpd_wire::MAX_MESSAGE_LEN
         }
     }
+    /// Check whether a prefix's address family is among the negotiated families.
     pub(super) fn is_family_negotiated(&self, prefix: &Prefix) -> bool {
         let family = match prefix {
             Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -124,7 +124,7 @@ impl PeerSession {
     /// session has no active TCP connection — same effect as today's
     /// "no stream" branch, just at a different layer.
     pub(super) fn enqueue_priority(&mut self, msg: &Message) -> Result<(), TransportError> {
-        let max_len = self.max_message_len();
+        let max_len = self.outbound_max_message_len();
         let encoded = rustbgpd_wire::encode_message_with_limit(msg, max_len)?;
         let Some(tx) = self.writer_priority_tx.as_ref() else {
             debug!(
@@ -145,7 +145,7 @@ impl PeerSession {
     /// rather than just logging and continuing. `WriterClosed` if there
     /// is no active TCP connection.
     pub(super) fn enqueue_bulk(&mut self, msg: &Message) -> Result<(), TransportError> {
-        let max_len = self.max_message_len();
+        let max_len = self.outbound_max_message_len();
         let encoded = rustbgpd_wire::encode_message_with_limit(msg, max_len)?;
         // Clone the sender so the caller's mutable borrow of self is
         // free for the saturation handler if try_send returns Full.

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -928,7 +928,7 @@ impl PeerSession {
                 .iter()
                 .map(|key| evpn_route_from_key(*key))
                 .collect();
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             if !self.send_evpn_unreach_chunked(&routes, four_octet_as, max_len) {
                 return;
             }
@@ -959,7 +959,7 @@ impl PeerSession {
                     _ => {}
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             if !base_routes.is_empty()
                 && !self.send_bgpls_unreach_chunked(
                     Safi::BgpLs,
@@ -1007,7 +1007,7 @@ impl PeerSession {
                     Afi::L2Vpn | Afi::BgpLs => {}
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for (afi, routes, add_path) in [
                 (Afi::Ipv4, v4_routes, add_path_vpnv4_send),
                 (Afi::Ipv6, v6_routes, add_path_vpnv6_send),
@@ -1051,7 +1051,7 @@ impl PeerSession {
                     Afi::L2Vpn | Afi::BgpLs => {}
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for (afi, routes, add_path) in [
                 (Afi::Ipv4, v4_routes, add_path_labeled_v4_send),
                 (Afi::Ipv6, v6_routes, add_path_labeled_v6_send),
@@ -1079,7 +1079,7 @@ impl PeerSession {
         {
             let routes: Vec<rustbgpd_wire::RtcNlri> =
                 update.rtc_withdraw.iter().map(|key| key.nlri).collect();
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             if !self.send_rtc_unreach_chunked(&routes, four_octet_as, max_len) {
                 return;
             }
@@ -1107,7 +1107,7 @@ impl PeerSession {
                     evpn_groups.push((nh, attrs, vec![evpn_route.route.clone()]));
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for (next_hop, attrs, routes) in evpn_groups {
                 if !self.send_evpn_reach_chunked(next_hop, &attrs, &routes, four_octet_as, max_len)
                 {
@@ -1148,7 +1148,7 @@ impl PeerSession {
                     ));
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for (family, next_hop, attrs, routes) in bgpls_groups {
                 if !self.send_bgpls_reach_chunked(
                     family.to_afi_safi().1,
@@ -1205,7 +1205,7 @@ impl PeerSession {
                     vpn_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in vpn_groups {
                 let add_path = match afi {
                     Afi::Ipv4 => add_path_vpnv4_send,
@@ -1268,7 +1268,7 @@ impl PeerSession {
                     labeled_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in labeled_groups {
                 let add_path = match afi {
                     Afi::Ipv4 => add_path_labeled_v4_send,
@@ -1316,7 +1316,7 @@ impl PeerSession {
                     rtc_groups.push((nh, attrs, vec![rtc_route.nlri]));
                 }
             }
-            let max_len = usize::from(self.max_message_len());
+            let max_len = usize::from(self.outbound_max_message_len());
             for (next_hop, attrs, routes) in rtc_groups {
                 if !self.send_rtc_reach_chunked(next_hop, &attrs, &routes, four_octet_as, max_len) {
                     return;

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -7586,3 +7586,103 @@ async fn send_hold_expiry_tears_down_without_notification() {
         &trailing[..n]
     );
 }
+/// RFC 8654 §2 directionality, inbound: OUR advertised Extended Message
+/// capability governs what we accept. The peer here did NOT advertise the
+/// capability (see `establish_test_session`'s OPEN), yet a >4096-byte
+/// UPDATE from it must be accepted because we always advertise it.
+#[tokio::test]
+async fn inbound_extended_message_accepted_from_peer_without_capability() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    assert!(
+        !session.negotiated.as_ref().unwrap().peer_extended_message,
+        "test premise: the peer did not advertise Extended Messages"
+    );
+    // ~1100 /24 prefixes at 4 bytes of NLRI each pushes the UPDATE past 4096.
+    let entries: Vec<Ipv4NlriEntry> = (0..1100_u32)
+        .map(|i| Ipv4NlriEntry {
+            path_id: 0,
+            prefix: Ipv4Prefix::new(
+                Ipv4Addr::new(
+                    10,
+                    u8::try_from(i / 256).unwrap(),
+                    u8::try_from(i % 256).unwrap(),
+                    0,
+                ),
+                24,
+            ),
+        })
+        .collect();
+    let update = rustbgpd_wire::UpdateMessage::build(
+        &entries,
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        ],
+        true,
+        false,
+        rustbgpd_wire::Ipv4UnicastMode::Body,
+    );
+    let encoded = rustbgpd_wire::encode_message_with_limit(
+        &Message::Update(update),
+        rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN,
+    )
+    .unwrap();
+    assert!(
+        encoded.len() > usize::from(rustbgpd_wire::MAX_MESSAGE_LEN),
+        "test premise: the UPDATE exceeds 4096 bytes (got {})",
+        encoded.len()
+    );
+    session.read_buf.buf.extend_from_slice(&encoded);
+    session.process_read_buffer().await;
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "an extended inbound message must not tear the session down"
+    );
+    // Establishment emits its own RibUpdate first; skip to the routes.
+    loop {
+        if let RibUpdate::RoutesReceived { announced, .. } =
+            rib_rx.recv().await.expect("routes delivered")
+        {
+            assert_eq!(announced.len(), 1100);
+            break;
+        }
+    }
+}
+/// RFC 8654 §2 directionality, outbound: the PEER's advertised Extended
+/// Message capability governs what we may send. Without it, an oversized
+/// message must fail to encode; with it, the extended limit applies.
+#[tokio::test]
+async fn outbound_extended_message_gated_on_peer_capability() {
+    let mut session = make_test_session(65001, 65002);
+    session.negotiated = Some(negotiated_session(65002, false));
+    assert_eq!(
+        session.outbound_max_message_len(),
+        rustbgpd_wire::MAX_MESSAGE_LEN
+    );
+    let big = Message::Notification(rustbgpd_wire::NotificationMessage::new(
+        rustbgpd_wire::NotificationCode::Cease,
+        2,
+        Bytes::from(vec![0_u8; 5000]),
+    ));
+    assert!(
+        session.enqueue_priority(&big).is_err(),
+        "oversized NOTIFICATION must not encode toward a peer without the capability"
+    );
+    session.negotiated.as_mut().unwrap().peer_extended_message = true;
+    assert_eq!(
+        session.outbound_max_message_len(),
+        rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN
+    );
+    assert!(
+        session.enqueue_priority(&big).is_ok(),
+        "the peer advertised Extended Messages — the extended limit applies"
+    );
+}

--- a/crates/wire/src/message.rs
+++ b/crates/wire/src/message.rs
@@ -134,8 +134,10 @@ pub fn encode_message(msg: &Message) -> Result<BytesMut, EncodeError> {
 
 /// Encode a BGP message with a custom maximum message length.
 ///
-/// Same as [`encode_message`] but uses `max_message_len` for UPDATE
-/// size validation (RFC 8654 Extended Messages).
+/// Same as [`encode_message`] but uses `max_message_len` for UPDATE,
+/// NOTIFICATION, and ROUTE-REFRESH size validation (RFC 8654 §3: Extended
+/// Messages apply to every message type except OPEN and KEEPALIVE, which
+/// always use the standard 4096-byte limit).
 ///
 /// # Errors
 ///
@@ -158,16 +160,17 @@ pub fn encode_message_with_limit(
             keepalive::encode_keepalive(&mut buf);
         }
         Message::Notification(n) => {
-            n.encode(&mut buf)?;
+            n.encode_with_limit(&mut buf, max_message_len)?;
         }
         Message::Open(o) => {
+            // RFC 8654 §3: OPEN is never extended — always 4096.
             o.encode(&mut buf)?;
         }
         Message::Update(u) => {
             u.encode_with_limit(&mut buf, max_message_len)?;
         }
         Message::RouteRefresh(rr) => {
-            rr.encode(&mut buf)?;
+            rr.encode_with_limit(&mut buf, max_message_len)?;
         }
     }
 
@@ -180,7 +183,7 @@ mod tests {
 
     use super::*;
     use crate::capability::{Afi, Capability, Safi};
-    use crate::constants::{BGP_VERSION, MAX_MESSAGE_LEN};
+    use crate::constants::{BGP_VERSION, EXTENDED_MAX_MESSAGE_LEN, MAX_MESSAGE_LEN};
     use crate::notification::NotificationCode;
 
     #[test]
@@ -202,6 +205,99 @@ mod tests {
         let mut bytes = encoded.freeze();
         let decoded = decode_message(&mut bytes, MAX_MESSAGE_LEN).unwrap();
         assert_eq!(decoded, msg);
+    }
+
+    // RFC 8654 §3: the extended limit applies to NOTIFICATION and
+    // ROUTE-REFRESH, not just UPDATE — and the standard 4096-byte limit
+    // must still bound them when Extended Messages was not negotiated.
+
+    fn big_notification(data_len: usize) -> Message {
+        Message::Notification(NotificationMessage::new(
+            NotificationCode::Cease,
+            2,
+            Bytes::from(vec![0_u8; data_len]),
+        ))
+    }
+
+    fn big_route_refresh(raw_orf_len: usize) -> Message {
+        use crate::orf::{OrfEntries, OrfEntryGroup, OrfPayload, OrfType, WhenToRefresh};
+        Message::RouteRefresh(RouteRefreshMessage::new_with_orf(
+            Afi::Ipv4,
+            Safi::Unicast,
+            OrfPayload {
+                when_to_refresh: WhenToRefresh::Immediate,
+                groups: vec![OrfEntryGroup {
+                    orf_type: OrfType::AddressPrefix,
+                    entries: OrfEntries::Raw(Bytes::from(vec![0_u8; raw_orf_len])),
+                }],
+            },
+        ))
+    }
+
+    #[test]
+    fn notification_respects_extended_limit_both_directions() {
+        let msg = big_notification(5000); // total 5021 bytes
+        assert!(matches!(
+            encode_message_with_limit(&msg, MAX_MESSAGE_LEN),
+            Err(EncodeError::MessageTooLong { size: 5021 })
+        ));
+        let encoded = encode_message_with_limit(&msg, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        assert_eq!(encoded.len(), 5021);
+        // Inbound: accepted at the extended limit, rejected at the standard one.
+        let decoded = decode_message(&mut encoded.clone().freeze(), EXTENDED_MAX_MESSAGE_LEN);
+        assert_eq!(decoded.unwrap(), msg);
+        assert!(decode_message(&mut encoded.freeze(), MAX_MESSAGE_LEN).is_err());
+    }
+
+    #[test]
+    fn route_refresh_respects_extended_limit_both_directions() {
+        let msg = big_route_refresh(5000); // header + body + ORF section > 4096
+        assert!(matches!(
+            encode_message_with_limit(&msg, MAX_MESSAGE_LEN),
+            Err(EncodeError::MessageTooLong { .. })
+        ));
+        let encoded = encode_message_with_limit(&msg, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        assert!(encoded.len() > usize::from(MAX_MESSAGE_LEN));
+        // Inbound: accepted at the extended limit (the raw ORF bytes
+        // re-decode as parsed entries, so compare the type, not the value),
+        // rejected at the standard one.
+        let decoded = decode_message(&mut encoded.clone().freeze(), EXTENDED_MAX_MESSAGE_LEN);
+        assert!(matches!(decoded.unwrap(), Message::RouteRefresh(_)));
+        assert!(decode_message(&mut encoded.freeze(), MAX_MESSAGE_LEN).is_err());
+    }
+
+    #[test]
+    fn notification_boundary_at_4096_and_65535() {
+        // Exactly 4096 total fits the standard limit; one more byte does not.
+        let at_limit = big_notification(usize::from(MAX_MESSAGE_LEN) - HEADER_LEN - 2);
+        let encoded = encode_message_with_limit(&at_limit, MAX_MESSAGE_LEN).unwrap();
+        assert_eq!(encoded.len(), usize::from(MAX_MESSAGE_LEN));
+        let over = big_notification(usize::from(MAX_MESSAGE_LEN) - HEADER_LEN - 1);
+        assert!(encode_message_with_limit(&over, MAX_MESSAGE_LEN).is_err());
+        assert!(encode_message_with_limit(&over, EXTENDED_MAX_MESSAGE_LEN).is_ok());
+        // Exactly 65535 total fits the extended limit; one more byte does not.
+        let at_ext = big_notification(usize::from(EXTENDED_MAX_MESSAGE_LEN) - HEADER_LEN - 2);
+        let encoded = encode_message_with_limit(&at_ext, EXTENDED_MAX_MESSAGE_LEN).unwrap();
+        assert_eq!(encoded.len(), usize::from(EXTENDED_MAX_MESSAGE_LEN));
+        let over_ext = big_notification(usize::from(EXTENDED_MAX_MESSAGE_LEN) - HEADER_LEN - 1);
+        assert!(encode_message_with_limit(&over_ext, EXTENDED_MAX_MESSAGE_LEN).is_err());
+    }
+
+    #[test]
+    fn open_never_uses_extended_limit() {
+        // RFC 8654 §3: OPEN is excluded from Extended Messages — an
+        // oversized OPEN must fail even with the extended limit.
+        let msg = Message::Open(OpenMessage {
+            version: BGP_VERSION,
+            my_as: 65001,
+            hold_time: 90,
+            bgp_identifier: Ipv4Addr::new(10, 0, 0, 1),
+            capabilities: vec![Capability::Unknown {
+                code: 128,
+                data: Bytes::from(vec![0_u8; 5000]),
+            }],
+        });
+        assert!(encode_message_with_limit(&msg, EXTENDED_MAX_MESSAGE_LEN).is_err());
     }
 
     #[test]

--- a/crates/wire/src/notification_msg.rs
+++ b/crates/wire/src/notification_msg.rs
@@ -63,15 +63,32 @@ impl NotificationMessage {
         buf.put_slice(&self.data);
     }
 
-    /// Encode a complete NOTIFICATION message (header + body).
+    /// Encode a complete NOTIFICATION message (header + body) using the
+    /// standard 4096-byte limit.
     ///
     /// # Errors
     ///
     /// Returns [`EncodeError::MessageTooLong`] if the encoded message exceeds
     /// the maximum BGP message size.
     pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.encode_with_limit(buf, crate::constants::MAX_MESSAGE_LEN)
+    }
+
+    /// Encode with a custom maximum message length. RFC 8654 §3: Extended
+    /// Messages apply to every message type except OPEN and KEEPALIVE, so a
+    /// NOTIFICATION may use the extended 65535-byte limit when negotiated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::MessageTooLong`] if the encoded message exceeds
+    /// `max_message_len`.
+    pub fn encode_with_limit(
+        &self,
+        buf: &mut impl BufMut,
+        max_message_len: u16,
+    ) -> Result<(), EncodeError> {
         let total_len = HEADER_LEN + 2 + self.data.len();
-        if total_len > usize::from(crate::constants::MAX_MESSAGE_LEN) {
+        if total_len > usize::from(max_message_len) {
             return Err(EncodeError::MessageTooLong { size: total_len });
         }
 

--- a/crates/wire/src/route_refresh.rs
+++ b/crates/wire/src/route_refresh.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut};
 
 use crate::capability::{Afi, Safi};
-use crate::constants::{HEADER_LEN, MARKER, message_type};
+use crate::constants::{HEADER_LEN, MARKER, MAX_MESSAGE_LEN, message_type};
 use crate::error::{DecodeError, EncodeError};
 use crate::orf::{
     OrfPayload, decode_route_refresh_orf, encode_route_refresh_orf, route_refresh_orf_len,
@@ -176,14 +176,36 @@ impl RouteRefreshMessage {
         })
     }
 
-    /// Encode a complete ROUTE-REFRESH message (header + body) into a buffer.
+    /// Encode a complete ROUTE-REFRESH message (header + body) into a buffer
+    /// using the standard 4096-byte limit.
     ///
     /// # Errors
     ///
     /// Returns [`EncodeError`] if the total message length (with an ORF
-    /// section) exceeds the 16-bit length field.
+    /// section) exceeds the maximum BGP message size.
     pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.encode_with_limit(buf, MAX_MESSAGE_LEN)
+    }
+
+    /// Encode with a custom maximum message length. RFC 8654 §3: Extended
+    /// Messages apply to every message type except OPEN and KEEPALIVE, so a
+    /// ROUTE-REFRESH (e.g. with a large ORF section) may use the extended
+    /// 65535-byte limit when negotiated — and MUST stay within 4096 bytes
+    /// when it was not.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::MessageTooLong`] if the encoded message exceeds
+    /// `max_message_len`.
+    pub fn encode_with_limit(
+        &self,
+        buf: &mut impl BufMut,
+        max_message_len: u16,
+    ) -> Result<(), EncodeError> {
         let total = self.encoded_len();
+        if total > usize::from(max_message_len) {
+            return Err(EncodeError::MessageTooLong { size: total });
+        }
         let total_u16 = u16::try_from(total).map_err(|_| EncodeError::ValueOutOfRange {
             field: "route_refresh_message_length",
             value: total.to_string(),

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -533,7 +533,7 @@ libFuzzer harnesses for:
 - Attribute decoding (all supported attributes)
 - NLRI parsing (IPv4 unicast)
 
-Short fuzz runs on every PR. Extended fuzz on nightly CI schedule.
+Fuzz runs on a nightly CI schedule (`fuzz.yml`, all targets); PRs gate on the unit/property/interop suites.
 
 ### Property Tests
 
@@ -544,8 +544,7 @@ Short fuzz runs on every PR. Extended fuzz on nightly CI schedule.
 ### CI Pipeline
 
 - Unit tests (every PR)
-- Fuzz smoke — short run (every PR)
-- Extended fuzz (nightly)
+- Fuzz — all targets, nightly schedule (not PR-gated)
 - Interop tests via containerlab (every PR, against FRR and BIRD at minimum)
 - Clippy + deny(warnings) + cargo deny for dependency audit
 
@@ -709,7 +708,7 @@ gRPC proto definitions are treated with semver discipline:
 ### Release Process
 
 Milestone-based releases. Each milestone (M0–M4) is a tagged release with:
-- Passing CI (unit tests, fuzz smoke, interop)
+- Passing CI (unit tests, interop; fuzz runs nightly)
 - Updated compatibility matrix
 - Updated CHANGELOG
 - Migration notes if protos changed


### PR DESCRIPTION
Post-v0.50 audit hardening (LAN-290: Extended-Messages + CI/fuzz-truth items).

## Extended Messages (RFC 8654)

- **Inbound was inverted**: acceptance of >4096-byte messages was gated on the PEER's capability; §2 gates it on OUR advertised capability (always advertised) — the framing limit now rises to 65535 at establishment.
- Outbound clamp stays gated on the peer's capability, renamed `outbound_max_message_len()` with direction-explicit docs.
- NOTIFICATION was hard-clamped to 4096 regardless of negotiation and ROUTE-REFRESH was checked only against u16 (a large ORF could exceed 4096 toward a non-extended peer): both gain `encode_with_limit`, and `encode_message_with_limit` routes the limit to UPDATE/NOTIFICATION/ROUTE-REFRESH with OPEN pinned at 4096 (§3).
- Tests: limit selection both directions, exact 4096/4097/65535/65536 boundaries, OPEN never extended, plus session-level tests (4419-byte UPDATE accepted from a capability-less peer; oversized NOTIFICATION gated on the peer's capability).

ROADMAP status row + gobgp-parity cell flip at v0.51.0 tag time (tracked in LAN-290).

## CI/fuzz truth

- `cargo check -p rustbgpd-transport --features bench-internals --benches` added to CI beside the rib check.
- fuzz.yml target enumeration now fails on error/empty instead of silently running zero targets.
- Docs corrected where they claimed fuzz runs on every PR (it's nightly): DESIGN.md ×3, README. The interop PR-smoke claims were verified true and untouched.

Gates: fmt / clippy -D warnings / wire+transport suites / full workspace / doc / yaml parse + bash -n — all 0.