### PR TITLE
test(policy): cover aspa-invalid and rpki-invalid terms with rpol fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,6 +497,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   typo'd `in` probes. Message/notes enrichment only — error codes and
   exit contracts are unchanged. (LAN-328)
 
+- **rpol coverage-gap fixtures.** In-language tests for the two terms
+  `rbgp policy check --coverage` found evaluated-but-never-matched:
+  an `aspa invalid` reject fixture in
+  `tests/interop/configs/m83-hygiene.rpol` and an `rpki invalid`
+  OV_INVALID-tagging fixture in `examples/route-server/hygiene.rpol`;
+  both corpora now report full term coverage. (LAN-342)
+
 ### Changed
 - **CLI consistency sweep (LAN-329).** One noun, one file-arg style, one
   empty-state shape across `rbgp`; every old spelling keeps working as

--- a/examples/route-server/hygiene.rpol
+++ b/examples/route-server/hygiene.rpol
@@ -49,3 +49,8 @@ test rpki-not-found-is-tagged-ov-not-found {
     route { prefix 203.0.113.0/24; as-path "64501" }
     expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
 }
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}

--- a/tests/interop/configs/m83-hygiene.rpol
+++ b/tests/interop/configs/m83-hygiene.rpol
@@ -19,6 +19,11 @@ test as-set-is-rejected {
     expect ixp-hygiene == reject
 }
 
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
 test clean-route-falls-through {
     route { prefix 203.0.113.0/24; as-path "64501 64510" }
     expect ixp-hygiene == accept


### PR DESCRIPTION
Closes LAN-342. Both terms were evaluated-but-never-matched under `policy check --coverage`; adds an `aspa invalid` fixture to the M83 hygiene policy and an `rpki invalid` fixture asserting the OV_INVALID tag in the route-server example.