### PR TITLE
docs: refresh cross-stack perf snapshot to v0.50.0 bgperf2 numbers

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -749,6 +749,23 @@ opt-in config); at those scales the on/off difference is within noise. The
 2p/100k row shows **both** the v0.32.0 default (event-history off) and the
 opt-in (on).
 
+**Re-run 2026-07-09** on current `main` (**v0.50.0**, default event-history
+off), same host and harness, all targets back to back on an idle machine —
+these are the current headline numbers (also summarized in
+[COMPARISON.md](COMPARISON.md)):
+
+| Scenario | rustbgpd 0.50.0 | BIRD 2.18 (master) | GoBGP 4.3.0 |
+|---|---|---|---|
+| 10p × 1k | conv 2 s · total 8.3 s · 42 MB | conv 2 s · total 9.3 s · 9 MB | conv 3 s · total 10.4 s · 51 MB |
+| 2p × 10k | conv 2 s · total 8.3 s · 52 MB | conv 2 s · total 9.3 s · 9 MB | conv 3 s · total 10.4 s · 43 MB |
+| 2p × 100k | conv 3 s · total 12.1 s · 246 MB | conv 3 s · total 12.2 s · 25 MB | conv 6 s · total 15.4 s · 197 MB |
+
+Deltas vs the v0.32.0 table below: rustbgpd 2p/100k RSS ~284 → 246 MB and
+10p/1k ~90 → 42 MB (trie prefix indexes, attribute interning, update-groups);
+convergence and total time flat-to-better everywhere; GoBGP's 2p/100k
+convergence doubled relative to rustbgpd's. BIRD/GoBGP versions identical to
+the prior run, so their cells move only within noise.
+
 **Re-confirmed 2026-06-02** on current `main` (post-v0.33.0, default
 **event-history off**), same host — this is a no-regression check, not a new set
 of headline numbers:

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -262,26 +262,33 @@ IPv4/IPv6 `Prefix` routes.
     multi-path *send* (RFC 7911, route-server mode) and EVPN aliasing ECMP
     (ADR-0059 FDB nexthop groups, default-on) also ship.
 
-## Memory Snapshot (2 peers × 100k prefixes, bgperf2 — 2026-05-29, v0.32.0)
+## Performance Snapshot (bgperf2 — 2026-07-09, v0.50.0)
 
-| Implementation | Max RSS |
-|---|---|
-| BIRD 2.18 | ~30 MB |
-| GoBGP 4.3.0 | ~203 MB |
-| rustbgpd (v0.32.0, default) | ~284 MB |
-| rustbgpd (event-history enabled) | ~346 MB |
+Same host and harness, all targets run back to back on an idle machine.
+"Converged" is bgperf2's elapsed-to-full-table figure; RSS is full-daemon
+max over the run.
 
-Full-daemon process RSS, same host and harness. rustbgpd's full-daemon RSS sits
-above GoBGP here because route storage is less compact: a 2026-06-02
-whole-daemon dhat profile attributes the live-at-peak heap primarily to the
-three-layer RIB model (Adj-RIB-In + Loc-RIB + Adj-RIB-Out) and its route-map /
-prefix-index storage, not operational surfaces. The first measured fix moved
-the Adj-RIB-In / Adj-RIB-Out prefix indexes to trie-backed storage, lowering the
-allocator-tracked RIB profile at this scale from 66.6 MB to 60.6 MB; the durable
-event-history outbox is opt-in (default off) as of v0.32.0, and enabling it is
-the ~284 → ~346 MB delta. FRR and OpenBGPd were not in this run. See
-[BENCHMARKS.md](BENCHMARKS.md) for the full cross-stack tables, the RIB memory
-profile, and methodology.
+| Scenario | rustbgpd 0.50.0 | BIRD 2.18 (master) | GoBGP 4.3.0 |
+|---|---|---|---|
+| 10 peers × 1k prefixes | 2 s / 42 MB | 2 s / 9 MB | 3 s / 51 MB |
+| 2 peers × 10k prefixes | 2 s / 52 MB | 2 s / 9 MB | 3 s / 43 MB |
+| 2 peers × 100k prefixes | 3 s / 246 MB | 3 s / 25 MB | 6 s / 197 MB |
+
+Convergence is at or ahead of both peers in every scenario (GoBGP takes
+twice as long at 2×100k). BIRD's single-process C core remains far ahead
+of both Go and Rust daemons on memory. rustbgpd's full-daemon RSS still
+sits above GoBGP at the 100k-per-peer scale — route storage is less
+compact: a 2026-06-02 whole-daemon dhat profile attributes the
+live-at-peak heap primarily to the three-layer RIB model (Adj-RIB-In +
+Loc-RIB + Adj-RIB-Out) and its route-map / prefix-index storage, not
+operational surfaces — though the gap has narrowed materially since
+v0.32.0 (~284 → 246 MB at this scale, ~90 → 42 MB at 10×1k) via the
+trie-backed prefix indexes, attribute interning, and the update-groups
+work. At smaller scales rustbgpd and GoBGP are equivalent. The durable
+event-history outbox is opt-in (default off); enabling it adds RSS
+roughly proportional to event volume. FRR and OpenBGPd were not in this
+run. See [BENCHMARKS.md](BENCHMARKS.md) for the full cross-stack tables,
+the RIB memory profile, and methodology.
 
 ## Positioning
 


### PR DESCRIPTION
## Summary

- reruns the bgperf2 matrix (10p×1k, 2p×10k, 2p×100k against BIRD 2.18-master and GoBGP 4.3.0) on v0.50.0 and replaces COMPARISON.md's v0.32.0-era memory snapshot, which was three perf arcs stale and understated the daemon
- headline movement: 2p/100k RSS ~284 → 246 MB and 10p/1k ~90 → 42 MB; convergence at or ahead of both peers in every scenario (GoBGP takes 2× at 2p/100k); BIRD remains far ahead on memory and the honest GoBGP RSS gap at 100k-per-peer scale stays in the text with the dhat attribution
- BENCHMARKS.md gains the dated 2026-07-09 re-run table above the historical v0.32.0 section; historical tables left as records
- benchmarking note: the bgperf2 rustbgpd target's embedded Dockerfile still copied the removed `rustbgpctl` binary path, so image rebuilds had been silently failing and benching a 5-week-old image; fixed locally in the harness (out-of-repo) — the numbers here are verified self-reported v0.50.0

## Verification

- all 9 runs sequential on an idle host, same harness; version column asserts rustbgpd 0.50.0; logs retained