### PR TITLE
feat(policy): suggest closest symbol for unknown rpol references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,6 +484,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (2^28), and gzip decompression (4 GiB). Groundwork for MRT warm-boot
   restore. (LAN-337)
 
+- **rpol did-you-mean for unknown set/policy/function/dataset
+  references.** Every unknown-symbol diagnostic (prefix-set /
+  community-set / asn-set probes, `apply` and test `expect` targets,
+  function calls, dataset references and test overrides) now suggests
+  the closest same-kind name by edit distance — the same threshold the
+  field suggestions use — with a labeled span at the suggested
+  symbol's definition site (file:line in the rendering). An exact name
+  match of a different kind is named as such (`` `bogons` is an
+  asn-set; `route.prefix in` needs a prefix-set ``) instead of a
+  spelling suggestion. Right-kind datasets count as candidates for
+  typo'd `in` probes. Message/notes enrichment only — error codes and
+  exit contracts are unchanged. (LAN-328)
+
 ### Changed
 - **CLI consistency sweep (LAN-329).** One noun, one file-arg style, one
   empty-state shape across `rbgp`; every old spelling keeps working as

--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -371,6 +371,167 @@ fn unknown_policy_in_apply_suggests() {
 }
 
 #[test]
+fn suggestions_label_the_definition_site() {
+    // LAN-328: the did-you-mean note carries a label at the
+    // candidate's definition, so the rendering names its file:line.
+    let (_, rendered) = diagnostics_of(
+        "prefix-set customers { 10.0.0.0/8 }
+         policy p { term t { if route.prefix in custmers { accept } } }",
+    );
+    assert!(rendered.contains("did you mean `customers`?"), "{rendered}");
+    assert!(
+        rendered.contains("`customers` is defined here"),
+        "{rendered}"
+    );
+
+    let (_, rendered) = diagnostics_of(
+        "policy bogon-filter { term t { reject } }
+         policy p { term t { if apply(bogon-fitler) { reject } } }",
+    );
+    assert!(
+        rendered.contains("`bogon-filter` is defined here"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn unknown_community_set_suggests() {
+    let (_, rendered) = diagnostics_of(
+        "community-set scrub-tags { 65000:1 }
+         policy p { term t { if route.communities in scrub-tagz { reject } } }",
+    );
+    assert!(
+        rendered.contains("unknown community-set `scrub-tagz`"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("did you mean `scrub-tags`?"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("`scrub-tags` is defined here"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn unknown_asn_set_suggests() {
+    let (_, rendered) = diagnostics_of(
+        "asn-set peers { 64500 }
+         policy p { term t { if route.origin-as in peerz { accept } } }",
+    );
+    assert!(rendered.contains("unknown asn-set `peerz`"), "{rendered}");
+    assert!(rendered.contains("did you mean `peers`?"), "{rendered}");
+    assert!(rendered.contains("`peers` is defined here"), "{rendered}");
+}
+
+#[test]
+fn unknown_fn_suggestion_labels_the_definition() {
+    let (_, rendered) = diagnostics_of(
+        "fn shift(a: u32) -> u32 { a + 1 }
+         policy p { term t { if shitf(1) >= 2 { reject } } }",
+    );
+    assert!(rendered.contains("did you mean `shift`?"), "{rendered}");
+    assert!(rendered.contains("`shift` is defined here"), "{rendered}");
+}
+
+#[test]
+fn unknown_dataset_reference_suggests() {
+    // A typo'd `in` probe near a declared dataset suggests the
+    // dataset (LAN-328) — right-kind datasets are valid probe targets.
+    let (_, rendered) = diagnostics_of(
+        "dataset prefix-set bogons
+         policy p { term t { if route.prefix in bogonz { reject } } }",
+    );
+    assert!(
+        rendered.contains("unknown prefix-set `bogonz`"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `bogons`?"), "{rendered}");
+    assert!(rendered.contains("`bogons` is defined here"), "{rendered}");
+
+    // Same for a test block's dataset override.
+    let (_, rendered) = diagnostics_of(
+        "dataset asn-set flappers
+         policy p { term t { if route.origin-as in flappers { accept } } }
+         test t { dataset flapperz { 64500 } route { prefix 10.0.0.0/8 } expect p == accept }",
+    );
+    assert!(
+        rendered.contains("unknown dataset `flapperz`"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("did you mean `flappers`?"), "{rendered}");
+    assert!(
+        rendered.contains("`flappers` is defined here"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn unknown_expect_policy_suggests() {
+    let (_, rendered) = diagnostics_of(
+        "policy guard { term t { reject } }
+         test t { route { prefix 10.0.0.0/8 } expect gaurd == reject }",
+    );
+    assert!(rendered.contains("unknown policy `gaurd`"), "{rendered}");
+    assert!(rendered.contains("did you mean `guard`?"), "{rendered}");
+    assert!(rendered.contains("`guard` is defined here"), "{rendered}");
+}
+
+#[test]
+fn no_suggestion_when_nothing_is_close() {
+    let (_, rendered) = diagnostics_of(
+        "prefix-set customers { 10.0.0.0/8 }
+         policy p { term t { if route.prefix in zzz { accept } } }",
+    );
+    assert!(rendered.contains("unknown prefix-set `zzz`"), "{rendered}");
+    assert!(!rendered.contains("did you mean"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of(
+        "policy bogon-filter { term t { reject } }
+         policy p { term t { if apply(zzz) { reject } } }",
+    );
+    assert!(rendered.contains("unknown policy `zzz`"), "{rendered}");
+    assert!(!rendered.contains("did you mean"), "{rendered}");
+}
+
+#[test]
+fn exact_match_of_another_kind_names_it() {
+    // An exact name match in a different kind is a wrong reference,
+    // not a typo (LAN-328): say what the name is instead of
+    // suggesting a spelling fix.
+    let (_, rendered) = diagnostics_of(
+        "asn-set bogons { 64500 }
+         policy p { term t { if route.prefix in bogons { reject } } }",
+    );
+    assert!(
+        rendered.contains("`bogons` is an asn-set; `route.prefix in` needs a prefix-set"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("`bogons` is defined here"), "{rendered}");
+    assert!(!rendered.contains("did you mean"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of(
+        "asn-set bogons { 64500 }
+         policy p { term t { if apply(bogons) { reject } } }",
+    );
+    assert!(
+        rendered.contains("`bogons` is an asn-set, not a policy"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("`bogons` is defined here"), "{rendered}");
+
+    let (_, rendered) = diagnostics_of(
+        "asn-set bogons { 64500 }
+         policy p { term t { if bogons(1) >= 2 { reject } } }",
+    );
+    assert!(
+        rendered.contains("`bogons` is an asn-set, not a function"),
+        "{rendered}"
+    );
+}
+
+#[test]
 fn unknown_field_suggests() {
     let (_, rendered) =
         diagnostics_of("policy p { term t { if route.local-perf >= 100 { accept } } }");

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -350,6 +350,19 @@ impl<'a> Checker<'a> {
         self.file.datasets.iter().find(|d| d.name.node == name)
     }
 
+    /// The names of every declared dataset of `kind`, for did-you-mean
+    /// candidate lists (LAN-328).
+    fn dataset_names(
+        &self,
+        kind: DatasetKind,
+    ) -> impl Iterator<Item = &'a Spanned<String>> + use<'a> {
+        self.file
+            .datasets
+            .iter()
+            .filter(move |d| d.kind == kind)
+            .map(|d| &d.name)
+    }
+
     /// The kind and definition span of a source-defined set by name.
     fn set_def_of(&self, name: &str) -> Option<(&'static str, Span)> {
         if let Some(def) = self.file.prefix_sets.iter().find(|s| s.name.node == name) {
@@ -366,6 +379,23 @@ impl<'a> Checker<'a> {
         } else {
             None
         }
+    }
+
+    /// The kind and definition span of any user-defined symbol by name
+    /// (LAN-328): sets, datasets, functions, policies. Used by the
+    /// unknown-reference diagnostics to say what an exact name match in
+    /// a different kind actually is, instead of suggesting a typo fix.
+    fn symbol_def_of(&self, name: &str) -> Option<(&'static str, Span)> {
+        self.set_def_of(name)
+            .or_else(|| self.dataset_of(name).map(|d| ("dataset", d.name.span)))
+            .or_else(|| {
+                self.file
+                    .fns
+                    .iter()
+                    .find(|f| f.name.node == name)
+                    .map(|f| ("function", f.name.span))
+            })
+            .or_else(|| self.policy(name).map(|p| ("policy", p.name.span)))
     }
 
     // ── functions (LAN-304) ─────────────────────────────────────────
@@ -774,13 +804,22 @@ impl<'a> Checker<'a> {
                          `route.prefix in` instead",
                     ),
                     _ => {
-                        if let Some(suggestion) = closest(
-                            &name.node,
-                            self.file.asn_sets.iter().map(|s| s.name.node.as_str()),
-                        ) {
-                            diag.with_note(format!("did you mean `{suggestion}`?"))
+                        if let Some((kind, span)) = self.symbol_def_of(&name.node) {
+                            diag.with_note(format!(
+                                "`{}` is {} {kind}, not an iterable asn-set",
+                                name.node,
+                                article(kind)
+                            ))
+                            .with_label(span, format!("`{}` is defined here", name.node))
                         } else {
-                            diag
+                            with_suggestion(
+                                diag,
+                                &name.node,
+                                self.file
+                                    .asn_sets
+                                    .iter()
+                                    .map(|s| (s.name.node.as_str(), Some(s.name.span))),
+                            )
                         }
                     }
                 };
@@ -1111,23 +1150,39 @@ impl<'a> Checker<'a> {
                         format!("unknown function or builtin `{}`", name.node),
                         "not a function or value builtin",
                     );
-                    if self.policy(&name.node).is_some() {
-                        diag = diag.with_note(format!(
-                            "`{}` is a policy — policies are predicates, composed with \
-                             `apply({}(...))`, not called for a value",
-                            name.node, name.node
-                        ));
-                    } else if let Some(suggestion) = closest(
-                        &name.node,
-                        VALUE_BUILTINS
-                            .iter()
-                            .map(|(b, _)| *b)
-                            .chain(self.file.fns.iter().map(|f| f.name.node.as_str())),
-                    ) {
-                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
-                    } else {
+                    if let Some((kind, span)) = self.symbol_def_of(&name.node) {
+                        let note = if kind == "policy" {
+                            format!(
+                                "`{}` is a policy — policies are predicates, composed with \
+                                 `apply({}(...))`, not called for a value",
+                                name.node, name.node
+                            )
+                        } else {
+                            format!(
+                                "`{}` is {} {kind}, not a function",
+                                name.node,
+                                article(kind)
+                            )
+                        };
                         diag = diag
-                            .with_note("value builtins: min(a, b), max(a, b), clamp(x, lo, hi)");
+                            .with_note(note)
+                            .with_label(span, format!("`{}` is defined here", name.node));
+                    } else {
+                        diag = with_suggestion(
+                            diag,
+                            &name.node,
+                            VALUE_BUILTINS.iter().map(|(b, _)| (*b, None)).chain(
+                                self.file
+                                    .fns
+                                    .iter()
+                                    .map(|f| (f.name.node.as_str(), Some(f.name.span))),
+                            ),
+                        );
+                        if diag.notes.is_empty() {
+                            diag = diag.with_note(
+                                "value builtins: min(a, b), max(a, b), clamp(x, lo, hi)",
+                            );
+                        }
                     }
                     self.diags.push(diag);
                     return;
@@ -1278,26 +1333,36 @@ impl<'a> Checker<'a> {
                         format!("unknown asn-set or community-set `{}`", set.node),
                         "binding membership probes asn-sets and community-sets",
                     );
-                    if self.set_kind_of(&set.node) == Some("prefix-set") {
-                        diag = diag.with_note(format!(
-                            "`{}` is a prefix-set; bindings are u32 values and cannot \
-                             probe prefixes",
-                            set.node
-                        ));
-                    } else if let Some(suggestion) = closest(
-                        &set.node,
-                        self.file
-                            .asn_sets
-                            .iter()
-                            .map(|s| s.name.node.as_str())
-                            .chain(
-                                self.file
-                                    .community_sets
-                                    .iter()
-                                    .map(|s| s.name.node.as_str()),
-                            ),
-                    ) {
-                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    if let Some((kind, span)) = self.symbol_def_of(&set.node) {
+                        let note = if kind == "prefix-set" {
+                            format!(
+                                "`{}` is a prefix-set; bindings are u32 values and cannot \
+                                 probe prefixes",
+                                set.node
+                            )
+                        } else {
+                            format!(
+                                "`{}` is {} {kind}, not an asn-set or community-set",
+                                set.node,
+                                article(kind)
+                            )
+                        };
+                        diag = diag
+                            .with_note(note)
+                            .with_label(span, format!("`{}` is defined here", set.node));
+                    } else {
+                        diag = with_suggestion(
+                            diag,
+                            &set.node,
+                            self.file
+                                .asn_sets
+                                .iter()
+                                .map(|s| &s.name)
+                                .chain(self.file.community_sets.iter().map(|s| &s.name))
+                                .chain(self.dataset_names(DatasetKind::Asn))
+                                .chain(self.dataset_names(DatasetKind::Community))
+                                .map(|n| (n.node.as_str(), Some(n.span))),
+                        );
                     }
                     self.diags.push(diag);
                 }
@@ -1367,14 +1432,23 @@ impl<'a> Checker<'a> {
                         format!("unknown policy `{}`", policy.node),
                         "no policy with this name",
                     );
-                    let names: Vec<&str> = self
-                        .file
-                        .policies
-                        .iter()
-                        .map(|p| p.name.node.as_str())
-                        .collect();
-                    if let Some(suggestion) = closest(&policy.node, names) {
-                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    if let Some((kind, span)) = self.symbol_def_of(&policy.node) {
+                        diag = diag
+                            .with_note(format!(
+                                "`{}` is {} {kind}, not a policy — `apply` composes policies",
+                                policy.node,
+                                article(kind)
+                            ))
+                            .with_label(span, format!("`{}` is defined here", policy.node));
+                    } else {
+                        diag = with_suggestion(
+                            diag,
+                            &policy.node,
+                            self.file
+                                .policies
+                                .iter()
+                                .map(|p| (p.name.node.as_str(), Some(p.name.span))),
+                        );
                     }
                     self.diags.push(diag);
                     return;
@@ -1713,8 +1787,9 @@ impl<'a> Checker<'a> {
         need: &str,
         names: impl Iterator<Item = &'n Spanned<String>>,
     ) {
-        let mut candidates = names.map(|n| n.node.as_str());
-        if candidates.any(|name| name == set.node) {
+        let candidates: Vec<(&str, Option<Span>)> =
+            names.map(|n| (n.node.as_str(), Some(n.span))).collect();
+        if candidates.iter().any(|&(name, _)| name == set.node) {
             return;
         }
         let mut diag = Diagnostic::new(
@@ -1722,32 +1797,18 @@ impl<'a> Checker<'a> {
             format!("unknown {kind} `{}`", set.node),
             format!("no {kind} with this name"),
         );
-        if let Some(actual) = self.set_kind_of(&set.node) {
-            diag = diag.with_note(format!("`{}` is a {actual}; {need}", set.node));
-        } else if let Some(suggestion) = closest(
-            &set.node,
-            match kind {
-                "prefix-set" => self
-                    .file
-                    .prefix_sets
-                    .iter()
-                    .map(|s| s.name.node.as_str())
-                    .collect::<Vec<_>>(),
-                "community-set" => self
-                    .file
-                    .community_sets
-                    .iter()
-                    .map(|s| s.name.node.as_str())
-                    .collect(),
-                _ => self
-                    .file
-                    .asn_sets
-                    .iter()
-                    .map(|s| s.name.node.as_str())
-                    .collect(),
-            },
-        ) {
-            diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+        // An exact name match of a different kind beats a typo
+        // suggestion (LAN-328): the reference is wrong, not misspelled.
+        if let Some((actual, span)) = self.symbol_def_of(&set.node) {
+            diag = diag
+                .with_note(format!(
+                    "`{}` is {} {actual}; {need}",
+                    set.node,
+                    article(actual)
+                ))
+                .with_label(span, format!("`{}` is defined here", set.node));
+        } else {
+            diag = with_suggestion(diag, &set.node, candidates);
         }
         self.diags.push(diag);
     }
@@ -1788,24 +1849,38 @@ impl<'a> Checker<'a> {
             return;
         }
         match resolved {
+            // Right-kind datasets are valid `in` targets (LAN-305), so
+            // they are suggestion candidates alongside the sets.
             Field::Prefix => self.check_set_reference(
                 set,
                 "prefix-set",
                 "`route.prefix in` needs a prefix-set",
-                self.file.prefix_sets.iter().map(|s| &s.name),
+                self.file
+                    .prefix_sets
+                    .iter()
+                    .map(|s| &s.name)
+                    .chain(self.dataset_names(DatasetKind::Prefix)),
             ),
             Field::Communities | Field::LargeCommunities | Field::ExtCommunities => self
                 .check_set_reference(
                     set,
                     "community-set",
                     "community membership needs a community-set",
-                    self.file.community_sets.iter().map(|s| &s.name),
+                    self.file
+                        .community_sets
+                        .iter()
+                        .map(|s| &s.name)
+                        .chain(self.dataset_names(DatasetKind::Community)),
                 ),
             Field::OriginAs | Field::PeerAsn => self.check_set_reference(
                 set,
                 "asn-set",
                 "ASN membership needs an asn-set",
-                self.file.asn_sets.iter().map(|s| &s.name),
+                self.file
+                    .asn_sets
+                    .iter()
+                    .map(|s| &s.name)
+                    .chain(self.dataset_names(DatasetKind::Asn)),
             ),
             _ => self.diags.push(
                 Diagnostic::new(
@@ -1994,11 +2069,24 @@ impl<'a> Checker<'a> {
                         format!("unknown dataset `{}`", def.name.node),
                         "no dataset declared with this name",
                     );
-                    if let Some(suggestion) = closest(
-                        &def.name.node,
-                        self.file.datasets.iter().map(|d| d.name.node.as_str()),
-                    ) {
-                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    if let Some((kind, span)) = self.symbol_def_of(&def.name.node) {
+                        diag = diag
+                            .with_note(format!(
+                                "`{}` is {} {kind}, not a dataset — overrides fill declared \
+                                 datasets",
+                                def.name.node,
+                                article(kind)
+                            ))
+                            .with_label(span, format!("`{}` is defined here", def.name.node));
+                    } else {
+                        diag = with_suggestion(
+                            diag,
+                            &def.name.node,
+                            self.file
+                                .datasets
+                                .iter()
+                                .map(|d| (d.name.node.as_str(), Some(d.name.span))),
+                        );
                     }
                     self.diags.push(diag);
                     continue;
@@ -2032,11 +2120,23 @@ impl<'a> Checker<'a> {
                         format!("unknown policy `{}`", expect.policy.node),
                         "no policy with this name",
                     );
-                    if let Some(suggestion) = closest(
-                        &expect.policy.node,
-                        self.file.policies.iter().map(|p| p.name.node.as_str()),
-                    ) {
-                        diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+                    if let Some((kind, span)) = self.symbol_def_of(&expect.policy.node) {
+                        diag = diag
+                            .with_note(format!(
+                                "`{}` is {} {kind}, not a policy — `expect` runs policies",
+                                expect.policy.node,
+                                article(kind)
+                            ))
+                            .with_label(span, format!("`{}` is defined here", expect.policy.node));
+                    } else {
+                        diag = with_suggestion(
+                            diag,
+                            &expect.policy.node,
+                            self.file
+                                .policies
+                                .iter()
+                                .map(|p| (p.name.node.as_str(), Some(p.name.span))),
+                        );
                     }
                     self.diags.push(diag);
                     continue;
@@ -2723,6 +2823,42 @@ fn find_cycle<'a>(
     path.pop();
     done.insert(node);
     None
+}
+
+/// "a" / "an" for a symbol-kind noun in a diagnostic note
+/// ("an asn-set", "a prefix-set").
+fn article(kind: &str) -> &'static str {
+    if kind.starts_with(['a', 'e', 'i', 'o', 'u']) {
+        "an"
+    } else {
+        "a"
+    }
+}
+
+/// Attach the shared "did you mean" note for the closest candidate
+/// (LAN-328), plus a definition-site label when the candidate is a
+/// user-defined symbol — ariadne renders the label with the defining
+/// file and line. Candidates without a span (builtins) get the note
+/// only; no candidate within the [`closest`] budget leaves `diag`
+/// untouched.
+fn with_suggestion<'n>(
+    diag: Diagnostic,
+    name: &str,
+    candidates: impl IntoIterator<Item = (&'n str, Option<Span>)>,
+) -> Diagnostic {
+    let candidates: Vec<(&str, Option<Span>)> = candidates.into_iter().collect();
+    let Some(suggestion) = closest(name, candidates.iter().map(|&(candidate, _)| candidate)) else {
+        return diag;
+    };
+    let diag = diag.with_note(format!("did you mean `{suggestion}`?"));
+    let defined = candidates
+        .iter()
+        .find(|&&(candidate, _)| candidate == suggestion)
+        .and_then(|&(_, span)| span);
+    match defined {
+        Some(span) => diag.with_label(span, format!("`{suggestion}` is defined here")),
+        None => diag,
+    }
 }
 
 fn type_mismatch(field: &FieldPath, expected: &str, found: &Rhs) -> Diagnostic {

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -1307,9 +1307,13 @@ expect      := "expect" IDENT ["(" INT,* ")"] "==" ("accept"|"reject") ["with" a
 
 Every error carries labeled source spans (ariadne rendering), and the
 compiler recovers to report multiple independent errors per file.
-Unknown names (sets, policies, fields, enum members, parameters, test
-fixture fields) get did-you-mean suggestions by edit distance;
-kind/type mismatches say what to write instead.
+Unknown names (sets, datasets, policies, functions, fields, enum
+members, parameters, test fixture fields) get did-you-mean suggestions
+by edit distance, with a label at the suggested symbol's definition
+site; an exact name match of a different kind is named as such
+(`` `bogons` is an asn-set; `route.prefix in` needs a prefix-set ``)
+instead of a spelling suggestion. Kind/type mismatches say what to
+write instead.
 
 ```text
 Error: unknown prefix-set `custmers`


### PR DESCRIPTION
Unknown set/policy/function/dataset references now get the same
did-you-mean treatment fields already had: one shared helper picks the
closest same-kind candidate by edit distance and labels its definition
site, so the rendering names the defining file and line. An exact name
match of a different kind is reported as such (`bogons` is an
asn-set; `route.prefix in` needs a prefix-set) instead of a spelling
suggestion, and right-kind datasets count as candidates for typo'd
`in` probes. Diagnostics enrichment only: error codes and exit
contracts are unchanged. (LAN-328)

Closes LAN-328.