### PR TITLE
feat(rpol): add immutable lexical bindings with static slot allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,30 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   matrix end-to-end (capture → canonical records → in-sync, divergent,
   and incomplete verdicts). Capture workflow documented in
   docs/ribdiff.md and the route-server migration cookbook. (LAN-309)
+- **`.rpol` immutable `let` bindings with static slot allocation.**
+  `let <name> = <value expression>` names a computed u32 in statement
+  position — term bodies and `if`/`else` bodies — with lexical block
+  scope and deterministic shadowing (innermost wins; a binding may
+  shadow an outer binding or a parameter, and resolution stays
+  position-typed, so enum members, builtins, and the `prepend as
+  origin` operand keep their meanings). Bindings are immutable and
+  u32-only; initializers are checked value expressions riding the
+  uniform fail-closed eval-error rails (an overflow or absent operand
+  in an initializer denies the route and discards staged
+  modifications, eagerly — used or not). Locals compile to fixed
+  slots in a 128-slot register file (64 per scope, the 65th is a
+  compile error with a span; slot assignment is a pure function of
+  the source, so unchanged reloads still diff as no-ops) materialized
+  lazily on the stack — binding-free policies pay nothing and no
+  evaluation heap-allocates. Reads always observe the route as it
+  arrived, never staged `set` writes (read-back stays excluded per
+  ADR-0103); use-before-definition and unknown names are spanned
+  compile errors; `apply` targets may not declare bindings this slice
+  (the inlined predicate has no term walk — LAN-304 functions are the
+  composition vehicle). Explain traces render `let` statements in
+  source form and resolve binding reads on demand; `peer.asn`
+  initializers register peer context for update-group
+  fingerprinting. (LAN-302, ADR-0103)
 
 ### Changed
 

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-bindings.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-bindings.rpol
@@ -1,0 +1,9 @@
+policy score {
+    term t {
+        let origin = route.origin-as
+        let penalty = route.as-path.len * 10
+        if penalty >= route.med { reject }
+        if origin == 64500 { set med penalty; accept }
+    }
+    term rest { accept }
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-errors.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-errors.rpol
@@ -1,0 +1,18 @@
+policy eager {
+    term t {
+        set local-pref 500
+        let x = route.med - 100
+        set med x
+        accept
+    }
+}
+
+test underflow-denies {
+    route { med 5 }
+    expect eager == reject
+}
+
+test ok-applies {
+    route { med 200 }
+    expect eager == accept with med 100, local-pref 500
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-shadowing.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-302-let-shadowing.rpol
@@ -1,0 +1,10 @@
+policy shadow(x: u32) {
+    term t {
+        let x = x + 1
+        let x = min(x * 2, 400)
+        if route.med >= x { let x = x + 100; set local-pref x; accept }
+        else { let y = x - 1; set med y }
+        set med x
+        accept
+    }
+}

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -159,7 +159,7 @@ pub fn explain_chain_statements(
                 // clauses, so a denying statement must not claim
                 // modifications in the trace either.
                 let modifications = if entry.action == PolicyAction::Permit {
-                    render_modifications(&entry.modifications, ctx, None)
+                    render_modifications(&entry.modifications, ctx, None, &[])
                 } else {
                     Vec::new()
                 };
@@ -329,6 +329,7 @@ fn render_modifications(
     mods: &RouteModifications,
     ctx: &RouteContext<'_>,
     tables: Option<&CompiledChain>,
+    locals: &[u32],
 ) -> Vec<String> {
     let mut out = Vec::new();
 
@@ -347,7 +348,7 @@ fn render_modifications(
     // term first — but renders honestly if it ever did.
     if let Some(expr) = &mods.set_local_pref_computed {
         let before = ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF);
-        match crate::eval::eval_value(expr, ctx) {
+        match crate::eval::eval_value(expr, ctx, locals) {
             Ok(value) => out.push(format!("local_pref {before} -> {expr} = {value}")),
             Err(kind) => out.push(format!(
                 "local_pref {before} -> {expr} (unresolvable: {kind})"
@@ -356,7 +357,7 @@ fn render_modifications(
     }
     if let Some(expr) = &mods.set_med_computed {
         let before = ctx.med.unwrap_or(IMPLICIT_MED);
-        match crate::eval::eval_value(expr, ctx) {
+        match crate::eval::eval_value(expr, ctx, locals) {
             Ok(value) => out.push(format!("med {before} -> {expr} = {value}")),
             Err(kind) => out.push(format!("med {before} -> {expr} (unresolvable: {kind})")),
         }
@@ -423,6 +424,10 @@ fn render_modifications(
 /// discarded by a deny), rendering a `term_traces` line per evaluated
 /// term. `tables` is the member's donor chain — its set/regex tables
 /// and names are self-contained.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one walk mirroring the live evaluator's term loop; splitting would decouple them"
+)]
 fn trace_rpol_policy(
     policy_index: usize,
     policy_name: Option<String>,
@@ -433,6 +438,10 @@ fn trace_rpol_policy(
     let mut term_traces = Vec::new();
     let mut continued: Option<RouteModifications> = None;
     let mut decided: Option<(usize, &Term)> = None;
+    // LAN-302: the trace walk re-derives `let` bindings term by term
+    // (explain may allocate/zero eagerly; the hot path never records)
+    // and feeds the frame into the shared guard evaluation.
+    let mut locals = [0u32; crate::eval::LOCAL_FRAME_SLOTS];
     // LAN-296/LAN-299: set when a term errors — an unresolvable
     // computed operand or a failed guard value expression. The live
     // evaluator fails the route closed at that term (the eval-error
@@ -440,7 +449,7 @@ fn trace_rpol_policy(
     // in `statement_trace.rs`).
     let mut eval_failed = false;
     for (index, term) in policy.terms.iter().enumerate() {
-        let matched = match tables.guard_matches(&term.guard, ctx) {
+        let matched = match tables.guard_matches(&term.guard, ctx, &locals) {
             Ok(matched) => matched,
             // Guard evaluation error (LAN-299): render the error in
             // place of a verdict (ADR-0103 Decision 6.4) and decide
@@ -467,31 +476,56 @@ fn trace_rpol_policy(
         if !matched {
             continue;
         }
+        // LAN-302: a matched Bind evaluates its initializer eagerly,
+        // exactly like the live walk — an error fails the route
+        // closed; success writes the frame and the walk keeps going.
+        if let TermAction::Bind { slot, expr, .. } = &term.action {
+            match crate::eval::eval_value(expr, ctx, &locals) {
+                Ok(value) => locals[usize::from(*slot)] = value,
+                Err(kind) => {
+                    term_traces.push(format!(
+                        "term {}: evaluation error: {kind} — fail closed => reject",
+                        term.name.as_deref().unwrap_or("<unnamed>"),
+                    ));
+                    eval_failed = true;
+                    decided = Some((index, term));
+                    break;
+                }
+            }
+            continue;
+        }
         // Mirror the live walk's action-execution resolution: an
         // unresolvable computed operand on the matched term (Permit or
         // Continue) decides the route as a fail-closed reject here.
         let action_mods = match &term.action {
             TermAction::Permit(mods) | TermAction::Continue(mods) => Some(mods),
-            TermAction::Deny => None,
+            TermAction::Deny | TermAction::Bind { .. } => None,
         };
-        if let Some(mods) = action_mods
-            && let Err(kind) = tables.resolve_computed(mods, ctx)
-        {
-            term_traces.push(format!(
-                "term {}: evaluation error: {kind} — fail closed => reject",
-                term.name.as_deref().unwrap_or("<unnamed>"),
-            ));
-            eval_failed = true;
-            decided = Some((index, term));
-            break;
-        }
+        let resolved = match action_mods.map(|mods| tables.resolve_computed(mods, ctx, &locals)) {
+            Some(Err(kind)) => {
+                term_traces.push(format!(
+                    "term {}: evaluation error: {kind} — fail closed => reject",
+                    term.name.as_deref().unwrap_or("<unnamed>"),
+                ));
+                eval_failed = true;
+                decided = Some((index, term));
+                break;
+            }
+            Some(Ok(resolved)) => resolved,
+            None => None,
+        };
         match &term.action {
             TermAction::Continue(mods) => {
+                // Merge the term-time resolution (LAN-302 live parity:
+                // a later sibling scope may reuse the frame slots this
+                // term's computed expressions read, so resolving at
+                // trace end could render a different value than the
+                // live walk applied).
                 continued
                     .get_or_insert_with(RouteModifications::default)
-                    .merge_from(mods.clone());
+                    .merge_from(resolved.unwrap_or_else(|| mods.clone()));
             }
-            TermAction::Permit(_) | TermAction::Deny => {
+            TermAction::Permit(_) | TermAction::Deny | TermAction::Bind { .. } => {
                 decided = Some((index, term));
                 break;
             }
@@ -507,7 +541,7 @@ fn trace_rpol_policy(
                 merged.merge_from(mods.clone());
                 (
                     PolicyAction::Permit,
-                    render_modifications(&merged, ctx, Some(tables)),
+                    render_modifications(&merged, ctx, Some(tables), &locals),
                 )
             }
             _ => (PolicyAction::Deny, Vec::new()),
@@ -526,7 +560,9 @@ fn trace_rpol_policy(
         // Fallthrough to the policy default; a permitting default
         // keeps accumulated Continue modifications (live parity).
         let modifications = match (policy.default_action, continued) {
-            (PolicyAction::Permit, Some(mods)) => render_modifications(&mods, ctx, Some(tables)),
+            (PolicyAction::Permit, Some(mods)) => {
+                render_modifications(&mods, ctx, Some(tables), &locals)
+            }
             _ => Vec::new(),
         };
         StatementAttribution {
@@ -551,6 +587,8 @@ fn render_term_action(action: &TermAction) -> String {
         TermAction::Permit(mods) => (Some(mods), "accept"),
         TermAction::Deny => (None, "reject"),
         TermAction::Continue(mods) => (Some(mods), "continue"),
+        // LAN-302: a lowered `let` renders in its source form.
+        TermAction::Bind { name, expr, .. } => return format!("let {name} = {expr}"),
     };
     let mut parts = mods.map_or_else(Vec::new, render_action_stmts);
     parts.push(verdict.to_string());

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -58,6 +58,13 @@ pub enum EvalErrorKind {
     /// unknown context value, or zero (ASN 0 is prohibited on the
     /// wire, RFC 7607).
     AbsentPrependOperand(PrependAs),
+    /// A `let`-binding slot was read with no frame written (LAN-302).
+    /// Unreachable through the compiler — definite assignment and
+    /// static slot allocation guarantee every `Local` read follows its
+    /// `Bind` in walk order — so this is the fail-closed disposition
+    /// of a compiler bug, mirroring how stale hit-counter shapes
+    /// degrade instead of panicking on the production path.
+    UnboundLocal,
 }
 
 impl EvalErrorKind {
@@ -72,6 +79,7 @@ impl EvalErrorKind {
             EvalErrorKind::ClampInverted => "clamp-inverted",
             EvalErrorKind::AbsentField(_) => "absent-operand",
             EvalErrorKind::AbsentPrependOperand(_) => "absent-prepend-operand",
+            EvalErrorKind::UnboundLocal => "unbound-local",
         }
     }
 }
@@ -96,17 +104,56 @@ impl fmt::Display for EvalErrorKind {
                 }
                 write!(f, ")")
             }
+            EvalErrorKind::UnboundLocal => {
+                write!(f, "internal error: unbound `let` slot (fail closed)")
+            }
         }
     }
 }
 
-/// Evaluate a compiled value expression against a route context.
-/// Pure and allocation-free; every arithmetic step is checked
-/// (ADR-0103 Decision 2 — the SIGFPE class is unrepresentable).
-/// Recursion depth is bounded by the frontend (`MAX_EXPR_DEPTH`).
-pub(crate) fn eval_value(expr: &ValueExpr, ctx: &RouteContext<'_>) -> Result<u32, EvalErrorKind> {
+/// Size of the per-evaluation `let`-binding register file (LAN-302):
+/// the language has exactly two nesting levels (a term body and one
+/// `if`/`else` body), each capped at `MAX_LOCALS` = 64 bindings per
+/// scope by the typechecker, so at most 2 × 64 slots are ever live.
+/// Slots reset per source term and sibling scopes reuse, keeping the
+/// frame this small forever (ADR-0103 Decision 3 caps the frame at
+/// 1,024 slots; we need an eighth of that).
+pub(crate) const LOCAL_FRAME_SLOTS: usize = 128;
+
+/// The fixed-size evaluation frame `let` bindings live in: a stack
+/// array, allocated (and zeroed) lazily only when a policy's walk
+/// reaches its first [`TermAction::Bind`] — policies without bindings
+/// never touch it, preserving the V1 hot-path cost exactly.
+type LocalFrame = [u32; LOCAL_FRAME_SLOTS];
+
+/// The frame as a read slice: empty when no binding has executed yet
+/// (a `Local` read against it is the fail-closed
+/// [`EvalErrorKind::UnboundLocal`] compiler-bug rail).
+#[inline]
+fn locals_slice(locals: Option<&LocalFrame>) -> &[u32] {
+    locals.map_or(&[], |frame| &frame[..])
+}
+
+/// Evaluate a compiled value expression against a route context and
+/// the current `let`-binding frame (`&[]` when the caller has none —
+/// expressions without `Local` reads never index it). Pure and
+/// allocation-free; every arithmetic step is checked (ADR-0103
+/// Decision 2 — the SIGFPE class is unrepresentable). Recursion depth
+/// is bounded by the frontend (`MAX_EXPR_DEPTH`).
+pub(crate) fn eval_value(
+    expr: &ValueExpr,
+    ctx: &RouteContext<'_>,
+    locals: &[u32],
+) -> Result<u32, EvalErrorKind> {
     match expr {
         ValueExpr::Const(value) => Ok(*value),
+        // One indexed load; the slot was written by this walk's Bind
+        // term (definite assignment). `get` degrades a compiler bug to
+        // a fail-closed eval error instead of a panic.
+        ValueExpr::Local { slot, .. } => locals
+            .get(*slot as usize)
+            .copied()
+            .ok_or(EvalErrorKind::UnboundLocal),
         ValueExpr::Field(field) => match field {
             ValueField::LocalPref => Ok(ctx.local_pref.unwrap_or(IMPLICIT_LOCAL_PREF)),
             ValueField::Med => Ok(ctx.med.unwrap_or(IMPLICIT_MED)),
@@ -121,16 +168,16 @@ pub(crate) fn eval_value(expr: &ValueExpr, ctx: &RouteContext<'_>) -> Result<u32
                 .ok_or(EvalErrorKind::AbsentField(ValueField::PeerAsn)),
         },
         ValueExpr::Binary { op, lhs, rhs } => {
-            let lhs = eval_value(lhs, ctx)?;
-            let rhs = eval_value(rhs, ctx)?;
+            let lhs = eval_value(lhs, ctx, locals)?;
+            let rhs = eval_value(rhs, ctx, locals)?;
             checked_arith(*op, lhs, rhs)
         }
-        ValueExpr::Min(a, b) => Ok(eval_value(a, ctx)?.min(eval_value(b, ctx)?)),
-        ValueExpr::Max(a, b) => Ok(eval_value(a, ctx)?.max(eval_value(b, ctx)?)),
+        ValueExpr::Min(a, b) => Ok(eval_value(a, ctx, locals)?.min(eval_value(b, ctx, locals)?)),
+        ValueExpr::Max(a, b) => Ok(eval_value(a, ctx, locals)?.max(eval_value(b, ctx, locals)?)),
         ValueExpr::Clamp(x, lo, hi) => {
-            let x = eval_value(x, ctx)?;
-            let lo = eval_value(lo, ctx)?;
-            let hi = eval_value(hi, ctx)?;
+            let x = eval_value(x, ctx, locals)?;
+            let lo = eval_value(lo, ctx, locals)?;
+            let hi = eval_value(hi, ctx, locals)?;
             if lo > hi {
                 return Err(EvalErrorKind::ClampInverted);
             }
@@ -436,9 +483,12 @@ impl CompiledChain {
             // `None` after the loop = fell through to default_action.
             let mut permit_mods: Option<Option<RouteModifications>> = None;
             let mut denied = false;
+            // LAN-302: same lazy `let` frame as the live walk.
+            let mut locals: Option<LocalFrame> = None;
             for (term, hit) in policy.terms.iter().zip(policy_hits.iter_mut()) {
                 let mut err = None;
-                let matched = self.eval_expr(&term.guard, ctx, &mut err);
+                let matched =
+                    self.eval_expr(&term.guard, ctx, locals_slice(locals.as_ref()), &mut err);
                 if err.is_some() {
                     // Guard evaluation error: fail closed (LAN-299).
                     denied = true;
@@ -448,7 +498,7 @@ impl CompiledChain {
                     *hit += 1;
                     match &term.action {
                         TermAction::Permit(mods) => {
-                            match self.resolve_computed(mods, ctx) {
+                            match self.resolve_computed(mods, ctx, locals_slice(locals.as_ref())) {
                                 Ok(resolved) => {
                                     permit_mods =
                                         Some(Some(resolved.unwrap_or_else(|| mods.clone())));
@@ -464,7 +514,9 @@ impl CompiledChain {
                             break;
                         }
                         TermAction::Continue(mods) => {
-                            if let Ok(resolved) = self.resolve_computed(mods, ctx) {
+                            if let Ok(resolved) =
+                                self.resolve_computed(mods, ctx, locals_slice(locals.as_ref()))
+                            {
                                 continued
                                     .get_or_insert_with(RouteModifications::default)
                                     .merge_from(resolved.unwrap_or_else(|| mods.clone()));
@@ -472,6 +524,16 @@ impl CompiledChain {
                                 denied = true;
                                 break;
                             }
+                        }
+                        // LAN-302: eager `let`, identical to the live
+                        // walk — initializer error fails closed.
+                        TermAction::Bind { slot, expr, .. } => {
+                            let Ok(value) = eval_value(expr, ctx, locals_slice(locals.as_ref()))
+                            else {
+                                denied = true;
+                                break;
+                            };
+                            locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[*slot as usize] = value;
                         }
                     }
                 }
@@ -513,9 +575,13 @@ impl CompiledChain {
         hits: Option<&[AtomicU64]>,
     ) -> PolicyDecision<'a> {
         let mut continued: Option<RouteModifications> = None;
+        // LAN-302: the `let`-binding register file, materialized (one
+        // stack zeroing, no heap) only when the walk reaches a Bind
+        // term — binding-free policies never touch it.
+        let mut locals: Option<LocalFrame> = None;
         for (term_index, term) in policy.terms.iter().enumerate() {
             let mut err = None;
-            let matched = self.eval_expr(&term.guard, ctx, &mut err);
+            let matched = self.eval_expr(&term.guard, ctx, locals_slice(locals.as_ref()), &mut err);
             if let Some(kind) = err {
                 // Guard evaluation error (LAN-299): terminal for the
                 // route regardless of the guard's boolean outcome.
@@ -538,10 +604,11 @@ impl CompiledChain {
                         // before the modifications leave the
                         // evaluator; an unresolvable operand fails the
                         // route closed on the eval-error rail.
-                        let resolved = match self.resolve_computed(mods, ctx) {
-                            Ok(resolved) => resolved,
-                            Err(kind) => return PolicyDecision::Error { kind, term_index },
-                        };
+                        let resolved =
+                            match self.resolve_computed(mods, ctx, locals_slice(locals.as_ref())) {
+                                Ok(resolved) => resolved,
+                                Err(kind) => return PolicyDecision::Error { kind, term_index },
+                            };
                         return match (continued, resolved) {
                             (Some(mut acc), resolved) => {
                                 acc.merge_from(resolved.unwrap_or_else(|| mods.clone()));
@@ -555,13 +622,28 @@ impl CompiledChain {
                     }
                     TermAction::Deny => return PolicyDecision::Deny,
                     TermAction::Continue(mods) => {
-                        let resolved = match self.resolve_computed(mods, ctx) {
-                            Ok(resolved) => resolved,
-                            Err(kind) => return PolicyDecision::Error { kind, term_index },
-                        };
+                        let resolved =
+                            match self.resolve_computed(mods, ctx, locals_slice(locals.as_ref())) {
+                                Ok(resolved) => resolved,
+                                Err(kind) => return PolicyDecision::Error { kind, term_index },
+                            };
                         continued
                             .get_or_insert_with(RouteModifications::default)
                             .merge_from(resolved.unwrap_or_else(|| mods.clone()));
+                    }
+                    // LAN-302: eager `let` — evaluate the initializer
+                    // (against the frame as written so far; earlier
+                    // bindings are readable), write the slot, keep
+                    // walking. An initializer error is terminal on the
+                    // uniform eval-error rail, used or not.
+                    TermAction::Bind { slot, expr, .. } => {
+                        match eval_value(expr, ctx, locals_slice(locals.as_ref())) {
+                            Ok(value) => {
+                                locals.get_or_insert([0; LOCAL_FRAME_SLOTS])[*slot as usize] =
+                                    value;
+                            }
+                            Err(kind) => return PolicyDecision::Error { kind, term_index },
+                        }
                     }
                 }
             }
@@ -590,6 +672,7 @@ impl CompiledChain {
         &self,
         mods: &RouteModifications,
         ctx: &RouteContext<'_>,
+        locals: &[u32],
     ) -> Result<Option<RouteModifications>, EvalErrorKind> {
         if mods.as_path_prepend_computed.is_none()
             && mods.set_local_pref_computed.is_none()
@@ -606,11 +689,11 @@ impl CompiledChain {
             resolved.as_path_prepend_computed = None;
         }
         if let Some(expr) = &mods.set_local_pref_computed {
-            resolved.set_local_pref = Some(eval_value(expr, ctx)?);
+            resolved.set_local_pref = Some(eval_value(expr, ctx, locals)?);
             resolved.set_local_pref_computed = None;
         }
         if let Some(expr) = &mods.set_med_computed {
-            resolved.set_med = Some(eval_value(expr, ctx)?);
+            resolved.set_med = Some(eval_value(expr, ctx, locals)?);
             resolved.set_med_computed = None;
         }
         Ok(Some(resolved))
@@ -623,13 +706,17 @@ impl CompiledChain {
     /// `PolicyStatement::matches`). `Err` when the guard contains a
     /// value expression that failed to evaluate — the live walk denies
     /// the route there (LAN-299), and explain must render the same.
+    /// `locals` is the caller's `let` frame (LAN-302): the explain
+    /// trace walk re-derives bindings term by term and passes its own
+    /// frame here, so guard evaluation stays shared.
     pub(crate) fn guard_matches(
         &self,
         expr: &MatchExpr,
         ctx: &RouteContext<'_>,
+        locals: &[u32],
     ) -> Result<bool, EvalErrorKind> {
         let mut err = None;
-        let matched = self.eval_expr(expr, ctx, &mut err);
+        let matched = self.eval_expr(expr, ctx, locals, &mut err);
         match err {
             Some(kind) => Err(kind),
             None => Ok(matched),
@@ -656,17 +743,23 @@ impl CompiledChain {
         &self,
         expr: &MatchExpr,
         ctx: &RouteContext<'_>,
+        locals: &[u32],
         err: &mut Option<EvalErrorKind>,
     ) -> bool {
         match expr {
             MatchExpr::True => true,
-            MatchExpr::And(children) => {
-                children.iter().all(|child| self.eval_expr(child, ctx, err))
-            }
-            MatchExpr::Or(children) => children.iter().any(|child| self.eval_expr(child, ctx, err)),
-            MatchExpr::Not(inner) => !self.eval_expr(inner, ctx, err),
+            MatchExpr::And(children) => children
+                .iter()
+                .all(|child| self.eval_expr(child, ctx, locals, err)),
+            MatchExpr::Or(children) => children
+                .iter()
+                .any(|child| self.eval_expr(child, ctx, locals, err)),
+            MatchExpr::Not(inner) => !self.eval_expr(inner, ctx, locals, err),
             MatchExpr::ValueCmp(node) => {
-                match (eval_value(&node.lhs, ctx), eval_value(&node.rhs, ctx)) {
+                match (
+                    eval_value(&node.lhs, ctx, locals),
+                    eval_value(&node.rhs, ctx, locals),
+                ) {
                     (Ok(lhs), Ok(rhs)) => match node.op {
                         ValueCmpOp::Eq => lhs == rhs,
                         ValueCmpOp::Ne => lhs != rhs,

--- a/crates/policy/src/ir.rs
+++ b/crates/policy/src/ir.rs
@@ -134,6 +134,18 @@ pub enum ValueExpr {
     Const(u32),
     /// A `u32` context field read.
     Field(ValueField),
+    /// A `let`-binding read (LAN-302): one indexed load from the
+    /// evaluation frame ([`TermAction::Bind`] wrote the slot earlier in
+    /// the same walk — definite assignment is a compile-time guarantee).
+    /// `name` is the source binding name, carried for explain rendering
+    /// and eval-error logs; it participates in equality like set names
+    /// do (renaming a binding is a source change).
+    Local {
+        /// Frame slot index (< `LOCAL_FRAME_SLOTS`).
+        slot: u8,
+        /// The binding name as written.
+        name: Box<str>,
+    },
     /// A checked binary arithmetic operation.
     Binary {
         /// The operator.
@@ -160,7 +172,7 @@ impl ValueExpr {
             return true;
         }
         match self {
-            ValueExpr::Const(_) | ValueExpr::Field(_) => false,
+            ValueExpr::Const(_) | ValueExpr::Field(_) | ValueExpr::Local { .. } => false,
             ValueExpr::Binary { lhs, rhs, .. }
             | ValueExpr::Min(lhs, rhs)
             | ValueExpr::Max(lhs, rhs) => lhs.any_node(pred) || rhs.any_node(pred),
@@ -201,6 +213,7 @@ impl fmt::Display for ValueExpr {
             match expr {
                 ValueExpr::Const(value) => write!(f, "{value}")?,
                 ValueExpr::Field(field) => write!(f, "{}", field.as_str())?,
+                ValueExpr::Local { name, .. } => write!(f, "{name}")?,
                 ValueExpr::Binary { op, lhs, rhs } => {
                     let this = binding(expr);
                     render(lhs, f, this)?;
@@ -517,6 +530,28 @@ pub enum TermAction {
     /// `Deny` discards them. The TOML frontend never emits this
     /// variant.
     Continue(RouteModifications),
+    /// Evaluate `expr` and write the result into frame slot `slot` — a
+    /// lowered `.rpol` `let` statement (LAN-302, ADR-0103 Decision 2).
+    /// Like [`Continue`](Self::Continue) it never decides: the walk
+    /// keeps going. The initializer is **eager**: it evaluates whenever
+    /// the walk reaches this term (its guard is the enclosing branch
+    /// condition — `True` for a term-body `let`), used or not, and any
+    /// evaluation error denies the route on the uniform eval-error
+    /// rail. Slots are statically allocated per source term; bindings
+    /// are immutable in the language, so a slot is written once per
+    /// scope activation (sibling scopes may reuse slots — never live
+    /// simultaneously). `name` is carried for explain rendering. The
+    /// TOML frontend never emits this variant, and `apply` targets are
+    /// rejected at typecheck when they declare bindings, so it never
+    /// appears inside an inlined predicate.
+    Bind {
+        /// Frame slot to write (< `LOCAL_FRAME_SLOTS`).
+        slot: u8,
+        /// The source binding name, for explain surfaces.
+        name: Box<str>,
+        /// The initializer (a checked value expression).
+        expr: ValueExpr,
+    },
 }
 
 /// One guarded action inside a [`CompiledPolicy`] — the compiled form
@@ -685,6 +720,13 @@ impl CompiledChain {
                     .flatten()
                     .any(|expr| expr.reads_peer())
             })
+            // A `let` initializer reading `peer.asn` (LAN-302)
+            // evaluates eagerly per route — an unknown peer ASN even
+            // denies — so the binding alone makes verdicts
+            // peer-dependent, whether or not the value is read.
+            || self.policies.iter().flat_map(|p| p.terms.iter()).any(
+                |term| matches!(&term.action, TermAction::Bind { expr, .. } if expr.reads_peer()),
+            )
     }
 
     /// The first `prepend as peer` action in the chain, as the owning
@@ -704,7 +746,7 @@ impl CompiledChain {
             for term in &policy.terms {
                 let mods = match &term.action {
                     TermAction::Permit(mods) | TermAction::Continue(mods) => mods,
-                    TermAction::Deny => continue,
+                    TermAction::Deny | TermAction::Bind { .. } => continue,
                 };
                 if matches!(mods.as_path_prepend_computed, Some((PrependAs::PeerAs, _))) {
                     return Some((policy.name.as_deref(), term.name.as_deref()));
@@ -730,7 +772,7 @@ impl CompiledChain {
             .flat_map(|policy| policy.terms.iter())
             .any(|term| match &term.action {
                 TermAction::Permit(mods) | TermAction::Continue(mods) => pred(mods),
-                TermAction::Deny => false,
+                TermAction::Deny | TermAction::Bind { .. } => false,
             })
     }
 }

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -335,6 +335,21 @@ pub enum ActionStmt {
         /// Whole-statement span.
         span: Span,
     },
+    /// `let <name> = <value-expr>` (LAN-302): an immutable, lexically
+    /// scoped `u32` binding, legal in statement position — a term body
+    /// or an `if`/`else` body. `let` is a contextual identifier
+    /// (statement position admits no other bare identifier), not a
+    /// reserved word — ADR-0103 Decision 2.2. Parsed alongside actions
+    /// because statement position is exactly where actions live;
+    /// the typechecker scopes it and the lowerer emits a `Bind` term.
+    Let {
+        /// The binding name.
+        name: Spanned<String>,
+        /// The initializer (a checked u32 value expression).
+        init: ValueExprAst,
+        /// Whole-statement span.
+        span: Span,
+    },
 }
 
 impl ActionStmt {
@@ -348,7 +363,8 @@ impl ActionStmt {
             | ActionStmt::SetMed(_, span)
             | ActionStmt::SetNextHop(_, span)
             | ActionStmt::Community { span, .. }
-            | ActionStmt::Prepend { span, .. } => *span,
+            | ActionStmt::Prepend { span, .. }
+            | ActionStmt::Let { span, .. } => *span,
         }
     }
 }

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -183,6 +183,12 @@ pub enum Tok {
     /// `==`
     #[token("==")]
     EqEq,
+    /// `=` — `let` binding initializer (LAN-302). Un-lexable before
+    /// bindings landed (`==` already lexed as one token, and logos
+    /// prefers the longer match), so purely additive — ADR-0103
+    /// Decision 2.3.
+    #[token("=")]
+    Eq,
     /// `!=`
     #[token("!=")]
     NotEq,
@@ -274,6 +280,7 @@ impl Tok {
             Tok::Dot => "`.`",
             Tok::Colon => "`:`",
             Tok::EqEq => "`==`",
+            Tok::Eq => "`=`",
             Tok::NotEq => "`!=`",
             Tok::GtEq => "`>=`",
             Tok::LtEq => "`<=`",

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -68,6 +68,60 @@ use super::ast::{
 };
 use super::typeck::{Field, resolve_field, value_field_of};
 
+/// Static slot allocation for `let` bindings (LAN-302): one register
+/// file per **source term** (bindings never cross terms), slots handed
+/// out in declaration order. Entering an `if`/`else` body saves a
+/// [`mark`](Self::mark) and leaving [`reset`](Self::reset)s to it, so
+/// sibling scopes reuse slots — they are never live simultaneously —
+/// and the frame stays within `2 × MAX_LOCALS` slots
+/// (`crate::eval::LOCAL_FRAME_SLOTS`) forever. Lookup scans innermost
+/// last (reverse), giving deterministic shadowing of outer bindings
+/// and parameters. Purely a function of the source, so identical
+/// source always compiles to identical slot assignments (ADR-0103
+/// Decision 5 determinism).
+#[derive(Default)]
+struct LetEnv {
+    lets: Vec<(String, u8)>,
+    next_slot: u8,
+}
+
+impl LetEnv {
+    /// The slot of the innermost visible binding named `name`.
+    fn lookup(&self, name: &str) -> Option<u8> {
+        self.lets
+            .iter()
+            .rev()
+            .find(|(local, _)| local == name)
+            .map(|&(_, slot)| slot)
+    }
+
+    /// Declare a binding, allocating the next slot. The typechecker's
+    /// per-scope `MAX_LOCALS` cap bounds `next_slot` below the frame
+    /// size (two nesting levels × 64).
+    fn declare(&mut self, name: &str) -> u8 {
+        let slot = self.next_slot;
+        assert!(
+            usize::from(slot) < crate::eval::LOCAL_FRAME_SLOTS,
+            "typechecked: per-scope caps bound the frame"
+        );
+        self.next_slot += 1;
+        self.lets.push((name.to_string(), slot));
+        slot
+    }
+
+    /// Snapshot the scope for a nested `if`/`else` body.
+    fn mark(&self) -> (usize, u8) {
+        (self.lets.len(), self.next_slot)
+    }
+
+    /// Leave a nested scope: its names go out of scope and its slots
+    /// become reusable by sibling scopes.
+    fn reset(&mut self, (len, next_slot): (usize, u8)) {
+        self.lets.truncate(len);
+        self.next_slot = next_slot;
+    }
+}
+
 /// Encode a community literal's concrete wire value (for
 /// `add`/`remove` actions and test assertions). RT/RO literals pick
 /// the RFC 4360 type from the global admin's shape, matching the
@@ -267,6 +321,16 @@ impl<'a> Lowerer<'a> {
 
     /// Lower one `.rpol` term to its IR terms (see module docs for the
     /// fallthrough encoding).
+    ///
+    /// `let` statements (LAN-302) lower to [`TermAction::Bind`] terms
+    /// guarded by their enclosing branch condition — `True` in term-body
+    /// position, the `if` guard (or its negation for `else`) inside a
+    /// body — so the initializer evaluates exactly when the statement
+    /// would execute (eager, fail-closed) and the slot is written
+    /// before any IR term that reads it. Pending modification staging
+    /// does not need flushing around a Bind: definite assignment means
+    /// staged computed expressions only ever read slots whose Bind
+    /// terms were emitted earlier.
     fn lower_term(
         &mut self,
         term: &super::ast::TermDef,
@@ -275,6 +339,8 @@ impl<'a> Lowerer<'a> {
     ) -> Vec<(MatchExpr, TermAction)> {
         let mut out: Vec<(MatchExpr, TermAction)> = Vec::new();
         let mut pending = RouteModifications::default();
+        // Slots reset per source term: bindings never cross terms.
+        let mut lets = LetEnv::default();
         for stmt in &term.stmts {
             match stmt {
                 Stmt::Action(ActionStmt::Accept(_)) => {
@@ -288,8 +354,23 @@ impl<'a> Lowerer<'a> {
                     out.push((MatchExpr::True, TermAction::Deny));
                     return out;
                 }
+                // Term-body `let`: lower the initializer against the
+                // scope *before* declaring, so `let x = x + 1` reads
+                // the prior `x` (shadowing, not self-reference).
+                Stmt::Action(ActionStmt::Let { name, init, .. }) => {
+                    let expr = lower_value(init, env, &lets);
+                    let slot = lets.declare(&name.node);
+                    out.push((
+                        MatchExpr::True,
+                        TermAction::Bind {
+                            slot,
+                            name: name.node.clone().into_boxed_str(),
+                            expr,
+                        },
+                    ));
+                }
                 Stmt::Action(action) => {
-                    apply_action(&mut pending, action, env);
+                    apply_action(&mut pending, action, env, &lets);
                 }
                 Stmt::If(if_stmt) => {
                     if !pending.is_empty() {
@@ -298,9 +379,18 @@ impl<'a> Lowerer<'a> {
                             TermAction::Continue(std::mem::take(&mut pending)),
                         ));
                     }
-                    let guard = self.lower_expr(&if_stmt.cond, env, store);
-                    let then_arm = lower_body(&if_stmt.then_actions, env);
+                    let guard = self.lower_expr(&if_stmt.cond, env, &lets, store);
+                    let scope = lets.mark();
+                    let (then_binds, then_arm) = lower_body(&if_stmt.then_actions, env, &mut lets);
+                    lets.reset(scope);
                     let needs_else_guard = if_stmt.else_actions.is_some();
+                    // Body `let`s become Bind terms guarded by the
+                    // branch condition, ahead of the body's action
+                    // term (guards are pure, so re-evaluating the
+                    // condition per term cannot diverge).
+                    for bind in then_binds {
+                        out.push((guard.clone(), bind));
+                    }
                     if let Some(action) = then_arm {
                         out.push((guard.clone(), action));
                     } else if needs_else_guard {
@@ -310,12 +400,17 @@ impl<'a> Lowerer<'a> {
                             TermAction::Continue(RouteModifications::default()),
                         ));
                     }
-                    if let Some(action) = if_stmt
-                        .else_actions
-                        .as_ref()
-                        .and_then(|actions| lower_body(actions, env))
-                    {
-                        out.push((MatchExpr::Not(Box::new(guard)), action));
+                    if let Some(else_actions) = &if_stmt.else_actions {
+                        let scope = lets.mark();
+                        let (else_binds, else_arm) = lower_body(else_actions, env, &mut lets);
+                        lets.reset(scope);
+                        let negated = MatchExpr::Not(Box::new(guard));
+                        for bind in else_binds {
+                            out.push((negated.clone(), bind));
+                        }
+                        if let Some(action) = else_arm {
+                            out.push((negated, action));
+                        }
                     }
                 }
             }
@@ -330,13 +425,14 @@ impl<'a> Lowerer<'a> {
         &mut self,
         expr: &Expr,
         env: &HashMap<&str, u32>,
+        lets: &LetEnv,
         store: &mut SetStore,
     ) -> MatchExpr {
         match expr {
             Expr::And(lhs, rhs) => {
                 let mut children = vec![
-                    self.lower_expr(lhs, env, store),
-                    self.lower_expr(rhs, env, store),
+                    self.lower_expr(lhs, env, lets, store),
+                    self.lower_expr(rhs, env, lets, store),
                 ];
                 // Guards are pure; order And-children cheapest-first
                 // (the IR invariant shared with the TOML compiler).
@@ -344,11 +440,13 @@ impl<'a> Lowerer<'a> {
                 MatchExpr::And(children)
             }
             Expr::Or(lhs, rhs) => MatchExpr::Or(vec![
-                self.lower_expr(lhs, env, store),
-                self.lower_expr(rhs, env, store),
+                self.lower_expr(lhs, env, lets, store),
+                self.lower_expr(rhs, env, lets, store),
             ]),
-            Expr::Not(inner, _) => MatchExpr::Not(Box::new(self.lower_expr(inner, env, store))),
-            Expr::Cmp { field, op, rhs, .. } => lower_cmp(field, *op, rhs, env),
+            Expr::Not(inner, _) => {
+                MatchExpr::Not(Box::new(self.lower_expr(inner, env, lets, store)))
+            }
+            Expr::Cmp { field, op, rhs, .. } => lower_cmp(field, *op, rhs, env, lets),
             // LAN-299: value comparisons keep their shape (constant
             // subtrees folded) — deliberately NOT rewritten to the
             // legacy scalar nodes even when one side folds to a
@@ -361,8 +459,8 @@ impl<'a> Lowerer<'a> {
                     CmpOp::Ge => ValueCmpOp::Ge,
                     CmpOp::Le => ValueCmpOp::Le,
                 },
-                lhs: lower_value(lhs, env),
-                rhs: lower_value(rhs, env),
+                lhs: lower_value(lhs, env, lets),
+                rhs: lower_value(rhs, env, lets),
             })),
             Expr::In { field, set } => match resolve_field(field).expect("typechecked") {
                 Field::Prefix => MatchExpr::PrefixInSet(self.prefix_set_ids[&set.node]),
@@ -416,8 +514,34 @@ fn lower_cmp(
     op: CmpOp,
     rhs: &Rhs,
     env: &HashMap<&str, u32>,
+    lets: &LetEnv,
 ) -> MatchExpr {
     let resolved = resolve_field(field).expect("typechecked");
+    // LAN-302: a `let` binding on the right of a u32-field comparison
+    // is a runtime value, so the comparison lowers to the checked
+    // value-comparison node (fail-closed absent-operand semantics,
+    // like every computed form) rather than a constant-bound scalar
+    // node. Gated on u32 fields: on enum-typed fields the member
+    // spelling wins (position-typed resolution — bindings are read
+    // only in value positions), mirroring the typechecker.
+    if let Rhs::Ident(name) = rhs
+        && let Some(field) = value_field_of(resolved)
+        && let Some(slot) = lets.lookup(&name.node)
+    {
+        return MatchExpr::ValueCmp(Box::new(ValueCmpNode {
+            op: match op {
+                CmpOp::Eq => ValueCmpOp::Eq,
+                CmpOp::Ne => ValueCmpOp::Ne,
+                CmpOp::Ge => ValueCmpOp::Ge,
+                CmpOp::Le => ValueCmpOp::Le,
+            },
+            lhs: ValueExpr::Field(field),
+            rhs: ValueExpr::Local {
+                slot,
+                name: name.node.clone().into_boxed_str(),
+            },
+        }));
+    }
     match resolved {
         Field::LocalPref => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::LocalPref),
         Field::Med => u32_cmp(op, rhs_u32(rhs, env), MatchExpr::Med),
@@ -570,40 +694,64 @@ fn lower_cmp(
     }
 }
 
-/// Lower an `if` body (a flat action list) to its term action:
+/// Lower an `if` body (a flat action list) to its `let` bindings
+/// (LAN-302 — [`TermAction::Bind`]s the caller emits ahead of the
+/// action term, guarded by the branch condition) and its term action:
 /// `Some(Permit)` on `accept`, `Some(Deny)` on `reject`,
 /// `Some(Continue)` when it only modifies, `None` when it does nothing.
-fn lower_body(actions: &[ActionStmt], env: &HashMap<&str, u32>) -> Option<TermAction> {
+/// The caller wraps this in a `lets` scope mark/reset — body bindings
+/// are not visible outside the body.
+fn lower_body(
+    actions: &[ActionStmt],
+    env: &HashMap<&str, u32>,
+    lets: &mut LetEnv,
+) -> (Vec<TermAction>, Option<TermAction>) {
+    let mut binds = Vec::new();
     let mut mods = RouteModifications::default();
     for action in actions {
         match action {
-            ActionStmt::Accept(_) => return Some(TermAction::Permit(mods)),
-            ActionStmt::Reject(_) => return Some(TermAction::Deny),
-            other => apply_action(&mut mods, other, env),
+            ActionStmt::Accept(_) => return (binds, Some(TermAction::Permit(mods))),
+            ActionStmt::Reject(_) => return (binds, Some(TermAction::Deny)),
+            ActionStmt::Let { name, init, .. } => {
+                let expr = lower_value(init, env, lets);
+                let slot = lets.declare(&name.node);
+                binds.push(TermAction::Bind {
+                    slot,
+                    name: name.node.clone().into_boxed_str(),
+                    expr,
+                });
+            }
+            other => apply_action(&mut mods, other, env, lets),
         }
     }
-    if mods.is_empty() {
+    let action = if mods.is_empty() {
         None
     } else {
         Some(TermAction::Continue(mods))
-    }
+    };
+    (binds, action)
 }
 
-fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMap<&str, u32>) {
+fn apply_action(
+    mods: &mut RouteModifications,
+    action: &ActionStmt,
+    env: &HashMap<&str, u32>,
+    lets: &LetEnv,
+) {
     match action {
-        ActionStmt::Accept(_) | ActionStmt::Reject(_) => {
-            unreachable!("verdicts handled by callers")
+        ActionStmt::Accept(_) | ActionStmt::Reject(_) | ActionStmt::Let { .. } => {
+            unreachable!("verdicts and `let` handled by callers")
         }
         // LAN-299: a computed set value that folds to a constant
         // (literal, parameter, or constant arithmetic) lowers to the
         // literal field — `set med 25 + 25` compiles to exactly what
         // `set med 50` does. Only expressions that read route/peer
         // fields stay computed (resolved per route by the evaluator).
-        ActionStmt::SetLocalPref(expr, _) => match lower_value(expr, env) {
+        ActionStmt::SetLocalPref(expr, _) => match lower_value(expr, env, lets) {
             ValueExpr::Const(value) => mods.set_local_pref = Some(value),
             computed => mods.set_local_pref_computed = Some(std::sync::Arc::new(computed)),
         },
-        ActionStmt::SetMed(expr, _) => match lower_value(expr, env) {
+        ActionStmt::SetMed(expr, _) => match lower_value(expr, env, lets) {
             ValueExpr::Const(value) => mods.set_med = Some(value),
             computed => mods.set_med_computed = Some(std::sync::Arc::new(computed)),
         },
@@ -672,27 +820,39 @@ fn apply_action(mods: &mut RouteModifications, action: &ActionStmt, env: &HashMa
     }
 }
 
-/// Lower a value expression to IR with parameters substituted, folding
-/// constant subtrees bottom-up with checked arithmetic (LAN-299). A
-/// constant step that fails its check (e.g. `4294967295 + p` with
-/// `p = 1` at instantiation — invisible to the typechecker, which only
-/// sees literals) is left unfolded and fails per route on the
-/// eval-error rail: fail closed, never wrap.
-fn lower_value(expr: &ValueExprAst, env: &HashMap<&str, u32>) -> ValueExpr {
+/// Lower a value expression to IR with parameters substituted and
+/// `let` bindings resolved to frame slots (innermost first — LAN-302
+/// shadowing), folding constant subtrees bottom-up with checked
+/// arithmetic (LAN-299). A constant step that fails its check (e.g.
+/// `4294967295 + p` with `p = 1` at instantiation — invisible to the
+/// typechecker, which only sees literals) is left unfolded and fails
+/// per route on the eval-error rail: fail closed, never wrap.
+fn lower_value(expr: &ValueExprAst, env: &HashMap<&str, u32>, lets: &LetEnv) -> ValueExpr {
     match expr {
         ValueExprAst::Lit(value, _) => ValueExpr::Const(*value),
-        ValueExprAst::Ident(name) => ValueExpr::Const(
-            *env.get(name.node.as_str())
-                .expect("typechecked: parameter in scope"),
-        ),
+        ValueExprAst::Ident(name) => {
+            // Innermost binding shadows parameters (and outer
+            // bindings) in value positions — the typechecker resolves
+            // by the same rule.
+            if let Some(slot) = lets.lookup(&name.node) {
+                return ValueExpr::Local {
+                    slot,
+                    name: name.node.clone().into_boxed_str(),
+                };
+            }
+            ValueExpr::Const(
+                *env.get(name.node.as_str())
+                    .expect("typechecked: parameter in scope"),
+            )
+        }
         ValueExprAst::Field(path) => {
             let field = value_field_of(resolve_field(path).expect("typechecked"))
                 .expect("typechecked: u32 field operand");
             ValueExpr::Field(field)
         }
         ValueExprAst::Binary { op, lhs, rhs, .. } => {
-            let lhs = lower_value(lhs, env);
-            let rhs = lower_value(rhs, env);
+            let lhs = lower_value(lhs, env, lets);
+            let rhs = lower_value(rhs, env, lets);
             if let (ValueExpr::Const(l), ValueExpr::Const(r)) = (&lhs, &rhs)
                 && let Ok(folded) = checked_arith(*op, *l, *r)
             {
@@ -705,7 +865,8 @@ fn lower_value(expr: &ValueExprAst, env: &HashMap<&str, u32>) -> ValueExpr {
             }
         }
         ValueExprAst::Call { name, args, .. } => {
-            let mut args: Vec<ValueExpr> = args.iter().map(|arg| lower_value(arg, env)).collect();
+            let mut args: Vec<ValueExpr> =
+                args.iter().map(|arg| lower_value(arg, env, lets)).collect();
             let consts: Vec<Option<u32>> = args
                 .iter()
                 .map(|arg| match arg {
@@ -818,6 +979,12 @@ fn accept_predicate(policy: &CompiledPolicy) -> MatchExpr {
     for term in &policy.terms {
         match term.action {
             TermAction::Continue(_) => {}
+            // LAN-302: the typechecker rejects `apply` of a policy
+            // that declares bindings, so an inlined predicate never
+            // contains Bind terms.
+            TermAction::Bind { .. } => {
+                unreachable!("typechecked: apply targets declare no `let` bindings")
+            }
             TermAction::Permit(_) => {
                 let mut children = not_prior.clone();
                 children.push(term.guard.clone());

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -681,10 +681,26 @@ impl Parser<'_> {
                 let span = token.span.to(count.span());
                 Ok(ActionStmt::Prepend { asn, count, span })
             }
+            // Statement-initial contextual `let` (LAN-302, ADR-0103
+            // Decision 2.2): no other statement begins with a bare
+            // identifier, so consuming `let` here is purely additive —
+            // sets, policies, and parameters named `let` keep working.
+            Tok::Ident if self.text(token) == "let" => self.let_stmt(),
             _ => Err(self.error_expected(
-                "an action (`accept`, `reject`, `set`, `add`, `remove`, or `prepend`)",
+                "an action (`accept`, `reject`, `set`, `add`, `remove`, `prepend`) or `let`",
             )),
         }
+    }
+
+    /// `let <name> = <value expression>` (LAN-302); the caller has
+    /// peeked the contextual `let` identifier.
+    fn let_stmt(&mut self) -> PResult<ActionStmt> {
+        let start = self.bump().expect("caller peeked `let`").span;
+        let name = self.expect_ident("a binding name")?;
+        self.expect(Tok::Eq, "`=` (`let <name> = <value expression>`)")?;
+        let init = self.value_expr(0)?;
+        let span = start.to(init.span());
+        Ok(ActionStmt::Let { name, init, span })
     }
 
     // ── expressions ─────────────────────────────────────────────────
@@ -744,8 +760,22 @@ impl Parser<'_> {
         if self.at(Tok::RouteKw) || self.at(Tok::PeerKw) {
             return self.predicate_expr();
         }
+        // LAN-302: an identifier-initial condition is a value
+        // comparison whose left side starts with a binding, parameter,
+        // or builtin call (`if penalty >= route.med`). Previously a
+        // parse error here, so purely additive.
+        if self.at(Tok::Ident) {
+            let name = self.expect_ident("a condition")?;
+            let atom = if self.at(Tok::LParen) {
+                self.value_call(name, depth)?
+            } else {
+                ValueExprAst::Ident(name)
+            };
+            let lhs = self.value_expr_from_atom(atom)?;
+            return self.value_cmp_tail(lhs);
+        }
         Err(self.error_expected(
-            "a condition (`route.<field> ...`, `peer.<field> ...`, `apply(...)`, `!`, or `(`)",
+            "a condition (`route.<field> ...`, `peer.<field> ...`, `apply(...)`, a value comparison, `!`, or `(`)",
         ))
     }
 

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -471,7 +471,7 @@ fn unknown_parameter_suggests() {
     let (_, rendered) =
         diagnostics_of("policy p(peer_lp: u32) { term t { set local-pref peer_pl; accept } }");
     assert!(
-        rendered.contains("unknown parameter `peer_pl`"),
+        rendered.contains("unknown parameter or binding `peer_pl`"),
         "{rendered}"
     );
     assert!(rendered.contains("did you mean `peer_lp`?"), "{rendered}");
@@ -1616,7 +1616,7 @@ fn prepend_ctx(peer_asn: Option<u32>, origin_asn: Option<u32>) -> RouteContext<'
 fn first_term_mods(chain: &crate::ir::CompiledChain) -> &RouteModifications {
     match &chain.policies[0].terms[0].action {
         TermAction::Permit(mods) | TermAction::Continue(mods) => mods,
-        TermAction::Deny => panic!("expected a modifying term"),
+        TermAction::Deny | TermAction::Bind { .. } => panic!("expected a modifying term"),
     }
 }
 
@@ -2201,7 +2201,7 @@ fn value_expression_type_diagnostics() {
     let (_, rendered) =
         diagnostics_of("policy p { term t { set med route.med + peer_lp; accept } }");
     assert!(
-        rendered.contains("unknown parameter `peer_lp`"),
+        rendered.contains("unknown parameter or binding `peer_lp`"),
         "{rendered}"
     );
 }
@@ -2366,5 +2366,588 @@ test builtin-passes-middle {
 "#;
     let report = run_rpol_tests(source).expect("compiles cleanly");
     assert_eq!(report.total, 10);
+    assert!(report.all_passed(), "failures: {:?}", report.failures);
+}
+
+// ── `let` bindings (LAN-302) ───────────────────────────────────────
+
+/// The issue's surface example: term-body `let`s lower to Bind terms
+/// with sequential slots, are readable in guards (including as the
+/// LEFT side of a comparison) and in `set` value expressions, and the
+/// policy evaluates them per route.
+#[test]
+fn let_bindings_lower_to_bind_terms_and_evaluate() {
+    let chain = compile_ok(
+        "policy p {
+            term score {
+                let origin = route.origin-as
+                let penalty = route.as-path.len * 10
+                if penalty >= route.med { reject }
+                if origin == 64500 { set med penalty; accept }
+            }
+            term rest { accept }
+         }",
+    );
+
+    // IR shape: two Bind terms, slots 0 and 1, guarded by True.
+    let terms = &chain.policies[0].terms;
+    let binds: Vec<(u8, &str)> = terms
+        .iter()
+        .filter_map(|term| match &term.action {
+            TermAction::Bind { slot, name, .. } => Some((*slot, &**name)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(binds, vec![(0, "origin"), (1, "penalty")]);
+
+    // Route: origin 64500, path len 2 → penalty 20, med 100 → accept
+    // with med 20 (a binding read inside a body's set expression).
+    let mut ctx = absent_ctx();
+    ctx.as_path_len = 2;
+    ctx.origin_asn = Some(64500);
+    ctx.med = Some(100);
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(20));
+
+    // Route: med 5 → penalty 20 >= 5 → reject.
+    ctx.med = Some(5);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+}
+
+/// Deterministic shadowing: a `let` may shadow a parameter and an
+/// outer binding; the innermost declaration wins in value positions,
+/// and initializers read the scope *before* their own declaration.
+#[test]
+fn let_shadows_parameters_and_outer_bindings() {
+    let mut store = SetStore::new();
+    let file = super::RpolFile::parse(
+        "policy p(x: u32) {
+            term t {
+                let x = x + 1
+                let x = x * 2
+                if route.med >= 1 { let x = x + 100; set med x; set local-pref x }
+                accept
+            }
+         }",
+    )
+    .expect("compiles");
+    let chain = file.compile_policy("p", &[10], &mut store).expect("policy");
+    let mut ctx = absent_ctx();
+    ctx.med = Some(1);
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    // param 10 → +1 = 11 → *2 = 22 → body +100 = 122.
+    assert_eq!(result.modifications.set_med, Some(122));
+    assert_eq!(result.modifications.set_local_pref, Some(122));
+}
+
+/// Shadowing a contextual identifier is position-typed (the #764
+/// `origin` precedent): `let origin` wins in value positions while
+/// `prepend as origin` keeps its computed-operand meaning.
+#[test]
+fn let_origin_shadows_only_value_positions() {
+    let chain = compile_ok(
+        "policy p {
+            term t {
+                let origin = 7
+                set med origin
+                prepend as origin 2
+                accept
+            }
+         }",
+    );
+    let mut ctx = absent_ctx();
+    ctx.origin_asn = Some(64496);
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(
+        result.modifications.set_med,
+        Some(7),
+        "value position: the binding"
+    );
+    assert_eq!(
+        result.modifications.as_path_prepend,
+        Some((64496, 2)),
+        "operand position: the route's origin AS"
+    );
+}
+
+/// Branch visibility: a `let` inside an `if` (or `else`) body is not
+/// visible outside it — afterwards in the term, or in the other branch.
+#[test]
+fn branch_locals_are_scoped_to_their_body() {
+    let (_, rendered) = diagnostics_of(
+        "policy p { term t { if route.med >= 10 { let x = 1; set med x } set local-pref x; accept } }",
+    );
+    assert!(
+        rendered.contains("unknown parameter or binding `x`"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of(
+        "policy p { term t { if route.med >= 10 { let x = 1 } else { set med x } accept } }",
+    );
+    assert!(
+        rendered.contains("unknown parameter or binding `x`"),
+        "{rendered}"
+    );
+
+    // And bindings never cross terms.
+    let (_, rendered) =
+        diagnostics_of("policy p { term a { let x = 1 } term b { set med x; accept } }");
+    assert!(
+        rendered.contains("unknown parameter or binding `x`"),
+        "{rendered}"
+    );
+}
+
+/// Definite assignment: use before definition is a compile error at
+/// the use's span, not a runtime zero.
+#[test]
+fn use_before_definition_is_a_compile_error() {
+    let (diags, rendered) = diagnostics_of("policy p { term t { set med y; let y = 5; accept } }");
+    assert!(
+        rendered.contains("unknown parameter or binding `y`"),
+        "{rendered}"
+    );
+    assert!(!diags.0.is_empty());
+}
+
+/// The `MAX_LOCALS` boundary: 64 bindings in one scope compile; the
+/// 65th is rejected with a span. A term scope plus a full body scope
+/// (64 + 64 = the whole frame) still compiles and evaluates.
+#[test]
+fn slot_exhaustion_at_the_limit_boundary() {
+    let lets = |n: usize| -> String {
+        (0..n).fold(String::new(), |mut src, i| {
+            use std::fmt::Write as _;
+            let _ = write!(src, "let v{i} = {i}; ");
+            src
+        })
+    };
+
+    let ok = format!(
+        "policy p {{ term t {{ {} set med v63; accept }} }}",
+        lets(64)
+    );
+    let chain = compile_ok(&ok);
+    let result = chain.evaluate(&absent_ctx());
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(63));
+
+    let over = format!("policy p {{ term t {{ {} accept }} }}", lets(65));
+    let mut store = SetStore::new();
+    let diags = compile_rpol(&over, &mut store).expect_err("65th binding rejected");
+    let rendered = diags.render("test.rpol", &over, false);
+    assert!(
+        rendered.contains("more than 64 `let` bindings in one scope"),
+        "{rendered}"
+    );
+    // Exactly one diagnostic: the cap fires once, at the 65th.
+    assert_eq!(diags.0.len(), 1, "{rendered}");
+
+    // Both nesting levels full: 64 term-scope + 64 body-scope bindings
+    // fit the 128-slot frame exactly.
+    let full = format!(
+        "policy p {{ term t {{ {} if route.med >= 0 {{ {} set med b63 }} set local-pref v63; accept }} }}",
+        lets(64),
+        (0..64).fold(String::new(), |mut src, i| {
+            use std::fmt::Write as _;
+            let _ = write!(src, "let b{i} = v63 + {i}; ");
+            src
+        }),
+    );
+    let chain = compile_ok(&full);
+    let result = chain.evaluate(&absent_ctx());
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(63 + 63));
+    assert_eq!(result.modifications.set_local_pref, Some(63));
+}
+
+/// Initializers ride the LAN-299 eval-error rails: a checked-arithmetic
+/// failure (or absent operand) in a `let` initializer is the same
+/// uniform Deny — staged modifications discarded, error counter
+/// bumped — whether or not the binding is ever read.
+#[test]
+fn initializer_errors_deny_and_discard_staged_mods() {
+    use crate::eval::PolicyHitCounters;
+
+    let chain = compile_ok(
+        "policy p {
+            term t {
+                set local-pref 500
+                let x = route.med - 100
+                set med x
+                accept
+            }
+         }",
+    );
+    let counters = PolicyHitCounters::for_chain(&chain);
+
+    // med 200: x = 100, everything applies.
+    let mut ctx = absent_ctx();
+    ctx.med = Some(200);
+    let result = chain.evaluate_counting(&ctx, &counters);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_local_pref, Some(500));
+    assert_eq!(result.modifications.set_med, Some(100));
+    assert_eq!(counters.eval_errors(), 0);
+
+    // med 5: `5 - 100` underflows in the initializer → uniform Deny,
+    // the staged local-pref discarded, counter bumped.
+    ctx.med = Some(5);
+    let result = chain.evaluate_counting(&ctx, &counters);
+    assert_eq!(result.action, PolicyAction::Deny);
+    assert!(result.modifications.is_empty(), "staged mods discarded");
+    assert_eq!(counters.eval_errors(), 1);
+
+    // The recording walk (dry runs) agrees.
+    let mut hits = chain.zero_term_hits();
+    let recorded = chain.evaluate_recording_hits(&ctx, &mut hits);
+    assert_eq!(recorded.action, PolicyAction::Deny);
+    assert!(recorded.modifications.is_empty());
+
+    // An initializer that never reads its binding still errors: eager,
+    // not lazy (an unused erroring binding denies).
+    let chain = compile_ok(
+        "policy p { term t { let unused = route.origin-as; accept } term rest { accept } }",
+    );
+    let ctx = absent_ctx(); // no origin → absent operand
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+}
+
+/// A `let` executes at its statement position: a decision *before* it
+/// short-circuits the walk and the initializer never runs.
+#[test]
+fn let_after_a_decision_never_evaluates() {
+    let chain = compile_ok(
+        "policy p {
+            term t {
+                if route.med >= 100 { accept }
+                let x = route.origin-as
+                if x == 1 { reject }
+                accept
+            }
+         }",
+    );
+    // med 200, absent origin: decided before the let → no error.
+    let mut ctx = absent_ctx();
+    ctx.med = Some(200);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Permit);
+    // med 5, absent origin: the let runs and errors → Deny.
+    ctx.med = Some(5);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+    // Same rule inside a branch: an untaken branch's binding never
+    // evaluates; a taken branch's binding evaluates even if unused.
+    let chain =
+        compile_ok("policy p { term t { if route.med >= 10 { let x = route.origin-as } accept } }");
+    let mut ctx = absent_ctx();
+    ctx.med = Some(5);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Permit);
+    ctx.med = Some(20);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+}
+
+/// The staged-mutation pin from the issue: reads always observe the
+/// ORIGINAL route — `set med 500` stages, and a following
+/// `let x = route.med` still sees the pre-staging MED. Read-back is
+/// out of scope (it breaks memoization; needs its own ADR).
+#[test]
+fn reads_see_the_original_route_never_staged_writes() {
+    let chain = compile_ok(
+        "policy p {
+            term t {
+                set med 500
+                let x = route.med
+                if x >= 500 { reject }
+                set local-pref x
+                accept
+            }
+         }",
+    );
+    let mut ctx = absent_ctx();
+    ctx.med = Some(7);
+    let result = chain.evaluate(&ctx);
+    // If reads observed staged writes, x would be 500 and the route
+    // would have been rejected.
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(500));
+    assert_eq!(
+        result.modifications.set_local_pref,
+        Some(7),
+        "x = original med"
+    );
+}
+
+/// Reload determinism (ADR-0103 Decision 5): compiling the same source
+/// twice yields structurally identical chains — term split, slot
+/// assignment, everything the live-impact planner diffs.
+#[test]
+fn identical_source_compiles_to_identical_ir() {
+    let source = "policy p {
+        term t {
+            let a = route.med + 1
+            if route.as-path.len >= 2 { let b = a * 2; set med b }
+            if route.as-path.len <= 1 { let c = a + 3; set med c }
+            set local-pref a
+            accept
+        }
+     }";
+    assert_eq!(compile_ok(source), compile_ok(source));
+}
+
+/// Parity: factoring a repeated subexpression through a `let`
+/// evaluates identically to the fully inlined form, across verdicts
+/// and modifications.
+#[test]
+fn let_parity_with_inlined_form() {
+    let with_let = compile_ok(
+        "policy p {
+            term t {
+                let penalty = route.as-path.len * 10
+                if penalty >= route.med { reject }
+                if penalty <= 20 { set med penalty; accept }
+            }
+            term rest { accept }
+         }",
+    );
+    let inlined = compile_ok(
+        "policy p {
+            term t {
+                if route.as-path.len * 10 >= route.med { reject }
+                if route.as-path.len * 10 <= 20 { set med route.as-path.len * 10; accept }
+            }
+            term rest { accept }
+         }",
+    );
+    for len in [0usize, 1, 2, 3, 9] {
+        for med in [0u32, 5, 20, 21, 100] {
+            let mut ctx = absent_ctx();
+            ctx.as_path_len = len;
+            ctx.med = Some(med);
+            assert_eq!(
+                with_let.evaluate(&ctx),
+                inlined.evaluate(&ctx),
+                "len {len} med {med}"
+            );
+        }
+    }
+}
+
+/// `apply` targets may not declare bindings this slice: the target
+/// inlines as a pure predicate with no term walk to execute Bind
+/// terms in (LAN-304 `fn` is the composition vehicle).
+#[test]
+fn apply_of_a_let_policy_is_rejected() {
+    let (_, rendered) = diagnostics_of(
+        "policy uses-let { term t { let x = 1; if route.med >= x { accept } } term rest { reject } }
+         policy outer { term t { if apply(uses-let) { accept } } }",
+    );
+    assert!(
+        rendered.contains("cannot `apply` policy `uses-let`: it declares `let` bindings"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("first `let` is here"), "{rendered}");
+}
+
+/// Bindings are runtime values: compile-time-constant positions
+/// (prepend arguments, `apply` args, `contains`) reject them with a
+/// dedicated diagnostic, not "unknown parameter".
+#[test]
+fn let_in_const_position_is_rejected() {
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { let x = 3; prepend as 65001 x; accept } }");
+    assert!(
+        rendered.contains("prepend count must be a literal"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of("policy p { term t { let x = 3; prepend as x 2; accept } }");
+    assert!(rendered.contains("`x` is a `let` binding"), "{rendered}");
+    assert!(rendered.contains("literal or parameter"), "{rendered}");
+
+    // Enum positions are position-typed: the member spelling wins and
+    // a non-member binding name is a type error, never a u32 read.
+    let (_, rendered) =
+        diagnostics_of("policy p { term t { let x = 1; if route.rpki == x { reject } accept } }");
+    assert!(
+        rendered.contains("`x` is a u32 `let` binding; `route.rpki` is an enum field"),
+        "{rendered}"
+    );
+}
+
+/// A binding read on the RIGHT of a plain u32-field comparison lowers
+/// to the checked value-comparison node — fail-closed absent-operand
+/// semantics, like every computed form.
+#[test]
+fn cmp_against_a_binding_lowers_to_value_cmp() {
+    let chain = compile_ok(
+        "policy p { term t { let x = 64500; if route.origin-as == x { reject } } term rest { accept } }",
+    );
+    // The guard is a ValueCmp, not an OriginAsEq scalar node.
+    assert!(
+        chain.policies[0].terms.iter().any(|term| matches!(
+            &term.guard,
+            crate::ir::MatchExpr::ValueCmp(node)
+                if matches!(node.rhs, crate::ir::ValueExpr::Local { slot: 0, .. })
+        )),
+        "expected a ValueCmp guard reading slot 0"
+    );
+    // Present origin: matches → reject.
+    let mut ctx = absent_ctx();
+    ctx.origin_asn = Some(64500);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+    // Absent origin: computed form denies (eval error), unlike the
+    // never-match scalar node.
+    assert_eq!(chain.evaluate(&absent_ctx()).action, PolicyAction::Deny);
+}
+
+/// `peer.asn` in a `let` initializer reads peer identity — the chain
+/// must disqualify update-group sharing even if the value is unused.
+/// Bindings over route fields alone never do.
+#[test]
+fn peer_asn_initializer_registers_peer_context() {
+    let peer = compile_ok("policy p { term t { let a = peer.asn; accept } }");
+    assert!(peer.requires_peer_context());
+
+    let route_only = compile_ok("policy p { term t { let a = route.med + 1; set med a; accept } }");
+    assert!(!route_only.requires_peer_context());
+}
+
+/// Explain traces render Bind terms in source form, resolve binding
+/// reads in modification lines, and agree with the live verdict —
+/// including on initializer errors.
+#[test]
+fn let_explain_renders_and_agrees() {
+    use crate::engine::PolicyChain;
+    use crate::engine::explain::explain_chain_statements;
+
+    let compiled = compile_ok(
+        "policy p {
+            term t {
+                let x = route.med + 1
+                set med x
+                accept
+            }
+         }",
+    );
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+    let mut ctx = absent_ctx();
+    ctx.med = Some(7);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, chain.evaluate(&ctx).action);
+    assert_eq!(trace.action, PolicyAction::Permit);
+    let step = &trace.steps[0];
+    assert!(
+        step.term_traces
+            .iter()
+            .any(|line| line.contains("let x = route.med + 1")),
+        "{:?}",
+        step.term_traces
+    );
+    assert!(
+        step.modifications
+            .iter()
+            .any(|line| line.contains("med 7 -> x = 8")),
+        "{:?}",
+        step.modifications
+    );
+
+    // An erroring initializer renders the error in place of a verdict
+    // and the trace verdict agrees with the live Deny.
+    let compiled =
+        compile_ok("policy p { term t { let x = route.med - 100; accept } term rest { accept } }");
+    let chain = PolicyChain::from_named(vec![crate::NamedPolicy::from_rpol(
+        "p".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+    let mut ctx = absent_ctx();
+    ctx.med = Some(5);
+    let trace = explain_chain_statements(Some(&chain), &ctx);
+    assert_eq!(trace.action, chain.evaluate(&ctx).action);
+    assert_eq!(trace.action, PolicyAction::Deny);
+    assert!(
+        trace.steps[0].term_traces.iter().any(|line| line
+            .contains("evaluation error: arithmetic underflow")
+            && line.contains("fail closed")),
+        "{:?}",
+        trace.steps[0].term_traces
+    );
+}
+
+/// `let` is contextual, not reserved (ADR-0103 Decision 2.2): sets and
+/// parameters named `let` keep working.
+#[test]
+fn let_is_not_a_reserved_word() {
+    let chain = compile_ok(
+        "asn-set let { 64500 }
+         policy p(let: u32) {
+            term t { if route.med >= let { reject } }
+            term o { if route.origin-as in let { reject } }
+            term rest { accept }
+         }",
+    );
+    // Zero-parameter chain skips the parameterized policy; the file
+    // still typechecks and the set named `let` interned.
+    assert_eq!(chain.asn_set_names[0].as_deref(), Some("let"));
+}
+
+/// In-language `test` fixtures exercise let-heavy policies end to end
+/// through `rbgp policy check`.
+#[test]
+fn in_language_tests_cover_let_bindings() {
+    let source = r#"
+policy dampen {
+    term score {
+        let penalty = route.as-path.len * 10
+        if penalty >= route.med { reject }
+        set med penalty
+        accept
+    }
+}
+policy shadow(base: u32) {
+    term t {
+        let base = base + 1
+        if route.med >= 1 { let base = base * 2; set local-pref base; accept }
+        set local-pref base
+        accept
+    }
+}
+policy eager-error {
+    term t { let x = route.origin-as; accept }
+    term rest { accept }
+}
+
+test dampen-rejects-long-paths {
+    route { as-path "65001 65002 65003"; med 25 }
+    expect dampen == reject
+}
+
+test dampen-scores-short-paths {
+    route { as-path "65001 65002"; med 100 }
+    expect dampen == accept with med 20
+}
+
+test shadow-inner-binding-wins {
+    route { med 5 }
+    expect shadow(10) == accept with local-pref 22
+}
+
+test shadow-outer-binding-on-fallthrough {
+    route { }
+    expect shadow(10) == accept with local-pref 11
+}
+
+test absent-origin-initializer-denies {
+    route { as-path "{64500 64501}" }
+    expect eager-error == reject
+}
+"#;
+    let report = run_rpol_tests(source).expect("compiles cleanly");
+    assert_eq!(report.total, 5);
     assert!(report.all_passed(), "failures: {:?}", report.failures);
 }

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -103,6 +103,38 @@ const MAX_EVAL_COST: u64 = 1_000_000;
 /// The value-expression builtins (LAN-299) and their arities.
 const VALUE_BUILTINS: &[(&str, usize)] = &[("min", 2), ("max", 2), ("clamp", 3)];
 
+/// Maximum `let` bindings per lexical scope (LAN-302, ADR-0103
+/// Decision 3). A scope is one term body or one `if`/`else` body; the
+/// grammar has exactly those two nesting levels, so the evaluation
+/// frame is statically `2 × MAX_LOCALS` slots
+/// (`crate::eval::LOCAL_FRAME_SLOTS`) — no runtime growth, ever.
+const MAX_LOCALS: usize = 64;
+
+/// Name-resolution scope for one policy body (LAN-302): the declared
+/// parameters plus the `let` bindings currently visible, in
+/// declaration order. Lookup is by reverse scan, so the innermost
+/// declaration wins — deterministic shadowing of outer bindings and
+/// of parameters. Bindings are visible only in **value positions**
+/// (comparison operands, `set local-pref`/`set med` expressions);
+/// position-typed identifiers — enum members, `origin` in
+/// `prepend as`, builtin call names — resolve exactly as before, the
+/// same per-position rule that lets a parameter named `origin` keep
+/// its meaning (LAN-296).
+struct Scope<'a> {
+    params: Vec<&'a str>,
+    lets: Vec<String>,
+}
+
+impl Scope<'_> {
+    fn is_param(&self, name: &str) -> bool {
+        self.params.contains(&name)
+    }
+
+    fn is_local(&self, name: &str) -> bool {
+        self.lets.iter().any(|local| local == name)
+    }
+}
+
 /// Enum members per enum-typed field, in language spelling.
 pub(super) const RPKI_MEMBERS: &[&str] = &["valid", "invalid", "not-found"];
 pub(super) const ASPA_MEMBERS: &[&str] = &["valid", "invalid", "unknown"];
@@ -239,8 +271,15 @@ impl Checker<'_> {
     fn check_policy(&mut self, policy: &PolicyDef) {
         self.duplicate_check("parameter", policy.params.iter());
         self.duplicate_check("term", policy.terms.iter().map(|t| &t.name));
-        let params: Vec<&str> = policy.params.iter().map(|p| p.node.as_str()).collect();
+        let mut scope = Scope {
+            params: policy.params.iter().map(|p| p.node.as_str()).collect(),
+            lets: Vec::new(),
+        };
         for term in &policy.terms {
+            // Each term body is its own scope: bindings never cross
+            // terms (LAN-302).
+            scope.lets.clear();
+            let mut term_locals = 0usize;
             let mut terminated: Option<Span> = None;
             for stmt in &term.stmts {
                 if let Some(verdict_span) = terminated {
@@ -259,17 +298,29 @@ impl Checker<'_> {
                     break;
                 }
                 match stmt {
+                    // A term-body `let`: check the initializer against
+                    // the scope *before* declaring (so `let x = x + 1`
+                    // reads the outer/prior `x`), then bring the name
+                    // into scope for everything after it.
+                    Stmt::Action(ActionStmt::Let { name, init, .. }) => {
+                        self.check_value_expr(init, &scope);
+                        if term_locals == MAX_LOCALS {
+                            self.locals_exceeded(name.span);
+                        }
+                        term_locals += 1;
+                        scope.lets.push(name.node.clone());
+                    }
                     Stmt::Action(action) => {
-                        self.check_action(action, &params);
+                        self.check_action(action, &scope);
                         if matches!(action, ActionStmt::Accept(_) | ActionStmt::Reject(_)) {
                             terminated = Some(action.span());
                         }
                     }
                     Stmt::If(if_stmt) => {
-                        self.check_expr(&if_stmt.cond, &params);
-                        self.check_action_list(&if_stmt.then_actions, &params);
+                        self.check_expr(&if_stmt.cond, &scope);
+                        self.check_action_list(&if_stmt.then_actions, &mut scope);
                         if let Some(else_actions) = &if_stmt.else_actions {
-                            self.check_action_list(else_actions, &params);
+                            self.check_action_list(else_actions, &mut scope);
                         }
                     }
                 }
@@ -277,7 +328,12 @@ impl Checker<'_> {
         }
     }
 
-    fn check_action_list(&mut self, actions: &[ActionStmt], params: &[&str]) {
+    /// One `if`/`else` body — its own lexical scope (LAN-302): `let`
+    /// bindings declared here are visible to the rest of the body and
+    /// nowhere else.
+    fn check_action_list(&mut self, actions: &[ActionStmt], scope: &mut Scope) {
+        let mark = scope.lets.len();
+        let mut body_locals = 0usize;
         let mut terminated: Option<Span> = None;
         for action in actions {
             if let Some(verdict_span) = terminated {
@@ -291,18 +347,45 @@ impl Checker<'_> {
                 );
                 break;
             }
-            self.check_action(action, params);
+            if let ActionStmt::Let { name, init, .. } = action {
+                self.check_value_expr(init, scope);
+                if body_locals == MAX_LOCALS {
+                    self.locals_exceeded(name.span);
+                }
+                body_locals += 1;
+                scope.lets.push(name.node.clone());
+                continue;
+            }
+            self.check_action(action, scope);
             if matches!(action, ActionStmt::Accept(_) | ActionStmt::Reject(_)) {
                 terminated = Some(action.span());
             }
         }
+        scope.lets.truncate(mark);
     }
 
-    fn check_action(&mut self, action: &ActionStmt, params: &[&str]) {
+    /// The 65th `let` of one scope (LAN-302, `MAX_LOCALS`): fires once,
+    /// at the first binding past the limit.
+    fn locals_exceeded(&mut self, span: Span) {
+        self.diags.push(
+            Diagnostic::new(
+                span,
+                format!("more than {MAX_LOCALS} `let` bindings in one scope"),
+                "binding limit exceeded",
+            )
+            .with_note(
+                "bindings compile to a fixed frame of 64 slots per scope (ADR-0103); \
+                 split the term or fold intermediate values",
+            ),
+        );
+    }
+
+    fn check_action(&mut self, action: &ActionStmt, scope: &Scope<'_>) {
         match action {
             ActionStmt::Accept(_) | ActionStmt::Reject(_) | ActionStmt::SetNextHop(..) => {}
+            ActionStmt::Let { .. } => unreachable!("`let` is scoped by the statement walkers"),
             ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => {
-                self.check_value_expr(expr, params);
+                self.check_value_expr(expr, scope);
             }
             ActionStmt::Community { kind, lit, .. } => {
                 if lit.node.kind() != *kind {
@@ -326,11 +409,14 @@ impl Checker<'_> {
                 // identifier that is not a declared parameter —
                 // LAN-296) needs no parameter check; the operand
                 // decision itself is shared with lowering via
-                // `PrependAsArg::operand`.
-                if asn.operand(|name| params.contains(&name)).is_none()
+                // `PrependAsArg::operand`. `let` bindings deliberately
+                // do not resolve here: this is not a value position
+                // (LAN-302 scoping rule), so `prepend as origin` keeps
+                // its operand meaning even under a `let origin`.
+                if asn.operand(|name| scope.is_param(name)).is_none()
                     && let PrependAsArg::Value(arg) = asn
                 {
-                    self.check_u32_arg(arg, params);
+                    self.check_u32_arg(arg, scope);
                 }
                 match count {
                     U32Arg::Lit(value, span) => {
@@ -357,17 +443,20 @@ impl Checker<'_> {
     }
 
     /// Typecheck a value expression (LAN-299): operands must be u32 —
-    /// literals, declared parameters, u32-typed fields — builtins must
-    /// be `min`/`max`/`clamp` with the right arity, and every
-    /// statically-evaluable subexpression must evaluate cleanly under
-    /// checked arithmetic (`4294967295 + 1` is a compile error at its
-    /// span, not a per-route runtime error).
-    fn check_value_expr(&mut self, expr: &ValueExprAst, params: &[&str]) {
+    /// literals, declared parameters, `let` bindings (LAN-302),
+    /// u32-typed fields — builtins must be `min`/`max`/`clamp` with
+    /// the right arity, and every statically-evaluable subexpression
+    /// must evaluate cleanly under checked arithmetic (`4294967295 +
+    /// 1` is a compile error at its span, not a per-route runtime
+    /// error).
+    fn check_value_expr(&mut self, expr: &ValueExprAst, scope: &Scope<'_>) {
         match expr {
             ValueExprAst::Lit(..) => {}
-            ValueExprAst::Ident(name) => {
-                self.check_u32_arg(&U32Arg::Param(name.clone()), params);
-            }
+            // A bare identifier in a value position resolves innermost
+            // `let` first, then parameters (LAN-302 shadowing). A name
+            // followed by `(` is a builtin call (the `Call` arm), the
+            // same per-position rule parameters already follow.
+            ValueExprAst::Ident(name) => self.check_value_ident(name, scope),
             ValueExprAst::Field(path) => match resolve_field(path) {
                 Err(diag) => self.diags.push(diag),
                 Ok(resolved) => {
@@ -387,8 +476,8 @@ impl Checker<'_> {
                 }
             },
             ValueExprAst::Binary { op, lhs, rhs, span } => {
-                self.check_value_expr(lhs, params);
-                self.check_value_expr(rhs, params);
+                self.check_value_expr(lhs, scope);
+                self.check_value_expr(rhs, scope);
                 // Constant folding diagnostic, reported at the
                 // smallest failing subexpression: both children fold
                 // cleanly, this operator fails.
@@ -404,7 +493,7 @@ impl Checker<'_> {
             }
             ValueExprAst::Call { name, args, span } => {
                 for arg in args {
-                    self.check_value_expr(arg, params);
+                    self.check_value_expr(arg, scope);
                 }
                 let Some(&(_, arity)) = VALUE_BUILTINS
                     .iter()
@@ -457,20 +546,60 @@ impl Checker<'_> {
         }
     }
 
-    fn check_u32_arg(&mut self, arg: &U32Arg, params: &[&str]) {
-        if let U32Arg::Param(name) = arg
-            && !params.contains(&name.node.as_str())
-        {
-            let mut diag = Diagnostic::new(
-                name.span,
-                format!("unknown parameter `{}`", name.node),
-                "not a parameter of this policy",
-            );
-            if let Some(suggestion) = closest(&name.node, params.iter().copied()) {
-                diag = diag.with_note(format!("did you mean `{suggestion}`?"));
-            }
-            self.diags.push(diag);
+    /// A bare identifier in a value position (LAN-302): innermost
+    /// `let` binding, else parameter, else a spanned unknown-name
+    /// diagnostic suggesting across both.
+    fn check_value_ident(&mut self, name: &Spanned<String>, scope: &Scope<'_>) {
+        if scope.is_local(&name.node) || scope.is_param(&name.node) {
+            return;
         }
+        let mut diag = Diagnostic::new(
+            name.span,
+            format!("unknown parameter or binding `{}`", name.node),
+            "not a parameter or `let` binding in scope",
+        );
+        if let Some(suggestion) = closest(
+            &name.node,
+            scope
+                .params
+                .iter()
+                .copied()
+                .chain(scope.lets.iter().map(String::as_str)),
+        ) {
+            diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+        }
+        self.diags.push(diag);
+    }
+
+    /// A compile-time-constant u32 position (prepend operands/counts,
+    /// `apply` arguments, `contains` ASNs): literals and parameters
+    /// only. `let` bindings are runtime values and get a dedicated
+    /// diagnostic instead of "unknown parameter" (LAN-302).
+    fn check_u32_arg(&mut self, arg: &U32Arg, scope: &Scope<'_>) {
+        let U32Arg::Param(name) = arg else { return };
+        if scope.is_param(&name.node) {
+            return;
+        }
+        if scope.is_local(&name.node) {
+            self.diags.push(
+                Diagnostic::new(
+                    name.span,
+                    format!("`{}` is a `let` binding", name.node),
+                    "this position needs a literal or parameter",
+                )
+                .with_note("bindings are runtime values; this argument is fixed at compile time"),
+            );
+            return;
+        }
+        let mut diag = Diagnostic::new(
+            name.span,
+            format!("unknown parameter `{}`", name.node),
+            "not a parameter of this policy",
+        );
+        if let Some(suggestion) = closest(&name.node, scope.params.iter().copied()) {
+            diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+        }
+        self.diags.push(diag);
     }
 
     // ── expressions ─────────────────────────────────────────────────
@@ -479,20 +608,20 @@ impl Checker<'_> {
         clippy::too_many_lines,
         reason = "exhaustive per-field/type dispatch; splitting would scatter the match"
     )]
-    fn check_expr(&mut self, expr: &Expr, params: &[&str]) {
+    fn check_expr(&mut self, expr: &Expr, scope: &Scope<'_>) {
         match expr {
             Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
-                self.check_expr(lhs, params);
-                self.check_expr(rhs, params);
+                self.check_expr(lhs, scope);
+                self.check_expr(rhs, scope);
             }
-            Expr::Not(inner, _) => self.check_expr(inner, params),
-            Expr::Cmp { field, op, rhs, .. } => self.check_cmp(field, *op, rhs, params),
+            Expr::Not(inner, _) => self.check_expr(inner, scope),
+            Expr::Cmp { field, op, rhs, .. } => self.check_cmp(field, *op, rhs, scope),
             // LAN-299: both sides of a value comparison are u32 value
             // expressions; all four operators apply (the checked
             // evaluation model has no unordered u32 fields).
             Expr::ValueCmp { lhs, rhs, .. } => {
-                self.check_value_expr(lhs, params);
-                self.check_value_expr(rhs, params);
+                self.check_value_expr(lhs, scope);
+                self.check_value_expr(rhs, scope);
             }
             Expr::In { field, set } => self.check_in(field, set),
             Expr::Has { field, lit } => match resolve_field(field) {
@@ -547,10 +676,14 @@ impl Checker<'_> {
             }
             Expr::Contains { field, asn } => {
                 self.require_as_path(field, "contains");
-                self.check_u32_arg(asn, params);
+                self.check_u32_arg(asn, scope);
             }
             Expr::Apply { policy, args, span } => {
-                let Some(target) = self.policy(&policy.node) else {
+                // Borrow the target through the file field directly so
+                // its lifetime is independent of `self` (diagnostics
+                // below need `&mut self`).
+                let file = self.file;
+                let Some(target) = file.policies.iter().find(|p| p.name.node == policy.node) else {
                     let mut diag = Diagnostic::new(
                         policy.span,
                         format!("unknown policy `{}`", policy.node),
@@ -585,8 +718,31 @@ impl Checker<'_> {
                         .with_label(target.name.span, "policy defined here"),
                     );
                 }
+                // LAN-302: `apply` inlines its target as a pure
+                // predicate expression — there is no term walk to
+                // execute the target's `Bind` terms in, so a target
+                // that declares bindings is rejected here rather than
+                // given silently divergent semantics. LAN-304 `fn` is
+                // the designed vehicle for composing computed values.
+                if let Some(let_span) = first_let(target) {
+                    self.diags.push(
+                        Diagnostic::new(
+                            *span,
+                            format!(
+                                "cannot `apply` policy `{}`: it declares `let` bindings",
+                                policy.node
+                            ),
+                            "`apply` targets cannot use `let`",
+                        )
+                        .with_label(let_span, "first `let` is here")
+                        .with_note(
+                            "`apply` inlines the target as a pure predicate; factor the \
+                             shared value into the applying policy instead",
+                        ),
+                    );
+                }
                 for arg in args {
-                    self.check_u32_arg(arg, params);
+                    self.check_u32_arg(arg, scope);
                 }
             }
         }
@@ -604,7 +760,7 @@ impl Checker<'_> {
         }
     }
 
-    fn check_cmp(&mut self, field: &FieldPath, op: CmpOp, rhs: &Rhs, params: &[&str]) {
+    fn check_cmp(&mut self, field: &FieldPath, op: CmpOp, rhs: &Rhs, scope: &Scope<'_>) {
         let resolved = match resolve_field(field) {
             Ok(resolved) => resolved,
             Err(diag) => {
@@ -612,6 +768,9 @@ impl Checker<'_> {
                 return;
             }
         };
+        if binding_value_cmp(rhs, resolved, scope) {
+            return;
+        }
         let eq_only = |checker: &mut Self| {
             if matches!(op, CmpOp::Ge | CmpOp::Le) {
                 checker.diags.push(Diagnostic::new(
@@ -623,11 +782,11 @@ impl Checker<'_> {
         };
         match resolved {
             Field::LocalPref | Field::Med | Field::AsPathLen => {
-                self.expect_u32_rhs(field, rhs, params);
+                self.expect_u32_rhs(field, rhs, scope);
             }
             Field::PeerAsn | Field::OriginAs => {
                 eq_only(self);
-                self.expect_u32_rhs(field, rhs, params);
+                self.expect_u32_rhs(field, rhs, scope);
             }
             Field::EvpnRouteType => {
                 eq_only(self);
@@ -635,19 +794,19 @@ impl Checker<'_> {
             }
             Field::Rpki => {
                 eq_only(self);
-                self.expect_enum_rhs(field, rhs, RPKI_MEMBERS, params);
+                self.expect_enum_rhs(field, rhs, RPKI_MEMBERS, scope);
             }
             Field::Aspa => {
                 eq_only(self);
-                self.expect_enum_rhs(field, rhs, ASPA_MEMBERS, params);
+                self.expect_enum_rhs(field, rhs, ASPA_MEMBERS, scope);
             }
             Field::RouteType => {
                 eq_only(self);
-                self.expect_enum_rhs(field, rhs, ROUTE_TYPE_MEMBERS, params);
+                self.expect_enum_rhs(field, rhs, ROUTE_TYPE_MEMBERS, scope);
             }
             Field::Family => {
                 eq_only(self);
-                self.expect_enum_rhs(field, rhs, FAMILY_MEMBERS, params);
+                self.expect_enum_rhs(field, rhs, FAMILY_MEMBERS, scope);
             }
             Field::NextHop => {
                 eq_only(self);
@@ -758,11 +917,11 @@ impl Checker<'_> {
         }
     }
 
-    fn expect_u32_rhs(&mut self, field: &FieldPath, rhs: &Rhs, params: &[&str]) {
+    fn expect_u32_rhs(&mut self, field: &FieldPath, rhs: &Rhs, scope: &Scope<'_>) {
         match rhs {
             Rhs::Int(..) => {}
             Rhs::Ident(name) => {
-                self.check_u32_arg(&U32Arg::Param(name.clone()), params);
+                self.check_u32_arg(&U32Arg::Param(name.clone()), scope);
             }
             other => self
                 .diags
@@ -770,7 +929,13 @@ impl Checker<'_> {
         }
     }
 
-    fn expect_enum_rhs(&mut self, field: &FieldPath, rhs: &Rhs, members: &[&str], params: &[&str]) {
+    fn expect_enum_rhs(
+        &mut self,
+        field: &FieldPath,
+        rhs: &Rhs,
+        members: &[&str],
+        scope: &Scope<'_>,
+    ) {
         let Rhs::Ident(name) = rhs else {
             self.diags.push(type_mismatch(
                 field,
@@ -787,7 +952,13 @@ impl Checker<'_> {
             format!("`{}` is not a valid `{}` value", name.node, field.render()),
             format!("expected one of {}", member_list(members)),
         );
-        if params.contains(&name.node.as_str()) {
+        if scope.is_local(&name.node) {
+            diag = diag.with_note(format!(
+                "`{}` is a u32 `let` binding; `{}` is an enum field",
+                name.node,
+                field.render()
+            ));
+        } else if scope.is_param(&name.node) {
             diag = diag.with_note(format!(
                 "`{}` is a u32 parameter; `{}` is an enum field",
                 name.node,
@@ -1223,6 +1394,13 @@ fn bound_policy<'a>(
                         .iter()
                         .chain(if_stmt.else_actions.iter().flatten())
                     {
+                        // A body `let` (LAN-302) lowers to its own Bind
+                        // term that re-evaluates the branch guard (the
+                        // else side adds a negation) — charge one arm
+                        // per binding on top of its initializer cost.
+                        if matches!(action, ActionStmt::Let { .. }) {
+                            arms.push(cost.saturating_add(1));
+                        }
                         action_cost = action_cost.saturating_add(action_value_cost(action));
                     }
                 }
@@ -1312,14 +1490,48 @@ fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>) -> u64 {
     }
 }
 
+/// LAN-302: a `let` binding on the right of a u32-field comparison
+/// makes it a value comparison (that is what it lowers to), so all
+/// four operators apply and both sides are u32 — nothing further to
+/// check. Non-u32 fields keep their per-field diagnostics (enum
+/// members win in enum positions; bindings resolve only in value
+/// positions).
+fn binding_value_cmp(rhs: &Rhs, resolved: Field, scope: &Scope<'_>) -> bool {
+    matches!(rhs, Rhs::Ident(name)
+        if scope.is_local(&name.node) && value_field_of(resolved).is_some())
+}
+
 /// The value-expression steps an action contributes to the
 /// evaluation-cost budget (LAN-299: only the computed `set` values
-/// carry expressions; everything else is constant-time).
+/// carry expressions; everything else is constant-time. LAN-302: a
+/// `let` charges its initializer plus one slot-write step; each read
+/// already costs one step as a `value_cost` operand).
 fn action_value_cost(action: &ActionStmt) -> u64 {
     match action {
         ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => value_cost(expr),
+        ActionStmt::Let { init, .. } => value_cost(init).saturating_add(1),
         _ => 0,
     }
+}
+
+/// Span of the first `let` statement anywhere in a policy — term
+/// bodies and `if`/`else` bodies — or `None`. Backs the LAN-302
+/// `apply`-target rejection.
+fn first_let(def: &PolicyDef) -> Option<Span> {
+    fn in_actions(actions: &[ActionStmt]) -> Option<Span> {
+        actions.iter().find_map(|action| match action {
+            ActionStmt::Let { span, .. } => Some(*span),
+            _ => None,
+        })
+    }
+    def.terms.iter().find_map(|term| {
+        term.stmts.iter().find_map(|stmt| match stmt {
+            Stmt::Action(ActionStmt::Let { span, .. }) => Some(*span),
+            Stmt::Action(_) => None,
+            Stmt::If(if_stmt) => in_actions(&if_stmt.then_actions)
+                .or_else(|| if_stmt.else_actions.as_deref().and_then(in_actions)),
+        })
+    })
 }
 
 /// Worst-case evaluation steps of a value expression (LAN-299): one

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -114,7 +114,7 @@ has a known type and every operator a fixed signature.
 | Type | Values | Where |
 |---|---|---|
 | bool | guard expressions | `if` conditions |
-| u32 | integer literals, parameters | `local-pref`, `med`, `as-path.len`, `origin-as`, `peer.asn`, arguments; the only arithmetic type — all arithmetic is **checked** (overflow/underflow/division-by-zero are evaluation errors, never wraps or traps) |
+| u32 | integer literals, parameters, `let` bindings | `local-pref`, `med`, `as-path.len`, `origin-as`, `peer.asn`, arguments; the only arithmetic type — all arithmetic is **checked** (overflow/underflow/division-by-zero are evaluation errors, never wraps or traps) |
 | prefix | prefix literals | `route.prefix` |
 | community (3 kinds) | community literals | community lists, sets, actions |
 | as-path | — (matched, never named) | `route.as-path` |
@@ -184,9 +184,10 @@ policy NAME[(param: u32, ...)] {
 }
 ```
 
-- Terms evaluate in order. Statements inside a term are: bare actions,
-  or `if <expr> { actions... } [else { actions... }]`. `if` bodies are
-  flat action lists — **no nested `if`** in V1 (split the condition
+- Terms evaluate in order. Statements inside a term are: bare
+  actions, `let` bindings (see "Bindings"), or `if <expr> {
+  actions... } [else { actions... }]`. `if` bodies are flat
+  action/`let` lists — **no nested `if`** in V1 (split the condition
   with `&&` or use another term).
 - **Verdicts**: `accept` permits the route (with all modifications
   executed so far in this policy); `reject` denies it (a denied route
@@ -216,6 +217,12 @@ to one or more IR terms:
   `Continue` IR term (a small IR addition made for this frontend:
   guard matched → apply modifications → keep walking this policy's
   terms).
+- Each `let` becomes a `Bind` IR term (LAN-302): guard = the
+  enclosing branch condition (`True` in term-body position; the `if`
+  guard — or its negation for `else` — for a body binding), action =
+  evaluate the initializer and write its frame slot. Like `Continue`
+  it never decides; body bindings re-evaluate the branch guard, which
+  is pure and cannot diverge.
 - When one `.rpol` term produces multiple IR terms they are named
   `<term>.<n>` (1-based); a lone IR term keeps the plain term name.
   Explain surfaces will render these names.
@@ -276,13 +283,13 @@ prefix-set precedent).
 
 ### Value expressions — checked u32 arithmetic
 
-u32 value positions — the right side of a u32 comparison, and the
+u32 value positions — either side of a u32 comparison, and the
 `set local-pref` / `set med` arguments — accept **value expressions**
 (ADR-0103, LAN-299): arithmetic over integer literals, parameters,
-u32-typed fields (`route.local-pref`, `route.med`,
-`route.as-path.len`, `route.origin-as`, `peer.asn`), and three bounded
-builtins. A comparison's left side may also carry arithmetic when it
-starts with a field.
+`let` bindings (below), u32-typed fields (`route.local-pref`,
+`route.med`, `route.as-path.len`, `route.origin-as`, `peer.asn`), and
+three bounded builtins. A comparison's left side may also carry
+arithmetic when it starts with a field or a binding.
 
 ```rpol
 set med route.med + 50
@@ -363,6 +370,131 @@ u32 with a pinned failure contract (deny + counter + explain), and
 the `min` cap makes the local-pref doubling total instead of relying
 on it.
 
+### Bindings — `let`
+
+`let <name> = <value expression>` names a computed `u32` in statement
+position — a term body, or an `if`/`else` body (ADR-0103, LAN-302):
+
+```rpol
+policy dampen {
+    term score {
+        let origin = route.origin-as
+        let penalty = route.as-path.len * 10
+        if penalty >= route.med { reject }
+        if origin == 64500 { set med penalty; accept }
+    }
+    term rest { accept }
+}
+```
+
+`let` is a contextual identifier, not a reserved word: statement
+position admits no other bare identifier, so sets, policies, and
+parameters named `let` keep working.
+
+**Immutable, u32-only.** There is no assignment, no `var`, and no
+mutation: a binding's value is fixed by its initializer for the rest
+of its scope. Bindings hold `u32` values only this slice — the
+initializer is a value expression, so the bindable inputs are integer
+literals, parameters, other bindings, and the u32 fields
+(`route.local-pref`, `route.med`, `route.as-path.len`,
+`route.origin-as`, `peer.asn`); binding a non-u32 field is a compile
+error naming the u32 field set.
+
+**Scope and shadowing (normative).**
+
+- A term body is a scope; each `if`/`else` body is a nested scope.
+  A binding is visible from its statement to the end of its scope —
+  a term-body binding reaches into later `if` bodies of the same
+  term; a body binding is invisible outside its body. Bindings never
+  cross terms, and never escape the policy (no globals, no
+  cross-route state, no closures — the purity contract).
+- A `let` may shadow an earlier binding, including one in the same
+  scope, and a policy parameter: the **innermost declaration wins**
+  at each use. The initializer is resolved *before* its own name is
+  declared, so `let x = x + 1` reads the outer `x` — shadowing, never
+  self-reference.
+- Resolution is **position-typed**, the same rule that lets a
+  parameter named `origin` keep its meaning under `prepend as`
+  (LAN-296): bindings are readable only in value positions. Enum
+  members (`valid`, `internal`, …) still win in enum comparisons,
+  `min`/`max`/`clamp` followed by `(` are still builtin calls, and
+  `prepend as origin` still means the origin operand even with a
+  `let origin` in scope. Compile-time-constant positions (`apply`
+  arguments, prepend operands/counts, `contains`) reject bindings
+  with a dedicated diagnostic — they are runtime values.
+- **Use before definition is a compile error** at the use's span, as
+  is any unknown name (with did-you-mean suggestions over parameters
+  and visible bindings).
+
+**Evaluation is eager and fail-closed.** The initializer evaluates
+when its statement executes — reached in the term walk, branch taken —
+whether or not the value is ever read. It rides the same rails as all
+checked arithmetic (LAN-299): overflow, underflow, division/modulo by
+zero, or an absent operand (`route.origin-as` on an origin-less route,
+unknown `peer.asn`) **denies the route** — staged modifications are
+discarded, the eval-error counter increments, explain renders the
+error in place of a verdict. A statement position the walk never
+reaches (an earlier verdict decided, the branch not taken) never
+evaluates. A binding whose comparison uses a plain u32 field
+(`route.origin-as == x`) makes that comparison a *value* comparison:
+fail-closed on absent operands, unlike the never-match plain form.
+
+**Reads see the original route — never staged writes.** Route
+mutation stays transactional: `set`/`add`/`remove`/`prepend` stage
+modifications applied only after a complete successful evaluation, so
+`set med 500` followed by `let x = route.med` binds the route's MED
+*as it arrived*, not 500. Read-back of staged writes is deliberately
+out of scope (it would break the memoization contract — `ExportMemo`
+keys on source attributes plus modifications — and needs its own ADR
+if ever demanded).
+
+**Static slots, zero allocation.** Bindings compile to fixed slots in
+a 128-slot register file (two nesting levels × the 64-binding
+per-scope cap): slot assignment is a pure function of the source
+(identical source → identical compiled form, so unchanged reloads
+still diff as no-ops), sibling scopes reuse slots, and the frame is a
+lazily-materialized stack array — policies without bindings pay
+nothing, and no evaluation ever heap-allocates for bindings. The
+**65th `let` in one scope is a compile error** at its span. The cost
+DP charges each binding its initializer cost plus one slot step; each
+read costs one step, so factoring a repeated subexpression through a
+`let` is never more expensive than inlining it (and evaluates
+identically — pinned by test).
+
+**`apply` restriction.** A policy that declares `let` bindings cannot
+be a target of `apply` this slice: `apply` inlines its target as a
+pure predicate expression, which has no term walk to execute bindings
+in. The compile error points at the offending `apply` and the target's
+first `let`; factor the shared value into the applying policy, or wait
+for user functions (LAN-304), the designed vehicle for composing
+computed values.
+
+Migration example — factoring a repeated computed value:
+
+```rpol
+# Before: the padded MED is computed twice and must be kept in sync.
+policy pad-med-inline {
+    term dampen { if route.med + 50 >= 1001 { reject } }
+    term pad { set med route.med + 50; accept }
+}
+
+# After: one binding, one place to change the padding.
+policy pad-med {
+    term pad {
+        let padded = route.med + 50
+        if padded >= 1001 { reject }
+        set med padded
+        accept
+    }
+}
+```
+
+**Update-group note.** A binding whose initializer reads `peer.asn`
+reads peer identity — even if the value is never used, an unknown
+peer ASN already denies — so it keeps its peers out of shared update
+groups, exactly like a `peer.asn` guard operand. Bindings over route
+fields alone never disqualify grouping.
+
 ### `route.family` — one chain, many families
 
 `route.family` is the route's **typed** AFI/SAFI family, carried by the
@@ -411,6 +543,9 @@ Two consequences worth internalizing:
   `reject`s is constant-true under `apply`. Predicate policies should
   decide both ways (see `bogon-filter` above: match → `accept`,
   final term → `reject`).
+- A policy that declares `let` bindings cannot be applied (LAN-302):
+  the inlined predicate has no term walk to execute bindings in. The
+  compile error names the target's first `let`.
 
 ## Actions
 
@@ -541,8 +676,10 @@ asn-set-def       := "asn-set" IDENT "{" [INT ("," INT)*] "}"
 policy-def  := "policy" IDENT ["(" param ("," param)* ")"] "{" term* "}"
 param       := IDENT ":" "u32"
 term        := "term" IDENT "{" stmt* "}"
-stmt        := if-stmt | action [";"]
-if-stmt     := "if" expr "{" (action [";"])* "}" ["else" "{" (action [";"])* "}"]
+stmt        := if-stmt | let-stmt | action [";"]
+let-stmt    := "let" IDENT "=" value [";"]        # contextual `let` (LAN-302)
+if-stmt     := "if" expr "{" body-stmt* "}" ["else" "{" body-stmt* "}"]
+body-stmt   := let-stmt | action [";"]
 action      := "accept" | "reject"
              | "set" ("local-pref" | "med") value
              | "set" "next-hop" (IP | "self")
@@ -551,12 +688,13 @@ action      := "accept" | "reject"
 expr        := and ("||" and)*
 and         := unary ("&&" unary)*
 unary       := "!" unary | "(" expr ")" | "apply" "(" IDENT ["(" u32arg,* ")"] ")" | predicate
+             | IDENT [arith-tail] ("=="|"!="|">="|"<=") value     # binding/parameter LHS
 predicate   := field (("=="|"!="|">="|"<=") (rhs | value) | "in" IDENT | "has" community
              | "matches" STRING | "contains" u32arg)
              | field arith-tail ("=="|"!="|">="|"<=") value    # LHS arithmetic
 value       := mul (("+"|"-") mul)*                            # checked u32
 mul         := atom (("*"|"/"|"%") atom)*
-atom        := INT | IDENT | field | "(" value ")"
+atom        := INT | IDENT | field | "(" value ")"        # IDENT: parameter or `let` binding
              | ("min"|"max") "(" value "," value ")"
              | "clamp" "(" value "," value "," value ")"
 field       := ("route" | "peer") ("." IDENT)+
@@ -848,8 +986,10 @@ No loops, no user-defined types, no maps (safety is total by
 construction — ADR-0096 Decision 2; the ADR-0103 extension program
 adds bounded constructs slice by slice — checked arithmetic shipped
 as LAN-299). No `as-path-set`. No `else if` chains and no nested `if`
-(keep terms small; use `&&` or more terms). No `let` bindings (the
-next ADR-0103 slice). EVPN route type takes only an integer literal
+(keep terms small; use `&&` or more terms). No mutable state of any
+kind — `let` bindings (LAN-302) are immutable, and reads never
+observe staged `set` writes (read-back would break memoization and
+needs its own ADR). EVPN route type takes only an integer literal
 (no parameters — the value is wire-encoded u8). Full-form all-numeric
 IPv6 literals (use `::` compression). These are scope decisions, not
 parser accidents; each has an error message steering to the


### PR DESCRIPTION
## Summary

- second ADR-0103 Phase B slice: immutable `let` bindings in term bodies and if/else bodies, lowering to Bind IR terms so eager evaluation falls out of the existing walk — no new runtime machinery
- static slot allocation: bindings compile to fixed frame slots (128-slot stack array = 2 nesting levels x the ADR's 64-locals bound; sibling scopes reuse slots); the frame materializes lazily on the evaluator's stack, so binding-free policies pay one register argument and nothing else — zero heap allocation on any evaluation path
- shadowing is position-typed per the contextual-identifier precedent: innermost declaration wins in value positions; enum members, builtins, and the prepend `origin` operand keep their meanings; const positions reject bindings with a dedicated diagnostic; `let` itself is not a reserved word
- reads always observe the original route, never staged writes (pinned: `set med 500` then `let x = route.med` sees pre-staging MED); read-back stays excluded pending its own ADR
- initializer errors ride the LAN-299 rails unchanged: uniform Deny, staged modifications discarded, error counter, explain agreement; bindings after a decision or in untaken branches never evaluate
- `apply` targets may not declare `let` (typed diagnostic): apply inlines as a pure predicate with no term walk to execute bindings in — user functions (next slice) are the composition vehicle; documented with the scoping/shadowing rules and a migration example
- compile-time: use-before-definition and slot exhaustion are span-pinned errors (64 ok, 65 rejected); identical source compiles to identical IR/slot assignment across reloads; cost DP charges initializer + slot costs

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy (270) / -p rustbgpd-rib (717) / --bin rustbgpd policy (77)
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build + 30s live run (47k execs, no findings; 3 corpus seeds added)
- cargo bench -p rustbgpd-policy -- --test
- cargo check -p rustbgpd-rib --features bench-internals --benches

Closes LAN-302.