### PR TITLE
fix(rbgp): render actionable connect, status, and persistence errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`rbgp` errors are now actionable.** Connect failures name the
+  endpoint the CLI actually dialed and the failure class (`cannot
+  reach rustbgpd at unix:///var/lib/rustbgpd/grpc.sock (socket does
+  not exist)`, connection refused, permission denied, timed out) plus
+  a hint pointing at `-s`/`RUSTBGPD_ADDR`, instead of the flat "daemon
+  is not running or unreachable". gRPC status codes map to short
+  lowercase prefixes (`precondition failed:`, `invalid argument:`,
+  `permission denied:`, ...) instead of tonic's sentence-length code
+  descriptions. Daemon-side config persistence failures name the file
+  being written (`failed to write /var/lib/rustbgpd/config.toml: ...`)
+  rather than a bare os error. Lifecycle commands (`config
+  apply`/`confirm`/`abort` with a confirmed-commit window, `neighbor
+  add`/`disable`, `gshut`) print a one-line `next:` footer on stderr
+  with the natural follow-up command; footers are suppressed under
+  `--json` so machine output stays pure JSON. (LAN-317)
+
 - **Policy reinstallation is scoped to peers whose resolved chain
   content actually moved.** SIGHUP reloads, rpol overlay swaps, catalog
   edits, and live-impact transactions re-resolve every affected peer's

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -111,7 +111,24 @@ pub async fn apply(
     } else {
         print_apply_human(&resp);
     }
+    if let Some(footer) = confirm_window_footer(resp.confirmation.as_ref()) {
+        crate::output::print_next_step(json, &footer);
+    }
     Ok(())
+}
+
+/// "What next" footer for an apply that opened a confirmed-commit window:
+/// the change auto-reverts unless the operator confirms in time.
+fn confirm_window_footer(confirmation: Option<&ConfigTransactionConfirmation>) -> Option<String> {
+    let confirmation = confirmation?;
+    let pending = ConfigTransactionConfirmationStatus::Pending as i32;
+    if confirmation.status != pending || confirmation.confirm_id.is_empty() {
+        return None;
+    }
+    let id = &confirmation.confirm_id;
+    Some(format!(
+        "confirm within the window or the change auto-reverts: rbgp config confirm {id} (roll back now: rbgp config abort {id})"
+    ))
 }
 
 pub async fn confirm(connection: Connection, confirm_id: &str, json: bool) -> Result<(), CliError> {
@@ -134,6 +151,10 @@ pub async fn confirm(connection: Connection, confirm_id: &str, json: bool) -> Re
         print!("{}", resp.human_text);
         print_confirmation(resp.confirmation.as_ref());
     }
+    crate::output::print_next_step(
+        json,
+        "the transaction is confirmed and permanent — verify with: rbgp config status",
+    );
     Ok(())
 }
 
@@ -161,6 +182,10 @@ pub async fn abort(connection: Connection, confirm_id: &str, json: bool) -> Resu
         }
         print_confirmation(resp.confirmation.as_ref());
     }
+    crate::output::print_next_step(
+        json,
+        "the transaction was rolled back — re-plan against the new runtime_snapshot_token (rbgp config plan)",
+    );
     Ok(())
 }
 
@@ -772,6 +797,27 @@ mod tests {
             "{err:?}"
         );
         assert_eq!(server.state.config_status_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn confirm_window_footer_only_for_pending_confirmations() {
+        let pending = ConfigTransactionConfirmation {
+            status: ConfigTransactionConfirmationStatus::Pending as i32,
+            confirm_id: "deploy-1".to_string(),
+            timeout_seconds: 120,
+            deadline_unix_seconds: 0,
+            committed_sections: Vec::new(),
+            runtime_snapshot_token: String::new(),
+            human_text: String::new(),
+        };
+        let footer = confirm_window_footer(Some(&pending)).unwrap();
+        assert!(footer.contains("rbgp config confirm deploy-1"), "{footer}");
+        assert!(footer.contains("rbgp config abort deploy-1"), "{footer}");
+
+        let mut confirmed = pending.clone();
+        confirmed.status = ConfigTransactionConfirmationStatus::Confirmed as i32;
+        assert!(confirm_window_footer(Some(&confirmed)).is_none());
+        assert!(confirm_window_footer(None).is_none());
     }
 
     #[test]

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -282,7 +282,14 @@ pub async fn add(
         "add_neighbor",
         address,
         &format!("Neighbor {address} added"),
-    )
+    )?;
+    output::print_next_step(
+        json,
+        &format!(
+            "watch the session establish: rbgp watch {address} (or check: rbgp neighbor {address})"
+        ),
+    );
+    Ok(())
 }
 
 pub async fn delete(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
@@ -342,7 +349,12 @@ pub async fn disable(
         "disable_neighbor",
         address,
         &format!("Neighbor {address} disabled"),
-    )
+    )?;
+    output::print_next_step(
+        json,
+        &format!("re-enable when ready: rbgp neighbor {address} enable"),
+    );
+    Ok(())
 }
 
 pub async fn softreset(
@@ -396,7 +408,13 @@ pub async fn set_graceful_shutdown(
         "set_graceful_shutdown",
         scope,
         &format!("GRACEFUL_SHUTDOWN advertise {verb} for {scope}"),
-    )
+    )?;
+    let status_cmd = match peer.as_deref() {
+        Some(peer) => format!("rbgp neighbor {peer}"),
+        None => "rbgp neighbor".to_string(),
+    };
+    output::print_next_step(json, &format!("check session status: {status_cmd}"));
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/cli/src/connection.rs
+++ b/crates/cli/src/connection.rs
@@ -67,10 +67,43 @@ enum EndpointTarget {
 pub(crate) async fn connect(addr: &str, token_file: Option<&str>) -> Result<Connection, CliError> {
     let token = load_bearer_token(token_file)?;
     let channel = match parse_endpoint_target(addr)? {
-        EndpointTarget::Tcp(uri) => connect_tcp(&uri).await?,
-        EndpointTarget::Uds(path) => connect_uds(&path).await?,
+        EndpointTarget::Tcp(uri) => connect_tcp(&uri, addr).await?,
+        EndpointTarget::Uds(path) => connect_uds(&path, addr).await?,
     };
     Ok(Connection::new(channel, token))
+}
+
+/// Map a connect-time transport error to a short human failure class,
+/// suppressing tonic/hyper wrapper debris ("transport error").
+///
+/// The useful cause is the `io::Error` buried in the source chain (ENOENT
+/// for a missing unix socket, ECONNREFUSED, ETIMEDOUT, EACCES, ...). When no
+/// io error is present (TLS handshake, HTTP/2 setup, internal timeout), the
+/// deepest source's own message is the honest fallback class.
+fn connect_failure_class(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut deepest = error;
+    let mut current = Some(error);
+    while let Some(err) = current {
+        if let Some(io) = err.downcast_ref::<std::io::Error>() {
+            return match io.kind() {
+                std::io::ErrorKind::NotFound => "socket does not exist".into(),
+                std::io::ErrorKind::ConnectionRefused => "connection refused".into(),
+                std::io::ErrorKind::PermissionDenied => "permission denied".into(),
+                std::io::ErrorKind::TimedOut => "connection timed out".into(),
+                _ => io.to_string(),
+            };
+        }
+        deepest = err;
+        current = err.source();
+    }
+    deepest.to_string()
+}
+
+fn connect_error(addr: &str, error: &tonic::transport::Error) -> CliError {
+    CliError::Connect {
+        addr: addr.to_string(),
+        detail: connect_failure_class(error),
+    }
 }
 
 fn parse_endpoint_target(addr: &str) -> Result<EndpointTarget, CliError> {
@@ -125,14 +158,17 @@ fn load_bearer_token(token_file: Option<&str>) -> Result<Option<AsciiMetadataVal
     Ok(Some(value))
 }
 
-async fn connect_tcp(uri: &str) -> Result<Channel, CliError> {
+async fn connect_tcp(uri: &str, display_addr: &str) -> Result<Channel, CliError> {
     let endpoint = Endpoint::from_shared(uri.to_string())
         .map_err(|e| CliError::Argument(format!("invalid address: {e}")))?
         .connect_timeout(CONNECT_TIMEOUT);
-    endpoint.connect().await.map_err(Into::into)
+    endpoint
+        .connect()
+        .await
+        .map_err(|e| connect_error(display_addr, &e))
 }
 
-async fn connect_uds(path: &Path) -> Result<Channel, CliError> {
+async fn connect_uds(path: &Path, display_addr: &str) -> Result<Channel, CliError> {
     let endpoint = Endpoint::try_from("http://[::]:50051")
         .map_err(|e| CliError::Argument(format!("invalid UDS endpoint: {e}")))?
         .connect_timeout(CONNECT_TIMEOUT);
@@ -146,7 +182,11 @@ async fn connect_uds(path: &Path) -> Result<Channel, CliError> {
     }));
     let channel = tokio::time::timeout(CONNECT_TIMEOUT, connect)
         .await
-        .map_err(|_| CliError::ConnectTimeout)??;
+        .map_err(|_| CliError::Connect {
+            addr: display_addr.to_string(),
+            detail: format!("connect timed out after {}s", CONNECT_TIMEOUT.as_secs()),
+        })?
+        .map_err(|e| connect_error(display_addr, &e))?;
     Ok(channel)
 }
 
@@ -247,12 +287,12 @@ mod tests {
     }
 
     // Connecting to a socket nothing is listening on must surface the
-    // friendly "daemon is not running or unreachable" message rather than
-    // leak a raw transport/io error. A nonexistent UDS path fails
+    // target address and a human failure class — never raw transport/io
+    // debris ("transport error: ..."). A nonexistent UDS path fails
     // immediately (ENOENT) so this stays fast and deterministic — no
     // dependence on the 5s connect timeout.
     #[tokio::test]
-    async fn connect_to_absent_socket_reports_daemon_unreachable() {
+    async fn connect_to_absent_socket_reports_address_and_class() {
         let dir = tempfile::tempdir().unwrap();
         let absent = dir.path().join("not-listening.sock");
         let addr = format!("unix://{}", absent.display());
@@ -263,6 +303,37 @@ mod tests {
             Err(err) => err,
         };
 
-        assert_eq!(err.to_string(), "daemon is not running or unreachable");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "cannot reach rustbgpd at {addr} (socket does not exist)\n  \
+                 hint: is the daemon running? if it uses a different endpoint, pass -s or set RUSTBGPD_ADDR"
+            )
+        );
+    }
+
+    // A socket file that exists but has no listener behind it (daemon
+    // crashed, stale socket) must be classified as "connection refused",
+    // not "does not exist".
+    #[tokio::test]
+    async fn connect_to_dead_socket_reports_connection_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join("stale.sock");
+        // Bind then drop the listener: the socket file remains, ECONNREFUSED.
+        drop(std::os::unix::net::UnixListener::bind(&stale).unwrap());
+        let addr = format!("unix://{}", stale.display());
+
+        let err = match connect(&addr, None).await {
+            Ok(_) => panic!("connecting to a dead socket must fail"),
+            Err(err) => err,
+        };
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&format!(
+                "cannot reach rustbgpd at {addr} (connection refused)"
+            )),
+            "{rendered}"
+        );
     }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,8 +1,13 @@
 use std::fmt;
 
 pub enum CliError {
-    Connect(#[expect(dead_code)] tonic::transport::Error),
-    ConnectTimeout,
+    /// Failed to reach the daemon at connect time. `addr` is the endpoint the
+    /// CLI actually dialed; `detail` is a short human failure class derived
+    /// from the transport error chain (never raw transport debris).
+    Connect {
+        addr: String,
+        detail: String,
+    },
     Rpc(String),
     Argument(String),
     Io(std::io::Error),
@@ -12,8 +17,11 @@ pub enum CliError {
 impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CliError::Connect(_) => write!(f, "daemon is not running or unreachable"),
-            CliError::ConnectTimeout => write!(f, "daemon is not running or unreachable"),
+            CliError::Connect { addr, detail } => write!(
+                f,
+                "cannot reach rustbgpd at {addr} ({detail})\n  \
+                 hint: is the daemon running? if it uses a different endpoint, pass -s or set RUSTBGPD_ADDR"
+            ),
             CliError::Rpc(msg) => write!(f, "{msg}"),
             CliError::Argument(msg) => write!(f, "{msg}"),
             CliError::Io(e) => write!(f, "{e}"),
@@ -28,21 +36,36 @@ impl fmt::Debug for CliError {
     }
 }
 
-impl From<tonic::transport::Error> for CliError {
-    fn from(e: tonic::transport::Error) -> Self {
-        CliError::Connect(e)
-    }
-}
-
 impl From<tonic::Status> for CliError {
     fn from(s: tonic::Status) -> Self {
-        match s.code() {
+        // tonic's `Code` Display strings are full sentences ("The system is
+        // not in a state required for the operation's execution: ..."), so
+        // every code maps to a short lowercase prefix and the daemon-side
+        // message reads as the sentence.
+        let prefix = match s.code() {
+            // Connect-time unreachability is handled by `CliError::Connect`
+            // (with address + failure class); an UNAVAILABLE that surfaces
+            // mid-RPC means the daemon went away, and the raw transport
+            // detail is intentionally suppressed.
             tonic::Code::Unavailable => {
-                CliError::Rpc("daemon is not running or unreachable".into())
+                return CliError::Rpc("daemon is not running or unreachable".into());
             }
-            tonic::Code::NotFound => CliError::Rpc(format!("not found: {}", s.message())),
-            _ => CliError::Rpc(format!("{}: {}", s.code(), s.message())),
-        }
+            tonic::Code::NotFound => "not found",
+            tonic::Code::InvalidArgument => "invalid argument",
+            tonic::Code::FailedPrecondition => "precondition failed",
+            tonic::Code::PermissionDenied => "permission denied",
+            tonic::Code::Unauthenticated => "unauthenticated",
+            tonic::Code::AlreadyExists => "already exists",
+            tonic::Code::ResourceExhausted => "resource exhausted",
+            tonic::Code::Unimplemented => "not supported by this daemon",
+            tonic::Code::DeadlineExceeded => "deadline exceeded",
+            tonic::Code::Aborted => "aborted",
+            tonic::Code::OutOfRange => "out of range",
+            tonic::Code::Cancelled => "cancelled",
+            tonic::Code::DataLoss => "data loss",
+            tonic::Code::Internal | tonic::Code::Unknown | tonic::Code::Ok => "daemon error",
+        };
+        CliError::Rpc(format!("{prefix}: {}", s.message()))
     }
 }
 
@@ -65,9 +88,22 @@ mod tests {
 
     // Every gRPC command routes its `Status` errors through
     // `From<Status>` via `?`, so this mapping is the CLI's single
-    // operator-facing error contract. These pin the three distinct arms
+    // operator-facing error contract. These pin the distinct arms
     // so a regression (reordering the match, dropping a special case, or
     // changing a prefix) is caught centrally rather than per command.
+
+    #[test]
+    fn connect_error_renders_address_class_and_hint() {
+        let err = CliError::Connect {
+            addr: "unix:///var/lib/rustbgpd/grpc.sock".into(),
+            detail: "socket does not exist".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "cannot reach rustbgpd at unix:///var/lib/rustbgpd/grpc.sock (socket does not exist)\n  \
+             hint: is the daemon running? if it uses a different endpoint, pass -s or set RUSTBGPD_ADDR"
+        );
+    }
 
     #[test]
     fn unavailable_is_reported_as_generic_unreachable() {
@@ -87,27 +123,53 @@ mod tests {
     }
 
     #[test]
-    fn invalid_argument_falls_through_with_code_and_message() {
-        // INVALID_ARGUMENT is not special-cased: it must surface via the
-        // generic "{code}: {message}" arm so operators see both.
+    fn invalid_argument_gets_short_prefix_not_tonic_sentence() {
         let err = CliError::from(Status::invalid_argument("prefix length 33 exceeds 32"));
         assert!(matches!(err, CliError::Rpc(_)));
         assert_eq!(
             err.to_string(),
-            "Client specified an invalid argument: prefix length 33 exceeds 32"
+            "invalid argument: prefix length 33 exceeds 32"
         );
     }
 
     #[test]
-    fn already_exists_falls_through_with_code_and_message() {
+    fn failed_precondition_gets_short_prefix_not_tonic_sentence() {
+        // The live 0.50.0 capture: tonic rendered this code as "The system
+        // is not in a state required for the operation's execution: ...".
+        let err = CliError::from(Status::failed_precondition(
+            "config persistence failed: failed to write /var/lib/rustbgpd/config.toml: No such file or directory (os error 2)",
+        ));
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(
+            err.to_string(),
+            "precondition failed: config persistence failed: failed to write /var/lib/rustbgpd/config.toml: No such file or directory (os error 2)"
+        );
+    }
+
+    #[test]
+    fn permission_denied_gets_short_prefix() {
+        let err = CliError::from(Status::permission_denied("token lacks write scope"));
+        assert_eq!(
+            err.to_string(),
+            "permission denied: token lacks write scope"
+        );
+    }
+
+    #[test]
+    fn already_exists_gets_short_prefix_not_tonic_sentence() {
         let err = CliError::from(Status::already_exists(
             "neighbor 10.0.0.2 already configured",
         ));
         assert!(matches!(err, CliError::Rpc(_)));
         assert_eq!(
             err.to_string(),
-            "Some entity that we attempted to create already exists: \
-             neighbor 10.0.0.2 already configured"
+            "already exists: neighbor 10.0.0.2 already configured"
         );
+    }
+
+    #[test]
+    fn internal_falls_back_to_daemon_error_prefix() {
+        let err = CliError::from(Status::internal("route processor panicked"));
+        assert_eq!(err.to_string(), "daemon error: route processor panicked");
     }
 }

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -601,6 +601,21 @@ pub fn print_result(json: bool, action: &str, target: &str, message: &str) -> Re
     Ok(())
 }
 
+/// Compose the one-line "what next" footer for a lifecycle command, or
+/// `None` under `--json` — machine output must stay pure JSON, so every
+/// footer routes through this suppression gate.
+pub fn next_step(json: bool, text: &str) -> Option<String> {
+    (!json).then(|| format!("next: {text}"))
+}
+
+/// Print the "what next" footer to stderr, so it never mixes into
+/// pipeable stdout. No-op under `--json`.
+pub fn print_next_step(json: bool, text: &str) {
+    if let Some(line) = next_step(json, text) {
+        eprintln!("{line}");
+    }
+}
+
 /// Print a pretty JSON value, returning a CLI error instead of panicking if
 /// serialization fails.
 pub fn print_json_pretty<T: Serialize>(value: &T) -> Result<(), CliError> {
@@ -655,6 +670,21 @@ mod tests {
     use super::*;
     use serde_json::Value;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn next_step_footer_golden_and_suppressed_under_json() {
+        // Golden shape for the human footer...
+        assert_eq!(
+            next_step(
+                false,
+                "confirm within the window: rbgp config confirm deploy-1"
+            ),
+            Some("next: confirm within the window: rbgp config confirm deploy-1".to_string())
+        );
+        // ...and proof `-j` output carries NO footer: every lifecycle footer
+        // routes through this gate.
+        assert_eq!(next_step(true, "anything"), None);
+    }
 
     #[test]
     fn test_format_duration() {

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -348,7 +348,20 @@ fn refuse_after_revert_message(
 
 /// Write temp file + fsync + rename + fsync dir. Shared with the config
 /// persister so every durable config write goes through the same primitive.
+///
+/// Failures name the destination path: a bare io error ("No such file or
+/// directory (os error 2)") is useless to an operator who doesn't know
+/// which file the daemon was writing.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    write_atomic_inner(path, bytes).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("failed to write {}: {error}", path.display()),
+        )
+    })
+}
+
+fn write_atomic_inner(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let parent = parent_dir(path)?;
     let mut tmp = path.as_os_str().to_os_string();
     tmp.push(".tmp");
@@ -554,6 +567,22 @@ log_format = "json"
         // Fail closed: config untouched, journal preserved.
         assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
         assert!(path.exists());
+    }
+
+    #[test]
+    fn write_atomic_failure_names_the_destination_path() {
+        // LAN-317: a persistence io failure must carry the destination path;
+        // a bare "No such file or directory (os error 2)" is unactionable.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-dir").join("config.toml");
+
+        let error = write_atomic(&path, b"x").unwrap_err();
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains(&format!("failed to write {}", path.display())),
+            "{rendered}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- connect failures now name the address tried and the failure class (socket does not exist / connection refused / permission denied / timed out, with an honest deepest-source fallback for TLS/h2 setup) plus a hint naming `-s`/`RUSTBGPD_ADDR` — replacing the informationless "daemon is not running or unreachable" for every failure mode
- gRPC status rendering maps codes to short prefixes (`precondition failed:`, `invalid argument:`, `permission denied:`, ...) instead of prepending tonic's sentence-length code descriptions; mid-RPC UNAVAILABLE keeps the deliberate suppression
- persistence errors carry the destination path: fixed once in the shared `write_atomic` primitive, so the confirm journal, boot revert, and config persister all report `failed to write <path>: ...`
- six lifecycle commands gain one-line next-step footers (config apply/confirm/abort, neighbor add/disable, gshut) on stderr, suppressed under `-j` so machine output stays pure
- diff's exit-code contract is untouched (its connect-failure interception keeps exit 2; suite passes)

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpctl / --bin rustbgpd (1352)
- cargo doc --workspace --no-deps
- release-binary live smoke: absent-socket and connection-refused variants render the new shapes (captured in-PR-body examples verified by the coordinator independently)

Closes LAN-317.