### PR TITLE
perf(transport): coalesce outbound writes into per-drain batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `LICENSE-MIT` and `LICENSE-APACHE`, with workflow assertions that
   fail the build if either file is missing from an artifact. (LAN-278)
 
+- **Outbound UPDATE writes are coalesced per writer drain.** The
+  per-peer session writer now drains up to 64 queued bulk frames
+  (UPDATE, ROUTE-REFRESH markers, EoR) or ~256 KiB per drain into one
+  contiguous `write + flush` instead of one syscall per message —
+  whole frames only, queue order preserved. Priority messages (OPEN,
+  KEEPALIVE, NOTIFICATION, Cease) still write individually, so
+  teardown ordering and biased preemption semantics are unchanged, as
+  are send-hold (RFC 9687) enforcement and the partial-PDU teardown
+  discipline. Measured on the writer flood path (loopback, 100-byte
+  frames, release build): write syscalls drop 64× (1.0 → 0.016 per
+  frame) and sustained writer throughput rises ~10×. (LAN-332)
+
 ### Fixed
 
 - **`rbgp policy explain` no longer reports `not_seen` when the truth

--- a/crates/transport/src/session/writer.rs
+++ b/crates/transport/src/session/writer.rs
@@ -4,8 +4,9 @@
 //! channels (bounded "bulk" + unbounded "priority") and runs a biased
 //! `tokio::select!` so priority traffic preempts bulk. The session task
 //! encodes BGP messages and enqueues their bytes; this task is a dumb
-//! pipe that does `write_all + flush` — with one exception: it owns the
-//! periodic KEEPALIVE cadence (ADR-0078).
+//! pipe that does `write_all + flush` — coalescing queued bulk frames
+//! into one write per drain (see [`coalesce_bulk`]) — with one
+//! exception: it owns the periodic KEEPALIVE cadence (ADR-0078).
 //!
 //! Splitting the writer out of the session task is the architectural
 //! fix tracked by ADR-0051. With the write half in its own task, TCP
@@ -38,10 +39,28 @@
 //! `PeerSession::trigger_outbound_saturation_teardown`; this module
 //! owns the discard/flush/close mechanics.
 //!
+//! # Bulk write coalescing (LAN-332)
+//!
+//! Per-message `write_all + flush` made writer+syscalls the largest
+//! CPU bucket at 1000-peer scale (31.8% of RR CPU under churn,
+//! `docs/perf/scale-receipt-2026-07.md`). Each drain of the bulk
+//! channel therefore coalesces up to [`MAX_BATCH_FRAMES`] /
+//! [`MAX_BATCH_BYTES`] of already-queued WHOLE frames into one
+//! contiguous buffer and issues a single `write_all + flush` — the
+//! same shape as FRR's packed subgroup streams. Only bulk frames
+//! coalesce: priority frames (OPEN, KEEPALIVE, NOTIFICATION, Cease)
+//! always write alone, so the saturation-teardown guarantee that the
+//! `Cease/8` is the final frame on the wire cannot be violated by a
+//! batch that pulled the Cease and then appended bulk behind it, and
+//! biased priority preemption keeps single-frame granularity on the
+//! priority side (bulk backlog can delay a priority frame by at most
+//! one in-flight batch instead of one in-flight frame).
+//!
 //! # Send hold timer (RFC 9687)
 //!
 //! The writer also owns `SendHoldTime` enforcement: each
-//! `write_all + flush` is wrapped in a timeout of the configured
+//! `write_all + flush` (one frame or one coalesced batch) is wrapped
+//! in a timeout of the configured
 //! `SendHoldTime`, and hitting it ends the task with
 //! [`WriterExit::SendHoldExpired`] — the session tears down through the
 //! TCP-failure path *without* sending a NOTIFICATION (§4.3 makes the
@@ -63,7 +82,7 @@
 
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use rustbgpd_telemetry::BgpMetrics;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
@@ -77,8 +96,9 @@ pub(super) enum WriterExit {
     /// TCP write or flush failed.
     Io(std::io::Error),
     /// RFC 9687 send hold timer expired: a single `write_all + flush`
-    /// could not complete within the configured `SendHoldTime` because
-    /// the peer stopped draining its socket.
+    /// (one frame or one coalesced batch, ≤ [`MAX_BATCH_BYTES`] plus
+    /// one frame) could not complete within the configured
+    /// `SendHoldTime` because the peer stopped draining its socket.
     SendHoldExpired {
         /// The configured `SendHoldTime` that elapsed.
         limit: Duration,
@@ -97,6 +117,46 @@ pub(super) enum WriterExit {
 /// saturated TCP window may never accept the Cease; the close must not
 /// wait on it.
 const TEARDOWN_LINGER: Duration = Duration::from_secs(2);
+
+/// Maximum frames coalesced into one bulk write. 64 standard
+/// maximum-size PDUs (4096 B, RFC 4271) is exactly
+/// [`MAX_BATCH_BYTES`], so the two caps agree at the worst-case
+/// standard frame size; typical UPDATEs are far smaller and hit the
+/// frame cap first, still cutting write syscalls by up to 64×.
+const MAX_BATCH_FRAMES: usize = 64;
+
+/// Byte threshold that stops batch growth. WHOLE FRAMES ONLY: the cap
+/// is checked before pulling the next frame, so a batch may overshoot
+/// by at most one frame (≤ 64 KiB under RFC 8654 extended messages).
+/// 256 KiB keeps a single coalesced write small enough that the
+/// send-hold deadline and the teardown linger bound roughly the same
+/// wire time as before, while amortizing the syscall + flush cost.
+const MAX_BATCH_BYTES: usize = 256 * 1024;
+
+/// Coalesce already-queued bulk frames behind `first` into one
+/// contiguous buffer, up to [`MAX_BATCH_FRAMES`] / [`MAX_BATCH_BYTES`].
+/// Non-blocking: only frames already sitting in the channel join the
+/// batch. Returns `first` untouched (zero copy) when the queue is
+/// empty — the idle/trickle path is unchanged. Frames keep their
+/// queue order; frames are never split.
+fn coalesce_bulk(first: Bytes, bulk_rx: &mut mpsc::Receiver<Bytes>) -> Bytes {
+    let Ok(second) = bulk_rx.try_recv() else {
+        return first;
+    };
+    let mut batch = BytesMut::with_capacity(first.len() + second.len());
+    batch.extend_from_slice(&first);
+    batch.extend_from_slice(&second);
+    let mut frames = 2;
+    while frames < MAX_BATCH_FRAMES && batch.len() < MAX_BATCH_BYTES {
+        // `Empty` and `Disconnected` both just end the batch; the run
+        // loop's `bulk_rx.recv()` arm observes closure and flips
+        // `bulk_open` on its own.
+        let Ok(next) = bulk_rx.try_recv() else { break };
+        batch.extend_from_slice(&next);
+        frames += 1;
+    }
+    batch.freeze()
+}
 
 /// Channel handles + a [`JoinHandle`] held by the session task.
 ///
@@ -242,7 +302,10 @@ impl WriterTask {
             // `biased` keeps NOTIFICATIONs and KEEPALIVEs from starving
             // behind a backlog of UPDATEs, and ensures the saturation
             // `Cease/8` reaches the wire before any further bulk work.
-            let bytes = tokio::select! {
+            // The bool marks bulk-arm frames as coalescible; priority
+            // and cadence frames always write alone (module docs,
+            // "Bulk write coalescing").
+            let (bytes, from_bulk) = tokio::select! {
                 biased;
                 changed = self.teardown_rx.changed(), if teardown_open => {
                     if changed.is_err() {
@@ -266,7 +329,7 @@ impl WriterTask {
                 }
                 msg = self.priority_rx.recv(), if priority_open => {
                     if let Some(b) = msg {
-                        b
+                        (b, false)
                     } else {
                         priority_open = false;
                         continue;
@@ -282,11 +345,11 @@ impl WriterTask {
                     }
                     self.metrics
                         .record_message_sent(&self.peer_label, "keepalive");
-                    Bytes::from_static(&KEEPALIVE_FRAME)
+                    (Bytes::from_static(&KEEPALIVE_FRAME), false)
                 }
                 msg = self.bulk_rx.recv(), if bulk_open => {
                     if let Some(b) = msg {
-                        b
+                        (b, true)
                     } else {
                         bulk_open = false;
                         continue;
@@ -294,14 +357,20 @@ impl WriterTask {
                 }
             };
 
+            let bytes = if from_bulk {
+                coalesce_bulk(bytes, &mut self.bulk_rx)
+            } else {
+                bytes
+            };
             self.write_message(&bytes).await?;
         }
     }
 
-    /// `write_all + flush` one message, bounded by the RFC 9687 send
-    /// hold timer when configured, and raced against the session's
-    /// hard-teardown signal — a writer wedged mid-write on a saturated
-    /// TCP window must not delay the teardown indefinitely.
+    /// `write_all + flush` one message (or one coalesced batch of
+    /// whole bulk frames), bounded by the RFC 9687 send hold timer
+    /// when configured, and raced against the session's hard-teardown
+    /// signal — a writer wedged mid-write on a saturated TCP window
+    /// must not delay the teardown indefinitely.
     async fn write_message(&mut self, bytes: &Bytes) -> Result<(), WriterExit> {
         let Self {
             write_half,
@@ -332,10 +401,12 @@ impl WriterTask {
                 return Err(WriterExit::SendHoldExpired { limit });
             }
             None => {
-                // Hard teardown while this frame is in flight: give the
-                // write a short linger to reach a frame boundary (so
-                // the Cease can still follow it intact), then abandon —
-                // a `write_all` cancelled mid-frame may have left a
+                // Hard teardown while this frame/batch is in flight:
+                // give the write a short linger to reach a frame
+                // boundary — batches hold only whole frames, so a
+                // completed write always ends on one (and the Cease
+                // can still follow it intact) — then abandon: a
+                // `write_all` cancelled mid-frame may have left a
                 // partial PDU on the wire, so nothing (not even the
                 // Cease) may be written after an abandoned write. On
                 // completion the run loop's top-of-iteration check
@@ -609,6 +680,195 @@ mod tests {
             "draining peer tripped the timer: {result:?}"
         );
         assert_eq!(reader.await.unwrap(), 8 * payload);
+    }
+
+    /// Batch cap: exactly [`MAX_BATCH_FRAMES`] whole frames coalesce;
+    /// the rest stay queued, in order.
+    #[test]
+    fn coalesce_respects_frame_cap() {
+        let (tx, mut rx) = mpsc::channel(256);
+        for i in 0..100u8 {
+            tx.try_send(Bytes::from(vec![i; 10])).unwrap();
+        }
+        let batch = coalesce_bulk(Bytes::from(vec![0xAA; 10]), &mut rx);
+        // `first` + 63 drained frames = MAX_BATCH_FRAMES.
+        assert_eq!(batch.len(), MAX_BATCH_FRAMES * 10);
+        assert_eq!(&batch[..10], &[0xAA; 10]);
+        assert_eq!(&batch[10..20], &[0u8; 10]);
+        // Frame 63 is the first one left behind — whole and in order.
+        assert_eq!(rx.try_recv().unwrap(), Bytes::from(vec![63u8; 10]));
+    }
+
+    /// Byte cap: growth stops once the batch crosses
+    /// [`MAX_BATCH_BYTES`] — checked before each pull, so the batch
+    /// overshoots by at most one whole frame and never splits one.
+    #[test]
+    fn coalesce_respects_byte_cap_whole_frames_only() {
+        const FRAME: usize = 100 * 1024;
+        let (tx, mut rx) = mpsc::channel(8);
+        for _ in 0..5 {
+            tx.try_send(Bytes::from(vec![0u8; FRAME])).unwrap();
+        }
+        let batch = coalesce_bulk(Bytes::from(vec![0u8; FRAME]), &mut rx);
+        // 100K + 100K = 200K < 256K -> pull one more whole frame ->
+        // 300K >= 256K -> stop.
+        assert_eq!(batch.len(), 3 * FRAME);
+        // Three frames remain queued, whole.
+        for _ in 0..3 {
+            assert_eq!(rx.try_recv().unwrap().len(), FRAME);
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// An empty queue returns `first` without copying it — the
+    /// idle/trickle single-frame path is unchanged.
+    #[test]
+    fn coalesce_empty_queue_is_zero_copy() {
+        let (_tx, mut rx) = mpsc::channel::<Bytes>(8);
+        let first = Bytes::from(vec![7u8; 32]);
+        let ptr = first.as_ptr();
+        let out = coalesce_bulk(first, &mut rx);
+        assert_eq!(out.as_ptr(), ptr, "single frame must not be copied");
+    }
+
+    /// Whole-frame integrity + FIFO order across many coalesced
+    /// batches: a flood far larger than one batch arrives on the wire
+    /// as the exact concatenation of the frames as enqueued.
+    #[tokio::test]
+    async fn bulk_flood_frames_intact_and_ordered_across_batches() {
+        let (server, mut client) = tcp_pair().await;
+        let (_read, write) = server.into_split();
+        let handle = spawn(
+            write,
+            512,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+            None,
+        );
+
+        // 300 frames of varying size (1..=600 bytes) and distinct
+        // content: > 4 full frame-cap batches.
+        let mut expected = Vec::new();
+        for i in 0..300usize {
+            let frame = vec![u8::try_from(i % 251).unwrap(); (i * 2) % 600 + 1];
+            expected.extend_from_slice(&frame);
+            handle.bulk_tx.send(Bytes::from(frame)).await.unwrap();
+        }
+        let join = handle.join;
+        drop(handle.bulk_tx);
+        drop(handle.priority_tx);
+
+        let mut got = vec![0u8; expected.len()];
+        client.read_exact(&mut got).await.unwrap();
+        assert_eq!(
+            got, expected,
+            "coalesced stream must equal frame concatenation"
+        );
+        join.await.unwrap().unwrap();
+    }
+
+    /// Forced short writes: tiny kernel buffers make every coalesced
+    /// batch complete through multiple partial `write_all` iterations;
+    /// the stream must still be the exact frame concatenation.
+    #[tokio::test]
+    async fn short_writes_keep_frames_intact() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect = tokio::spawn(async move {
+            let socket = tokio::net::TcpSocket::new_v4().unwrap();
+            socket.set_recv_buffer_size(4096).unwrap();
+            socket.connect(addr).await.unwrap()
+        });
+        let (server, _) = listener.accept().await.unwrap();
+        socket2::SockRef::from(&server)
+            .set_send_buffer_size(4096)
+            .unwrap();
+        let mut client = connect.await.unwrap();
+
+        let (_read, write) = server.into_split();
+        let handle = spawn(
+            write,
+            256,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+            None,
+        );
+
+        // One full byte-cap batch worth of max-size standard PDUs:
+        // 64 x 4096 B, far beyond the 4 KiB kernel buffers.
+        let mut expected = Vec::new();
+        for i in 0..64usize {
+            let frame = vec![u8::try_from(i).unwrap(); 4096];
+            expected.extend_from_slice(&frame);
+            handle.bulk_tx.send(Bytes::from(frame)).await.unwrap();
+        }
+        let join = handle.join;
+        drop(handle.bulk_tx);
+        drop(handle.priority_tx);
+
+        let mut got = vec![0u8; expected.len()];
+        client.read_exact(&mut got).await.unwrap();
+        assert_eq!(got, expected, "short writes must not tear frames");
+        join.await.unwrap().unwrap();
+    }
+
+    /// Teardown while coalesced batches are in flight on a healthy
+    /// socket: the linger lets the in-flight write finish, so the
+    /// bytes on the wire are a frame-aligned prefix of the enqueued
+    /// stream — no partial frame emitted.
+    #[tokio::test]
+    async fn teardown_mid_batch_ends_on_frame_boundary() {
+        const FRAME: usize = 1000;
+        let (server, mut client) = tcp_pair().await;
+        let (_read, write) = server.into_split();
+        let handle = spawn(
+            write,
+            512,
+            BgpMetrics::with_registry(prometheus::Registry::new()),
+            "test-peer".to_string(),
+            None,
+        );
+
+        let mut sent = Vec::new();
+        for i in 0..256usize {
+            let frame = vec![u8::try_from(i % 251).unwrap(); FRAME];
+            sent.extend_from_slice(&frame);
+            handle.bulk_tx.send(Bytes::from(frame)).await.unwrap();
+        }
+        // Observe some bytes on the wire, then signal hard teardown
+        // while later batches are still queued/in flight.
+        let mut head = [0u8; 2 * FRAME];
+        client.read_exact(&mut head).await.unwrap();
+        handle.teardown_tx.send(true).unwrap();
+
+        let join = handle.join;
+        drop(handle.bulk_tx);
+        drop(handle.priority_tx);
+        let result = tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("writer must exit after teardown")
+            .unwrap();
+        assert!(
+            matches!(result, Err(WriterExit::TornDown)),
+            "expected TornDown, got {result:?}"
+        );
+
+        // Drain to EOF (writer dropped the socket on exit).
+        let mut rest = Vec::new();
+        client.read_to_end(&mut rest).await.unwrap();
+        let mut got = head.to_vec();
+        got.extend_from_slice(&rest);
+        assert_eq!(
+            got.len() % FRAME,
+            0,
+            "teardown emitted a partial frame ({} bytes)",
+            got.len()
+        );
+        assert_eq!(
+            got,
+            sent[..got.len()],
+            "wire bytes must be a prefix of the enqueued frame stream"
+        );
     }
 
     /// Dropping both senders is the clean shutdown signal.


### PR DESCRIPTION
## Summary

- the session writer issued one write_all + flush per BGP message — 31.8% of RR CPU at 1000 peers in the scale receipt; bulk frames now coalesce into per-drain batches (64 frames / 256 KiB caps, whole frames only, one write + one flush per batch)
- contiguous staging over vectored writes: tokio has no write_all_vectored, and hand-rolled IoSlice advance would have to live inside the send-hold/teardown machinery, while write_all over one buffer inherits it verbatim; a ≤256 KiB memcpy is noise against the syscalls removed; single-frame drains stay zero-copy so the idle/trickle path is unchanged
- priority frames (OPEN/KEEPALIVE/NOTIFICATION/Cease) always write alone — Cease-finality is unviolable by construction rather than guarded; bulk FIFO order preserved inside batches; the send-hold wrapper now bounds one coalesced write with the deadline structure unchanged; teardown linger completes the in-flight batch so the wire always ends on a frame boundary
- measured on a loopback flood proxy (the CI-shape rrharness is deliberately out-of-repo): write syscalls 500,000 → 7,813 (exactly 64 frames/write), release-build writer-path throughput ~613k → ~6.05M frames/s (~10x, 3-run medians); the churn-latency receipt could not be re-run locally — risk bounded because single-frame and priority paths are byte-identical and the drain is non-blocking (no timers or nagling added)
- forced-short-write, teardown-mid-batch, ordering, and cap-boundary tests added; the existing saturation Cease-ordering and send-hold suites pass unchanged

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-transport (238) / -p rustbgpd-fsm / --bin rustbgpd
- cargo doc --workspace --no-deps
- strace + throughput receipts in the issue

Closes LAN-332.