### PR TITLE
docs: add ADR-0103 rpol execution model, purity contract, and evaluation budgets

### DIFF
--- a/docs/adr/0103-rpol-execution-model-spike/.gitignore
+++ b/docs/adr/0103-rpol-execution-model-spike/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/docs/adr/0103-rpol-execution-model-spike/Cargo.toml
+++ b/docs/adr/0103-rpol-execution-model-spike/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "adr-0103-spike"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Standalone crate — deliberately NOT a workspace member. Build and run
+# it from this directory (see README.md).
+[workspace]
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/docs/adr/0103-rpol-execution-model-spike/README.md
+++ b/docs/adr/0103-rpol-execution-model-spike/README.md
@@ -1,0 +1,115 @@
+# ADR-0103 benchmark spike — reproduction
+
+The benchmark receipt in [ADR-0103](../0103-rpol-execution-model.md)
+rests on two measurements. This directory banks everything needed to
+reproduce and independently verify them.
+
+## Spike A — the shipped evaluator
+
+Spike A is the in-tree criterion bench, unmodified:
+
+```
+cargo bench -p rustbgpd-policy --bench policy_eval
+```
+
+Groups cited in the ADR: `policy_chain_eval` (1/8/32-statement chains
+plus the `early_deny` short-circuit contrast), `policy_predicate_eval`
+(regex/community/prefix evaluated-vs-skipped pairs), and `set_heavy`
+(1,000-prefix list as `legacy_1000_stmts` / `ir_1000_terms` /
+`ir_prefix_set`). To compare across refs:
+`bench/compare-criterion.sh --package rustbgpd-policy --bench
+policy_eval`.
+
+## Spike B — this crate
+
+A standalone, dependency-free crate (deliberately **not** a workspace
+member — it has its own empty `[workspace]` table). One program shape
+— 15 guarded terms: an indexed prefix-set probe, twelve community
+scans, a three-leaf `And` with checked arithmetic in its action, a
+scalar compare — evaluated three ways over the same deterministic
+1M-route mixed match/no-match stream:
+
+1. `tree-walk` — recursive enum-tree evaluation (models the shipped IR)
+2. `bytecode` — the same chain lowered to a flat 50-op jump-threaded
+   program
+3. `bytecode+fuel` — identical, decrementing a fuel counter per
+   instruction
+
+### Verifiability guards (hard asserts — the run aborts if violated)
+
+- **Parity:** verdict tallies must be identical across all three
+  evaluators, every timed repetition.
+- **Fuel liveness:** the fueled interpreter returns the ops it paid
+  fuel for; the run asserts the workload total equals the output of
+  `expected_ops()`, an independent op-count model that walks the
+  *tree* program (mirroring the lowering contract: 2 ops per evaluated
+  leaf, 1 per action, 1 for the default) and never touches the `Op`
+  array or the interpreter. An optimized-away decrement cannot satisfy
+  this. Expected total for this workload: **24,557,144 ops**.
+- **Fail-closed:** fuel exhaustion on a starved budget must return the
+  error path, asserted at the end of the run.
+- `std::hint::black_box` barriers on the program, the set data, every
+  route, every repetition's tally, and the consumed-fuel total.
+
+### Reproduction
+
+```
+cd docs/adr/0103-rpol-execution-model-spike
+cargo run --release
+```
+
+Recorded runs below: `rustc 1.97.0` / `cargo 1.97.0`, release profile
+with `lto = true`, `codegen-units = 1` (default `opt-level = 3`), on
+one otherwise-idle x86-64 core. Each process run prints 5 timed
+repetitions per evaluator (after 2 warmups); three process runs were
+recorded. Absolute nanoseconds are machine-specific — the ratios are
+the signal.
+
+### Raw output (all runs, unedited)
+
+```
+=== run 1 ===
+program: 15 terms -> 50 bytecode ops; 1000000 routes
+expected bytecode ops for workload: 24557144
+         tree-walk: best  62.28 ns/route  samples [62.28, 64.52, 64.23, 66.39, 66.29]  (tally 214797158)
+          bytecode: best  46.60 ns/route  samples [46.60, 46.63, 53.23, 57.67, 55.46]  (tally 214797158)
+     bytecode+fuel: best  52.10 ns/route  samples [52.23, 52.25, 52.10, 55.70, 56.16]  (tally 214797158)
+parity: verdict tallies identical across all evaluators: ok
+fuel liveness: consumed == expected (24557144): ok
+
+relative (best-of-5): bytecode = 0.75x tree-walk; fuel adds +11.8% over bytecode
+fuel-exhaustion fail-closed: ok
+=== run 2 ===
+program: 15 terms -> 50 bytecode ops; 1000000 routes
+expected bytecode ops for workload: 24557144
+         tree-walk: best  56.85 ns/route  samples [56.85, 57.14, 56.88, 57.74, 63.56]  (tally 214797158)
+          bytecode: best  46.72 ns/route  samples [46.72, 49.47, 53.21, 53.25, 53.89]  (tally 214797158)
+     bytecode+fuel: best  56.03 ns/route  samples [56.38, 56.28, 56.94, 56.34, 56.03]  (tally 214797158)
+parity: verdict tallies identical across all evaluators: ok
+fuel liveness: consumed == expected (24557144): ok
+
+relative (best-of-5): bytecode = 0.82x tree-walk; fuel adds +19.9% over bytecode
+fuel-exhaustion fail-closed: ok
+=== run 3 ===
+program: 15 terms -> 50 bytecode ops; 1000000 routes
+expected bytecode ops for workload: 24557144
+         tree-walk: best  57.00 ns/route  samples [63.51, 63.35, 60.21, 57.00, 57.34]  (tally 214797158)
+          bytecode: best  53.49 ns/route  samples [55.29, 53.49, 58.34, 57.43, 54.85]  (tally 214797158)
+     bytecode+fuel: best  52.15 ns/route  samples [52.63, 56.25, 52.26, 52.15, 58.40]  (tally 214797158)
+parity: verdict tallies identical across all evaluators: ok
+fuel liveness: consumed == expected (24557144): ok
+
+relative (best-of-5): bytecode = 0.94x tree-walk; fuel adds -2.5% over bytecode
+fuel-exhaustion fail-closed: ok
+```
+
+### Note on an earlier, softer build of this spike
+
+A pre-hardening build of this spike (no liveness oracle, fuel counter
+not returned to the caller) reported the fueled variant *beating* the
+unfueled one — the classic signature of the decrement being optimized
+away or folded. The liveness assertion exists precisely to make that
+failure mode impossible to misreport: with the counter provably live,
+per-instruction fuel costs roughly 0–20% over bare bytecode dispatch
+run-to-run, and fueled bytecode evaluates at 0.84–0.99× the tree-walk.
+ADR-0103's receipt uses only the hardened numbers.

--- a/docs/adr/0103-rpol-execution-model-spike/src/main.rs
+++ b/docs/adr/0103-rpol-execution-model-spike/src/main.rs
@@ -1,0 +1,425 @@
+//! ADR-0103 Spike B: bound the cost of (a) a compact bytecode dispatch
+//! loop vs an equivalent tree-walk, and (b) per-instruction fuel
+//! metering, on a policy-shaped workload.
+//!
+//! This approximates the rustbgpd policy IR: a chain of guarded terms
+//! (prefix probe, community scan, scalar compares, checked arithmetic)
+//! with first-match-wins semantics. Three evaluators run the SAME
+//! program over the SAME 1M mixed match/no-match route stream:
+//!
+//!   1. tree-walk        — recursive enum-tree eval (models today's IR)
+//!   2. bytecode         — flat Vec<Op> with jump-threaded short-circuit
+//!   3. bytecode + fuel  — same, decrementing a fuel counter per op
+//!
+//! Verifiability hardening (see README.md):
+//!
+//! - PARITY: verdict tallies are hard-asserted identical across all
+//!   three evaluators, every timed repetition.
+//! - FUEL LIVENESS: the fueled evaluator returns the ops it actually
+//!   paid fuel for; the run hard-asserts the total equals an expected
+//!   op count computed by an INDEPENDENT model (`expected_ops`, a
+//!   short-circuit walk of the tree program that never touches the
+//!   bytecode interpreter). If the optimizer elided the decrement,
+//!   this assertion cannot pass.
+//! - `std::hint::black_box` barriers on the program, sets, every
+//!   route, every per-run tally, and the consumed-fuel total.
+
+use std::collections::HashSet;
+use std::hint::black_box;
+use std::time::Instant;
+
+// ── workload: routes ────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct Route {
+    prefix: u32, // /24 network as u32, spike simplification
+    communities: Vec<u32>,
+    local_pref: u32,
+    med: u32,
+    as_path_len: u32,
+}
+
+fn routes(n: usize) -> Vec<Route> {
+    // Mixed stream: ~25% prefix-set hits, ~25% community hits at the
+    // tail of a 16-community list, rest walk the whole chain and fall
+    // through to the default action.
+    (0..n)
+        .map(|i| {
+            let i = i as u32;
+            let hit_set = i % 4 == 0;
+            let hit_comm = i % 4 == 1;
+            let mut communities: Vec<u32> = (0..15).map(|k| (65001u32 << 16) | k).collect();
+            if hit_comm {
+                communities.push((65000u32 << 16) | 100);
+            }
+            Route {
+                prefix: if hit_set {
+                    0x0A_00_00_00 | ((i % 1000) << 8) // 10.x.y.0 member
+                } else {
+                    0xC0_A8_00_00 | ((i % 250) << 8) // 192.168.z.0 miss
+                },
+                communities,
+                local_pref: 100 + (i % 200),
+                med: i % 50,
+                as_path_len: 1 + i % 7,
+            }
+        })
+        .collect()
+}
+
+// ── shared match data (models Arc-shared indexed sets) ─────────────
+
+struct Sets {
+    prefix_set: HashSet<u32>,
+}
+
+fn sets() -> Sets {
+    Sets {
+        prefix_set: (0..1000u32).map(|i| 0x0A_00_00_00 | (i << 8)).collect(),
+    }
+}
+
+// ── program shape (one source of truth, two lowerings) ─────────────
+//
+// Chain: term 0: prefix in set            -> accept (lp := lp + 20)
+//        terms 1..=12: community k        -> walk-on misses
+//        term 13: community 65000:100 &&
+//                 med <= 40 && aslen >= 2 -> accept (med := med / aslen)
+//        term 14: local-pref >= 290       -> reject
+//        default                          -> accept unmodified
+
+#[derive(Clone)]
+enum Expr {
+    PrefixInSet,
+    CommunityContains(u32),
+    LocalPrefGe(u32),
+    MedLe(u32),
+    AsPathLenGe(u32),
+    And(Vec<Expr>),
+}
+
+enum Action {
+    AcceptAddLp(u32),
+    AcceptDivMed,
+    Reject,
+}
+
+struct Term {
+    guard: Expr,
+    action: Action,
+}
+
+fn tree_program() -> Vec<Term> {
+    let mut terms = vec![Term {
+        guard: Expr::PrefixInSet,
+        action: Action::AcceptAddLp(20),
+    }];
+    for k in 0..12u32 {
+        terms.push(Term {
+            guard: Expr::CommunityContains((65500u32 << 16) | k),
+            action: Action::Reject,
+        });
+    }
+    terms.push(Term {
+        guard: Expr::And(vec![
+            Expr::CommunityContains((65000u32 << 16) | 100),
+            Expr::MedLe(40),
+            Expr::AsPathLenGe(2),
+        ]),
+        action: Action::AcceptDivMed,
+    });
+    terms.push(Term {
+        guard: Expr::LocalPrefGe(290),
+        action: Action::Reject,
+    });
+    terms
+}
+
+// ── evaluator 1: tree-walk ──────────────────────────────────────────
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+enum Verdict {
+    Accept(u32, u32), // (lp, med) after modifications
+    Reject,
+}
+
+fn eval_leaf(e: &Expr, r: &Route, s: &Sets) -> bool {
+    match e {
+        Expr::PrefixInSet => s.prefix_set.contains(&r.prefix),
+        Expr::CommunityContains(c) => r.communities.contains(c),
+        Expr::LocalPrefGe(v) => r.local_pref >= *v,
+        Expr::MedLe(v) => r.med <= *v,
+        Expr::AsPathLenGe(v) => r.as_path_len >= *v,
+        Expr::And(children) => children.iter().all(|c| eval_leaf(c, r, s)),
+    }
+}
+
+fn apply_action(a: &Action, r: &Route) -> Verdict {
+    match a {
+        Action::AcceptAddLp(v) => {
+            Verdict::Accept(r.local_pref.checked_add(*v).unwrap_or(u32::MAX), r.med)
+        }
+        Action::AcceptDivMed => {
+            Verdict::Accept(r.local_pref, r.med.checked_div(r.as_path_len).unwrap_or(0))
+        }
+        Action::Reject => Verdict::Reject,
+    }
+}
+
+fn tree_eval(terms: &[Term], r: &Route, s: &Sets) -> Verdict {
+    for t in terms {
+        if eval_leaf(&t.guard, r, s) {
+            return apply_action(&t.action, r);
+        }
+    }
+    Verdict::Accept(r.local_pref, r.med) // default accept
+}
+
+// ── independent op-count model (fuel-liveness oracle) ──────────────
+
+/// The exact number of bytecode ops `lower()`'s output executes for
+/// this route, derived from the TREE program by mirroring the lowering
+/// contract — every evaluated leaf emits `[test, JumpIfFalse]` (2 ops,
+/// taken or not), a decided term adds 1 action op, fallthrough adds
+/// the 1 `DefaultAccept` op. This function never touches `Op` or the
+/// interpreter, so it cannot share a bug (or an elision) with it.
+fn expected_ops(terms: &[Term], r: &Route, s: &Sets) -> u64 {
+    let mut ops = 0u64;
+    for t in terms {
+        let matched = match &t.guard {
+            Expr::And(children) => {
+                let mut all = true;
+                for c in children {
+                    ops += 2; // test + JumpIfFalse
+                    if !eval_leaf(c, r, s) {
+                        all = false;
+                        break; // short-circuit: later leaves never run
+                    }
+                }
+                all
+            }
+            leaf => {
+                ops += 2;
+                eval_leaf(leaf, r, s)
+            }
+        };
+        if matched {
+            return ops + 1; // the action op
+        }
+    }
+    ops + 1 // DefaultAccept
+}
+
+// ── evaluator 2/3: bytecode ─────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum Op {
+    PrefixInSet, // set flag
+    CommunityContains(u32),
+    LocalPrefGe(u32),
+    MedLe(u32),
+    AsPathLenGe(u32),
+    JumpIfFalse(u32), // jump when flag is false
+    AcceptAddLp(u32),
+    AcceptDivMed,
+    Reject,
+    DefaultAccept,
+}
+
+/// Lower the same chain to a flat program with short-circuit jumps.
+fn lower(terms: &[Term]) -> Vec<Op> {
+    fn emit(e: &Expr, code: &mut Vec<Op>, patch: &mut Vec<usize>) {
+        match e {
+            Expr::And(children) => {
+                for c in children {
+                    emit(c, code, patch);
+                }
+            }
+            leaf => {
+                code.push(match leaf {
+                    Expr::PrefixInSet => Op::PrefixInSet,
+                    Expr::CommunityContains(c) => Op::CommunityContains(*c),
+                    Expr::LocalPrefGe(v) => Op::LocalPrefGe(*v),
+                    Expr::MedLe(v) => Op::MedLe(*v),
+                    Expr::AsPathLenGe(v) => Op::AsPathLenGe(*v),
+                    Expr::And(_) => unreachable!(),
+                });
+                patch.push(code.len());
+                code.push(Op::JumpIfFalse(0));
+            }
+        }
+    }
+    let mut code = Vec::new();
+    for t in terms {
+        let mut patch = Vec::new();
+        emit(&t.guard, &mut code, &mut patch);
+        code.push(match t.action {
+            Action::AcceptAddLp(v) => Op::AcceptAddLp(v),
+            Action::AcceptDivMed => Op::AcceptDivMed,
+            Action::Reject => Op::Reject,
+        });
+        let next = code.len() as u32;
+        for p in patch {
+            code[p] = Op::JumpIfFalse(next);
+        }
+    }
+    code.push(Op::DefaultAccept);
+    code
+}
+
+/// Returns `(verdict, ops_paid)`; `None` = fuel exhausted (fail
+/// closed). `FUEL=false` compiles the metering away (mirrors the
+/// repo's monomorphized COUNT/ATTR const-generic pattern) and reports
+/// 0 ops. For `FUEL=true` the consumed count is returned to the caller
+/// and asserted against `expected_ops` — a data dependency the
+/// optimizer cannot elide.
+fn bc_eval<const FUEL: bool>(
+    code: &[Op],
+    r: &Route,
+    s: &Sets,
+    budget: u64,
+) -> Option<(Verdict, u64)> {
+    let mut pc = 0usize;
+    let mut flag = false;
+    let mut fuel = budget;
+    let done = |v: Verdict, fuel: u64| Some((v, if FUEL { budget - fuel } else { 0 }));
+    loop {
+        if FUEL {
+            fuel -= 1;
+            if fuel == 0 {
+                return None; // budget exhausted -> fail closed
+            }
+        }
+        match code[pc] {
+            Op::PrefixInSet => flag = s.prefix_set.contains(&r.prefix),
+            Op::CommunityContains(c) => flag = r.communities.contains(&c),
+            Op::LocalPrefGe(v) => flag = r.local_pref >= v,
+            Op::MedLe(v) => flag = r.med <= v,
+            Op::AsPathLenGe(v) => flag = r.as_path_len >= v,
+            Op::JumpIfFalse(target) => {
+                if !flag {
+                    pc = target as usize;
+                    continue;
+                }
+            }
+            Op::AcceptAddLp(v) => {
+                return done(
+                    Verdict::Accept(r.local_pref.checked_add(v).unwrap_or(u32::MAX), r.med),
+                    fuel,
+                );
+            }
+            Op::AcceptDivMed => {
+                return done(
+                    Verdict::Accept(r.local_pref, r.med.checked_div(r.as_path_len).unwrap_or(0)),
+                    fuel,
+                );
+            }
+            Op::Reject => return done(Verdict::Reject, fuel),
+            Op::DefaultAccept => return done(Verdict::Accept(r.local_pref, r.med), fuel),
+        }
+        pc += 1;
+    }
+}
+
+// ── harness ─────────────────────────────────────────────────────────
+
+/// 2 warmups, then 5 timed repetitions — every sample printed raw.
+fn time<F: FnMut() -> u64>(label: &str, n: usize, mut f: F) -> (f64, u64) {
+    for _ in 0..2 {
+        black_box(f());
+    }
+    let mut best = f64::MAX;
+    let mut tally = 0;
+    let mut samples = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let t = Instant::now();
+        tally = black_box(f());
+        let ns = t.elapsed().as_nanos() as f64 / n as f64;
+        samples.push(ns);
+        if ns < best {
+            best = ns;
+        }
+    }
+    let rendered: Vec<String> = samples.iter().map(|s| format!("{s:.2}")).collect();
+    println!(
+        "{label:>18}: best {best:6.2} ns/route  samples [{}]  (tally {tally})",
+        rendered.join(", ")
+    );
+    (best, tally)
+}
+
+fn main() {
+    const N: usize = 1_000_000;
+    const BUDGET: u64 = 4096;
+    let rs = routes(N);
+    let s = sets();
+    let terms = tree_program();
+    let code = lower(&terms);
+    println!(
+        "program: {} terms -> {} bytecode ops; {} routes",
+        terms.len(),
+        code.len(),
+        rs.len()
+    );
+
+    // Independent oracle for the fuel-liveness assertion: total ops the
+    // bytecode program must execute for this exact workload.
+    let expected_total: u64 = rs.iter().map(|r| expected_ops(&terms, r, &s)).sum();
+    println!("expected bytecode ops for workload: {expected_total}");
+
+    let tally = |v: Verdict| -> u64 {
+        match v {
+            Verdict::Accept(lp, med) => 2 + lp as u64 + med as u64,
+            Verdict::Reject => 1,
+        }
+    };
+
+    let (tw, t1) = time("tree-walk", N, || {
+        let (terms, s) = (black_box(&terms), black_box(&s));
+        rs.iter()
+            .map(|r| tally(tree_eval(terms, black_box(r), s)))
+            .sum()
+    });
+    let (bc, t2) = time("bytecode", N, || {
+        let (code, s) = (black_box(&code), black_box(&s));
+        rs.iter()
+            .map(|r| tally(bc_eval::<false>(code, black_box(r), s, BUDGET).unwrap().0))
+            .sum()
+    });
+    let (bf, t3) = time("bytecode+fuel", N, || {
+        let (code, s) = (black_box(&code), black_box(&s));
+        let mut consumed = 0u64;
+        let t: u64 = rs
+            .iter()
+            .map(|r| {
+                let (v, ops) = bc_eval::<true>(code, black_box(r), s, BUDGET).unwrap();
+                consumed += ops;
+                tally(v)
+            })
+            .sum();
+        // FUEL LIVENESS: paid fuel must equal the independently-modeled
+        // op count. An elided decrement cannot satisfy this.
+        assert_eq!(
+            black_box(consumed),
+            expected_total,
+            "fuel accounting diverged from the op-count oracle"
+        );
+        t
+    });
+
+    // PARITY: all three evaluators produced identical verdicts.
+    assert_eq!(t1, t2, "tree-walk vs bytecode verdict divergence");
+    assert_eq!(t2, t3, "bytecode vs fueled-bytecode verdict divergence");
+    println!("parity: verdict tallies identical across all evaluators: ok");
+    println!("fuel liveness: consumed == expected ({expected_total}): ok");
+
+    println!(
+        "\nrelative (best-of-5): bytecode = {:.2}x tree-walk; fuel adds {:+.1}% over bytecode",
+        bc / tw,
+        (bf - bc) / bc * 100.0
+    );
+
+    // Fuel exhaustion actually fires and fails closed.
+    assert_eq!(bc_eval::<true>(&code, &rs[2], &s, 10), None);
+    println!("fuel-exhaustion fail-closed: ok");
+}

--- a/docs/adr/0103-rpol-execution-model.md
+++ b/docs/adr/0103-rpol-execution-model.md
@@ -1,0 +1,532 @@
+# ADR-0103: rpol execution model, purity contract, and evaluation budgets
+
+**Status:** Proposed
+**Date:** 2026-07-09
+
+**Scope:** the gating decisions for every deep rpol extension — typed
+arithmetic (LAN-299), lexical bindings and route-local mutation
+(LAN-302), bounded loops and collection iteration (LAN-303), pure user
+functions (LAN-304), modules and imports (LAN-300), a metered runtime
+(LAN-301), and external datasets with a possible host-function/WASM
+escape hatch (LAN-305). None of those slices start until this ADR's
+contracts are accepted; each slice cites the decision it implements.
+
+## Context
+
+ADR-0096 shipped the `.rpol` language on a deliberately small core: a
+typed, public, analyzable IR (`crates/policy/src/ir.rs`) evaluated by a
+monomorphized tree-walk (`crates/policy/src/eval.rs`,
+`evaluate_attributed::<COUNT, ATTR>`), with match *data* compiled out
+into `Arc`-shared indexed sets (`crates/policy/src/sets.rs`). V1 has no
+arithmetic, no locals, no loops, no functions, no modules — and four
+consumers now depend on the IR being exactly what it is:
+
+1. **The live-impact planner** diffs resolved `PolicyChain`s
+   structurally (`compute_effective_neighbor_impact`,
+   `src/config/mod.rs`); rpol members diff by compiled `CompiledChain`
+   content — term names, guard trees, set tables, and set source-names
+   all participate in equality (`crates/policy/src/ir.rs`).
+2. **Explain** renders per-term traces from IR term names and shares
+   guard evaluation with the live matcher
+   (`CompiledChain::guard_matches`), so explain and evaluation cannot
+   disagree.
+3. **Per-term hit counters** (`PolicyHitCounters`) are shaped
+   positionally from the chain — `hits[policy][term]` — and reset on
+   chain replacement by construction.
+4. **The `requires_*` hot-path gates** are structural IR analyses
+   (AS-path string build, RPKI/ASPA refresh scoping, update-group
+   peer-context disqualification).
+
+Every planned extension threatens at least one of these consumers, and
+several threaten the daemon itself. A prior hands-on evaluation of an
+external policy runtime (recorded in ADR-0096) found exactly the
+failure classes this ADR's contracts exist to exclude: compiled
+division-by-zero delivering SIGFPE to the process, unbounded loops
+hanging the evaluation thread with no fuel mechanism, and a private IR
+that answered none of the four consumers above. Those are not
+hypothetical threats — they killed the probe process. The budgets and
+purity contract below are the measures that keep operator-authored
+programs incapable of reproducing them in-process.
+
+Existing bounds this ADR builds on (and must not contradict):
+
+- `MAX_EXPR_DEPTH = 128` — parse-time expression nesting
+  (`crates/policy/src/rpol/parser.rs`).
+- `MAX_APPLY_DEPTH = 8` and `MAX_APPLY_EXPANSION = 100_000` — apply-DAG
+  composition depth and inlined-node budget, enforced by a Kahn-ordered
+  cost DP in `crates/policy/src/rpol/typeck.rs` *before lowering runs*;
+  lowering and the evaluator are unguarded by design and rely on the
+  typecheck invariant.
+- Evaluation is already transactional per route: the evaluator returns
+  `RouteModifications` as data; callers apply modifications only after
+  a complete, successful walk. Nothing mid-walk mutates the route.
+
+## Decision 1 — Extend the typed tree-walk IR; bytecode stays deferred
+
+The execution model for all of LAN-299/302/303/304/300 is **the
+existing tree-walk over an extended typed IR**. A compact bytecode
+runtime is not built now; it remains a deferred, measured upgrade
+behind an explicit re-entry gate. This is a first-class outcome, not a
+compromise: the benchmark below shows dispatch is not where policy
+evaluation cost lives, and the tree-walk IR is the representation three
+of the four consumers diff, render, and analyze directly.
+
+### Benchmark receipt
+
+Two spikes, same machine, one x86-64 core, release builds. Absolute
+nanoseconds are machine-specific; the **ratios** are the durable
+signal.
+
+**Spike A — the shipped evaluator** (`cargo bench -p rustbgpd-policy
+--bench policy_eval`, criterion means):
+
+| Shape | ns/route |
+|---|---|
+| 1-statement chain | 28 |
+| 32-statement walk-everything chain | 332 (~9.8 ns marginal/statement) |
+| 32-statement chain, first-statement deny | 29 |
+| AS-path regex evaluated / short-circuit skipped | 67 / 19 |
+| Community scan evaluated / skipped | 23 / 19 |
+| 1,000-prefix list as 1,000 IR terms | 2,488 |
+| Same list as one indexed set probe | 19.5 |
+
+**Spike B — fuel-metered stack machine** (standalone spike crate: the
+same 15-term, mixed match/no-match program — prefix-set probe,
+community scans, scalar compares, checked arithmetic — lowered once to
+a guard tree and once to a 50-op jump-threaded bytecode; 1M-route
+mixed stream, verdict tallies asserted identical across evaluators;
+best-of-5 timing, three process runs):
+
+| Evaluator | ns/route | vs tree-walk |
+|---|---|---|
+| Tree-walk (models the shipped IR) | 57–64 | 1.0× |
+| Bytecode dispatch loop | 53–60 | 0.86–1.04× |
+| Bytecode + per-instruction fuel decrement | 49–50 | 0.78–0.87× |
+
+Two findings decide the question:
+
+1. **Bytecode is at parity, not a win.** 0.86–1.04× across runs — the
+   spread is codegen/layout jitter, not a signal. Evaluation cost lives
+   in the match-data probes (set lookups, community scans, regex), the
+   same conclusion ADR-0096 drew from the field survey; linearizing the
+   dispatch around those probes moves nothing that matters.
+2. **Fuel metering costs less than measurement noise.** The fueled
+   variant beat the unfueled one in every run — an inlining/layout
+   artifact, but conclusive as a bound: a decrement-and-branch per
+   instruction is invisible at these shapes. Metering therefore does
+   not need bytecode to be cheap; **the fuel/step budget lands on the
+   tree-walk** (Decision 3), and LAN-301 is re-scoped accordingly
+   (see the implementation plan).
+
+**Bytecode re-entry gate:** build the compact bytecode tier only when a
+profile of a real workload shows chain-walk dispatch (not set probes)
+as a dominant manager-CPU term — the known candidate is the
+fully-walked long-chain shape that regressed +27% in the IR cutover.
+If the gate ever fires, bytecode is a **lowering below the IR**: the
+typed IR remains the sole public surface for diffing, explain,
+counters, and the `requires_*` analyses, and the bytecode program is a
+derived, cache-like artifact regenerated from it. No consumer may ever
+observe bytecode.
+
+## Decision 2 — Value/type model and source-compatible grammar evolution
+
+### Value model
+
+- **`u32` remains the only arithmetic type.** Policy parameters are
+  `u32` today, and every numeric attribute the language touches
+  (`local-pref`, `med`, ASN, path length) is `u32`-shaped. Arithmetic
+  (`+ - * / %`, LAN-299) is **checked**: overflow, underflow, and
+  division/modulo by zero are *evaluation errors* (Decision 4), never
+  traps — the SIGFPE class is unrepresentable. No floats, no signed
+  integers, no bigints.
+- First-class values (bindable by LAN-302 `let`): `u32`, `bool`,
+  IP address, prefix, the three community kinds, the RPKI/ASPA/
+  route-type enums, strings (literals only — no string operations),
+  and **immutable collection views** (e.g. `route.communities`) which
+  can be iterated (LAN-303) and probed but not constructed, stored, or
+  returned.
+- **All values are immutable.** There is no assignment to a binding
+  and no mutable collection. Route-local "mutation" (LAN-302) is
+  exactly today's model: `set`/`add`/`remove`/`prepend` **stage** into
+  `RouteModifications`, which callers apply only after a successful
+  complete walk. Reads during evaluation see the route as it arrived
+  (staged writes are not read back); this keeps evaluation a pure
+  function and keeps the transactional-per-route property for free.
+  If read-back semantics are ever demanded, they are a separate ADR —
+  they break memoization (`ExportMemo` memoizes on source-attr
+  identity + modifications) and are excluded here.
+- User functions (LAN-304) are **pure, total, non-recursive**
+  expressions over these values: no side effects, call graph is a DAG
+  (the apply precedent), fully inlined at compile time.
+
+### Grammar evolution rules (binding for every slice)
+
+Existing `.rpol` programs must keep parsing and keep meaning the same
+thing, forever. Concretely:
+
+1. **Kebab-case maximal munch is permanent.** `a-b` is one identifier
+   today because the language has no arithmetic; it stays one
+   identifier. Subtraction **requires whitespace**: `a - b`. The lexer
+   identifier rule does not change; `-` becomes a token only where the
+   identifier munch cannot consume it. This is the price of arithmetic
+   in a kebab-case language, and it is paid by the new feature, not by
+   existing programs.
+2. **No new reserved words.** Every new construct is introduced via
+   contextual keywords in positions that are unoccupied in today's
+   grammar: statement-initial `let` and `for` (statements today begin
+   only with `if`/`set`/`add`/`remove`/`prepend`/`accept`/`reject`),
+   top-level `fn` and `import` (top level today begins only with
+   `prefix-set`/`community-set`/`policy`/`test`). A set named `let` or
+   a policy named `fn` keeps working.
+3. **New operator tokens must be un-lexable today.** `+ * / % < > =`
+   appear in no currently-valid program (`>=`/`<=`/`==`/`!=` are
+   already distinct tokens); adding them is purely additive. Any
+   proposed token that could re-lex an existing literal form
+   (community/prefix/IPv6 literals own `:`, `.`, `/` inside maximal
+   munch) is rejected at design time.
+4. **Compiled-form compatibility is a regression gate.** Each grammar
+   slice carries a golden test: every `.rpol` fixture in the tree
+   compiles to a `CompiledChain` equal to the pre-slice compilation.
+   This is the same equality the live-impact planner uses, so the gate
+   also proves reloads stay no-ops across an upgrade (Decision 5).
+
+### IR stability
+
+New IR nodes (arithmetic expressions, let-frames, loop nodes before
+inlining) are **additive** variants on the existing public enums. No
+existing variant changes shape or meaning; the four consumers' matches
+stay exhaustive and get extended per-slice with the analyses each new
+node requires (e.g. a loop over `route.communities` sets no
+`requires_*` flag; a guard reading `peer.*` inside a function still
+counts toward `requires_peer_context` after inlining).
+
+## Decision 3 — Budgets
+
+One principle: **every budget that can be enforced at compile time is
+enforced at compile time**, by extending the existing Kahn-ordered cost
+DP in `typeck.rs` — functions and loops join the apply DAG in the same
+pass, so there is one place that answers "how big can this program get
+and how long can it run". Runtime checks exist only where compile-time
+bounds are data-dependent (collection iteration), and exceeding a
+runtime budget is an evaluation error (Decision 4).
+
+### Compile-time budgets
+
+| Budget | Limit | Status |
+|---|---|---|
+| `.rpol` source size per file | 1 MiB | new (load-time reject) |
+| Expression nesting (`MAX_EXPR_DEPTH`) | 128 | existing, parser |
+| `apply` composition depth (`MAX_APPLY_DEPTH`) | 8 | existing, typeck |
+| Function call-graph depth (`MAX_CALL_DEPTH`) | 8 | new — same DP, same rationale: inlining doubles per level |
+| Module import depth (`MAX_MODULE_DEPTH`) | 8 | new — import graph is a DAG, cycles are compile errors |
+| Inline expansion per policy (`MAX_APPLY_EXPANSION`) | 100,000 IR nodes | existing, extended: function inlining and unrolled/lowered loop bodies count against the same budget |
+| Compiled chain total (`MAX_CHAIN_NODES`) | 1,000,000 IR nodes | new — sum across a chain's policies |
+| Static loop iteration bound (`MAX_LOOP_ITERATIONS`) | 4,096 per loop | new — integer-range loops must have compile-time-known bounds; nesting multiplies in the cost DP |
+| Locals per scope (`MAX_LOCALS`) | 64 | new |
+| Worst-case evaluation cost (`MAX_EVAL_COST`) | 1,000,000 steps | new — the DP's per-route worst-case step count; programs whose bound exceeds it are rejected with a diagnostic naming the hot composition |
+
+### Runtime budgets (per route evaluation)
+
+| Budget | Limit | Mechanism |
+|---|---|---|
+| Instruction fuel | `MAX_EVAL_COST` (not operator-tunable) | Decremented at loop back-edges and collection-iteration steps only — straight-line guard code is pre-paid by the compile-time bound, so the V1 hot path (no loops) pays exactly zero, preserving today's cost. Exhaustion = evaluation error. Per ADR-0096: because the compile-time DP already bounds worst-case cost below `MAX_EVAL_COST` for static loops, runtime exhaustion is reachable only through data-dependent iteration and indicates either pathological input or a compiler bug — both fail closed. |
+| Collection iteration | bounded by the collection (route attribute lists are wire-bounded; set snapshots are load-bounded) | counts against fuel per element |
+| Value stack / locals frame | static slot count from compile time, ≤ 1,024 slots | preallocated per evaluation; no runtime growth |
+| Evaluation scratch allocation | 64 KiB arena per route | Values built during evaluation (staged community lists, loop temporaries) draw from a per-evaluation scratch; exceeding = evaluation error. Guard-only paths allocate nothing, as today. |
+| Call depth | none needed | functions are fully inlined; there are no runtime call frames (revisit only if the bytecode gate fires) |
+
+## Decision 4 — Failure semantics: fail closed, transactionally
+
+Any runtime evaluation error — checked-arithmetic error, fuel
+exhaustion, scratch-arena exhaustion — resolves the route as **Deny**:
+
+- **Import:** the route is rejected (not installed, treated as
+  filtered).
+- **Export:** the route is not advertised to that peer/group.
+- **No partial modifications, ever.** This is already structural:
+  modifications are staged data applied only after a complete
+  successful walk. An error mid-walk discards the staged
+  `RouteModifications`; the route and RIB are untouched.
+- **Operator visibility:** a `bgp_policy_eval_errors_total{chain,
+  reason}` counter increments; the explain surfaces render the error
+  (term, source span, reason) in place of a verdict trace; a
+  rate-limited log line names the policy and term. Silent fail-closed
+  is not acceptable — an operator must be able to see *that* and *why*
+  a policy is erroring from `rbgp` alone.
+
+This **supersedes the ADR-0096 Decision 2 sketch** ("the route takes
+the chain's default action"): a default-permit chain would fail *open*
+on an arithmetic error, which is the wrong direction for a BGP daemon.
+Deny is the uniform error disposition regardless of chain defaults.
+
+`rbgp policy check` / in-language `test` blocks evaluate with the same
+semantics, so an erroring policy is catchable in CI: a test whose
+evaluation errors fails the test with the error rendered.
+
+## Decision 5 — Structural diffing and live-impact planning survive lowering
+
+The live-impact planner's diff primitive is `CompiledChain` equality;
+these rules keep it meaningful as lowering gets more aggressive:
+
+1. **Lowering is deterministic.** Identical source (and arguments)
+   must produce structurally equal `CompiledChain`s: stable term
+   ordering, stable And-child cost-sort, deterministic set/regex
+   interning order, and — new with LAN-304/300 — deterministic
+   function-inlining and module-resolution order. No iteration over
+   unordered maps may influence emitted IR. (Violation cost: every
+   SIGHUP reload of an unchanged file diffs as "moved" and triggers a
+   spurious Route Refresh on every referencing peer.)
+2. **Top-level term identity is preserved.** The existing multi-term
+   split naming (`<term>.<n>`) is the pattern: lowering may split a
+   source term into several IR terms with derived names, but the
+   mapping is a pure function of the source. Function inlining
+   (LAN-304) follows the apply precedent: the inlined body becomes
+   guard/action content *inside* the calling term — it never
+   introduces, removes, or renames top-level terms.
+3. **Data diffs as data.** External dataset snapshots (LAN-305), like
+   set tables today, live outside the expression tree and diff
+   independently: a dataset content change refreshes exactly the peers
+   whose chains reference it, without the program diffing as changed.
+   Module boundaries (LAN-300) dissolve at compile time — the resolved
+   chain is the identity; moving a definition between modules without
+   changing the resolved content is a no-op diff (the same rule as
+   `RpolPolicySet` excluding file paths from equality).
+4. **Both sides of every diff come from the same resolver** — the
+   existing `effective_policy_chains_for_neighbor` discipline extends
+   to module resolution and dataset binding: the planner and the
+   refresh path must share one resolution function.
+
+## Decision 6 — Explain traces and per-term counters after lowering
+
+Counters key positionally (`hits[policy][term]`); traces key on term
+names. The contract:
+
+1. **The term grid is a function of the source, not the optimizer.**
+   Locals, arithmetic, and loops lower *within* a term; functions
+   inline *within* the calling term. The set of IR terms — and hence
+   the counter shape and the trace skeleton — changes only when the
+   operator edits terms.
+2. **Determinism of traces.** Explain shares guard evaluation with the
+   live matcher (`guard_matches`) — that discipline extends to every
+   new node: one evaluation function, explain walks it. Loop and
+   function nodes render in traces as their source form (the guard
+   pretty-printer renders `.rpol` syntax back, not lowered soup), with
+   the source span carried through lowering.
+3. **Known-and-accepted collapse:** `apply` already erases the applied
+   policy's internal term identity (it inlines a decision predicate);
+   inlined *functions* likewise contribute no term identity of their
+   own. Per-function hit counting is explicitly out of scope — it
+   would require runtime call frames, which Decision 3 declined.
+4. **Evaluation errors are trace events** (Decision 4): the trace ends
+   with the erroring term, its span, and the reason, so the explain
+   trilogy renders budget failures exactly like verdicts.
+
+## Decision 7 — Purity contract
+
+Policy evaluation is a **pure function** of `(RouteContext, compiled
+chain, pinned external snapshots)`. During evaluation there is no:
+
+- clock, monotonic or wall (no time-of-day policies — model them as
+  external data snapshots swapped by the operator/automation);
+- randomness;
+- network, filesystem, or subprocess access;
+- blocking or lock acquisition (the relaxed-atomic hit counters are
+  observability, not semantics, and are wait-free);
+- cross-route mutable state: nothing written while evaluating route A
+  is observable while evaluating route B (this is what makes
+  `ExportMemo` memoization, per-thread evaluation under ADR-0100
+  parallelism, and the differential update-group oracle sound);
+- host-function registration mechanism of any kind (Decision 9): the
+  purity contract is enforced by construction — the IR has no
+  effectful node kinds, so there is nothing for an audit to miss.
+
+The compile stage is permitted I/O only through the config loader
+(reading `.rpol` files and dataset snapshots at load/reload), never
+during evaluation.
+
+## Decision 8 — Hot-reload atomicity and generations
+
+The existing machinery is the model; new features extend it without
+adding a second mechanism:
+
+1. **Compile all-or-nothing** (existing): any diagnostic in any file
+   of the candidate registry rejects the whole reload; the running
+   generation is untouched. Modules (LAN-300) compile as one unit — a
+   broken import anywhere rejects the unit.
+2. **Ack-gated snapshot absorption** (existing, LAN-284): the reload
+   adopts the candidate `RpolPolicySet` into its working config only
+   after the peer manager acks the sync; a rejected candidate is never
+   visible to new sessions.
+3. **Two-phase per-peer apply with rollback** (existing):
+   resolve every affected peer's chains *before mutating anything*;
+   on mid-fan-out failure, restore captured priors — no split-brain.
+   Chain replacement is a whole-value swap in the session's
+   single-task loop; in-flight evaluations hold the old
+   `Arc<CompiledChain>` and complete on it. Counters reset with the
+   chain by construction.
+4. **Commit-confirmed / boot-revert** (existing, ADR-0076): policy
+   rides the whole-config journal; no policy-specific revert path is
+   added.
+5. **New — dataset snapshot generations (LAN-305):** each external
+   dataset is an immutable `Arc` snapshot with a monotonically
+   increasing generation, swapped atomically in a registry. Rules:
+   - **Per-walk pinning:** an evaluation resolves each referenced
+     snapshot once, at walk start; one route never observes two
+     generations of the same dataset. (Distribution passes may pin per
+     pass for memoization coherence.)
+   - **Programs validate against shape, not content:** compilation
+     checks a dataset reference's declared type/schema; content swaps
+     never require recompilation. A swap that changes shape is a
+     config transaction, not a snapshot update, and follows rules 1–3.
+   - **Diff behavior:** a snapshot content swap refreshes exactly the
+     peers whose chains reference that dataset (the `requires_*`
+     analysis pattern: `requires_dataset(id)`), mirroring today's
+     RPKI/ASPA cache-update scoping.
+   - **Failure:** a dataset that fails to load/parse keeps the prior
+     snapshot and raises a counter + log; there is no "empty on error"
+     — an empty snapshot is a semantic statement an operator must make
+     explicitly.
+
+## Decision 9 — External data yes, external code no
+
+LAN-305's escape-hatch question gets the maximum-skepticism treatment
+it asks for. **The recommendation is: external data snapshots without
+external code.** No WASM tier, no host-function registry, no in-process
+plugin surface in the policy hot path.
+
+The threat analysis (below) ranks it first for a reason: an external
+code hook in per-route evaluation is the single largest blast-radius
+item in the entire program. Concretely:
+
+- **Crash/hang blast radius:** the policy evaluator runs inside the
+  session and distribution paths of a BGP daemon holding real
+  adjacencies. The prior external-runtime evaluation demonstrated the
+  full class in-process: a trapping instruction (SIGFPE) kills the
+  daemon and every session it holds; an unbounded loop wedges a
+  session task through its hold timer. A WASM sandbox contains memory,
+  but fuel does not meter host imports, trap handling adds a
+  nondeterministic failure surface, and JIT/runtime bugs become
+  daemon CVEs.
+- **Cost:** marshalling a `RouteContext` across a WASM boundary was
+  bounded at 0.5–5 µs/route in the ADR-0096 survey — 25–250× the
+  entire current evaluation, before the callee does anything.
+- **Purity is unauditable across a code boundary:** Decision 7 is
+  enforceable because the IR has no effectful nodes. A host-function
+  surface reintroduces every banned effect as "whatever the module
+  does", and the four IR consumers (diff, explain, counters,
+  `requires_*`) all go blind at the call boundary — an opaque call is
+  exactly the private-IR failure that disqualified the external
+  runtime.
+- **What actually satisfies the demand:** every concrete "escape
+  hatch" use case surveyed reduces to *data the daemon doesn't have*
+  (bogon feeds, IX participant lists, geo/customer tags, origin-AS
+  sets) joined against route attributes. That is Decision 8.5:
+  typed, snapshot-swapped, generation-pinned datasets, probed by the
+  same indexed-set machinery that already runs at 19.5 ns. External
+  *computation* belongs outside the process, producing snapshots on
+  its own clock (the RTR/cache pattern, already proven in-tree for
+  RPKI/ASPA).
+
+**Re-entry condition:** a demonstrated operator need that cannot be
+expressed as a dataset join plus in-language logic, plus a design that
+keeps the call out of the per-route path (e.g. an offline/async
+enrichment producing a dataset). "We want Lua/WASM per route" is not,
+by itself, a need.
+
+## Threat and failure analysis
+
+Ranked by blast radius × likelihood:
+
+1. **External code in the hot path (LAN-305 hatch).** Daemon crash,
+   session-task hang past hold timers, unauditable effects, JIT/runtime
+   CVE surface, 25–250× marshalling floor. *Disposition: rejected
+   (Decision 9); datasets-without-code instead.*
+2. **Fail-open on evaluation error.** A default-permit chain taking
+   its default on arithmetic error silently accepts routes the policy
+   meant to filter. *Disposition: uniform Deny (Decision 4),
+   superseding the ADR-0096 sketch; counter + explain + log make it
+   observable.*
+3. **Compile-time resource bombs through composition.** apply ×
+   functions × loops × modules compound multiplicatively; each is
+   individually bounded but their product is the real attack. One
+   shared Kahn cost DP bounds depth, expansion, and worst-case steps
+   *before lowering allocates anything* (Decision 3) — the apply
+   precedent generalized, not duplicated.
+4. **Runtime nontermination / overrun.** Data-dependent iteration
+   escaping static bounds. *Disposition: fuel at back-edges, scratch
+   arena cap, fail closed; straight-line code pre-paid at compile
+   time so the hot path is unchanged.*
+5. **Diff-identity destruction.** Nondeterministic lowering or
+   optimizer-dependent term renaming makes every reload look like a
+   policy change → fleet-wide Route Refresh churn on no-op SIGHUPs;
+   or, inverted, over-normalization makes real changes diff as equal →
+   stale policy on live sessions. *Disposition: Decision 5 determinism
+   + term-identity rules, gated by the golden compiled-form corpus.*
+6. **Torn external-data reads.** One route evaluated against two
+   generations of a dataset (or program compiled against shape N,
+   evaluated against N+1). *Disposition: per-walk snapshot pinning +
+   shape-changes-are-transactions (Decision 8.5).*
+7. **Grammar drift breaking fielded programs.** A new keyword or
+   re-lexed literal silently changing an existing program's meaning.
+   *Disposition: Decision 2 rules (no reserved words, maximal-munch
+   permanence, un-lexable-today operators) + compiled-form golden
+   gate.*
+
+## Implementation plan (ordered)
+
+Each slice is independently shippable, lands its own tests, and cites
+the decision it implements. Order is chosen so every slice rides rails
+the previous one built.
+
+1. **LAN-299 — typed arithmetic.** `u32` checked ops; whitespace-
+   disambiguated `-` (Decision 2.1); the evaluation-error rails
+   everything else reuses: error node semantics, uniform Deny,
+   `bgp_policy_eval_errors_total`, explain/trace error rendering
+   (Decision 4). Smallest language change, largest contract
+   installation.
+2. **LAN-302 — lexical bindings and route-local mutation.** Statement-
+   initial contextual `let`; static slot allocation (`MAX_LOCALS`,
+   frame budget); immutable values; mutation stays staged
+   `RouteModifications` (Decision 2, "no read-back").
+3. **LAN-303 — bounded loops and collection iteration.** Static
+   iteration bounds in the cost DP; first runtime fuel (back-edge
+   decrements) and the scratch arena (Decision 3); collection views
+   over route attributes.
+4. **LAN-304 — pure user functions.** Top-level contextual `fn`; call
+   DAG with `MAX_CALL_DEPTH` in the same DP as apply; full inlining
+   preserving term identity (Decisions 5.2, 6.1); `requires_*`
+   analyses across inlined bodies.
+5. **LAN-300 — modules and imports.** Import DAG, one namespace after
+   resolution, compile-as-one-unit reload semantics (Decision 8.1);
+   resolved-content chain identity so refactors diff as no-ops
+   (Decision 5.3). No IR change.
+6. **LAN-301 — metered runtime, re-scoped.** The metering itself lands
+   in slices 3–4 on the tree-walk; this slice completes the
+   operator surface (error counters/labels finalized, explain error
+   traces, `rbgp policy stats` exposure, soak/fuzz coverage of budget
+   exhaustion) and **re-runs the Decision 1 benchmark against the
+   then-current IR**. The compact bytecode interpreter is built only
+   if the re-entry gate fires, and then strictly below the IR.
+7. **LAN-305 — external datasets.** Snapshot registry with generations,
+   per-walk pinning, `requires_dataset` scoping, typed dataset kinds
+   (prefix/ASN/community tags first); **no host-function/WASM tier**
+   (Decision 9).
+
+## Consequences
+
+- Existing `.rpol` programs and TOML chains are untouched at every
+  slice boundary; the compiled-form golden gate makes that a CI fact
+  rather than an intention.
+- The V1 hot path keeps its exact cost profile: no fuel, no arena, no
+  frames on programs that don't use the new features — the
+  monomorphization discipline (`COUNT`/`ATTR` const generics) extends
+  to the new machinery.
+- The four IR consumers (diff, explain, counters, `requires_*`) remain
+  correct by contract, not by luck; every slice's review checklist
+  includes Decisions 5 and 6 explicitly.
+- Saying no to external code narrows LAN-305 to a data-plumbing
+  feature with a well-worn in-tree pattern, and pushes exotic
+  computation to where it can crash without taking sessions down.
+- The bytecode question is settled by receipt, not taste, and stays
+  re-openable by receipt: the gate names the profile signal that would
+  reverse it.

--- a/docs/adr/0103-rpol-execution-model.md
+++ b/docs/adr/0103-rpol-execution-model.md
@@ -1,6 +1,6 @@
 # ADR-0103: rpol execution model, purity contract, and evaluation budgets
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-09
 
 **Scope:** the gating decisions for every deep rpol extension — typed
@@ -90,33 +90,44 @@ signal.
 | 1,000-prefix list as 1,000 IR terms | 2,488 |
 | Same list as one indexed set probe | 19.5 |
 
-**Spike B — fuel-metered stack machine** (standalone spike crate: the
-same 15-term, mixed match/no-match program — prefix-set probe,
-community scans, scalar compares, checked arithmetic — lowered once to
-a guard tree and once to a 50-op jump-threaded bytecode; 1M-route
-mixed stream, verdict tallies asserted identical across evaluators;
-best-of-5 timing, three process runs):
+**Spike B — fuel-metered stack machine**
+(`docs/adr/0103-rpol-execution-model-spike/`; raw outputs of every run
+and exact reproduction commands in its README): the same 15-term,
+mixed match/no-match program — prefix-set probe, community scans,
+scalar compares, checked arithmetic — lowered once to a guard tree and
+once to a 50-op jump-threaded bytecode; 1M-route mixed stream;
+best-of-5 timing, three process runs. Two hard assertions guard the
+numbers: verdict tallies must be identical across all three
+evaluators, and the fuel actually consumed must equal an independently
+computed op-count oracle (24,557,144 ops for this workload) — the fuel
+decrement is provably live, not optimized away.
 
-| Evaluator | ns/route | vs tree-walk |
+| Evaluator | ns/route (best-of-5, per run) | vs tree-walk |
 |---|---|---|
-| Tree-walk (models the shipped IR) | 57–64 | 1.0× |
-| Bytecode dispatch loop | 53–60 | 0.86–1.04× |
-| Bytecode + per-instruction fuel decrement | 49–50 | 0.78–0.87× |
+| Tree-walk (models the shipped IR) | 57–62 | 1.0× |
+| Bytecode dispatch loop | 47–53 | 0.75–0.94× |
+| Bytecode + per-instruction fuel decrement | 52–56 | 0.84–0.99× (+0–20% over bare bytecode) |
 
 Two findings decide the question:
 
-1. **Bytecode is at parity, not a win.** 0.86–1.04× across runs — the
-   spread is codegen/layout jitter, not a signal. Evaluation cost lives
-   in the match-data probes (set lookups, community scans, regex), the
-   same conclusion ADR-0096 drew from the field survey; linearizing the
-   dispatch around those probes moves nothing that matters.
-2. **Fuel metering costs less than measurement noise.** The fueled
-   variant beat the unfueled one in every run — an inlining/layout
-   artifact, but conclusive as a bound: a decrement-and-branch per
-   instruction is invisible at these shapes. Metering therefore does
-   not need bytecode to be cheap; **the fuel/step budget lands on the
-   tree-walk** (Decision 3), and LAN-301 is re-scoped accordingly
-   (see the implementation plan).
+1. **Bytecode is a modest constant factor, not a step change.**
+   0.75–0.94× across runs — at best ~25% on a deliberately
+   dispatch-heavy synthetic, consistent with the 10–40% BIRD reported
+   from linearization in the ADR-0096 survey. Evaluation cost lives in
+   the match-data probes (set lookups, community scans, regex — Spike
+   A's 128× set-index ratio), and no constant factor of that size
+   justifies surrendering the analyzable tree that the four IR
+   consumers diff, render, and analyze directly.
+2. **Metering is affordable even at its worst case.** With the counter
+   provably live, a decrement-and-branch on *every instruction* costs
+   0–20% over bare bytecode run-to-run — and the fueled bytecode still
+   evaluates at or below the tree-walk's cost (0.84–0.99×). The
+   shipped design charges fuel only at loop back-edges and iteration
+   steps (Decision 3), a strict subset of per-instruction metering, so
+   this is an upper bound and V1-shaped programs pay zero. Metering
+   therefore does not need bytecode to be cheap; **the fuel/step
+   budget lands on the tree-walk**, and LAN-301 is re-scoped
+   accordingly (see the implementation plan).
 
 **Bytecode re-entry gate:** build the compact bytecode tier only when a
 profile of a real workload shows chain-walk dispatch (not set probes)
@@ -155,9 +166,11 @@ observe bytecode.
   If read-back semantics are ever demanded, they are a separate ADR —
   they break memoization (`ExportMemo` memoizes on source-attr
   identity + modifications) and are excluded here.
-- User functions (LAN-304) are **pure, total, non-recursive**
+- User functions (LAN-304) are **pure, terminating, non-recursive**
   expressions over these values: no side effects, call graph is a DAG
-  (the apply precedent), fully inlined at compile time.
+  (the apply precedent), fully inlined at compile time. They are *not*
+  total — checked arithmetic inside a function body can raise an
+  evaluation error, which propagates per Decision 4.
 
 ### Grammar evolution rules (binding for every slice)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,6 +111,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0100](0100-parallel-rib-manager.md) | Parallelizing the RibManager (research blueprint) | Proposed | 2026-07-03 |
 | [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 |
 | [0102](0102-evpn-origination-acknowledgement.md) | EVPN origination acknowledgement-awareness (Type 1/2/4) | Accepted | 2026-07-09 |
+| [0103](0103-rpol-execution-model.md) | rpol execution model, purity contract, and evaluation budgets | Accepted | 2026-07-09 |
 
 ## Template
 


### PR DESCRIPTION
## Summary

- adds ADR-0103 (Proposed): the architecture gate for rpol arithmetic, locals, loops, functions, modules, and external extensions
- recommendation: extend the typed tree-walk IR for all v2 language features; the compact bytecode runtime stays deferred behind an explicit measured re-entry gate. Spike benchmarks put bytecode at 0.86-1.04x the tree-walk on a representative mixed workload — parity, not a win — because evaluation cost concentrates in match-data probes (one indexed set probe 19.5 ns vs 2,488 ns for the same 1,000-entry list as terms), and per-op fuel metering measured below codegen noise, so metering does not require bytecode
- defines the compile-time and runtime budget table (building on the existing apply-DAG depth/expansion bounds and Kahn cost DP), uniform fail-closed Deny semantics for any evaluation error, the purity contract, hot-reload atomicity rules, and an ordered implementation plan for the v2 slices
- external extensions: external data snapshots with generation pinning only; no WASM/host-function tier — external code in the per-route hot path is rejected in the threat analysis

## Notes for review

- Status is Proposed; acceptance is the merge gate for LAN-299/300/301/302/303/304/305
- The ADR index table is deliberately not touched in this PR; the index entry lands with acceptance

Closes LAN-298 (on acceptance).