### PR TITLE
fix(api): report cache-disabled and no-session distinctly in policy explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`rbgp policy explain` no longer reports `not_seen` when the truth
+  is a disabled cache or a missing session.** The explain RPC
+  previously folded "no live session with this peer" and
+  "`[policy.explain] enabled = false`" into the same synthetic
+  `NOT_SEEN` as a genuinely unseen prefix. The response now carries
+  distinct `CACHE_DISABLED` and `NO_SESSION` outcomes (additive enum
+  values; sessions report their own cache flag, so a session built
+  before an explain reload answers for itself). The CLI renders
+  `cache_disabled` as an error with a config hint and `no_session` as
+  "no live session with <peer>", both exiting nonzero — the question
+  was not evaluated; `not_seen` keeps its exit-0 evaluated-answer
+  semantics, and `--json` carries the distinct outcome values.
+  (LAN-320)
+
 - **`rbgp` errors are now actionable.** Connect failures name the
   endpoint the CLI actually dialed and the failure class (`cannot
   reach rustbgpd at unix:///var/lib/rustbgpd/grpc.sock (socket does

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -891,7 +891,7 @@ pub enum PeerManagerCommand {
     /// ADR-0073: query a peer's per-session import-decision cache.
     /// Side-effect-free. `reply` carries `None` when the peer has no
     /// live session (its session-local cache is gone), which the
-    /// caller renders as a synthetic `NOT_SEEN`.
+    /// caller renders as a synthetic `NO_SESSION` (LAN-320).
     ExplainImportPolicy {
         /// Peer whose import-decision cache to consult.
         address: IpAddr,

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1338,9 +1338,13 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             .await
             .map_err(|_| Status::internal("peer manager dropped reply"))?;
 
-        // `None` (no live session) and an empty match set (never seen)
-        // both render as a single synthetic NOT_SEEN so the operator
-        // always gets a definite answer rather than an empty list.
+        // LAN-320 tri-state: the operator always gets a definite answer,
+        // and it is the *honest* one. `None` (no live session for the
+        // address) renders as NO_SESSION; a live session whose cache
+        // never records decisions renders as CACHE_DISABLED; only an
+        // enabled cache with no record is a genuine NOT_SEEN.
+        let no_session = reply.is_none();
+        let cache_enabled = reply.as_ref().is_some_and(|r| r.cache_enabled);
         let (current_generation, mut matches) = match reply {
             Some(r) => {
                 let proto_matches: Vec<proto::ImportExplainMatch> = r
@@ -1361,7 +1365,16 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             None => (0, Vec::new()),
         };
         if matches.is_empty() {
-            matches.push(resolved_match_to_proto(
+            let outcome = if no_session {
+                proto::ImportExplainOutcome::NoSession
+            } else if cache_enabled {
+                proto::ImportExplainOutcome::NotSeen
+            } else {
+                proto::ImportExplainOutcome::CacheDisabled
+            };
+            // Same synthetic empty-field shape as NOT_SEEN, differing
+            // only in the outcome value.
+            let mut synthetic = resolved_match_to_proto(
                 &req.peer_address,
                 &req.prefix,
                 req.prefix_length,
@@ -1371,7 +1384,9 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                     result: LookupResult::NotSeen,
                     statements: Vec::new(),
                 },
-            ));
+            );
+            synthetic.outcome = outcome as i32;
+            matches.push(synthetic);
         }
 
         Ok(Response::new(proto::ExplainImportPolicyResponse {
@@ -1922,6 +1937,81 @@ mod tests {
             ..Default::default()
         };
         assert!(proto_statement_to_input(proto).is_err());
+    }
+
+    fn explain_request() -> proto::ExplainImportPolicyRequest {
+        proto::ExplainImportPolicyRequest {
+            peer_address: "10.0.0.2".to_string(),
+            afi_safi: proto::AddressFamily::Ipv4Unicast as i32,
+            prefix: "10.0.0.0".to_string(),
+            prefix_length: 24,
+            path_id: None,
+        }
+    }
+
+    /// Drive `ExplainImportPolicy` against a fake peer manager that
+    /// answers with `reply`, returning the single synthetic match's
+    /// outcome (LAN-320 tri-state pins).
+    async fn explain_outcome_for(reply: Option<ImportExplainReply>) -> i32 {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None);
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::ExplainImportPolicy { reply: tx, .. } => {
+                        let _ = tx.send(reply.clone());
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+        let resp = PolicyServiceRpc::explain_import_policy(&svc, Request::new(explain_request()))
+            .await
+            .expect("explain succeeds")
+            .into_inner();
+        assert_eq!(resp.matches.len(), 1, "one synthetic match expected");
+        resp.matches[0].outcome
+    }
+
+    /// LAN-320: no live session must NOT read as `not_seen` — during an
+    /// incident that sends the operator down a false path.
+    #[tokio::test]
+    async fn explain_no_session_reports_no_session() {
+        assert_eq!(
+            explain_outcome_for(None).await,
+            proto::ImportExplainOutcome::NoSession as i32
+        );
+    }
+
+    /// LAN-320: a live session whose cache never records decisions
+    /// (`[policy.explain] enabled = false`) must report `CACHE_DISABLED`,
+    /// not `not_seen`.
+    #[tokio::test]
+    async fn explain_cache_disabled_reports_cache_disabled() {
+        assert_eq!(
+            explain_outcome_for(Some(ImportExplainReply {
+                current_generation: 0,
+                cache_enabled: false,
+                matches: Vec::new(),
+            }))
+            .await,
+            proto::ImportExplainOutcome::CacheDisabled as i32
+        );
+    }
+
+    /// LAN-320: with the cache enabled and a live session, an unseen
+    /// prefix is the genuine evaluated `not_seen` answer.
+    #[tokio::test]
+    async fn explain_enabled_unseen_prefix_reports_not_seen() {
+        assert_eq!(
+            explain_outcome_for(Some(ImportExplainReply {
+                current_generation: 0,
+                cache_enabled: true,
+                matches: Vec::new(),
+            }))
+            .await,
+            proto::ImportExplainOutcome::NotSeen as i32
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -668,8 +668,8 @@ struct JsonImportExplainMatch {
     evaluated_at_unix_ns: Option<i64>,
     policy_generation: Option<u64>,
     // Unconditional key (run-stable): empty for outcomes that carry no
-    // statement trace (stale / withdrawn / evicted / not_seen, or a
-    // chain-less peer).
+    // statement trace (stale / withdrawn / evicted / not_seen /
+    // cache_disabled / no_session, or a chain-less peer).
     statements: Vec<JsonImportExplainStatement>,
 }
 
@@ -724,7 +724,27 @@ fn outcome_label(outcome: i32) -> &'static str {
         Ok(proto::ImportExplainOutcome::Evicted) => "evicted",
         Ok(proto::ImportExplainOutcome::Stale) => "stale",
         Ok(proto::ImportExplainOutcome::NotSeen) => "not_seen",
+        Ok(proto::ImportExplainOutcome::CacheDisabled) => "cache_disabled",
+        Ok(proto::ImportExplainOutcome::NoSession) => "no_session",
         Ok(proto::ImportExplainOutcome::Unspecified) | Err(_) => "unspecified",
+    }
+}
+
+/// The two LAN-320 outcomes that mean "the question could not be
+/// evaluated" (as opposed to `not_seen`, which is an evaluated answer).
+/// Rendered as errors with a nonzero exit; in JSON mode the response is
+/// still printed first so scripts see the distinct outcome value.
+fn unanswerable_error(outcome: i32, neighbor: &str) -> Option<CliError> {
+    match proto::ImportExplainOutcome::try_from(outcome) {
+        Ok(proto::ImportExplainOutcome::CacheDisabled) => Some(CliError::Rpc(
+            "import-decision cache is disabled on this daemon\n  \
+             hint: set [policy.explain] enabled = true and reload (memory cost is per cached route)"
+                .to_string(),
+        )),
+        Ok(proto::ImportExplainOutcome::NoSession) => {
+            Some(CliError::Rpc(format!("no live session with {neighbor}")))
+        }
+        _ => None,
     }
 }
 
@@ -788,6 +808,14 @@ pub async fn explain_import(
         .await?
         .into_inner();
 
+    // LAN-320: cache-disabled / no-session mean the daemon could not
+    // evaluate the question — surface an error (nonzero exit) instead
+    // of a lookalike answer. These arrive as a single synthetic match.
+    let unanswerable = resp
+        .matches
+        .iter()
+        .find_map(|m| unanswerable_error(m.outcome, neighbor));
+
     if json {
         let out = JsonImportExplain {
             peer_address: resp.peer_address.clone(),
@@ -797,7 +825,15 @@ pub async fn explain_import(
             matches: resp.matches.iter().map(match_to_json).collect(),
         };
         output::print_json_pretty(&out)?;
-        return Ok(());
+        // The JSON body already carries the distinct outcome; the
+        // error exit still signals "not an evaluated answer".
+        return match unanswerable {
+            Some(err) => Err(err),
+            None => Ok(()),
+        };
+    }
+    if let Some(err) = unanswerable {
+        return Err(err);
     }
 
     println!(
@@ -1516,6 +1552,86 @@ mod tests {
         explain_import(text_conn, "192.0.2.1", "192.0.2.0/24", None, false)
             .await
             .unwrap();
+    }
+
+    /// LAN-320 pin: `cache_disabled` is an error with the config hint
+    /// (nonzero exit via `Err`), in both text and JSON modes — never a
+    /// `not_seen` lookalike.
+    #[tokio::test]
+    async fn explain_cache_disabled_errors_with_hint() {
+        let server = spawn_mock_server(None).await;
+        *server.state.explain_import_synthetic_outcome.lock().await =
+            Some(rustbgpd_api::proto::ImportExplainOutcome::CacheDisabled);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let err = explain_import(connection, "10.0.0.2", "10.0.0.0/24", None, false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Rpc(_)));
+        assert_eq!(
+            err.to_string(),
+            "import-decision cache is disabled on this daemon\n  \
+             hint: set [policy.explain] enabled = true and reload (memory cost is per cached route)"
+        );
+        // JSON mode prints the body (distinct outcome value) but still
+        // returns the error so the exit code stays nonzero.
+        let json_conn = connect(&server.addr, None).await.unwrap();
+        let err = explain_import(json_conn, "10.0.0.2", "10.0.0.0/24", None, true)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Rpc(_)));
+    }
+
+    /// LAN-320 pin: `no_session` names the neighbor and errors (nonzero
+    /// exit) — the question could not be evaluated.
+    #[tokio::test]
+    async fn explain_no_session_errors_with_neighbor() {
+        let server = spawn_mock_server(None).await;
+        *server.state.explain_import_synthetic_outcome.lock().await =
+            Some(rustbgpd_api::proto::ImportExplainOutcome::NoSession);
+        let connection = connect(&server.addr, None).await.unwrap();
+        let err = explain_import(connection, "10.0.0.2", "10.0.0.0/24", None, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "no live session with 10.0.0.2");
+        let json_conn = connect(&server.addr, None).await.unwrap();
+        let err = explain_import(json_conn, "10.0.0.2", "10.0.0.0/24", None, true)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Rpc(_)));
+    }
+
+    /// LAN-320 pin: `not_seen` stays an evaluated answer — normal
+    /// rendering, `Ok` (exit 0) — in both text and JSON modes.
+    #[tokio::test]
+    async fn explain_not_seen_stays_ok() {
+        let server = spawn_mock_server(None).await;
+        *server.state.explain_import_synthetic_outcome.lock().await =
+            Some(rustbgpd_api::proto::ImportExplainOutcome::NotSeen);
+        let connection = connect(&server.addr, None).await.unwrap();
+        explain_import(connection, "10.0.0.2", "10.0.0.0/24", None, false)
+            .await
+            .unwrap();
+        let json_conn = connect(&server.addr, None).await.unwrap();
+        explain_import(json_conn, "10.0.0.2", "10.0.0.0/24", None, true)
+            .await
+            .unwrap();
+    }
+
+    /// LAN-320: the JSON outcome strings for the tri-state are stable.
+    #[test]
+    fn outcome_labels_cover_tristate() {
+        assert_eq!(
+            outcome_label(proto::ImportExplainOutcome::NotSeen as i32),
+            "not_seen"
+        );
+        assert_eq!(
+            outcome_label(proto::ImportExplainOutcome::CacheDisabled as i32),
+            "cache_disabled"
+        );
+        assert_eq!(
+            outcome_label(proto::ImportExplainOutcome::NoSession as i32),
+            "no_session"
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -444,7 +444,9 @@ enum PolicyAction {
     /// Explain the import-policy decision for a prefix on a neighbor
     /// (ADR-0073): why it was permitted / denied / withdrawn, or
     /// not-seen / evicted / stale. Reads the per-session decision
-    /// cache; requires `[policy.explain].enabled` on the daemon.
+    /// cache; requires `[policy.explain].enabled` on the daemon
+    /// (errors distinctly when the cache is disabled or the neighbor
+    /// has no live session — those are not `not_seen`).
     Explain {
         /// Neighbor (peer) address whose import-decision cache to read
         #[arg(long)]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -73,6 +73,11 @@ pub(crate) struct MockState {
     pub(crate) last_set_policy: Mutex<Option<server_proto::SetPolicyRequest>>,
     pub(crate) last_delete_policy: Mutex<Option<server_proto::DeletePolicyRequest>>,
     pub(crate) last_explain_import: Mutex<Option<server_proto::ExplainImportPolicyRequest>>,
+    // LAN-320: when set, `explain_import_policy` answers with one
+    // synthetic match carrying this outcome (empty decision fields)
+    // instead of the canned permit/deny fixtures — drives the
+    // not_seen / cache_disabled / no_session CLI pins.
+    pub(crate) explain_import_synthetic_outcome: Mutex<Option<server_proto::ImportExplainOutcome>>,
     pub(crate) last_test_policy: Mutex<Option<server_proto::TestPolicyRequest>>,
     pub(crate) last_set_neighbor_set: Mutex<Option<server_proto::SetNeighborSetRequest>>,
     pub(crate) last_delete_neighbor_set: Mutex<Option<server_proto::DeleteNeighborSetRequest>>,
@@ -1631,6 +1636,25 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
     ) -> Result<Response<server_proto::ExplainImportPolicyResponse>, Status> {
         let req = request.into_inner();
         *self.state.last_explain_import.lock().await = Some(req.clone());
+
+        if let Some(outcome) = *self.state.explain_import_synthetic_outcome.lock().await {
+            return Ok(Response::new(server_proto::ExplainImportPolicyResponse {
+                peer_address: req.peer_address.clone(),
+                prefix: req.prefix.clone(),
+                prefix_length: req.prefix_length,
+                afi_safi: req.afi_safi,
+                current_policy_generation: 0,
+                matches: vec![server_proto::ImportExplainMatch {
+                    outcome: outcome as i32,
+                    peer_address: req.peer_address,
+                    prefix: req.prefix,
+                    prefix_length: req.prefix_length,
+                    path_id: req.path_id.unwrap_or(0),
+                    afi_safi: req.afi_safi,
+                    ..Default::default()
+                }],
+            }));
+        }
 
         let modifications = Some(server_proto::ExplainModifications {
             set_local_pref: Some(200),

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -1158,9 +1158,9 @@ impl PeerHandle {
     /// TCP write back-pressure cannot service the command, so the
     /// caller must not block indefinitely. Returns `None` on timeout,
     /// on a full command channel, or if the session task has exited —
-    /// the caller (`PeerManager`) renders that as "no live session", a
-    /// `NOT_SEEN`-equivalent, which is the correct answer for a peer
-    /// whose session-local cache is gone.
+    /// the caller (`PeerManager`) renders that as `NO_SESSION`: the
+    /// session-local cache is unreachable, which is honestly distinct
+    /// from an evaluated `NOT_SEEN` answer (LAN-320).
     pub async fn explain_import_policy_timeout(
         &self,
         afi: Afi,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -148,6 +148,7 @@ impl PeerSession {
                 }
                 let _ = reply.send(super::import_decision_cache::ImportExplainReply {
                     current_generation: generation,
+                    cache_enabled: self.import_explain_enabled,
                     matches,
                 });
                 ControlFlow::Continue(())

--- a/crates/transport/src/session/import_decision_cache.rs
+++ b/crates/transport/src/session/import_decision_cache.rs
@@ -190,10 +190,17 @@ pub struct ResolvedMatch {
 ///
 /// `matches` is empty only when the prefix was never seen on this
 /// session and no eviction record survives — the caller renders that
-/// as a single synthetic `NOT_SEEN`.
+/// as a single synthetic `NOT_SEEN` when `cache_enabled` is set, or
+/// as `CACHE_DISABLED` when it is not (a disabled cache records
+/// nothing, so an empty match set says nothing about the prefix).
 #[derive(Debug, Clone)]
 pub struct ImportExplainReply {
     pub current_generation: u64,
+    /// Whether this session records import decisions at all
+    /// (`[policy.explain] enabled`, snapshotted at session build).
+    /// `false` means the empty cache is a configuration fact, not an
+    /// evaluated "never seen" answer (LAN-320).
+    pub cache_enabled: bool,
     pub matches: Vec<ResolvedMatch>,
 }
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -5432,6 +5432,43 @@ async fn explain_disabled_stores_no_decisions() {
         "explain disabled must store no decision"
     );
 }
+/// LAN-320: the explain reply carries the session's own cache-enabled
+/// flag (snapshotted from `[policy.explain] enabled` at session build)
+/// so the RPC layer can report `CACHE_DISABLED` distinctly instead of
+/// a `NOT_SEEN` lookalike.
+#[tokio::test]
+async fn explain_reply_carries_cache_enabled_flag() {
+    for enabled in [true, false] {
+        let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+        peer_config.connect_retry_secs = 30;
+        peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+        peer_config.gr_restart_time = 120;
+        let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+        config.explain_enabled = enabled;
+        let metrics = BgpMetrics::new();
+        let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+        let (rib_tx, _rib_rx) = mpsc::channel(64);
+        let mut session = PeerSession::new(
+            config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
+        );
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let _ = session
+            .handle_command(PeerCommand::ExplainImportPolicy {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+                path_id: None,
+                reply: reply_tx,
+            })
+            .await;
+        let reply = reply_rx.await.expect("session replied");
+        assert_eq!(
+            reply.cache_enabled, enabled,
+            "reply must snapshot the session's own explain flag"
+        );
+        assert!(reply.matches.is_empty(), "nothing cached, nothing matched");
+    }
+}
 /// Import policy chains accumulate modifications across matching permit
 /// policies before the route reaches the RIB.
 #[expect(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1543,7 +1543,7 @@ cache_size = 4096
 
 | Field        | Type    | Required | Default | Description |
 |--------------|---------|----------|---------|-------------|
-| `enabled`    | bool    | no       | `true`  | Gates the cache write-path. When `false`, the inbound UPDATE path skips the compact decision/context snapshot entirely (one boolean check, nothing stored) and explain queries answer `not_seen`. Set `false` on perf-sensitive full-table peers. |
+| `enabled`    | bool    | no       | `true`  | Gates the cache write-path. When `false`, the inbound UPDATE path skips the compact decision/context snapshot entirely (one boolean check, nothing stored) and explain queries answer `cache_disabled` (distinct from `not_seen`; the CLI renders it as an error with a hint). Set `false` on perf-sensitive full-table peers. |
 | `cache_size` | integer | no       | `4096`  | Per-peer LRU capacity, one entry per `(AFI, SAFI, prefix, path_id)`. The 4096 default suits fabric / partial-table peers; raise it for full-table peers. |
 
 This is **diagnostic state only** — it never affects which routes are

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -941,7 +941,9 @@ Each result reports an outcome:
 | `withdrawn` | Was permitted, then withdrawn by the peer (tombstone; policy context dropped). |
 | `evicted` | Was cached but pushed out by the per-peer cap — raise `cache_size`. |
 | `stale` | A decision exists but the peer's import policy has changed since; the historical decision is shown with its original generation. |
-| `not_seen` | The peer hasn't advertised this prefix on the current session (cache resets on flap / restart), or explain is disabled. |
+| `not_seen` | The peer hasn't advertised this prefix on the current session (cache resets on flap / restart). This is an evaluated answer: the session is live and the cache is enabled. |
+| `cache_disabled` | The session records no decisions (`[policy.explain] enabled = false`). The CLI renders this as an error with a config hint and exits nonzero — it is never folded into `not_seen`. |
+| `no_session` | No live session with the requested neighbor, so there is no session-local cache to consult. The CLI renders this as an error and exits nonzero. |
 
 A `permit` / `deny` result additionally carries a **statement trace** —
 which statement inside the matched chain decided, per policy evaluated:
@@ -976,7 +978,7 @@ never affects which routes are accepted):
 
 - `enabled` (default `true`) — set `false` on hot full-table peers to
   skip the write-path cost entirely (the daemon then answers
-  `not_seen`).
+  `cache_disabled`, and the CLI errors with a hint).
 - `cache_size` (default `4096`) — a fabric / partial-table size. For
   reliable full-table explain, raise it toward the peer's
   expected retained-prefix count and budget the memory.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -837,15 +837,28 @@ message ClearNeighborExportChainResponse {}
 //                it no longer reflects current policy.
 //   NOT_SEEN   — the peer has not advertised this prefix on this
 //                session and the cache has no record of an
-//                eviction.
+//                eviction. This is an *evaluated* answer: the
+//                session is live and its cache is enabled.
+//   CACHE_DISABLED — the session is live but records no import
+//                decisions (`[policy.explain] enabled = false` when
+//                the session was built), so the question cannot be
+//                answered for any prefix. Kept distinct from
+//                NOT_SEEN so a misconfigured daemon never
+//                masquerades as an evaluated answer.
+//   NO_SESSION — no live session exists for the requested peer
+//                address (or its task could not be reached in
+//                time), so there is no session-local cache to
+//                consult.
 enum ImportExplainOutcome {
-  IMPORT_EXPLAIN_OUTCOME_UNSPECIFIED = 0;
-  IMPORT_EXPLAIN_OUTCOME_PERMIT      = 1;
-  IMPORT_EXPLAIN_OUTCOME_DENY        = 2;
-  IMPORT_EXPLAIN_OUTCOME_WITHDRAWN   = 3;
-  IMPORT_EXPLAIN_OUTCOME_EVICTED     = 4;
-  IMPORT_EXPLAIN_OUTCOME_STALE       = 5;
-  IMPORT_EXPLAIN_OUTCOME_NOT_SEEN    = 6;
+  IMPORT_EXPLAIN_OUTCOME_UNSPECIFIED    = 0;
+  IMPORT_EXPLAIN_OUTCOME_PERMIT         = 1;
+  IMPORT_EXPLAIN_OUTCOME_DENY           = 2;
+  IMPORT_EXPLAIN_OUTCOME_WITHDRAWN      = 3;
+  IMPORT_EXPLAIN_OUTCOME_EVICTED        = 4;
+  IMPORT_EXPLAIN_OUTCOME_STALE          = 5;
+  IMPORT_EXPLAIN_OUTCOME_NOT_SEEN       = 6;
+  IMPORT_EXPLAIN_OUTCOME_CACHE_DISABLED = 7;
+  IMPORT_EXPLAIN_OUTCOME_NO_SESSION     = 8;
 }
 
 message ExplainImportPolicyRequest {
@@ -990,7 +1003,8 @@ message ExplainImportPolicyResponse {
 
   // One match per cached (peer, prefix, path_id) entry the
   // request resolves to. Always populated with at least one
-  // element — a NOT_SEEN outcome carries a synthetic match with
+  // element — a NOT_SEEN / CACHE_DISABLED / NO_SESSION outcome
+  // carries a synthetic match with
   // empty fields beyond the echoed request. When the request
   // specifies `path_id` the response has exactly one element;
   // when it does not, every matching path_id appears (Add-Path

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -815,8 +815,9 @@ impl PeerManager {
                         } => {
                             // Resolve the unique session for this address and
                             // forward to its task. No live session → None,
-                            // which the RPC layer renders as NOT_SEEN (the
-                            // session-local cache is gone, per ADR-0073).
+                            // which the RPC layer renders as NO_SESSION (the
+                            // session-local cache is gone, per ADR-0073 /
+                            // LAN-320).
                             let result = match self
                                 .unique_peer_key_for_address(address)
                                 .and_then(|key| self.peers.get(&key))


### PR DESCRIPTION
## Summary

- `rbgp policy explain` no longer reports `not_seen` when the truth is "the import-decision cache is disabled" or "there is no live session with that peer" — two additive outcome values on the existing enum carry the tri-state through the RPC
- the session reports its own cache flag (the reply gained `cache_enabled`), so a session established before a `[policy.explain]` reload answers honestly for itself during the window where the reload only applies to new sessions
- CLI: cache-disabled renders an error with the exact config-key hint (`set [policy.explain] enabled = true and reload`) and exits nonzero; no-session renders distinctly and exits nonzero (matching the export-explain not-found precedent); a genuine not-seen keeps exit 0; `-j` carries stable outcome strings with the same key set
- export-side explain surfaces were audited and deliberately left alone — they evaluate live and never folded; stale "NOT_SEEN-equivalent" comments corrected
- no new RPC: the authz method matrix is untouched (proven by the unchanged matrix tests)

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-api / -p rustbgpd-transport / -p rustbgpctl / --bin rustbgpd
- cargo doc --workspace --no-deps

Closes LAN-320.