### PR TITLE
Converge partial managed-netdev creation instead of wedging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fails to encode toward an extended-message peer, and a ROUTE-REFRESH with
   a large ORF section can no longer exceed 4096 bytes toward a peer that
   never advertised the capability. (LAN-290)
+- **Partial managed-netdev creation now converges instead of wedging.** An
+  ADR-0091 managed link create that failed between the netlink add and the
+  `IFLA_ALT_IFNAME` ownership stamp used to strand an unstamped link the
+  daemon would forever classify foreign-present; the failed create now
+  deletes its own unstamped link before surfacing the error, so the next
+  pass retries from absent. A link that *is* stamped but whose follow-on
+  completion steps failed (SVD bridge VLAN/tunnel bindings, VLAN-upper
+  admin-up) used to be treated complete-by-existence and/or permanently
+  suppressed; the reconciler now re-emits the convergent create for
+  exactly-ours stamped-but-incomplete links and classifies post-stamp
+  completion failures as retryable. Transiently failed managed-netdev ops
+  also wake the actor on their own backoff deadline (previously only
+  FDB/BUM/AC-gate/NHG retries did). Finally, managed-netdev and FDB-NHG
+  permanent-failure suppressions are pruned once the underlying intent is
+  withdrawn — completing LAN-124's pruning, which covered the FDB and L3
+  maps but left a withdrawn-then-re-added managed link or NHG member
+  update suppressed until restart (and the stale NHG record kept the
+  adoption-cleanup gate blocked). (LAN-290)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/evpn-linux/src/in_memory.rs
+++ b/crates/evpn-linux/src/in_memory.rs
@@ -551,96 +551,74 @@ impl InMemoryDataplane {
                 name,
                 spec,
                 ownership_stamp,
-            } => match state.kernel.vxlans.get_mut(name) {
-                Some(link) if managed_svd_vxlan_exact(link, name, spec, ownership_stamp) => {}
-                Some(_) => {
-                    return Err(crate::error::DataplaneError::InvalidArgument(format!(
-                        "managed SVD VXLAN {name} changed during apply"
-                    )));
-                }
-                None => {
-                    if state.kernel.link_name_exists(name) {
+            } => {
+                let existing = state.kernel.vxlans.get(name).map(|link| {
+                    (
+                        link.ifindex,
+                        managed_svd_vxlan_exact(link, name, spec, ownership_stamp),
+                    )
+                });
+                match existing {
+                    // LAN-290: convergent re-apply on our own
+                    // exactly-stamped link — (re-)ensure the bridge
+                    // VLAN/tunnel bindings, mirroring the linux impl's
+                    // `ensure_svd_vlan_bindings` completion steps.
+                    Some((ifindex, true)) => {
+                        svd_populate_bridge_bindings(&mut state.kernel, spec, ifindex, name);
+                    }
+                    Some((_, false)) => {
                         return Err(crate::error::DataplaneError::InvalidArgument(format!(
-                            "managed SVD VXLAN {name} cannot be created: desired name is occupied by a non-VXLAN link"
+                            "managed SVD VXLAN {name} changed during apply"
                         )));
                     }
-                    if !state.kernel.links.contains_key(&spec.bridge) {
-                        if state.kernel.link_name_exists(&spec.bridge) {
+                    None => {
+                        if state.kernel.link_name_exists(name) {
                             return Err(crate::error::DataplaneError::InvalidArgument(format!(
-                                "managed SVD VXLAN {name} cannot be created: desired bridge name {} is occupied by a non-bridge link",
+                                "managed SVD VXLAN {name} cannot be created: desired name is occupied by a non-VXLAN link"
+                            )));
+                        }
+                        if !state.kernel.links.contains_key(&spec.bridge) {
+                            if state.kernel.link_name_exists(&spec.bridge) {
+                                return Err(crate::error::DataplaneError::InvalidArgument(
+                                    format!(
+                                        "managed SVD VXLAN {name} cannot be created: desired bridge name {} is occupied by a non-bridge link",
+                                        spec.bridge
+                                    ),
+                                ));
+                            }
+                            return Err(crate::error::DataplaneError::Other(format!(
+                                "managed SVD VXLAN {name} cannot be created: desired bridge {} is absent",
                                 spec.bridge
                             )));
                         }
-                        return Err(crate::error::DataplaneError::Other(format!(
-                            "managed SVD VXLAN {name} cannot be created: desired bridge {} is absent",
-                            spec.bridge
-                        )));
-                    }
-                    let next_ifindex = state
-                        .kernel
-                        .links
-                        .values()
-                        .map(|link| link.ifindex)
-                        .chain(state.kernel.vxlans.values().map(|link| link.ifindex))
-                        .max()
-                        .unwrap_or(0)
-                        .saturating_add(1);
-                    state.kernel.insert_vxlan(KernelVxlanLinkInfo {
-                        ifindex: next_ifindex,
-                        name: name.clone(),
-                        altnames: vec![ownership_stamp.clone()],
-                        up: true,
-                        vni: None,
-                        local_ip: spec.local_ip,
-                        dstport: Some(spec.dstport),
-                        learning_disabled: Some(true),
-                        collect_metadata: true,
-                        vnifilter: true,
-                        bridge: Some(spec.bridge.clone()),
-                        master: Some(spec.bridge.clone()),
-                        mac: None,
-                    });
-                    if let Some(bridge) = state.kernel.links.get_mut(&spec.bridge) {
-                        for binding in &spec.bindings {
-                            if !bridge
-                                .vlans
-                                .iter()
-                                .any(|row| row.vid == binding.bridge_vlan)
-                            {
-                                bridge.vlans.push(KernelBridgeVlanInfo {
-                                    vid: binding.bridge_vlan,
-                                    flags: KernelBridgeVlanFlags::default(),
-                                });
-                            }
-                        }
-                        bridge.port_vlan_inventory.retain(|row| {
-                            !(row.ifindex == next_ifindex || row.name.as_deref() == Some(name))
-                        });
-                        bridge.port_vlan_inventory.push(KernelBridgePortVlanInfo {
+                        let next_ifindex = state
+                            .kernel
+                            .links
+                            .values()
+                            .map(|link| link.ifindex)
+                            .chain(state.kernel.vxlans.values().map(|link| link.ifindex))
+                            .max()
+                            .unwrap_or(0)
+                            .saturating_add(1);
+                        state.kernel.insert_vxlan(KernelVxlanLinkInfo {
                             ifindex: next_ifindex,
-                            name: Some(name.clone()),
-                            is_vxlan: true,
-                            vlans: spec
-                                .bindings
-                                .iter()
-                                .map(|binding| KernelBridgeVlanInfo {
-                                    vid: binding.bridge_vlan,
-                                    flags: KernelBridgeVlanFlags::default(),
-                                })
-                                .collect(),
-                            vlan_tunnels: spec
-                                .bindings
-                                .iter()
-                                .map(|binding| KernelBridgeVlanTunnelInfo {
-                                    tunnel_id: Some(binding.vni),
-                                    vid: Some(binding.bridge_vlan),
-                                    flags: KernelBridgeVlanFlags::default(),
-                                })
-                                .collect(),
+                            name: name.clone(),
+                            altnames: vec![ownership_stamp.clone()],
+                            up: true,
+                            vni: None,
+                            local_ip: spec.local_ip,
+                            dstport: Some(spec.dstport),
+                            learning_disabled: Some(true),
+                            collect_metadata: true,
+                            vnifilter: true,
+                            bridge: Some(spec.bridge.clone()),
+                            master: Some(spec.bridge.clone()),
+                            mac: None,
                         });
+                        svd_populate_bridge_bindings(&mut state.kernel, spec, next_ifindex, name);
                     }
                 }
-            },
+            }
             DataplaneOp::RemoveManagedSvdVxlan {
                 name,
                 ownership_stamp,
@@ -1708,6 +1686,59 @@ impl InMemoryHandle {
     pub fn l3_op_log(&self) -> Vec<DataplaneOp> {
         self.state.lock().expect("poisoned").l3_op_log.clone()
     }
+}
+
+/// Populate (or repair) the fake bridge's VLAN + port-VLAN/tunnel
+/// inventory for an SVD VXLAN's bindings — the fake-kernel analogue of
+/// the linux impl's `ensure_svd_vlan_bindings` completion steps. Called
+/// on fresh create and on convergent re-apply against an exactly-ours
+/// stamped link (LAN-290 stamped-but-incomplete retry).
+fn svd_populate_bridge_bindings(
+    kernel: &mut KernelSnapshot,
+    spec: &rustbgpd_evpn::ManagedSvdVxlanNetdevSpec,
+    vxlan_ifindex: u32,
+    name: &str,
+) {
+    let Some(bridge) = kernel.links.get_mut(&spec.bridge) else {
+        return;
+    };
+    for binding in &spec.bindings {
+        if !bridge
+            .vlans
+            .iter()
+            .any(|row| row.vid == binding.bridge_vlan)
+        {
+            bridge.vlans.push(KernelBridgeVlanInfo {
+                vid: binding.bridge_vlan,
+                flags: KernelBridgeVlanFlags::default(),
+            });
+        }
+    }
+    bridge
+        .port_vlan_inventory
+        .retain(|row| !(row.ifindex == vxlan_ifindex || row.name.as_deref() == Some(name)));
+    bridge.port_vlan_inventory.push(KernelBridgePortVlanInfo {
+        ifindex: vxlan_ifindex,
+        name: Some(name.to_string()),
+        is_vxlan: true,
+        vlans: spec
+            .bindings
+            .iter()
+            .map(|binding| KernelBridgeVlanInfo {
+                vid: binding.bridge_vlan,
+                flags: KernelBridgeVlanFlags::default(),
+            })
+            .collect(),
+        vlan_tunnels: spec
+            .bindings
+            .iter()
+            .map(|binding| KernelBridgeVlanTunnelInfo {
+                tunnel_id: Some(binding.vni),
+                vid: Some(binding.bridge_vlan),
+                flags: KernelBridgeVlanFlags::default(),
+            })
+            .collect(),
+    });
 }
 
 fn managed_bridge_exact(

--- a/crates/evpn-linux/src/linux/managed_netdev.rs
+++ b/crates/evpn-linux/src/linux/managed_netdev.rs
@@ -148,10 +148,9 @@ async fn create_bridge(
         Ok(()) => {}
         Err(err) if is_errno(&err, ERRNO_EEXIST) => {}
         Err(err) => {
-            return Err(classify_link_apply_error(
-                &err,
-                "managed bridge altname stamp",
-            ));
+            let stamp_err = classify_link_apply_error(&err, "managed bridge altname stamp");
+            rollback_unstamped_create(handle, bridge.ifindex, name, "managed bridge").await;
+            return Err(stamp_err);
         }
     }
 
@@ -255,10 +254,9 @@ async fn create_vxlan(
         Ok(()) => {}
         Err(err) if is_errno(&err, ERRNO_EEXIST) => {}
         Err(err) => {
-            return Err(classify_link_apply_error(
-                &err,
-                "managed VXLAN altname stamp",
-            ));
+            let stamp_err = classify_link_apply_error(&err, "managed VXLAN altname stamp");
+            rollback_unstamped_create(handle, vxlan.ifindex, name, "managed VXLAN").await;
+            return Err(stamp_err);
         }
     }
 
@@ -381,10 +379,9 @@ async fn create_svd_vxlan(
             Ok(()) => {}
             Err(err) if is_errno(&err, ERRNO_EEXIST) => {}
             Err(err) => {
-                return Err(classify_link_apply_error(
-                    &err,
-                    "managed SVD VXLAN altname stamp",
-                ));
+                let stamp_err = classify_link_apply_error(&err, "managed SVD VXLAN altname stamp");
+                rollback_unstamped_create(handle, vxlan.ifindex, name, "managed SVD VXLAN").await;
+                return Err(stamp_err);
             }
         }
     }
@@ -411,7 +408,11 @@ async fn ensure_svd_vxlan_converged(
     bridges: &std::collections::HashMap<String, BridgeLink>,
 ) -> Result<(), DataplaneError> {
     ensure_exact_owned_svd_vxlan(name, vxlan, spec, ownership_stamp, bridges)?;
-    ensure_svd_vlan_bindings(handle, name, vxlan.ifindex, spec, bridges).await?;
+    // Completion steps past this point run on a link that provably
+    // carries our exact stamp; failures are retried, never suppressed.
+    ensure_svd_vlan_bindings(handle, name, vxlan.ifindex, spec, bridges)
+        .await
+        .map_err(retryable_completion)?;
     let fresh = fresh_vxlan_state(handle, name).await?;
     let Some(vxlan) = fresh.vxlan.as_ref() else {
         return Err(transient_link_race(format!(
@@ -420,6 +421,7 @@ async fn ensure_svd_vxlan_converged(
     };
     ensure_exact_owned_svd_vxlan(name, vxlan, spec, ownership_stamp, &fresh.bridges)?;
     ensure_svd_vlan_bindings_observed(name, vxlan, spec, &fresh.bridges)
+        .map_err(retryable_completion)
 }
 
 async fn ensure_svd_vlan_bindings(
@@ -569,7 +571,9 @@ async fn create_vrf(
         Ok(()) => {}
         Err(err) if is_errno(&err, ERRNO_EEXIST) => {}
         Err(err) => {
-            return Err(classify_link_apply_error(&err, "managed VRF altname stamp"));
+            let stamp_err = classify_link_apply_error(&err, "managed VRF altname stamp");
+            rollback_unstamped_create(handle, vrf.ifindex, name, "managed VRF").await;
+            return Err(stamp_err);
         }
     }
 
@@ -678,10 +682,9 @@ async fn create_l3vxlan(
         Ok(()) => {}
         Err(err) if is_errno(&err, ERRNO_EEXIST) => {}
         Err(err) => {
-            return Err(classify_link_apply_error(
-                &err,
-                "managed L3VXLAN altname stamp",
-            ));
+            let stamp_err = classify_link_apply_error(&err, "managed L3VXLAN altname stamp");
+            rollback_unstamped_create(handle, vxlan.ifindex, name, "managed L3VXLAN").await;
+            return Err(stamp_err);
         }
     }
 
@@ -762,9 +765,15 @@ async fn create_vlan_upper(
     if !created {
         return adopt_existing_vlan_upper(handle, name, link, spec, ownership_stamp).await;
     }
-    ensure_vlan_upper_attrs(name, link, spec)?;
-    if !link.altnames.iter().any(|alt| alt == ownership_stamp) {
-        stamp_vlan_upper(handle, link.ifindex, ownership_stamp).await?;
+    if let Err(err) = ensure_vlan_upper_attrs(name, link, spec) {
+        rollback_unstamped_create(handle, link.ifindex, name, "managed VLAN upper").await;
+        return Err(err);
+    }
+    if !link.altnames.iter().any(|alt| alt == ownership_stamp)
+        && let Err(err) = stamp_vlan_upper(handle, link.ifindex, ownership_stamp).await
+    {
+        rollback_unstamped_create(handle, link.ifindex, name, "managed VLAN upper").await;
+        return Err(err);
     }
     let fresh = fresh_vlan_upper_state(handle, name).await?;
     let Some(link) = fresh.vlan_upper.as_ref() else {
@@ -794,7 +803,11 @@ async fn ensure_vlan_upper_up_and_owned(
     if link.up {
         return ensure_exact_owned_vlan_upper(name, link, spec, ownership_stamp);
     }
-    set_link_up(handle, link.ifindex, "managed VLAN upper set up").await?;
+    // Stamp + attrs were verified above; a set-up failure is our own
+    // incomplete state — keep it retryable, never permanently suppressed.
+    set_link_up(handle, link.ifindex, "managed VLAN upper set up")
+        .await
+        .map_err(retryable_completion)?;
     let fresh = fresh_vlan_upper_state(handle, name).await?;
     let Some(link) = fresh.vlan_upper.as_ref() else {
         return Err(missing_vlan_upper_after(name, &fresh, "set up"));
@@ -1340,6 +1353,42 @@ fn ensure_exact_vlan_upper_stamp(
         "managed VLAN upper {name} ownership stamp changed during apply: observed {:?}, expected {ownership_stamp}",
         link.altnames
     )))
+}
+
+/// Best-effort delete of a link this operation just created but failed
+/// to stamp. An unstamped link would be classified foreign-present on
+/// every later pass — a self-inflicted permanent wedge — so the failed
+/// create rolls its own creation back and leaves the kernel as if the
+/// create never ran; the next pass retries from absent.
+async fn rollback_unstamped_create(handle: &Handle, ifindex: u32, name: &str, context: &str) {
+    match handle.link().del(ifindex).execute().await {
+        Ok(()) => {
+            tracing::debug!(name, context, "rolled back unstamped just-created link");
+        }
+        Err(err) if is_errno(&err, ERRNO_ENODEV) || is_errno(&err, ERRNO_ENOENT) => {}
+        Err(err) => {
+            tracing::warn!(
+                name,
+                context,
+                error = ?err,
+                "failed to roll back unstamped just-created link; \
+                 it will be reported foreign-present until removed out of band"
+            );
+        }
+    }
+}
+
+/// Downgrade a would-be-permanent failure from a post-stamp completion
+/// step to the transient class. The link provably carries our exact
+/// ownership stamp at this point, so incomplete follow-on state
+/// (bridge VLAN bindings, admin-up) is ours to finish — the reconciler
+/// must retry the completion steps on backoff instead of permanently
+/// suppressing the op until restart.
+fn retryable_completion(err: DataplaneError) -> DataplaneError {
+    match err.class() {
+        crate::error::FailureClass::Permanent => DataplaneError::Other(err.to_string()),
+        _ => err,
+    }
 }
 
 async fn set_link_up(

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -621,16 +621,20 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
 
         loop {
-            // Compute the next retry deadline across the four retry
+            // Compute the next retry deadline across the five retry
             // schedules — FDB ops keyed by `(VNI, MAC)`, BUM and
-            // AC-gate ops keyed by ifindex (separate schedules), and
-            // FDB-NHG group-level ops keyed by `AliasGroupKey`. The
-            // earliest wakes the actor.
+            // AC-gate ops keyed by ifindex (separate schedules),
+            // FDB-NHG group-level ops keyed by `AliasGroupKey`, and
+            // managed-netdev ops keyed by `ManagedNetdevOpKey` (LAN-290:
+            // previously missing, so a transiently failed managed op
+            // only retried on the next unrelated wake). The earliest
+            // wakes the actor.
             let next_fdb = self.state.retry.earliest_due();
             let next_bum = self.state.bum_retry.earliest_due();
             let next_ac_gate = self.state.ac_gate_retry.earliest_due();
             let next_nhg = self.state.nhg_retry.earliest_due();
-            let retry_due = [next_fdb, next_bum, next_ac_gate, next_nhg]
+            let next_managed = self.state.managed_retry.earliest_due();
+            let retry_due = [next_fdb, next_bum, next_ac_gate, next_nhg, next_managed]
                 .into_iter()
                 .flatten()
                 .min()
@@ -1118,6 +1122,7 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             &intent.managed_netdevs,
             &snapshot,
         ));
+        self.prune_stale_managed_permanent_failures(&intent.managed_netdevs, &snapshot);
 
         let attempted_managed_netdev_op = plan.ops.iter().any(|op| {
             matches!(
@@ -1137,6 +1142,10 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
             )
         });
         let (applied, failed) = self.apply_plan(&plan, intent.remote_macs.as_ref()).await;
+        // Runs after apply so a group torn down this pass (intent
+        // withdrawal → RemoveFdbNhg) is already gone from owned state
+        // and its stale suppression record is pruned in the same pass.
+        self.prune_stale_nhg_permanent_failures(intent.remote_macs.as_ref());
         let managed_status_snapshot = if attempted_managed_netdev_op {
             match self.dataplane.dump_snapshot().await {
                 Ok(snapshot) => snapshot,
@@ -3663,6 +3672,108 @@ impl<D: Dataplane + crate::dataplane::NexthopOps> ReconcileActor<D> {
         }
     }
 
+    /// LAN-290 counterpart of [`Self::prune_stale_fdb_permanent_failures`]
+    /// for the FDB-NHG group-op suppression map. A group key is live
+    /// while any desired remote-MAC entry still derives it or while the
+    /// group is still tracked in owned state; once the intent is
+    /// withdrawn and the group torn down, the suppression record must
+    /// go — it would otherwise block a later same-shape
+    /// `UpdateFdbNhgMembers` forever and permanently wedge the
+    /// adoption-cleanup gate (which blocks while this map is non-empty).
+    fn prune_stale_nhg_permanent_failures(&mut self, desired: &RemoteMacTable) {
+        if self.state.nhg_permanent_failures.is_empty() {
+            return;
+        }
+
+        let mut live_keys: BTreeSet<crate::group_state::AliasGroupKey> = desired
+            .iter()
+            .filter_map(|(&(vni, _mac), entry)| {
+                entry
+                    .alias_group_key
+                    .map(|(esi, tag)| crate::group_state::AliasGroupKey::new(vni, esi, tag))
+            })
+            .collect();
+        live_keys.extend(self.state.groups.iter_groups().map(|(key, _)| *key));
+
+        let before = self.state.nhg_permanent_failures.len();
+        self.state
+            .nhg_permanent_failures
+            .retain(|key, _| live_keys.contains(key));
+        let removed = before.saturating_sub(self.state.nhg_permanent_failures.len());
+        if removed > 0 {
+            tracing::debug!(
+                removed,
+                "pruned stale FDB-NHG permanent-failure suppressions for withdrawn groups"
+            );
+        }
+    }
+
+    /// LAN-290 counterpart for the managed-netdev suppression map. A
+    /// suppressed Create stays live while its name is still desired in
+    /// its class; a suppressed Remove stays live while the link still
+    /// exists in the kernel and is not desired (i.e. the orphan-reap
+    /// Remove could still be emitted). Everything else — withdrawn
+    /// intent, links deleted out of band — is pruned so a later
+    /// same-shape re-add is retried without a daemon restart.
+    fn prune_stale_managed_permanent_failures(
+        &mut self,
+        managed: &ManagedNetdevTable,
+        snapshot: &KernelSnapshot,
+    ) {
+        if self.state.managed_permanent_failures.is_empty() {
+            return;
+        }
+
+        let bridges: BTreeSet<&str> = managed.bridges().map(|n| n.name.as_str()).collect();
+        let vxlans: BTreeSet<&str> = managed.vxlans().map(|n| n.name.as_str()).collect();
+        let svd_vxlans: BTreeSet<&str> = managed.svd_vxlans().map(|n| n.name.as_str()).collect();
+        let vrfs: BTreeSet<&str> = managed.vrfs().map(|n| n.name.as_str()).collect();
+        let l3vxlans: BTreeSet<&str> = managed.l3vxlans().map(|n| n.name.as_str()).collect();
+        let vlan_uppers: BTreeSet<&str> = managed.vlan_uppers().map(|n| n.name.as_str()).collect();
+
+        let before = self.state.managed_permanent_failures.len();
+        self.state
+            .managed_permanent_failures
+            .retain(|_, op| match op {
+                DataplaneOp::CreateManagedBridge { name, .. } => bridges.contains(name.as_str()),
+                DataplaneOp::RemoveManagedBridge { name, .. } => {
+                    !bridges.contains(name.as_str()) && snapshot.links.contains_key(name)
+                }
+                DataplaneOp::CreateManagedVxlan { name, .. } => vxlans.contains(name.as_str()),
+                DataplaneOp::RemoveManagedVxlan { name, .. } => {
+                    !vxlans.contains(name.as_str()) && snapshot.vxlans.contains_key(name)
+                }
+                DataplaneOp::CreateManagedSvdVxlan { name, .. } => {
+                    svd_vxlans.contains(name.as_str())
+                }
+                DataplaneOp::RemoveManagedSvdVxlan { name, .. } => {
+                    !svd_vxlans.contains(name.as_str()) && snapshot.vxlans.contains_key(name)
+                }
+                DataplaneOp::CreateManagedVrf { name, .. } => vrfs.contains(name.as_str()),
+                DataplaneOp::RemoveManagedVrf { name, .. } => {
+                    !vrfs.contains(name.as_str()) && snapshot.vrfs.contains_key(name)
+                }
+                DataplaneOp::CreateManagedL3Vxlan { name, .. } => l3vxlans.contains(name.as_str()),
+                DataplaneOp::RemoveManagedL3Vxlan { name, .. } => {
+                    !l3vxlans.contains(name.as_str()) && snapshot.vxlans.contains_key(name)
+                }
+                DataplaneOp::CreateManagedVlanUpper { name, .. } => {
+                    vlan_uppers.contains(name.as_str())
+                }
+                DataplaneOp::RemoveManagedVlanUpper { name, .. } => {
+                    !vlan_uppers.contains(name.as_str()) && snapshot.vlan_uppers.contains_key(name)
+                }
+                _ => true,
+            });
+        let removed = before.saturating_sub(self.state.managed_permanent_failures.len());
+        if removed > 0 {
+            tracing::debug!(
+                removed,
+                "pruned stale managed-netdev permanent-failure suppressions for withdrawn intent"
+            );
+        }
+    }
+
     fn prune_stale_l3_permanent_failures(
         &mut self,
         desired: &rustbgpd_evpn::ip_vrf::RemoteIpPrefixTable,
@@ -4488,14 +4599,27 @@ fn compute_managed_netdev_create_ops(
     }
     for svd_vxlan in managed.svd_vxlans() {
         desired.svd_vxlans.insert(svd_vxlan.name.clone());
-        if !snapshot.vxlans.contains_key(&svd_vxlan.name)
-            && !snapshot.link_name_exists(&svd_vxlan.name)
-        {
-            ops.push(DataplaneOp::CreateManagedSvdVxlan {
-                name: svd_vxlan.name.clone(),
-                spec: svd_vxlan.spec.clone(),
-                ownership_stamp: svd_vxlan.ownership_stamp.clone(),
-            });
+        match snapshot.vxlans.get(&svd_vxlan.name) {
+            None if !snapshot.link_name_exists(&svd_vxlan.name) => {
+                ops.push(DataplaneOp::CreateManagedSvdVxlan {
+                    name: svd_vxlan.name.clone(),
+                    spec: svd_vxlan.spec.clone(),
+                    ownership_stamp: svd_vxlan.ownership_stamp.clone(),
+                });
+            }
+            // LAN-290: a link that carries exactly our stamp but whose
+            // bridge VLAN/tunnel bindings are missing is our own
+            // incomplete creation (stamp landed, binding steps failed).
+            // Re-emit the convergent Create so the completion steps are
+            // retried instead of the link sitting incomplete forever.
+            Some(link) if svd_stamped_ours_incomplete(svd_vxlan, link, snapshot) => {
+                ops.push(DataplaneOp::CreateManagedSvdVxlan {
+                    name: svd_vxlan.name.clone(),
+                    spec: svd_vxlan.spec.clone(),
+                    ownership_stamp: svd_vxlan.ownership_stamp.clone(),
+                });
+            }
+            _ => {}
         }
     }
     for vrf in managed.vrfs() {
@@ -4521,18 +4645,69 @@ fn compute_managed_netdev_create_ops(
     }
     for vlan_upper in managed.vlan_uppers() {
         desired.vlan_uppers.insert(vlan_upper.name.clone());
-        if !snapshot.vlan_uppers.contains_key(&vlan_upper.name)
-            && !snapshot.link_name_exists(&vlan_upper.name)
-        {
-            ops.push(DataplaneOp::CreateManagedVlanUpper {
-                name: vlan_upper.name.clone(),
-                spec: vlan_upper.spec.clone(),
-                ownership_stamp: vlan_upper.ownership_stamp.clone(),
-            });
+        match snapshot.vlan_uppers.get(&vlan_upper.name) {
+            None if !snapshot.link_name_exists(&vlan_upper.name) => {
+                ops.push(DataplaneOp::CreateManagedVlanUpper {
+                    name: vlan_upper.name.clone(),
+                    spec: vlan_upper.spec.clone(),
+                    ownership_stamp: vlan_upper.ownership_stamp.clone(),
+                });
+            }
+            // LAN-290: exactly-ours-stamped but administratively down —
+            // the post-stamp set-up step failed. Re-emit the convergent
+            // Create so the completion step is retried.
+            Some(link) if vlan_upper_stamped_ours_incomplete(vlan_upper, link) => {
+                ops.push(DataplaneOp::CreateManagedVlanUpper {
+                    name: vlan_upper.name.clone(),
+                    spec: vlan_upper.spec.clone(),
+                    ownership_stamp: vlan_upper.ownership_stamp.clone(),
+                });
+            }
+            _ => {}
         }
     }
 
     desired
+}
+
+/// A desired SVD VXLAN that exists, is exclusively ours (exactly one
+/// rustbgpd stamp, equal to the expected one), and whose link attrs
+/// all match — but whose bridge VLAN/tunnel bindings are not fully
+/// observed. This is stamped-but-incomplete state from a partial
+/// creation; it is safe to re-run the convergent Create against it.
+fn svd_stamped_ours_incomplete(
+    svd_vxlan: &ManagedSvdVxlanNetdev,
+    link: &KernelVxlanLinkInfo,
+    snapshot: &KernelSnapshot,
+) -> bool {
+    let stamps = rustbgpd_stamps(&link.altnames);
+    if stamps.len() != 1 || stamps[0] != svd_vxlan.ownership_stamp {
+        return false;
+    }
+    if classify_svd_link_attrs(svd_vxlan, link).is_some() {
+        return false;
+    }
+    !snapshot
+        .links
+        .get(&svd_vxlan.spec.bridge)
+        .is_some_and(|bridge| {
+            svd_vlan_bindings_present(bridge, link.ifindex, &link.name, &svd_vxlan.spec.bindings)
+        })
+}
+
+/// A desired VLAN upper that exists with exactly our stamp and matching
+/// bridge/VLAN attrs, but is administratively down — the post-stamp
+/// set-up completion step failed. Safe to re-run the convergent Create.
+fn vlan_upper_stamped_ours_incomplete(
+    vlan_upper: &ManagedVlanUpperNetdev,
+    link: &KernelVlanUpperLinkInfo,
+) -> bool {
+    let stamps = rustbgpd_stamps(&link.altnames);
+    stamps.len() == 1
+        && stamps[0] == vlan_upper.ownership_stamp
+        && link.bridge.as_deref() == Some(vlan_upper.spec.bridge.as_str())
+        && link.vlan == Some(vlan_upper.spec.vlan)
+        && !link.up
 }
 
 fn compute_managed_netdev_orphan_reap_ops(
@@ -8534,6 +8709,147 @@ mod managed_netdev_tests {
         ));
         occupied.insert_link_name("br100.10");
         assert!(compute_managed_netdev_ops(&table, &occupied).is_empty());
+    }
+
+    // LAN-290: a desired SVD VXLAN that exists with exactly our stamp
+    // and matching attrs but missing bridge VLAN/tunnel bindings is a
+    // stamped-but-incomplete creation — the convergent Create must be
+    // re-emitted; once the bindings are observed, no op is emitted.
+    #[test]
+    fn managed_netdev_ops_reemit_create_for_stamped_incomplete_svd() {
+        let spec = rustbgpd_evpn::ManagedSvdVxlanNetdevSpec {
+            local_ip: Some("10.0.0.1".parse().unwrap()),
+            dstport: 4789,
+            bridge: "br100".to_string(),
+            bindings: vec![rustbgpd_evpn::ManagedSvdVxlanBinding {
+                bridge_vlan: 10,
+                vni: 100,
+            }],
+        };
+        let table = ManagedNetdevTable::from_all_maps_with_svd(
+            "leaf-1".to_string(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([("vxlan-svd".to_string(), spec.clone())]),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+
+        let mut svd = vxlan_link(
+            "vxlan-svd",
+            20,
+            vec!["rustbgpd:svd-vxlan:leaf-1:vxlan-svd"],
+            0,
+        );
+        svd.vni = None;
+        svd.collect_metadata = true;
+        svd.vnifilter = true;
+
+        // Bridge present but with no port/VLAN inventory — bindings
+        // are missing, so the Create must be re-emitted.
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_link(link("br100", 10, true, Vec::new()));
+        snapshot.insert_vxlan(svd.clone());
+        assert_eq!(
+            compute_managed_netdev_ops(&table, &snapshot),
+            vec![DataplaneOp::CreateManagedSvdVxlan {
+                name: "vxlan-svd".to_string(),
+                spec: spec.clone(),
+                ownership_stamp: "rustbgpd:svd-vxlan:leaf-1:vxlan-svd".to_string(),
+            }]
+        );
+
+        // With the bindings observed, the link is complete — no op.
+        let mut bridge = link("br100", 10, true, Vec::new());
+        bridge.vlans.push(crate::snapshot::KernelBridgeVlanInfo {
+            vid: 10,
+            flags: crate::snapshot::KernelBridgeVlanFlags::default(),
+        });
+        bridge
+            .port_vlan_inventory
+            .push(crate::snapshot::KernelBridgePortVlanInfo {
+                ifindex: 20,
+                name: Some("vxlan-svd".to_string()),
+                is_vxlan: true,
+                vlans: vec![crate::snapshot::KernelBridgeVlanInfo {
+                    vid: 10,
+                    flags: crate::snapshot::KernelBridgeVlanFlags::default(),
+                }],
+                vlan_tunnels: vec![crate::snapshot::KernelBridgeVlanTunnelInfo {
+                    tunnel_id: Some(100),
+                    vid: Some(10),
+                    flags: crate::snapshot::KernelBridgeVlanFlags::default(),
+                }],
+            });
+        let mut complete = KernelSnapshot::new();
+        complete.insert_link(bridge);
+        complete.insert_vxlan(svd.clone());
+        assert!(compute_managed_netdev_ops(&table, &complete).is_empty());
+
+        // A foreign (unstamped) incomplete link must NOT be touched.
+        let mut foreign_snapshot = KernelSnapshot::new();
+        foreign_snapshot.insert_link(link("br100", 10, true, Vec::new()));
+        svd.altnames.clear();
+        foreign_snapshot.insert_vxlan(svd);
+        assert!(compute_managed_netdev_ops(&table, &foreign_snapshot).is_empty());
+    }
+
+    // LAN-290: a desired VLAN upper with exactly our stamp and matching
+    // attrs but administratively down had its post-stamp set-up step
+    // fail — the convergent Create must be re-emitted. Foreign
+    // (unstamped) down links are left alone.
+    #[test]
+    fn managed_netdev_ops_reemit_create_for_stamped_down_vlan_upper() {
+        let table = ManagedNetdevTable::from_all_maps(
+            "leaf-1".to_string(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([(
+                "br100.10".to_string(),
+                rustbgpd_evpn::ManagedVlanUpperNetdevSpec {
+                    bridge: "br100".to_string(),
+                    vlan: 10,
+                },
+            )]),
+        );
+
+        let mut snapshot = KernelSnapshot::new();
+        snapshot.insert_link(link("br100", 10, true, Vec::new()));
+        snapshot.insert_vlan_upper(vlan_upper_link(
+            "br100.10",
+            50,
+            vec!["rustbgpd:vlan-upper:leaf-1:br100.10"],
+            Some("br100"),
+            Some(10),
+            false,
+        ));
+        assert_eq!(
+            compute_managed_netdev_ops(&table, &snapshot),
+            vec![DataplaneOp::CreateManagedVlanUpper {
+                name: "br100.10".to_string(),
+                spec: rustbgpd_evpn::ManagedVlanUpperNetdevSpec {
+                    bridge: "br100".to_string(),
+                    vlan: 10,
+                },
+                ownership_stamp: "rustbgpd:vlan-upper:leaf-1:br100.10".to_string(),
+            }]
+        );
+
+        // Same link but foreign (no stamp): no op.
+        let mut foreign_snapshot = KernelSnapshot::new();
+        foreign_snapshot.insert_link(link("br100", 10, true, Vec::new()));
+        foreign_snapshot.insert_vlan_upper(vlan_upper_link(
+            "br100.10",
+            50,
+            Vec::new(),
+            Some("br100"),
+            Some(10),
+            false,
+        ));
+        assert!(compute_managed_netdev_ops(&table, &foreign_snapshot).is_empty());
     }
 
     #[test]

--- a/crates/evpn-linux/tests/reconcile_actor.rs
+++ b/crates/evpn-linux/tests/reconcile_actor.rs
@@ -496,6 +496,153 @@ async fn managed_svd_vxlan_lifecycle_creates_and_reports_owned_safe() {
     h.shutdown().await;
 }
 
+// LAN-290 (1): a managed create that fails between link add and the
+// ownership stamp must leave the kernel exactly as if the create never
+// ran (the linux impl deletes its own unstamped link before surfacing
+// the error as transient — modeled here by the fake's atomic apply),
+// and the actor must retry the create from absent on the next backoff
+// tick instead of wedging on a foreign-present classification.
+#[tokio::test(start_paused = true)]
+async fn failed_managed_create_leaves_kernel_clean_and_retries() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let table = || {
+        ManagedNetdevTable::from_maps(
+            "leaf-1".to_string(),
+            BTreeMap::from([("br200".to_string(), true)]),
+            BTreeMap::new(),
+        )
+    };
+    h.handle.inject_failure_other(
+        Some(DataplaneOp::CreateManagedBridge {
+            name: "br200".to_string(),
+            vlan_filtering: true,
+            ownership_stamp: "rustbgpd:bridge:leaf-1:br200".to_string(),
+        }),
+        "managed bridge altname stamp failed; unstamped link rolled back",
+    );
+    h.intent_tx
+        .send(intent_with_managed_netdevs(1, table()))
+        .unwrap();
+
+    let _ = h.try_drain_reports().await;
+    tokio::task::yield_now().await;
+    // The failed create must not strand an unstamped link.
+    let snapshot = h.handle.kernel_snapshot();
+    assert!(
+        !snapshot.links.contains_key("br200") && !snapshot.link_name_exists("br200"),
+        "failed managed create left link state behind"
+    );
+
+    // Past the max jittered first-failure backoff the retry timer
+    // re-fires the pass and the create converges.
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+
+    let snapshot = h.handle.kernel_snapshot();
+    let link = snapshot
+        .links
+        .get("br200")
+        .expect("failed managed create was not retried");
+    assert_eq!(link.altnames, vec!["rustbgpd:bridge:leaf-1:br200"]);
+    h.shutdown().await;
+}
+
+// LAN-290 (2): an SVD VXLAN that already carries exactly our stamp but
+// whose bridge VLAN/tunnel bindings never landed (creation failed after
+// the stamp step) is OUR incomplete state. The reconciler must re-emit
+// the convergent Create for it and retry the completion steps on
+// backoff — not classify it complete-by-existence and never touch it,
+// and not permanently suppress the retry.
+#[tokio::test(start_paused = true)]
+async fn stamped_incomplete_svd_bindings_are_completed_not_wedged() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let spec = rustbgpd_evpn::ManagedSvdVxlanNetdevSpec {
+        local_ip: Some(ipa("10.0.0.1")),
+        dstport: 4789,
+        bridge: "br100".to_string(),
+        bindings: vec![rustbgpd_evpn::ManagedSvdVxlanBinding {
+            bridge_vlan: 10,
+            vni: 100,
+        }],
+    };
+    // Operator bridge with no port/VLAN inventory + a stamped SVD link:
+    // the exact shape left behind when a create failed post-stamp.
+    h.handle.set_links(BTreeMap::from([(
+        "br100".to_string(),
+        managed_link("br100", 10, true, Vec::new()),
+    )]));
+    h.handle.set_vxlans(BTreeMap::from([(
+        "vxlan-svd".to_string(),
+        KernelVxlanLinkInfo {
+            ifindex: 20,
+            name: "vxlan-svd".to_string(),
+            altnames: vec!["rustbgpd:svd-vxlan:leaf-1:vxlan-svd".to_string()],
+            up: true,
+            vni: None,
+            local_ip: Some(ipa("10.0.0.1")),
+            dstport: Some(4789),
+            learning_disabled: Some(true),
+            collect_metadata: true,
+            vnifilter: true,
+            bridge: Some("br100".to_string()),
+            master: Some("br100".to_string()),
+            mac: None,
+        },
+    )]));
+    let table = ManagedNetdevTable::from_all_maps_with_svd(
+        "leaf-1".to_string(),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        BTreeMap::from([("vxlan-svd".to_string(), spec.clone())]),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        BTreeMap::new(),
+    );
+    // First completion attempt fails; it must be retried on backoff,
+    // never permanently suppressed (post-stamp failures surface as
+    // transient from the linux impl).
+    h.handle.inject_failure_other(
+        Some(DataplaneOp::CreateManagedSvdVxlan {
+            name: "vxlan-svd".to_string(),
+            spec: spec.clone(),
+            ownership_stamp: "rustbgpd:svd-vxlan:leaf-1:vxlan-svd".to_string(),
+        }),
+        "managed SVD bridge VLAN add failed",
+    );
+    h.intent_tx
+        .send(intent_with_managed_netdevs(1, table))
+        .unwrap();
+
+    let _ = h.try_drain_reports().await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        h.handle.apply_count() >= 2,
+        "stamped-incomplete SVD completion was not retried; apply_count={}",
+        h.handle.apply_count()
+    );
+    let snapshot = h.handle.kernel_snapshot();
+    let bridge = snapshot.links.get("br100").expect("bridge present");
+    let port = bridge
+        .port_vlan_inventory
+        .iter()
+        .find(|port| port.name.as_deref() == Some("vxlan-svd"))
+        .expect("SVD bindings were never completed");
+    assert!(
+        port.vlan_tunnels
+            .iter()
+            .any(|row| row.vid == Some(10) && row.tunnel_id == Some(100)),
+        "SVD VLAN/tunnel mapping missing after retry: {port:?}"
+    );
+    h.shutdown().await;
+}
+
 #[tokio::test]
 async fn managed_vxlan_lifecycle_reaps_only_safe_owner_orphans() {
     let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
@@ -1274,6 +1421,152 @@ async fn permanent_failure_suppression_is_pruned_after_desired_withdraw() {
     assert!(
         h.handle.kernel_has_fdb(vni(100), mac(1)),
         "same-shape re-add after desired withdraw did not program the FDB"
+    );
+
+    h.shutdown().await;
+}
+
+// LAN-290 (3a): managed-netdev permanent suppression must be pruned
+// once the managed intent is withdrawn — a later same-shape re-add is
+// retried instead of staying suppressed until restart. Counterpart of
+// the LAN-124 FDB/L3 pruning above for `managed_permanent_failures`.
+#[tokio::test]
+async fn managed_permanent_suppression_is_pruned_after_intent_withdraw() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    let table = || {
+        ManagedNetdevTable::from_maps(
+            "leaf-1".to_string(),
+            BTreeMap::from([("br300".to_string(), true)]),
+            BTreeMap::new(),
+        )
+    };
+    h.handle
+        .inject_failure_kernel_too_old(Some(DataplaneOp::CreateManagedBridge {
+            name: "br300".to_string(),
+            vlan_filtering: true,
+            ownership_stamp: "rustbgpd:bridge:leaf-1:br300".to_string(),
+        }));
+
+    h.intent_tx
+        .send(intent_with_managed_netdevs(1, table()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 1).await;
+    assert!(!h.handle.kernel_snapshot().links.contains_key("br300"));
+
+    // Withdraw the managed intent — prunes the stale suppression.
+    h.intent_tx
+        .send(intent_with_managed_netdevs(2, ManagedNetdevTable::new()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 2).await;
+
+    // Same-shape re-add must be attempted again.
+    h.intent_tx
+        .send(intent_with_managed_netdevs(3, table()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 3).await;
+    let snapshot = h.handle.kernel_snapshot();
+    let link = snapshot
+        .links
+        .get("br300")
+        .expect("same-shape managed re-add after withdraw stayed permanently suppressed");
+    assert_eq!(link.altnames, vec!["rustbgpd:bridge:leaf-1:br300"]);
+    h.shutdown().await;
+}
+
+// LAN-290 (3b): FDB-NHG group-op permanent suppression (keyed by
+// `AliasGroupKey`) must be pruned once the group's intent is withdrawn
+// and the group torn down. A stale record would suppress a later
+// same-shape `UpdateFdbNhgMembers` forever and keep the adoption
+// cleanup gate wedged (it blocks while the map is non-empty).
+#[tokio::test]
+async fn nhg_permanent_suppression_is_pruned_after_group_withdraw() {
+    let mut h = Harness::spawn(ReconcileActorConfig::for_tests());
+    h.handle.set_probe(vni(100), InstanceProbe::Ready);
+    let inst = one_instance_table(instance(100, Some("br100"), "10.0.0.1"));
+
+    // Phase 1: install the group with members {.2, .3}.
+    let mut macs = RemoteMacTable::builder();
+    macs.insert(
+        vni(100),
+        mac(1),
+        entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+    )
+    .unwrap();
+    h.intent_tx
+        .send(intent(1, inst.clone(), macs.build()))
+        .unwrap();
+    let r = wait_for_generation(&mut h, 1).await;
+    assert!(r.failed.is_empty(), "{:?}", r.failed);
+
+    // Phase 2: member change {.2, .4} fails permanently — the
+    // UpdateFdbNhgMembers op is recorded in the NHG suppression map.
+    // NHG ops route through the coordinator's NexthopOps calls, which
+    // only consume *untargeted* injected failures; the Update is the
+    // only op in this pass, so the injection lands on it.
+    h.handle.inject_failure_kernel_too_old(None);
+    let mut macs2 = RemoteMacTable::builder();
+    macs2
+        .insert(
+            vni(100),
+            mac(1),
+            entry_multi_homed("10.0.0.2", &["10.0.0.4"], 7),
+        )
+        .unwrap();
+    h.intent_tx
+        .send(intent(2, inst.clone(), macs2.build()))
+        .unwrap();
+    let r = wait_for_generation(&mut h, 2).await;
+    assert!(
+        !r.failed.is_empty(),
+        "injected permanent Update failure never surfaced"
+    );
+
+    // Phase 3: withdraw the MAC — group refcount hits zero, teardown
+    // runs, and the stale NHG suppression is pruned in the same pass.
+    h.intent_tx
+        .send(intent(3, inst.clone(), RemoteMacTable::new()))
+        .unwrap();
+    let _ = wait_for_generation(&mut h, 3).await;
+
+    // Phase 4: re-add with the original members {.2, .3}.
+    let mut macs4 = RemoteMacTable::builder();
+    macs4
+        .insert(
+            vni(100),
+            mac(1),
+            entry_multi_homed("10.0.0.2", &["10.0.0.3"], 7),
+        )
+        .unwrap();
+    h.intent_tx
+        .send(intent(4, inst.clone(), macs4.build()))
+        .unwrap();
+    let r = wait_for_generation(&mut h, 4).await;
+    assert!(r.failed.is_empty(), "{:?}", r.failed);
+
+    // Phase 5: the exact same member change {.2, .4} as the suppressed
+    // op. Pre-fix this stayed suppressed forever; it must apply now.
+    let mut macs5 = RemoteMacTable::builder();
+    macs5
+        .insert(
+            vni(100),
+            mac(1),
+            entry_multi_homed("10.0.0.2", &["10.0.0.4"], 7),
+        )
+        .unwrap();
+    h.intent_tx.send(intent(5, inst, macs5.build())).unwrap();
+    let r = wait_for_generation(&mut h, 5).await;
+    assert!(r.failed.is_empty(), "{:?}", r.failed);
+    assert_eq!(r.fdb_nexthops.groups.len(), 1);
+    let mut gateways: Vec<IpAddr> = r.fdb_nexthops.groups[0]
+        .members
+        .iter()
+        .map(|m| m.gateway)
+        .collect();
+    gateways.sort();
+    assert_eq!(
+        gateways,
+        vec![ipa("10.0.0.2"), ipa("10.0.0.4")],
+        "same-shape UpdateFdbNhgMembers after withdraw + re-add stayed suppressed"
     );
 
     h.shutdown().await;


### PR DESCRIPTION
Post-v0.50 audit hardening (LAN-290, managed-netdev convergence item).

## Problems and fixes

1. **Pre-stamp failure self-wedge.** Every `create_*` does link-add → stamp → verify, so a stamp failure stranded a just-created unstamped link that the next pass classified foreign-present and refused to touch. `rollback_unstamped_create()` now deletes the unstamped link at every stamp-failure site (all six classes) so the next pass retries from absent.
2. **Stamped-incomplete suppression.** A stamped link whose completion steps failed (SVD bridge-VLAN/tunnel bindings, VLAN-upper link-up) got no op at all from the create pass and its failure was classified Permanent. The pass now re-emits the convergent Create for exactly-ours stamped-incomplete links (foreign/mis-stamped untouched), and post-stamp completion failures are transient with capped backoff.
3. **Bonus bug**: the actor's retry-deadline wake computed the min over FDB/BUM/AC-gate/NHG schedules but omitted `managed_retry` — a transiently failed managed op never woke the actor on its own backoff. Fixed.
4. **LAN-124 gap closed**: `managed_permanent_failures` and `nhg_permanent_failures` outlived withdrawn intent (#606 pruned only the FDB/L3 maps). Both now prune against desired state; the NHG prune runs after `apply_plan` so a teardown pass prunes its own stale record, un-wedging the adoption-cleanup gate.

## Tests

Four actor tests (kernel-clean rollback + retry; SVD stamped-incomplete completion; both suppression prunes — verified regression-sensitive: they fail with the prunes disabled) + unit re-emission tests incl. foreign negative cases. Gates: fmt / clippy -D warnings / evpn+evpn-linux suites / full workspace / doc — all 0.