### PR TITLE
ci: cache interop setup artifacts to remove download flakes

### DIFF
--- a/.github/actions/install-containerlab/action.yml
+++ b/.github/actions/install-containerlab/action.yml
@@ -1,11 +1,14 @@
 name: "Install containerlab (hardened)"
 description: >-
-  Download and install a pinned containerlab release with retry + archive
-  validation (issue #208). The bare `curl … -o /tmp/clab.deb && dpkg -i` has
-  failed when the download is truncated or returns an HTML error body
-  ("dpkg-deb: '/tmp/clab.deb' is not a Debian format archive"). This retries
-  with backoff and validates the file with `dpkg-deb --info` — the exact tool
-  that errored — before invoking `dpkg -i`, and fails with a clear diagnostic.
+  Install a pinned containerlab release from the Actions cache, downloading
+  only on a cache miss with retry + archive validation (issue #208). The bare
+  `curl … -o /tmp/clab.deb && dpkg -i` has failed when the download is
+  truncated or returns an HTML error body ("dpkg-deb: '/tmp/clab.deb' is not
+  a Debian format archive"). The cache (LAN-252) removes the download — the
+  interop workflows' flakiest external fetch — from warm runs entirely; a
+  cold run retries with backoff and validates the file with
+  `dpkg-deb --info` — the exact tool that errored — before it is installed
+  and saved to the cache.
 inputs:
   version:
     description: "containerlab release version (without leading v)."
@@ -14,14 +17,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install containerlab ${{ inputs.version }} (retry + validate)
+    # The key includes the pinned version, so bumping the version input
+    # naturally invalidates the cache and re-downloads.
+    - name: Restore containerlab ${{ inputs.version }} .deb from cache
+      id: clab-deb
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/containerlab/containerlab_${{ inputs.version }}_linux_amd64.deb
+        key: containerlab-deb-${{ inputs.version }}
+
+    - name: Download containerlab ${{ inputs.version }} (retry + validate)
+      if: steps.clab-deb.outputs.cache-hit != 'true'
       shell: bash
       env:
         CLAB_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         url="https://github.com/srl-labs/containerlab/releases/download/v${CLAB_VERSION}/containerlab_${CLAB_VERSION}_linux_amd64.deb"
-        deb=/tmp/clab.deb
+        deb="$HOME/.cache/containerlab/containerlab_${CLAB_VERSION}_linux_amd64.deb"
+        mkdir -p "$(dirname "$deb")"
         # Single retry mechanism: the outer loop owns retry + backoff, because
         # the load-bearing failure (#208) is a 200-OK truncated/HTML body that
         # `curl --retry` treats as success — only the `dpkg-deb --info` check
@@ -41,6 +55,21 @@ runs:
         done
         if [ "$ok" != 1 ]; then
           echo "::error::containerlab .deb download/validation failed after ${attempts} attempts (issue #208)"
+          exit 1
+        fi
+
+    - name: Install containerlab ${{ inputs.version }}
+      shell: bash
+      env:
+        CLAB_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        deb="$HOME/.cache/containerlab/containerlab_${CLAB_VERSION}_linux_amd64.deb"
+        # Validate on both paths (fresh download and cache restore) with the
+        # exact tool that errored in #208, so a bad artifact fails loudly
+        # here rather than as an opaque dpkg error.
+        if ! dpkg-deb --info "$deb" >/dev/null 2>&1; then
+          echo "::error::containerlab .deb failed validation; evict cache key containerlab-deb-${CLAB_VERSION} and re-run"
           exit 1
         fi
         sudo dpkg -i "$deb"

--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -334,9 +334,23 @@ jobs:
             echo "::warning::M43 skipped: $(uname -r) does not advertise CONFIG_TCP_AO=y"
           fi
 
+      # Buildx GHA layer cache (LAN-252): the bird.nic.cz tarball fetch and
+      # the full BIRD source build live in layers keyed on the Dockerfile
+      # content (which pins BIRD_VERSION and the configure flags), so warm
+      # runs skip both the flaky download and the compile; a version bump
+      # edits the Dockerfile and naturally invalidates. Buildx itself is set
+      # up by setup-dataplane-host above. The dedicated scope keeps this
+      # image's cache separate from rustbgpd:dev's.
       - name: Build BIRD 3.2.1 TCP-AO image
         if: steps.tcp_ao.outputs.supported == 'true'
-        run: docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
+        uses: docker/build-push-action@v7
+        with:
+          context: tests/interop
+          file: tests/interop/Dockerfile.bird3
+          load: true
+          tags: bird:3.2.1-tcpao
+          cache-from: type=gha,scope=bird3-tcpao
+          cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true
 
       - name: Run M43 (deploy + test + destroy with retry)
         if: steps.tcp_ao.outputs.supported == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1055,6 +1055,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the Prometheus endpoint, refreshed at scrape time:
   `jemalloc_allocated_bytes`, `jemalloc_active_bytes`,
   `jemalloc_resident_bytes`, and `jemalloc_mapped_bytes`. (LAN-331)
+- **Interop CI no longer re-downloads its flakiest setup artifacts every
+  run.** The containerlab `.deb` is cached via `actions/cache` keyed on the
+  pinned version (warm runs skip the download entirely; cold runs keep the
+  #208 retry + `dpkg-deb` validation), and the M43 BIRD 3.2.1 TCP-AO image
+  build now uses the buildx GHA layer cache, so the bird.nic.cz tarball
+  fetch and source compile are skipped on warm runs. (LAN-252)
 
 ## [0.50.0] — 2026-07-05
 


### PR DESCRIPTION
Closes LAN-252. Caches the containerlab .deb (actions/cache keyed on the pinned version, one edit in the install-containerlab composite covering all interop and kernel-dataplane jobs) and moves the M43 BIRD 3.2.1 image build to buildx GHA layer cache (dedicated scope), so warm runs skip the two flakiest external fetches entirely. Cold-cache paths keep the existing retry+validate behavior; both paths validate the .deb with dpkg-deb before install.