### PR TITLE
feat(rpol): add checked u32 value expressions with fail-closed evaluation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,31 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   per-incumbent capture commands, prerequisites, limitations, and example
   equal / explained-difference reports.
 
+- **`.rpol` checked u32 value expressions** (LAN-299, the first
+  ADR-0103 slice). Arithmetic (`+ - * / %`) and the bounded builtins
+  `min`/`max`/`clamp` in value positions — `set med route.med + 50`,
+  `set local-pref min(route.local-pref * 2, 400)`, comparisons like
+  `route.as-path.len * 10 >= route.med` — over u32 literals,
+  parameters, and the u32 fields (`route.local-pref`, `route.med`,
+  `route.as-path.len`, `route.origin-as`, `peer.asn`). Every operation
+  is checked: overflow, underflow, division/modulo by zero, an
+  inverted clamp, or an absent operand (origin AS on an `AS_SET`-only
+  path, unknown peer ASN) is an evaluation error that denies the route
+  with staged modifications discarded, a per-chain error counter, a
+  rate-limited WARN naming the failing policy and term, and the error
+  rendered in explain traces in place of a verdict — the uniform
+  fail-closed rail later ADR-0103 slices reuse, and the computed
+  as-path prepend operands now ride it too. Constant subexpressions
+  fold at compile time with the same checked operators (`set med
+  25 + 25` compiles to exactly `set med 50`; `4294967295 + 1` is a
+  compile error at its span), operator costs land in the typecheck
+  cost DP under the ADR's `MAX_EVAL_COST` budget, and grammar
+  evolution is source-compatible: kebab-case maximal munch is
+  permanent, so `route.med - 1` subtracts while `route.med-1` stays an
+  unknown-field error. `peer.asn` operands register peer context for
+  update-group fingerprinting; route-field arithmetic never
+  disqualifies grouping.
+
 ### Changed
 
 - **Release publication is now fail-closed.** The binary-release and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,6 +2897,7 @@ dependencies = [
  "rustbgpd-wire",
  "rustc-hash 2.1.3",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -19,6 +19,8 @@ regex = "1"
 rustc-hash.workspace = true
 rustbgpd-wire.workspace = true
 thiserror.workspace = true
+# Rate-limited eval-error WARN (LAN-299, ADR-0103 Decision 4).
+tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -464,10 +464,81 @@ fn bench_set_heavy(c: &mut Criterion) {
     group.finish();
 }
 
+/// LAN-299 value expressions: the arithmetic cost itself, and the
+/// constant-action contrast proving chains that use NO arithmetic keep
+/// their cost (constant expressions fold to the same IR as literals,
+/// and the eval-error slot rides the walk for free). Both chains
+/// compile from `.rpol` so they exercise the real frontend output.
+fn bench_value_expr(c: &mut Criterion) {
+    let mut store = SetStore::new();
+    let constant = rustbgpd_policy::rpol::compile_rpol(
+        "policy p { term t { if route.med >= 10 { set med 50; set local-pref 200; accept } } }",
+        &mut store,
+    )
+    .expect("compiles");
+    // Folded constant ACTIONS are IR-identical to the literal form
+    // (guards with arithmetic keep their ValueCmp shape by design —
+    // different absent-operand semantics); the bench then contrasts
+    // real arithmetic (field operands, builtins).
+    let folded = rustbgpd_policy::rpol::compile_rpol(
+        "policy p { term t { if route.med >= 10 { set med 25 + 25; set local-pref 2 * 100; accept } } }",
+        &mut store,
+    )
+    .expect("compiles");
+    assert_eq!(
+        constant, folded,
+        "constant arithmetic actions fold to the literal IR"
+    );
+    let arithmetic = rustbgpd_policy::rpol::compile_rpol(
+        "policy p { term t { if route.as-path.len * 10 >= route.med { set med route.med + 50; set local-pref min(route.local-pref * 2, 400); accept } } }",
+        &mut store,
+    )
+    .expect("compiles");
+
+    let communities: Vec<u32> = Vec::new();
+    let as_path_str = String::new();
+    let ctx = RouteContext {
+        prefix: Some(matching_prefix()),
+        next_hop: None,
+        extended_communities: &[],
+        communities: &communities,
+        large_communities: &[],
+        as_path_str: &as_path_str,
+        as_path_len: 3,
+        origin_asn: Some(65200),
+        validation_state: RpkiValidation::NotFound,
+        aspa_state: AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: Some(65001),
+        peer_group: None,
+        route_type: None,
+        family: None,
+        evpn_route_type: None,
+        local_pref: Some(100),
+        med: Some(20),
+    };
+
+    let mut group = c.benchmark_group("value_expr");
+    group.bench_function("constant_actions", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&constant).evaluate_with_attribution(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("arithmetic_actions", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&arithmetic).evaluate_with_attribution(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_policy_eval,
     bench_policy_predicate_eval,
-    bench_set_heavy
+    bench_set_heavy,
+    bench_value_expr
 );
 criterion_main!(benches);

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-299-arithmetic.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-299-arithmetic.rpol
@@ -1,0 +1,10 @@
+policy arith(bump: u32) {
+    term compute {
+        if route.as-path.len * 10 >= route.med && route.med + bump <= 4294967295 {
+            set med route.med + 50;
+            set local-pref min(route.local-pref * 2, 400);
+            accept
+        }
+    }
+    term rest { reject }
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-299-builtins.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-299-builtins.rpol
@@ -1,0 +1,14 @@
+policy edges {
+    term t {
+        if route.origin-as % 2 == 0 || peer.asn - 1 >= route.med / 3 {
+            set local-pref clamp(route.local-pref, 100, 400);
+            set med max(min(route.med, 400), 25 + 25);
+            accept
+        }
+    }
+}
+
+test boundary {
+    route { med 4294967295 }
+    expect edges == reject
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-299-fold-errors.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-299-fold-errors.rpol
@@ -1,0 +1,6 @@
+policy bad {
+    term overflow { set med 4294967295 + 1; accept }
+    term divzero { if route.med >= 1 / 0 { reject } }
+    term inverted { set med clamp(5, 10, 2) }
+    term kebab { if route.med-1 >= 0 { accept } }
+}

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -378,6 +378,22 @@ pub struct RouteModifications {
     /// downstream of them — [`apply_modifications`], the export memo,
     /// API explain surfaces — only ever see the literal field.**
     pub as_path_prepend_computed: Option<(PrependAs, u8)>,
+    /// Computed `LOCAL_PREF` value (LAN-299, `.rpol`
+    /// `set local-pref <expr>` where the expression reads route/peer
+    /// fields). Shares one logical "set local-pref" slot with
+    /// [`set_local_pref`](Self::set_local_pref) — at most one of the
+    /// pair is `Some` in frontend-produced modifications, and merges
+    /// treat them as one scalar. The evaluator resolves it into the
+    /// literal field at term execution (an evaluation error fails the
+    /// route closed, ADR-0103 Decision 4), so evaluation results and
+    /// everything downstream only ever see the literal field —
+    /// exactly the [`as_path_prepend_computed`](Self::as_path_prepend_computed)
+    /// discipline. `Arc`: modifications clone on the evaluation path
+    /// and the expression tree is immutable compile-time data.
+    pub set_local_pref_computed: Option<Arc<crate::ir::ValueExpr>>,
+    /// Computed `MED` value (LAN-299) — see
+    /// [`set_local_pref_computed`](Self::set_local_pref_computed).
+    pub set_med_computed: Option<Arc<crate::ir::ValueExpr>>,
 }
 
 impl RouteModifications {
@@ -386,6 +402,8 @@ impl RouteModifications {
     pub fn is_empty(&self) -> bool {
         self.set_local_pref.is_none()
             && self.set_med.is_none()
+            && self.set_local_pref_computed.is_none()
+            && self.set_med_computed.is_none()
             && self.set_next_hop.is_none()
             && self.as_path_prepend.is_none()
             && self.as_path_prepend_computed.is_none()
@@ -405,11 +423,16 @@ impl RouteModifications {
     /// on conflicts. A later remove cancels an earlier add of the same
     /// logical value, and a later add cancels an earlier remove.
     pub fn merge_from(&mut self, other: RouteModifications) {
-        if other.set_local_pref.is_some() {
+        // Literal and computed set-values share one logical slot each
+        // (LAN-299), like the prepend pair below: a later set of
+        // either form replaces an earlier one of either form.
+        if other.set_local_pref.is_some() || other.set_local_pref_computed.is_some() {
             self.set_local_pref = other.set_local_pref;
+            self.set_local_pref_computed = other.set_local_pref_computed;
         }
-        if other.set_med.is_some() {
+        if other.set_med.is_some() || other.set_med_computed.is_some() {
             self.set_med = other.set_med;
+            self.set_med_computed = other.set_med_computed;
         }
         if other.set_next_hop.is_some() {
             self.set_next_hop = other.set_next_hop;
@@ -1498,6 +1521,13 @@ pub fn apply_modifications(
     debug_assert!(
         mods.as_path_prepend_computed.is_none(),
         "computed prepend operand reached apply_modifications unresolved"
+    );
+    // Same contract for computed set-values (LAN-299): the evaluator
+    // folds them into the literal fields (or denies the route) before
+    // modifications reach an apply site.
+    debug_assert!(
+        mods.set_local_pref_computed.is_none() && mods.set_med_computed.is_none(),
+        "computed set-value reached apply_modifications unresolved"
     );
     if let Some((asn, count)) = mods.as_path_prepend {
         apply_as_path_prepend(attrs, asn, count);

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -341,6 +341,26 @@ fn render_modifications(
     if let Some(med) = mods.set_med {
         out.push(format!("med {} -> {med}", ctx.med.unwrap_or(IMPLICIT_MED)));
     }
+    // LAN-299: computed set values render with their source expression
+    // plus the value they resolve to for this route. The unresolvable
+    // case never reaches here — the trace walk denies at the failing
+    // term first — but renders honestly if it ever did.
+    if let Some(expr) = &mods.set_local_pref_computed {
+        let before = ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF);
+        match crate::eval::eval_value(expr, ctx) {
+            Ok(value) => out.push(format!("local_pref {before} -> {expr} = {value}")),
+            Err(kind) => out.push(format!(
+                "local_pref {before} -> {expr} (unresolvable: {kind})"
+            )),
+        }
+    }
+    if let Some(expr) = &mods.set_med_computed {
+        let before = ctx.med.unwrap_or(IMPLICIT_MED);
+        match crate::eval::eval_value(expr, ctx) {
+            Ok(value) => out.push(format!("med {before} -> {expr} = {value}")),
+            Err(kind) => out.push(format!("med {before} -> {expr} (unresolvable: {kind})")),
+        }
+    }
     if let Some(action) = mods.set_next_hop.as_ref() {
         let before = ctx
             .next_hop
@@ -413,13 +433,30 @@ fn trace_rpol_policy(
     let mut term_traces = Vec::new();
     let mut continued: Option<RouteModifications> = None;
     let mut decided: Option<(usize, &Term)> = None;
-    // LAN-296: set when a matched term's computed prepend operand
-    // cannot resolve — the live evaluator fails the route closed at
-    // that term, and the trace must agree (pinned by the agreement
-    // matrix in `statement_trace.rs`).
-    let mut prepend_failed = false;
+    // LAN-296/LAN-299: set when a term errors — an unresolvable
+    // computed operand or a failed guard value expression. The live
+    // evaluator fails the route closed at that term (the eval-error
+    // rail), and the trace must agree (pinned by the agreement matrix
+    // in `statement_trace.rs`).
+    let mut eval_failed = false;
     for (index, term) in policy.terms.iter().enumerate() {
-        let matched = tables.guard_matches(&term.guard, ctx);
+        let matched = match tables.guard_matches(&term.guard, ctx) {
+            Ok(matched) => matched,
+            // Guard evaluation error (LAN-299): render the error in
+            // place of a verdict (ADR-0103 Decision 6.4) and decide
+            // the route as a fail-closed reject, mirroring the live
+            // walk.
+            Err(kind) => {
+                term_traces.push(format!(
+                    "term {}: {} => evaluation error: {kind} — fail closed => reject",
+                    term.name.as_deref().unwrap_or("<unnamed>"),
+                    render_expr(&term.guard, tables),
+                ));
+                eval_failed = true;
+                decided = Some((index, term));
+                break;
+            }
+        };
         term_traces.push(format!(
             "term {}: {} => {} [{}]",
             term.name.as_deref().unwrap_or("<unnamed>"),
@@ -438,18 +475,13 @@ fn trace_rpol_policy(
             TermAction::Deny => None,
         };
         if let Some(mods) = action_mods
-            && tables.resolve_computed_prepend(mods, ctx).is_err()
+            && let Err(kind) = tables.resolve_computed(mods, ctx)
         {
-            let (operand, _) = mods
-                .as_path_prepend_computed
-                .expect("resolution only fails on a computed operand");
             term_traces.push(format!(
-                "term {}: prepend as {} unresolvable ({}) — fail closed => reject",
+                "term {}: evaluation error: {kind} — fail closed => reject",
                 term.name.as_deref().unwrap_or("<unnamed>"),
-                operand.as_str(),
-                missing_operand_reason(operand),
             ));
-            prepend_failed = true;
+            eval_failed = true;
             decided = Some((index, term));
             break;
         }
@@ -468,10 +500,9 @@ fn trace_rpol_policy(
     if let Some((index, term)) = decided {
         // Live-path parity: a deny discards accumulated Continue
         // modifications and contributes none of its own; a fail-closed
-        // computed-prepend failure denies regardless of the term's own
-        // action.
+        // evaluation error denies regardless of the term's own action.
         let (action, modifications) = match &term.action {
-            TermAction::Permit(mods) if !prepend_failed => {
+            TermAction::Permit(mods) if !eval_failed => {
                 let mut merged = continued.unwrap_or_default();
                 merged.merge_from(mods.clone());
                 (
@@ -526,17 +557,6 @@ fn render_term_action(action: &TermAction) -> String {
     parts.join("; ")
 }
 
-/// Why a computed prepend operand could not resolve for this route —
-/// the explain-side rendering of the fail-closed reasons in
-/// `PrependAs::resolve` (zero values count as unknown: RFC 7607).
-fn missing_operand_reason(operand: crate::engine::PrependAs) -> &'static str {
-    match operand {
-        crate::engine::PrependAs::LocalAs => "the chain carries no local ASN",
-        crate::engine::PrependAs::PeerAs => "the peer ASN is unknown",
-        crate::engine::PrependAs::OriginAs => "the route has no origin AS",
-    }
-}
-
 /// Modifications as `.rpol` action statements (static description of
 /// what the term *does* — contrast `render_modifications`, which
 /// renders the `before -> after` transition for a specific route).
@@ -547,6 +567,13 @@ fn render_action_stmts(mods: &RouteModifications) -> Vec<String> {
     }
     if let Some(med) = mods.set_med {
         out.push(format!("set med {med}"));
+    }
+    // LAN-299 computed set values render in their source form.
+    if let Some(expr) = &mods.set_local_pref_computed {
+        out.push(format!("set local-pref {expr}"));
+    }
+    if let Some(expr) = &mods.set_med_computed {
+        out.push(format!("set med {expr}"));
     }
     if let Some(action) = mods.set_next_hop.as_ref() {
         let target = match action {
@@ -687,6 +714,11 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
         ),
         MatchExpr::LocalPref(cmp) => render_cmp("route.local-pref", *cmp),
         MatchExpr::Med(cmp) => render_cmp("route.med", *cmp),
+        // LAN-299: value expressions carry their own precedence-aware
+        // Display; the comparison itself binds like the other atoms.
+        MatchExpr::ValueCmp(node) => {
+            format!("{} {} {}", node.lhs, node.op.symbol(), node.rhs)
+        }
         MatchExpr::NextHopEq(addr) => format!("route.next-hop == {addr}"),
         MatchExpr::NextHopNe(addr) => format!("route.next-hop != {addr}"),
         MatchExpr::NextHopEqPeer => "route.next-hop == peer.address".to_string(),

--- a/crates/policy/src/engine/tests/ir_parity.rs
+++ b/crates/policy/src/engine/tests/ir_parity.rs
@@ -64,6 +64,8 @@ fn full_mods() -> RouteModifications {
         as_path_prepend: Some((65001, 2)),
         // TOML statements never carry computed operands (rpol-only).
         as_path_prepend_computed: None,
+        set_local_pref_computed: None,
+        set_med_computed: None,
     }
 }
 

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -15,14 +15,166 @@
 //! (the `ATTR` const generic) — the plain [`CompiledChain::evaluate`]
 //! path never touches it.
 
+use std::fmt;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use crate::engine::{
-    IMPLICIT_LOCAL_PREF, IMPLICIT_MED, PolicyAction, PolicyEvaluation, PolicyResult, RouteContext,
-    RouteModifications,
+    IMPLICIT_LOCAL_PREF, IMPLICIT_MED, PolicyAction, PolicyEvaluation, PolicyResult, PrependAs,
+    RouteContext, RouteModifications,
 };
-use crate::ir::{Cmp, CompiledChain, CompiledPolicy, MatchExpr, TermAction};
+use crate::ir::{
+    ArithOp, Cmp, CompiledChain, CompiledPolicy, MatchExpr, TermAction, ValueCmpOp, ValueExpr,
+    ValueField,
+};
 use crate::sets::prefix_entry_matches;
+
+/// Why a route evaluation failed (LAN-299, the ADR-0103 Decision 4
+/// rails). ANY of these resolves the route as a uniform **Deny**:
+/// staged modifications are discarded, the chain's
+/// [`PolicyHitCounters::eval_errors`] counter increments on the
+/// counting paths, a rate-limited WARN names the failing policy/term,
+/// and explain traces render the error in place of a verdict. Later
+/// language slices (locals, loops, functions — ADR-0103) add kinds
+/// here; the disposition never varies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvalErrorKind {
+    /// `+` or `*` exceeded `u32::MAX`.
+    Overflow,
+    /// `-` went below zero (no signed types in the value model).
+    Underflow,
+    /// `/` with a zero divisor.
+    DivideByZero,
+    /// `%` with a zero divisor.
+    RemainderByZero,
+    /// `clamp(x, lo, hi)` evaluated with `lo > hi` (the statically
+    /// known case is a compile error; this is the data-dependent one).
+    ClampInverted,
+    /// A `u32` field operand with no default was absent (origin AS on
+    /// an empty/`AS_SET`-only path, unknown peer ASN).
+    AbsentField(ValueField),
+    /// A computed prepend operand (LAN-296) could not resolve —
+    /// unknown context value, or zero (ASN 0 is prohibited on the
+    /// wire, RFC 7607).
+    AbsentPrependOperand(PrependAs),
+}
+
+impl EvalErrorKind {
+    /// Stable short label (counter/log-friendly).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            EvalErrorKind::Overflow => "overflow",
+            EvalErrorKind::Underflow => "underflow",
+            EvalErrorKind::DivideByZero => "divide-by-zero",
+            EvalErrorKind::RemainderByZero => "remainder-by-zero",
+            EvalErrorKind::ClampInverted => "clamp-inverted",
+            EvalErrorKind::AbsentField(_) => "absent-operand",
+            EvalErrorKind::AbsentPrependOperand(_) => "absent-prepend-operand",
+        }
+    }
+}
+
+impl fmt::Display for EvalErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EvalErrorKind::Overflow => write!(f, "arithmetic overflow"),
+            EvalErrorKind::Underflow => write!(f, "arithmetic underflow"),
+            EvalErrorKind::DivideByZero => write!(f, "division by zero"),
+            EvalErrorKind::RemainderByZero => write!(f, "remainder by zero"),
+            EvalErrorKind::ClampInverted => write!(f, "clamp bounds inverted (lo > hi)"),
+            EvalErrorKind::AbsentField(field) => {
+                write!(f, "`{}` has no value for this route", field.as_str())
+            }
+            EvalErrorKind::AbsentPrependOperand(operand) => {
+                write!(f, "prepend as {} unresolvable (", operand.as_str())?;
+                match operand {
+                    PrependAs::LocalAs => write!(f, "the chain carries no local ASN")?,
+                    PrependAs::PeerAs => write!(f, "the peer ASN is unknown")?,
+                    PrependAs::OriginAs => write!(f, "the route has no origin AS")?,
+                }
+                write!(f, ")")
+            }
+        }
+    }
+}
+
+/// Evaluate a compiled value expression against a route context.
+/// Pure and allocation-free; every arithmetic step is checked
+/// (ADR-0103 Decision 2 — the SIGFPE class is unrepresentable).
+/// Recursion depth is bounded by the frontend (`MAX_EXPR_DEPTH`).
+pub(crate) fn eval_value(expr: &ValueExpr, ctx: &RouteContext<'_>) -> Result<u32, EvalErrorKind> {
+    match expr {
+        ValueExpr::Const(value) => Ok(*value),
+        ValueExpr::Field(field) => match field {
+            ValueField::LocalPref => Ok(ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF)),
+            ValueField::Med => Ok(ctx.med.unwrap_or(IMPLICIT_MED)),
+            // Wire-bounded far below u32::MAX; saturate rather than
+            // invent an error kind for an impossible input.
+            ValueField::AsPathLen => Ok(u32::try_from(ctx.as_path_len).unwrap_or(u32::MAX)),
+            ValueField::OriginAs => ctx
+                .origin_asn
+                .ok_or(EvalErrorKind::AbsentField(ValueField::OriginAs)),
+            ValueField::PeerAsn => ctx
+                .peer_asn
+                .ok_or(EvalErrorKind::AbsentField(ValueField::PeerAsn)),
+        },
+        ValueExpr::Binary { op, lhs, rhs } => {
+            let lhs = eval_value(lhs, ctx)?;
+            let rhs = eval_value(rhs, ctx)?;
+            checked_arith(*op, lhs, rhs)
+        }
+        ValueExpr::Min(a, b) => Ok(eval_value(a, ctx)?.min(eval_value(b, ctx)?)),
+        ValueExpr::Max(a, b) => Ok(eval_value(a, ctx)?.max(eval_value(b, ctx)?)),
+        ValueExpr::Clamp(x, lo, hi) => {
+            let x = eval_value(x, ctx)?;
+            let lo = eval_value(lo, ctx)?;
+            let hi = eval_value(hi, ctx)?;
+            if lo > hi {
+                return Err(EvalErrorKind::ClampInverted);
+            }
+            Ok(x.clamp(lo, hi))
+        }
+    }
+}
+
+/// One checked arithmetic step — the only place `u32` operators are
+/// applied, shared by evaluation and compile-time constant folding so
+/// the two can never disagree about what overflows.
+pub(crate) fn checked_arith(op: ArithOp, lhs: u32, rhs: u32) -> Result<u32, EvalErrorKind> {
+    match op {
+        ArithOp::Add => lhs.checked_add(rhs).ok_or(EvalErrorKind::Overflow),
+        ArithOp::Sub => lhs.checked_sub(rhs).ok_or(EvalErrorKind::Underflow),
+        ArithOp::Mul => lhs.checked_mul(rhs).ok_or(EvalErrorKind::Overflow),
+        ArithOp::Div => lhs.checked_div(rhs).ok_or(EvalErrorKind::DivideByZero),
+        ArithOp::Rem => lhs.checked_rem(rhs).ok_or(EvalErrorKind::RemainderByZero),
+    }
+}
+
+/// Rate-limited operator-visible WARN for evaluation errors: at most
+/// one line per second process-wide (errors are per-route and can
+/// arrive at line rate; the counters carry the volume). The clock read
+/// is on the error path only — the ADR-0103 Decision 7 purity contract
+/// exempts observability, and the hot path never reaches here.
+fn warn_eval_error(policy: Option<&str>, term: Option<&str>, kind: EvalErrorKind) {
+    static START: OnceLock<Instant> = OnceLock::new();
+    static LAST_WARN: AtomicU64 = AtomicU64::new(0);
+    let now = START.get_or_init(Instant::now).elapsed().as_secs() + 1;
+    let last = LAST_WARN.load(Ordering::Relaxed);
+    if now > last
+        && LAST_WARN
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    {
+        tracing::warn!(
+            policy = policy.unwrap_or("<inline>"),
+            term = term.unwrap_or("<unnamed>"),
+            reason = kind.label(),
+            "policy evaluation error: {kind} — route denied (fail closed)"
+        );
+    }
+}
 
 /// Live per-term guard-hit counters for one chain (ADR-0096 Decision
 /// 3.3, the IOS-XR `show pcl` idea): `hits[p][t]` counts how many
@@ -39,6 +191,7 @@ use crate::sets::prefix_entry_matches;
 pub struct PolicyHitCounters {
     policies: Vec<Vec<AtomicU64>>,
     evals: AtomicU64,
+    eval_errors: AtomicU64,
 }
 
 impl PolicyHitCounters {
@@ -52,6 +205,7 @@ impl PolicyHitCounters {
                 .map(|policy| (0..policy.terms.len()).map(|_| AtomicU64::new(0)).collect())
                 .collect(),
             evals: AtomicU64::new(0),
+            eval_errors: AtomicU64::new(0),
         }
     }
 
@@ -60,6 +214,16 @@ impl PolicyHitCounters {
     #[must_use]
     pub fn evals(&self) -> u64 {
         self.evals.load(Ordering::Relaxed)
+    }
+
+    /// Routes denied by an evaluation error (LAN-299, ADR-0103
+    /// Decision 4: checked-arithmetic failure or absent operand) since
+    /// chain install. A nonzero value means some policy is erroring —
+    /// the rate-limited WARN log and explain traces name where and
+    /// why.
+    #[must_use]
+    pub fn eval_errors(&self) -> u64 {
+        self.eval_errors.load(Ordering::Relaxed)
     }
 
     /// Snapshot of the per-term hit grid (`snapshot()[p][t]`).
@@ -81,11 +245,17 @@ impl PolicyHitCounters {
 /// modifications (cloned only if merged). `PermitOwned` carries
 /// modifications accumulated from `Continue` terms merged with the
 /// deciding term's own — only policies that actually hit a `Continue`
-/// term (an `.rpol`-only construct) pay the clone.
+/// term (an `.rpol`-only construct) pay the clone. `Error` is the
+/// LAN-299 evaluation-error rail: a guard or action-time value
+/// expression failed; the caller denies the route, counts, and warns.
 enum PolicyDecision<'a> {
     Permit(Option<&'a RouteModifications>),
     PermitOwned(RouteModifications),
     Deny,
+    Error {
+        kind: EvalErrorKind,
+        term_index: usize,
+    },
 }
 
 impl CompiledChain {
@@ -176,6 +346,27 @@ impl CompiledChain {
                         },
                     );
                 }
+                // The LAN-299 eval-error rail (ADR-0103 Decision 4):
+                // uniform Deny, staged modifications discarded (the
+                // accumulator drops here), operator-visible counter +
+                // rate-limited WARN naming the failing policy/term.
+                PolicyDecision::Error { kind, term_index } => {
+                    if COUNT && let Some(hits) = hits {
+                        hits.eval_errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                    let term = policy
+                        .terms
+                        .get(term_index)
+                        .and_then(|term| term.name.as_deref());
+                    warn_eval_error(policy.name.as_deref(), term, kind);
+                    return (
+                        PolicyResult::deny(),
+                        PolicyEvaluation {
+                            action: PolicyAction::Deny,
+                            matched_policy: if ATTR { policy.name.clone() } else { None },
+                        },
+                    );
+                }
                 PolicyDecision::Permit(Some(mods)) if !mods.is_empty() => {
                     accumulated.merge_from(mods.clone());
                 }
@@ -220,7 +411,9 @@ impl CompiledChain {
     /// Evaluate recording per-term guard hits — the `rbgp policy test`
     /// backend (ADR-0096 Decision 6). Decision semantics are identical
     /// to [`evaluate_with_attribution`](Self::evaluate_with_attribution)
-    /// (same walk, same merge rules); additionally `hits[p][t]` is
+    /// (same walk, same merge rules; an evaluation error denies the
+    /// route, LAN-299 — dry runs move no live counters and log no
+    /// WARN); additionally `hits[p][t]` is
     /// incremented whenever policy `p`'s term `t`'s guard matches
     /// during the walk (`Continue` terms included; terms after the
     /// deciding term are not evaluated, mirroring first-match-wins).
@@ -244,18 +437,25 @@ impl CompiledChain {
             let mut permit_mods: Option<Option<RouteModifications>> = None;
             let mut denied = false;
             for (term, hit) in policy.terms.iter().zip(policy_hits.iter_mut()) {
-                if self.eval_expr(&term.guard, ctx) {
+                let mut err = None;
+                let matched = self.eval_expr(&term.guard, ctx, &mut err);
+                if err.is_some() {
+                    // Guard evaluation error: fail closed (LAN-299).
+                    denied = true;
+                    break;
+                }
+                if matched {
                     *hit += 1;
                     match &term.action {
                         TermAction::Permit(mods) => {
-                            match self.resolve_computed_prepend(mods, ctx) {
+                            match self.resolve_computed(mods, ctx) {
                                 Ok(resolved) => {
                                     permit_mods =
                                         Some(Some(resolved.unwrap_or_else(|| mods.clone())));
                                 }
-                                // Unresolvable computed prepend operand:
-                                // fail closed (same rule as the live walk).
-                                Err(()) => denied = true,
+                                // Unresolvable computed operand: fail
+                                // closed (same rule as the live walk).
+                                Err(_) => denied = true,
                             }
                             break;
                         }
@@ -264,7 +464,7 @@ impl CompiledChain {
                             break;
                         }
                         TermAction::Continue(mods) => {
-                            if let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) {
+                            if let Ok(resolved) = self.resolve_computed(mods, ctx) {
                                 continued
                                     .get_or_insert_with(RouteModifications::default)
                                     .merge_from(resolved.unwrap_or_else(|| mods.clone()));
@@ -314,7 +514,14 @@ impl CompiledChain {
     ) -> PolicyDecision<'a> {
         let mut continued: Option<RouteModifications> = None;
         for (term_index, term) in policy.terms.iter().enumerate() {
-            if self.eval_expr(&term.guard, ctx) {
+            let mut err = None;
+            let matched = self.eval_expr(&term.guard, ctx, &mut err);
+            if let Some(kind) = err {
+                // Guard evaluation error (LAN-299): terminal for the
+                // route regardless of the guard's boolean outcome.
+                return PolicyDecision::Error { kind, term_index };
+            }
+            if matched {
                 if COUNT && let Some(hits) = hits {
                     // Same shape invariant as the per-policy slice: a
                     // term row shorter than the policy is impossible by
@@ -326,12 +533,14 @@ impl CompiledChain {
                 }
                 match &term.action {
                     TermAction::Permit(mods) => {
-                        // LAN-296: fold a computed prepend operand into
-                        // the literal field before the modifications
-                        // leave the evaluator; an unresolvable operand
-                        // fails the route closed.
-                        let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) else {
-                            return PolicyDecision::Deny;
+                        // LAN-296/LAN-299: fold computed operands
+                        // (prepend, set values) into literal fields
+                        // before the modifications leave the
+                        // evaluator; an unresolvable operand fails the
+                        // route closed on the eval-error rail.
+                        let resolved = match self.resolve_computed(mods, ctx) {
+                            Ok(resolved) => resolved,
+                            Err(kind) => return PolicyDecision::Error { kind, term_index },
                         };
                         return match (continued, resolved) {
                             (Some(mut acc), resolved) => {
@@ -346,8 +555,9 @@ impl CompiledChain {
                     }
                     TermAction::Deny => return PolicyDecision::Deny,
                     TermAction::Continue(mods) => {
-                        let Ok(resolved) = self.resolve_computed_prepend(mods, ctx) else {
-                            return PolicyDecision::Deny;
+                        let resolved = match self.resolve_computed(mods, ctx) {
+                            Ok(resolved) => resolved,
+                            Err(kind) => return PolicyDecision::Error { kind, term_index },
                         };
                         continued
                             .get_or_insert_with(RouteModifications::default)
@@ -363,33 +573,46 @@ impl CompiledChain {
         }
     }
 
-    /// Resolve a matched term's computed prepend operand (LAN-296)
-    /// against the evaluation context, at action-execution time.
+    /// Resolve a matched term's computed operands — the LAN-296
+    /// prepend operand and the LAN-299 computed `set` values — against
+    /// the evaluation context, at action-execution time.
     ///
-    /// - `Ok(None)` — no computed operand (the hot path; no clone).
-    /// - `Ok(Some(owned))` — a clone with the operand folded into the
-    ///   literal `as_path_prepend`, so downstream consumers (merge,
-    ///   apply, memoization, API surfaces) only ever see concrete ASNs.
-    /// - `Err(())` — the operand's context value is unknown (absent
-    ///   origin / unknown peer ASN / chain without `local_asn`, or a
-    ///   zero value): the caller fails the route **closed** (uniform
-    ///   Deny, the ADR-0103 Decision 4 disposition; this migrates onto
-    ///   the LAN-299 evaluation-error rails — counter + trace error
-    ///   events — when they land). ASN 0 is never prepended.
-    pub(crate) fn resolve_computed_prepend(
+    /// - `Ok(None)` — nothing computed (the hot path; no clone).
+    /// - `Ok(Some(owned))` — a clone with every operand folded into
+    ///   its literal field, so downstream consumers (merge, apply,
+    ///   memoization, API surfaces) only ever see concrete values.
+    /// - `Err(kind)` — an operand is unresolvable (absent context
+    ///   value, checked-arithmetic failure): the caller fails the
+    ///   route **closed** on the eval-error rail (uniform Deny +
+    ///   counter + rate-limited WARN + explain error trace, ADR-0103
+    ///   Decision 4). ASN 0 is never prepended (RFC 7607).
+    pub(crate) fn resolve_computed(
         &self,
         mods: &RouteModifications,
         ctx: &RouteContext<'_>,
-    ) -> Result<Option<RouteModifications>, ()> {
-        let Some((operand, count)) = mods.as_path_prepend_computed else {
+    ) -> Result<Option<RouteModifications>, EvalErrorKind> {
+        if mods.as_path_prepend_computed.is_none()
+            && mods.set_local_pref_computed.is_none()
+            && mods.set_med_computed.is_none()
+        {
             return Ok(None);
-        };
-        let Some(asn) = operand.resolve(self.local_asn, ctx) else {
-            return Err(());
-        };
+        }
         let mut resolved = mods.clone();
-        resolved.as_path_prepend = Some((asn, count));
-        resolved.as_path_prepend_computed = None;
+        if let Some((operand, count)) = mods.as_path_prepend_computed {
+            let asn = operand
+                .resolve(self.local_asn, ctx)
+                .ok_or(EvalErrorKind::AbsentPrependOperand(operand))?;
+            resolved.as_path_prepend = Some((asn, count));
+            resolved.as_path_prepend_computed = None;
+        }
+        if let Some(expr) = &mods.set_local_pref_computed {
+            resolved.set_local_pref = Some(eval_value(expr, ctx)?);
+            resolved.set_local_pref_computed = None;
+        }
+        if let Some(expr) = &mods.set_med_computed {
+            resolved.set_med = Some(eval_value(expr, ctx)?);
+            resolved.set_med_computed = None;
+        }
         Ok(Some(resolved))
     }
 
@@ -397,9 +620,20 @@ impl CompiledChain {
     /// explain walk's window into the live matcher, so explain and
     /// evaluation cannot disagree about whether a guard fires (the
     /// same discipline as the legacy walk sharing
-    /// `PolicyStatement::matches`).
-    pub(crate) fn guard_matches(&self, expr: &MatchExpr, ctx: &RouteContext<'_>) -> bool {
-        self.eval_expr(expr, ctx)
+    /// `PolicyStatement::matches`). `Err` when the guard contains a
+    /// value expression that failed to evaluate — the live walk denies
+    /// the route there (LAN-299), and explain must render the same.
+    pub(crate) fn guard_matches(
+        &self,
+        expr: &MatchExpr,
+        ctx: &RouteContext<'_>,
+    ) -> Result<bool, EvalErrorKind> {
+        let mut err = None;
+        let matched = self.eval_expr(expr, ctx, &mut err);
+        match err {
+            Some(kind) => Err(kind),
+            None => Ok(matched),
+        }
     }
 
     /// Evaluate one guard node. Pure and allocation-free; set/regex
@@ -410,12 +644,41 @@ impl CompiledChain {
     /// is capped by the frontend (`MAX_EXPR_DEPTH` at parse,
     /// `MAX_APPLY_DEPTH`/`MAX_APPLY_EXPANSION` at typecheck — LAN-184 /
     /// LAN-290), so this recursion is statically bounded.
-    fn eval_expr(&self, expr: &MatchExpr, ctx: &RouteContext<'_>) -> bool {
+    ///
+    /// `err` is the LAN-299 eval-error slot: a [`MatchExpr::ValueCmp`]
+    /// whose value expression fails sets it (first error wins) and
+    /// yields `false`; callers must treat a set slot as terminal for
+    /// the route (uniform Deny) — the boolean is then meaningless.
+    /// Short-circuited subtrees are never evaluated, so an error on a
+    /// path the walk never reaches does not fire (lazy, like the
+    /// arithmetic itself).
+    fn eval_expr(
+        &self,
+        expr: &MatchExpr,
+        ctx: &RouteContext<'_>,
+        err: &mut Option<EvalErrorKind>,
+    ) -> bool {
         match expr {
             MatchExpr::True => true,
-            MatchExpr::And(children) => children.iter().all(|child| self.eval_expr(child, ctx)),
-            MatchExpr::Or(children) => children.iter().any(|child| self.eval_expr(child, ctx)),
-            MatchExpr::Not(inner) => !self.eval_expr(inner, ctx),
+            MatchExpr::And(children) => {
+                children.iter().all(|child| self.eval_expr(child, ctx, err))
+            }
+            MatchExpr::Or(children) => children.iter().any(|child| self.eval_expr(child, ctx, err)),
+            MatchExpr::Not(inner) => !self.eval_expr(inner, ctx, err),
+            MatchExpr::ValueCmp(node) => {
+                match (eval_value(&node.lhs, ctx), eval_value(&node.rhs, ctx)) {
+                    (Ok(lhs), Ok(rhs)) => match node.op {
+                        ValueCmpOp::Eq => lhs == rhs,
+                        ValueCmpOp::Ne => lhs != rhs,
+                        ValueCmpOp::Ge => lhs >= rhs,
+                        ValueCmpOp::Le => lhs <= rhs,
+                    },
+                    (Err(kind), _) | (_, Err(kind)) => {
+                        err.get_or_insert(kind);
+                        false
+                    }
+                }
+            }
             MatchExpr::PrefixEq { prefix, ge, le } => ctx
                 .prefix
                 .is_some_and(|candidate| prefix_entry_matches(*prefix, *ge, *le, candidate)),

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -18,6 +18,7 @@
 //! Spans and term names are optional carriers for the future `.rpol`
 //! frontend; the TOML compiler leaves term names empty.
 
+use std::fmt;
 use std::net::IpAddr;
 use std::sync::Arc;
 
@@ -46,6 +47,242 @@ pub enum Cmp {
     Ge(u32),
     /// Value must be `<=` the operand.
     Le(u32),
+}
+
+/// A checked `u32` arithmetic operator (LAN-299, ADR-0103 Decision 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithOp {
+    /// `+` — checked; overflow is an evaluation error.
+    Add,
+    /// `-` — checked; underflow is an evaluation error.
+    Sub,
+    /// `*` — checked; overflow is an evaluation error.
+    Mul,
+    /// `/` — checked; division by zero is an evaluation error.
+    Div,
+    /// `%` — checked; modulo by zero is an evaluation error.
+    Rem,
+}
+
+impl ArithOp {
+    /// The source spelling.
+    #[must_use]
+    pub fn symbol(self) -> &'static str {
+        match self {
+            ArithOp::Add => "+",
+            ArithOp::Sub => "-",
+            ArithOp::Mul => "*",
+            ArithOp::Div => "/",
+            ArithOp::Rem => "%",
+        }
+    }
+}
+
+/// A `u32`-typed context field readable as a value-expression operand
+/// (LAN-299). Absent-value semantics per field, mirroring today's
+/// comparison defaults where a documented default exists:
+///
+/// - [`LocalPref`](Self::LocalPref) / [`Med`](Self::Med): the RFC 4271
+///   implicit defaults (100 / 0) when the attribute is absent — the
+///   same values plain comparisons already see.
+/// - [`AsPathLen`](Self::AsPathLen): always present (0 for an empty
+///   path).
+/// - [`OriginAs`](Self::OriginAs) / [`PeerAsn`](Self::PeerAsn): no
+///   default exists. An absent value makes the whole expression
+///   unresolvable — an **evaluation error** (uniform Deny, ADR-0103
+///   Decision 4), mirroring how computed prepend operands fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueField {
+    /// `route.local-pref` (absent → 100).
+    LocalPref,
+    /// `route.med` (absent → 0).
+    Med,
+    /// `route.as-path.len`.
+    AsPathLen,
+    /// `route.origin-as` (absent → evaluation error).
+    OriginAs,
+    /// `peer.asn` (absent → evaluation error). Reads peer identity, so
+    /// a chain whose value expressions contain it counts toward
+    /// [`CompiledChain::requires_peer_context`].
+    PeerAsn,
+}
+
+impl ValueField {
+    /// The `.rpol` source spelling (also the explain rendering).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ValueField::LocalPref => "route.local-pref",
+            ValueField::Med => "route.med",
+            ValueField::AsPathLen => "route.as-path.len",
+            ValueField::OriginAs => "route.origin-as",
+            ValueField::PeerAsn => "peer.asn",
+        }
+    }
+}
+
+/// A compiled `u32` value expression (LAN-299): checked arithmetic over
+/// constants, context fields, and the bounded builtins. Evaluated per
+/// route by `eval_value` (`crate::eval`); any checked-arithmetic
+/// failure or absent operand is an evaluation error that resolves the
+/// route as Deny (ADR-0103 Decision 4). Constant subtrees are folded at
+/// compile time (with checked ops); a constant expression that cannot
+/// fold safely is left in place and fails per route, closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueExpr {
+    /// A constant (literal, parameter, or folded subtree).
+    Const(u32),
+    /// A `u32` context field read.
+    Field(ValueField),
+    /// A checked binary arithmetic operation.
+    Binary {
+        /// The operator.
+        op: ArithOp,
+        /// Left operand.
+        lhs: Box<ValueExpr>,
+        /// Right operand.
+        rhs: Box<ValueExpr>,
+    },
+    /// `min(a, b)`.
+    Min(Box<ValueExpr>, Box<ValueExpr>),
+    /// `max(a, b)`.
+    Max(Box<ValueExpr>, Box<ValueExpr>),
+    /// `clamp(x, lo, hi)` — `lo > hi` is a compile error when statically
+    /// known, an evaluation error otherwise.
+    Clamp(Box<ValueExpr>, Box<ValueExpr>, Box<ValueExpr>),
+}
+
+impl ValueExpr {
+    /// Does any node satisfy `pred`? The value-expression sibling of
+    /// [`MatchExpr::any_node`], used by the `requires_*` analyses.
+    pub fn any_node(&self, pred: &impl Fn(&ValueExpr) -> bool) -> bool {
+        if pred(self) {
+            return true;
+        }
+        match self {
+            ValueExpr::Const(_) | ValueExpr::Field(_) => false,
+            ValueExpr::Binary { lhs, rhs, .. }
+            | ValueExpr::Min(lhs, rhs)
+            | ValueExpr::Max(lhs, rhs) => lhs.any_node(pred) || rhs.any_node(pred),
+            ValueExpr::Clamp(x, lo, hi) => {
+                x.any_node(pred) || lo.any_node(pred) || hi.any_node(pred)
+            }
+        }
+    }
+
+    /// Whether evaluating this expression reads the evaluation peer's
+    /// identity (a [`ValueField::PeerAsn`] operand).
+    #[must_use]
+    pub fn reads_peer(&self) -> bool {
+        self.any_node(&|node| matches!(node, ValueExpr::Field(ValueField::PeerAsn)))
+    }
+}
+
+impl fmt::Display for ValueExpr {
+    /// Render in `.rpol` surface syntax with minimal parentheses
+    /// (`*`/`/`/`%` bind tighter than `+`/`-`), for explain traces and
+    /// eval-error logs.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn binding(expr: &ValueExpr) -> u8 {
+            match expr {
+                ValueExpr::Binary {
+                    op: ArithOp::Add | ArithOp::Sub,
+                    ..
+                } => 0,
+                ValueExpr::Binary { .. } => 1,
+                _ => 2,
+            }
+        }
+        fn render(expr: &ValueExpr, f: &mut fmt::Formatter<'_>, min_binding: u8) -> fmt::Result {
+            let paren = binding(expr) < min_binding;
+            if paren {
+                write!(f, "(")?;
+            }
+            match expr {
+                ValueExpr::Const(value) => write!(f, "{value}")?,
+                ValueExpr::Field(field) => write!(f, "{}", field.as_str())?,
+                ValueExpr::Binary { op, lhs, rhs } => {
+                    let this = binding(expr);
+                    render(lhs, f, this)?;
+                    write!(f, " {} ", op.symbol())?;
+                    // Right side binds one tighter so `a - (b - c)`
+                    // keeps its parentheses.
+                    render(rhs, f, this + 1)?;
+                }
+                ValueExpr::Min(a, b) => {
+                    write!(f, "min(")?;
+                    render(a, f, 0)?;
+                    write!(f, ", ")?;
+                    render(b, f, 0)?;
+                    write!(f, ")")?;
+                }
+                ValueExpr::Max(a, b) => {
+                    write!(f, "max(")?;
+                    render(a, f, 0)?;
+                    write!(f, ", ")?;
+                    render(b, f, 0)?;
+                    write!(f, ")")?;
+                }
+                ValueExpr::Clamp(x, lo, hi) => {
+                    write!(f, "clamp(")?;
+                    render(x, f, 0)?;
+                    write!(f, ", ")?;
+                    render(lo, f, 0)?;
+                    write!(f, ", ")?;
+                    render(hi, f, 0)?;
+                    write!(f, ")")?;
+                }
+            }
+            if paren {
+                write!(f, ")")?;
+            }
+            Ok(())
+        }
+        render(self, f, 0)
+    }
+}
+
+/// Comparison operator of a [`MatchExpr::ValueCmp`] guard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueCmpOp {
+    /// `==`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `>=`
+    Ge,
+    /// `<=`
+    Le,
+}
+
+impl ValueCmpOp {
+    /// The source spelling.
+    #[must_use]
+    pub fn symbol(self) -> &'static str {
+        match self {
+            ValueCmpOp::Eq => "==",
+            ValueCmpOp::Ne => "!=",
+            ValueCmpOp::Ge => ">=",
+            ValueCmpOp::Le => "<=",
+        }
+    }
+}
+
+/// A comparison between two value expressions (LAN-299) — the compiled
+/// form of any `.rpol` comparison containing arithmetic or a builtin.
+/// Boxed behind [`MatchExpr::ValueCmp`] so plain guard nodes keep their
+/// size. Unlike the plain scalar nodes, an unresolvable operand here
+/// (absent origin/peer ASN, checked-arithmetic failure) is an
+/// **evaluation error**, not a non-match: the route is denied
+/// (ADR-0103 Decision 4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValueCmpNode {
+    /// The comparison operator.
+    pub op: ValueCmpOp,
+    /// Left value expression.
+    pub lhs: ValueExpr,
+    /// Right value expression.
+    pub rhs: ValueExpr,
 }
 
 /// A typed match expression — the guard side of a [`Term`].
@@ -174,6 +411,13 @@ pub enum MatchExpr {
     RpkiIs(RpkiValidation),
     /// ASPA path verification state equals this state.
     AspaIs(AspaValidation),
+    /// A comparison between two `u32` value expressions (LAN-299) —
+    /// any `.rpol` comparison containing arithmetic or a builtin. An
+    /// unresolvable operand or checked-arithmetic failure during
+    /// evaluation is an evaluation error: the route is denied
+    /// (ADR-0103 Decision 4), unlike the never-match semantics of the
+    /// plain scalar nodes above.
+    ValueCmp(Box<ValueCmpNode>),
     /// All children match (empty = true).
     And(Vec<MatchExpr>),
     /// Any child matches (empty = false).
@@ -208,7 +452,10 @@ impl MatchExpr {
             | MatchExpr::FamilyIs(_)
             | MatchExpr::FamilyNe(_)
             | MatchExpr::RpkiIs(_)
-            | MatchExpr::AspaIs(_) => 0,
+            | MatchExpr::AspaIs(_)
+            // Straight-line checked arithmetic over scalars — the
+            // cheap tier, like the comparisons it generalizes.
+            | MatchExpr::ValueCmp(_) => 0,
             MatchExpr::PrefixInSet(_)
             | MatchExpr::PrefixEq { .. }
             | MatchExpr::PrefixNe { .. }
@@ -409,26 +656,35 @@ impl CompiledChain {
     /// identity (any [`MatchExpr::NeighborIn`] node — peer address,
     /// ASN, or peer-group matching — a strict-next-hop
     /// [`MatchExpr::NextHopEqPeer`] / [`MatchExpr::NextHopNePeer`]
-    /// node, a [`MatchExpr::PeerAsInSet`] membership probe, or a
-    /// peer-derived `prepend as peer` action, LAN-296 — the last is
+    /// node, a [`MatchExpr::PeerAsInSet`] membership probe, a
+    /// `peer.asn` operand inside a value expression — guard
+    /// [`MatchExpr::ValueCmp`] or a computed `set` value, LAN-299 — or
+    /// a peer-derived `prepend as peer` action, LAN-296 — the last is
     /// defense in depth: export attachment rejects it outright).
     /// Content-equal chains with
     /// such a guard can still yield peer-different verdicts, so
     /// update-group fingerprinting must not group peers that share one.
     /// `prepend as self` / `prepend as origin` are chain/route-context
-    /// only and deliberately do NOT count here. Import chains are
-    /// evaluated per-session and are unaffected by this flag.
+    /// only and deliberately do NOT count here; arithmetic over route
+    /// fields alone likewise never disqualifies grouping. Import
+    /// chains are evaluated per-session and are unaffected by this
+    /// flag.
     #[must_use]
     pub fn requires_peer_context(&self) -> bool {
-        self.any_guard_node(&|expr| {
-            matches!(
-                expr,
-                MatchExpr::NeighborIn(_)
-                    | MatchExpr::NextHopEqPeer
-                    | MatchExpr::NextHopNePeer
-                    | MatchExpr::PeerAsInSet(_)
-            )
+        self.any_guard_node(&|expr| match expr {
+            MatchExpr::NeighborIn(_)
+            | MatchExpr::NextHopEqPeer
+            | MatchExpr::NextHopNePeer
+            | MatchExpr::PeerAsInSet(_) => true,
+            MatchExpr::ValueCmp(node) => node.lhs.reads_peer() || node.rhs.reads_peer(),
+            _ => false,
         }) || self.peer_prepend_action().is_some()
+            || self.any_action_mods(&|mods| {
+                [&mods.set_local_pref_computed, &mods.set_med_computed]
+                    .into_iter()
+                    .flatten()
+                    .any(|expr| expr.reads_peer())
+            })
     }
 
     /// The first `prepend as peer` action in the chain, as the owning
@@ -464,5 +720,17 @@ impl CompiledChain {
             .iter()
             .flat_map(|policy| policy.terms.iter())
             .any(|term| term.guard.any_node(pred))
+    }
+
+    /// Do any term's action modifications (Permit or Continue) across
+    /// all policies satisfy `pred`?
+    fn any_action_mods(&self, pred: &impl Fn(&RouteModifications) -> bool) -> bool {
+        self.policies
+            .iter()
+            .flat_map(|policy| policy.terms.iter())
+            .any(|term| match &term.action {
+                TermAction::Permit(mods) | TermAction::Continue(mods) => pred(mods),
+                TermAction::Deny => false,
+            })
     }
 }

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -24,4 +24,4 @@ pub use engine::{
     RouteContext, RouteFamily, RouteModifications, RouteType, TermHitRow, apply_modifications,
     evaluate_chain, evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
 };
-pub use eval::PolicyHitCounters;
+pub use eval::{EvalErrorKind, PolicyHitCounters};

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -186,6 +186,60 @@ pub struct IfStmt {
     pub span: Span,
 }
 
+/// A `u32` value expression (LAN-299): checked arithmetic over
+/// literals, parameters, u32-typed context fields, and the bounded
+/// builtins (`min`/`max`/`clamp`). Appears in `set local-pref`/`set
+/// med` value positions and on either side of a comparison; the
+/// typechecker enforces u32 operand typing, the lowerer
+/// constant-folds (with checked ops) into [`crate::ir::ValueExpr`].
+#[derive(Debug, Clone)]
+pub enum ValueExprAst {
+    /// Integer literal.
+    Lit(u32, Span),
+    /// Parameter reference (bare identifier in a value position).
+    Ident(Spanned<String>),
+    /// A `route.`/`peer.` field read (u32-typed fields only, checked
+    /// by the typechecker).
+    Field(FieldPath),
+    /// A checked binary arithmetic operation.
+    Binary {
+        /// The operator.
+        op: crate::ir::ArithOp,
+        /// Left operand.
+        lhs: Box<ValueExprAst>,
+        /// Right operand.
+        rhs: Box<ValueExprAst>,
+        /// Whole-expression span.
+        span: Span,
+    },
+    /// A builtin call: `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)`.
+    /// The name is contextual (a parameter named `min` used bare keeps
+    /// its parameter meaning); the typechecker validates name and
+    /// arity.
+    Call {
+        /// The builtin name as written.
+        name: Spanned<String>,
+        /// Argument expressions.
+        args: Vec<ValueExprAst>,
+        /// Whole-call span.
+        span: Span,
+    },
+}
+
+impl ValueExprAst {
+    /// The expression's source span.
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            ValueExprAst::Lit(_, span)
+            | ValueExprAst::Binary { span, .. }
+            | ValueExprAst::Call { span, .. } => *span,
+            ValueExprAst::Ident(name) => name.span,
+            ValueExprAst::Field(path) => path.span,
+        }
+    }
+}
+
 /// A `u32`-valued argument position: literal or parameter reference.
 #[derive(Debug, Clone)]
 pub enum U32Arg {
@@ -253,10 +307,11 @@ pub enum ActionStmt {
     Accept(Span),
     /// `reject` — terminal deny.
     Reject(Span),
-    /// `set local-pref <u32>`.
-    SetLocalPref(U32Arg, Span),
-    /// `set med <u32>`.
-    SetMed(U32Arg, Span),
+    /// `set local-pref <value-expr>` (a plain literal or parameter is
+    /// the degenerate expression).
+    SetLocalPref(ValueExprAst, Span),
+    /// `set med <value-expr>`.
+    SetMed(ValueExprAst, Span),
     /// `set next-hop <ip|self>`.
     SetNextHop(NextHopArg, Span),
     /// `add`/`remove` `community`/`large-community`/`ext-community`.
@@ -458,6 +513,22 @@ pub enum Expr {
         /// The ASN to look for (boundary-anchored).
         asn: U32Arg,
     },
+    /// A comparison containing arithmetic or a builtin on either side
+    /// (LAN-299): `route.med + 50 >= p`, `route.as-path.len * 10 >=
+    /// route.med`, `route.med == min(a, b)`. Plain comparisons keep
+    /// the [`Cmp`](Self::Cmp) shape (and its never-match absent
+    /// semantics); this shape evaluates checked, and an unresolvable
+    /// operand denies the route (ADR-0103 Decision 4).
+    ValueCmp {
+        /// Left value expression.
+        lhs: ValueExprAst,
+        /// The operator.
+        op: CmpOp,
+        /// Right value expression.
+        rhs: ValueExprAst,
+        /// Whole-comparison span.
+        span: Span,
+    },
     /// `apply(policy)` / `apply(policy(args))` — policy-as-predicate.
     Apply {
         /// The referenced policy.
@@ -475,7 +546,10 @@ impl Expr {
     pub fn span(&self) -> Span {
         match self {
             Expr::Or(l, r) | Expr::And(l, r) => l.span().to(r.span()),
-            Expr::Not(_, span) | Expr::Cmp { span, .. } | Expr::Apply { span, .. } => *span,
+            Expr::Not(_, span)
+            | Expr::Cmp { span, .. }
+            | Expr::ValueCmp { span, .. }
+            | Expr::Apply { span, .. } => *span,
             Expr::In { field, set } => field.span.to(set.span),
             Expr::Has { field, lit } => field.span.to(lit.span),
             Expr::Matches { field, pattern } => field.span.to(pattern.span),

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -6,8 +6,10 @@
 //!   (`local-pref`, `communities`, …) and enum members (`valid`,
 //!   `internal`, …) are *contextual* identifiers matched by the parser.
 //! - Identifiers are kebab-case: `[A-Za-z_][A-Za-z0-9_]*(-[part])*`.
-//!   There is no arithmetic in the language, so `-` inside a name is
-//!   unambiguous.
+//!   Maximal munch is permanent (ADR-0103 Decision 2.1): `a-b` is one
+//!   identifier, so binary `-` (LAN-299 arithmetic) requires
+//!   whitespace — `route.med - 1` subtracts, `route.med-1` is an
+//!   unknown-field error.
 //! - Community, prefix, and IP literals are single tokens resolved by
 //!   maximal munch: `10.0.0.0/8` is one prefix token, `65000:100` one
 //!   standard-community token, `65000:1:2` one large-community token,
@@ -199,6 +201,25 @@ pub enum Tok {
     /// `!`
     #[token("!")]
     Bang,
+    /// `+` (LAN-299 checked arithmetic; un-lexable before arithmetic
+    /// landed, so purely additive — ADR-0103 Decision 2.3).
+    #[token("+")]
+    Plus,
+    /// `-` as an operator token. Kebab-case maximal munch is permanent
+    /// (ADR-0103 Decision 2.1): the identifier rule consumes `a-b` as
+    /// one name, so subtraction requires whitespace (`a - b`);
+    /// `route.med-1` is an unknown-field error, not `med - 1`.
+    #[token("-")]
+    Minus,
+    /// `*`
+    #[token("*")]
+    Star,
+    /// `/`
+    #[token("/")]
+    Slash,
+    /// `%`
+    #[token("%")]
+    Percent,
 }
 
 impl Tok {
@@ -259,6 +280,11 @@ impl Tok {
             Tok::AndAnd => "`&&`",
             Tok::OrOr => "`||`",
             Tok::Bang => "`!`",
+            Tok::Plus => "`+`",
+            Tok::Minus => "`-`",
+            Tok::Star => "`*`",
+            Tok::Slash => "`/`",
+            Tok::Percent => "`%`",
         }
     }
 }
@@ -324,6 +350,36 @@ mod tests {
         assert_eq!(kinds("RT:65001:100"), vec![Tok::ExtCommunityLit]);
         assert_eq!(kinds("RO:192.0.2.1:5"), vec![Tok::ExtCommunityLit]);
         assert_eq!(kinds("42"), vec![Tok::Int]);
+    }
+
+    /// LAN-299 / ADR-0103 Decision 2.1: kebab-case maximal munch is
+    /// permanent — `med-1` is one identifier; binary `-` needs
+    /// whitespace. The other operators cannot collide with names.
+    #[test]
+    fn arithmetic_operators_vs_kebab_munch() {
+        assert_eq!(
+            kinds("med - 1"),
+            vec![Tok::Ident, Tok::Minus, Tok::Int],
+            "spaced minus is subtraction"
+        );
+        assert_eq!(kinds("med-1"), vec![Tok::Ident], "unspaced minus munches");
+        assert_eq!(
+            kinds("1 + 2 * 3 / 4 % 5"),
+            vec![
+                Tok::Int,
+                Tok::Plus,
+                Tok::Int,
+                Tok::Star,
+                Tok::Int,
+                Tok::Slash,
+                Tok::Int,
+                Tok::Percent,
+                Tok::Int
+            ]
+        );
+        // Prefix literals own `/` inside maximal munch; arithmetic `/`
+        // only appears where a prefix cannot lex.
+        assert_eq!(kinds("10.0.0.0/8"), vec![Tok::PrefixLit]);
     }
 
     #[test]

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -55,16 +55,18 @@ use rustbgpd_wire::ExtendedCommunity;
 use crate::engine::{
     AsPathRegex, CommunityMatch, NeighborSetMatch, NextHopAction, PolicyAction, RouteModifications,
 };
+use crate::eval::checked_arith;
 use crate::ir::{
     Cmp, CompiledChain, CompiledPolicy, MatchExpr, PolicySource, RegexId, SetId, Term, TermAction,
+    ValueCmpNode, ValueCmpOp, ValueExpr,
 };
 use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry, SetStore};
 
 use super::ast::{
     ActionStmt, CmpOp, CommunityLit, Expr, NextHopArg, PolicyDef, PrependAsArg, Rhs, SourceFile,
-    Stmt, U32Arg,
+    Stmt, U32Arg, ValueExprAst,
 };
-use super::typeck::{Field, resolve_field};
+use super::typeck::{Field, resolve_field, value_field_of};
 
 /// Encode a community literal's concrete wire value (for
 /// `add`/`remove` actions and test assertions). RT/RO literals pick
@@ -347,6 +349,21 @@ impl<'a> Lowerer<'a> {
             ]),
             Expr::Not(inner, _) => MatchExpr::Not(Box::new(self.lower_expr(inner, env, store))),
             Expr::Cmp { field, op, rhs, .. } => lower_cmp(field, *op, rhs, env),
+            // LAN-299: value comparisons keep their shape (constant
+            // subtrees folded) — deliberately NOT rewritten to the
+            // legacy scalar nodes even when one side folds to a
+            // constant, because the two have different absent-operand
+            // semantics (never-match vs. fail-closed eval error).
+            Expr::ValueCmp { lhs, op, rhs, .. } => MatchExpr::ValueCmp(Box::new(ValueCmpNode {
+                op: match op {
+                    CmpOp::Eq => ValueCmpOp::Eq,
+                    CmpOp::Ne => ValueCmpOp::Ne,
+                    CmpOp::Ge => ValueCmpOp::Ge,
+                    CmpOp::Le => ValueCmpOp::Le,
+                },
+                lhs: lower_value(lhs, env),
+                rhs: lower_value(rhs, env),
+            })),
             Expr::In { field, set } => match resolve_field(field).expect("typechecked") {
                 Field::Prefix => MatchExpr::PrefixInSet(self.prefix_set_ids[&set.node]),
                 Field::OriginAs => MatchExpr::OriginAsInSet(self.asn_set_ids[&set.node]),
@@ -577,8 +594,19 @@ fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMa
         ActionStmt::Accept(_) | ActionStmt::Reject(_) => {
             unreachable!("verdicts handled by callers")
         }
-        ActionStmt::SetLocalPref(arg, _) => mods.set_local_pref = Some(resolve_u32(arg, env)),
-        ActionStmt::SetMed(arg, _) => mods.set_med = Some(resolve_u32(arg, env)),
+        // LAN-299: a computed set value that folds to a constant
+        // (literal, parameter, or constant arithmetic) lowers to the
+        // literal field — `set med 25 + 25` compiles to exactly what
+        // `set med 50` does. Only expressions that read route/peer
+        // fields stay computed (resolved per route by the evaluator).
+        ActionStmt::SetLocalPref(expr, _) => match lower_value(expr, env) {
+            ValueExpr::Const(value) => mods.set_local_pref = Some(value),
+            computed => mods.set_local_pref_computed = Some(std::sync::Arc::new(computed)),
+        },
+        ActionStmt::SetMed(expr, _) => match lower_value(expr, env) {
+            ValueExpr::Const(value) => mods.set_med = Some(value),
+            computed => mods.set_med_computed = Some(std::sync::Arc::new(computed)),
+        },
         ActionStmt::SetNextHop(arg, _) => {
             mods.set_next_hop = Some(match arg {
                 NextHopArg::Self_(_) => NextHopAction::Self_,
@@ -639,6 +667,77 @@ fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMa
                     unreachable!("non-Value prepend args always denote an operand")
                 };
                 mods.as_path_prepend = Some((resolve_u32(arg, env), count));
+            }
+        }
+    }
+}
+
+/// Lower a value expression to IR with parameters substituted, folding
+/// constant subtrees bottom-up with checked arithmetic (LAN-299). A
+/// constant step that fails its check (e.g. `4294967295 + p` with
+/// `p = 1` at instantiation — invisible to the typechecker, which only
+/// sees literals) is left unfolded and fails per route on the
+/// eval-error rail: fail closed, never wrap.
+fn lower_value(expr: &ValueExprAst, env: &HashMap<&str, u32>) -> ValueExpr {
+    match expr {
+        ValueExprAst::Lit(value, _) => ValueExpr::Const(*value),
+        ValueExprAst::Ident(name) => ValueExpr::Const(
+            *env.get(name.node.as_str())
+                .expect("typechecked: parameter in scope"),
+        ),
+        ValueExprAst::Field(path) => {
+            let field = value_field_of(resolve_field(path).expect("typechecked"))
+                .expect("typechecked: u32 field operand");
+            ValueExpr::Field(field)
+        }
+        ValueExprAst::Binary { op, lhs, rhs, .. } => {
+            let lhs = lower_value(lhs, env);
+            let rhs = lower_value(rhs, env);
+            if let (ValueExpr::Const(l), ValueExpr::Const(r)) = (&lhs, &rhs)
+                && let Ok(folded) = checked_arith(*op, *l, *r)
+            {
+                return ValueExpr::Const(folded);
+            }
+            ValueExpr::Binary {
+                op: *op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+            }
+        }
+        ValueExprAst::Call { name, args, .. } => {
+            let mut args: Vec<ValueExpr> = args.iter().map(|arg| lower_value(arg, env)).collect();
+            let consts: Vec<Option<u32>> = args
+                .iter()
+                .map(|arg| match arg {
+                    ValueExpr::Const(value) => Some(*value),
+                    _ => None,
+                })
+                .collect();
+            match (name.node.as_str(), consts.as_slice()) {
+                ("min", [Some(a), Some(b)]) => ValueExpr::Const((*a).min(*b)),
+                ("max", [Some(a), Some(b)]) => ValueExpr::Const((*a).max(*b)),
+                ("clamp", [Some(x), Some(lo), Some(hi)]) if lo <= hi => {
+                    ValueExpr::Const((*x).clamp(*lo, *hi))
+                }
+                ("min", _) => {
+                    let b = Box::new(args.pop().expect("typechecked arity"));
+                    let a = Box::new(args.pop().expect("typechecked arity"));
+                    ValueExpr::Min(a, b)
+                }
+                ("max", _) => {
+                    let b = Box::new(args.pop().expect("typechecked arity"));
+                    let a = Box::new(args.pop().expect("typechecked arity"));
+                    ValueExpr::Max(a, b)
+                }
+                // Statically inverted constant clamps are typecheck
+                // errors; a parameter-dependent inversion stays a
+                // Clamp node and fails per route.
+                _ => {
+                    let hi = Box::new(args.pop().expect("typechecked arity"));
+                    let lo = Box::new(args.pop().expect("typechecked arity"));
+                    let x = Box::new(args.pop().expect("typechecked arity"));
+                    ValueExpr::Clamp(x, lo, hi)
+                }
             }
         }
     }

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -12,10 +12,13 @@ use rustbgpd_wire::{Ipv4Prefix, Ipv6Prefix, LargeCommunity, Prefix};
 
 use crate::engine::{CommunityMatch, parse_community_match};
 
+use crate::ir::ArithOp;
+
 use super::ast::{
     ActionStmt, AsnSetDef, CmpOp, CommunityKind, CommunityLit, CommunitySetDef, ExpectDef, Expr,
     FieldPath, FieldRoot, IfStmt, NextHopArg, PeerField, PolicyDef, PrefixEntryAst, PrefixSetDef,
-    PrependAsArg, Rhs, RouteField, SourceFile, Stmt, TermDef, TestDef, U32Arg, WithAssertion,
+    PrependAsArg, Rhs, RouteField, SourceFile, Stmt, TermDef, TestDef, U32Arg, ValueExprAst,
+    WithAssertion,
 };
 use super::diag::{Diagnostic, Span, Spanned};
 use super::lexer::{Tok, Token, lex};
@@ -594,12 +597,12 @@ impl Parser<'_> {
                 let target = self.expect_ident("`local-pref`, `med`, or `next-hop`")?;
                 match target.node.as_str() {
                     "local-pref" => {
-                        let arg = self.u32_arg("a u32 value or parameter")?;
+                        let arg = self.value_expr(0)?;
                         let span = token.span.to(arg.span());
                         Ok(ActionStmt::SetLocalPref(arg, span))
                     }
                     "med" => {
-                        let arg = self.u32_arg("a u32 value or parameter")?;
+                        let arg = self.value_expr(0)?;
                         let span = token.span.to(arg.span());
                         Ok(ActionStmt::SetMed(arg, span))
                     }
@@ -768,6 +771,175 @@ impl Parser<'_> {
         })
     }
 
+    // ── value expressions (LAN-299) ─────────────────────────────────
+
+    /// The arithmetic operator at the cursor, if any.
+    fn peek_arith(&self) -> Option<ArithOp> {
+        match self.peek().map(|t| t.kind) {
+            Some(Tok::Plus) => Some(ArithOp::Add),
+            Some(Tok::Minus) => Some(ArithOp::Sub),
+            Some(Tok::Star) => Some(ArithOp::Mul),
+            Some(Tok::Slash) => Some(ArithOp::Div),
+            Some(Tok::Percent) => Some(ArithOp::Rem),
+            _ => None,
+        }
+    }
+
+    /// `value_expr := value_mul (("+"|"-") value_mul)*` — checked u32
+    /// arithmetic (LAN-299). `*`/`/`/`%` bind tighter than `+`/`-`;
+    /// both bind tighter than comparisons. Chained operators count
+    /// toward [`MAX_EXPR_DEPTH`] like `&&`/`||` chains do.
+    fn value_expr(&mut self, mut depth: u32) -> PResult<ValueExprAst> {
+        let mut lhs = self.value_mul(depth)?;
+        while let Some(op @ (ArithOp::Add | ArithOp::Sub)) = self.peek_arith() {
+            self.bump();
+            depth += 1;
+            self.check_expr_depth(depth)?;
+            let rhs = self.value_mul(depth)?;
+            let span = lhs.span().to(rhs.span());
+            lhs = ValueExprAst::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    /// `value_mul := value_atom (("*"|"/"|"%") value_atom)*`.
+    fn value_mul(&mut self, mut depth: u32) -> PResult<ValueExprAst> {
+        let mut lhs = self.value_atom(depth)?;
+        while let Some(op @ (ArithOp::Mul | ArithOp::Div | ArithOp::Rem)) = self.peek_arith() {
+            self.bump();
+            depth += 1;
+            self.check_expr_depth(depth)?;
+            let rhs = self.value_atom(depth)?;
+            let span = lhs.span().to(rhs.span());
+            lhs = ValueExprAst::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    /// One value operand: integer literal, parameter or builtin call
+    /// (`min`/`max`/`clamp` — contextual: only an identifier followed
+    /// by `(` is a call), `route.`/`peer.` field, or a parenthesized
+    /// value expression.
+    fn value_atom(&mut self, depth: u32) -> PResult<ValueExprAst> {
+        self.check_expr_depth(depth)?;
+        match self.peek().map(|t| t.kind) {
+            Some(Tok::Int) => {
+                let (value, span) = self.expect_u32("a u32 value")?;
+                Ok(ValueExprAst::Lit(value, span))
+            }
+            Some(Tok::Ident) => {
+                let name = self.expect_ident("a parameter or builtin")?;
+                if self.at(Tok::LParen) {
+                    self.value_call(name, depth)
+                } else {
+                    Ok(ValueExprAst::Ident(name))
+                }
+            }
+            Some(Tok::RouteKw | Tok::PeerKw) => Ok(ValueExprAst::Field(self.field_path()?)),
+            Some(Tok::LParen) => {
+                self.bump();
+                let inner = self.value_expr(depth + 1)?;
+                self.expect(Tok::RParen, "`)`")?;
+                Ok(inner)
+            }
+            _ => Err(self.error_expected(
+                "a u32 value (integer, parameter, `route.<field>`, `min(`/`max(`/`clamp(`, or `(`)",
+            )),
+        }
+    }
+
+    /// The argument list of a builtin call; the typechecker validates
+    /// the name and arity.
+    fn value_call(&mut self, name: Spanned<String>, depth: u32) -> PResult<ValueExprAst> {
+        self.expect(Tok::LParen, "`(`")?;
+        let mut args = Vec::new();
+        while !self.at(Tok::RParen) {
+            args.push(self.value_expr(depth + 1)?);
+            if self.eat(Tok::Comma).is_none() {
+                break;
+            }
+        }
+        let end = self
+            .expect(Tok::RParen, "`)` or `,` and another argument")?
+            .span;
+        let span = name.span.to(end);
+        Ok(ValueExprAst::Call { name, args, span })
+    }
+
+    /// Continue a value expression whose first atom is already parsed
+    /// (the comparison-RHS path: `rhs()` consumed an atom, then an
+    /// arithmetic operator appeared). Finishes the `*`-level run the
+    /// atom opens, then the `+`-level.
+    fn value_expr_from_atom(&mut self, atom: ValueExprAst) -> PResult<ValueExprAst> {
+        let mut lhs = atom;
+        let mut depth = 0u32;
+        while let Some(op @ (ArithOp::Mul | ArithOp::Div | ArithOp::Rem)) = self.peek_arith() {
+            self.bump();
+            depth += 1;
+            self.check_expr_depth(depth)?;
+            let rhs = self.value_atom(depth)?;
+            let span = lhs.span().to(rhs.span());
+            lhs = ValueExprAst::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span,
+            };
+        }
+        while let Some(op @ (ArithOp::Add | ArithOp::Sub)) = self.peek_arith() {
+            self.bump();
+            depth += 1;
+            self.check_expr_depth(depth)?;
+            let rhs = self.value_mul(depth)?;
+            let span = lhs.span().to(rhs.span());
+            lhs = ValueExprAst::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span,
+            };
+        }
+        Ok(lhs)
+    }
+
+    /// Reinterpret an already-parsed comparison RHS as a value-expr
+    /// atom (the arithmetic-continuation path). Non-u32-shaped
+    /// operands get a spanned diagnostic.
+    fn rhs_into_value_atom(&mut self, rhs: Rhs) -> PResult<ValueExprAst> {
+        match rhs {
+            Rhs::Int(value, span) => Ok(ValueExprAst::Lit(value, span)),
+            Rhs::Ident(name) => {
+                if self.at(Tok::LParen) {
+                    self.value_call(name, 0)
+                } else {
+                    Ok(ValueExprAst::Ident(name))
+                }
+            }
+            Rhs::Field(path) => Ok(ValueExprAst::Field(path)),
+            other => {
+                self.diags.push(Diagnostic::new(
+                    other.span(),
+                    format!(
+                        "arithmetic requires u32 operands, found {}",
+                        other.describe()
+                    ),
+                    "not a u32 operand",
+                ));
+                Err(Fail)
+            }
+        }
+    }
+
     fn field_path(&mut self) -> PResult<FieldPath> {
         let root_token = self.bump().expect("caller checked route/peer");
         let root = if root_token.kind == Tok::RouteKw {
@@ -790,6 +962,12 @@ impl Parser<'_> {
 
     fn predicate_expr(&mut self) -> PResult<Expr> {
         let field = self.field_path()?;
+        // LAN-299: arithmetic after the field makes the whole
+        // comparison a value comparison (`route.med + 50 >= p`).
+        if self.peek_arith().is_some() {
+            let lhs = self.value_expr_from_atom(ValueExprAst::Field(field))?;
+            return self.value_cmp_tail(lhs);
+        }
         let Some(op_token) = self.peek() else {
             return Err(self.error_expected(
                 "an operator (`==`, `!=`, `>=`, `<=`, `in`, `has`, `matches`, or `contains`)",
@@ -804,7 +982,37 @@ impl Parser<'_> {
                     Tok::GtEq => CmpOp::Ge,
                     _ => CmpOp::Le,
                 };
+                // LAN-299: `(` after a comparison operator can only
+                // open a value expression (it was a parse error before
+                // arithmetic landed), e.g. `route.med == (x + 2) * 3`.
+                if self.at(Tok::LParen) {
+                    let rhs = self.value_expr(0)?;
+                    let span = field.span.to(rhs.span());
+                    return Ok(Expr::ValueCmp {
+                        lhs: ValueExprAst::Field(field),
+                        op,
+                        rhs,
+                        span,
+                    });
+                }
                 let rhs = self.rhs()?;
+                // LAN-299: an arithmetic operator (or a builtin call's
+                // `(`) after the RHS atom upgrades the comparison to a
+                // value comparison; plain shapes keep the legacy
+                // (never-match-on-absent) `Cmp` form.
+                if self.peek_arith().is_some()
+                    || (matches!(rhs, Rhs::Ident(_)) && self.at(Tok::LParen))
+                {
+                    let atom = self.rhs_into_value_atom(rhs)?;
+                    let rhs = self.value_expr_from_atom(atom)?;
+                    let span = field.span.to(rhs.span());
+                    return Ok(Expr::ValueCmp {
+                        lhs: ValueExprAst::Field(field),
+                        op,
+                        rhs,
+                        span,
+                    });
+                }
                 let span = field.span.to(rhs.span());
                 Ok(Expr::Cmp {
                     field,
@@ -837,6 +1045,26 @@ impl Parser<'_> {
                 "an operator (`==`, `!=`, `>=`, `<=`, `in`, `has`, `matches`, or `contains`)",
             )),
         }
+    }
+
+    /// The `<cmp-op> <value-expr>` tail of a value comparison whose
+    /// left side is already parsed (LAN-299).
+    fn value_cmp_tail(&mut self, lhs: ValueExprAst) -> PResult<Expr> {
+        let op = match self.peek().map(|t| t.kind) {
+            Some(Tok::EqEq) => CmpOp::Eq,
+            Some(Tok::NotEq) => CmpOp::Ne,
+            Some(Tok::GtEq) => CmpOp::Ge,
+            Some(Tok::LtEq) => CmpOp::Le,
+            _ => {
+                return Err(
+                    self.error_expected("a comparison operator (`==`, `!=`, `>=`, or `<=`)")
+                );
+            }
+        };
+        self.bump();
+        let rhs = self.value_expr(0)?;
+        let span = lhs.span().to(rhs.span());
+        Ok(Expr::ValueCmp { lhs, op, rhs, span })
     }
 
     fn rhs(&mut self) -> PResult<Rhs> {

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1899,3 +1899,472 @@ test missing-local-as-fails-closed {
     assert_eq!(report.total, 6);
     assert!(report.all_passed(), "failures: {:?}", report.failures);
 }
+
+// ── LAN-299: typed arithmetic, value comparisons, eval-error rails ──
+
+/// `set med 25 + 25` must compile to *exactly* what `set med 50`
+/// compiles to (constant folding at lower time, checked ops), so the
+/// evaluator, memoization, diffing, and every downstream consumer see
+/// identical `RouteModifications`.
+#[test]
+fn constant_arithmetic_actions_fold_to_literals() {
+    let folded =
+        compile_ok("policy p { term t { set med 25 + 25; set local-pref 2 * 100; accept } }");
+    let literal = compile_ok("policy p { term t { set med 50; set local-pref 200; accept } }");
+    assert_eq!(
+        folded, literal,
+        "constant arithmetic folds to the literal form"
+    );
+    let mods = first_term_mods(&folded);
+    assert_eq!(mods.set_med, Some(50));
+    assert_eq!(mods.set_local_pref, Some(200));
+    assert!(mods.set_med_computed.is_none() && mods.set_local_pref_computed.is_none());
+
+    // Builtins fold too, including through parameter substitution.
+    let chain = compile_ok(
+        "policy q(n: u32) { term t { set med min(n * 2, 400); accept } }
+         policy p { term t { if apply(q(50)) { accept } } }",
+    );
+    // q(50) is instantiated inside apply as a predicate — instantiate
+    // it directly to observe the folded mods.
+    let mut store = SetStore::new();
+    let file =
+        super::RpolFile::parse("policy q(n: u32) { term t { set med min(n * 2, 400); accept } }")
+            .expect("clean");
+    let inst = file
+        .compile_policy("q", &[300], &mut store)
+        .expect("exists");
+    assert_eq!(
+        first_term_mods(&inst).set_med,
+        Some(400),
+        "min(600, 400) folds"
+    );
+    drop(chain);
+}
+
+/// Kebab-case maximal munch is permanent (ADR-0103 Decision 2.1):
+/// `route.med - 1` is subtraction, `route.med-1` is one identifier and
+/// therefore an unknown-field error suggesting `med`.
+#[test]
+fn subtraction_requires_whitespace_around_minus() {
+    let chain = reject_if("route.med - 1 >= 9");
+    let med10 = RouteContext {
+        med: Some(10),
+        ..absent_ctx()
+    };
+    assert_eq!(chain.evaluate(&med10).action, PolicyAction::Deny, "9 >= 9");
+    let med5 = RouteContext {
+        med: Some(5),
+        ..absent_ctx()
+    };
+    assert_eq!(chain.evaluate(&med5).action, PolicyAction::Permit, "4 < 9");
+
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.med-1 >= 9 { reject } } }");
+    assert!(
+        rendered.contains("unknown field `route.med-1`"),
+        "maximal munch keeps `med-1` one identifier: {rendered}"
+    );
+    assert!(rendered.contains("did you mean `route.med`?"), "{rendered}");
+}
+
+/// The ADR guard example: arithmetic on both sides of a comparison,
+/// with fields as operands (`route.as-path.len * 10 >= route.med`).
+#[test]
+fn value_comparisons_evaluate_both_sides() {
+    let chain = reject_if("route.as-path.len * 10 >= route.med");
+    let mut ctx = absent_ctx();
+    ctx.as_path_len = 3;
+    ctx.med = Some(30);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny, "30 >= 30");
+    ctx.med = Some(31);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Permit, "30 < 31");
+
+    // Precedence: `*` binds tighter than `+`, both tighter than the
+    // comparison; parentheses group within value positions (a guard
+    // may not *start* with a value parenthesis — `(` at guard start
+    // opens a boolean group).
+    let chain = reject_if("route.med + 2 * 3 == 16");
+    let mut ctx = absent_ctx();
+    ctx.med = Some(10);
+    assert_eq!(
+        chain.evaluate(&ctx).action,
+        PolicyAction::Deny,
+        "10 + 6 == 16"
+    );
+    let chain = reject_if("route.med == (2 + 4) * 2");
+    ctx.med = Some(12);
+    assert_eq!(
+        chain.evaluate(&ctx).action,
+        PolicyAction::Deny,
+        "12 == 6 * 2"
+    );
+    let chain = reject_if("route.med * (route.med - 2) == 8");
+    ctx.med = Some(4);
+    assert_eq!(
+        chain.evaluate(&ctx).action,
+        PolicyAction::Deny,
+        "4 * 2 == 8"
+    );
+}
+
+/// Computed `set` values resolve per route at action execution; the
+/// evaluation result carries only the literal field (the LAN-296
+/// prepend discipline).
+#[test]
+fn computed_set_values_resolve_per_route() {
+    let chain = compile_ok(
+        "policy p { term t { set med route.med + 50; set local-pref min(route.local-pref * 2, 250); accept } }",
+    );
+    let mods = first_term_mods(&chain);
+    assert!(mods.set_med.is_none() && mods.set_med_computed.is_some());
+    let mut ctx = absent_ctx();
+    ctx.med = Some(7);
+    ctx.local_pref = Some(100);
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(57));
+    assert_eq!(result.modifications.set_local_pref, Some(200));
+    assert!(
+        result.modifications.set_med_computed.is_none()
+            && result.modifications.set_local_pref_computed.is_none(),
+        "downstream consumers only ever see literal values"
+    );
+    // Absent med/local-pref use the documented implicit defaults
+    // (0 / 100), consistent with comparisons.
+    let result = chain.evaluate(&absent_ctx());
+    assert_eq!(result.modifications.set_med, Some(50));
+    assert_eq!(result.modifications.set_local_pref, Some(200));
+}
+
+/// The eval-error rail end to end on the counting path: uniform Deny,
+/// staged modifications (an earlier Continue term's) discarded, the
+/// per-chain error counter incremented, hit counters untouched by the
+/// error itself.
+#[test]
+fn eval_error_denies_discards_mods_and_counts() {
+    use crate::eval::PolicyHitCounters;
+
+    let chain = compile_ok(
+        "policy p {
+            term tag { set local-pref 200 }
+            term guard { if route.med + 1 >= 1 { accept } }
+            term rest { accept }
+         }",
+    );
+    let counters = PolicyHitCounters::for_chain(&chain);
+
+    // Normal route: Continue mods merge under the eventual accept.
+    let mut ctx = absent_ctx();
+    ctx.med = Some(5);
+    let result = chain.evaluate_counting(&ctx, &counters);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_local_pref, Some(200));
+    assert_eq!(counters.eval_errors(), 0);
+
+    // Overflowing route: `u32::MAX + 1` is an evaluation error →
+    // uniform Deny, staged Continue mods discarded, counter bumped.
+    ctx.med = Some(u32::MAX);
+    let result = chain.evaluate_counting(&ctx, &counters);
+    assert_eq!(result.action, PolicyAction::Deny);
+    assert!(result.modifications.is_empty(), "staged mods discarded");
+    assert_eq!(counters.eval_errors(), 1);
+    assert_eq!(counters.evals(), 2);
+
+    // The recording walk (dry runs) agrees on the verdict.
+    let mut hits = chain.zero_term_hits();
+    let recorded = chain.evaluate_recording_hits(&ctx, &mut hits);
+    assert_eq!(recorded.action, PolicyAction::Deny);
+    assert!(recorded.modifications.is_empty());
+    // Dry runs never move the live error counter.
+    assert_eq!(counters.eval_errors(), 1);
+}
+
+/// An absent operand without a documented default (origin-as on an
+/// AS_SET-only path, unknown peer.asn) is unresolvable → the same
+/// eval-error rail. Plain (arithmetic-free) comparisons keep their
+/// legacy never-match semantics — the two deliberately diverge.
+#[test]
+fn absent_operand_is_an_eval_error_not_a_non_match() {
+    // Arithmetic form: absent origin denies the route.
+    let arith = reject_if("route.origin-as * 1 == 64500");
+    assert_eq!(
+        arith.evaluate(&absent_ctx()).action,
+        PolicyAction::Deny,
+        "absent origin in arithmetic fails closed"
+    );
+    // Plain form: absent origin matches neither == nor != and the
+    // route falls through to the accepting term.
+    let plain = reject_if("route.origin-as == 64500");
+    assert_eq!(
+        plain.evaluate(&absent_ctx()).action,
+        PolicyAction::Permit,
+        "plain comparison keeps never-match-on-absent semantics"
+    );
+    // peer.asn as an operand behaves the same.
+    let peer = reject_if("peer.asn + 0 == 65010");
+    assert_eq!(peer.evaluate(&absent_ctx()).action, PolicyAction::Deny);
+    let mut ctx = absent_ctx();
+    ctx.peer_asn = Some(65010);
+    assert_eq!(
+        peer.evaluate(&ctx).action,
+        PolicyAction::Deny,
+        "matches → reject term fires"
+    );
+}
+
+/// min/max/clamp evaluate per route with checked operand evaluation;
+/// a data-dependent inverted clamp is an eval error.
+#[test]
+fn builtin_edges_evaluate_and_inverted_clamp_fails_closed() {
+    let chain = compile_ok("policy p { term t { set med clamp(route.med, 10, 20); accept } }");
+    for (med, expected) in [(5u32, 10u32), (15, 15), (25, 20), (10, 10), (20, 20)] {
+        let mut ctx = absent_ctx();
+        ctx.med = Some(med);
+        assert_eq!(
+            chain.evaluate(&ctx).modifications.set_med,
+            Some(expected),
+            "clamp({med}, 10, 20)"
+        );
+    }
+    // Parameter-dependent inversion is invisible to the typechecker
+    // (it only folds literals) and fails per route, closed.
+    let mut store = SetStore::new();
+    let file = super::RpolFile::parse(
+        "policy q(lo: u32, hi: u32) { term t { set med clamp(route.med, lo, hi); accept } }",
+    )
+    .expect("clean");
+    let inverted = file
+        .compile_policy("q", &[20, 10], &mut store)
+        .expect("exists");
+    assert_eq!(inverted.evaluate(&absent_ctx()).action, PolicyAction::Deny);
+}
+
+/// Statically invalid constant expressions are compile errors at the
+/// failing subexpression's span, not per-route runtime errors.
+#[test]
+fn constant_folding_diagnostics_carry_spans() {
+    let src = "policy p { term t { set med 4294967295 + 1; accept } }";
+    let (diags, rendered) = diagnostics_of(src);
+    assert!(
+        rendered.contains("this expression always fails: arithmetic overflow"),
+        "{rendered}"
+    );
+    let (span, _) = diags.0[0].labels[0];
+    assert_eq!(
+        &src[span.range()],
+        "4294967295 + 1",
+        "span pins the expression"
+    );
+
+    let (_, rendered) = diagnostics_of("policy p { term t { set med 1 / 0; accept } }");
+    assert!(rendered.contains("division by zero"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy p { term t { set med clamp(5, 10, 2); accept } }");
+    assert!(
+        rendered.contains("clamp bounds are inverted: lo (10) > hi (2)"),
+        "{rendered}"
+    );
+
+    // The error reports at the smallest failing subexpression, once.
+    let src = "policy p { term t { if route.med >= (4294967295 + 1) * 2 { reject } } }";
+    let (diags, rendered) = diagnostics_of(src);
+    assert_eq!(
+        diags.len(),
+        1,
+        "one diagnostic, at the inner overflow: {rendered}"
+    );
+    let (span, _) = diags.0[0].labels[0];
+    assert_eq!(&src[span.range()], "4294967295 + 1");
+}
+
+/// Builtin misuse diagnostics: unknown names get did-you-mean, wrong
+/// arity says what was expected, non-u32 fields are rejected as
+/// operands.
+#[test]
+fn value_expression_type_diagnostics() {
+    let (_, rendered) = diagnostics_of("policy p { term t { set med mim(1, 2); accept } }");
+    assert!(rendered.contains("unknown builtin `mim`"), "{rendered}");
+    assert!(rendered.contains("did you mean `min`?"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of("policy p { term t { set med min(1); accept } }");
+    assert!(
+        rendered.contains("`min` takes 2 arguments but 1 was supplied"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of("policy p { term t { if route.rpki + 1 >= 2 { reject } } }");
+    assert!(
+        rendered.contains("`route.rpki` is not a u32 field"),
+        "{rendered}"
+    );
+
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { set med route.med + peer_lp; accept } }");
+    assert!(
+        rendered.contains("unknown parameter `peer_lp`"),
+        "{rendered}"
+    );
+}
+
+/// Arithmetic chains count toward the expression-depth budget like
+/// `&&`/`||` chains: a pathological operator run is a diagnostic, not
+/// a lowering/evaluation hazard.
+#[test]
+fn deep_arithmetic_chains_are_depth_diagnostics() {
+    let ones = " + 1".repeat(200);
+    let report = check_on_small_stack(format!(
+        "policy p {{ term t {{ set med 1{ones}; accept }} }}"
+    ));
+    let rendered = format!("{:?}", report.diagnostics);
+    assert!(
+        rendered.contains("expression nesting exceeds"),
+        "want the depth diagnostic, got: {rendered:.300}"
+    );
+}
+
+/// `peer.asn` as a value-expression operand reads peer identity and
+/// must disqualify update-group sharing; route-field arithmetic must
+/// not (grouping stays unaffected).
+#[test]
+fn peer_asn_operand_registers_peer_context() {
+    let peer_guard = reject_if("route.med + peer.asn >= 100");
+    assert!(peer_guard.requires_peer_context());
+
+    let route_only = reject_if("route.med * 2 >= route.as-path.len + 10");
+    assert!(!route_only.requires_peer_context());
+
+    let peer_action = compile_ok("policy p { term t { set med peer.asn + 1; accept } }");
+    assert!(
+        peer_action.requires_peer_context(),
+        "computed set value reading peer.asn"
+    );
+
+    let route_action = compile_ok("policy p { term t { set med route.med + 1; accept } }");
+    assert!(!route_action.requires_peer_context());
+}
+
+/// Guard evaluation errors render in explain traces in place of a
+/// verdict, in agreement with the live walk (ADR-0103 Decision 6.4).
+#[test]
+fn eval_error_explain_renders_and_agrees() {
+    use crate::engine::PolicyChain;
+    use crate::engine::explain::explain_chain_statements;
+
+    let compiled = compile_ok(
+        "policy p { term big-med { if route.med + 1 >= 1 { reject } } term rest { accept } }",
+    );
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+
+    let mut ctx = absent_ctx();
+    ctx.med = Some(u32::MAX);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, chain.evaluate(&ctx).action);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    let step = &trace.steps[0];
+    assert_eq!(step.term_name.as_deref(), Some("big-med"));
+    assert!(
+        step.term_traces.iter().any(|line| line
+            .contains("route.med + 1 >= 1 => evaluation error: arithmetic overflow")
+            && line.contains("fail closed")),
+        "error renders in place of a verdict: {:?}",
+        step.term_traces
+    );
+    assert!(step.modifications.is_empty());
+
+    // Computed set values render in source form in the action lines.
+    let compiled = compile_ok("policy p { term t { set med route.med + 50; accept } }");
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+    let mut ctx = absent_ctx();
+    ctx.med = Some(7);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    let step = &trace.steps[0];
+    assert!(
+        step.term_traces
+            .iter()
+            .any(|line| line.contains("set med route.med + 50")),
+        "{:?}",
+        step.term_traces
+    );
+    assert!(
+        step.modifications
+            .iter()
+            .any(|line| line.contains("med 7 -> route.med + 50 = 57")),
+        "{:?}",
+        step.modifications
+    );
+}
+
+/// In-language `test` fixtures exercise the boundary arithmetic and
+/// the deny-on-error contract end to end through `rbgp policy check`.
+#[test]
+fn in_language_tests_cover_arithmetic_boundaries() {
+    let source = r#"
+policy overflow-guard { term t { if route.med + 1 >= 1 { accept } } term rest { reject } }
+policy div-zero { term t { if route.med / 0 >= 0 { accept } } term rest { reject } }
+policy mod-zero { term t { if route.med % route.med >= 0 { accept } } term rest { reject } }
+policy absent-origin { term t { if route.origin-as * 1 >= 0 { accept } } term rest { reject } }
+policy folded-parity(bump: u32) { term t { set med 25 + 25; set local-pref bump * 2; accept } }
+policy builtin-edges {
+    term t { set med max(min(route.med, 400), 100); accept }
+}
+
+test overflow-denies {
+    route { med 4294967295 }
+    expect overflow-guard == reject
+}
+
+test no-overflow-accepts {
+    route { med 5 }
+    expect overflow-guard == accept
+}
+
+test divide-by-zero-denies {
+    route { med 5 }
+    expect div-zero == reject
+}
+
+test modulo-zero-denies {
+    route { }
+    expect mod-zero == reject
+}
+
+test absent-origin-denies {
+    route { as-path "{64500 64501}" }
+    expect absent-origin == reject
+}
+
+test present-origin-accepts {
+    route { as-path "65010 64500" }
+    expect absent-origin == accept
+}
+
+test folded-constants-match-literals {
+    route { }
+    expect folded-parity(100) == accept with med 50, local-pref 200
+}
+
+test builtin-clamps-low {
+    route { med 5 }
+    expect builtin-edges == accept with med 100
+}
+
+test builtin-clamps-high {
+    route { med 900 }
+    expect builtin-edges == accept with med 400
+}
+
+test builtin-passes-middle {
+    route { med 250 }
+    expect builtin-edges == accept with med 250
+}
+"#;
+    let report = run_rpol_tests(source).expect("compiles cleanly");
+    assert_eq!(report.total, 10);
+    assert!(report.all_passed(), "failures: {:?}", report.failures);
+}

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -13,10 +13,12 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::engine::AsPathRegex;
+use crate::eval::checked_arith;
+use crate::ir::ValueField;
 
 use super::ast::{
     ActionStmt, CmpOp, CommunityKind, Expr, FieldPath, FieldRoot, PolicyDef, PrependAsArg, Rhs,
-    RouteField, SourceFile, Stmt, U32Arg,
+    RouteField, SourceFile, Stmt, U32Arg, ValueExprAst,
 };
 use super::diag::{Diagnostic, Span, Spanned, closest};
 
@@ -87,6 +89,20 @@ const MAX_APPLY_DEPTH: u32 = 8;
 /// human-written guard is under ten nodes.
 const MAX_APPLY_EXPANSION: u64 = 100_000;
 
+/// Maximum worst-case per-route evaluation steps for one policy
+/// (ADR-0103 Decision 3, `MAX_EVAL_COST`). Computed in the same
+/// Kahn-ordered DP as the apply bounds: every guard node — including
+/// each value-expression operator and builtin (LAN-299) — and every
+/// action's value operators count one step, apply targets contribute
+/// their inlined predicate cost. Straight-line programs whose bound
+/// fits need no runtime fuel (fuel starts at loop back-edges,
+/// LAN-303); a program whose bound exceeds this is rejected with a
+/// diagnostic naming the policy.
+const MAX_EVAL_COST: u64 = 1_000_000;
+
+/// The value-expression builtins (LAN-299) and their arities.
+const VALUE_BUILTINS: &[(&str, usize)] = &[("min", 2), ("max", 2), ("clamp", 3)];
+
 /// Enum members per enum-typed field, in language spelling.
 pub(super) const RPKI_MEMBERS: &[&str] = &["valid", "invalid", "not-found"];
 pub(super) const ASPA_MEMBERS: &[&str] = &["valid", "invalid", "unknown"];
@@ -139,6 +155,22 @@ pub(super) fn resolve_field(path: &FieldPath) -> Result<Field, Diagnostic> {
             )
             .with_note("the only sub-field is `route.as-path.len`"))
         }
+    }
+}
+
+/// The u32-typed [`ValueField`] a resolved field reads as a
+/// value-expression operand (LAN-299), or `None` for non-u32 fields.
+/// The single decision point shared by the typechecker and the
+/// lowerer, so the two passes cannot disagree about which fields are
+/// arithmetic operands.
+pub(super) fn value_field_of(field: Field) -> Option<ValueField> {
+    match field {
+        Field::LocalPref => Some(ValueField::LocalPref),
+        Field::Med => Some(ValueField::Med),
+        Field::AsPathLen => Some(ValueField::AsPathLen),
+        Field::OriginAs => Some(ValueField::OriginAs),
+        Field::PeerAsn => Some(ValueField::PeerAsn),
+        _ => None,
     }
 }
 
@@ -269,8 +301,8 @@ impl Checker<'_> {
     fn check_action(&mut self, action: &ActionStmt, params: &[&str]) {
         match action {
             ActionStmt::Accept(_) | ActionStmt::Reject(_) | ActionStmt::SetNextHop(..) => {}
-            ActionStmt::SetLocalPref(arg, _) | ActionStmt::SetMed(arg, _) => {
-                self.check_u32_arg(arg, params);
+            ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => {
+                self.check_value_expr(expr, params);
             }
             ActionStmt::Community { kind, lit, .. } => {
                 if lit.node.kind() != *kind {
@@ -324,6 +356,107 @@ impl Checker<'_> {
         }
     }
 
+    /// Typecheck a value expression (LAN-299): operands must be u32 —
+    /// literals, declared parameters, u32-typed fields — builtins must
+    /// be `min`/`max`/`clamp` with the right arity, and every
+    /// statically-evaluable subexpression must evaluate cleanly under
+    /// checked arithmetic (`4294967295 + 1` is a compile error at its
+    /// span, not a per-route runtime error).
+    fn check_value_expr(&mut self, expr: &ValueExprAst, params: &[&str]) {
+        match expr {
+            ValueExprAst::Lit(..) => {}
+            ValueExprAst::Ident(name) => {
+                self.check_u32_arg(&U32Arg::Param(name.clone()), params);
+            }
+            ValueExprAst::Field(path) => match resolve_field(path) {
+                Err(diag) => self.diags.push(diag),
+                Ok(resolved) => {
+                    if value_field_of(resolved).is_none() {
+                        self.diags.push(
+                            Diagnostic::new(
+                                path.span,
+                                format!("`{}` is not a u32 field", path.render()),
+                                "arithmetic operands are u32",
+                            )
+                            .with_note(
+                                "u32 fields: route.local-pref, route.med, route.as-path.len, \
+                                 route.origin-as, peer.asn",
+                            ),
+                        );
+                    }
+                }
+            },
+            ValueExprAst::Binary { op, lhs, rhs, span } => {
+                self.check_value_expr(lhs, params);
+                self.check_value_expr(rhs, params);
+                // Constant folding diagnostic, reported at the
+                // smallest failing subexpression: both children fold
+                // cleanly, this operator fails.
+                if let (Some(l), Some(r)) = (fold_const(lhs), fold_const(rhs))
+                    && let Err(kind) = checked_arith(*op, l, r)
+                {
+                    self.diags.push(Diagnostic::new(
+                        *span,
+                        format!("this expression always fails: {kind}"),
+                        "statically invalid arithmetic",
+                    ));
+                }
+            }
+            ValueExprAst::Call { name, args, span } => {
+                for arg in args {
+                    self.check_value_expr(arg, params);
+                }
+                let Some(&(_, arity)) = VALUE_BUILTINS
+                    .iter()
+                    .find(|(builtin, _)| *builtin == name.node)
+                else {
+                    let mut diag = Diagnostic::new(
+                        name.span,
+                        format!("unknown builtin `{}`", name.node),
+                        "not a value builtin",
+                    );
+                    if let Some(suggestion) =
+                        closest(&name.node, VALUE_BUILTINS.iter().map(|(b, _)| *b))
+                    {
+                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    } else {
+                        diag = diag
+                            .with_note("value builtins: min(a, b), max(a, b), clamp(x, lo, hi)");
+                    }
+                    self.diags.push(diag);
+                    return;
+                };
+                if args.len() != arity {
+                    self.diags.push(Diagnostic::new(
+                        *span,
+                        format!(
+                            "`{}` takes {arity} argument{} but {} {} supplied",
+                            name.node,
+                            if arity == 1 { "" } else { "s" },
+                            args.len(),
+                            if args.len() == 1 { "was" } else { "were" },
+                        ),
+                        "wrong number of arguments",
+                    ));
+                    return;
+                }
+                // Statically inverted clamp bounds are a compile
+                // error (the data-dependent case fails per route on
+                // the eval-error rail).
+                if name.node == "clamp"
+                    && let (Some(lo), Some(hi)) = (fold_const(&args[1]), fold_const(&args[2]))
+                    && lo > hi
+                {
+                    self.diags.push(Diagnostic::new(
+                        *span,
+                        format!("clamp bounds are inverted: lo ({lo}) > hi ({hi})"),
+                        "this clamp always fails",
+                    ));
+                }
+            }
+        }
+    }
+
     fn check_u32_arg(&mut self, arg: &U32Arg, params: &[&str]) {
         if let U32Arg::Param(name) = arg
             && !params.contains(&name.node.as_str())
@@ -354,6 +487,13 @@ impl Checker<'_> {
             }
             Expr::Not(inner, _) => self.check_expr(inner, params),
             Expr::Cmp { field, op, rhs, .. } => self.check_cmp(field, *op, rhs, params),
+            // LAN-299: both sides of a value comparison are u32 value
+            // expressions; all four operators apply (the checked
+            // evaluation model has no unordered u32 fields).
+            Expr::ValueCmp { lhs, rhs, .. } => {
+                self.check_value_expr(lhs, params);
+                self.check_value_expr(rhs, params);
+            }
             Expr::In { field, set } => self.check_in(field, set),
             Expr::Has { field, lit } => match resolve_field(field) {
                 Err(diag) => self.diags.push(diag),
@@ -1007,6 +1147,19 @@ fn apply_edges(file: &SourceFile) -> HashMap<&str, Vec<(&str, Span)>> {
     edges
 }
 
+/// Record trivial costs for an over-limit (or dependent-of-over-limit)
+/// policy so one root cause yields one diagnostic, not a cascade.
+fn poison_policy<'a>(
+    name: &'a str,
+    depth: &mut HashMap<&'a str, u32>,
+    pred_cost: &mut HashMap<&'a str, u64>,
+    poisoned: &mut HashSet<&'a str>,
+) {
+    poisoned.insert(name);
+    depth.insert(name, 0);
+    pred_cost.insert(name, 1);
+}
+
 /// One policy's LAN-290 bound check (see
 /// [`Checker::check_apply_bounds`]): update the `depth` / `pred_cost`
 /// memo tables (its apply targets are already present — Kahn order)
@@ -1022,9 +1175,7 @@ fn bound_policy<'a>(
 ) -> Option<Diagnostic> {
     let name = def.name.node.as_str();
     if targets.iter().any(|(target, _)| poisoned.contains(target)) {
-        poisoned.insert(name);
-        depth.insert(name, 0);
-        pred_cost.insert(name, 1);
+        poison_policy(name, depth, pred_cost, poisoned);
         return None;
     }
     // Composition depth: one past the deepest apply target (unknown
@@ -1035,9 +1186,7 @@ fn bound_policy<'a>(
         .max_by_key(|&(d, _)| d);
     if let Some((d, span)) = deepest {
         if d > MAX_APPLY_DEPTH {
-            poisoned.insert(name);
-            depth.insert(name, 0);
-            pred_cost.insert(name, 1);
+            poison_policy(name, depth, pred_cost, poisoned);
             return Some(
                 Diagnostic::new(
                     span,
@@ -1056,8 +1205,10 @@ fn bound_policy<'a>(
     }
     // Expansion: per-arm guard costs in decision order (upper bound:
     // every `if` decides; an `else` adds a negated arm; a bare action
-    // run lowers to one `True`-guarded term).
+    // run lowers to one `True`-guarded term). Action value expressions
+    // (LAN-299) count toward the evaluation-cost budget alongside.
     let mut arms: Vec<u64> = Vec::new();
+    let mut action_cost: u64 = 0;
     for term in &def.terms {
         for stmt in &term.stmts {
             match stmt {
@@ -1067,16 +1218,45 @@ fn bound_policy<'a>(
                     if if_stmt.else_actions.is_some() {
                         arms.push(cost.saturating_add(1));
                     }
+                    for action in if_stmt
+                        .then_actions
+                        .iter()
+                        .chain(if_stmt.else_actions.iter().flatten())
+                    {
+                        action_cost = action_cost.saturating_add(action_value_cost(action));
+                    }
                 }
-                Stmt::Action(_) => arms.push(1),
+                Stmt::Action(action) => {
+                    arms.push(1);
+                    action_cost = action_cost.saturating_add(action_value_cost(action));
+                }
             }
         }
     }
     let lowered: u64 = arms.iter().fold(0u64, |acc, &g| acc.saturating_add(g));
+    // ADR-0103 Decision 3: the worst-case per-route step bound. With
+    // no loops, every lowered guard node and action value operator
+    // evaluates at most once per route, so the bound is the same DP
+    // sum the expansion budget uses plus the action value costs.
+    if lowered.saturating_add(action_cost) > MAX_EVAL_COST {
+        poison_policy(name, depth, pred_cost, poisoned);
+        return Some(
+            Diagnostic::new(
+                def.name.span,
+                format!(
+                    "policy `{name}` exceeds the worst-case evaluation budget \
+                     of {MAX_EVAL_COST} steps per route"
+                ),
+                "evaluation cost limit exceeded",
+            )
+            .with_note(
+                "every guard node, arithmetic operator, and builtin counts one step; \
+                 `apply` inlining multiplies — split or flatten the composition",
+            ),
+        );
+    }
     if lowered > MAX_APPLY_EXPANSION {
-        poisoned.insert(name);
-        depth.insert(name, 0);
-        pred_cost.insert(name, 1);
+        poison_policy(name, depth, pred_cost, poisoned);
         return Some(
             Diagnostic::new(
                 def.name.span,
@@ -1109,8 +1289,11 @@ fn bound_policy<'a>(
 /// Upper bound on the IR nodes `expr` lowers to, given the predicate
 /// costs of already-processed `apply` targets (a missing entry —
 /// unknown name or on a diagnosed cycle — counts as trivial; the file
-/// has errors and will never lower). Recursion depth is capped by the
-/// parser's `MAX_EXPR_DEPTH` (LAN-184).
+/// has errors and will never lower). Doubles as the worst-case
+/// per-route step count for the `MAX_EVAL_COST` budget: with no loops
+/// (LAN-303), every lowered node evaluates at most once per route.
+/// Recursion depth is capped by the parser's `MAX_EXPR_DEPTH`
+/// (LAN-184).
 fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>) -> u64 {
     match expr {
         Expr::And(lhs, rhs) | Expr::Or(lhs, rhs) => 1u64
@@ -1119,8 +1302,65 @@ fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>) -> u64 {
         Expr::Not(inner, _) => 1u64.saturating_add(guard_cost(inner, pred_cost)),
         // `==`/`!=` on u32 fields lower widest: `Not(And(Ge, Le))`.
         Expr::Cmp { .. } => 4,
+        // LAN-299: every operator/builtin in the value expressions
+        // counts one step in the DP.
+        Expr::ValueCmp { lhs, rhs, .. } => 1u64
+            .saturating_add(value_cost(lhs))
+            .saturating_add(value_cost(rhs)),
         Expr::Apply { policy, .. } => pred_cost.get(policy.node.as_str()).copied().unwrap_or(1),
         _ => 1,
+    }
+}
+
+/// The value-expression steps an action contributes to the
+/// evaluation-cost budget (LAN-299: only the computed `set` values
+/// carry expressions; everything else is constant-time).
+fn action_value_cost(action: &ActionStmt) -> u64 {
+    match action {
+        ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => value_cost(expr),
+        _ => 0,
+    }
+}
+
+/// Worst-case evaluation steps of a value expression (LAN-299): one
+/// per operand read and one per operator/builtin step (`clamp`
+/// charges two — it is a min/max pair).
+fn value_cost(expr: &ValueExprAst) -> u64 {
+    match expr {
+        ValueExprAst::Lit(..) | ValueExprAst::Ident(_) | ValueExprAst::Field(_) => 1,
+        ValueExprAst::Binary { lhs, rhs, .. } => 1u64
+            .saturating_add(value_cost(lhs))
+            .saturating_add(value_cost(rhs)),
+        ValueExprAst::Call { name, args, .. } => {
+            let op_cost = if name.node == "clamp" { 2 } else { 1 };
+            args.iter()
+                .map(value_cost)
+                .fold(op_cost, u64::saturating_add)
+        }
+    }
+}
+
+/// A constant subtree's checked-folded value, or `None` when it
+/// contains a parameter/field or a folding step that itself fails
+/// (reported where it happens — see `check_value_expr`). Folding uses
+/// the same [`checked_arith`] as evaluation, so compile-time folding
+/// and per-route evaluation can never disagree about what overflows.
+fn fold_const(expr: &ValueExprAst) -> Option<u32> {
+    match expr {
+        ValueExprAst::Lit(value, _) => Some(*value),
+        ValueExprAst::Ident(_) | ValueExprAst::Field(_) => None,
+        ValueExprAst::Binary { op, lhs, rhs, .. } => {
+            checked_arith(*op, fold_const(lhs)?, fold_const(rhs)?).ok()
+        }
+        ValueExprAst::Call { name, args, .. } => match (name.node.as_str(), args.as_slice()) {
+            ("min", [a, b]) => Some(fold_const(a)?.min(fold_const(b)?)),
+            ("max", [a, b]) => Some(fold_const(a)?.max(fold_const(b)?)),
+            ("clamp", [x, lo, hi]) => {
+                let (x, lo, hi) = (fold_const(x)?, fold_const(lo)?, fold_const(hi)?);
+                (lo <= hi).then(|| x.clamp(lo, hi))
+            }
+            _ => None,
+        },
     }
 }
 

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -69,8 +69,10 @@ report.
 
 - **Comments**: `#` to end of line.
 - **Identifiers** (set, policy, term, test, parameter names) are
-  kebab-case: `[A-Za-z_][A-Za-z0-9_]*(-[A-Za-z0-9_]+)*`. There is no
-  arithmetic in the language, so `-` inside names is unambiguous.
+  kebab-case: `[A-Za-z_][A-Za-z0-9_]*(-[A-Za-z0-9_]+)*`. Maximal munch
+  is permanent (ADR-0103): `a-b` is always one identifier, so binary
+  subtraction requires whitespace — `route.med - 1` subtracts,
+  `route.med-1` is an unknown-field error (with a did-you-mean note).
 - **Reserved keywords** (not usable as names): `prefix-set`,
   `community-set`, `policy`, `term`, `test`, `if`, `else`, `set`,
   `add`, `remove`, `prepend`, `accept`, `reject`, `apply`, `in`,
@@ -112,7 +114,7 @@ has a known type and every operator a fixed signature.
 | Type | Values | Where |
 |---|---|---|
 | bool | guard expressions | `if` conditions |
-| u32 | integer literals, parameters | `local-pref`, `med`, `as-path.len`, `origin-as`, `peer.asn`, arguments |
+| u32 | integer literals, parameters | `local-pref`, `med`, `as-path.len`, `origin-as`, `peer.asn`, arguments; the only arithmetic type — all arithmetic is **checked** (overflow/underflow/division-by-zero are evaluation errors, never wraps or traps) |
 | prefix | prefix literals | `route.prefix` |
 | community (3 kinds) | community literals | community lists, sets, actions |
 | as-path | — (matched, never named) | `route.as-path` |
@@ -247,6 +249,7 @@ group. Comparisons: `==`, `!=`, `>=`, `<=`.
 | `route.origin-as in customers` | asn-set membership (one hash probe) |
 | `peer.asn in customers` | evaluation-peer ASN against the same asn-sets |
 | `route.local-pref >= 200`, `route.med <= 50` | u32 comparisons; `==`/`!=` also allowed |
+| `route.med + 50 >= threshold`, `route.as-path.len * 10 >= route.med` | checked-arithmetic comparison (see "Value expressions"); an unresolvable operand **denies** the route |
 | `route.next-hop == 10.0.0.1` | next-hop equality (`==`/`!=` only) |
 | `route.next-hop == peer.address` | strict next-hop — the one field-vs-field comparison; reads peer identity, so an export chain using it makes the peer ineligible for update-group sharing (`policy_peer_context`) |
 | `route.rpki == invalid` | RPKI origin validation state |
@@ -270,6 +273,95 @@ nor `!=` nor `in` (`!(... in ...)` negates plainly, matching the
 prefix-set precedent).
 
 `==` on u32 fields lowers to `>= v && <= v`; `!=` is its negation.
+
+### Value expressions — checked u32 arithmetic
+
+u32 value positions — the right side of a u32 comparison, and the
+`set local-pref` / `set med` arguments — accept **value expressions**
+(ADR-0103, LAN-299): arithmetic over integer literals, parameters,
+u32-typed fields (`route.local-pref`, `route.med`,
+`route.as-path.len`, `route.origin-as`, `peer.asn`), and three bounded
+builtins. A comparison's left side may also carry arithmetic when it
+starts with a field.
+
+```rpol
+set med route.med + 50
+set local-pref min(route.local-pref * 2, 400)
+if route.as-path.len * 10 >= route.med { reject }
+if route.med >= threshold + 20 { set local-pref 90 }
+```
+
+- **Operators**: `+ - * / %`, with `* / %` binding tighter than
+  `+ -`, and both tighter than comparisons. Parentheses group inside
+  value positions (a `(` at the *start* of an `if` condition opens a
+  boolean group, so lead with the field: `route.med + 2 * 3 >= n`,
+  or put the parenthesized arithmetic on the right).
+- **Whitespace disambiguates `-`**: identifiers are kebab-case with
+  permanent maximal munch, so `route.med - 1` is subtraction and
+  `route.med-1` is an unknown-field error.
+- **Builtins**: `min(a, b)`, `max(a, b)`, `clamp(x, lo, hi)`.
+  Statically inverted clamp bounds (`lo > hi` with both constant) are
+  a compile error; a data-dependent inversion is an evaluation error.
+- **Everything is checked.** All arithmetic is checked u32: overflow,
+  underflow, and division/modulo by zero are **evaluation errors**,
+  never wraps or process traps.
+- **Constant folding.** Constant subexpressions fold at compile time
+  with the same checked operators: `set med 25 + 25` compiles to
+  exactly what `set med 50` does, and a statically invalid constant
+  expression (`4294967295 + 1`, `1 / 0`) is a compile error at its
+  source span.
+
+**Failure is closed (the evaluation-error contract).** Any evaluation
+error — checked-arithmetic failure, inverted clamp, or an **absent
+operand** (`route.origin-as` on an empty/`AS_SET`-only path, unknown
+`peer.asn`) — denies the route: staged modifications are discarded,
+the chain's eval-error counter increments, a rate-limited WARN names
+the failing policy and term, and explain traces render the error in
+place of a verdict. `route.local-pref` and `route.med` read their
+implicit defaults (100 / 0) when absent, consistent with comparisons.
+Note the deliberate divergence from plain comparisons: an
+arithmetic-free `route.origin-as == 64500` on an origin-less route
+matches neither `==` nor `!=` (never-match), while
+`route.origin-as * 1 == 64500` is unresolvable and **denies** — the
+computed form has no non-verdict to fall back to, exactly like
+computed prepend operands.
+
+**Update-group note.** `peer.asn` as an operand (guard or computed
+`set` value) reads peer identity and keeps its peers out of shared
+update groups; arithmetic over route fields alone never disqualifies
+grouping.
+
+Migration example — BIRD's arithmetic filters are the natural
+comparison. A BIRD MED-dampening filter:
+
+```text
+filter pad_med {
+    if bgp_med + 50 > 1000 then reject;
+    bgp_med = bgp_med + 50;
+    bgp_local_pref = bgp_local_pref * 2;
+    accept;
+}
+```
+
+becomes:
+
+```rpol
+policy pad-med {
+    term dampen { if route.med + 50 >= 1001 { reject } }
+    term pad {
+        set med route.med + 50;
+        set local-pref min(route.local-pref * 2, 400);
+        accept
+    }
+}
+```
+
+The difference under the syntax: BIRD's integer arithmetic evaluates
+in a general-purpose interpreter, and an out-of-range result is
+whatever the interpreter does that day; `.rpol` arithmetic is checked
+u32 with a pinned failure contract (deny + counter + explain), and
+the `min` cap makes the local-pref doubling total instead of relying
+on it.
 
 ### `route.family` — one chain, many families
 
@@ -325,8 +417,8 @@ Two consequences worth internalizing:
 | Action | Effect |
 |---|---|
 | `accept` / `reject` | terminal verdict (see evaluation order) |
-| `set local-pref <u32>` | override `LOCAL_PREF` |
-| `set med <u32>` | override `MED` |
+| `set local-pref <u32 \| value-expr>` | override `LOCAL_PREF`, e.g. `set local-pref min(route.local-pref * 2, 400)` |
+| `set med <u32 \| value-expr>` | override `MED`, e.g. `set med route.med + 50` |
 | `set next-hop <ip>` / `set next-hop self` | override `NEXT_HOP` |
 | `add community 65001:999` / `remove community ...` | standard communities |
 | `add large-community 65000:1:2` / `remove ...` | large communities |
@@ -340,7 +432,12 @@ policy, later `set`s of the same attribute win; across a chain, the
 existing merge semantics apply (later policy wins scalars, add/remove
 lists merge with later-policy-wins cancellation). Literal and computed
 prepends share one scalar slot: a later prepend of either form
-replaces an earlier one of either form.
+replaces an earlier one of either form; computed `set` values share
+their attribute's slot the same way. A computed `set` value resolves
+when the matched term's action executes — constant expressions have
+already folded to literals at compile time, and expressions reading
+route/peer fields evaluate per route (an evaluation error denies the
+route; see "Value expressions").
 
 ### Computed prepend operands
 
@@ -447,15 +544,21 @@ term        := "term" IDENT "{" stmt* "}"
 stmt        := if-stmt | action [";"]
 if-stmt     := "if" expr "{" (action [";"])* "}" ["else" "{" (action [";"])* "}"]
 action      := "accept" | "reject"
-             | "set" ("local-pref" | "med") u32arg
+             | "set" ("local-pref" | "med") value
              | "set" "next-hop" (IP | "self")
              | ("add" | "remove") ("community" | "large-community" | "ext-community") community
              | "prepend" "as" (u32arg | "self" | "peer" | "origin") INT
 expr        := and ("||" and)*
 and         := unary ("&&" unary)*
 unary       := "!" unary | "(" expr ")" | "apply" "(" IDENT ["(" u32arg,* ")"] ")" | predicate
-predicate   := field (("=="|"!="|">="|"<=") rhs | "in" IDENT | "has" community
+predicate   := field (("=="|"!="|">="|"<=") (rhs | value) | "in" IDENT | "has" community
              | "matches" STRING | "contains" u32arg)
+             | field arith-tail ("=="|"!="|">="|"<=") value    # LHS arithmetic
+value       := mul (("+"|"-") mul)*                            # checked u32
+mul         := atom (("*"|"/"|"%") atom)*
+atom        := INT | IDENT | field | "(" value ")"
+             | ("min"|"max") "(" value "," value ")"
+             | "clamp" "(" value "," value "," value ")"
 field       := ("route" | "peer") ("." IDENT)+
 u32arg      := INT | IDENT          # parameter reference
 test-def    := "test" IDENT "{" route-block [peer-block] expect+ "}"
@@ -742,10 +845,12 @@ hit counters — those come free after the rewrite.
 ## Deliberate V1 exclusions
 
 No loops, no user-defined types, no maps (safety is total by
-construction — ADR-0096 Decision 2). No `as-path-set`. No `else if`
-chains and no nested `if` (keep terms small; use `&&` or more terms).
-No arithmetic. EVPN route type takes only an integer literal (no
-parameters — the value is wire-encoded u8). Full-form all-numeric
+construction — ADR-0096 Decision 2; the ADR-0103 extension program
+adds bounded constructs slice by slice — checked arithmetic shipped
+as LAN-299). No `as-path-set`. No `else if` chains and no nested `if`
+(keep terms small; use `&&` or more terms). No `let` bindings (the
+next ADR-0103 slice). EVPN route type takes only an integer literal
+(no parameters — the value is wire-encoded u8). Full-form all-numeric
 IPv6 literals (use `::` compression). These are scope decisions, not
 parser accidents; each has an error message steering to the
 supported form.

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -558,9 +558,11 @@ fn parse_modifications(
         extended_communities_remove: remove.extended,
         large_communities_add: add.large,
         large_communities_remove: remove.large,
-        // Computed prepend operands (LAN-296) are an `.rpol`-only
-        // surface; the TOML frontend stays literal-only.
+        // Computed operands (LAN-296 prepend, LAN-299 set values) are
+        // an `.rpol`-only surface; the TOML frontend stays literal-only.
         as_path_prepend_computed: None,
+        set_local_pref_computed: None,
+        set_med_computed: None,
         as_path_prepend,
     })
 }


### PR DESCRIPTION
## Summary

- first ADR-0103 Phase B slice: checked u32 arithmetic (`+ - * / %`, `min`/`max`/`clamp`, parentheses) in guard comparisons and `set med`/`set local-pref` values — and with it the shared evaluation-error rails every later slice (locals, loops, functions) reuses
- any evaluation error (overflow, underflow, divide/remainder by zero, inverted clamp, absent operand) uniformly denies the route with staged modifications discarded, a per-chain error counter, a rate-limited WARN naming policy/term/reason, and the identical verdict in explain traces — one checked-op implementation shared by evaluation, constant folding, and diagnostics so compile time and runtime can never disagree
- the computed-prepend fail-closed path from the prepend work now rides the same rail (its bespoke error handling deleted)
- constant expressions fold at compile time with span-pinned diagnostics for statically invalid arithmetic; folded actions are IR-identical to their literal equivalents; every operator is costed into the existing compile-time cost DP with the ADR's MAX_EVAL_COST bound installed
- absent-operand semantics pinned per field: med/local-pref use their RFC 4271 defaults (matching comparisons), absent origin-as/peer-asn are evaluation errors; peer.asn as an operand registers as peer-dependent for update-group fingerprinting, route-field arithmetic never does
- grammar stays source-compatible: `route.med - 1` subtracts, `route.med-1` is an unknown-field error with a did-you-mean
- criterion: no-arithmetic chains regress within run-to-run noise (sign-inconsistent deltas, one register + no new branch on the hot path); computed actions cost ~82ns vs ~45ns constant

## Note for review

In-language `test` blocks currently treat an evaluation error as the deny verdict (so fixtures can pin the rail); ADR-0103 Decision 4 sketches "erroring test fails with the error rendered" instead. Flagged for the LAN-301 operator-surface pass.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy (252) / -p rustbgpd-rib / --bin rustbgpd policy (77)
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build (3 arithmetic corpus seeds added)
- cargo bench -p rustbgpd-policy -- --test

Closes LAN-299.