### PR TITLE
feat(rpol): add direction-aware computed as-path prepend operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   so they never disqualify a peer from update-group sharing. Explain traces
   render the source-level expression, and `test` fixtures take an explicit
   `family` field. (LAN-295)
+- **Direction-aware computed AS_PATH prepend operands in `.rpol`** —
+  `prepend as self|peer|origin <count>` prepends the local speaker's ASN
+  (`[global] asn`, stamped onto the chain at attach time), the evaluation
+  peer's ASN, or the route's origin AS (the `route.origin-as` value). `peer`
+  is import-only: bound as an export chain it would prepend the receiving
+  peer's own ASN (rejected by the receiver as an own-AS loop, RFC 4271
+  §9.1.2), so the config resolver refuses the attachment with a diagnostic
+  naming the policy and term — at load, reload, and transaction time alike.
+  `prepend as peer` registers as peer-dependent for update-group
+  fingerprinting; `self`/`origin` chains still group. Operands resolve when
+  the matched term's action executes; a missing or zero context value fails
+  the route closed (ASN 0 never reaches the wire), with the failing operand
+  and reason rendered in explain traces. The fixed-AS form and a policy
+  parameter named `origin` keep their existing meaning, and test fixtures
+  gain a `peer { local-as N }` field backing `self`. (LAN-296)
 - **`bgp_rib_attr_intern_size{peer}` gauge** — unique interned attribute sets
   in each peer's Adj-RIB-In table (attribute-memory dedup); sum across peers
   for the daemon-wide total. Three containerlab soak harnesses (GR-restart

--- a/crates/policy/src/compile.rs
+++ b/crates/policy/src/compile.rs
@@ -39,8 +39,14 @@ use crate::sets::{AsnSet, CommunitySet, PrefixSet, SetStore};
 pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain {
     let mut sets = ChainSets::default();
     let mut policies = Vec::with_capacity(chain.policies.len());
+    // `prepend as self` operand value (LAN-296): every rpol member of
+    // one chain is stamped by the same config resolve with the same
+    // `[global] asn`, so propagating the first `Some` into the spliced
+    // chain is exact.
+    let mut local_asn = None;
     for named in &chain.policies {
         if let Some(rpol) = named.rpol.as_deref() {
+            local_asn = local_asn.or(rpol.local_asn);
             for policy in &rpol.policies {
                 let mut spliced = splice_policy(policy, rpol, &mut sets);
                 // Attribute to the configured chain-reference name
@@ -72,6 +78,7 @@ pub fn compile_chain(chain: &PolicyChain, store: &mut SetStore) -> CompiledChain
         prefix_set_names: sets.prefix_set_names,
         community_set_names: sets.community_set_names,
         asn_set_names: sets.asn_set_names,
+        local_asn,
     }
 }
 

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -246,6 +246,103 @@ pub enum NextHopAction {
     Specific(IpAddr),
 }
 
+/// Computed `AS_PATH` prepend operand (LAN-296): `.rpol`
+/// `prepend as self|peer|origin <count>`.
+///
+/// # Decision note — direction-aware computed prepend operands
+///
+/// **Operand definitions.** `self` is the local speaker's ASN — the
+/// daemon's configured `[global] asn`, carried on the compiled chain
+/// ([`CompiledChain::local_asn`](crate::ir::CompiledChain)) because it
+/// is attach-time constant, not per-route data (rustbgpd has no
+/// per-session local-as override today; if one ever lands, `self`
+/// moves to the per-evaluation context and follows the session's
+/// effective local AS). `peer` is the evaluation peer's ASN
+/// (`RouteContext::peer_asn`). `origin` is the route's origin AS —
+/// the last ASN of the rightmost non-empty `AS_SEQUENCE`
+/// (`AsPath::origin_asn`, already carried as
+/// `RouteContext::origin_asn` since LAN-249; never recomputed here).
+///
+/// **Direction legality.** `self` and `origin` are legal on import
+/// and export. `peer` is **import-only**: on export it would prepend
+/// the *receiving* peer's own ASN, which the receiver rejects as an
+/// own-AS loop (RFC 4271 §9.1.2) unless it runs allowas-in — there is
+/// no documented legitimate use. This mirrors FRR, whose
+/// `set as-path prepend last-as N` (prepend the neighbor's AS) is the
+/// inbound traffic-engineering idiom; BIRD's `bgp_path.prepend()`
+/// takes only explicit ASN values and has no peer-derived operand at
+/// all. Enforcement is at **attachment time** (config chain resolve —
+/// `resolve_chain` in `src/config/parse.rs` — which every install
+/// path routes through: initial load, SIGHUP reload, rpol overlay,
+/// config transactions), via
+/// [`CompiledChain::peer_prepend_action`](crate::ir::CompiledChain):
+/// a chain using `prepend as peer` is rejected when bound as an
+/// export chain, never discovered per-route at runtime.
+///
+/// **Update-group eligibility.** `PeerAs` reads peer identity, so it
+/// counts toward
+/// [`CompiledChain::requires_peer_context`](crate::ir::CompiledChain::requires_peer_context)
+/// (defense in depth behind the attach-time rejection); `LocalAs` and
+/// `OriginAs` are route/chain-context-only and never disqualify a
+/// peer from update-group sharing.
+///
+/// **Failure semantics.** A computed operand resolves during
+/// evaluation, when the owning term's action executes. An
+/// unresolvable operand — absent origin (empty or `AS_SET`-only
+/// path), unknown peer ASN, a chain without `local_asn`, or a zero
+/// context value (AS 0 is prohibited on the wire, RFC 7607) — fails
+/// the route **closed**: the chain evaluates to `Deny`, staged
+/// modifications are discarded, and ASN 0 is never prepended. This
+/// follows ADR-0103 Decision 4's uniform-Deny error disposition; when
+/// the LAN-299 evaluation-error rails land (error counters, trace
+/// error events), this failure migrates onto them. Explain traces
+/// render the failing operand and reason in the deciding term's line.
+///
+/// **Source compatibility.** The fixed-AS form
+/// (`prepend as 65001 3`, including parameter references) is
+/// untouched and still lowers to the literal
+/// [`RouteModifications::as_path_prepend`]; a policy parameter named
+/// `origin` keeps its parameter meaning (the operand reading applies
+/// only where no such parameter is in scope).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrependAs {
+    /// `prepend as self` — the local speaker's ASN (from the compiled
+    /// chain's attach-time `local_asn`).
+    LocalAs,
+    /// `prepend as peer` — the evaluation peer's ASN. Import-only;
+    /// peer-dependent for update-group fingerprinting.
+    PeerAs,
+    /// `prepend as origin` — the route's origin AS
+    /// (`RouteContext::origin_asn`).
+    OriginAs,
+}
+
+impl PrependAs {
+    /// The `.rpol` source spelling (also the explain rendering).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PrependAs::LocalAs => "self",
+            PrependAs::PeerAs => "peer",
+            PrependAs::OriginAs => "origin",
+        }
+    }
+
+    /// Resolve the operand to a concrete ASN, or `None` when the
+    /// needed context value is unknown (the fail-closed case). A zero
+    /// value counts as unknown — ASN 0 must never reach the wire
+    /// (RFC 7607).
+    #[must_use]
+    pub fn resolve(self, local_asn: Option<u32>, ctx: &RouteContext<'_>) -> Option<u32> {
+        match self {
+            PrependAs::LocalAs => local_asn,
+            PrependAs::PeerAs => ctx.peer_asn,
+            PrependAs::OriginAs => ctx.origin_asn,
+        }
+        .filter(|&asn| asn != 0)
+    }
+}
+
 /// Route attribute modifications to apply after a policy match.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RouteModifications {
@@ -269,6 +366,18 @@ pub struct RouteModifications {
     pub large_communities_remove: Vec<LargeCommunity>,
     /// `(ASN, count)` — prepend `count` copies of `ASN` to the `AS_PATH`.
     pub as_path_prepend: Option<(u32, u8)>,
+    /// Computed prepend operand (LAN-296, `.rpol`
+    /// `prepend as self|peer|origin <count>`) — see [`PrependAs`] for
+    /// the full decision note. Shares one logical "prepend" slot with
+    /// [`as_path_prepend`](Self::as_path_prepend): at most one of the
+    /// pair is `Some` in frontend-produced modifications, and merges
+    /// treat them as a single scalar (a later prepend of either form
+    /// replaces an earlier one of either form). The evaluator resolves
+    /// this into a concrete `as_path_prepend` at term execution (or
+    /// fails the route closed), so **evaluation results and everything
+    /// downstream of them — [`apply_modifications`], the export memo,
+    /// API explain surfaces — only ever see the literal field.**
+    pub as_path_prepend_computed: Option<(PrependAs, u8)>,
 }
 
 impl RouteModifications {
@@ -279,6 +388,7 @@ impl RouteModifications {
             && self.set_med.is_none()
             && self.set_next_hop.is_none()
             && self.as_path_prepend.is_none()
+            && self.as_path_prepend_computed.is_none()
             && self.communities_add.is_empty()
             && self.communities_remove.is_empty()
             && self.extended_communities_add.is_empty()
@@ -304,8 +414,13 @@ impl RouteModifications {
         if other.set_next_hop.is_some() {
             self.set_next_hop = other.set_next_hop;
         }
-        if other.as_path_prepend.is_some() {
+        // Literal and computed prepends share one logical slot: a
+        // later prepend of either form replaces an earlier one of
+        // either form (scalar last-writer-wins, like the other
+        // scalars).
+        if other.as_path_prepend.is_some() || other.as_path_prepend_computed.is_some() {
             self.as_path_prepend = other.as_path_prepend;
+            self.as_path_prepend_computed = other.as_path_prepend_computed;
         }
         merge_exact_list(
             &mut self.communities_add,
@@ -1376,6 +1491,14 @@ pub fn apply_modifications(
     );
 
     // 6. AS_PATH prepend
+    // Computed operands (LAN-296) are resolved into the literal field
+    // by the evaluator (or fail the route closed) before modifications
+    // ever reach an apply site; there is no context here to resolve
+    // one against, and silently skipping it would fail open.
+    debug_assert!(
+        mods.as_path_prepend_computed.is_none(),
+        "computed prepend operand reached apply_modifications unresolved"
+    );
     if let Some((asn, count)) = mods.as_path_prepend {
         apply_as_path_prepend(attrs, asn, count);
     }

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -159,7 +159,7 @@ pub fn explain_chain_statements(
                 // clauses, so a denying statement must not claim
                 // modifications in the trace either.
                 let modifications = if entry.action == PolicyAction::Permit {
-                    render_modifications(&entry.modifications, ctx)
+                    render_modifications(&entry.modifications, ctx, None)
                 } else {
                     Vec::new()
                 };
@@ -325,7 +325,11 @@ fn render_matched_conditions(entry: &PolicyStatement, ctx: &RouteContext<'_>) ->
 /// values use the same implicit defaults the match engine uses
 /// (`LOCAL_PREF` 100 / `MED` 0, RFC 4271) so the rendered transition is
 /// consistent with what `local_pref >= N` matching saw.
-fn render_modifications(mods: &RouteModifications, ctx: &RouteContext<'_>) -> Vec<String> {
+fn render_modifications(
+    mods: &RouteModifications,
+    ctx: &RouteContext<'_>,
+    tables: Option<&CompiledChain>,
+) -> Vec<String> {
     let mut out = Vec::new();
 
     if let Some(lp) = mods.set_local_pref {
@@ -368,6 +372,24 @@ fn render_modifications(mods: &RouteModifications, ctx: &RouteContext<'_>) -> Ve
     if let Some((asn, count)) = mods.as_path_prepend {
         out.push(format!("as_path prepend {asn} x{count}"));
     }
+    // LAN-296: a computed operand renders with its source spelling plus
+    // the value it resolves to for this route (`tables` carries the
+    // chain's attach-time `local_asn` for `self`). The unresolvable
+    // case never reaches here — the trace walk denies at the failing
+    // term first — but renders honestly if it ever did.
+    if let Some((operand, count)) = mods.as_path_prepend_computed {
+        let resolved = tables.and_then(|chain| operand.resolve(chain.local_asn, ctx));
+        match resolved {
+            Some(asn) => out.push(format!(
+                "as_path prepend {}={asn} x{count}",
+                operand.as_str()
+            )),
+            None => out.push(format!(
+                "as_path prepend {} x{count} (unresolvable)",
+                operand.as_str()
+            )),
+        }
+    }
     out
 }
 
@@ -391,6 +413,11 @@ fn trace_rpol_policy(
     let mut term_traces = Vec::new();
     let mut continued: Option<RouteModifications> = None;
     let mut decided: Option<(usize, &Term)> = None;
+    // LAN-296: set when a matched term's computed prepend operand
+    // cannot resolve — the live evaluator fails the route closed at
+    // that term, and the trace must agree (pinned by the agreement
+    // matrix in `statement_trace.rs`).
+    let mut prepend_failed = false;
     for (index, term) in policy.terms.iter().enumerate() {
         let matched = tables.guard_matches(&term.guard, ctx);
         term_traces.push(format!(
@@ -402,6 +429,29 @@ fn trace_rpol_policy(
         ));
         if !matched {
             continue;
+        }
+        // Mirror the live walk's action-execution resolution: an
+        // unresolvable computed operand on the matched term (Permit or
+        // Continue) decides the route as a fail-closed reject here.
+        let action_mods = match &term.action {
+            TermAction::Permit(mods) | TermAction::Continue(mods) => Some(mods),
+            TermAction::Deny => None,
+        };
+        if let Some(mods) = action_mods
+            && tables.resolve_computed_prepend(mods, ctx).is_err()
+        {
+            let (operand, _) = mods
+                .as_path_prepend_computed
+                .expect("resolution only fails on a computed operand");
+            term_traces.push(format!(
+                "term {}: prepend as {} unresolvable ({}) — fail closed => reject",
+                term.name.as_deref().unwrap_or("<unnamed>"),
+                operand.as_str(),
+                missing_operand_reason(operand),
+            ));
+            prepend_failed = true;
+            decided = Some((index, term));
+            break;
         }
         match &term.action {
             TermAction::Continue(mods) => {
@@ -417,12 +467,17 @@ fn trace_rpol_policy(
     }
     if let Some((index, term)) = decided {
         // Live-path parity: a deny discards accumulated Continue
-        // modifications and contributes none of its own.
+        // modifications and contributes none of its own; a fail-closed
+        // computed-prepend failure denies regardless of the term's own
+        // action.
         let (action, modifications) = match &term.action {
-            TermAction::Permit(mods) => {
+            TermAction::Permit(mods) if !prepend_failed => {
                 let mut merged = continued.unwrap_or_default();
                 merged.merge_from(mods.clone());
-                (PolicyAction::Permit, render_modifications(&merged, ctx))
+                (
+                    PolicyAction::Permit,
+                    render_modifications(&merged, ctx, Some(tables)),
+                )
             }
             _ => (PolicyAction::Deny, Vec::new()),
         };
@@ -440,7 +495,7 @@ fn trace_rpol_policy(
         // Fallthrough to the policy default; a permitting default
         // keeps accumulated Continue modifications (live parity).
         let modifications = match (policy.default_action, continued) {
-            (PolicyAction::Permit, Some(mods)) => render_modifications(&mods, ctx),
+            (PolicyAction::Permit, Some(mods)) => render_modifications(&mods, ctx, Some(tables)),
             _ => Vec::new(),
         };
         StatementAttribution {
@@ -469,6 +524,17 @@ fn render_term_action(action: &TermAction) -> String {
     let mut parts = mods.map_or_else(Vec::new, render_action_stmts);
     parts.push(verdict.to_string());
     parts.join("; ")
+}
+
+/// Why a computed prepend operand could not resolve for this route —
+/// the explain-side rendering of the fail-closed reasons in
+/// `PrependAs::resolve` (zero values count as unknown: RFC 7607).
+fn missing_operand_reason(operand: crate::engine::PrependAs) -> &'static str {
+    match operand {
+        crate::engine::PrependAs::LocalAs => "the chain carries no local ASN",
+        crate::engine::PrependAs::PeerAs => "the peer ASN is unknown",
+        crate::engine::PrependAs::OriginAs => "the route has no origin AS",
+    }
 }
 
 /// Modifications as `.rpol` action statements (static description of
@@ -515,6 +581,10 @@ fn render_action_stmts(mods: &RouteModifications) -> Vec<String> {
     }
     if let Some((asn, count)) = mods.as_path_prepend {
         out.push(format!("prepend {asn} {count}"));
+    }
+    // LAN-296 computed operands render in their source form.
+    if let Some((operand, count)) = mods.as_path_prepend_computed {
+        out.push(format!("prepend as {} {count}", operand.as_str()));
     }
     out
 }

--- a/crates/policy/src/engine/tests/ir_parity.rs
+++ b/crates/policy/src/engine/tests/ir_parity.rs
@@ -62,6 +62,8 @@ fn full_mods() -> RouteModifications {
             local_data2: 2,
         }],
         as_path_prepend: Some((65001, 2)),
+        // TOML statements never carry computed operands (rpol-only).
+        as_path_prepend_computed: None,
     }
 }
 

--- a/crates/policy/src/engine/tests/modifications.rs
+++ b/crates/policy/src/engine/tests/modifications.rs
@@ -423,3 +423,127 @@ fn apply_noop_default() {
     assert!(nh.is_none());
     assert_eq!(attrs, orig);
 }
+
+/// LAN-296 wire-boundary pins for the prepend mutation site: the
+/// leading `AS_SEQUENCE` length field is a u8 (RFC 4271 §4.3), so a
+/// prepend that would push it past 255 must open a new segment —
+/// exactly at the boundary, not just far past it.
+#[test]
+fn apply_as_path_prepend_segment_boundary_254_plus_3() {
+    let long_seq: Vec<u32> = (0..254).map(|i| 64000 + i).collect();
+    let mut attrs = vec![PathAttribute::AsPath(AsPath {
+        segments: vec![AsPathSegment::AsSequence(long_seq.clone())],
+    })];
+    let mods = RouteModifications {
+        as_path_prepend: Some((65001, 3)),
+        ..Default::default()
+    };
+    apply_modifications(&mut attrs, &mods);
+    let path = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::AsPath(p) => Some(p),
+            _ => None,
+        })
+        .unwrap();
+    // 254 + 3 = 257 > 255: a fresh leading segment of exactly the
+    // prepended ASNs, original segment untouched.
+    assert_eq!(path.segments.len(), 2);
+    assert_eq!(
+        path.segments[0],
+        AsPathSegment::AsSequence(vec![65001, 65001, 65001])
+    );
+    assert_eq!(path.segments[1], AsPathSegment::AsSequence(long_seq));
+}
+
+#[test]
+fn apply_as_path_prepend_segment_boundary_255_plus_1() {
+    let full_seq: Vec<u32> = (0..255).map(|i| 64000 + i).collect();
+    let mut attrs = vec![PathAttribute::AsPath(AsPath {
+        segments: vec![AsPathSegment::AsSequence(full_seq.clone())],
+    })];
+    let mods = RouteModifications {
+        as_path_prepend: Some((65001, 1)),
+        ..Default::default()
+    };
+    apply_modifications(&mut attrs, &mods);
+    let path = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::AsPath(p) => Some(p),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(path.segments.len(), 2);
+    assert_eq!(path.segments[0], AsPathSegment::AsSequence(vec![65001]));
+    assert_eq!(path.segments[1], AsPathSegment::AsSequence(full_seq));
+}
+
+/// 254 + 1 = 255 still fits: no new segment.
+#[test]
+fn apply_as_path_prepend_segment_boundary_254_plus_1_fits() {
+    let long_seq: Vec<u32> = (0..254).map(|i| 64000 + i).collect();
+    let mut attrs = vec![PathAttribute::AsPath(AsPath {
+        segments: vec![AsPathSegment::AsSequence(long_seq)],
+    })];
+    let mods = RouteModifications {
+        as_path_prepend: Some((65001, 1)),
+        ..Default::default()
+    };
+    apply_modifications(&mut attrs, &mods);
+    let path = attrs
+        .iter()
+        .find_map(|a| match a {
+            PathAttribute::AsPath(p) => Some(p),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(path.segments.len(), 1);
+    match &path.segments[0] {
+        AsPathSegment::AsSequence(seq) => {
+            assert_eq!(seq.len(), 255);
+            assert_eq!(seq[0], 65001);
+        }
+        AsPathSegment::AsSet(_) => panic!("expected AS_SEQUENCE"),
+    }
+}
+
+/// LAN-296: literal and computed prepends occupy one logical merge
+/// slot — a later prepend of either form replaces an earlier one of
+/// either form, exactly like the other scalar modifications.
+#[test]
+fn merge_prepend_slot_shared_between_literal_and_computed() {
+    use crate::engine::PrependAs;
+
+    // computed then literal → literal wins, computed cleared.
+    let mut mods = RouteModifications {
+        as_path_prepend_computed: Some((PrependAs::OriginAs, 2)),
+        ..Default::default()
+    };
+    mods.merge_from(RouteModifications {
+        as_path_prepend: Some((65001, 1)),
+        ..Default::default()
+    });
+    assert_eq!(mods.as_path_prepend, Some((65001, 1)));
+    assert_eq!(mods.as_path_prepend_computed, None);
+
+    // literal then computed → computed wins, literal cleared.
+    let mut mods = RouteModifications {
+        as_path_prepend: Some((65001, 1)),
+        ..Default::default()
+    };
+    mods.merge_from(RouteModifications {
+        as_path_prepend_computed: Some((PrependAs::PeerAs, 3)),
+        ..Default::default()
+    });
+    assert_eq!(mods.as_path_prepend, None);
+    assert_eq!(mods.as_path_prepend_computed, Some((PrependAs::PeerAs, 3)));
+
+    // a merge with neither leaves the slot alone.
+    let mut mods = RouteModifications {
+        as_path_prepend_computed: Some((PrependAs::LocalAs, 2)),
+        ..Default::default()
+    };
+    mods.merge_from(RouteModifications::default());
+    assert_eq!(mods.as_path_prepend_computed, Some((PrependAs::LocalAs, 2)));
+}

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -241,14 +241,22 @@ impl CompiledChain {
             let mut continued: Option<RouteModifications> = None;
             // `Some(None)` = permit with no deciding-term mods;
             // `None` after the loop = fell through to default_action.
-            let mut permit_mods: Option<Option<&RouteModifications>> = None;
+            let mut permit_mods: Option<Option<RouteModifications>> = None;
             let mut denied = false;
             for (term, hit) in policy.terms.iter().zip(policy_hits.iter_mut()) {
                 if self.eval_expr(&term.guard, ctx) {
                     *hit += 1;
                     match &term.action {
                         TermAction::Permit(mods) => {
-                            permit_mods = Some(Some(mods));
+                            match self.resolve_computed_prepend(mods, ctx) {
+                                Ok(resolved) => {
+                                    permit_mods =
+                                        Some(Some(resolved.unwrap_or_else(|| mods.clone())));
+                                }
+                                // Unresolvable computed prepend operand:
+                                // fail closed (same rule as the live walk).
+                                Err(()) => denied = true,
+                            }
                             break;
                         }
                         TermAction::Deny => {
@@ -256,9 +264,14 @@ impl CompiledChain {
                             break;
                         }
                         TermAction::Continue(mods) => {
-                            continued
-                                .get_or_insert_with(RouteModifications::default)
-                                .merge_from(mods.clone());
+                            if let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) {
+                                continued
+                                    .get_or_insert_with(RouteModifications::default)
+                                    .merge_from(resolved.unwrap_or_else(|| mods.clone()));
+                            } else {
+                                denied = true;
+                                break;
+                            }
                         }
                     }
                 }
@@ -274,7 +287,7 @@ impl CompiledChain {
             }
             let mut merged = continued.unwrap_or_default();
             if let Some(Some(mods)) = permit_mods {
-                merged.merge_from(mods.clone());
+                merged.merge_from(mods);
             }
             if !merged.is_empty() {
                 accumulated.merge_from(merged);
@@ -313,19 +326,32 @@ impl CompiledChain {
                 }
                 match &term.action {
                     TermAction::Permit(mods) => {
-                        return match continued {
-                            Some(mut acc) => {
-                                acc.merge_from(mods.clone());
+                        // LAN-296: fold a computed prepend operand into
+                        // the literal field before the modifications
+                        // leave the evaluator; an unresolvable operand
+                        // fails the route closed.
+                        let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) else {
+                            return PolicyDecision::Deny;
+                        };
+                        return match (continued, resolved) {
+                            (Some(mut acc), resolved) => {
+                                acc.merge_from(resolved.unwrap_or_else(|| mods.clone()));
                                 PolicyDecision::PermitOwned(acc)
                             }
-                            None => PolicyDecision::Permit(Some(mods)),
+                            (None, Some(owned)) => PolicyDecision::PermitOwned(owned),
+                            // The hot path: no Continue terms, nothing
+                            // computed — borrow as before.
+                            (None, None) => PolicyDecision::Permit(Some(mods)),
                         };
                     }
                     TermAction::Deny => return PolicyDecision::Deny,
                     TermAction::Continue(mods) => {
+                        let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) else {
+                            return PolicyDecision::Deny;
+                        };
                         continued
                             .get_or_insert_with(RouteModifications::default)
-                            .merge_from(mods.clone());
+                            .merge_from(resolved.unwrap_or_else(|| mods.clone()));
                     }
                 }
             }
@@ -335,6 +361,36 @@ impl CompiledChain {
             (PolicyAction::Permit, None) => PolicyDecision::Permit(None),
             (PolicyAction::Deny, _) => PolicyDecision::Deny,
         }
+    }
+
+    /// Resolve a matched term's computed prepend operand (LAN-296)
+    /// against the evaluation context, at action-execution time.
+    ///
+    /// - `Ok(None)` — no computed operand (the hot path; no clone).
+    /// - `Ok(Some(owned))` — a clone with the operand folded into the
+    ///   literal `as_path_prepend`, so downstream consumers (merge,
+    ///   apply, memoization, API surfaces) only ever see concrete ASNs.
+    /// - `Err(())` — the operand's context value is unknown (absent
+    ///   origin / unknown peer ASN / chain without `local_asn`, or a
+    ///   zero value): the caller fails the route **closed** (uniform
+    ///   Deny, the ADR-0103 Decision 4 disposition; this migrates onto
+    ///   the LAN-299 evaluation-error rails — counter + trace error
+    ///   events — when they land). ASN 0 is never prepended.
+    pub(crate) fn resolve_computed_prepend(
+        &self,
+        mods: &RouteModifications,
+        ctx: &RouteContext<'_>,
+    ) -> Result<Option<RouteModifications>, ()> {
+        let Some((operand, count)) = mods.as_path_prepend_computed else {
+            return Ok(None);
+        };
+        let Some(asn) = operand.resolve(self.local_asn, ctx) else {
+            return Err(());
+        };
+        let mut resolved = mods.clone();
+        resolved.as_path_prepend = Some((asn, count));
+        resolved.as_path_prepend_computed = None;
+        Ok(Some(resolved))
     }
 
     /// Evaluate a single guard against this chain's set tables — the

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -343,6 +343,19 @@ pub struct CompiledChain {
     pub community_set_names: Vec<Option<String>>,
     /// Source names of `asn_sets` entries (same indexing).
     pub asn_set_names: Vec<Option<String>>,
+    /// The local speaker's ASN, stamped at attach time by the config
+    /// chain resolver — the value `.rpol` `prepend as self` resolves
+    /// to (LAN-296, see [`crate::engine::PrependAs`]). Carried on the
+    /// chain rather than the per-route context because it is
+    /// config-constant (`[global] asn`) and rides with the policy into
+    /// every evaluation path (live distribution, import, explain
+    /// dry-runs) without per-site plumbing. `None` for chains compiled
+    /// outside a daemon config (standalone `rbgp policy check`, unit
+    /// tests) unless the harness provides one — `prepend as self` then
+    /// fails closed. Participates in `PartialEq` like everything else:
+    /// deterministic from config, so unchanged reloads still diff as
+    /// no-ops.
+    pub local_asn: Option<u32>,
 }
 
 impl CompiledChain {
@@ -358,6 +371,7 @@ impl CompiledChain {
             prefix_set_names: Vec::new(),
             community_set_names: Vec::new(),
             asn_set_names: Vec::new(),
+            local_asn: None,
         }
     }
 
@@ -395,12 +409,15 @@ impl CompiledChain {
     /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
     /// ASN, or peer-group matching — a strict-next-hop
     /// [`MatchExpr::NextHopEqPeer`] / [`MatchExpr::NextHopNePeer`]
-    /// node, or a [`MatchExpr::PeerAsInSet`] membership probe).
+    /// node, a [`MatchExpr::PeerAsInSet`] membership probe, or a
+    /// peer-derived `prepend as peer` action, LAN-296 — the last is
+    /// defense in depth: export attachment rejects it outright).
     /// Content-equal chains with
     /// such a guard can still yield peer-different verdicts, so
     /// update-group fingerprinting must not group peers that share one.
-    /// Import chains are evaluated per-session and are unaffected by
-    /// this flag.
+    /// `prepend as self` / `prepend as origin` are chain/route-context
+    /// only and deliberately do NOT count here. Import chains are
+    /// evaluated per-session and are unaffected by this flag.
     #[must_use]
     pub fn requires_peer_context(&self) -> bool {
         self.any_guard_node(&|expr| {
@@ -411,7 +428,34 @@ impl CompiledChain {
                     | MatchExpr::NextHopNePeer
                     | MatchExpr::PeerAsInSet(_)
             )
-        })
+        }) || self.peer_prepend_action().is_some()
+    }
+
+    /// The first `prepend as peer` action in the chain, as the owning
+    /// `(policy-name, term-name)` pair for diagnostics — `None` when
+    /// the chain carries no peer-derived prepend.
+    ///
+    /// Direction legality (LAN-296): such an action is import-only. On
+    /// an export chain it would prepend the *receiving* peer's own ASN
+    /// — dropped by the receiver as an own-AS loop (RFC 4271 §9.1.2) —
+    /// so the config chain resolver rejects export attachment using
+    /// this probe (see [`crate::engine::PrependAs`] for the decision
+    /// note and the FRR/BIRD comparison).
+    #[must_use]
+    pub fn peer_prepend_action(&self) -> Option<(Option<&str>, Option<&str>)> {
+        use crate::engine::PrependAs;
+        for policy in &self.policies {
+            for term in &policy.terms {
+                let mods = match &term.action {
+                    TermAction::Permit(mods) | TermAction::Continue(mods) => mods,
+                    TermAction::Deny => continue,
+                };
+                if matches!(mods.as_path_prepend_computed, Some((PrependAs::PeerAs, _))) {
+                    return Some((policy.name.as_deref(), term.name.as_deref()));
+                }
+            }
+        }
+        None
     }
 
     /// Does any guard node across all policies satisfy `pred`?

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -20,8 +20,8 @@ mod eval;
 pub use engine::explain::{ChainStatementTrace, StatementAttribution, explain_chain_statements};
 pub use engine::{
     AsPathRegex, CommunityMatch, NamedPolicy, NeighborSetMatch, NextHopAction, Policy,
-    PolicyAction, PolicyChain, PolicyEvaluation, PolicyResult, PolicyStatement, RouteContext,
-    RouteFamily, RouteModifications, RouteType, TermHitRow, apply_modifications, evaluate_chain,
-    evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
+    PolicyAction, PolicyChain, PolicyEvaluation, PolicyResult, PolicyStatement, PrependAs,
+    RouteContext, RouteFamily, RouteModifications, RouteType, TermHitRow, apply_modifications,
+    evaluate_chain, evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
 };
 pub use eval::PolicyHitCounters;

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -207,6 +207,45 @@ impl U32Arg {
     }
 }
 
+/// The `prepend as <operand>` argument (LAN-296): a literal/parameter
+/// ASN or a computed operand.
+#[derive(Debug)]
+pub enum PrependAsArg {
+    /// Literal ASN or parameter reference (`prepend as 65001 3`,
+    /// `prepend as n 3`). A bare identifier `origin` that is **not** a
+    /// declared parameter of the enclosing policy also arrives here
+    /// and denotes the origin operand (see [`Self::operand`]) — the
+    /// grammar-evolution rules (ADR-0103 Decision 2) forbid reserving
+    /// `origin`, so a parameter of that name keeps its existing
+    /// meaning.
+    Value(U32Arg),
+    /// `prepend as self <count>` — the local speaker's ASN.
+    SelfAs,
+    /// `prepend as peer <count>` — the evaluation peer's ASN
+    /// (import-only; rejected on export attachment).
+    Peer,
+}
+
+impl PrependAsArg {
+    /// The computed operand this argument denotes, or `None` for the
+    /// literal/parameter form. `is_param` answers whether a name is a
+    /// declared parameter of the enclosing policy — the single
+    /// decision point shared by the typechecker and the lowerer, so
+    /// the two passes cannot disagree about an `origin` identifier.
+    pub fn operand(&self, is_param: impl Fn(&str) -> bool) -> Option<crate::engine::PrependAs> {
+        match self {
+            PrependAsArg::SelfAs => Some(crate::engine::PrependAs::LocalAs),
+            PrependAsArg::Peer => Some(crate::engine::PrependAs::PeerAs),
+            PrependAsArg::Value(U32Arg::Param(name))
+                if name.node == "origin" && !is_param(&name.node) =>
+            {
+                Some(crate::engine::PrependAs::OriginAs)
+            }
+            PrependAsArg::Value(_) => None,
+        }
+    }
+}
+
 /// An action statement inside a term or `if` body.
 #[derive(Debug)]
 pub enum ActionStmt {
@@ -231,10 +270,11 @@ pub enum ActionStmt {
         /// Whole-statement span.
         span: Span,
     },
-    /// `prepend as <asn> <count>`.
+    /// `prepend as <asn|self|peer|origin> <count>`.
     Prepend {
-        /// ASN to prepend.
-        asn: U32Arg,
+        /// ASN to prepend: literal/parameter, or a computed operand
+        /// (LAN-296).
+        asn: PrependAsArg,
         /// Number of copies (1–255, checked by the typechecker).
         count: U32Arg,
         /// Whole-statement span.
@@ -495,6 +535,11 @@ pub enum PeerField {
     Address(IpAddr),
     /// `asn 65001`.
     Asn(u32),
+    /// `local-as 64512` — the session's local speaker ASN, backing the
+    /// `prepend as self` operand (LAN-296). In the daemon this comes
+    /// from `[global] asn` at chain attach; a test fixture states it
+    /// explicitly (omitted ⇒ `prepend as self` fails closed).
+    LocalAs(u32),
     /// `group "leaf"`.
     Group(Spanned<String>),
 }

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -61,7 +61,8 @@ use crate::ir::{
 use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry, SetStore};
 
 use super::ast::{
-    ActionStmt, CmpOp, CommunityLit, Expr, NextHopArg, PolicyDef, Rhs, SourceFile, Stmt, U32Arg,
+    ActionStmt, CmpOp, CommunityLit, Expr, NextHopArg, PolicyDef, PrependAsArg, Rhs, SourceFile,
+    Stmt, U32Arg,
 };
 use super::typeck::{Field, resolve_field};
 
@@ -192,6 +193,7 @@ impl<'a> Lowerer<'a> {
             prefix_set_names: self.prefix_set_names.clone(),
             community_set_names: self.community_set_names.clone(),
             asn_set_names: self.asn_set_names.clone(),
+            local_asn: None,
         }
     }
 
@@ -219,6 +221,7 @@ impl<'a> Lowerer<'a> {
             prefix_set_names: self.prefix_set_names.clone(),
             community_set_names: self.community_set_names.clone(),
             asn_set_names: self.asn_set_names.clone(),
+            local_asn: None,
         }
     }
 
@@ -622,11 +625,21 @@ fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMa
             }
         },
         ActionStmt::Prepend { asn, count, .. } => {
-            let count = resolve_u32(count, env);
-            mods.as_path_prepend = Some((
-                resolve_u32(asn, env),
-                u8::try_from(count).expect("typechecked: count is a 1-255 literal"),
-            ));
+            let count = u8::try_from(resolve_u32(count, env))
+                .expect("typechecked: count is a 1-255 literal");
+            // LAN-296: computed operands lower to the staged
+            // `as_path_prepend_computed` slot (resolved per route by
+            // the evaluator); the literal/parameter form keeps its
+            // existing lowering. The operand decision is shared with
+            // the typechecker (`PrependAsArg::operand`).
+            if let Some(operand) = asn.operand(|name| env.contains_key(name)) {
+                mods.as_path_prepend_computed = Some((operand, count));
+            } else {
+                let PrependAsArg::Value(arg) = asn else {
+                    unreachable!("non-Value prepend args always denote an operand")
+                };
+                mods.as_path_prepend = Some((resolve_u32(arg, env), count));
+            }
         }
     }
 }

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -15,7 +15,7 @@ use crate::engine::{CommunityMatch, parse_community_match};
 use super::ast::{
     ActionStmt, AsnSetDef, CmpOp, CommunityKind, CommunityLit, CommunitySetDef, ExpectDef, Expr,
     FieldPath, FieldRoot, IfStmt, NextHopArg, PeerField, PolicyDef, PrefixEntryAst, PrefixSetDef,
-    Rhs, RouteField, SourceFile, Stmt, TermDef, TestDef, U32Arg, WithAssertion,
+    PrependAsArg, Rhs, RouteField, SourceFile, Stmt, TermDef, TestDef, U32Arg, WithAssertion,
 };
 use super::diag::{Diagnostic, Span, Spanned};
 use super::lexer::{Tok, Token, lex};
@@ -657,8 +657,23 @@ impl Parser<'_> {
             }
             Tok::PrependKw => {
                 self.bump();
-                self.expect(Tok::AsKw, "`as` (`prepend as <asn> <count>`)")?;
-                let asn = self.u32_arg("an ASN")?;
+                self.expect(
+                    Tok::AsKw,
+                    "`as` (`prepend as <asn|self|peer|origin> <count>`)",
+                )?;
+                // Computed operands (LAN-296): `self` / `peer` are
+                // keyword tokens (previously parse errors here, so
+                // purely additive); `origin` is a contextual
+                // identifier that flows through the parameter path and
+                // is disambiguated against the policy's declared
+                // parameters (`PrependAsArg::operand`).
+                let asn = if self.eat(Tok::SelfKw).is_some() {
+                    PrependAsArg::SelfAs
+                } else if self.eat(Tok::PeerKw).is_some() {
+                    PrependAsArg::Peer
+                } else {
+                    PrependAsArg::Value(self.u32_arg("an ASN, `self`, `peer`, or `origin`")?)
+                };
                 let count = self.u32_arg("a prepend count")?;
                 let span = token.span.to(count.span());
                 Ok(ActionStmt::Prepend { asn, count, span })
@@ -999,7 +1014,8 @@ impl Parser<'_> {
     }
 
     fn peer_field(&mut self) -> PResult<PeerField> {
-        let field = self.expect_ident("a peer fixture field (`address`, `asn`, `group`)")?;
+        let field =
+            self.expect_ident("a peer fixture field (`address`, `asn`, `local-as`, `group`)")?;
         match field.node.as_str() {
             "address" => {
                 let (addr, _) = self.expect_ip("an IP address")?;
@@ -1009,6 +1025,10 @@ impl Parser<'_> {
                 let (value, _) = self.expect_u32("an ASN")?;
                 Ok(PeerField::Asn(value))
             }
+            "local-as" => {
+                let (value, _) = self.expect_u32("an ASN")?;
+                Ok(PeerField::LocalAs(value))
+            }
             "group" => Ok(PeerField::Group(self.expect_str("a group name string")?)),
             other => {
                 let mut diag = Diagnostic::new(
@@ -1016,7 +1036,9 @@ impl Parser<'_> {
                     format!("unknown peer fixture field `{other}`"),
                     "not a peer fixture field",
                 );
-                if let Some(suggestion) = super::diag::closest(other, ["address", "asn", "group"]) {
+                if let Some(suggestion) =
+                    super::diag::closest(other, ["address", "asn", "local-as", "group"])
+                {
                     diag = diag.with_note(format!("did you mean `{suggestion}`?"));
                 }
                 self.diags.push(diag);

--- a/crates/policy/src/rpol/testing.rs
+++ b/crates/policy/src/rpol/testing.rs
@@ -71,6 +71,9 @@ struct Fixture {
     evpn_route_type: Option<u8>,
     peer_address: Option<IpAddr>,
     peer_asn: Option<u32>,
+    /// Backs `prepend as self` (LAN-296); stamped onto the chain under
+    /// test, mirroring how the config resolver stamps `[global] asn`.
+    local_asn: Option<u32>,
     peer_group: Option<String>,
 }
 
@@ -163,6 +166,7 @@ impl Fixture {
             match field {
                 PeerField::Address(addr) => fixture.peer_address = Some(*addr),
                 PeerField::Asn(asn) => fixture.peer_asn = Some(*asn),
+                PeerField::LocalAs(asn) => fixture.local_asn = Some(*asn),
                 PeerField::Group(group) => fixture.peer_group = Some(group.node.clone()),
             }
         }
@@ -231,7 +235,10 @@ pub(super) fn run_tests(
         let mut problems: Vec<String> = Vec::new();
         for expect in &test.expects {
             let args: Vec<u32> = expect.args.iter().map(|arg| arg.node).collect();
-            let chain = lowerer.instantiate_chain(&expect.policy.node, &args, store);
+            let mut chain = lowerer.instantiate_chain(&expect.policy.node, &args, store);
+            // The fixture's `peer { local-as N }` plays the config
+            // resolver's role for `prepend as self` (LAN-296).
+            chain.local_asn = fixture.local_asn;
             let result = chain.evaluate(&ctx);
             let call = render_call(&expect.policy.node, &args);
             let accepted = result.action == PolicyAction::Permit;

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1600,3 +1600,302 @@ fn family_fixture_rejects_unknown_member() {
     assert_eq!(diags.len(), 1, "{rendered}");
     assert!(rendered.contains("did you mean `evpn`?"), "{rendered}");
 }
+
+// ── computed prepend operands (LAN-296) ────────────────────────────
+
+/// A context with just the fields the prepend operands read.
+fn prepend_ctx(peer_asn: Option<u32>, origin_asn: Option<u32>) -> RouteContext<'static> {
+    RouteContext {
+        origin_asn,
+        peer_asn,
+        ..route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound)
+    }
+}
+
+/// The mods a single-policy chain's first term action carries.
+fn first_term_mods(chain: &crate::ir::CompiledChain) -> &RouteModifications {
+    match &chain.policies[0].terms[0].action {
+        TermAction::Permit(mods) | TermAction::Continue(mods) => mods,
+        TermAction::Deny => panic!("expected a modifying term"),
+    }
+}
+
+#[test]
+fn computed_prepend_operands_lower_to_computed_slot() {
+    use crate::engine::PrependAs;
+    for (source_operand, expected) in [
+        ("self", PrependAs::LocalAs),
+        ("peer", PrependAs::PeerAs),
+        ("origin", PrependAs::OriginAs),
+    ] {
+        let chain = compile_ok(&format!(
+            "policy p {{ term t {{ prepend as {source_operand} 3; accept }} }}"
+        ));
+        let mods = first_term_mods(&chain);
+        assert_eq!(
+            mods.as_path_prepend_computed,
+            Some((expected, 3)),
+            "operand {source_operand}"
+        );
+        assert_eq!(mods.as_path_prepend, None, "operand {source_operand}");
+    }
+}
+
+/// Zero source-compatibility break: the literal and parameter forms
+/// still lower to the literal slot, and a policy parameter named
+/// `origin` keeps its parameter meaning (grammar-evolution rule).
+#[test]
+fn fixed_prepend_forms_unchanged() {
+    let chain = compile_ok("policy p { term t { prepend as 65001 3; accept } }");
+    let mods = first_term_mods(&chain);
+    assert_eq!(mods.as_path_prepend, Some((65001, 3)));
+    assert_eq!(mods.as_path_prepend_computed, None);
+
+    let mut store = SetStore::new();
+    let set =
+        super::RpolFile::parse("policy p(origin: u32) { term t { prepend as origin 2; accept } }")
+            .expect("compiles");
+    let chain = set
+        .compile_policy("p", &[64999], &mut store)
+        .expect("policy exists");
+    let mods = first_term_mods(&chain);
+    assert_eq!(
+        mods.as_path_prepend,
+        Some((64999, 2)),
+        "a parameter named `origin` must stay a parameter"
+    );
+    assert_eq!(mods.as_path_prepend_computed, None);
+}
+
+#[test]
+fn prepend_peer_resolves_to_peer_asn_on_import_eval() {
+    let chain = compile_ok("policy p { term t { prepend as peer 3; accept } }");
+    let result = chain.evaluate(&prepend_ctx(Some(65010), None));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((65010, 3)));
+    assert_eq!(result.modifications.as_path_prepend_computed, None);
+}
+
+#[test]
+fn prepend_origin_resolves_to_origin_asn() {
+    let chain = compile_ok("policy p { term t { prepend as origin 2; accept } }");
+    let result = chain.evaluate(&prepend_ctx(None, Some(64500)));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((64500, 2)));
+    assert_eq!(result.modifications.as_path_prepend_computed, None);
+}
+
+#[test]
+fn prepend_self_resolves_from_chain_local_asn() {
+    let mut chain = compile_ok("policy p { term t { prepend as self 4; accept } }");
+    chain.local_asn = Some(64512);
+    let result = chain.evaluate(&prepend_ctx(None, None));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((64512, 4)));
+    assert_eq!(result.modifications.as_path_prepend_computed, None);
+}
+
+/// Missing context fails the route CLOSED (uniform Deny) — and never
+/// prepends ASN 0. Covers all three operands, plus a zero context
+/// value (RFC 7607: AS 0 must never reach the wire).
+#[test]
+fn computed_prepend_missing_context_fails_closed() {
+    let cases: [(&str, RouteContext<'static>); 4] = [
+        ("peer", prepend_ctx(None, Some(64500))),
+        ("origin", prepend_ctx(Some(65010), None)),
+        ("self", prepend_ctx(Some(65010), Some(64500))),
+        // Zero peer ASN counts as unknown.
+        ("peer", prepend_ctx(Some(0), Some(64500))),
+    ];
+    for (operand, ctx) in cases {
+        let chain = compile_ok(&format!(
+            "policy p {{ term t {{ prepend as {operand} 3; accept }} }}"
+        ));
+        // No local_asn stamped: the `self` case is the missing case.
+        let result = chain.evaluate(&ctx);
+        assert_eq!(result.action, PolicyAction::Deny, "operand {operand}");
+        assert!(
+            result.modifications.is_empty(),
+            "fail closed discards staged modifications ({operand})"
+        );
+    }
+}
+
+/// A Continue term's failing computed operand also denies (the action
+/// executes when the term matches, even without a verdict).
+#[test]
+fn computed_prepend_failure_in_continue_term_denies() {
+    let chain = compile_ok(
+        "policy p {
+            term tag { prepend as origin 1 }
+            term rest { accept }
+        }",
+    );
+    let result = chain.evaluate(&prepend_ctx(None, None));
+    assert_eq!(result.action, PolicyAction::Deny);
+    // With an origin present the same chain permits.
+    let result = chain.evaluate(&prepend_ctx(None, Some(64500)));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((64500, 1)));
+}
+
+/// `prepend as peer` is peer-dependent for update-group
+/// fingerprinting; `self` and `origin` are not (they must never
+/// disqualify grouping).
+#[test]
+fn computed_prepend_peer_context_flags() {
+    let peer_chain = compile_ok("policy p { term t { prepend as peer 3; accept } }");
+    assert!(peer_chain.requires_peer_context());
+    assert!(peer_chain.peer_prepend_action().is_some());
+
+    for operand in ["self", "origin"] {
+        let chain = compile_ok(&format!(
+            "policy p {{ term t {{ prepend as {operand} 3; accept }} }}"
+        ));
+        assert!(!chain.requires_peer_context(), "operand {operand}");
+        assert!(chain.peer_prepend_action().is_none(), "operand {operand}");
+    }
+    // Literal prepends never flag either.
+    let literal = compile_ok("policy p { term t { prepend as 65001 3; accept } }");
+    assert!(!literal.requires_peer_context());
+}
+
+/// Literal and computed prepends share one merge slot: the later term
+/// wins regardless of form.
+#[test]
+fn computed_and_literal_prepends_share_the_merge_slot() {
+    let chain = compile_ok(
+        "policy p {
+            term tag { prepend as origin 2 }
+            term decide { prepend as 65001 1; accept }
+        }",
+    );
+    let result = chain.evaluate(&prepend_ctx(None, Some(64500)));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((65001, 1)));
+
+    let chain = compile_ok(
+        "policy p {
+            term tag { prepend as 65001 1 }
+            term decide { prepend as origin 2; accept }
+        }",
+    );
+    let result = chain.evaluate(&prepend_ctx(None, Some(64500)));
+    assert_eq!(result.modifications.as_path_prepend, Some((64500, 2)));
+}
+
+/// `evaluate_recording_hits` (the `rbgp policy test` backend) applies
+/// the same resolution and fail-closed rules as the live walk.
+#[test]
+fn recording_hits_resolves_and_fails_closed_like_live_eval() {
+    let chain = compile_ok("policy p { term t { prepend as peer 3; accept } }");
+    for ctx in [prepend_ctx(Some(65010), None), prepend_ctx(None, None)] {
+        let mut hits = chain.zero_term_hits();
+        let recorded = chain.evaluate_recording_hits(&ctx, &mut hits);
+        let live = chain.evaluate(&ctx);
+        assert_eq!(recorded, live);
+        assert_eq!(hits, vec![vec![1]], "matched term still counts");
+    }
+}
+
+/// Explain traces render the source-level operand — and agree with
+/// the live verdict, including the fail-closed case.
+#[test]
+fn computed_prepend_explain_renders_operand_and_agrees() {
+    use crate::engine::PolicyChain;
+    use crate::engine::explain::explain_chain_statements;
+
+    let mut compiled = compile_ok("policy p { term t { prepend as peer 3; accept } }");
+    compiled.local_asn = Some(64512);
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+
+    // Resolvable: permit, with the operand rendered in both the static
+    // term line and the resolved before→after modification line.
+    let ctx = prepend_ctx(Some(65010), None);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, chain.evaluate(&ctx).action);
+    assert_eq!(trace.action, PolicyAction::Permit);
+    let step = &trace.steps[0];
+    assert!(
+        step.term_traces
+            .iter()
+            .any(|line| line.contains("prepend as peer 3")),
+        "term trace renders the source operand: {:?}",
+        step.term_traces
+    );
+    assert!(
+        step.modifications
+            .iter()
+            .any(|line| line.contains("as_path prepend peer=65010 x3")),
+        "modifications render operand + resolved value: {:?}",
+        step.modifications
+    );
+
+    // Unresolvable: fail-closed deny, rendered in the trace and in
+    // agreement with the live walk.
+    let ctx = prepend_ctx(None, None);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, chain.evaluate(&ctx).action);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    let step = &trace.steps[0];
+    assert!(
+        step.term_traces
+            .iter()
+            .any(|line| line.contains("prepend as peer unresolvable")
+                && line.contains("fail closed")),
+        "failure is explainable: {:?}",
+        step.term_traces
+    );
+    assert!(step.modifications.is_empty(), "a deny contributes no mods");
+}
+
+/// In-language `test` fixtures cover all three operands: `peer { asn }`
+/// backs `peer`, the as-path fixture backs `origin`, and the new
+/// `peer { local-as }` field backs `self`.
+#[test]
+fn in_language_tests_cover_computed_operands() {
+    let source = r#"
+policy peer-pad { term t { prepend as peer 3; accept } }
+policy origin-pad { term t { prepend as origin 2; accept } }
+policy self-pad { term t { prepend as self 4; accept } }
+
+test peer-operand {
+    route { prefix 10.0.0.0/24 }
+    peer { asn 65010 }
+    expect peer-pad == accept with prepend as 65010 3
+}
+
+test origin-operand {
+    route { prefix 10.0.0.0/24; as-path "65010 64500" }
+    expect origin-pad == accept with prepend as 64500 2
+}
+
+test self-operand {
+    route { prefix 10.0.0.0/24 }
+    peer { asn 65010; local-as 64512 }
+    expect self-pad == accept with prepend as 64512 4
+}
+
+test missing-origin-fails-closed {
+    route { prefix 10.0.0.0/24; as-path "{64500 64501}" }
+    expect origin-pad == reject
+}
+
+test missing-peer-fails-closed {
+    route { prefix 10.0.0.0/24 }
+    expect peer-pad == reject
+}
+
+test missing-local-as-fails-closed {
+    route { prefix 10.0.0.0/24 }
+    peer { asn 65010 }
+    expect self-pad == reject
+}
+"#;
+    let report = run_rpol_tests(source).expect("compiles");
+    assert_eq!(report.total, 6);
+    assert!(report.all_passed(), "failures: {:?}", report.failures);
+}

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -15,8 +15,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::engine::AsPathRegex;
 
 use super::ast::{
-    ActionStmt, CmpOp, CommunityKind, Expr, FieldPath, FieldRoot, PolicyDef, Rhs, RouteField,
-    SourceFile, Stmt, U32Arg,
+    ActionStmt, CmpOp, CommunityKind, Expr, FieldPath, FieldRoot, PolicyDef, PrependAsArg, Rhs,
+    RouteField, SourceFile, Stmt, U32Arg,
 };
 use super::diag::{Diagnostic, Span, Spanned, closest};
 
@@ -290,7 +290,16 @@ impl Checker<'_> {
                 }
             }
             ActionStmt::Prepend { asn, count, .. } => {
-                self.check_u32_arg(asn, params);
+                // A computed operand (`self`/`peer`, or an `origin`
+                // identifier that is not a declared parameter —
+                // LAN-296) needs no parameter check; the operand
+                // decision itself is shared with lowering via
+                // `PrependAsArg::operand`.
+                if asn.operand(|name| params.contains(&name)).is_none()
+                    && let PrependAsArg::Value(arg) = asn
+                {
+                    self.check_u32_arg(arg, params);
+                }
                 match count {
                     U32Arg::Lit(value, span) => {
                         if *value == 0 || *value > 255 {

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -594,6 +594,90 @@ async fn family_predicate_export_chain_still_groups() {
     handle.await.unwrap();
 }
 
+/// LAN-296: computed prepend operands and update-group eligibility —
+/// the second level of the proof (`requires_peer_context` at the chain
+/// level is pinned in `crates/policy/src/rpol/tests.rs`). A
+/// `prepend as peer` export chain reads peer identity, so its peers
+/// fall back to `policy_peer_context` (defense in depth: config
+/// attachment rejects such chains on export outright — this pins the
+/// fingerprint for chains installed through other paths). `prepend as
+/// self` / `prepend as origin` are chain/route-context-only and must
+/// still group.
+#[tokio::test]
+async fn computed_prepend_export_chains_group_unless_peer_dependent() {
+    use std::sync::Arc;
+
+    use rustbgpd_policy::NamedPolicy;
+    use rustbgpd_policy::rpol::RpolFile;
+    use rustbgpd_policy::sets::SetStore;
+
+    fn rpol_chain(source: &str, name: &str) -> PolicyChain {
+        let mut store = SetStore::new();
+        let compiled = RpolFile::parse(source)
+            .expect("clean rpol")
+            .compile_policy(name, &[], &mut store)
+            .expect("policy exists");
+        PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+            name.to_string(),
+            Arc::new(compiled),
+        )])
+    }
+
+    let self_pad = "policy self-pad { term t { prepend as self 3; accept } }";
+    let origin_pad = "policy origin-pad { term t { prepend as origin 2; accept } }";
+    let peer_pad = "policy peer-pad { term t { prepend as peer 3; accept } }";
+
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    // Two peers sharing a `prepend as self` chain and two sharing a
+    // `prepend as origin` chain: both pairs must group.
+    let self_a = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 1));
+    let self_b = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 2));
+    for peer in [self_a, self_b] {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.export_policy = Some(rpol_chain(self_pad, "self-pad"));
+        let _rx = peer_up(&tx, spec).await;
+    }
+    let origin_a = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 3));
+    let origin_b = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 4));
+    for peer in [origin_a, origin_b] {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.export_policy = Some(rpol_chain(origin_pad, "origin-pad"));
+        let _rx = peer_up(&tx, spec).await;
+    }
+    // A `prepend as peer` chain disqualifies its peer from grouping.
+    let peer_dep = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 5));
+    let mut spec = PeerUpSpec::ibgp(peer_dep);
+    spec.export_policy = Some(rpol_chain(peer_pad, "peer-pad"));
+    let _rx = peer_up(&tx, spec).await;
+
+    let self_group = query_update_group(&tx, self_a).await;
+    assert!(
+        self_group.starts_with("group:"),
+        "`prepend as self` must not disqualify grouping: {self_group}"
+    );
+    assert_eq!(query_update_group(&tx, self_b).await, self_group);
+
+    let origin_group = query_update_group(&tx, origin_a).await;
+    assert!(
+        origin_group.starts_with("group:"),
+        "`prepend as origin` must not disqualify grouping: {origin_group}"
+    );
+    assert_eq!(query_update_group(&tx, origin_b).await, origin_group);
+
+    assert_eq!(
+        query_update_group(&tx, peer_dep).await,
+        "policy_peer_context",
+        "`prepend as peer` must register as peer-dependent"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// LAN-210: a grouped member's export-policy counters must not drift
 /// from an otherwise-identical ungrouped peer's across a dirty resync.
 /// Before the fix the dirty-resync distribution pass replayed the group

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -334,12 +334,63 @@ Two consequences worth internalizing:
 | `add large-community 65000:1:2` / `remove ...` | large communities |
 | `add ext-community RT:65001:100` / `remove ...` | extended communities (RT/RO, or well-known: `add ext-community OV_INVALID`) |
 | `prepend as <asn> <count>` | prepend `<count>` copies of `<asn>` (count: literal 1–255) |
+| `prepend as self\|peer\|origin <count>` | prepend a computed ASN (see below) |
 
 The kind keyword must match the literal's kind (`add community
 RT:...` is a compile error pointing at `add ext-community`). Within a
 policy, later `set`s of the same attribute win; across a chain, the
 existing merge semantics apply (later policy wins scalars, add/remove
-lists merge with later-policy-wins cancellation).
+lists merge with later-policy-wins cancellation). Literal and computed
+prepends share one scalar slot: a later prepend of either form
+replaces an earlier one of either form.
+
+### Computed prepend operands
+
+`prepend as` also takes a computed operand instead of a literal ASN:
+
+- **`self`** — the local speaker's ASN (the daemon's `[global] asn`,
+  stamped onto the chain when it is attached; in-language tests state
+  it with the `peer { local-as N }` fixture field).
+- **`peer`** — the evaluation peer's ASN.
+- **`origin`** — the route's origin AS: the last ASN of the rightmost
+  non-empty `AS_SEQUENCE` (the same value `route.origin-as` reads).
+  A policy *parameter* named `origin` shadows the operand — the
+  parameter keeps its existing meaning.
+
+**Direction legality.** `self` and `origin` are legal on import and
+export chains. `peer` is **import-only**: on an export chain it would
+prepend the *receiving* peer's own ASN, which the receiver rejects as
+an own-AS loop (RFC 4271 §9.1.2) unless it runs allowas-in. A chain
+using `prepend as peer` is rejected when it is attached as an export
+chain (config load, reload, transaction) — a config error naming the
+policy and term, never a per-route runtime surprise.
+
+| operand  | import | export | notes |
+|---|---|---|---|
+| `self`   | yes | yes | outbound TE; inbound self-prepend biases best-path like the literal form already could |
+| `peer`   | yes | **rejected at attach** | the inbound "prepend the neighbor's AS" idiom |
+| `origin` | yes | yes | origin AS is already in the path — no loop-detection impact |
+
+*Comparison:* FRR's `set as-path prepend last-as N` (prepend the
+neighbor's AS) is its inbound route-map idiom and the model for
+`prepend as peer`; FRR has no `self`/`origin` operands (operators
+write literals). BIRD's `bgp_path.prepend()` takes only explicit ASN
+values — no peer-derived operand exists there at all. Neither
+implementation documents a legitimate outbound use of a
+peer-AS prepend, hence the attach-time rejection.
+
+**Failure is closed.** A computed operand resolves when the matched
+term's action executes. If the value is unknown — no usable
+`AS_SEQUENCE` for `origin`, unknown peer ASN for `peer`, a chain
+evaluated outside a daemon config for `self` — or the context value is
+zero (AS 0 is prohibited on the wire, RFC 7607), the route is
+**denied**: staged modifications are discarded, ASN 0 is never
+prepended, and explain traces name the failing term, operand, and
+reason.
+
+**Update-group note.** `prepend as peer` reads peer identity, so (like
+`peer.asn` guards) it keeps its peers out of shared update groups;
+`self` and `origin` never disqualify grouping.
 
 Extended-community wire encoding follows the daemon's other
 frontends: dotted-quad admin → RFC 4360 type 0x01, ASN > 65535 →
@@ -350,7 +401,7 @@ type 0x02, otherwise type 0x00 (subtype 0x02 RT / 0x03 RO).
 ```rpol
 test NAME {
     route { FIELD VALUE; ... }
-    [peer { address IP; asn N; group "NAME" }]
+    [peer { address IP; asn N; local-as N; group "NAME" }]
     expect POLICY[(args)] == accept|reject [with ASSERTION, ...]
     [expect ...]
 }
@@ -373,7 +424,12 @@ typed-path rule), so `as-path "65010 64500"` has origin 64500 and
 (the frontend has no live route to apply them to): `local-pref N`,
 `med N`, `next-hop IP|self`, `community LIT` (and
 `large-community`/`ext-community`, asserting presence in the add
-lists), `prepend as ASN COUNT`.
+lists), `prepend as ASN COUNT`. Computed prepend operands resolve
+during evaluation, so the assertion states the **resolved** ASN:
+`peer { asn 65010 }` + `prepend as peer 3` asserts as
+`with prepend as 65010 3`. `peer { local-as N }` supplies the value
+`prepend as self` resolves to (omitted ⇒ it fails closed and the
+expectation is a `reject`).
 
 Tests run at check time (`rbgp policy check`, CI) with zero daemon
 involvement. Testing a *candidate* policy against a live RIB is
@@ -396,7 +452,7 @@ action      := "accept" | "reject"
              | "set" ("local-pref" | "med") u32arg
              | "set" "next-hop" (IP | "self")
              | ("add" | "remove") ("community" | "large-community" | "ext-community") community
-             | "prepend" "as" u32arg INT
+             | "prepend" "as" (u32arg | "self" | "peer" | "origin") INT
 expr        := and ("||" and)*
 and         := unary ("&&" unary)*
 unary       := "!" unary | "(" expr ")" | "apply" "(" IDENT ["(" u32arg,* ")"] ")" | predicate

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,7 @@ use rustbgpd_wire::{
 pub use schema::*;
 pub(crate) use validation::{effective_prefix, effective_prefix_str};
 
-use self::parse::{parse_families, parse_policy, resolve_chain};
+use self::parse::{ChainDirection, parse_families, parse_policy, resolve_chain};
 use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};
 
 #[cfg(test)]
@@ -429,6 +429,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Import,
+                self.global.asn,
             )?;
 
             Ok(chain)
@@ -451,6 +453,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Export,
+                self.global.asn,
             )
         }
     }
@@ -582,6 +586,8 @@ impl Config {
                     &self.policy.rpol,
                     &self.policy.neighbor_sets,
                     &self.peer_groups,
+                    ChainDirection::Import,
+                    self.global.asn,
                 )?
             }
         } else {
@@ -602,6 +608,8 @@ impl Config {
                     &self.policy.rpol,
                     &self.policy.neighbor_sets,
                     &self.peer_groups,
+                    ChainDirection::Export,
+                    self.global.asn,
                 )?
             }
         } else {
@@ -626,6 +634,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Import,
+                self.global.asn,
             )?
         }
         .or_else(|| global_import.clone());
@@ -647,6 +657,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Export,
+                self.global.asn,
             )?
         }
         .or_else(|| global_export.clone());

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -291,6 +291,18 @@ pub(super) fn parse_named_policy(
     })
 }
 
+/// Which direction a policy chain is being bound to. Direction is
+/// knowable at every attachment site (the global / peer-group /
+/// neighbor import vs export config keys), so direction legality is
+/// enforced once at attach time — never discovered per route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChainDirection {
+    /// Inbound policy (`import_policy_chain` / `[policy] import_chain`).
+    Import,
+    /// Outbound policy (`export_policy_chain` / `[policy] export_chain`).
+    Export,
+}
+
 /// Resolve a list of policy names to a `PolicyChain`. Each entry is
 /// tagged with its configured name so the chain-eval attribution path
 /// (used by `bgp_policy_routes_total` and the explain surface) can
@@ -304,12 +316,22 @@ pub(super) fn parse_named_policy(
 /// and the ADR-0076 planner's structural diff both see the compiled
 /// content. Every `.rpol` member of one chain compiles through one
 /// `SetStore`, so identical set data dedupes within the chain.
+///
+/// LAN-296: every `.rpol` member is stamped with `local_asn` (the
+/// `[global] asn`, backing `prepend as self`), and an export-bound
+/// chain is rejected when any member carries the import-only
+/// `prepend as peer` action. Every install path — initial load, SIGHUP
+/// reload, the rpol overlay, config transactions, and the gRPC policy
+/// admin — resolves through this function, so the direction check
+/// holds everywhere by construction.
 pub(super) fn resolve_chain(
     names: &[String],
     definitions: &HashMap<String, NamedPolicyConfig>,
     rpol: &rustbgpd_policy::rpol::RpolPolicySet,
     neighbor_sets: &HashMap<String, NeighborSetConfig>,
     peer_groups: &HashMap<String, PeerGroupConfig>,
+    direction: ChainDirection,
+    local_asn: u32,
 ) -> Result<Option<PolicyChain>, ConfigError> {
     if names.is_empty() {
         return Ok(None);
@@ -327,9 +349,33 @@ pub(super) fn resolve_chain(
                     }
                 });
             }
-            resolve_rpol_chain_ref(name, rpol, &mut store)
+            resolve_rpol_chain_ref(name, rpol, &mut store, local_asn)
         })
         .collect::<Result<Vec<_>, _>>()?;
+    // LAN-296 direction legality: `prepend as peer` on an export chain
+    // would prepend the RECEIVING peer's own ASN — rejected by the
+    // receiver as an own-AS loop (RFC 4271 §9.1.2) — so it is refused
+    // at attach time, not discovered per route. TOML members cannot
+    // carry computed operands, so only `.rpol` members are probed.
+    if direction == ChainDirection::Export {
+        for named in &policies {
+            if let Some(compiled) = named.rpol.as_deref()
+                && let Some((_, term)) = compiled.peer_prepend_action()
+            {
+                return Err(ConfigError::InvalidPolicyEntry {
+                    reason: format!(
+                        "export policy chain member {:?} (term {:?}) uses `prepend as peer`: \
+                         on export this prepends the receiving peer's own ASN, which the \
+                         receiver rejects as an own-AS loop (RFC 4271 §9.1.2); \
+                         `prepend as peer` is import-only — use `prepend as self` or \
+                         a literal ASN on export",
+                        named.name.as_deref().unwrap_or("<inline>"),
+                        term.unwrap_or("<unnamed>"),
+                    ),
+                });
+            }
+        }
+    }
     Ok(Some(PolicyChain::from_named(policies)))
 }
 
@@ -340,6 +386,7 @@ fn resolve_rpol_chain_ref(
     reference: &str,
     rpol: &rustbgpd_policy::rpol::RpolPolicySet,
     store: &mut rustbgpd_policy::sets::SetStore,
+    local_asn: u32,
 ) -> Result<rustbgpd_policy::NamedPolicy, ConfigError> {
     let (base, args) = rustbgpd_policy::rpol::parse_call_form(reference).map_err(|detail| {
         ConfigError::InvalidPolicyEntry {
@@ -362,10 +409,14 @@ fn resolve_rpol_chain_ref(
             ),
         });
     }
-    let compiled = entry
+    let mut compiled = entry
         .file
         .compile_policy(base, &args, store)
         .expect("registry entry names a policy defined in its file");
+    // Attach-time stamp backing `prepend as self` (LAN-296): the
+    // daemon's `[global] asn`. Deterministic from config, so reloads
+    // of an unchanged file still diff as no-ops.
+    compiled.local_asn = Some(local_asn);
     Ok(rustbgpd_policy::NamedPolicy::from_rpol(
         reference.to_string(),
         std::sync::Arc::new(compiled),
@@ -507,6 +558,9 @@ fn parse_modifications(
         extended_communities_remove: remove.extended,
         large_communities_add: add.large,
         large_communities_remove: remove.large,
+        // Computed prepend operands (LAN-296) are an `.rpol`-only
+        // surface; the TOML frontend stays literal-only.
+        as_path_prepend_computed: None,
         as_path_prepend,
     })
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11919,6 +11919,164 @@ fn rpol_files_load_resolve_and_evaluate_in_chains() {
     assert_eq!(eval.matched_policy.as_deref(), Some("bogon-filter"));
 }
 
+// ── LAN-296: computed prepend operands at config attachment ─────────
+
+/// A config dir whose neighbor binds `.rpol` chains in BOTH
+/// directions, for direction-legality tests.
+fn rpol_directional_config_dir(
+    rpol_source: &str,
+    import_chain: &str,
+    export_chain: &str,
+) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(dir.path().join("policies")).expect("mkdir");
+    fs::write(dir.path().join("policies/core.rpol"), rpol_source).expect("write rpol");
+    let toml = format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[policy]
+rpol_files = ["policies/core.rpol"]
+
+[[neighbors]]
+address = "192.0.2.1"
+remote_asn = 65002
+import_policy_chain = [{import_chain}]
+export_policy_chain = [{export_chain}]
+"#,
+    );
+    fs::write(dir.path().join("config.toml"), toml).expect("write config");
+    dir
+}
+
+const PREPEND_OPERANDS_RPOL: &str = r"
+policy peer-pad { term inbound-pad { prepend as peer 3; accept } }
+policy self-pad { term outbound-pad { prepend as self 3; accept } }
+policy origin-pad { term origin-pad { prepend as origin 2; accept } }
+";
+
+/// Direction legality is enforced when the chain is attached: a
+/// `prepend as peer` member is import-only, and binding it as an
+/// export chain fails the config load with the exact diagnostic.
+#[test]
+fn prepend_as_peer_rejected_on_export_attachment() {
+    let dir = rpol_directional_config_dir(PREPEND_OPERANDS_RPOL, r#""peer-pad""#, r#""peer-pad""#);
+    let error = load_dir(&dir).expect_err("export-bound `prepend as peer` must fail the load");
+    assert!(error.contains("peer-pad"), "{error}");
+    assert!(error.contains("inbound-pad"), "{error}");
+    assert!(error.contains("prepend as peer"), "{error}");
+    assert!(error.contains("import-only"), "{error}");
+    assert!(error.contains("own-AS loop"), "{error}");
+}
+
+/// The legal cells of the matrix: `peer` on import, `self`/`origin` on
+/// export (and import). The export chain's rpol members carry the
+/// attach-time `[global] asn`, so `prepend as self` resolves to it.
+#[test]
+fn prepend_operand_legal_directions_attach_and_resolve() {
+    let dir = rpol_directional_config_dir(
+        PREPEND_OPERANDS_RPOL,
+        r#""peer-pad", "origin-pad""#,
+        r#""self-pad", "origin-pad""#,
+    );
+    let config = load_dir(&dir).expect("legal operand placements load");
+    let neighbor = &config.neighbors[0];
+    let (import, export) = config
+        .effective_policy_chains_for_neighbor(neighbor)
+        .expect("chains resolve");
+    let import = import.expect("import chain configured");
+    let export = export.expect("export chain configured");
+
+    // Attach-time local_asn stamp on every rpol member.
+    for chain in [&import, &export] {
+        for member in &chain.policies {
+            let compiled = member.rpol.as_deref().expect("rpol member");
+            assert_eq!(compiled.local_asn, Some(65001));
+        }
+    }
+
+    let ctx = rustbgpd_policy::RouteContext {
+        prefix: Some(Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+            "10.10.3.0".parse().unwrap(),
+            24,
+        ))),
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path_len: 1,
+        origin_asn: Some(64500),
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: Some(65002),
+        peer_group: None,
+        route_type: None,
+        family: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+    // Import: `prepend as peer` resolves to the neighbor's ASN (the
+    // later `origin-pad` member wins the shared prepend slot — chain
+    // merge semantics — so evaluate the peer-pad member's chain alone).
+    let peer_only = rustbgpd_policy::PolicyChain::from_named(vec![import.policies[0].clone()]);
+    let result = peer_only.evaluate(&ctx);
+    assert_eq!(result.action, rustbgpd_policy::PolicyAction::Permit);
+    assert_eq!(result.modifications.as_path_prepend, Some((65002, 3)));
+
+    // Export: `prepend as self` resolves to the daemon's [global] asn.
+    let self_only = rustbgpd_policy::PolicyChain::from_named(vec![export.policies[0].clone()]);
+    let result = self_only.evaluate(&ctx);
+    assert_eq!(result.modifications.as_path_prepend, Some((65001, 3)));
+
+    // Both directions: `origin` resolves from the route.
+    let result = export.evaluate(&ctx);
+    assert_eq!(result.modifications.as_path_prepend, Some((64500, 2)));
+}
+
+/// `prepend as peer` on the GLOBAL export chain is rejected too — the
+/// direction check lives in the shared resolver, not per-neighbor.
+#[test]
+fn prepend_as_peer_rejected_on_global_export_chain() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(dir.path().join("policies")).expect("mkdir");
+    fs::write(dir.path().join("policies/core.rpol"), PREPEND_OPERANDS_RPOL).expect("write rpol");
+    fs::write(
+        dir.path().join("config.toml"),
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[policy]
+rpol_files = ["policies/core.rpol"]
+export_chain = ["peer-pad"]
+"#,
+    )
+    .expect("write config");
+    let error = load_dir(&dir).expect_err("global export `prepend as peer` must fail");
+    assert!(error.contains("prepend as peer"), "{error}");
+    assert!(error.contains("import-only"), "{error}");
+}
+
 #[test]
 fn rpol_compile_diagnostics_fail_config_load() {
     let dir = rpol_config_dir(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -3,7 +3,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
 use super::parse::{
-    parse_families, parse_named_policy, parse_neighbor_set, parse_policy, resolve_chain,
+    ChainDirection, parse_families, parse_named_policy, parse_neighbor_set, parse_policy,
+    resolve_chain,
 };
 use super::schema::{
     ManagedBridgeNetdevConfig, ManagedL3VxlanNetdevConfig, ManagedNetdevsConfig,
@@ -231,6 +232,7 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                self.global.asn,
             )?;
         }
 
@@ -246,6 +248,8 @@ impl Config {
             &self.policy.rpol,
             &self.policy.neighbor_sets,
             &self.peer_groups,
+            ChainDirection::Import,
+            self.global.asn,
         )?;
         resolve_chain(
             &self.policy.export_chain,
@@ -253,6 +257,8 @@ impl Config {
             &self.policy.rpol,
             &self.policy.neighbor_sets,
             &self.peer_groups,
+            ChainDirection::Export,
+            self.global.asn,
         )?;
 
         // Validate neighbor address/interface identity. Numbered peers remain
@@ -698,6 +704,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Import,
+                self.global.asn,
             )?;
             resolve_chain(
                 &neighbor.export_policy_chain,
@@ -705,6 +713,8 @@ impl Config {
                 &self.policy.rpol,
                 &self.policy.neighbor_sets,
                 &self.peer_groups,
+                ChainDirection::Export,
+                self.global.asn,
             )?;
         }
 
@@ -1757,6 +1767,7 @@ fn validate_peer_group(
     rpol: &rustbgpd_policy::rpol::RpolPolicySet,
     neighbor_sets: &std::collections::HashMap<String, super::NeighborSetConfig>,
     peer_groups: &std::collections::HashMap<String, PeerGroupConfig>,
+    local_asn: u32,
 ) -> Result<(), ConfigError> {
     let hold_time = group.hold_time.unwrap_or(DEFAULT_HOLD_TIME);
     if hold_time != 0 && hold_time < 3 {
@@ -1874,6 +1885,8 @@ fn validate_peer_group(
         rpol,
         neighbor_sets,
         peer_groups,
+        ChainDirection::Import,
+        local_asn,
     )?;
     resolve_chain(
         &group.export_policy_chain,
@@ -1881,6 +1894,8 @@ fn validate_peer_group(
         rpol,
         neighbor_sets,
         peer_groups,
+        ChainDirection::Export,
+        local_asn,
     )?;
 
     Ok(())


### PR DESCRIPTION
## Summary

- adds computed prepend operands to rpol: `prepend as self N` (local ASN), `prepend as peer N` (evaluation peer's ASN), `prepend as origin N` (rightmost non-empty AS_SEQUENCE origin, reusing `AsPath::origin_asn`)
- direction legality enforced once at attachment time through the single chain-resolution choke point: `as peer` on an export chain is rejected at install with a named policy/term diagnostic — prepending the receiver's own ASN invites own-AS loop rejection (RFC 4271 §9.1.2), and neither FRR nor BIRD has an export peer-AS idiom (`last-as` is FRR's inbound-only equivalent); `self` and `origin` are legal both directions
- fail-closed per ADR-0103: unresolvable operands (missing origin/peer, or AS 0 per RFC 7607) deny the route with staged modifications discarded and the explain trace naming the unresolvable term — ASN 0 is never prepended
- the local ASN rides on the compiled chain (stamped at attach), not the route context, since no per-session local-as override exists — eliminating per-construction-site plumbing; the ceiling is documented where a future override would move it
- `as peer` registers as peer-dependent for update-group fingerprinting (defense in depth behind the attach rejection); `self`/`origin` chains still group, pinned at chain and rib level
- `origin` is a contextual identifier (parameters may shadow it), keeping the grammar additively compatible; fixed-AS and parameter prepends unchanged
- adds exact u8 segment-boundary pins for prepend (254+3, 255+1, 254+1) and a language-reference section with the operand semantics

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy (238) / -p rustbgpd-rib (708) / -p rustbgpd-transport / --bin rustbgpd (1350)
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build
- cargo check -p rustbgpd-rib --features bench-internals --benches

Closes LAN-296.