### PR TITLE
feat(rpol): expose evaluation metering and finish the v2 operator surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,6 +396,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in list/detail JSON). With zero peers, `rbgp neighbor` now prints
   `no neighbors configured — add one: rbgp neighbor <addr> add --asn
   <asn>` instead of a bare notice; `-j` still prints `[]`. (LAN-322)
+- **rpol evaluation-error observability surface.** The final ADR-0103
+  slice (LAN-301) finishes the operator surface over the fail-closed
+  evaluation-error rail the runtime slices built: a new
+  `bgp_policy_eval_errors_total{direction, kind}` Prometheus counter
+  aggregates fail-closed denies by direction and the closed
+  `EvalErrorKind` label set (24-series worst case — per-chain detail
+  deliberately lives on the stats RPC, not labels); `GetPolicyStats`
+  / `rbgp policy stats` chain rows gain `eval_errors` (count since
+  chain install) and `last_error` (the most recent error rendered as
+  `<kind> in policy <name> term <name>`), shown above the term table
+  when nonzero. In-language tests gain an error-pinning expectation:
+  `expect p == error` (any evaluation error) and `expect p == error
+  KIND` (kind-pinned, e.g. `error divide-by-zero`; unknown kinds are
+  compile diagnostics with a suggestion). The ADR-0103 Decision 1
+  bytecode re-entry benchmark was re-run against the post-program
+  evaluator (bindings, loops, functions, datasets all landed) and the
+  gate did not fire — dispatch is still not where evaluation cost
+  lives; the receipt addendum is in the ADR. (LAN-301)
 
 ### Changed
 - Removed the deprecated `bgp_aspa_records_total` gauge alias; `bgp_aspa_records` is the only exported name
@@ -405,6 +423,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   per-method tier authorization is not enforced and that tier
   enforcement becomes mandatory in a future release — migrate to
   `enforcement = "tier"` with `[security.grpc.roles]`. (LAN-194)
+- **In-language `test` blocks no longer treat an evaluation error as a
+  `reject` verdict.** Per ADR-0103 Decision 4, an `expect ... ==
+  accept|reject` whose evaluation ERRORS now FAILS the test with the
+  error kind and failing policy/term rendered (previously an error
+  silently satisfied `== reject`, so a broken policy could pass as
+  "rejects correctly"). Migration: expectations that deliberately pin
+  the fail-closed rail switch to the new form — `expect p == error`
+  or `expect p == error <kind>`. (LAN-301)
 
 - **Release publication is now fail-closed.** The binary-release and
   container-image workflows refuse to publish unless the pushed tag

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1588,6 +1588,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                         .map_or_else(|| "global".to_string(), |peer| peer.to_string()),
                     direction: "export".to_string(),
                     routes_evaluated: chain.evals,
+                    eval_errors: chain.eval_errors,
+                    last_error: chain.last_error.unwrap_or_default(),
                     terms: term_stats(chain.terms),
                     // Export chains do not track an install generation yet
                     // (LAN-311); 0 = untracked, per the proto contract.
@@ -1614,6 +1616,8 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                         peer_address: peer.to_string(),
                         direction: "import".to_string(),
                         routes_evaluated: snapshot.evals,
+                        eval_errors: snapshot.eval_errors,
+                        last_error: snapshot.last_error.unwrap_or_default(),
                         terms: term_stats(snapshot.terms),
                         policy_generation: snapshot.generation,
                     }),
@@ -2850,6 +2854,8 @@ policy customer-in(peer_lp: u32) {
                             rustbgpd_transport::ImportPolicyTermHits {
                                 generation: 3,
                                 evals: 11,
+                                eval_errors: 0,
+                                last_error: None,
                                 terms: vec![rustbgpd_policy::TermHitRow {
                                     policy_index: 0,
                                     policy: Some("customer-in(200)".to_string()),
@@ -2885,6 +2891,11 @@ policy customer-in(peer_lp: u32) {
                         let _ = reply.send(vec![rustbgpd_rib::update::ExportPolicyTermHits {
                             peer,
                             evals: 7,
+                            eval_errors: 2,
+                            last_error: Some(
+                                "overflow in policy customer-in(200) term customer-routes"
+                                    .to_string(),
+                            ),
                             terms: vec![
                                 rustbgpd_policy::TermHitRow {
                                     policy_index: 0,
@@ -2939,6 +2950,13 @@ policy customer-in(peer_lp: u32) {
             chain.policy_generation, 0,
             "export chains do not track an install generation yet (LAN-311)"
         );
+        // LAN-301: eval-error counters and the rendered last error
+        // ride the chain rows.
+        assert_eq!(chain.eval_errors, 2);
+        assert_eq!(
+            chain.last_error,
+            "overflow in policy customer-in(200) term customer-routes"
+        );
         // LAN-305: dataset status rides the same response.
         assert_eq!(resp.datasets.len(), 1);
         let dataset = &resp.datasets[0];
@@ -2976,6 +2994,8 @@ policy customer-in(peer_lp: u32) {
         assert_eq!(chain.terms.len(), 1);
         assert_eq!(chain.terms[0].term, "customer-routes");
         assert_eq!(chain.terms[0].hits, 9);
+        assert_eq!(chain.eval_errors, 0);
+        assert_eq!(chain.last_error, "", "no error since install");
     }
 
     /// `direction = "both"` returns the export block first, then the

--- a/crates/cli/src/commands/policy.rs
+++ b/crates/cli/src/commands/policy.rs
@@ -455,6 +455,13 @@ struct JsonPolicyStats {
     peer_address: String,
     direction: String,
     routes_evaluated: u64,
+    /// Routes denied by an evaluation error since chain install
+    /// (ADR-0103 Decision 4 fail-closed rail).
+    eval_errors: u64,
+    /// Most recent evaluation error (kind + failing policy/term);
+    /// `None` when no evaluation has errored since chain install.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
     /// Install identity of the chain instance the counters belong to.
     /// `None` for export chains (install generation not tracked yet,
     /// LAN-311); import chains always report it, so counters that
@@ -521,6 +528,8 @@ pub async fn stats(
                 peer_address: chain.peer_address.clone(),
                 direction: chain.direction.clone(),
                 routes_evaluated: chain.routes_evaluated,
+                eval_errors: chain.eval_errors,
+                last_error: (!chain.last_error.is_empty()).then(|| chain.last_error.clone()),
                 policy_generation: (chain.direction == "import").then_some(chain.policy_generation),
                 terms: chain
                     .terms
@@ -571,6 +580,20 @@ pub async fn stats(
             "{} {} chain — {} routes evaluated since install{generation}",
             chain.peer_address, chain.direction, chain.routes_evaluated
         );
+        // LAN-301: evaluation errors are fail-closed denies — surface
+        // the count and the most recent blame line when nonzero.
+        if chain.eval_errors > 0 {
+            println!(
+                "  {} route{} denied by evaluation errors (fail closed); last: {}",
+                chain.eval_errors,
+                if chain.eval_errors == 1 { "" } else { "s" },
+                if chain.last_error.is_empty() {
+                    "<unknown>"
+                } else {
+                    &chain.last_error
+                },
+            );
+        }
         println!("  {:<32} {:<24} HITS", "POLICY", "TERM");
         for t in &chain.terms {
             let policy = if t.policy.is_empty() {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1774,6 +1774,8 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             direction: "export".to_string(),
             routes_evaluated: 7,
             policy_generation: 0,
+            eval_errors: 2,
+            last_error: "overflow in policy customer-in(200) term customer-routes".to_string(),
             terms: vec![
                 server_proto::PolicyTermStat {
                     policy_index: 0,
@@ -1796,6 +1798,8 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
             direction: "import".to_string(),
             routes_evaluated: 11,
             policy_generation: 3,
+            eval_errors: 0,
+            last_error: String::new(),
             terms: vec![server_proto::PolicyTermStat {
                 policy_index: 0,
                 policy: "customer-in(200)".to_string(),

--- a/crates/policy/benches/policy_eval.rs
+++ b/crates/policy/benches/policy_eval.rs
@@ -613,6 +613,78 @@ fn bench_loop_eval(c: &mut Criterion) {
     group.finish();
 }
 
+/// LAN-304 pure functions: the fn-heavy representative workload for
+/// the ADR-0103 bytecode re-entry gate (LAN-301). `fn_calls` routes a
+/// damping formula through a user `fn` from both a guard and two `set`
+/// value positions (three call sites, each fully inlined at compile
+/// time into caller-frame binds); `hand_inlined` writes the identical
+/// arithmetic out by hand. Functions are a compile-time construct —
+/// the delta between the two arms is the honest runtime cost of using
+/// `fn`, and the contract says it is the cost of the equivalent `let`
+/// bindings, not of any call machinery (there are no runtime frames).
+fn bench_fn_eval(c: &mut Criterion) {
+    let mut store = SetStore::new();
+    let fn_calls = rustbgpd_policy::rpol::compile_rpol(
+        "fn penalty(len: u32, weight: u32) -> u32 {
+             let base = len * weight
+             min(base, 1000)
+         }
+         policy p {
+             term dampen { if penalty(route.as-path.len, 10) >= route.med { reject } }
+             term pad {
+                 set med penalty(route.as-path.len, 20);
+                 set local-pref penalty(route.as-path.len, 30);
+                 accept
+             }
+         }",
+        &mut store,
+    )
+    .expect("compiles");
+    let hand_inlined = rustbgpd_policy::rpol::compile_rpol(
+        "policy p {
+             term dampen {
+                 let base = route.as-path.len * 10
+                 if min(base, 1000) >= route.med { reject }
+             }
+             term pad {
+                 let pad-med = route.as-path.len * 20
+                 let pad-lp = route.as-path.len * 30
+                 set med min(pad-med, 1000);
+                 set local-pref min(pad-lp, 1000);
+                 accept
+             }
+         }",
+        &mut store,
+    )
+    .expect("compiles");
+
+    // A route that walks both terms (guard non-match, then the pads).
+    let communities: Vec<u32> = Vec::new();
+    let as_path_str = "65001 65100 65200".to_string();
+    let mut ctx = predicate_ctx(
+        matching_prefix(),
+        &communities,
+        &as_path_str,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+    );
+    ctx.med = Some(100); // penalty(3, 10) = 30 < 100 → dampen misses
+
+    let mut group = c.benchmark_group("fn_eval");
+    group.bench_function("fn_calls", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&fn_calls).evaluate(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.bench_function("hand_inlined", |b| {
+        b.iter(|| {
+            let r = std::hint::black_box(&hand_inlined).evaluate(&ctx);
+            std::hint::black_box(r);
+        });
+    });
+    group.finish();
+}
+
 /// LAN-305 dataset parity: a dataset probe runs the SAME indexed
 /// structure as its in-language set sibling (`AsnSet` here), so the
 /// pair pins the per-walk pin overhead (one wait-free handle load +
@@ -696,6 +768,7 @@ criterion_group!(
     bench_set_heavy,
     bench_value_expr,
     bench_loop_eval,
+    bench_fn_eval,
     bench_dataset_parity
 );
 criterion_main!(benches);

--- a/crates/policy/fuzz/seeds/rpol_compile/lan-301-error-expect.rpol
+++ b/crates/policy/fuzz/seeds/rpol_compile/lan-301-error-expect.rpol
@@ -1,0 +1,21 @@
+policy overflowing {
+    term guard { if route.med + 1 >= 1 { accept } }
+    term rest { reject }
+}
+
+policy error { term t { accept } }
+
+test any-error {
+    route { med 4294967295 }
+    expect overflowing == error
+}
+
+test kind-pinned {
+    route { med 4294967295 }
+    expect overflowing == error overflow
+}
+
+test contextual-error-name {
+    route { }
+    expect error == accept
+}

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1135,6 +1135,12 @@ pub struct PolicyEvaluation {
     pub action: PolicyAction,
     /// Configured name of the terminal-decision policy, if it has one.
     pub matched_policy: Option<String>,
+    /// Set when the Deny is the fail-closed disposition of an
+    /// evaluation error (ADR-0103 Decision 4) rather than a clean
+    /// policy verdict — the kind plus the failing policy/term. Always
+    /// `None` on a Permit; built on the error path only, so the hot
+    /// path never allocates for it.
+    pub eval_error: Option<crate::eval::EvalError>,
 }
 
 /// An ordered sequence of policies evaluated in chain.
@@ -1409,6 +1415,7 @@ impl PolicyChain {
                         PolicyEvaluation {
                             action: PolicyAction::Deny,
                             matched_policy: named.name.clone(),
+                            eval_error: None,
                         },
                     );
                 }
@@ -1427,6 +1434,7 @@ impl PolicyChain {
             PolicyEvaluation {
                 action: PolicyAction::Permit,
                 matched_policy,
+                eval_error: None,
             },
         )
     }
@@ -1472,6 +1480,7 @@ pub fn evaluate_chain_with_attribution(
             PolicyEvaluation {
                 action: PolicyAction::Permit,
                 matched_policy: None,
+                eval_error: None,
             },
         ),
     }

--- a/crates/policy/src/eval.rs
+++ b/crates/policy/src/eval.rs
@@ -127,6 +127,34 @@ pub enum EvalErrorKind {
     DatasetUnpinned,
 }
 
+/// One evaluation error with its blame context (LAN-301): the kind
+/// plus the failing policy/term names, as the live walk resolved them.
+/// Carried on [`PolicyEvaluation`](crate::engine::PolicyEvaluation)
+/// (error path only — the hot path never builds one) and retained per
+/// chain as [`PolicyHitCounters::last_error`] for the stats surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalError {
+    /// Why the evaluation failed.
+    pub kind: EvalErrorKind,
+    /// Name of the failing policy (`None` = inline / anonymous).
+    pub policy: Option<String>,
+    /// Name of the failing term (`Bind` terms carry the qualified
+    /// `term (let binding)` form); `None` for unnamed TOML statements.
+    pub term: Option<String>,
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} in policy {} term {}",
+            self.kind.label(),
+            self.policy.as_deref().unwrap_or("<inline>"),
+            self.term.as_deref().unwrap_or("<unnamed>"),
+        )
+    }
+}
+
 impl EvalErrorKind {
     /// Stable short label (counter/log-friendly).
     #[must_use]
@@ -146,6 +174,25 @@ impl EvalErrorKind {
             EvalErrorKind::DatasetUnpinned => "dataset-unpinned",
         }
     }
+
+    /// Every stable label, for surfaces that validate operator-written
+    /// kind names (the in-language `expect ... == error KIND` form).
+    /// The kind set is closed by construction — extending the enum
+    /// extends this list (the exhaustive `label` match enforces it).
+    pub const LABELS: &'static [&'static str] = &[
+        "overflow",
+        "underflow",
+        "divide-by-zero",
+        "remainder-by-zero",
+        "clamp-inverted",
+        "absent-operand",
+        "absent-prepend-operand",
+        "unbound-local",
+        "fuel-exhausted",
+        "loop-limit-exceeded",
+        "stray-loop-control",
+        "dataset-unpinned",
+    ];
 }
 
 impl fmt::Display for EvalErrorKind {
@@ -328,6 +375,11 @@ pub struct PolicyHitCounters {
     policies: Vec<Vec<AtomicU64>>,
     evals: AtomicU64,
     eval_errors: AtomicU64,
+    /// Most recent evaluation error (LAN-301) — the "why" behind a
+    /// nonzero `eval_errors`, surfaced by `rbgp policy stats`. Behind
+    /// a `Mutex` because it carries names; written on the (cold,
+    /// rate-bounded) error path only, never on the hot path.
+    last_error: std::sync::Mutex<Option<EvalError>>,
 }
 
 impl PolicyHitCounters {
@@ -342,6 +394,7 @@ impl PolicyHitCounters {
                 .collect(),
             evals: AtomicU64::new(0),
             eval_errors: AtomicU64::new(0),
+            last_error: std::sync::Mutex::new(None),
         }
     }
 
@@ -360,6 +413,23 @@ impl PolicyHitCounters {
     #[must_use]
     pub fn eval_errors(&self) -> u64 {
         self.eval_errors.load(Ordering::Relaxed)
+    }
+
+    /// The most recent evaluation error, if any route has errored
+    /// since chain install (LAN-301) — kind plus the failing
+    /// policy/term, for the stats surface.
+    #[must_use]
+    pub fn last_error(&self) -> Option<EvalError> {
+        self.last_error.lock().map_or(None, |guard| guard.clone())
+    }
+
+    /// Record one evaluation error: bump the counter and retain the
+    /// error as [`last_error`](Self::last_error). Error path only.
+    fn record_eval_error(&self, error: &EvalError) {
+        self.eval_errors.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut guard) = self.last_error.lock() {
+            *guard = Some(error.clone());
+        }
     }
 
     /// Snapshot of the per-term hit grid (`snapshot()[p][t]`).
@@ -601,6 +671,7 @@ impl CompiledChain {
                         PolicyEvaluation {
                             action: PolicyAction::Deny,
                             matched_policy: if ATTR { policy.name.clone() } else { None },
+                            eval_error: None,
                         },
                     );
                 }
@@ -609,9 +680,6 @@ impl CompiledChain {
                 // accumulator drops here), operator-visible counter +
                 // rate-limited WARN naming the failing policy/term.
                 PolicyDecision::Error { kind, term_index } => {
-                    if COUNT && let Some(hits) = hits {
-                        hits.eval_errors.fetch_add(1, Ordering::Relaxed);
-                    }
                     // A failing Bind names its binding — for
                     // call-inlined binds (LAN-304) the qualified
                     // `fn.binding` name, so the WARN names both the
@@ -626,11 +694,20 @@ impl CompiledChain {
                         }
                     });
                     warn_eval_error(policy.name.as_deref(), term_label.as_deref(), kind);
+                    let error = EvalError {
+                        kind,
+                        policy: policy.name.clone(),
+                        term: term_label,
+                    };
+                    if COUNT && let Some(hits) = hits {
+                        hits.record_eval_error(&error);
+                    }
                     return (
                         PolicyResult::deny(),
                         PolicyEvaluation {
                             action: PolicyAction::Deny,
                             matched_policy: if ATTR { policy.name.clone() } else { None },
+                            eval_error: Some(error),
                         },
                     );
                 }
@@ -661,6 +738,7 @@ impl CompiledChain {
             PolicyEvaluation {
                 action: PolicyAction::Permit,
                 matched_policy,
+                eval_error: None,
             },
         )
     }

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -25,4 +25,4 @@ pub use engine::{
     RouteContext, RouteFamily, RouteModifications, RouteType, TermHitRow, apply_modifications,
     evaluate_chain, evaluate_chain_with_attribution, evaluate_policy, parse_community_match,
 };
-pub use eval::{EvalErrorKind, PolicyHitCounters};
+pub use eval::{EvalError, EvalErrorKind, PolicyHitCounters};

--- a/crates/policy/src/rpol/ast.rs
+++ b/crates/policy/src/rpol/ast.rs
@@ -800,19 +800,37 @@ pub enum PeerField {
     Group(Spanned<String>),
 }
 
-/// `expect policy(args) == accept|reject [with assertions]`.
+/// `expect policy(args) == accept|reject|error [KIND] [with assertions]`.
 #[derive(Debug)]
 pub struct ExpectDef {
     /// The policy under test.
     pub policy: Spanned<String>,
     /// Instantiation arguments (literals only in `expect`).
     pub args: Vec<Spanned<u32>>,
-    /// True for `accept`, false for `reject`.
-    pub accept: bool,
-    /// `with` attribute assertions.
+    /// The expected verdict.
+    pub verdict: ExpectVerdict,
+    /// `with` attribute assertions (accept/reject verdicts only —
+    /// an error discards modifications, so the parser rejects `with`
+    /// after `error`).
     pub with: Vec<WithAssertion>,
     /// Whole-expect span.
     pub span: Span,
+}
+
+/// The right-hand side of an `expect ... ==` (LAN-301, ADR-0103
+/// Decision 4): `accept` and `reject` assert clean verdicts — an
+/// evaluation error FAILS either one, with the error rendered — and
+/// `error [KIND]` pins the fail-closed rail itself, optionally down
+/// to the [`EvalErrorKind`](crate::eval::EvalErrorKind) label
+/// (`error divide-by-zero`).
+#[derive(Debug)]
+pub enum ExpectVerdict {
+    /// `== accept` — clean permit.
+    Accept,
+    /// `== reject` — clean deny (NOT an evaluation error).
+    Reject,
+    /// `== error [KIND]` — evaluation error, any kind when `None`.
+    Error(Option<Spanned<String>>),
 }
 
 /// One `with` assertion — checked against the evaluation result's

--- a/crates/policy/src/rpol/parser.rs
+++ b/crates/policy/src/rpol/parser.rs
@@ -19,10 +19,10 @@ use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry};
 
 use super::ast::{
     ActionStmt, AsnSetDef, CmpOp, CommunityArg, CommunityKind, CommunityLit, CommunitySetDef,
-    DatasetDecl, DatasetEntryAst, ExpectDef, Expr, FieldPath, FieldRoot, FnDef, FnLet, ForSource,
-    ForStmt, IfStmt, NextHopArg, PeerField, PolicyDef, PrefixEntryAst, PrefixSetDef, PrependAsArg,
-    Rhs, RouteField, SourceFile, Stmt, TermDef, TestDatasetDef, TestDef, U32Arg, ValueExprAst,
-    WithAssertion,
+    DatasetDecl, DatasetEntryAst, ExpectDef, ExpectVerdict, Expr, FieldPath, FieldRoot, FnDef,
+    FnLet, ForSource, ForStmt, IfStmt, NextHopArg, PeerField, PolicyDef, PrefixEntryAst,
+    PrefixSetDef, PrependAsArg, Rhs, RouteField, SourceFile, Stmt, TermDef, TestDatasetDef,
+    TestDef, U32Arg, ValueExprAst, WithAssertion,
 };
 use super::diag::{Diagnostic, Span, Spanned};
 use super::lexer::{Tok, Token, lex};
@@ -1517,7 +1517,7 @@ impl Parser<'_> {
             self.diags.push(Diagnostic::new(
                 self.here(),
                 "test has no `expect`",
-                "expected at least one `expect <policy> == accept|reject`",
+                "expected at least one `expect <policy> == accept|reject|error`",
             ));
             return Err(Fail);
         }
@@ -1675,20 +1675,60 @@ impl Parser<'_> {
             self.expect(Tok::RParen, "`)`")?;
         }
         self.expect(Tok::EqEq, "`==`")?;
-        let accept = match self.peek().map(|t| t.kind) {
+        let verdict = match self.peek().map(|t| t.kind) {
             Some(Tok::AcceptKw) => {
                 self.bump();
-                true
+                ExpectVerdict::Accept
             }
             Some(Tok::RejectKw) => {
                 self.bump();
-                false
+                ExpectVerdict::Reject
             }
-            _ => return Err(self.error_expected("`accept` or `reject`")),
+            // `error` is contextual (LAN-301): this position held only
+            // `accept`/`reject` before, so no reserved word is added.
+            // An optional kind identifier pins the EvalErrorKind label
+            // (kebab-case munch keeps `divide-by-zero` one token).
+            Some(Tok::Ident) if self.peek().is_some_and(|t| self.text(t) == "error") => {
+                self.bump();
+                let kind = if self.at(Tok::Ident) {
+                    let kind = self.expect_ident("an evaluation-error kind")?;
+                    if !crate::eval::EvalErrorKind::LABELS.contains(&kind.node.as_str()) {
+                        let mut diag = Diagnostic::new(
+                            kind.span,
+                            format!("`{}` is not an evaluation-error kind", kind.node),
+                            "unknown error kind",
+                        );
+                        if let Some(suggestion) = super::diag::closest(
+                            &kind.node,
+                            crate::eval::EvalErrorKind::LABELS.iter().copied(),
+                        ) {
+                            diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                        }
+                        self.diags.push(diag);
+                        return Err(Fail);
+                    }
+                    Some(kind)
+                } else {
+                    None
+                };
+                ExpectVerdict::Error(kind)
+            }
+            _ => return Err(self.error_expected("`accept`, `reject`, or `error`")),
         };
         let mut with = Vec::new();
         let mut end = self.here();
-        if self.eat(Tok::WithKw).is_some() {
+        if let Some(with_kw) = self.eat(Tok::WithKw) {
+            if matches!(verdict, ExpectVerdict::Error(_)) {
+                // An erroring evaluation discards every staged
+                // modification (ADR-0103 Decision 4), so there is
+                // nothing for a `with` assertion to check.
+                self.diags.push(Diagnostic::new(
+                    with_kw.span,
+                    "`with` assertions cannot follow `== error`".to_string(),
+                    "an evaluation error discards all modifications",
+                ));
+                return Err(Fail);
+            }
             loop {
                 with.push(self.with_assertion()?);
                 if self.eat(Tok::Comma).is_none() {
@@ -1700,7 +1740,7 @@ impl Parser<'_> {
         Ok(ExpectDef {
             policy,
             args,
-            accept,
+            verdict,
             with,
             span: start.to(end),
         })

--- a/crates/policy/src/rpol/testing.rs
+++ b/crates/policy/src/rpol/testing.rs
@@ -22,7 +22,8 @@ use crate::engine::{NextHopAction, PolicyAction, RouteContext, RouteFamily, Rout
 use crate::sets::{AsnSet, CommunitySet, PrefixSet, PrefixSetEntry, SetStore};
 
 use super::ast::{
-    CommunityLit, DatasetEntryAst, NextHopArg, PeerField, RouteField, TestDef, WithAssertion,
+    CommunityLit, DatasetEntryAst, ExpectVerdict, NextHopArg, PeerField, RouteField, TestDef,
+    WithAssertion,
 };
 use super::lower::{Lowerer, ext_community_value};
 
@@ -312,13 +313,50 @@ pub(super) fn run_tests(
             // The fixture's `peer { local-as N }` plays the config
             // resolver's role for `prepend as self` (LAN-296).
             chain.local_asn = fixture.local_asn;
-            let result = chain.evaluate(&ctx);
+            let (result, evaluation) = chain.evaluate_with_attribution(&ctx);
             let call = render_call(&expect.policy.node, &args);
+            // ADR-0103 Decision 4: an erroring evaluation is not a
+            // clean verdict. `accept`/`reject` expectations FAIL on an
+            // error with the error rendered; `error [KIND]` pins the
+            // fail-closed rail itself.
+            match (&expect.verdict, &evaluation.eval_error) {
+                (ExpectVerdict::Error(expected_kind), Some(error)) => {
+                    if let Some(expected) = expected_kind
+                        && error.kind.label() != expected.node
+                    {
+                        problems.push(format!(
+                            "{call}: expected error {}, got error {} ({})",
+                            expected.node,
+                            error.kind.label(),
+                            error,
+                        ));
+                    }
+                    continue;
+                }
+                (ExpectVerdict::Error(_), None) => {
+                    problems.push(format!(
+                        "{call}: expected an evaluation error, got {}",
+                        verdict(result.action == PolicyAction::Permit),
+                    ));
+                    continue;
+                }
+                (ExpectVerdict::Accept | ExpectVerdict::Reject, Some(error)) => {
+                    problems.push(format!(
+                        "{call}: expected {}, got evaluation error: {error} \
+                         (use `== error {}` to pin the fail-closed rail)",
+                        verdict(matches!(expect.verdict, ExpectVerdict::Accept)),
+                        error.kind.label(),
+                    ));
+                    continue;
+                }
+                (ExpectVerdict::Accept | ExpectVerdict::Reject, None) => {}
+            }
             let accepted = result.action == PolicyAction::Permit;
-            if accepted != expect.accept {
+            let expect_accept = matches!(expect.verdict, ExpectVerdict::Accept);
+            if accepted != expect_accept {
                 problems.push(format!(
                     "{call}: expected {}, got {}",
-                    verdict(expect.accept),
+                    verdict(expect_accept),
                     verdict(accepted),
                 ));
                 continue;

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -1967,18 +1967,18 @@ test self-operand {
 
 test missing-origin-fails-closed {
     route { prefix 10.0.0.0/24; as-path "{64500 64501}" }
-    expect origin-pad == reject
+    expect origin-pad == error absent-prepend-operand
 }
 
 test missing-peer-fails-closed {
     route { prefix 10.0.0.0/24 }
-    expect peer-pad == reject
+    expect peer-pad == error absent-prepend-operand
 }
 
 test missing-local-as-fails-closed {
     route { prefix 10.0.0.0/24 }
     peer { asn 65010 }
-    expect self-pad == reject
+    expect self-pad == error absent-prepend-operand
 }
 "#;
     let report = run_rpol_tests(source).expect("compiles");
@@ -2155,6 +2155,13 @@ fn eval_error_denies_discards_mods_and_counts() {
     assert!(result.modifications.is_empty(), "staged mods discarded");
     assert_eq!(counters.eval_errors(), 1);
     assert_eq!(counters.evals(), 2);
+    // LAN-301: the counters retain the last error with blame context
+    // for the stats surface.
+    let last = counters.last_error().expect("last error retained");
+    assert_eq!(last.kind, crate::eval::EvalErrorKind::Overflow);
+    assert_eq!(last.policy.as_deref(), Some("p"));
+    assert_eq!(last.term.as_deref(), Some("guard"));
+    assert_eq!(last.to_string(), "overflow in policy p term guard");
 
     // The recording walk (dry runs) agrees on the verdict.
     let mut hits = chain.zero_term_hits();
@@ -2405,7 +2412,7 @@ policy builtin-edges {
 
 test overflow-denies {
     route { med 4294967295 }
-    expect overflow-guard == reject
+    expect overflow-guard == error overflow
 }
 
 test no-overflow-accepts {
@@ -2415,17 +2422,17 @@ test no-overflow-accepts {
 
 test divide-by-zero-denies {
     route { med 5 }
-    expect div-zero == reject
+    expect div-zero == error divide-by-zero
 }
 
 test modulo-zero-denies {
     route { }
-    expect mod-zero == reject
+    expect mod-zero == error remainder-by-zero
 }
 
 test absent-origin-denies {
     route { as-path "{64500 64501}" }
-    expect absent-origin == reject
+    expect absent-origin == error absent-operand
 }
 
 test present-origin-accepts {
@@ -2456,6 +2463,167 @@ test builtin-passes-middle {
     let report = run_rpol_tests(source).expect("compiles cleanly");
     assert_eq!(report.total, 10);
     assert!(report.all_passed(), "failures: {:?}", report.failures);
+}
+
+// ── LAN-301: `expect ... == error [KIND]` and eval-error observability ──
+
+/// The bare and kind-pinned `error` expectation forms pass on the
+/// rails they pin, and the kind mismatch renders both kinds.
+#[test]
+fn error_expectation_pins_the_fail_closed_rail() {
+    let source = r"
+policy overflowing { term t { if route.med + 1 >= 1 { accept } } term rest { reject } }
+
+test any-error-passes {
+    route { med 4294967295 }
+    expect overflowing == error
+}
+
+test kind-pinned-passes {
+    route { med 4294967295 }
+    expect overflowing == error overflow
+}
+";
+    let report = run_rpol_tests(source).expect("compiles cleanly");
+    assert!(report.all_passed(), "failures: {:?}", report.failures);
+}
+
+/// A clean verdict is not an error (and vice versa): `== error` fails
+/// on a clean reject, `== reject` fails on an erroring evaluation with
+/// the error (kind, policy, term) rendered, and a kind-pinned `error`
+/// fails on a different kind.
+#[test]
+fn error_expectation_mismatches_render_the_divergence() {
+    let source = r"
+policy clean-reject { term t { reject } }
+policy overflowing { term t { if route.med + 1 >= 1 { accept } } term rest { reject } }
+
+test clean-reject-is-not-an-error {
+    route { }
+    expect clean-reject == error
+}
+
+test error-is-not-a-clean-reject {
+    route { med 4294967295 }
+    expect overflowing == reject
+}
+
+test wrong-kind-fails {
+    route { med 4294967295 }
+    expect overflowing == error divide-by-zero
+}
+";
+    let report = run_rpol_tests(source).expect("compiles cleanly");
+    assert_eq!(report.total, 3);
+    assert_eq!(report.failures.len(), 3, "{:?}", report.failures);
+    let by_name = |name: &str| {
+        report
+            .failures
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("{name} should fail"))
+            .message
+            .clone()
+    };
+    assert!(
+        by_name("clean-reject-is-not-an-error")
+            .contains("expected an evaluation error, got reject"),
+        "{:?}",
+        report.failures
+    );
+    let msg = by_name("error-is-not-a-clean-reject");
+    assert!(
+        msg.contains(
+            "expected reject, got evaluation error: overflow in policy overflowing term t"
+        ),
+        "{msg}"
+    );
+    assert!(
+        msg.contains("use `== error overflow`"),
+        "steers to the pinning form: {msg}"
+    );
+    let msg = by_name("wrong-kind-fails");
+    assert!(
+        msg.contains("expected error divide-by-zero, got error overflow"),
+        "{msg}"
+    );
+}
+
+/// An unknown error kind after `== error` is a compile diagnostic with
+/// a closest-label suggestion, and `with` assertions cannot follow
+/// `== error` (an error discards all modifications).
+#[test]
+fn error_expectation_grammar_diagnostics() {
+    let (_, rendered) = diagnostics_of(
+        "policy p { term t { reject } }
+         test t { route { } expect p == error divide-by-zeroo }",
+    );
+    assert!(
+        rendered.contains("`divide-by-zeroo` is not an evaluation-error kind"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("did you mean `divide-by-zero`?"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of(
+        "policy p { term t { reject } }
+         test t { route { } expect p == error with med 5 }",
+    );
+    assert!(
+        rendered.contains("`with` assertions cannot follow `== error`"),
+        "{rendered}"
+    );
+}
+
+/// `error` stays contextual: a policy (or set) named `error` keeps
+/// compiling and keeps being referencable from expects.
+#[test]
+fn policy_named_error_still_works() {
+    let source = r"
+policy error { term t { accept } }
+
+test error-policy-accepts {
+    route { }
+    expect error == accept
+}
+";
+    let report = run_rpol_tests(source).expect("compiles cleanly");
+    assert!(report.all_passed(), "failures: {:?}", report.failures);
+}
+
+/// The attribution surface carries the evaluation error (LAN-301):
+/// `eval_error` is `Some` with kind/policy/term on the error rail and
+/// `None` on a clean deny — the discriminator the test runner and the
+/// metrics sites read.
+#[test]
+fn evaluation_carries_eval_error_on_the_error_rail_only() {
+    let chain = compile_ok(
+        "policy p {
+            term guard { if route.med + 1 >= 1 { accept } }
+            term rest { reject }
+         }",
+    );
+    let mut ctx = absent_ctx();
+    ctx.med = Some(u32::MAX);
+    let (result, evaluation) = chain.evaluate_with_attribution(&ctx);
+    assert_eq!(result.action, PolicyAction::Deny);
+    let error = evaluation.eval_error.expect("error rail carries blame");
+    assert_eq!(error.kind, crate::eval::EvalErrorKind::Overflow);
+    assert_eq!(error.policy.as_deref(), Some("p"));
+    assert_eq!(error.term.as_deref(), Some("guard"));
+
+    ctx.med = Some(1);
+    let (result, evaluation) = chain.evaluate_with_attribution(&ctx);
+    assert_eq!(result.action, PolicyAction::Permit);
+    assert_eq!(evaluation.eval_error, None);
+
+    // Clean deny (guard non-match falls to the reject term): no error.
+    let clean = compile_ok("policy p { term t { reject } }");
+    let (result, evaluation) = clean.evaluate_with_attribution(&absent_ctx());
+    assert_eq!(result.action, PolicyAction::Deny);
+    assert_eq!(evaluation.eval_error, None);
 }
 
 // ── `let` bindings (LAN-302) ───────────────────────────────────────
@@ -3033,7 +3201,7 @@ test shadow-outer-binding-on-fallthrough {
 
 test absent-origin-initializer-denies {
     route { as-path "{64500 64501}" }
-    expect eager-error == reject
+    expect eager-error == error absent-operand
 }
 "#;
     let report = run_rpol_tests(source).expect("compiles cleanly");

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -395,6 +395,7 @@ impl<'a> ExportTarget<'a> {
                     PolicyEvaluation {
                         action: PolicyAction::Permit,
                         matched_policy: None,
+                        eval_error: None,
                     },
                 ),
             },
@@ -444,6 +445,11 @@ fn record_export_policy_eval(
         }
     };
     metrics.record_policy_routes(peer_label, policy, "export", action);
+    // LAN-301: a fail-closed deny also counts on the eval-error
+    // aggregate (direction × closed error kind). Error path only.
+    if let Some(error) = &evaluation.eval_error {
+        metrics.record_policy_eval_error("export", error.kind.label());
+    }
 }
 
 impl RibManager {

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -643,6 +643,7 @@ impl RibManager {
                 rustbgpd_policy::PolicyEvaluation {
                     action: PolicyAction::Permit,
                     matched_policy: None,
+                    eval_error: None,
                 },
             ),
         };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2451,6 +2451,11 @@ impl RibManager {
             crate::update::ExportPolicyTermHits {
                 peer: owner,
                 evals: chain.hit_counters().evals(),
+                eval_errors: chain.hit_counters().eval_errors(),
+                last_error: chain
+                    .hit_counters()
+                    .last_error()
+                    .map(|error| error.to_string()),
                 terms: chain.term_hit_rows(),
             }
         };

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -110,6 +110,12 @@ pub struct ExportPolicyTermHits {
     pub peer: Option<IpAddr>,
     /// Routes evaluated through the chain since install.
     pub evals: u64,
+    /// Routes denied by an evaluation error since install (ADR-0103
+    /// Decision 4 fail-closed rail).
+    pub eval_errors: u64,
+    /// Most recent evaluation error, rendered (`None` = no evaluation
+    /// has errored since install).
+    pub last_error: Option<String>,
     /// Per-term labeled hit counts, in chain walk order.
     pub terms: Vec<rustbgpd_policy::TermHitRow>,
 }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -171,6 +171,7 @@ pub struct BgpMetrics {
 
     // ── Policy dataset refresh failures (LAN-305) ─────────────
     policy_dataset_refresh_errors: IntCounterVec,
+    policy_eval_errors: IntCounterVec,
 
     // ── Enhanced Route Refresh ────────────────────────────────
     route_refresh_in_progress: IntGaugeVec,
@@ -871,6 +872,19 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let policy_eval_errors = IntCounterVec::new(
+            Opts::new(
+                "bgp_policy_eval_errors_total",
+                "Routes denied by a policy evaluation error (ADR-0103 Decision 4 \
+                 fail-closed rail) by direction (import, export) and error kind \
+                 (the closed EvalErrorKind label set: overflow, divide-by-zero, \
+                 absent-operand, fuel-exhausted, ...). Per-chain counts and the \
+                 failing policy/term are on `rbgp policy stats`, not labels.",
+            ),
+            &["direction", "kind"],
+        )
+        .expect("valid metric definition");
+
         let route_refresh_in_progress = IntGaugeVec::new(
             Opts::new(
                 "bgp_route_refresh_in_progress",
@@ -1518,6 +1532,9 @@ impl BgpMetrics {
             .register(Box::new(policy_dataset_refresh_errors.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(policy_eval_errors.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(route_refresh_in_progress.clone()))
             .expect("metric not already registered");
         registry
@@ -1753,6 +1770,7 @@ impl BgpMetrics {
             aspa_records,
             validation_import_refreshes,
             policy_dataset_refresh_errors,
+            policy_eval_errors,
             route_refresh_in_progress,
             route_refresh_stale_entries,
             evpn_local_originations,
@@ -2589,6 +2607,19 @@ impl BgpMetrics {
     pub fn record_policy_dataset_refresh_error(&self, dataset: &str) {
         self.policy_dataset_refresh_errors
             .with_label_values(&[dataset])
+            .inc();
+    }
+
+    /// Count one route denied by a policy evaluation error (LAN-301,
+    /// ADR-0103 Decision 4). Labels are bounded and closed:
+    /// - `direction`: `"import"` or `"export"`.
+    /// - `kind`: an `EvalErrorKind` stable label (`"overflow"`,
+    ///   `"divide-by-zero"`, `"fuel-exhausted"`, ...).
+    ///
+    /// Error path only — the evaluator's hot path never reaches this.
+    pub fn record_policy_eval_error(&self, direction: &str, kind: &str) {
+        self.policy_eval_errors
+            .with_label_values(&[direction, kind])
             .inc();
     }
 
@@ -3541,6 +3572,32 @@ mod tests {
         assert!(text.contains(r#"policy="ingress-filter""#));
         assert!(text.contains(r#"direction="import""#));
         assert!(text.contains(r#"action="deny""#));
+    }
+
+    /// LAN-301: the eval-error counter aggregates by direction and
+    /// closed error kind — no peer label, so no reap discipline needed.
+    #[test]
+    fn policy_eval_errors_counter_uses_direction_and_kind() {
+        let m = BgpMetrics::new();
+        m.record_policy_eval_error("import", "overflow");
+        m.record_policy_eval_error("import", "overflow");
+        m.record_policy_eval_error("export", "fuel-exhausted");
+
+        assert_eq!(
+            m.policy_eval_errors
+                .with_label_values(&["import", "overflow"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.policy_eval_errors
+                .with_label_values(&["export", "fuel-exhausted"])
+                .get(),
+            1
+        );
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_policy_eval_errors_total"));
+        assert!(text.contains(r#"kind="overflow""#));
     }
 
     /// Reaping a peer must invalidate the thread-local memoized counter

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -366,6 +366,12 @@ pub struct ImportPolicyTermHits {
     pub generation: u64,
     /// Routes evaluated through the chain since install.
     pub evals: u64,
+    /// Routes denied by an evaluation error since install (ADR-0103
+    /// Decision 4 fail-closed rail).
+    pub eval_errors: u64,
+    /// Most recent evaluation error, rendered (`None` = no evaluation
+    /// has errored since install).
+    pub last_error: Option<String>,
     /// Per-term labeled hit counts, in chain walk order.
     pub terms: Vec<rustbgpd_policy::TermHitRow>,
 }

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -167,6 +167,11 @@ impl PeerSession {
                         .map(|chain| crate::handle::ImportPolicyTermHits {
                             generation: self.import_policy_generation,
                             evals: chain.hit_counters().evals(),
+                            eval_errors: chain.hit_counters().eval_errors(),
+                            last_error: chain
+                                .hit_counters()
+                                .last_error()
+                                .map(|error| error.to_string()),
                             terms: chain.term_hit_rows(),
                         });
                 let _ = reply.send(snapshot);

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -38,6 +38,11 @@ fn record_import_policy_eval(
         }
     };
     metrics.record_policy_routes(peer_label, policy, "import", action);
+    // LAN-301: a fail-closed deny also counts on the eval-error
+    // aggregate (direction × closed error kind). Error path only.
+    if let Some(error) = &evaluation.eval_error {
+        metrics.record_policy_eval_error("import", error.kind.label());
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OtcState {

--- a/docs/adr/0103-rpol-execution-model.md
+++ b/docs/adr/0103-rpol-execution-model.md
@@ -139,6 +139,46 @@ counters, and the `requires_*` analyses, and the bytecode program is a
 derived, cache-like artifact regenerated from it. No consumer may ever
 observe bytecode.
 
+### Re-measurement addendum — 2026-07-10, post-slice-6 (LAN-301)
+
+The Decision 1 benches re-run against the completed evaluator — every
+program slice landed since the original receipt (arithmetic, bindings,
+loops, functions, modules, datasets, fuel at back-edges, per-walk
+dataset pinning). Same bench targets plus the LAN-303 loop shape and a
+new fn-heavy arm (`cargo bench -p rustbgpd-policy --bench
+policy_eval`). Conditions: 64-core x86-64 box, otherwise quiet (load
+average < 2, no concurrent workspace builds), `--noplot`, three full
+process runs, medians of criterion point estimates. Absolute
+nanoseconds are not comparable to the Spike A table (different
+machine); the ratios are the signal.
+
+| Shape | ns/route (median of 3) |
+|---|---|
+| 1-statement chain | 39 |
+| 32-statement walk-everything chain | 385 (~11.2 ns marginal/statement) |
+| 32-statement chain, first-statement deny | 37 |
+| AS-path regex evaluated / short-circuit skipped | 69 / 20 |
+| Community scan evaluated / skipped | 29 / 20 |
+| 1,000-prefix list as IR terms / as one indexed set probe | 4,409 / 28 (**156×**) |
+| Constant actions / arithmetic actions (LAN-299) | 44 / 80 |
+| Community scrub: set probe / per-element fueled loop (LAN-303) | 28 / 73 (~4.5 ns per element incl. fuel) |
+| Damping via `fn` (3 call sites) / hand-inlined `let`s (LAN-304) | 152 / 105 (~15 ns/call — argument-bind slot writes, no frames) |
+| 50k-ASN set probe / dataset probe with per-walk pin (LAN-305) | 20–25 / 28–34 |
+
+**Gate verdict: the re-entry condition does not fire.** Chain-walk
+dispatch is still a ~11 ns/statement marginal term, and match data
+expressed the idiomatic way (indexed sets/datasets) still beats the
+walked form by two orders of magnitude — the set-index ratio *grew*
+(128× → 156×) as the walk gained the extended-IR machinery. Every
+cost the new constructs added prices as expression evaluation
+(checked-arithmetic ops, per-element fuel + slot writes, per-call
+argument binds), not as dispatch — exactly the term bytecode cannot
+help, per Spike B's 0.75–0.94×. No profile shows the fully-walked
+long-chain shape dominating manager CPU. The compact bytecode tier
+stays unbuilt; the gate stays open on the same trigger (a real-
+workload profile with chain-walk dispatch as a dominant manager-CPU
+term).
+
 ## Decision 2 — Value/type model and source-compatible grammar evolution
 
 ### Value model

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -479,6 +479,21 @@ daemon process** — use Prometheus `rate()` / `increase()` to read it.
 rate(bgp_policy_routes_total{direction="import", action="deny"}[5m])
 ```
 
+**Policy evaluation errors — Prometheus.** `bgp_policy_eval_errors_total
+{direction, kind}` counts routes denied by the fail-closed evaluation-
+error rail (ADR-0103 Decision 4: checked-arithmetic failure, absent
+operand, fuel/loop-cap exhaustion, ...). These denies also appear in
+`bgp_policy_routes_total` as `action="deny"`; this counter separates
+"the policy said no" from "the policy is broken". Any nonzero rate
+deserves a look — `rbgp policy stats` names the failing chain, policy,
+and term (`eval_errors` count + `last_error` per chain), and the
+rate-limited daemon WARN carries the same blame line.
+
+```promql
+# Any policy erroring anywhere is alert-worthy:
+sum by (kind) (rate(bgp_policy_eval_errors_total[5m])) > 0
+```
+
 **Policy filtering visibility — gRPC scalar aggregates.** `NeighborState`
 carries four per-peer running totals to give operators a cheap
 sanity-check on the labelled Prometheus counter:

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -482,9 +482,11 @@ if route.med >= threshold + 20 { set local-pref 90 }
 error — checked-arithmetic failure, inverted clamp, or an **absent
 operand** (`route.origin-as` on an empty/`AS_SET`-only path, unknown
 `peer.asn`) — denies the route: staged modifications are discarded,
-the chain's eval-error counter increments, a rate-limited WARN names
-the failing policy and term, and explain traces render the error in
-place of a verdict. `route.local-pref` and `route.med` read their
+`bgp_policy_eval_errors_total{direction, kind}` and the chain's
+eval-error counter increment (the latter with the failing
+policy/term retained, surfaced by `rbgp policy stats`), a
+rate-limited WARN names the failing policy and term, and explain
+traces render the error in place of a verdict. `route.local-pref` and `route.med` read their
 implicit defaults (100 / 0) when absent, consistent with comparisons.
 Note the deliberate divergence from plain comparisons: an
 arithmetic-free `route.origin-as == 64500` on an origin-less route
@@ -1056,6 +1058,7 @@ test NAME {
     route { FIELD VALUE; ... }
     [peer { address IP; asn N; local-as N; group "NAME" }]
     expect POLICY[(args)] == accept|reject [with ASSERTION, ...]
+    expect POLICY[(args)] == error [KIND]
     [expect ...]
 }
 ```
@@ -1083,6 +1086,26 @@ during evaluation, so the assertion states the **resolved** ASN:
 `with prepend as 65010 3`. `peer { local-as N }` supplies the value
 `prepend as self` resolves to (omitted ⇒ it fails closed and the
 expectation is a `reject`).
+
+**Errors are not verdicts.** An evaluation error (checked-arithmetic
+failure, absent operand, budget exhaustion — the ADR-0103 Decision 4
+fail-closed rail) FAILS an `accept` *or* `reject` expectation, with
+the error kind and the failing policy/term rendered — a test cannot
+accidentally pin a broken policy as "rejects correctly". To pin the
+rail itself, expect it: `expect p == error` passes on any evaluation
+error, and `expect p == error KIND` pins the kind (`error overflow`,
+`error divide-by-zero`, `error absent-prepend-operand`, ...; unknown
+kinds are compile diagnostics with a suggestion). `with` assertions
+cannot follow `== error` — an error discards every staged
+modification. In the daemon the same route is denied; the test form
+exists so CI can prove *which* rail fires:
+
+```rpol
+test missing-origin-fails-closed {
+    route { as-path "{64500 64501}" }
+    expect origin-pad == error absent-prepend-operand
+}
+```
 
 Tests run at check time (`rbgp policy check`, CI) with zero daemon
 involvement. Testing a *candidate* policy against a live RIB is
@@ -1384,7 +1407,15 @@ $ rbgp policy stats --peer 10.0.0.2 --direction both
   does. Export chains do not track an install generation yet.
 - Explain queries and `policy test` dry runs never move these
   counters — only live route evaluation counts.
-- `--json` emits the rows structurally.
+- Chains that have denied routes through the **evaluation-error rail**
+  (ADR-0103 Decision 4) report the count and the most recent blame
+  line above the term table — `2 routes denied by evaluation errors
+  (fail closed); last: overflow in policy pad-med term pad` — the
+  drill-down for a nonzero `bgp_policy_eval_errors_total{direction,
+  kind}` rate. Error counts reset with the chain instance, like every
+  other counter here.
+- `--json` emits the rows structurally (`eval_errors`, `last_error`
+  included).
 
 ## Positioning — how `.rpol` differs from BIRD filters and route-maps
 
@@ -1511,10 +1542,7 @@ hit counters — those come free after the rewrite.
 No `while` and no unbounded iteration of any kind — `for` (LAN-303)
 iterates finite sources only, capped and fuel-metered. No
 user-defined types, no maps (safety is total by construction —
-ADR-0096 Decision 2; the ADR-0103 extension program adds bounded
-constructs slice by slice — checked arithmetic shipped as LAN-299,
-bindings as LAN-302, bounded loops as LAN-303, pure functions as
-LAN-304, modules and imports as LAN-300). No `as-path-set`. No `else if` chains and no nested `if`
+ADR-0096 Decision 2). No `as-path-set`. No `else if` chains and no nested `if`
 (keep terms small; use `&&` or more terms). No mutable state of any
 kind — `let` bindings (LAN-302) are immutable, and reads never
 observe staged `set` writes (read-back would break memoization and
@@ -1523,3 +1551,16 @@ needs its own ADR). EVPN route type takes only an integer literal
 IPv6 literals (use `::` compression). These are scope decisions, not
 parser accidents; each has an error message steering to the
 supported form.
+
+The ADR-0103 v2 extension program is **complete**: checked arithmetic
+(LAN-299), `let` bindings (LAN-302), bounded loops (LAN-303), pure
+functions (LAN-304), modules and imports (LAN-300), external datasets
+(LAN-305), and the metered-runtime operator surface — eval-error
+counters, `rbgp policy stats` exposure, error-pinning test
+expectations (LAN-301) — have all shipped on the tree-walk evaluator.
+What deliberately did **not** ship: a bytecode tier (deferred behind
+the ADR-0103 Decision 1 re-entry gate — built only if a real-workload
+profile ever shows chain-walk dispatch dominating, which the
+post-program re-measurement did not) and any WASM/host-function
+escape hatch (rejected outright, ADR-0103 Decision 9 — external
+*data* via datasets, never external code in the per-route path).

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1105,6 +1105,16 @@ message PolicyChainStats {
   // do not track an install generation yet and always report 0
   // (LAN-311).
   uint64 policy_generation = 5;
+  // Routes denied by an evaluation error since chain install
+  // (ADR-0103 Decision 4 fail-closed rail: checked-arithmetic
+  // failure, absent operand, fuel/loop-cap exhaustion, ...). A
+  // nonzero value means some policy is erroring; last_error names
+  // where and why.
+  uint64 eval_errors = 6;
+  // Most recent evaluation error, rendered as
+  // "KIND in policy NAME term NAME". Empty when no evaluation has
+  // errored since chain install.
+  string last_error = 7;
 }
 
 message GetPolicyStatsResponse {


### PR DESCRIPTION
## Summary

- the final rpol v2 slice: the runtime rails built across the program get their operator surface, and the ADR-0103 bytecode re-entry gate gets its re-measured verdict
- `bgp_policy_eval_errors_total{direction,kind}` — 24-series worst case (two directions x the closed error-kind set), deliberately unlabeled by peer so no series reaping is needed; per-chain detail rides GetPolicyStats instead (`eval_errors` + rendered `last_error`), surfaced by `rbgp policy stats` with a fail-closed summary line; authz matrix untouched
- in-language test blocks implement the ADR's error semantics: an evaluation error now FAILS an accept/reject expectation with the error rendered, and the new `expect p == error [kind]` form pins the fail-closed rails explicitly (kind validated against the closed label set with suggestions); the 8 fixtures that relied on error-counts-as-reject are migrated
- bytecode gate verdict: does NOT fire — chain-walk dispatch is still a ~11 ns/statement marginal term on the completed language (bindings, loops, functions, datasets all landed), the set-index ratio grew to 156x, and every new-construct cost is expression evaluation the measured 0.75-0.94x bytecode cannot help; the dated addendum is recorded in ADR-0103's receipt section and bytecode stays unbuilt
- docs consolidate the failure contract, the stats surface, and the completed-v2 exclusions (bytecode gated, WASM rejected)

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpd-policy x2 parallel (359) / -p rustbgpd-api (405) / -p rustbgpctl (343) / -p rustbgpd-telemetry (62) / --bin rustbgpd (1367)
- cargo doc --workspace --no-deps
- cargo +nightly fuzz build (+1 error-expectation seed)
- bench medians of 3 at load <2, receipts in the ADR addendum

Closes LAN-301.