### PR TITLE
Make Type-1/2/4 EVPN origination acknowledgement-aware (ADR-0102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EVPN Type 1/2/4 origination is acknowledgement-aware.** The local Type 2
+  MAC/MAC+IP originator and the Ethernet Segment orchestrator's Type 1
+  EAD/Type 4 publication treated send-success as done: a dropped RIB reply,
+  an ack timeout, or a rejection was only logged, permanently diverging the
+  originator's state from the RIB (the Type 5 originator already gated its
+  state on acks; Types 1/2/4 now match). Every inject/withdraw is tracked as
+  pending under `(route identity, generation)` until the RIB acknowledges it;
+  unacknowledged operations retry with bounded exponential backoff (1 s
+  doubling to a 30 s cap), newer intent for the same route supersedes older
+  pending work, stale acknowledgements are ignored, and withdrawals are never
+  forgotten until acked (a `NotFound` rejection counts as done — the route is
+  already absent). Nothing is persisted: a restart rebuilds intent from
+  kernel/config observation and reconciles idempotently. The MAC+IP path's
+  unmatched pending-IP-binding buffer is now bounded (4096 MAC entries, 16
+  IPs per MAC). See ADR-0102. (LAN-293)
 - **BFD actor bounds its receive work and publishes remote-AdminDown flips
   while already Down.** A packet flood could pin the BFD socket actor in its
   drain loop, starving timer ticks and the shutdown command; each actor turn

--- a/docs/adr/0102-evpn-origination-acknowledgement.md
+++ b/docs/adr/0102-evpn-origination-acknowledgement.md
@@ -1,0 +1,160 @@
+# ADR-0102: EVPN origination acknowledgement-awareness (Type 1/2/4)
+
+**Status:** Accepted
+**Date:** 2026-07-09
+
+## Context
+
+Three daemon-side actors originate EVPN routes into the RIB over the
+`RibUpdate` mpsc channel, each command carrying a reply oneshot the RIB
+answers after applying the operation (`handle_inject_evpn` /
+`handle_withdraw_evpn`, `crates/rib/src/manager/distribution/evpn.rs`):
+
+- the **local Type 2 MAC / MAC+IP originator**
+  (`src/evpn_originator/`), driven by kernel FDB/neighbor observations
+  through the `LocalMacOriginator` / `LocalMacIpOriginator` state
+  machines;
+- the **Ethernet Segment orchestrator** (`src/evpn_segment.rs`),
+  publishing Type 4 ES, Type 1 EAD-per-ES, and Type 1 EAD-per-EVI
+  routes;
+- the **IP-VRF Type 5 originator** (`src/evpn_l3_originator.rs`).
+
+The Type 5 originator was already acknowledgement-aware: its
+`inject_one` / `withdraw_one` return `true` only on an acked `Ok(())`,
+callers gate their `originated` map on that return value, and the
+level-triggered reconcile pass retries anything still divergent.
+
+The Type 1/2/4 paths were not. They awaited the reply oneshot but only
+**logged** failures — a RIB rejection, a dropped reply, or a wedged RIB
+left the originator believing it had published (or withdrawn) state the
+RIB never applied. The asymmetry matters because the Type 2 state
+machines commit their state (mobility-sequence ratchet,
+`originated_key`) at *action-generation* time, necessarily — the
+ratchet must advance atomically with the decision — so a lost operation
+silently diverged the machine from the RIB with no reconcile pass to
+repair it: the periodic RIB repoll projects *remote* (non-self-NH)
+routes for contention tracking, not our own originations. The same
+fire-and-log shape applied to the ES orchestrator's Type 1/4
+publication, including teardown withdraws, whose loss strands routes in
+peers' RIBs. Additionally, the MAC+IP path's `pending_ip_bindings`
+buffer (ARP/ND observations racing ahead of AF_BRIDGE FDB) grew without
+bound if the bridge never learned the MAC.
+
+The Type 5 pattern cannot be copied verbatim: Type 5 *desired state* is
+fully re-derivable on every pass from watch-channel snapshots, so
+"don't advance `have` until acked" suffices. Type 2/1/4 intent lives in
+state machines that advance when they emit actions. The
+acknowledgement gate therefore has to sit **between** the machines and
+the RIB, tracking emitted-but-unacknowledged operations explicitly.
+
+## Decisions
+
+1. **Three-tier model: desired / pending / confirmed.**
+   *Desired* remains what it already was — the state machines' view,
+   derived from kernel/config observation. *Pending* is a new
+   per-actor tracker (`PendingRibOps`, `src/evpn_ack.rs`): every
+   inject/withdraw sent to the RIB is registered under
+   `(route identity = EvpnRouteKey, generation)` before its first
+   attempt. *Confirmed* is reached only when the RIB's reply oneshot
+   acknowledges the operation; only then does the success bookkeeping
+   run (origination metrics, `OriginatedLocalMacCounts`).
+
+2. **Timeouts and dropped replies keep the operation pending; a retry
+   arm re-drives it with bounded backoff.** Each attempt awaits the
+   reply for at most 5 s (`RIB_ACK_TIMEOUT`; the RIB replies inline
+   while processing, so the timeout only trips when the RIB is wedged
+   or severely backlogged). On any failure — closed channel, dropped
+   reply, timeout, or active rejection — the operation stays pending
+   and its next attempt is scheduled at `1s · 2^(attempts−1)` capped
+   at **30 s** (`RETRY_BACKOFF_BASE` / `RETRY_BACKOFF_MAX`). Retries
+   never give up: a withdraw must not be forgotten until acknowledged,
+   and the cap bounds the cost of a persistent failure to one attempt
+   per 30 s per route. Both actors gained a `select!` arm that sleeps
+   until the tracker's earliest deadline and parks forever when
+   nothing is pending.
+
+3. **Supersession by route identity; stale acks dropped by
+   generation.** The tracker holds at most one pending operation per
+   `EvpnRouteKey`; submitting a new one replaces the old under a fresh
+   generation. `confirm`/`defer`/`forget` are generation-checked, so
+   an acknowledgement for a superseded operation can never clear (or
+   re-schedule) its successor. Because every state transition already
+   flows through the state machines — lifecycle drains emit withdraws
+   for exactly the keys the machines believe outstanding, including
+   unacknowledged injects — VNI removal/redefine, ESI drain, and
+   segment teardown supersede stale pending work for free.
+
+4. **Retries rebuild from the current model; unbuildable injects are
+   dropped, withdraws never are.** An inject retry re-derives its
+   route from the *current* instance/segment tables (Type 2:
+   `build_originated_route` from the live `EvpnInstance` +
+   `vni_to_esi`; Type 1/4: `build_es_route` from the live
+   `SegmentState` + instance). If the VNI/segment left the model — or
+   a Type 2 key's RD no longer matches its instance — the pending
+   inject is dropped (`forget`): the model change that removed it
+   already superseded the route's state with withdraws. Withdraw
+   retries need only the key and always proceed. A withdraw rejected
+   with `NotFound` is treated as **confirmed**: absence is the
+   withdraw's goal (the typical cause is a paired inject that was
+   itself lost), and retrying it forever would be a livelock against a
+   route that will never exist.
+
+5. **Correctness leans on three existing properties, now
+   load-bearing.** (a) RIB inject/withdraw are idempotent per key —
+   `insert_evpn` is last-write-wins, withdraw of an absent key is a
+   reported no-op — so retrying an operation whose earlier attempt
+   actually applied (e.g. an ack lost after apply) is harmless.
+   (b) The RIB command channel is FIFO, so a superseding operation
+   sent after a possibly-applied predecessor lands after it and the
+   final RIB state matches the final intent. (c) Origination is
+   single-writer per route identity within each actor. No RIB-side
+   changes were needed: the reply oneshot is created per attempt by
+   the originator, so the reply is already correlated to
+   `(key, generation)` at the await site — no identity echo required
+   in the protocol.
+
+6. **Nothing is persisted; restart rebuilds intent from observation
+   and reconciles idempotently.** The trackers are in-memory only. On
+   restart the kernel dump replays FDB/neighbor state into fresh state
+   machines and config replays segment definitions; origination then
+   re-injects idempotently against whatever the (also restarted) RIB
+   holds. Persisting pending operations would add a second source of
+   truth that can contradict observation — the class of bug this ADR
+   removes. This also settles **MAC-mobility ratchet safe-forget**:
+   `our_seq` is deliberately not persisted; after a restart the first
+   contended learn re-derives it as `remote_seq + 1` from the live
+   remote view, which is exactly RFC 7432 §15.1's recovery behavior.
+
+7. **The unmatched pending-IP-binding buffer is bounded.**
+   `pending_ip_bindings` exists only to absorb AF_INET/AF_INET6 NEIGH
+   events racing ahead of AF_BRIDGE FDB — a reorder buffer, not a
+   database. It is now capped at **4096 `(VNI, MAC)` entries** and
+   **16 IPs per MAC** (`MAX_PENDING_IP_BINDING_MACS` /
+   `MAX_PENDING_IPS_PER_MAC`, `src/evpn_originator/observation.rs`).
+   Overflow drops the new binding with a warning rather than evicting
+   an old one (eviction just moves the loss); a dropped binding
+   self-heals on the next kernel neighbor event for the pair once the
+   MAC has surfaced. The caps comfortably exceed default kernel
+   neighbor-table sizes (`gc_thresh3` = 1024).
+
+## Consequences
+
+- A dropped reply, RIB backpressure, or a transient wedge can no
+  longer permanently lose a Type 1/2/4 origination or withdrawal; the
+  worst case is delayed convergence at the backoff cadence, visible as
+  `evpn_local_origination_errors_total` increments plus per-attempt
+  warnings.
+- Type 2 withdraw semantics changed slightly: a `NotFound` rejection
+  now also runs `OriginatedLocalMacCounts::record_withdraw`, keeping
+  the operator-facing per-VNI MAC counts honest when the paired inject
+  was lost (previously the count could strand).
+- A persistently rejecting RIB retries forever at 30 s intervals per
+  route. Acceptable: today's RIB never rejects injects and rejects
+  withdraws only with `NotFound` (which confirms), so this arm is
+  future-proofing, and the log/metric trail makes it diagnosable.
+- The actors do one extra map insert/remove per operation and hold a
+  clone of each in-flight action — noise next to route construction.
+- Scope: Type 3 (IMET) and SVI publication keep their existing
+  shapes; they are config-derived, re-published on reconfiguration,
+  and were not part of the observed loss class. Extending the tracker
+  to them is mechanical if evidence appears.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,6 +110,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0099](0099-update-groups-v2.md) | Update groups v2 — per-family keying and RT-aware VPN emit | Accepted | 2026-07-03 |
 | [0100](0100-parallel-rib-manager.md) | Parallelizing the RibManager (research blueprint) | Proposed | 2026-07-03 |
 | [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 |
+| [0102](0102-evpn-origination-acknowledgement.md) | EVPN origination acknowledgement-awareness (Type 1/2/4) | Accepted | 2026-07-09 |
 
 ## Template
 

--- a/src/evpn_ack.rs
+++ b/src/evpn_ack.rs
@@ -1,0 +1,341 @@
+//! Acknowledgement-aware EVPN origination toward the RIB (ADR-0102).
+//!
+//! Shared by the local Type 2 MAC/MAC+IP originator
+//! ([`crate::evpn_originator`]) and the Ethernet Segment orchestrator's
+//! Type 1/4 publication ([`crate::evpn_segment`]). Both actors keep a
+//! [`PendingRibOps`] tracker: every inject/withdraw sent to the RIB is
+//! recorded as *pending* under `(route identity, generation)` and only
+//! forgotten once the RIB's reply oneshot acknowledges it. A dropped
+//! reply, an ack timeout, or a closed channel keeps the operation
+//! pending; the owning actor's retry arm re-attempts it with bounded
+//! exponential backoff. New intent for the same route identity
+//! supersedes older pending work (fresh generation), and
+//! acknowledgement handling is generation-checked so a stale ack can
+//! never confirm a superseded operation.
+//!
+//! Correctness leans on three properties recorded in ADR-0102:
+//!
+//! 1. RIB inject/withdraw are idempotent per key (`insert_evpn` is
+//!    last-write-wins; `withdraw_evpn` of an absent key is a no-op
+//!    reported as `NotFound`), so a retry of an operation whose first
+//!    attempt actually applied is harmless.
+//! 2. The RIB command channel is FIFO, so a superseding operation sent
+//!    after a possibly-applied predecessor always lands after it.
+//! 3. Nothing here is persisted: on restart, intent is rebuilt from
+//!    kernel/config observation and reconciled idempotently.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use rustbgpd_evpn::{EvpnInstanceId, OriginationAction};
+use rustbgpd_rib::{RibCommandError, RibUpdate};
+use rustbgpd_wire::EvpnRouteKey;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+
+/// How long an inject/withdraw waits for the RIB's reply before the
+/// attempt counts as unacknowledged. The RIB actor replies inline while
+/// processing the command, so this only trips when the RIB is wedged or
+/// severely backlogged.
+pub(crate) const RIB_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// First retry delay after a failed attempt.
+pub(crate) const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+/// Backoff ceiling: 1s → 2s → 4s → 8s → 16s → 30s, then 30s forever.
+/// Retries never give up — a withdraw must not be forgotten until the
+/// RIB acknowledges it — but the interval is bounded so a persistent
+/// failure costs one attempt per 30s per route, not a hot loop.
+pub(crate) const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Outcome of one inject/withdraw attempt against the RIB.
+#[derive(Debug)]
+pub(crate) enum RibAckOutcome {
+    /// The RIB applied the operation.
+    Acked,
+    /// The RIB actively rejected the operation.
+    Rejected(RibCommandError),
+    /// No acknowledgement: channel closed, reply dropped, or timeout.
+    /// The operation may or may not have been applied.
+    NoAck(&'static str),
+}
+
+impl RibAckOutcome {
+    /// A withdraw rejected with `NotFound` means the route is already
+    /// absent — exactly the state the withdraw wanted. Callers treat
+    /// it as confirmation (e.g. the paired inject was lost earlier).
+    pub(crate) fn is_not_found(&self) -> bool {
+        matches!(self, Self::Rejected(RibCommandError::NotFound(_)))
+    }
+}
+
+/// Send one RIB command carrying a reply oneshot and await the
+/// acknowledgement, bounded by [`RIB_ACK_TIMEOUT`].
+pub(crate) async fn send_and_ack(
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    update: impl FnOnce(oneshot::Sender<Result<(), RibCommandError>>) -> RibUpdate,
+) -> RibAckOutcome {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if rib_tx.send(update(reply_tx)).await.is_err() {
+        return RibAckOutcome::NoAck("RIB channel closed");
+    }
+    match tokio::time::timeout(RIB_ACK_TIMEOUT, reply_rx).await {
+        Ok(Ok(Ok(()))) => RibAckOutcome::Acked,
+        Ok(Ok(Err(e))) => RibAckOutcome::Rejected(e),
+        Ok(Err(_)) => RibAckOutcome::NoAck("reply dropped"),
+        Err(_) => RibAckOutcome::NoAck("ack timeout"),
+    }
+}
+
+/// One unacknowledged origination operation.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingOp {
+    /// EVPN instance the operation was built against. Inject retries
+    /// rebuild their route from the *current* model for this VNI (and
+    /// are dropped if it disappeared); withdraw retries only need the
+    /// key.
+    pub vni: EvpnInstanceId,
+    /// The originating state machine's action, replayed on retry.
+    pub action: OriginationAction,
+    /// Supersession stamp: only an ack carrying the current generation
+    /// confirms the operation.
+    pub generation: u64,
+    /// Failed attempts so far (drives the backoff schedule).
+    pub attempts: u32,
+    /// Earliest time the next attempt may run.
+    pub next_attempt: Instant,
+}
+
+/// Generation-stamped pending-operation tracker (ADR-0102).
+///
+/// Keyed by route identity ([`EvpnRouteKey`]): at most one operation is
+/// pending per route, and submitting a new one supersedes the old.
+#[derive(Debug, Default)]
+pub(crate) struct PendingRibOps {
+    ops: HashMap<EvpnRouteKey, PendingOp>,
+    next_generation: u64,
+}
+
+impl PendingRibOps {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a new operation as pending, superseding any older
+    /// pending operation for the same route identity. Returns the
+    /// generation the caller must present to [`Self::confirm`] /
+    /// [`Self::defer`].
+    pub(crate) fn submit(
+        &mut self,
+        key: EvpnRouteKey,
+        vni: EvpnInstanceId,
+        action: OriginationAction,
+    ) -> u64 {
+        self.next_generation += 1;
+        let generation = self.next_generation;
+        self.ops.insert(
+            key,
+            PendingOp {
+                vni,
+                action,
+                generation,
+                attempts: 0,
+                next_attempt: Instant::now(),
+            },
+        );
+        generation
+    }
+
+    /// Acknowledge an operation. Returns `true` and forgets the entry
+    /// only when `generation` matches the currently-pending one; a
+    /// stale ack (the operation was superseded) is ignored.
+    pub(crate) fn confirm(&mut self, key: EvpnRouteKey, generation: u64) -> bool {
+        if self
+            .ops
+            .get(&key)
+            .is_some_and(|op| op.generation == generation)
+        {
+            self.ops.remove(&key);
+            return true;
+        }
+        false
+    }
+
+    /// Record a failed attempt: keep the operation pending and push its
+    /// next attempt out on the bounded backoff schedule. No-op if the
+    /// operation was superseded meanwhile.
+    pub(crate) fn defer(&mut self, key: EvpnRouteKey, generation: u64) {
+        if let Some(op) = self.ops.get_mut(&key)
+            && op.generation == generation
+        {
+            op.attempts = op.attempts.saturating_add(1);
+            op.next_attempt = Instant::now() + backoff_after(op.attempts);
+        }
+    }
+
+    /// Drop a pending operation without acknowledgement — used when a
+    /// retry can no longer rebuild an inject (its VNI/segment left the
+    /// model; the lifecycle drain that removed it already superseded
+    /// the route's state with withdraws). Generation-checked like
+    /// [`Self::confirm`].
+    pub(crate) fn forget(&mut self, key: EvpnRouteKey, generation: u64) {
+        if self
+            .ops
+            .get(&key)
+            .is_some_and(|op| op.generation == generation)
+        {
+            self.ops.remove(&key);
+        }
+    }
+
+    /// Snapshot of the operations whose backoff has elapsed.
+    pub(crate) fn due(&self, now: Instant) -> Vec<(EvpnRouteKey, PendingOp)> {
+        self.ops
+            .iter()
+            .filter(|(_, op)| op.next_attempt <= now)
+            .map(|(key, op)| (*key, op.clone()))
+            .collect()
+    }
+
+    /// Earliest scheduled attempt, if anything is pending. Drives the
+    /// owning actor's retry `select!` arm.
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.ops.values().map(|op| op.next_attempt).min()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    /// The pending operation for a route identity, if any.
+    #[cfg(test)]
+    pub(crate) fn get(&self, key: &EvpnRouteKey) -> Option<&PendingOp> {
+        self.ops.get(key)
+    }
+}
+
+/// Bounded exponential backoff: `BASE * 2^(attempts-1)` capped at
+/// [`RETRY_BACKOFF_MAX`].
+fn backoff_after(attempts: u32) -> Duration {
+    let exp = attempts.saturating_sub(1).min(5);
+    RETRY_BACKOFF_BASE
+        .saturating_mul(1 << exp)
+        .min(RETRY_BACKOFF_MAX)
+}
+
+/// Sleep until the tracker's next deadline, or forever when nothing is
+/// pending (so the owning `select!` services its other arms).
+pub(crate) async fn retry_delay(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{mac, rd, vni as make_vni};
+    use rustbgpd_wire::EthernetTagId;
+
+    fn key(mac_byte: u8) -> EvpnRouteKey {
+        EvpnRouteKey::MacIp {
+            rd: rd(65000, 100),
+            ethernet_tag: EthernetTagId(0),
+            mac: mac(mac_byte),
+            ip: None,
+        }
+    }
+
+    fn inject(mac_byte: u8) -> OriginationAction {
+        OriginationAction::Inject {
+            mac: mac(mac_byte),
+            mobility_seq: None,
+            sticky: false,
+            key: key(mac_byte),
+        }
+    }
+
+    fn withdraw(mac_byte: u8) -> OriginationAction {
+        OriginationAction::Withdraw {
+            mac: mac(mac_byte),
+            key: key(mac_byte),
+        }
+    }
+
+    fn vni() -> EvpnInstanceId {
+        make_vni(100)
+    }
+
+    #[tokio::test]
+    async fn supersession_ignores_stale_ack_and_new_generation_wins() {
+        let mut pending = PendingRibOps::new();
+        let g1 = pending.submit(key(1), vni(), inject(1));
+        // New intent for the same route identity supersedes the
+        // pending inject with a withdraw.
+        let g2 = pending.submit(key(1), vni(), withdraw(1));
+        assert!(g2 > g1);
+        assert_eq!(pending.len(), 1);
+        assert!(matches!(
+            pending.get(&key(1)).unwrap().action,
+            OriginationAction::Withdraw { .. }
+        ));
+
+        // A stale ack for the superseded generation must not confirm.
+        assert!(!pending.confirm(key(1), g1));
+        assert_eq!(pending.len(), 1, "stale ack must not clear the op");
+        // Stale defer is equally inert.
+        pending.defer(key(1), g1);
+        assert_eq!(pending.get(&key(1)).unwrap().attempts, 0);
+
+        // The current generation confirms.
+        assert!(pending.confirm(key(1), g2));
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backoff_doubles_from_base_and_caps_at_max() {
+        let mut pending = PendingRibOps::new();
+        let generation = pending.submit(key(1), vni(), inject(1));
+
+        let mut expected = vec![];
+        for attempt in 1..=8u32 {
+            let before = Instant::now();
+            pending.defer(key(1), generation);
+            let deadline = pending.next_deadline().expect("op pending");
+            expected.push((attempt, deadline - before));
+        }
+        assert_eq!(
+            expected
+                .iter()
+                .map(|(_, d)| d.as_secs())
+                .collect::<Vec<_>>(),
+            vec![1, 2, 4, 8, 16, 30, 30, 30],
+            "backoff must double from 1s and stay capped at 30s"
+        );
+
+        // Nothing is due before the deadline; everything after.
+        assert!(pending.due(Instant::now()).is_empty());
+        assert_eq!(
+            pending.due(Instant::now() + Duration::from_secs(31)).len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn forget_is_generation_checked() {
+        let mut pending = PendingRibOps::new();
+        let g1 = pending.submit(key(1), vni(), inject(1));
+        let g2 = pending.submit(key(1), vni(), inject(1));
+        pending.forget(key(1), g1);
+        assert_eq!(pending.len(), 1, "stale forget must not clear the op");
+        pending.forget(key(1), g2);
+        assert!(pending.is_empty());
+    }
+}

--- a/src/evpn_originator/duplicate_mac.rs
+++ b/src/evpn_originator/duplicate_mac.rs
@@ -222,6 +222,7 @@ pub(super) async fn apply_actions_with_duplicate_policy(
         return;
     }
     apply_actions(
+        &mut state.pending_rib_ops,
         actions,
         inst,
         rib_tx,
@@ -261,6 +262,7 @@ pub(super) async fn suppress_local_originations_for_mac(
         return;
     }
     apply_actions(
+        &mut state.pending_rib_ops,
         actions,
         inst,
         rib_tx,
@@ -416,6 +418,7 @@ pub(super) async fn replay_local_mac_after_recovery(
         let view = state.remote_mac_view.get(&(vni, mac));
         let actions = orig.on_local_learned(mac, ifindex, sticky, view);
         apply_actions(
+            &mut state.pending_rib_ops,
             actions,
             inst,
             rib_tx,
@@ -433,6 +436,7 @@ pub(super) async fn replay_local_mac_after_recovery(
         let view = state.remote_mac_ip_view.get(&(vni, mac, ip));
         let actions = orig.on_local_ip_learned(mac, ip, sticky, view);
         apply_actions(
+            &mut state.pending_rib_ops,
             actions,
             inst,
             rib_tx,

--- a/src/evpn_originator/mod.rs
+++ b/src/evpn_originator/mod.rs
@@ -64,6 +64,7 @@ use std::net::IpAddr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use crate::evpn_ack::PendingRibOps;
 use crate::evpn_originator::duplicate_mac::{handle_originator_command, recover_duplicate_macs};
 use crate::evpn_originator::lifecycle::apply_runtime_model;
 use crate::evpn_originator::observation::handle_observation;
@@ -71,7 +72,7 @@ use crate::evpn_originator::rib_polling::{
     handle_evpn_event_coalesced, recv_evpn_event, repoll_rib, subscribe_evpn_events,
 };
 use crate::evpn_originator::rib_write::{
-    drain_to_withdraws, extract_ip_from_key, next_hop_path_attribute,
+    drain_to_withdraws, extract_ip_from_key, next_hop_path_attribute, retry_pending_rib_ops,
 };
 use rustbgpd_evpn::{
     DuplicateMacAction, DuplicateMacDecision, DuplicateMacDetector, DuplicateMacKey, EvpnInstance,
@@ -552,6 +553,12 @@ struct OriginatorState {
     /// remote-FDB intent while leaving Loc-RIB/RR visibility intact.
     active_duplicate_mac_quarantines: BTreeSet<DuplicateMacKey>,
     duplicate_mac_quarantine_tx: watch::Sender<Arc<BTreeSet<DuplicateMacKey>>>,
+    /// ADR-0102 acknowledgement tracker: every inject/withdraw sent to
+    /// the RIB stays pending here until the RIB acks it; the actor's
+    /// retry arm re-drives unacknowledged operations with bounded
+    /// backoff. In-memory only — a restart rebuilds intent from kernel
+    /// observation instead of replaying pending operations.
+    pending_rib_ops: PendingRibOps,
 }
 
 impl OriginatorState {
@@ -578,6 +585,7 @@ impl OriginatorState {
             known_duplicate_mac_keys: BTreeSet::new(),
             active_duplicate_mac_quarantines: BTreeSet::new(),
             duplicate_mac_quarantine_tx,
+            pending_rib_ops: PendingRibOps::new(),
         }
     }
 
@@ -721,6 +729,19 @@ async fn originator_loop(
                     evpn_event_rx = None;
                 }
             },
+            // ADR-0102: re-drive RIB operations whose acknowledgement
+            // was lost (dropped reply, timeout, backpressure). Parks
+            // forever while nothing is pending.
+            () = crate::evpn_ack::retry_delay(state.pending_rib_ops.next_deadline()) => {
+                retry_pending_rib_ops(
+                    &mut state,
+                    &runtime.instances,
+                    &runtime.rib_tx,
+                    &runtime.metrics,
+                    &runtime.originated_local_mac_counts,
+                    &runtime.vni_to_esi,
+                ).await;
+            }
             _ = poll_tick.tick() => {
                 recover_duplicate_macs(
                     &mut state,

--- a/src/evpn_originator/observation.rs
+++ b/src/evpn_originator/observation.rs
@@ -8,6 +8,56 @@ use crate::evpn_originator::duplicate_mac::{
     outstanding_route_keys_for_mac, sticky_for, suppress_local_originations_for_mac,
 };
 use crate::evpn_originator::rib_write::apply_actions;
+use tracing::warn;
+
+/// ADR-0102: bound the unmatched pending-IP-binding buffer. The buffer
+/// exists only to absorb `AF_INET`/`AF_INET6` NEIGH racing ahead of
+/// `AF_BRIDGE` FDB during cold start — it is a reorder buffer, not a
+/// database. Caps keep a misbehaving feed (ARP/ND events for MACs the
+/// bridge never learns) from growing it without bound; a dropped
+/// binding self-heals on the next kernel neighbor event for the pair
+/// once the MAC has surfaced.
+pub(super) const MAX_PENDING_IP_BINDING_MACS: usize = 4096;
+pub(super) const MAX_PENDING_IPS_PER_MAC: usize = 16;
+
+/// Insert an unmatched `(VNI, MAC) → IP` binding, enforcing the
+/// ADR-0102 caps. Drops (with a warning) rather than evicts: the
+/// oldest parked bindings are as likely to be replayed as the newest,
+/// and eviction would just move the loss.
+fn park_pending_ip_binding(
+    state: &mut OriginatorState,
+    vni: EvpnInstanceId,
+    mac: MacAddress,
+    ip: IpAddr,
+) {
+    if let Some(set) = state.pending_ip_bindings.get_mut(&(vni, mac)) {
+        if set.len() >= MAX_PENDING_IPS_PER_MAC {
+            warn!(
+                ?vni,
+                ?mac,
+                ?ip,
+                cap = MAX_PENDING_IPS_PER_MAC,
+                "pending IP-binding per-MAC cap reached — dropping binding"
+            );
+            return;
+        }
+        set.insert(ip);
+        return;
+    }
+    if state.pending_ip_bindings.len() >= MAX_PENDING_IP_BINDING_MACS {
+        warn!(
+            ?vni,
+            ?mac,
+            ?ip,
+            cap = MAX_PENDING_IP_BINDING_MACS,
+            "pending IP-binding MAC cap reached — dropping binding"
+        );
+        return;
+    }
+    state
+        .pending_ip_bindings
+        .insert((vni, mac), std::collections::BTreeSet::from([ip]));
+}
 
 /// Dispatch a single observation from the kernel observation feed.
 ///
@@ -210,11 +260,7 @@ fn handle_observation_while_drained(obs: &LocalMacObservation, state: &mut Origi
                     .or_default()
                     .insert(ip);
             } else {
-                state
-                    .pending_ip_bindings
-                    .entry((vni, mac))
-                    .or_default()
-                    .insert(ip);
+                park_pending_ip_binding(state, vni, mac, ip);
             }
         }
         LocalMacObservation::IpRemoved { vni, mac, ip } => {
@@ -367,6 +413,7 @@ pub(super) async fn handle_learned(
         };
         let mac_only_actions = mac_orig.on_local_aged(mac);
         apply_actions(
+            &mut state.pending_rib_ops,
             mac_only_actions,
             inst,
             rib_tx,
@@ -443,6 +490,7 @@ pub(super) async fn handle_aged(
     if let Some(mac_orig) = state.mac_originators.get_mut(&vni) {
         let actions = mac_orig.on_local_aged(mac);
         apply_actions(
+            &mut state.pending_rib_ops,
             actions,
             inst,
             rib_tx,
@@ -455,6 +503,7 @@ pub(super) async fn handle_aged(
     if let Some(mac_ip_orig) = state.mac_ip_originators.get_mut(&vni) {
         let actions = mac_ip_orig.on_local_mac_aged(mac);
         apply_actions(
+            &mut state.pending_rib_ops,
             actions,
             inst,
             rib_tx,
@@ -494,11 +543,7 @@ pub(super) async fn handle_ip_added(
             ?ip,
             "IpAdded for MAC not yet locally learned — parking in pending_ip_bindings"
         );
-        state
-            .pending_ip_bindings
-            .entry((vni, mac))
-            .or_default()
-            .insert(ip);
+        park_pending_ip_binding(state, vni, mac, ip);
         return;
     }
 
@@ -533,6 +578,7 @@ pub(super) async fn handle_ip_added(
     if was_mac_only && let Some(mac_orig) = state.mac_originators.get_mut(&vni) {
         let actions = mac_orig.on_local_aged(mac);
         apply_actions(
+            &mut state.pending_rib_ops,
             actions,
             inst,
             rib_tx,
@@ -606,6 +652,7 @@ pub(super) async fn handle_ip_removed(
     };
     let actions = mac_ip_orig.on_local_ip_aged(mac, ip);
     apply_actions(
+        &mut state.pending_rib_ops,
         actions,
         inst,
         rib_tx,

--- a/src/evpn_originator/rib_write.rs
+++ b/src/evpn_originator/rib_write.rs
@@ -4,6 +4,7 @@ use super::{
     OriginationAction, OriginatorState, PathAttribute, RibUpdate, build_originated_route, debug,
     mpsc, warn,
 };
+use crate::evpn_ack::{PendingRibOps, RibAckOutcome, send_and_ack};
 
 /// Drain on shutdown: emit Withdraws for every still-advertised
 /// route across both originators. MAC+IP first so peer state
@@ -55,6 +56,7 @@ pub(super) async fn drain_vni_to_withdraws(
         let actions = orig.drain_to_withdraws();
         if !actions.is_empty() {
             apply_actions(
+                &mut state.pending_rib_ops,
                 actions,
                 inst,
                 rib_tx,
@@ -69,6 +71,7 @@ pub(super) async fn drain_vni_to_withdraws(
         let actions = orig.drain_to_withdraws();
         if !actions.is_empty() {
             apply_actions(
+                &mut state.pending_rib_ops,
                 actions,
                 inst,
                 rib_tx,
@@ -82,8 +85,14 @@ pub(super) async fn drain_vni_to_withdraws(
 }
 
 /// Translate `OriginationAction`s into `RibUpdate`s and ship them to
-/// the RIB. Awaits each oneshot reply so failed injects are logged.
+/// the RIB, acknowledgement-aware per ADR-0102: each operation is
+/// registered as pending (superseding any older pending operation for
+/// the same route identity) before its first attempt, and only the
+/// RIB's acknowledgement clears it. Failed attempts stay pending; the
+/// actor's retry arm re-drives them with bounded backoff.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn apply_actions(
+    pending: &mut PendingRibOps,
     actions: Vec<OriginationAction>,
     instance: &EvpnInstance,
     rib_tx: &mpsc::Sender<RibUpdate>,
@@ -92,81 +101,159 @@ pub(super) async fn apply_actions(
     vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
 ) {
     for action in actions {
-        match action {
-            OriginationAction::Inject {
-                mac,
-                mobility_seq,
-                sticky,
-                key,
-            } => {
-                // ESI-aware origination: when the VNI is part of a
-                // configured Ethernet Segment, attach the segment's
-                // ESI so peers can resolve aliasing alternatives.
-                // Single-homed VNIs default to ZERO.
-                let esi = vni_to_esi
-                    .get(&instance.id)
-                    .copied()
-                    .unwrap_or(EthernetSegmentIdentifier::ZERO);
-                let route = build_originated_route(instance, mac, mobility_seq, sticky, key, esi);
-                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-                if rib_tx
-                    .send(RibUpdate::InjectEvpn {
-                        route,
-                        reply: reply_tx,
-                    })
-                    .await
-                    .is_err()
-                {
-                    metrics.record_evpn_local_origination_error(ACTION_INJECT);
-                    warn!("RIB channel closed; cannot inject EVPN Type 2");
-                    return;
+        let key = action_key(&action);
+        let generation = pending.submit(key, instance.id, action.clone());
+        attempt_action(
+            pending,
+            generation,
+            &action,
+            instance.id,
+            Some(instance),
+            rib_tx,
+            metrics,
+            originated_local_mac_counts,
+            vni_to_esi,
+        )
+        .await;
+    }
+}
+
+/// Re-drive every pending operation whose backoff has elapsed.
+/// Injects rebuild their route from the *current* instance model; a
+/// pending inject whose VNI left the model (or changed RD) is dropped
+/// — the lifecycle drain that removed it already superseded the
+/// route's state with withdraws. Withdraws only need the key and are
+/// retried until the RIB acknowledges them.
+pub(super) async fn retry_pending_rib_ops(
+    state: &mut OriginatorState,
+    instances: &EvpnInstanceTable,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) {
+    for (_key, op) in state.pending_rib_ops.due(tokio::time::Instant::now()) {
+        attempt_action(
+            &mut state.pending_rib_ops,
+            op.generation,
+            &op.action,
+            op.vni,
+            instances.get(op.vni),
+            rib_tx,
+            metrics,
+            originated_local_mac_counts,
+            vni_to_esi,
+        )
+        .await;
+    }
+}
+
+fn action_key(action: &OriginationAction) -> EvpnRouteKey {
+    match action {
+        OriginationAction::Inject { key, .. } | OriginationAction::Withdraw { key, .. } => *key,
+    }
+}
+
+/// One send-and-ack attempt for a registered pending operation.
+/// Confirms (and does the success bookkeeping) on ack, defers on any
+/// failure. Shared by the first attempt ([`apply_actions`]) and the
+/// retry path ([`retry_pending_rib_ops`]).
+#[allow(clippy::too_many_arguments)]
+async fn attempt_action(
+    pending: &mut PendingRibOps,
+    generation: u64,
+    action: &OriginationAction,
+    vni: EvpnInstanceId,
+    instance: Option<&EvpnInstance>,
+    rib_tx: &mpsc::Sender<RibUpdate>,
+    metrics: &BgpMetrics,
+    originated_local_mac_counts: &OriginatedLocalMacCounts,
+    vni_to_esi: &std::collections::BTreeMap<EvpnInstanceId, EthernetSegmentIdentifier>,
+) {
+    match action {
+        OriginationAction::Inject {
+            mac,
+            mobility_seq,
+            sticky,
+            key,
+        } => {
+            // The route is rebuilt from the current model on every
+            // attempt. A VNI that left the model — or was redefined
+            // under a new RD — invalidates the pending inject; the
+            // lifecycle path that changed the model already drained
+            // (superseded) the route's state, so drop rather than
+            // re-inject under stale fields.
+            let stale = match instance {
+                None => true,
+                Some(inst) => matches!(key, EvpnRouteKey::MacIp { rd, .. } if *rd != inst.rd),
+            };
+            let Some(inst) = instance.filter(|_| !stale) else {
+                pending.forget(*key, generation);
+                debug!(
+                    ?key,
+                    "dropping pending Type 2 inject for removed/redefined VNI"
+                );
+                return;
+            };
+            // ESI-aware origination: when the VNI is part of a
+            // configured Ethernet Segment, attach the segment's
+            // ESI so peers can resolve aliasing alternatives.
+            // Single-homed VNIs default to ZERO.
+            let esi = vni_to_esi
+                .get(&inst.id)
+                .copied()
+                .unwrap_or(EthernetSegmentIdentifier::ZERO);
+            let route = build_originated_route(inst, *mac, *mobility_seq, *sticky, *key, esi);
+            match send_and_ack(rib_tx, |reply| RibUpdate::InjectEvpn { route, reply }).await {
+                RibAckOutcome::Acked => {
+                    pending.confirm(*key, generation);
+                    metrics.record_evpn_local_origination(ACTION_INJECT);
+                    originated_local_mac_counts.record_inject(inst.id, *mac, *key);
+                    debug!(?key, ?mobility_seq, "originated Type 2");
                 }
-                match reply_rx.await {
-                    Ok(Ok(())) => {
-                        metrics.record_evpn_local_origination(ACTION_INJECT);
-                        originated_local_mac_counts.record_inject(instance.id, mac, key);
-                        debug!(?key, ?mobility_seq, "originated Type 2");
-                    }
-                    Ok(Err(e)) => {
-                        metrics.record_evpn_local_origination_error(ACTION_INJECT);
-                        warn!(?key, error = %e, "RIB rejected Type 2 inject");
-                    }
-                    Err(_) => {
-                        metrics.record_evpn_local_origination_error(ACTION_INJECT);
-                        warn!(?key, "RIB inject reply dropped");
-                    }
+                RibAckOutcome::Rejected(e) => {
+                    pending.defer(*key, generation);
+                    metrics.record_evpn_local_origination_error(ACTION_INJECT);
+                    warn!(?key, error = %e, "RIB rejected Type 2 inject; will retry");
+                }
+                RibAckOutcome::NoAck(reason) => {
+                    pending.defer(*key, generation);
+                    metrics.record_evpn_local_origination_error(ACTION_INJECT);
+                    warn!(?key, reason, "Type 2 inject unacknowledged; will retry");
                 }
             }
-            OriginationAction::Withdraw { mac, key } => {
-                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-                if rib_tx
-                    .send(RibUpdate::WithdrawEvpn {
-                        key,
-                        reply: reply_tx,
-                    })
-                    .await
-                    .is_err()
-                {
-                    metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
-                    warn!("RIB channel closed; cannot withdraw EVPN Type 2");
-                    return;
+        }
+        OriginationAction::Withdraw { mac, key } => {
+            let outcome =
+                send_and_ack(rib_tx, |reply| RibUpdate::WithdrawEvpn { key: *key, reply }).await;
+            let not_found = outcome.is_not_found();
+            match outcome {
+                RibAckOutcome::Acked => {
+                    pending.confirm(*key, generation);
+                    metrics.record_evpn_local_origination(ACTION_WITHDRAW);
+                    originated_local_mac_counts.record_withdraw(vni, *mac, *key);
+                    debug!(?key, "withdrew Type 2");
                 }
-                match reply_rx.await {
-                    Ok(Ok(())) => {
-                        metrics.record_evpn_local_origination(ACTION_WITHDRAW);
-                        originated_local_mac_counts.record_withdraw(instance.id, mac, key);
-                        debug!(?key, "withdrew Type 2");
-                    }
-                    Ok(Err(e)) => {
-                        metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
-                        // Withdraws for unknown keys can race with
-                        // in-flight inject failures; log at debug.
-                        debug!(?key, error = %e, "RIB withdraw declined");
-                    }
-                    Err(_) => {
-                        metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
-                        warn!(?key, "RIB withdraw reply dropped");
-                    }
+                // NotFound means the route is already absent — e.g.
+                // its inject was lost before ever applying, or the
+                // withdraw raced an in-flight inject failure. Absence
+                // is the withdraw's goal: confirm instead of retrying
+                // forever against a route that will never exist.
+                RibAckOutcome::Rejected(e) if not_found => {
+                    pending.confirm(*key, generation);
+                    metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
+                    originated_local_mac_counts.record_withdraw(vni, *mac, *key);
+                    debug!(?key, error = %e, "RIB withdraw target absent — treating as complete");
+                }
+                RibAckOutcome::Rejected(e) => {
+                    pending.defer(*key, generation);
+                    metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
+                    warn!(?key, error = %e, "RIB rejected Type 2 withdraw; will retry");
+                }
+                RibAckOutcome::NoAck(reason) => {
+                    pending.defer(*key, generation);
+                    metrics.record_evpn_local_origination_error(ACTION_WITHDRAW);
+                    warn!(?key, reason, "Type 2 withdraw unacknowledged; will retry");
                 }
             }
         }

--- a/src/evpn_originator/tests.rs
+++ b/src/evpn_originator/tests.rs
@@ -8,7 +8,9 @@ use rustbgpd_evpn::{
 use rustbgpd_rib::{RibCommandError, route::RouteOrigin};
 use rustbgpd_wire::{EvpnImet, EvpnMacIp};
 
-use crate::test_support::{evpn_instance, gather_metrics_text, ip as ipa, mac, rd, vni};
+use crate::test_support::{
+    RibReplyMode, ScriptedRib, evpn_instance, gather_metrics_text, ip as ipa, mac, rd, vni,
+};
 
 fn assert_quarantine_metric(metrics: &BgpMetrics, v: u32, m: u8, value: u32) {
     let text = gather_metrics_text(metrics);
@@ -2061,7 +2063,10 @@ async fn rib_rejection_increments_evpn_local_origination_error_counter() {
 
     for _ in 0..50 {
         let text = gather_metrics_text(&metrics);
-        if text.contains("evpn_local_origination_errors_total{action=\"inject\"} 1") {
+        // ADR-0102: a rejected inject stays pending and retries with
+        // backoff, so the error counter may exceed 1 — assert presence,
+        // not an exact count.
+        if text.contains("evpn_local_origination_errors_total{action=\"inject\"}") {
             assert_eq!(counts.count(vni(100)), 0);
             h.shutdown().await;
             return;
@@ -4101,5 +4106,448 @@ async fn vxlan_port_observation_for_unclaimed_mac_is_ignored() {
             .get(&(vni(100), mac(0xBB)))
             .is_some_and(|ips| ips.contains(&ipa("192.0.2.20"))),
         "unclaimed VXLAN-port rows must not clear pending IP bindings"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ADR-0102: acknowledgement-aware origination (pending / confirmed / retry).
+// Decision-level tests: handlers and the retry driver are called directly
+// against a scripted RIB whose reply behavior is switchable per phase.
+// ---------------------------------------------------------------------------
+
+/// Advance past the backoff cap and re-drive pending operations.
+async fn retry_after_backoff(
+    state: &mut OriginatorState,
+    instances: &EvpnInstanceTable,
+    rib: &ScriptedRib,
+    metrics: &BgpMetrics,
+    counts: &OriginatedLocalMacCounts,
+) {
+    tokio::time::advance(Duration::from_secs(35)).await;
+    retry_pending_rib_ops(
+        state,
+        instances,
+        &rib.rib_tx,
+        metrics,
+        counts,
+        &std::collections::BTreeMap::new(),
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn dropped_inject_reply_is_retried_until_confirmed() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert_eq!(rib.inject_count(), 1, "first attempt was sent");
+    assert_eq!(
+        counts.count(vni(100)),
+        0,
+        "unacknowledged inject must not be counted as confirmed"
+    );
+    assert_eq!(state.pending_rib_ops.len(), 1, "op stays pending");
+
+    rib.set_mode(RibReplyMode::Ok);
+    retry_after_backoff(&mut state, &instances, &rib, &metrics, &counts).await;
+
+    assert_eq!(rib.inject_count(), 2, "retry re-sent the inject");
+    assert_eq!(counts.count(vni(100)), 1, "ack confirms the origination");
+    assert!(state.pending_rib_ops.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn inject_ack_timeout_keeps_op_pending_and_retries() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    // HoldReply: the RIB keeps the reply sender alive but never
+    // answers — the originator's 5 s ack timeout must fire (the paused
+    // clock auto-advances through it).
+    let rib = ScriptedRib::spawn(RibReplyMode::HoldReply);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert_eq!(state.pending_rib_ops.len(), 1, "timed-out op stays pending");
+    assert_eq!(counts.count(vni(100)), 0);
+
+    rib.set_mode(RibReplyMode::Ok);
+    retry_after_backoff(&mut state, &instances, &rib, &metrics, &counts).await;
+
+    assert_eq!(rib.inject_count(), 2);
+    assert_eq!(counts.count(vni(100)), 1);
+    assert!(state.pending_rib_ops.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn withdrawal_survives_dropped_reply_and_completes() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::Ok);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    assert_eq!(counts.count(vni(100)), 1);
+
+    rib.set_mode(RibReplyMode::DropReply);
+    observe_test(
+        LocalMacObservation::Aged {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert_eq!(rib.withdraw_count(), 1, "withdraw attempt was sent");
+    assert_eq!(
+        state.pending_rib_ops.len(),
+        1,
+        "unacknowledged withdraw must not be forgotten"
+    );
+    assert_eq!(
+        counts.count(vni(100)),
+        1,
+        "unconfirmed withdraw must not decrement the count"
+    );
+
+    rib.set_mode(RibReplyMode::Ok);
+    retry_after_backoff(&mut state, &instances, &rib, &metrics, &counts).await;
+
+    assert_eq!(rib.withdraw_count(), 2, "withdraw retried");
+    assert_eq!(counts.count(vni(100)), 0, "ack completes the withdrawal");
+    assert!(state.pending_rib_ops.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn withdraw_not_found_counts_as_confirmed() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::Ok);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    // The RIB reports the route absent (e.g. the inject was lost
+    // before ever applying): absence is the withdraw's goal, so the
+    // operation confirms instead of retrying forever.
+    rib.set_mode(RibReplyMode::NotFound);
+    observe_test(
+        LocalMacObservation::Aged {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert!(
+        state.pending_rib_ops.is_empty(),
+        "NotFound withdraw must confirm, not retry"
+    );
+    assert_eq!(counts.count(vni(100)), 0, "count stays honest");
+}
+
+#[tokio::test(start_paused = true)]
+async fn new_intent_supersedes_pending_op_for_same_route() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+
+    // Inject attempt fails and stays pending...
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    assert_eq!(state.pending_rib_ops.len(), 1);
+
+    // ...then the MAC ages: the withdrawal is new intent for the same
+    // route identity and must supersede the pending inject.
+    observe_test(
+        LocalMacObservation::Aged {
+            vni: vni(100),
+            mac: mac(0xAA),
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert_eq!(
+        state.pending_rib_ops.len(),
+        1,
+        "supersession keeps one op per route identity"
+    );
+    let (_, op) = state
+        .pending_rib_ops
+        .due(tokio::time::Instant::now() + Duration::from_mins(1))
+        .pop()
+        .expect("pending op present");
+    assert!(
+        matches!(op.action, OriginationAction::Withdraw { .. }),
+        "newest intent (withdraw) wins over the superseded inject"
+    );
+
+    rib.set_mode(RibReplyMode::Ok);
+    retry_after_backoff(&mut state, &instances, &rib, &metrics, &counts).await;
+    assert!(state.pending_rib_ops.is_empty());
+    assert_eq!(
+        rib.inject_count(),
+        1,
+        "the superseded inject must not be retried"
+    );
+    assert_eq!(rib.withdraw_count(), 2, "the withdraw completed on retry");
+}
+
+#[tokio::test(start_paused = true)]
+async fn retry_drops_pending_inject_for_removed_vni() {
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    assert_eq!(state.pending_rib_ops.len(), 1);
+
+    // The VNI leaves the model before the retry fires: the pending
+    // inject can no longer be rebuilt and must be dropped (the
+    // lifecycle drain that removes a VNI supersedes its routes with
+    // withdraws through the state machines).
+    let empty = EvpnInstanceTable::new();
+    rib.set_mode(RibReplyMode::Ok);
+    tokio::time::advance(Duration::from_secs(35)).await;
+    retry_pending_rib_ops(
+        &mut state,
+        &empty,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+        &std::collections::BTreeMap::new(),
+    )
+    .await;
+
+    assert!(state.pending_rib_ops.is_empty(), "stale inject dropped");
+    assert_eq!(rib.inject_count(), 1, "no re-inject under stale fields");
+}
+
+#[tokio::test(start_paused = true)]
+async fn restart_rebuilds_intent_from_observation_without_persisted_pending_state() {
+    let instances = instance_table(100);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+
+    // First life: the inject is lost and pending when the daemon dies.
+    let mut state = originator_state(&instances);
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+    assert_eq!(state.pending_rib_ops.len(), 1);
+    drop(state); // restart: pending state is deliberately NOT persisted
+
+    // Second life: fresh state, intent rebuilt purely from the kernel
+    // observation replay, reconciles idempotently against the RIB.
+    let counts = OriginatedLocalMacCounts::default();
+    let mut state = originator_state(&instances);
+    assert!(
+        state.pending_rib_ops.is_empty(),
+        "restart starts with no pending state"
+    );
+    rib.set_mode(RibReplyMode::Ok);
+    observe_test(
+        LocalMacObservation::Learned {
+            vni: vni(100),
+            mac: mac(0xAA),
+            ifindex: 7,
+        },
+        &mut state,
+        &instances,
+        &rib.rib_tx,
+        &metrics,
+        &counts,
+    )
+    .await;
+
+    assert_eq!(counts.count(vni(100)), 1, "observation replay converges");
+    assert!(state.pending_rib_ops.is_empty());
+}
+
+#[tokio::test]
+async fn pending_ip_bindings_per_mac_cap_bounds_the_set() {
+    use crate::evpn_originator::observation::MAX_PENDING_IPS_PER_MAC;
+
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::Ok);
+
+    // IpAdded for a MAC the bridge never learned parks in the pending
+    // buffer — which must stay bounded.
+    for i in 0..(MAX_PENDING_IPS_PER_MAC + 8) {
+        observe_test(
+            LocalMacObservation::IpAdded {
+                vni: vni(100),
+                mac: mac(0xAA),
+                ip: ipa(&format!("10.0.1.{i}")),
+            },
+            &mut state,
+            &instances,
+            &rib.rib_tx,
+            &metrics,
+            &counts,
+        )
+        .await;
+    }
+
+    assert_eq!(
+        state
+            .pending_ip_bindings
+            .get(&(vni(100), mac(0xAA)))
+            .map(std::collections::BTreeSet::len),
+        Some(MAX_PENDING_IPS_PER_MAC),
+        "per-MAC pending IP set is capped"
+    );
+}
+
+#[tokio::test]
+async fn pending_ip_bindings_mac_entry_cap_bounds_the_map() {
+    use crate::evpn_originator::observation::MAX_PENDING_IP_BINDING_MACS;
+
+    let instances = instance_table(100);
+    let mut state = originator_state(&instances);
+    let metrics = BgpMetrics::new();
+    let counts = OriginatedLocalMacCounts::default();
+    let rib = ScriptedRib::spawn(RibReplyMode::Ok);
+
+    for i in 0..(MAX_PENDING_IP_BINDING_MACS + 5) {
+        let mac = MacAddress::new([
+            0x02,
+            0,
+            0,
+            0,
+            u8::try_from(i >> 8).unwrap(),
+            u8::try_from(i & 0xFF).unwrap(),
+        ]);
+        observe_test(
+            LocalMacObservation::IpAdded {
+                vni: vni(100),
+                mac,
+                ip: ipa("10.0.2.1"),
+            },
+            &mut state,
+            &instances,
+            &rib.rib_tx,
+            &metrics,
+            &counts,
+        )
+        .await;
+    }
+
+    assert_eq!(
+        state.pending_ip_bindings.len(),
+        MAX_PENDING_IP_BINDING_MACS,
+        "pending-binding MAC entries are capped"
     );
 }

--- a/src/evpn_segment.rs
+++ b/src/evpn_segment.rs
@@ -62,6 +62,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use crate::evpn_ack::{PendingRibOps, RibAckOutcome, send_and_ack};
 use crate::evpn_es_link_drain::EsLinkBindings;
 use crate::evpn_originator::{LOCAL_PEER, route_target_to_extcomm};
 
@@ -327,6 +328,10 @@ async fn segment_loop(
     mut es_link_bindings_rx: Option<watch::Receiver<EsLinkBindings>>,
 ) {
     let mut by_esi: HashMap<EthernetSegmentIdentifier, SegmentState> = HashMap::new();
+    // ADR-0102 acknowledgement tracker for Type 1/4 publication.
+    // In-memory only: a restart re-derives segment intent from config
+    // and re-originates idempotently.
+    let mut pending_rib_ops = PendingRibOps::new();
     // One allocator per spawn so two operators on different daemons
     // don't have to coordinate label space; the allocator survives
     // for the lifetime of the actor task and assignments stay
@@ -356,7 +361,7 @@ async fn segment_loop(
     }
 
     // Initial origination + election.
-    initial_startup(&runtime, &mut by_esi).await;
+    initial_startup(&runtime, &mut by_esi, &mut pending_rib_ops).await;
     publish_dataplane_snapshots(&runtime, &by_esi);
 
     // Periodic re-election timer — backstop in case we're in poll-only mode
@@ -368,7 +373,7 @@ async fn segment_loop(
         tokio::select! {
             biased;
             () = runtime.shutdown.cancelled() => {
-                drain(&runtime, &mut by_esi).await;
+                drain(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                 publish_empty_dataplane_snapshots(&runtime);
                 return;
             }
@@ -386,11 +391,12 @@ async fn segment_loop(
                         &mut by_esi,
                         &mut esi_label_allocator,
                         segments,
+                        &mut pending_rib_ops,
                     )
                     .await;
                 } else {
                     debug!("EVPN segment: runtime segment watch closed; draining");
-                    drain(&runtime, &mut by_esi).await;
+                    drain(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                     publish_empty_dataplane_snapshots(&runtime);
                     return;
                 }
@@ -404,7 +410,7 @@ async fn segment_loop(
                         &by_esi,
                     ) {
                         let segments = segments_rx.borrow().as_ref().clone();
-                        drain(&runtime, &mut by_esi).await;
+                        drain(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                         apply_runtime_instance_snapshot(&mut runtime, instances);
                         rebuild_segment_states(
                             &runtime,
@@ -412,14 +418,14 @@ async fn segment_loop(
                             &mut esi_label_allocator,
                             segments,
                         );
-                        initial_startup(&runtime, &mut by_esi).await;
+                        initial_startup(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                         publish_dataplane_snapshots(&runtime, &by_esi);
                     } else {
                         apply_runtime_instance_snapshot(&mut runtime, instances);
                     }
                 } else {
                     debug!("EVPN segment: runtime instance watch closed; draining");
-                    drain(&runtime, &mut by_esi).await;
+                    drain(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                     publish_empty_dataplane_snapshots(&runtime);
                     return;
                 }
@@ -427,13 +433,13 @@ async fn segment_loop(
             changed = drained_esis_rx.changed() => {
                 if let Ok(()) = changed {
                     let drained = drained_esis_rx.borrow_and_update().clone();
-                    apply_drained_esi_snapshot(&mut runtime, &mut by_esi, drained).await;
+                    apply_drained_esi_snapshot(&mut runtime, &mut by_esi, drained, &mut pending_rib_ops).await;
                 } else {
                     // The drained-set sender lives on the same handle as the
                     // instance/segment senders, so a closed watch here means
                     // daemon teardown — same exit path as the other watches.
                     debug!("EVPN segment: runtime drained-ESI watch closed; draining");
-                    drain(&runtime, &mut by_esi).await;
+                    drain(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                     publish_empty_dataplane_snapshots(&runtime);
                     return;
                 }
@@ -460,22 +466,27 @@ async fn segment_loop(
             },
             event = recv_evpn_event(&mut evpn_event_rx) => match event {
                 Ok(ev) => {
-                    handle_evpn_event(&runtime, &mut by_esi, &ev).await;
+                    handle_evpn_event(&runtime, &mut by_esi, &ev, &mut pending_rib_ops).await;
                 }
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
                     warn!(
                         skipped,
                         "EVPN segment orchestrator: event broadcast lagged; running full re-election sweep"
                     );
-                    reelection_sweep(&runtime, &mut by_esi).await;
+                    reelection_sweep(&runtime, &mut by_esi, &mut pending_rib_ops).await;
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     warn!("EVPN segment orchestrator: RIB event broadcast closed; reverting to poll-only");
                     evpn_event_rx = None;
                 }
             },
+            // ADR-0102: re-drive RIB operations whose acknowledgement
+            // was lost. Parks forever while nothing is pending.
+            () = crate::evpn_ack::retry_delay(pending_rib_ops.next_deadline()) => {
+                retry_pending_rib_ops(&runtime, &by_esi, &mut pending_rib_ops).await;
+            }
             _ = tick.tick() => {
-                reelection_sweep(&runtime, &mut by_esi).await;
+                reelection_sweep(&runtime, &mut by_esi, &mut pending_rib_ops).await;
             }
         }
     }
@@ -615,6 +626,7 @@ async fn apply_runtime_segment_snapshot(
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
     esi_label_allocator: &mut rustbgpd_evpn::EsiLabelAllocator,
     segments: Vec<EthernetSegment>,
+    pending: &mut PendingRibOps,
 ) {
     let changed = segments.len() != by_esi.len()
         || segments.iter().any(|seg| {
@@ -626,9 +638,9 @@ async fn apply_runtime_segment_snapshot(
         return;
     }
 
-    drain(runtime, by_esi).await;
+    drain(runtime, by_esi, pending).await;
     rebuild_segment_states(runtime, by_esi, esi_label_allocator, segments);
-    initial_startup(runtime, by_esi).await;
+    initial_startup(runtime, by_esi, pending).await;
     publish_dataplane_snapshots(runtime, by_esi);
 }
 
@@ -668,6 +680,7 @@ async fn bindings_changed(
 async fn initial_startup(
     runtime: &SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+    pending: &mut PendingRibOps,
 ) {
     for state in by_esi.values_mut() {
         // ADR-0084: an operator-drained ESI stays withdrawn across
@@ -676,33 +689,38 @@ async fn initial_startup(
         if runtime.drained_esis.contains(&state.config.esi) {
             continue;
         }
-        startup_segment_state(runtime, state).await;
+        startup_segment_state(runtime, state, pending).await;
     }
 }
 
 /// Originate one ES's Type 4 + EAD-per-ES and run its DF election.
 /// Shared by startup and by an ADR-0084 undrain, which mirrors what
 /// segment-set application does for a new ES.
-async fn startup_segment_state(runtime: &SegmentRuntime, state: &mut SegmentState) {
+async fn startup_segment_state(
+    runtime: &SegmentRuntime,
+    state: &mut SegmentState,
+    pending: &mut PendingRibOps,
+) {
     // Type 4 ES first so peers see us as a candidate before any
     // EAD routes show up.
     let actions = state.es_origin.on_startup();
-    apply(runtime, state, actions).await;
+    apply(runtime, state, actions, pending).await;
 
     let actions = state.ead_per_es.on_startup();
-    apply(runtime, state, actions).await;
+    apply(runtime, state, actions, pending).await;
 
     // Initial election with self as sole candidate. Local PE is
     // DF for all member VNIs.
-    run_election_for(runtime, state).await;
+    run_election_for(runtime, state, pending).await;
 }
 
 async fn drain(
     runtime: &SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+    pending: &mut PendingRibOps,
 ) {
     for state in by_esi.values_mut() {
-        drain_segment_state(runtime, state).await;
+        drain_segment_state(runtime, state, pending).await;
     }
 }
 
@@ -712,13 +730,17 @@ async fn drain(
 /// tracking so a later re-origination re-runs election from a clean
 /// slate (the EAD-per-EVI re-emit rides the role-transition diff) and
 /// the BUM enforcement table stops carrying rows for the ES.
-async fn drain_segment_state(runtime: &SegmentRuntime, state: &mut SegmentState) {
+async fn drain_segment_state(
+    runtime: &SegmentRuntime,
+    state: &mut SegmentState,
+    pending: &mut PendingRibOps,
+) {
     let actions = state.ead_per_evi.drain_to_withdraws();
-    apply(runtime, state, actions).await;
+    apply(runtime, state, actions, pending).await;
     let actions = state.ead_per_es.on_shutdown();
-    apply(runtime, state, actions).await;
+    apply(runtime, state, actions, pending).await;
     let actions = state.es_origin.on_shutdown();
-    apply(runtime, state, actions).await;
+    apply(runtime, state, actions, pending).await;
 
     let esi_str = format_esi(state.config.esi);
     for (vni, _) in std::mem::take(&mut state.last_roles) {
@@ -737,6 +759,7 @@ async fn apply_drained_esi_snapshot(
     runtime: &mut SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
     drained: Arc<BTreeSet<EthernetSegmentIdentifier>>,
+    pending: &mut PendingRibOps,
 ) {
     let prior = std::mem::replace(&mut runtime.drained_esis, drained.clone());
     if *prior == *drained {
@@ -748,7 +771,7 @@ async fn apply_drained_esi_snapshot(
             continue;
         };
         info!(esi = %format_esi(*esi), "EVPN segment: draining Ethernet Segment (operator)");
-        drain_segment_state(runtime, state).await;
+        drain_segment_state(runtime, state, pending).await;
         changed = true;
     }
     for esi in prior.iter().filter(|esi| !drained.contains(*esi)) {
@@ -756,7 +779,7 @@ async fn apply_drained_esi_snapshot(
             continue;
         };
         info!(esi = %format_esi(*esi), "EVPN segment: undraining Ethernet Segment (operator)");
-        startup_segment_state(runtime, state).await;
+        startup_segment_state(runtime, state, pending).await;
         changed = true;
     }
     if changed {
@@ -768,6 +791,7 @@ async fn handle_evpn_event(
     runtime: &SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
     event: &EvpnRouteEvent,
+    pending: &mut PendingRibOps,
 ) {
     // Only Type 4 events affect the candidate set.
     let EvpnRouteKey::Es { esi, .. } = event.key else {
@@ -785,13 +809,14 @@ async fn handle_evpn_event(
     let Some(state) = by_esi.get_mut(&esi) else {
         return;
     };
-    run_election_for(runtime, state).await;
+    run_election_for(runtime, state, pending).await;
     publish_dataplane_snapshots(runtime, by_esi);
 }
 
 async fn reelection_sweep(
     runtime: &SegmentRuntime,
     by_esi: &mut HashMap<EthernetSegmentIdentifier, SegmentState>,
+    pending: &mut PendingRibOps,
 ) {
     let routes = match query_evpn_routes(&runtime.rib_tx).await {
         Ok(r) => r,
@@ -801,7 +826,7 @@ async fn reelection_sweep(
         }
     };
     for state in by_esi.values_mut() {
-        run_election_for_routes(runtime, state, &routes).await;
+        run_election_for_routes(runtime, state, &routes, pending).await;
     }
     publish_dataplane_snapshots(runtime, by_esi);
 }
@@ -809,7 +834,11 @@ async fn reelection_sweep(
 /// Re-gather candidates from the RIB and re-run election for one
 /// ESI. Diffs against the prior `last_roles` map; per-VNI flips
 /// trigger `on_vni_role_changed` plus telemetry updates.
-async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
+async fn run_election_for(
+    runtime: &SegmentRuntime,
+    state: &mut SegmentState,
+    pending: &mut PendingRibOps,
+) {
     let candidates = match gather_candidates(state, &runtime.rib_tx).await {
         Ok(c) => c,
         Err(e) => {
@@ -817,22 +846,24 @@ async fn run_election_for(runtime: &SegmentRuntime, state: &mut SegmentState) {
             return;
         }
     };
-    run_election_with_candidates(runtime, state, candidates).await;
+    run_election_with_candidates(runtime, state, candidates, pending).await;
 }
 
 async fn run_election_for_routes(
     runtime: &SegmentRuntime,
     state: &mut SegmentState,
     routes: &[EvpnRibRoute],
+    pending: &mut PendingRibOps,
 ) {
     let candidates = gather_candidates_from_routes(state, routes);
-    run_election_with_candidates(runtime, state, candidates).await;
+    run_election_with_candidates(runtime, state, candidates, pending).await;
 }
 
 async fn run_election_with_candidates(
     runtime: &SegmentRuntime,
     state: &mut SegmentState,
     candidates: Vec<DfCandidate>,
+    pending: &mut PendingRibOps,
 ) {
     // ADR-0084: a drained ES has withdrawn its Type 4 and exited DF
     // election; role transitions must not re-emit EAD-per-EVI routes
@@ -893,6 +924,7 @@ async fn run_election_with_candidates(
             state.config.df_dont_preempt,
             state.config.redundancy_mode,
             actions,
+            pending,
         )
         .await;
         debug!(
@@ -1365,14 +1397,19 @@ enum RibQueryError {
     ReplyDropped,
 }
 
-async fn apply(runtime: &SegmentRuntime, state: &SegmentState, actions: Vec<OriginationAction>) {
+async fn apply(
+    runtime: &SegmentRuntime,
+    state: &SegmentState,
+    actions: Vec<OriginationAction>,
+    pending: &mut PendingRibOps,
+) {
     let Some(inst) = runtime.instances.get(state.reference_instance_id).cloned() else {
         // The reference instance is gone — e.g. a tenant teardown removed the
         // member L2VNI before this drain runs. Inject actions can't be built
         // without the instance's path attributes, but Withdraw actions only
         // need the route key, so still emit those; otherwise teardown would
         // strand the segment's Type 1/4 routes in peers' RIBs.
-        apply_withdraws_only(runtime, actions).await;
+        apply_withdraws_only(runtime, state.reference_instance_id, actions, pending).await;
         return;
     };
     apply_with_instance(
@@ -1384,6 +1421,7 @@ async fn apply(runtime: &SegmentRuntime, state: &SegmentState, actions: Vec<Orig
         state.config.df_dont_preempt,
         state.config.redundancy_mode,
         actions,
+        pending,
     )
     .await;
 }
@@ -1392,33 +1430,31 @@ async fn apply(runtime: &SegmentRuntime, state: &SegmentState, actions: Vec<Orig
 /// can't be built without the now-removed reference instance). Used when the
 /// member L2VNI has already been torn down but the segment's routes still need
 /// to be withdrawn from the RIB.
-async fn apply_withdraws_only(runtime: &SegmentRuntime, actions: Vec<OriginationAction>) {
+async fn apply_withdraws_only(
+    runtime: &SegmentRuntime,
+    vni: EvpnInstanceId,
+    actions: Vec<OriginationAction>,
+    pending: &mut PendingRibOps,
+) {
     for action in actions {
-        let OriginationAction::Withdraw { key, .. } = action else {
+        let OriginationAction::Withdraw { key, .. } = &action else {
             continue;
         };
-        let (reply_tx, reply_rx) = oneshot::channel();
-        if runtime
-            .rib_tx
-            .send(RibUpdate::WithdrawEvpn {
-                key,
-                reply: reply_tx,
-            })
-            .await
-            .is_err()
-        {
-            warn!(?key, "EVPN segment: RIB channel closed; cannot withdraw");
-            return;
-        }
-        match reply_rx.await {
-            Ok(Ok(())) => debug!(
-                ?key,
-                "EVPN segment: withdrew (member instance already removed)"
-            ),
-            Ok(Err(e)) => debug!(?key, error = %e, "EVPN segment: RIB withdraw declined"),
-            Err(_) => warn!(?key, "EVPN segment: RIB withdraw reply dropped"),
-        }
+        let generation = pending.submit(*key, vni, action.clone());
+        attempt_es_action(runtime, pending, generation, &action, None).await;
     }
+}
+
+/// Per-ES route-build context an inject attempt needs. Rebuilt from
+/// the *current* `SegmentState` + instance table on every attempt so
+/// retries never re-inject under stale fields.
+struct EsRouteBuildCtx<'a> {
+    inst: &'a EvpnInstance,
+    esi_label: MplsLabel,
+    df_algorithm: DfAlgorithm,
+    df_preference: u32,
+    df_dont_preempt: bool,
+    redundancy_mode: RedundancyMode,
 }
 
 #[expect(
@@ -1434,57 +1470,158 @@ async fn apply_with_instance(
     df_dont_preempt: bool,
     redundancy_mode: RedundancyMode,
     actions: Vec<OriginationAction>,
+    pending: &mut PendingRibOps,
 ) {
+    let ctx = EsRouteBuildCtx {
+        inst,
+        esi_label,
+        df_algorithm,
+        df_preference,
+        df_dont_preempt,
+        redundancy_mode,
+    };
     for action in actions {
-        match action {
-            OriginationAction::Inject { key, .. } => {
-                let route = build_es_route(
-                    inst,
-                    &key,
-                    esi_label,
-                    df_algorithm,
-                    df_preference,
-                    df_dont_preempt,
-                    redundancy_mode,
+        let key = match &action {
+            OriginationAction::Inject { key, .. } | OriginationAction::Withdraw { key, .. } => *key,
+        };
+        let generation = pending.submit(key, inst.id, action.clone());
+        attempt_es_action(runtime, pending, generation, &action, Some(&ctx)).await;
+    }
+}
+
+/// One send-and-ack attempt for a registered pending Type 1/4
+/// operation (ADR-0102). Confirms on ack, defers on failure so the
+/// actor's retry arm re-drives it. An inject attempted without a build
+/// context (segment/instance no longer in the model) is dropped — the
+/// teardown that removed it already superseded the route's state with
+/// withdraws.
+async fn attempt_es_action(
+    runtime: &SegmentRuntime,
+    pending: &mut PendingRibOps,
+    generation: u64,
+    action: &OriginationAction,
+    ctx: Option<&EsRouteBuildCtx<'_>>,
+) {
+    let key = match action {
+        OriginationAction::Inject { key, .. } | OriginationAction::Withdraw { key, .. } => *key,
+    };
+    match action {
+        OriginationAction::Inject { .. } => {
+            let Some(ctx) = ctx else {
+                pending.forget(key, generation);
+                debug!(
+                    ?key,
+                    "EVPN segment: dropping pending inject — segment or instance left the model"
                 );
-                let (reply_tx, reply_rx) = oneshot::channel();
-                if runtime
-                    .rib_tx
-                    .send(RibUpdate::InjectEvpn {
-                        route,
-                        reply: reply_tx,
-                    })
-                    .await
-                    .is_err()
-                {
-                    warn!(?key, "EVPN segment: RIB channel closed; cannot inject");
-                    return;
+                return;
+            };
+            let route = build_es_route(
+                ctx.inst,
+                &key,
+                ctx.esi_label,
+                ctx.df_algorithm,
+                ctx.df_preference,
+                ctx.df_dont_preempt,
+                ctx.redundancy_mode,
+            );
+            match send_and_ack(&runtime.rib_tx, |reply| RibUpdate::InjectEvpn {
+                route,
+                reply,
+            })
+            .await
+            {
+                RibAckOutcome::Acked => {
+                    pending.confirm(key, generation);
+                    debug!(?key, "EVPN segment: originated");
                 }
-                match reply_rx.await {
-                    Ok(Ok(())) => debug!(?key, "EVPN segment: originated"),
-                    Ok(Err(e)) => warn!(?key, error = %e, "EVPN segment: RIB rejected inject"),
-                    Err(_) => warn!(?key, "EVPN segment: RIB inject reply dropped"),
+                RibAckOutcome::Rejected(e) => {
+                    pending.defer(key, generation);
+                    warn!(?key, error = %e, "EVPN segment: RIB rejected inject; will retry");
+                }
+                RibAckOutcome::NoAck(reason) => {
+                    pending.defer(key, generation);
+                    warn!(
+                        ?key,
+                        reason, "EVPN segment: inject unacknowledged; will retry"
+                    );
                 }
             }
-            OriginationAction::Withdraw { key, .. } => {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                if runtime
-                    .rib_tx
-                    .send(RibUpdate::WithdrawEvpn {
-                        key,
-                        reply: reply_tx,
+        }
+        OriginationAction::Withdraw { .. } => {
+            let outcome = send_and_ack(&runtime.rib_tx, |reply| RibUpdate::WithdrawEvpn {
+                key,
+                reply,
+            })
+            .await;
+            let not_found = outcome.is_not_found();
+            match outcome {
+                RibAckOutcome::Acked => {
+                    pending.confirm(key, generation);
+                    debug!(?key, "EVPN segment: withdrew");
+                }
+                // Already absent — e.g. the paired inject was lost
+                // before ever applying. Absence is the goal: confirm.
+                RibAckOutcome::Rejected(e) if not_found => {
+                    pending.confirm(key, generation);
+                    debug!(?key, error = %e, "EVPN segment: withdraw target absent — treating as complete");
+                }
+                RibAckOutcome::Rejected(e) => {
+                    pending.defer(key, generation);
+                    warn!(?key, error = %e, "EVPN segment: RIB rejected withdraw; will retry");
+                }
+                RibAckOutcome::NoAck(reason) => {
+                    pending.defer(key, generation);
+                    warn!(
+                        ?key,
+                        reason, "EVPN segment: withdraw unacknowledged; will retry"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The ESI carried by a Type 1/4 route key, used to relocate the
+/// owning `SegmentState` when a pending inject is retried.
+fn es_key_esi(key: &EvpnRouteKey) -> Option<EthernetSegmentIdentifier> {
+    match key {
+        EvpnRouteKey::Es { esi, .. }
+        | EvpnRouteKey::EadPerEs { esi, .. }
+        | EvpnRouteKey::EadPerEvi { esi, .. } => Some(*esi),
+        _ => None,
+    }
+}
+
+/// Re-drive every pending Type 1/4 operation whose backoff has
+/// elapsed (ADR-0102). Withdraws only need the key; injects rebuild
+/// their route from the current segment/instance model and are
+/// dropped when that model no longer contains them (the removal path
+/// already superseded the route's state with withdraws).
+async fn retry_pending_rib_ops(
+    runtime: &SegmentRuntime,
+    by_esi: &HashMap<EthernetSegmentIdentifier, SegmentState>,
+    pending: &mut PendingRibOps,
+) {
+    for (key, op) in pending.due(tokio::time::Instant::now()) {
+        match &op.action {
+            OriginationAction::Withdraw { .. } => {
+                attempt_es_action(runtime, pending, op.generation, &op.action, None).await;
+            }
+            OriginationAction::Inject { .. } => {
+                let segment = es_key_esi(&key)
+                    .filter(|esi| !runtime.drained_esis.contains(esi))
+                    .and_then(|esi| by_esi.get(&esi));
+                let ctx = segment.and_then(|state| {
+                    runtime.instances.get(op.vni).map(|inst| EsRouteBuildCtx {
+                        inst,
+                        esi_label: state.esi_label,
+                        df_algorithm: state.config.df_algorithm,
+                        df_preference: state.config.df_preference,
+                        df_dont_preempt: state.config.df_dont_preempt,
+                        redundancy_mode: state.config.redundancy_mode,
                     })
-                    .await
-                    .is_err()
-                {
-                    warn!(?key, "EVPN segment: RIB channel closed; cannot withdraw");
-                    return;
-                }
-                match reply_rx.await {
-                    Ok(Ok(())) => debug!(?key, "EVPN segment: withdrew"),
-                    Ok(Err(e)) => debug!(?key, error = %e, "EVPN segment: RIB withdraw declined"),
-                    Err(_) => warn!(?key, "EVPN segment: RIB withdraw reply dropped"),
-                }
+                });
+                attempt_es_action(runtime, pending, op.generation, &op.action, ctx.as_ref()).await;
             }
         }
     }
@@ -1671,7 +1808,7 @@ mod tests {
     use rustbgpd_evpn::{EvpnInstance, EvpnInstanceTable};
     use rustbgpd_wire::{EthernetTagId, ExtendedCommunity};
 
-    use crate::test_support::{evpn_instance, ip as ipa, rd, vni};
+    use crate::test_support::{RibReplyMode, ScriptedRib, evpn_instance, ip as ipa, rd, vni};
 
     fn esi(seed: u8) -> EthernetSegmentIdentifier {
         EthernetSegmentIdentifier::new([seed; 10])
@@ -3523,5 +3660,109 @@ mod tests {
         .await;
 
         handle.shutdown().await;
+    }
+
+    // -----------------------------------------------------------------
+    // ADR-0102: acknowledgement-aware Type 1/4 publication.
+    // -----------------------------------------------------------------
+
+    fn scripted_runtime(rib: &ScriptedRib) -> SegmentRuntime {
+        let mut table = EvpnInstanceTable::new();
+        table.insert(instance(100)).unwrap();
+        SegmentRuntime {
+            instances: Arc::new(table),
+            rib_tx: rib.rib_tx.clone(),
+            bum_enforcement_tx: None,
+            same_esi_bias_tx: None,
+            metrics: BgpMetrics::new(),
+            shutdown: CancellationToken::new(),
+            drained_esis: Arc::new(BTreeSet::new()),
+            es_link_bindings: EsLinkBindings::default(),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn es_dropped_replies_keep_type_1_4_ops_pending_and_retry_confirms() {
+        let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+        let runtime = scripted_runtime(&rib);
+        let mut pending = crate::evpn_ack::PendingRibOps::new();
+        let mut state = segment_state(esi(1));
+
+        // Startup publishes Type 4 ES + Type 1 EAD-per-ES, then the
+        // self-only election emits Type 1 EAD-per-EVI for the member
+        // VNI — all three replies are dropped.
+        startup_segment_state(&runtime, &mut state, &mut pending).await;
+
+        assert_eq!(rib.inject_count(), 3, "ES + EAD-per-ES + EAD-per-EVI sent");
+        assert_eq!(
+            pending.len(),
+            3,
+            "unacknowledged Type 1/4 injects stay pending"
+        );
+
+        // The retry re-drives all three from the current model and the
+        // acks clear the tracker.
+        rib.set_mode(RibReplyMode::Ok);
+        tokio::time::advance(Duration::from_secs(35)).await;
+        let mut by_esi = HashMap::new();
+        by_esi.insert(state.config.esi, state);
+        retry_pending_rib_ops(&runtime, &by_esi, &mut pending).await;
+
+        assert_eq!(rib.inject_count(), 6, "all three injects retried");
+        assert!(pending.is_empty(), "acks confirmed every pending op");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn es_withdrawals_survive_dropped_replies_even_after_segment_removal() {
+        let rib = ScriptedRib::spawn(RibReplyMode::Ok);
+        let runtime = scripted_runtime(&rib);
+        let mut pending = crate::evpn_ack::PendingRibOps::new();
+        let mut state = segment_state(esi(1));
+
+        startup_segment_state(&runtime, &mut state, &mut pending).await;
+        assert!(pending.is_empty(), "startup acked cleanly");
+
+        // Teardown withdraws lose their replies...
+        rib.set_mode(RibReplyMode::DropReply);
+        drain_segment_state(&runtime, &mut state, &mut pending).await;
+        assert_eq!(rib.withdraw_count(), 3, "three withdraw attempts sent");
+        assert_eq!(
+            pending.len(),
+            3,
+            "unacknowledged withdrawals must not be forgotten"
+        );
+
+        // ...and the segment is gone entirely by the time the retry
+        // fires. Withdraws need only their key, so they still complete
+        // against an empty segment map.
+        rib.set_mode(RibReplyMode::Ok);
+        tokio::time::advance(Duration::from_secs(35)).await;
+        let by_esi = HashMap::new();
+        retry_pending_rib_ops(&runtime, &by_esi, &mut pending).await;
+
+        assert_eq!(rib.withdraw_count(), 6, "withdrawals retried to completion");
+        assert!(pending.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn es_retry_drops_pending_inject_when_segment_left_the_model() {
+        let rib = ScriptedRib::spawn(RibReplyMode::DropReply);
+        let runtime = scripted_runtime(&rib);
+        let mut pending = crate::evpn_ack::PendingRibOps::new();
+        let mut state = segment_state(esi(1));
+
+        startup_segment_state(&runtime, &mut state, &mut pending).await;
+        assert_eq!(pending.len(), 3);
+
+        // The segment is removed before the retry fires: pending
+        // injects can no longer be rebuilt and are dropped (segment
+        // teardown already drains routes through the state machines).
+        rib.set_mode(RibReplyMode::Ok);
+        tokio::time::advance(Duration::from_secs(35)).await;
+        let by_esi = HashMap::new();
+        retry_pending_rib_ops(&runtime, &by_esi, &mut pending).await;
+
+        assert!(pending.is_empty(), "stale injects dropped");
+        assert_eq!(rib.inject_count(), 3, "no re-inject under stale fields");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ mod fib;
 // --all-features --lib` fails with E0433 on `crate::evpn_plan_decomposer`
 // (LAN-198).
 #[cfg(feature = "bench-internals")]
+mod evpn_ack;
+#[cfg(feature = "bench-internals")]
 mod evpn_dataplane;
 #[cfg(feature = "bench-internals")]
 mod evpn_es_drain;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod config;
 mod config_persister;
 mod config_transaction_control;
 mod confirm_journal;
+mod evpn_ack;
 mod evpn_dataplane;
 mod evpn_es_drain;
 mod evpn_es_link_drain;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -160,3 +160,109 @@ pub(crate) fn route_event(prefix: Prefix, peer: IpAddr) -> RouteEvent {
         reason: String::new(),
     }
 }
+
+/// Reply behavior for [`ScriptedRib`], switchable mid-test so one
+/// phase can lose acknowledgements and the next can grant them
+/// (ADR-0102 acknowledgement-awareness tests).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RibReplyMode {
+    /// Acknowledge with `Ok(())`.
+    Ok,
+    /// Drop the reply sender (originator sees a dropped reply).
+    DropReply,
+    /// Reject with `RibCommandError::NotFound`.
+    NotFound,
+    /// Keep the reply sender alive without answering (originator sees
+    /// an ack timeout; requires a paused tokio clock).
+    HoldReply,
+}
+
+type HeldRibReplies = Arc<
+    std::sync::Mutex<Vec<tokio::sync::oneshot::Sender<Result<(), rustbgpd_rib::RibCommandError>>>>,
+>;
+
+/// Minimal scripted RIB actor for EVPN inject/withdraw tests: records
+/// the keys it saw and answers per the current [`RibReplyMode`].
+/// `QueryEvpnRoutes` always gets an empty snapshot; the event
+/// subscription is ignored (poll-only mode).
+pub(crate) struct ScriptedRib {
+    pub(crate) rib_tx: tokio::sync::mpsc::Sender<rustbgpd_rib::RibUpdate>,
+    mode: Arc<std::sync::Mutex<RibReplyMode>>,
+    injects: Arc<std::sync::Mutex<Vec<rustbgpd_wire::EvpnRouteKey>>>,
+    withdraws: Arc<std::sync::Mutex<Vec<rustbgpd_wire::EvpnRouteKey>>>,
+    // Keeps HoldReply senders alive so the originator sees a timeout
+    // (a dropped sender would resolve the reply immediately).
+    _held: HeldRibReplies,
+}
+
+impl ScriptedRib {
+    pub(crate) fn spawn(initial_mode: RibReplyMode) -> Self {
+        use rustbgpd_rib::{RibCommandError, RibUpdate};
+        use tokio::sync::oneshot;
+
+        let (rib_tx, mut rib_rx) = tokio::sync::mpsc::channel::<RibUpdate>(64);
+        let mode = Arc::new(std::sync::Mutex::new(initial_mode));
+        let injects = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let withdraws = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let held = Arc::new(std::sync::Mutex::new(Vec::new()));
+        {
+            let mode = Arc::clone(&mode);
+            let injects = Arc::clone(&injects);
+            let withdraws = Arc::clone(&withdraws);
+            let held = Arc::clone(&held);
+            tokio::spawn(async move {
+                fn respond(
+                    mode: RibReplyMode,
+                    reply: oneshot::Sender<Result<(), RibCommandError>>,
+                    held: &std::sync::Mutex<Vec<oneshot::Sender<Result<(), RibCommandError>>>>,
+                ) {
+                    match mode {
+                        RibReplyMode::Ok => {
+                            let _ = reply.send(Ok(()));
+                        }
+                        RibReplyMode::DropReply => drop(reply),
+                        RibReplyMode::NotFound => {
+                            let _ = reply.send(Err(RibCommandError::not_found("scripted")));
+                        }
+                        RibReplyMode::HoldReply => held.lock().unwrap().push(reply),
+                    }
+                }
+                while let Some(update) = rib_rx.recv().await {
+                    match update {
+                        RibUpdate::QueryEvpnRoutes { reply } => {
+                            let _ = reply.send(vec![]);
+                        }
+                        RibUpdate::InjectEvpn { route, reply } => {
+                            injects.lock().unwrap().push(route.key());
+                            respond(*mode.lock().unwrap(), reply, &held);
+                        }
+                        RibUpdate::WithdrawEvpn { key, reply } => {
+                            withdraws.lock().unwrap().push(key);
+                            respond(*mode.lock().unwrap(), reply, &held);
+                        }
+                        _ => {}
+                    }
+                }
+            });
+        }
+        Self {
+            rib_tx,
+            mode,
+            injects,
+            withdraws,
+            _held: held,
+        }
+    }
+
+    pub(crate) fn set_mode(&self, mode: RibReplyMode) {
+        *self.mode.lock().unwrap() = mode;
+    }
+
+    pub(crate) fn inject_count(&self) -> usize {
+        self.injects.lock().unwrap().len()
+    }
+
+    pub(crate) fn withdraw_count(&self) -> usize {
+        self.withdraws.lock().unwrap().len()
+    }
+}


### PR DESCRIPTION
LAN-293 — reviewed slice; merge held for review.

## Problem

The EVPN originators (local Type-2 MAC/MAC+IP, ES orchestrator Type-1/EAD and Type-4) treated a successful send toward the RIB as done. A dropped reply, RIB backpressure, or a timeout permanently lost the operation — the originator believed it had published or withdrawn state the RIB never applied.

## Design (ADR-0102)

- **desired**: current intent from kernel/config observation (the existing caches/projections).
- **pending**: operation sent to the RIB, keyed by (route identity, generation).
- **confirmed**: updated only on RIB acknowledgement.
- Timeouts / dropped replies stay pending and retry with bounded backoff.
- New intent supersedes older pending work; stale (older-generation) acknowledgements are ignored.
- Withdrawals are not forgotten until acknowledged.
- Restart: rebuild intent from observation and reconcile idempotently — no persisted transient pending state (this also settles the MAC-mobility ratchet safe-forget question).
- Unmatched pending IP bindings are bounded.

## Verification

Gates were green (fmt / clippy -D warnings / evpn+rib suites / full workspace / doc); spot re-verified post-salvage: fmt 0, clippy 0, ack tests pass. Full CI runs on this PR.

Note: this branch's final commit was assembled from a verified working tree after the implementation session ended mid-commit; review with normal scrutiny.