### PR TITLE
fix(policy): scope chain reinstallation to peers whose resolved content changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Update-group growth and residue observability.** Three new metrics
+  make the registry's append-only growth and the dirty-member
+  withdrawal residue visible before they matter:
+  `bgp_update_group_interned_chains` and `bgp_update_group_keys` track
+  the distinct export-chain contents and fingerprint keys ever created
+  (append-only for the process lifetime — the early-warning signal for
+  a deployment cycling generated policy contents), and
+  `bgp_update_group_residue_entries` tracks group tombstones plus
+  per-member pending extra withdraws, emitted at every mutation site
+  (growth and clear) and returning to zero when the resync drains a
+  dirty member. (LAN-311)
+
 - **Import-side policy hit counters readable via `rbgp policy stats`.**
   `GetPolicyStats` / `rbgp policy stats` now accept
   `--direction import|export|both`: import chains report the same
@@ -256,6 +268,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fail the build if either file is missing from an artifact. (LAN-278)
 
 ### Fixed
+
+- **Policy reinstallation is scoped to peers whose resolved chain
+  content actually moved.** SIGHUP reloads, rpol overlay swaps, catalog
+  edits, and live-impact transactions re-resolve every affected peer's
+  chains, but previously reinstalled them even when the resolved
+  content was identical (`PolicyChain` content equality — the same
+  keying the update-group registry uses). A content-equal reinstall now
+  sends nothing: the session keeps its import chain instance (no
+  install-generation bump, no term-hit counter reset on peers an
+  unrelated edit never touched) and the RIB keeps its export chain
+  instance, so a grouped peer's export term-hit counters — accumulated
+  through the group's shared staging handle — keep counting instead of
+  freezing behind a fresh snapshot instance the stats query reads.
+  Peers whose chain content did change get exactly the previous
+  behavior: session installs, RIB replacement, regroup, counter reset,
+  and Route Refresh. (LAN-311)
 
 - **Fatal RTR errors now flush the affected cache's data and emit Error
   Reports per draft-ietf-sidrops-8210bis-26, instead of retaining until

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -630,7 +630,18 @@ impl RibManager {
             return;
         }
 
-        self.peer_export_policies.insert(peer, export_policy);
+        // A content-equal replacement keeps the installed chain
+        // INSTANCE, not just the group key: an update group's staging
+        // handle shares the installed instance's ADR-0096 term-hit
+        // counters (`PolicyChain::share`), so swapping in a fresh
+        // (zeroed) content-equal instance would freeze what the
+        // term-hits query reports while evaluations keep landing on
+        // the group's old instance. The peer manager already skips
+        // content-equal reinstalls at the fan-out; this guards the
+        // seam itself for any other sender.
+        if self.peer_export_policies.get(&peer) != Some(&export_policy) {
+            self.peer_export_policies.insert(peer, export_policy);
+        }
         // Update-group membership recompute on the policy replacement
         // seam (per-peer gRPC edits, ADR-0076 live-impact txns, and
         // SIGHUP rpol overlays all funnel through this handler).
@@ -2061,6 +2072,7 @@ impl RibManager {
                                 .unicast
                                 .extend(lost);
                         }
+                        self.refresh_group_residue_gauge();
                     }
                 }
             } else {

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -834,6 +834,7 @@ impl RibManager {
                             .vpn
                             .extend(lost);
                     }
+                    self.refresh_group_residue_gauge();
                 }
                 continue;
             }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -459,6 +459,9 @@ impl RibManager {
         self.pending_regroup_baseline.remove(&peer);
         self.pending_extra_withdraws.remove(&peer);
         self.remove_update_group_member(peer);
+        // The extra-withdraw drop above mutates residue even for a peer
+        // whose membership removal doesn't touch a group.
+        self.refresh_group_residue_gauge();
         self.clear_peer_refresh_state(peer);
     }
 

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -406,6 +406,16 @@ async fn content_identical_policy_replace_is_key_stable() {
 
     assert_eq!(query_update_group(&tx, peer).await, "group:0");
     assert_metric(regroups_total(&metrics), 0.0, "regroups_total");
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_interned_chains", &[]),
+        1.0,
+        "bgp_update_group_interned_chains",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_keys", &[]),
+        1.0,
+        "bgp_update_group_keys",
+    );
 
     // Reinstall a content-identical chain: freshly constructed, so a
     // distinct instance with a cold compiled-IR cache. Same content ⇒
@@ -430,6 +440,11 @@ async fn content_identical_policy_replace_is_key_stable() {
         0.0,
         "content-identical reinstall must not count as a regroup",
     );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_interned_chains", &[]),
+        1.0,
+        "content-identical reinstall must not grow the interned-chain registry",
+    );
 
     // A materially different chain regroups the peer.
     let other = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
@@ -445,6 +460,19 @@ async fn content_identical_policy_replace_is_key_stable() {
 
     assert_eq!(query_update_group(&tx, peer).await, "group:1");
     assert_metric(regroups_total(&metrics), 1.0, "regroups_total");
+    // Registry growth is append-only: the new content and key ADD to
+    // the registry (LAN-311 growth observability; slot 0 is retained
+    // for key-stable reuse, not evicted).
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_interned_chains", &[]),
+        2.0,
+        "bgp_update_group_interned_chains after a content change",
+    );
+    assert_metric(
+        gauge_metric_value(&metrics, "bgp_update_group_keys", &[]),
+        2.0,
+        "bgp_update_group_keys after a content change",
+    );
 
     // And replacing with a peer-context chain moves it to the fallback
     // path with the recorded reason (also a regroup).
@@ -463,6 +491,234 @@ async fn content_identical_policy_replace_is_key_stable() {
         gauge_metric_value(&metrics, "bgp_update_group_fallback_peers", &[]),
         1.0,
         "bgp_update_group_fallback_peers",
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-311 item 2: the withdrawal-residue gauge follows tombstones
+/// held while a member is dirty and returns to zero when the resync
+/// clears them — emitted at growth AND clear (the gate-metric rule),
+/// so a soak slope-gate on it can actually fail.
+#[tokio::test]
+async fn residue_gauge_tracks_tombstones_and_clears_on_resync() {
+    tokio::time::pause();
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let residue = || gauge_metric_value(&metrics, "bgp_update_group_residue_entries", &[]);
+    let quiesce = async || {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
+            .await
+            .unwrap();
+        let _ = reply_rx.await.unwrap();
+    };
+    let send_routes = async |announced: Vec<crate::route::Route>, withdrawn: Vec<(Prefix, u32)>| {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(Ipv4Addr::new(10, 0, 5, 9)),
+            announced,
+            withdrawn,
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    };
+
+    // Grouped member with a capacity-1 outbound channel so a second
+    // update jams it (the wedged-writer shape from the seam sweep).
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 5, 1));
+    let (out_tx, mut out_rx) = mpsc::channel(1);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    assert_eq!(query_update_group(&tx, peer).await, "group:0");
+
+    let p1 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let p2 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 101, 0), 24);
+    let mk = |p: Ipv4Prefix| crate::test_support::make_route(p, Ipv4Addr::new(10, 0, 5, 9));
+
+    // p1 fills the channel; p2's emission fails → member goes dirty;
+    // p1 withdrawn WHILE dirty → tombstone.
+    send_routes(vec![mk(p1)], vec![]).await;
+    send_routes(vec![mk(p2)], vec![]).await;
+    send_routes(vec![], vec![(Prefix::V4(p1), 0)]).await;
+    quiesce().await;
+    assert_metric(
+        residue(),
+        1.0,
+        "tombstone recorded while a member is dirty must show in the residue gauge",
+    );
+
+    // Free the channel and let the resync timer clear the residue.
+    let jammed = out_rx.recv().await.unwrap();
+    assert_eq!(jammed.announce.len(), 1, "p1 was delivered before the jam");
+    tokio::time::advance(std::time::Duration::from_secs(2)).await;
+    let resync = out_rx.recv().await.unwrap();
+    assert!(
+        resync
+            .withdraw
+            .iter()
+            .any(|(prefix, _)| *prefix == Prefix::V4(p1)),
+        "resync must (over-)withdraw the tombstoned prefix"
+    );
+    quiesce().await;
+    assert_metric(
+        residue(),
+        0.0,
+        "a completed resync (last dirty member) must clear the residue gauge",
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// LAN-311 item 3 (the term-hit freeze): a content-equal chain
+/// reinstall must keep the INSTALLED chain instance, not just the
+/// group key. The group's staging handle shares the installed
+/// instance's ADR-0096 term-hit counters (`PolicyChain::share`), so
+/// swapping in a fresh content-equal instance leaves evaluations
+/// landing on the group's old instance while the term-hits query
+/// snapshots the new (forever-zero) one — grouped peers read frozen
+/// counters. A content-CHANGED chain still installs fresh (counters
+/// reset — "since install" semantics).
+#[tokio::test]
+async fn content_identical_replace_keeps_export_term_hit_counters() {
+    async fn send_route(tx: &mpsc::Sender<RibUpdate>, source: IpAddr, prefix: Ipv4Prefix) {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: source,
+            announced: vec![crate::test_support::make_route(
+                prefix,
+                Ipv4Addr::new(10, 0, 4, 9),
+            )],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+
+    /// (total evaluations, deny-term guard hits) of the peer's
+    /// installed chain instance.
+    async fn hits_for(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> (u64, u64) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryExportPolicyTermHits {
+            peer: Some(peer),
+            reply: reply_tx,
+        })
+        .await
+        .unwrap();
+        let hits = reply_rx.await.unwrap();
+        assert_eq!(hits.len(), 1, "peer must report an installed chain");
+        (hits[0].evals, hits[0].terms[0].hits)
+    }
+
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let denied = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 1));
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 4, 9));
+    let mut spec = PeerUpSpec::ibgp(peer);
+    spec.export_policy = Some(deny_chain(denied));
+    let mut out_rx = peer_up(&tx, spec).await;
+    assert_eq!(query_update_group(&tx, peer).await, "group:0");
+
+    // One permitted route: the shared group staging pass evaluates the
+    // chain once, through the handle sharing the installed instance's
+    // counters.
+    send_route(
+        &tx,
+        source,
+        Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+    )
+    .await;
+    assert_eq!(out_rx.recv().await.unwrap().announce.len(), 1);
+    assert_eq!(hits_for(&tx, peer).await, (1, 0));
+
+    // Content-equal reinstall (fresh instance, zeroed counters — the
+    // SIGHUP / txn no-op shape). The installed instance must survive.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(deny_chain(denied)),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+
+    send_route(
+        &tx,
+        source,
+        Ipv4Prefix::new(Ipv4Addr::new(198, 51, 101, 0), 24),
+    )
+    .await;
+    assert_eq!(out_rx.recv().await.unwrap().announce.len(), 1);
+    assert_eq!(
+        hits_for(&tx, peer).await,
+        (2, 0),
+        "term-hit counters must survive a content-equal reinstall and keep counting \
+         (a frozen/zero reading means the query snapshots a fresh instance while the \
+         group keeps evaluating the old one)"
+    );
+
+    // The denied prefix evaluates (and matches the deny term) without
+    // emitting — still on the surviving instance. The query rides the
+    // same serial channel, so its reply proves the route was staged.
+    send_route(&tx, source, denied).await;
+    assert_eq!(hits_for(&tx, peer).await, (3, 1));
+
+    // A content-CHANGED chain installs fresh: the peer regroups and the
+    // query snapshots the NEW instance — the join-time table rebuild
+    // re-evaluates the three staged prefixes (evals 3) but the old
+    // instance's deny-term history is gone (its deny matches nothing
+    // in the table), pinning "reset on material change".
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(deny_chain(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24))),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+    assert_eq!(query_update_group(&tx, peer).await, "group:1");
+    assert_eq!(
+        hits_for(&tx, peer).await,
+        (3, 0),
+        "a content-changed install must evaluate through a fresh instance \
+         (rebuild evals only; no carried deny-term history)"
     );
 
     drop(tx);

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -926,6 +926,27 @@ impl RibManager {
         }
     }
 
+    /// Re-derive the withdrawal-residue gauge: group tombstones
+    /// (unicast + VPN) plus per-member pending extra withdraws. Called
+    /// from EVERY residue mutation site — growth and clear alike, never
+    /// behind a clear guard — so a soak slope-gate on the metric can
+    /// actually fail (the gate-metric rule). O(groups +
+    /// members-with-residue) integer sums over small maps.
+    pub(in crate::manager) fn refresh_group_residue_gauge(&self) {
+        let residue = self
+            .group_ribs
+            .values()
+            .map(|group| group.tombstones.len() + group.vpn_tombstones.len())
+            .sum::<usize>()
+            + self
+                .pending_extra_withdraws
+                .values()
+                .map(|extras| extras.unicast.len() + extras.vpn.len())
+                .sum::<usize>();
+        self.metrics
+            .set_update_group_residue_entries(i64::try_from(residue).unwrap_or(i64::MAX));
+    }
+
     /// A grouped member's resync succeeded (or had nothing to send):
     /// drop its regroup residue and its group dirty flag; the last
     /// dirty member syncing clears the tombstones.
@@ -947,6 +968,7 @@ impl RibManager {
                 group.vpn_tombstones.clear();
             }
         }
+        self.refresh_group_residue_gauge();
     }
 
     /// Whether `peer` is a grouped member whose VPN advertised state is
@@ -1108,6 +1130,7 @@ impl RibManager {
                         .extend(lost);
                 }
             }
+            self.refresh_group_residue_gauge();
         }
         out
     }
@@ -1257,6 +1280,7 @@ impl RibManager {
             group
                 .vpn_tombstones
                 .extend(out.deltas.iter().filter(|d| d.new.is_none()).map(|d| d.key));
+            self.refresh_group_residue_gauge();
         }
         out
     }
@@ -1470,6 +1494,7 @@ impl RibManager {
                     .or_default()
                     .vpn
                     .extend(vpn_withdraw.iter().map(|key| key.nlri_key));
+                self.refresh_group_residue_gauge();
             }
             return;
         }
@@ -1514,6 +1539,7 @@ impl RibManager {
                 .or_default()
                 .vpn
                 .extend(withdraw_keys);
+            self.refresh_group_residue_gauge();
         }
     }
 
@@ -1843,6 +1869,9 @@ impl RibManager {
             }
         }
         self.refresh_update_group_gauges();
+        // The regroup carry (a dirty leaver's tombstones riding into
+        // its extra withdraws) mutates residue on this path too.
+        self.refresh_group_residue_gauge();
     }
 
     /// Add a member; a group seen for the first time snapshots its
@@ -1909,6 +1938,7 @@ impl RibManager {
         if group.members.is_empty() {
             self.group_ribs.remove(&gid);
         }
+        self.refresh_group_residue_gauge();
     }
 
     /// Drop a departing peer's membership and group state (the
@@ -2011,6 +2041,18 @@ impl RibManager {
         self.metrics
             .set_update_groups(i64::try_from(member_counts.len()).unwrap_or(i64::MAX));
         self.metrics.set_update_group_fallback_peers(fallback);
+        // Registry growth (LAN-311 observability, no eviction): both
+        // vecs are append-only for the process lifetime, so the gauges
+        // read as "distinct contents / keys ever seen" — the signal a
+        // policy-content-churn deployment watches before the growth
+        // costs memory. Every intern happens inside a membership
+        // recompute, and every recompute/removal ends here.
+        self.metrics.set_update_group_interned_chains(
+            i64::try_from(self.update_groups.chains.len()).unwrap_or(i64::MAX),
+        );
+        self.metrics.set_update_group_keys(
+            i64::try_from(self.update_groups.groups.len()).unwrap_or(i64::MAX),
+        );
         for id in 0..self.update_groups.groups.len() {
             match member_counts.get(&id) {
                 Some(count) => self

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -129,6 +129,9 @@ pub struct BgpMetrics {
     update_group_members: IntGaugeVec,
     update_group_regroups: IntCounter,
     update_group_fallback_peers: IntGauge,
+    update_group_residue_entries: IntGauge,
+    update_group_interned_chains: IntGauge,
+    update_group_keys: IntGauge,
     blackhole_discard_installed: IntCounter,
     blackhole_discard_withdrawn: IntCounter,
     blackhole_discard_adopted: IntCounter,
@@ -619,6 +622,33 @@ impl BgpMetrics {
              send, ORR vantage, or negotiated ORF) and therefore permanently on \
              the per-peer distribution path. Per-peer reasons surface in the \
              neighbor status API.",
+        )
+        .expect("valid metric definition");
+
+        let update_group_residue_entries = IntGauge::new(
+            "bgp_update_group_residue_entries",
+            "Withdrawal residue currently held for dirty update-group members: \
+             group tombstones (unicast + VPN) plus per-member pending extra \
+             withdraws. Bounded in practice by the resync timer; a sustained \
+             climb means a wedged member is accumulating residue its resync \
+             never clears.",
+        )
+        .expect("valid metric definition");
+
+        let update_group_interned_chains = IntGauge::new(
+            "bgp_update_group_interned_chains",
+            "Distinct export-chain contents interned by the update-group \
+             registry since process start. Append-only for the process \
+             lifetime (no eviction): a deployment cycling generated policy \
+             contents shows unbounded growth here before it costs memory.",
+        )
+        .expect("valid metric definition");
+
+        let update_group_keys = IntGauge::new(
+            "bgp_update_group_keys",
+            "Distinct update-group fingerprint keys created since process \
+             start. Append-only for the process lifetime: an emptied group \
+             keeps its slot so a recurring key reuses its stable id.",
         )
         .expect("valid metric definition");
 
@@ -1392,6 +1422,15 @@ impl BgpMetrics {
             .register(Box::new(update_group_fallback_peers.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(update_group_residue_entries.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(update_group_interned_chains.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(update_group_keys.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(blackhole_discard_installed.clone()))
             .expect("metric not already registered");
         registry
@@ -1666,6 +1705,9 @@ impl BgpMetrics {
             update_group_members,
             update_group_regroups,
             update_group_fallback_peers,
+            update_group_residue_entries,
+            update_group_interned_chains,
+            update_group_keys,
             blackhole_discard_installed,
             blackhole_discard_withdrawn,
             blackhole_discard_adopted,
@@ -2149,6 +2191,25 @@ impl BgpMetrics {
     /// Set the number of peers on the ungrouped (per-peer) fallback path.
     pub fn set_update_group_fallback_peers(&self, count: i64) {
         self.update_group_fallback_peers.set(count);
+    }
+
+    /// Set the total withdrawal-residue entry count (group tombstones +
+    /// per-member pending extra withdraws) held for dirty update-group
+    /// members.
+    pub fn set_update_group_residue_entries(&self, count: i64) {
+        self.update_group_residue_entries.set(count);
+    }
+
+    /// Set the number of export-chain contents interned by the
+    /// update-group registry (append-only for the process lifetime).
+    pub fn set_update_group_interned_chains(&self, count: i64) {
+        self.update_group_interned_chains.set(count);
+    }
+
+    /// Set the number of update-group fingerprint keys created
+    /// (append-only for the process lifetime).
+    pub fn set_update_group_keys(&self, count: i64) {
+        self.update_group_keys.set(count);
     }
 
     /// Record a `PeerUp` that replaced a still-registered outbound sender

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1240,7 +1240,11 @@ path-id correction is unsound without per-member state).
 `rbgp neighbor show <peer>` prints the membership (`group:N`) or the
 fallback reason on its `Update Group` line. Metrics:
 `bgp_update_groups`, `bgp_update_group_members{group}`,
-`bgp_update_group_regroups_total`, `bgp_update_group_fallback_peers`.
+`bgp_update_group_regroups_total`, `bgp_update_group_fallback_peers`,
+`bgp_update_group_interned_chains` and `bgp_update_group_keys`
+(registry growth — append-only for the process lifetime), and
+`bgp_update_group_residue_entries` (withdrawal residue held while a
+member is dirty; returns to zero when its resync completes).
 
 ---
 

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -845,8 +845,11 @@ $ rbgp policy stats --peer 10.0.0.2 --direction both
 
 - Counters read as **since chain install**: replacing a peer's chain
   (policy reload / hot-apply / gNMI Set) installs a fresh instance and
-  resets its counters to zero. A session flap does not reset the
-  RIB-side export counters (the chain instance survives).
+  resets its counters to zero. A reload that re-resolves a peer to a
+  **content-equal** chain skips the reinstall entirely — the installed
+  instance and its counters survive; only peers whose resolved chain
+  content moved reset. A session flap does not reset the RIB-side
+  export counters (the chain instance survives).
 - TOML chain members count too; their unnamed statements report by
   `term_index` (`statement 0`, `statement 1`, ...).
 - `--direction` selects **export** (the default), **import**, or
@@ -854,9 +857,11 @@ $ rbgp policy stats --peer 10.0.0.2 --direction both
   are read from each live session task, so a peer without a live
   session reports no import chain.
 - Import chains report their **install generation** (bumps on every
-  chain install, content-equal reinstalls included), so counters that
-  reset to zero read as a chain replacement, not continuous history.
-  Export chains do not track an install generation yet.
+  chain install), so counters that reset to zero read as a chain
+  replacement, not continuous history. A session's initial chain
+  reports generation 0; content-equal re-resolves are not reinstalled,
+  so the generation moves only when the peer's resolved chain content
+  does. Export chains do not track an install generation yet.
 - Explain queries and `policy test` dry runs never move these
   counters — only live route evaluation counts.
 - `--json` emits the rows structurally.

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -503,10 +503,23 @@ impl PeerManager {
         // then fire Route Refresh against the session, which would
         // re-evaluate AdjRibIn against the *old* policy and silently
         // keep forbidden routes flowing.
-        let import_apply_result = managed
-            .handle
-            .update_import_policy_timeout(import_policy.clone(), PEER_POLICY_UPDATE_TIMEOUT)
-            .await;
+        //
+        // A side whose resolved chain is CONTENT-EQUAL to the installed
+        // one (`PolicyChain: PartialEq` — the same equality the
+        // update-group registry keys on) is skipped entirely: no
+        // session command, so no import-generation bump and no term-hit
+        // counter reset on a peer an rpol/catalog edit didn't actually
+        // touch. Every reinstall fan-out (SIGHUP rpol overlay, catalog
+        // edits, the ADR-0076 txn executor, honor-knob toggles) routes
+        // through here, so this is the one place the scoping lives.
+        let import_apply_result = if import_changed {
+            managed
+                .handle
+                .update_import_policy_timeout(import_policy.clone(), PEER_POLICY_UPDATE_TIMEOUT)
+                .await
+        } else {
+            Ok(())
+        };
         let import_apply_failed = if let Err(error) = &import_apply_result {
             warn!(
                 %address,
@@ -515,14 +528,20 @@ impl PeerManager {
             );
             true
         } else {
-            managed.import_policy = import_policy;
+            if import_changed {
+                managed.import_policy = import_policy;
+            }
             false
         };
 
-        let export_apply_result = managed
-            .handle
-            .update_export_policy_timeout(export_policy.clone(), PEER_POLICY_UPDATE_TIMEOUT)
-            .await;
+        let export_apply_result = if export_changed {
+            managed
+                .handle
+                .update_export_policy_timeout(export_policy.clone(), PEER_POLICY_UPDATE_TIMEOUT)
+                .await
+        } else {
+            Ok(())
+        };
         let export_apply_failed = if let Err(error) = &export_apply_result {
             warn!(
                 %address,
@@ -531,7 +550,9 @@ impl PeerManager {
             );
             true
         } else {
-            managed.export_policy.clone_from(&export_policy);
+            if export_changed {
+                managed.export_policy.clone_from(&export_policy);
+            }
             false
         };
 
@@ -626,7 +647,7 @@ impl PeerManager {
             ));
         }
 
-        if is_established {
+        if is_established && needs_export_apply {
             // The RIB step sits between session-side hot-apply (already
             // succeeded if we reached here) and Route Refresh. If it
             // fails, we still need to preserve any unfired refresh
@@ -636,6 +657,14 @@ impl PeerManager {
             // `pending_refresh` carry — the same silent-skip class as
             // the cross-side bail bug. Use explicit match so the Err
             // arms can re-arm `pending_refresh` before returning.
+            //
+            // Gated on export-apply intent (content moved, or a prior
+            // call's unfired intent): re-sending a content-equal chain
+            // would swap the RIB's installed instance out from under a
+            // grouped peer's shared staging handle — the group keeps
+            // evaluating (and counting term hits) on the old instance
+            // while the stats query snapshots the fresh one, freezing
+            // the reported counters.
             let (reply_tx, reply_rx) = oneshot::channel();
             let send_outcome = self
                 .rib_tx

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -5849,6 +5849,202 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
     );
 }
 
+/// LAN-311: a policy fan-out (SIGHUP rpol overlay, catalog edit, and
+/// the ADR-0076 txn snapshot all funnel through
+/// `update_runtime_policies_for_peer_key`) must scope reinstallation to
+/// peers whose resolved chain CONTENT moved. A peer re-resolving to a
+/// content-equal chain gets no session command at all — the session
+/// bumps its import-policy generation (and swaps the counter-bearing
+/// chain instance) inside the `UpdateImportPolicy` handler, so "no
+/// command" IS the #761 generation-unchanged / counters-survive
+/// guarantee (the M80 finding: SIGHUP bumped generation 0→1 on peers
+/// whose chains didn't change) — and no RIB `ReplacePeerExportPolicy`.
+/// The peer whose content moved gets exactly the prior behavior:
+/// session installs, RIB replace, and a Route Refresh.
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn content_equal_policy_fanout_skips_unaffected_peers() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+    use rustbgpd_transport::PeerCommand;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[derive(Default)]
+    struct SessionCounters {
+        import_installs: AtomicU32,
+        export_installs: AtomicU32,
+        refreshes: AtomicU32,
+    }
+
+    fn fake_session(addr: IpAddr) -> (PeerHandle, Arc<SessionCounters>) {
+        let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+        let counters = Arc::new(SessionCounters::default());
+        let counters_in_task = counters.clone();
+        let task = tokio::spawn(async move {
+            while let Some(cmd) = session_rx.recv().await {
+                match cmd {
+                    PeerCommand::UpdateImportPolicy { reply, .. } => {
+                        counters_in_task
+                            .import_installs
+                            .fetch_add(1, Ordering::SeqCst);
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerCommand::UpdateExportPolicy { reply, .. } => {
+                        counters_in_task
+                            .export_installs
+                            .fetch_add(1, Ordering::SeqCst);
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerCommand::SendRouteRefresh { reply, .. } => {
+                        counters_in_task.refreshes.fetch_add(1, Ordering::SeqCst);
+                        let _ = reply.send(Ok(()));
+                    }
+                    PeerCommand::QueryState { reply } => {
+                        let _ = reply.send(PeerSessionState {
+                            fsm_state: SessionState::Established,
+                            peer_ip: addr,
+                            peer_asn: None,
+                            prefix_count: 0,
+                            negotiated_hold_time: Some(90),
+                            four_octet_as: Some(true),
+                            remote_router_id: None,
+                            local_role: None,
+                            remote_role: None,
+                            role_negotiated: false,
+                            updates_received: 0,
+                            updates_sent: 0,
+                            notifications_received: 0,
+                            notifications_sent: 0,
+                            otc_routes_blocked: 0,
+                            import_policy_routes_permitted: 0,
+                            import_policy_routes_denied: 0,
+                            flap_count: 0,
+                            uptime_secs: 1,
+                            last_error: String::new(),
+                        });
+                    }
+                    PeerCommand::Shutdown => break,
+                    _ => {}
+                }
+            }
+            Ok(())
+        });
+        (PeerHandle::from_parts(session_tx, task), counters)
+    }
+
+    fn permit_policy_chain() -> PolicyChain {
+        use rustbgpd_policy::{Policy, PolicyAction};
+        PolicyChain::new(vec![Policy {
+            entries: Vec::new(),
+            default_action: PolicyAction::Permit,
+        }])
+    }
+
+    let a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let (handle_a, counters_a) = fake_session(a);
+    let (handle_b, counters_b) = fake_session(b);
+
+    // RIB drainer counting ReplacePeerExportPolicy per peer.
+    let rib_replaces_a = Arc::new(AtomicU32::new(0));
+    let rib_replaces_b = Arc::new(AtomicU32::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(64);
+    let (replaces_a, replaces_b) = (rib_replaces_a.clone(), rib_replaces_b.clone());
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = update {
+                if peer == a {
+                    replaces_a.fetch_add(1, Ordering::SeqCst);
+                } else {
+                    replaces_b.fetch_add(1, Ordering::SeqCst);
+                }
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+
+    let (_cmd_tx, cmd_rx) = mpsc::channel(16);
+    let mut mgr = PeerManager::new(
+        cmd_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(&mut mgr, a, handle_a, false);
+    insert_test_managed_peer(&mut mgr, b, handle_b, false);
+
+    // Initial install through the atomic fan-out both edits ride.
+    let target = |address: IpAddr, chain: PolicyChain| ResolvedPeerPolicy {
+        address,
+        interface: None,
+        import_policy: Some(chain.clone()),
+        export_policy: Some(chain),
+    };
+    mgr.apply_resolved_policy_snapshot(vec![
+        target(a, permit_policy_chain()),
+        target(b, permit_policy_chain()),
+    ])
+    .await
+    .expect("initial install");
+    assert_eq!(counters_a.import_installs.load(Ordering::SeqCst), 1);
+    assert_eq!(counters_a.refreshes.load(Ordering::SeqCst), 1);
+    assert_eq!(rib_replaces_a.load(Ordering::SeqCst), 1);
+
+    // The M80 shape: an edit re-resolves BOTH peers, but only B's chain
+    // content moved; A resolves to a content-equal (fresh-instance)
+    // chain.
+    mgr.apply_resolved_policy_snapshot(vec![
+        target(a, permit_policy_chain()),
+        target(b, deny_policy_chain()),
+    ])
+    .await
+    .expect("scoped re-apply");
+
+    // (ii) Unaffected peer: NO reinstall of any kind — generation and
+    // live counters in the session survive untouched.
+    assert_eq!(
+        counters_a.import_installs.load(Ordering::SeqCst),
+        1,
+        "content-equal re-resolve must not send UpdateImportPolicy \
+         (each send bumps the session's import generation and resets its counters)"
+    );
+    assert_eq!(
+        counters_a.export_installs.load(Ordering::SeqCst),
+        1,
+        "content-equal re-resolve must not send UpdateExportPolicy"
+    );
+    assert_eq!(
+        rib_replaces_a.load(Ordering::SeqCst),
+        1,
+        "content-equal re-resolve must not send ReplacePeerExportPolicy \
+         (a fresh instance would strand the update group's term-hit counters)"
+    );
+    assert_eq!(
+        counters_a.refreshes.load(Ordering::SeqCst),
+        1,
+        "content-equal re-resolve must not fire Route Refresh"
+    );
+
+    // (iii) Changed peer: full reinstall — session installs, RIB
+    // replace, Route Refresh — and bookkeeping advances to the new
+    // chain.
+    assert_eq!(counters_b.import_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(counters_b.export_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(rib_replaces_b.load(Ordering::SeqCst), 2);
+    assert_eq!(counters_b.refreshes.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        mgr.peers.get(&key(b)).unwrap().import_policy,
+        Some(deny_policy_chain()),
+        "changed peer's bookkeeping must advance to the new chain"
+    );
+
+    rib_drainer.abort();
+}
+
 #[tokio::test(start_paused = true)]
 async fn gshut_toggle_times_out_when_rib_reply_wedges() {
     use rustbgpd_transport::PeerCommand;

--- a/tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
+++ b/tests/interop/scripts/test-m80-rpol-policy-parity-frr.sh
@@ -531,14 +531,21 @@ fi
 
 # The reload reinstalled src's chain — its install generation bumps,
 # so counters that reset read as a chain replacement (#761 contract).
-# NOTE: down's generation bumps too (a content-equal reinstall —
-# explicitly documented #761 behavior); the WIRE-visible scoping is
-# the Route Refresh assertion above, so only src's bump is asserted.
+# down's chain re-resolved content-equal, so it is NOT reinstalled
+# (LAN-311 reinstall scoping): its generation — and its live hit
+# counters — survive the reload, matching the wire-visible Route
+# Refresh scoping asserted above.
 gen_src_after=$(import_chain_gen "$SRC_PEER")
 if [ "$gen_src_after" -gt "$gen_src_before" ]; then
     ok "src import-chain install generation bumped ($gen_src_before -> $gen_src_after)"
 else
     fail "src import-chain generation did not bump ($gen_src_before -> $gen_src_after)"
+fi
+gen_down_after=$(import_chain_gen "$DOWN_PEER")
+if [ "$gen_down_after" -eq "$gen_down_before" ]; then
+    ok "down import-chain generation unchanged ($gen_down_before) — content-equal chain not reinstalled"
+else
+    fail "down import-chain generation moved ($gen_down_before -> $gen_down_after) despite a content-equal re-resolve"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- policy reload fan-out (SIGHUP rpol overlay, catalog/gRPC edits, and the txn executor all funnel through one choke point) now skips peers whose newly resolved chain is content-equal to the installed one: no session command, no install-generation bump, no counter reset — peers whose content moved keep exactly today's behavior
- one fix closes two observability bugs at once: grouped peers' export term-hit counters no longer freeze after a content-equal reinstall (the group keeps the counter-bearing chain instance at the RIB seam, composing with the existing key-stable fast path), and an unrelated policy edit no longer resets import hit counters and generations on unaffected peers (observed in the M80 extension)
- both proof tests fail without the fix: the grouped-counter freeze reads (0,0) pre-fix, and the two-peer fan-out test shows the unaffected peer receiving a second install
- adds the residue gauge (`bgp_update_group_residue_entries`: tombstones + pending extra withdraws, refreshed at every mutation site — growth and clear) and append-only registry gauges (`bgp_update_group_interned_chains` / `bgp_update_group_keys`) so content-churn growth is visible before it matters
- M80's runner note that documented the old behavior is replaced by an assertion that the unaffected peer's generation is unchanged

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-rib (710) / -p rustbgpd-policy (252) / -p rustbgpd-transport / --bin rustbgpd (1351) / telemetry
- cargo check -p rustbgpd-rib --features bench-internals --benches
- cargo doc --workspace --no-deps
- live M80 lab from this branch: 45 passed, 0 failed (fresh deploy, including the strengthened generation-scoping assertion)

Closes LAN-311.