### PR TITLE
fix(api): add MED absence marker to Route and migrate consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Peers whose chain content did change get exactly the previous
   behavior: session installs, RIB replacement, regroup, counter reset,
   and Route Refresh. (LAN-311)
+- **The gRPC `Route` message now marks MED absence honestly.** A new
+  optional `med_attr` field (mirroring `local_pref_attr`) distinguishes
+  "no MED attribute" from "MED 0", which the bare 0-defaulted `med`
+  field conflates. `rbgp` route tables render an absent MED as `-` and
+  route JSON as `null` when the daemon populates the field (older
+  daemons keep the bare-field rendering), and `rbgp diff` compares MED
+  exactly against such daemons — an explicit MED 0 in a snapshot now
+  diffs clean against a live MED 0 — dropping the MED-conflation caveat
+  from `live_source_notes`; the caveat and the med=0-as-absent mapping
+  remain only for daemons without the field. (LAN-313)
 
 - **Fatal RTR errors now flush the affected cache's data and emit Error
   Reports per draft-ietf-sidrops-8210bis-26, instead of retaining until

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1053,6 +1053,9 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
         // tagged route (otherwise local_pref=0 is ambiguous between
         // "policy set it" and "no LOCAL_PREF on EBGP wire").
         local_pref_attr: route.local_pref_attr(),
+        // Distinguishes "explicit MED attribute" from "no attribute" —
+        // the bare `med` field encodes absent as 0 (LAN-313).
+        med_attr: route.med_attr(),
         // Receive wall time recovered from the monotonic receive
         // instant, the same recovery the BMP Loc-RIB dump uses for its
         // RFC 9069 per-peer header timestamp. Approximation: `now()` and
@@ -4212,6 +4215,58 @@ mod tests {
             resp.next_page_token,
             encode_route_page_token(&route_query_key(&route))
         );
+    }
+
+    #[tokio::test]
+    async fn list_routes_distinguishes_med_absent_from_med_zero() {
+        // LAN-313: `med_attr` is the honest absence marker — a route
+        // whose MED attribute is explicitly 0 and a route with no MED
+        // attribute both encode bare `med = 0`, but must differ in
+        // `med_attr` through the service and a wire round trip.
+        use prost::Message;
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let med_zero = test_route(
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+            vec![PathAttribute::Med(0)],
+        );
+        let med_absent = test_route(
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 1, 0), 24)),
+            vec![],
+        );
+        let page = vec![med_zero, med_absent];
+        tokio::spawn(async move {
+            while let Some(update) = rx.recv().await {
+                if let RibUpdate::QueryRoutesPage { reply, .. } = update {
+                    let _ = reply.send(RoutePage {
+                        routes: page.clone(),
+                        total: 2,
+                        has_more: false,
+                    });
+                }
+            }
+        });
+
+        let svc = RibService::new(tx);
+        let resp = svc
+            .list_received_routes(Request::new(list_routes_request()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.routes.len(), 2);
+        let zero = &resp.routes[0];
+        let absent = &resp.routes[1];
+        assert_eq!(zero.med, 0);
+        assert_eq!(absent.med, 0, "bare med conflates absent with 0");
+        assert_eq!(zero.med_attr, Some(0));
+        assert_eq!(absent.med_attr, None);
+
+        // The distinction must survive protobuf encode/decode.
+        let decoded = proto::Route::decode(zero.encode_to_vec().as_slice()).unwrap();
+        assert_eq!(decoded.med_attr, Some(0));
+        let decoded = proto::Route::decode(absent.encode_to_vec().as_slice()).unwrap();
+        assert_eq!(decoded.med_attr, None);
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -58,9 +58,6 @@ const IGNORABLE_ATTRIBUTES: &[&str] = &[
 /// human and JSON output so a reader knows exactly what the comparison
 /// could and could not see.
 const LIVE_SOURCE_NOTES: &[&str] = &[
-    "med: the daemon proto carries MED as a bare integer, so MED-absent and MED 0 are \
-     indistinguishable over gRPC; live med=0 is compared as absent (snapshot producers \
-     should omit `med` when it is zero or absent)",
     "as_path: the daemon proto exposes a flattened ASN list, so AS_PATH is compared as a \
      single AS_SEQUENCE on both sides; AS_SET structure is not compared",
     "unknown attributes: path attributes outside the typed set (origin, as_path, next_hop, \
@@ -70,6 +67,25 @@ const LIVE_SOURCE_NOTES: &[&str] = &[
      drift is detected via per-page total_count instead, and the snapshot header's \
      generation is adopted for the live side",
 ];
+
+/// MED-conflation caveat, emitted only when the daemon never populated
+/// `med_attr` in the run (an older daemon whose bare `med` field cannot
+/// distinguish absent from 0). Daemons that populate `med_attr` are
+/// compared exactly (absent = absent, 0 = 0) and need no caveat.
+const MED_CONFLATION_NOTE: &str = "med: this daemon carries MED as a bare integer only \
+     (no med_attr), so MED-absent and MED 0 are indistinguishable over gRPC; live med=0 \
+     is compared as absent (snapshot producers should omit `med` when it is zero or absent)";
+
+/// The live-source notes for one run: the MED-conflation caveat is
+/// version-conditional, the rest are structural.
+fn live_source_notes(med_attr_seen: bool) -> Vec<&'static str> {
+    let mut notes = Vec::with_capacity(LIVE_SOURCE_NOTES.len() + 1);
+    if !med_attr_seen {
+        notes.push(MED_CONFLATION_NOTE);
+    }
+    notes.extend_from_slice(LIVE_SOURCE_NOTES);
+    notes
+}
 
 /// Requested page size — matches the server's per-page cap.
 const ROUTE_PAGE_SIZE: u32 = 1000;
@@ -171,6 +187,9 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
 
     let mut rib_client =
         RibServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    // True once any live route carries `med_attr` — the daemon is
+    // MED-absence-aware and the MED-conflation caveat does not apply.
+    let mut med_attr_seen = false;
 
     let mut report = DiffReport {
         schema: ribdiff::SCHEMA_VERSION,
@@ -254,7 +273,7 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
             },
             limits,
         );
-        fetch_advertised_into(
+        med_attr_seen |= fetch_advertised_into(
             &mut rib_client,
             &peer_id,
             &mut live,
@@ -288,10 +307,11 @@ async fn run(connection: Connection, opts: &AdvertisedDiffOpts) -> Result<(Strin
         Verdict::Divergent => EXIT_DIVERGENT,
         Verdict::Incomparable => EXIT_INCOMPARABLE,
     };
+    let notes = live_source_notes(med_attr_seen);
     let rendered = if opts.json {
-        render_json(&report, &ignored)?
+        render_json(&report, &ignored, &notes)?
     } else {
-        render_human(&report, &ignored, opts.detail)
+        render_human(&report, &ignored, &notes, opts.detail)
     };
     Ok((rendered, code))
 }
@@ -755,6 +775,10 @@ fn as_path_segment(asns: &[u32]) -> Vec<AsPathSegment> {
 /// - the fetched route count must equal the server's `total_count`;
 /// - `--max-routes` is enforced before each page is buffered into the set;
 /// - the shared deadline is checked before every RPC.
+///
+/// Returns whether any fetched route carried `med_attr` (a
+/// MED-absence-aware daemon); the MED-conflation caveat is dropped
+/// from the report notes for such runs.
 async fn fetch_advertised_into(
     client: &mut RibClient,
     peer: &PeerId,
@@ -763,7 +787,7 @@ async fn fetch_advertised_into(
     ignored: &[String],
     max_routes: usize,
     deadline: Instant,
-) -> Result<(), CliError> {
+) -> Result<bool, CliError> {
     let peer_addr = peer.address;
     let mut req = ListRoutesRequest {
         neighbor_address: peer_addr.to_string(),
@@ -780,6 +804,7 @@ async fn fetch_advertised_into(
     let mut seen_tokens: HashSet<String> = HashSet::new();
     let mut fetched: u64 = 0;
     let mut expected_total: Option<u64> = None;
+    let mut med_attr_seen = false;
     loop {
         if Instant::now() >= deadline {
             return Err(op(format!(
@@ -811,6 +836,7 @@ async fn fetch_advertised_into(
         }
         for route in &resp.routes {
             fetched += 1;
+            med_attr_seen |= route.med_attr.is_some();
             let (family, nlri, path) = convert_live_route(route)
                 .map_err(|msg| op(format!("daemon returned an unusable route: {msg}")))?;
             if !family_retained(family, family_filter) {
@@ -840,7 +866,7 @@ async fn fetch_advertised_into(
              routes but the server reported total_count {total}; refusing to compare"
         )));
     }
-    Ok(())
+    Ok(med_attr_seen)
 }
 
 fn convert_live_route(route: &Route) -> Result<(FamilyId, Nlri, RoutePath), String> {
@@ -866,9 +892,11 @@ fn convert_live_route(route: &Route) -> Result<(FamilyId, Nlri, RoutePath), Stri
         origin: Some(origin),
         as_path: as_path_segment(&route.as_path),
         next_hop,
-        // The proto carries MED as a bare u32: absent and 0 are
-        // indistinguishable, so 0 maps to absent (see LIVE_SOURCE_NOTES).
-        med: (route.med != 0).then_some(route.med),
+        // `med_attr` is the honest optional field (absent = absent,
+        // 0 = 0). Older daemons only carry the bare u32 where absent
+        // and 0 are indistinguishable, so 0 maps to absent (see
+        // MED_CONFLATION_NOTE).
+        med: route.med_attr.or((route.med != 0).then_some(route.med)),
         // local_pref_attr is the honest optional field; the bare
         // `local_pref` is the effective (defaulted) value.
         local_pref: route.local_pref_attr,
@@ -906,20 +934,21 @@ fn ignored_display(ignored: &[String]) -> String {
     }
 }
 
-fn render_json(report: &DiffReport, ignored: &[String]) -> Result<String, CliError> {
+fn render_json(
+    report: &DiffReport,
+    ignored: &[String],
+    notes: &[&str],
+) -> Result<String, CliError> {
     let mut value = serde_json::to_value(report)?;
     let object = value
         .as_object_mut()
         .expect("DiffReport serializes to an object");
     object.insert("ignored_attributes".to_string(), serde_json::json!(ignored));
-    object.insert(
-        "live_source_notes".to_string(),
-        serde_json::json!(LIVE_SOURCE_NOTES),
-    );
+    object.insert("live_source_notes".to_string(), serde_json::json!(notes));
     Ok(format!("{}\n", serde_json::to_string_pretty(&value)?))
 }
 
-fn render_human(report: &DiffReport, ignored: &[String], detail: usize) -> String {
+fn render_human(report: &DiffReport, ignored: &[String], notes: &[&str], detail: usize) -> String {
     use std::fmt::Write;
 
     let mut out = String::new();
@@ -936,7 +965,7 @@ fn render_human(report: &DiffReport, ignored: &[String], detail: usize) -> Strin
         ignored_display(ignored)
     );
     out.push_str("live-source notes:\n");
-    for note in LIVE_SOURCE_NOTES {
+    for note in notes {
         let _ = writeln!(out, "  - {note}");
     }
     let verdict = match report.verdict {
@@ -1087,6 +1116,17 @@ mod tests {
             med,
             communities: vec![(64501 << 16) | 100],
             ..Default::default()
+        }
+    }
+
+    fn live_route_with_med_attr(
+        prefix: &str,
+        med: u32,
+        med_attr: Option<u32>,
+    ) -> server_proto::Route {
+        server_proto::Route {
+            med_attr,
+            ..live_route(prefix, med)
         }
     }
 
@@ -1470,6 +1510,67 @@ mod tests {
         let server = server_with_pages(vec![page(vec![live_route("10.0.0.0", 0)], "", 1)]).await;
         let (rendered, code) = run_against(&server, &opts(file.path())).await.unwrap();
         assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+    }
+
+    #[tokio::test]
+    async fn med_attr_compares_exactly_and_drops_conflation_caveat() {
+        // A MED-absence-aware daemon (med_attr populated): explicit
+        // MED 0 stays 0 and absent stays absent, so a snapshot carrying
+        // explicit med:0 diffs clean against a live med=0 — and the
+        // MED-conflation caveat disappears from the report notes.
+        let file = snapshot_file(&[
+            header_line(),
+            route_line("10.0.0.0/24", Some(0)),
+            route_line("10.0.1.0/24", None),
+            trailer_line(2),
+        ]);
+        let server = server_with_pages(vec![page(
+            vec![
+                live_route_with_med_attr("10.0.0.0", 0, Some(0)),
+                live_route_with_med_attr("10.0.1.0", 0, None),
+            ],
+            "",
+            2,
+        )])
+        .await;
+        let mut json_opts = opts(file.path());
+        json_opts.json = true;
+        let (rendered, code) = run_against(&server, &json_opts).await.unwrap();
+        assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let notes = value["live_source_notes"].as_array().unwrap();
+        assert!(
+            notes
+                .iter()
+                .all(|n| !n.as_str().unwrap().starts_with("med:")),
+            "MED caveat should be dropped when med_attr is present: {notes:?}"
+        );
+        assert!(!notes.is_empty(), "structural notes remain");
+    }
+
+    #[tokio::test]
+    async fn med_attr_missing_keeps_fallback_mapping_and_caveat() {
+        // Older daemon (med_attr populated nowhere): live med=0 still
+        // maps to absent and the MED-conflation caveat stays in the
+        // report notes.
+        let file = snapshot_file(&[
+            header_line(),
+            route_line("10.0.0.0/24", None),
+            trailer_line(1),
+        ]);
+        let server = server_with_pages(vec![page(vec![live_route("10.0.0.0", 0)], "", 1)]).await;
+        let mut json_opts = opts(file.path());
+        json_opts.json = true;
+        let (rendered, code) = run_against(&server, &json_opts).await.unwrap();
+        assert_eq!(code, EXIT_IN_SYNC, "output was:\n{rendered}");
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let notes = value["live_source_notes"].as_array().unwrap();
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.as_str().unwrap().starts_with("med:")),
+            "MED caveat should be kept for daemons without med_attr: {notes:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -578,9 +578,13 @@ impl Serialize for JsonRoutes<'_> {
     where
         S: Serializer,
     {
+        let med_attr_supported = self.0.iter().any(|r| r.med_attr.is_some());
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
         for route in self.0 {
-            seq.serialize_element(&JsonRouteRef(route))?;
+            seq.serialize_element(&JsonRouteRef {
+                route,
+                med_attr_supported,
+            })?;
         }
         seq.end()
     }
@@ -675,14 +679,21 @@ fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
-struct JsonRouteRef<'a>(&'a Route);
+struct JsonRouteRef<'a> {
+    route: &'a Route,
+    /// Whether any route in the enclosing response carried `med_attr`
+    /// — i.e. the daemon distinguishes MED-absent from MED 0. When
+    /// true, an absent MED serializes as `null`; when false (older
+    /// daemon), the bare 0-defaulted `med` field is emitted as-is.
+    med_attr_supported: bool,
+}
 
 impl Serialize for JsonRouteRef<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let route = self.0;
+        let route = self.route;
         let mut len = 10;
         if route.path_id != 0 {
             len += 1;
@@ -696,7 +707,11 @@ impl Serialize for JsonRouteRef<'_> {
         map.serialize_entry("next_hop", &route.next_hop)?;
         map.serialize_entry("as_path", &route.as_path)?;
         map.serialize_entry("local_pref", &route.local_pref)?;
-        map.serialize_entry("med", &route.med)?;
+        match route.med_attr {
+            Some(med) => map.serialize_entry("med", &med)?,
+            None if self.med_attr_supported => map.serialize_entry("med", &None::<u32>)?,
+            None => map.serialize_entry("med", &route.med)?,
+        }
         map.serialize_entry("origin", output::format_origin(route.origin))?;
         map.serialize_entry("best", &route.best)?;
         map.serialize_entry("peer_address", &route.peer_address)?;
@@ -1268,6 +1283,11 @@ impl Serialize for JsonExplainBestPathRef<'_> {
     {
         let resp = self.0;
         let peer_scoped = !resp.peer_address.is_empty();
+        let med_attr_supported = resp
+            .best_route
+            .iter()
+            .chain(resp.candidates.iter().filter_map(|c| c.route.as_ref()))
+            .any(|r| r.med_attr.is_some());
         let mut len = 5;
         if peer_scoped {
             len += 2;
@@ -1281,7 +1301,10 @@ impl Serialize for JsonExplainBestPathRef<'_> {
         }
         map.serialize_entry(
             "best_route",
-            &JsonOptionalRouteRef(resp.best_route.as_ref()),
+            &JsonOptionalRouteRef {
+                route: resp.best_route.as_ref(),
+                med_attr_supported,
+            },
         )?;
         map.serialize_entry("best_reason", &resp.best_reason)?;
         map.serialize_entry("best_reason_detail", &resp.best_reason_detail)?;
@@ -1290,6 +1313,7 @@ impl Serialize for JsonExplainBestPathRef<'_> {
             &JsonExplainCandidatesRef {
                 candidates: &resp.candidates,
                 peer_scoped,
+                med_attr_supported,
             },
         )?;
         map.end()
@@ -1307,15 +1331,22 @@ impl Serialize for JsonExplainPrefix<'_> {
     }
 }
 
-struct JsonOptionalRouteRef<'a>(Option<&'a Route>);
+struct JsonOptionalRouteRef<'a> {
+    route: Option<&'a Route>,
+    med_attr_supported: bool,
+}
 
 impl Serialize for JsonOptionalRouteRef<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        match self.0 {
-            Some(route) => JsonRouteRef(route).serialize(serializer),
+        match self.route {
+            Some(route) => JsonRouteRef {
+                route,
+                med_attr_supported: self.med_attr_supported,
+            }
+            .serialize(serializer),
             None => serializer.serialize_none(),
         }
     }
@@ -1324,6 +1355,7 @@ impl Serialize for JsonOptionalRouteRef<'_> {
 struct JsonExplainCandidatesRef<'a> {
     candidates: &'a [crate::proto::BestPathCandidate],
     peer_scoped: bool,
+    med_attr_supported: bool,
 }
 
 impl Serialize for JsonExplainCandidatesRef<'_> {
@@ -1336,6 +1368,7 @@ impl Serialize for JsonExplainCandidatesRef<'_> {
             seq.serialize_element(&JsonExplainCandidateRef {
                 candidate,
                 peer_scoped: self.peer_scoped,
+                med_attr_supported: self.med_attr_supported,
             })?;
         }
         seq.end()
@@ -1345,6 +1378,7 @@ impl Serialize for JsonExplainCandidatesRef<'_> {
 struct JsonExplainCandidateRef<'a> {
     candidate: &'a crate::proto::BestPathCandidate,
     peer_scoped: bool,
+    med_attr_supported: bool,
 }
 
 impl Serialize for JsonExplainCandidateRef<'_> {
@@ -1359,7 +1393,13 @@ impl Serialize for JsonExplainCandidateRef<'_> {
         }
 
         let mut map = serializer.serialize_map(Some(len))?;
-        map.serialize_entry("route", &JsonOptionalRouteRef(candidate.route.as_ref()))?;
+        map.serialize_entry(
+            "route",
+            &JsonOptionalRouteRef {
+                route: candidate.route.as_ref(),
+                med_attr_supported: self.med_attr_supported,
+            },
+        )?;
         map.serialize_entry("vs_best_reason", &candidate.vs_best_reason)?;
         map.serialize_entry("vs_best_detail", &candidate.vs_best_detail)?;
         map.serialize_entry("vs_best_ordering", &candidate.vs_best_ordering)?;
@@ -2423,6 +2463,32 @@ mod tests {
         let legacy = serde_json::to_string_pretty(&legacy).unwrap();
 
         assert_eq!(direct, legacy);
+    }
+
+    #[test]
+    fn route_list_json_honors_med_absence_marker() {
+        // MED-absence-aware daemon: `med_attr` present somewhere in
+        // the response, so an explicit MED 0 stays 0 and an absent MED
+        // serializes as null.
+        let mut zero = route_for_json(0, "");
+        zero.med = 0;
+        zero.med_attr = Some(0);
+        let mut absent = route_for_json(0, "");
+        absent.med = 0;
+        absent.med_attr = None;
+        let value: serde_json::Value = serde_json::to_value(JsonRoutes(&[zero, absent])).unwrap();
+        assert_eq!(value[0]["med"], 0);
+        assert_eq!(value[1]["med"], serde_json::Value::Null);
+
+        // Older daemon: `med_attr` populated nowhere — the bare
+        // 0-defaulted field passes through unchanged.
+        let with_med = route_for_json(0, ""); // med: 50, med_attr: None
+        let mut zero_med = route_for_json(0, "");
+        zero_med.med = 0;
+        let value: serde_json::Value =
+            serde_json::to_value(JsonRoutes(&[with_med, zero_med])).unwrap();
+        assert_eq!(value[0]["med"], 50);
+        assert_eq!(value[1]["med"], 0);
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -485,6 +485,18 @@ pub fn print_neighbor_table(neighbors: &[proto::NeighborState]) {
     }
 }
 
+/// Render one MED table cell. `med_attr` is the honest absence marker
+/// (LAN-313): when the daemon supports it (populated anywhere in the
+/// response), an absent MED renders as "-"; against an older daemon the
+/// bare 0-defaulted `med` field is shown as-is.
+fn format_med(med: u32, med_attr: Option<u32>, med_attr_supported: bool) -> String {
+    match med_attr {
+        Some(m) => m.to_string(),
+        None if med_attr_supported => "-".to_string(),
+        None => med.to_string(),
+    }
+}
+
 /// Print route table with dynamic column widths and colored best marker.
 pub fn print_route_table(routes: &[proto::Route]) {
     struct Row {
@@ -499,6 +511,10 @@ pub fn print_route_table(routes: &[proto::Route]) {
         path_id: String,
     }
 
+    // A daemon that populates `med_attr` anywhere in the response is
+    // MED-absence-aware: render an absent MED as "-". Older daemons
+    // never set it, so fall back to the bare (0-defaulted) `med` field.
+    let med_attr_supported = routes.iter().any(|r| r.med_attr.is_some());
     let rows: Vec<Row> = routes
         .iter()
         .map(|r| {
@@ -514,7 +530,7 @@ pub fn print_route_table(routes: &[proto::Route]) {
                 next_hop: r.next_hop.clone(),
                 as_path: format_as_path(&r.as_path),
                 lp: r.local_pref.to_string(),
-                med: r.med.to_string(),
+                med: format_med(r.med, r.med_attr, med_attr_supported),
                 origin: format_origin(r.origin).to_string(),
                 path_id,
             }
@@ -655,6 +671,19 @@ mod tests {
         // >= 7 days
         assert_eq!(format_duration(604800), "7d 0h");
         assert_eq!(format_duration(615600), "7d 3h");
+    }
+
+    #[test]
+    fn test_format_med() {
+        // MED-absence-aware daemon: explicit values (including 0) render
+        // as numbers, an absent MED renders as "-".
+        assert_eq!(format_med(0, Some(0), true), "0");
+        assert_eq!(format_med(50, Some(50), true), "50");
+        assert_eq!(format_med(0, None, true), "-");
+        // Older daemon (med_attr populated nowhere): the bare
+        // 0-defaulted field passes through unchanged.
+        assert_eq!(format_med(0, None, false), "0");
+        assert_eq!(format_med(50, None, false), "50");
     }
 
     #[test]

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -54,10 +54,13 @@ difference, not equality. Divergence classes: `incumbent_only`,
 
 Live-source limitations (also printed in every report):
 
-- **MED**: the daemon proto carries MED as a bare integer, so MED-absent
-  and MED 0 are indistinguishable over gRPC. Live `med=0` is compared as
-  absent; snapshot producers should omit `med` when it is zero or absent,
-  or pass `--ignore-attribute med`.
+- **MED** (older daemons only): daemons that populate the `med_attr`
+  proto field are compared exactly — MED-absent and MED 0 are distinct —
+  and no MED note appears in the report. Older daemons carry MED as a
+  bare integer only, where absent and 0 are indistinguishable over gRPC:
+  their live `med=0` is compared as absent (and the report says so);
+  snapshot producers targeting them should omit `med` when it is zero or
+  absent, or pass `--ignore-attribute med`.
 - **AS_PATH**: compared as a single flattened `AS_SEQUENCE` on both sides
   (the proto exposes a flat ASN list); `AS_SET` structure is not compared.
 - **Unknown attributes**: path attributes outside the typed set are not
@@ -120,8 +123,9 @@ duplicates; multiplicity is compared):
 - `as_path`: flat ASN list (compared as one `AS_SEQUENCE`). Omit or `[]`
   for an empty path.
 - `med`, `local_pref`: omit when the attribute is absent — absent and 0
-  are distinct in the comparison (but see the MED live-source note above:
-  omit `med` when it is zero).
+  are distinct in the comparison (when targeting an older daemon without
+  `med_attr`, also omit `med` when it is zero — see the MED live-source
+  note above).
 - `communities`: `"ASN:value"` strings (well-known aliases like
   `NO_EXPORT` accepted) or raw u32 values.
 - `extended_communities`: raw 8-octet values as unsigned integers
@@ -169,8 +173,8 @@ for member, routes in export_routes():          # your incumbent's export
         rec = {"record": "route", "peer": member.ip, "peer_asn": member.asn,
                "prefix": r.prefix, "origin": r.origin, "as_path": r.as_path,
                "next_hop": r.next_hop, "communities": r.communities}
-        if r.med:                                # omit MED 0 (see note above)
-            rec["med"] = r.med
+        if r.med is not None:                    # omit MED 0 too for older
+            rec["med"] = r.med                   # daemons (see note above)
         if r.local_pref is not None:
             rec["local_pref"] = r.local_pref
         emit(rec)
@@ -206,8 +210,10 @@ the incumbent side. Common rules:
   omitted, never defaulted. Attribute kinds a source renders only
   symbolically (BIRD/FRR/GoBGP extended communities) are skipped with a
   note on stderr — compare with `--ignore-attribute extended_communities`.
-- **MED 0 is omitted** like an absent MED, matching the live side's
-  documented MED conflation.
+- **MED 0 is omitted** like an absent MED, matching the historical live
+  MED conflation. Against a daemon that populates `med_attr`, an
+  explicit live MED 0 therefore reports as a MED difference — pass
+  `--ignore-attribute med` until the adapter contracts are revised.
 
 | Adapter | Capture command (verified against) | Form |
 |---------|-------------------------------------|------|

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1652,6 +1652,9 @@ message Route {
   uint32 origin = 5;
   repeated uint32 as_path = 6;
   uint32 local_pref = 7;
+  // Deprecated for absence-sensitive consumers: a bare integer cannot
+  // distinguish "no MED attribute" from "MED 0" (absent encodes as 0).
+  // Prefer `med_attr`.
   uint32 med = 8;
   bool best = 9;
   repeated uint32 communities = 10;
@@ -1677,6 +1680,11 @@ message Route {
   // same recovery the RFC 9069 BMP Loc-RIB dump uses for its per-peer
   // header timestamp). 0 = unknown.
   uint64 received_at_epoch_seconds = 17;
+  // Distinguishes "explicit MED attribute set on the wire or by policy"
+  // (Some(value)) from "no MED attribute" (absent). Without this
+  // distinction `med = 0` could mean either "MED zero" or "no
+  // attribute". Mirrors `local_pref_attr`.
+  optional uint32 med_attr = 18;
 }
 
 message WatchRoutesRequest {


### PR DESCRIPTION
## Summary

- adds `optional uint32 med_attr` to the gRPC Route message (mirroring the existing `local_pref_attr` pattern; bare `med` deprecated in place, additive-only change) so MED-absent and MED-0 are finally distinguishable to API consumers
- populated at the single proto-Route conversion site, feeding all route listings, watch, and explain surfaces; the internal policy-context structs already carried the Option-typed twin
- rbgp renderers migrate with version-skew tolerance: the table renders absent as `-` when the daemon is absence-aware and passes the bare field through for older daemons; JSON keeps its stable key set with an honest `null`
- `rbgp diff` uses `med_attr` exactly when present (explicit med:0 snapshots now diff clean against live MED 0) and drops the MED-conflation caveat from its report notes for absence-aware daemons, retaining the old mapping and caveat against older daemons; docs updated to make the limitation version-conditional
- authz method matrix undisturbed (new field on an existing message), proven by the inventory tests

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-api (incl. authz) / -p rustbgpctl
- cargo doc --workspace --no-deps
- cargo build -p rustbgpctl --release

Closes LAN-313.