### PR TITLE
chore(telemetry): remove the deprecated bgp_aspa_records_total alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (LAN-318)
 
 ### Changed
+- Removed the deprecated `bgp_aspa_records_total` gauge alias; `bgp_aspa_records` is the only exported name
 
 - **Release publication is now fail-closed.** The binary-release and
   container-image workflows refuse to publish unless the pushed tag

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -361,7 +361,7 @@ impl RibManager {
         let Some(table) = self.aspa_table.as_ref() else {
             return;
         };
-        self.metrics.set_aspa_records_total(gauge_val(table.len()));
+        self.metrics.set_aspa_records(gauge_val(table.len()));
 
         let mut affected = HashSet::new();
         for rib in self.ribs.values_mut() {

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -165,10 +165,6 @@ pub struct BgpMetrics {
 
     // ── ASPA ───────────────────────────────────────────────────
     aspa_records: IntGauge,
-    /// Deprecated alias kept for one release; remove after the
-    /// `bgp_aspa_records` rename ships (a gauge must not carry a
-    /// `_total` suffix).
-    aspa_records_total: IntGauge,
 
     // ── Validation-cache import refresh ───────────────────────
     validation_import_refreshes: IntCounterVec,
@@ -854,13 +850,6 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
-        let aspa_records_total = IntGauge::new(
-            "bgp_aspa_records_total",
-            "DEPRECATED: gauge misnamed with a counter `_total` suffix; \
-             use bgp_aspa_records instead. Removed in the next release.",
-        )
-        .expect("valid metric definition");
-
         let validation_import_refreshes = IntCounterVec::new(
             Opts::new(
                 "bgp_validation_import_refreshes_total",
@@ -1511,9 +1500,6 @@ impl BgpMetrics {
             .register(Box::new(aspa_records.clone()))
             .expect("metric not already registered");
         registry
-            .register(Box::new(aspa_records_total.clone()))
-            .expect("metric not already registered");
-        registry
             .register(Box::new(validation_import_refreshes.clone()))
             .expect("metric not already registered");
         registry
@@ -1750,7 +1736,6 @@ impl BgpMetrics {
             gr_timer_expired,
             rpki_vrp_count,
             aspa_records,
-            aspa_records_total,
             validation_import_refreshes,
             route_refresh_in_progress,
             route_refresh_stale_entries,
@@ -2539,12 +2524,8 @@ impl BgpMetrics {
     }
 
     /// Set ASPA record count.
-    ///
-    /// Also updates the deprecated `bgp_aspa_records_total` alias,
-    /// kept for one release after the `bgp_aspa_records` rename.
-    pub fn set_aspa_records_total(&self, count: i64) {
+    pub fn set_aspa_records(&self, count: i64) {
         self.aspa_records.set(count);
-        self.aspa_records_total.set(count);
     }
 
     /// Record validation-cache-triggered inbound Route Refresh work.
@@ -3586,15 +3567,14 @@ mod tests {
     }
 
     #[test]
-    fn aspa_records_exports_new_name_and_deprecated_alias() {
+    fn aspa_records_exports_only_the_correct_gauge_name() {
         let m = BgpMetrics::new();
-        m.set_aspa_records_total(3);
+        m.set_aspa_records(3);
 
         let text = gather_text(&m);
         assert!(text.contains("bgp_aspa_records 3"));
-        // Deprecated alias kept for one release after the rename.
-        assert!(text.contains("bgp_aspa_records_total 3"));
-        assert!(text.contains("DEPRECATED"));
+        // The misnamed `_total` alias is gone; a gauge must not carry it.
+        assert!(!text.contains("bgp_aspa_records_total"));
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -761,7 +761,7 @@ details stay in the structured daemon log and RPC status.
 |--------|-------------------|
 | `bgp_rpki_vrp_count{af="ipv4"}` | IPv4 VRP entries loaded |
 | `bgp_rpki_vrp_count{af="ipv6"}` | IPv6 VRP entries loaded |
-| `bgp_aspa_records` | ASPA customer records loaded in the merged table. Renamed from `bgp_aspa_records_total` (a gauge must not carry the counter `_total` suffix); the old name is still exported as a deprecated alias for one release |
+| `bgp_aspa_records` | ASPA customer records loaded in the merged table. Renamed from `bgp_aspa_records_total` (a gauge must not carry the counter `_total` suffix) |
 | `bgp_validation_import_refreshes_total{dependency, outcome}` | Inbound Route Refresh work triggered by VRP / ASPA cache updates for peers whose import policy matches validation state. `dependency` is `rpki` or `aspa`; `outcome` is `eligible`, `refreshed`, `skipped_not_established`, or `failed`. |
 
 A sudden drop in VRP count likely means a cache connection was lost or the


### PR DESCRIPTION
## Summary

- the gauge rename to `bgp_aspa_records` (#790) and this removal land in the same unreleased cycle, so no released artifact ever exported the alias — carrying a one-release deprecation window for a name nobody could have scraped is ceremony; removed
- the setter is renamed to match (`set_aspa_records`), the telemetry test now asserts the misnamed `_total` form is absent, and the OPERATIONS.md note drops the alias sentence

## Verification

- cargo fmt --all -- --check
- cargo clippy -p rustbgpd-telemetry -p rustbgpd-rib --all-targets -- -D warnings
- cargo test -p rustbgpd-telemetry / -p rustbgpd-rib (graceful-restart caller updated)