### PR TITLE
docs: add bmp to cli dev-dependency note in ARCHITECTURE.md crate graph

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ evpn-linux     ──► evpn
 rib            ──► wire, policy, telemetry, rpki, bmp
 transport      ──► wire, fsm, rib, policy, rpki, telemetry, bmp
 api            ──► wire, fsm, rib, policy, transport, telemetry, evpn, event-history
-cli            ──► wire, policy    (dev tests also use api, evpn)
+cli            ──► wire, policy    (dev tests also use api, evpn, bmp)
 ```
 
 The daemon binary (`src/`) depends on every crate above; it wires them


### PR DESCRIPTION
The `cli` crate row in the ARCHITECTURE.md dependency graph listed only `api` and `evpn` as dev-test dependencies. `crates/cli/Cargo.toml` also carries `rustbgpd-bmp` as a dev-dependency (BMP-framed fixtures for the from-bmp adapter tests in `ribsnap_bmp.rs`). Closes LAN-340.