### PR TITLE
fix(config): apply hot-applicable neighbor edits in place on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **SIGHUP config edits limited to hot-applicable neighbor fields no
+  longer rebuild the session.** The reload reconciler previously
+  delete/re-added the session task for any changed static-neighbor
+  field, bouncing an Established session even for a `description` or
+  `log_level` edit that `docs/reload-matrix.md` classes as live.
+  Changed neighbors are now partitioned by the reload-matrix impact of
+  their changed-field set: an edit touching only hot-applied fields
+  (`description`, `max_prefixes`, `gr_stale_routes_time`,
+  `local_ipv6_nexthop`, `remove_private_as`, `log_level`, import/export
+  policies and chains) applies in place — session task, TCP connection,
+  and FSM untouched, with policy edits still driving Route Refresh and
+  Adj-RIB-Out re-emit. Any session-reset or restart-required field in
+  the same edit keeps the neighbor on the rebuild path, which applies
+  the whole edit through one session reset. `remote_asn` and
+  `peer_group` edits — previously unannotated because the matrix and
+  the reconcile mechanics disagreed — are now classed as session
+  resets in `rustbgpd --diff` / `rbgp config diff` output, matching
+  the shipped behavior (an ASN edit rebuilds the session immediately
+  under the new ASN; a peer-group reassignment rebuilds to re-resolve
+  inheritance), and the reload matrix's `[[neighbors]]` section now
+  documents the real diff key (`address`, `interface`) and the
+  immediate-rebuild semantics of session-reset fields. (LAN-341)
+
 - **`rbgp policy explain` no longer reports `not_seen` when the truth
   is a disabled cache or a missing session.** The explain RPC
   previously folded "no live session with this peer" and
@@ -414,9 +437,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inline-policy fields stay summarized as `<changed>`. Each changed
   neighbor / peer-group field is annotated with its reload-matrix
   impact class (`[hot-applied]`, `[session reset: OPEN renegotiation]`
-  / `TCP re-establish` / `session re-establish`, `[restart required]`;
-  fields whose class the existing classifiers disagree on carry no
-  annotation), and the diff ends with a rollup line (`Plan: 1 to add,
+  / `TCP re-establish` / `session re-establish`, `[restart required]`),
+  and the diff ends with a rollup line (`Plan: 1 to add,
   1 to change · 1 session will reset`). The JSON diff's `changes`
   entries are now structured objects with the stable key set `{field,
   old, new, impact}` (honest `null` for absent values and unknown

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -851,6 +851,22 @@ pub enum PeerManagerCommand {
         /// Reply channel with reconciliation results.
         reply: oneshot::Sender<ReconcileResult>,
     },
+    /// LAN-341: apply a config change whose every edited field is
+    /// reload-matrix `live` (hot-applied) to an existing static peer in
+    /// place — no session-task delete/re-add, no TCP/FSM impact. The
+    /// SIGHUP reload path routes a changed neighbor here instead of
+    /// `ReconcilePeers.changed` when the changed-field set is entirely
+    /// hot-applicable (`description`, `max_prefixes`,
+    /// `gr_stale_routes_time`, `local_ipv6_nexthop`,
+    /// `remove_private_as`, `log_level`, import/export policies and
+    /// chains).
+    HotUpdatePeer {
+        /// Full replacement neighbor configuration (only hot-applicable
+        /// fields may differ from the live peer's).
+        config: PeerManagerNeighborConfig,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), PeerLifecycleError>>,
+    },
     /// ADR-0073: refresh the peer manager's `[policy.explain]` snapshot
     /// (`enabled` / `cache_size`) ahead of any reload step that
     /// constructs sessions. `build_transport_config` reads these from

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -295,6 +295,24 @@ pub enum PeerCommand {
         /// Reply channel for success/failure.
         reply: oneshot::Sender<Result<(), PeerCommandError>>,
     },
+    /// Hot-apply reload-matrix `live` per-session runtime knobs without
+    /// tearing the session task down (LAN-341). Every carried field is
+    /// re-read from the session config on each evaluation (inbound UPDATE
+    /// for `max_prefixes`, outbound emission for `local_ipv6_nexthop` /
+    /// `remove_private_as`, GR peer-down for `gr_stale_routes_time`), so
+    /// the swap takes effect on the next evaluation.
+    UpdateRuntimeConfig {
+        /// Maximum prefixes accepted before Cease/1 (None = unlimited).
+        max_prefixes: Option<u32>,
+        /// Stale-route retention after peer restart (seconds).
+        gr_stale_routes_time: u64,
+        /// Explicit IPv6 next-hop for eBGP (None = derive from socket).
+        local_ipv6_nexthop: Option<std::net::Ipv6Addr>,
+        /// Private AS removal mode for outbound `AS_PATH`.
+        remove_private_as: crate::config::RemovePrivateAs,
+        /// Reply channel for success/failure.
+        reply: oneshot::Sender<Result<(), PeerCommandError>>,
+    },
     /// RFC 8326 graceful-shutdown initiator: toggle attaching the
     /// `GRACEFUL_SHUTDOWN` community to outbound updates from this
     /// session. Receiver behavior on the *other* side of the session
@@ -1265,6 +1283,49 @@ impl PeerHandle {
             Ok(result) => result,
             Err(_elapsed) => Err(PeerCommandError::TimedOut {
                 operation: "update_export_policy",
+                deadline,
+            }),
+        }
+    }
+
+    /// Bounded hot-apply of reload-matrix `live` per-session runtime
+    /// knobs ([`PeerCommand::UpdateRuntimeConfig`]). Mirrors
+    /// [`Self::update_import_policy_timeout`]'s bounded shape for the
+    /// same reason: the peer-manager actor calls this and must not park
+    /// behind a wedged session task.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is unreachable, replies with one,
+    /// or doesn't acknowledge inside `deadline`.
+    pub async fn update_runtime_config_timeout(
+        &self,
+        max_prefixes: Option<u32>,
+        gr_stale_routes_time: u64,
+        local_ipv6_nexthop: Option<std::net::Ipv6Addr>,
+        remove_private_as: crate::config::RemovePrivateAs,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
+        let commands = self.commands.clone();
+        match tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::UpdateRuntimeConfig {
+                    max_prefixes,
+                    gr_stale_routes_time,
+                    local_ipv6_nexthop,
+                    remove_private_as,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| PeerCommandError::SessionExited)?;
+            reply_rx.await.map_err(|_| PeerCommandError::ReplyDropped)?
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(PeerCommandError::TimedOut {
+                operation: "update_runtime_config",
                 deadline,
             }),
         }

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -173,6 +173,27 @@ impl PeerSession {
                 let _ = reply.send(Ok(()));
                 ControlFlow::Continue(())
             }
+            PeerCommand::UpdateRuntimeConfig {
+                max_prefixes,
+                gr_stale_routes_time,
+                local_ipv6_nexthop,
+                remove_private_as,
+                reply,
+            } => {
+                // LAN-341 hot-apply: these knobs are read from
+                // `self.config` on every evaluation (see the command's
+                // doc), so swapping them here is the whole apply — no
+                // FSM event, no TCP impact. A lowered `max_prefixes`
+                // trips on the next received UPDATE, matching the
+                // reload matrix's documented semantics.
+                self.config.max_prefixes = max_prefixes;
+                self.config.gr_stale_routes_time = gr_stale_routes_time;
+                self.config.local_ipv6_nexthop = local_ipv6_nexthop;
+                self.config.remove_private_as = remove_private_as;
+                info!(peer = %self.peer_label, "hot-applied runtime config knobs");
+                let _ = reply.send(Ok(()));
+                ControlFlow::Continue(())
+            }
             PeerCommand::UpdateGracefulShutdown { enabled, reply } => {
                 // Idempotent: re-setting to the same value is a no-op.
                 // The toggle takes effect for the next outbound update;

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -4,8 +4,10 @@ Reference for every user-facing config key: what does it take to put a
 change into effect?
 
 This doc is the operator-facing index. The authoritative classification
-lives in the source — `neighbor_runtime_equal()` and `ConfigDiff` (in
-`src/config/mod.rs`), `reload.rs` (pinning helpers `pin_tcp_ao_startup_only_runtime`,
+lives in the source — `neighbor_runtime_equal()`, `config_field_impact()`,
+`neighbor_change_hot_applicable()`, and `ConfigDiff` (in
+`src/config/mod.rs`), `reload.rs` (the changed-neighbor hot/rebuild
+partition, pinning helpers `pin_tcp_ao_startup_only_runtime`,
 `pin_bfd_startup_only_runtime`, and the per-section error/warn arms), and
 the parse-time `ConfigError` family in `src/config/validation.rs`. If
 the matrix and the code disagree, the code is right and the matrix has a
@@ -24,13 +26,26 @@ bug — file an issue.
 
 ## Session-establishment caveat
 
-Several **live** fields take effect on the *next session establishment*,
-not mid-session. Examples: `md5_password`, `families`, `add_path`,
-`graceful_restart`. These are not restart-required (the daemon doesn't
-need to restart to pick them up) but they only become observable after
-the affected session is bounced — by the peer, by `rbgp neighbor
-disable`/`enable`, or by any natural flap. The matrix calls this out per
-row.
+Several **live** fields bind at session establishment (OPEN negotiation
+or socket creation), not mid-session. Examples: `md5_password`,
+`families`, `add_path`, `graceful_restart`, `hold_time`. These are not
+restart-required, but applying them takes a session reset — and on
+SIGHUP reload of a static neighbor the reconciler performs that reset
+**immediately**: any changed session-reset-class field routes the
+neighbor through the session rebuild path (delete + re-add of the
+session task), so the new value is negotiated right away rather than
+waiting for a natural flap. The matrix calls this out per row as
+"live (effective next session)"; `rustbgpd --diff` annotates these
+fields "session reset".
+
+Static-neighbor edits whose **every** changed field is hot-applied
+(`description`, `max_prefixes`, `gr_stale_routes_time`,
+`local_ipv6_nexthop`, `remove_private_as`, `log_level`, and the
+import/export policy and chain fields) are applied **in place**: the
+session task, its TCP connection, and the FSM are untouched, and policy
+edits trigger the usual Route Refresh / Adj-RIB-Out re-emit. Mixing a
+hot-applied edit with a session-reset edit on the same neighbor applies
+both through one session rebuild.
 
 ---
 
@@ -63,28 +78,31 @@ sessions.
 
 ## `[[neighbors]]`
 
-The diff key is the `(address, interface, remote_asn)` triple. Changing
-any of those three is treated as **delete + add** by the reconciler —
-the old neighbor is torn down, the new one starts fresh.
+The diff key is the `(address, interface)` pair. Changing either is
+treated as **delete + add** by the reconciler — the old neighbor is torn
+down, the new one starts fresh. `remote_asn` is *not* part of the diff
+key: an ASN edit flows through reconcile as an immediate session rebuild
+under the new ASN (the same delete + re-add semantics, applied in one
+reload).
 
 | Field | Class | Notes |
 |---|---|---|
 | `address` | restart-required (identity) | Part of the diff key. Edit = delete + add. To change the peer address in place, delete the old neighbor (gRPC or remove from config + reload), then add the new one. |
 | `interface` | restart-required (identity) | Part of the diff key. Same as `address`. Used by IPv6 link-local + BGP unnumbered peering. |
-| `remote_asn` | restart-required (identity) | Part of the diff key. Same as `address`. |
-| `description` | live | Metadata only; flows through reconcile. |
-| `peer_group` | live | Group inheritance resolves at reconcile time; effective fields update in place. |
-| `hold_time` | live (effective next session) | New value used in the next OPEN exchange. Existing session keeps the negotiated hold time until renegotiation. |
+| `remote_asn` | live (session reset, identity) | Not part of the diff key: on SIGHUP the reconciler rebuilds the session immediately with the new ASN. Equivalent to delete + add of the neighbor — no daemon restart needed. Annotated "session reset: peer re-established with new ASN" by `rustbgpd --diff`. |
+| `description` | live | Metadata only; hot-applied in place — session task untouched. |
+| `peer_group` | live (session reset) | A reassignment changes the peer's effective inherited config, so SIGHUP reconcile (and the transaction session-reshape executor) rebuild the session. Group *field* edits on an unchanged membership hot-apply per the `[peer_groups.<name>]` table below. |
+| `hold_time` | live (effective next session) | Negotiated in OPEN. On SIGHUP the reconciler rebuilds the session immediately, so the new value is negotiated right away. |
 | `send_hold_time` | live (effective next session) | RFC 9687 send hold timer. The per-peer writer task captures the value when its TCP connection is established, so a new value (including 0 = disable) guards the next session; the existing session keeps the old timer. |
 | `max_prefixes` | live | Threshold re-evaluated on every received UPDATE. |
-| `md5_password` | live (effective next session) | New password is staged in the transport config; the next active-open socket installs it. **TCP-MD5 keys are per-socket**, so the running session keeps the old key until it bounces. To rotate, change the value and either wait for a natural flap or disable+enable the neighbor. |
+| `md5_password` | live (effective next session) | **TCP-MD5 keys are per-socket.** On SIGHUP the reconciler rebuilds the session immediately, so the new key is installed on the rebuilt socket right away. |
 | `tcp_ao` | restart-required | Pinned by `pin_tcp_ao_startup_only_runtime`. RFC 5925 MKTs are installed only when the socket is created (active-open) or when the passive listener boots. Add/remove/rotate requires a daemon restart. Logged at `ERROR` during reload. |
 | `bfd` | restart-required | Pinned by `pin_bfd_startup_only_runtime`. The ADR-0067 BFD actor resolves `[[bfd_profiles]]` plus per-neighbor/peer-group `bfd` once at startup. Logged at `ERROR` during reload. |
 | `ttl_security` | live (effective next session) | New value passed through reconcile; takes effect on next TCP connect (GTSM is a socket option). |
 | `families` | live (effective next session) | Address families to negotiate in OPEN. Negotiated capability set is fixed for the life of a session. |
 | `graceful_restart` | live (effective next session) | GR capability advertised in OPEN. Toggling on an established session has no in-session effect. |
 | `gr_restart_time` | live (effective next session) | Advertised in GR capability. |
-| `gr_stale_routes_time` | live | Used by the local stale-route reaper for received GR routes. Re-evaluated against existing stale routes on reconcile. |
+| `gr_stale_routes_time` | live | Used by the local stale-route reaper for received GR routes. Hot-applied in place; the new value governs the next GR peer-down event. |
 | `llgr_stale_time` | live (effective next session) | RFC 9494 LLGR capability stale time. |
 | `local_ipv6_nexthop` | live | Used on outbound advertisements; new value applied on next route emission. |
 | `route_reflector_client` | live (effective next session) | RFC 4456 RR-client flag affects iBGP best-path + reflection behavior. Toggling re-evaluates the existing Adj-RIB-Out on the next distribution pass. |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1645,13 +1645,18 @@ pub enum ConfigFieldImpact {
 /// peer-group field named by [`describe_neighbor_changes`] /
 /// [`describe_peer_group_changes`].
 ///
-/// Fields whose class the existing classifiers disagree on return `None`
-/// and the diff renders no annotation rather than guessing:
-/// - `remote_asn`: the matrix classes it restart-required identity, but
-///   `diff_neighbors` keys on `(address, interface)` only, so an edit
-///   flows through the reconcile delete/re-add path.
-/// - `peer_group`: the matrix classes it live, but the transaction
-///   executor routes a reassignment to the session-reshape executor.
+/// Adjudicated live against a lab peer for LAN-341, so the classes below
+/// are the shipped reload behavior, not aspiration:
+/// - Hot-applied fields are applied in place by the reload partition
+///   (`neighbor_change_hot_applicable` → `HotUpdatePeer`) without
+///   touching the session task.
+/// - `remote_asn`: `diff_neighbors` keys on `(address, interface)`, so
+///   an ASN edit flows through reconcile as an immediate session rebuild
+///   under the new ASN — identity delete+add semantics without a daemon
+///   restart.
+/// - `peer_group`: a reassignment changes the peer's effective inherited
+///   config, so both SIGHUP reconcile and the transaction session-reshape
+///   executor rebuild the session.
 fn config_field_impact(field: &str) -> Option<(ConfigFieldImpact, &'static str)> {
     Some(match field {
         "description"
@@ -1664,6 +1669,14 @@ fn config_field_impact(field: &str) -> Option<(ConfigFieldImpact, &'static str)>
         | "export_policy"
         | "import_policy_chain"
         | "export_policy_chain" => (ConfigFieldImpact::HotApplied, "hot-applied"),
+        "remote_asn" => (
+            ConfigFieldImpact::SessionReset,
+            "session reset: peer re-established with new ASN",
+        ),
+        "peer_group" => (
+            ConfigFieldImpact::SessionReset,
+            "session reset: reassignment rebuilds the session",
+        ),
         "hold_time"
         | "families"
         | "graceful_restart"
@@ -1848,6 +1861,23 @@ pub fn describe_neighbor_changes(old: &Neighbor, new: &Neighbor) -> Vec<FieldCha
     cmp_field!(export_policy_chain);
 
     changes
+}
+
+/// True when every field that differs between `old` and `new` is
+/// reload-matrix `live` (hot-applied), so a SIGHUP reload can apply the
+/// change to the running peer in place instead of delete/re-adding the
+/// session task (LAN-341).
+///
+/// Conservative on both edges: an empty change list (a runtime-relevant
+/// field `describe_neighbor_changes` doesn't cover) and any field with an
+/// unknown impact class both return `false`, keeping the rebuild path as
+/// the fallback.
+pub fn neighbor_change_hot_applicable(old: &Neighbor, new: &Neighbor) -> bool {
+    let changes = describe_neighbor_changes(old, new);
+    !changes.is_empty()
+        && changes
+            .iter()
+            .all(|change| change.impact == Some(ConfigFieldImpact::HotApplied))
 }
 
 /// Compare two neighbor lists and return the differences.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4893,10 +4893,48 @@ fn config_field_impact_surfaces_reload_matrix_classes() {
     // Restart-required, matching the reload matrix pins.
     assert_eq!(class("tcp_ao"), Some(RestartRequired));
     assert_eq!(class("bfd"), Some(RestartRequired));
-    // The existing classifiers disagree on these (reload matrix vs the
-    // reconcile / reshape executors), so the diff renders no annotation.
-    assert_eq!(class("remote_asn"), None);
-    assert_eq!(class("peer_group"), None);
+    // LAN-341 adjudication: both flow through the reconcile rebuild path
+    // (remote_asn is not part of the diff key; a peer_group reassignment
+    // changes the peer's effective inherited config), so both are honest
+    // session resets in the diff annotations.
+    assert_eq!(class("remote_asn"), Some(SessionReset));
+    assert_eq!(class("peer_group"), Some(SessionReset));
+}
+
+// ── LAN-341: hot-applicable partition predicate ───────────────────────
+
+#[test]
+fn neighbor_change_hot_applicable_partitions_by_impact_class() {
+    let old = test_neighbor("10.0.0.2", 65002);
+
+    // Hot-applied-only edit → in-place apply.
+    let mut hot = old.clone();
+    hot.description = Some("edge".to_string());
+    hot.max_prefixes = Some(500);
+    hot.import_policy_chain = vec!["allow-all".to_string()];
+    assert!(super::neighbor_change_hot_applicable(&old, &hot));
+
+    // No change at all → not hot-applicable (nothing to apply; the
+    // caller's diff should not have flagged it).
+    assert!(!super::neighbor_change_hot_applicable(&old, &old));
+
+    // A session-reset field alone → rebuild.
+    let mut reset = old.clone();
+    reset.hold_time = Some(30);
+    assert!(!super::neighbor_change_hot_applicable(&old, &reset));
+
+    // Mixed hot + session-reset → rebuild (one bounce applies both).
+    let mut mixed = hot.clone();
+    mixed.hold_time = Some(30);
+    assert!(!super::neighbor_change_hot_applicable(&old, &mixed));
+
+    // remote_asn and peer_group edits are session resets, never hot.
+    let mut asn = old.clone();
+    asn.remote_asn = 65003;
+    assert!(!super::neighbor_change_hot_applicable(&old, &asn));
+    let mut group = old.clone();
+    group.peer_group = Some("ix".to_string());
+    assert!(!super::neighbor_change_hot_applicable(&old, &group));
 }
 
 #[test]

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -366,6 +366,96 @@ impl PeerManager {
         Ok(previous)
     }
 
+    /// LAN-341: apply a hot-applicable-only config change to a live static
+    /// peer in place — the counterpart to [`Self::reconfigure_peer`] for
+    /// edits whose every changed field is reload-matrix `live`
+    /// (hot-applied). The session task, its TCP connection, and the FSM
+    /// are untouched: per-session runtime knobs swap through
+    /// `PeerCommand::UpdateRuntimeConfig`, and policy chains go through
+    /// the same live-policy seam as gRPC chain edits (Route Refresh +
+    /// Adj-RIB-Out re-emit included).
+    ///
+    /// The caller (reload's changed-neighbor partition) guarantees only
+    /// hot fields differ; this function doesn't re-verify, it just never
+    /// touches anything session-bound (identity, OPEN-negotiated, or
+    /// socket-scoped fields are copied from `config` into the stored
+    /// transport config by the next rebuild path, which resolves from the
+    /// config snapshot anyway).
+    pub(super) async fn hot_update_peer(
+        &mut self,
+        config: PeerManagerNeighborConfig,
+    ) -> Result<(), PeerLifecycleError> {
+        let peer = PeerKey::new(config.address, config.interface.clone());
+        let (knobs_changed, policies_changed) = {
+            let managed = self
+                .peers
+                .get(&peer)
+                .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
+            if managed.is_dynamic {
+                return Err(PeerLifecycleError::Invalid(format!(
+                    "hot update target {peer} is a dynamic peer; reload reconciles static neighbors only"
+                )));
+            }
+            let tc = &managed.transport_config;
+            (
+                tc.max_prefixes != config.max_prefixes
+                    || tc.gr_stale_routes_time != config.gr_stale_routes_time
+                    || tc.local_ipv6_nexthop != config.local_ipv6_nexthop
+                    || tc.remove_private_as != config.remove_private_as,
+                managed.import_policy != config.import_policy
+                    || managed.export_policy != config.export_policy,
+            )
+        };
+
+        // Policy first: the live-policy seam has its own rollback, so a
+        // failure here leaves the peer fully on its prior config. A
+        // later knob failure leaves policies advanced — safe, because
+        // reload halts, keeps the OLD neighbor in its snapshot, and the
+        // next SIGHUP re-detects and re-applies both (idempotent).
+        if policies_changed {
+            self.update_runtime_policies_fatal(
+                peer.clone(),
+                config.import_policy.clone(),
+                config.export_policy.clone(),
+            )
+            .await
+            .map_err(PeerLifecycleError::Internal)?;
+        }
+
+        let managed = self
+            .peers
+            .get_mut(&peer)
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
+        if knobs_changed {
+            managed
+                .handle
+                .update_runtime_config_timeout(
+                    config.max_prefixes,
+                    config.gr_stale_routes_time,
+                    config.local_ipv6_nexthop,
+                    config.remove_private_as,
+                    PEER_POLICY_UPDATE_TIMEOUT,
+                )
+                .await
+                .map_err(|error| {
+                    PeerLifecycleError::Internal(format!(
+                        "failed to hot-apply runtime knobs to {peer}: {error}"
+                    ))
+                })?;
+        }
+
+        // Manager-side bookkeeping so `rbgp neighbor list` and any later
+        // session rebuild see the new values.
+        managed.description.clone_from(&config.description);
+        managed.max_prefixes = config.max_prefixes;
+        managed.transport_config.max_prefixes = config.max_prefixes;
+        managed.transport_config.gr_stale_routes_time = config.gr_stale_routes_time;
+        managed.transport_config.local_ipv6_nexthop = config.local_ipv6_nexthop;
+        managed.transport_config.remove_private_as = config.remove_private_as;
+        info!(%peer, "hot-applied neighbor config change in place (no session rebuild)");
+        Ok(())
+    }
+
     pub(super) async fn apply_peer_reshape_snapshot(
         &mut self,
         targets: Vec<PeerManagerNeighborConfig>,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -794,6 +794,10 @@ impl PeerManager {
                             let result = self.reconcile_peers(added, removed, changed).await;
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::HotUpdatePeer { config, reply } => {
+                            let result = self.hot_update_peer(config).await;
+                            let _ = reply.send(result);
+                        }
                         PeerManagerCommand::SyncExplainConfig { enabled, cache_size, reply } => {
                             // ADR-0073: make the explain snapshot fresh before
                             // any subsequent reconcile/peer-group command on

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -153,6 +153,20 @@ impl PeerManager {
         let Some(peer_key) = self.unique_peer_key_for_address(address) else {
             return Ok(());
         };
+        self.update_runtime_policies_fatal(peer_key, import_policy, export_policy)
+            .await
+    }
+
+    /// Forward-apply resolved chains to one live peer with fatal refresh
+    /// handling — the seam LAN-341's `hot_update_peer` shares with the
+    /// gRPC chain-edit paths (session hot-apply, Route Refresh,
+    /// Adj-RIB-Out re-emit, `pending_*` retry carry).
+    pub(super) async fn update_runtime_policies_fatal(
+        &mut self,
+        peer_key: PeerKey,
+        import_policy: Option<PolicyChain>,
+        export_policy: Option<PolicyChain>,
+    ) -> Result<(), String> {
         self.update_runtime_policies_for_peer_key(
             peer_key,
             import_policy,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1135,6 +1135,131 @@ async fn reconfigure_peer_preserves_graceful_shutdown_intent() {
     assert!(managed.advertise_graceful_shutdown);
 }
 
+// ── LAN-341: hot-applicable-only edits apply in place ─────────────────
+
+#[tokio::test]
+async fn hot_update_peer_applies_in_place_without_session_rebuild() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+    let session_id_before = mgr.peers.get(&key(addr)).expect("peer").session_id;
+
+    let mut updated = make_config(addr, 65002);
+    updated.description = "hot-updated".to_string();
+    updated.max_prefixes = Some(500);
+    updated.gr_stale_routes_time = 300;
+    mgr.hot_update_peer(updated).await.unwrap();
+
+    let managed = mgr.peers.get(&key(addr)).expect("hot-updated peer");
+    // The load-bearing pin: the session task was NOT delete/re-added.
+    // Every rebuild path (`reconfigure_peer`, `reconcile_peers` changed)
+    // allocates a fresh session id; hot update must keep the same one.
+    assert_eq!(managed.session_id, session_id_before);
+    assert_eq!(managed.description, "hot-updated");
+    assert_eq!(managed.max_prefixes, Some(500));
+    assert_eq!(managed.transport_config.max_prefixes, Some(500));
+    assert_eq!(managed.transport_config.gr_stale_routes_time, 300);
+}
+
+#[tokio::test]
+async fn hot_update_peer_applies_policy_chains_in_place() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+    let session_id_before = mgr.peers.get(&key(addr)).expect("peer").session_id;
+
+    let mut updated = make_config(addr, 65002);
+    let chain = deny_policy_chain();
+    updated.import_policy = Some(chain.clone());
+    mgr.hot_update_peer(updated).await.unwrap();
+
+    let managed = mgr.peers.get(&key(addr)).expect("hot-updated peer");
+    assert_eq!(managed.session_id, session_id_before);
+    assert_eq!(managed.import_policy, Some(chain));
+}
+
+#[tokio::test]
+async fn hot_update_peer_unknown_peer_returns_not_found() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99));
+    let result = mgr.hot_update_peer(make_config(addr, 65002)).await;
+    assert!(matches!(
+        result,
+        Err(rustbgpd_api::peer_types::PeerLifecycleError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn reconcile_changed_peer_still_rebuilds_session_task() {
+    // The contrast pin for LAN-341: a session-reset-class change routed
+    // through `ReconcilePeers.changed` (the reload rebuild path) must
+    // still delete/re-add the session task — observable as a fresh
+    // session id.
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+    let session_id_before = mgr.peers.get(&key(addr)).expect("peer").session_id;
+
+    let mut changed = make_config(addr, 65002);
+    changed.hold_time = Some(30);
+    let result = mgr
+        .reconcile_peers(Vec::new(), Vec::new(), vec![changed])
+        .await;
+    assert!(result.failures.is_empty(), "{:?}", result.failures);
+
+    let managed = mgr.peers.get(&key(addr)).expect("rebuilt peer");
+    assert_ne!(managed.session_id, session_id_before);
+    assert_eq!(managed.hold_time, Some(30));
+}
+
 #[tokio::test]
 async fn reconfigure_peer_restores_previous_peer_when_replacement_add_fails() {
     let (_tx, rx) = mpsc::channel(16);

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1205,26 +1205,27 @@ pub(crate) async fn reload_config(
     // 5. Neighbor reconciliation. Only fires when the neighbor list
     //    itself moved; steps 1–4 already reshaped runtime state for
     //    inheritance-driven impact on existing neighbors.
+    //
+    //    LAN-341: changed neighbors are partitioned by the reload-matrix
+    //    impact of their changed-field set. A neighbor whose every
+    //    changed field is `live` (hot-applied) is updated in place via
+    //    `HotUpdatePeer` — no session-task delete/re-add, no flap. Any
+    //    session-reset or unknown-impact field keeps the neighbor on the
+    //    existing `ReconcilePeers` rebuild path.
     if !neighbors_unchanged {
-        info!(
-            added = diff.added.len(),
-            removed = diff.removed.len(),
-            changed = diff.changed.len(),
-            "reconciling neighbors after config reload"
-        );
-        for n in &diff.added {
-            info!(address = %n.address, asn = n.remote_asn, "neighbor added");
-        }
-        for addr in &diff.removed {
-            info!(address = %addr, "neighbor removed");
-        }
-        let old_map: std::collections::HashMap<&str, &config::Neighbor> = current
+        let old_map: std::collections::HashMap<(&str, Option<&str>), &config::Neighbor> = current
             .neighbors
             .iter()
-            .map(|n| (n.address.as_str(), n))
+            .map(|n| ((n.address.as_str(), n.interface.as_deref()), n))
             .collect();
+        let mut hot_changed: Vec<&config::Neighbor> = Vec::new();
+        let mut rebuild_changed: Vec<config::Neighbor> = Vec::new();
         for n in &diff.changed {
-            if let Some(old_n) = old_map.get(n.address.as_str()) {
+            let old_n = old_map
+                .get(&(n.address.as_str(), n.interface.as_deref()))
+                .copied();
+            let hot = old_n.is_some_and(|old_n| config::neighbor_change_hot_applicable(old_n, n));
+            if let Some(old_n) = old_n {
                 let changes: Vec<String> = config::describe_neighbor_changes(old_n, n)
                     .iter()
                     .map(config::FieldChange::render)
@@ -1232,9 +1233,28 @@ pub(crate) async fn reload_config(
                 info!(
                     address = %n.address,
                     changes = %changes.join(", "),
+                    apply = if hot { "hot-apply in place" } else { "session rebuild" },
                     "neighbor changed"
                 );
             }
+            if hot {
+                hot_changed.push(n);
+            } else {
+                rebuild_changed.push(n.clone());
+            }
+        }
+        info!(
+            added = diff.added.len(),
+            removed = diff.removed.len(),
+            hot_applied = hot_changed.len(),
+            rebuilt = rebuild_changed.len(),
+            "reconciling neighbors after config reload"
+        );
+        for n in &diff.added {
+            info!(address = %n.address, asn = n.remote_asn, "neighbor added");
+        }
+        for addr in &diff.removed {
+            info!(address = %addr, "neighbor removed");
         }
 
         let peer_configs = match new_config.resolved_neighbors() {
@@ -1282,83 +1302,126 @@ pub(crate) async fn reload_config(
                 .collect()
         };
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        if let Err(e) = peer_mgr_tx
-            .send(PeerManagerCommand::ReconcilePeers {
-                added: resolve(&diff.added),
-                removed: diff.removed.clone(),
-                changed: resolve(&diff.changed),
-                reply: reply_tx,
+        // Hot-applicable-only changes first: each peer is updated in
+        // place (session task untouched), and its entry in the honest
+        // working snapshot advances per peer on success. A failure halts
+        // like any other reload step — safe, because a hot update never
+        // deletes anything, and the stale snapshot entry makes the next
+        // SIGHUP re-detect and retry the same in-place update.
+        for n in hot_changed {
+            let Some(cfg) = resolve(std::slice::from_ref(n)).pop() else {
+                warn!(
+                    address = %n.address,
+                    "reload: hot-applicable neighbor missing from resolved set; skipping"
+                );
+                continue;
+            };
+            if let Err(error) = send_pm_result_step(peer_mgr_tx, |reply| {
+                PeerManagerCommand::HotUpdatePeer { config: cfg, reply }
             })
             .await
-        {
-            return halt_partial(
-                working_config,
-                &desired_config,
-                ReloadStepFailure {
-                    bucket: "neighbors.reconcile",
-                    target: String::new(),
-                    error: format!("send: {e}"),
-                },
-            );
-        }
-        match reply_rx.await {
-            Ok(reconcile) if reconcile.is_success() => {
-                working_config.neighbors = new_config.neighbors.clone();
+            {
+                return halt_partial(
+                    working_config,
+                    &desired_config,
+                    ReloadStepFailure {
+                        bucket: "neighbors.hot_update",
+                        target: n.address.clone(),
+                        error,
+                    },
+                );
             }
-            Ok(reconcile) => {
-                // Reconcile is the one step where partial failure
-                // leaves the live state genuinely ambiguous: it
-                // sequences delete-then-readd for changed peers,
-                // independent removes, and adds — any subset can
-                // succeed before the failure point, the manager
-                // doesn't update its own `current_config` during the
-                // run, and `delete_peer` / `add_peer` of the wrong
-                // ordering can leave orphaned `PeerHandle`s. Returning
-                // a guessed snapshot here would let the next reload
-                // diff against state that doesn't match live, which is
-                // worse than just bailing.
-                //
-                // Instead: return `None` so the daemon's in-memory
-                // config stays at `current` and log clearly that live
-                // state may differ. Operators investigate via
-                // `rbgp neighbor list`, fix the failing TOML,
-                // and reload again. The retry-succeeded-operations
-                // concern is bounded by the underlying ops being
-                // mostly idempotent (`delete_peer` of a missing peer
-                // returns Ok, `add_peer` of an existing peer returns
-                // a visible error rather than silent corruption); the
-                // operator gets surfaced errors on the retry rather
-                // than hidden drift.
-                for failure in &reconcile.failures {
-                    warn!(
-                        bucket = "neighbors.reconcile",
-                        target = %failure.peer,
-                        kind = ?failure.kind,
-                        error = %failure.error,
-                        "config reload step failed"
-                    );
+            if let Some(entry) = working_config
+                .neighbors
+                .iter_mut()
+                .find(|w| w.address == n.address && w.interface == n.interface)
+            {
+                *entry = n.clone();
+            }
+            info!(address = %n.address, "reload: neighbor hot-applied in place");
+        }
+
+        let needs_rebuild_pass =
+            !diff.added.is_empty() || !diff.removed.is_empty() || !rebuild_changed.is_empty();
+        if needs_rebuild_pass {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if let Err(e) = peer_mgr_tx
+                .send(PeerManagerCommand::ReconcilePeers {
+                    added: resolve(&diff.added),
+                    removed: diff.removed.clone(),
+                    changed: resolve(&rebuild_changed),
+                    reply: reply_tx,
+                })
+                .await
+            {
+                return halt_partial(
+                    working_config,
+                    &desired_config,
+                    ReloadStepFailure {
+                        bucket: "neighbors.reconcile",
+                        target: String::new(),
+                        error: format!("send: {e}"),
+                    },
+                );
+            }
+            match reply_rx.await {
+                Ok(reconcile) if reconcile.is_success() => {
+                    working_config.neighbors = new_config.neighbors.clone();
                 }
-                error!(
-                    failures = reconcile.failures.len(),
-                    "config reload halted at neighbor reconcile — live peer-manager state \
+                Ok(reconcile) => {
+                    // Reconcile is the one step where partial failure
+                    // leaves the live state genuinely ambiguous: it
+                    // sequences delete-then-readd for changed peers,
+                    // independent removes, and adds — any subset can
+                    // succeed before the failure point, the manager
+                    // doesn't update its own `current_config` during the
+                    // run, and `delete_peer` / `add_peer` of the wrong
+                    // ordering can leave orphaned `PeerHandle`s. Returning
+                    // a guessed snapshot here would let the next reload
+                    // diff against state that doesn't match live, which is
+                    // worse than just bailing.
+                    //
+                    // Instead: return `None` so the daemon's in-memory
+                    // config stays at `current` and log clearly that live
+                    // state may differ. Operators investigate via
+                    // `rbgp neighbor list`, fix the failing TOML,
+                    // and reload again. The retry-succeeded-operations
+                    // concern is bounded by the underlying ops being
+                    // mostly idempotent (`delete_peer` of a missing peer
+                    // returns Ok, `add_peer` of an existing peer returns
+                    // a visible error rather than silent corruption); the
+                    // operator gets surfaced errors on the retry rather
+                    // than hidden drift.
+                    for failure in &reconcile.failures {
+                        warn!(
+                            bucket = "neighbors.reconcile",
+                            target = %failure.peer,
+                            kind = ?failure.kind,
+                            error = %failure.error,
+                            "config reload step failed"
+                        );
+                    }
+                    error!(
+                        failures = reconcile.failures.len(),
+                        "config reload halted at neighbor reconcile — live peer-manager state \
                      may differ from the in-memory config snapshot. Inspect live state via \
                      `rbgp neighbor list` and re-edit the failing TOML before \
                      reloading again. Earlier reload steps (policy / peer-group / chain \
                      edits) DID land at the manager and remain in effect."
-                );
-                return None;
-            }
-            Err(e) => {
-                error!(
-                    error = %e,
-                    "config reload halted: peer manager dropped reconcile reply — live \
-                     state may differ from the in-memory config snapshot. Inspect via \
-                     `rbgp neighbor list` before reloading again. Earlier reload \
-                     steps (policy / peer-group / chain edits) DID land at the manager \
-                     and remain in effect."
-                );
-                return None;
+                    );
+                    return None;
+                }
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        "config reload halted: peer manager dropped reconcile reply — live \
+                         state may differ from the in-memory config snapshot. Inspect via \
+                         `rbgp neighbor list` before reloading again. Earlier reload \
+                         steps (policy / peer-group / chain edits) DID land at the manager \
+                         and remain in effect."
+                    );
+                    return None;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- lab adjudication of the reload matrix vs the reconcile mechanics found the mechanics lying in the operator-hostile direction: EVERY matrix-"live" neighbor field (description, max_prefixes, log_level, policy chains, gr_stale_routes_time) bounced the session on SIGHUP, because reconcile delete/re-added the session task for any changed field
- reload now partitions changed neighbors by the per-field impact classifier (single source of truth shared with the config-diff annotations): change sets that are entirely hot-applicable go through a new in-place update path — policy chains via the existing live-policy seam (with Route Refresh + Adj-RIB-Out re-emit), runtime knobs via a new bounded session command — while any session-reset-class change keeps today's rebuild exactly
- all ten hot-class fields now apply in place; the after-fix lab run shows zero bounces across five consecutive SIGHUP edits with values provably live (denied prefix leaves the RIB via refresh), and reset-class edits still rebuild as documented
- the matrix's own errors are corrected: remote_asn is reclassified as an immediate identity rebuild (the diff keys on address+interface, not the ASN triple the doc claimed) and surfaced as session reset in diff annotations; peer_group reassignment is honestly session reset; the "effective next session" caveat wording replaced (SIGHUP rebuilds immediately, never waits)
- session-task survival is pinned in tests via session-id stability, with a contrast pin proving reset-class changes still rebuild

## Note

A pre-existing cosmetic quirk observed (not introduced): after a hot import-chain swap, the session-level Prefixes Received counter keeps counting a now-denied route the RIB correctly drops.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --bin rustbgpd (1363) / -p rustbgpd-transport / -p rustbgpd-api / -p rustbgpctl
- cargo doc --workspace --no-deps
- before/after live-lab verdict tables against FRR 10.3.1 (in the issue)

Closes LAN-341.