### PR TITLE
test: accept the changes-present exit code from rbgp config plan

### DIFF
--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -91,9 +91,13 @@ fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
 
 fn rbgp_json(grpc_addr: &str, args: &[&str]) -> serde_json::Value {
     let output = rbgp(grpc_addr, args);
+    // `config diff`/`config plan` exit 2 when changes are present (the
+    // detailed exit-code contract); their JSON is still the successful
+    // answer. Everything else must exit 0; 1 stays an error.
+    let code = output.status.code();
     assert!(
-        output.status.success(),
-        "rbgp {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        output.status.success() || code == Some(2),
+        "rbgp {args:?} failed (exit {code:?})\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );


### PR DESCRIPTION
## Summary

- `rbgp config plan` intentionally exits 2 when changes are present (#789's detailed exit-code contract), but the commit-confirm integration helper still required `status.success()`, failing both journal tests on any committable plan
- the helper now accepts 0 or 2 and keeps rejecting 1 and everything else; the gap survived the #789 landing because these are workspace integration-test targets, which the per-package landing gates do not compile

## Verification

- cargo test --test commit_confirm_binary (4 passed; reproduced the failure first)
- cargo test --workspace --no-fail-fast (full sweep clean — no other stale exit-code assumptions)