### PR TITLE
fix(build): ship release-profile artifacts with jemalloc and allocator metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Build release binaries
+        # --features rustbgpd/jemalloc: the shipped daemon must be the
+        # same build the published benchmarks are measured on (jemalloc
+        # as the global allocator + allocator gauges on /metrics).
+        # tikv-jemalloc-sys cross-compiles for aarch64 via the
+        # aarch64-linux-gnu-gcc toolchain installed above.
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --workspace --release --target ${{ matrix.target }}
+        run: cargo build --workspace --release --features rustbgpd/jemalloc --target ${{ matrix.target }}
 
       - name: Package binaries
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rules are now `prefix = None` in the policy context, matching the import
   path and the BGP-LS prefixless-context convention; rules that do carry a
   destination prefix still evaluate it unchanged. (LAN-291)
+- **Published artifacts now match the benchmarked build.** The GHCR
+  runtime image and the release tarballs previously shipped without the
+  `jemalloc` feature — and the image additionally used the fast CI
+  profile (`lto = false`, `codegen-units = 16`) — while every published
+  benchmark is measured on a fat-LTO `--release` build with jemalloc as
+  the global allocator. Both artifacts are now built `--release
+  --features jemalloc`; the `dev` interop image keeps the CI profile
+  for lab build speed. jemalloc builds also export allocator gauges on
+  the Prometheus endpoint, refreshed at scrape time:
+  `jemalloc_allocated_bytes`, `jemalloc_active_bytes`,
+  `jemalloc_resident_bytes`, and `jemalloc_mapped_bytes`. (LAN-331)
 
 ## [0.50.0] — 2026-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2942,6 +2942,7 @@ version = "0.50.0"
 dependencies = [
  "prometheus",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3025,7 +3026,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3393,7 +3394,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3525,6 +3526,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4232,7 +4244,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,8 @@ rustc-hash = "2"
 prefix-trie = "0.9.2"
 ipnet = "2.12.0"
 lru = "0.18"
-tikv-jemallocator = { version = "0.7", features = ["profiling"] }
+tikv-jemallocator = { version = "0.7", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 dhat = "0.3"
 rcgen = "0.14"
 tempfile = "3"
@@ -109,7 +110,7 @@ categories.workspace = true
 
 [features]
 bench-internals = []
-jemalloc = ["tikv-jemallocator"]
+jemalloc = ["tikv-jemallocator", "rustbgpd-telemetry/jemalloc"]
 dhat-heap = ["dhat"]
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,19 @@
 #   runtime (DEFAULT) — lean production image: the daemon + the `rbgp`
 #     CLI, nonroot user, nothing else. This is what the GHCR release
 #     image publishes (.github/workflows/container.yml builds the
-#     default target).
+#     default target). Built with the full `release` profile (fat-LTO,
+#     codegen-units=1) and `--features jemalloc` — the exact build
+#     every number in docs/BENCHMARKS.md is measured on.
 #   dev — interop / CI / lab image: adds the EVPN load-gen helpers
 #     (evpn-tester / evpn-monitor), the interop start script, and
-#     iproute2/ping for containerlab topologies.
+#     iproute2/ping for containerlab topologies. Built with the fast
+#     `ci` profile — interop M-jobs rebuild this image constantly and
+#     the fat-LTO serial link would slow every lab run.
 #
 # Multi-stage build with cargo-chef separating dep compilation from
-# workspace compilation. Builds the `ci` profile (release-shaped but
-# without fat-LTO / codegen-units=1) so the 15 workspace crates plus
-# ~300 deps actually parallelize.
+# workspace compilation. Two builder stages share the planner recipe
+# and the BuildKit cache mounts; only the stages a given --target
+# needs are built.
 #
 # Cache levers:
 #   - cargo-chef: dep build layer invalidates only on Cargo.lock change
@@ -48,6 +52,7 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
+# ── builder: fast `ci`-profile build for the dev image ───────────────
 FROM chef AS builder
 COPY --from=planner /build/recipe.json recipe.json
 # Cook deps under cache mounts. Dep layer invalidates only when
@@ -69,6 +74,25 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp target/ci/rbgp /out/ && \
     cp target/ci/evpn-tester /out/ && \
     cp target/ci/evpn-monitor /out/
+
+# ── builder-release: benchmarked-profile build for the runtime image ─
+# Full `release` profile (fat-LTO, codegen-units=1) with jemalloc as
+# the global allocator — the published image must be the same build
+# the benchmarks are measured on, not the CI-shaped one.
+FROM chef AS builder-release
+COPY --from=planner /build/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/build/target,sharing=locked \
+    cargo chef cook --release --features rustbgpd/jemalloc --recipe-path recipe.json
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/build/target,sharing=locked \
+    cargo build --release --features rustbgpd/jemalloc -p rustbgpd -p rustbgpctl && \
+    mkdir -p /out && \
+    cp target/release/rustbgpd /out/ && \
+    cp target/release/rbgp /out/
 
 # ── dev: interop / CI / lab image ────────────────────────────────────
 # Ships the daemon + CLI plus the development-only helpers the
@@ -96,8 +120,9 @@ EXPOSE 179 9179
 CMD ["rustbgpd", "/etc/rustbgpd/config.toml"]
 
 # ── runtime: lean production image (DEFAULT target) ──────────────────
-# Daemon + rbgp only — no dev/test/bench helpers. Runs as a nonroot
-# user; Docker's default net.ipv4.ip_unprivileged_port_start=0 lets it
+# Daemon + rbgp only — no dev/test/bench helpers. Binaries come from
+# builder-release (fat-LTO + jemalloc, the benchmarked build). Runs as
+# a nonroot user; Docker's default net.ipv4.ip_unprivileged_port_start=0 lets it
 # bind port 179 (grant CAP_NET_BIND_SERVICE explicitly on runtimes
 # that don't, e.g. some Kubernetes setups). Kernel-dataplane features
 # (Linux FIB / EVPN VTEP) additionally need CAP_NET_ADMIN — see
@@ -112,8 +137,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /var/lib/rustbgpd \
     && chown rustbgpd:rustbgpd /var/lib/rustbgpd
 
-COPY --from=builder /out/rustbgpd /usr/local/bin/rustbgpd
-COPY --from=builder /out/rbgp /usr/local/bin/rbgp
+COPY --from=builder-release /out/rustbgpd /usr/local/bin/rustbgpd
+COPY --from=builder-release /out/rbgp /usr/local/bin/rbgp
 COPY LICENSE-MIT LICENSE-APACHE /
 
 USER rustbgpd

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -11,8 +11,15 @@ categories.workspace = true
 description = "Prometheus metrics and structured tracing for rustbgpd"
 readme = "README.md"
 
+[features]
+# Export jemalloc allocator statistics on the Prometheus registry.
+# Enabled by the root `jemalloc` feature so the gauges exist exactly
+# when jemalloc is the global allocator.
+jemalloc = ["tikv-jemalloc-ctl"]
+
 [dependencies]
 prometheus.workspace = true
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 thiserror.workspace = true

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1662,6 +1662,11 @@ impl BgpMetrics {
             .register(Box::new(event_outbox_cursor_gap.clone()))
             .expect("metric not already registered");
 
+        #[cfg(feature = "jemalloc")]
+        registry
+            .register(Box::new(jemalloc_stats::JemallocCollector::new()))
+            .expect("metric not already registered");
+
         Self {
             registry,
             instance_id: NEXT_METRICS_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
@@ -3080,6 +3085,105 @@ impl Drop for EventStreamSubscriberGuard {
     }
 }
 
+/// jemalloc allocator statistics, refreshed at scrape time.
+///
+/// A custom [`prometheus::core::Collector`] rather than plain gauges:
+/// `Registry::gather()` calls `collect()` on every scrape, so the
+/// values are always current without any refresh plumbing in the
+/// daemon. Compiled only under the `jemalloc` feature — the same
+/// feature that installs jemalloc as the global allocator — so a
+/// glibc-malloc build registers nothing.
+#[cfg(feature = "jemalloc")]
+mod jemalloc_stats {
+    use prometheus::IntGauge;
+    use prometheus::core::{Collector, Desc};
+    use prometheus::proto::MetricFamily;
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    pub(super) struct JemallocCollector {
+        allocated: IntGauge,
+        active: IntGauge,
+        resident: IntGauge,
+        mapped: IntGauge,
+        descs: Vec<Desc>,
+    }
+
+    impl JemallocCollector {
+        pub(super) fn new() -> Self {
+            let allocated = IntGauge::new(
+                "jemalloc_allocated_bytes",
+                "Bytes allocated by the application (jemalloc stats.allocated).",
+            )
+            .expect("valid metric definition");
+            let active = IntGauge::new(
+                "jemalloc_active_bytes",
+                "Bytes in active pages allocated by the application (jemalloc stats.active); allocated plus allocator fragmentation.",
+            )
+            .expect("valid metric definition");
+            let resident = IntGauge::new(
+                "jemalloc_resident_bytes",
+                "Bytes in physically resident data pages mapped by the allocator (jemalloc stats.resident); jemalloc's contribution to RSS.",
+            )
+            .expect("valid metric definition");
+            let mapped = IntGauge::new(
+                "jemalloc_mapped_bytes",
+                "Bytes in active extents mapped by the allocator (jemalloc stats.mapped).",
+            )
+            .expect("valid metric definition");
+            let descs = allocated
+                .desc()
+                .into_iter()
+                .chain(active.desc())
+                .chain(resident.desc())
+                .chain(mapped.desc())
+                .cloned()
+                .collect();
+            Self {
+                allocated,
+                active,
+                resident,
+                mapped,
+                descs,
+            }
+        }
+    }
+
+    fn saturating(v: usize) -> i64 {
+        i64::try_from(v).unwrap_or(i64::MAX)
+    }
+
+    impl Collector for JemallocCollector {
+        fn desc(&self) -> Vec<&Desc> {
+            self.descs.iter().collect()
+        }
+
+        fn collect(&self) -> Vec<MetricFamily> {
+            // jemalloc caches its stats; advancing the epoch refreshes
+            // them. On any mallctl error keep the last-seen values —
+            // a scrape must never fail on allocator introspection.
+            if epoch::advance().is_ok() {
+                if let Ok(v) = stats::allocated::read() {
+                    self.allocated.set(saturating(v));
+                }
+                if let Ok(v) = stats::active::read() {
+                    self.active.set(saturating(v));
+                }
+                if let Ok(v) = stats::resident::read() {
+                    self.resident.set(saturating(v));
+                }
+                if let Ok(v) = stats::mapped::read() {
+                    self.mapped.set(saturating(v));
+                }
+            }
+            let mut families = self.allocated.collect();
+            families.extend(self.active.collect());
+            families.extend(self.resident.collect());
+            families.extend(self.mapped.collect());
+            families
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use prometheus::Encoder;
@@ -4356,5 +4460,20 @@ mod tests {
             .with_label_values(&["127.0.0.1:5001"])
             .get();
         assert_eq!(b, 1);
+    }
+
+    #[cfg(feature = "jemalloc")]
+    #[test]
+    fn jemalloc_gauges_registered_and_scrapable() {
+        let m = BgpMetrics::new();
+        let text = gather_text(&m);
+        for name in [
+            "jemalloc_allocated_bytes",
+            "jemalloc_active_bytes",
+            "jemalloc_resident_bytes",
+            "jemalloc_mapped_bytes",
+        ] {
+            assert!(text.contains(name), "{name} missing from scrape:\n{text}");
+        }
     }
 }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -7,6 +7,12 @@ For the consolidated operator-facing proof index that rolls benchmark, memory,
 interop, dataplane, and soak receipts together, see
 [`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md).
 
+Releases newer than v0.50.0 build the published artifacts — the GHCR
+runtime image and the release tarballs — with this same `--release`
+profile plus `--features jemalloc`, so shipped binaries match the
+benchmarked build (earlier releases shipped a CI-profile, glibc-malloc
+build).
+
 **Last measured:** RIB Operations pinned A/B: 2026-05-29; same-host
 current-main reconfirmation, distribution-fanout baseline, and memory
 attribution correction: 2026-06-02; structured high-N RIB memory profile:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -433,6 +433,13 @@ serves `/livez` and `/readyz` for orchestrators. Key counters operators watch:
   `bgp_rib_loc_prefixes{afi_safi}`, `bgp_max_prefix_exceeded_total`.
 - **GR / FIB** — `bgp_gr_active_peers`, `bgp_gr_stale_routes`,
   `bgp_fib_routes_installed_total`, `bgp_fib_kernel_failures_total`.
+- **Allocator** — `jemalloc_allocated_bytes`, `jemalloc_active_bytes`,
+  `jemalloc_resident_bytes`, `jemalloc_mapped_bytes`. Present in builds
+  with the `jemalloc` feature (the published container image and
+  release tarballs); refreshed at scrape time. `allocated` is live
+  application bytes, `resident` is jemalloc's contribution to RSS —
+  a widening gap between the two is retained-but-unused allocator
+  memory, the first thing to check before suspecting a leak.
 - **Durable event outbox** (ADR-0072) —
   `bgp_event_outbox_committed_total{category}`,
   `bgp_event_outbox_dropped_total{category, reason}`,


### PR DESCRIPTION
## Summary

- closes the published-artifact integrity gap: the GHCR runtime image and release tarballs were built with the CI profile (no LTO) and without the jemalloc feature, while every published benchmark measures the fat-LTO jemalloc build — the numbers described a binary nobody could pull
- the Dockerfile gains a `builder-release` stage (fat LTO, `rustbgpd/jemalloc`) feeding the published `runtime` target; the `dev` target keeps the CI profile so interop lab builds stay fast (verified: all 10 interop workflow builds use `target: dev`, and only the tag-triggered container publish pays the LTO cost)
- release.yml tarballs build with the jemalloc feature on both architectures (tikv-jemalloc-sys cross-compiles for aarch64 via the toolchain already installed)
- allocator introspection ships with it: a jemalloc collector registered in the telemetry registry exposes `jemalloc_{allocated,active,resident,mapped}_bytes`, refreshed at scrape time via the mallctl epoch — the diagnose-first surface for any allocator tuning (allocated-vs-resident gap framing documented in deployment docs)
- both feature states pass clippy at -D warnings; runtime image verified to carry jemalloc symbols and the dev image verified not to

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings (with and without --features jemalloc)
- cargo test -p rustbgpd-telemetry (both feature states; live-scrape test included)
- cargo build --release --features jemalloc
- docker build --target dev and --target runtime both green; runtime image binary carries jemalloc, dev does not (grep-verified independently)
- live metrics scrape from the release binary captured in the issue

Closes LAN-331.