### PR TITLE
fix(flowspec): represent destination-less rules as prefix=None in policy context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   maps but left a withdrawn-then-re-added managed link or NHG member
   update suppressed until restart (and the stale NHG record kept the
   adoption-cleanup gate blocked). (LAN-290)
+- **Destination-less FlowSpec rules no longer fabricate `0.0.0.0/0` in the
+  export policy context.** A legal FlowSpec rule without a destination-prefix
+  component was presented to export policy as an IPv4 default route — for
+  IPv6 rules too — so exact-match `0.0.0.0/0` policy terms spuriously matched
+  (and could suppress or admit) rules that carry no destination at all. Such
+  rules are now `prefix = None` in the policy context, matching the import
+  path and the BGP-LS prefixless-context convention; rules that do carry a
+  destination prefix still evaluate it unchanged. (LAN-291)
 
 ## [0.50.0] — 2026-07-05
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -72,8 +72,9 @@ impl PolicyResult {
 pub struct RouteContext<'a> {
     /// The route's NLRI prefix, when the address family carries one.
     ///
-    /// Prefix predicates do not match prefixless families such as BGP-LS
-    /// topology NLRIs.
+    /// Prefix predicates do not match prefixless routes such as BGP-LS
+    /// topology NLRIs or `FlowSpec` rules without a destination-prefix
+    /// component.
     pub prefix: Option<Prefix>,
     /// The route's resolved next-hop, if any.
     pub next_hop: Option<IpAddr>,

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -246,10 +246,10 @@ impl RibManager {
                     continue;
                 }
 
+                // A rule without a destination-prefix component stays
+                // `None` — fabricating `0.0.0.0/0` would spuriously match
+                // prefix-based policy terms (same class as the BGP-LS fix).
                 let dest_prefix = best.rule.destination_prefix();
-                let prefix_for_policy = dest_prefix.unwrap_or(Prefix::V4(
-                    rustbgpd_wire::Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0),
-                ));
                 let aspath_str = if needs_as_path_string {
                     best.as_path()
                         .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
@@ -258,7 +258,7 @@ impl RibManager {
                 };
                 let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
                 let ctx = RouteContext {
-                    prefix: Some(prefix_for_policy),
+                    prefix: dest_prefix,
                     next_hop: None,
                     extended_communities: best.extended_communities(),
                     communities: best.communities(),

--- a/crates/rib/src/manager/tests/flowspec.rs
+++ b/crates/rib/src/manager/tests/flowspec.rs
@@ -330,6 +330,160 @@ async fn gr_flowspec_eor_recomputes_and_redistributes() {
     handle.await.unwrap();
 }
 
+/// A legal `FlowSpec` route with no destination-prefix component
+/// (IP-protocol match only), for the given address family.
+fn make_destless_flowspec_route(afi: Afi, peer: Ipv4Addr, protocol: u8) -> FlowSpecRoute {
+    let mut route = make_flowspec_route(peer);
+    route.afi = afi;
+    route.rule.components = vec![rustbgpd_wire::FlowSpecComponent::IpProtocol(vec![
+        rustbgpd_wire::NumericMatch {
+            end_of_list: true,
+            and_bit: false,
+            lt: false,
+            gt: false,
+            eq: true,
+            value: u64::from(protocol),
+        },
+    ])];
+    route
+}
+
+/// LAN-291: a destination-less `FlowSpec` rule must be `prefix = None` in
+/// the export policy context — a fabricated `0.0.0.0/0` would spuriously
+/// match prefix-based deny terms and suppress the rule.
+#[tokio::test]
+async fn flowspec_export_prefix_term_does_not_match_destination_less_rules() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(deny_prefixes_chain(&[
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0)),
+            Prefix::V6(Ipv6Prefix::new(Ipv6Addr::UNSPECIFIED, 0)),
+        ])),
+        sendable_families: vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)],
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let v4_route = make_destless_flowspec_route(Afi::Ipv4, Ipv4Addr::new(10, 0, 0, 1), 6);
+    let v6_route = make_destless_flowspec_route(Afi::Ipv6, Ipv4Addr::new(10, 0, 0, 1), 17);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![v4_route.clone(), v6_route.clone()],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    let announced: BTreeSet<_> = update
+        .flowspec_announce
+        .iter()
+        .map(|r| r.rule.clone())
+        .collect();
+    assert_eq!(
+        announced,
+        BTreeSet::from([v4_route.rule, v6_route.rule]),
+        "destination-less FlowSpec rules are prefixless and must not match \
+         default-prefix deny terms"
+    );
+    assert!(update.flowspec_withdraw.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-291 companion: a `FlowSpec` rule that DOES carry a destination
+/// prefix still evaluates it against prefix-based export terms.
+#[tokio::test]
+async fn flowspec_export_prefix_term_still_matches_real_destination_prefix() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        // Denies the fixture rule's real destination prefix.
+        export_policy: Some(deny_prefixes_chain(&[Prefix::V4(Ipv4Prefix::new(
+            Ipv4Addr::new(192, 0, 2, 0),
+            24,
+        ))])),
+        sendable_families: ipv4_flowspec_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    // Destination 192.0.2.0/24 — must be denied by the export term.
+    let denied = make_flowspec_route(Ipv4Addr::new(10, 0, 0, 1));
+    // Destination-less — must pass through to the default Permit.
+    let permitted = make_destless_flowspec_route(Afi::Ipv4, Ipv4Addr::new(10, 0, 0, 1), 6);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![],
+        withdrawn: vec![],
+        flowspec_announced: vec![denied, permitted.clone()],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let update = out_rx.recv().await.unwrap();
+    assert_eq!(
+        update.flowspec_announce.len(),
+        1,
+        "the rule whose real destination prefix matches the deny term must \
+         be suppressed"
+    );
+    assert_eq!(update.flowspec_announce[0].rule, permitted.rule);
+    assert!(update.flowspec_withdraw.is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// A `FlowSpec` rule distinct from the shared `make_flowspec_route` fixture
 /// rule, so one source peer can hold two Adj-RIB-In entries.
 fn make_flowspec_route_alt(peer: Ipv4Addr) -> FlowSpecRoute {

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -28,31 +28,39 @@ fn bgpls_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::BgpLs, Safi::BgpLs)]
 }
 
-fn deny_default_prefix_chain() -> rustbgpd_policy::PolicyChain {
+/// A chain with one exact-match Deny statement per prefix, default Permit.
+fn deny_prefixes_chain(prefixes: &[Prefix]) -> rustbgpd_policy::PolicyChain {
     rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
-        entries: vec![rustbgpd_policy::PolicyStatement {
-            prefix: Some(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),
-            ge: None,
-            le: None,
-            action: rustbgpd_policy::PolicyAction::Deny,
-            match_community: vec![],
-            match_as_path: None,
-            match_neighbor_set: None,
-            match_route_type: None,
-            match_evpn_route_type: None,
-            match_rpki_validation: None,
-            match_aspa_validation: None,
-            match_as_path_length_ge: None,
-            match_as_path_length_le: None,
-            match_local_pref_ge: None,
-            match_local_pref_le: None,
-            match_med_ge: None,
-            match_med_le: None,
-            match_next_hop: None,
-            modifications: rustbgpd_policy::RouteModifications::default(),
-        }],
+        entries: prefixes
+            .iter()
+            .map(|prefix| rustbgpd_policy::PolicyStatement {
+                prefix: Some(*prefix),
+                ge: None,
+                le: None,
+                action: rustbgpd_policy::PolicyAction::Deny,
+                match_community: vec![],
+                match_as_path: None,
+                match_neighbor_set: None,
+                match_route_type: None,
+                match_evpn_route_type: None,
+                match_rpki_validation: None,
+                match_aspa_validation: None,
+                match_as_path_length_ge: None,
+                match_as_path_length_le: None,
+                match_local_pref_ge: None,
+                match_local_pref_le: None,
+                match_med_ge: None,
+                match_med_le: None,
+                match_next_hop: None,
+                modifications: rustbgpd_policy::RouteModifications::default(),
+            })
+            .collect(),
         default_action: rustbgpd_policy::PolicyAction::Permit,
     }])
+}
+
+fn deny_default_prefix_chain() -> rustbgpd_policy::PolicyChain {
+    deny_prefixes_chain(&[Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))])
 }
 
 fn make_evpn_imet(peer: Ipv4Addr, ethernet_tag: u32) -> EvpnRibRoute {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -7,8 +7,8 @@ use rustbgpd_policy::{
 };
 use rustbgpd_wire::{
     AddressPrefixOrf, AsPath, AsPathSegment, FlowSpecComponent, FlowSpecPrefix, FlowSpecRule,
-    Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, LlgrFamily, Message, MplsLabelEntry, OrfAction,
-    OrfEntries, OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin, PathAttribute,
+    Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, LlgrFamily, Message, MplsLabelEntry, NumericMatch,
+    OrfAction, OrfEntries, OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin, PathAttribute,
     RouteDistinguisher, VpnNlri, VpnPrefix, WhenToRefresh,
     bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri},
 };
@@ -4527,6 +4527,152 @@ async fn import_policy_denied_routes_do_not_reach_rib() {
         all_announced.len()
     );
     assert_eq!(all_announced[0].prefix, Prefix::V4(permitted_prefix));
+}
+
+/// LAN-291: a `FlowSpec` rule without a destination-prefix component is
+/// `prefix = None` in the import policy context — prefix-based deny terms
+/// (including exact-default ones) must not match it, while a rule with a
+/// real destination prefix still evaluates that prefix. Covers IPv4 and
+/// IPv6 `FlowSpec`.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "covers destination-less v4 + v6 rules and a real-prefix deny in one session scenario"
+)]
+async fn import_policy_prefix_term_does_not_match_destination_less_flowspec() {
+    use rustbgpd_wire::attribute::MpReachNlri;
+
+    let destless_rule = |protocol: u8| FlowSpecRule {
+        components: vec![FlowSpecComponent::IpProtocol(vec![NumericMatch {
+            end_of_list: true,
+            and_bit: false,
+            lt: false,
+            gt: false,
+            eq: true,
+            value: u64::from(protocol),
+        }])],
+    };
+    let deny = |prefix: Prefix| PolicyStatement {
+        prefix: Some(prefix),
+        ge: None,
+        le: None,
+        action: PolicyAction::Deny,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![
+            deny(Prefix::V4(Ipv4Prefix::new(Ipv4Addr::UNSPECIFIED, 0))),
+            deny(Prefix::V6(Ipv6Prefix::new(Ipv6Addr::UNSPECIFIED, 0))),
+            deny(Prefix::V4(Ipv4Prefix::new(
+                Ipv4Addr::new(198, 51, 100, 0),
+                24,
+            ))),
+        ],
+        default_action: PolicyAction::Permit,
+    }])));
+    session.negotiated = Some(negotiated_session(65002, false));
+    session.negotiated_families = vec![(Afi::Ipv4, Safi::FlowSpec), (Afi::Ipv6, Safi::FlowSpec)];
+
+    let destless_v4 = destless_rule(6);
+    let destless_v6 = destless_rule(17);
+    let with_denied_prefix = FlowSpecRule {
+        components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
+            Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+        ))],
+    };
+
+    let attrs_for = |mp: MpReachNlri| {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::MpReachNlri(mp),
+        ]
+    };
+    let v4_update = rustbgpd_wire::UpdateMessage::build(
+        &[],
+        &[],
+        &attrs_for(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::FlowSpec,
+            next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![destless_v4.clone(), with_denied_prefix.clone()],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+        true,
+        false,
+        rustbgpd_wire::Ipv4UnicastMode::Body,
+    );
+    session.process_update(v4_update).await;
+    let v6_update = rustbgpd_wire::UpdateMessage::build(
+        &[],
+        &[],
+        &attrs_for(MpReachNlri {
+            afi: Afi::Ipv6,
+            safi: Safi::FlowSpec,
+            next_hop: "2001:db8::2".parse().unwrap(),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![destless_v6.clone()],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+        true,
+        false,
+        rustbgpd_wire::Ipv4UnicastMode::Body,
+    );
+    session.process_update(v6_update).await;
+
+    assert_eq!(
+        session.import_policy_routes_permitted, 2,
+        "both destination-less rules must pass through to the default Permit"
+    );
+    assert_eq!(
+        session.import_policy_routes_denied, 1,
+        "the rule with a real destination prefix must match the deny term"
+    );
+
+    let mut announced = vec![];
+    while let Ok(msg) = rib_rx.try_recv() {
+        if let RibUpdate::RoutesReceived {
+            flowspec_announced, ..
+        } = msg
+        {
+            announced.extend(flowspec_announced);
+        }
+    }
+    let rules: Vec<_> = announced.iter().map(|r| r.rule.clone()).collect();
+    assert_eq!(rules, vec![destless_v4, destless_v6]);
+    assert_eq!(
+        announced.iter().map(|r| r.afi).collect::<Vec<_>>(),
+        vec![Afi::Ipv4, Afi::Ipv6]
+    );
 }
 /// ADR-0073 end-to-end pins 1 + 2: after `process_update`, the
 /// per-session import-decision cache holds an explainable `Deny` entry


### PR DESCRIPTION
## Summary

- FlowSpec rules without a destination-prefix component were exported with a fabricated IPv4 0.0.0.0/0 in the policy context (for IPv6 rules too), so prefix-based policy terms could spuriously match them; the export staging path now carries `prefix = None`, matching the import path, which was already honest
- extends the RouteContext optional-prefix convention established for BGP-LS (#616) to the FlowSpec family per ADR-0077's honest-context rule
- adds export tests proving destination-less v4/v6 rules are not matched by 0.0.0.0/0 and ::/0 deny terms while rules with a real destination prefix still match, plus an import regression-lock test

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-rib / -p rustbgpd-policy / -p rustbgpd-transport
- cargo doc --workspace --no-deps
- cargo check -p rustbgpd-rib --features bench-internals --benches
- cargo +nightly fuzz build

Closes LAN-291.