### PR TITLE
feat(rbgp): rework doctor into live triage checks plus one tar.gz bundle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,11 @@ assignees: ''
 **Describe the bug**
 A clear description of what went wrong.
 
+**Support bundle**
+If possible, attach the tarball produced by `rbgp doctor`. It is redacted
+(no raw config file, no passwords/tokens) and carries the effective config,
+peer states, recent events, crash reports, and system facts in one file.
+
 **To reproduce**
 Steps to reproduce the behavior:
 1. Config (redact sensitive fields):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,6 +489,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   counted, and hard caps bound per-record size (16 MiB), total entries
   (2^28), and gzip decompression (4 GiB). Groundwork for MRT warm-boot
   restore. (LAN-337)
+- **Doctor bundle v2 (`rbgp doctor`).** The support-bundle command now
+  prints red/green triage checks live while it collects — daemon
+  reachable/healthy, peers stuck outside Established with
+  time-in-state, flap loops, daemon `nofile` rlimits, recent panic
+  reports — and produces one `rustbgpd-doctor-<ts>.tar.gz` with a
+  stable layout: `manifest.json`, `config/effective.toml` (the
+  daemon's secret-redacted `GetEffectiveConfig` dump — the raw config
+  file is never copied), `peers/`, `logs/tail-1000.jsonl` (opt-in
+  `--log-file`; stdout/journald-only logging is recorded in the
+  manifest instead), `crashes/`, and `system/`. The manifest records
+  tool + daemon versions, that redaction ran, and which sections were
+  collected vs unavailable — a run against a down daemon still
+  produces a bundle and says what is missing. Detailed exit codes: 0
+  all green / 1 error / 2 red checks found. The daemon side gains
+  panic hygiene: a global panic hook writes a bounded, secret-free
+  `crash/panic-<ts>.toml` report (message, location, thread, version —
+  never env or argv) under `runtime_state_dir`, keeping the 10 most
+  recent, and `HealthResponse` now carries `daemon_version`. The
+  GitHub bug-report template asks for the bundle. (LAN-324)
 
 - **rpol did-you-mean for unknown set/policy/function/dataset
   references.** Every unknown-symbol diagnostic (prefix-set /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,6 +2749,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "crossterm",
+ "flate2",
  "hyper-util",
  "owo-colors",
  "prost",
@@ -2750,6 +2761,7 @@ dependencies = [
  "rustbgpd-wire",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -3475,6 +3487,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4600,6 +4623,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -86,6 +86,7 @@ impl proto::control_service_server::ControlService for ControlService {
             uptime_seconds: uptime,
             active_peers: u32::try_from(active_peers).unwrap_or(u32::MAX),
             total_routes: u32::try_from(snapshot.total_routes).unwrap_or(u32::MAX),
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
         }))
     }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,6 +36,9 @@ serde_json.workspace = true
 toml.workspace = true
 tower = { version = "0.5", features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
+# `rbgp doctor` bundle output (one gzipped tarball).
+tar = "0.4"
+flate2 = "1"
 owo-colors.workspace = true
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -15,7 +15,7 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 ```bash
 rbgp global       # ASN, router ID, families, TCP-AO support
 rbgp health       # daemon health check
-rbgp doctor       # redacted support bundle
+rbgp doctor       # triage checks + redacted support bundle (tar.gz)
 rbgp metrics      # Prometheus metrics snapshot
 rbgp top          # live terminal dashboard
 ```
@@ -156,7 +156,7 @@ a non-TTY.
 | Explain import policy | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |
 | Policy hit counters | `rbgp policy stats` or `rbgp policy counters` |
 | Route-server clients | `rbgp summary`, then `rbgp neighbor <peer>` for distribution mode |
-| Support bundle | `rbgp doctor --output ./support` |
+| Support bundle + triage checks | `rbgp doctor --output ./support.tar.gz` |
 
 Confirmed config transaction handles must be non-empty, at most 128
 characters, and contain no control characters. `--confirm-timeout` requires

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1,4 +1,15 @@
+//! `rbgp doctor`: live red/green triage checks plus one redacted
+//! `rustbgpd-doctor-<ts>.tar.gz` support bundle.
+//!
+//! Hard rules: the raw daemon config file is never copied (the config
+//! section is the daemon's own secret-redacted `GetEffectiveConfig`
+//! dump) and no bearer-token material is collected. Log collection is
+//! opt-in via `--log-file`; the daemon logs to stdout/journald and the
+//! manifest records that instead of shelling out to journalctl.
+
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -8,13 +19,14 @@ use crate::commands::watch::bgp_event_json_value;
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{self, JsonNeighbor};
+use crate::proto::config_service_client::ConfigServiceClient;
 use crate::proto::control_service_client::ControlServiceClient;
 use crate::proto::event_service_client::EventServiceClient;
 use crate::proto::global_service_client::GlobalServiceClient;
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
-    GetGlobalRequest, HealthRequest, ListNeighborsRequest, ListPolicyEventsRequest,
-    ListSessionEventsRequest, MetricsRequest,
+    GetEffectiveConfigRequest, GetGlobalRequest, HealthRequest, ListNeighborsRequest,
+    ListPolicyEventsRequest, ListSessionEventsRequest, MetricsRequest,
 };
 
 /// Bounded recent slice pulled from each event history for triage. The
@@ -26,13 +38,141 @@ const EVENT_HISTORY_LIMIT: u32 = 256;
 /// reasons). Redacted the same way `tcp_ao_detail`/metrics are.
 const EVENT_FREE_TEXT_KEYS: &[&str] = &["summary", "reason", "shutdown_reason", "target"];
 
+/// A non-Established peer that transitioned longer ago than this (or has
+/// no recent transition event at all) is red, not merely "settling".
+const STUCK_PEER_SECS: u64 = 120;
+
+/// Established peers that have flapped at least this often get a red
+/// check (hold-time expiry loops and unstable transport look like this).
+const FLAP_FAIL_THRESHOLD: u64 = 5;
+
+/// Daemon soft `nofile` limits below this are flagged: each peer costs
+/// sockets plus per-session file handles, and the systemd default of
+/// 1024 exhausts quickly at scale.
+const NOFILE_SOFT_MIN: u64 = 4096;
+
+/// Number of lines tailed from `--log-file` into `logs/tail-1000.jsonl`.
+const LOG_TAIL_LINES: usize = 1000;
+
+/// At most this many panic reports are swept into `crashes/` and each is
+/// size-capped, so a pathological crash directory cannot bloat the bundle.
+const MAX_CRASH_REPORTS: usize = 10;
+const MAX_CRASH_BYTES: u64 = 64 * 1024;
+
+/// Where the daemon keeps runtime state when the effective config is not
+/// available (daemon down). Mirrors the config default.
+const DEFAULT_STATE_DIR: &str = "/var/lib/rustbgpd";
+
+pub(crate) struct DoctorOptions<'a> {
+    /// Bundle output path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`.
+    pub output: Option<&'a Path>,
+    /// Daemon log file to tail into the bundle (the daemon itself logs to
+    /// stdout/journald; only an operator-named file is ever read).
+    pub log_file: Option<&'a Path>,
+    pub daemon_address: &'a str,
+    pub token_file_configured: bool,
+    pub json: bool,
+}
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
 #[derive(Serialize)]
-struct BundleManifest<'a> {
+struct Check {
+    name: String,
+    status: CheckStatus,
+    detail: String,
+}
+
+/// Records checks and prints them live (human mode) as they are produced.
+struct Reporter {
+    json: bool,
+    checks: Vec<Check>,
+}
+
+impl Reporter {
+    fn record(&mut self, name: impl Into<String>, status: CheckStatus, detail: impl Into<String>) {
+        let check = Check {
+            name: name.into(),
+            status,
+            detail: detail.into(),
+        };
+        if !self.json {
+            use owo_colors::{OwoColorize, Stream::Stdout};
+            let marker = match check.status {
+                CheckStatus::Ok => format!("  {}", "ok".if_supports_color(Stdout, |s| s.green())),
+                CheckStatus::Warn => {
+                    format!("{}", "warn".if_supports_color(Stdout, |s| s.yellow()))
+                }
+                CheckStatus::Fail => format!("{}", "FAIL".if_supports_color(Stdout, |s| s.red())),
+            };
+            println!("{marker}  {}", check.detail);
+        }
+        self.checks.push(check);
+    }
+
+    fn any_fail(&self) -> bool {
+        self.checks.iter().any(|c| c.status == CheckStatus::Fail)
+    }
+}
+
+/// Bundle contents buffered in memory (every section is small and
+/// bounded), then written as one gzipped tarball under a single root
+/// directory so extraction never splatters files into the cwd.
+struct Bundle {
+    files: Vec<(String, Vec<u8>)>,
+}
+
+impl Bundle {
+    fn add(&mut self, rel_path: &str, bytes: Vec<u8>) {
+        self.files.push((rel_path.to_string(), bytes));
+    }
+
+    fn add_json<T: Serialize>(&mut self, rel_path: &str, value: &T) -> Result<(), CliError> {
+        self.add(rel_path, serde_json::to_vec_pretty(value)?);
+        Ok(())
+    }
+
+    fn write_tar_gz(&self, path: &Path, root: &str) -> Result<(), CliError> {
+        let file = fs::File::create(path)?;
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        let mtime = now_unix_seconds();
+        for (rel_path, bytes) in &self.files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(mtime);
+            tar.append_data(&mut header, format!("{root}/{rel_path}"), bytes.as_slice())?;
+        }
+        tar.into_inner()?.finish()?.flush()?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct ManifestV2<'a> {
+    /// Bundle layout version. 2 = tar.gz with manifest/config/peers/
+    /// logs/crashes/system (v1 was a bare directory of seven files).
+    format: u32,
     generated_at_unix_seconds: u64,
     cli_version: &'a str,
+    /// `None` when the daemon was unreachable or predates the
+    /// `daemon_version` health field.
+    daemon_version: Option<String>,
     daemon_address: &'a str,
     token_file_configured: bool,
-    files: Vec<&'static str>,
+    redaction: &'static str,
+    /// Section name -> "collected"/"unavailable: `<reason>`" so a bundle
+    /// from a down daemon says exactly what is missing and why.
+    sections: BTreeMap<&'static str, String>,
+    files: Vec<String>,
+    checks: &'a [Check],
     note: &'static str,
 }
 
@@ -42,6 +182,7 @@ struct HealthSnapshot {
     uptime_seconds: u64,
     active_peers: u32,
     total_routes: u32,
+    daemon_version: String,
 }
 
 #[derive(Serialize)]
@@ -57,6 +198,7 @@ struct GlobalSnapshot {
 struct EnvironmentSnapshot<'a> {
     os: &'a str,
     arch: &'a str,
+    kernel_release: String,
     current_dir: String,
     daemon_address: &'a str,
     token_file_configured: bool,
@@ -73,10 +215,6 @@ fn now_unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn default_bundle_dir() -> PathBuf {
-    PathBuf::from(format!("rustbgpd-support-{}", now_unix_seconds()))
 }
 
 fn tcp_ao_support_label(value: i32) -> &'static str {
@@ -121,168 +259,641 @@ fn redact_event(mut value: serde_json::Value) -> serde_json::Value {
     value
 }
 
-fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), CliError> {
-    let bytes = serde_json::to_vec_pretty(value)?;
-    fs::write(path, bytes)?;
-    Ok(())
+/// Last N lines of a log text, redacted line-wise.
+fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
 }
 
-pub async fn run(
-    connection: Connection,
-    output_dir: Option<&Path>,
-    daemon_address: &str,
-    token_file_configured: bool,
-    json: bool,
-) -> Result<(), CliError> {
-    let bundle_dir = output_dir
+/// `[global] runtime_state_dir` from the daemon's effective-config TOML.
+fn parse_state_dir(effective_toml: &str) -> Option<String> {
+    let value: toml::Value = toml::from_str(effective_toml).ok()?;
+    Some(
+        value
+            .get("global")?
+            .get("runtime_state_dir")?
+            .as_str()?
+            .to_string(),
+    )
+}
+
+/// Parse the soft/hard "Max open files" row of a `/proc/<pid>/limits`
+/// dump. "unlimited" maps to `u64::MAX`.
+fn parse_max_open_files(limits: &str) -> Option<(u64, u64)> {
+    let line = limits.lines().find(|l| l.starts_with("Max open files"))?;
+    let mut fields = line.trim_start_matches("Max open files").split_whitespace();
+    let parse = |token: &str| {
+        if token == "unlimited" {
+            Some(u64::MAX)
+        } else {
+            token.parse::<u64>().ok()
+        }
+    };
+    let soft = parse(fields.next()?)?;
+    let hard = parse(fields.next()?)?;
+    Some((soft, hard))
+}
+
+/// Local rustbgpd processes found by `/proc/<pid>/comm`, with their
+/// rlimit dumps. Empty on non-Linux hosts, remote daemons, or when the
+/// daemon runs in another namespace — the manifest records that.
+fn local_daemon_limits() -> Vec<(u32, String)> {
+    let mut found = Vec::new();
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let comm = fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default();
+        if comm.trim_end() != "rustbgpd" {
+            continue;
+        }
+        if let Ok(limits) = fs::read_to_string(format!("/proc/{pid}/limits")) {
+            found.push((pid, limits));
+        }
+    }
+    found.sort_by_key(|(pid, _)| *pid);
+    found
+}
+
+/// Pure rlimit check: red when the soft `nofile` limit is below
+/// [`NOFILE_SOFT_MIN`].
+fn nofile_check(pid: u32, soft: u64, hard: u64) -> Check {
+    let (status, verdict) = if soft < NOFILE_SOFT_MIN {
+        (CheckStatus::Fail, "low — peers exhaust fds at scale")
+    } else {
+        (CheckStatus::Ok, "ok")
+    };
+    Check {
+        name: format!("daemon.rlimit.nofile.{pid}"),
+        status,
+        detail: format!("daemon pid {pid} rlimit nofile soft {soft} hard {hard}: {verdict}"),
+    }
+}
+
+/// Pure per-peer session checks: state (with time-in-state derived from
+/// the most recent session event) and flap count.
+fn peer_checks(
+    address: &str,
+    state: &str,
+    stale: bool,
+    uptime_seconds: u64,
+    flap_count: u64,
+    last_transition_unix: Option<u64>,
+    now: u64,
+) -> Vec<Check> {
+    let mut checks = Vec::new();
+    if stale {
+        checks.push(Check {
+            name: format!("peer.{address}.session"),
+            status: CheckStatus::Warn,
+            detail: format!("peer {address} state read timed out (stale) — session task busy"),
+        });
+    } else if state == "Established" {
+        checks.push(Check {
+            name: format!("peer.{address}.session"),
+            status: CheckStatus::Ok,
+            detail: format!(
+                "peer {address} Established for {}",
+                output::format_duration(uptime_seconds)
+            ),
+        });
+    } else {
+        let (status, since) = match last_transition_unix {
+            Some(ts) => {
+                let elapsed = now.saturating_sub(ts);
+                let status = if elapsed >= STUCK_PEER_SECS {
+                    CheckStatus::Fail
+                } else {
+                    CheckStatus::Warn
+                };
+                (status, format!("for {}", output::format_duration(elapsed)))
+            }
+            // No recent transition event: it has been stuck at least as
+            // long as the event window covers.
+            None => (
+                CheckStatus::Fail,
+                "with no recent state transition".to_string(),
+            ),
+        };
+        checks.push(Check {
+            name: format!("peer.{address}.session"),
+            status,
+            detail: format!("peer {address} in {state} {since}"),
+        });
+    }
+    if flap_count >= FLAP_FAIL_THRESHOLD {
+        checks.push(Check {
+            name: format!("peer.{address}.flaps"),
+            status: CheckStatus::Fail,
+            detail: format!(
+                "peer {address} flapped {flap_count} times (possible hold-time expiry loop)"
+            ),
+        });
+    }
+    checks
+}
+
+/// Most recent session-event timestamp per peer, for time-in-state.
+fn last_transition_by_peer(events: &[serde_json::Value]) -> HashMap<String, u64> {
+    let mut map: HashMap<String, u64> = HashMap::new();
+    for event in events {
+        let Some(peer) = event.get("peer_address").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(ts) = event
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        let entry = map.entry(peer.to_string()).or_insert(0);
+        *entry = (*entry).max(ts);
+    }
+    map
+}
+
+/// Sweep bounded panic reports (written by the daemon's panic hook under
+/// `<runtime_state_dir>/crash/`) into the bundle. Returns the collected
+/// file names, newest first.
+fn sweep_crash_reports(crash_dir: &Path, bundle: &mut Bundle) -> Vec<String> {
+    let Ok(entries) = fs::read_dir(crash_dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("panic-") && n.ends_with(".toml"))
+        .collect();
+    // Timestamped names: lexicographic sort is chronological. Newest first.
+    names.sort_by(|a, b| b.cmp(a));
+    names.truncate(MAX_CRASH_REPORTS);
+    let mut collected = Vec::new();
+    for name in names {
+        let path = crash_dir.join(&name);
+        if path
+            .metadata()
+            .map(|m| m.len() > MAX_CRASH_BYTES)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        if let Ok(contents) = fs::read_to_string(&path) {
+            bundle.add(
+                &format!("crashes/{name}"),
+                redact_text(&contents).into_bytes(),
+            );
+            collected.push(name);
+        }
+    }
+    collected
+}
+
+pub(crate) async fn run(
+    connection: Result<Connection, CliError>,
+    opts: &DoctorOptions<'_>,
+) -> Result<i32, CliError> {
+    let now = now_unix_seconds();
+    let bundle_path = opts
+        .output
         .map(PathBuf::from)
-        .unwrap_or_else(default_bundle_dir);
-    fs::create_dir_all(&bundle_dir)?;
+        .unwrap_or_else(|| PathBuf::from(format!("rustbgpd-doctor-{now}.tar.gz")));
+    // Root directory inside the tar: the bundle file name without
+    // extensions, so `tar xzf` yields exactly one directory.
+    let root = bundle_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.trim_end_matches(".tar.gz").trim_end_matches(".tgz"))
+        .filter(|n| !n.is_empty())
+        .map_or_else(|| format!("rustbgpd-doctor-{now}"), str::to_string);
 
-    let mut control =
-        ControlServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut global =
-        GlobalServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut neighbor =
-        NeighborServiceClient::with_interceptor(connection.channel(), connection.interceptor());
-    let mut events =
-        EventServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let mut reporter = Reporter {
+        json: opts.json,
+        checks: Vec::new(),
+    };
+    let mut bundle = Bundle { files: Vec::new() };
+    let mut sections: BTreeMap<&'static str, String> = BTreeMap::new();
+    let mut daemon_version: Option<String> = None;
+    let mut state_dir: Option<String> = None;
 
-    let health = control.get_health(HealthRequest {}).await?.into_inner();
-    let global_state = global.get_global(GetGlobalRequest {}).await?.into_inner();
-    let metrics = control.get_metrics(MetricsRequest {}).await?.into_inner();
-    let neighbors = neighbor
-        .list_neighbors(ListNeighborsRequest {})
-        .await?
-        .into_inner();
-    let session_events = events
-        .list_session_events(ListSessionEventsRequest {
-            neighbor_address: String::new(),
-            event_types: Vec::new(),
-            limit: EVENT_HISTORY_LIMIT,
-        })
-        .await?
-        .into_inner();
-    let policy_events = events
-        .list_policy_events(ListPolicyEventsRequest {
-            neighbor_address: String::new(),
-            event_types: Vec::new(),
-            limit: EVENT_HISTORY_LIMIT,
-        })
-        .await?
-        .into_inner();
+    // ---- daemon-backed sections -------------------------------------
+    match connection {
+        Ok(connection) => {
+            reporter.record(
+                "daemon.reachable",
+                CheckStatus::Ok,
+                format!("daemon reachable at {}", opts.daemon_address),
+            );
+            let mut control = ControlServiceClient::with_interceptor(
+                connection.channel(),
+                connection.interceptor(),
+            );
+            let mut global = GlobalServiceClient::with_interceptor(
+                connection.channel(),
+                connection.interceptor(),
+            );
+            let mut neighbor = NeighborServiceClient::with_interceptor(
+                connection.channel(),
+                connection.interceptor(),
+            );
+            let mut events = EventServiceClient::with_interceptor(
+                connection.channel(),
+                connection.interceptor(),
+            );
 
-    write_json(
-        &bundle_dir.join("health.json"),
-        &HealthSnapshot {
-            healthy: health.healthy,
-            uptime_seconds: health.uptime_seconds,
-            active_peers: health.active_peers,
-            total_routes: health.total_routes,
-        },
-    )?;
-    write_json(
-        &bundle_dir.join("global.json"),
-        &GlobalSnapshot {
-            asn: global_state.asn,
-            router_id: global_state.router_id,
-            listen_port: global_state.listen_port,
-            tcp_ao_support: tcp_ao_support_label(global_state.tcp_ao_support).to_string(),
-            tcp_ao_detail: redact_text(&global_state.tcp_ao_detail),
-        },
-    )?;
-    fs::write(
-        bundle_dir.join("metrics.prom"),
-        redact_text(&metrics.prometheus_text),
-    )?;
-    write_json(
-        &bundle_dir.join("environment.json"),
+            // system/health.json + the healthy check.
+            match control.get_health(HealthRequest {}).await {
+                Ok(resp) => {
+                    let health = resp.into_inner();
+                    if !health.daemon_version.is_empty() {
+                        daemon_version = Some(health.daemon_version.clone());
+                    }
+                    reporter.record(
+                        "daemon.healthy",
+                        if health.healthy {
+                            CheckStatus::Ok
+                        } else {
+                            CheckStatus::Fail
+                        },
+                        format!(
+                            "daemon {} (uptime {}, {} active peers, {} routes)",
+                            if health.healthy {
+                                "healthy"
+                            } else {
+                                "reports UNHEALTHY"
+                            },
+                            output::format_duration(health.uptime_seconds),
+                            health.active_peers,
+                            health.total_routes
+                        ),
+                    );
+                    bundle.add_json(
+                        "system/health.json",
+                        &HealthSnapshot {
+                            healthy: health.healthy,
+                            uptime_seconds: health.uptime_seconds,
+                            active_peers: health.active_peers,
+                            total_routes: health.total_routes,
+                            daemon_version: health.daemon_version,
+                        },
+                    )?;
+                }
+                Err(e) => {
+                    reporter.record(
+                        "daemon.healthy",
+                        CheckStatus::Fail,
+                        format!("health RPC failed: {e}"),
+                    );
+                }
+            }
+
+            // system/global.json.
+            match global.get_global(GetGlobalRequest {}).await {
+                Ok(resp) => {
+                    let global_state = resp.into_inner();
+                    bundle.add_json(
+                        "system/global.json",
+                        &GlobalSnapshot {
+                            asn: global_state.asn,
+                            router_id: global_state.router_id,
+                            listen_port: global_state.listen_port,
+                            tcp_ao_support: tcp_ao_support_label(global_state.tcp_ao_support)
+                                .to_string(),
+                            tcp_ao_detail: redact_text(&global_state.tcp_ao_detail),
+                        },
+                    )?;
+                }
+                Err(e) => {
+                    sections.insert("system", format!("partial: global RPC failed: {e}"));
+                }
+            }
+
+            // system/metrics.prom.
+            match control.get_metrics(MetricsRequest {}).await {
+                Ok(resp) => {
+                    bundle.add(
+                        "system/metrics.prom",
+                        redact_text(&resp.into_inner().prometheus_text).into_bytes(),
+                    );
+                }
+                Err(e) => {
+                    sections.insert("system", format!("partial: metrics RPC failed: {e}"));
+                }
+            }
+
+            // config/effective.toml: the daemon's own redacted, normalized
+            // dump (same RPC as `rbgp config effective`). Never the raw file.
+            let mut config_client = ConfigServiceClient::with_interceptor(
+                connection.channel(),
+                connection.interceptor(),
+            );
+            match config_client
+                .get_effective_config(GetEffectiveConfigRequest {})
+                .await
+            {
+                Ok(resp) => {
+                    let toml_text = resp.into_inner().toml;
+                    state_dir = parse_state_dir(&toml_text);
+                    bundle.add("config/effective.toml", toml_text.into_bytes());
+                    sections.insert(
+                        "config",
+                        "collected (daemon-redacted effective config)".to_string(),
+                    );
+                }
+                Err(e) => {
+                    sections.insert(
+                        "config",
+                        format!("unavailable: effective-config RPC failed: {e}"),
+                    );
+                }
+            }
+
+            // peers/: neighbors + recent session/policy events, then the
+            // per-peer red/green checks.
+            let session_events = match events
+                .list_session_events(ListSessionEventsRequest {
+                    neighbor_address: String::new(),
+                    event_types: Vec::new(),
+                    limit: EVENT_HISTORY_LIMIT,
+                })
+                .await
+            {
+                Ok(resp) => resp
+                    .into_inner()
+                    .events
+                    .iter()
+                    .map(|e| bgp_event_json_value(e).map(redact_event))
+                    .collect::<Result<Vec<_>, _>>()?,
+                Err(_) => Vec::new(),
+            };
+            let policy_events = match events
+                .list_policy_events(ListPolicyEventsRequest {
+                    neighbor_address: String::new(),
+                    event_types: Vec::new(),
+                    limit: EVENT_HISTORY_LIMIT,
+                })
+                .await
+            {
+                Ok(resp) => resp
+                    .into_inner()
+                    .events
+                    .iter()
+                    .map(|e| bgp_event_json_value(e).map(redact_event))
+                    .collect::<Result<Vec<_>, _>>()?,
+                Err(_) => Vec::new(),
+            };
+            match neighbor.list_neighbors(ListNeighborsRequest {}).await {
+                Ok(resp) => {
+                    let neighbors = resp.into_inner();
+                    let transitions = last_transition_by_peer(&session_events);
+                    let snapshots: Vec<JsonNeighbor> = neighbors
+                        .neighbors
+                        .iter()
+                        .map(|n| {
+                            let cfg = n.config.as_ref();
+                            JsonNeighbor {
+                                address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
+                                interface: cfg.map(|c| c.interface.clone()).unwrap_or_default(),
+                                remote_asn: cfg.map(|c| c.remote_asn).unwrap_or(0),
+                                state: output::format_state_with_stale(n.state, n.stale)
+                                    .to_string(),
+                                stale: n.stale,
+                                uptime_seconds: n.uptime_seconds,
+                                prefixes_received: n.prefixes_received,
+                                prefixes_sent: n.prefixes_sent,
+                                messages_received: n.messages_received,
+                                messages_sent: n.messages_sent,
+                                flap_count: n.flap_count,
+                                route_reflector_client: n.route_reflector_client,
+                                description: redact_text(
+                                    &cfg.map(|c| c.description.clone()).unwrap_or_default(),
+                                ),
+                            }
+                        })
+                        .collect();
+                    if snapshots.is_empty() {
+                        reporter.record(
+                            "peers.configured",
+                            CheckStatus::Warn,
+                            "no neighbors configured",
+                        );
+                    }
+                    for snapshot in &snapshots {
+                        for check in peer_checks(
+                            &snapshot.address,
+                            &snapshot.state,
+                            snapshot.stale,
+                            snapshot.uptime_seconds,
+                            snapshot.flap_count,
+                            transitions.get(&snapshot.address).copied(),
+                            now,
+                        ) {
+                            reporter.record(check.name, check.status, check.detail);
+                        }
+                    }
+                    bundle.add_json("peers/neighbors.json", &snapshots)?;
+                    bundle.add_json(
+                        "peers/events.json",
+                        &EventsSnapshot {
+                            session: session_events,
+                            policy: policy_events,
+                        },
+                    )?;
+                    sections.insert("peers", "collected".to_string());
+                }
+                Err(e) => {
+                    sections.insert("peers", format!("unavailable: neighbor RPC failed: {e}"));
+                }
+            }
+            sections
+                .entry("system")
+                .or_insert_with(|| "collected".to_string());
+        }
+        Err(e) => {
+            reporter.record(
+                "daemon.reachable",
+                CheckStatus::Fail,
+                format!("daemon unreachable: {e}"),
+            );
+            sections.insert("config", "unavailable: daemon unreachable".to_string());
+            sections.insert("peers", "unavailable: daemon unreachable".to_string());
+            sections.insert(
+                "system",
+                "partial: daemon unreachable (host facts only)".to_string(),
+            );
+        }
+    }
+
+    // ---- system/environment.json (always available) ------------------
+    bundle.add_json(
+        "system/environment.json",
         &EnvironmentSnapshot {
             os: std::env::consts::OS,
             arch: std::env::consts::ARCH,
-            current_dir: std::env::current_dir()?.display().to_string(),
-            daemon_address,
-            token_file_configured,
+            kernel_release: fs::read_to_string("/proc/sys/kernel/osrelease")
+                .map(|s| s.trim_end().to_string())
+                .unwrap_or_default(),
+            current_dir: std::env::current_dir()
+                .map(|d| d.display().to_string())
+                .unwrap_or_default(),
+            daemon_address: opts.daemon_address,
+            token_file_configured: opts.token_file_configured,
         },
     )?;
-    let neighbor_snapshots: Vec<JsonNeighbor> = neighbors
-        .neighbors
-        .iter()
-        .map(|n| {
-            let cfg = n.config.as_ref();
-            JsonNeighbor {
-                address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
-                interface: cfg.map(|c| c.interface.clone()).unwrap_or_default(),
-                remote_asn: cfg.map(|c| c.remote_asn).unwrap_or(0),
-                state: output::format_state_with_stale(n.state, n.stale).to_string(),
-                stale: n.stale,
-                uptime_seconds: n.uptime_seconds,
-                prefixes_received: n.prefixes_received,
-                prefixes_sent: n.prefixes_sent,
-                messages_received: n.messages_received,
-                messages_sent: n.messages_sent,
-                flap_count: n.flap_count,
-                route_reflector_client: n.route_reflector_client,
-                description: redact_text(&cfg.map(|c| c.description.clone()).unwrap_or_default()),
+
+    // ---- daemon rlimits (local processes only) ------------------------
+    let daemon_limits = local_daemon_limits();
+    if daemon_limits.is_empty() {
+        sections.insert(
+            "rlimits",
+            "unavailable: no local rustbgpd process found".to_string(),
+        );
+    } else {
+        for (pid, limits) in &daemon_limits {
+            match parse_max_open_files(limits) {
+                Some((soft, hard)) => {
+                    let check = nofile_check(*pid, soft, hard);
+                    reporter.record(check.name, check.status, check.detail);
+                }
+                None => reporter.record(
+                    format!("daemon.rlimit.nofile.{pid}"),
+                    CheckStatus::Warn,
+                    format!("daemon pid {pid}: could not parse Max open files from /proc limits"),
+                ),
             }
-        })
-        .collect();
-    write_json(&bundle_dir.join("neighbors.json"), &neighbor_snapshots)?;
-    write_json(
-        &bundle_dir.join("events.json"),
-        &EventsSnapshot {
-            session: session_events
-                .events
-                .iter()
-                .map(|e| bgp_event_json_value(e).map(redact_event))
-                .collect::<Result<Vec<_>, _>>()?,
-            policy: policy_events
-                .events
-                .iter()
-                .map(|e| bgp_event_json_value(e).map(redact_event))
-                .collect::<Result<Vec<_>, _>>()?,
+            bundle.add(
+                &format!("system/daemon-limits-{pid}.txt"),
+                limits.clone().into_bytes(),
+            );
+        }
+        sections.insert("rlimits", "collected".to_string());
+    }
+
+    // ---- crashes/ ------------------------------------------------------
+    let crash_dir = PathBuf::from(state_dir.as_deref().unwrap_or(DEFAULT_STATE_DIR)).join("crash");
+    let crash_reports = sweep_crash_reports(&crash_dir, &mut bundle);
+    if crash_reports.is_empty() {
+        reporter.record(
+            "crashes.recent",
+            CheckStatus::Ok,
+            format!("no panic reports in {}", crash_dir.display()),
+        );
+        sections.insert(
+            "crashes",
+            format!("collected (0 reports in {})", crash_dir.display()),
+        );
+    } else {
+        reporter.record(
+            "crashes.recent",
+            CheckStatus::Fail,
+            format!(
+                "{} panic report(s) collected from {} — the daemon has crashed recently",
+                crash_reports.len(),
+                crash_dir.display()
+            ),
+        );
+        sections.insert(
+            "crashes",
+            format!(
+                "collected ({} reports from {})",
+                crash_reports.len(),
+                crash_dir.display()
+            ),
+        );
+    }
+
+    // ---- logs/ -----------------------------------------------------------
+    match opts.log_file {
+        Some(log_file) => match fs::read_to_string(log_file) {
+            Ok(contents) => {
+                bundle.add(
+                    "logs/tail-1000.jsonl",
+                    redact_text(&tail_lines(&contents, LOG_TAIL_LINES)).into_bytes(),
+                );
+                sections.insert(
+                    "logs",
+                    format!(
+                        "collected (last {LOG_TAIL_LINES} lines of {})",
+                        log_file.display()
+                    ),
+                );
+            }
+            Err(e) => {
+                sections.insert(
+                    "logs",
+                    format!("unavailable: cannot read {}: {e}", log_file.display()),
+                );
+            }
         },
-    )?;
-    write_json(
-        &bundle_dir.join("manifest.json"),
-        &BundleManifest {
-            generated_at_unix_seconds: now_unix_seconds(),
+        None => {
+            sections.insert(
+                "logs",
+                "unavailable: daemon logs to stdout/journald; pass --log-file if stdout \
+                 is redirected to a file"
+                    .to_string(),
+            );
+        }
+    }
+
+    // ---- manifest.json + tarball ------------------------------------
+    let mut files: Vec<String> = bundle.files.iter().map(|(p, _)| p.clone()).collect();
+    files.push("manifest.json".to_string());
+    files.sort();
+    let sections_summary = sections.clone();
+    bundle.add_json(
+        "manifest.json",
+        &ManifestV2 {
+            format: 2,
+            generated_at_unix_seconds: now,
             cli_version: env!("CARGO_PKG_VERSION"),
-            daemon_address,
-            token_file_configured,
-            files: vec![
-                "manifest.json",
-                "health.json",
-                "global.json",
-                "metrics.prom",
-                "environment.json",
-                "neighbors.json",
-                "events.json",
-            ],
+            daemon_version,
+            daemon_address: opts.daemon_address,
+            token_file_configured: opts.token_file_configured,
+            redaction: "config is the daemon's secret-redacted effective dump; metrics, \
+                        event free text, descriptions, crash reports, and log lines are \
+                        scrubbed client-side for password/secret/token/bearer material",
+            sections,
+            files,
+            checks: &reporter.checks,
             note: "No daemon config file or bearer token material is copied. Route \
                    contents are not collected; when route-level divergence against an \
                    incumbent is suspected, run `rbgp diff advertised` separately and \
                    attach its report if appropriate.",
         },
     )?;
+    bundle.write_tar_gz(&bundle_path, &root)?;
 
-    if json {
+    let failed = reporter.any_fail();
+    if opts.json {
         output::print_json_line(&serde_json::json!({
-            "bundle_dir": bundle_dir.display().to_string()
+            "bundle": bundle_path.display().to_string(),
+            "ok": !failed,
+            "checks": serde_json::to_value(&reporter.checks)?,
+            "sections": serde_json::to_value(&sections_summary)?,
         }))?;
     } else {
-        println!("Support bundle written: {}", bundle_dir.display());
+        println!("Support bundle written: {}", bundle_path.display());
     }
-    Ok(())
+    Ok(if failed { 2 } else { 0 })
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
+    use std::io::Read;
 
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
+
+    // ---- pure-logic checks -------------------------------------------
 
     #[test]
     fn redact_text_replaces_sensitive_lines() {
@@ -305,43 +916,421 @@ mod tests {
         assert_eq!(redacted["new_state"], "Idle");
     }
 
+    #[test]
+    fn established_peer_is_green() {
+        let checks = peer_checks("10.0.0.2", "Established", false, 3600, 0, None, 1_000_000);
+        assert_eq!(checks.len(), 1);
+        assert!(checks[0].status == CheckStatus::Ok);
+        assert!(checks[0].detail.contains("Established"));
+    }
+
+    #[test]
+    fn peer_stuck_in_connect_past_threshold_is_red_with_duration() {
+        let now = 1_000_000;
+        let transitioned = now - (4 * 3600 + 12 * 60); // 4h12m ago
+        let checks = peer_checks("10.0.0.2", "Connect", false, 0, 0, Some(transitioned), now);
+        assert_eq!(checks.len(), 1);
+        assert!(checks[0].status == CheckStatus::Fail);
+        assert!(
+            checks[0].detail.contains("in Connect for 04:12:00"),
+            "{}",
+            checks[0].detail
+        );
+    }
+
+    #[test]
+    fn peer_in_connect_just_after_transition_is_warn_not_red() {
+        let now = 1_000_000;
+        let checks = peer_checks(
+            "10.0.0.2",
+            "Connect",
+            false,
+            0,
+            0,
+            Some(now - STUCK_PEER_SECS + 1),
+            now,
+        );
+        assert!(checks[0].status == CheckStatus::Warn);
+    }
+
+    #[test]
+    fn peer_in_connect_with_no_transition_event_is_red() {
+        let checks = peer_checks("10.0.0.2", "Connect", false, 0, 0, None, 1_000_000);
+        assert!(checks[0].status == CheckStatus::Fail);
+        assert!(checks[0].detail.contains("no recent state transition"));
+    }
+
+    #[test]
+    fn flapping_peer_gets_extra_red_check() {
+        let checks = peer_checks(
+            "10.0.0.2",
+            "Established",
+            false,
+            60,
+            FLAP_FAIL_THRESHOLD,
+            None,
+            1_000_000,
+        );
+        assert_eq!(checks.len(), 2);
+        assert!(checks[1].status == CheckStatus::Fail);
+        assert!(checks[1].detail.contains("flapped 5 times"));
+    }
+
+    #[test]
+    fn stale_peer_is_warn() {
+        let checks = peer_checks("10.0.0.2", "Stale", true, 0, 0, None, 1_000_000);
+        assert!(checks[0].status == CheckStatus::Warn);
+        assert!(checks[0].detail.contains("stale"));
+    }
+
+    #[test]
+    fn low_nofile_soft_limit_is_red() {
+        let check = nofile_check(42, 1024, 524_288);
+        assert!(check.status == CheckStatus::Fail);
+        assert!(check.detail.contains("soft 1024"));
+        assert!(nofile_check(42, 4096, 524_288).status == CheckStatus::Ok);
+    }
+
+    #[test]
+    fn parse_max_open_files_reads_proc_limits_format() {
+        let limits = "Limit                     Soft Limit           Hard Limit           Units\n\
+                      Max cpu time              unlimited            unlimited            seconds\n\
+                      Max open files            1024                 524288               files\n";
+        assert_eq!(parse_max_open_files(limits), Some((1024, 524_288)));
+        let unlimited =
+            "Max open files            unlimited            unlimited            files\n";
+        assert_eq!(parse_max_open_files(unlimited), Some((u64::MAX, u64::MAX)));
+        assert_eq!(parse_max_open_files("no such row"), None);
+    }
+
+    #[test]
+    fn tail_lines_keeps_only_the_last_n() {
+        let text = (1..=5)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(tail_lines(&text, 2), "line 4\nline 5");
+        assert_eq!(tail_lines(&text, 10), text);
+    }
+
+    #[test]
+    fn parse_state_dir_reads_global_runtime_state_dir() {
+        let toml = "[global]\nasn = 65000\nruntime_state_dir = \"/tmp/x\"\n";
+        assert_eq!(parse_state_dir(toml), Some("/tmp/x".to_string()));
+        assert_eq!(parse_state_dir("[global]\nasn = 65000\n"), None);
+        assert_eq!(parse_state_dir("not toml ["), None);
+    }
+
+    #[test]
+    fn last_transition_by_peer_takes_newest_event() {
+        let events = vec![
+            serde_json::json!({"peer_address": "10.0.0.2", "timestamp": "100"}),
+            serde_json::json!({"peer_address": "10.0.0.2", "timestamp": "250"}),
+            serde_json::json!({"peer_address": "10.0.0.3", "timestamp": "50"}),
+            serde_json::json!({"peer_address": "", "timestamp": "999"}),
+        ];
+        let map = last_transition_by_peer(&events);
+        assert_eq!(map.get("10.0.0.2"), Some(&250));
+        assert_eq!(map.get("10.0.0.3"), Some(&50));
+    }
+
+    // ---- bundle integration ------------------------------------------
+
+    /// Extract a produced tar.gz into (root-relative path -> contents).
+    fn extract_bundle(path: &Path) -> Vec<(String, String)> {
+        let file = fs::File::open(path).unwrap();
+        let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(file));
+        let mut out = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let full = entry.path().unwrap().to_string_lossy().to_string();
+            let rel = full
+                .split_once('/')
+                .map(|(_, rest)| rest.to_string())
+                .expect("all entries live under one root directory");
+            let mut contents = String::new();
+            entry.read_to_string(&mut contents).unwrap();
+            out.push((rel, contents));
+        }
+        out
+    }
+
+    fn find<'a>(files: &'a [(String, String)], rel: &str) -> &'a str {
+        &files
+            .iter()
+            .find(|(p, _)| p == rel)
+            .unwrap_or_else(|| panic!("bundle missing {rel}"))
+            .1
+    }
+
+    fn neighbor(
+        address: &str,
+        state: i32,
+        flaps: u64,
+        description: &str,
+    ) -> rustbgpd_api::proto::NeighborState {
+        rustbgpd_api::proto::NeighborState {
+            config: Some(rustbgpd_api::proto::NeighborConfig {
+                address: address.to_string(),
+                remote_asn: 65002,
+                description: description.to_string(),
+                hold_time: 90,
+                ..Default::default()
+            }),
+            state,
+            uptime_seconds: 3600,
+            flap_count: flaps,
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
-    async fn doctor_writes_bundle_and_calls_core_rpcs() {
+    async fn doctor_bundle_has_v2_layout_and_manifest() {
         let server = spawn_mock_server(None).await;
-        let connection = connect(&server.addr, None).await.unwrap();
+        let state_dir = tempfile::tempdir().unwrap();
+        *server.state.config_effective_toml.lock().await = Some(format!(
+            "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\nruntime_state_dir = \"{}\"\n",
+            state_dir.path().display()
+        ));
+        *server.state.list_neighbors_response.lock().await =
+            vec![neighbor("10.0.0.2", 6, 0, "core peer")];
+        let connection = connect(&server.addr, None).await;
         let dir = tempfile::tempdir().unwrap();
-        let bundle = dir.path().join("bundle");
+        let bundle_path = dir.path().join("bundle.tar.gz");
 
-        run(connection, Some(&bundle), &server.addr, false, true)
-            .await
-            .unwrap();
+        let code = run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+        // Exit code is 0 or 2 depending on host facts (e.g. a real local
+        // rustbgpd with a low rlimit); the contract-level cases are pinned
+        // by the pure-logic tests and the daemon-down test below.
+        assert!(code == 0 || code == 2);
 
-        assert!(bundle.join("manifest.json").exists());
-        assert!(bundle.join("health.json").exists());
-        assert!(bundle.join("global.json").exists());
-        assert!(bundle.join("metrics.prom").exists());
-        assert!(bundle.join("environment.json").exists());
-        assert!(bundle.join("neighbors.json").exists());
-        assert!(bundle.join("events.json").exists());
-        assert_eq!(server.state.health_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(server.state.global_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(server.state.metrics_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(server.state.list_neighbors_calls.load(Ordering::SeqCst), 1);
+        let files = extract_bundle(&bundle_path);
+        for expected in [
+            "manifest.json",
+            "config/effective.toml",
+            "peers/neighbors.json",
+            "peers/events.json",
+            "system/environment.json",
+            "system/health.json",
+            "system/global.json",
+            "system/metrics.prom",
+        ] {
+            find(&files, expected);
+        }
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert_eq!(manifest["format"], 2);
+        assert_eq!(manifest["cli_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest["daemon_version"], "0.0.0-mock");
+        assert_eq!(manifest["sections"]["peers"], "collected");
+        assert!(
+            manifest["sections"]["logs"]
+                .as_str()
+                .unwrap()
+                .contains("stdout/journald"),
+            "logs section records the stdout-only default"
+        );
+        assert!(
+            manifest["checks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| { c["name"] == "daemon.reachable" && c["status"] == "ok" })
+        );
+        assert!(
+            manifest["note"]
+                .as_str()
+                .unwrap()
+                .contains("No daemon config file or bearer token material is copied.")
+        );
+
+        // The effective config is the daemon dump, verbatim.
+        assert!(find(&files, "config/effective.toml").contains("asn = 65000"));
+        assert!(find(&files, "peers/neighbors.json").contains("10.0.0.2"));
+    }
+
+    #[tokio::test]
+    async fn doctor_flags_stuck_peer_and_exits_red() {
+        let server = spawn_mock_server(None).await;
+        let state_dir = tempfile::tempdir().unwrap();
+        *server.state.config_effective_toml.lock().await = Some(format!(
+            "[global]\nasn = 65000\nruntime_state_dir = \"{}\"\n",
+            state_dir.path().display()
+        ));
+        // State 2 = Connect, no session events => stuck with no recent
+        // transition => red.
+        *server.state.list_neighbors_response.lock().await =
+            vec![neighbor("10.0.0.9", 2, 0, "stuck peer")];
+        let connection = connect(&server.addr, None).await;
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+
+        let code = run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &server.addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 2, "stuck peer must produce the red exit code");
+
+        let files = extract_bundle(&bundle_path);
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert!(manifest["checks"].as_array().unwrap().iter().any(|c| {
+            c["name"] == "peer.10.0.0.9.session"
+                && c["status"] == "fail"
+                && c["detail"].as_str().unwrap().contains("in Connect")
+        }));
+    }
+
+    /// LAN-324 scope item 5: a seeded `md5_password` value and a bearer
+    /// token must never appear anywhere in a produced bundle. Secrets are
+    /// pushed through every client-side collection path (metrics text,
+    /// neighbor description, event free text, crash reports, the log
+    /// tail), the tar is extracted, and every file is grepped.
+    #[tokio::test]
+    async fn seeded_secrets_never_appear_anywhere_in_the_bundle() {
+        const MD5_SECRET: &str = "hunter2-md5-seekrit";
+        const BEARER_SECRET: &str = "tok-sekrit-bearer-value";
+
+        let server = spawn_mock_server(None).await;
+        let state_dir = tempfile::tempdir().unwrap();
+        // Crash report a hostile/buggy panic message could have produced.
+        let crash_dir = state_dir.path().join("crash");
+        fs::create_dir_all(&crash_dir).unwrap();
+        fs::write(
+            crash_dir.join("panic-0000000001-000.toml"),
+            format!(
+                "message = \"config md5_password {MD5_SECRET} echoed\"\nlocation = \"x:1:1\"\n"
+            ),
+        )
+        .unwrap();
+        // The daemon redacts the effective config itself; what doctor must
+        // guarantee is that the raw file (with the real md5_password) is
+        // never read. Serve the daemon-redacted form.
+        *server.state.config_effective_toml.lock().await = Some(format!(
+            "[global]\nasn = 65000\nruntime_state_dir = \"{}\"\n\n[[neighbors]]\naddress = \"192.0.2.2\"\nmd5_password = \"<redacted>\"\n",
+            state_dir.path().display()
+        ));
+        *server.state.metrics_text.lock().await = Some(format!(
+            "bgp_peers_total 1\ndebug_password_echo{{password=\"{MD5_SECRET}\"}} 1\n"
+        ));
+        *server.state.list_neighbors_response.lock().await = vec![neighbor(
+            "192.0.2.2",
+            6,
+            0,
+            &format!("md5_password={MD5_SECRET} for this peer"),
+        )];
+        *server.state.session_events.lock().await = vec![rustbgpd_api::proto::BgpEvent {
+            timestamp: "100".to_string(),
+            peer_address: "192.0.2.2".to_string(),
+            summary: format!("peer offered bearer {BEARER_SECRET}"),
+            ..Default::default()
+        }];
+        // Operator-tailed log file carrying a token line.
+        let log_file = state_dir.path().join("daemon.jsonl");
+        fs::write(
+            &log_file,
+            format!("{{\"msg\":\"ok\"}}\n{{\"msg\":\"auth\",\"token\":\"{BEARER_SECRET}\"}}\n"),
+        )
+        .unwrap();
+
+        let connection = connect(&server.addr, None).await;
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+        run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: Some(&log_file),
+                daemon_address: &server.addr,
+                token_file_configured: true,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = extract_bundle(&bundle_path);
+        // The seeded material took its intended paths...
+        find(&files, "crashes/panic-0000000001-000.toml");
+        find(&files, "logs/tail-1000.jsonl");
+        // ...and no file in the bundle carries either secret.
+        for (path, contents) in &files {
+            assert!(
+                !contents.contains(MD5_SECRET),
+                "md5 secret leaked into {path}:\n{contents}"
+            );
+            assert!(
+                !contents.contains(BEARER_SECRET),
+                "bearer token leaked into {path}:\n{contents}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn doctor_against_down_daemon_still_produces_a_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("bundle.tar.gz");
+        let absent = dir.path().join("nobody-home.sock");
+        let addr = format!("unix://{}", absent.display());
+        let connection = connect(&addr, None).await;
+        assert!(connection.is_err(), "precondition: daemon is down");
+
+        let code = run(
+            connection,
+            &DoctorOptions {
+                output: Some(&bundle_path),
+                log_file: None,
+                daemon_address: &addr,
+                token_file_configured: false,
+                json: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(code, 2, "unreachable daemon is a red check");
+
+        let files = extract_bundle(&bundle_path);
+        find(&files, "system/environment.json");
+        let manifest: serde_json::Value =
+            serde_json::from_str(find(&files, "manifest.json")).unwrap();
+        assert_eq!(manifest["daemon_version"], serde_json::Value::Null);
         assert_eq!(
-            server
-                .state
-                .list_session_events_calls
-                .load(Ordering::SeqCst),
-            1
+            manifest["sections"]["config"],
+            "unavailable: daemon unreachable"
         );
         assert_eq!(
-            server.state.list_policy_events_calls.load(Ordering::SeqCst),
-            1
+            manifest["sections"]["peers"],
+            "unavailable: daemon unreachable"
         );
-
-        let manifest = fs::read_to_string(bundle.join("manifest.json")).unwrap();
-        assert!(manifest.contains("No daemon config file or bearer token material is copied."));
-        assert!(manifest.contains("neighbors.json"));
-        assert!(manifest.contains("events.json"));
+        assert!(
+            manifest["checks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| { c["name"] == "daemon.reachable" && c["status"] == "fail" })
+        );
+        // No daemon-backed files sneak in.
+        assert!(!files.iter().any(|(p, _)| p == "config/effective.toml"));
+        assert!(!files.iter().any(|(p, _)| p == "peers/neighbors.json"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -60,6 +60,7 @@ const EXIT_CODES_HELP: &str = "Exit codes:\n  \
     diff advertised      0 no differences / 1 differences / 2 non-comparable input or error\n  \
     diff snapshot ...    0 snapshot emitted / 2 refused or malformed input\n  \
     config diff, plan    0 no changes / 1 error / 2 changes present\n  \
+    doctor               0 all checks green / 1 error / 2 red checks found\n  \
     policy check         0 clean / 1 diagnostics / 2 test failures / 3 coverage below --coverage-min\n  \
     policy test          0 ran / 1 compile diagnostics\n  \
     policy fmt           0 clean or formatted / 1 needs formatting (--check) or error";
@@ -256,11 +257,30 @@ enum Command {
     /// Check daemon health
     Health,
 
-    /// Write a redacted support bundle for operators and issue reports
+    /// Run red/green triage checks and write a redacted support bundle
+    ///
+    /// Prints live checks (peer stuck in Connect, flap loops, daemon
+    /// rlimits, recent panic reports) while collecting one
+    /// `rustbgpd-doctor-<ts>.tar.gz` with manifest.json,
+    /// config/effective.toml (the daemon's secret-redacted dump), peers/,
+    /// logs/, crashes/, and system/. The raw daemon config file and
+    /// bearer-token material are never collected. A bundle is still
+    /// produced when the daemon is down; the manifest records which
+    /// sections are missing.
+    #[command(after_help = "Exit codes:\n  \
+        0  all checks green\n  \
+        1  error (could not produce a bundle)\n  \
+        2  bundle written but one or more checks are red")]
     Doctor {
-        /// Output directory. Defaults to `rustbgpd-support-<unix-seconds>`.
-        #[arg(long, value_name = "DIR")]
+        /// Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`.
+        #[arg(long, value_name = "FILE")]
         output: Option<PathBuf>,
+
+        /// Daemon log file to tail (last 1000 lines) into the bundle.
+        /// Without it the manifest records that the daemon logs to
+        /// stdout/journald.
+        #[arg(long, value_name = "FILE")]
+        log_file: Option<PathBuf>,
     },
 
     /// Show Prometheus metrics
@@ -1798,8 +1818,27 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         std::process::exit(commands::ribsnap_bmp::from_bmp(&opts));
     }
 
-    let addr = cli.addr.clone();
-    let token_file_configured = cli.token_file.is_some();
+    // `doctor` must produce a bundle even when the daemon is down, so it
+    // handles the connect result itself instead of failing here; it also
+    // owns a detailed 0/1/2 exit-code contract.
+    if let Command::Doctor { output, log_file } = &cli.command {
+        let connection = connect(&cli.addr, cli.token_file.as_deref()).await;
+        let code = commands::doctor::run(
+            connection,
+            &commands::doctor::DoctorOptions {
+                output: output.as_deref(),
+                log_file: log_file.as_deref(),
+                daemon_address: &cli.addr,
+                token_file_configured: cli.token_file.is_some(),
+                json: cli.json,
+            },
+        )
+        .await?;
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        std::process::exit(code);
+    }
+
     let connection = connect(&cli.addr, cli.token_file.as_deref()).await?;
     let json = cli.json;
 
@@ -2546,16 +2585,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
         }
 
         Command::Health => commands::control::health(connection, json).await,
-        Command::Doctor { output } => {
-            commands::doctor::run(
-                connection,
-                output.as_deref(),
-                &addr,
-                token_file_configured,
-                json,
-            )
-            .await
-        }
+        Command::Doctor { .. } => unreachable!("handled before connect"),
         Command::Metrics => {
             if json {
                 eprintln!(
@@ -2960,9 +2990,24 @@ mod tests {
 
     #[test]
     fn test_parse_doctor() {
-        let cli = Cli::try_parse_from(["rbgp", "doctor", "--output", "support"]).unwrap();
-        if let Command::Doctor { output } = cli.command {
-            assert_eq!(output.as_deref(), Some(std::path::Path::new("support")));
+        let cli = Cli::try_parse_from([
+            "rbgp",
+            "doctor",
+            "--output",
+            "support.tar.gz",
+            "--log-file",
+            "/var/log/rustbgpd.jsonl",
+        ])
+        .unwrap();
+        if let Command::Doctor { output, log_file } = cli.command {
+            assert_eq!(
+                output.as_deref(),
+                Some(std::path::Path::new("support.tar.gz"))
+            );
+            assert_eq!(
+                log_file.as_deref(),
+                Some(std::path::Path::new("/var/log/rustbgpd.jsonl"))
+            );
         } else {
             panic!("expected Doctor command");
         }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -40,6 +40,12 @@ pub(crate) struct MockState {
     pub(crate) config_status_calls: AtomicUsize,
     pub(crate) config_effective_calls: AtomicUsize,
     pub(crate) config_effective_error: Mutex<Option<(Code, String)>>,
+    // Doctor-bundle overrides: canned effective-config TOML, metrics
+    // text, and session events so redaction/layout tests can seed
+    // secret-looking material through every collection path.
+    pub(crate) config_effective_toml: Mutex<Option<String>>,
+    pub(crate) metrics_text: Mutex<Option<String>>,
+    pub(crate) session_events: Mutex<Vec<server_proto::BgpEvent>>,
     pub(crate) config_confirm_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_abort_error: Mutex<Option<(Code, String)>>,
     pub(crate) config_status_error: Mutex<Option<(Code, String)>>,
@@ -526,8 +532,11 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
         if let Some((code, message)) = self.state.config_effective_error.lock().await.clone() {
             return Err(Status::new(code, message));
         }
+        let toml = self.state.config_effective_toml.lock().await.clone().unwrap_or_else(|| {
+            "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n\n[[neighbors]]\naddress = \"192.0.2.2\"\nhold_time = 90\nremote_asn = 65000\n".to_string()
+        });
         Ok(Response::new(server_proto::GetEffectiveConfigResponse {
-            toml: "[global]\nasn = 65000\nrouter_id = \"192.0.2.1\"\n\n[[neighbors]]\naddress = \"192.0.2.2\"\nhold_time = 90\nremote_asn = 65000\n".to_string(),
+            toml,
         }))
     }
 }
@@ -591,6 +600,7 @@ impl rustbgpd_api::proto::control_service_server::ControlService for MockControl
             uptime_seconds: 42,
             active_peers: 2,
             total_routes: 10,
+            daemon_version: "0.0.0-mock".to_string(),
         }))
     }
 
@@ -599,12 +609,21 @@ impl rustbgpd_api::proto::control_service_server::ControlService for MockControl
         _request: Request<server_proto::MetricsRequest>,
     ) -> Result<Response<server_proto::MetricsResponse>, Status> {
         self.state.metrics_calls.fetch_add(1, Ordering::SeqCst);
-        Ok(Response::new(server_proto::MetricsResponse {
-            prometheus_text: r#"# HELP test 1
+        let prometheus_text = self
+            .state
+            .metrics_text
+            .lock()
+            .await
+            .clone()
+            .unwrap_or_else(|| {
+                r#"# HELP test 1
 evpn_local_originations_total{action="inject"} 1
 evpn_duplicate_mac_moves_total{vni="100",mac="02:aa:bb:cc:dd:01"} 2
 "#
-            .to_string(),
+                .to_string()
+            });
+        Ok(Response::new(server_proto::MetricsResponse {
+            prometheus_text,
         }))
     }
 
@@ -1037,7 +1056,7 @@ impl rustbgpd_api::proto::event_service_server::EventService for MockEventServic
             .list_session_events_calls
             .fetch_add(1, Ordering::SeqCst);
         Ok(Response::new(server_proto::ListSessionEventsResponse {
-            events: vec![],
+            events: self.state.session_events.lock().await.clone(),
         }))
     }
 

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -384,6 +384,7 @@ mod tests {
                 uptime_seconds: 1,
                 active_peers: neighbors.len() as u32,
                 total_routes: 0,
+                daemon_version: String::new(),
             }),
             neighbors,
             rpki_vrp_count: None,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -877,6 +877,54 @@ rustbgpd uses structured JSON logging. Key messages to watch for:
 
 ---
 
+## Support bundles and triage checks (`rbgp doctor`)
+
+`rbgp doctor` runs red/green triage checks live (daemon reachable and
+healthy, peers stuck outside Established with time-in-state, flap loops,
+daemon `nofile` rlimits, recent panic reports) and writes one redacted
+`rustbgpd-doctor-<ts>.tar.gz`:
+
+```
+rustbgpd-doctor-<ts>/
+├── manifest.json            # versions, redaction note, per-section collected/unavailable, check results
+├── config/effective.toml    # the daemon's GetEffectiveConfig dump (defaults materialized, secrets <redacted>)
+├── peers/neighbors.json     # per-peer state, counters, flap counts
+├── peers/events.json        # recent session + policy events (free text scrubbed)
+├── logs/tail-1000.jsonl     # only with --log-file; see below
+├── crashes/panic-*.toml     # panic reports swept from <runtime_state_dir>/crash/
+└── system/                  # environment.json, health.json, global.json, metrics.prom, daemon rlimits
+```
+
+Exit codes: `0` all checks green, `1` error, `2` bundle written but one or
+more checks are red. A doctor run against a down daemon still produces a
+bundle (system facts + crash reports) and the manifest records which
+sections are missing.
+
+What is never collected: the raw daemon config file (the config section is
+the daemon's own secret-redacted effective dump — the same document as
+`rbgp config effective`) and bearer-token material. Metrics, event free
+text, peer descriptions, crash reports, and log lines are additionally
+scrubbed for password/secret/token/bearer lines client-side.
+
+Logs: the daemon logs JSON to stdout (journald under systemd), so no log
+file is collected by default — the manifest records that instead. If stdout
+is redirected to a file, pass it explicitly:
+
+```bash
+rbgp doctor --log-file /var/log/rustbgpd.jsonl   # tails the last 1000 lines
+```
+
+Crash reports: a daemon panic writes a small TOML report (panic message,
+source location, thread, version — never environment variables or argv)
+to `<runtime_state_dir>/crash/panic-<ts>.toml`, keeping the 10 most
+recent. `rbgp doctor` sweeps them into `crashes/`; a report in a bug
+ticket usually pinpoints the crash without a core dump.
+
+Attach the tarball to bug reports — the GitHub bug-report template asks
+for it.
+
+---
+
 ## Common operational tasks
 
 ### Check session status

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -220,7 +220,7 @@ hygiene and per-member export views without carrying member traffic yet.
 6. Generate a support bundle before and after the trial:
 
    ```console
-   $ rbgp doctor --output ./support-rs-shadow
+   $ rbgp doctor --output ./support-rs-shadow.tar.gz
    ```
 
 Migration mapping for FRR, BIRD, and ARouteServer lives in

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -2713,6 +2713,9 @@ message HealthResponse {
   uint64 uptime_seconds = 2;
   uint32 active_peers = 3;
   uint32 total_routes = 4;
+  // Daemon package version (e.g. "0.50.0"). Empty when answered by a
+  // daemon predating the field.
+  string daemon_version = 5;
 }
 
 message MetricsRequest {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1110,6 +1110,12 @@ fn main() {
         process::exit(1);
     }
 
+    // Panic hygiene: write a bounded, secret-free crash report under
+    // `<runtime_state_dir>/crash/` for `rbgp doctor` to sweep into
+    // support bundles. Installed after config resolution so reports
+    // land under the operator's runtime_state_dir.
+    install_panic_hook(config.runtime_state_dir().join("crash"));
+
     #[cfg(feature = "dhat-heap")]
     let profiler = Some(
         dhat::Profiler::builder()
@@ -1127,6 +1133,101 @@ fn main() {
         .build()
         .unwrap_or_else(|e| fatal_startup_error("failed to create tokio runtime", e));
     rt.block_on(run(config, boot_revert_notice, profiler));
+}
+
+/// Number of panic reports retained in `<runtime_state_dir>/crash/`;
+/// older reports are pruned on every write.
+const PANIC_REPORTS_KEPT: usize = 10;
+
+/// Shape of one `crash/panic-<ts>.toml` report (human-panic pattern:
+/// message, location, thread, version, timestamp only — never env vars
+/// or argv, which could carry secrets).
+#[derive(Serialize)]
+struct PanicReport<'a> {
+    message: &'a str,
+    location: &'a str,
+    thread: &'a str,
+    version: &'a str,
+    timestamp_unix_seconds: u64,
+}
+
+/// Install a global panic hook that writes a panic report under
+/// `crash_dir` before delegating to the previous hook (the default
+/// stderr backtrace). `rbgp doctor` sweeps these reports into support
+/// bundles.
+fn install_panic_hook(crash_dir: std::path::PathBuf) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let message = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "non-string panic payload".to_string());
+        let location = info.location().map(ToString::to_string).unwrap_or_default();
+        let thread = std::thread::current()
+            .name()
+            .unwrap_or("unnamed")
+            .to_string();
+        // Best-effort: a failing report write must never mask the panic.
+        let _ = write_panic_report(&crash_dir, &message, &location, &thread);
+        previous(info);
+    }));
+}
+
+/// Write one panic report and prune the crash directory to the most
+/// recent [`PANIC_REPORTS_KEPT`] reports.
+fn write_panic_report(
+    crash_dir: &Path,
+    message: &str,
+    location: &str,
+    thread: &str,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(crash_dir)?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let report = PanicReport {
+        message,
+        location,
+        thread,
+        version: env!("CARGO_PKG_VERSION"),
+        timestamp_unix_seconds: now.as_secs(),
+    };
+    let body = toml::to_string(&report).map_err(std::io::Error::other)?;
+    // Zero-padded seconds + millisecond suffix: lexicographic order is
+    // chronological, and near-simultaneous panicking threads rarely
+    // clobber each other (last write wins if they do).
+    let path = crash_dir.join(format!(
+        "panic-{:010}-{:03}.toml",
+        now.as_secs(),
+        now.subsec_millis()
+    ));
+    std::fs::write(path, body)?;
+    prune_panic_reports(crash_dir);
+    Ok(())
+}
+
+/// Remove the oldest `panic-*.toml` reports beyond [`PANIC_REPORTS_KEPT`].
+fn prune_panic_reports(crash_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(crash_dir) else {
+        return;
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| {
+            n.starts_with("panic-")
+                && Path::new(n)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+        })
+        .collect();
+    names.sort();
+    while names.len() > PANIC_REPORTS_KEPT {
+        let oldest = names.remove(0);
+        let _ = std::fs::remove_file(crash_dir.join(oldest));
+    }
 }
 
 /// Default tokio worker-thread cap when neither env nor config specifies one.
@@ -3205,6 +3306,85 @@ mod tests {
         let config = Config::load_with_diagnostics(path.to_str().unwrap()).unwrap();
         std::fs::remove_file(&path).ok();
         config
+    }
+
+    #[test]
+    fn panic_report_has_expected_shape_and_no_env_or_args() {
+        let dir = tempfile::tempdir().unwrap();
+        write_panic_report(
+            dir.path(),
+            "explicit panic for shape test",
+            "src/main.rs:1:1",
+            "main",
+        )
+        .unwrap();
+
+        let report_path = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                let name = p.file_name().unwrap().to_str().unwrap();
+                name.starts_with("panic-")
+                    && Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+            })
+            .expect("one panic report written");
+        let body = std::fs::read_to_string(report_path).unwrap();
+        let value: toml::Value = toml::from_str(&body).expect("report is valid TOML");
+
+        assert_eq!(
+            value.get("message").and_then(toml::Value::as_str),
+            Some("explicit panic for shape test")
+        );
+        assert_eq!(
+            value.get("location").and_then(toml::Value::as_str),
+            Some("src/main.rs:1:1")
+        );
+        assert_eq!(
+            value.get("thread").and_then(toml::Value::as_str),
+            Some("main")
+        );
+        assert_eq!(
+            value.get("version").and_then(toml::Value::as_str),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert!(
+            value.get("timestamp_unix_seconds").is_some(),
+            "timestamp recorded"
+        );
+        // Human-panic pattern: never environment or argv material.
+        assert!(value.get("env").is_none());
+        assert!(value.get("args").is_none());
+    }
+
+    #[test]
+    fn panic_reports_are_pruned_to_retention_keeping_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        // Seed 12 pre-existing reports older than anything written now.
+        for i in 0..12 {
+            std::fs::write(
+                dir.path().join(format!("panic-{i:010}-000.toml")),
+                "message = \"old\"\n",
+            )
+            .unwrap();
+        }
+        write_panic_report(dir.path(), "newest", "src/main.rs:1:1", "main").unwrap();
+
+        let mut names: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .collect();
+        names.sort();
+        assert_eq!(names.len(), PANIC_REPORTS_KEPT, "pruned to retention");
+        // The newest report (largest timestamp) survives the prune.
+        let newest = std::fs::read_to_string(dir.path().join(names.last().unwrap())).unwrap();
+        assert!(newest.contains("newest"));
+        // The oldest seeded reports were removed first.
+        assert!(!names.contains(&"panic-0000000000-000.toml".to_string()));
+        assert!(!names.contains(&"panic-0000000001-000.toml".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
- rbgp doctor now prints red/green checks live while collecting (daemon
  reachable/healthy, peers stuck outside Established with time-in-state
  derived from session events, flap loops, daemon nofile rlimits, recent
  panic reports) and writes one rustbgpd-doctor-<ts>.tar.gz with a stable
  layout: manifest.json, config/effective.toml, peers/, logs/, crashes/,
  system/. Detailed exit codes 0/1/2 registered in EXIT_CODES_HELP and
  the subcommand help.
- The config section is the daemon's secret-redacted GetEffectiveConfig
  dump (same RPC as `rbgp config effective`); the raw config file and
  bearer-token material are never collected. Metrics, event free text,
  descriptions, crash reports, and log lines are scrubbed client-side.
- Logs are collected only from an operator-named --log-file (last 1000
  lines); stdout/journald-only logging is recorded in the manifest.
- A doctor run against a down daemon still produces a bundle (host facts
  plus crash sweep) and the manifest records what is missing.
- Daemon panic hygiene: a global panic hook writes crash/panic-<ts>.toml
  (message, location, thread, version; never env or argv) under
  runtime_state_dir, retaining the 10 most recent reports.
- HealthResponse gains daemon_version so the manifest records both tool
  and daemon versions.
- Bug-report issue template asks for the doctor bundle; docs/OPERATIONS.md
  documents the bundle shape and redaction guarantees.

Closes LAN-324.