### PR TITLE
feat(rpol): add explicit module imports with atomic graph compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,6 +312,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   finite-source grammar is what keeps every bound provable or
   meterable. (LAN-303, ADR-0103)
 
+- **rpol modules and imports.** The fifth ADR-0103 Phase B slice:
+  `import "lib/bogons.rpol"` splices another file's definitions —
+  sets, functions, policies, `test` blocks — into one flat-namespace
+  compilation unit, so shared bogon/customer libraries live in one
+  file (qualified names deferred; duplicate names across modules are
+  compile errors naming both files). Modules are a resolution
+  feature with **no IR change**: imports resolve depth-first in
+  declaration order against the importing file's directory plus the
+  new `[policy] rpol_roots` (CLI: repeatable `--root`), canonicalized
+  with escapes above every root rejected, diamonds loaded once,
+  cycles named in the diagnostic, and budgets enforced (nesting ≤ 8,
+  1 MiB/file, 8 MiB / 64 files per graph). Each unit compiles
+  all-or-nothing, and the reload identity covers the whole resolved
+  graph — a leaf-module edit re-syncs every dependent chain while an
+  untouched graph stays a content-equal no-op. Diagnostics carry
+  per-module spans (errors excerpt the file they're in), and
+  `rbgp policy check --list-deps` prints the resolved graph with
+  SHA-256 content hashes for packaging/audit. (LAN-300, ADR-0103)
+
 ### Changed
 
 - **Release publication is now fail-closed.** The binary-release and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,6 +2897,8 @@ dependencies = [
  "regex",
  "rustbgpd-wire",
  "rustc-hash 2.1.3",
+ "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -141,22 +141,46 @@ struct JsonChains {
 }
 
 /// `rbgp policy check <file.rpol>` — run the `.rpol` frontend
-/// in-process (parse, typecheck, in-language tests); no daemon.
+/// in-process (import resolution, parse, typecheck, in-language
+/// tests); no daemon. `roots` are extra `import` resolution roots
+/// (the file's own directory is always one); `list_deps` prints the
+/// resolved import graph + content hashes instead of running tests.
 ///
 /// Returns the process exit code: 0 clean, 1 diagnostics (or an
 /// unreadable file), 2 test failures. Diagnostics render to stderr,
 /// results to stdout.
-pub fn check_local(path: &str, json: bool) -> i32 {
+pub fn check_local(path: &str, roots: &[String], list_deps: bool, json: bool) -> i32 {
     use std::io::IsTerminal;
+    use std::path::PathBuf;
 
-    let source = match std::fs::read_to_string(path) {
-        Ok(source) => source,
-        Err(error) => {
-            eprintln!("Error: cannot read {path}: {error}");
+    use rustbgpd_policy::rpol::{LoadError, RpolFile};
+
+    let root_paths: Vec<PathBuf> = roots.iter().map(PathBuf::from).collect();
+    let (file, diagnostics) = match RpolFile::load(std::path::Path::new(path), &root_paths) {
+        Ok(file) => (Some(file), Vec::new()),
+        Err(LoadError::Io { path, reason }) => {
+            eprintln!("Error: cannot read {path}: {reason}");
             return 1;
         }
+        Err(error @ LoadError::Compile { .. }) => {
+            if !json {
+                let color = std::io::stderr().is_terminal();
+                eprint!("{}", error.render(color));
+            }
+            let messages = error
+                .diagnostics()
+                .map(|diags| diags.0.iter().map(|d| d.message.clone()).collect())
+                .unwrap_or_default();
+            (None, messages)
+        }
     };
-    let report = rustbgpd_policy::rpol::check_rpol(&source);
+
+    // --list-deps on a broken graph falls through to the compile
+    // diagnostics below (exit 1).
+    if list_deps && let Some(file) = &file {
+        return print_deps(path, file, json);
+    }
+    let tests = file.as_ref().map(RpolFile::run_tests);
 
     if json {
         #[derive(Serialize)]
@@ -168,26 +192,23 @@ pub fn check_local(path: &str, json: bool) -> i32 {
         struct JsonCheck<'a> {
             file: &'a str,
             ok: bool,
-            diagnostics: Vec<String>,
+            diagnostics: &'a [String],
             tests_total: usize,
             tests_passed: usize,
             failures: Vec<JsonFailure<'a>>,
         }
         let out = JsonCheck {
             file: path,
-            ok: report.is_ok(),
-            diagnostics: report
-                .diagnostics
-                .0
-                .iter()
-                .map(|diag| diag.message.clone())
-                .collect(),
-            tests_total: report.tests.as_ref().map_or(0, |t| t.total),
-            tests_passed: report
-                .tests
+            ok: diagnostics.is_empty()
+                && tests
+                    .as_ref()
+                    .is_none_or(rustbgpd_policy::rpol::TestReport::all_passed),
+            diagnostics: &diagnostics,
+            tests_total: tests.as_ref().map_or(0, |t| t.total),
+            tests_passed: tests
                 .as_ref()
                 .map_or(0, rustbgpd_policy::rpol::TestReport::passed),
-            failures: report.tests.as_ref().map_or_else(Vec::new, |t| {
+            failures: tests.as_ref().map_or_else(Vec::new, |t| {
                 t.failures
                     .iter()
                     .map(|f| JsonFailure {
@@ -200,19 +221,14 @@ pub fn check_local(path: &str, json: bool) -> i32 {
         if output::print_json_pretty(&out).is_err() {
             return 1;
         }
-    } else if !report.diagnostics.is_empty() {
-        let color = std::io::stderr().is_terminal();
-        eprint!("{}", report.diagnostics.render(path, &source, color));
+    } else if !diagnostics.is_empty() {
+        // Rendered excerpts already went to stderr above.
         eprintln!(
             "{path}: {} error{}",
-            report.diagnostics.len(),
-            if report.diagnostics.len() == 1 {
-                ""
-            } else {
-                "s"
-            }
+            diagnostics.len(),
+            if diagnostics.len() == 1 { "" } else { "s" }
         );
-    } else if let Some(tests) = &report.tests {
+    } else if let Some(tests) = &tests {
         if tests.total == 0 {
             println!("{path}: ok (no tests)");
         } else {
@@ -227,17 +243,64 @@ pub fn check_local(path: &str, json: bool) -> i32 {
         }
     }
 
-    if !report.diagnostics.is_empty() {
+    if !diagnostics.is_empty() {
         1
-    } else if report
-        .tests
-        .as_ref()
-        .is_some_and(|tests| !tests.all_passed())
-    {
+    } else if tests.as_ref().is_some_and(|tests| !tests.all_passed()) {
         2
     } else {
         0
     }
+}
+
+/// `rbgp policy check --list-deps` output: the resolved module graph
+/// with content hashes, module 0 first (the main file), imports in
+/// declaration order. Always exit 0 — the graph compiled.
+fn print_deps(path: &str, file: &rustbgpd_policy::rpol::RpolFile, json: bool) -> i32 {
+    let modules = file.modules();
+    if json {
+        #[derive(Serialize)]
+        struct JsonDep<'a> {
+            path: &'a str,
+            sha256: &'a str,
+            imports: Vec<&'a str>,
+        }
+        #[derive(Serialize)]
+        struct JsonDeps<'a> {
+            file: &'a str,
+            modules: Vec<JsonDep<'a>>,
+        }
+        let out = JsonDeps {
+            file: path,
+            modules: modules
+                .iter()
+                .map(|m| JsonDep {
+                    path: &m.path,
+                    sha256: &m.digest,
+                    imports: m
+                        .imports
+                        .iter()
+                        .map(|&id| modules[id as usize].path.as_str())
+                        .collect(),
+                })
+                .collect(),
+        };
+        if output::print_json_pretty(&out).is_err() {
+            return 1;
+        }
+        return 0;
+    }
+    println!(
+        "{path}: {} module{}",
+        modules.len(),
+        if modules.len() == 1 { "" } else { "s" }
+    );
+    for module in modules {
+        println!("  {} sha256:{}", module.path, module.digest);
+        for &id in &module.imports {
+            println!("    imports {}", modules[id as usize].path);
+        }
+    }
+    0
 }
 
 /// Options for `rbgp policy test` (ADR-0096 live-RIB dry run).
@@ -1264,16 +1327,67 @@ mod tests {
                  expect p == reject
              }",
         );
-        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 0);
-        assert_eq!(check_local(tmp.path().to_str().unwrap(), true), 0);
+        assert_eq!(
+            check_local(tmp.path().to_str().unwrap(), &[], false, false),
+            0
+        );
+        assert_eq!(
+            check_local(tmp.path().to_str().unwrap(), &[], false, true),
+            0
+        );
     }
 
     #[test]
     fn check_local_diagnostics_exit_one() {
         let tmp = write_rpol("policy p { term t { if route.zzz == 1 { accept } } }");
-        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 1);
+        assert_eq!(
+            check_local(tmp.path().to_str().unwrap(), &[], false, false),
+            1
+        );
         // Unreadable file is also exit 1.
-        assert_eq!(check_local("/nonexistent/nope.rpol", false), 1);
+        assert_eq!(check_local("/nonexistent/nope.rpol", &[], false, false), 1);
+    }
+
+    /// LAN-300: `check` resolves the import graph (tests in the main
+    /// file exercise imported definitions), `--root` resolves imports
+    /// outside the main file's directory, and `--list-deps` exits 0 on
+    /// a clean graph / 1 on a broken one.
+    #[test]
+    fn check_local_resolves_imports_and_lists_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        let lib = tempfile::tempdir().unwrap();
+        std::fs::write(
+            lib.path().join("bogons.rpol"),
+            "prefix-set bogons { 127.0.0.0/8 le 32 }",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("main.rpol"),
+            "import \"bogons.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }\n\
+             test rejects-loopback {\n\
+                 route { prefix 127.0.0.1/32 }\n\
+                 expect p == reject\n\
+             }",
+        )
+        .unwrap();
+        let main = dir.path().join("main.rpol");
+        let main = main.to_str().unwrap();
+        let root = lib.path().to_str().unwrap().to_string();
+        // Without the root the import cannot resolve.
+        assert_eq!(check_local(main, &[], false, false), 1);
+        // With it: clean check (the cross-module test runs) and deps.
+        assert_eq!(
+            check_local(main, std::slice::from_ref(&root), false, false),
+            0
+        );
+        assert_eq!(
+            check_local(main, std::slice::from_ref(&root), true, false),
+            0
+        );
+        assert_eq!(check_local(main, &[root], true, true), 0);
+        // --list-deps on a broken graph still exits 1.
+        assert_eq!(check_local(main, &[], true, false), 1);
     }
 
     #[test]
@@ -1285,7 +1399,10 @@ mod tests {
                  expect p == accept
              }",
         );
-        assert_eq!(check_local(tmp.path().to_str().unwrap(), false), 2);
+        assert_eq!(
+            check_local(tmp.path().to_str().unwrap(), &[], false, false),
+            2
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -356,12 +356,23 @@ enum ConfigAction {
 enum PolicyAction {
     /// List configured policies (names + statement counts)
     List,
-    /// Check an `.rpol` policy file locally: parse, typecheck, and run
-    /// its in-language `test` blocks. No daemon connection. Exit codes:
-    /// 0 clean, 1 diagnostics, 2 test failures.
+    /// Check an `.rpol` policy file locally: resolve its `import`
+    /// graph, parse, typecheck, and run its in-language `test` blocks
+    /// (from every module). No daemon connection. Exit codes: 0 clean,
+    /// 1 diagnostics, 2 test failures.
     Check {
-        /// Path to the `.rpol` file
+        /// Path to the main `.rpol` file
         file: String,
+        /// Additional policy root for `import` resolution (repeatable;
+        /// the main file's directory is always a root) — mirror of the
+        /// daemon's `[policy] rpol_roots`
+        #[arg(long = "root")]
+        roots: Vec<String>,
+        /// Print the resolved import graph — each module's path,
+        /// SHA-256 content hash, and imports — instead of running
+        /// tests (audit/packaging aid)
+        #[arg(long)]
+        list_deps: bool,
     },
     /// Dry-run a candidate `.rpol` policy against the daemon's live
     /// RIB (ADR-0096): the file compiles server-side and evaluates
@@ -1405,10 +1416,17 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
 
     // `policy check` runs the .rpol frontend in-process — no daemon.
     if let Command::Policy {
-        action: PolicyAction::Check { file },
+        action:
+            PolicyAction::Check {
+                file,
+                roots,
+                list_deps,
+            },
     } = &cli.command
     {
-        std::process::exit(commands::policy::check_local(file, cli.json));
+        std::process::exit(commands::policy::check_local(
+            file, roots, *list_deps, cli.json,
+        ));
     }
 
     // `diff` owns its 0/1/2 exit-code contract (2 = any operational

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -18,12 +18,16 @@ logos = "0.16"
 regex = "1"
 rustc-hash.workspace = true
 rustbgpd-wire.workspace = true
+# Module content digests for `rbgp policy check --list-deps`
+# (LAN-300); already in the workspace dependency graph.
+sha2 = "0.10"
 thiserror.workspace = true
 # Rate-limited eval-error WARN (LAN-299, ADR-0103 Decision 4).
 tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 name = "policy_eval"

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-300-imports.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-300-imports.rpol
@@ -1,0 +1,8 @@
+import "lib/bogons.rpol"
+import "lib/../lib/customers.rpol"
+
+prefix-set import { 10.0.0.0/8 le 32 }
+
+policy p {
+    term t { if route.prefix in import { reject } }
+}

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -16,6 +16,10 @@ use super::diag::{Span, Spanned};
 /// A parsed `.rpol` source file.
 #[derive(Debug, Default)]
 pub struct SourceFile {
+    /// `import "path"` declarations (LAN-300), in source order.
+    /// Consumed by the module resolver ([`super::modules`]); the merged
+    /// compilation unit it produces carries none.
+    pub imports: Vec<Spanned<String>>,
     /// `prefix-set` definitions.
     pub prefix_sets: Vec<PrefixSetDef>,
     /// `community-set` definitions.

--- a/crates/policy/src/rpol/diag.rs
+++ b/crates/policy/src/rpol/diag.rs
@@ -10,22 +10,35 @@
 use std::fmt;
 use std::ops::Range;
 
-/// A byte range into the source text.
+/// A byte range into one source file of a compile.
+///
+/// `file` indexes the module list of the compile that produced the
+/// span (LAN-300): 0 is the main file, which is also the only file a
+/// single-source compile ([`crate::rpol::RpolFile::parse`]) ever has.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Span {
     /// Byte offset of the first character.
     pub start: usize,
     /// Byte offset one past the last character.
     pub end: usize,
+    /// Module (file) index within the compile; 0 = main file.
+    pub file: u32,
 }
 
 impl Span {
-    /// Construct a span from a byte range.
+    /// Construct a span from a byte range into the main file.
     #[must_use]
     pub fn new(range: Range<usize>) -> Self {
+        Self::in_file(range, 0)
+    }
+
+    /// Construct a span from a byte range into module `file`.
+    #[must_use]
+    pub fn in_file(range: Range<usize>, file: u32) -> Self {
         Self {
             start: range.start,
             end: range.end,
+            file,
         }
     }
 
@@ -35,6 +48,7 @@ impl Span {
         Span {
             start: self.start.min(other.start),
             end: self.end.max(other.end),
+            file: self.file,
         }
     }
 
@@ -117,24 +131,44 @@ impl Diagnostics {
     }
 
     /// Render every diagnostic as an ariadne report against `source`,
-    /// attributed to `filename`. `color` enables ANSI styling.
+    /// attributed to `filename` — the single-source form; every span's
+    /// `file` index is expected to be 0. `color` enables ANSI styling.
+    #[must_use]
+    pub fn render(&self, filename: &str, source: &str, color: bool) -> String {
+        self.render_sources(&[(filename.to_string(), source.to_string())], color)
+    }
+
+    /// Render every diagnostic against a multi-module compile
+    /// (LAN-300): `sources[i]` is the `(display path, text)` of module
+    /// `i`, matching each span's `file` index, so an error in an
+    /// imported file renders an excerpt of — and names — that file.
     ///
     /// # Panics
     ///
     /// Never in practice: writing to an in-memory buffer is infallible.
     #[must_use]
-    pub fn render(&self, filename: &str, source: &str, color: bool) -> String {
+    pub fn render_sources(&self, sources: &[(String, String)], color: bool) -> String {
         use ariadne::{Config, Label, Report, ReportKind};
 
+        let name_of = |span: &Span| -> String {
+            sources
+                .get(span.file as usize)
+                .or_else(|| sources.first())
+                .map(|(name, _)| name.clone())
+                .unwrap_or_default()
+        };
         let mut out = Vec::new();
         for diag in &self.0 {
-            let primary = diag.labels.first().map_or(0..0, |(span, _)| span.range());
-            let mut report = Report::build(ReportKind::Error, (filename.to_string(), primary))
+            let primary = diag.labels.first().map_or_else(
+                || (name_of(&Span::new(0..0)), 0..0),
+                |(span, _)| (name_of(span), span.range()),
+            );
+            let mut report = Report::build(ReportKind::Error, primary)
                 .with_config(Config::default().with_color(color))
                 .with_message(&diag.message);
             for (index, (span, label)) in diag.labels.iter().enumerate() {
                 report = report.with_label(
-                    Label::new((filename.to_string(), span.range()))
+                    Label::new((name_of(span), span.range()))
                         .with_message(label)
                         .with_order(i32::try_from(index).unwrap_or(i32::MAX)),
                 );
@@ -144,10 +178,7 @@ impl Diagnostics {
             }
             report
                 .finish()
-                .write(
-                    ariadne::sources([(filename.to_string(), source.to_string())]),
-                    &mut out,
-                )
+                .write(ariadne::sources(sources.to_vec()), &mut out)
                 .expect("writing a diagnostic to an in-memory buffer cannot fail");
         }
         String::from_utf8_lossy(&out).into_owned()

--- a/crates/policy/src/rpol/lexer.rs
+++ b/crates/policy/src/rpol/lexer.rs
@@ -313,15 +313,17 @@ pub struct Token {
     pub span: Span,
 }
 
-/// Lex the entire source. Unrecognized characters become diagnostics
-/// (one per contiguous bad region) and lexing continues, so the parser
-/// still sees — and can report on — the rest of the file.
+/// Lex the entire source, attributing spans to module index `file`
+/// (0 for a single-source compile). Unrecognized characters become
+/// diagnostics (one per contiguous bad region) and lexing continues,
+/// so the parser still sees — and can report on — the rest of the
+/// file.
 #[must_use]
-pub fn lex(source: &str) -> (Vec<Token>, Vec<Diagnostic>) {
+pub fn lex(source: &str, file: u32) -> (Vec<Token>, Vec<Diagnostic>) {
     let mut tokens = Vec::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     for (result, range) in Tok::lexer(source).spanned() {
-        let span = Span::new(range);
+        let span = Span::in_file(range, file);
         let Ok(kind) = result else {
             // Coalesce adjacent error characters into one diagnostic.
             if let Some(last) = diagnostics.last_mut()
@@ -348,7 +350,7 @@ mod tests {
     use super::*;
 
     fn kinds(src: &str) -> Vec<Tok> {
-        let (tokens, diags) = lex(src);
+        let (tokens, diags) = lex(src, 0);
         assert!(diags.is_empty(), "unexpected lex errors: {diags:?}");
         tokens.into_iter().map(|t| t.kind).collect()
     }
@@ -430,7 +432,7 @@ mod tests {
 
     #[test]
     fn unrecognized_tokens_are_reported_and_skipped() {
-        let (tokens, diags) = lex("policy @@ demo");
+        let (tokens, diags) = lex("policy @@ demo", 0);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("unrecognized token"));
         assert_eq!(

--- a/crates/policy/src/rpol/mod.rs
+++ b/crates/policy/src/rpol/mod.rs
@@ -24,32 +24,43 @@ mod ast;
 mod diag;
 mod lexer;
 mod lower;
+mod modules;
 mod parser;
 mod testing;
 mod typeck;
 
 pub use diag::{Diagnostic, Diagnostics, Span, Spanned};
+pub use modules::{
+    LoadError, MAX_FILE_BYTES, MAX_GRAPH_BYTES, MAX_MODULE_DEPTH, MAX_MODULE_FILES, ModuleSource,
+};
 pub use testing::{TestFailure, TestReport};
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::ir::CompiledChain;
 use crate::sets::SetStore;
 
-/// A parsed + typechecked `.rpol` source file, retained (with its
-/// source text) so config chain references — including parameterized
-/// call-forms like `"customer-in(200)"` — can be monomorphized at
-/// chain-resolve time.
+/// A parsed + typechecked `.rpol` compilation unit — the main source
+/// plus every module its `import` graph resolved (LAN-300) — retained
+/// (with all source texts) so config chain references — including
+/// parameterized call-forms like `"customer-in(200)"` — can be
+/// monomorphized at chain-resolve time.
 #[derive(Debug)]
 pub struct RpolFile {
-    source: String,
+    /// Per-module `(path, text, imports, digest)`, indexed by the
+    /// `file` field of every [`Span`]; index 0 is the main file.
+    modules: Vec<ModuleSource>,
+    /// The merged compilation unit (imports dissolved).
     file: ast::SourceFile,
 }
 
 impl RpolFile {
-    /// Parse and typecheck `.rpol` source, retaining it for later
-    /// per-policy compilation.
+    /// Parse and typecheck a single `.rpol` source with no filesystem
+    /// access, retaining it for later per-policy compilation. `import`
+    /// declarations are compile errors here — use [`Self::load`] for
+    /// file-based, import-capable loading.
     ///
     /// # Errors
     ///
@@ -57,15 +68,75 @@ impl RpolFile {
     pub fn parse(source: &str) -> Result<Self, Diagnostics> {
         let (file, _) = front(source)?;
         Ok(Self {
-            source: source.to_string(),
+            modules: vec![ModuleSource::inline(source)],
             file,
         })
     }
 
-    /// The original source text.
+    /// Read `path`, resolve its `import` graph against the importing
+    /// files' directories plus `roots` (LAN-300), and typecheck the
+    /// merged unit. All budgets (depth, per-file and total size, file
+    /// count), path confinement, cycle and duplicate-name checks apply.
+    ///
+    /// # Errors
+    ///
+    /// [`LoadError::Io`] when the main file or a configured root is
+    /// unreadable; [`LoadError::Compile`] with multi-file diagnostics
+    /// otherwise.
+    pub fn load(path: &Path, roots: &[PathBuf]) -> Result<Self, LoadError> {
+        let graph = modules::resolve(path, roots)?;
+        let type_diags = typeck::typecheck(&graph.merged);
+        if !type_diags.is_empty() {
+            return Err(LoadError::Compile {
+                sources: graph
+                    .modules
+                    .iter()
+                    .map(|m| (m.path.clone(), m.text.clone()))
+                    .collect(),
+                diagnostics: Diagnostics(type_diags),
+            });
+        }
+        Ok(Self {
+            modules: graph.modules,
+            file: graph.merged,
+        })
+    }
+
+    /// The main file's source text.
     #[must_use]
     pub fn source(&self) -> &str {
-        &self.source
+        &self.modules[0].text
+    }
+
+    /// Every module of the compilation unit in resolution (span
+    /// `file`-index) order; index 0 is the main file. This is the
+    /// resolved-content identity: two units are policy-equal exactly
+    /// when these texts are pairwise equal (paths excluded).
+    #[must_use]
+    pub fn modules(&self) -> &[ModuleSource] {
+        &self.modules
+    }
+
+    /// Resolved-content equality (ADR-0103 Decision 5.3): pairwise
+    /// module-text equality in resolution order, display paths
+    /// excluded — moving an unchanged graph to new paths is not a
+    /// policy change, while an edit to any imported leaf is.
+    #[must_use]
+    pub fn content_eq(&self, other: &Self) -> bool {
+        self.modules.len() == other.modules.len()
+            && self
+                .modules
+                .iter()
+                .zip(&other.modules)
+                .all(|(a, b)| a.text == b.text)
+    }
+
+    /// Run the unit's in-language `test` blocks (from every module).
+    #[must_use]
+    pub fn run_tests(&self) -> TestReport {
+        let mut store = SetStore::new();
+        let mut lowerer = lower::Lowerer::new(&self.file, &mut store);
+        testing::run_tests(&self.file.tests, &mut lowerer, &mut store)
     }
 
     /// `(name, parameter count)` for every policy defined in the file,
@@ -173,9 +244,10 @@ impl PartialEq for RpolPolicySet {
     fn eq(&self, other: &Self) -> bool {
         self.policies.len() == other.policies.len()
             && self.policies.iter().all(|(name, entry)| {
-                other.policies.get(name).is_some_and(|o| {
-                    o.params == entry.params && o.file.source() == entry.file.source()
-                })
+                other
+                    .policies
+                    .get(name)
+                    .is_some_and(|o| o.params == entry.params && o.file.content_eq(&entry.file))
             })
     }
 }
@@ -245,9 +317,26 @@ pub fn check_rpol(source: &str) -> CheckReport {
     }
 }
 
-/// Shared frontend: lex + parse + typecheck, all diagnostics combined.
+/// Shared single-source frontend: lex + parse + typecheck, all
+/// diagnostics combined. Inline sources cannot import (there is no
+/// filesystem to resolve against — ADR-0103 Decision 7 permits compile
+/// I/O only through the config loader), so `import` declarations are
+/// rejected here; [`RpolFile::load`] is the import-capable path.
 fn front(source: &str) -> Result<(ast::SourceFile, Vec<Diagnostic>), Diagnostics> {
     let (file, mut diags) = parser::parse(source);
+    for import in &file.imports {
+        diags.push(
+            Diagnostic::new(
+                import.span,
+                "`import` is not available for inline sources",
+                "imports need file-based loading",
+            )
+            .with_note(
+                "load this policy from a file (config `rpol_files` or `rbgp policy check`) \
+                 to use imports",
+            ),
+        );
+    }
     diags.extend(typeck::typecheck(&file));
     if diags.is_empty() {
         Ok((file, Vec::new()))

--- a/crates/policy/src/rpol/modules.rs
+++ b/crates/policy/src/rpol/modules.rs
@@ -1,0 +1,911 @@
+//! `.rpol` module resolution (LAN-300, ADR-0103 Decision 8.1 /
+//! plan item 5).
+//!
+//! Modules are a **frontend feature with no IR change**: `import
+//! "lib/common.rpol"` declarations are resolved here — against the
+//! importing file's directory and the configured policy roots — into
+//! one merged compilation unit that the typechecker and lowerer see as
+//! a single [`ast::SourceFile`]. After resolution the compiled
+//! artifact is indistinguishable from a concatenated single source;
+//! only span attribution (each [`Span`] carries its module index)
+//! remembers the file boundaries.
+//!
+//! Resolution rules:
+//!
+//! - Import paths are **relative** (absolute paths are rejected) and
+//!   resolve against the importing file's directory first, then each
+//!   configured root in declaration order. The first candidate that
+//!   exists wins.
+//! - Every resolved file is canonicalized before it is read (the
+//!   LAN-218 TOCTOU discipline), and the canonical path must stay
+//!   inside one of the roots (the main file's directory is always a
+//!   root). Symlinks that resolve inside a root are fine; symlinks or
+//!   `..` traversal escaping every root are compile errors.
+//! - The import graph is a DAG walked depth-first following
+//!   declaration order — resolution order never depends on filesystem
+//!   iteration, so identical graphs compile identically (ADR-0103
+//!   Decision 5.1). Diamond imports load once; cycles are compile
+//!   errors naming the cycle (the `apply`/`fn` DAG precedent).
+//! - Budgets: [`MAX_MODULE_DEPTH`] import nesting, [`MAX_FILE_BYTES`]
+//!   per file, [`MAX_GRAPH_BYTES`] and [`MAX_MODULE_FILES`] for the
+//!   whole graph.
+//! - The merge appends definitions dependency-first (post-order), main
+//!   file last; all definitions share one flat namespace and duplicate
+//!   names across modules are compile errors naming both files (the
+//!   typechecker's existing duplicate check over the merged unit).
+//!
+//! Everything here runs at load/reload time only — evaluation never
+//! touches the filesystem (ADR-0103 Decision 7).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use super::ast;
+use super::diag::{Diagnostic, Diagnostics, Span, Spanned};
+use super::parser;
+
+/// Maximum import nesting depth (ADR-0103 Decision 3): the main file
+/// is depth 0; an import chain deeper than this is a compile error.
+pub const MAX_MODULE_DEPTH: u32 = 8;
+
+/// Maximum size of one `.rpol` source file (ADR-0103 Decision 3:
+/// load-time reject).
+pub const MAX_FILE_BYTES: usize = 1024 * 1024;
+
+/// Maximum total source size of a resolved module graph.
+pub const MAX_GRAPH_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum number of files in a resolved module graph.
+pub const MAX_MODULE_FILES: usize = 64;
+
+/// One resolved module of a compile: its display path, source text,
+/// resolved import edges, and content digest. Index in
+/// [`crate::rpol::RpolFile::modules`] = the `file` index spans carry.
+#[derive(Debug, Clone)]
+pub struct ModuleSource {
+    /// Canonical filesystem path (`"<inline>"` for source-only parses).
+    pub path: String,
+    /// The module's source text.
+    pub text: String,
+    /// Module indices this module imports, in declaration order.
+    pub imports: Vec<u32>,
+    /// Lowercase-hex SHA-256 of `text` — the audit-facing content
+    /// hash printed by `rbgp policy check --list-deps`.
+    pub digest: String,
+}
+
+impl ModuleSource {
+    pub(super) fn inline(text: &str) -> Self {
+        Self {
+            path: "<inline>".to_string(),
+            text: text.to_string(),
+            imports: Vec::new(),
+            digest: digest_hex(text),
+        }
+    }
+}
+
+/// Lowercase-hex SHA-256 of a module text.
+fn digest_hex(text: &str) -> String {
+    let mut hex = String::with_capacity(64);
+    for byte in Sha256::digest(text.as_bytes()) {
+        use std::fmt::Write;
+        write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    hex
+}
+
+/// Why a file-based `.rpol` load failed.
+#[derive(Debug)]
+pub enum LoadError {
+    /// The main file (or a configured root) could not be resolved or
+    /// read — there is no source to attribute diagnostics to.
+    Io {
+        /// The offending path, as given.
+        path: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+    /// Compilation failed; diagnostics span the resolved module graph.
+    Compile {
+        /// `(display path, text)` per module index, for rendering.
+        sources: Vec<(String, String)>,
+        /// Every diagnostic found, across all modules.
+        diagnostics: Diagnostics,
+    },
+}
+
+impl LoadError {
+    /// Render the error for humans (ariadne excerpts for compile
+    /// errors, a plain line for I/O errors).
+    #[must_use]
+    pub fn render(&self, color: bool) -> String {
+        match self {
+            LoadError::Io { path, reason } => format!("{path}: {reason}"),
+            LoadError::Compile {
+                sources,
+                diagnostics,
+            } => diagnostics.render_sources(sources, color),
+        }
+    }
+
+    /// The diagnostics of a compile failure, if that is what this is.
+    #[must_use]
+    pub fn diagnostics(&self) -> Option<&Diagnostics> {
+        match self {
+            LoadError::Io { .. } => None,
+            LoadError::Compile { diagnostics, .. } => Some(diagnostics),
+        }
+    }
+}
+
+/// A fully resolved (but not yet typechecked) module graph: per-module
+/// sources in discovery order (index = span `file`) and the merged
+/// compilation unit.
+pub(super) struct ResolvedGraph {
+    pub(super) modules: Vec<ModuleSource>,
+    pub(super) merged: ast::SourceFile,
+}
+
+/// Resolve `main_path`'s import graph. `roots` are the configured
+/// policy roots (the main file's directory is always added). Returns
+/// the resolved graph, or an error for unreadable inputs / resolution
+/// and parse diagnostics.
+pub(super) fn resolve(main_path: &Path, roots: &[PathBuf]) -> Result<ResolvedGraph, LoadError> {
+    let io = |path: &Path, reason: String| LoadError::Io {
+        path: path.display().to_string(),
+        reason,
+    };
+    let main_canon = main_path
+        .canonicalize()
+        .map_err(|e| io(main_path, format!("failed to read: {e}")))?;
+    let main_dir = main_canon
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| io(main_path, "file has no parent directory".to_string()))?;
+
+    // Confinement roots: the main file's directory plus every
+    // configured root, canonicalized. A configured root that does not
+    // exist is a load error — a silently dropped root would quietly
+    // change which file an import resolves to.
+    let mut confine: Vec<PathBuf> = vec![main_dir];
+    for root in roots {
+        confine.push(
+            root.canonicalize()
+                .map_err(|e| io(root, format!("policy root is unusable: {e}")))?,
+        );
+    }
+
+    let mut resolver = Resolver {
+        confine,
+        modules: Vec::new(),
+        asts: Vec::new(),
+        canon: Vec::new(),
+        index: HashMap::new(),
+        in_progress: Vec::new(),
+        post_order: Vec::new(),
+        total_bytes: 0,
+        diags: Vec::new(),
+    };
+    let text = std::fs::read_to_string(&main_canon)
+        .map_err(|e| io(main_path, format!("failed to read: {e}")))?;
+    resolver.visit(main_canon, text, 0);
+
+    let sources: Vec<(String, String)> = resolver
+        .modules
+        .iter()
+        .map(|m| (m.path.clone(), m.text.clone()))
+        .collect();
+    if !resolver.diags.is_empty() {
+        return Err(LoadError::Compile {
+            sources,
+            diagnostics: Diagnostics(resolver.diags),
+        });
+    }
+
+    // Merge dependency-first (post-order); the main file — visited
+    // first, finished last — lands at the end, so `compile_rpol`'s
+    // "zero-parameter policies in source order" reads as imports
+    // first, then the main file, deterministically.
+    let mut merged = ast::SourceFile::default();
+    let mut asts = resolver.asts;
+    for &id in &resolver.post_order {
+        let module = std::mem::take(&mut asts[id as usize]);
+        merged.prefix_sets.extend(module.prefix_sets);
+        merged.community_sets.extend(module.community_sets);
+        merged.asn_sets.extend(module.asn_sets);
+        merged.fns.extend(module.fns);
+        merged.policies.extend(module.policies);
+        merged.tests.extend(module.tests);
+    }
+    Ok(ResolvedGraph {
+        modules: resolver.modules,
+        merged,
+    })
+}
+
+struct Resolver {
+    /// Canonicalized confinement roots (main dir + configured roots).
+    confine: Vec<PathBuf>,
+    /// Per-module metadata, indexed by module (`file`) id.
+    modules: Vec<ModuleSource>,
+    /// Parsed ASTs, same indexing (consumed by the merge).
+    asts: Vec<ast::SourceFile>,
+    /// Canonical paths, same indexing.
+    canon: Vec<PathBuf>,
+    /// Canonical path → module id (diamond dedupe + cycle detection).
+    index: HashMap<PathBuf, u32>,
+    /// Whether a module is still on the DFS stack.
+    in_progress: Vec<bool>,
+    /// Dependency-first merge order.
+    post_order: Vec<u32>,
+    /// Running total of loaded source bytes.
+    total_bytes: usize,
+    /// Resolution + parse diagnostics, across all modules.
+    diags: Vec<Diagnostic>,
+}
+
+impl Resolver {
+    /// Load, parse, and recurse into one module whose canonical path
+    /// and text are already in hand. Returns its module id.
+    fn visit(&mut self, canon: PathBuf, text: String, depth: u32) -> u32 {
+        let id = u32::try_from(self.modules.len()).expect("MAX_MODULE_FILES bounds the count");
+        let display = canon.display().to_string();
+        self.index.insert(canon.clone(), id);
+        self.canon.push(canon);
+        let text_len = text.len();
+        self.total_bytes += text_len;
+        let (ast, mut parse_diags) = parser::parse_module(&text, id);
+        self.diags.append(&mut parse_diags);
+        let digest = digest_hex(&text);
+        self.modules.push(ModuleSource {
+            path: display,
+            text,
+            imports: Vec::new(),
+            digest,
+        });
+        self.asts.push(ast::SourceFile::default());
+        self.in_progress.push(true);
+
+        if text_len > MAX_FILE_BYTES {
+            self.diags.push(Diagnostic::new(
+                Span::in_file(0..0, id),
+                format!("`.rpol` file is {text_len} bytes; the per-file limit is {MAX_FILE_BYTES}"),
+                "this file is too large",
+            ));
+        }
+        if self.total_bytes > MAX_GRAPH_BYTES {
+            self.diags.push(Diagnostic::new(
+                Span::in_file(0..0, id),
+                format!(
+                    "resolved module graph exceeds {MAX_GRAPH_BYTES} total source bytes \
+                     at this file"
+                ),
+                "graph source budget exhausted here",
+            ));
+        }
+
+        // Resolve this module's imports in declaration order.
+        let imports = ast.imports.clone();
+        let mut edges = Vec::with_capacity(imports.len());
+        for import in &imports {
+            if let Some(dep) = self.resolve_import(id, import, depth) {
+                edges.push(dep);
+            }
+        }
+        self.modules[id as usize].imports = edges;
+        self.asts[id as usize] = ast;
+        self.in_progress[id as usize] = false;
+        self.post_order.push(id);
+        id
+    }
+
+    /// Resolve one `import "path"` declaration of module `importer` at
+    /// nesting `depth`. Returns the imported module's id, or `None`
+    /// with a diagnostic recorded.
+    fn resolve_import(
+        &mut self,
+        importer: u32,
+        import: &Spanned<String>,
+        depth: u32,
+    ) -> Option<u32> {
+        let rel = Path::new(&import.node);
+        if rel.is_absolute() {
+            self.diags.push(
+                Diagnostic::new(
+                    import.span,
+                    format!("import path {:?} is absolute", import.node),
+                    "imports must be relative paths",
+                )
+                .with_note(
+                    "imports resolve against the importing file's directory and the configured \
+                 policy roots",
+                ),
+            );
+            return None;
+        }
+        if depth >= MAX_MODULE_DEPTH {
+            self.diags.push(Diagnostic::new(
+                import.span,
+                format!("imports nest more than {MAX_MODULE_DEPTH} deep"),
+                "this import exceeds the module depth budget",
+            ));
+            return None;
+        }
+
+        // Candidate order: the importing file's directory, then each
+        // configured root — declaration order, never filesystem order.
+        let importer_dir = self.canon[importer as usize]
+            .parent()
+            .map(Path::to_path_buf)
+            .expect("canonicalized module paths have parents");
+        let mut candidates = vec![importer_dir];
+        candidates.extend(self.confine[1..].iter().cloned());
+        let Some(canon) = candidates
+            .iter()
+            .find_map(|dir| dir.join(rel).canonicalize().ok())
+        else {
+            self.diags.push(Diagnostic::new(
+                import.span,
+                format!("cannot resolve import {:?}", import.node),
+                "not found relative to this file or any configured policy root",
+            ));
+            return None;
+        };
+        if !self.confine.iter().any(|root| canon.starts_with(root)) {
+            self.diags.push(
+                Diagnostic::new(
+                    import.span,
+                    format!(
+                        "import {:?} escapes the configured policy roots",
+                        import.node
+                    ),
+                    format!("resolves to {}", canon.display()),
+                )
+                .with_note(
+                    "imports (including symlink targets) must stay under the main file's \
+                     directory or a configured policy root",
+                ),
+            );
+            return None;
+        }
+
+        if let Some(&existing) = self.index.get(&canon) {
+            if self.in_progress[existing as usize] {
+                // Name the cycle like the `fn` / `apply` DAG errors.
+                let start = existing as usize;
+                let mut names: Vec<String> = self
+                    .modules
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| self.in_progress[*i] && *i >= start)
+                    .map(|(_, m)| m.path.clone())
+                    .collect();
+                names.push(self.modules[existing as usize].path.clone());
+                self.diags.push(Diagnostic::new(
+                    import.span,
+                    format!("import cycle: {}", names.join(" -> ")),
+                    "this import closes the cycle",
+                ));
+                return None;
+            }
+            return Some(existing); // diamond: already loaded once
+        }
+
+        if self.modules.len() >= MAX_MODULE_FILES {
+            self.diags.push(Diagnostic::new(
+                import.span,
+                format!("module graph has more than {MAX_MODULE_FILES} files"),
+                "file-count budget exhausted at this import",
+            ));
+            return None;
+        }
+        let text = match std::fs::read_to_string(&canon) {
+            Ok(text) => text,
+            Err(e) => {
+                self.diags.push(Diagnostic::new(
+                    import.span,
+                    format!("cannot read import {:?}: {e}", import.node),
+                    "failed to read this import",
+                ));
+                return None;
+            }
+        };
+        Some(self.visit(canon, text, depth + 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use super::super::RpolFile;
+    use super::*;
+    use crate::sets::SetStore;
+
+    fn write(dir: &Path, rel: &str, text: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir");
+        }
+        fs::write(path, text).expect("write");
+    }
+
+    fn load(dir: &Path, main: &str) -> Result<RpolFile, LoadError> {
+        RpolFile::load(&dir.join(main), &[])
+    }
+
+    /// The rendered compile error of a load expected to fail.
+    fn load_err(dir: &Path, main: &str) -> String {
+        match load(dir, main) {
+            Ok(_) => panic!("load unexpectedly succeeded"),
+            Err(err) => err.render(false),
+        }
+    }
+
+    const BOGONS: &str = "prefix-set bogons { 10.0.0.0/8 le 32, 192.168.0.0/16 le 32 }";
+
+    #[test]
+    fn import_resolves_relative_to_the_importing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Nested: main -> lib/sets.rpol -> deep/asns.rpol (relative to lib/).
+        write(
+            dir.path(),
+            "lib/deep/asns.rpol",
+            "asn-set transit { 65010, 65020 }",
+        );
+        write(
+            dir.path(),
+            "lib/sets.rpol",
+            &format!("import \"deep/asns.rpol\"\n{BOGONS}"),
+        );
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"lib/sets.rpol\"\n\
+             policy edge-in {\n\
+               term bogon { if route.prefix in bogons { reject } }\n\
+               term transit { if route.origin-as in transit { set local-pref 50; accept } }\n\
+               term rest { accept }\n\
+             }",
+        );
+        let file = load(dir.path(), "main.rpol").expect("clean load");
+        assert_eq!(file.modules().len(), 3, "main + 2 modules");
+        // Module 0 is the main file; discovery order follows declarations.
+        assert!(file.modules()[0].path.ends_with("main.rpol"));
+        assert!(file.modules()[1].path.ends_with("sets.rpol"));
+        assert!(file.modules()[2].path.ends_with("asns.rpol"));
+        assert_eq!(file.modules()[0].imports, vec![1]);
+        assert_eq!(file.modules()[1].imports, vec![2]);
+        let mut store = SetStore::new();
+        assert!(file.compile_policy("edge-in", &[], &mut store).is_some());
+    }
+
+    #[test]
+    fn import_resolves_via_a_configured_root() {
+        let main_dir = tempfile::tempdir().expect("tempdir");
+        let lib_dir = tempfile::tempdir().expect("tempdir");
+        write(lib_dir.path(), "common/bogons.rpol", BOGONS);
+        write(
+            main_dir.path(),
+            "main.rpol",
+            "import \"common/bogons.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        // Without the root the import cannot resolve …
+        let err = load_err(main_dir.path(), "main.rpol");
+        assert!(err.contains("cannot resolve import"), "{err}");
+        // … with it, it does.
+        let file = RpolFile::load(
+            &main_dir.path().join("main.rpol"),
+            &[lib_dir.path().to_path_buf()],
+        )
+        .expect("clean load with root");
+        assert_eq!(file.modules().len(), 2);
+    }
+
+    #[test]
+    fn traversal_above_every_root_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "outside.rpol", BOGONS);
+        write(
+            dir.path(),
+            "nested/main.rpol",
+            "import \"../outside.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        let err = load_err(dir.path(), "nested/main.rpol");
+        assert!(err.contains("escapes the configured policy roots"), "{err}");
+        // The same file is fine when its directory IS a root.
+        let file = RpolFile::load(
+            &dir.path().join("nested/main.rpol"),
+            &[dir.path().to_path_buf()],
+        )
+        .expect("clean load once the parent is a root");
+        assert_eq!(file.modules().len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_inside_a_root_is_fine_and_dedupes_with_its_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "real.rpol", BOGONS);
+        std::os::unix::fs::symlink(dir.path().join("real.rpol"), dir.path().join("link.rpol"))
+            .expect("symlink");
+        // Diamond through a symlink: both spellings canonicalize to the
+        // same module — loaded once, no duplicate-set diagnostics.
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"link.rpol\"\nimport \"real.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        let file = load(dir.path(), "main.rpol").expect("clean load");
+        assert_eq!(file.modules().len(), 2, "symlink and target are one module");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_every_root_is_rejected() {
+        let outside = tempfile::tempdir().expect("tempdir");
+        write(outside.path(), "real.rpol", BOGONS);
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::os::unix::fs::symlink(
+            outside.path().join("real.rpol"),
+            dir.path().join("link.rpol"),
+        )
+        .expect("symlink");
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"link.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("escapes the configured policy roots"), "{err}");
+    }
+
+    #[test]
+    fn absolute_import_paths_are_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "lib.rpol", BOGONS);
+        write(
+            dir.path(),
+            "main.rpol",
+            &format!(
+                "import {:?}\npolicy p {{ term t {{ if route.prefix in bogons {{ reject }} }} }}",
+                dir.path().join("lib.rpol").display().to_string()
+            ),
+        );
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("is absolute"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_import_names_the_declaration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "main.rpol", "import \"nope.rpol\"");
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("cannot resolve import \"nope.rpol\""), "{err}");
+        assert!(err.contains("main.rpol"), "names the importing file: {err}");
+    }
+
+    #[test]
+    fn an_import_cycle_is_named() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "a.rpol", "import \"b.rpol\"");
+        write(dir.path(), "b.rpol", "import \"a.rpol\"");
+        let err = load_err(dir.path(), "a.rpol");
+        assert!(err.contains("import cycle"), "{err}");
+        assert!(err.contains("a.rpol") && err.contains("b.rpol"), "{err}");
+    }
+
+    #[test]
+    fn diamond_imports_load_the_shared_module_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "d.rpol", BOGONS);
+        write(
+            dir.path(),
+            "b.rpol",
+            "import \"d.rpol\"\npolicy from-b { term t { if route.prefix in bogons { reject } } }",
+        );
+        write(
+            dir.path(),
+            "c.rpol",
+            "import \"d.rpol\"\npolicy from-c { term t { if route.prefix in bogons { reject } } }",
+        );
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"b.rpol\"\nimport \"c.rpol\"",
+        );
+        let file = load(dir.path(), "main.rpol").expect("diamond loads");
+        assert_eq!(file.modules().len(), 4, "d.rpol loads once");
+        let mut store = SetStore::new();
+        assert!(file.compile_policy("from-b", &[], &mut store).is_some());
+        assert!(file.compile_policy("from-c", &[], &mut store).is_some());
+    }
+
+    #[test]
+    fn duplicate_names_across_modules_error_naming_both_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "a.rpol", "policy dup { term t { accept } }");
+        write(dir.path(), "b.rpol", "policy dup { term t { reject } }");
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"a.rpol\"\nimport \"b.rpol\"",
+        );
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("duplicate policy `dup`"), "{err}");
+        assert!(
+            err.contains("a.rpol") && err.contains("b.rpol"),
+            "both defining files are named: {err}"
+        );
+    }
+
+    #[test]
+    fn resolution_order_is_declaration_driven_and_compiled_identity_is_stable() {
+        // The same definitions reached through differently-ordered
+        // imports compile to structurally equal chains (ADR-0103
+        // Decision 5.1: deterministic module-resolution order).
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "b.rpol", BOGONS);
+        write(dir.path(), "c.rpol", "asn-set transit { 65010, 65020 }");
+        let policy = "policy edge-in {\n\
+             term bogon { if route.prefix in bogons { reject } }\n\
+             term transit { if route.origin-as in transit { set local-pref 50; accept } }\n\
+           }";
+        write(
+            dir.path(),
+            "one.rpol",
+            &format!("import \"b.rpol\"\nimport \"c.rpol\"\n{policy}"),
+        );
+        write(
+            dir.path(),
+            "two.rpol",
+            &format!("import \"c.rpol\"\nimport \"b.rpol\"\n{policy}"),
+        );
+        let one = load(dir.path(), "one.rpol").expect("one loads");
+        let two = load(dir.path(), "two.rpol").expect("two loads");
+        let mut store_one = SetStore::new();
+        let mut store_two = SetStore::new();
+        let chain_one = one
+            .compile_policy("edge-in", &[], &mut store_one)
+            .expect("compiles");
+        let chain_two = two
+            .compile_policy("edge-in", &[], &mut store_two)
+            .expect("compiles");
+        assert_eq!(
+            chain_one, chain_two,
+            "import declaration order must not change the compiled identity"
+        );
+    }
+
+    #[test]
+    fn import_depth_eight_is_fine_and_nine_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Chain main(depth 0) -> m1 -> … -> m8 (depth 8): allowed.
+        write(dir.path(), "m8.rpol", BOGONS);
+        for level in (1..8).rev() {
+            write(
+                dir.path(),
+                &format!("m{level}.rpol"),
+                &format!("import \"m{}.rpol\"", level + 1),
+            );
+        }
+        write(dir.path(), "main.rpol", "import \"m1.rpol\"");
+        let file = load(dir.path(), "main.rpol").expect("depth 8 loads");
+        assert_eq!(file.modules().len(), 9);
+
+        // One more level: m8 imports m9 — the edge at depth 8 exceeds
+        // the budget.
+        write(dir.path(), "m9.rpol", BOGONS);
+        write(dir.path(), "m8.rpol", "import \"m9.rpol\"");
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(
+            err.contains(&format!("nest more than {MAX_MODULE_DEPTH} deep")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_oversized_file_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut big = String::from("# padding\n");
+        big.push_str(&"#".repeat(MAX_FILE_BYTES));
+        write(dir.path(), "big.rpol", &big);
+        write(dir.path(), "main.rpol", "import \"big.rpol\"");
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("per-file limit"), "{err}");
+    }
+
+    #[test]
+    fn an_oversized_graph_is_rejected() {
+        use std::fmt::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Nine modules of exactly 1 MiB each pass the per-file limit
+        // but blow the 8 MiB graph budget.
+        let filler = format!("# leaf\n{}", "#".repeat(MAX_FILE_BYTES - 7));
+        assert_eq!(filler.len(), MAX_FILE_BYTES);
+        let mut main = String::new();
+        for index in 0..9 {
+            write(dir.path(), &format!("leaf{index}.rpol"), &filler);
+            let _ = writeln!(main, "import \"leaf{index}.rpol\"");
+        }
+        write(dir.path(), "main.rpol", &main);
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("total source bytes"), "{err}");
+    }
+
+    #[test]
+    fn the_file_count_budget_is_enforced() {
+        use std::fmt::Write;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let mut main = String::new();
+        for index in 0..MAX_MODULE_FILES {
+            write(dir.path(), &format!("leaf{index}.rpol"), "# empty\n");
+            let _ = writeln!(main, "import \"leaf{index}.rpol\"");
+        }
+        write(dir.path(), "main.rpol", &main);
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(
+            err.contains(&format!("more than {MAX_MODULE_FILES} files")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn diagnostics_attribute_spans_to_the_defining_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "lib.rpol",
+            "policy broken { term t { if route.zzz == 1 { accept } } }",
+        );
+        write(dir.path(), "main.rpol", "import \"lib.rpol\"");
+        let err = load_err(dir.path(), "main.rpol");
+        assert!(err.contains("lib.rpol"), "names the imported file: {err}");
+        assert!(
+            err.contains("route.zzz") || err.contains("zzz"),
+            "excerpts the offending source: {err}"
+        );
+    }
+
+    #[test]
+    fn tests_in_the_main_file_exercise_imported_policies_and_fns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "lib.rpol",
+            &format!(
+                "{BOGONS}\n\
+                 fn floor(value: u32, minimum: u32) -> u32 {{ max(value, minimum) }}\n\
+                 policy hygiene {{ term bogon {{ if route.prefix in bogons {{ reject }} }} }}"
+            ),
+        );
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"lib.rpol\"\n\
+             policy edge-in {\n\
+               term guard { if !apply(hygiene) { reject } }\n\
+               term pad { set local-pref floor(10, 100); accept }\n\
+             }\n\
+             test rejects-bogons {\n\
+                 route { prefix 10.1.0.0/24 }\n\
+                 expect edge-in == reject\n\
+             }\n\
+             test floors-local-pref {\n\
+                 route { prefix 198.51.100.0/24 }\n\
+                 expect edge-in == accept with local-pref 100\n\
+             }",
+        );
+        let file = load(dir.path(), "main.rpol").expect("clean load");
+        let report = file.run_tests();
+        assert_eq!(report.total, 2, "both tests ran");
+        assert!(
+            report.all_passed(),
+            "cross-module tests pass: {:?}",
+            report.failures
+        );
+    }
+
+    #[test]
+    fn inline_sources_reject_imports_with_a_pointer_to_file_loading() {
+        let report = super::super::check_rpol("import \"lib.rpol\"");
+        assert_eq!(report.diagnostics.len(), 1);
+        assert!(
+            report.diagnostics.0[0]
+                .message
+                .contains("not available for inline sources"),
+            "{}",
+            report.diagnostics.0[0].message
+        );
+        assert!(super::super::RpolFile::parse("import \"lib.rpol\"").is_err());
+    }
+
+    #[test]
+    fn policy_set_equality_follows_the_resolved_module_graph() {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use super::super::{RpolPolicyEntry, RpolPolicySet};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "leaf.rpol", BOGONS);
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"leaf.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        let set_for = |dir: &Path| -> RpolPolicySet {
+            let file = Arc::new(load(dir, "main.rpol").expect("loads"));
+            let mut policies = HashMap::new();
+            policies.insert(
+                "p".to_string(),
+                RpolPolicyEntry {
+                    file,
+                    params: 0,
+                    path: "main.rpol".to_string(),
+                },
+            );
+            RpolPolicySet { policies }
+        };
+        let before = set_for(dir.path());
+        // Untouched graph: content-equal — the #775 skip's input reads
+        // an rpol-only reload with no edits as a no-op.
+        assert_eq!(before, set_for(dir.path()));
+        // A leaf-module edit makes every dependent unit read as
+        // changed, even though the registered main file is untouched.
+        write(
+            dir.path(),
+            "leaf.rpol",
+            "prefix-set bogons { 10.0.0.0/8 le 32 }",
+        );
+        assert_ne!(before, set_for(dir.path()));
+    }
+
+    #[test]
+    fn resolved_content_identity_tracks_leaf_edits_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "leaf.rpol", BOGONS);
+        write(
+            dir.path(),
+            "main.rpol",
+            "import \"leaf.rpol\"\n\
+             policy p { term t { if route.prefix in bogons { reject } } }",
+        );
+        let before = load(dir.path(), "main.rpol").expect("loads");
+        // Untouched graph: content-equal (the #775 skip's precondition).
+        let unchanged = load(dir.path(), "main.rpol").expect("loads");
+        assert!(before.content_eq(&unchanged));
+
+        // A leaf edit flips the identity even though the main file is
+        // byte-identical.
+        write(
+            dir.path(),
+            "leaf.rpol",
+            "prefix-set bogons { 10.0.0.0/8 le 32 }",
+        );
+        let after = load(dir.path(), "main.rpol").expect("loads");
+        assert!(!before.content_eq(&after), "leaf edits read as changes");
+        assert_ne!(
+            before.modules()[1].digest,
+            after.modules()[1].digest,
+            "the leaf digest moved"
+        );
+        assert_eq!(
+            before.modules()[0].digest,
+            after.modules()[0].digest,
+            "the main digest did not"
+        );
+    }
+}

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -29,11 +29,19 @@ use super::lexer::{Tok, Token, lex};
 /// errors in the same run.
 #[must_use]
 pub fn parse(source: &str) -> (SourceFile, Vec<Diagnostic>) {
-    let (tokens, mut diags) = lex(source);
+    parse_module(source, 0)
+}
+
+/// [`parse`] with spans attributed to module index `file` — the
+/// multi-module (LAN-300) entry point used by the import resolver.
+#[must_use]
+pub fn parse_module(source: &str, file: u32) -> (SourceFile, Vec<Diagnostic>) {
+    let (tokens, mut diags) = lex(source, file);
     let mut parser = Parser {
         src: source,
         tokens,
         pos: 0,
+        file,
         diags: Vec::new(),
     };
     let file = parser.source_file();
@@ -45,6 +53,8 @@ struct Parser<'src> {
     src: &'src str,
     tokens: Vec<Token>,
     pos: usize,
+    /// Module index for synthesized (EOF) spans.
+    file: u32,
     diags: Vec<Diagnostic>,
 }
 
@@ -93,7 +103,7 @@ impl Parser<'_> {
 
     fn eof_span(&self) -> Span {
         let end = self.src.len();
-        Span::new(end..end)
+        Span::in_file(end..end, self.file)
     }
 
     fn here(&self) -> Span {
@@ -391,8 +401,15 @@ impl Parser<'_> {
                 Tok::Ident if self.text(token) == "fn" => {
                     self.fn_def().map(|def| file.fns.push(def))
                 }
+                // Top-level contextual `import` (LAN-300, ADR-0103
+                // Decision 2.2): same additive footing as `fn` — top
+                // level never admitted a bare identifier, so a set or
+                // policy named `import` keeps working.
+                Tok::Ident if self.text(token) == "import" => {
+                    self.import_def().map(|path| file.imports.push(path))
+                }
                 _ => Err(self.error_expected(
-                    "a top-level item (`prefix-set`, `community-set`, `asn-set`, `fn`, `policy`, or `test`)",
+                    "a top-level item (`import`, `prefix-set`, `community-set`, `asn-set`, `fn`, `policy`, or `test`)",
                 )),
             };
             if result.is_err() {
@@ -405,6 +422,16 @@ impl Parser<'_> {
             }
         }
         file
+    }
+
+    /// `import "relative/path.rpol"` (LAN-300). The parser records the
+    /// declaration; resolution — path handling, cycle/budget checks,
+    /// and the merge — happens in [`super::modules`].
+    fn import_def(&mut self) -> PResult<Spanned<String>> {
+        self.bump(); // the contextual `import` identifier
+        // No terminator: top-level items are self-delimiting, like the
+        // brace-block definitions.
+        self.expect_str("a quoted import path (`import \"lib/common.rpol\"`)")
     }
 
     fn prefix_set_def(&mut self) -> PResult<PrefixSetDef> {

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -928,10 +928,97 @@ Tests run at check time (`rbgp policy check`, CI) with zero daemon
 involvement. Testing a *candidate* policy against a live RIB is
 `rbgp policy test` (below).
 
+## Modules and imports
+
+```rpol
+import "lib/bogons.rpol"
+import "lib/customers.rpol"
+
+policy edge-in {
+    term bogon { if route.prefix in bogons { reject } }        # from lib/bogons.rpol
+    term customer { if route.prefix in customers { accept } }  # from lib/customers.rpol
+}
+```
+
+`import "relative/path.rpol"` is a top-level declaration that splices
+another file's definitions — sets, functions, policies, and `test`
+blocks — into the compilation unit. Modules are a **resolution
+feature, not a language feature** (ADR-0103): after resolution the
+compiled artifact is indistinguishable from one concatenated source,
+and only diagnostics remember file boundaries (an error in an imported
+file renders an excerpt of *that* file).
+
+**Resolution and roots.** Import paths must be relative. Each resolves
+against the importing file's directory first, then against each
+configured policy root in order — `[policy] rpol_roots` in the daemon
+config, repeatable `--root DIR` for `rbgp policy check`. The resolved
+file (after symlinks and `..` are canonicalized away) must stay inside
+the main file's directory or one of the roots; escaping every root is
+a compile error. There is no ambient working-directory lookup.
+
+**One flat namespace.** All modules share a single namespace after
+resolution; defining the same set/fn/policy/test name in two modules
+is a compile error naming both files. This is the deliberate V1 shape
+— shared libraries (bogon lists, customer sets, hygiene policies) get
+short unprefixed names at every use site. Qualified names
+(`bogons.martians`) and selective imports are compatible later
+extensions if real collision pain shows up; today, rename at the
+definition.
+
+**Determinism and reload identity.** Imports resolve depth-first in
+declaration order — never filesystem order — and each file loads once
+(diamond imports are fine; cycles are compile errors naming the
+cycle). The policy identity the reload planner compares is the
+**resolved module graph's content**: editing an imported leaf makes
+every unit that (transitively) imports it read as changed, while a
+byte-identical graph reloads as a content-equal no-op regardless of
+file paths. One unit compiles all-or-nothing — a broken or missing
+import anywhere rejects the whole load and the running generation is
+untouched.
+
+**Budgets.** Import nesting ≤ 8; each file ≤ 1 MiB; a unit's total
+source ≤ 8 MiB across ≤ 64 files. All enforced at load with
+diagnostics; evaluation never touches the filesystem.
+
+**Auditing.** `rbgp policy check FILE --list-deps [--root DIR]...`
+prints the resolved graph — every module's canonical path, SHA-256
+content hash, and imports — for packaging and change review.
+
+Inline sources (`rbgp policy test`, the `TestPolicy` RPC) cannot
+import: there is no filesystem to resolve against, and the diagnostic
+says so. Check import-using files with `rbgp policy check`; the daemon
+resolves them at config load / SIGHUP.
+
+### Migration example — extracting a shared library
+
+```rpol
+# Before: every edge policy file carries its own bogon list.
+prefix-set bogons { 10.0.0.0/8 le 32, 192.168.0.0/16 le 32, ... }
+policy edge-in { term bogon { if route.prefix in bogons { reject } } ... }
+```
+
+```rpol
+# lib/bogons.rpol — the shared library (sets, fns, even policies):
+prefix-set bogons { 10.0.0.0/8 le 32, 192.168.0.0/16 le 32, ... }
+
+# edge.rpol — after: one definition, imported where needed.
+import "lib/bogons.rpol"
+policy edge-in { term bogon { if route.prefix in bogons { reject } } ... }
+
+test still-rejects-bogons {           # tests see imported names too
+    route { prefix 10.1.0.0/24 }
+    expect edge-in == reject
+}
+```
+
+Because the resolved content is identical, this refactor reloads as a
+no-op: no chain reinstall, no Route Refresh.
+
 ## Grammar sketch
 
 ```text
-file        := (prefix-set-def | community-set-def | asn-set-def | fn-def | policy-def | test-def)*
+file        := (import-decl | prefix-set-def | community-set-def | asn-set-def | fn-def | policy-def | test-def)*
+import-decl := "import" STRING                    # contextual `import` (LAN-300)
 prefix-set-def    := "prefix-set" IDENT "{" [prefix-entry ("," prefix-entry)*] "}"
 prefix-entry      := PREFIX ["ge" INT] ["le" INT]
 community-set-def := "community-set" IDENT "{" [community ("," community)*] "}"
@@ -1004,6 +1091,7 @@ in the config (full reference:
 ```toml
 [policy]
 rpol_files = ["policies/core.rpol"]        # relative to the config file
+rpol_roots = ["policies/lib"]              # extra `import` roots, same resolution
 
 [[neighbors]]
 address = "10.0.0.2"
@@ -1266,7 +1354,7 @@ user-defined types, no maps (safety is total by construction —
 ADR-0096 Decision 2; the ADR-0103 extension program adds bounded
 constructs slice by slice — checked arithmetic shipped as LAN-299,
 bindings as LAN-302, bounded loops as LAN-303, pure functions as
-LAN-304). No `as-path-set`. No `else if` chains and no nested `if`
+LAN-304, modules and imports as LAN-300). No `as-path-set`. No `else if` chains and no nested `if`
 (keep terms small; use `&&` or more terms). No mutable state of any
 kind — `let` bindings (LAN-302) are immutable, and reads never
 observe staged `set` writes (read-back would break memoization and

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -97,8 +97,27 @@ impl Config {
     /// `load_toml_with_diagnostics` with `base_dir = None`, so relative
     /// entries resolve against the process CWD and never against a
     /// caller-influenced base.)
+    ///
+    /// In-language `import` declarations (LAN-300) are the opposite:
+    /// they are transitive rather than operator-listed, so they ARE
+    /// confined — every import must resolve inside the importing
+    /// entry's directory or a configured `[policy] rpol_roots` entry
+    /// (enforced by `RpolFile::load`).
     fn load_rpol_files(&mut self, base_dir: Option<&std::path::Path>) -> Result<(), ConfigError> {
-        use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry};
+        use rustbgpd_policy::rpol::{LoadError, RpolFile, RpolPolicyEntry};
+
+        // Policy roots for `import` resolution (LAN-300): absolutize
+        // against the config directory and rewrite, like `rpol_files`.
+        for root in &mut self.policy.rpol_roots {
+            let mut path = PathBuf::from(&*root);
+            if path.is_relative()
+                && let Some(base) = base_dir
+            {
+                path = base.join(path);
+            }
+            *root = path.display().to_string();
+        }
+        let roots: Vec<PathBuf> = self.policy.rpol_roots.iter().map(PathBuf::from).collect();
 
         let mut owner_by_name: HashMap<String, String> = HashMap::new();
         for entry in &mut self.policy.rpol_files {
@@ -109,31 +128,21 @@ impl Config {
                 path = base.join(path);
             }
             let display = path.display().to_string();
-            // Canonicalize before reading (LAN-218): resolve symlinks and
-            // `..` once, then read that resolved path so the file we open is
-            // the file we resolved (closes a symlink TOCTOU window).
-            // canonicalize() also errors on a missing/unreadable path — we
-            // surface that identically to a read failure.
-            let path = path
-                .canonicalize()
-                .map_err(|e| ConfigError::InvalidRpolFile {
-                    path: display.clone(),
-                    reason: format!("failed to read: {e}"),
-                })?;
-            let source =
-                std::fs::read_to_string(&path).map_err(|e| ConfigError::InvalidRpolFile {
-                    path: display.clone(),
-                    reason: format!("failed to read: {e}"),
-                })?;
-            let file = match RpolFile::parse(&source) {
+            // `RpolFile::load` canonicalizes before reading (LAN-218):
+            // symlinks and `..` resolve once, then that resolved path
+            // is read (closes the symlink TOCTOU window). It also
+            // resolves the file's `import` graph against `roots`
+            // (LAN-300) as one compilation unit — a missing or broken
+            // import anywhere rejects the whole load.
+            let file = match RpolFile::load(&path, &roots) {
                 Ok(file) => Arc::new(file),
-                Err(diagnostics) => {
+                Err(LoadError::Io { path, reason }) => {
+                    return Err(ConfigError::InvalidRpolFile { path, reason });
+                }
+                Err(error @ LoadError::Compile { .. }) => {
                     return Err(ConfigError::InvalidRpolFile {
                         path: display.clone(),
-                        reason: format!(
-                            "compile failed\n{}",
-                            diagnostics.render(&display, &source, false)
-                        ),
+                        reason: format!("compile failed\n{}", error.render(false)),
                     });
                 }
             };

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -939,10 +939,20 @@ pub struct PolicyConfig {
     /// (`"customer-in(200)"`).
     #[serde(default)]
     pub rpol_files: Vec<String>,
+    /// Additional policy roots for `.rpol` `import` resolution
+    /// (LAN-300). Imports resolve against the importing file's
+    /// directory first, then these directories in order, and the
+    /// resolved file must stay inside the main file's directory or one
+    /// of these roots. Relative entries resolve against the config
+    /// file's directory and are rewritten absolute at load, like
+    /// `rpol_files`.
+    #[serde(default)]
+    pub rpol_roots: Vec<String>,
     /// Compiled `.rpol` policy registry (populated at load, not
-    /// serialized). `PartialEq` is source-content-based, so config
-    /// diffs see an edited `.rpol` file as a policy change and an
-    /// unchanged reload as a no-op.
+    /// serialized). `PartialEq` is resolved-content-based across each
+    /// unit's whole module graph, so config diffs see an edit to any
+    /// imported `.rpol` module as a policy change and an unchanged
+    /// reload as a no-op.
     #[serde(skip)]
     pub rpol: rustbgpd_policy::rpol::RpolPolicySet,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11922,6 +11922,89 @@ fn rpol_files_load_resolve_and_evaluate_in_chains() {
     assert_eq!(eval.matched_policy.as_deref(), Some("bogon-filter"));
 }
 
+/// LAN-300: a config-referenced `.rpol` file resolves its `import`
+/// graph — from its own directory and from `[policy] rpol_roots`
+/// (rewritten absolute like `rpol_files`) — and a broken import
+/// anywhere rejects the whole load (one atomic candidate per unit,
+/// ADR-0103 Decision 8.1).
+#[test]
+fn rpol_imports_resolve_through_config_roots_and_fail_atomically() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(dir.path().join("policies")).expect("mkdir");
+    fs::create_dir_all(dir.path().join("shared/lib")).expect("mkdir");
+    fs::write(
+        dir.path().join("shared/lib/bogons.rpol"),
+        "prefix-set bogons { 127.0.0.0/8 le 32 }",
+    )
+    .expect("write lib");
+    fs::write(
+        dir.path().join("policies/core.rpol"),
+        "import \"lib/bogons.rpol\"\n\
+         policy edge-in { term bogon { if route.prefix in bogons { reject } } }",
+    )
+    .expect("write rpol");
+    let toml = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[policy]
+rpol_files = ["policies/core.rpol"]
+rpol_roots = ["shared"]
+import_chain = ["edge-in"]
+"#;
+    fs::write(dir.path().join("config.toml"), toml).expect("write config");
+    let config = load_dir(&dir).expect("config with rpol imports loads");
+    // Roots rewritten absolute, like rpol_files.
+    assert_eq!(config.policy.rpol_roots.len(), 1);
+    assert!(Path::new(&config.policy.rpol_roots[0]).is_absolute());
+    // The imported prefix-set participates in the compiled chain.
+    let chain = config.import_chain().expect("resolves").expect("present");
+    let ctx = rustbgpd_policy::RouteContext {
+        prefix: Some(Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+            "127.0.0.1".parse().unwrap(),
+            32,
+        ))),
+        next_hop: None,
+        extended_communities: &[],
+        communities: &[],
+        large_communities: &[],
+        as_path_str: "",
+        as_path: None,
+        as_path_len: 0,
+        origin_asn: None,
+        validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+        aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+        peer_address: None,
+        peer_asn: None,
+        peer_group: None,
+        route_type: None,
+        family: None,
+        evpn_route_type: None,
+        local_pref: None,
+        med: None,
+    };
+    let result = chain.evaluate(&ctx);
+    assert_eq!(result.action, rustbgpd_policy::PolicyAction::Deny);
+
+    // Break the imported leaf: the WHOLE config load is rejected —
+    // no partial registry, and the diagnostic names the leaf file.
+    fs::write(
+        dir.path().join("shared/lib/bogons.rpol"),
+        "prefix-set bogons { not-a-prefix }",
+    )
+    .expect("rewrite lib");
+    let err = load_dir(&dir).expect_err("broken import rejects the load");
+    assert!(err.contains("bogons.rpol"), "names the leaf module: {err}");
+}
+
 // ── LAN-296: computed prepend operands at config attachment ─────────
 
 /// A config dir whose neighbor binds `.rpol` chains in BOTH

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -3962,6 +3962,133 @@ hold_time = 90
         std::fs::remove_file(&rpol_path).ok();
     }
 
+    /// LAN-300: the rpol reload identity covers the whole resolved
+    /// module graph. Editing ONLY an imported leaf (main file and TOML
+    /// byte-identical) reads as an rpol content change — the reload
+    /// sends `SyncRpolPolicies` and the returned snapshot evaluates
+    /// the new leaf content. Reloading again with nothing touched is
+    /// content-equal: no command fires (the #775 skip's input).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one scenario drives two full reload rounds (leaf edit, then no-op) end to end"
+    )]
+    #[tokio::test]
+    async fn reload_rpol_imported_leaf_edit_syncs_and_untouched_graph_is_a_noop() {
+        let dir = unique_temp_path("reload-rpol-modules");
+        std::fs::create_dir(&dir).unwrap();
+        let leaf_path = dir.join("leaf.rpol");
+        std::fs::write(&leaf_path, "prefix-set drop-list { 127.0.0.0/8 le 32 }").unwrap();
+        let main_path = dir.join("main.rpol");
+        std::fs::write(
+            &main_path,
+            "import \"leaf.rpol\"\n\
+             policy edge-in { term drop { if route.prefix in drop-list { reject } } }",
+        )
+        .unwrap();
+        let toml = format!(
+            "{}\n[policy]\nrpol_files = [{:?}]\nimport_chain = [\"edge-in\"]\n",
+            baseline_toml(),
+            main_path.to_str().unwrap(),
+        );
+        let path = dir.join("config.toml");
+        std::fs::write(&path, &toml).unwrap();
+        let initial = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
+        let live_grpc_tcp = initial.global.telemetry.grpc_tcp.clone();
+        let live_grpc_uds = initial.global.telemetry.grpc_uds.clone();
+
+        // Edit ONLY the imported leaf; main.rpol and the TOML are
+        // byte-identical.
+        std::fs::write(&leaf_path, "prefix-set drop-list { 192.0.2.0/24 le 32 }").unwrap();
+
+        let run = |initial: Config| {
+            let live_grpc_tcp = live_grpc_tcp.clone();
+            let live_grpc_uds = live_grpc_uds.clone();
+            let path = path.clone();
+            async move {
+                let (peer_mgr_tx, mut peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+                let mock = tokio::spawn(async move {
+                    let mut tags = Vec::new();
+                    while let Some(cmd) = peer_mgr_rx.recv().await {
+                        tags.push(cmd_tag(&cmd));
+                        if let PeerManagerCommand::SyncRpolPolicies { reply, .. } = cmd {
+                            let _ = reply.send(Ok(()));
+                        }
+                    }
+                    tags
+                });
+                let returned = reload_config(
+                    path.to_str().unwrap(),
+                    &initial,
+                    live_grpc_tcp.as_ref(),
+                    live_grpc_uds.as_ref(),
+                    &peer_mgr_tx,
+                    None,
+                    None,
+                )
+                .await;
+                drop(peer_mgr_tx);
+                (returned, mock.await.unwrap())
+            }
+        };
+
+        let (returned, tags) = run(initial).await;
+        assert_eq!(
+            tags,
+            vec!["SyncRpolPolicies(1)".to_string()],
+            "a leaf-module edit is an rpol content change"
+        );
+        let reloaded = returned.expect("reload completes");
+        let chain = reloaded
+            .import_chain()
+            .expect("chain resolves")
+            .expect("chain configured");
+        let ctx = |addr: &str, len: u8| rustbgpd_policy::RouteContext {
+            prefix: Some(rustbgpd_wire::Prefix::V4(rustbgpd_wire::Ipv4Prefix::new(
+                addr.parse().unwrap(),
+                len,
+            ))),
+            next_hop: None,
+            extended_communities: &[],
+            communities: &[],
+            large_communities: &[],
+            as_path_str: "",
+            as_path: None,
+            as_path_len: 0,
+            origin_asn: None,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            peer_address: None,
+            peer_asn: None,
+            peer_group: None,
+            route_type: None,
+            family: None,
+            evpn_route_type: None,
+            local_pref: None,
+            med: None,
+        };
+        // The NEW leaf content decides: 192.0.2.0/24 now rejects,
+        // 127.0.0.0/8 no longer does.
+        assert_eq!(
+            chain.evaluate(&ctx("192.0.2.0", 24)).action,
+            rustbgpd_policy::PolicyAction::Deny
+        );
+        assert_eq!(
+            chain.evaluate(&ctx("127.0.0.0", 8)).action,
+            rustbgpd_policy::PolicyAction::Permit
+        );
+
+        // Round 2: nothing touched — the resolved graph is
+        // content-equal, so no rpol sync (or any other command) fires.
+        let (returned, tags) = run(reloaded.runtime.clone()).await;
+        assert!(returned.is_some(), "no-op reload completes");
+        assert!(
+            tags.is_empty(),
+            "untouched module graph is a no-op: {tags:?}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// LAN-284: a REJECTED rpol sync must not publish the candidate
     /// registry to the runtime snapshot. Sessions created after the
     /// failed reload resolve chains from that snapshot, so it has to


### PR DESCRIPTION
## Summary

- fifth ADR-0103 Phase B slice: `import "lib/bogons.rpol"` — explicit relative imports resolved against the importing file's directory then configured `[policy] rpol_roots`, with canonicalized confinement (traversal and symlink escapes above every root are compile errors; a missing configured root is a load error rather than a silent resolution change)
- flat namespace after resolution per the ADR: duplicate set/fn/policy/test names across modules are compile errors naming both files; qualified names and selective imports are documented deferred extensions
- the resolved graph merges dependency-first into one AST — no IR change; budgets enforced (depth 8, 1 MiB/file now actually enforced, 8 MiB/graph, 64 files); cycles named; diamonds dedupe by canonical path; resolution follows declaration order, never filesystem iteration
- spans now carry a file id, so multi-file diagnostics attribute to the defining file with ariadne multi-source rendering; the IR stores no spans, so compiled-chain identity is unaffected
- resolved-content identity (module texts in resolution order, paths excluded) backs reload impact: editing only an imported leaf fires exactly one policy sync evaluating the new content, an untouched graph is a zero-command no-op (the content-equal reinstall skip preserved), and a broken leaf rejects the whole config load atomically
- `rbgp policy check` gains repeatable `--root` and `--list-deps` (paths, SHA-256, import edges) for packaging/audit; inline sources (TestPolicy RPC) reject imports with a pointer to file-based loading — documented limitation this slice
- no runtime module loading: resolution happens at load/SIGHUP only

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy x2 parallel (339 both) / --bin rustbgpd (1353) / -p rustbgpctl (321) / -p rustbgpd-rib
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build (+1 import seed)
- cargo bench -p rustbgpd-policy -- --test
- real-CLI smoke: multi-file check, --list-deps output, escape/missing-import attribution

Closes LAN-300.