### PR TITLE
feat(rpol): add pure user-defined functions with compile-time inlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **rpol pure user-defined functions (`fn`).** The fourth ADR-0103
+  Phase B slice: `fn penalty(len: u32, weight: u32) -> u32 { let base
+  = len * weight  min(base, 1000) }` names a pure `u32` computation
+  callable from any value position. Bodies are expression-shaped
+  (`let` bindings + one result expression) and closed over nothing —
+  every input arrives as a parameter, which keeps `requires_*`
+  analyses call-site-local (a `peer.asn` argument disqualifies
+  update-group sharing; route-only arguments never do). No recursion
+  (the call graph is a DAG, cycles named in the diagnostic; depth
+  capped at 8 through the same Kahn cost DP as `apply`); calls fully
+  inline at compile time into caller-frame binding terms — no runtime
+  call frames, zero cost for programs that don't call. Inlined bodies
+  count against the existing expansion/eval-cost budgets per call
+  site and consume caller-frame slots (a term whose calls exceed the
+  256-slot frame is a compile error); explain renders calls
+  source-level and errors inside a body name both the function and
+  the calling term. (LAN-304)
+
 - **Update-group growth and residue observability.** Three new metrics
   make the registry's append-only growth and the dirty-member
   withdrawal residue visible before they matter:

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-304-fn-depth.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-304-fn-depth.rpol
@@ -1,0 +1,12 @@
+fn f1(x: u32) -> u32 { f2(x) + 1 }
+fn f2(x: u32) -> u32 { f3(x) + 1 }
+fn f3(x: u32) -> u32 { f4(x) + 1 }
+fn f4(x: u32) -> u32 { x + 1 }
+
+policy p {
+    term t {
+        let total = f1(route.med)
+        if total >= 1000 { reject }
+        accept
+    }
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-304-fn-errors.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-304-fn-errors.rpol
@@ -1,0 +1,11 @@
+fn share(total: u32, parts: u32) -> u32 { total / parts }
+
+fn f(a: u32) -> u32 { g(a) }
+fn g(a: u32) -> u32 { f(a) }
+
+fn impure(a: u32) -> u32 { a + route.med }
+
+policy p {
+    term t { if share(100, route.med) >= 1 { reject } accept }
+    term arity { if share(1) >= 2 { reject } }
+}

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-304-functions.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-304-functions.rpol
@@ -1,0 +1,16 @@
+fn penalty(len: u32, weight: u32) -> u32 {
+    let base = len * weight
+    min(base, 1000)
+}
+
+fn padded(x: u32) -> u32 { penalty(x, 10) + 7 }
+
+policy p {
+    term dampen { if penalty(route.as-path.len, 10) >= route.med { reject } }
+    term pad { set med padded(route.as-path.len); accept }
+}
+
+test penalty-rejects-long-paths {
+    route { prefix 10.0.0.0/24; as-path "65001 65002 65003"; med 20 }
+    expect p == reject
+}

--- a/crates/policy/src/engine/tests/statement_trace.rs
+++ b/crates/policy/src/engine/tests/statement_trace.rs
@@ -624,6 +624,55 @@ fn rpol_fallthrough_keeps_continue_mods_under_the_permit_default() {
     assert!(step.term_traces[2].ends_with("[not matched]"));
 }
 
+/// LAN-304 dual attribution: an evaluation error inside an inlined
+/// function body renders with the calling term's name AND the
+/// function-qualified binding names — the trace names both.
+#[test]
+fn rpol_fn_body_error_names_function_and_calling_term() {
+    const FN_RPOL: &str = r"
+fn share(total: u32, parts: u32) -> u32 {
+    let each = total / parts
+    each
+}
+policy divide {
+    term compute { if share(100, route.med) >= 1 { reject } accept }
+}
+";
+    let file = crate::rpol::RpolFile::parse(FN_RPOL).expect("clean rpol");
+    let mut store = crate::sets::SetStore::new();
+    let compiled = file
+        .compile_policy("divide", &[], &mut store)
+        .expect("policy exists");
+    let chain = PolicyChain::from_named(vec![NamedPolicy::from_rpol(
+        "divide".to_string(),
+        std::sync::Arc::new(compiled),
+    )]);
+    // med absent -> implicit 0 -> divide-by-zero inside share().
+    let trace = explain_chain_statements(Some(&chain), &plain_ctx(v4_prefix([10, 0, 0, 0], 24)));
+    assert_eq!(trace.action, PolicyAction::Deny, "fail closed");
+    let step = &trace.steps[0];
+    let traces = step.term_traces.join(
+        "
+",
+    );
+    // The calling term (compute.<n> split names) attributes the walk...
+    assert!(traces.contains("term compute."), "{traces}");
+    // ...the erroring bind names the function-qualified binding...
+    assert!(traces.contains("let share.each"), "{traces}");
+    // ...and the error renders on the uniform rail.
+    assert!(traces.contains("division by zero"), "{traces}");
+    assert!(traces.contains("fail closed => reject"), "{traces}");
+
+    // On a resolvable route the walk reaches the comparison, which
+    // renders the call source-level (the result slot's name).
+    let mut ok = plain_ctx(v4_prefix([10, 0, 0, 0], 24));
+    ok.med = Some(50);
+    let trace = explain_chain_statements(Some(&chain), &ok);
+    assert_eq!(trace.action, PolicyAction::Deny, "100/50 = 2 >= 1 rejects");
+    let traces = trace.steps[0].term_traces.join("\n");
+    assert!(traces.contains("share(100, route.med) >= 1"), "{traces}");
+}
+
 /// The rpol agreement matrix: mixed TOML + rpol chains, contexts that
 /// exercise deny terms, Continue accumulation, and fallthrough.
 fn rpol_agreement_chains() -> Vec<(&'static str, PolicyChain)> {

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -560,11 +560,20 @@ impl CompiledChain {
                     if COUNT && let Some(hits) = hits {
                         hits.eval_errors.fetch_add(1, Ordering::Relaxed);
                     }
-                    let term = policy
-                        .terms
-                        .get(term_index)
-                        .and_then(|term| term.name.as_deref());
-                    warn_eval_error(policy.name.as_deref(), term, kind);
+                    // A failing Bind names its binding — for
+                    // call-inlined binds (LAN-304) the qualified
+                    // `fn.binding` name, so the WARN names both the
+                    // function and the calling term. Error path only;
+                    // the hot path never allocates here.
+                    let term = policy.terms.get(term_index);
+                    let term_label = term.map(|term| {
+                        let name = term.name.as_deref().unwrap_or("<unnamed>");
+                        match &term.action {
+                            TermAction::Bind { name: bind, .. } => format!("{name} (let {bind})"),
+                            _ => name.to_string(),
+                        }
+                    });
+                    warn_eval_error(policy.name.as_deref(), term_label.as_deref(), kind);
                     return (
                         PolicyResult::deny(),
                         PolicyEvaluation {

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -22,10 +22,42 @@ pub struct SourceFile {
     pub community_sets: Vec<CommunitySetDef>,
     /// `asn-set` definitions.
     pub asn_sets: Vec<AsnSetDef>,
+    /// `fn` definitions (LAN-304), in source order.
+    pub fns: Vec<FnDef>,
     /// `policy` definitions, in source order.
     pub policies: Vec<PolicyDef>,
     /// `test` blocks.
     pub tests: Vec<TestDef>,
+}
+
+/// `fn NAME(params) -> u32 { lets… result }` — a pure user-defined
+/// value function (LAN-304, ADR-0103 Decision 2). Bodies are
+/// expression-shaped: `let` bindings followed by exactly one result
+/// expression — no verdicts, actions, `if`, or loops. Functions are
+/// closed over nothing (no `route.`/`peer.` reads inside bodies; every
+/// input arrives as a parameter — enforced by the typechecker), so
+/// they are pure functions of their arguments, and calls fully inline
+/// at lowering (no runtime call frames).
+#[derive(Debug)]
+pub struct FnDef {
+    /// Function name. `fn` is a top-level contextual identifier
+    /// (ADR-0103 Decision 2.2), not a reserved word.
+    pub name: Spanned<String>,
+    /// Declared parameters (all `u32` this slice).
+    pub params: Vec<Spanned<String>>,
+    /// Body `let` bindings, in source order.
+    pub lets: Vec<FnLet>,
+    /// The result expression (the body's last — and only — expression).
+    pub result: ValueExprAst,
+}
+
+/// One `let <name> = <expr>` inside a function body (LAN-304).
+#[derive(Debug)]
+pub struct FnLet {
+    /// The binding name (may shadow a parameter or earlier binding).
+    pub name: Spanned<String>,
+    /// The initializer.
+    pub init: ValueExprAst,
 }
 
 /// `prefix-set NAME { entries }`.

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -226,6 +226,13 @@ pub enum Tok {
     /// `%`
     #[token("%")]
     Percent,
+    /// `->` — the function return-type arrow (LAN-304). Un-lexable
+    /// before functions landed (`-` was a token but `>` alone was
+    /// not, so any `->` was a lex error), and the kebab identifier
+    /// rule cannot consume it (`>` is not an identifier character):
+    /// purely additive — ADR-0103 Decision 2.3.
+    #[token("->")]
+    Arrow,
 }
 
 impl Tok {
@@ -292,6 +299,7 @@ impl Tok {
             Tok::Star => "`*`",
             Tok::Slash => "`/`",
             Tok::Percent => "`%`",
+            Tok::Arrow => "`->`",
         }
     }
 }
@@ -387,6 +395,16 @@ mod tests {
         // Prefix literals own `/` inside maximal munch; arithmetic `/`
         // only appears where a prefix cannot lex.
         assert_eq!(kinds("10.0.0.0/8"), vec![Tok::PrefixLit]);
+    }
+
+    /// LAN-304: the return-type arrow lexes as one token and never
+    /// collides with kebab identifiers or spaced subtraction.
+    #[test]
+    fn arrow_vs_minus_and_kebab_munch() {
+        assert_eq!(kinds(") -> u32"), vec![Tok::RParen, Tok::Arrow, Tok::U32Kw]);
+        assert_eq!(kinds("a - b"), vec![Tok::Ident, Tok::Minus, Tok::Ident]);
+        // `>` is not an identifier character, so the munch stops at `a`.
+        assert_eq!(kinds("a->b"), vec![Tok::Ident, Tok::Arrow, Tok::Ident]);
     }
 
     #[test]

--- a/crates/policy/src/rpol/lower.rs
+++ b/crates/policy/src/rpol/lower.rs
@@ -63,7 +63,7 @@ use crate::ir::{
 use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry, SetStore};
 
 use super::ast::{
-    ActionStmt, CmpOp, CommunityArg, CommunityLit, Expr, ForSource, NextHopArg, PolicyDef,
+    ActionStmt, CmpOp, CommunityArg, CommunityLit, Expr, FnDef, ForSource, NextHopArg, PolicyDef,
     PrependAsArg, Rhs, SourceFile, Stmt, U32Arg, ValueExprAst,
 };
 use super::typeck::{Field, resolve_field, value_field_of};
@@ -83,7 +83,11 @@ use super::typeck::{Field, resolve_field, value_field_of};
 #[derive(Default)]
 struct LetEnv {
     lets: Vec<(String, u8)>,
-    next_slot: u8,
+    // u16, not u8: a full frame's last declare leaves next_slot ==
+    // LOCAL_FRAME_SLOTS (256), which the slot type cannot hold — the
+    // typecheck frame budget admits exactly-full frames (LAN-304
+    // boundary test).
+    next_slot: u16,
 }
 
 impl LetEnv {
@@ -100,27 +104,97 @@ impl LetEnv {
     /// per-scope `MAX_LOCALS` cap bounds `next_slot` below the frame
     /// size (two nesting levels × 64).
     fn declare(&mut self, name: &str) -> u8 {
-        let slot = self.next_slot;
         assert!(
-            usize::from(slot) < crate::eval::LOCAL_FRAME_SLOTS,
-            "typechecked: per-scope caps bound the frame"
+            usize::from(self.next_slot) < crate::eval::LOCAL_FRAME_SLOTS,
+            "typechecked: per-scope and frame budgets bound the allocation"
         );
+        let slot = u8::try_from(self.next_slot).expect("bounded by the frame assert");
         self.next_slot += 1;
         self.lets.push((name.to_string(), slot));
         slot
     }
 
     /// Snapshot the scope for a nested `if`/`else` body.
-    fn mark(&self) -> (usize, u8) {
+    fn mark(&self) -> (usize, u16) {
         (self.lets.len(), self.next_slot)
     }
 
     /// Leave a nested scope: its names go out of scope and its slots
     /// become reusable by sibling scopes.
-    fn reset(&mut self, (len, next_slot): (usize, u8)) {
+    fn reset(&mut self, (len, next_slot): (usize, u16)) {
         self.lets.truncate(len);
         self.next_slot = next_slot;
     }
+}
+
+/// How bare identifiers resolve while lowering a value expression:
+/// the policy scope (visible `let` bindings shadowing policy
+/// parameters — the LAN-302 rule), or an inlined function body
+/// (LAN-304), which is closed over nothing — its parameters and body
+/// lets are already slot-allocated, and nothing else is visible.
+enum Names<'a> {
+    /// Policy context: `env` maps parameters to their instantiation
+    /// constants; the `LetEnv` resolves visible bindings.
+    Policy(&'a HashMap<&'a str, u32>),
+    /// Inlined function body: `(source name, qualified render name,
+    /// slot)` for the parameters and body lets bound so far, innermost
+    /// last (reverse scan gives shadowing).
+    FnBody(&'a [(&'a str, Box<str>, u8)]),
+}
+
+/// Render a value expression back to `.rpol` source form — the name a
+/// call's result slot carries, so guards containing an inlined call
+/// render source-level in explain (`penalty(route.as-path.len, 10) >=
+/// route.med`). Deterministic from the AST (Decision 5: names
+/// participate in chain equality). Minimal parentheses, mirroring
+/// [`crate::ir::ValueExpr`]'s Display precedence.
+fn render_value_ast(expr: &ValueExprAst) -> String {
+    fn binding(expr: &ValueExprAst) -> u8 {
+        match expr {
+            ValueExprAst::Binary {
+                op: crate::ir::ArithOp::Add | crate::ir::ArithOp::Sub,
+                ..
+            } => 0,
+            ValueExprAst::Binary { .. } => 1,
+            _ => 2,
+        }
+    }
+    fn render(expr: &ValueExprAst, out: &mut String, min_binding: u8) {
+        let paren = binding(expr) < min_binding;
+        if paren {
+            out.push('(');
+        }
+        match expr {
+            ValueExprAst::Lit(value, _) => {
+                let _ = std::fmt::Write::write_fmt(out, format_args!("{value}"));
+            }
+            ValueExprAst::Ident(name) => out.push_str(&name.node),
+            ValueExprAst::Field(path) => out.push_str(&path.render()),
+            ValueExprAst::Binary { op, lhs, rhs, .. } => {
+                let this = binding(expr);
+                render(lhs, out, this);
+                let _ = std::fmt::Write::write_fmt(out, format_args!(" {} ", op.symbol()));
+                render(rhs, out, this + 1);
+            }
+            ValueExprAst::Call { name, args, .. } => {
+                out.push_str(&name.node);
+                out.push('(');
+                for (index, arg) in args.iter().enumerate() {
+                    if index > 0 {
+                        out.push_str(", ");
+                    }
+                    render(arg, out, 0);
+                }
+                out.push(')');
+            }
+        }
+        if paren {
+            out.push(')');
+        }
+    }
+    let mut out = String::new();
+    render(expr, &mut out, 0);
+    out
 }
 
 /// Encode a community literal's concrete wire value (for
@@ -392,9 +466,15 @@ impl<'a> Lowerer<'a> {
                 }
                 // Body `let`: lower the initializer against the scope
                 // *before* declaring, so `let x = x + 1` reads the
-                // prior `x` (shadowing, not self-reference).
+                // prior `x` (shadowing, not self-reference). Function
+                // calls in the initializer hoist their binds ahead of
+                // the binding's own (LAN-304).
                 Stmt::Action(ActionStmt::Let { name, init, .. }) => {
-                    let expr = lower_value(init, env, lets);
+                    let mut call_binds = Vec::new();
+                    let expr = self.lower_value(init, &Names::Policy(env), lets, &mut call_binds);
+                    for bind in call_binds {
+                        out.push((MatchExpr::True, bind));
+                    }
                     let slot = lets.declare(&name.node);
                     out.push((
                         MatchExpr::True,
@@ -428,17 +508,34 @@ impl<'a> Lowerer<'a> {
                             },
                         ));
                     } else {
-                        apply_action(&mut pending, action, env, lets);
+                        let mut call_binds = Vec::new();
+                        self.apply_action(&mut pending, action, env, lets, &mut call_binds);
+                        for bind in call_binds {
+                            out.push((MatchExpr::True, bind));
+                        }
                     }
                 }
                 Stmt::Action(action) => {
-                    apply_action(&mut pending, action, env, lets);
+                    let mut call_binds = Vec::new();
+                    self.apply_action(&mut pending, action, env, lets, &mut call_binds);
+                    for bind in call_binds {
+                        out.push((MatchExpr::True, bind));
+                    }
                 }
                 Stmt::If(if_stmt) => {
                     flush_pending(&mut out, &mut pending);
-                    let guard = self.lower_expr(&if_stmt.cond, env, lets, store);
+                    // Function calls in the guard hoist their binds as
+                    // unconditional terms ahead of the guard's own
+                    // (LAN-304): they evaluate when the walk reaches
+                    // this statement — eager like `let`, so both the
+                    // positive and negated guard read written slots.
+                    let mut guard_binds = Vec::new();
+                    let guard = self.lower_expr(&if_stmt.cond, env, lets, store, &mut guard_binds);
+                    for bind in guard_binds {
+                        out.push((MatchExpr::True, bind));
+                    }
                     let scope = lets.mark();
-                    let (then_binds, then_tail) = lower_body(&if_stmt.then_actions, env, lets);
+                    let (then_binds, then_tail) = self.lower_body(&if_stmt.then_actions, env, lets);
                     lets.reset(scope);
                     let needs_else_guard = if_stmt.else_actions.is_some();
                     // Body `let`s become Bind terms guarded by the
@@ -460,7 +557,7 @@ impl<'a> Lowerer<'a> {
                     }
                     if let Some(else_actions) = &if_stmt.else_actions {
                         let scope = lets.mark();
-                        let (else_binds, else_tail) = lower_body(else_actions, env, lets);
+                        let (else_binds, else_tail) = self.lower_body(else_actions, env, lets);
                         lets.reset(scope);
                         let negated = MatchExpr::Not(Box::new(guard));
                         for bind in else_binds {
@@ -521,30 +618,36 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// `binds` receives the hoisted `Bind` terms of any user-function
+    /// calls inside the guard's value expressions (LAN-304); the
+    /// caller emits them ahead of the guard's terms.
     fn lower_expr(
         &mut self,
         expr: &Expr,
         env: &HashMap<&str, u32>,
-        lets: &LetEnv,
+        lets: &mut LetEnv,
         store: &mut SetStore,
+        binds: &mut Vec<TermAction>,
     ) -> MatchExpr {
         match expr {
             Expr::And(lhs, rhs) => {
                 let mut children = vec![
-                    self.lower_expr(lhs, env, lets, store),
-                    self.lower_expr(rhs, env, lets, store),
+                    self.lower_expr(lhs, env, lets, store, binds),
+                    self.lower_expr(rhs, env, lets, store, binds),
                 ];
                 // Guards are pure; order And-children cheapest-first
                 // (the IR invariant shared with the TOML compiler).
+                // Call binds hoisted above already wrote their slots,
+                // so reordering the reads cannot diverge.
                 children.sort_by_key(MatchExpr::cost_class);
                 MatchExpr::And(children)
             }
             Expr::Or(lhs, rhs) => MatchExpr::Or(vec![
-                self.lower_expr(lhs, env, lets, store),
-                self.lower_expr(rhs, env, lets, store),
+                self.lower_expr(lhs, env, lets, store, binds),
+                self.lower_expr(rhs, env, lets, store, binds),
             ]),
             Expr::Not(inner, _) => {
-                MatchExpr::Not(Box::new(self.lower_expr(inner, env, lets, store)))
+                MatchExpr::Not(Box::new(self.lower_expr(inner, env, lets, store, binds)))
             }
             Expr::Cmp { field, op, rhs, .. } => lower_cmp(field, *op, rhs, env, lets),
             // LAN-299: value comparisons keep their shape (constant
@@ -559,8 +662,8 @@ impl<'a> Lowerer<'a> {
                     CmpOp::Ge => ValueCmpOp::Ge,
                     CmpOp::Le => ValueCmpOp::Le,
                 },
-                lhs: lower_value(lhs, env, lets),
-                rhs: lower_value(rhs, env, lets),
+                lhs: self.lower_value(lhs, &Names::Policy(env), lets, binds),
+                rhs: self.lower_value(rhs, &Names::Policy(env), lets, binds),
             })),
             Expr::In { field, set } => match resolve_field(field).expect("typechecked") {
                 Field::Prefix => MatchExpr::PrefixInSet(self.prefix_set_ids[&set.node]),
@@ -845,274 +948,396 @@ fn flush_pending(out: &mut Vec<(MatchExpr, TermAction)>, pending: &mut RouteModi
 
 /// Lower an `if` body (a flat action list) to its `let` bindings
 /// (LAN-302 — [`TermAction::Bind`]s the caller emits ahead of the
-/// action terms, guarded by the branch condition) and its ordered
-/// action tail: staged modifications as `Continue` terms interleaved
-/// (in execution order) with binding-valued community actions
-/// (LAN-303), ending with the body's terminal — `Permit` on `accept`,
-/// `Deny` on `reject`, `Break`/`ContinueLoop` on loop control — or
-/// nothing when the body only modifies/does nothing. The caller wraps
-/// this in a `lets` scope mark/reset — body bindings are not visible
-/// outside the body.
-fn lower_body(
-    actions: &[ActionStmt],
-    env: &HashMap<&str, u32>,
-    lets: &mut LetEnv,
-) -> (Vec<TermAction>, Vec<TermAction>) {
-    let mut binds = Vec::new();
-    let mut tail: Vec<TermAction> = Vec::new();
-    let mut mods = RouteModifications::default();
-    let flush = |tail: &mut Vec<TermAction>, mods: &mut RouteModifications| {
-        if !mods.is_empty() {
-            tail.push(TermAction::Continue(std::mem::take(mods)));
+/// action terms, guarded by the branch condition; function-call binds
+/// hoist here too, LAN-304) and its ordered action tail: staged
+/// modifications as `Continue` terms interleaved (in execution order)
+/// with binding-valued community actions (LAN-303), ending with the
+/// body's terminal — `Permit` on `accept`, `Deny` on `reject`,
+/// `Break`/`ContinueLoop` on loop control — or nothing when the body
+/// only modifies/does nothing. The caller wraps this in a `lets` scope
+/// mark/reset — body bindings are not visible outside the body.
+impl Lowerer<'_> {
+    fn lower_body(
+        &self,
+        actions: &[ActionStmt],
+        env: &HashMap<&str, u32>,
+        lets: &mut LetEnv,
+    ) -> (Vec<TermAction>, Vec<TermAction>) {
+        let mut binds = Vec::new();
+        let mut tail: Vec<TermAction> = Vec::new();
+        let mut mods = RouteModifications::default();
+        let flush = |tail: &mut Vec<TermAction>, mods: &mut RouteModifications| {
+            if !mods.is_empty() {
+                tail.push(TermAction::Continue(std::mem::take(mods)));
+            }
+        };
+        for action in actions {
+            match action {
+                ActionStmt::Accept(_) => {
+                    tail.push(TermAction::Permit(mods));
+                    return (binds, tail);
+                }
+                ActionStmt::Reject(_) => {
+                    tail.push(TermAction::Deny);
+                    return (binds, tail);
+                }
+                // Loop control (LAN-303): staged modifications still
+                // apply, then the branch is terminal.
+                ActionStmt::Break(_) => {
+                    flush(&mut tail, &mut mods);
+                    tail.push(TermAction::Break);
+                    return (binds, tail);
+                }
+                ActionStmt::Continue(_) => {
+                    flush(&mut tail, &mut mods);
+                    tail.push(TermAction::ContinueLoop);
+                    return (binds, tail);
+                }
+                ActionStmt::Let { name, init, .. } => {
+                    let expr = self.lower_value(init, &Names::Policy(env), lets, &mut binds);
+                    let slot = lets.declare(&name.node);
+                    binds.push(TermAction::Bind {
+                        slot,
+                        name: name.node.clone().into_boxed_str(),
+                        expr,
+                    });
+                }
+                // LAN-303: binding-valued community action — its own
+                // term, in execution order relative to staged
+                // modifications.
+                ActionStmt::Community {
+                    add,
+                    arg: CommunityArg::Var(name),
+                    ..
+                } if lets.lookup(&name.node).is_some() => {
+                    flush(&mut tail, &mut mods);
+                    tail.push(TermAction::CommunityVar {
+                        add: *add,
+                        slot: lets.lookup(&name.node).expect("checked above"),
+                        name: name.node.clone().into_boxed_str(),
+                    });
+                }
+                other => self.apply_action(&mut mods, other, env, lets, &mut binds),
+            }
         }
-    };
-    for action in actions {
+        flush(&mut tail, &mut mods);
+        (binds, tail)
+    }
+
+    /// Stage one modification action into `mods`. Function calls in
+    /// computed `set` values hoist their `Bind` terms into `binds`
+    /// (LAN-304); the caller emits them ahead of the term that carries
+    /// the staged modifications, so the computed expression's `Local`
+    /// reads always follow their writes in walk order.
+    fn apply_action(
+        &self,
+        mods: &mut RouteModifications,
+        action: &ActionStmt,
+        env: &HashMap<&str, u32>,
+        lets: &mut LetEnv,
+        binds: &mut Vec<TermAction>,
+    ) {
         match action {
-            ActionStmt::Accept(_) => {
-                tail.push(TermAction::Permit(mods));
-                return (binds, tail);
+            ActionStmt::Accept(_)
+            | ActionStmt::Reject(_)
+            | ActionStmt::Let { .. }
+            | ActionStmt::Break(_)
+            | ActionStmt::Continue(_) => {
+                unreachable!("verdicts, `let`, and loop control handled by callers")
             }
-            ActionStmt::Reject(_) => {
-                tail.push(TermAction::Deny);
-                return (binds, tail);
+            // LAN-299: a computed set value that folds to a constant
+            // (literal, parameter, or constant arithmetic) lowers to
+            // the literal field — `set med 25 + 25` compiles to
+            // exactly what `set med 50` does. Only expressions that
+            // read route/peer fields (or an inlined call's result,
+            // LAN-304) stay computed (resolved per route by the
+            // evaluator).
+            ActionStmt::SetLocalPref(expr, _) => {
+                match self.lower_value(expr, &Names::Policy(env), lets, binds) {
+                    ValueExpr::Const(value) => mods.set_local_pref = Some(value),
+                    computed => {
+                        mods.set_local_pref_computed = Some(std::sync::Arc::new(computed));
+                    }
+                }
             }
-            // Loop control (LAN-303): staged modifications still
-            // apply, then the branch is terminal.
-            ActionStmt::Break(_) => {
-                flush(&mut tail, &mut mods);
-                tail.push(TermAction::Break);
-                return (binds, tail);
+            ActionStmt::SetMed(expr, _) => {
+                match self.lower_value(expr, &Names::Policy(env), lets, binds) {
+                    ValueExpr::Const(value) => mods.set_med = Some(value),
+                    computed => mods.set_med_computed = Some(std::sync::Arc::new(computed)),
+                }
             }
-            ActionStmt::Continue(_) => {
-                flush(&mut tail, &mut mods);
-                tail.push(TermAction::ContinueLoop);
-                return (binds, tail);
-            }
-            ActionStmt::Let { name, init, .. } => {
-                let expr = lower_value(init, env, lets);
-                let slot = lets.declare(&name.node);
-                binds.push(TermAction::Bind {
-                    slot,
-                    name: name.node.clone().into_boxed_str(),
-                    expr,
+            ActionStmt::SetNextHop(arg, _) => {
+                mods.set_next_hop = Some(match arg {
+                    NextHopArg::Self_(_) => NextHopAction::Self_,
+                    NextHopArg::Addr(addr, _) => NextHopAction::Specific(*addr),
                 });
             }
-            // LAN-303: binding-valued community action — its own term,
-            // in execution order relative to staged modifications.
+            // LAN-303: a parameter-valued community reference is a
+            // compile-time constant — it stages as a literal, exactly like
+            // writing the value. (Binding-valued references are emitted as
+            // their own CommunityVar terms by the statement/body lowerers
+            // and never reach here.)
             ActionStmt::Community {
                 add,
                 arg: CommunityArg::Var(name),
                 ..
-            } if lets.lookup(&name.node).is_some() => {
-                flush(&mut tail, &mut mods);
-                tail.push(TermAction::CommunityVar {
-                    add: *add,
-                    slot: lets.lookup(&name.node).expect("checked above"),
-                    name: name.node.clone().into_boxed_str(),
-                });
-            }
-            other => apply_action(&mut mods, other, env, lets),
-        }
-    }
-    flush(&mut tail, &mut mods);
-    (binds, tail)
-}
-
-fn apply_action(
-    mods: &mut RouteModifications,
-    action: &ActionStmt,
-    env: &HashMap<&str, u32>,
-    lets: &LetEnv,
-) {
-    match action {
-        ActionStmt::Accept(_)
-        | ActionStmt::Reject(_)
-        | ActionStmt::Let { .. }
-        | ActionStmt::Break(_)
-        | ActionStmt::Continue(_) => {
-            unreachable!("verdicts, `let`, and loop control handled by callers")
-        }
-        // LAN-299: a computed set value that folds to a constant
-        // (literal, parameter, or constant arithmetic) lowers to the
-        // literal field — `set med 25 + 25` compiles to exactly what
-        // `set med 50` does. Only expressions that read route/peer
-        // fields stay computed (resolved per route by the evaluator).
-        ActionStmt::SetLocalPref(expr, _) => match lower_value(expr, env, lets) {
-            ValueExpr::Const(value) => mods.set_local_pref = Some(value),
-            computed => mods.set_local_pref_computed = Some(std::sync::Arc::new(computed)),
-        },
-        ActionStmt::SetMed(expr, _) => match lower_value(expr, env, lets) {
-            ValueExpr::Const(value) => mods.set_med = Some(value),
-            computed => mods.set_med_computed = Some(std::sync::Arc::new(computed)),
-        },
-        ActionStmt::SetNextHop(arg, _) => {
-            mods.set_next_hop = Some(match arg {
-                NextHopArg::Self_(_) => NextHopAction::Self_,
-                NextHopArg::Addr(addr, _) => NextHopAction::Specific(*addr),
-            });
-        }
-        // LAN-303: a parameter-valued community reference is a
-        // compile-time constant — it stages as a literal, exactly like
-        // writing the value. (Binding-valued references are emitted as
-        // their own CommunityVar terms by the statement/body lowerers
-        // and never reach here.)
-        ActionStmt::Community {
-            add,
-            arg: CommunityArg::Var(name),
-            ..
-        } => {
-            let value = *env
-                .get(name.node.as_str())
-                .expect("typechecked: non-binding community var is a parameter");
-            if *add {
-                mods.communities_add.push(value);
-            } else {
-                mods.communities_remove.push(value);
-            }
-        }
-        ActionStmt::Community {
-            add,
-            arg: CommunityArg::Lit(lit),
-            ..
-        } => match lit.node {
-            CommunityLit::Standard(value) => {
+            } => {
+                let value = *env
+                    .get(name.node.as_str())
+                    .expect("typechecked: non-binding community var is a parameter");
                 if *add {
                     mods.communities_add.push(value);
                 } else {
                     mods.communities_remove.push(value);
                 }
             }
-            CommunityLit::Large(lc) => {
-                if *add {
-                    mods.large_communities_add.push(lc);
-                } else {
-                    mods.large_communities_remove.push(lc);
+            ActionStmt::Community {
+                add,
+                arg: CommunityArg::Lit(lit),
+                ..
+            } => match lit.node {
+                CommunityLit::Standard(value) => {
+                    if *add {
+                        mods.communities_add.push(value);
+                    } else {
+                        mods.communities_remove.push(value);
+                    }
                 }
-            }
-            CommunityLit::Ext {
-                route_target,
-                global,
-                local,
-                ipv4_admin,
-            } => {
-                let value = ext_community_value(route_target, global, local, ipv4_admin);
-                if *add {
-                    mods.extended_communities_add.push(value);
-                } else {
-                    mods.extended_communities_remove.push(value);
+                CommunityLit::Large(lc) => {
+                    if *add {
+                        mods.large_communities_add.push(lc);
+                    } else {
+                        mods.large_communities_remove.push(lc);
+                    }
                 }
-            }
-            // Well-known extended communities (RFC 8097 OV_* states):
-            // add/remove by exact raw wire value.
-            CommunityLit::ExtRaw(raw) => {
-                let value = ExtendedCommunity::new(raw);
-                if *add {
-                    mods.extended_communities_add.push(value);
-                } else {
-                    mods.extended_communities_remove.push(value);
+                CommunityLit::Ext {
+                    route_target,
+                    global,
+                    local,
+                    ipv4_admin,
+                } => {
+                    let value = ext_community_value(route_target, global, local, ipv4_admin);
+                    if *add {
+                        mods.extended_communities_add.push(value);
+                    } else {
+                        mods.extended_communities_remove.push(value);
+                    }
                 }
-            }
-        },
-        ActionStmt::Prepend { asn, count, .. } => {
-            let count = u8::try_from(resolve_u32(count, env))
-                .expect("typechecked: count is a 1-255 literal");
-            // LAN-296: computed operands lower to the staged
-            // `as_path_prepend_computed` slot (resolved per route by
-            // the evaluator); the literal/parameter form keeps its
-            // existing lowering. The operand decision is shared with
-            // the typechecker (`PrependAsArg::operand`).
-            if let Some(operand) = asn.operand(|name| env.contains_key(name)) {
-                mods.as_path_prepend_computed = Some((operand, count));
-            } else {
-                let PrependAsArg::Value(arg) = asn else {
-                    unreachable!("non-Value prepend args always denote an operand")
-                };
-                mods.as_path_prepend = Some((resolve_u32(arg, env), count));
+                // Well-known extended communities (RFC 8097 OV_* states):
+                // add/remove by exact raw wire value.
+                CommunityLit::ExtRaw(raw) => {
+                    let value = ExtendedCommunity::new(raw);
+                    if *add {
+                        mods.extended_communities_add.push(value);
+                    } else {
+                        mods.extended_communities_remove.push(value);
+                    }
+                }
+            },
+            ActionStmt::Prepend { asn, count, .. } => {
+                let count = u8::try_from(resolve_u32(count, env))
+                    .expect("typechecked: count is a 1-255 literal");
+                // LAN-296: computed operands lower to the staged
+                // `as_path_prepend_computed` slot (resolved per route by
+                // the evaluator); the literal/parameter form keeps its
+                // existing lowering. The operand decision is shared with
+                // the typechecker (`PrependAsArg::operand`).
+                if let Some(operand) = asn.operand(|name| env.contains_key(name)) {
+                    mods.as_path_prepend_computed = Some((operand, count));
+                } else {
+                    let PrependAsArg::Value(arg) = asn else {
+                        unreachable!("non-Value prepend args always denote an operand")
+                    };
+                    mods.as_path_prepend = Some((resolve_u32(arg, env), count));
+                }
             }
         }
     }
 }
 
-/// Lower a value expression to IR with parameters substituted and
-/// `let` bindings resolved to frame slots (innermost first — LAN-302
-/// shadowing), folding constant subtrees bottom-up with checked
-/// arithmetic (LAN-299). A constant step that fails its check (e.g.
-/// `4294967295 + p` with `p = 1` at instantiation — invisible to the
-/// typechecker, which only sees literals) is left unfolded and fails
-/// per route on the eval-error rail: fail closed, never wrap.
-fn lower_value(expr: &ValueExprAst, env: &HashMap<&str, u32>, lets: &LetEnv) -> ValueExpr {
-    match expr {
-        ValueExprAst::Lit(value, _) => ValueExpr::Const(*value),
-        ValueExprAst::Ident(name) => {
-            // Innermost binding shadows parameters (and outer
-            // bindings) in value positions — the typechecker resolves
-            // by the same rule.
-            if let Some(slot) = lets.lookup(&name.node) {
-                return ValueExpr::Local {
-                    slot,
-                    name: name.node.clone().into_boxed_str(),
-                };
+impl<'a> Lowerer<'a> {
+    /// Lower a value expression to IR: parameters substituted, `let`
+    /// bindings resolved to frame slots (innermost first — LAN-302
+    /// shadowing), constant subtrees folded bottom-up with checked
+    /// arithmetic (LAN-299), and user-function calls fully inlined
+    /// (LAN-304) — each call hoists `Bind` terms into `binds` (the
+    /// caller emits them ahead of the reading term) and reads its
+    /// result slot. A constant step that fails its check (e.g.
+    /// `4294967295 + p` with `p = 1` at instantiation — invisible to
+    /// the typechecker, which only sees literals) is left unfolded and
+    /// fails per route on the eval-error rail: fail closed, never
+    /// wrap.
+    fn lower_value(
+        &self,
+        expr: &ValueExprAst,
+        names: &Names<'_>,
+        lets: &mut LetEnv,
+        binds: &mut Vec<TermAction>,
+    ) -> ValueExpr {
+        match expr {
+            ValueExprAst::Lit(value, _) => ValueExpr::Const(*value),
+            ValueExprAst::Ident(name) => match names {
+                // Innermost binding shadows parameters (and outer
+                // bindings) in value positions — the typechecker
+                // resolves by the same rule.
+                Names::Policy(env) => {
+                    if let Some(slot) = lets.lookup(&name.node) {
+                        return ValueExpr::Local {
+                            slot,
+                            name: name.node.clone().into_boxed_str(),
+                        };
+                    }
+                    ValueExpr::Const(
+                        *env.get(name.node.as_str())
+                            .expect("typechecked: parameter in scope"),
+                    )
+                }
+                // Function bodies see their parameters and earlier
+                // body lets, nothing else (closed over nothing). The
+                // read renders by its qualified `fn.binding` name so
+                // explain and eval-error surfaces name the function.
+                Names::FnBody(bound) => {
+                    let (_, qualified, slot) = bound
+                        .iter()
+                        .rev()
+                        .find(|(source, _, _)| *source == name.node)
+                        .expect("typechecked: fn-body names resolve");
+                    ValueExpr::Local {
+                        slot: *slot,
+                        name: qualified.clone(),
+                    }
+                }
+            },
+            ValueExprAst::Field(path) => {
+                debug_assert!(
+                    matches!(names, Names::Policy(_)),
+                    "typechecked: function bodies read no context fields"
+                );
+                let field = value_field_of(resolve_field(path).expect("typechecked"))
+                    .expect("typechecked: u32 field operand");
+                ValueExpr::Field(field)
             }
-            ValueExpr::Const(
-                *env.get(name.node.as_str())
-                    .expect("typechecked: parameter in scope"),
-            )
+            ValueExprAst::Binary { op, lhs, rhs, .. } => {
+                let lhs = self.lower_value(lhs, names, lets, binds);
+                let rhs = self.lower_value(rhs, names, lets, binds);
+                if let (ValueExpr::Const(l), ValueExpr::Const(r)) = (&lhs, &rhs)
+                    && let Ok(folded) = checked_arith(*op, *l, *r)
+                {
+                    return ValueExpr::Const(folded);
+                }
+                ValueExpr::Binary {
+                    op: *op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                }
+            }
+            ValueExprAst::Call { name, args, .. } => {
+                // A user-defined function inlines (LAN-304); the
+                // builtins keep their dedicated IR nodes below.
+                if let Some(def) = self.file.fns.iter().find(|f| f.name.node == name.node) {
+                    return self.inline_call(def, args, names, lets, binds);
+                }
+                let mut args: Vec<ValueExpr> = args
+                    .iter()
+                    .map(|arg| self.lower_value(arg, names, lets, binds))
+                    .collect();
+                let consts: Vec<Option<u32>> = args
+                    .iter()
+                    .map(|arg| match arg {
+                        ValueExpr::Const(value) => Some(*value),
+                        _ => None,
+                    })
+                    .collect();
+                match (name.node.as_str(), consts.as_slice()) {
+                    ("min", [Some(a), Some(b)]) => ValueExpr::Const((*a).min(*b)),
+                    ("max", [Some(a), Some(b)]) => ValueExpr::Const((*a).max(*b)),
+                    ("clamp", [Some(x), Some(lo), Some(hi)]) if lo <= hi => {
+                        ValueExpr::Const((*x).clamp(*lo, *hi))
+                    }
+                    ("min", _) => {
+                        let b = Box::new(args.pop().expect("typechecked arity"));
+                        let a = Box::new(args.pop().expect("typechecked arity"));
+                        ValueExpr::Min(a, b)
+                    }
+                    ("max", _) => {
+                        let b = Box::new(args.pop().expect("typechecked arity"));
+                        let a = Box::new(args.pop().expect("typechecked arity"));
+                        ValueExpr::Max(a, b)
+                    }
+                    // Statically inverted constant clamps are typecheck
+                    // errors; a parameter-dependent inversion stays a
+                    // Clamp node and fails per route.
+                    _ => {
+                        let hi = Box::new(args.pop().expect("typechecked arity"));
+                        let lo = Box::new(args.pop().expect("typechecked arity"));
+                        let x = Box::new(args.pop().expect("typechecked arity"));
+                        ValueExpr::Clamp(x, lo, hi)
+                    }
+                }
+            }
         }
-        ValueExprAst::Field(path) => {
-            let field = value_field_of(resolve_field(path).expect("typechecked"))
-                .expect("typechecked: u32 field operand");
-            ValueExpr::Field(field)
+    }
+
+    /// Inline one user-function call (LAN-304, ADR-0103 Decision 2): a
+    /// call is sugar for a scope of lets — each argument binds to a
+    /// caller-frame slot named `fn.param`, each body `let` to
+    /// `fn.binding`, and the result expression to a slot named by the
+    /// rendered call itself, which the call site reads. Slots allocate
+    /// monotonically (never reused within a statement — later terms
+    /// may read them when computed modifications resolve), a pure
+    /// function of the source (Decision 5 determinism); the frame,
+    /// depth, and expansion budgets are typecheck-enforced through the
+    /// same Kahn DP as `apply` before lowering runs, so this recursion
+    /// (bounded by `MAX_CALL_DEPTH`) cannot overflow or explode.
+    fn inline_call(
+        &self,
+        def: &'a FnDef,
+        args: &[ValueExprAst],
+        names: &Names<'_>,
+        lets: &mut LetEnv,
+        binds: &mut Vec<TermAction>,
+    ) -> ValueExpr {
+        debug_assert_eq!(def.params.len(), args.len(), "typechecked arity");
+        let mut bound: Vec<(&str, Box<str>, u8)> = Vec::new();
+        for (param, arg) in def.params.iter().zip(args) {
+            // Arguments evaluate in the CALLER's name context.
+            let expr = self.lower_value(arg, names, lets, binds);
+            let qualified: Box<str> = format!("{}.{}", def.name.node, param.node).into();
+            let slot = lets.declare(&qualified);
+            binds.push(TermAction::Bind {
+                slot,
+                name: qualified.clone(),
+                expr,
+            });
+            bound.push((param.node.as_str(), qualified, slot));
         }
-        ValueExprAst::Binary { op, lhs, rhs, .. } => {
-            let lhs = lower_value(lhs, env, lets);
-            let rhs = lower_value(rhs, env, lets);
-            if let (ValueExpr::Const(l), ValueExpr::Const(r)) = (&lhs, &rhs)
-                && let Ok(folded) = checked_arith(*op, *l, *r)
-            {
-                return ValueExpr::Const(folded);
-            }
-            ValueExpr::Binary {
-                op: *op,
-                lhs: Box::new(lhs),
-                rhs: Box::new(rhs),
-            }
+        for l in &def.lets {
+            // Initializers resolve before their own name is bound —
+            // shadowing, never self-reference (the LAN-302 rule).
+            let expr = self.lower_value(&l.init, &Names::FnBody(&bound), lets, binds);
+            let qualified: Box<str> = format!("{}.{}", def.name.node, l.name.node).into();
+            let slot = lets.declare(&qualified);
+            binds.push(TermAction::Bind {
+                slot,
+                name: qualified.clone(),
+                expr,
+            });
+            bound.push((l.name.node.as_str(), qualified, slot));
         }
-        ValueExprAst::Call { name, args, .. } => {
-            let mut args: Vec<ValueExpr> =
-                args.iter().map(|arg| lower_value(arg, env, lets)).collect();
-            let consts: Vec<Option<u32>> = args
-                .iter()
-                .map(|arg| match arg {
-                    ValueExpr::Const(value) => Some(*value),
-                    _ => None,
-                })
-                .collect();
-            match (name.node.as_str(), consts.as_slice()) {
-                ("min", [Some(a), Some(b)]) => ValueExpr::Const((*a).min(*b)),
-                ("max", [Some(a), Some(b)]) => ValueExpr::Const((*a).max(*b)),
-                ("clamp", [Some(x), Some(lo), Some(hi)]) if lo <= hi => {
-                    ValueExpr::Const((*x).clamp(*lo, *hi))
-                }
-                ("min", _) => {
-                    let b = Box::new(args.pop().expect("typechecked arity"));
-                    let a = Box::new(args.pop().expect("typechecked arity"));
-                    ValueExpr::Min(a, b)
-                }
-                ("max", _) => {
-                    let b = Box::new(args.pop().expect("typechecked arity"));
-                    let a = Box::new(args.pop().expect("typechecked arity"));
-                    ValueExpr::Max(a, b)
-                }
-                // Statically inverted constant clamps are typecheck
-                // errors; a parameter-dependent inversion stays a
-                // Clamp node and fails per route.
-                _ => {
-                    let hi = Box::new(args.pop().expect("typechecked arity"));
-                    let lo = Box::new(args.pop().expect("typechecked arity"));
-                    let x = Box::new(args.pop().expect("typechecked arity"));
-                    ValueExpr::Clamp(x, lo, hi)
-                }
-            }
+        let result = self.lower_value(&def.result, &Names::FnBody(&bound), lets, binds);
+        // The result slot is named by the rendered call, so guards
+        // reading it render source-level in explain.
+        let rendered_args: Vec<String> = args.iter().map(render_value_ast).collect();
+        let call_name: Box<str> = format!("{}({})", def.name.node, rendered_args.join(", ")).into();
+        let slot = lets.declare(&call_name);
+        binds.push(TermAction::Bind {
+            slot,
+            name: call_name.clone(),
+            expr: result,
+        });
+        ValueExpr::Local {
+            slot,
+            name: call_name,
         }
     }
 }

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -16,9 +16,9 @@ use crate::ir::ArithOp;
 
 use super::ast::{
     ActionStmt, AsnSetDef, CmpOp, CommunityArg, CommunityKind, CommunityLit, CommunitySetDef,
-    ExpectDef, Expr, FieldPath, FieldRoot, ForSource, ForStmt, IfStmt, NextHopArg, PeerField,
-    PolicyDef, PrefixEntryAst, PrefixSetDef, PrependAsArg, Rhs, RouteField, SourceFile, Stmt,
-    TermDef, TestDef, U32Arg, ValueExprAst, WithAssertion,
+    ExpectDef, Expr, FieldPath, FieldRoot, FnDef, FnLet, ForSource, ForStmt, IfStmt, NextHopArg,
+    PeerField, PolicyDef, PrefixEntryAst, PrefixSetDef, PrependAsArg, Rhs, RouteField, SourceFile,
+    Stmt, TermDef, TestDef, U32Arg, ValueExprAst, WithAssertion,
 };
 use super::diag::{Diagnostic, Span, Spanned};
 use super::lexer::{Tok, Token, lex};
@@ -129,11 +129,16 @@ impl Parser<'_> {
     /// Skip tokens until one of `stops` at local brace depth zero (or
     /// EOF). A closing brace that would take the depth negative is
     /// consumed and resets to zero — it closed the enclosing block the
-    /// error occurred in.
-    fn recover_to(&mut self, stops: &[Tok]) {
+    /// error occurred in. `stop_at_fn` additionally stops at the
+    /// top-level contextual `fn` identifier (LAN-304) — it is not a
+    /// keyword token, so top-level recovery names it explicitly.
+    fn recover_to(&mut self, stops: &[Tok], stop_at_fn: bool) {
         let mut depth: u32 = 0;
         while let Some(token) = self.peek() {
-            if depth == 0 && stops.contains(&token.kind) {
+            if depth == 0
+                && (stops.contains(&token.kind)
+                    || (stop_at_fn && token.kind == Tok::Ident && self.text(token) == "fn"))
+            {
                 return;
             }
             self.pos += 1;
@@ -378,8 +383,16 @@ impl Parser<'_> {
                 Tok::AsnSetKw => self.asn_set_def().map(|def| file.asn_sets.push(def)),
                 Tok::PolicyKw => self.policy_def().map(|def| file.policies.push(def)),
                 Tok::TestKw => self.test_def().map(|def| file.tests.push(def)),
+                // Top-level contextual `fn` (LAN-304, ADR-0103
+                // Decision 2.2): top level previously admitted no bare
+                // identifier, so consuming it is purely additive — a
+                // set or policy named `fn` keeps working (those appear
+                // after their own keyword).
+                Tok::Ident if self.text(token) == "fn" => {
+                    self.fn_def().map(|def| file.fns.push(def))
+                }
                 _ => Err(self.error_expected(
-                    "a top-level item (`prefix-set`, `community-set`, `asn-set`, `policy`, or `test`)",
+                    "a top-level item (`prefix-set`, `community-set`, `asn-set`, `fn`, `policy`, or `test`)",
                 )),
             };
             if result.is_err() {
@@ -388,7 +401,7 @@ impl Parser<'_> {
                 if self.peek().map(|t| t.kind) == Some(token.kind) && self.here() == token.span {
                     self.pos += 1;
                 }
-                self.recover_to(Self::TOP_LEVEL);
+                self.recover_to(Self::TOP_LEVEL, true);
             }
         }
         file
@@ -470,6 +483,92 @@ impl Parser<'_> {
         Ok(AsnSetDef { name, entries })
     }
 
+    // ── functions (LAN-304) ─────────────────────────────────────────
+
+    /// `fn NAME(param: u32, ...) -> u32 { lets… result }`; the caller
+    /// has peeked the contextual `fn` identifier. Bodies are
+    /// expression-shaped — `let` bindings then exactly one result
+    /// expression (the last-expression rule; there is no `return`) —
+    /// so nothing here joins the expression recursion cycle
+    /// (`value_expr` runs with a fresh depth, as everywhere else).
+    fn fn_def(&mut self) -> PResult<FnDef> {
+        self.bump().expect("caller peeked `fn`");
+        let name = self.expect_ident("a function name")?;
+        self.expect(Tok::LParen, "`(` and the parameter list")?;
+        let mut params = Vec::new();
+        while !self.at(Tok::RParen) {
+            let param = self.expect_ident("a parameter name")?;
+            self.expect(Tok::Colon, "`:` and the parameter type")?;
+            self.expect(Tok::U32Kw, "`u32` (the only parameter type)")?;
+            params.push(param);
+            if self.eat(Tok::Comma).is_none() {
+                break;
+            }
+        }
+        self.expect(Tok::RParen, "`)`")?;
+        self.expect(
+            Tok::Arrow,
+            "`->` (functions declare their return type: `-> u32`)",
+        )?;
+        self.expect(Tok::U32Kw, "`u32` (the only return type)")?;
+        self.expect(Tok::LBrace, "`{`")?;
+        let mut lets = Vec::new();
+        while let Some(token) = self.peek()
+            && token.kind == Tok::Ident
+            && self.text(token) == "let"
+        {
+            self.bump();
+            let let_name = self.expect_ident("a binding name")?;
+            self.expect(Tok::Eq, "`=` (`let <name> = <value expression>`)")?;
+            let init = self.value_expr(0)?;
+            self.eat(Tok::Semi);
+            lets.push(FnLet {
+                name: let_name,
+                init,
+            });
+        }
+        // Statements are policy-term territory: a typed diagnostic
+        // beats "expected a u32 value" when someone reaches for them.
+        if let Some(token) = self.peek()
+            && (matches!(
+                token.kind,
+                Tok::AcceptKw
+                    | Tok::RejectKw
+                    | Tok::SetKw
+                    | Tok::AddKw
+                    | Tok::RemoveKw
+                    | Tok::PrependKw
+                    | Tok::IfKw
+            ) || (token.kind == Tok::Ident && self.text(token) == "for"))
+        {
+            self.diags.push(
+                Diagnostic::new(
+                    token.span,
+                    "functions compute a value; they cannot execute statements",
+                    "not allowed in a function body",
+                )
+                .with_note(
+                    "a function body is `let` bindings followed by one result expression — \
+                     verdicts, `set`/`add`/`remove`/`prepend`, `if`, and `for` live in policy \
+                     terms",
+                ),
+            );
+            return Err(Fail);
+        }
+        let result = self.value_expr(0)?;
+        self.eat(Tok::Semi);
+        self.expect(
+            Tok::RBrace,
+            "`}` (a function body ends with one result expression)",
+        )?;
+        Ok(FnDef {
+            name,
+            params,
+            lets,
+            result,
+        })
+    }
+
     // ── policies ────────────────────────────────────────────────────
 
     fn policy_def(&mut self) -> PResult<PolicyDef> {
@@ -494,7 +593,7 @@ impl Parser<'_> {
             if let Ok(term) = self.term_def() {
                 terms.push(term);
             } else {
-                self.recover_to(&[Tok::TermKw, Tok::RBrace]);
+                self.recover_to(&[Tok::TermKw, Tok::RBrace], false);
                 if self.peek().is_none() {
                     return Err(Fail);
                 }
@@ -517,7 +616,7 @@ impl Parser<'_> {
             if let Ok(stmt) = self.stmt(0) {
                 stmts.push(stmt);
             } else {
-                self.recover_to(&[Tok::Semi, Tok::RBrace, Tok::TermKw]);
+                self.recover_to(&[Tok::Semi, Tok::RBrace, Tok::TermKw], false);
                 if self.eat(Tok::Semi).is_none() {
                     break;
                 }
@@ -573,7 +672,7 @@ impl Parser<'_> {
             if let Ok(stmt) = self.stmt(depth + 1) {
                 body.push(stmt);
             } else {
-                self.recover_to(&[Tok::Semi, Tok::RBrace]);
+                self.recover_to(&[Tok::Semi, Tok::RBrace], false);
                 if self.eat(Tok::Semi).is_none() {
                     break;
                 }

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -2269,7 +2269,10 @@ fn constant_folding_diagnostics_carry_spans() {
 #[test]
 fn value_expression_type_diagnostics() {
     let (_, rendered) = diagnostics_of("policy p { term t { set med mim(1, 2); accept } }");
-    assert!(rendered.contains("unknown builtin `mim`"), "{rendered}");
+    assert!(
+        rendered.contains("unknown function or builtin `mim`"),
+        "{rendered}"
+    );
     assert!(rendered.contains("did you mean `min`?"), "{rendered}");
 
     let (_, rendered) = diagnostics_of("policy p { term t { set med min(1); accept } }");
@@ -3702,4 +3705,568 @@ fn dry_run_recording_hits_agrees_with_live_loop_walk() {
         let live = chain.evaluate(&ctx);
         assert_eq!(recorded, live, "communities {communities:?}");
     }
+}
+
+// ── LAN-304: pure user-defined functions ────────────────────────────
+
+/// The headline shape: a factored penalty computation, called with
+/// route fields as arguments.
+const FN_EXAMPLE: &str = "
+fn penalty(len: u32, weight: u32) -> u32 {
+    let base = len * weight
+    min(base, 1000)
+}
+
+policy p {
+    term t { if penalty(route.as-path.len, 10) >= route.med { reject } }
+    term rest { accept }
+}
+";
+
+/// The same policy with the function body written inline — the parity
+/// oracle.
+const FN_EXAMPLE_INLINE: &str = "
+policy p {
+    term t { if min(route.as-path.len * 10, 1000) >= route.med { reject } }
+    term rest { accept }
+}
+";
+
+fn ctx_with_path_and_med(as_path_len: usize, med: Option<u32>) -> RouteContext<'static> {
+    let mut ctx = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+    ctx.as_path_len = as_path_len;
+    ctx.med = med;
+    ctx
+}
+
+#[test]
+fn fn_calls_compile_and_evaluate() {
+    let chain = compile_ok(FN_EXAMPLE);
+    // penalty(3, 10) = 30 >= med 20 -> reject.
+    assert_eq!(
+        chain.evaluate(&ctx_with_path_and_med(3, Some(20))).action,
+        PolicyAction::Deny
+    );
+    // penalty(3, 10) = 30 < med 50 -> falls through to accept.
+    assert_eq!(
+        chain.evaluate(&ctx_with_path_and_med(3, Some(50))).action,
+        PolicyAction::Permit
+    );
+    // The min clamp: penalty(200, 10) = min(2000, 1000) = 1000 < 2000.
+    assert_eq!(
+        chain
+            .evaluate(&ctx_with_path_and_med(200, Some(2000)))
+            .action,
+        PolicyAction::Permit
+    );
+}
+
+/// Calling `penalty(a, b)` behaves — verdicts, modifications, and
+/// runtime fuel — exactly like writing the body inline (the call is
+/// sugar for a scope of lets; both shapes are loop-free, so both
+/// consume zero fuel).
+#[test]
+fn fn_inlined_parity_with_manual_body() {
+    let called = compile_ok(FN_EXAMPLE);
+    let inline = compile_ok(FN_EXAMPLE_INLINE);
+    for (len, med) in [(0, None), (3, Some(20)), (3, Some(50)), (200, Some(2000))] {
+        let ctx = ctx_with_path_and_med(len, med);
+        let (lhs, lhs_fuel) = called.evaluate_measuring_fuel(&ctx);
+        let (rhs, rhs_fuel) = inline.evaluate_measuring_fuel(&ctx);
+        assert_eq!(lhs.action, rhs.action, "len={len} med={med:?}");
+        assert_eq!(
+            lhs.modifications, rhs.modifications,
+            "len={len} med={med:?}"
+        );
+        assert_eq!(lhs_fuel, 0, "loop-free walks pay zero fuel");
+        assert_eq!(rhs_fuel, 0);
+    }
+}
+
+/// Functions work in every value position: `set` values, `let`
+/// initializers, and nested calls as arguments.
+#[test]
+fn fn_calls_in_set_values_and_nested_calls() {
+    let chain = compile_ok(
+        "
+        fn double(x: u32) -> u32 { x * 2 }
+        fn pad(x: u32, amount: u32) -> u32 { x + amount }
+        policy p {
+            term t {
+                let bumped = pad(double(route.med), 7)
+                set med bumped;
+                set local-pref double(double(5));
+                accept
+            }
+        }
+        ",
+    );
+    let result = chain.evaluate(&ctx_with_path_and_med(0, Some(10)));
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(result.modifications.set_med, Some(27), "pad(double(10), 7)");
+    // Constant arguments fold through the inlined body's checked
+    // arithmetic at compile time or evaluate identically at runtime.
+    assert_eq!(result.modifications.set_local_pref, Some(20));
+}
+
+#[test]
+fn fn_declaration_diagnostics() {
+    // Arity mismatch, with the definition labelled.
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32, b: u32) -> u32 { a + b }
+         policy p { term t { if f(1) >= 2 { reject } } }",
+    );
+    assert!(
+        rendered.contains("takes 2 arguments but 1 was supplied"),
+        "{rendered}"
+    );
+
+    // Unknown function, suggesting across builtins and fns.
+    let (_, rendered) = diagnostics_of(
+        "fn shift(a: u32) -> u32 { a + 1 }
+         policy p { term t { if shitf(1) >= 2 { reject } } }",
+    );
+    assert!(
+        rendered.contains("unknown function or builtin"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `shift`?"), "{rendered}");
+
+    // Duplicate function names.
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32) -> u32 { a }
+         fn f(b: u32) -> u32 { b }
+         policy p { term t { accept } }",
+    );
+    assert!(rendered.contains("duplicate fn `f`"), "{rendered}");
+
+    // Builtin shadowing is rejected.
+    let (_, rendered) = diagnostics_of(
+        "fn min(a: u32) -> u32 { a }
+         policy p { term t { accept } }",
+    );
+    assert!(rendered.contains("shadows the builtin"), "{rendered}");
+
+    // Calling a policy for a value points at apply().
+    let (_, rendered) = diagnostics_of(
+        "policy helper { term t { reject } }
+         policy p { term t { if helper(1) >= 2 { reject } } }",
+    );
+    assert!(rendered.contains("is a policy"), "{rendered}");
+    assert!(rendered.contains("apply"), "{rendered}");
+}
+
+/// Functions get their own namespace: a set and a policy may share a
+/// function's name — every reference position is disjoint.
+#[test]
+fn fn_namespace_coexists_with_sets_and_policies() {
+    let chain = compile_ok(
+        "
+        asn-set scale { 64512 }
+        policy scale(threshold: u32) { term t { reject } }
+        fn scale(x: u32) -> u32 { x * 100 }
+        policy p {
+            term t {
+                if scale(route.med) >= 1000 && route.origin-as in scale { reject }
+                accept
+            }
+        }
+        ",
+    );
+    let mut ctx = ctx_with_path_and_med(0, Some(50));
+    ctx.origin_asn = Some(64512);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Deny);
+    ctx.med = Some(5);
+    assert_eq!(chain.evaluate(&ctx).action, PolicyAction::Permit);
+}
+
+/// Purity by construction: bodies read no context fields — inputs
+/// arrive as parameters.
+#[test]
+fn fn_purity_rejects_field_reads() {
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32) -> u32 { a + route.med }
+         policy p { term t { if f(1) >= 2 { reject } } }",
+    );
+    assert!(rendered.contains("closed over nothing"), "{rendered}");
+    assert!(
+        rendered.contains("pass the field as an argument"),
+        "{rendered}"
+    );
+}
+
+/// Bodies are expression-shaped: verdicts/actions/loops get a typed
+/// diagnostic, not a generic parse error.
+#[test]
+fn fn_body_rejects_statements() {
+    for body in ["accept", "reject", "set med 5", "for a in s { break }"] {
+        let src = format!(
+            "asn-set s {{ 1 }} fn f(a: u32) -> u32 {{ {body} }} policy p {{ term t {{ accept }} }}"
+        );
+        let (_, rendered) = diagnostics_of(&src);
+        assert!(
+            rendered.contains("cannot execute statements"),
+            "body {body:?}: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn fn_recursion_cycle_named() {
+    // Direct recursion.
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32) -> u32 { f(a) }
+         policy p { term t { accept } }",
+    );
+    assert!(
+        rendered.contains("function call cycle: f -> f"),
+        "{rendered}"
+    );
+
+    // Mutual recursion names the full cycle.
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32) -> u32 { g(a) }
+         fn g(a: u32) -> u32 { f(a) }
+         policy p { term t { accept } }",
+    );
+    assert!(rendered.contains("function call cycle"), "{rendered}");
+    assert!(
+        rendered.contains('f') && rendered.contains('g'),
+        "{rendered}"
+    );
+}
+
+/// A linear chain of `levels` functions, `f1` calling `f2` … calling
+/// `f<levels>`, with a policy calling `f1`.
+fn fn_chain(levels: u32) -> String {
+    use std::fmt::Write;
+
+    let mut src = String::new();
+    for i in 1..levels {
+        writeln!(src, "fn f{i}(x: u32) -> u32 {{ f{}(x) + 1 }}", i + 1).expect("string io");
+    }
+    writeln!(src, "fn f{levels}(x: u32) -> u32 {{ x + 1 }}").expect("string io");
+    writeln!(
+        src,
+        "policy p {{ term t {{ if f1(route.med) >= 1000 {{ reject }} accept }} }}"
+    )
+    .expect("string io");
+    src
+}
+
+#[test]
+fn fn_call_depth_8_ok_9_rejected() {
+    let chain = compile_ok(&fn_chain(8));
+    // med 0 (default): f1(0) = 8 < 1000 -> accept.
+    assert_eq!(
+        chain.evaluate(&ctx_with_path_and_med(0, None)).action,
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        chain.evaluate(&ctx_with_path_and_med(0, Some(995))).action,
+        PolicyAction::Deny,
+        "995 + 8 >= 1000"
+    );
+
+    let (diags, rendered) = diagnostics_of(&fn_chain(9));
+    assert!(
+        rendered.contains("function call chain nests more than 8 deep"),
+        "{rendered}"
+    );
+    // Poisoning: one root cause, one diagnostic.
+    assert_eq!(diags.0.len(), 1, "{rendered}");
+}
+
+/// A function whose inlined body consumes `62` frame slots per call
+/// site (1 parameter + 60 body lets + 1 result), for the frame-budget
+/// tests: 4 statement-level calls fit the 256-slot frame exactly; one
+/// more binding tips it over.
+fn wide_fn() -> String {
+    use std::fmt::Write;
+
+    let mut src = String::from("fn wide(x: u32) -> u32 {\n");
+    writeln!(src, "    let l1 = x + 1").expect("string io");
+    for i in 2..=60 {
+        writeln!(src, "    let l{i} = l{} + 1", i - 1).expect("string io");
+    }
+    src.push_str("    l60\n}\n");
+    src
+}
+
+#[test]
+fn fn_slot_exhaustion_via_call_chain() {
+    // 4 × 62 = 248 slots, plus 8 explicit lets = 256: exactly the
+    // frame. Compiles AND evaluates — pinning that the typecheck
+    // accounting and the lowerer's allocator agree at the boundary
+    // (the lowerer asserts on overflow; the DP must reject first).
+    let boundary = format!(
+        "{}policy p {{ term t {{
+            if wide(1) >= 0 {{ set med 1 }}
+            if wide(2) >= 0 {{ set med 2 }}
+            if wide(3) >= 0 {{ set med 3 }}
+            if wide(4) >= 0 {{ set med 4 }}
+            let a1 = 1
+            let a2 = 1
+            let a3 = 1
+            let a4 = 1
+            let a5 = 1
+            let a6 = 1
+            let a7 = 1
+            let a8 = 1
+            if a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 >= 8 {{ reject }}
+            accept
+        }} }}",
+        wide_fn()
+    );
+    let chain = compile_ok(&boundary);
+    assert_eq!(
+        chain.evaluate(&ctx_with_path_and_med(0, None)).action,
+        PolicyAction::Deny
+    );
+
+    // One more binding: 257 slots -> compile error with the term span.
+    let over = boundary.replace("let a8 = 1", "let a8 = 1\n            let a9 = 1");
+    let (_, rendered) = diagnostics_of(&over);
+    assert!(
+        rendered.contains("binding slots after function inlining"),
+        "{rendered}"
+    );
+}
+
+/// The expansion bomb: a moderately sized body multiplied through a
+/// legal-depth call tree exceeds the inlined-node budget and is
+/// rejected at compile time — never lowered.
+#[test]
+fn fn_expansion_bomb_rejected() {
+    use std::fmt::Write;
+
+    // f1: ~100 arithmetic steps. f2..f8 each call the previous level
+    // three times: 3^7 ≈ 2187 × the base body ≫ 100k nodes, at legal
+    // call depth 8.
+    let mut src = String::from("fn f1(x: u32) -> u32 { x");
+    for _ in 0..100 {
+        src.push_str(" + 1");
+    }
+    src.push_str(" }\n");
+    for i in 2..=8 {
+        writeln!(
+            src,
+            "fn f{i}(x: u32) -> u32 {{ f{p}(x) + f{p}(x) + f{p}(x) }}",
+            p = i - 1
+        )
+        .expect("string io");
+    }
+    src.push_str("policy p { term t { if f8(route.med) >= 1 { reject } accept } }\n");
+    let report = check_on_small_stack(src);
+    let rendered = format!("{:?}", report.diagnostics);
+    assert!(
+        rendered.contains("expands past"),
+        "want an expansion diagnostic, got: {rendered:.300}"
+    );
+}
+
+/// An evaluation error inside an inlined body denies the route on the
+/// uniform rail and counts, exactly like any checked-arithmetic error.
+#[test]
+fn fn_eval_error_inside_body_denies_and_counts() {
+    let chain = compile_ok(
+        "
+        fn share(total: u32, parts: u32) -> u32 { total / parts }
+        policy p {
+            term t { if share(100, route.med) >= 1 { reject } accept }
+        }
+        ",
+    );
+    let hits = crate::eval::PolicyHitCounters::for_chain(&chain);
+    // med absent -> implicit 0 -> divide-by-zero inside the body ->
+    // Deny, error counted.
+    let denied = chain.evaluate_counting(&ctx_with_path_and_med(0, None), &hits);
+    assert_eq!(denied.action, PolicyAction::Deny);
+    assert_eq!(hits.eval_errors(), 1);
+    // A resolvable call decides normally.
+    // 100 / 200 = 0; `0 >= 1` is false -> falls through to accept.
+    let permitted = chain.evaluate_counting(&ctx_with_path_and_med(0, Some(200)), &hits);
+    assert_eq!(permitted.action, PolicyAction::Permit);
+    assert_eq!(hits.eval_errors(), 1, "no new error");
+}
+
+/// `requires_peer_context` is a property of the CALL SITE's arguments —
+/// functions are closed over nothing, so a route-only call never
+/// disqualifies update-group sharing and a `peer.asn` argument counts
+/// exactly like a bare `peer.asn` operand.
+#[test]
+fn fn_peer_argument_sets_requires_peer_context() {
+    let route_only = compile_ok(
+        "fn f(a: u32) -> u32 { a + 1 }
+         policy p { term t { if f(route.med) >= 10 { reject } accept } }",
+    );
+    assert!(!route_only.requires_peer_context());
+
+    let peer_arg = compile_ok(
+        "fn f(a: u32) -> u32 { a + 1 }
+         policy p { term t { if f(peer.asn) >= 64512 { reject } accept } }",
+    );
+    assert!(peer_arg.requires_peer_context());
+}
+
+/// Explain renders the call site source-level: the result slot is
+/// named by the rendered call expression.
+#[test]
+fn fn_explain_renders_call_source_level() {
+    let chain = compile_ok(FN_EXAMPLE);
+    let terms = &chain.policies[0].terms;
+    // The source term `t` lowers to bind terms + the guard term, all
+    // named `t.<n>` — term identity stays a function of the source.
+    let guard_term = terms
+        .iter()
+        .find(|term| matches!(term.guard, MatchExpr::ValueCmp(_)))
+        .expect("the comparison term");
+    assert!(
+        guard_term.name.as_deref().unwrap_or("").starts_with("t."),
+        "{:?}",
+        guard_term.name
+    );
+    let rendered = crate::engine::explain::render_expr(&guard_term.guard, &chain);
+    assert_eq!(rendered, "penalty(route.as-path.len, 10) >= route.med");
+    // The hoisted binds carry qualified fn.binding names.
+    let bind_names: Vec<&str> = terms
+        .iter()
+        .filter_map(|term| match &term.action {
+            TermAction::Bind { name, .. } => Some(&**name),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        bind_names,
+        [
+            "penalty.len",
+            "penalty.weight",
+            "penalty.base",
+            "penalty(route.as-path.len, 10)"
+        ]
+    );
+}
+
+/// Per-term hit counters survive inlining: the body dissolves into
+/// `t.<n>` terms of the calling source term, so the counter grid stays
+/// a function of the source and every walk counts the term once per
+/// evaluated guard.
+#[test]
+fn fn_counters_stay_term_shaped() {
+    let chain = compile_ok(FN_EXAMPLE);
+    let hits = crate::eval::PolicyHitCounters::for_chain(&chain);
+    let _ = chain.evaluate_counting(&ctx_with_path_and_med(3, Some(50)), &hits);
+    let snapshot = hits.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(
+        snapshot[0].len(),
+        chain.policies[0].terms.len(),
+        "one counter row per IR term"
+    );
+    // The unconditional binds and the fallthrough term all matched.
+    assert_eq!(hits.evals(), 1);
+    assert!(snapshot[0].iter().sum::<u64>() >= 4, "{snapshot:?}");
+}
+
+/// Calls in loop-body guards re-bind their slots per iteration; fuel
+/// is charged per iteration only (calls are straight-line code).
+#[test]
+fn fn_calls_inside_loop_bodies() {
+    let chain = compile_ok(
+        "
+        asn-set candidates { 64512, 64513, 64514 }
+        fn shifted(asn: u32, bump: u32) -> u32 { asn + bump }
+        policy p {
+            term t {
+                for a in candidates {
+                    if shifted(a, 1) >= 64515 { reject }
+                }
+                accept
+            }
+        }
+        ",
+    );
+    let ctx = ctx_with_path_and_med(0, None);
+    let (result, fuel) = chain.evaluate_measuring_fuel(&ctx);
+    // 64514 + 1 >= 64515 on the third member.
+    assert_eq!(result.action, PolicyAction::Deny);
+    assert_eq!(fuel, 3, "one fuel step per iteration, none for the calls");
+}
+
+/// In-language tests exercise fn-using policies through the same
+/// compile + evaluate pipeline.
+#[test]
+fn fn_in_language_test_fixture() {
+    let report = check_rpol(
+        "
+        fn penalty(len: u32, weight: u32) -> u32 {
+            let base = len * weight
+            min(base, 1000)
+        }
+        policy p {
+            term t { if penalty(route.as-path.len, 10) >= route.med { reject } }
+            term rest { accept }
+        }
+        test penalty-rejects-long-paths {
+            route { prefix 10.0.0.0/24; as-path \"65001 65002 65003\"; med 20 }
+            expect p == reject
+        }
+        test penalty-passes-short-paths {
+            route { prefix 10.0.0.0/24; as-path \"65001\"; med 20 }
+            expect p == accept
+        }
+        ",
+    );
+    assert!(report.is_ok(), "{report:?}");
+}
+
+/// `apply` targets cannot call functions — a call is sugar for `let`
+/// binds, which a pure inlined predicate cannot execute (the LAN-302
+/// rule extended).
+#[test]
+fn fn_apply_target_with_calls_rejected() {
+    let (_, rendered) = diagnostics_of(
+        "fn f(a: u32) -> u32 { a + 1 }
+         policy helper { term t { if f(route.med) >= 10 { reject } } term rest { accept } }
+         policy p { term t { if apply(helper) { accept } } }",
+    );
+    assert!(rendered.contains("it calls functions"), "{rendered}");
+    assert!(rendered.contains("first call is here"), "{rendered}");
+}
+
+/// Legal-depth stack shape for functions (the #777 discipline): a
+/// max-depth call chain wrapped in deep expressions compiles AND
+/// evaluates on the small stack — every recursive pass runs.
+#[test]
+fn fn_legal_call_depth_on_small_stack() {
+    // Depth-8 call chain where every body carries a deep-ish
+    // arithmetic chain, called from a 60-deep expression.
+    let mut src = String::new();
+    {
+        use std::fmt::Write;
+        writeln!(src, "fn f8(x: u32) -> u32 {{ x{} }}", " + 1".repeat(60)).expect("string io");
+        for i in (1..8).rev() {
+            writeln!(src, "fn f{i}(x: u32) -> u32 {{ f{}(x) + 1 }}", i + 1).expect("string io");
+        }
+        writeln!(
+            src,
+            "policy p {{ term t {{ if f1(route.med){} >= 100000 {{ reject }} accept }} }}",
+            " + 1".repeat(60),
+        )
+        .expect("string io");
+    }
+    let verdict = std::thread::Builder::new()
+        .stack_size(SMALL_STACK)
+        .spawn(move || {
+            let chain = compile_ok(&src);
+            let ctx = route_ctx(v4(10, 0, 0, 0, 24), &[], RpkiValidation::NotFound);
+            let action = chain.evaluate(&ctx).action;
+            drop(chain);
+            action
+        })
+        .expect("spawn")
+        .join()
+        .expect("legal-depth fn chain crashed the small stack");
+    // med 0: f1(0) = 60 + 7 = 67; 67 + 60 = 127 < 100000 -> accept.
+    assert_eq!(verdict, PolicyAction::Permit);
 }

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -17,8 +17,8 @@ use crate::eval::{MAX_EVAL_COST, MAX_LOOP_ITERATIONS, checked_arith};
 use crate::ir::ValueField;
 
 use super::ast::{
-    ActionStmt, CmpOp, CommunityArg, CommunityKind, Expr, FieldPath, FieldRoot, ForSource, ForStmt,
-    PolicyDef, PrependAsArg, Rhs, RouteField, SourceFile, Stmt, U32Arg, ValueExprAst,
+    ActionStmt, CmpOp, CommunityArg, CommunityKind, Expr, FieldPath, FieldRoot, FnDef, ForSource,
+    ForStmt, PolicyDef, PrependAsArg, Rhs, RouteField, SourceFile, Stmt, U32Arg, ValueExprAst,
 };
 use super::diag::{Diagnostic, Span, Spanned, closest};
 
@@ -106,6 +106,35 @@ const MAX_LOOP_DEPTH: u32 = 4;
 /// The value-expression builtins (LAN-299) and their arities.
 const VALUE_BUILTINS: &[(&str, usize)] = &[("min", 2), ("max", 2), ("clamp", 3)];
 
+/// Maximum function call-graph depth (LAN-304, ADR-0103 Decision 3):
+/// calls fully inline at lowering, so — exactly like `apply` — every
+/// level of the call chain multiplies the inlined shape, and useful
+/// compositions are intrinsically shallow. Enforced in the same
+/// Kahn-ordered DP as the apply bounds, before lowering runs; the
+/// lowering recursion trusts it.
+const MAX_CALL_DEPTH: u32 = 8;
+
+/// One function's inlining budget entry (LAN-304), computed by
+/// [`Checker::check_fn_graph`] in Kahn (callee-first) order so every
+/// entry is exact for the fully-inlined shape:
+///
+/// - `depth`: call-graph depth (a leaf is 1) — bounded by
+///   [`MAX_CALL_DEPTH`].
+/// - `cost`: worst-case evaluation steps / IR nodes one call site
+///   expands to, excluding the argument expressions (those are charged
+///   at the call site): one `Bind` term per parameter, each body
+///   `let`'s bind + initializer, and the result bind + expression.
+/// - `slots`: caller-frame slots one call site consumes — parameters +
+///   body lets + the result slot + every nested call's slots. Mirrors
+///   the lowerer's monotonic allocation exactly (nested-call binds
+///   inside argument expressions are charged by the caller's
+///   `call_slots` walk, not here).
+struct FnCost {
+    depth: u32,
+    cost: u64,
+    slots: u64,
+}
+
 /// Maximum `let` bindings per lexical scope (LAN-302, ADR-0103
 /// Decision 3). A scope is one term body or one `if`/`else` body; the
 /// grammar has exactly those two nesting levels, so the evaluation
@@ -126,6 +155,11 @@ const MAX_LOCALS: usize = 64;
 struct Scope<'a> {
     params: Vec<&'a str>,
     lets: Vec<String>,
+    /// False inside a function body (LAN-304): functions are closed
+    /// over nothing — `route.`/`peer.` field reads are rejected there;
+    /// every input arrives as a parameter, which keeps the
+    /// `requires_*` analyses call-site-local and memoization trivial.
+    fields_allowed: bool,
 }
 
 impl Scope<'_> {
@@ -217,11 +251,15 @@ pub fn typecheck(file: &SourceFile) -> Vec<Diagnostic> {
         diags: Vec::new(),
     };
     checker.check_declarations();
+    // Functions first (LAN-304): their Kahn DP produces the per-fn
+    // cost/slot/depth table the policy bounds below fold in.
+    let fn_costs = checker.check_fns();
     for policy in &file.policies {
         checker.check_policy(policy);
+        checker.check_policy_frames(policy, &fn_costs);
     }
     checker.check_apply_dag();
-    checker.check_apply_bounds();
+    checker.check_apply_bounds(&fn_costs);
     checker.check_tests();
     checker.diags
 }
@@ -231,7 +269,7 @@ struct Checker<'a> {
     diags: Vec<Diagnostic>,
 }
 
-impl Checker<'_> {
+impl<'a> Checker<'a> {
     fn policy(&self, name: &str) -> Option<&PolicyDef> {
         self.file.policies.iter().find(|p| p.name.node == name)
     }
@@ -265,8 +303,225 @@ impl Checker<'_> {
             self.file.community_sets.iter().map(|s| &s.name),
         );
         self.duplicate_check("asn-set", self.file.asn_sets.iter().map(|s| &s.name));
+        // Functions get their own namespace (LAN-304): duplicates are
+        // errors; sharing a name with a set or policy is allowed —
+        // every reference position is disjoint (calls in value
+        // positions, `apply` for policies, `in` for sets), the same
+        // positional rule the contextual keywords ride on.
+        self.duplicate_check("fn", self.file.fns.iter().map(|f| &f.name));
         self.duplicate_check("policy", self.file.policies.iter().map(|p| &p.name));
         self.duplicate_check("test", self.file.tests.iter().map(|t| &t.name));
+    }
+
+    // ── functions (LAN-304) ─────────────────────────────────────────
+
+    /// Check every `fn` body — parameters, `let` scoping, purity (no
+    /// context-field reads), builtin-name collisions — then validate
+    /// the call graph and return the per-function cost table.
+    fn check_fns(&mut self) -> HashMap<&'a str, FnCost> {
+        for def in &self.file.fns {
+            if VALUE_BUILTINS.iter().any(|(b, _)| *b == def.name.node) {
+                self.diags.push(
+                    Diagnostic::new(
+                        def.name.span,
+                        format!(
+                            "function `{}` shadows the builtin of the same name",
+                            def.name.node
+                        ),
+                        "`min`, `max`, and `clamp` are reserved value builtins",
+                    )
+                    .with_note("rename the function; builtin calls always win in value positions"),
+                );
+            }
+            self.duplicate_check("parameter", def.params.iter());
+            let mut scope = Scope {
+                params: def.params.iter().map(|p| p.node.as_str()).collect(),
+                lets: Vec::new(),
+                fields_allowed: false,
+            };
+            // Parameters and lets share the body's single scope, so
+            // both count against the per-scope binding cap.
+            for (index, l) in def.lets.iter().enumerate() {
+                // Initializer checked before declaring, so
+                // `let x = x + 1` reads a parameter/earlier `x`
+                // (shadowing, never self-reference) — the LAN-302 rule.
+                self.check_value_expr(&l.init, &scope);
+                if def.params.len() + index == MAX_LOCALS {
+                    self.locals_exceeded(l.name.span);
+                }
+                scope.lets.push(l.name.node.clone());
+            }
+            self.check_value_expr(&def.result, &scope);
+        }
+        self.check_fn_graph()
+    }
+
+    /// Validate the function call graph — a DAG (cycles are compile
+    /// errors naming the cycle), depth-capped at [`MAX_CALL_DEPTH`] —
+    /// and compute each function's inlining cost/slot footprint in the
+    /// same Kahn-ordered DP discipline as the apply bounds
+    /// (ADR-0103 Decision 3: one place answers "how big can this
+    /// program get").
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one Kahn pass — cycle check, depth, cost, slots; splitting would scatter the DP"
+    )]
+    fn check_fn_graph(&mut self) -> HashMap<&'a str, FnCost> {
+        let file = self.file;
+        let mut edges: HashMap<&str, Vec<(&str, Span)>> = HashMap::new();
+        for def in &file.fns {
+            let mut targets = Vec::new();
+            for l in &def.lets {
+                collect_fn_calls(&l.init, file, &mut targets);
+            }
+            collect_fn_calls(&def.result, file, &mut targets);
+            edges.insert(&def.name.node, targets);
+        }
+        // Cycles: reuse the apply DFS — same diagnostic shape.
+        let mut done: HashSet<&str> = HashSet::new();
+        for def in &file.fns {
+            let name = def.name.node.as_str();
+            if done.contains(name) {
+                continue;
+            }
+            let mut path: Vec<&str> = Vec::new();
+            if let Some((cycle, span)) = find_cycle(name, &edges, &mut path, &mut done) {
+                self.diags.push(
+                    Diagnostic::new(
+                        span,
+                        format!("function call cycle: {}", cycle.join(" -> ")),
+                        "this call closes the cycle",
+                    )
+                    .with_note(
+                        "functions cannot recurse, directly or mutually — the call graph \
+                         must form a DAG (ADR-0103)",
+                    ),
+                );
+            }
+        }
+        // Kahn DP (callee-first). Functions on a diagnosed cycle never
+        // become ready and are skipped; call sites naming them find no
+        // entry and charge trivially (the file already has errors).
+        let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+        let mut pending: HashMap<&str, usize> = HashMap::new();
+        let mut ready: VecDeque<&str> = VecDeque::new();
+        for def in &file.fns {
+            let name = def.name.node.as_str();
+            let known: Vec<&str> = edges[name]
+                .iter()
+                .map(|&(target, _)| target)
+                .filter(|target| edges.contains_key(target))
+                .collect();
+            if known.is_empty() {
+                ready.push_back(name);
+            } else {
+                pending.insert(name, known.len());
+                for target in known {
+                    dependents.entry(target).or_default().push(name);
+                }
+            }
+        }
+        let defs: HashMap<&str, &FnDef> =
+            file.fns.iter().map(|f| (f.name.node.as_str(), f)).collect();
+        let mut costs: HashMap<&str, FnCost> = HashMap::new();
+        while let Some(name) = ready.pop_front() {
+            let def = defs[name];
+            let deepest = edges[name]
+                .iter()
+                .filter_map(|&(target, span)| costs.get(target).map(|c| (c.depth + 1, span)))
+                .max_by_key(|&(d, _)| d);
+            let depth = match deepest {
+                Some((d, span)) if d > MAX_CALL_DEPTH => {
+                    self.diags.push(
+                        Diagnostic::new(
+                            span,
+                            format!("function call chain nests more than {MAX_CALL_DEPTH} deep"),
+                            "this call exceeds the call-depth limit",
+                        )
+                        .with_note(
+                            "calls fully inline at compile time, so every level multiplies \
+                             the inlined shape (ADR-0103); flatten the composition",
+                        ),
+                    );
+                    // Record trivially so dependents don't cascade —
+                    // one root cause, one diagnostic.
+                    costs.insert(
+                        name,
+                        FnCost {
+                            depth: 0,
+                            cost: 1,
+                            slots: 0,
+                        },
+                    );
+                    for &dependent in dependents.get(name).into_iter().flatten() {
+                        let left = pending.get_mut(dependent).expect("counted above");
+                        *left -= 1;
+                        if *left == 0 {
+                            ready.push_back(dependent);
+                        }
+                    }
+                    continue;
+                }
+                Some((d, _)) => d,
+                None => 1,
+            };
+            // One call site's fully-inlined shape: a Bind term per
+            // parameter, each body let's bind + initializer, the
+            // result bind + expression (argument costs land at the
+            // call site via `value_cost`).
+            let mut cost: u64 = def.params.len() as u64;
+            let mut slots: u64 = (def.params.len() + def.lets.len() + 1) as u64;
+            for l in &def.lets {
+                cost = cost
+                    .saturating_add(1)
+                    .saturating_add(value_cost(&l.init, &costs));
+                slots = slots.saturating_add(call_slots(&l.init, &costs));
+            }
+            cost = cost
+                .saturating_add(1)
+                .saturating_add(value_cost(&def.result, &costs));
+            slots = slots.saturating_add(call_slots(&def.result, &costs));
+            costs.insert(name, FnCost { depth, cost, slots });
+            for &dependent in dependents.get(name).into_iter().flatten() {
+                let left = pending.get_mut(dependent).expect("counted above");
+                *left -= 1;
+                if *left == 0 {
+                    ready.push_back(dependent);
+                }
+            }
+        }
+        costs
+    }
+
+    /// The LAN-304 frame budget: inlined function bodies consume
+    /// caller-frame slots, invisibly to the source-level `let`
+    /// accounting, so each term's slot high-water mark — mirroring the
+    /// lowerer's monotonic allocation with body-level scope reuse
+    /// exactly — must fit the register file. Deep call chains × locals
+    /// exceed it at compile time, never at the lowerer's assert.
+    fn check_policy_frames(&mut self, policy: &PolicyDef, fns: &HashMap<&'a str, FnCost>) {
+        for term in &policy.terms {
+            let hw = stmts_slot_high_water(&term.stmts, 0, fns);
+            let frame = crate::eval::LOCAL_FRAME_SLOTS as u64;
+            if hw > frame {
+                self.diags.push(
+                    Diagnostic::new(
+                        term.name.span,
+                        format!(
+                            "term `{}` needs {hw} binding slots after function inlining — \
+                             more than the {frame}-slot frame",
+                            term.name.node
+                        ),
+                        "binding frame exceeded",
+                    )
+                    .with_note(
+                        "every call site materializes its arguments, body bindings, and \
+                         result as caller-frame slots; shallow the call chain or split \
+                         the term",
+                    ),
+                );
+            }
+        }
     }
 
     // ── policies ────────────────────────────────────────────────────
@@ -277,6 +532,7 @@ impl Checker<'_> {
         let mut scope = Scope {
             params: policy.params.iter().map(|p| p.node.as_str()).collect(),
             lets: Vec::new(),
+            fields_allowed: true,
         };
         for term in &policy.terms {
             // Each term body is its own scope: bindings never cross
@@ -684,6 +940,10 @@ impl Checker<'_> {
     /// must evaluate cleanly under checked arithmetic (`4294967295 +
     /// 1` is a compile error at its span, not a per-route runtime
     /// error).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one arm per value-expression kind; splitting would scatter the operand rules"
+    )]
     fn check_value_expr(&mut self, expr: &ValueExprAst, scope: &Scope<'_>) {
         match expr {
             ValueExprAst::Lit(..) => {}
@@ -692,6 +952,23 @@ impl Checker<'_> {
             // followed by `(` is a builtin call (the `Call` arm), the
             // same per-position rule parameters already follow.
             ValueExprAst::Ident(name) => self.check_value_ident(name, scope),
+            // Purity by construction (LAN-304): function bodies are
+            // closed over nothing — every input arrives as a
+            // parameter, so `requires_*` analyses stay call-site-local
+            // and a call is a pure function of its arguments.
+            ValueExprAst::Field(path) if !scope.fields_allowed => {
+                self.diags.push(
+                    Diagnostic::new(
+                        path.span,
+                        format!("`{}` read inside a function body", path.render()),
+                        "functions are closed over nothing",
+                    )
+                    .with_note(
+                        "functions are pure over their parameters (ADR-0103); pass the \
+                         field as an argument at the call site",
+                    ),
+                );
+            }
             ValueExprAst::Field(path) => match resolve_field(path) {
                 Err(diag) => self.diags.push(diag),
                 Ok(resolved) => {
@@ -734,14 +1011,47 @@ impl Checker<'_> {
                     .iter()
                     .find(|(builtin, _)| *builtin == name.node)
                 else {
+                    // A user-defined function (LAN-304): arity-checked
+                    // here; the call graph and budgets are validated
+                    // in `check_fn_graph`.
+                    if let Some(def) = self.file.fns.iter().find(|f| f.name.node == name.node) {
+                        if def.params.len() != args.len() {
+                            self.diags.push(
+                                Diagnostic::new(
+                                    *span,
+                                    format!(
+                                        "function `{}` takes {} argument{} but {} {} supplied",
+                                        name.node,
+                                        def.params.len(),
+                                        if def.params.len() == 1 { "" } else { "s" },
+                                        args.len(),
+                                        if args.len() == 1 { "was" } else { "were" },
+                                    ),
+                                    "wrong number of arguments",
+                                )
+                                .with_label(def.name.span, "function defined here"),
+                            );
+                        }
+                        return;
+                    }
                     let mut diag = Diagnostic::new(
                         name.span,
-                        format!("unknown builtin `{}`", name.node),
-                        "not a value builtin",
+                        format!("unknown function or builtin `{}`", name.node),
+                        "not a function or value builtin",
                     );
-                    if let Some(suggestion) =
-                        closest(&name.node, VALUE_BUILTINS.iter().map(|(b, _)| *b))
-                    {
+                    if self.policy(&name.node).is_some() {
+                        diag = diag.with_note(format!(
+                            "`{}` is a policy — policies are predicates, composed with \
+                             `apply({}(...))`, not called for a value",
+                            name.node, name.node
+                        ));
+                    } else if let Some(suggestion) = closest(
+                        &name.node,
+                        VALUE_BUILTINS
+                            .iter()
+                            .map(|(b, _)| *b)
+                            .chain(self.file.fns.iter().map(|f| f.name.node.as_str())),
+                    ) {
                         diag = diag.with_note(format!("did you mean `{suggestion}`?"));
                     } else {
                         diag = diag
@@ -1037,6 +1347,27 @@ impl Checker<'_> {
                         .with_note(
                             "`apply` inlines the target as a pure predicate; keep loops \
                              in the applying policy instead",
+                        ),
+                    );
+                }
+                // LAN-304: a function call is sugar for a scope of
+                // `let` bindings, so it rides the same rule — a pure
+                // inlined predicate has no walk to execute binds in.
+                if let Some(call_span) = first_fn_call(target, self.file) {
+                    self.diags.push(
+                        Diagnostic::new(
+                            *span,
+                            format!(
+                                "cannot `apply` policy `{}`: it calls functions",
+                                policy.node
+                            ),
+                            "`apply` targets cannot call functions",
+                        )
+                        .with_label(call_span, "first call is here")
+                        .with_note(
+                            "`apply` inlines the target as a pure predicate, and a call \
+                             lowers to binding terms a predicate cannot execute; call the \
+                             function in the applying policy instead",
                         ),
                     );
                 }
@@ -1411,8 +1742,10 @@ impl Checker<'_> {
     /// `apply` cycle (diagnosed by [`Self::check_apply_dag`]) never
     /// become ready and are skipped. A policy over a limit gets one
     /// diagnostic and poisons its dependents (their costs clamp to
-    /// trivial), so a single root cause does not cascade.
-    fn check_apply_bounds(&mut self) {
+    /// trivial), so a single root cause does not cascade. `fns` folds
+    /// LAN-304 function inlining into the same DP: every call site
+    /// charges the callee's fully-inlined cost.
+    fn check_apply_bounds(&mut self, fns: &HashMap<&'a str, FnCost>) {
         let file = self.file;
         let edges = apply_edges(file);
         // Kahn scaffolding: a policy is ready once every *known* apply
@@ -1449,6 +1782,7 @@ impl Checker<'_> {
                 defs[name],
                 &edges[name],
                 file,
+                fns,
                 &mut depth,
                 &mut pred_cost,
                 &mut poisoned,
@@ -1652,6 +1986,7 @@ fn bound_policy<'a>(
     def: &'a PolicyDef,
     targets: &[(&'a str, Span)],
     file: &SourceFile,
+    fns: &HashMap<&'a str, FnCost>,
     depth: &mut HashMap<&'a str, u32>,
     pred_cost: &mut HashMap<&'a str, u64>,
     poisoned: &mut HashSet<&'a str>,
@@ -1699,7 +2034,7 @@ fn bound_policy<'a>(
         for stmt in &term.stmts {
             match stmt {
                 Stmt::If(if_stmt) => {
-                    let cost = guard_cost(&if_stmt.cond, pred_cost);
+                    let cost = guard_cost(&if_stmt.cond, pred_cost, fns);
                     arms.push(cost);
                     if if_stmt.else_actions.is_some() {
                         arms.push(cost.saturating_add(1));
@@ -1716,12 +2051,12 @@ fn bound_policy<'a>(
                         if matches!(action, ActionStmt::Let { .. }) {
                             arms.push(cost.saturating_add(1));
                         }
-                        action_cost = action_cost.saturating_add(action_value_cost(action));
+                        action_cost = action_cost.saturating_add(action_value_cost(action, fns));
                     }
                 }
                 Stmt::Action(action) => {
                     arms.push(1);
-                    action_cost = action_cost.saturating_add(action_value_cost(action));
+                    action_cost = action_cost.saturating_add(action_value_cost(action, fns));
                 }
                 // LAN-303: one IR term for the loop itself; the body
                 // charges the eval-cost budget at bound × per-iteration
@@ -1731,7 +2066,7 @@ fn bound_policy<'a>(
                 // rather than metering it per route.
                 Stmt::For(for_stmt) => {
                     arms.push(1);
-                    let (nodes, steps) = for_costs(for_stmt, pred_cost, file);
+                    let (nodes, steps) = for_costs(for_stmt, pred_cost, file, fns);
                     loop_nodes = loop_nodes.saturating_add(nodes);
                     action_cost = action_cost.saturating_add(steps);
                 }
@@ -1775,8 +2110,8 @@ fn bound_policy<'a>(
                 "compiled size limit exceeded",
             )
             .with_note(
-                "apply(p) inlines p's decision predicate at every use site; \
-                 split or flatten the composition",
+                "apply(p) inlines p's decision predicate — and every function call its \
+                 fully-inlined body — at every use site; split or flatten the composition",
             ),
         );
     }
@@ -1802,19 +2137,20 @@ fn bound_policy<'a>(
 /// (LAN-303), every lowered node evaluates at most once per route.
 /// Recursion depth is capped by the parser's `MAX_EXPR_DEPTH`
 /// (LAN-184).
-fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>) -> u64 {
+fn guard_cost(expr: &Expr, pred_cost: &HashMap<&str, u64>, fns: &HashMap<&str, FnCost>) -> u64 {
     match expr {
         Expr::And(lhs, rhs) | Expr::Or(lhs, rhs) => 1u64
-            .saturating_add(guard_cost(lhs, pred_cost))
-            .saturating_add(guard_cost(rhs, pred_cost)),
-        Expr::Not(inner, _) => 1u64.saturating_add(guard_cost(inner, pred_cost)),
+            .saturating_add(guard_cost(lhs, pred_cost, fns))
+            .saturating_add(guard_cost(rhs, pred_cost, fns)),
+        Expr::Not(inner, _) => 1u64.saturating_add(guard_cost(inner, pred_cost, fns)),
         // `==`/`!=` on u32 fields lower widest: `Not(And(Ge, Le))`.
         Expr::Cmp { .. } => 4,
         // LAN-299: every operator/builtin in the value expressions
-        // counts one step in the DP.
+        // counts one step in the DP. LAN-304: a function call charges
+        // its fully-inlined body per call site.
         Expr::ValueCmp { lhs, rhs, .. } => 1u64
-            .saturating_add(value_cost(lhs))
-            .saturating_add(value_cost(rhs)),
+            .saturating_add(value_cost(lhs, fns))
+            .saturating_add(value_cost(rhs, fns)),
         Expr::Apply { policy, .. } => pred_cost.get(policy.node.as_str()).copied().unwrap_or(1),
         _ => 1,
     }
@@ -1841,13 +2177,18 @@ fn loop_iteration_bound(source: &ForSource, file: &SourceFile) -> u64 {
 /// the static iteration bound × per-iteration body cost — nested loops
 /// multiply through the recursion, which is the ADR-0103 Decision 3
 /// compounding-composition defense.
-fn for_costs(for_stmt: &ForStmt, pred_cost: &HashMap<&str, u64>, file: &SourceFile) -> (u64, u64) {
+fn for_costs(
+    for_stmt: &ForStmt,
+    pred_cost: &HashMap<&str, u64>,
+    file: &SourceFile,
+    fns: &HashMap<&str, FnCost>,
+) -> (u64, u64) {
     let mut nodes: u64 = 1; // the ForEach term
     let mut body_steps: u64 = 1; // the loop-var bind per iteration
     for stmt in &for_stmt.body {
         match stmt {
             Stmt::If(if_stmt) => {
-                let guard = guard_cost(&if_stmt.cond, pred_cost);
+                let guard = guard_cost(&if_stmt.cond, pred_cost, fns);
                 // Upper bound per iteration: the guard (twice with an
                 // else — the negated arm) plus every body action.
                 let arms: u64 = if if_stmt.else_actions.is_some() { 2 } else { 1 };
@@ -1861,17 +2202,17 @@ fn for_costs(for_stmt: &ForStmt, pred_cost: &HashMap<&str, u64>, file: &SourceFi
                     nodes = nodes.saturating_add(1);
                     body_steps = body_steps
                         .saturating_add(1)
-                        .saturating_add(action_value_cost(action));
+                        .saturating_add(action_value_cost(action, fns));
                 }
             }
             Stmt::Action(action) => {
                 nodes = nodes.saturating_add(1);
                 body_steps = body_steps
                     .saturating_add(1)
-                    .saturating_add(action_value_cost(action));
+                    .saturating_add(action_value_cost(action, fns));
             }
             Stmt::For(inner) => {
-                let (inner_nodes, inner_steps) = for_costs(inner, pred_cost, file);
+                let (inner_nodes, inner_steps) = for_costs(inner, pred_cost, file, fns);
                 nodes = nodes.saturating_add(inner_nodes);
                 body_steps = body_steps.saturating_add(inner_steps);
             }
@@ -1897,10 +2238,10 @@ fn binding_value_cmp(rhs: &Rhs, resolved: Field, scope: &Scope<'_>) -> bool {
 /// carry expressions; everything else is constant-time. LAN-302: a
 /// `let` charges its initializer plus one slot-write step; each read
 /// already costs one step as a `value_cost` operand).
-fn action_value_cost(action: &ActionStmt) -> u64 {
+fn action_value_cost(action: &ActionStmt, fns: &HashMap<&str, FnCost>) -> u64 {
     match action {
-        ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => value_cost(expr),
-        ActionStmt::Let { init, .. } => value_cost(init).saturating_add(1),
+        ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => value_cost(expr, fns),
+        ActionStmt::Let { init, .. } => value_cost(init, fns).saturating_add(1),
         _ => 0,
     }
 }
@@ -1940,19 +2281,198 @@ fn first_loop(def: &PolicyDef) -> Option<Span> {
     def.terms.iter().find_map(|term| in_stmts(&term.stmts))
 }
 
+/// Span of the first user-function call anywhere in a policy — guard
+/// value expressions, `set` values, and `let` initializers, in every
+/// statement position — or `None`. Backs the LAN-304 `apply`-target
+/// rejection (calls lower to binding terms a pure predicate cannot
+/// execute).
+fn first_fn_call(def: &PolicyDef, file: &SourceFile) -> Option<Span> {
+    fn in_value(expr: &ValueExprAst, file: &SourceFile) -> Option<Span> {
+        match expr {
+            ValueExprAst::Lit(..) | ValueExprAst::Ident(_) | ValueExprAst::Field(_) => None,
+            ValueExprAst::Binary { lhs, rhs, .. } => {
+                in_value(lhs, file).or_else(|| in_value(rhs, file))
+            }
+            ValueExprAst::Call { name, args, span } => {
+                if file.fns.iter().any(|f| f.name.node == name.node) {
+                    return Some(*span);
+                }
+                args.iter().find_map(|arg| in_value(arg, file))
+            }
+        }
+    }
+    fn in_expr(expr: &Expr, file: &SourceFile) -> Option<Span> {
+        match expr {
+            Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
+                in_expr(lhs, file).or_else(|| in_expr(rhs, file))
+            }
+            Expr::Not(inner, _) => in_expr(inner, file),
+            Expr::ValueCmp { lhs, rhs, .. } => in_value(lhs, file).or_else(|| in_value(rhs, file)),
+            _ => None,
+        }
+    }
+    fn in_action(action: &ActionStmt, file: &SourceFile) -> Option<Span> {
+        match action {
+            ActionStmt::SetLocalPref(expr, _)
+            | ActionStmt::SetMed(expr, _)
+            | ActionStmt::Let { init: expr, .. } => in_value(expr, file),
+            _ => None,
+        }
+    }
+    fn in_stmts(stmts: &[Stmt], file: &SourceFile) -> Option<Span> {
+        stmts.iter().find_map(|stmt| match stmt {
+            Stmt::Action(action) => in_action(action, file),
+            Stmt::If(if_stmt) => in_expr(&if_stmt.cond, file)
+                .or_else(|| if_stmt.then_actions.iter().find_map(|a| in_action(a, file)))
+                .or_else(|| {
+                    if_stmt
+                        .else_actions
+                        .iter()
+                        .flatten()
+                        .find_map(|a| in_action(a, file))
+                }),
+            Stmt::For(for_stmt) => in_stmts(&for_stmt.body, file),
+        })
+    }
+    def.terms
+        .iter()
+        .find_map(|term| in_stmts(&term.stmts, file))
+}
+
+/// Every user-function call in a value expression, as `(name, span)`
+/// call-graph edges (LAN-304) — builtins and unknown names excluded,
+/// arguments walked for nested calls.
+fn collect_fn_calls<'a>(expr: &'a ValueExprAst, file: &SourceFile, out: &mut Vec<(&'a str, Span)>) {
+    match expr {
+        ValueExprAst::Lit(..) | ValueExprAst::Ident(_) | ValueExprAst::Field(_) => {}
+        ValueExprAst::Binary { lhs, rhs, .. } => {
+            collect_fn_calls(lhs, file, out);
+            collect_fn_calls(rhs, file, out);
+        }
+        ValueExprAst::Call { name, args, span } => {
+            if file.fns.iter().any(|f| f.name.node == name.node) {
+                out.push((&name.node, *span));
+            }
+            for arg in args {
+                collect_fn_calls(arg, file, out);
+            }
+        }
+    }
+}
+
+/// Caller-frame slots a value expression's function calls consume when
+/// inlined (LAN-304): each call site allocates its callee's full slot
+/// footprint plus whatever its argument expressions' own calls need —
+/// exactly the lowerer's monotonic allocation order.
+fn call_slots(expr: &ValueExprAst, fns: &HashMap<&str, FnCost>) -> u64 {
+    match expr {
+        ValueExprAst::Lit(..) | ValueExprAst::Ident(_) | ValueExprAst::Field(_) => 0,
+        ValueExprAst::Binary { lhs, rhs, .. } => {
+            call_slots(lhs, fns).saturating_add(call_slots(rhs, fns))
+        }
+        ValueExprAst::Call { name, args, .. } => {
+            let own = fns.get(name.node.as_str()).map_or(0, |fc| fc.slots);
+            args.iter()
+                .map(|arg| call_slots(arg, fns))
+                .fold(own, u64::saturating_add)
+        }
+    }
+}
+
+/// Function-call slots consumed by a guard expression's value
+/// comparisons (LAN-304 frame accounting; other guard forms carry no
+/// value expressions).
+fn guard_call_slots(expr: &Expr, fns: &HashMap<&str, FnCost>) -> u64 {
+    match expr {
+        Expr::Or(lhs, rhs) | Expr::And(lhs, rhs) => {
+            guard_call_slots(lhs, fns).saturating_add(guard_call_slots(rhs, fns))
+        }
+        Expr::Not(inner, _) => guard_call_slots(inner, fns),
+        Expr::ValueCmp { lhs, rhs, .. } => {
+            call_slots(lhs, fns).saturating_add(call_slots(rhs, fns))
+        }
+        // `apply` targets cannot call functions (rejected above).
+        _ => 0,
+    }
+}
+
+/// One statement sequence's frame-slot high-water mark (LAN-304),
+/// mirroring the lowerer's `LetEnv` discipline exactly: statement-level
+/// allocations (guard call binds, `set` value call binds, `let`s and
+/// their initializer call binds) persist for the rest of the term;
+/// `if`/`else` and loop bodies mark/reset, so sibling scopes reuse
+/// slots (their readers execute before the sibling's binds — LAN-302).
+fn stmts_slot_high_water(stmts: &[Stmt], base: u64, fns: &HashMap<&str, FnCost>) -> u64 {
+    fn actions_high_water(actions: &[ActionStmt], base: u64, fns: &HashMap<&str, FnCost>) -> u64 {
+        let mut cur = base;
+        for action in actions {
+            match action {
+                ActionStmt::Let { init, .. } => {
+                    cur = cur.saturating_add(call_slots(init, fns)).saturating_add(1);
+                }
+                ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _) => {
+                    cur = cur.saturating_add(call_slots(expr, fns));
+                }
+                _ => {}
+            }
+        }
+        cur
+    }
+    let mut cur = base;
+    let mut high = base;
+    for stmt in stmts {
+        match stmt {
+            Stmt::Action(ActionStmt::Let { init, .. }) => {
+                cur = cur.saturating_add(call_slots(init, fns)).saturating_add(1);
+            }
+            Stmt::Action(ActionStmt::SetLocalPref(expr, _) | ActionStmt::SetMed(expr, _)) => {
+                cur = cur.saturating_add(call_slots(expr, fns));
+            }
+            Stmt::Action(_) => {}
+            Stmt::If(if_stmt) => {
+                cur = cur.saturating_add(guard_call_slots(&if_stmt.cond, fns));
+                high = high.max(actions_high_water(&if_stmt.then_actions, cur, fns));
+                if let Some(else_actions) = &if_stmt.else_actions {
+                    high = high.max(actions_high_water(else_actions, cur, fns));
+                }
+            }
+            // Loop variable + body in a nested scope, reset on exit.
+            Stmt::For(for_stmt) => {
+                high = high.max(stmts_slot_high_water(
+                    &for_stmt.body,
+                    cur.saturating_add(1),
+                    fns,
+                ));
+            }
+        }
+        high = high.max(cur);
+    }
+    high
+}
+
 /// Worst-case evaluation steps of a value expression (LAN-299): one
 /// per operand read and one per operator/builtin step (`clamp`
 /// charges two — it is a min/max pair).
-fn value_cost(expr: &ValueExprAst) -> u64 {
+fn value_cost(expr: &ValueExprAst, fns: &HashMap<&str, FnCost>) -> u64 {
     match expr {
         ValueExprAst::Lit(..) | ValueExprAst::Ident(_) | ValueExprAst::Field(_) => 1,
         ValueExprAst::Binary { lhs, rhs, .. } => 1u64
-            .saturating_add(value_cost(lhs))
-            .saturating_add(value_cost(rhs)),
+            .saturating_add(value_cost(lhs, fns))
+            .saturating_add(value_cost(rhs, fns)),
         ValueExprAst::Call { name, args, .. } => {
-            let op_cost = if name.node == "clamp" { 2 } else { 1 };
+            // LAN-304: a user-function call charges its fully-inlined
+            // body (the Kahn table entry) plus the result read; its
+            // arguments are charged below like any operand. A name in
+            // neither table is an unknown-call diagnostic elsewhere.
+            let op_cost = if let Some(fc) = fns.get(name.node.as_str()) {
+                fc.cost.saturating_add(1)
+            } else if name.node == "clamp" {
+                2
+            } else {
+                1
+            };
             args.iter()
-                .map(value_cost)
+                .map(|arg| value_cost(arg, fns))
                 .fold(op_cost, u64::saturating_add)
         }
     }

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -449,8 +449,9 @@ keys on source attributes plus modifications — and needs its own ADR
 if ever demanded).
 
 **Static slots, zero allocation.** Bindings compile to fixed slots in
-a 128-slot register file (two nesting levels × the 64-binding
-per-scope cap): slot assignment is a pure function of the source
+a 256-slot register file (term, nested loop, and `if` scopes at the
+64-binding per-scope cap; inlined function calls draw on the same
+frame, LAN-304): slot assignment is a pure function of the source
 (identical source → identical compiled form, so unchanged reloads
 still diff as no-ops), sibling scopes reuse slots, and the frame is a
 lazily-materialized stack array — policies without bindings pay
@@ -465,8 +466,8 @@ identically — pinned by test).
 be a target of `apply` this slice: `apply` inlines its target as a
 pure predicate expression, which has no term walk to execute bindings
 in. The compile error points at the offending `apply` and the target's
-first `let`; factor the shared value into the applying policy, or wait
-for user functions (LAN-304), the designed vehicle for composing
+first `let`; factor the shared value into the applying policy, or use
+a user function (`fn`, LAN-304) — the designed vehicle for composing
 computed values.
 
 Migration example — factoring a repeated computed value:
@@ -632,6 +633,129 @@ policy bogon-guard {
 }
 ```
 
+### Functions — `fn`
+
+`fn NAME(param: u32, ...) -> u32 { ... }` names a pure computation
+over `u32` values (ADR-0103 Decision 2, LAN-304):
+
+```rpol
+fn penalty(len: u32, weight: u32) -> u32 {
+    let base = len * weight
+    min(base, 1000)
+}
+
+policy p {
+    term dampen { if penalty(route.as-path.len, 10) >= route.med { reject } }
+    term rest { accept }
+}
+```
+
+`fn` is a top-level contextual identifier like statement-`let`: top
+level previously admitted no bare identifier, so existing names keep
+working. Functions get their own namespace — duplicate `fn` names are
+errors, but a set or policy may share a function's name (every
+reference position is disjoint); the builtin names `min`/`max`/`clamp`
+are reserved and cannot be shadowed.
+
+**Bodies are expression-shaped.** A body is zero or more `let`
+bindings followed by exactly **one result expression** — the
+last-expression rule; there is no `return`. Verdicts, `set`/`add`/
+`remove`/`prepend`, `if`, and `for` are policy-term territory and get
+a typed diagnostic inside a body (`if` would need expression-`if`,
+which does not exist in the language — `min`/`max`/`clamp` cover
+selection; a later slice may revisit). Parameters and return values
+are `u32` this slice, and the return type is spelled explicitly
+(`-> u32`).
+
+**Closed over nothing (normative).** A function body may not read
+`route.*`/`peer.*` fields — every input arrives as a parameter, so a
+function is a pure function of its arguments. This is what keeps the
+hot-path analyses call-site-local: `penalty(peer.asn, 10)` counts
+toward `requires_peer_context` because the *argument* reads peer
+identity; `penalty(route.as-path.len, 10)` never disqualifies
+update-group sharing, no matter what the body does. The compile error
+says to pass the field as an argument.
+
+**No recursion.** The call graph must form a DAG — direct or mutual
+recursion is a compile error naming the cycle, exactly like `apply`.
+Call chains are depth-capped at 8 (`MAX_CALL_DEPTH`), enforced in the
+same Kahn-ordered cost DP as the `apply` bounds.
+
+**Full inlining (normative).** A call is compile-time sugar for a
+scope of `let` bindings: each argument binds to a caller-frame slot
+(named `fn.param` in explain surfaces), each body `let` to
+`fn.binding`, and the result expression to a slot named by the
+rendered call itself, which the call site reads. There are **no
+runtime call frames** — evaluation walks the same flat term list as
+before, and a program that never calls functions pays nothing.
+Consequences:
+
+- **Evaluation is eager, like `let`.** Arguments and the body evaluate
+  when the walk reaches the statement containing the call — even if a
+  `&&` short-circuit would have skipped the value — so a call that
+  errors (checked arithmetic; functions are pure and terminating but
+  *not* total) denies the route on the uniform eval-error rail
+  whenever its statement executes.
+- **Term identity survives.** The inlined binds become `<term>.<n>`
+  IR terms of the *calling* term (the established multi-term split
+  naming), so the counter grid and trace skeleton stay a function of
+  the source; per-function hit counting is explicitly out of scope
+  (Decision 6.3 — it would need runtime call frames).
+- **Attribution names both sides.** An error inside a body renders
+  with the calling term's name and the qualified binding, e.g.
+  `term compute.3: let share.each = share.total / share.parts [matched]`
+  followed by
+  `term compute.3: evaluation error: division by zero — fail closed => reject`;
+  the live-path WARN carries the same `(let share.each)` label.
+  Guards render calls source-level:
+  `penalty(route.as-path.len, 10) >= route.med`.
+- **Budgets compound honestly.** The cost DP charges the fully-inlined
+  body per call site, against the same `MAX_APPLY_EXPANSION` /
+  `MAX_EVAL_COST` budgets as `apply` — a big body called from many
+  sites is rejected at compile time. Inlined bodies also consume
+  caller-frame binding slots (arguments + body lets + the result, per
+  call site); a term whose calls exceed the 256-slot frame is a
+  compile error at the term's span.
+
+**Calling parity.** `penalty(a, b)` evaluates exactly like writing the
+body inline — same verdicts, same modifications, zero fuel (calls are
+straight-line code; only loop iterations meter) — pinned by test.
+
+**`apply` restriction.** Like `let` and `for`, a policy that calls
+functions cannot be an `apply` target: calls lower to binding terms a
+pure inlined predicate cannot execute. Call the function in the
+applying policy instead.
+
+Migration example — factoring a computation repeated across policies
+(the step beyond LAN-302's single-policy `let`):
+
+```rpol
+# Before: the damping formula is duplicated — and must be kept in
+# sync — across two policies.
+policy transit-in {
+    term dampen { if min(route.as-path.len * 10, 1000) >= route.med { reject } }
+    term rest { accept }
+}
+policy peer-in {
+    term dampen { if min(route.as-path.len * 12, 1000) >= route.med { reject } }
+    term rest { accept }
+}
+
+# After: one definition, weights at the call sites.
+fn penalty(len: u32, weight: u32) -> u32 {
+    let base = len * weight
+    min(base, 1000)
+}
+policy transit-in {
+    term dampen { if penalty(route.as-path.len, 10) >= route.med { reject } }
+    term rest { accept }
+}
+policy peer-in {
+    term dampen { if penalty(route.as-path.len, 12) >= route.med { reject } }
+    term rest { accept }
+}
+```
+
 ### `route.family` — one chain, many families
 
 `route.family` is the route's **typed** AFI/SAFI family, carried by the
@@ -682,7 +806,9 @@ Two consequences worth internalizing:
   final term → `reject`).
 - A policy that declares `let` bindings cannot be applied (LAN-302):
   the inlined predicate has no term walk to execute bindings in. The
-  compile error names the target's first `let`.
+  compile error names the target's first `let`. The same rule covers
+  `for` loops (LAN-303) and function calls (LAN-304 — a call is sugar
+  for a scope of lets).
 
 ## Actions
 
@@ -805,11 +931,14 @@ involvement. Testing a *candidate* policy against a live RIB is
 ## Grammar sketch
 
 ```text
-file        := (prefix-set-def | community-set-def | asn-set-def | policy-def | test-def)*
+file        := (prefix-set-def | community-set-def | asn-set-def | fn-def | policy-def | test-def)*
 prefix-set-def    := "prefix-set" IDENT "{" [prefix-entry ("," prefix-entry)*] "}"
 prefix-entry      := PREFIX ["ge" INT] ["le" INT]
 community-set-def := "community-set" IDENT "{" [community ("," community)*] "}"
 asn-set-def       := "asn-set" IDENT "{" [INT ("," INT)*] "}"
+fn-def      := "fn" IDENT "(" [param ("," param)*] ")" "->" "u32"
+               "{" fn-let* value "}"               # contextual `fn` (LAN-304)
+fn-let      := "let" IDENT "=" value [";"]
 policy-def  := "policy" IDENT ["(" param ("," param)* ")"] "{" term* "}"
 param       := IDENT ":" "u32"
 term        := "term" IDENT "{" stmt* "}"
@@ -839,6 +968,7 @@ mul         := atom (("*"|"/"|"%") atom)*
 atom        := INT | STD-COMMUNITY | IDENT | field | "(" value ")"   # IDENT: parameter or binding
              | ("min"|"max") "(" value "," value ")"
              | "clamp" "(" value "," value "," value ")"
+             | IDENT "(" [value ("," value)*] ")"  # user-function call (LAN-304)
 field       := ("route" | "peer") ("." IDENT)+
 u32arg      := INT | IDENT          # parameter reference
 test-def    := "test" IDENT "{" route-block [peer-block] expect+ "}"
@@ -1022,10 +1152,11 @@ $ rbgp policy stats --peer 10.0.0.2 --direction both
   dry run; `.rpol` has both.
 - **vs BIRD filters:** BIRD's filter language is a general-purpose
   interpreter — variables, arbitrary control flow, user-defined
-  functions. `.rpol` is deliberately smaller: no loops, no variables,
-  no user types, so every policy terminates by construction and
-  compiles to an indexed IR (a 1,000-member set is one hash probe,
-  not a linear scan). What BIRD can't do: test a candidate policy
+  functions. `.rpol` is deliberately smaller: immutable bindings, only
+  bounded `for` loops over finite sources, only pure non-recursive
+  functions (fully inlined at compile time), no user types — so every
+  policy terminates by construction and compiles to an indexed IR (a
+  1,000-member set is one hash probe, not a linear scan). What BIRD can't do: test a candidate policy
   read-only against the *running* daemon's RIB (`rbgp policy test`),
   trace which term decided a live route (`rbgp policy explain`), or
   read per-term live hit counters (`rbgp policy stats`).
@@ -1134,7 +1265,8 @@ iterates finite sources only, capped and fuel-metered. No
 user-defined types, no maps (safety is total by construction —
 ADR-0096 Decision 2; the ADR-0103 extension program adds bounded
 constructs slice by slice — checked arithmetic shipped as LAN-299,
-bindings as LAN-302, bounded loops as LAN-303). No `as-path-set`. No `else if` chains and no nested `if`
+bindings as LAN-302, bounded loops as LAN-303, pure functions as
+LAN-304). No `as-path-set`. No `else if` chains and no nested `if`
 (keep terms small; use `&&` or more terms). No mutable state of any
 kind — `let` bindings (LAN-302) are immutable, and reads never
 observe staged `set` writes (read-back would break memoization and


### PR DESCRIPTION
## Summary

- fourth ADR-0103 Phase B slice: `fn name(params: u32) -> u32` with bodies of let-bindings plus one result expression, fully inlined at compile time — calls dissolve into the existing Bind/Local IR, so the evaluator is unchanged and there are no runtime call frames
- purity by construction: function bodies are closed over nothing — field reads inside a body are a compile error steering to "pass the field as an argument", which makes every requires_* analysis free (a peer.asn argument registers peer-dependence at the call site, pinned both ways for update-group fingerprinting)
- no recursion direct or mutual (call DAG validated like the apply DAG, cycles named); MAX_CALL_DEPTH 8 through the shared cost DP; expansion bombs (big body × deep call tree) rejected at compile time; inlined bodies consume caller frame slots with the high-water check mirroring the lowerer exactly
- boundary bug found and fixed while pinning the slot budget: the slot allocator counter was u8 and overflowed at an exactly-256-slot frame — now u16, with 256-compiles/257-rejects pinned
- inlining preserves attribution: explain traces and eval errors name both the function and the calling term; per-term counters stay term-shaped; guards render the source-level call expression
- functions get their own namespace (builtins reserved; sets/policies may coexist — every reference position is disjoint); `->` is a new token that kebab-munch cannot consume, keeping the grammar additively compatible; the parser frame-size discipline from the loops slice is respected and the 2 MiB stack suite gains a call-depth × expression-depth shape

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy x2 parallel (319 both runs) / -p rustbgpd-rib / --bin rustbgpd policy (78)
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build + seed-corpus pass (3 new seeds)
- cargo bench -p rustbgpd-policy -- --test
- cargo check -p rustbgpd-rib --features bench-internals --benches

Closes LAN-304.