### PR TITLE
fix(rbgp): render config diffs with impact classification and exit-code contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   was not evaluated; `not_seen` keeps its exit-0 evaluated-answer
   semantics, and `--json` carries the distinct outcome values.
   (LAN-320)
+- **Config diffs render operator values, impact classes, and a plan
+  summary instead of Rust debug output.** `rbgp config diff` /
+  `config plan` / `rustbgpd --diff` no longer leak `Some(90) →
+  Some(30)` into field change lines: values render bare (`hold_time:
+  90 → 30`), absent optionals render `(unset)`, and secret-bearing or
+  inline-policy fields stay summarized as `<changed>`. Each changed
+  neighbor / peer-group field is annotated with its reload-matrix
+  impact class (`[hot-applied]`, `[session reset: OPEN renegotiation]`
+  / `TCP re-establish` / `session re-establish`, `[restart required]`;
+  fields whose class the existing classifiers disagree on carry no
+  annotation), and the diff ends with a rollup line (`Plan: 1 to add,
+  1 to change · 1 session will reset`). The JSON diff's `changes`
+  entries are now structured objects with the stable key set `{field,
+  old, new, impact}` (honest `null` for absent values and unknown
+  impact) plus a top-level `summary` object with neighbor counts,
+  `sessions_will_reset`, and `restart_required`. `rbgp config diff`
+  and `config plan` adopt detailed exit codes documented in `--help`:
+  0 = no changes, 1 = error, 2 = changes present (a separate contract
+  from the `rbgp diff` route diff). (LAN-321)
 
 - **`rbgp` errors are now actionable.** Connect failures name the
   endpoint the CLI actually dialed and the failure class (`cannot

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -21,7 +21,16 @@ pub struct ApplyOptions<'a> {
     pub confirm_timeout_seconds: Option<u32>,
 }
 
-pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result<(), CliError> {
+/// Detailed exit code for `config diff` / `config plan`: 0 when the
+/// candidate matches the runtime config, 2 when changes are present
+/// (errors exit 1 through the generic CLI error path).
+pub fn change_status_exit_code(has_changes: bool) -> i32 {
+    if has_changes { 2 } else { 0 }
+}
+
+/// Returns whether the candidate differs from the runtime config, for the
+/// 0 (no changes) / 2 (changes present) exit-code contract.
+pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result<bool, CliError> {
     let candidate_toml = read_candidate_toml(from_file)?;
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -35,15 +44,17 @@ pub async fn diff(connection: Connection, from_file: &str, json: bool) -> Result
     } else {
         print!("{}", resp.human_text);
     }
-    Ok(())
+    Ok(resp.has_any_changes)
 }
 
+/// Returns whether the plan contains changes (status other than noop),
+/// for the 0 (no changes) / 2 (changes present) exit-code contract.
 pub async fn plan(
     connection: Connection,
     from_file: &str,
     expected_runtime_snapshot_token: Option<&str>,
     json: bool,
-) -> Result<(), CliError> {
+) -> Result<bool, CliError> {
     let candidate_toml = read_candidate_toml(from_file)?;
     let mut client =
         ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
@@ -62,7 +73,7 @@ pub async fn plan(
     } else {
         print_plan_human(&resp);
     }
-    Ok(())
+    Ok(resp.status != ConfigTransactionPlanStatus::Noop as i32)
 }
 
 pub async fn apply(
@@ -411,15 +422,58 @@ mod tests {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
 
-        diff(connection, path.to_str().unwrap(), true)
+        let has_changes = diff(connection, path.to_str().unwrap(), true)
             .await
             .unwrap();
 
+        assert!(has_changes, "mock serves a changed diff → exit code 2");
         assert_eq!(server.state.config_diff_calls.load(Ordering::SeqCst), 1);
         assert_eq!(
             server.state.last_config_diff.lock().await.as_deref(),
             Some("[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n")
         );
+    }
+
+    #[tokio::test]
+    async fn diff_without_changes_reports_no_changes_for_exit_code_0() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        server
+            .state
+            .config_diff_no_changes
+            .store(true, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let has_changes = diff(connection, path.to_str().unwrap(), true)
+            .await
+            .unwrap();
+
+        assert!(!has_changes, "no-changes diff must map to exit code 0");
+    }
+
+    #[tokio::test]
+    async fn diff_rpc_error_maps_to_cli_error_for_exit_code_1() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        *server.state.config_diff_error.lock().await = Some((
+            tonic::Code::InvalidArgument,
+            "candidate config invalid".to_string(),
+        ));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let result = diff(connection, path.to_str().unwrap(), true).await;
+
+        assert!(result.is_err(), "daemon error must take the exit-1 path");
+    }
+
+    #[test]
+    fn change_status_exit_codes_are_terraform_style() {
+        assert_eq!(change_status_exit_code(false), 0);
+        assert_eq!(change_status_exit_code(true), 2);
     }
 
     #[tokio::test]
@@ -430,10 +484,11 @@ mod tests {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
 
-        plan(connection, path.to_str().unwrap(), Some("kv1:old:1"), true)
+        let has_changes = plan(connection, path.to_str().unwrap(), Some("kv1:old:1"), true)
             .await
             .unwrap();
 
+        assert!(has_changes, "committable plan → exit code 2");
         assert_eq!(server.state.config_plan_calls.load(Ordering::SeqCst), 1);
         let request = server.state.last_config_plan.lock().await.clone().unwrap();
         assert_eq!(
@@ -441,6 +496,22 @@ mod tests {
             "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n"
         );
         assert_eq!(request.expected_runtime_snapshot_token, "kv1:old:1");
+    }
+
+    #[tokio::test]
+    async fn plan_noop_reports_no_changes_for_exit_code_0() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("candidate.toml");
+        std::fs::write(&path, "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\n").unwrap();
+        let server = spawn_mock_server(None).await;
+        server.state.config_plan_noop.store(true, Ordering::SeqCst);
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let has_changes = plan(connection, path.to_str().unwrap(), None, true)
+            .await
+            .unwrap();
+
+        assert!(!has_changes, "noop plan must map to exit code 0");
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -288,6 +288,16 @@ enum Command {
 #[derive(Subcommand)]
 enum ConfigAction {
     /// Diff a candidate TOML file against the daemon's live runtime snapshot
+    ///
+    /// Changed neighbor / peer-group fields are annotated with their
+    /// live-impact class ([hot-applied], [session reset: ...], [restart
+    /// required]) and the diff ends with a plan summary line. Exit codes
+    /// are terraform-style detailed codes (`rbgp diff`, the route diff,
+    /// has its own separate 0/1/2 contract).
+    #[command(after_help = "Exit codes:\n  \
+        0  candidate matches the runtime config (no changes)\n  \
+        1  error (unreadable candidate, invalid config, connection or daemon failure)\n  \
+        2  changes present")]
     Diff {
         /// Candidate TOML file to validate and compare
         #[arg(long, value_name = "PATH")]
@@ -295,6 +305,13 @@ enum ConfigAction {
     },
 
     /// Validate and classify a candidate transaction without mutation
+    ///
+    /// Exit codes are terraform-style detailed codes (`rbgp diff`, the
+    /// route diff, has its own separate 0/1/2 contract).
+    #[command(after_help = "Exit codes:\n  \
+        0  no changes (plan is a noop)\n  \
+        1  error (unreadable candidate, invalid config, connection or daemon failure)\n  \
+        2  changes present (plan is committable or rejected)")]
     Plan {
         /// Candidate TOML file to validate and classify
         #[arg(long, value_name = "PATH")]
@@ -1409,6 +1426,15 @@ fn generate_completions(shell: Shell, binary_name: &'static str, output: &mut dy
     clap_complete::generate(shell, &mut cli_command(binary_name), binary_name, output);
 }
 
+/// Terminate with the `config diff` / `config plan` detailed exit code:
+/// 0 when the candidate matches the runtime config, 2 when changes are
+/// present (errors take the generic exit-1 path in `main`).
+fn exit_with_change_status(has_changes: bool) -> ! {
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
+    std::process::exit(commands::config::change_status_exit_code(has_changes));
+}
+
 async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
     // Shell completions don't need a gRPC connection.
     if let Command::Completions { shell } = cli.command {
@@ -1537,19 +1563,21 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
 
         Command::Config { action } => match action {
             ConfigAction::Diff { from_file } => {
-                commands::config::diff(connection, &from_file, json).await
+                let has_changes = commands::config::diff(connection, &from_file, json).await?;
+                exit_with_change_status(has_changes);
             }
             ConfigAction::Plan {
                 from_file,
                 expected_runtime_snapshot_token,
             } => {
-                commands::config::plan(
+                let has_changes = commands::config::plan(
                     connection,
                     &from_file,
                     expected_runtime_snapshot_token.as_deref(),
                     json,
                 )
-                .await
+                .await?;
+                exit_with_change_status(has_changes);
             }
             ConfigAction::Apply {
                 from_file,
@@ -2490,6 +2518,33 @@ mod tests {
         let cli = Cli::from_arg_matches(&matches).unwrap();
 
         assert!(matches!(cli.command, Command::Global));
+    }
+
+    #[test]
+    fn config_diff_and_plan_help_document_detailed_exit_codes() {
+        let mut command = cli_command(BINARY_NAME);
+        let config = command
+            .find_subcommand_mut("config")
+            .expect("config subcommand exists");
+        for name in ["diff", "plan"] {
+            let help = config
+                .find_subcommand_mut(name)
+                .unwrap_or_else(|| panic!("config {name} subcommand exists"))
+                .render_long_help()
+                .to_string();
+            assert!(
+                help.contains("Exit codes:"),
+                "config {name} --help must document exit codes: {help}"
+            );
+            assert!(
+                help.contains("2  changes present"),
+                "config {name} --help must document exit code 2: {help}"
+            );
+            assert!(
+                help.contains("1  error"),
+                "config {name} --help must document exit code 1: {help}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, oneshot};
@@ -41,6 +41,11 @@ pub(crate) struct MockState {
     pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
+    pub(crate) config_diff_error: Mutex<Option<(Code, String)>>,
+    // Serve a "candidate matches runtime" diff / noop plan so the CLI
+    // detailed exit-code contract (0 = no changes) can be pinned.
+    pub(crate) config_diff_no_changes: AtomicBool,
+    pub(crate) config_plan_noop: AtomicBool,
     pub(crate) bfd_error: Mutex<Option<(Code, String)>>,
     pub(crate) bfd_sessions: Mutex<Vec<server_proto::BfdSession>>,
     pub(crate) last_bfd_request: Mutex<Option<server_proto::GetBfdSessionsRequest>>,
@@ -350,6 +355,20 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
     ) -> Result<Response<server_proto::DiffRuntimeConfigResponse>, Status> {
         self.state.config_diff_calls.fetch_add(1, Ordering::SeqCst);
         *self.state.last_config_diff.lock().await = Some(request.into_inner().candidate_toml);
+        if let Some((code, message)) = self.state.config_diff_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
+        if self.state.config_diff_no_changes.load(Ordering::SeqCst) {
+            return Ok(Response::new(server_proto::DiffRuntimeConfigResponse {
+                has_actionable_changes: false,
+                has_reload_applied_changes: false,
+                has_restart_required_changes: false,
+                has_informational_changes: false,
+                has_any_changes: false,
+                human_text: "No changes.\n".to_string(),
+                diff_json: "{\"has_any_changes\":false}".to_string(),
+            }));
+        }
         Ok(Response::new(server_proto::DiffRuntimeConfigResponse {
             has_actionable_changes: true,
             has_reload_applied_changes: false,
@@ -367,6 +386,17 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
     ) -> Result<Response<server_proto::ConfigTransactionPlanResponse>, Status> {
         self.state.config_plan_calls.fetch_add(1, Ordering::SeqCst);
         *self.state.last_config_plan.lock().await = Some(request.into_inner());
+        if self.state.config_plan_noop.load(Ordering::SeqCst) {
+            return Ok(Response::new(server_proto::ConfigTransactionPlanResponse {
+                status: server_proto::ConfigTransactionPlanStatus::Noop as i32,
+                runtime_snapshot_token: "kv1:planned:1".to_string(),
+                diff: None,
+                supported_sections: Vec::new(),
+                unsupported_sections: Vec::new(),
+                restart_required_sections: Vec::new(),
+                human_text: "Config transaction is a noop.\n".to_string(),
+            }));
+        }
         Ok(Response::new(server_proto::ConfigTransactionPlanResponse {
             status: server_proto::ConfigTransactionPlanStatus::Committable as i32,
             runtime_snapshot_token: "kv1:planned:1".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1622,20 +1622,180 @@ pub struct NeighborDiff {
     pub changed: Vec<Neighbor>,
 }
 
-/// Describe which fields changed between two `Neighbor` configurations.
+/// Live-impact class for a single `[[neighbors]]` / `[peer_groups]` field
+/// edit, surfaced from the reload matrix (`docs/reload-matrix.md`, the
+/// per-field classification pinned by the reload-matrix structural tests)
+/// so diff renderings can annotate each changed field with what applying
+/// it does to the affected peer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigFieldImpact {
+    /// Reload-matrix class `live`: the value applies to the running peer
+    /// without renegotiating the session.
+    HotApplied,
+    /// Reload-matrix class `live (effective next session)`: the value is
+    /// OPEN-negotiated, socket-scoped, or registered at session
+    /// establishment, so applying it takes a session reset.
+    SessionReset,
+    /// Reload-matrix class `restart-required`: a daemon restart is needed.
+    RestartRequired,
+}
+
+/// Reload-matrix impact class + human annotation for one neighbor /
+/// peer-group field named by [`describe_neighbor_changes`] /
+/// [`describe_peer_group_changes`].
 ///
-/// Returns a list of human-readable change descriptions (e.g. "`hold_time`: 90 → 45").
-pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<String> {
+/// Fields whose class the existing classifiers disagree on return `None`
+/// and the diff renders no annotation rather than guessing:
+/// - `remote_asn`: the matrix classes it restart-required identity, but
+///   `diff_neighbors` keys on `(address, interface)` only, so an edit
+///   flows through the reconcile delete/re-add path.
+/// - `peer_group`: the matrix classes it live, but the transaction
+///   executor routes a reassignment to the session-reshape executor.
+fn config_field_impact(field: &str) -> Option<(ConfigFieldImpact, &'static str)> {
+    Some(match field {
+        "description"
+        | "max_prefixes"
+        | "gr_stale_routes_time"
+        | "local_ipv6_nexthop"
+        | "remove_private_as"
+        | "log_level"
+        | "import_policy"
+        | "export_policy"
+        | "import_policy_chain"
+        | "export_policy_chain" => (ConfigFieldImpact::HotApplied, "hot-applied"),
+        "hold_time"
+        | "families"
+        | "graceful_restart"
+        | "gr_restart_time"
+        | "llgr_stale_time"
+        | "role"
+        | "strict_role"
+        | "prefix_orf_receive"
+        | "disable_ipv4_unicast"
+        | "add_path" => (
+            ConfigFieldImpact::SessionReset,
+            "session reset: OPEN renegotiation",
+        ),
+        "md5_password" | "ttl_security" | "send_hold_time" => (
+            ConfigFieldImpact::SessionReset,
+            "session reset: TCP re-establish",
+        ),
+        "route_reflector_client" | "orr_vantage" | "route_server_client" | "per_client_best" => (
+            ConfigFieldImpact::SessionReset,
+            "session reset: session re-establish",
+        ),
+        "tcp_ao" | "bfd" => (ConfigFieldImpact::RestartRequired, "restart required"),
+        _ => return None,
+    })
+}
+
+/// One changed field on a neighbor or peer group.
+///
+/// Serializes with the stable key set `{field, old, new, impact}`:
+/// `old`/`new` are the JSON forms of the config values with honest `null`
+/// for an absent optional (rendered `(unset)` in human output), and
+/// `impact` is the reload-matrix class or `null` when unknown.
+/// Secret-bearing and inline-policy fields carry `null` on both value
+/// sides and render `<changed>` — the values are never exposed.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct FieldChange {
+    pub field: &'static str,
+    pub old: serde_json::Value,
+    pub new: serde_json::Value,
+    pub impact: Option<ConfigFieldImpact>,
+    #[serde(skip)]
+    annotation: Option<&'static str>,
+    #[serde(skip)]
+    values_summarized: bool,
+}
+
+impl FieldChange {
+    fn new<T: serde::Serialize>(field: &'static str, old: &T, new: &T) -> Self {
+        let (impact, annotation) = match config_field_impact(field) {
+            Some((impact, annotation)) => (Some(impact), Some(annotation)),
+            None => (None, None),
+        };
+        Self {
+            field,
+            old: json_config_value(old),
+            new: json_config_value(new),
+            impact,
+            annotation,
+            values_summarized: false,
+        }
+    }
+
+    /// A change whose values are deliberately withheld (secrets such as
+    /// `md5_password` / `tcp_ao`, or inline policy bodies too large to
+    /// inline): both value sides are `null` and the human rendering says
+    /// `<changed>`.
+    fn summarized(field: &'static str) -> Self {
+        let (impact, annotation) = match config_field_impact(field) {
+            Some((impact, annotation)) => (Some(impact), Some(annotation)),
+            None => (None, None),
+        };
+        Self {
+            field,
+            old: serde_json::Value::Null,
+            new: serde_json::Value::Null,
+            impact,
+            annotation,
+            values_summarized: true,
+        }
+    }
+
+    /// Human line for this change: `hold_time: 90 → 30  [session reset:
+    /// OPEN renegotiation]`. Absent values render `(unset)`; withheld
+    /// values render `<changed>`.
+    pub fn render(&self) -> String {
+        let values = if self.values_summarized {
+            "<changed>".to_string()
+        } else {
+            format!(
+                "{} → {}",
+                render_json_config_value(&self.old),
+                render_json_config_value(&self.new)
+            )
+        };
+        match self.annotation {
+            Some(annotation) => format!("{}: {values}  [{annotation}]", self.field),
+            None => format!("{}: {values}", self.field),
+        }
+    }
+
+    /// True when applying this field edit resets the affected session.
+    pub fn resets_session(&self) -> bool {
+        self.impact == Some(ConfigFieldImpact::SessionReset)
+    }
+}
+
+fn json_config_value<T: serde::Serialize>(value: &T) -> serde_json::Value {
+    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+}
+
+/// Render one JSON config value for human output: `null` → `(unset)`,
+/// strings bare, everything else (numbers, bools, arrays, objects) as
+/// compact JSON — never Rust `Debug` syntax.
+fn render_json_config_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "(unset)".to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Describe which fields changed between two `Neighbor` configurations.
+pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<FieldChange> {
     let mut changes = Vec::new();
 
     macro_rules! cmp_field {
         ($field:ident) => {
             if old.$field != new.$field {
-                changes.push(format!(
-                    "{}: {:?} → {:?}",
+                changes.push(FieldChange::new(
                     stringify!($field),
-                    old.$field,
-                    new.$field
+                    &old.$field,
+                    &new.$field,
                 ));
             }
         };
@@ -1666,36 +1826,26 @@ pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<String> 
     cmp_field!(add_path);
     cmp_field!(log_level);
 
-    // md5_password: log change without revealing values
+    // Secret-bearing fields: report the change without revealing values.
     if old.md5_password != new.md5_password {
-        changes.push("md5_password: <changed>".to_string());
+        changes.push(FieldChange::summarized("md5_password"));
     }
     if old.tcp_ao != new.tcp_ao {
-        changes.push("tcp_ao: <changed restart-required>".to_string());
+        changes.push(FieldChange::summarized("tcp_ao"));
     }
     if old.bfd != new.bfd {
-        changes.push("bfd: <changed restart-required>".to_string());
+        changes.push(FieldChange::summarized("bfd"));
     }
 
-    // Policy changes: summarize rather than dump full config
+    // Inline policy bodies: summarize rather than dump full config.
     if old.import_policy != new.import_policy {
-        changes.push("import_policy: <changed>".to_string());
+        changes.push(FieldChange::summarized("import_policy"));
     }
     if old.export_policy != new.export_policy {
-        changes.push("export_policy: <changed>".to_string());
+        changes.push(FieldChange::summarized("export_policy"));
     }
-    if old.import_policy_chain != new.import_policy_chain {
-        changes.push(format!(
-            "import_policy_chain: {:?} → {:?}",
-            old.import_policy_chain, new.import_policy_chain
-        ));
-    }
-    if old.export_policy_chain != new.export_policy_chain {
-        changes.push(format!(
-            "export_policy_chain: {:?} → {:?}",
-            old.export_policy_chain, new.export_policy_chain
-        ));
-    }
+    cmp_field!(import_policy_chain);
+    cmp_field!(export_policy_chain);
 
     changes
 }
@@ -1836,7 +1986,7 @@ pub struct ConfigDiff {
     /// not just in the raw `peer_groups` / `policy` diffs.
     pub effective_neighbor_impact: Vec<EffectiveNeighborImpact>,
     pub peer_groups: PeerGroupDiff,
-    pub peer_group_details: Vec<(String, Vec<String>)>,
+    pub peer_group_details: Vec<(String, Vec<FieldChange>)>,
     pub policy: PolicyDiff,
     /// `[global] honor_graceful_shutdown` changed. This is
     /// reload-applied through the peer manager, not restart-required.
@@ -2080,7 +2230,7 @@ pub struct NeighborAddSummary {
 #[derive(Debug, serde::Serialize)]
 pub struct NeighborChangeSummary {
     pub address: String,
-    pub changes: Vec<String>,
+    pub changes: Vec<FieldChange>,
 }
 
 impl ConfigDiff {
@@ -2153,6 +2303,72 @@ impl ConfigDiff {
     pub fn has_any_changes(&self) -> bool {
         self.has_actionable_changes() || self.has_informational_changes()
     }
+
+    /// Distinct config entries (static neighbors or dynamic ranges) whose
+    /// live session(s) the classifiers say will reset when this diff is
+    /// applied: changed neighbors with at least one session-reset-class
+    /// field edit, plus inheritance-driven session-reshape impacts. Counts
+    /// config entries, not live TCP sessions (a dynamic range counts once
+    /// however many sessions it currently holds).
+    pub fn session_reset_entries(&self) -> usize {
+        let mut addresses: std::collections::BTreeSet<&str> = self
+            .neighbors
+            .changed
+            .iter()
+            .filter(|change| change.changes.iter().any(FieldChange::resets_session))
+            .map(|change| change.address.as_str())
+            .collect();
+        addresses.extend(
+            self.effective_neighbor_impact
+                .iter()
+                .filter(|impact| !impact.kind.is_policy_chain())
+                .map(|impact| impact.address.as_str()),
+        );
+        addresses.len()
+    }
+}
+
+/// Terraform-style rollup line for the human diff: neighbor
+/// add/change/remove counts, the session-reset count from
+/// [`ConfigDiff::session_reset_entries`], and whether a daemon restart is
+/// required for part of the change.
+fn plan_summary_line(diff: &ConfigDiff) -> String {
+    use std::fmt::Write as _;
+
+    let mut counts = Vec::new();
+    let added = diff.neighbors.added.len();
+    let changed = diff.neighbors.changed.len();
+    let removed = diff.neighbors.removed.len();
+    if added > 0 {
+        counts.push(format!("{added} to add"));
+    }
+    if changed > 0 {
+        counts.push(format!("{changed} to change"));
+    }
+    if removed > 0 {
+        counts.push(format!("{removed} to remove"));
+    }
+    if counts.is_empty() {
+        counts.push("no neighbor changes".to_string());
+    }
+    let mut line = format!("Plan: {}", counts.join(", "));
+    let resets = diff.session_reset_entries();
+    match resets {
+        // A restart-required change resets every session anyway, so a
+        // "no session resets" claim would mislead.
+        0 if !diff.has_restart_required_changes() => {
+            line.push_str(" · no session resets expected");
+        }
+        0 => {}
+        1 => line.push_str(" · 1 session will reset"),
+        n => {
+            let _ = write!(line, " · {n} sessions will reset");
+        }
+    }
+    if diff.has_restart_required_changes() {
+        line.push_str(" · daemon restart required for some changes");
+    }
+    line
 }
 
 /// Section-level v1 transaction support classification.
@@ -2545,6 +2761,13 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
         "has_informational_changes": diff.has_informational_changes(),
         "has_any_changes": diff.has_any_changes(),
         "evpn_runtime_change_class": diff.evpn_runtime_change_class,
+        "summary": {
+            "neighbors_added": diff.neighbors.added.len(),
+            "neighbors_changed": diff.neighbors.changed.len(),
+            "neighbors_removed": diff.neighbors.removed.len(),
+            "sessions_will_reset": diff.session_reset_entries(),
+            "restart_required": diff.has_restart_required_changes(),
+        },
         "reload_applied": {
             "neighbors": &diff.neighbors,
             "peer_groups": &diff.peer_groups,
@@ -2677,7 +2900,7 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             for n in &diff.neighbors.changed {
                 let _ = writeln!(out, "    {} {}:", style.change_marker, n.address);
                 for change in &n.changes {
-                    let _ = writeln!(out, "        {change}");
+                    let _ = writeln!(out, "        {}", change.render());
                 }
             }
             out.push('\n');
@@ -2694,7 +2917,7 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
             for (name, details) in &diff.peer_group_details {
                 let _ = writeln!(out, "    {} {name}:", style.change_marker);
                 for change in details {
-                    let _ = writeln!(out, "        {change}");
+                    let _ = writeln!(out, "        {}", change.render());
                 }
             }
             out.push('\n');
@@ -2863,7 +3086,9 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
         out.push('\n');
     }
 
-    if !diff.has_any_changes() {
+    if diff.has_any_changes() {
+        let _ = writeln!(out, "{}", plan_summary_line(diff));
+    } else {
         let _ = writeln!(out, "{}", style.no_changes);
     }
     out
@@ -4168,8 +4393,9 @@ fn compute_effective_neighbor_impact(
 
         if old_resolved.peer_group != new_resolved.peer_group {
             reasons.push(format!(
-                "peer_group resolved as {:?} (was {:?})",
-                new_resolved.peer_group, old_resolved.peer_group
+                "peer_group resolved as {} (was {})",
+                new_resolved.peer_group.as_deref().unwrap_or("(unset)"),
+                old_resolved.peer_group.as_deref().unwrap_or("(unset)")
             ));
         } else if let Some(name) = new_resolved.peer_group.as_deref()
             && pg_changed.contains(name)
@@ -4359,17 +4585,19 @@ pub fn diff_peer_groups(
 }
 
 /// Describe which fields changed between two `PeerGroupConfig` values.
-pub fn describe_peer_group_changes(old: &PeerGroupConfig, new: &PeerGroupConfig) -> Vec<String> {
+pub fn describe_peer_group_changes(
+    old: &PeerGroupConfig,
+    new: &PeerGroupConfig,
+) -> Vec<FieldChange> {
     let mut changes = Vec::new();
 
     macro_rules! cmp_field {
         ($field:ident) => {
             if old.$field != new.$field {
-                changes.push(format!(
-                    "{}: {:?} → {:?}",
+                changes.push(FieldChange::new(
                     stringify!($field),
-                    old.$field,
-                    new.$field
+                    &old.$field,
+                    &new.$field,
                 ));
             }
         };
@@ -4398,26 +4626,16 @@ pub fn describe_peer_group_changes(old: &PeerGroupConfig, new: &PeerGroupConfig)
     cmp_field!(log_level);
 
     if old.md5_password != new.md5_password {
-        changes.push("md5_password: <changed>".to_string());
+        changes.push(FieldChange::summarized("md5_password"));
     }
     if old.import_policy != new.import_policy {
-        changes.push("import_policy: <changed>".to_string());
+        changes.push(FieldChange::summarized("import_policy"));
     }
     if old.export_policy != new.export_policy {
-        changes.push("export_policy: <changed>".to_string());
+        changes.push(FieldChange::summarized("export_policy"));
     }
-    if old.import_policy_chain != new.import_policy_chain {
-        changes.push(format!(
-            "import_policy_chain: {:?} → {:?}",
-            old.import_policy_chain, new.import_policy_chain
-        ));
-    }
-    if old.export_policy_chain != new.export_policy_chain {
-        changes.push(format!(
-            "export_policy_chain: {:?} → {:?}",
-            old.export_policy_chain, new.export_policy_chain
-        ));
-    }
+    cmp_field!(import_policy_chain);
+    cmp_field!(export_policy_chain);
 
     changes
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4093,7 +4093,9 @@ fn diff_neighbors_detects_prefix_orf_receive_only_change() {
 
     let changes = super::describe_neighbor_changes(&old[0], &diff.changed[0]);
     assert!(
-        changes.iter().any(|c| c.contains("prefix_orf_receive")),
+        changes
+            .iter()
+            .any(|c| c.render().contains("prefix_orf_receive")),
         "describe_neighbor_changes must name prefix_orf_receive, got {changes:?}"
     );
 }
@@ -4114,7 +4116,9 @@ fn diff_neighbors_detects_disable_ipv4_unicast_only_change() {
 
     let changes = super::describe_neighbor_changes(&old[0], &diff.changed[0]);
     assert!(
-        changes.iter().any(|c| c.contains("disable_ipv4_unicast")),
+        changes
+            .iter()
+            .any(|c| c.render().contains("disable_ipv4_unicast")),
         "describe_neighbor_changes must name disable_ipv4_unicast, got {changes:?}"
     );
 }
@@ -4826,9 +4830,9 @@ fn describe_neighbor_changes_detects_field_diffs() {
 
     let changes = super::describe_neighbor_changes(&old, &new);
     assert_eq!(changes.len(), 3);
-    assert!(changes[0].contains("remote_asn"));
-    assert!(changes[1].contains("hold_time"));
-    assert!(changes[2].contains("families"));
+    assert!(changes[0].render().contains("remote_asn"));
+    assert!(changes[1].render().contains("hold_time"));
+    assert!(changes[2].render().contains("families"));
 }
 
 #[test]
@@ -4846,8 +4850,8 @@ fn describe_neighbor_changes_hides_md5_value() {
 
     let changes = super::describe_neighbor_changes(&old, &new);
     assert_eq!(changes.len(), 1);
-    assert!(changes[0].contains("<changed>"));
-    assert!(!changes[0].contains("secret"));
+    assert!(changes[0].render().contains("<changed>"));
+    assert!(!changes[0].render().contains("secret"));
 }
 
 #[test]
@@ -4864,10 +4868,133 @@ fn describe_neighbor_changes_hides_tcp_ao_key() {
     });
 
     let changes = super::describe_neighbor_changes(&old, &new);
-    assert_eq!(
-        changes,
-        vec!["tcp_ao: <changed restart-required>".to_string()]
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].render(), "tcp_ao: <changed>  [restart required]");
+    assert!(!changes[0].render().contains("secret"));
+    assert_eq!(changes[0].old, serde_json::Value::Null);
+    assert_eq!(changes[0].new, serde_json::Value::Null);
+}
+
+// ── LAN-321: operator-grade diff rendering + impact classification ───
+
+#[test]
+fn config_field_impact_surfaces_reload_matrix_classes() {
+    use super::ConfigFieldImpact::{HotApplied, RestartRequired, SessionReset};
+    let class = |field: &str| super::config_field_impact(field).map(|(class, _)| class);
+
+    // Session-affecting: a hold_time edit classifies as session reset.
+    assert_eq!(class("hold_time"), Some(SessionReset));
+    assert_eq!(class("families"), Some(SessionReset));
+    assert_eq!(class("md5_password"), Some(SessionReset));
+    // Hot-applied: a description edit never touches the session.
+    assert_eq!(class("description"), Some(HotApplied));
+    assert_eq!(class("log_level"), Some(HotApplied));
+    assert_eq!(class("max_prefixes"), Some(HotApplied));
+    // Restart-required, matching the reload matrix pins.
+    assert_eq!(class("tcp_ao"), Some(RestartRequired));
+    assert_eq!(class("bfd"), Some(RestartRequired));
+    // The existing classifiers disagree on these (reload matrix vs the
+    // reconcile / reshape executors), so the diff renders no annotation.
+    assert_eq!(class("remote_asn"), None);
+    assert_eq!(class("peer_group"), None);
+}
+
+#[test]
+fn config_diff_human_output_is_operator_grade() {
+    // Mixed diff: one added, one changed (hot + session-reset fields),
+    // one untouched neighbor.
+    let mut old = parse(valid_toml()).unwrap();
+    old.neighbors = vec![
+        test_neighbor("10.0.0.2", 65002),
+        test_neighbor("10.0.0.9", 65009),
+    ];
+    old.neighbors[0].hold_time = Some(90);
+    let mut new = old.clone();
+    new.neighbors[0].hold_time = Some(30);
+    new.neighbors[0].description = Some("edge".to_string());
+    new.neighbors.push(test_neighbor("10.0.0.3", 65003));
+
+    let diff = super::diff_config(&old, &new);
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+
+    // The 0.50.0 defect: Rust Debug formatting leaked into operator output.
+    assert!(!text.contains("Some("), "{text}");
+    assert!(!text.contains("None"), "{text}");
+
+    assert!(text.contains("+ 10.0.0.3 (AS 65003)"), "{text}");
+    assert!(
+        text.contains("hold_time: 90 → 30  [session reset: OPEN renegotiation]"),
+        "{text}"
     );
+    assert!(
+        text.contains("description: (unset) → edge  [hot-applied]"),
+        "{text}"
+    );
+    assert!(
+        !text.contains("10.0.0.9"),
+        "unchanged neighbors must not appear: {text}"
+    );
+    assert!(
+        text.ends_with("Plan: 1 to add, 1 to change · 1 session will reset\n"),
+        "{text}"
+    );
+}
+
+#[test]
+fn config_diff_json_changes_have_stable_field_shape() {
+    let mut old = parse(valid_toml()).unwrap();
+    old.neighbors = vec![test_neighbor("10.0.0.2", 65002)];
+    old.neighbors[0].hold_time = Some(90);
+    let mut new = old.clone();
+    new.neighbors[0].hold_time = Some(30);
+    new.neighbors[0].description = Some("edge".to_string());
+
+    let diff = super::diff_config(&old, &new);
+    let json = super::config_diff_json_value(&diff);
+
+    let changes = &json["reload_applied"]["neighbors"]["changed"][0]["changes"];
+    // describe order: description before hold_time.
+    assert_eq!(changes[0]["field"], "description");
+    assert_eq!(changes[0]["old"], serde_json::Value::Null);
+    assert_eq!(changes[0]["new"], "edge");
+    assert_eq!(changes[0]["impact"], "hot_applied");
+    assert_eq!(changes[1]["field"], "hold_time");
+    assert_eq!(changes[1]["old"], 90);
+    assert_eq!(changes[1]["new"], 30);
+    assert_eq!(changes[1]["impact"], "session_reset");
+
+    assert_eq!(json["summary"]["neighbors_added"], 0);
+    assert_eq!(json["summary"]["neighbors_changed"], 1);
+    assert_eq!(json["summary"]["neighbors_removed"], 0);
+    assert_eq!(json["summary"]["sessions_will_reset"], 1);
+    assert_eq!(json["summary"]["restart_required"], false);
+}
+
+#[test]
+fn config_diff_summary_line_covers_restart_and_no_reset_cases() {
+    // Hot-applied-only change: no session resets expected.
+    let mut old = parse(valid_toml()).unwrap();
+    old.neighbors = vec![test_neighbor("10.0.0.2", 65002)];
+    let mut new = old.clone();
+    new.neighbors[0].description = Some("edge".to_string());
+    let diff = super::diff_config(&old, &new);
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(
+        text.ends_with("Plan: 1 to change · no session resets expected\n"),
+        "{text}"
+    );
+
+    // Restart-required change ([policy.explain]): the summary names the
+    // restart and makes no "no resets" claim.
+    let mut new = old.clone();
+    new.policy.explain.cache_size = 512;
+    let diff = super::diff_config(&old, &new);
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(
+        text.ends_with("Plan: no neighbor changes · daemon restart required for some changes\n"),
+        "{text}"
+    );
+    assert!(!text.contains("no session resets expected"), "{text}");
 }
 
 #[test]
@@ -4985,7 +5112,7 @@ hold_time = 45
         diff.neighbors.changed[0]
             .changes
             .iter()
-            .any(|c| c.contains("hold_time"))
+            .any(|c| c.render().contains("hold_time"))
     );
 }
 
@@ -5073,11 +5200,14 @@ fn diff_config_role_change_is_reload_applied() {
             .changed
             .iter()
             .any(|summary| summary.address == "10.0.0.2"
-                && summary.changes.iter().any(|change| change.contains("role"))
                 && summary
                     .changes
                     .iter()
-                    .any(|change| change.contains("strict_role"))),
+                    .any(|change| change.render().contains("role"))
+                && summary
+                    .changes
+                    .iter()
+                    .any(|change| change.render().contains("strict_role"))),
         "neighbor details must explain role/strict_role drift: {:?}",
         diff.neighbors.changed
     );
@@ -5199,9 +5329,9 @@ fn diff_peer_group_changes_detects_field_diffs() {
     };
     let changes = super::describe_peer_group_changes(&old, &new);
     assert_eq!(changes.len(), 1);
-    assert!(changes[0].contains("hold_time"));
-    assert!(changes[0].contains("90"));
-    assert!(changes[0].contains("45"));
+    assert!(changes[0].render().contains("hold_time"));
+    assert!(changes[0].render().contains("90"));
+    assert!(changes[0].render().contains("45"));
 }
 
 /// Policy-only edits are now reload-applied (per-named definitions
@@ -12432,7 +12562,9 @@ fn send_hold_time_change_is_a_runtime_neighbor_change() {
     assert_eq!(diff.changed.len(), 1);
     let changes = super::describe_neighbor_changes(&old, &new);
     assert!(
-        changes.iter().any(|c| c.contains("send_hold_time")),
+        changes
+            .iter()
+            .any(|c| c.render().contains("send_hold_time")),
         "{changes:?}"
     );
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -707,7 +707,7 @@ md5_password = "new-secret"
     assert!(diff.human_text.contains("md5_password: <changed>"));
     assert!(!diff.human_text.contains("old-secret"));
     assert!(!diff.human_text.contains("new-secret"));
-    assert!(diff.diff_json.contains("md5_password: <changed>"));
+    assert!(diff.diff_json.contains("\"field\": \"md5_password\""));
     assert!(!diff.diff_json.contains("old-secret"));
     assert!(!diff.diff_json.contains("new-secret"));
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1225,7 +1225,10 @@ pub(crate) async fn reload_config(
             .collect();
         for n in &diff.changed {
             if let Some(old_n) = old_map.get(n.address.as_str()) {
-                let changes = config::describe_neighbor_changes(old_n, n);
+                let changes: Vec<String> = config::describe_neighbor_changes(old_n, n)
+                    .iter()
+                    .map(config::FieldChange::render)
+                    .collect();
                 info!(
                     address = %n.address,
                     changes = %changes.join(", "),


### PR DESCRIPTION
## Summary

- config diff/plan output no longer leaks Rust Debug formatting (`Some(90) → Some(30)`, `{:?}` policy chains) — fixed server-side in the shared diff renderer, so `rustbgpd --diff` benefits too
- every changed field is annotated with its reload-matrix impact class (`[hot-applied]`, `[session reset: OPEN renegotiation / TCP re-establish / session re-establish]`, `[restart required]`), with a terraform-style summary line (`Plan: 1 to add, 1 to change · 1 session will reset`); fields whose impact the classifier does not know render without an annotation rather than guessing
- exit codes adopt the detailed contract CI pipelines key on: 0 no changes, 1 error, 2 changes present — documented in help for both diff and plan, noted as distinct from the route-diff contract
- JSON gains structured change objects ({field, old, new, impact}, honest nulls per house convention) and a machine summary including sessions_will_reset; secrets and inline policy bodies stay redacted in both forms
- verified live against a lab daemon: rendering, all exit-code cases, and JSON shape captured

## Note for follow-up (tracked separately)

The reload matrix's per-field "live" classifications are in tension with the reconcile mechanics, which delete-and-re-add the session task for any changed static-neighbor field. This PR surfaces the matrix verbatim per its test-pinned classes; the doc-vs-mechanics discrepancy is filed for adjudication.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpctl (350) / --bin rustbgpd (1356) / -p rustbgpd-api / -p rustbgpd --lib
- cargo doc --workspace --no-deps
- release build + live lab smoke (captures in the issue)

Closes LAN-321.