### PR TITLE
feat(rbgp): add RFC 8671 post-policy BMP Adj-RIB-Out snapshot importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   update-group fingerprinting; route-field arithmetic never
   disqualifies grouping.
 
+- **`rbgp diff snapshot from-bmp`: RFC 8671 post-policy Adj-RIB-Out BMP
+  importer.** A fifth snapshot adapter converts an offline capture of
+  an incumbent's raw BMP version 3 byte stream into an `rbgp-ribsnap/1`
+  snapshot for `rbgp diff advertised`. Only Route Monitoring messages
+  flagged O=1/L=1 contribute routes: the Adj-RIB-In feed (O=0) is
+  skipped with a note and a pre-policy Adj-RIB-Out stream (O=1/L=0) is
+  refused as non-comparable. Embedded UPDATEs are decoded with
+  `rustbgpd-wire` under the Add-Path state negotiated in each Peer Up's
+  OPENs (RFC 7911 send/receive directionality per family) and the
+  per-message 2-/4-octet AS flag; state is kept per (connection
+  generation, peer, family, NLRI, source path ID) so live updates
+  interleaved with the initial dump supersede it, and a reconnect, Peer
+  Up, or Peer Down invalidates exactly the affected generation. A
+  peer/family is complete only after its End-of-RIB — an incomplete
+  dump is refused (exit 2, nothing emitted), and RFC 8671 stat types
+  15/17 arriving after End-of-RIB are cross-checked against the folded
+  counts (never required for completeness). Attributes outside the
+  snapshot's typed set (ORIGINATOR_ID, CLUSTER_LIST, OTC, unknowns) are
+  preserved byte-exact in a new optional `unknown_attrs` route-record
+  field, compared byte-exact by the diff engine and excludable with the
+  new `--ignore-attribute unknown`. Hard bounds on input bytes, message
+  length, peers, routes, and paths per NLRI refuse over-limit input;
+  golden byte fixtures framed by the daemon's own BMP encoder pin the
+  matrix end-to-end (capture → canonical records → in-sync, divergent,
+  and incomplete verdicts). Capture workflow documented in
+  docs/ribdiff.md and the route-server migration cookbook. (LAN-309)
+
 ### Changed
 
 - **Release publication is now fail-closed.** The binary-release and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "prost",
  "ratatui",
  "rustbgpd-api",
+ "rustbgpd-bmp",
  "rustbgpd-evpn",
  "rustbgpd-policy",
  "rustbgpd-wire",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -48,3 +48,6 @@ tempfile = "3"
 tokio-stream = { workspace = true, features = ["net"] }
 rustbgpd-api.workspace = true
 rustbgpd-evpn.workspace = true
+# Fixture builder for the from-bmp adapter tests: captures are framed by
+# the daemon's own RFC-pinned BMP encoder.
+rustbgpd-bmp.workspace = true

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -25,7 +25,7 @@ use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{ListNeighborsRequest, ListRoutesRequest, Route};
 use rustbgpctl::ribdiff::{
     self, AsPathSegment, AsSegmentKind, DiffClass, DiffLimits, DiffReport, FamilyId, Nlri,
-    PathAttrs, PeerId, RoutePath, RouteSet, SnapshotMeta, Verdict,
+    PathAttrs, PeerId, RoutePath, RouteSet, SnapshotMeta, UnknownAttr, Verdict,
 };
 use serde::Deserialize;
 
@@ -51,6 +51,7 @@ const IGNORABLE_ATTRIBUTES: &[&str] = &[
     "communities",
     "extended_communities",
     "large_communities",
+    "unknown",
 ];
 
 /// Honest limitations of the live gRPC source, emitted verbatim in both
@@ -372,6 +373,7 @@ fn apply_ignores(attrs: &mut PathAttrs, ignored: &[String]) {
             "communities" => attrs.communities.clear(),
             "extended_communities" => attrs.extended_communities.clear(),
             "large_communities" => attrs.large_communities.clear(),
+            "unknown" => attrs.unknown.clear(),
             _ => unreachable!("validated in validate_ignore_attributes"),
         }
     }
@@ -396,6 +398,23 @@ fn parse_prefix(prefix: &str) -> Result<(IpAddr, u8, FamilyId), String> {
         return Err(format!("prefix length {len} exceeds {max_len}: {prefix}"));
     }
     Ok((addr, len, family))
+}
+
+/// Decode a lowercase/uppercase hex string into bytes (`unknown_attrs`
+/// values). Odd length or non-hex digits are malformed.
+fn parse_hex(s: &str) -> Result<Vec<u8>, String> {
+    if !s.is_ascii() || !s.len().is_multiple_of(2) {
+        return Err(format!(
+            "invalid hex value {s:?} (expected an even number of hex digits)"
+        ));
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&s[i..i + 2], 16)
+                .map_err(|_| format!("invalid hex value {s:?} (non-hex digit)"))
+        })
+        .collect()
 }
 
 fn parse_large_community(s: &str) -> Result<[u32; 3], String> {
@@ -456,6 +475,19 @@ struct RouteRecord {
     extended_communities: Vec<u64>,
     #[serde(default)]
     large_communities: Vec<String>,
+    #[serde(default)]
+    unknown_attrs: Vec<UnknownAttrRecord>,
+}
+
+/// An untyped path attribute preserved by a snapshot producer (e.g. the
+/// from-bmp adapter): wire flags + type code + hex-encoded value octets.
+/// Compared byte-exact by the engine ([`UnknownAttr`]).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UnknownAttrRecord {
+    type_code: u8,
+    flags: u8,
+    value: String,
 }
 
 #[derive(Deserialize)]
@@ -663,6 +695,17 @@ fn convert_snapshot_route(route: RouteRecord) -> Result<SnapshotRoute, String> {
         .iter()
         .map(|s| parse_large_community(s))
         .collect::<Result<Vec<_>, _>>()?;
+    let unknown = route
+        .unknown_attrs
+        .into_iter()
+        .map(|attr| {
+            Ok(UnknownAttr {
+                type_code: attr.type_code,
+                flags: attr.flags,
+                value: parse_hex(&attr.value)?,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
     let attrs = PathAttrs {
         origin: route.origin,
         as_path: as_path_segment(&route.as_path),
@@ -672,7 +715,7 @@ fn convert_snapshot_route(route: RouteRecord) -> Result<SnapshotRoute, String> {
         communities,
         extended_communities: route.extended_communities,
         large_communities,
-        unknown: Vec::new(),
+        unknown,
     };
     Ok((
         family,
@@ -1216,6 +1259,20 @@ mod tests {
         let err = run_against(&server, &opts(file.path())).await.unwrap_err();
         assert!(
             err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
+
+        // Malformed unknown_attrs hex value.
+        let file = snapshot_file(&[
+            header_line(),
+            format!(
+                r#"{{"record":"route","peer":"{PEER}","peer_asn":{PEER_ASN},"prefix":"10.0.0.0/24","unknown_attrs":[{{"type_code":35,"flags":192,"value":"0zz0"}}]}}"#
+            ),
+            trailer_line(1),
+        ]);
+        let err = run_against(&server, &opts(file.path())).await.unwrap_err();
+        assert!(
+            err.to_string().contains("invalid hex value"),
             "unexpected error: {err}"
         );
     }
@@ -1811,6 +1868,127 @@ mod tests {
             // Add-Path copies matched as a multiplicity-2 multiset).
             assert!(rendered.contains("ipv4_unicast: matched 1"));
             assert!(rendered.contains("ipv6_unicast: matched 1"));
+        }
+
+        /// Wire-truth routes matching the from-bmp golden capture
+        /// (crates/cli/src/commands/ribsnap_bmp.rs `golden_capture`,
+        /// regenerated with `BLESS=1`).
+        fn from_bmp_wire_truth() -> Vec<Vec<server_proto::Route>> {
+            let peer_a = vec![
+                server_proto::Route {
+                    prefix: "100.64.0.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "192.0.2.254".to_string(),
+                    origin: 1,
+                    as_path: vec![65500],
+                    local_pref_attr: Some(200),
+                    extended_communities: vec![0x0002_FFDC_0000_0064],
+                    large_communities: vec!["65500:7:9".to_string()],
+                    path_id: 1,
+                    ..Default::default()
+                },
+                server_proto::Route {
+                    prefix: "203.0.113.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "192.0.2.254".to_string(),
+                    origin: 0,
+                    as_path: vec![65500, 64999],
+                    med: 121,
+                    communities: vec![(65500 << 16) | 100],
+                    path_id: 1,
+                    ..Default::default()
+                },
+                server_proto::Route {
+                    prefix: "203.0.113.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "192.0.2.253".to_string(),
+                    origin: 0,
+                    as_path: vec![65500, 64998],
+                    path_id: 2,
+                    ..Default::default()
+                },
+            ];
+            let peer_b = vec![
+                server_proto::Route {
+                    prefix: "100.65.0.0".to_string(),
+                    prefix_length: 24,
+                    next_hop: "192.0.2.254".to_string(),
+                    origin: 0,
+                    as_path: vec![65500, 64997],
+                    ..Default::default()
+                },
+                server_proto::Route {
+                    prefix: "2001:db8:100::".to_string(),
+                    prefix_length: 48,
+                    next_hop: "2001:db8::1".to_string(),
+                    origin: 0,
+                    as_path: vec![65500, 64997],
+                    med: 51,
+                    ..Default::default()
+                },
+            ];
+            vec![peer_a, peer_b]
+        }
+
+        async fn from_bmp_server(
+            pages: Vec<Vec<server_proto::Route>>,
+        ) -> crate::test_support::MockServerHandle {
+            let server = spawn_mock_server(None).await;
+            *server.state.list_neighbors_response.lock().await =
+                vec![neighbor("192.0.2.1", 65001), neighbor("2001:db8::2", 65002)];
+            *server.state.list_route_pages.lock().await = pages
+                .into_iter()
+                .map(|routes| {
+                    let total = routes.len() as u64;
+                    page(routes, "", total)
+                })
+                .collect();
+            server
+        }
+
+        /// End-to-end for the from-bmp adapter's in-sync verdict: the
+        /// golden snapshot (BMP capture → canonical records) diffs
+        /// clean against a daemon advertising the same wire truth.
+        /// `--ignore-attribute unknown` reflects the documented live
+        /// limitation: the snapshot preserves the capture's OTC and
+        /// unknown transitive attributes byte-exact, but they are not
+        /// visible over gRPC.
+        #[tokio::test]
+        async fn from_bmp_golden_diffs_clean() {
+            let golden = fixture_path("from-bmp.expected.ndjson");
+            let server = from_bmp_server(from_bmp_wire_truth()).await;
+            let mut opts = opts(&golden);
+            opts.ignore_attributes = vec!["unknown".to_string()];
+            let (rendered, code) = run_against(&server, &opts).await.unwrap();
+            assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+            assert!(rendered.contains("192.0.2.1 AS65001 ipv4_unicast: matched 2"));
+            assert!(rendered.contains("2001:db8::2 AS65002 ipv4_unicast: matched 1"));
+            assert!(rendered.contains("2001:db8::2 AS65002 ipv6_unicast: matched 1"));
+        }
+
+        /// End-to-end divergent verdict: preserved unknown attributes
+        /// surface as divergence when not ignored (the operator must
+        /// decide, never a silent drop), and an attribute delta on the
+        /// live side reads as attribute-changed.
+        #[tokio::test]
+        async fn from_bmp_golden_divergence_is_reported() {
+            let golden = fixture_path("from-bmp.expected.ndjson");
+            // Unignored unknown attributes: the incumbent capture has
+            // them, gRPC cannot see them.
+            let server = from_bmp_server(from_bmp_wire_truth()).await;
+            let (rendered, code) = run_against(&server, &opts(&golden)).await.unwrap();
+            assert_eq!(code, EXIT_DIVERGENT, "output was:\n{rendered}");
+            assert!(rendered.contains("100.64.0.0/24 [attribute-changed] unknown:"));
+
+            // A real attribute delta (MED drift on the v6 route).
+            let mut truth = from_bmp_wire_truth();
+            truth[1][1].med = 999;
+            let server = from_bmp_server(truth).await;
+            let mut opts = opts(&golden);
+            opts.ignore_attributes = vec!["unknown".to_string()];
+            let (rendered, code) = run_against(&server, &opts).await.unwrap();
+            assert_eq!(code, EXIT_DIVERGENT, "output was:\n{rendered}");
+            assert!(rendered.contains("med: 51 -> 999"));
         }
     }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,5 +16,6 @@ pub mod policy;
 pub mod policy_input;
 pub mod rib;
 pub mod ribsnap;
+pub mod ribsnap_bmp;
 pub mod topology;
 pub mod watch;

--- a/crates/cli/src/commands/ribsnap.rs
+++ b/crates/cli/src/commands/ribsnap.rs
@@ -57,19 +57,27 @@ pub struct FromMrtOpts<'a> {
     pub generation: u64,
 }
 
+/// An attribute outside the typed snapshot fields, preserved as its wire
+/// triple (flags, type code, value octets) in `unknown_attrs`.
+pub(crate) type UnknownWireAttr = (u8, u8, Vec<u8>);
+
 /// One decoded RIB entry, reduced to the `rbgp-ribsnap/1` route fields.
 /// Absent attributes stay `None`/empty — never defaulted.
 #[derive(Default)]
-struct SnapRoute {
-    path_id: Option<u32>,
-    origin: Option<u8>,
-    as_path: Vec<u32>,
-    next_hop: Option<IpAddr>,
-    med: Option<u32>,
-    local_pref: Option<u32>,
-    communities: Vec<u32>,
-    extended_communities: Vec<u64>,
-    large_communities: Vec<[u32; 3]>,
+pub(crate) struct SnapRoute {
+    pub(crate) path_id: Option<u32>,
+    pub(crate) origin: Option<u8>,
+    pub(crate) as_path: Vec<u32>,
+    pub(crate) next_hop: Option<IpAddr>,
+    pub(crate) med: Option<u32>,
+    pub(crate) local_pref: Option<u32>,
+    pub(crate) communities: Vec<u32>,
+    pub(crate) extended_communities: Vec<u64>,
+    pub(crate) large_communities: Vec<[u32; 3]>,
+    /// Untyped attributes preserved byte-exact (see `unknown_attrs` in
+    /// docs/ribdiff.md). The MRT adapter leaves this empty (documented
+    /// limitation); the BMP adapter fills it.
+    pub(crate) unknown_attrs: Vec<UnknownWireAttr>,
 }
 
 /// Run the adapter: print the snapshot to stdout on success, an error to
@@ -130,53 +138,7 @@ fn render(opts: &FromMrtOpts<'_>, peer: IpAddr, routes: &[(IpAddr, u8, SnapRoute
     out.push_str(&header.to_string());
     out.push('\n');
     for (addr, len, route) in routes {
-        let mut record = serde_json::json!({
-            "record": "route",
-            "peer": peer.to_string(),
-            "peer_asn": opts.peer_asn,
-            "prefix": format!("{addr}/{len}"),
-        });
-        let object = record.as_object_mut().expect("literal object");
-        if let Some(origin) = route.origin {
-            object.insert("origin".into(), origin.into());
-        }
-        if !route.as_path.is_empty() {
-            object.insert("as_path".into(), route.as_path.clone().into());
-        }
-        if let Some(next_hop) = route.next_hop {
-            object.insert("next_hop".into(), next_hop.to_string().into());
-        }
-        // MED 0 is omitted like an absent MED: the consumer's live side
-        // cannot distinguish them (documented in docs/ribdiff.md).
-        if let Some(med) = route.med
-            && med != 0
-        {
-            object.insert("med".into(), med.into());
-        }
-        if let Some(local_pref) = route.local_pref {
-            object.insert("local_pref".into(), local_pref.into());
-        }
-        if !route.communities.is_empty() {
-            object.insert("communities".into(), route.communities.clone().into());
-        }
-        if !route.extended_communities.is_empty() {
-            object.insert(
-                "extended_communities".into(),
-                route.extended_communities.clone().into(),
-            );
-        }
-        if !route.large_communities.is_empty() {
-            let rendered: Vec<String> = route
-                .large_communities
-                .iter()
-                .map(|[a, b, c]| format!("{a}:{b}:{c}"))
-                .collect();
-            object.insert("large_communities".into(), rendered.into());
-        }
-        if let Some(path_id) = route.path_id {
-            object.insert("path_id".into(), path_id.into());
-        }
-        out.push_str(&record.to_string());
+        out.push_str(&route_record_json(peer, opts.peer_asn, *addr, *len, route));
         out.push('\n');
     }
     let trailer = serde_json::json!({"record": "trailer", "routes": routes.len()});
@@ -185,21 +147,98 @@ fn render(opts: &FromMrtOpts<'_>, peer: IpAddr, routes: &[(IpAddr, u8, SnapRoute
     out
 }
 
-/// Bounds-checked big-endian reader over a byte slice.
-struct Cursor<'a> {
+/// Render one `rbgp-ribsnap/1` route record (shared by the MRT and BMP
+/// adapters). Absent attributes are omitted, never defaulted.
+pub(crate) fn route_record_json(
+    peer: IpAddr,
+    peer_asn: u32,
+    addr: IpAddr,
+    len: u8,
+    route: &SnapRoute,
+) -> String {
+    let mut record = serde_json::json!({
+        "record": "route",
+        "peer": peer.to_string(),
+        "peer_asn": peer_asn,
+        "prefix": format!("{addr}/{len}"),
+    });
+    let object = record.as_object_mut().expect("literal object");
+    if let Some(origin) = route.origin {
+        object.insert("origin".into(), origin.into());
+    }
+    if !route.as_path.is_empty() {
+        object.insert("as_path".into(), route.as_path.clone().into());
+    }
+    if let Some(next_hop) = route.next_hop {
+        object.insert("next_hop".into(), next_hop.to_string().into());
+    }
+    // MED 0 is omitted like an absent MED: the consumer's live side
+    // cannot distinguish them (documented in docs/ribdiff.md).
+    if let Some(med) = route.med
+        && med != 0
+    {
+        object.insert("med".into(), med.into());
+    }
+    if let Some(local_pref) = route.local_pref {
+        object.insert("local_pref".into(), local_pref.into());
+    }
+    if !route.communities.is_empty() {
+        object.insert("communities".into(), route.communities.clone().into());
+    }
+    if !route.extended_communities.is_empty() {
+        object.insert(
+            "extended_communities".into(),
+            route.extended_communities.clone().into(),
+        );
+    }
+    if !route.large_communities.is_empty() {
+        let rendered: Vec<String> = route
+            .large_communities
+            .iter()
+            .map(|[a, b, c]| format!("{a}:{b}:{c}"))
+            .collect();
+        object.insert("large_communities".into(), rendered.into());
+    }
+    if !route.unknown_attrs.is_empty() {
+        let rendered: Vec<serde_json::Value> = route
+            .unknown_attrs
+            .iter()
+            .map(|(flags, type_code, value)| {
+                let hex: String = value.iter().fold(String::new(), |mut s, b| {
+                    let _ = write!(s, "{b:02x}");
+                    s
+                });
+                serde_json::json!({"flags": flags, "type_code": type_code, "value": hex})
+            })
+            .collect();
+        object.insert("unknown_attrs".into(), rendered.into());
+    }
+    if let Some(path_id) = route.path_id {
+        object.insert("path_id".into(), path_id.into());
+    }
+    record.to_string()
+}
+
+/// Bounds-checked big-endian reader over a byte slice (shared by the MRT
+/// and BMP adapters).
+pub(crate) struct Cursor<'a> {
     buf: &'a [u8],
 }
 
 impl<'a> Cursor<'a> {
-    fn new(buf: &'a [u8]) -> Self {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
         Self { buf }
     }
 
-    fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.buf.is_empty()
     }
 
-    fn take(&mut self, n: usize) -> Result<&'a [u8], String> {
+    pub(crate) fn remaining(&self) -> &'a [u8] {
+        self.buf
+    }
+
+    pub(crate) fn take(&mut self, n: usize) -> Result<&'a [u8], String> {
         if self.buf.len() < n {
             return Err(format!(
                 "truncated record: need {n} bytes, have {}",
@@ -211,18 +250,23 @@ impl<'a> Cursor<'a> {
         Ok(head)
     }
 
-    fn read_u8(&mut self) -> Result<u8, String> {
+    pub(crate) fn read_u8(&mut self) -> Result<u8, String> {
         Ok(self.take(1)?[0])
     }
 
-    fn read_u16(&mut self) -> Result<u16, String> {
+    pub(crate) fn read_u16(&mut self) -> Result<u16, String> {
         let b = self.take(2)?;
         Ok(u16::from_be_bytes([b[0], b[1]]))
     }
 
-    fn read_u32(&mut self) -> Result<u32, String> {
+    pub(crate) fn read_u32(&mut self) -> Result<u32, String> {
         let b = self.take(4)?;
         Ok(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    pub(crate) fn read_u64(&mut self) -> Result<u64, String> {
+        let b = self.take(8)?;
+        Ok(u64::from_be_bytes(b.try_into().expect("length checked")))
     }
 }
 

--- a/crates/cli/src/commands/ribsnap_bmp.rs
+++ b/crates/cli/src/commands/ribsnap_bmp.rs
@@ -1,0 +1,1899 @@
+//! `rbgp diff snapshot from-bmp` — convert a captured RFC 7854 BMP byte
+//! stream carrying the RFC 8671 post-policy Adj-RIB-Out view into an
+//! `rbgp-ribsnap/1` NDJSON snapshot for `rbgp diff advertised` (adapter
+//! contract `from-bmp/1`, see docs/ribdiff.md).
+//!
+//! Input is an offline file of raw, concatenated BMP version 3 messages
+//! (e.g. the TCP payload of the incumbent's BMP feed, captured from the
+//! start of the session). Streaming-socket ingestion is out of scope for
+//! this adapter — capture to a file first.
+//!
+//! View contract (RFC 8671): only Route Monitoring messages whose
+//! per-peer header carries O=1 (Adj-RIB-Out) and L=1 (post-policy)
+//! contribute routes. O=0 messages are the pre-policy Adj-RIB-In view
+//! that most feeds also carry; they are skipped with a note. O=1 with
+//! L=0 is the *pre-policy* Adj-RIB-Out — a different view whose
+//! comparison against a post-policy Adj-RIB-Out would report every
+//! export-policy effect as divergence — so it refuses the conversion
+//! (exit 2), matching the from-mrt `--view` refusal pattern. O/L flags
+//! on Peer Up / Peer Down are not view selectors and are ignored there.
+//!
+//! Completeness and generations (RFC 7854 §5, §9): announce/withdraw
+//! state is kept per (connection generation, peer, family, NLRI, source
+//! path ID); a later update for the same key supersedes an earlier one,
+//! so live updates interleaved with the initial dump fold correctly. A
+//! (peer, family) is complete only once its End-of-RIB arrives in the
+//! current generation. A new Initiation (reconnect) invalidates all
+//! state; a Peer Up resets the peer; a Peer Down discards it — old and
+//! new generations are never mixed. Missing End-of-RIB at end of input
+//! refuses the conversion: `rbgp-ribsnap/1` carries no per-peer
+//! completeness field, so an incomplete peer must not be emitted under
+//! a counted trailer that would read as complete.
+//!
+//! Negotiated state comes from the Peer Up OPENs: Add-Path is in effect
+//! for a family iff the incumbent's sent OPEN advertised send (2/3) and
+//! the peer's received OPEN advertised receive (1/3) for it (RFC 7911);
+//! AS_PATH width follows each message's per-peer-header A flag. RFC 8671
+//! stat types 15/17 arriving after End-of-RIB are cross-checked against
+//! the folded route counts (completeness never *requires* them; a
+//! mismatch means a decode gap and refuses the conversion).
+//!
+//! Fail-closed: any framing error, embedded-UPDATE decode error,
+//! truncation, out-of-protocol sequence, or exceeded hard bound exits 2
+//! with nothing on stdout — a half-converted snapshot with a valid
+//! trailer cannot exist. Unknown and untyped path attributes are
+//! preserved byte-exact in `unknown_attrs`, never dropped.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::path::Path;
+
+use rustbgpd_wire::attribute::{AsPath, MpReachNlri, MpUnreachNlri, PathAttribute};
+use rustbgpd_wire::capability::{AddPathMode, Afi, Capability, Safi};
+use rustbgpd_wire::constants::{EXTENDED_MAX_MESSAGE_LEN, HEADER_LEN, attr_flags, attr_type};
+use rustbgpd_wire::header::{BgpHeader, MessageType};
+use rustbgpd_wire::nlri::Prefix;
+use rustbgpd_wire::open::OpenMessage;
+use rustbgpd_wire::update::UpdateMessage;
+
+use super::ribsnap::{Cursor, EXIT_OK, EXIT_REFUSED, SnapRoute, route_record_json};
+
+// BMP message types (RFC 7854 §4.1).
+const BMP_MSG_ROUTE_MONITORING: u8 = 0;
+const BMP_MSG_STATS_REPORT: u8 = 1;
+const BMP_MSG_PEER_DOWN: u8 = 2;
+const BMP_MSG_PEER_UP: u8 = 3;
+const BMP_MSG_INITIATION: u8 = 4;
+const BMP_MSG_TERMINATION: u8 = 5;
+const BMP_MSG_ROUTE_MIRRORING: u8 = 6;
+
+// Per-peer header flags (RFC 7854 §4.2, RFC 8671 §4).
+const PEER_FLAG_V: u8 = 0x80;
+const PEER_FLAG_L: u8 = 0x40;
+const PEER_FLAG_A: u8 = 0x20;
+const PEER_FLAG_O: u8 = 0x10;
+
+/// BMP common header: version(1) + length(4) + type(1).
+const BMP_COMMON_HEADER_LEN: usize = 6;
+
+/// RFC 8671 stat types cross-checked after End-of-RIB.
+const STAT_ADJ_RIB_OUT_POST: u16 = 15;
+const STAT_ADJ_RIB_OUT_POST_PER_AFI: u16 = 17;
+
+/// Hard resource bounds. Deliberately constants, not flags: exceeding
+/// any of them refuses the conversion (exit 2) — a bound is a safety
+/// property, not a tuning knob. Attribute-per-path and message-size
+/// bounds are additionally enforced by the BGP wire decoder itself.
+#[derive(Clone, Copy)]
+struct Limits {
+    /// Maximum capture bytes read.
+    max_input_bytes: u64,
+    /// Maximum single BMP message length (the common-header length
+    /// field). The largest legitimate message is a Route Monitoring
+    /// around one extended UPDATE (~64 KiB); 1 MiB leaves TLV headroom.
+    max_bmp_message_len: usize,
+    /// Maximum monitored peers.
+    max_peers: usize,
+    /// Maximum retained routes across all peers.
+    max_routes: usize,
+    /// Maximum distinct source path IDs per (peer, family, NLRI).
+    max_paths_per_nlri: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_input_bytes: 1 << 30,
+            max_bmp_message_len: 1 << 20,
+            max_peers: 4096,
+            max_routes: 4_000_000,
+            max_paths_per_nlri: 64,
+        }
+    }
+}
+
+/// Options for `rbgp diff snapshot from-bmp`.
+pub struct FromBmpOpts<'a> {
+    /// Path to the captured BMP byte stream.
+    pub file: &'a Path,
+    /// Peers to emit (empty = every complete global-instance peer).
+    /// Every listed peer must be present and complete.
+    pub peers: &'a [String],
+    /// Free-form provenance label appended to the header `source`.
+    pub source: Option<&'a str>,
+    /// Capture-round generation stamped into the snapshot header.
+    pub generation: u64,
+}
+
+/// Run the adapter: print the snapshot to stdout on success (notes to
+/// stderr), an error to stderr on refusal, and return the exit code.
+pub fn from_bmp(opts: &FromBmpOpts<'_>) -> i32 {
+    match run(opts) {
+        Ok((snapshot, notes)) => {
+            for note in notes {
+                eprintln!("note: {note}");
+            }
+            print!("{snapshot}");
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            EXIT_REFUSED
+        }
+    }
+}
+
+fn run(opts: &FromBmpOpts<'_>) -> Result<(String, Vec<String>), String> {
+    run_with_limits(opts, Limits::default())
+}
+
+fn run_with_limits(
+    opts: &FromBmpOpts<'_>,
+    limits: Limits,
+) -> Result<(String, Vec<String>), String> {
+    let peer_filter: BTreeSet<IpAddr> = opts
+        .peers
+        .iter()
+        .map(|p| {
+            p.parse()
+                .map_err(|e| format!("invalid --peer address {p:?}: {e}"))
+        })
+        .collect::<Result<_, _>>()?;
+    let display = opts.file.display();
+    let size = std::fs::metadata(opts.file)
+        .map_err(|e| format!("cannot read {display}: {e}"))?
+        .len();
+    if size > limits.max_input_bytes {
+        return Err(format!(
+            "{display}: {size} bytes exceeds the input limit of {} bytes; refusing",
+            limits.max_input_bytes
+        ));
+    }
+    let data = std::fs::read(opts.file).map_err(|e| format!("cannot read {display}: {e}"))?;
+
+    let mut importer = Importer::default();
+    let mut offset = 0_usize;
+    let mut index = 0_usize;
+    while offset < data.len() {
+        index += 1;
+        let context = |e: String| format!("{display}: BMP message #{index} at byte {offset}: {e}");
+        let rest = &data[offset..];
+        if rest.len() < BMP_COMMON_HEADER_LEN {
+            return Err(context(format!(
+                "truncated common header ({} trailing bytes)",
+                rest.len()
+            )));
+        }
+        let version = rest[0];
+        if version != 3 {
+            return Err(context(format!(
+                "BMP version {version} is not supported (this adapter reads RFC 7854 \
+                 version 3 streams; if the byte is not 3 or 4, the file is likely not \
+                 a raw BMP capture)"
+            )));
+        }
+        let length = u32::from_be_bytes([rest[1], rest[2], rest[3], rest[4]]) as usize;
+        let msg_type = rest[5];
+        if length < BMP_COMMON_HEADER_LEN {
+            return Err(context(format!(
+                "message length {length} below header size"
+            )));
+        }
+        if length > limits.max_bmp_message_len {
+            return Err(context(format!(
+                "message length {length} exceeds the {} byte limit; refusing",
+                limits.max_bmp_message_len
+            )));
+        }
+        if length > rest.len() {
+            return Err(context(format!(
+                "truncated: message declares {length} bytes but only {} remain \
+                 (the capture is cut mid-message)",
+                rest.len()
+            )));
+        }
+        let body = &rest[BMP_COMMON_HEADER_LEN..length];
+        importer.handle(msg_type, body, limits).map_err(context)?;
+        offset += length;
+    }
+
+    importer.finish(opts, &peer_filter)
+}
+
+/// Family key for the state maps — the two families `rbgp-ribsnap/1`
+/// can express.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Fam {
+    V4Unicast,
+    V6Unicast,
+}
+
+impl Fam {
+    fn from_afi_safi(afi: Afi, safi: Safi) -> Option<Self> {
+        match (afi, safi) {
+            (Afi::Ipv4, Safi::Unicast) => Some(Self::V4Unicast),
+            (Afi::Ipv6, Safi::Unicast) => Some(Self::V6Unicast),
+            _ => None,
+        }
+    }
+
+    fn from_wire(afi: u16, safi: u8) -> Option<Self> {
+        match (afi, safi) {
+            (1, 1) => Some(Self::V4Unicast),
+            (2, 1) => Some(Self::V6Unicast),
+            _ => None,
+        }
+    }
+
+    fn wire(self) -> (Afi, Safi) {
+        match self {
+            Self::V4Unicast => (Afi::Ipv4, Safi::Unicast),
+            Self::V6Unicast => (Afi::Ipv6, Safi::Unicast),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::V4Unicast => "ipv4_unicast",
+            Self::V6Unicast => "ipv6_unicast",
+        }
+    }
+}
+
+/// State key: (family, NLRI, source-local RFC 7911 path ID). Path IDs
+/// are internal keys only — they select which announcement a later
+/// update or withdraw supersedes, and are never compared downstream.
+type RouteKey = (Fam, IpAddr, u8, u32);
+
+/// One monitored peer's state within the current connection generation.
+struct PeerState {
+    asn: u32,
+    /// Families where Add-Path is in effect incumbent→peer (path IDs
+    /// present in the encapsulated UPDATEs).
+    addpath: BTreeSet<Fam>,
+    /// Families that must reach End-of-RIB for the peer to be complete:
+    /// the unicast families negotiated in the OPENs, plus any family
+    /// with observed Route Monitoring activity.
+    expected: BTreeSet<Fam>,
+    /// Families whose End-of-RIB has been seen in this generation.
+    eor: BTreeSet<Fam>,
+    routes: BTreeMap<RouteKey, SnapRoute>,
+    /// Non-unicast NLRI carriers skipped for this peer (not expressible
+    /// in `rbgp-ribsnap/1`).
+    non_unicast_skipped: u64,
+}
+
+/// Decoded RFC 7854 §4.2 per-peer header (fields the adapter uses).
+struct PerPeerHeader {
+    peer_type: u8,
+    flags: u8,
+    distinguisher: u64,
+    addr: IpAddr,
+    asn: u32,
+}
+
+fn parse_per_peer_header(cur: &mut Cursor<'_>) -> Result<PerPeerHeader, String> {
+    let peer_type = cur.read_u8()?;
+    let flags = cur.read_u8()?;
+    let distinguisher = cur.read_u64()?;
+    let raw = cur.take(16)?;
+    let addr = if flags & PEER_FLAG_V != 0 {
+        IpAddr::V6(Ipv6Addr::from(
+            <[u8; 16]>::try_from(raw).expect("length checked"),
+        ))
+    } else {
+        IpAddr::V4(Ipv4Addr::new(raw[12], raw[13], raw[14], raw[15]))
+    };
+    let asn = cur.read_u32()?;
+    let _bgp_id = cur.read_u32()?;
+    let _timestamp_secs = cur.read_u32()?;
+    let _timestamp_usecs = cur.read_u32()?;
+    Ok(PerPeerHeader {
+        peer_type,
+        flags,
+        distinguisher,
+        addr,
+        asn,
+    })
+}
+
+#[derive(Default)]
+struct Importer {
+    /// Connection generation: bumped by every Initiation; 0 = none seen.
+    generation: u64,
+    /// A Termination was seen; only a new Initiation may follow.
+    terminated: bool,
+    peers: BTreeMap<IpAddr, PeerState>,
+    /// Non-global instance peers (peer type != 0 or distinguisher != 0):
+    /// VPN views `rbgp-ribsnap/1` cannot express; skipped entirely.
+    ignored_instance_peers: BTreeSet<IpAddr>,
+    /// Total retained routes across peers (bound by `max_routes`).
+    total_routes: usize,
+    /// Pre-policy Adj-RIB-In Route Monitoring messages skipped (O=0).
+    rib_in_skipped: u64,
+    /// Route Mirroring messages skipped.
+    mirrored_skipped: u64,
+}
+
+impl Importer {
+    fn handle(&mut self, msg_type: u8, body: &[u8], limits: Limits) -> Result<(), String> {
+        if msg_type == BMP_MSG_INITIATION {
+            // Reconnect: a new connection generation invalidates all
+            // prior state — old and new are never mixed.
+            self.generation += 1;
+            self.terminated = false;
+            self.peers.clear();
+            self.ignored_instance_peers.clear();
+            self.total_routes = 0;
+            return Ok(());
+        }
+        if self.generation == 0 {
+            return Err(
+                "message before the Initiation message — the capture must start at the \
+                 beginning of a BMP session (a mid-stream capture is missing the Peer Up \
+                 negotiation state and cannot be decoded soundly)"
+                    .to_string(),
+            );
+        }
+        if self.terminated {
+            return Err("message after a Termination message without a new Initiation".to_string());
+        }
+        match msg_type {
+            BMP_MSG_TERMINATION => {
+                self.terminated = true;
+                Ok(())
+            }
+            BMP_MSG_PEER_UP => self.handle_peer_up(body, limits),
+            BMP_MSG_PEER_DOWN => self.handle_peer_down(body),
+            BMP_MSG_ROUTE_MONITORING => self.handle_route_monitoring(body, limits),
+            BMP_MSG_STATS_REPORT => self.handle_stats(body),
+            BMP_MSG_ROUTE_MIRRORING => {
+                self.mirrored_skipped += 1;
+                Ok(())
+            }
+            other => Err(format!("unknown BMP message type {other}; refusing")),
+        }
+    }
+
+    fn handle_peer_up(&mut self, body: &[u8], limits: Limits) -> Result<(), String> {
+        let mut cur = Cursor::new(body);
+        let pph = parse_per_peer_header(&mut cur)?;
+        // O/L flags on Peer Up are NOT route-view selectors (RFC 8671
+        // §5: receivers ignore them here) — only Route Monitoring
+        // per-peer-header flags select the view.
+        if pph.peer_type != 0 || pph.distinguisher != 0 {
+            self.ignored_instance_peers.insert(pph.addr);
+            return Ok(());
+        }
+        cur.take(20)?; // local address (16) + local port (2) + remote port (2)
+        let sent_open =
+            parse_open_pdu(&mut cur).map_err(|e| format!("peer {}: sent OPEN: {e}", pph.addr))?;
+        let received_open = parse_open_pdu(&mut cur)
+            .map_err(|e| format!("peer {}: received OPEN: {e}", pph.addr))?;
+        // Trailing Information TLVs are ignored.
+
+        // Negotiated unicast families: the intersection of both OPENs'
+        // MP capabilities; a side with no MP capability is plain IPv4
+        // unicast (RFC 4760).
+        let expected: BTreeSet<Fam> = unicast_families(&sent_open)
+            .intersection(&unicast_families(&received_open))
+            .copied()
+            .collect();
+        // Add-Path is directional (RFC 7911 §4): path IDs appear in the
+        // incumbent's UPDATEs toward this peer iff the incumbent's sent
+        // OPEN advertised send AND the peer's received OPEN advertised
+        // receive for the family.
+        let sent_modes = addpath_modes(&sent_open);
+        let received_modes = addpath_modes(&received_open);
+        let addpath: BTreeSet<Fam> = expected
+            .iter()
+            .copied()
+            .filter(|fam| {
+                matches!(
+                    sent_modes.get(fam),
+                    Some(AddPathMode::Send | AddPathMode::Both)
+                ) && matches!(
+                    received_modes.get(fam),
+                    Some(AddPathMode::Receive | AddPathMode::Both)
+                )
+            })
+            .collect();
+
+        // A repeated Peer Up resets the peer: prior routes and
+        // End-of-RIB state belong to the previous peer generation.
+        if let Some(old) = self.peers.remove(&pph.addr) {
+            self.total_routes -= old.routes.len();
+        } else if self.peers.len() >= limits.max_peers {
+            return Err(format!(
+                "more than {} monitored peers; refusing",
+                limits.max_peers
+            ));
+        }
+        self.peers.insert(
+            pph.addr,
+            PeerState {
+                asn: pph.asn,
+                addpath,
+                expected,
+                eor: BTreeSet::new(),
+                routes: BTreeMap::new(),
+                non_unicast_skipped: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn handle_peer_down(&mut self, body: &[u8]) -> Result<(), String> {
+        let mut cur = Cursor::new(body);
+        let pph = parse_per_peer_header(&mut cur)?;
+        if pph.peer_type != 0 || pph.distinguisher != 0 {
+            return Ok(());
+        }
+        // Reason payload is irrelevant: the peer's Adj-RIB-Out ceased to
+        // exist, so its state is invalidated. Without a later Peer Up it
+        // contributes nothing to the snapshot.
+        match self.peers.remove(&pph.addr) {
+            Some(state) => {
+                self.total_routes -= state.routes.len();
+                Ok(())
+            }
+            None => Err(format!(
+                "Peer Down for peer {} without a Peer Up in this connection generation",
+                pph.addr
+            )),
+        }
+    }
+
+    fn handle_route_monitoring(&mut self, body: &[u8], limits: Limits) -> Result<(), String> {
+        let mut cur = Cursor::new(body);
+        let pph = parse_per_peer_header(&mut cur)?;
+        if pph.peer_type != 0
+            || pph.distinguisher != 0
+            || self.ignored_instance_peers.contains(&pph.addr)
+        {
+            // Instance-peer monitoring (VPN views) is skipped with the
+            // peer itself.
+            return Ok(());
+        }
+        if pph.flags & PEER_FLAG_O == 0 {
+            // Pre-policy Adj-RIB-In monitoring (RFC 7854 default view):
+            // most feeds carry it alongside; it is not the requested
+            // view and is skipped, never folded.
+            self.rib_in_skipped += 1;
+            return Ok(());
+        }
+        if pph.flags & PEER_FLAG_L == 0 {
+            return Err(format!(
+                "peer {}: Route Monitoring carries the pre-policy Adj-RIB-Out view \
+                 (O=1, L=0), which is not comparable against a post-policy \
+                 Adj-RIB-Out: comparing it would report every export-policy effect \
+                 as divergence (or mask one as expected). Configure the incumbent's \
+                 BMP export for post-policy Adj-RIB-Out (RFC 8671, L=1) and \
+                 re-capture.",
+                pph.addr
+            ));
+        }
+        let Some(state) = self.peers.get_mut(&pph.addr) else {
+            return Err(format!(
+                "Route Monitoring for peer {} without a Peer Up in this connection \
+                 generation — negotiated Add-Path state is unknown, so the UPDATE \
+                 cannot be decoded soundly",
+                pph.addr
+            ));
+        };
+        if state.asn != pph.asn {
+            return Err(format!(
+                "peer {}: per-peer header ASN {} conflicts with the Peer Up ASN {}",
+                pph.addr, pph.asn, state.asn
+            ));
+        }
+        // RFC 7854 §4.2: the A flag marks legacy 2-octet AS_PATH
+        // encoding in the encapsulated message.
+        let four_octet_as = pph.flags & PEER_FLAG_A == 0;
+        fold_update(
+            state,
+            &mut self.total_routes,
+            limits,
+            four_octet_as,
+            cur.remaining(),
+        )
+        .map_err(|e| format!("peer {}: {e}", pph.addr))
+    }
+
+    fn handle_stats(&mut self, body: &[u8]) -> Result<(), String> {
+        let mut cur = Cursor::new(body);
+        let pph = parse_per_peer_header(&mut cur)?;
+        if pph.peer_type != 0 || pph.distinguisher != 0 {
+            return Ok(());
+        }
+        let Some(state) = self.peers.get(&pph.addr) else {
+            return Err(format!(
+                "Stats Report for peer {} without a Peer Up in this connection generation",
+                pph.addr
+            ));
+        };
+        let count = cur.read_u32()?;
+        for _ in 0..count {
+            let stat_type = cur.read_u16()?;
+            let len = cur.read_u16()? as usize;
+            let value = cur.take(len)?;
+            match stat_type {
+                // RFC 8671 type 17: per-AFI/SAFI post-policy Adj-RIB-Out
+                // gauge. After that family's End-of-RIB the folded state
+                // must match it exactly (same ordered stream) — a
+                // mismatch means a decode gap.
+                STAT_ADJ_RIB_OUT_POST_PER_AFI => {
+                    let [a0, a1, s, v @ ..] = value else {
+                        return Err(format!("stat type 17 length {len} != 11"));
+                    };
+                    let v: [u8; 8] = v
+                        .try_into()
+                        .map_err(|_| format!("stat type 17 length {len} != 11"))?;
+                    let reported = u64::from_be_bytes(v);
+                    let Some(fam) = Fam::from_wire(u16::from_be_bytes([*a0, *a1]), *s) else {
+                        continue; // non-unicast family gauge: not tracked
+                    };
+                    if !state.eor.contains(&fam) {
+                        continue; // cross-check applies only after End-of-RIB
+                    }
+                    let folded = state.routes.keys().filter(|(f, ..)| *f == fam).count() as u64;
+                    if folded != reported {
+                        return Err(format!(
+                            "peer {} family {}: RFC 8671 stat 17 reports {reported} \
+                             post-policy Adj-RIB-Out routes but the folded state holds \
+                             {folded} — a Route Monitoring message was missed or \
+                             misdecoded; refusing",
+                            pph.addr,
+                            fam.name()
+                        ));
+                    }
+                }
+                // RFC 8671 type 15: total post-policy Adj-RIB-Out gauge.
+                // Only checkable when every family the peer carries is a
+                // tracked unicast family that has reached End-of-RIB.
+                STAT_ADJ_RIB_OUT_POST => {
+                    let v: [u8; 8] = value
+                        .try_into()
+                        .map_err(|_| format!("stat type 15 length {len} != 8"))?;
+                    let reported = u64::from_be_bytes(v);
+                    if state.non_unicast_skipped > 0
+                        || !state.expected.iter().all(|f| state.eor.contains(f))
+                    {
+                        continue;
+                    }
+                    let folded = state.routes.len() as u64;
+                    if folded != reported {
+                        return Err(format!(
+                            "peer {}: RFC 8671 stat 15 reports {reported} post-policy \
+                             Adj-RIB-Out routes but the folded state holds {folded} — \
+                             a Route Monitoring message was missed or misdecoded; \
+                             refusing",
+                            pph.addr
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate completeness and render the snapshot.
+    fn finish(
+        self,
+        opts: &FromBmpOpts<'_>,
+        peer_filter: &BTreeSet<IpAddr>,
+    ) -> Result<(String, Vec<String>), String> {
+        let display = opts.file.display();
+        if self.generation == 0 {
+            return Err(format!(
+                "{display}: no BMP Initiation message found — not a BMP capture, or \
+                 the capture does not start at the beginning of a session"
+            ));
+        }
+        let mut selected: Vec<(IpAddr, &PeerState)> = Vec::new();
+        if peer_filter.is_empty() {
+            selected.extend(self.peers.iter().map(|(a, s)| (*a, s)));
+        } else {
+            for addr in peer_filter {
+                let Some(state) = self.peers.get(addr) else {
+                    return Err(format!(
+                        "{display}: peer {addr} has no state in the capture's final \
+                         connection generation (no Peer Up, or invalidated by a \
+                         Peer Down or reconnect); refusing"
+                    ));
+                };
+                selected.push((*addr, state));
+            }
+        }
+        if selected.is_empty() {
+            return Err(format!(
+                "{display}: no global-instance peers with post-policy Adj-RIB-Out \
+                 state in the capture; nothing to emit"
+            ));
+        }
+        for (addr, state) in &selected {
+            for fam in &state.expected {
+                if !state.eor.contains(fam) {
+                    return Err(format!(
+                        "{display}: peer {addr} family {}: End-of-RIB not seen in the \
+                         current connection generation — the post-policy Adj-RIB-Out \
+                         dump is incomplete and equality must never be asserted from \
+                         it. Re-capture a complete stream (or exclude the peer with \
+                         --peer).",
+                        fam.name()
+                    ));
+                }
+            }
+        }
+
+        let mut out = String::new();
+        let mut source = "from-bmp/1 view=adj-rib-out-post-policy".to_string();
+        if let Some(label) = opts.source {
+            source.push(' ');
+            source.push_str(label);
+        }
+        let header = serde_json::json!({
+            "record": "header",
+            "schema": super::diff::SNAPSHOT_SCHEMA,
+            "source": source,
+            "generation": opts.generation,
+        });
+        out.push_str(&header.to_string());
+        out.push('\n');
+        let mut count = 0_usize;
+        for (addr, state) in &selected {
+            for ((_, prefix, len, _), route) in &state.routes {
+                out.push_str(&route_record_json(*addr, state.asn, *prefix, *len, route));
+                out.push('\n');
+                count += 1;
+            }
+        }
+        let trailer = serde_json::json!({"record": "trailer", "routes": count});
+        out.push_str(&trailer.to_string());
+        out.push('\n');
+
+        let mut notes = Vec::new();
+        if self.rib_in_skipped > 0 {
+            notes.push(format!(
+                "{} pre-policy Adj-RIB-In Route Monitoring messages (O=0) ignored — \
+                 from-bmp imports the post-policy Adj-RIB-Out view only",
+                self.rib_in_skipped
+            ));
+        }
+        if self.mirrored_skipped > 0 {
+            notes.push(format!(
+                "{} Route Mirroring messages ignored",
+                self.mirrored_skipped
+            ));
+        }
+        for addr in &self.ignored_instance_peers {
+            notes.push(format!(
+                "instance peer {addr} skipped (non-global peer type or distinguisher; \
+                 rbgp-ribsnap/1 carries the global unicast view only)"
+            ));
+        }
+        for (addr, state) in &selected {
+            if state.non_unicast_skipped > 0 {
+                notes.push(format!(
+                    "peer {addr}: {} non-unicast NLRI carriers skipped \
+                     (rbgp-ribsnap/1 carries IPv4/IPv6 unicast only)",
+                    state.non_unicast_skipped
+                ));
+            }
+        }
+        Ok((out, notes))
+    }
+}
+
+/// Decode one full BGP OPEN PDU (with 19-byte header) from the cursor
+/// and advance past it.
+fn parse_open_pdu(cur: &mut Cursor<'_>) -> Result<OpenMessage, String> {
+    let mut buf = cur.remaining();
+    let header =
+        BgpHeader::decode(&mut buf, EXTENDED_MAX_MESSAGE_LEN).map_err(|e| e.to_string())?;
+    if header.message_type != MessageType::Open {
+        return Err(format!("expected an OPEN, got {:?}", header.message_type));
+    }
+    let body_len = usize::from(header.length) - HEADER_LEN;
+    let open = OpenMessage::decode(&mut buf, body_len).map_err(|e| e.to_string())?;
+    cur.take(usize::from(header.length))?;
+    Ok(open)
+}
+
+/// Unicast families a speaker's OPEN supports: its MP capabilities
+/// filtered to IPv4/IPv6 unicast, or plain IPv4 unicast when it carries
+/// no MP capability at all (RFC 4760 §8).
+fn unicast_families(open: &OpenMessage) -> BTreeSet<Fam> {
+    let mut families = BTreeSet::new();
+    let mut saw_mp = false;
+    for capability in &open.capabilities {
+        if let Capability::MultiProtocol { afi, safi } = capability {
+            saw_mp = true;
+            if let Some(fam) = Fam::from_afi_safi(*afi, *safi) {
+                families.insert(fam);
+            }
+        }
+    }
+    if !saw_mp {
+        families.insert(Fam::V4Unicast);
+    }
+    families
+}
+
+/// Per-family Add-Path modes advertised in an OPEN (last entry wins).
+fn addpath_modes(open: &OpenMessage) -> BTreeMap<Fam, AddPathMode> {
+    let mut modes = BTreeMap::new();
+    for capability in &open.capabilities {
+        if let Capability::AddPath(families) = capability {
+            for family in families {
+                if let Some(fam) = Fam::from_afi_safi(family.afi, family.safi) {
+                    modes.insert(fam, family.send_receive);
+                }
+            }
+        }
+    }
+    modes
+}
+
+/// Decode and fold one encapsulated BGP UPDATE into the peer's state.
+fn fold_update(
+    state: &mut PeerState,
+    total_routes: &mut usize,
+    limits: Limits,
+    four_octet_as: bool,
+    pdu: &[u8],
+) -> Result<(), String> {
+    let mut buf = pdu;
+    let header =
+        BgpHeader::decode(&mut buf, EXTENDED_MAX_MESSAGE_LEN).map_err(|e| e.to_string())?;
+    if header.message_type != MessageType::Update {
+        return Err(format!(
+            "Route Monitoring carries a {:?} PDU, expected UPDATE",
+            header.message_type
+        ));
+    }
+    if usize::from(header.length) != pdu.len() {
+        return Err(format!(
+            "encapsulated UPDATE declares {} bytes but the message carries {} — \
+             framing is corrupt",
+            header.length,
+            pdu.len()
+        ));
+    }
+    let body_len = usize::from(header.length) - HEADER_LEN;
+    let update = UpdateMessage::decode(&mut buf, body_len).map_err(|e| e.to_string())?;
+
+    // RFC 4724 §2: the IPv4-unicast End-of-RIB is a completely empty
+    // UPDATE.
+    if update.withdrawn_routes.is_empty()
+        && update.path_attributes.is_empty()
+        && update.nlri.is_empty()
+    {
+        state.expected.insert(Fam::V4Unicast);
+        state.eor.insert(Fam::V4Unicast);
+        return Ok(());
+    }
+
+    let addpath_v4 = state.addpath.contains(&Fam::V4Unicast);
+    let addpath_families: Vec<(Afi, Safi)> = state.addpath.iter().map(|f| f.wire()).collect();
+    let parsed = update
+        .parse(four_octet_as, addpath_v4, &addpath_families)
+        .map_err(|e| e.to_string())?;
+
+    // RFC 4724 §2: a non-IPv4 End-of-RIB is an UPDATE whose only
+    // content is an empty MP_UNREACH_NLRI naming the family.
+    if update.withdrawn_routes.is_empty()
+        && update.nlri.is_empty()
+        && let [PathAttribute::MpUnreachNlri(mp)] = parsed.attributes.as_slice()
+        && mp_unreach_nlri_count(mp) == 0
+    {
+        match Fam::from_afi_safi(mp.afi, mp.safi) {
+            Some(fam) => {
+                state.expected.insert(fam);
+                state.eor.insert(fam);
+            }
+            None => state.non_unicast_skipped += 1,
+        }
+        return Ok(());
+    }
+
+    let mut base = SnapRoute::default();
+    let mut mp_reach: Option<&MpReachNlri> = None;
+    let mut mp_unreach: Option<&MpUnreachNlri> = None;
+    for attribute in &parsed.attributes {
+        convert_attribute(attribute, &mut base, &mut mp_reach, &mut mp_unreach)?;
+    }
+
+    // Body IPv4-unicast withdrawals and announcements.
+    for entry in &parsed.withdrawn {
+        remove_route(
+            state,
+            total_routes,
+            Fam::V4Unicast,
+            IpAddr::V4(entry.prefix.addr),
+            entry.prefix.len,
+            entry.path_id,
+        );
+    }
+    for entry in &parsed.announced {
+        let route = clone_route(&base, base.next_hop, addpath_v4.then_some(entry.path_id));
+        insert_route(
+            state,
+            total_routes,
+            limits,
+            (
+                Fam::V4Unicast,
+                IpAddr::V4(entry.prefix.addr),
+                entry.prefix.len,
+                entry.path_id,
+            ),
+            route,
+        )?;
+    }
+
+    // MP withdrawals and announcements (unicast families only).
+    if let Some(mp) = mp_unreach {
+        match Fam::from_afi_safi(mp.afi, mp.safi) {
+            Some(fam) => {
+                for entry in &mp.withdrawn {
+                    let (addr, len) = split_prefix(entry.prefix);
+                    remove_route(state, total_routes, fam, addr, len, entry.path_id);
+                }
+            }
+            None => state.non_unicast_skipped += 1,
+        }
+    }
+    if let Some(mp) = mp_reach {
+        match Fam::from_afi_safi(mp.afi, mp.safi) {
+            Some(fam) => {
+                let addpath = state.addpath.contains(&fam);
+                for entry in &mp.announced {
+                    let (addr, len) = split_prefix(entry.prefix);
+                    let route =
+                        clone_route(&base, Some(mp.next_hop), addpath.then_some(entry.path_id));
+                    insert_route(
+                        state,
+                        total_routes,
+                        limits,
+                        (fam, addr, len, entry.path_id),
+                        route,
+                    )?;
+                }
+            }
+            None => state.non_unicast_skipped += 1,
+        }
+    }
+    Ok(())
+}
+
+fn split_prefix(prefix: Prefix) -> (IpAddr, u8) {
+    match prefix {
+        Prefix::V4(p) => (IpAddr::V4(p.addr), p.len),
+        Prefix::V6(p) => (IpAddr::V6(p.addr), p.len),
+    }
+}
+
+/// Total NLRI units carried by an MP_UNREACH_NLRI across all its family
+/// shapes (0 = the End-of-RIB form).
+fn mp_unreach_nlri_count(mp: &MpUnreachNlri) -> usize {
+    mp.withdrawn.len()
+        + mp.flowspec_withdrawn.len()
+        + mp.evpn_withdrawn.len()
+        + mp.bgpls_withdrawn.len()
+        + mp.vpn_withdrawn.len()
+        + mp.labeled_withdrawn.len()
+        + mp.rtc_withdrawn.len()
+}
+
+/// Fold one decoded path attribute into the shared `SnapRoute` template.
+///
+/// Attributes with typed snapshot fields map directly; attributes the
+/// snapshot does not type (ORIGINATOR_ID, CLUSTER_LIST, OTC, and
+/// anything the wire decoder itself does not type) are preserved
+/// byte-exact in `unknown_attrs` with their canonical wire encoding —
+/// never dropped. The EXTENDED_LENGTH bit is cleared from preserved
+/// flags: it is an encoding artifact, not attribute semantics.
+fn convert_attribute<'a>(
+    attribute: &'a PathAttribute,
+    base: &mut SnapRoute,
+    mp_reach: &mut Option<&'a MpReachNlri>,
+    mp_unreach: &mut Option<&'a MpUnreachNlri>,
+) -> Result<(), String> {
+    match attribute {
+        PathAttribute::Origin(origin) => base.origin = Some(*origin as u8),
+        PathAttribute::AsPath(path) => base.as_path = flatten_as_path(path),
+        PathAttribute::NextHop(next_hop) => base.next_hop = Some(IpAddr::V4(*next_hop)),
+        PathAttribute::Med(med) => base.med = Some(*med),
+        PathAttribute::LocalPref(local_pref) => base.local_pref = Some(*local_pref),
+        PathAttribute::Communities(communities) => base.communities = communities.clone(),
+        PathAttribute::ExtendedCommunities(communities) => {
+            base.extended_communities = communities.iter().map(|c| c.as_u64()).collect();
+        }
+        PathAttribute::LargeCommunities(communities) => {
+            base.large_communities = communities
+                .iter()
+                .map(|c| [c.global_admin, c.local_data1, c.local_data2])
+                .collect();
+        }
+        PathAttribute::OriginatorId(id) => base.unknown_attrs.push((
+            attr_flags::OPTIONAL,
+            attr_type::ORIGINATOR_ID,
+            id.octets().to_vec(),
+        )),
+        PathAttribute::ClusterList(clusters) => base.unknown_attrs.push((
+            attr_flags::OPTIONAL,
+            attr_type::CLUSTER_LIST,
+            clusters.iter().flat_map(|c| c.octets()).collect(),
+        )),
+        PathAttribute::OnlyToCustomer(asn) => base.unknown_attrs.push((
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::ONLY_TO_CUSTOMER,
+            asn.to_be_bytes().to_vec(),
+        )),
+        PathAttribute::MpReachNlri(mp) => *mp_reach = Some(mp),
+        PathAttribute::MpUnreachNlri(mp) => *mp_unreach = Some(mp),
+        PathAttribute::PmsiTunnel(_) => {
+            return Err(
+                "PMSI_TUNNEL attribute on a unicast Adj-RIB-Out route is not supported".to_string(),
+            );
+        }
+        PathAttribute::Unknown(raw) => base.unknown_attrs.push((
+            raw.flags & !attr_flags::EXTENDED_LENGTH,
+            raw.type_code,
+            raw.data.to_vec(),
+        )),
+    }
+    Ok(())
+}
+
+/// Flatten AS_PATH segments into the snapshot's single ASN list
+/// (documented consumer limitation shared with the from-mrt adapter:
+/// segment structure is not compared).
+fn flatten_as_path(path: &AsPath) -> Vec<u32> {
+    use rustbgpd_wire::attribute::AsPathSegment;
+    path.segments
+        .iter()
+        .flat_map(|segment| match segment {
+            AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => asns.iter().copied(),
+        })
+        .collect()
+}
+
+/// Copy the shared attribute template for one NLRI entry.
+fn clone_route(base: &SnapRoute, next_hop: Option<IpAddr>, path_id: Option<u32>) -> SnapRoute {
+    SnapRoute {
+        path_id,
+        origin: base.origin,
+        as_path: base.as_path.clone(),
+        next_hop,
+        med: base.med,
+        local_pref: base.local_pref,
+        communities: base.communities.clone(),
+        extended_communities: base.extended_communities.clone(),
+        large_communities: base.large_communities.clone(),
+        unknown_attrs: base.unknown_attrs.clone(),
+    }
+}
+
+/// Insert (or supersede — RFC 7854 §5: a later update for the same key
+/// wins) one route under the hard bounds.
+fn insert_route(
+    state: &mut PeerState,
+    total_routes: &mut usize,
+    limits: Limits,
+    key: RouteKey,
+    route: SnapRoute,
+) -> Result<(), String> {
+    let (fam, addr, len, _) = key;
+    state.expected.insert(fam);
+    if !state.routes.contains_key(&key) {
+        if *total_routes >= limits.max_routes {
+            return Err(format!(
+                "more than {} retained routes; refusing",
+                limits.max_routes
+            ));
+        }
+        let paths = state
+            .routes
+            .range((fam, addr, len, 0)..=(fam, addr, len, u32::MAX))
+            .count();
+        if paths >= limits.max_paths_per_nlri {
+            return Err(format!(
+                "more than {} paths for {addr}/{len}; refusing",
+                limits.max_paths_per_nlri
+            ));
+        }
+        *total_routes += 1;
+    }
+    state.routes.insert(key, route);
+    Ok(())
+}
+
+/// Remove one route (a withdraw for an absent key is a legal no-op).
+fn remove_route(
+    state: &mut PeerState,
+    total_routes: &mut usize,
+    fam: Fam,
+    addr: IpAddr,
+    len: u8,
+    path_id: u32,
+) {
+    state.expected.insert(fam);
+    if state.routes.remove(&(fam, addr, len, path_id)).is_some() {
+        *total_routes -= 1;
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_fixture {
+    //! Synthetic BMP capture builder. Messages are framed by the
+    //! daemon's own RFC-pinned BMP encoder (`rustbgpd-bmp`), OPENs by
+    //! the wire crate's encoder, and UPDATE bodies by hand — so the
+    //! fixtures exercise the importer against independently golden-
+    //! pinned wire bytes rather than its own encoding assumptions.
+
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::UNIX_EPOCH;
+
+    use rustbgpd_bmp::codec::{
+        AfiStatCounter, StatCounter, encode_initiation, encode_peer_down, encode_peer_up,
+        encode_route_monitoring, encode_stats_report, encode_termination,
+    };
+    use rustbgpd_bmp::types::{BmpPeerInfo, BmpPeerType, BmpVersion, PeerDownReason};
+    use rustbgpd_wire::capability::{AddPathFamily, AddPathMode, Afi, Capability, Safi};
+    use rustbgpd_wire::constants::attr_type;
+    use rustbgpd_wire::open::OpenMessage;
+
+    pub(crate) use super::super::ribsnap::test_fixture::as_path_attr;
+
+    /// Encode one path attribute with its canonical RFC flags (the wire
+    /// decoder validates flags per type, unlike the MRT fixture path).
+    pub(crate) fn attr(type_code: u8, value: &[u8]) -> Vec<u8> {
+        use rustbgpd_wire::constants::attr_flags::{OPTIONAL, TRANSITIVE};
+        let flags = match type_code {
+            attr_type::MULTI_EXIT_DISC | attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI => {
+                OPTIONAL
+            }
+            attr_type::COMMUNITIES
+            | attr_type::EXTENDED_COMMUNITIES
+            | attr_type::LARGE_COMMUNITIES
+            | attr_type::ONLY_TO_CUSTOMER => OPTIONAL | TRANSITIVE,
+            _ => TRANSITIVE,
+        };
+        let mut buf = vec![flags, type_code, u8::try_from(value.len()).unwrap()];
+        buf.extend_from_slice(value);
+        buf
+    }
+
+    /// Peer identity for the post-policy Adj-RIB-Out view (O=1, L=1).
+    pub(crate) fn rib_out_info(addr: &str, asn: u32) -> BmpPeerInfo {
+        let addr: IpAddr = addr.parse().unwrap();
+        BmpPeerInfo {
+            peer_addr: addr,
+            peer_asn: asn,
+            peer_bgp_id: Ipv4Addr::new(192, 0, 2, 99),
+            peer_type: BmpPeerType::Global,
+            is_ipv6: addr.is_ipv6(),
+            is_post_policy: true,
+            is_rib_out: true,
+            is_as4: true,
+            timestamp: UNIX_EPOCH,
+        }
+    }
+
+    /// Full BGP OPEN PDU (with header) carrying the given capabilities.
+    pub(crate) fn open_pdu(asn: u32, capabilities: Vec<Capability>) -> Vec<u8> {
+        let open = OpenMessage {
+            version: 4,
+            my_as: u16::try_from(asn).unwrap_or(23456),
+            hold_time: 90,
+            bgp_identifier: Ipv4Addr::new(192, 0, 2, 99),
+            capabilities,
+        };
+        let mut buf = Vec::new();
+        open.encode(&mut buf).unwrap();
+        buf
+    }
+
+    pub(crate) fn mp(afi: Afi, safi: Safi) -> Capability {
+        Capability::MultiProtocol { afi, safi }
+    }
+
+    pub(crate) fn add_path(afi: Afi, safi: Safi, send_receive: AddPathMode) -> Capability {
+        Capability::AddPath(vec![AddPathFamily {
+            afi,
+            safi,
+            send_receive,
+        }])
+    }
+
+    /// Full BGP UPDATE PDU from raw body sections.
+    pub(crate) fn update_pdu(withdrawn: &[u8], attrs: &[u8], nlri: &[u8]) -> Vec<u8> {
+        let total = 19 + 4 + withdrawn.len() + attrs.len() + nlri.len();
+        let mut pdu = vec![0xFF; 16];
+        pdu.extend_from_slice(&u16::try_from(total).unwrap().to_be_bytes());
+        pdu.push(2); // UPDATE
+        pdu.extend_from_slice(&u16::try_from(withdrawn.len()).unwrap().to_be_bytes());
+        pdu.extend_from_slice(withdrawn);
+        pdu.extend_from_slice(&u16::try_from(attrs.len()).unwrap().to_be_bytes());
+        pdu.extend_from_slice(attrs);
+        pdu.extend_from_slice(nlri);
+        pdu
+    }
+
+    /// IPv4 NLRI bytes: optional Add-Path ID + length + prefix octets.
+    pub(crate) fn v4_nlri(addr: [u8; 4], len: u8, path_id: Option<u32>) -> Vec<u8> {
+        let mut nlri = Vec::new();
+        if let Some(id) = path_id {
+            nlri.extend_from_slice(&id.to_be_bytes());
+        }
+        nlri.push(len);
+        nlri.extend_from_slice(&addr[..(usize::from(len)).div_ceil(8)]);
+        nlri
+    }
+
+    /// MP_REACH_NLRI attribute for IPv6 unicast.
+    pub(crate) fn mp_reach_v6_attr(next_hop: &str, nlri: &[u8]) -> Vec<u8> {
+        let nh: std::net::Ipv6Addr = next_hop.parse().unwrap();
+        let mut value = vec![0, 2, 1, 16];
+        value.extend_from_slice(&nh.octets());
+        value.push(0); // reserved
+        value.extend_from_slice(nlri);
+        attr(attr_type::MP_REACH_NLRI, &value)
+    }
+
+    /// IPv6 NLRI bytes (no Add-Path).
+    pub(crate) fn v6_nlri(prefix: &str, len: u8) -> Vec<u8> {
+        let addr: std::net::Ipv6Addr = prefix.parse().unwrap();
+        let mut nlri = vec![len];
+        nlri.extend_from_slice(&addr.octets()[..(usize::from(len)).div_ceil(8)]);
+        nlri
+    }
+
+    /// IPv4-unicast End-of-RIB: the empty UPDATE (RFC 4724 §2).
+    pub(crate) fn eor_v4() -> Vec<u8> {
+        update_pdu(&[], &[], &[])
+    }
+
+    /// Family End-of-RIB: an UPDATE carrying only an empty
+    /// MP_UNREACH_NLRI for the family.
+    pub(crate) fn eor_mp(afi: u16, safi: u8) -> Vec<u8> {
+        let mut value = afi.to_be_bytes().to_vec();
+        value.push(safi);
+        update_pdu(&[], &attr(attr_type::MP_UNREACH_NLRI, &value), &[])
+    }
+
+    /// MP_UNREACH_NLRI withdraw for IPv6 unicast.
+    pub(crate) fn mp_unreach_v6(nlri: &[u8]) -> Vec<u8> {
+        let mut value = 2u16.to_be_bytes().to_vec();
+        value.push(1);
+        value.extend_from_slice(nlri);
+        attr(attr_type::MP_UNREACH_NLRI, &value)
+    }
+
+    pub(crate) fn initiation() -> Vec<u8> {
+        encode_initiation("incumbent", "synthetic capture", BmpVersion::V3).to_vec()
+    }
+
+    pub(crate) fn peer_up(info: &BmpPeerInfo, sent_open: &[u8], received_open: &[u8]) -> Vec<u8> {
+        encode_peer_up(
+            info,
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99)),
+            179,
+            40000,
+            sent_open,
+            received_open,
+            BmpVersion::V3,
+        )
+        .to_vec()
+    }
+
+    pub(crate) fn peer_down(info: &BmpPeerInfo) -> Vec<u8> {
+        encode_peer_down(info, &PeerDownReason::RemoteNoNotification, BmpVersion::V3).to_vec()
+    }
+
+    pub(crate) fn route_monitoring(info: &BmpPeerInfo, pdu: &[u8]) -> Vec<u8> {
+        encode_route_monitoring(info, pdu, None, BmpVersion::V3).to_vec()
+    }
+
+    /// RFC 8671 stats: type 15 total + type 17 per-family gauges.
+    pub(crate) fn stats(info: &BmpPeerInfo, total: u64, per_family: &[(u16, u8, u64)]) -> Vec<u8> {
+        let counters = vec![StatCounter {
+            stat_type: 15,
+            value: total,
+        }];
+        let afi_counters: Vec<AfiStatCounter> = per_family
+            .iter()
+            .map(|&(afi, safi, value)| AfiStatCounter {
+                stat_type: 17,
+                afi,
+                safi,
+                value,
+            })
+            .collect();
+        encode_stats_report(info, &counters, &afi_counters, BmpVersion::V3).to_vec()
+    }
+
+    pub(crate) fn termination() -> Vec<u8> {
+        encode_termination(0, "capture end", BmpVersion::V3).to_vec()
+    }
+
+    /// The golden multi-peer capture, built synthetically with the
+    /// daemon's own BMP encoder (an M83 lab capture would carry
+    /// rustbgpd's *own* view rather than an incumbent's, so a synthetic
+    /// stream is both cheaper and the honest source here). Exercises:
+    /// Initiation; Add-Path and plain peers; body and MP_REACH/UNREACH
+    /// announce + withdraw; dump/live interleave supersede; End-of-RIB
+    /// per family; post-EoR live update; matching RFC 8671 stats;
+    /// typed-but-unsnapshotted (OTC) and fully unknown attributes;
+    /// interleaved Adj-RIB-In messages; Termination.
+    pub(crate) fn golden_capture() -> Vec<u8> {
+        let peer_a = rib_out_info("192.0.2.1", 65001);
+        let peer_b = rib_out_info("2001:db8::2", 65002);
+        let mut capture = initiation();
+
+        // Peer A: IPv4 unicast with Add-Path in effect (incumbent sends
+        // Both, member receives Both) and 4-octet ASNs.
+        let a_sent = open_pdu(
+            65500,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                add_path(Afi::Ipv4, Safi::Unicast, AddPathMode::Both),
+                Capability::FourOctetAs { asn: 65500 },
+            ],
+        );
+        let a_received = open_pdu(
+            65001,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                add_path(Afi::Ipv4, Safi::Unicast, AddPathMode::Both),
+                Capability::FourOctetAs { asn: 65001 },
+            ],
+        );
+        capture.extend(peer_up(&peer_a, &a_sent, &a_received));
+
+        // Peer B: IPv4 + IPv6 unicast, no Add-Path.
+        let b_sent = open_pdu(
+            65500,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                mp(Afi::Ipv6, Safi::Unicast),
+                Capability::FourOctetAs { asn: 65500 },
+            ],
+        );
+        let b_received = open_pdu(
+            65002,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                mp(Afi::Ipv6, Safi::Unicast),
+                Capability::FourOctetAs { asn: 65002 },
+            ],
+        );
+        capture.extend(peer_up(&peer_b, &b_sent, &b_received));
+
+        // Peer A initial dump: 203.0.113.0/24 as two Add-Path paths.
+        let mut attrs_1 = attr(attr_type::ORIGIN, &[0]);
+        attrs_1.extend(as_path_attr(&[65500, 64999]));
+        attrs_1.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 254]));
+        attrs_1.extend(attr(attr_type::MULTI_EXIT_DISC, &120u32.to_be_bytes()));
+        attrs_1.extend(attr(
+            attr_type::COMMUNITIES,
+            &((65500u32 << 16) | 100).to_be_bytes(),
+        ));
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&[], &attrs_1, &v4_nlri([203, 0, 113, 0], 24, Some(1))),
+        ));
+        let mut attrs_2 = attr(attr_type::ORIGIN, &[0]);
+        attrs_2.extend(as_path_attr(&[65500, 64998]));
+        attrs_2.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 253]));
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&[], &attrs_2, &v4_nlri([203, 0, 113, 0], 24, Some(2))),
+        ));
+
+        // 198.51.100.0/24 announced then withdrawn before End-of-RIB —
+        // must not appear in the snapshot.
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&[], &attrs_2, &v4_nlri([198, 51, 100, 0], 24, Some(1))),
+        ));
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&v4_nlri([198, 51, 100, 0], 24, Some(1)), &[], &[]),
+        ));
+
+        // Dump/live interleave: path 1 re-announced with MED 121 before
+        // End-of-RIB — the later update supersedes.
+        let mut attrs_1b = attr(attr_type::ORIGIN, &[0]);
+        attrs_1b.extend(as_path_attr(&[65500, 64999]));
+        attrs_1b.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 254]));
+        attrs_1b.extend(attr(attr_type::MULTI_EXIT_DISC, &121u32.to_be_bytes()));
+        attrs_1b.extend(attr(
+            attr_type::COMMUNITIES,
+            &((65500u32 << 16) | 100).to_be_bytes(),
+        ));
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&[], &attrs_1b, &v4_nlri([203, 0, 113, 0], 24, Some(1))),
+        ));
+
+        // An interleaved pre-policy Adj-RIB-In message (O=0): skipped.
+        let mut rib_in = rib_out_info("192.0.2.1", 65001);
+        rib_in.is_rib_out = false;
+        rib_in.is_post_policy = false;
+        capture.extend(route_monitoring(
+            &rib_in,
+            &update_pdu(&[], &attrs_2, &v4_nlri([10, 99, 0, 0], 16, None)),
+        ));
+
+        capture.extend(route_monitoring(&peer_a, &eor_v4()));
+
+        // Live update after End-of-RIB: OTC (typed, unsnapshotted) and a
+        // fully unknown transitive attribute — both preserved.
+        let mut attrs_live = attr(attr_type::ORIGIN, &[1]);
+        attrs_live.extend(as_path_attr(&[65500]));
+        attrs_live.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 254]));
+        attrs_live.extend(attr(attr_type::LOCAL_PREF, &200u32.to_be_bytes()));
+        attrs_live.extend(attr(
+            attr_type::EXTENDED_COMMUNITIES,
+            &0x0002_FFDC_0000_0064_u64.to_be_bytes(),
+        ));
+        let mut large = 65500u32.to_be_bytes().to_vec();
+        large.extend(7u32.to_be_bytes());
+        large.extend(9u32.to_be_bytes());
+        attrs_live.extend(attr(attr_type::LARGE_COMMUNITIES, &large));
+        attrs_live.extend(attr(attr_type::ONLY_TO_CUSTOMER, &65500u32.to_be_bytes()));
+        let mut unknown = vec![0xC0, 200, 4];
+        unknown.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        attrs_live.extend(unknown);
+        capture.extend(route_monitoring(
+            &peer_a,
+            &update_pdu(&[], &attrs_live, &v4_nlri([100, 64, 0, 0], 24, Some(1))),
+        ));
+
+        // Post-EoR RFC 8671 stats matching the folded state: peer A
+        // holds 3 v4 routes.
+        capture.extend(stats(&peer_a, 3, &[(1, 1, 3)]));
+
+        // Peer B: one v4 body route, one v6 MP route (announced twice —
+        // second announcement supersedes with a different MED), one v6
+        // route withdrawn via MP_UNREACH.
+        let mut b_v4 = attr(attr_type::ORIGIN, &[0]);
+        b_v4.extend(as_path_attr(&[65500, 64997]));
+        b_v4.extend(attr(attr_type::NEXT_HOP, &[192, 0, 2, 254]));
+        capture.extend(route_monitoring(
+            &peer_b,
+            &update_pdu(&[], &b_v4, &v4_nlri([100, 65, 0, 0], 24, None)),
+        ));
+        let mut b_v6 = attr(attr_type::ORIGIN, &[0]);
+        b_v6.extend(as_path_attr(&[65500, 64997]));
+        b_v6.extend(attr(attr_type::MULTI_EXIT_DISC, &50u32.to_be_bytes()));
+        b_v6.extend(mp_reach_v6_attr(
+            "2001:db8::1",
+            &v6_nlri("2001:db8:100::", 48),
+        ));
+        capture.extend(route_monitoring(&peer_b, &update_pdu(&[], &b_v6, &[])));
+        let mut b_v6b = attr(attr_type::ORIGIN, &[0]);
+        b_v6b.extend(as_path_attr(&[65500, 64997]));
+        b_v6b.extend(attr(attr_type::MULTI_EXIT_DISC, &51u32.to_be_bytes()));
+        b_v6b.extend(mp_reach_v6_attr(
+            "2001:db8::1",
+            &v6_nlri("2001:db8:100::", 48),
+        ));
+        capture.extend(route_monitoring(&peer_b, &update_pdu(&[], &b_v6b, &[])));
+        let mut b_v6_gone = attr(attr_type::ORIGIN, &[0]);
+        b_v6_gone.extend(as_path_attr(&[65500, 64997]));
+        b_v6_gone.extend(mp_reach_v6_attr(
+            "2001:db8::1",
+            &v6_nlri("2001:db8:200::", 48),
+        ));
+        capture.extend(route_monitoring(&peer_b, &update_pdu(&[], &b_v6_gone, &[])));
+        capture.extend(route_monitoring(
+            &peer_b,
+            &update_pdu(&[], &mp_unreach_v6(&v6_nlri("2001:db8:200::", 48)), &[]),
+        ));
+        capture.extend(route_monitoring(&peer_b, &eor_v4()));
+        capture.extend(route_monitoring(&peer_b, &eor_mp(2, 1)));
+        capture.extend(stats(&peer_b, 2, &[(1, 1, 1), (2, 1, 1)]));
+
+        capture.extend(termination());
+        capture
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_fixture::*;
+    use super::*;
+    use rustbgpd_wire::capability::AddPathMode as Mode;
+    use std::io::Write;
+
+    fn write_capture(bytes: &[u8]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(bytes).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn opts<'a>(file: &'a Path, peers: &'a [String]) -> FromBmpOpts<'a> {
+        FromBmpOpts {
+            file,
+            peers,
+            source: Some("synthetic-lab"),
+            generation: 3,
+        }
+    }
+
+    fn run_capture(bytes: &[u8]) -> Result<(String, Vec<String>), String> {
+        let file = write_capture(bytes);
+        run(&opts(file.path(), &[]))
+    }
+
+    /// Standard single-peer prologue: Initiation + a plain v4-only peer.
+    fn v4_peer_capture() -> (Vec<u8>, rustbgpd_bmp::types::BmpPeerInfo) {
+        let info = rib_out_info("192.0.2.1", 65001);
+        let open = open_pdu(65500, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let peer_open = open_pdu(65001, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let mut capture = initiation();
+        capture.extend(peer_up(&info, &open, &peer_open));
+        (capture, info)
+    }
+
+    fn simple_announce(prefix: [u8; 4], len: u8) -> Vec<u8> {
+        let mut attrs = attr(rustbgpd_wire::constants::attr_type::ORIGIN, &[0]);
+        attrs.extend(as_path_attr(&[65500]));
+        attrs.extend(attr(
+            rustbgpd_wire::constants::attr_type::NEXT_HOP,
+            &[192, 0, 2, 254],
+        ));
+        update_pdu(&[], &attrs, &v4_nlri(prefix, len, None))
+    }
+
+    #[test]
+    fn emits_golden_snapshot() {
+        let (snapshot, notes) = run_capture(&golden_capture()).unwrap();
+        let golden_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/ribsnap/from-bmp.expected.ndjson"
+        );
+        // BLESS=1 rewrites the golden (fixture refresh; review the diff).
+        if std::env::var_os("BLESS").is_some() {
+            std::fs::write(golden_path, &snapshot).unwrap();
+        }
+        let golden = std::fs::read_to_string(golden_path).unwrap();
+        assert_eq!(snapshot, golden);
+        // The withdrawn routes never appear.
+        assert!(!snapshot.contains("198.51.100.0"));
+        assert!(!snapshot.contains("2001:db8:200::"));
+        // The rib-in prefix never appears.
+        assert!(!snapshot.contains("10.99.0.0"));
+        // The interleaved dump/live update superseded (MED 121, not 120).
+        assert!(snapshot.contains("\"med\":121"));
+        assert!(!snapshot.contains("\"med\":120"));
+        // Second announcement of the same v6 NLRI superseded.
+        assert!(snapshot.contains("\"med\":51"));
+        assert!(!snapshot.contains("\"med\":50"));
+        // OTC and the raw unknown attribute are preserved byte-exact.
+        assert!(snapshot.contains(r#"{"flags":192,"type_code":35,"value":"0000ffdc"}"#));
+        assert!(snapshot.contains(r#"{"flags":192,"type_code":200,"value":"deadbeef"}"#));
+        // Add-Path IDs surface as diagnostics-only path_id.
+        assert!(snapshot.contains("\"path_id\":1"));
+        assert!(snapshot.contains("\"path_id\":2"));
+        // The skipped rib-in message is noted.
+        assert!(notes.iter().any(|n| n.contains("Adj-RIB-In")), "{notes:?}");
+    }
+
+    #[test]
+    fn pre_policy_adj_rib_out_is_refused() {
+        let (mut capture, mut info) = v4_peer_capture();
+        info.is_post_policy = false; // O=1, L=0
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("pre-policy Adj-RIB-Out"), "{err}");
+        assert!(err.contains("not comparable"), "{err}");
+    }
+
+    #[test]
+    fn missing_end_of_rib_is_refused() {
+        // v4 announce but no EoR at all.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("End-of-RIB not seen"), "{err}");
+        assert!(err.contains("incomplete"), "{err}");
+
+        // Negotiated v6 without a v6 EoR is incomplete even when v4
+        // completed.
+        let info = rib_out_info("192.0.2.1", 65001);
+        let caps = || vec![mp(Afi::Ipv4, Safi::Unicast), mp(Afi::Ipv6, Safi::Unicast)];
+        let mut capture = initiation();
+        capture.extend(peer_up(
+            &info,
+            &open_pdu(65500, caps()),
+            &open_pdu(65001, caps()),
+        ));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("ipv6_unicast"), "{err}");
+        assert!(err.contains("End-of-RIB not seen"), "{err}");
+
+        // --peer can exclude the incomplete peer.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let incomplete = rib_out_info("192.0.2.7", 65007);
+        let open = open_pdu(65500, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let peer_open = open_pdu(65007, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        capture.extend(peer_up(&incomplete, &open, &peer_open));
+        capture.extend(route_monitoring(
+            &incomplete,
+            &simple_announce([10, 7, 0, 0], 24),
+        ));
+        let file = write_capture(&capture);
+        let err = run(&opts(file.path(), &[])).unwrap_err();
+        assert!(err.contains("192.0.2.7"), "{err}");
+        let filter = vec!["192.0.2.1".to_string()];
+        let (snapshot, _) = run(&opts(file.path(), &filter)).unwrap();
+        assert!(snapshot.contains("10.0.0.0/24"));
+        assert!(!snapshot.contains("10.7.0.0/24"));
+    }
+
+    #[test]
+    fn reconnect_invalidates_previous_generation() {
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 1, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        // Reconnect: new Initiation, fresh Peer Up, different route.
+        let (second, info) = v4_peer_capture();
+        capture.extend(second);
+        capture.extend(route_monitoring(&info, &simple_announce([10, 2, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let (snapshot, _) = run_capture(&capture).unwrap();
+        assert!(!snapshot.contains("10.1.0.0/24"), "old generation leaked");
+        assert!(snapshot.contains("10.2.0.0/24"));
+
+        // A pre-reconnect EoR must not satisfy the new generation.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let (second, info) = v4_peer_capture();
+        capture.extend(second);
+        capture.extend(route_monitoring(&info, &simple_announce([10, 3, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("End-of-RIB not seen"), "{err}");
+    }
+
+    #[test]
+    fn peer_down_invalidates_peer_state() {
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 1, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(peer_down(&info));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("no global-instance peers"), "{err}");
+
+        // Down then re-up requires a fresh dump: the old EoR is gone.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(peer_down(&info));
+        let open = open_pdu(65500, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let peer_open = open_pdu(65001, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        capture.extend(peer_up(&info, &open, &peer_open));
+        capture.extend(route_monitoring(&info, &simple_announce([10, 4, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("End-of-RIB not seen"), "{err}");
+    }
+
+    #[test]
+    fn out_of_protocol_sequences_are_refused() {
+        // Route Monitoring before Initiation.
+        let info = rib_out_info("192.0.2.1", 65001);
+        let capture = route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("before the Initiation"), "{err}");
+
+        // Route Monitoring without a Peer Up.
+        let mut capture = initiation();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("without a Peer Up"), "{err}");
+
+        // Peer Down without a Peer Up.
+        let mut capture = initiation();
+        capture.extend(peer_down(&info));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("Peer Down for peer"), "{err}");
+
+        // Message after Termination without a new Initiation.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(termination());
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("after a Termination"), "{err}");
+
+        // ASN conflict between Peer Up and a later per-peer header.
+        let (mut capture, _) = v4_peer_capture();
+        let liar = rib_out_info("192.0.2.1", 64999);
+        capture.extend(route_monitoring(&liar, &simple_announce([10, 0, 0, 0], 24)));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("conflicts with the Peer Up ASN"), "{err}");
+    }
+
+    #[test]
+    fn malformed_and_truncated_input_is_refused() {
+        // Empty file: no Initiation.
+        let err = run_capture(&[]).unwrap_err();
+        assert!(err.contains("no BMP Initiation"), "{err}");
+
+        // Truncated mid-message.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.truncate(capture.len() - 3);
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("truncated"), "{err}");
+
+        // Wrong version byte (a BMPv4 or non-BMP stream).
+        let mut capture = initiation();
+        capture[0] = 4;
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("version 4"), "{err}");
+
+        // Unknown message type.
+        let mut capture = initiation();
+        let mut bogus = initiation();
+        bogus[5] = 99;
+        capture.extend(bogus);
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("unknown BMP message type 99"), "{err}");
+
+        // Corrupt embedded UPDATE (bad marker).
+        let (mut capture, info) = v4_peer_capture();
+        let mut pdu = simple_announce([10, 0, 0, 0], 24);
+        pdu[0] = 0x00;
+        capture.extend(route_monitoring(&info, &pdu));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("BMP message #3"), "{err}");
+
+        // Non-UPDATE PDU inside Route Monitoring.
+        let (mut capture, info) = v4_peer_capture();
+        let open = open_pdu(65500, vec![]);
+        capture.extend(route_monitoring(&info, &open));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("expected UPDATE"), "{err}");
+
+        // Trailing bytes after the declared PDU length.
+        let (mut capture, info) = v4_peer_capture();
+        let mut pdu = eor_v4();
+        pdu.push(0);
+        capture.extend(route_monitoring(&info, &pdu));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("framing is corrupt"), "{err}");
+    }
+
+    /// RFC 7911 directionality: path IDs are present only when the
+    /// incumbent advertised *send* and the member advertised *receive*.
+    /// A receive-only incumbent mode must not switch the decoder into
+    /// Add-Path framing.
+    #[test]
+    fn add_path_requires_send_and_receive_directions() {
+        let info = rib_out_info("192.0.2.1", 65001);
+        let sent = open_pdu(
+            65500,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                add_path(Afi::Ipv4, Safi::Unicast, Mode::Receive),
+            ],
+        );
+        let received = open_pdu(
+            65001,
+            vec![
+                mp(Afi::Ipv4, Safi::Unicast),
+                add_path(Afi::Ipv4, Safi::Unicast, Mode::Both),
+            ],
+        );
+        let mut capture = initiation();
+        capture.extend(peer_up(&info, &sent, &received));
+        // Plain (non-Add-Path) NLRI must parse; path_id never emitted.
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let (snapshot, _) = run_capture(&capture).unwrap();
+        assert!(snapshot.contains("10.0.0.0/24"));
+        assert!(!snapshot.contains("path_id"));
+    }
+
+    /// The per-peer header A flag switches AS_PATH decoding to legacy
+    /// 2-octet ASNs (RFC 7854 §4.2).
+    #[test]
+    fn legacy_two_octet_as_path_parses_via_a_flag() {
+        let mut info = rib_out_info("192.0.2.1", 65001);
+        info.is_as4 = false;
+        let open = open_pdu(65500, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let peer_open = open_pdu(65001, vec![mp(Afi::Ipv4, Safi::Unicast)]);
+        let mut capture = initiation();
+        capture.extend(peer_up(&info, &open, &peer_open));
+        // AS_SEQUENCE of two 2-octet ASNs.
+        let mut attrs = attr(rustbgpd_wire::constants::attr_type::ORIGIN, &[0]);
+        let mut as_path = vec![2, 2];
+        as_path.extend(65500u16.to_be_bytes());
+        as_path.extend(64999u16.to_be_bytes());
+        attrs.extend(attr(rustbgpd_wire::constants::attr_type::AS_PATH, &as_path));
+        attrs.extend(attr(
+            rustbgpd_wire::constants::attr_type::NEXT_HOP,
+            &[192, 0, 2, 254],
+        ));
+        capture.extend(route_monitoring(
+            &info,
+            &update_pdu(&[], &attrs, &v4_nlri([10, 0, 0, 0], 24, None)),
+        ));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let (snapshot, _) = run_capture(&capture).unwrap();
+        assert!(snapshot.contains("\"as_path\":[65500,64999]"), "{snapshot}");
+    }
+
+    #[test]
+    fn stats_mismatch_after_end_of_rib_is_refused() {
+        // Total gauge (type 15) mismatch.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(stats(&info, 2, &[(1, 1, 1)])); // folded state holds 1
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("stat 15"), "{err}");
+        assert!(err.contains("reports 2"), "{err}");
+
+        // Per-family gauge (type 17) mismatch.
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(stats(&info, 1, &[(1, 1, 2)]));
+        let err = run_capture(&capture).unwrap_err();
+        assert!(err.contains("stat 17"), "{err}");
+        assert!(err.contains("reports 2"), "{err}");
+
+        // Matching stats pass (and completeness never required them —
+        // the golden capture also proves the no-stats path completes).
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        capture.extend(stats(&info, 1, &[(1, 1, 1)]));
+        assert!(run_capture(&capture).is_ok());
+
+        // Pre-EoR stats are not cross-checked (dump still in flight).
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(stats(&info, 99, &[(1, 1, 99)]));
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        assert!(run_capture(&capture).is_ok());
+    }
+
+    #[test]
+    fn instance_peers_are_skipped_with_a_note() {
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &simple_announce([10, 0, 0, 0], 24)));
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let mut rd_peer = rib_out_info("192.0.2.200", 65200);
+        rd_peer.peer_type = rustbgpd_bmp::types::BmpPeerType::RdInstance;
+        let open = open_pdu(65500, vec![]);
+        capture.extend(peer_up(&rd_peer, &open, &open));
+        capture.extend(route_monitoring(
+            &rd_peer,
+            &simple_announce([10, 200, 0, 0], 24),
+        ));
+        let (snapshot, notes) = run_capture(&capture).unwrap();
+        assert!(!snapshot.contains("10.200.0.0"));
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.contains("instance peer 192.0.2.200")),
+            "{notes:?}"
+        );
+    }
+
+    #[test]
+    fn hard_bounds_are_enforced() {
+        let tiny = Limits {
+            max_routes: 2,
+            ..Limits::default()
+        };
+        let (mut capture, info) = v4_peer_capture();
+        for i in 0..3u8 {
+            capture.extend(route_monitoring(&info, &simple_announce([10, i, 0, 0], 24)));
+        }
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let file = write_capture(&capture);
+        let err = run_with_limits(&opts(file.path(), &[]), tiny).unwrap_err();
+        assert!(err.contains("more than 2 retained routes"), "{err}");
+
+        // Paths-per-NLRI bound: many Add-Path IDs for one prefix.
+        let tiny = Limits {
+            max_paths_per_nlri: 2,
+            ..Limits::default()
+        };
+        let info = rib_out_info("192.0.2.1", 65001);
+        let caps = |asn| {
+            open_pdu(
+                asn,
+                vec![
+                    mp(Afi::Ipv4, Safi::Unicast),
+                    add_path(Afi::Ipv4, Safi::Unicast, Mode::Both),
+                ],
+            )
+        };
+        let mut capture = initiation();
+        capture.extend(peer_up(&info, &caps(65500), &caps(65001)));
+        for id in 1..=3u32 {
+            let mut attrs = attr(rustbgpd_wire::constants::attr_type::ORIGIN, &[0]);
+            attrs.extend(as_path_attr(&[65500]));
+            attrs.extend(attr(
+                rustbgpd_wire::constants::attr_type::NEXT_HOP,
+                &[192, 0, 2, 254],
+            ));
+            capture.extend(route_monitoring(
+                &info,
+                &update_pdu(&[], &attrs, &v4_nlri([10, 0, 0, 0], 24, Some(id))),
+            ));
+        }
+        let file = write_capture(&capture);
+        let err = run_with_limits(&opts(file.path(), &[]), tiny).unwrap_err();
+        assert!(err.contains("more than 2 paths"), "{err}");
+
+        // Oversized BMP message length field.
+        let tiny = Limits {
+            max_bmp_message_len: 64,
+            ..Limits::default()
+        };
+        let (capture, _) = v4_peer_capture();
+        let file = write_capture(&capture);
+        let err = run_with_limits(&opts(file.path(), &[]), tiny).unwrap_err();
+        assert!(err.contains("exceeds the 64 byte limit"), "{err}");
+    }
+
+    #[test]
+    fn peer_filter_missing_peer_is_refused() {
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let file = write_capture(&capture);
+        let filter = vec!["192.0.2.99".to_string()];
+        let err = run(&opts(file.path(), &filter)).unwrap_err();
+        assert!(err.contains("192.0.2.99"), "{err}");
+        assert!(err.contains("no state"), "{err}");
+
+        let bad = vec!["not-an-ip".to_string()];
+        let err = run(&opts(file.path(), &bad)).unwrap_err();
+        assert!(err.contains("invalid --peer"), "{err}");
+    }
+
+    /// The public entry point maps refusal to exit 2 with no stdout.
+    #[test]
+    fn refusal_exit_code_contract() {
+        let (capture, _) = v4_peer_capture(); // no EoR: incomplete
+        let file = write_capture(&capture);
+        assert_eq!(from_bmp(&opts(file.path(), &[])), EXIT_REFUSED);
+        let (mut capture, info) = v4_peer_capture();
+        capture.extend(route_monitoring(&info, &eor_v4()));
+        let file = write_capture(&capture);
+        assert_eq!(from_bmp(&opts(file.path(), &[])), EXIT_OK);
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -707,7 +707,8 @@ enum DiffAction {
 
         /// Attribute to exclude from comparison on both sides (origin,
         /// as_path, next_hop, med, local_pref, communities,
-        /// extended_communities, large_communities); may be repeated
+        /// extended_communities, large_communities, unknown); may be
+        /// repeated
         #[arg(long)]
         ignore_attribute: Vec<String>,
 
@@ -766,6 +767,44 @@ enum SnapshotAction {
         /// ASN of that peer
         #[arg(long)]
         peer_asn: u32,
+
+        /// Free-form provenance label appended to the header `source`
+        #[arg(long)]
+        source: Option<String>,
+
+        /// Capture-round generation stamped into the header
+        #[arg(long, default_value_t = 1)]
+        generation: u64,
+    },
+
+    /// Convert a captured RFC 7854/8671 BMP byte stream into a snapshot
+    ///
+    /// Input is an offline file of raw BMP version 3 messages captured
+    /// from the START of the incumbent's BMP session (e.g. the TCP
+    /// payload of its BMP export); streaming-socket ingestion is out of
+    /// scope. Only Route Monitoring for the post-policy Adj-RIB-Out view
+    /// (O=1, L=1) contributes routes: Adj-RIB-In messages (O=0) are
+    /// skipped with a note, and a pre-policy Adj-RIB-Out stream (O=1,
+    /// L=0) is refused as non-comparable. Add-Path decoding follows the
+    /// negotiation in each Peer Up's OPENs; live updates interleaved
+    /// with the initial dump supersede dump entries; a reconnect or
+    /// Peer Down invalidates the affected state. Every emitted
+    /// peer/family must have reached End-of-RIB — an incomplete dump is
+    /// refused, never emitted. See docs/ribdiff.md.
+    #[command(after_help = "Exit codes:\n  \
+        0  snapshot emitted on stdout\n  \
+        2  refused: pre-policy view, incomplete (missing End-of-RIB), \
+        malformed, truncated, out-of-sequence, or over-limit input \
+        (nothing emitted)")]
+    FromBmp {
+        /// Path to the captured BMP byte stream
+        file: PathBuf,
+
+        /// Peer address to emit; may be repeated. Omit to emit every
+        /// complete global-instance peer (all of which must then be
+        /// complete)
+        #[arg(long)]
+        peer: Vec<String>,
 
         /// Free-form provenance label appended to the header `source`
         #[arg(long)]
@@ -1436,6 +1475,29 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
             generation: *generation,
         };
         std::process::exit(commands::ribsnap::from_mrt(&opts));
+    }
+
+    // `diff snapshot from-bmp` is likewise a pure offline adapter.
+    if let Command::Diff {
+        action:
+            DiffAction::Snapshot {
+                action:
+                    SnapshotAction::FromBmp {
+                        file,
+                        peer,
+                        source,
+                        generation,
+                    },
+            },
+    } = &cli.command
+    {
+        let opts = commands::ribsnap_bmp::FromBmpOpts {
+            file,
+            peers: peer,
+            source: source.as_deref(),
+            generation: *generation,
+        };
+        std::process::exit(commands::ribsnap_bmp::from_bmp(&opts));
     }
 
     let addr = cli.addr.clone();

--- a/crates/cli/tests/fixtures/ribsnap/from-bmp.expected.ndjson
+++ b/crates/cli/tests/fixtures/ribsnap/from-bmp.expected.ndjson
@@ -1,0 +1,7 @@
+{"generation":3,"record":"header","schema":"rbgp-ribsnap/1","source":"from-bmp/1 view=adj-rib-out-post-policy synthetic-lab"}
+{"as_path":[65500],"extended_communities":[844270311309412],"large_communities":["65500:7:9"],"local_pref":200,"next_hop":"192.0.2.254","origin":1,"path_id":1,"peer":"192.0.2.1","peer_asn":65001,"prefix":"100.64.0.0/24","record":"route","unknown_attrs":[{"flags":192,"type_code":35,"value":"0000ffdc"},{"flags":192,"type_code":200,"value":"deadbeef"}]}
+{"as_path":[65500,64999],"communities":[4292608100],"med":121,"next_hop":"192.0.2.254","origin":0,"path_id":1,"peer":"192.0.2.1","peer_asn":65001,"prefix":"203.0.113.0/24","record":"route"}
+{"as_path":[65500,64998],"next_hop":"192.0.2.253","origin":0,"path_id":2,"peer":"192.0.2.1","peer_asn":65001,"prefix":"203.0.113.0/24","record":"route"}
+{"as_path":[65500,64997],"next_hop":"192.0.2.254","origin":0,"peer":"2001:db8::2","peer_asn":65002,"prefix":"100.65.0.0/24","record":"route"}
+{"as_path":[65500,64997],"med":51,"next_hop":"2001:db8::1","origin":0,"peer":"2001:db8::2","peer_asn":65002,"prefix":"2001:db8:100::/48","record":"route"}
+{"record":"trailer","routes":5}

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -258,6 +258,38 @@ capture (`adj-rib-out-capture`) is comparable. `--view loc-rib` and
 `--view adj-rib-in` are refused with exit 2 — a Loc-RIB compared against
 an Adj-RIB-Out reports every export-policy effect as divergence.
 
+### BMP (RFC 8671 post-policy Adj-RIB-Out)
+
+If the incumbent supports BMP with the RFC 8671 post-policy Adj-RIB-Out
+view, its BMP feed is a wire-true multi-member capture — no per-member
+CLI exports, and it carries attributes no CLI view renders (preserved
+as `unknown_attrs`). Point the incumbent's BMP export at a listener,
+capture the raw bytes from the **start** of the BMP session, and stop
+only after every member's initial dump has completed:
+
+```bash
+nc -l 11019 > incumbent.bmp
+rbgp diff snapshot from-bmp incumbent.bmp > incumbent.ndjson
+```
+
+Prerequisites and limitations:
+
+- The incumbent must be configured to export the **post-policy
+  Adj-RIB-Out** monitoring view (O=1/L=1). The default Adj-RIB-In feed
+  is skipped with a note; a pre-policy Adj-RIB-Out feed (L=0) is
+  refused as non-comparable.
+- The capture must include the session start (Initiation and Peer Ups
+  carry the negotiated OPENs that drive Add-Path decoding) and each
+  member's End-of-RIB. **A peer/family without End-of-RIB is an
+  incomplete dump and the conversion is refused (exit 2)** — a
+  truncated capture must never read as "in sync". Exclude peers you
+  don't care about with `--peer` if they never completed.
+- Live churn during the capture is fine: updates that interleave with
+  the initial dump supersede it, and post-End-of-RIB stats (RFC 8671
+  types 15/17) are cross-checked against the folded state.
+- Offline only: capture to a file first; the adapter does not read from
+  a socket. Full contract in [`docs/ribdiff.md`](../ribdiff.md).
+
 ### Example reports
 
 From the M83 multi-stack lab (FRR member AS 65003 advertising three

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -32,7 +32,7 @@ $ echo $?
 | `--peer <IP>` | all snapshot peers | Peer to compare; repeatable |
 | `--against <PATH>` | required | Incumbent `rbgp-ribsnap/1` NDJSON snapshot |
 | `--family <F>` | ipv4\_unicast + ipv6\_unicast | Family filter; repeatable |
-| `--ignore-attribute <A>` | none | Exclude an attribute from comparison on both sides; repeatable (`origin`, `as_path`, `next_hop`, `med`, `local_pref`, `communities`, `extended_communities`, `large_communities`) |
+| `--ignore-attribute <A>` | none | Exclude an attribute from comparison on both sides; repeatable (`origin`, `as_path`, `next_hop`, `med`, `local_pref`, `communities`, `extended_communities`, `large_communities`, `unknown`) |
 | `--max-routes <N>` | 4,000,000 | Maximum retained routes per side; exceeding refuses the comparison |
 | `--max-input-bytes <N>` | 1 GiB | Maximum snapshot bytes read; exceeding refuses the comparison |
 | `--detail <N>` | 20 | Maximum difference rows in human output (`--json` is always complete) |
@@ -127,6 +127,13 @@ duplicates; multiplicity is compared):
 - `extended_communities`: raw 8-octet values as unsigned integers
   (big-endian wire order).
 - `large_communities`: `"global:data1:data2"` strings.
+- `unknown_attrs`: optional; attributes outside the typed set, preserved
+  as `{"type_code":N,"flags":N,"value":"<hex>"}` wire triples (the
+  from-bmp adapter emits them; e.g. ORIGINATOR_ID or OTC). Compared
+  byte-exact by the engine — but the live gRPC side cannot see unknown
+  attributes, so a snapshot carrying them diverges against a live
+  comparison unless `--ignore-attribute unknown` is passed (an explicit
+  operator decision, never a silent drop).
 - `path_id`: optional; diagnostics only, never compared.
 
 Unknown fields are rejected (typo protection). All fields except
@@ -186,7 +193,7 @@ Or with `jq`, from a JSON export shaped like
 
 ## Snapshot adapters
 
-Four adapters turn an incumbent's own output into `rbgp-ribsnap/1`
+Five adapters turn an incumbent's own output into `rbgp-ribsnap/1`
 NDJSON. Each is a versioned contract: the header's `source` field is
 `<adapter>/<contract-version> view=adj-rib-out-capture [label]`, so a
 report always names which adapter (and which of its revisions) produced
@@ -205,6 +212,7 @@ the incumbent side. Common rules:
 | Adapter | Capture command (verified against) | Form |
 |---------|-------------------------------------|------|
 | `from-mrt/1` | `rbgp diff snapshot from-mrt <file> --view adj-rib-out-capture --peer <ip> --peer-asn <asn>` (RFC 6396 `TABLE_DUMP_V2`, RFC 8050 Add-Path subtypes) | in-binary subcommand |
+| `from-bmp/1` | `rbgp diff snapshot from-bmp <capture> [--peer <ip>]` (RFC 7854 BMP v3 byte stream carrying the RFC 8671 post-policy Adj-RIB-Out view, O=1/L=1) | in-binary subcommand |
 | `bird2-export/1` | `birdc show route export <member-proto> all` (BIRD 2.0.12) | [`scripts/ribsnap/bird2-export-to-ribsnap.py`](../scripts/ribsnap/bird2-export-to-ribsnap.py) |
 | `frr-advertised/1` | `vtysh -c "show ip bgp neighbor <ip> advertised-routes detail json"` (FRR 10.3.1) | [`scripts/ribsnap/frr-advertised-to-ribsnap.py`](../scripts/ribsnap/frr-advertised-to-ribsnap.py) |
 | `gobgp-adjout/1` | `gobgp neighbor <ip> adj-out -j` (GoBGP 3.37.0) | [`scripts/ribsnap/gobgp-adjout-to-ribsnap.py`](../scripts/ribsnap/gobgp-adjout-to-ribsnap.py) |
@@ -241,6 +249,62 @@ RFC 8050 Add-Path entries carry their path identifier through as
 `path_id`. Extended and large communities are emitted from the raw
 attribute bytes.
 
+### `rbgp diff snapshot from-bmp` — RFC 8671 post-policy BMP captures
+
+If the incumbent exports BMP with the RFC 8671 post-policy Adj-RIB-Out
+view enabled, its own BMP feed is a wire-true source of what it sent
+each member — including attributes no CLI view renders. Capture the
+feed's raw bytes **from the start of the BMP session** (the adapter is
+offline; streaming-socket ingestion is out of scope), then convert:
+
+```bash
+# Stand in as the incumbent's BMP station and capture the raw stream;
+# stop once every peer's dump has completed (End-of-RIB seen).
+nc -l 11019 > incumbent.bmp        # or: socat TCP-LISTEN:11019 - > incumbent.bmp
+rbgp diff snapshot from-bmp incumbent.bmp > incumbent.ndjson
+```
+
+The capture must begin at session start because the Peer Up messages
+carry the negotiated OPENs — without them the adapter cannot know the
+per-family Add-Path state (RFC 7911: path IDs appear in the incumbent's
+UPDATEs toward a member iff the incumbent advertised *send* and the
+member advertised *receive*) and refuses rather than misparse NLRI.
+
+View selection is per Route Monitoring message, from its per-peer
+header flags (O/L flags on Peer Up/Down select nothing):
+
+- **O=1, L=1** (post-policy Adj-RIB-Out) — the comparison source; folded
+  into the snapshot.
+- **O=0** (pre-policy Adj-RIB-In, the RFC 7854 default most feeds also
+  carry) — skipped with a stderr note, never folded.
+- **O=1, L=0** (pre-policy Adj-RIB-Out) — refused (exit 2): a
+  pre-policy view compared against a post-policy Adj-RIB-Out would
+  report every export-policy effect as divergence, or mask a real one.
+
+State is kept per (connection generation, peer, family, NLRI, source
+path ID); a later update supersedes an earlier one, so live updates
+interleaved with the initial dump fold correctly. A reconnect (new
+Initiation) invalidates everything; a Peer Up resets its peer; a Peer
+Down discards it. **A peer/family is complete only after its End-of-RIB
+in the current generation** — a capture cut before End-of-RIB is
+refused (exit 2, nothing emitted), because `rbgp-ribsnap/1`'s counted
+trailer would otherwise present a truncated view as complete and the
+downstream diff could assert a false "in sync". Use `--peer` to emit a
+complete subset when an uninteresting peer never finished. RFC 8671
+stat types 15/17 arriving after End-of-RIB are cross-checked against
+the folded counts (a mismatch means a decode gap and refuses);
+completeness never requires them.
+
+Scope and bounds: BMP version 3 streams; global-instance peers
+(RD/local-instance peers are skipped with a note); IPv4/IPv6 unicast
+NLRI (other families are skipped with a note). ORIGINATOR_ID,
+CLUSTER_LIST, OTC, and any attribute the decoder does not type are
+preserved byte-exact as `unknown_attrs` — compare with
+`--ignore-attribute unknown` if accepting that gRPC cannot verify them.
+Hard limits (not flags) bound input bytes (1 GiB), per-message length
+(1 MiB), peers (4096), routes (4M), and paths per NLRI (64); exceeding
+any refuses the conversion.
+
 ### Golden fixtures
 
 Each converter is pinned by golden tests in `cargo test -p rustbgpctl`
@@ -251,7 +315,11 @@ FRR 10.3.1, GoBGP 3.37.0) must convert byte-for-byte to its checked-in
 the same capture's wire-truth values. An upstream output-format change
 breaks these tests first. The fixture-refresh procedure (redeploy the
 lab, recapture, re-run the converters with `BLESS=1`) is documented in
-the test module.
+the test module. The from-bmp golden is built synthetically instead,
+framed by the daemon's own RFC-pinned BMP encoder (an M83 capture would
+carry rustbgpd's own view, not an incumbent's), and its end-to-end
+tests prove capture → canonical records → in-sync, divergent, and
+incomplete verdicts.
 
 ## JSON report
 


### PR DESCRIPTION
## Summary

- completes the rbgp diff source matrix: `rbgp diff snapshot from-bmp <capture-file>` reconstructs an incumbent's per-peer post-policy Adj-RIB-Out from a captured BMP v3 byte stream and emits canonical ribsnap NDJSON
- protocol contract per RFC 7854/8671: Route Monitoring accepted only for O=1; L=0 pre-policy is refused as a different view; per-connection-generation state keyed by (peer, family, NLRI, path ID) with dump/live interleave folding; a peer/family is complete only after the correct End-of-RIB for the current generation; Initiation/Peer Up/Peer Down/decode gaps/limits invalidate the affected generation — old and new state never mix; Stats 15/17 after EoR cross-checks counts (mismatch refuses) without being required for completeness
- Add-Path is directional per RFC 7911: in effect only when the Peer Up's sent OPEN advertises send AND the received OPEN advertises receive, per family; path IDs are internal keys and diagnostics only
- embedded UPDATEs decode via rustbgpd-wire (no wire code duplicated); test captures are framed by the daemon's own golden-pinned BMP encoders as a dev-dependency, so the importer is proven against independent wire bytes
- ribsnap/1 gains an optional additive `unknown_attrs` field (byte-exact hex) so unknown transitive attributes survive into the engine's comparison, plus `--ignore-attribute unknown` for live-gRPC comparisons that cannot see them
- fail-closed throughout with hard bounds (input/message/peers/routes/paths), typed refusals for malformed/truncated/out-of-protocol input, and exit-2 semantics matching the from-mrt pattern; BMP v4 TLV framing and streaming-socket ingestion are documented out of scope

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpctl (334 passed; 17 new importer/diff tests)
- cargo doc --workspace --no-deps
- cargo build -p rustbgpctl --release + smoke (help renders, garbage input exits 2)

Closes LAN-309.