### PR TITLE
feat(rbgp): add config effective for the running post-defaults config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   canonical style. New "Formatting" section in
   `docs/rpol-language.md`. (LAN-323)
 
+- **`rbgp config effective` — dump the running post-defaults config.**
+  New `ConfigService.GetEffectiveConfig` RPC (`sensitive_read`) returns
+  the daemon's live config as normalized, deterministic TOML with
+  per-neighbor defaults materialized: peer-group inheritance and
+  computed defaults (`hold_time`, the RFC 9687 `send_hold_time`
+  derivation, GR/LLGR timers, address families, `ttl_security`,
+  RR/RS-client flags) are resolved to the values the daemon is using.
+  `rbgp -j config effective` re-renders the same document as JSON.
+  Secret material (`md5_password`, `tcp_ao.key`) is replaced with
+  `<redacted>` server-side before the document leaves the daemon, and
+  config validation now rejects the placeholder loudly — a dump taken
+  from a secret-bearing config cannot silently boot as-is. Secretless
+  dumps round-trip: they reload through `rustbgpd --check` and re-dump
+  to the identical document. (LAN-325)
+
 ### Changed
 - Removed the deprecated `bgp_aspa_records_total` gauge alias; `bgp_aspa_records` is the only exported name
 - **Docs reorganized by task shape (Diátaxis).** `docs/README.md` now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",

--- a/crates/api/src/audit.rs
+++ b/crates/api/src/audit.rs
@@ -140,6 +140,13 @@ pub(crate) fn get_config_transaction_status_summary() -> GrpcRequestSummary {
     GrpcRequestSummary::new("request=empty")
 }
 
+/// Summary for `GetEffectiveConfig`; there are no request fields. The
+/// response TOML is redacted by the peer manager before it reaches the
+/// service, so nothing response-side needs masking here either.
+pub(crate) fn get_effective_config_summary() -> GrpcRequestSummary {
+    GrpcRequestSummary::new("request=empty")
+}
+
 /// Summary for `gnmi.gNMI/Set`. Set payloads can carry future secret-bearing
 /// config values, so log only operation counts and extension count.
 pub(crate) fn gnmi_set_summary(request: &crate::gnmi::SetRequest) -> GrpcRequestSummary {

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -179,6 +179,12 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         AuthTier::SensitiveRead,
     ),
     method(
+        "rustbgpd.v1.ConfigService",
+        "GetEffectiveConfig",
+        "/rustbgpd.v1.ConfigService/GetEffectiveConfig",
+        AuthTier::SensitiveRead,
+    ),
+    method(
         "rustbgpd.v1.NeighborService",
         "AddNeighbor",
         "/rustbgpd.v1.NeighborService/AddNeighbor",
@@ -835,7 +841,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 97);
+        assert_eq!(METHODS.len(), 98);
     }
 
     #[test]
@@ -876,7 +882,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 56);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 57);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 22);
     }
@@ -952,6 +958,14 @@ mod tests {
         );
         assert_eq!(
             method_authz("/rustbgpd.v1.ConfigService/GetConfigTransactionStatus").map(|m| m.tier),
+            Some(AuthTier::SensitiveRead)
+        );
+        // The effective-config dump discloses the whole config (peer lists,
+        // policy, topology) but never secret material — the peer manager
+        // redacts before the document reaches the service. Read-only
+        // full-config disclosure pins at sensitive_read, never read.
+        assert_eq!(
+            method_authz("/rustbgpd.v1.ConfigService/GetEffectiveConfig").map(|m| m.tier),
             Some(AuthTier::SensitiveRead)
         );
         assert_eq!(

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -6,7 +6,8 @@ use tonic::{Request, Response, Status};
 use crate::audit::{
     abort_config_transaction_summary, apply_config_transaction_summary,
     confirm_config_transaction_summary, diff_runtime_config_summary,
-    get_config_transaction_status_summary, plan_config_transaction_summary, set_request_summary,
+    get_config_transaction_status_summary, get_effective_config_summary,
+    plan_config_transaction_summary, set_request_summary,
 };
 use crate::peer_types::{
     PeerManagerCommand, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
@@ -251,6 +252,26 @@ impl proto::config_service_server::ConfigService for ConfigService {
             .map(Response::new)
             .map_err(ConfigTransactionApplyError::into_status)
     }
+
+    async fn get_effective_config(
+        &self,
+        request: Request<proto::GetEffectiveConfigRequest>,
+    ) -> Result<Response<proto::GetEffectiveConfigResponse>, Status> {
+        set_request_summary(&request, get_effective_config_summary());
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::EffectiveRuntimeConfig { reply: reply_tx })
+            .await
+            .map_err(|_| Status::unavailable("peer manager is unavailable"))?;
+
+        match reply_rx
+            .await
+            .map_err(|_| Status::unavailable("peer manager dropped effective config reply"))?
+        {
+            Ok(toml) => Ok(Response::new(proto::GetEffectiveConfigResponse { toml })),
+            Err(error) => Err(Status::internal(error)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -301,6 +322,51 @@ mod tests {
         assert!(resp.has_restart_required_changes);
         assert_eq!(resp.human_text, "Restart-required changes:\n");
         assert_eq!(resp.diff_json, "{\"has_any_changes\":true}");
+    }
+
+    #[tokio::test]
+    async fn get_effective_config_returns_peer_manager_toml() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        let server = tokio::spawn(async move {
+            let Some(PeerManagerCommand::EffectiveRuntimeConfig { reply }) = rx.recv().await else {
+                panic!("expected EffectiveRuntimeConfig command");
+            };
+            let _ = reply.send(Ok(
+                "[global]\nasn = 65001\nhold_time = 90\nrouter_id = \"10.0.0.1\"\n".to_string(),
+            ));
+        });
+
+        let resp = svc
+            .get_effective_config(Request::new(proto::GetEffectiveConfigRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+
+        server.await.unwrap();
+        assert_eq!(
+            resp.toml,
+            "[global]\nasn = 65001\nhold_time = 90\nrouter_id = \"10.0.0.1\"\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_effective_config_maps_serialization_failure_to_internal() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::EffectiveRuntimeConfig { reply }) = rx.recv().await else {
+                panic!("expected EffectiveRuntimeConfig command");
+            };
+            let _ = reply.send(Err("failed to serialize effective config".to_string()));
+        });
+
+        let err = svc
+            .get_effective_config(Request::new(proto::GetEffectiveConfigRequest {}))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::Internal);
     }
 
     fn sample_runtime_diff() -> RuntimeConfigDiff {

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -664,6 +664,15 @@ pub enum PeerManagerCommand {
         /// Reply returns normalized TOML plus the live rpol registry.
         reply: oneshot::Sender<Result<RuntimeConfigSnapshotReply, String>>,
     },
+    /// Return the effective running config as normalized TOML with defaults
+    /// materialized and secret material redacted, for
+    /// `ConfigService.GetEffectiveConfig`. Unlike
+    /// [`PeerManagerCommand::RuntimeConfigSnapshot`], the reply is safe to
+    /// hand to `sensitive_read` API callers: secrets never leave the daemon.
+    EffectiveRuntimeConfig {
+        /// Reply returns the redacted effective config TOML.
+        reply: oneshot::Sender<Result<String, String>>,
+    },
     /// Atomically apply resolved import/export policy chains to a set of live
     /// peer sessions, returning each peer's PRIOR chains for rollback.
     ///

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ clap_complete.workspace = true
 clap_mangen.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 tower = { version = "0.5", features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 owo-colors.workspace = true

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -6,7 +6,7 @@ use crate::proto::{
     ConfigTransactionConfirmation, ConfigTransactionConfirmationStatus,
     ConfigTransactionPlanResponse, ConfigTransactionPlanStatus, ConfigTransactionStatusResponse,
     ConfirmConfigTransactionRequest, DiffRuntimeConfigRequest, DiffRuntimeConfigResponse,
-    GetConfigTransactionStatusRequest, PlanConfigTransactionRequest,
+    GetConfigTransactionStatusRequest, GetEffectiveConfigRequest, PlanConfigTransactionRequest,
 };
 
 const MAX_CONFIRM_ID_CHARS: usize = 128;
@@ -215,6 +215,39 @@ pub async fn status(connection: Connection, json: bool) -> Result<(), CliError> 
         print_confirmation(resp.confirmation.as_ref());
     }
     Ok(())
+}
+
+/// Dump the daemon's effective running config: normalized TOML with
+/// defaults materialized and secrets redacted server-side. `--json`
+/// re-renders the same document as JSON; the daemon only ships TOML.
+pub async fn effective(connection: Connection, json: bool) -> Result<(), CliError> {
+    let mut client =
+        ConfigServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .get_effective_config(GetEffectiveConfigRequest {})
+        .await?
+        .into_inner();
+
+    if json {
+        print_json(effective_to_json(&resp.toml)?)?;
+    } else {
+        print!("{}", resp.toml);
+    }
+    Ok(())
+}
+
+/// Re-render the daemon's effective-config TOML document as JSON for `-j`.
+fn effective_to_json(toml_text: &str) -> Result<serde_json::Value, CliError> {
+    let value: toml::Value = toml::from_str(toml_text).map_err(|error| {
+        CliError::Argument(format!(
+            "daemon returned unparseable effective config TOML: {error}"
+        ))
+    })?;
+    serde_json::to_value(value).map_err(|error| {
+        CliError::Argument(format!(
+            "failed to convert effective config to JSON: {error}"
+        ))
+    })
 }
 
 fn read_candidate_toml(from_file: &str) -> Result<String, CliError> {
@@ -474,6 +507,63 @@ mod tests {
     fn change_status_exit_codes_are_terraform_style() {
         assert_eq!(change_status_exit_code(false), 0);
         assert_eq!(change_status_exit_code(true), 2);
+    }
+
+    #[tokio::test]
+    async fn effective_fetches_running_config() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        effective(connection, false).await.unwrap();
+
+        assert_eq!(
+            server.state.config_effective_calls.load(Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn effective_json_renders_config_as_structured_json() {
+        let server = spawn_mock_server(None).await;
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        effective(connection, true).await.unwrap();
+
+        assert_eq!(
+            server.state.config_effective_calls.load(Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[test]
+    fn effective_to_json_produces_structured_config() {
+        let value = effective_to_json(
+            "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n\n[[neighbors]]\naddress = \"192.0.2.2\"\nhold_time = 90\nremote_asn = 65000\n",
+        )
+        .unwrap();
+        assert_eq!(value["global"]["asn"], 65000);
+        assert_eq!(value["neighbors"][0]["hold_time"], 90);
+    }
+
+    #[test]
+    fn effective_to_json_rejects_unparseable_toml() {
+        // A daemon reply that is not parseable TOML must error rather
+        // than print garbage.
+        assert!(effective_to_json("not = [valid").is_err());
+    }
+
+    #[tokio::test]
+    async fn effective_rpc_error_maps_to_cli_error() {
+        let server = spawn_mock_server(None).await;
+        *server.state.config_effective_error.lock().await = Some((
+            tonic::Code::PermissionDenied,
+            "sensitive_read required".to_string(),
+        ));
+        let connection = connect(&server.addr, None).await.unwrap();
+
+        let result = effective(connection, false).await;
+
+        assert!(result.is_err(), "daemon error must take the exit-1 path");
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -380,6 +380,18 @@ enum ConfigAction {
 
     /// Show pending or last confirmed-transaction lifecycle state
     Status,
+
+    /// Dump the daemon's effective running config (defaults materialized)
+    ///
+    /// Prints the live post-defaults config as normalized TOML: peer-group
+    /// inheritance and computed defaults (hold_time, send_hold_time, GR
+    /// timers, families) are resolved to the values the daemon is using.
+    /// Secret material (md5_password, tcp_ao key) is replaced with
+    /// `<redacted>` before it leaves the daemon; a dump containing the
+    /// placeholder fails `rustbgpd --check` loudly, so restore real secrets
+    /// before reusing it as a config file. Use --json (-j) for a JSON
+    /// rendering; the default output is TOML.
+    Effective,
 }
 
 #[derive(Subcommand)]
@@ -1723,6 +1735,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 commands::config::abort(connection, &confirm_id, json).await
             }
             ConfigAction::Status => commands::config::status(connection, json).await,
+            ConfigAction::Effective => commands::config::effective(connection, json).await,
         },
 
         Command::Neighbor {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -38,6 +38,8 @@ pub(crate) struct MockState {
     pub(crate) config_confirm_calls: AtomicUsize,
     pub(crate) config_abort_calls: AtomicUsize,
     pub(crate) config_status_calls: AtomicUsize,
+    pub(crate) config_effective_calls: AtomicUsize,
+    pub(crate) config_effective_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
@@ -512,6 +514,21 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
                 human_text: "No confirmed config transaction is pending.\n".to_string(),
             },
         ))
+    }
+
+    async fn get_effective_config(
+        &self,
+        _request: Request<server_proto::GetEffectiveConfigRequest>,
+    ) -> Result<Response<server_proto::GetEffectiveConfigResponse>, Status> {
+        self.state
+            .config_effective_calls
+            .fetch_add(1, Ordering::SeqCst);
+        if let Some((code, message)) = self.state.config_effective_error.lock().await.clone() {
+            return Err(Status::new(code, message));
+        }
+        Ok(Response::new(server_proto::GetEffectiveConfigResponse {
+            toml: "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n\n[[neighbors]]\naddress = \"192.0.2.2\"\nhold_time = 90\nremote_asn = 65000\n".to_string(),
+        }))
     }
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -153,7 +153,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | Service | Read-only RPCs | Mutating RPCs rejected on `read_only` |
 |---------|----------------|---------------------------------------|
 | `GlobalService` | `GetGlobal` | — |
-| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction`, `GetConfigTransactionStatus` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, pure live policy-chain impact for static neighbors and accepted dynamic peers, or peer-group/session reshape impact for static members and live dynamic sessions; mixed or unsupported candidates rejected without mutation), `ConfirmConfigTransaction`, `AbortConfigTransaction` |
+| `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction`, `GetConfigTransactionStatus`, `GetEffectiveConfig` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, pure live policy-chain impact for static neighbors and accepted dynamic peers, or peer-group/session reshape impact for static members and live dynamic sessions; mixed or unsupported candidates rejected without mutation), `ConfirmConfigTransaction`, `AbortConfigTransaction` |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy`, `TestPolicy`, `GetPolicyStats` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
@@ -248,9 +248,12 @@ dynamic neighbor wildcard-MKT support are not exposed through the API yet.
 
 ## ConfigService
 
-Live runtime config diagnostics and transaction planning. This service never
-exports the daemon's full live config snapshot; callers submit candidate TOML
-and receive only redacted diff / plan output.
+Live runtime config diagnostics and transaction planning. Diff / plan
+callers submit candidate TOML and receive only redacted diff / plan
+output; `GetEffectiveConfig` is the one deliberate full-document export
+— it returns the effective running config as normalized TOML with
+defaults materialized and secret material replaced with `<redacted>`
+before it leaves the daemon (`rbgp config effective`).
 
 | RPC | Description |
 |-----|-------------|
@@ -260,6 +263,7 @@ and receive only redacted diff / plan output.
 | `ConfirmConfigTransaction` | Confirm a pending confirmed transaction before its timer expires |
 | `AbortConfigTransaction` | Abort a pending confirmed transaction and roll back immediately |
 | `GetConfigTransactionStatus` | Return redacted confirmed-transaction lifecycle state |
+| `GetEffectiveConfig` | Return the effective running config as normalized TOML — defaults materialized, secrets redacted (`rbgp config effective`) |
 
 `DiffRuntimeConfigResponse` contains boolean summary fields, a
 plain-text `human_text` rendering, and `diff_json` using the

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -63,6 +63,21 @@ Note that the schema checks structure, types, and enum values; semantic
 rules (ASN/hold-time ranges, cross-field requirements, name references)
 are still enforced by `rustbgpd --check`. Run both for full coverage.
 
+To see what a **running** daemon is actually using — the post-defaults
+config, with peer-group inheritance and computed defaults (`hold_time`,
+`send_hold_time`, GR timers, address families) materialized on every
+static neighbor — dump it live:
+
+```
+rbgp config effective            # normalized TOML
+rbgp -j config effective         # same document as JSON
+```
+
+Secret material (`md5_password`, `tcp_ao` keys) is replaced with
+`<redacted>` before it leaves the daemon; a dump containing the
+placeholder deliberately fails `rustbgpd --check`, so restore real
+secrets before reusing a dump as a config file.
+
 ### SchemaStore submission (not yet submitted)
 
 Once submitted to [SchemaStore](https://github.com/SchemaStore/schemastore),

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -91,6 +91,12 @@ transaction with an optimistic runtime snapshot token:
 `rbgp` is the supported CLI spelling.
 
 ```bash
+# What is the daemon actually running? Dump the effective config with
+# defaults materialized (hold_time, send_hold_time, GR timers, families)
+# and secrets redacted:
+rbgp config effective
+rbgp -j config effective
+
 rbgp config diff --from-file /tmp/new-config.toml
 rbgp --json config diff --from-file /tmp/new-config.toml
 

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -56,6 +56,14 @@ oracle:
 rbgp config diff --from-file /etc/rustbgpd/candidate.toml
 ```
 
+Not sure what a value on the live RR *currently* is (an inherited
+peer-group timer, a defaulted `hold_time`)? Dump the effective running
+config first — defaults materialized, secrets redacted:
+
+```bash
+rbgp config effective
+```
+
 The diff annotates each changed field. Two classes matter here:
 
 - **Hot-applied** (`description`, `max_prefixes`,

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 97,
+  "method_count": 98,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 56,
+    "sensitive_read": 57,
     "mutating": 19,
     "operator_only": 22
   },
@@ -25,6 +25,7 @@
     { "service": "rustbgpd.v1.ConfigService", "method": "ConfirmConfigTransaction", "path": "/rustbgpd.v1.ConfigService/ConfirmConfigTransaction", "tier": "operator_only" },
     { "service": "rustbgpd.v1.ConfigService", "method": "AbortConfigTransaction", "path": "/rustbgpd.v1.ConfigService/AbortConfigTransaction", "tier": "operator_only" },
     { "service": "rustbgpd.v1.ConfigService", "method": "GetConfigTransactionStatus", "path": "/rustbgpd.v1.ConfigService/GetConfigTransactionStatus", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.ConfigService", "method": "GetEffectiveConfig", "path": "/rustbgpd.v1.ConfigService/GetEffectiveConfig", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.NeighborService", "method": "AddNeighbor", "path": "/rustbgpd.v1.NeighborService/AddNeighbor", "tier": "mutating" },
     { "service": "rustbgpd.v1.NeighborService", "method": "DeleteNeighbor", "path": "/rustbgpd.v1.NeighborService/DeleteNeighbor", "tier": "mutating" },
     { "service": "rustbgpd.v1.NeighborService", "method": "ListNeighbors", "path": "/rustbgpd.v1.NeighborService/ListNeighbors", "tier": "sensitive_read" },

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -60,7 +60,7 @@ shape itself does not raise the tier.
 |-----|------|-------|
 | `GetGlobal` | `sensitive_read` | Returns `GlobalState`: `asn`, `router_id`, `listen_port`, TCP-AO kernel-support probe. Topology disclosure. |
 
-### ConfigService (6 RPCs)
+### ConfigService (7 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -70,6 +70,7 @@ shape itself does not raise the tier.
 | `ConfirmConfigTransaction` | `operator_only` | Confirm a pending confirmed config transaction before its timeout expires. Confirms deployment reachability rather than reading config contents. |
 | `AbortConfigTransaction` | `operator_only` | Abort a pending confirmed config transaction and roll back immediately through the transaction executor. |
 | `GetConfigTransactionStatus` | `sensitive_read` | Returns redacted confirmed-transaction lifecycle status: pending/last state, confirm id, deadline, committed sections, and snapshot token, but never candidate TOML. |
+| `GetEffectiveConfig` | `sensitive_read` | Returns the full effective running config as normalized TOML with defaults materialized (`rbgp config effective`). Whole-config disclosure: peer lists, policy structure, topology. Secret material (`md5_password`, `tcp_ao.key`) is replaced with `<redacted>` before the document leaves the daemon. |
 
 ### NeighborService (11 RPCs)
 
@@ -216,13 +217,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 56 | 57.7% |
-| `mutating` | 19 | 19.6% |
-| `operator_only` | 22 | 22.7% |
-| **Total** | **97** | **100%** |
+| `sensitive_read` | 57 | 58.2% |
+| `mutating` | 19 | 19.4% |
+| `operator_only` | 22 | 22.4% |
+| **Total** | **98** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 97
-total is 93 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 98
+total is 94 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -130,6 +130,24 @@ service ConfigService {
   // Return the current confirmed-transaction lifecycle state. The response is
   // redacted and never includes candidate config contents.
   rpc GetConfigTransactionStatus(GetConfigTransactionStatusRequest) returns (ConfigTransactionStatusResponse);
+
+  // Return the daemon's effective running config as normalized TOML with
+  // per-neighbor defaults materialized (peer-group inheritance and computed
+  // defaults such as hold_time / send_hold_time resolved to the values the
+  // daemon is using). Secret material (md5_password, tcp_ao.key) is replaced
+  // with the `<redacted>` placeholder before the document leaves the daemon;
+  // config validation rejects the placeholder loudly, so a dump taken from a
+  // secret-bearing config cannot silently boot as-is.
+  rpc GetEffectiveConfig(GetEffectiveConfigRequest) returns (GetEffectiveConfigResponse);
+}
+
+message GetEffectiveConfigRequest {}
+
+message GetEffectiveConfigResponse {
+  // Normalized effective config TOML, defaults materialized, secrets
+  // redacted. Key order is canonical (sorted), so the output is stable
+  // across calls against an unchanged runtime config.
+  string toml = 1;
 }
 
 message DiffRuntimeConfigRequest {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2661,6 +2661,168 @@ impl RuntimeSnapshotKey {
     }
 }
 
+/// Placeholder emitted in place of secret material by the effective-config
+/// dump (`rbgp config effective`). `Config::validate` rejects it loudly so a
+/// dumped config with secrets cannot silently boot with the placeholder as a
+/// live credential.
+pub const REDACTED_SECRET: &str = "<redacted>";
+
+impl Config {
+    /// The running post-defaults config for `rbgp config effective`:
+    /// a clone of this config with per-neighbor session defaults
+    /// materialized (peer-group inheritance and computed defaults such
+    /// as `hold_time` / RFC 9687 `send_hold_time` resolved to the
+    /// values the daemon is using) and secret material replaced with
+    /// [`REDACTED_SECRET`].
+    ///
+    /// Peer-group and dynamic-neighbor rows are shown as written —
+    /// their values resolve per-session; static `[[neighbors]]` rows
+    /// carry the resolved values. Fields whose absence *is* the
+    /// effective value (`max_prefixes` unset = unlimited,
+    /// `remove_private_as` unset = disabled) stay absent.
+    ///
+    /// The default constants below are pinned to `resolve_neighbor` by
+    /// the `effective_redacted_matches_resolve_neighbor` config test,
+    /// so they cannot drift silently.
+    #[must_use]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one inheritance/default chain per materialized neighbor field; splitting would scatter the pins"
+    )]
+    pub fn effective_redacted(&self) -> Config {
+        let mut effective = self.clone();
+
+        for neighbor in &mut effective.neighbors {
+            // Runtime configs are validated, so referenced groups exist;
+            // a dangling reference just skips inheritance here.
+            let group = self.peer_group_for_neighbor(neighbor).unwrap_or(None);
+            let hold_time = neighbor
+                .hold_time
+                .or_else(|| group.and_then(|g| g.hold_time))
+                .unwrap_or(DEFAULT_HOLD_TIME);
+            neighbor.hold_time = Some(hold_time);
+            neighbor.send_hold_time = Some(
+                neighbor
+                    .send_hold_time
+                    .or_else(|| group.and_then(|g| g.send_hold_time))
+                    .unwrap_or_else(|| rustbgpd_fsm::default_send_hold_time(hold_time)),
+            );
+            neighbor.graceful_restart = Some(
+                neighbor
+                    .graceful_restart
+                    .or_else(|| group.and_then(|g| g.graceful_restart))
+                    .unwrap_or(true),
+            );
+            neighbor.gr_restart_time = Some(
+                neighbor
+                    .gr_restart_time
+                    .or_else(|| group.and_then(|g| g.gr_restart_time))
+                    .unwrap_or(120),
+            );
+            neighbor.gr_stale_routes_time = Some(
+                neighbor
+                    .gr_stale_routes_time
+                    .or_else(|| group.and_then(|g| g.gr_stale_routes_time))
+                    .unwrap_or(360),
+            );
+            neighbor.llgr_stale_time = Some(
+                neighbor
+                    .llgr_stale_time
+                    .or_else(|| group.and_then(|g| g.llgr_stale_time))
+                    .unwrap_or(0),
+            );
+            neighbor.ttl_security = Some(
+                neighbor
+                    .ttl_security
+                    .or_else(|| group.and_then(|g| g.ttl_security))
+                    .unwrap_or(false),
+            );
+            neighbor.max_prefixes = neighbor
+                .max_prefixes
+                .or_else(|| group.and_then(|g| g.max_prefixes));
+            neighbor.route_reflector_client = Some(
+                neighbor
+                    .route_reflector_client
+                    .or_else(|| group.and_then(|g| g.route_reflector_client))
+                    .unwrap_or(false),
+            );
+            neighbor.route_server_client = Some(
+                neighbor
+                    .route_server_client
+                    .or_else(|| group.and_then(|g| g.route_server_client))
+                    .unwrap_or(false),
+            );
+            neighbor.per_client_best = Some(
+                neighbor
+                    .per_client_best
+                    .or_else(|| group.and_then(|g| g.per_client_best))
+                    .unwrap_or(false),
+            );
+            neighbor.strict_role = Some(
+                neighbor
+                    .strict_role
+                    .or_else(|| group.and_then(|g| g.strict_role))
+                    .unwrap_or(false),
+            );
+            neighbor.prefix_orf_receive = Some(
+                neighbor
+                    .prefix_orf_receive
+                    .or_else(|| group.and_then(|g| g.prefix_orf_receive))
+                    .unwrap_or(false),
+            );
+            neighbor.disable_ipv4_unicast = Some(
+                neighbor
+                    .disable_ipv4_unicast
+                    .or_else(|| group.and_then(|g| g.disable_ipv4_unicast))
+                    .unwrap_or(false),
+            );
+            if neighbor.families.is_empty() {
+                if let Some(group_families) = group.map(|g| &g.families).filter(|f| !f.is_empty()) {
+                    neighbor.families.clone_from(group_families);
+                } else {
+                    neighbor.families.push("ipv4_unicast".to_string());
+                    if neighbor
+                        .address
+                        .parse::<IpAddr>()
+                        .is_ok_and(|addr| addr.is_ipv6())
+                    {
+                        neighbor.families.push("ipv6_unicast".to_string());
+                    }
+                }
+            }
+        }
+
+        // Redact secret material everywhere it appears in the schema:
+        // neighbor md5_password / tcp_ao.key and peer-group md5_password.
+        for neighbor in &mut effective.neighbors {
+            if neighbor.md5_password.is_some() {
+                neighbor.md5_password = Some(REDACTED_SECRET.to_string());
+            }
+            if let Some(tcp_ao) = &mut neighbor.tcp_ao {
+                tcp_ao.key = REDACTED_SECRET.to_string();
+            }
+        }
+        for group in effective.peer_groups.values_mut() {
+            if group.md5_password.is_some() {
+                group.md5_password = Some(REDACTED_SECRET.to_string());
+            }
+        }
+
+        effective
+    }
+
+    /// Deterministic TOML rendering of [`Config::effective_redacted`].
+    /// Canonicalized through `toml::Value` (BTreeMap-backed, keys
+    /// sorted) exactly like the runtime snapshot token, so the output
+    /// is stable across `HashMap` iteration orders.
+    pub fn effective_redacted_toml(&self) -> Result<String, String> {
+        let canonical = toml::Value::try_from(self.effective_redacted())
+            .map_err(|error| format!("failed to canonicalize effective config: {error}"))?;
+        toml::to_string_pretty(&canonical)
+            .map_err(|error| format!("failed to serialize effective config: {error}"))
+    }
+}
+
 /// Classify a validated config diff for the v1 config transaction model.
 ///
 /// This deliberately does not mirror all SIGHUP reload-applied sections. The

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -12946,3 +12946,232 @@ fn dataset_reload_reuses_handles_swaps_scoped_and_keeps_prior_on_failure() {
         "old data still probing"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Effective running config dump (`rbgp config effective`, LAN-325)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn effective_redacted_materializes_neighbor_defaults() {
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+"#;
+    let config = Config::load_toml_with_diagnostics(toml_str, "test.toml").unwrap();
+    let rendered = config.effective_redacted_toml().unwrap();
+
+    // Computed defaults appear as concrete values: DEFAULT_HOLD_TIME and
+    // the RFC 9687 §6 derived send-hold default (max(480, 2 × hold)).
+    assert!(rendered.contains("hold_time = 90"), "{rendered}");
+    assert!(rendered.contains("send_hold_time = 480"), "{rendered}");
+    assert!(rendered.contains("graceful_restart = true"), "{rendered}");
+    assert!(rendered.contains("gr_restart_time = 120"), "{rendered}");
+    assert!(
+        rendered.contains("gr_stale_routes_time = 360"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("llgr_stale_time = 0"), "{rendered}");
+    assert!(rendered.contains("ttl_security = false"), "{rendered}");
+    assert!(rendered.contains("\"ipv4_unicast\""), "{rendered}");
+}
+
+#[test]
+fn effective_redacted_matches_resolve_neighbor() {
+    // Drift guard: the materialization constants in `effective_redacted`
+    // must agree with `resolve_neighbor` for both a bare neighbor and a
+    // group-inheriting neighbor.
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.rr-clients]
+hold_time = 30
+gr_restart_time = 200
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65001
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65001
+peer_group = "rr-clients"
+"#;
+    let config = Config::load_toml_with_diagnostics(toml_str, "test.toml").unwrap();
+    let effective = config.effective_redacted();
+    for (original, materialized) in config.neighbors.iter().zip(&effective.neighbors) {
+        let resolved = config.resolve_neighbor(original).unwrap();
+        let peer = &resolved.transport_config.peer;
+        assert_eq!(materialized.hold_time, Some(peer.hold_time));
+        assert_eq!(materialized.send_hold_time, Some(peer.send_hold_time));
+        assert_eq!(materialized.graceful_restart, Some(peer.graceful_restart));
+        assert_eq!(materialized.gr_restart_time, Some(peer.gr_restart_time));
+        assert_eq!(
+            materialized.gr_stale_routes_time,
+            Some(resolved.transport_config.gr_stale_routes_time)
+        );
+        assert_eq!(
+            materialized.llgr_stale_time,
+            Some(resolved.transport_config.llgr_stale_time)
+        );
+        assert_eq!(
+            materialized.ttl_security,
+            Some(resolved.transport_config.ttl_security)
+        );
+    }
+    // Group inheritance visible on the second neighbor.
+    assert_eq!(effective.neighbors[1].hold_time, Some(30));
+    assert_eq!(effective.neighbors[1].gr_restart_time, Some(200));
+}
+
+#[test]
+fn effective_redacted_never_leaks_secrets() {
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.md5-group]
+md5_password = "group-hunter2-seed"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+md5_password = "neighbor-hunter2-seed"
+
+[[neighbors]]
+address = "10.0.0.3"
+remote_asn = 65003
+
+[neighbors.tcp_ao]
+key = "tcp-ao-hunter2-seed"
+send_id = 1
+recv_id = 2
+algorithm = "hmac(sha256)"
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65001
+peer_group = "md5-group"
+"#;
+    let config = Config::load_toml_with_diagnostics(toml_str, "test.toml").unwrap();
+    let rendered = config.effective_redacted_toml().unwrap();
+    assert!(!rendered.contains("hunter2"), "{rendered}");
+    assert!(rendered.contains(REDACTED_SECRET), "{rendered}");
+}
+
+#[test]
+fn effective_redacted_toml_is_deterministic_and_round_trips() {
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[peer_groups.zeta]
+hold_time = 15
+
+[peer_groups.alpha]
+hold_time = 45
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65001
+peer_group = "alpha"
+
+[[neighbors]]
+address = "2001:db8::2"
+remote_asn = 65002
+"#;
+    let config = Config::load_toml_with_diagnostics(toml_str, "test.toml").unwrap();
+    let first = config.effective_redacted_toml().unwrap();
+    let second = config.effective_redacted_toml().unwrap();
+    assert_eq!(first, second, "effective dump must be deterministic");
+
+    // Secretless dumps round-trip through the normal loader + validator.
+    let reloaded = Config::load_toml_with_diagnostics(&first, "effective.toml")
+        .expect("secretless effective dump must reload cleanly");
+    assert_eq!(reloaded.neighbors[0].hold_time, Some(45));
+    // Implicit-family default for the IPv6 neighbor is materialized.
+    let v6 = reloaded
+        .neighbors
+        .iter()
+        .find(|n| n.address == "2001:db8::2")
+        .unwrap();
+    assert_eq!(
+        v6.families,
+        vec!["ipv4_unicast".to_string(), "ipv6_unicast".to_string()]
+    );
+
+    // Reloading the dump and dumping again is a fixpoint.
+    assert_eq!(reloaded.effective_redacted_toml().unwrap(), first);
+}
+
+#[test]
+fn redacted_placeholder_fails_validation_loudly() {
+    for (label, snippet) in [
+        (
+            "neighbor md5",
+            "[[neighbors]]\naddress = \"10.0.0.2\"\nremote_asn = 65002\nmd5_password = \"<redacted>\"\n",
+        ),
+        (
+            "tcp_ao key",
+            "[[neighbors]]\naddress = \"10.0.0.2\"\nremote_asn = 65002\n[neighbors.tcp_ao]\nkey = \"<redacted>\"\nsend_id = 1\nrecv_id = 2\nalgorithm = \"hmac(sha256)\"\n",
+        ),
+        (
+            "peer group md5",
+            "[peer_groups.g]\nmd5_password = \"<redacted>\"\n",
+        ),
+    ] {
+        let toml_str = format!(
+            "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n[global.telemetry]\nlog_format = \"json\"\n\n{snippet}"
+        );
+        let err = Config::load_toml_with_diagnostics(&toml_str, "effective.toml").expect_err(label);
+        assert!(err.contains("rbgp config effective"), "{label}: {err}");
+    }
+}
+
+#[test]
+fn effective_redacted_dump_with_secrets_does_not_reload() {
+    // The documented contract: a dump taken from a secret-bearing config
+    // must fail --check/load loudly rather than boot with the placeholder.
+    let toml_str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+md5_password = "hunter2"
+"#;
+    let config = Config::load_toml_with_diagnostics(toml_str, "test.toml").unwrap();
+    let rendered = config.effective_redacted_toml().unwrap();
+    let err = Config::load_toml_with_diagnostics(&rendered, "effective.toml").unwrap_err();
+    assert!(err.contains("md5_password"), "{err}");
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -90,6 +90,7 @@ impl Config {
 
         validate_event_history(&self.event_history)?;
         validate_grpc_security(&self.security)?;
+        self.validate_no_redacted_secrets()?;
 
         // Validate prometheus_addr is a valid SocketAddr (if configured)
         if let Some(ref addr) = self.global.telemetry.prometheus_addr {
@@ -949,6 +950,45 @@ impl Config {
             };
             effective.iter().any(|f| f == "linkstate")
         })
+    }
+}
+
+impl Config {
+    /// Reject the literal `<redacted>` placeholder that `rbgp config
+    /// effective` emits in place of secret material. A dumped config that
+    /// still carries the placeholder must fail loudly at load instead of
+    /// silently booting with `<redacted>` as a live credential.
+    fn validate_no_redacted_secrets(&self) -> Result<(), ConfigError> {
+        let placeholder_error = |address: &str, field: &str| ConfigError::InvalidNeighborConfig {
+            address: address.to_string(),
+            field: field.to_string(),
+            reason: format!(
+                "is the literal {:?} placeholder emitted by `rbgp config effective`; \
+                 restore the real secret before loading this config",
+                super::REDACTED_SECRET
+            ),
+        };
+        for neighbor in &self.neighbors {
+            if neighbor.md5_password.as_deref() == Some(super::REDACTED_SECRET) {
+                return Err(placeholder_error(&neighbor.address, "md5_password"));
+            }
+            if neighbor
+                .tcp_ao
+                .as_ref()
+                .is_some_and(|tcp_ao| tcp_ao.key == super::REDACTED_SECRET)
+            {
+                return Err(placeholder_error(&neighbor.address, "tcp_ao.key"));
+            }
+        }
+        for (name, group) in &self.peer_groups {
+            if group.md5_password.as_deref() == Some(super::REDACTED_SECRET) {
+                return Err(placeholder_error(
+                    &format!("peer_groups.{name}"),
+                    "md5_password",
+                ));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -723,6 +723,9 @@ impl PeerManager {
                                 });
                             let _ = reply.send(result);
                         }
+                        PeerManagerCommand::EffectiveRuntimeConfig { reply } => {
+                            let _ = reply.send(self.current_config.effective_redacted_toml());
+                        }
                         PeerManagerCommand::ApplyResolvedPolicySnapshot { targets, reply } => {
                             let result = self.apply_resolved_policy_snapshot(targets).await;
                             let _ = reply.send(result);


### PR DESCRIPTION
## Summary

- `rbgp config effective [--toml|-j]` dumps the daemon's running configuration with peer-group inheritance and computed defaults materialized (hold/send-hold timers, GR/LLGR times, families including implicit IPv6, RR/RS flags) — wired from the runtime snapshot, never from re-parsing the file, with a drift-guard test pinning the materialized constants against the actual resolver
- new `GetEffectiveConfig` RPC at sensitive_read (whole-config disclosure is never plain read; tier rationale pinned in the authz tests, matrix 97→98 with the inventory regenerated): investigated extending an existing RPC first, but no method ships config content and the API docs explicitly promise the diff service never exports the live snapshot
- redaction happens inside the peer manager — secret material (md5_password, tcp_ao.key, group md5) never crosses the API boundary; file paths and the publicly-stamped netdev owner token are deliberately not redacted
- round-trip honesty: a secretless dump reloads cleanly and re-dumps byte-identical (fixpoint test); a dump containing the `<redacted>` placeholder fails validation loudly with a span-annotated diagnostic naming the restore step — a config with placeholder secrets must never silently boot
- deterministic output via the same canonicalization the snapshot token uses; live smoke captures the materialized defaults and zero secret leakage

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p rustbgpctl (368) / -p rustbgpd-api (405, authz + inventory) / --bin rustbgpd (1367)
- cargo doc --workspace --no-deps
- live lab smoke: defaults materialized, secrets absent by grep, JSON shape verified

Closes LAN-325.