### PR TITLE
feat(policy): expose import-side per-term hit counters via policy stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Import-side policy hit counters readable via `rbgp policy stats`.**
+  `GetPolicyStats` / `rbgp policy stats` now accept
+  `--direction import|export|both`: import chains report the same
+  per-term hit rows as export chains (already accumulating in each
+  session task — pure read surface, no new hot-path work), read from
+  the live session tasks with the same peer filtering and JSON shape.
+  Import chains additionally report their install generation
+  (`policy_generation`, bumps on every chain install including
+  content-equal reinstalls), so counters that reset to zero read as a
+  chain replacement rather than continuous history; export chains do
+  not track an install generation yet. Explain queries and dry runs
+  remain non-counting, now pinned by test on the import path. (LAN-248)
+
 - **`.rpol` indexed ASN sets and origin-AS predicates.** New `asn-set`
   declarations (`asn-set customers { 64500, 64501 }`) compile to
   content-interned hash sets probed in O(1) by two new predicates:

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, Ipv6Addr};
 use bytes::Bytes;
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
-use rustbgpd_transport::{ImportExplainReply, RemovePrivateAs, TcpAoConfig};
+use rustbgpd_transport::{ImportExplainReply, ImportPolicyTermHits, RemovePrivateAs, TcpAoConfig};
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use tokio::net::TcpStream;
 use tokio::sync::{broadcast, oneshot};
@@ -905,6 +905,17 @@ pub enum PeerManagerCommand {
         path_id: Option<u32>,
         /// Reply channel; `None` = no live session for `address`.
         reply: oneshot::Sender<Option<ImportExplainReply>>,
+    },
+    /// Snapshot the live import-chain per-term hit counters of peer
+    /// sessions (ADR-0096 Decision 3.3, import direction). Read-only —
+    /// no counter moves. Peers without a live session or without an
+    /// installed import chain are omitted from the reply.
+    QueryImportPolicyTermHits {
+        /// Optional peer filter; `None` = every session.
+        peer: Option<IpAddr>,
+        /// Reply channel: `(peer address, snapshot)` sorted by peer
+        /// address for deterministic output.
+        reply: oneshot::Sender<Vec<(IpAddr, ImportPolicyTermHits)>>,
     },
     /// Query a single named policy definition.
     GetPolicy {

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1514,20 +1514,16 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         use rustbgpd_rib::RibUpdate;
 
         let req = request.into_inner();
-        match req.direction.as_str() {
-            "" | "export" => {}
-            "import" => {
-                return Err(Status::unimplemented(
-                    "import-side hit counters have no read surface yet; \
-                     counters accumulate and the query arrives in a later slice",
-                ));
-            }
+        let (want_export, want_import) = match req.direction.as_str() {
+            "" | "export" => (true, false),
+            "import" => (false, true),
+            "both" => (true, true),
             other => {
                 return Err(Status::invalid_argument(format!(
-                    "direction must be \"import\" or \"export\", got {other:?}"
+                    "direction must be \"import\", \"export\", or \"both\", got {other:?}"
                 )));
             }
-        }
+        };
         let peer: Option<IpAddr> = if req.peer_address.is_empty() {
             None
         } else {
@@ -1535,44 +1531,77 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                 Status::invalid_argument(format!("invalid peer address {:?}", req.peer_address))
             })?)
         };
-        let rib_tx = self.rib_tx.as_ref().ok_or_else(|| {
-            Status::failed_precondition("policy stats runtime unavailable on this listener")
-        })?;
-        let (reply_tx, reply_rx) = oneshot::channel();
-        rib_tx
-            .send(RibUpdate::QueryExportPolicyTermHits {
-                peer,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| Status::internal("RIB manager unavailable"))?;
-        let chains = reply_rx
-            .await
-            .map_err(|_| Status::internal("RIB manager dropped reply"))?;
-
-        Ok(Response::new(proto::GetPolicyStatsResponse {
-            chains: chains
+        let term_stats = |terms: Vec<rustbgpd_policy::TermHitRow>| -> Vec<proto::PolicyTermStat> {
+            terms
                 .into_iter()
-                .map(|chain| proto::PolicyChainStats {
+                .map(|row| proto::PolicyTermStat {
+                    policy_index: u32::try_from(row.policy_index).unwrap_or(u32::MAX),
+                    policy: row.policy.unwrap_or_default(),
+                    term_index: u32::try_from(row.term_index).unwrap_or(u32::MAX),
+                    term: row.term.unwrap_or_default(),
+                    hits: row.hits,
+                })
+                .collect()
+        };
+
+        // "both" reports export chains first, then import chains, each
+        // block sorted by peer address (deterministic output).
+        let mut out = Vec::new();
+        if want_export {
+            let rib_tx = self.rib_tx.as_ref().ok_or_else(|| {
+                Status::failed_precondition("policy stats runtime unavailable on this listener")
+            })?;
+            let (reply_tx, reply_rx) = oneshot::channel();
+            rib_tx
+                .send(RibUpdate::QueryExportPolicyTermHits {
+                    peer,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| Status::internal("RIB manager unavailable"))?;
+            let chains = reply_rx
+                .await
+                .map_err(|_| Status::internal("RIB manager dropped reply"))?;
+            out.extend(chains.into_iter().map(|chain| {
+                proto::PolicyChainStats {
                     peer_address: chain
                         .peer
                         .map_or_else(|| "global".to_string(), |peer| peer.to_string()),
                     direction: "export".to_string(),
                     routes_evaluated: chain.evals,
-                    terms: chain
-                        .terms
-                        .into_iter()
-                        .map(|row| proto::PolicyTermStat {
-                            policy_index: u32::try_from(row.policy_index).unwrap_or(u32::MAX),
-                            policy: row.policy.unwrap_or_default(),
-                            term_index: u32::try_from(row.term_index).unwrap_or(u32::MAX),
-                            term: row.term.unwrap_or_default(),
-                            hits: row.hits,
-                        })
-                        .collect(),
+                    terms: term_stats(chain.terms),
+                    // Export chains do not track an install generation yet
+                    // (LAN-311); 0 = untracked, per the proto contract.
+                    policy_generation: 0,
+                }
+            }));
+        }
+        if want_import {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.peer_mgr_tx
+                .send(PeerManagerCommand::QueryImportPolicyTermHits {
+                    peer,
+                    reply: reply_tx,
                 })
-                .collect(),
-        }))
+                .await
+                .map_err(|_| Status::internal("peer manager unavailable"))?;
+            let chains = reply_rx
+                .await
+                .map_err(|_| Status::internal("peer manager dropped reply"))?;
+            out.extend(
+                chains
+                    .into_iter()
+                    .map(|(peer, snapshot)| proto::PolicyChainStats {
+                        peer_address: peer.to_string(),
+                        direction: "import".to_string(),
+                        routes_evaluated: snapshot.evals,
+                        terms: term_stats(snapshot.terms),
+                        policy_generation: snapshot.generation,
+                    }),
+            );
+        }
+
+        Ok(Response::new(proto::GetPolicyStatsResponse { chains: out }))
     }
 }
 
@@ -2687,10 +2716,34 @@ policy customer-in(peer_lp: u32) {
 
     // -- GetPolicyStats (ADR-0096 Decision 3.3) ---------------------
 
-    /// Fake RIB backend answering the term-hits query with one
-    /// installed chain snapshot.
+    /// Fake RIB + peer-manager backends answering the term-hits
+    /// queries with one installed chain snapshot each.
     fn stats_service() -> PolicyService {
-        let (peer_tx, _peer_rx) = mpsc::channel(8);
+        let (peer_tx, mut peer_rx) = mpsc::channel::<PeerManagerCommand>(8);
+        tokio::spawn(async move {
+            while let Some(command) = peer_rx.recv().await {
+                match command {
+                    PeerManagerCommand::QueryImportPolicyTermHits { peer, reply } => {
+                        assert_eq!(peer, Some("10.0.0.2".parse().unwrap()));
+                        let _ = reply.send(vec![(
+                            "10.0.0.2".parse().unwrap(),
+                            rustbgpd_transport::ImportPolicyTermHits {
+                                generation: 3,
+                                evals: 11,
+                                terms: vec![rustbgpd_policy::TermHitRow {
+                                    policy_index: 0,
+                                    policy: Some("customer-in(200)".to_string()),
+                                    term_index: 0,
+                                    term: Some("customer-routes".to_string()),
+                                    hits: 9,
+                                }],
+                            },
+                        )]);
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
         let (rib_tx, mut rib_rx) = mpsc::channel::<rustbgpd_rib::RibUpdate>(8);
         tokio::spawn(async move {
             while let Some(update) = rib_rx.recv().await {
@@ -2750,22 +2803,66 @@ policy customer-in(peer_lp: u32) {
         assert_eq!(chain.terms[1].term, "", "TOML statements are unnamed");
         assert_eq!(chain.terms[1].term_index, 1);
         assert_eq!(chain.terms[1].hits, 2);
+        assert_eq!(
+            chain.policy_generation, 0,
+            "export chains do not track an install generation yet (LAN-311)"
+        );
     }
 
+    /// The import direction reads the session-side counters through
+    /// the peer manager and reports the install generation, so a
+    /// replaced chain (counters back to zero, generation advanced) is
+    /// never presented as continuous history.
     #[tokio::test]
-    async fn get_policy_stats_rejects_import_and_bad_direction() {
+    async fn get_policy_stats_reports_import_chains_with_generation() {
         let svc = stats_service();
-        let err = PolicyServiceRpc::get_policy_stats(
+        let resp = PolicyServiceRpc::get_policy_stats(
             &svc,
             Request::new(proto::GetPolicyStatsRequest {
-                peer_address: String::new(),
+                peer_address: "10.0.0.2".to_string(),
                 direction: "import".to_string(),
             }),
         )
         .await
-        .expect_err("import read surface is a follow-up");
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        .expect("import stats query succeeds")
+        .into_inner();
+        assert_eq!(resp.chains.len(), 1);
+        let chain = &resp.chains[0];
+        assert_eq!(chain.peer_address, "10.0.0.2");
+        assert_eq!(chain.direction, "import");
+        assert_eq!(chain.routes_evaluated, 11);
+        assert_eq!(chain.policy_generation, 3);
+        assert_eq!(chain.terms.len(), 1);
+        assert_eq!(chain.terms[0].term, "customer-routes");
+        assert_eq!(chain.terms[0].hits, 9);
+    }
 
+    /// `direction = "both"` returns the export block first, then the
+    /// import block — one deterministic response, not two commands.
+    #[tokio::test]
+    async fn get_policy_stats_both_orders_export_then_import() {
+        let svc = stats_service();
+        let resp = PolicyServiceRpc::get_policy_stats(
+            &svc,
+            Request::new(proto::GetPolicyStatsRequest {
+                peer_address: "10.0.0.2".to_string(),
+                direction: "both".to_string(),
+            }),
+        )
+        .await
+        .expect("both-directions stats query succeeds")
+        .into_inner();
+        let directions: Vec<&str> = resp
+            .chains
+            .iter()
+            .map(|chain| chain.direction.as_str())
+            .collect();
+        assert_eq!(directions, ["export", "import"]);
+    }
+
+    #[tokio::test]
+    async fn get_policy_stats_rejects_bad_direction() {
+        let svc = stats_service();
         let err = PolicyServiceRpc::get_policy_stats(
             &svc,
             Request::new(proto::GetPolicyStatsRequest {

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -392,6 +392,12 @@ struct JsonPolicyStats {
     peer_address: String,
     direction: String,
     routes_evaluated: u64,
+    /// Install identity of the chain instance the counters belong to.
+    /// `None` for export chains (install generation not tracked yet,
+    /// LAN-311); import chains always report it, so counters that
+    /// reset to zero read as "new chain instance", not continuous
+    /// history.
+    policy_generation: Option<u64>,
     terms: Vec<JsonPolicyTermStat>,
 }
 
@@ -404,8 +410,8 @@ struct JsonPolicyTermStat {
     hits: u64,
 }
 
-/// `rbgp policy stats [--peer ADDR] [--direction export]` — live
-/// per-term hit counters of the installed chains (ADR-0096).
+/// `rbgp policy stats [--peer ADDR] [--direction import|export|both]`
+/// — live per-term hit counters of the installed chains (ADR-0096).
 pub async fn stats(
     connection: Connection,
     peer: Option<&str>,
@@ -430,6 +436,7 @@ pub async fn stats(
                 peer_address: chain.peer_address.clone(),
                 direction: chain.direction.clone(),
                 routes_evaluated: chain.routes_evaluated,
+                policy_generation: (chain.direction == "import").then_some(chain.policy_generation),
                 terms: chain
                     .terms
                     .iter()
@@ -452,8 +459,16 @@ pub async fn stats(
         return Ok(());
     }
     for chain in &resp.chains {
+        // Import chains carry an install generation (bumps on every
+        // chain install, content-equal reinstalls included); export
+        // chains do not track one yet (LAN-311).
+        let generation = if chain.direction == "import" {
+            format!(" (install generation {})", chain.policy_generation)
+        } else {
+            String::new()
+        };
         println!(
-            "{} {} chain — {} routes evaluated since install",
+            "{} {} chain — {} routes evaluated since install{generation}",
             chain.peer_address, chain.direction, chain.routes_evaluated
         );
         println!("  {:<32} {:<24} HITS", "POLICY", "TERM");
@@ -1395,6 +1410,20 @@ mod tests {
             .unwrap();
         let text_conn = connect(&server.addr, None).await.unwrap();
         stats(text_conn, None, "export", false).await.unwrap();
+    }
+
+    /// The direction flag passes through to the RPC: the mock server
+    /// answers "import" and "both" with direction-tagged chains
+    /// (import ones carrying an install generation), and both render.
+    #[tokio::test]
+    async fn stats_renders_import_and_both_directions() {
+        let server = spawn_mock_server(None).await;
+        let json_conn = connect(&server.addr, None).await.unwrap();
+        stats(json_conn, Some("10.0.0.2"), "import", true)
+            .await
+            .unwrap();
+        let text_conn = connect(&server.addr, None).await.unwrap();
+        stats(text_conn, None, "both", false).await.unwrap();
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -411,16 +411,17 @@ enum PolicyAction {
         action: PolicyChainAction,
     },
     /// Show live per-term policy hit counters (ADR-0096): how many
-    /// routes matched each term of the installed export chains since
-    /// chain install. Counters reset when a chain is replaced (policy
-    /// reload / hot-apply). Import counters have no read surface yet.
+    /// routes matched each term of the installed import/export chains
+    /// since chain install. Counters reset when a chain is replaced
+    /// (policy reload / hot-apply); import chains report their install
+    /// generation so a replacement is visible.
     #[command(visible_alias = "counters")]
     Stats {
         /// Restrict to one peer's installed chain
         #[arg(long)]
         peer: Option<String>,
-        /// Direction: export (default). import is reserved
-        #[arg(long, default_value = "export")]
+        /// Direction: export (default), import, or both
+        #[arg(long, default_value = "export", value_parser = ["import", "export", "both"])]
         direction: String,
     },
     /// Explain the import-policy decision for a prefix on a neighbor

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1713,30 +1713,56 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
 
     async fn get_policy_stats(
         &self,
-        _request: Request<server_proto::GetPolicyStatsRequest>,
+        request: Request<server_proto::GetPolicyStatsRequest>,
     ) -> Result<Response<server_proto::GetPolicyStatsResponse>, Status> {
-        Ok(Response::new(server_proto::GetPolicyStatsResponse {
-            chains: vec![server_proto::PolicyChainStats {
-                peer_address: "10.0.0.2".to_string(),
-                direction: "export".to_string(),
-                routes_evaluated: 7,
-                terms: vec![
-                    server_proto::PolicyTermStat {
-                        policy_index: 0,
-                        policy: "customer-in(200)".to_string(),
-                        term_index: 0,
-                        term: "customer-routes".to_string(),
-                        hits: 5,
-                    },
-                    server_proto::PolicyTermStat {
-                        policy_index: 0,
-                        policy: "customer-in(200)".to_string(),
-                        term_index: 1,
-                        term: String::new(),
-                        hits: 2,
-                    },
-                ],
+        let req = request.into_inner();
+        let export_chain = server_proto::PolicyChainStats {
+            peer_address: "10.0.0.2".to_string(),
+            direction: "export".to_string(),
+            routes_evaluated: 7,
+            policy_generation: 0,
+            terms: vec![
+                server_proto::PolicyTermStat {
+                    policy_index: 0,
+                    policy: "customer-in(200)".to_string(),
+                    term_index: 0,
+                    term: "customer-routes".to_string(),
+                    hits: 5,
+                },
+                server_proto::PolicyTermStat {
+                    policy_index: 0,
+                    policy: "customer-in(200)".to_string(),
+                    term_index: 1,
+                    term: String::new(),
+                    hits: 2,
+                },
+            ],
+        };
+        let import_chain = server_proto::PolicyChainStats {
+            peer_address: "10.0.0.2".to_string(),
+            direction: "import".to_string(),
+            routes_evaluated: 11,
+            policy_generation: 3,
+            terms: vec![server_proto::PolicyTermStat {
+                policy_index: 0,
+                policy: "customer-in(200)".to_string(),
+                term_index: 0,
+                term: "customer-routes".to_string(),
+                hits: 9,
             }],
+        };
+        let chains = match req.direction.as_str() {
+            "" | "export" => vec![export_chain],
+            "import" => vec![import_chain],
+            "both" => vec![export_chain, import_chain],
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "unexpected direction {other:?}"
+                )));
+            }
+        };
+        Ok(Response::new(server_proto::GetPolicyStatsResponse {
+            chains,
         }))
     }
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -325,6 +325,31 @@ pub enum PeerCommand {
         /// session's current import-policy generation.
         reply: oneshot::Sender<ImportExplainReply>,
     },
+    /// Snapshot this session's live import-chain per-term hit counters
+    /// (ADR-0096 Decision 3.3, the import-side read surface). Read-only
+    /// — must not mutate session state or counters. `None` when no
+    /// import chain is installed (permit-all sessions have nothing to
+    /// count).
+    QueryImportPolicyTermHits {
+        /// Reply channel.
+        reply: oneshot::Sender<Option<ImportPolicyTermHits>>,
+    },
+}
+
+/// Per-term hit-counter snapshot for one session's installed import
+/// chain (`PeerCommand::QueryImportPolicyTermHits`).
+#[derive(Debug, Clone)]
+pub struct ImportPolicyTermHits {
+    /// Session-local import-policy generation (ADR-0073): starts at 0
+    /// at session-task construction and advances on every chain
+    /// install — including a content-equal reinstall — so counters
+    /// that reset to zero read as "new chain instance", not continuous
+    /// history.
+    pub generation: u64,
+    /// Routes evaluated through the chain since install.
+    pub evals: u64,
+    /// Per-term labeled hit counts, in chain walk order.
+    pub terms: Vec<rustbgpd_policy::TermHitRow>,
 }
 
 /// Outcome of a bounded session-state query
@@ -1161,6 +1186,29 @@ impl PeerHandle {
         })
         .await
         .ok()
+        .flatten()
+    }
+
+    /// Bounded snapshot of this session's import-chain per-term hit
+    /// counters. `None` folds together "no import chain installed",
+    /// "deadline expired", and "session task gone" — the stats surface
+    /// simply omits the peer in all three cases.
+    pub async fn query_import_policy_term_hits_timeout(
+        &self,
+        deadline: Duration,
+    ) -> Option<ImportPolicyTermHits> {
+        let commands = self.commands.clone();
+        tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::QueryImportPolicyTermHits { reply: reply_tx })
+                .await
+                .ok()?;
+            reply_rx.await.ok()
+        })
+        .await
+        .ok()
+        .flatten()
         .flatten()
     }
 

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -31,8 +31,8 @@ pub use event_sink::{
     NoopTransportEventSink, OtcDirection, OtcRouteBlockedEvent, TransportEventSink,
 };
 pub use handle::{
-    PeerCommand, PeerCommandError, PeerHandle, PeerSessionState, PeerShutdownError,
-    SessionIdentity, SessionLifecycleNotification, SessionNotification,
+    ImportPolicyTermHits, PeerCommand, PeerCommandError, PeerHandle, PeerSessionState,
+    PeerShutdownError, SessionIdentity, SessionLifecycleNotification, SessionNotification,
     SessionNotificationDirection, SessionNotificationEvent, SessionRole, StateQueryOutcome,
 };
 pub use listener::{AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerKey};

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -152,6 +152,21 @@ impl PeerSession {
                 });
                 ControlFlow::Continue(())
             }
+            PeerCommand::QueryImportPolicyTermHits { reply } => {
+                // Read-only snapshot of the live counters (ADR-0096
+                // Decision 3.3). No counter moves; a session without an
+                // installed import chain has nothing to report.
+                let snapshot =
+                    self.import_policy
+                        .as_ref()
+                        .map(|chain| crate::handle::ImportPolicyTermHits {
+                            generation: self.import_policy_generation,
+                            evals: chain.hit_counters().evals(),
+                            terms: chain.term_hit_rows(),
+                        });
+                let _ = reply.send(snapshot);
+                ControlFlow::Continue(())
+            }
             PeerCommand::UpdateExportPolicy { policy, reply } => {
                 self.export_policy = policy;
                 let _ = reply.send(Ok(()));

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4981,6 +4981,140 @@ async fn explain_import_policy_command_does_not_touch_counters() {
     assert_eq!(session.import_policy_routes_permitted, permitted_before);
     assert_eq!(session.import_policy_routes_denied, denied_before);
 }
+/// The import-side stats read surface (LAN-248): the query command
+/// snapshots the live per-term hit counters plus the install
+/// generation, an explain read never moves them, and a chain
+/// reinstall — content-equal included — advances the generation and
+/// resets the counters instead of presenting continuous history.
+#[expect(
+    clippy::too_many_lines,
+    reason = "regression test keeps snapshot, explain-non-counting, and reinstall assertions together"
+)]
+#[tokio::test]
+async fn query_import_policy_term_hits_snapshots_without_counting() {
+    use rustbgpd_policy::NamedPolicy;
+
+    async fn snapshot(session: &mut PeerSession) -> Option<crate::handle::ImportPolicyTermHits> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let flow = session
+            .handle_command(PeerCommand::QueryImportPolicyTermHits { reply: reply_tx })
+            .await;
+        assert_eq!(flow, ControlFlow::Continue(()));
+        reply_rx.await.expect("session replied")
+    }
+    async fn install(session: &mut PeerSession, chain: PolicyChain) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let _ = session
+            .handle_command(PeerCommand::UpdateImportPolicy {
+                policy: Some(chain),
+                reply: reply_tx,
+            })
+            .await;
+        reply_rx
+            .await
+            .expect("session replied")
+            .expect("install succeeds");
+    }
+
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_enhanced_route_refresh = true;
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+
+    // No import chain installed → nothing to report.
+    assert!(snapshot(&mut session).await.is_none());
+
+    let permit_all = PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Permit,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    };
+    let chain = PolicyChain::from_named(vec![NamedPolicy {
+        name: Some("edge-import".to_string()),
+        policy: Policy {
+            entries: vec![permit_all],
+            default_action: PolicyAction::Permit,
+        },
+        rpol: None,
+    }]);
+    install(&mut session, chain.clone()).await;
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+
+    let first = snapshot(&mut session).await.expect("chain installed");
+    assert_eq!(
+        first.generation, 1,
+        "session constructs at generation 0; one install advances it"
+    );
+    assert_eq!(first.evals, 1, "one route evaluated through the chain");
+    assert_eq!(first.terms.len(), 1);
+    assert_eq!(first.terms[0].policy.as_deref(), Some("edge-import"));
+    assert_eq!(first.terms[0].hits, 1);
+
+    // An explain read must not move the term-hit counters (LAN-248
+    // pin, same contract as the permit/deny counters above).
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let _ = session
+        .handle_command(PeerCommand::ExplainImportPolicy {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            prefix: Prefix::V4(prefix),
+            path_id: None,
+            reply: reply_tx,
+        })
+        .await;
+    reply_rx.await.expect("session replied");
+    let second = snapshot(&mut session).await.expect("chain installed");
+    assert_eq!(second.evals, first.evals, "explain must not bump evals");
+    assert_eq!(
+        second.terms[0].hits, first.terms[0].hits,
+        "explain must not bump term hits"
+    );
+
+    // A content-equal reinstall is a fresh chain instance: counters
+    // reset and the generation advances, so the read surface never
+    // presents the new instance as continuous history.
+    install(&mut session, chain).await;
+    let third = snapshot(&mut session).await.expect("chain installed");
+    assert_eq!(third.generation, 2);
+    assert_eq!(third.evals, 0);
+    assert_eq!(third.terms[0].hits, 0);
+}
 /// Statement-level explain (the ADR-0073 deferred enrichment): a
 /// current-generation Hit re-derives WHICH statement inside the matched
 /// chain decided, through the real command dispatch path. A

--- a/docs/API.md
+++ b/docs/API.md
@@ -625,7 +625,7 @@ changes do not retroactively re-evaluate existing Adj-RIB-In state; use
 | `ClearNeighborImportChain` / `ClearNeighborExportChain` | Remove one neighbor's chain assignment |
 | `ExplainImportPolicy` | Explain why a prefix was permitted / denied / withdrawn / evicted / stale / not-seen on import for a given neighbor, reading the per-session import-decision cache (ADR-0073). For `.rpol` chain members the statement trace names the deciding term and carries per-term trace lines (ADR-0096). Side-effect-free; IPv4/IPv6 unicast only. `SensitiveRead` tier. |
 | `TestPolicy` | Dry-run a candidate `.rpol` policy (source sent in the request, compiled server-side) read-only over a live Adj-RIB-In / Loc-RIB snapshot: accepted/rejected/modified counts, per-term hit counters, before/after attribute diff samples. No route, session, or counter impact; IPv4/IPv6 unicast (ADR-0096). CLI: `rbgp policy test`. `SensitiveRead` tier. |
-| `GetPolicyStats` | Read the live per-term hit counters of the installed policy chains (since chain install; export direction in V1 — import counters accumulate but have no read surface yet). CLI: `rbgp policy stats`. `SensitiveRead` tier. |
+| `GetPolicyStats` | Read the live per-term hit counters of the installed policy chains (since chain install; direction `import`, `export`, or `both` — import chains also report their install generation). CLI: `rbgp policy stats`. `SensitiveRead` tier. |
 
 Policy statements support the same match surface as TOML config:
 `prefix`, `ge`, `le`, `match_community`, `match_as_path`,

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -111,7 +111,7 @@ shape itself does not raise the tier.
 | `ClearNeighborImportChain` | `mutating` | Per-neighbor. |
 | `ExplainImportPolicy` | `sensitive_read` | ADR-0073. Reads the per-session import-decision cache to explain why a prefix was permitted / denied / withdrawn on import. Side-effect-free; no RIB or counter mutation. |
 | `TestPolicy` | `sensitive_read` | ADR-0096. Compiles a submitted .rpol policy server-side and dry-runs it read-only over a live-RIB snapshot (counts, per-term hits, before/after diffs). Side-effect-free; no RIB, session, or counter mutation. |
-| `GetPolicyStats` | `sensitive_read` | ADR-0096 Decision 3.3. Snapshots the live per-term guard-hit counters of installed export chains (since chain install; reset on chain replace). Discloses policy structure and traffic shape. Side-effect-free; does not reset counters. |
+| `GetPolicyStats` | `sensitive_read` | ADR-0096 Decision 3.3. Snapshots the live per-term guard-hit counters of installed import/export chains (since chain install; reset on chain replace — import chains also report their install generation). Discloses policy structure and traffic shape. Side-effect-free; does not reset counters. |
 | `ClearNeighborExportChain` | `mutating` | Per-neighbor. |
 
 ### PeerGroupService (6 RPCs)

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -534,17 +534,22 @@ surfaces (ADR-0073 / ADR-0096 Decision 3.3):
 
 Where `policy test` counts hits over a one-shot dry run, `rbgp policy
 stats` reads the **live** counters of the chains actually installed on
-the daemon: every route evaluated on the export path bumps its matched
-terms' counters (relaxed atomics — no measurable eval cost), and the
-query snapshots them without resetting anything (`SensitiveRead`).
+the daemon: every route evaluated on the import or export path bumps
+its matched terms' counters (relaxed atomics — no measurable eval
+cost), and the query snapshots them without resetting anything
+(`SensitiveRead`).
 
 ```console
-$ rbgp policy stats --peer 10.0.0.2
+$ rbgp policy stats --peer 10.0.0.2 --direction both
 10.0.0.2 export chain — 1204 routes evaluated since install
   POLICY                           TERM                     HITS
   customer-in(200)                 rpki-guard               3
   customer-in(200)                 customer-routes          990
   bogon-filter                     bogons                   211
+10.0.0.2 import chain — 890 routes evaluated since install (install generation 2)
+  POLICY                           TERM                     HITS
+  customer-in(200)                 rpki-guard               1
+  customer-in(200)                 customer-routes          889
 ```
 
 - Counters read as **since chain install**: replacing a peer's chain
@@ -553,10 +558,14 @@ $ rbgp policy stats --peer 10.0.0.2
   RIB-side export counters (the chain instance survives).
 - TOML chain members count too; their unnamed statements report by
   `term_index` (`statement 0`, `statement 1`, ...).
-- V1 surfaces the **export** direction (the RIB manager owns those
-  chains). Import-side counters accumulate identically inside each
-  session but have no read surface yet; `--direction import` says so
-  explicitly rather than guessing.
+- `--direction` selects **export** (the default), **import**, or
+  **both**. Export chains are read from the RIB manager; import chains
+  are read from each live session task, so a peer without a live
+  session reports no import chain.
+- Import chains report their **install generation** (bumps on every
+  chain install, content-equal reinstalls included), so counters that
+  reset to zero read as a chain replacement, not continuous history.
+  Export chains do not track an install generation yet.
 - Explain queries and `policy test` dry runs never move these
   counters — only live route evaluation counts.
 - `--json` emits the rows structurally.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -527,12 +527,14 @@ service PolicyService {
   // policy chains (ADR-0096 Decision 3.3, the IOS-XR "show pcl" idea).
   // Counters accumulate on the live evaluation path since a chain
   // instance was installed and reset when the chain is replaced
-  // (policy reload / hot-apply installs a fresh instance). V1 surfaces
-  // the export direction (the RIB manager owns those chains); import
-  // counters accumulate in the session tasks but have no read surface
-  // yet.
+  // (policy reload / hot-apply installs a fresh instance). Export
+  // chains are read from the RIB manager; import chains are read from
+  // each live session task (a peer with no live session reports no
+  // import chain).
   //
-  // Side-effect free read; does not reset any counter.
+  // Side-effect free read; does not reset any counter. Explain queries
+  // and TestPolicy dry runs never move these counters either — only
+  // live route evaluation counts.
   rpc GetPolicyStats(GetPolicyStatsRequest) returns (GetPolicyStatsResponse);
 }
 
@@ -1045,9 +1047,9 @@ message GetPolicyStatsRequest {
   // Optional peer filter (IPv4 or IPv6 literal). Empty = every peer
   // with an installed chain.
   string peer_address = 1;
-  // Direction filter: "export" (the default when empty). "import" is
-  // reserved — the daemon rejects it until the import-side read
-  // surface lands.
+  // Direction filter: "export" (the default when empty), "import", or
+  // "both". "both" returns export chains first, then import chains,
+  // each block sorted by peer address.
   string direction = 2;
 }
 
@@ -1074,12 +1076,21 @@ message PolicyChainStats {
   // fallback chain instance (peers evaluated against the fallback
   // before any per-peer install).
   string peer_address = 1;
-  // "export" (import arrives with the import-side read surface).
+  // "import" or "export".
   string direction = 2;
   // Routes evaluated through this chain since install — the
   // denominator for the per-term hit counts.
   uint64 routes_evaluated = 3;
   repeated PolicyTermStat terms = 4;
+  // Install identity of the chain the counters belong to. Import
+  // chains report the session-local import-policy generation
+  // (ADR-0073): it starts at 0 when the session task constructs and
+  // advances on every chain install — including a content-equal
+  // reinstall — so counters that reset to zero are attributable to a
+  // replacement rather than read as continuous history. Export chains
+  // do not track an install generation yet and always report 0
+  // (LAN-311).
+  uint64 policy_generation = 5;
 }
 
 message GetPolicyStatsResponse {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -833,6 +833,37 @@ impl PeerManager {
                             };
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::QueryImportPolicyTermHits { peer, reply } => {
+                            // Read-only snapshot forwarded to each session
+                            // task (the import chain and its counters live
+                            // there). Bounded per session like explain: a
+                            // wedged task drops out of the answer instead of
+                            // parking the actor. Sessions without an
+                            // installed import chain reply None and are
+                            // omitted.
+                            let keys: Vec<_> = match peer {
+                                Some(address) => self
+                                    .unique_peer_key_for_address(address)
+                                    .into_iter()
+                                    .collect(),
+                                None => self.peers.keys().cloned().collect(),
+                            };
+                            let mut out = Vec::new();
+                            for key in keys {
+                                let Some(managed) = self.peers.get(&key) else {
+                                    continue;
+                                };
+                                if let Some(snapshot) = managed
+                                    .handle
+                                    .query_import_policy_term_hits_timeout(EXPLAIN_QUERY_TIMEOUT)
+                                    .await
+                                {
+                                    out.push((key.address, snapshot));
+                                }
+                            }
+                            out.sort_unstable_by_key(|(address, _)| *address);
+                            let _ = reply.send(out);
+                        }
                         PeerManagerCommand::GetPolicy { name, reply } => {
                             let _ = reply.send(named_policy_from_config(&self.current_config, &name));
                         }


### PR DESCRIPTION
## Summary

- `rbgp policy stats` grows `--direction import|export|both`: import-side per-term hit counters (already accumulating on the inbound evaluation path) are now readable through the existing GetPolicyStats RPC — the reserved "import" direction is implemented rather than a new method added, so the authz matrix and inventory are unchanged (sensitive_read, proven by the untouched matrix tests)
- import chains report their install generation (new proto field), which bumps on every install including content-equal reinstalls — a replaced chain's counters read as a fresh series, never as continuous history; export chains report 0/untracked, documented as the known gap
- the query is snapshot-only via the existing per-session command channel with the established explain-query timeout; the route-evaluation hot path is untouched
- pinned non-counting: a transport test proves ExplainImportPolicy leaves eval and term-hit counters unmoved, and a content-equal reinstall shows generation bump + counter reset
- CLI renders both directions deterministically (export block then import for both); API.md, method-inventory prose, and the language reference updated

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-api / -p rustbgpd-transport / -p rustbgpctl / -p rustbgpd
- cargo doc --workspace --no-deps

Closes LAN-248.