### PR TITLE
Enforce the reserved NHID range contract with fail-closed validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   warn-once transition logs plus new `evpn_foreign_replaces_blocked_total`,
   `evpn_foreign_deletes_skipped_total`, and
   `evpn_foreign_owned_relinquished_total` counters. (LAN-283)
+- **EVPN Linux dataplane: reserved NHID ranges are now an enforced
+  single-writer contract.** rustbgpd's kernel nexthop-ID tag ranges
+  (`0x3000_0000`/`0x4000_0000` L2, `0x5000_0000`/`0x6000_0000` L3VXLAN) are
+  documented as exclusively rustbgpd-owned (`docs/deployment.md`), and the
+  startup-adoption and drift-recovery dumps now validate the shape of every
+  in-range object (FDB flag, member-vs-group structure matching the tag)
+  instead of silently dropping unexpected ones — previously a co-resident
+  writer's mis-shaped object in the range was invisible to the allocator, so
+  a later allocation could `NLM_F_REPLACE`-clobber it, while an FDB-flagged
+  one could be adopted and reaped. Shape conflicts now fail closed per ID:
+  the object is left untouched, excluded from adoption and every reap/delete
+  path, its ID quarantined so the allocator never hands it out, with a
+  warn-once log and a new `evpn_foreign_nhid_range_conflicts_total` counter.
+  (LAN-290)
 
 - **LLGR lifecycle is now per-AFI/SAFI and honors the original Long-Lived
   Stale Time through reconnects (RFC 9494).** LLGR stale deadlines are

--- a/crates/evpn-linux/src/dataplane.rs
+++ b/crates/evpn-linux/src/dataplane.rs
@@ -787,4 +787,16 @@ pub enum KernelNexthopKind {
     Member { gateway: IpAddr },
     /// FDB nexthop group naming a set of per-VTEP member IDs.
     Group { member_ids: Vec<u32> },
+    /// LAN-290: the ID sits inside a rustbgpd-reserved NHID range but
+    /// the kernel object is not shaped like anything rustbgpd writes
+    /// (missing `NHA_FDB`, a group object under a member tag, a
+    /// member/gateway object under a group tag, or neither gateway
+    /// nor group). rustbgpd never produces this shape, so it is
+    /// evidence a co-resident netlink writer violated the reserved
+    /// NHID range contract (see `docs/deployment.md`). The reconcile
+    /// actor fails closed on these: the ID is reserved in the
+    /// allocator so it can never be handed out (and thus never
+    /// `NLM_F_REPLACE`-clobbered), and the object is excluded from
+    /// adoption and from every reap/delete path.
+    ShapeConflict,
 }

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -1473,7 +1473,8 @@ impl InMemoryHandle {
                 *member_ids = members;
                 Some(prev)
             }
-            crate::dataplane::KernelNexthopKind::Member { .. } => None,
+            crate::dataplane::KernelNexthopKind::Member { .. }
+            | crate::dataplane::KernelNexthopKind::ShapeConflict => None,
         }
     }
 

--- a/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
+++ b/crates/evpn-linux/src/linux/nexthop_raw/socket.rs
@@ -623,21 +623,45 @@ fn parse_dump_message_for_class(
         attrs = &attrs[advance..];
     }
 
-    // Filter: must have an ID, must be rustbgpd-tagged in the
-    // selected ownership domain, and must be FDB.
+    // Filter: must have an ID and be rustbgpd-tagged in the selected
+    // ownership domain. Foreign-tagged IDs are invisible to adoption.
     let Some(nh_id) = id else { return Ok(None) };
-    if !class.accepts(nh_id) || !is_fdb {
+    if !class.accepts(nh_id) {
         return Ok(None);
+    }
+
+    // LAN-290 shape validation: rustbgpd only ever writes FDB
+    // nexthops in its reserved ranges — a gateway member under a
+    // member tag, a group under a group tag, never both, never a
+    // non-FDB object (the kernel forbids `NHA_OIF` on FDB nexthops,
+    // so "has a device" is subsumed by the missing-FDB case). An
+    // in-range object failing these checks was written by another
+    // netlink agent in violation of the single-writer contract;
+    // surface it as `ShapeConflict` so the reconcile actor can fail
+    // closed (reserve the ID, never adopt, never delete) instead of
+    // silently dropping it — a dropped ID would leave its allocator
+    // slot free and a later alloc would `NLM_F_REPLACE` the foreign
+    // object.
+    let tag_is_group = NhIdAllocator::is_nhg(nh_id) || NhIdAllocator::is_l3_nhg(nh_id);
+    let shape_ok = is_fdb
+        && if tag_is_group {
+            member_ids.is_some() && gateway.is_none()
+        } else {
+            gateway.is_some() && member_ids.is_none()
+        };
+    if !shape_ok {
+        return Ok(Some(KernelNexthop {
+            id: nh_id,
+            kind: KernelNexthopKind::ShapeConflict,
+        }));
     }
 
     let kind = if let Some(member_ids) = member_ids {
         KernelNexthopKind::Group { member_ids }
-    } else if let Some(gateway) = gateway {
-        KernelNexthopKind::Member { gateway }
     } else {
-        // Tagged + FDB but neither group nor gateway — malformed;
-        // skip rather than fail the whole dump.
-        return Ok(None);
+        KernelNexthopKind::Member {
+            gateway: gateway.expect("shape_ok guarantees gateway for member tags"),
+        }
     };
 
     Ok(Some(KernelNexthop { id: nh_id, kind }))
@@ -809,7 +833,9 @@ mod tests {
             KernelNexthopKind::Member { gateway } => {
                 assert_eq!(gateway, "10.0.0.2".parse::<IpAddr>().unwrap());
             }
-            KernelNexthopKind::Group { .. } => panic!("expected Member, got Group"),
+            KernelNexthopKind::Group { .. } | KernelNexthopKind::ShapeConflict => {
+                panic!("expected Member, got {:?}", entry.kind)
+            }
         }
     }
 
@@ -835,7 +861,9 @@ mod tests {
             KernelNexthopKind::Group { member_ids } => {
                 assert_eq!(member_ids, vec![12, 13]);
             }
-            KernelNexthopKind::Member { .. } => panic!("expected Group, got Member"),
+            KernelNexthopKind::Member { .. } | KernelNexthopKind::ShapeConflict => {
+                panic!("expected Group, got other kind")
+            }
         }
     }
 
@@ -976,22 +1004,72 @@ mod tests {
             KernelNexthopKind::Group { member_ids } => {
                 assert_eq!(member_ids, vec![0x5000_0001, 0x5000_0002]);
             }
-            KernelNexthopKind::Member { .. } => panic!("expected Group, got Member"),
+            KernelNexthopKind::Member { .. } | KernelNexthopKind::ShapeConflict => {
+                panic!("expected Group, got other kind")
+            }
         }
     }
 
     #[test]
-    fn parse_dump_skips_non_fdb() {
-        // Rustbgpd-tagged but no NHA_FDB attribute — L3 nexthop, not ours.
+    fn parse_dump_flags_non_fdb_in_range_as_shape_conflict() {
+        // Rustbgpd-tagged but no NHA_FDB attribute — a co-resident
+        // writer squatting in our reserved range (LAN-290). Must be
+        // surfaced (not dropped) so the actor can fail closed.
         let body = build_dump_body(&[
             (NHA_ID, 0x3000_0001u32.to_ne_bytes().to_vec()),
             (NHA_GATEWAY, vec![10, 0, 0, 2]),
         ]);
-        assert!(
-            parse_dump_message_for_class(&body, NexthopDumpClass::L2FdbNhg)
-                .unwrap()
-                .is_none()
-        );
+        let entry = parse_dump_message_for_class(&body, NexthopDumpClass::L2FdbNhg)
+            .unwrap()
+            .expect("in-range object must be surfaced");
+        assert_eq!(entry.id, 0x3000_0001);
+        assert!(matches!(entry.kind, KernelNexthopKind::ShapeConflict));
+    }
+
+    #[test]
+    fn parse_dump_flags_group_under_member_tag_as_shape_conflict() {
+        // FDB group object squatting on a member-tagged ID.
+        let mut group_payload = Vec::new();
+        group_payload.extend_from_slice(&12u32.to_ne_bytes());
+        group_payload.extend_from_slice(&[0u8, 0, 0, 0]);
+        let body = build_dump_body(&[
+            (NHA_ID, 0x3000_0002u32.to_ne_bytes().to_vec()),
+            (NHA_GROUP, group_payload),
+            (NHA_FDB, vec![]),
+        ]);
+        let entry = parse_dump_message_for_class(&body, NexthopDumpClass::L2FdbNhg)
+            .unwrap()
+            .expect("entry");
+        assert!(matches!(entry.kind, KernelNexthopKind::ShapeConflict));
+    }
+
+    #[test]
+    fn parse_dump_flags_gateway_under_group_tag_as_shape_conflict() {
+        // FDB member object squatting on a group-tagged ID (L3 range
+        // exercised via the L3 class for coverage of both domains).
+        let body = build_dump_body(&[
+            (NHA_ID, 0x6000_0001u32.to_ne_bytes().to_vec()),
+            (NHA_GATEWAY, vec![10, 0, 0, 2]),
+            (NHA_FDB, vec![]),
+        ]);
+        let entry = parse_dump_message_for_class(&body, NexthopDumpClass::L3FdbNhg)
+            .unwrap()
+            .expect("entry");
+        assert!(matches!(entry.kind, KernelNexthopKind::ShapeConflict));
+    }
+
+    #[test]
+    fn parse_dump_flags_fdb_without_gateway_or_group_as_shape_conflict() {
+        // Tagged + FDB but neither gateway nor group — malformed /
+        // foreign; previously silently dropped, now fail-closed.
+        let body = build_dump_body(&[
+            (NHA_ID, 0x4000_0003u32.to_ne_bytes().to_vec()),
+            (NHA_FDB, vec![]),
+        ]);
+        let entry = parse_dump_message_for_class(&body, NexthopDumpClass::L2FdbNhg)
+            .unwrap()
+            .expect("entry");
+        assert!(matches!(entry.kind, KernelNexthopKind::ShapeConflict));
     }
 
     #[test]

--- a/crates/evpn-linux/src/nh_id_alloc.rs
+++ b/crates/evpn-linux/src/nh_id_alloc.rs
@@ -24,6 +24,22 @@
 //! already exists in the kernel (which would silently `NLM_F_REPLACE`
 //! the existing object — see ADR-0059 §5 invariant 6 + slice 3 review
 //! callout #3).
+//!
+//! ## LAN-290: reserved-range single-writer contract
+//!
+//! The four tag ranges above are an **exclusive deployment contract**
+//! (documented for operators in `docs/deployment.md`): no co-resident
+//! netlink writer may create nexthop objects whose ID carries one of
+//! rustbgpd's high-nibble tags. The kernel does not enforce this, so
+//! the adoption/drift dump parse validates the *shape* of every
+//! in-range object (FDB flag, member-vs-group structure matching the
+//! tag) and the reconcile actor fails closed on conflicts: the ID is
+//! reserved here (never handed out → never clobbered), the object is
+//! excluded from adoption and every reap path, and the violation is
+//! counted on `evpn_foreign_nhid_range_conflicts_total`. Stamping
+//! `nh_protocol` on owned objects is a possible future
+//! defense-in-depth provenance marker only — another writer can set
+//! the same value, so it can never be the ownership basis.
 
 use thiserror::Error;
 

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -325,6 +325,14 @@ struct ActorState {
     /// kernel row occupies the exact key (route / neighbor / L3VXLAN
     /// FDB). Same warn-once discipline as `warned_foreign_fdb`.
     warned_foreign_l3: BTreeSet<L3OpKey>,
+    /// LAN-290: NHIDs inside rustbgpd's reserved ranges whose kernel
+    /// object is shape-conflicting (written by a co-resident netlink
+    /// agent in violation of the single-writer contract). Each ID is
+    /// quarantined: reserved in the allocator so it can never be
+    /// handed out (and thus never `NLM_F_REPLACE`-clobbered),
+    /// excluded from adoption and every reap/delete path, and warned
+    /// + counted once on first sight.
+    foreign_nhids: BTreeSet<u32>,
     /// LAN-283 foreign-state deltas (replaces blocked, deletes
     /// skipped, ownership relinquished) accumulated since the last
     /// [`DataplaneReport`]. Same drain-into-Prometheus contract as
@@ -525,6 +533,7 @@ impl ActorState {
             warned_ipv6_fallback: BTreeSet::new(),
             warned_foreign_fdb: BTreeSet::new(),
             warned_foreign_l3: BTreeSet::new(),
+            foreign_nhids: BTreeSet::new(),
             foreign_since_report: ForeignStateCounters::default(),
             warned_managed_netdevs: BTreeSet::new(),
             last_intent_generation: 0,
@@ -835,6 +844,9 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             match self.dataplane.dump_owned_nexthops().await {
                 Ok(adopted) => {
                     for nh in adopted {
+                        if self.quarantine_if_foreign_shape(&nh) {
+                            continue;
+                        }
                         match self.state.nh_id_alloc.reserve(nh.id) {
                             Ok(()) => {
                                 self.state.adopted_unreferenced.insert(nh.id, nh);
@@ -903,6 +915,9 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 match self.dataplane.dump_owned_l3_nexthops().await {
                     Ok(adopted) => {
                         for nh in adopted {
+                            if self.quarantine_if_foreign_shape(&nh) {
+                                continue;
+                            }
                             if self.state.adopted_l3_unreferenced.contains_key(&nh.id) {
                                 continue;
                             }
@@ -2092,6 +2107,47 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
     }
 
+    /// LAN-290 reserved-NHID-range contract enforcement: if `nh` is a
+    /// [`KernelNexthopKind::ShapeConflict`] (an in-range kernel object
+    /// not shaped like anything rustbgpd writes — i.e. a co-resident
+    /// netlink writer violated the single-writer contract on our
+    /// documented ranges, see `docs/deployment.md`), fail closed for
+    /// that ID and return `true` so the caller skips adoption:
+    ///
+    /// - reserve the allocator slot (best effort) so the ID can never
+    ///   be handed out — an alloc at this ID would `NLM_F_REPLACE` the
+    ///   foreign object;
+    /// - drop the ID from both adopted maps so no reap/cleanup pass
+    ///   can ever delete the object (covers an adopted well-shaped
+    ///   object later replaced by a foreign writer between dumps);
+    /// - warn + count once per ID (`evpn_foreign_nhid_range_conflicts_total`).
+    ///
+    /// Returns `false` (caller proceeds normally) for well-shaped
+    /// entries.
+    fn quarantine_if_foreign_shape(&mut self, nh: &crate::dataplane::KernelNexthop) -> bool {
+        if !matches!(nh.kind, crate::dataplane::KernelNexthopKind::ShapeConflict) {
+            return false;
+        }
+        // Best-effort reserve: `OutOfRange` means the bitmap portion
+        // is outside what the allocator can ever hand out, so there
+        // is no collision to prevent; the object is still excluded
+        // from adoption below.
+        let _ = self.state.nh_id_alloc.reserve(nh.id);
+        self.state.adopted_unreferenced.remove(&nh.id);
+        self.state.adopted_l3_unreferenced.remove(&nh.id);
+        if self.state.foreign_nhids.insert(nh.id) {
+            self.state.foreign_since_report.nhid_range_conflicts += 1;
+            tracing::warn!(
+                id = format_args!("{:#010x}", nh.id),
+                "foreign nexthop object inside a rustbgpd-reserved NHID range \
+                 (shape conflict — another netlink writer violated the reserved-range \
+                 contract, see docs/deployment.md); failing closed: ID quarantined, \
+                 object left untouched and excluded from adoption/cleanup"
+            );
+        }
+        true
+    }
+
     /// ADR-0059 slice 3b cleanup helper: walk `adopted_unreferenced`
     /// after the first reconcile's apply phase and delete any
     /// rustbgpd-tagged kernel nexthop that's *both* unclaimed by a
@@ -2311,7 +2367,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 KernelNexthopKind::Member { gateway } => {
                     members.insert(*gateway);
                 }
-                KernelNexthopKind::Group { .. } => {
+                KernelNexthopKind::Group { .. } | KernelNexthopKind::ShapeConflict => {
                     tracing::warn!(
                         ?key,
                         nh_id,
@@ -2623,7 +2679,11 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 None => true,
                 Some(nh) => match &nh.kind {
                     KernelNexthopKind::Member { gateway } => gateway != ip,
-                    KernelNexthopKind::Group { .. } => true,
+                    // A tracked ID is ours by construction; a group or
+                    // shape-conflicting object squatting on it is
+                    // drift to heal (LAN-290 quarantine applies only
+                    // to untracked IDs).
+                    KernelNexthopKind::Group { .. } | KernelNexthopKind::ShapeConflict => true,
                 },
             };
             if !needs_action {
@@ -2664,7 +2724,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                         let eset: BTreeSet<u32> = expected_member_ids.iter().copied().collect();
                         kset != eset
                     }
-                    KernelNexthopKind::Member { .. } => true,
+                    KernelNexthopKind::Member { .. } | KernelNexthopKind::ShapeConflict => true,
                 },
             };
             if !needs_action {
@@ -2752,6 +2812,12 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         let mut adopted_any = false;
         for (id, nh) in actual_by_id {
             if tracked_ids.contains(&id) {
+                // Tracked IDs are ours by construction (allocated and
+                // installed this run); shape drift at a tracked ID was
+                // healed by steps (1)/(2) above, not quarantined.
+                continue;
+            }
+            if self.quarantine_if_foreign_shape(&nh) {
                 continue;
             }
             if self.state.adopted_unreferenced.contains_key(&id) {
@@ -2850,7 +2916,15 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
 
         let mut adopted_any = false;
         for (id, nh) in actual_by_id {
-            if tracked_ids.contains(&id) || self.state.adopted_l3_unreferenced.contains_key(&id) {
+            if tracked_ids.contains(&id) {
+                // Ours by construction; shape drift healed by the
+                // repair helpers above, not quarantined.
+                continue;
+            }
+            if self.quarantine_if_foreign_shape(&nh) {
+                continue;
+            }
+            if self.state.adopted_l3_unreferenced.contains_key(&id) {
                 continue;
             }
             match self.state.nh_id_alloc.reserve(id) {
@@ -2896,7 +2970,11 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                 None => true,
                 Some(nh) => match &nh.kind {
                     KernelNexthopKind::Member { gateway } => gateway != ip,
-                    KernelNexthopKind::Group { .. } => true,
+                    // A tracked ID is ours by construction; a group or
+                    // shape-conflicting object squatting on it is
+                    // drift to heal (LAN-290 quarantine applies only
+                    // to untracked IDs).
+                    KernelNexthopKind::Group { .. } | KernelNexthopKind::ShapeConflict => true,
                 },
             };
             if !needs_action {
@@ -2941,7 +3019,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
                         let eset: BTreeSet<u32> = expected_member_ids.iter().copied().collect();
                         kset != eset
                     }
-                    KernelNexthopKind::Member { .. } => true,
+                    KernelNexthopKind::Member { .. } | KernelNexthopKind::ShapeConflict => true,
                 },
             };
             if !needs_action {

--- a/crates/evpn-linux/tests/netns_foreign_state.rs
+++ b/crates/evpn-linux/tests/netns_foreign_state.rs
@@ -349,6 +349,152 @@ async fn l2_foreign_takeover_row_survives_withdrawal_and_shutdown() {
 }
 
 // ─────────────────────────────────────────────────────────────────
+// LAN-290: reserved NHID range single-writer contract
+// ─────────────────────────────────────────────────────────────────
+
+/// The exact ID the actor's allocator would otherwise hand out first
+/// for a per-VTEP member (`VTEP_NH_TAG | 1` = 0x3000_0001) — the
+/// strongest clobber proof: without quarantine, `add_nexthop_member`
+/// would `NLM_F_REPLACE` the foreign object at this ID.
+const FOREIGN_NHID: u32 = 0x3000_0001;
+
+fn l2_nhg_macs(desired: bool) -> RemoteMacTable {
+    let mut builder = RemoteMacTable::builder();
+    if desired {
+        builder
+            .insert(
+                EvpnInstanceId::new(L2_VNI).unwrap(),
+                l2_mac(),
+                RemoteMacEntry {
+                    remote_vtep_ip: "10.0.0.2".parse().unwrap(),
+                    mobility_sequence: None,
+                    alias_vtep_ips: vec!["10.0.0.3".parse().unwrap()],
+                    alias_group_key: Some((
+                        rustbgpd_evpn::EthernetSegmentIdentifier::new([7; 10]),
+                        rustbgpd_evpn::EthernetTagId(0),
+                    )),
+                    single_active_backup_vtep_ip: None,
+                    source: RemoteMacSource::EvpnRibBestPath,
+                },
+            )
+            .unwrap();
+    }
+    builder.build()
+}
+
+fn l2_nhg_intent(generation: u64, desired: bool) -> Arc<DataplaneIntent> {
+    Arc::new(DataplaneIntent {
+        generation,
+        instances: Arc::new(l2_instances()),
+        remote_macs: Arc::new(l2_nhg_macs(desired)),
+        bum_enforcement: Arc::new(BumEnforcementTable::new()),
+        ip_vrfs: Arc::new(IpVrfTable::new()),
+        remote_ip_prefixes: Arc::new(RemoteIpPrefixTable::new()),
+        managed_netdevs: Arc::new(rustbgpd_evpn::ManagedNetdevTable::new()),
+    })
+}
+
+fn foreign_nhid_line() -> String {
+    // `ip nexthop show id <id>` prints one line for the object or
+    // nothing when it is absent.
+    shell("ip", &["nexthop", "show", "id", &FOREIGN_NHID.to_string()])
+}
+
+/// LAN-290: a co-resident netlink writer creates a shape-conflicting
+/// object (`ip nexthop add id 0x3000_0001 dev lo` — non-FDB, device
+/// nexthop) inside rustbgpd's reserved per-VTEP member range before
+/// the daemon starts. rustbgpd must fail closed: quarantine the ID
+/// (never hand it out — its own members/groups land on other IDs),
+/// never adopt it, never reap it, and spare it through withdrawal and
+/// the shutdown drain.
+#[tokio::test]
+async fn nhid_reserved_range_foreign_object_not_clobbered_adopted_or_reaped() {
+    if !netns_gate() {
+        eprintln!("skipping: set EVPN_LINUX_NETNS=1 to run privileged foreign-state test");
+        return;
+    }
+    if !is_inner() {
+        let ns = NetnsFixture::create("nhid");
+        setup_l2_topology(&ns);
+        // Co-resident writer squats on the reserved range with a
+        // shape rustbgpd never writes (no NHA_FDB, has a device).
+        ns.exec(
+            "ip",
+            &[
+                "nexthop",
+                "add",
+                "id",
+                &FOREIGN_NHID.to_string(),
+                "dev",
+                "lo",
+            ],
+        );
+        run_inner(
+            &ns,
+            "nhid_reserved_range_foreign_object_not_clobbered_adopted_or_reaped",
+        );
+        return;
+    }
+
+    // ── inner: actor runs inside the netns ──
+    let (intent_tx, mut report_rx, shutdown, actor_join) = spawn_reconcile_actor().await;
+    let mac = mac_str(l2_mac());
+
+    let before = foreign_nhid_line();
+    assert!(
+        before.contains("dev lo"),
+        "foreign in-range nexthop missing before start: {before}"
+    );
+
+    // 1. Install a multi-homed MAC (member NHs + FDB group + row)
+    //    through the normal reconcile path. Startup adoption sees the
+    //    foreign object and must quarantine, not adopt or delete.
+    intent_tx.send(l2_nhg_intent(1, true)).unwrap();
+    let report = wait_for_report_generation(&mut report_rx, 1).await;
+    assert!(report.failed.is_empty(), "install: {:?}", report.failed);
+    let fdb = shell("bridge", &["fdb", "show", "dev", "vxlan100"]);
+    assert!(
+        fdb.lines().any(|l| l.contains(&mac) && l.contains("nhid")),
+        "multi-homed MAC should land as an FDB-NHG row:\n{fdb}"
+    );
+
+    // Not clobbered: still a plain `dev lo` object, no gateway, not
+    // FDB — the actor's own member NHs landed on other IDs.
+    let line = foreign_nhid_line();
+    assert!(
+        line.contains("dev lo") && !line.contains("via") && !line.contains("fdb"),
+        "foreign in-range object must not be NLM_F_REPLACE-clobbered: {line}"
+    );
+
+    // 2. A second pass (post-adoption cleanup) must not reap it.
+    intent_tx.send(l2_nhg_intent(2, true)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 2).await;
+    let line = foreign_nhid_line();
+    assert!(
+        line.contains("dev lo"),
+        "foreign object must survive adoption cleanup: {line}"
+    );
+
+    // 3. Withdraw the MAC — group/member teardown must spare it.
+    intent_tx.send(l2_nhg_intent(3, false)).unwrap();
+    let _ = wait_for_report_generation(&mut report_rx, 3).await;
+    let line = foreign_nhid_line();
+    assert!(
+        line.contains("dev lo"),
+        "foreign object must survive withdrawal teardown: {line}"
+    );
+
+    // 4. Shutdown drain — must spare it too.
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(10), actor_join).await;
+    let line = foreign_nhid_line();
+    assert!(
+        line.contains("dev lo"),
+        "foreign object must survive the shutdown drain: {line}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
 // L3: VRF route + L3 neighbor + L3VXLAN FDB
 // ─────────────────────────────────────────────────────────────────
 

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -1420,6 +1420,8 @@ fn split_nexthop_ops(
         match &nh.kind {
             KernelNexthopKind::Member { .. } => members.push(nh.clone()),
             KernelNexthopKind::Group { .. } => groups.push(nh.clone()),
+            // LAN-290 quarantined foreign objects are neither.
+            KernelNexthopKind::ShapeConflict => {}
         }
     }
     (members, groups)
@@ -1468,6 +1470,100 @@ async fn fdb_nhg_multihomed_intent_installs_members_group_and_row() {
     );
 
     h.shutdown().await;
+}
+
+// 1a. LAN-290 reserved-NHID-range contract: a shape-conflicting
+//     foreign object inside a rustbgpd-owned range is quarantined at
+//     startup adoption — its allocator slot is reserved (so a fresh
+//     alloc can never land on it and NLM_F_REPLACE-clobber it), it is
+//     never adopted or reaped, it survives withdrawal + the shutdown
+//     drain, and the conflict is counted once per ID on
+//     `foreign_state_counters.nhid_range_conflicts`.
+#[tokio::test]
+async fn fdb_nhg_foreign_shape_in_range_is_quarantined_not_clobbered_or_reaped() {
+    use rustbgpd_evpn_linux::dataplane::{KernelNexthop, KernelNexthopKind};
+
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+
+    // A co-resident writer squatted on member-range slot 1 and
+    // group-range slot 2 with objects rustbgpd never writes.
+    let foreign_member_range = KernelNexthop {
+        id: 0x3000_0001,
+        kind: KernelNexthopKind::ShapeConflict,
+    };
+    let foreign_group_range = KernelNexthop {
+        id: 0x4000_0002,
+        kind: KernelNexthopKind::ShapeConflict,
+    };
+    h.handle.pre_load_nexthop_op(foreign_member_range.clone());
+    h.handle.pre_load_nexthop_op(foreign_group_range.clone());
+
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+    )
+    .unwrap();
+    let macs = macs.build();
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+    h.intent_tx.send(intent(1, inst.clone(), macs)).unwrap();
+
+    // Accumulate the per-report counter deltas while converging.
+    let mut conflicts = 0u64;
+    let mut last = h.next_report().await;
+    conflicts += last.foreign_state_counters.nhid_range_conflicts;
+    while last.intent_generation == 0 {
+        last = h.next_report().await;
+        conflicts += last.foreign_state_counters.nhid_range_conflicts;
+    }
+    assert!(last.failed.is_empty(), "{:?}", last.failed);
+    assert_eq!(conflicts, 2, "each conflicting ID counted exactly once");
+
+    // Fail closed: both foreign objects untouched (not clobbered, not
+    // adopted), and the allocator skipped their slots — every ID the
+    // actor installed has a bitmap portion above the quarantined
+    // slots 1 and 2.
+    let nhs = h.handle.nexthop_ops();
+    assert_eq!(
+        nhs.get(&0x3000_0001),
+        Some(&foreign_member_range),
+        "foreign in-range object must survive adoption untouched: {nhs:?}"
+    );
+    assert_eq!(nhs.get(&0x4000_0002), Some(&foreign_group_range));
+    let (members, groups) = split_nexthop_ops(&nhs);
+    assert_eq!(members.len(), 2, "expected 2 per-VTEP members: {nhs:?}");
+    assert_eq!(groups.len(), 1, "expected 1 group: {nhs:?}");
+    assert!(
+        members
+            .iter()
+            .chain(groups.iter())
+            .all(|nh| nh.id & 0x0FFF_FFFF > 2),
+        "allocator must not hand out the quarantined slots: {nhs:?}"
+    );
+
+    // Withdraw the MAC: group + member teardown must spare the
+    // quarantined objects.
+    h.intent_tx
+        .send(intent(2, inst, RemoteMacTable::builder().build()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+    let nhs = h.handle.nexthop_ops();
+    assert_eq!(
+        nhs.len(),
+        2,
+        "only the foreign objects should remain after withdrawal: {nhs:?}"
+    );
+
+    // Shutdown drain must spare them too.
+    let handle = h.handle.clone();
+    let _ = h.shutdown().await;
+    let nhs = handle.nexthop_ops();
+    assert!(
+        nhs.contains_key(&0x3000_0001) && nhs.contains_key(&0x4000_0002),
+        "foreign objects must survive the shutdown drain: {nhs:?}"
+    );
 }
 
 // 1b. The `DataplaneReport.fdb_nexthops` projection mirrors the
@@ -5063,6 +5159,7 @@ fn sum_foreign_counters(
             acc.replaces_blocked += r.foreign_state_counters.replaces_blocked;
             acc.deletes_skipped += r.foreign_state_counters.deletes_skipped;
             acc.owned_relinquished += r.foreign_state_counters.owned_relinquished;
+            acc.nhid_range_conflicts += r.foreign_state_counters.nhid_range_conflicts;
             acc
         },
     )

--- a/crates/evpn/src/dataplane.rs
+++ b/crates/evpn/src/dataplane.rs
@@ -581,6 +581,14 @@ pub struct ForeignStateCounters {
     /// Owned keys dropped from the in-memory owned state because a
     /// live snapshot showed a foreign row had replaced ours.
     pub owned_relinquished: u64,
+    /// LAN-290: kernel nexthop objects found inside a
+    /// rustbgpd-reserved NHID range whose shape does not match
+    /// anything rustbgpd writes — a co-resident netlink writer
+    /// violated the reserved-range contract. Each conflicting ID is
+    /// counted once (on first sight) and quarantined: reserved in the
+    /// allocator, excluded from adoption and from every reap/delete
+    /// path.
+    pub nhid_range_conflicts: u64,
 }
 
 /// Per-report deltas for ADR-0083 single-active backup-path failover

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -207,6 +207,7 @@ pub struct BgpMetrics {
     evpn_foreign_replaces_blocked: IntCounter,
     evpn_foreign_deletes_skipped: IntCounter,
     evpn_foreign_owned_relinquished: IntCounter,
+    evpn_foreign_nhid_range_conflicts: IntCounter,
 
     // ── EVPN runtime apply (ADR-0063, #268 decomposition) ──────────
     evpn_runtime_decomposed_fail_stops: IntCounter,
@@ -1141,6 +1142,12 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let evpn_foreign_nhid_range_conflicts = IntCounter::new(
+            "evpn_foreign_nhid_range_conflicts_total",
+            "Foreign kernel nexthop objects found inside a rustbgpd-reserved NHID range (shape conflict; LAN-290 fail-closed quarantine). Counted once per conflicting ID.",
+        )
+        .expect("valid metric definition");
+
         let evpn_single_active_backup_active = IntGauge::new(
             "evpn_single_active_backup_active",
             "Number of (ESI, EthernetTag) single-active groups currently retargeted at \
@@ -1568,6 +1575,9 @@ impl BgpMetrics {
             .register(Box::new(evpn_foreign_owned_relinquished.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(evpn_foreign_nhid_range_conflicts.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(evpn_single_active_backup_active.clone()))
             .expect("metric not already registered");
         registry
@@ -1718,6 +1728,7 @@ impl BgpMetrics {
             evpn_foreign_replaces_blocked,
             evpn_foreign_deletes_skipped,
             evpn_foreign_owned_relinquished,
+            evpn_foreign_nhid_range_conflicts,
             evpn_runtime_decomposed_fail_stops,
             bmp_source_drops,
             bmp_collector_drops,
@@ -2837,6 +2848,14 @@ impl BgpMetrics {
             return;
         }
         self.evpn_foreign_owned_relinquished.inc_by(delta);
+    }
+
+    /// Increment the LAN-290 reserved-NHID-range conflict counter.
+    pub fn add_evpn_foreign_nhid_range_conflicts(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.evpn_foreign_nhid_range_conflicts.inc_by(delta);
     }
 
     /// Increment the #268 decomposed-apply fail-stop counter: a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -186,6 +186,47 @@ restart (ADR-0079). Co-residency with another daemon that claims
 `proto bgp` kernel state (e.g. FRR zebra) is unsupported for the
 same reason.
 
+#### Reserved nexthop-ID ranges (EVPN dataplane)
+
+When the EVPN VTEP/IRB dataplane is enabled, rustbgpd **exclusively
+owns** four kernel nexthop-ID ranges, distinguished by the ID's high
+nibble (deliberately offset from FRR's `0x1000`/`0x2000` tags so both
+daemons can't collide on `NLM_F_REPLACE`):
+
+| Range | Use |
+|---|---|
+| `0x3000_0000`–`0x3FFF_FFFF` | L2 per-VTEP FDB nexthop members (ADR-0059 aliasing ECMP) |
+| `0x4000_0000`–`0x4FFF_FFFF` | L2 FDB nexthop groups (ADR-0059) |
+| `0x5000_0000`–`0x5FFF_FFFF` | L3VXLAN per-VTEP nexthop members (all-active Type 5) |
+| `0x6000_0000`–`0x6FFF_FFFF` | L3VXLAN FDB nexthop groups (all-active Type 5) |
+
+This is a deployment contract: **no co-resident netlink writer may
+create nexthop objects with IDs in these ranges** (`ip nexthop add
+id …`, another routing daemon, orchestration tooling). rustbgpd
+adopts objects it finds there across restarts and garbage-collects
+the ones nothing references — an unrelated agent's object parked in
+the range would be treated as rustbgpd state.
+
+rustbgpd validates the shape of every in-range object it dumps at
+startup adoption and during drift recovery (FDB flag, member vs
+group structure matching the tag). An in-range object that does not
+look like anything rustbgpd writes fails closed per ID: the object is
+left untouched, excluded from adoption and from every reap/delete
+path, its ID is quarantined so the allocator can never hand it out
+(and thus never `NLM_F_REPLACE` over it), and the violation is
+logged once and counted on the
+`evpn_foreign_nhid_range_conflicts_total` Prometheus counter. A
+nonzero counter means a co-resident writer is violating this
+contract — find and remove that writer; the quarantined IDs are not
+reclaimed until a daemon restart after the foreign objects are gone.
+
+Note this shape check cannot distinguish a foreign object that is
+byte-for-byte identical to what rustbgpd writes; stamping
+`nh_protocol` on owned nexthop objects as a provenance marker is a
+possible future defense-in-depth, not a substitute for this
+contract (any netlink writer can set the same protocol value — it is
+provenance, not kernel-enforced exclusivity).
+
 ### Operational checks
 
 ```sh

--- a/docs/evpn-vtep-troubleshooting.md
+++ b/docs/evpn-vtep-troubleshooting.md
@@ -362,7 +362,11 @@ nexthop **group**, not a single-dst `dst <ip>` row.
 2. `ip nexthop show` — expect one group line `id <gid> group
    <mid>/<mid> ... fdb` and the corresponding member lines `id
    <mid> via <ip> fdb`. NHIDs are tagged: groups at
-   `0x4000_xxxx`, members at `0x3000_xxxx`.
+   `0x4000_xxxx`, members at `0x3000_xxxx` (L3VXLAN: `0x6000_xxxx` /
+   `0x5000_xxxx`). These ranges are reserved for rustbgpd — see the
+   single-writer contract in `docs/deployment.md`. A foreign object
+   parked in a range is quarantined (left untouched, never adopted or
+   deleted) and surfaces on `evpn_foreign_nhid_range_conflicts_total`.
 3. Confirm rustbgpd actually observed both alias VTEPs' Type 1
    EAD-per-EVI routes for the shared ESI — check
    `rbgp evpn instances` or the gRPC `ListEvpnInstances`,

--- a/src/evpn_dataplane.rs
+++ b/src/evpn_dataplane.rs
@@ -642,6 +642,7 @@ fn record_foreign_state_metrics(
     metrics.add_evpn_foreign_replaces_blocked(counters.replaces_blocked);
     metrics.add_evpn_foreign_deletes_skipped(counters.deletes_skipped);
     metrics.add_evpn_foreign_owned_relinquished(counters.owned_relinquished);
+    metrics.add_evpn_foreign_nhid_range_conflicts(counters.nhid_range_conflicts);
 }
 
 fn record_l3_adoption_metrics(metrics: &BgpMetrics, counters: L3AdoptionCounters) {


### PR DESCRIPTION
Post-v0.50 audit hardening (LAN-290, NHID-authority item). Resolution: document and enforce the single-writer reserved-range deployment contract; `nh_protocol` is recorded as a future defense-in-depth provenance marker, not the ownership basis (another netlink writer can set the same value — it is not kernel-enforced exclusivity).

## The contract

Reserved ranges documented in `docs/deployment.md` (L2 FDB members/groups per ADR-0059; L3VXLAN members/groups from the all-active Type 5 work): no co-resident netlink writer may create nexthop objects in these ranges.

## Enforcement

- The nexthop dump parse now validates FDB flag + member-vs-group structure against the ID's range tag; conflicts surface as `ShapeConflict` instead of being silently dropped. The silent drop was the actual clobber hole: a dropped in-range ID left its allocator slot free, so a later allocation would `NLM_F_REPLACE` the foreign object — and an FDB-flagged mis-shaped one could be adopted and reaped.
- `quarantine_if_foreign_shape()` at all four dump-fold sites (startup + drift, L2 + L3): reserves the allocator slot, evicts the ID from adoption maps, warn-once, and counts via `evpn_foreign_nhid_range_conflicts_total`.
- Reap coverage: #741 explicitly scoped NHIDs out; adopted-NHID deletes now act only on same-pass shape-validated dump entries, and quarantine evicts a morphed entry before cleanup runs. A byte-identical foreign replacement remains undetectable without the deferred `nh_protocol` marker (documented).

## Tests

In-memory actor test (quarantine, slot-skip, counter-once, survival through cleanup/withdrawal/shutdown) runs everywhere; env-gated netns collision proof (`ip nexthop add` at the exact first-allocable member ID; asserts not clobbered/adopted/reaped) compiles and skips clean ungated — to be executed under the privileged kernel-dataplane harness. Gates: fmt / clippy -D warnings / evpn-linux suites / full workspace / doc — all 0.