### PR TITLE
fix: harden durable config writes and boot-revert diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Guard test for the `src/lib.rs` module mirror.**
+  `tests/lib_module_mirror.rs` parses the `mod` declarations of
+  `src/main.rs` and `src/lib.rs` at test time and fails when a new
+  `main.rs` module is neither mirrored in `lib.rs` nor added to the
+  documented not-mirrored list — making the LAN-198 mirror decision
+  explicit at ordinary `cargo test` time instead of surfacing only on
+  an `--all-features --lib` build. (LAN-205)
 - **Grafana dashboard aligned with the shipped metric set.** New panels
   on `docs/grafana/rustbgpd-overview.json`: graceful restart, per-peer
   attribute-intern size, update-group index internals, policy engine
@@ -636,6 +643,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Durable config/journal writes are owner-only and symlink-safe.**
+  The shared atomic-write primitive behind the config persister and the
+  commit-confirm revert journal now creates its temp file with mode
+  `0o600` (the journal embeds config snapshots, which may carry secrets
+  such as TCP-MD5 passwords; a permissive umask previously left it
+  world-readable) and resolves symlinks before writing, so a write
+  through a symlinked config lands on the real file instead of
+  replacing the symlink with a regular file. The boot-time
+  commit-confirm revert likewise resolves the config path up front, so
+  a symlinked config survives a revert with its symlink intact and the
+  candidate saved aside next to the real file. Plain (non-symlink)
+  paths behave exactly as before. (LAN-205)
+- **Boot diagnostics distinguish a failed live rollback.** The
+  commit-confirm revert journal records when an abort/timeout rollback
+  failed at runtime (`rollback_failed`, absent in older journals and
+  defaulting to false), and the boot-revert banner then states that the
+  pre-restart on-disk state was uncertain instead of only the generic
+  never-confirmed message. (LAN-205)
 - **SIGHUP config edits limited to hot-applicable neighbor fields no
   longer rebuild the session.** The reload reconciler previously
   delete/re-added the session task for any changed static-neighbor

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -22,7 +22,7 @@ use rustbgpd_api::server::{
     GnmiSetCommitAction, GnmiSetError, GnmiSetFn, GnmiSetOutcome,
 };
 use rustbgpd_telemetry::BgpMetrics;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::config::{Config, EffectiveNeighborImpactKind, Neighbor, diff_config, diff_neighbors};
 use crate::fib_table_control::{
@@ -371,6 +371,7 @@ impl ConfigTransactionController {
                     confirm_id: confirmed.confirm_id.clone(),
                     deadline_unix_seconds,
                     rollback_toml: rollback_toml.clone(),
+                    rollback_failed: false,
                 },
             )
             .map_err(|error| {
@@ -984,6 +985,29 @@ impl ConfigTransactionController {
             && pending.confirm_id == confirm_id
         {
             pending.rollback_failed = Some(status);
+            // Persist the failure into the retained on-disk journal so a
+            // later boot's revert diagnostics can say "a rollback already
+            // failed; the pre-restart state was uncertain" instead of the
+            // generic never-confirmed message. Best-effort: the journal
+            // (with the proven rollback snapshot) is already on disk, and
+            // failing to annotate it must not mask the rollback failure.
+            if let Some(journal_path) = &self.deps.confirm_journal_path
+                && let Err(error) = crate::confirm_journal::write(
+                    journal_path,
+                    &crate::confirm_journal::ConfirmJournal {
+                        confirm_id: pending.confirm_id.clone(),
+                        deadline_unix_seconds: pending.deadline_unix_seconds,
+                        rollback_toml: pending.rollback_toml.clone(),
+                        rollback_failed: true,
+                    },
+                )
+            {
+                warn!(
+                    journal = %journal_path.display(),
+                    error = %error,
+                    "failed to record the rollback failure in the commit-confirm revert journal"
+                );
+            }
         }
     }
 
@@ -4723,8 +4747,13 @@ remote_asn = 65010
         ));
         let (config_tx, config_rx) = mpsc::channel(8);
         let ack_task = tokio::spawn(ack_config_transaction_commits(config_rx));
+        let journal_dir = tempfile::tempdir().unwrap();
+        let journal_path = journal_dir.path().join("commit-confirm-journal.json");
         let controller = ConfigTransactionController::new(
-            deps_value(None, peer_tx, Some(config_tx), Vec::new()),
+            FibTableControlDeps {
+                confirm_journal_path: Some(journal_path.clone()),
+                ..deps_value(None, peer_tx, Some(config_tx), Vec::new())
+            },
             BgpMetrics::new(),
         );
 
@@ -4737,6 +4766,10 @@ remote_asn = 65010
             ))
             .await
             .expect("confirmed apply must succeed");
+        assert!(
+            !read_journal(&journal_path).rollback_failed,
+            "a fresh journal must not carry a rollback failure"
+        );
 
         let err = controller
             .clone()
@@ -4745,6 +4778,13 @@ remote_asn = 65010
             })
             .await
             .expect_err("abort rollback failure must be reported");
+        // The retained on-disk journal now records the failed rollback, so a
+        // restart's boot-revert diagnostics can say the pre-restart state was
+        // uncertain rather than the generic never-confirmed message.
+        assert!(
+            read_journal(&journal_path).rollback_failed,
+            "a failed rollback must be recorded in the retained journal"
+        );
         // A rollback re-apply that fails candidate validation is an internal
         // condition (the captured snapshot is bad), not a malformed abort
         // request, so the abort surfaces INTERNAL rather than INVALID_ARGUMENT.
@@ -4807,6 +4847,10 @@ remote_asn = 65010
             .await
             .expect("successful abort retry must open the mutation gate");
         assert_snapshot_matches_config(&snapshot_toml.lock().await, &previous_toml);
+        assert!(
+            !journal_path.exists(),
+            "a successful abort retry must consume the journal"
+        );
         ack_task.abort();
     }
 

--- a/src/confirm_journal.rs
+++ b/src/confirm_journal.rs
@@ -18,8 +18,9 @@
 
 #![deny(unsafe_code)]
 
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read as _, Write as _};
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -45,6 +46,15 @@ pub struct ConfirmJournal {
     /// TOML snapshot of the running config captured before the candidate
     /// committed; this is what boot restores.
     pub rollback_toml: String,
+    /// Set when a live abort/timeout rollback of this transaction FAILED
+    /// (LAN-277 three-way inconsistency: runtime part-candidate, disk holds
+    /// the candidate, journal holds the pre-transaction snapshot). Boot
+    /// diagnostics use it to say "a rollback already failed; the state
+    /// before this restart was uncertain" instead of the generic
+    /// never-confirmed message. Defaults to `false` so journals written by
+    /// older versions still parse.
+    #[serde(default)]
+    pub rollback_failed: bool,
 }
 
 /// Boot-revert outcome consumed by `main`.
@@ -65,6 +75,10 @@ pub struct BootRevertNotice {
     pub confirm_id: String,
     /// Where the unconfirmed candidate was saved aside.
     pub backup_path: PathBuf,
+    /// The journal recorded a failed live rollback of this transaction: the
+    /// state the daemon was in before this restart is uncertain (the banner
+    /// says so), even though the boot revert itself succeeded.
+    pub rollback_failed: bool,
 }
 
 #[must_use]
@@ -115,6 +129,22 @@ pub fn boot_revert_check(
     journal_path: &Path,
     config_path: &Path,
 ) -> Result<Option<BootRevert>, String> {
+    // Resolve a symlinked config up front (operators legitimately symlink
+    // configs into place): every operation below — save-aside, restore
+    // write, refusal messages — then targets the REAL file, so the revert
+    // updates the file the symlink points at and the symlink itself
+    // survives, instead of the restore replacing the symlink with a regular
+    // file (or landing wherever a later-swapped symlink points). A plain
+    // path canonicalizes to itself; a missing config (crash resume) is used
+    // as-is.
+    let resolved_config;
+    let config_path = match fs::canonicalize(config_path) {
+        Ok(real) => {
+            resolved_config = real;
+            resolved_config.as_path()
+        }
+        Err(_) => config_path,
+    };
     // LAN-221: the journal must be a regular file. A FIFO/socket/device reports
     // `len() == 0` (silently bypassing the size guard) and then blocks or reads
     // unbounded; a directory is nonsense. Reject anything non-regular before
@@ -217,6 +247,7 @@ pub fn boot_revert_check(
         notice: BootRevertNotice {
             confirm_id: journal.confirm_id,
             backup_path,
+            rollback_failed: journal.rollback_failed,
         },
     }))
 }
@@ -362,16 +393,48 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 fn write_atomic_inner(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    let parent = parent_dir(path)?;
-    let mut tmp = path.as_os_str().to_os_string();
+    // Resolve symlinks so the write lands on the REAL file: `rename(2)` over
+    // a symlink replaces the symlink itself (orphaning its target), and
+    // resolving at write time means the rename cannot be redirected by a
+    // symlink swapped in underneath us in a world-writable directory. A
+    // plain path canonicalizes to itself, so the non-symlink case is
+    // unchanged.
+    let target = match fs::canonicalize(path) {
+        Ok(real) => real,
+        // Destination absent (first write) or a dangling symlink: resolve
+        // the parent so a symlinked directory still lands on the real one.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let name = path.file_name().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("path {} has no file name", path.display()),
+                )
+            })?;
+            fs::canonicalize(parent_dir(path)?)?.join(name)
+        }
+        Err(error) => return Err(error),
+    };
+    let mut tmp = target.clone().into_os_string();
     tmp.push(".tmp");
     let tmp = PathBuf::from(tmp);
-    let mut file = File::create(&tmp)?;
+    // Owner-only from the first byte: the payload embeds config snapshots
+    // (which may carry secrets such as TCP-MD5 passwords), and a permissive
+    // umask must not make them world-readable. The rename below preserves
+    // the temp file's mode — it moves the inode.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&tmp)?;
+    // `mode` applies only when the file is CREATED; clamp a stale leftover
+    // temp file to owner-only too before secrets are written into it.
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     file.write_all(bytes)?;
     file.sync_all()?;
     drop(file);
-    fs::rename(&tmp, path)?;
-    fsync_dir(parent)
+    fs::rename(&tmp, &target)?;
+    fsync_dir(parent_dir(&target)?)
 }
 
 fn parent_dir(path: &Path) -> io::Result<&Path> {
@@ -407,6 +470,7 @@ log_format = "json"
             confirm_id: "deploy-1".to_string(),
             deadline_unix_seconds: 1234,
             rollback_toml: PREVIOUS_TOML.to_string(),
+            rollback_failed: false,
         }
     }
 
@@ -567,6 +631,138 @@ log_format = "json"
         // Fail closed: config untouched, journal preserved.
         assert_eq!(fs::read_to_string(&config_path).unwrap(), "candidate");
         assert!(path.exists());
+    }
+
+    #[test]
+    fn write_atomic_sets_owner_only_permissions() {
+        // The payload may embed config secrets; the file must be 0o600 from
+        // creation, under any umask, and the rename must preserve that mode.
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("journal.json");
+        write_atomic(&path, b"secret").unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+
+        // Overwriting a pre-existing world-readable file tightens it: the
+        // rename moves the 0o600 temp inode over the old one.
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        write_atomic(&path, b"secret2").unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o600);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "secret2");
+    }
+
+    #[test]
+    fn write_atomic_writes_through_symlink_to_real_file() {
+        // A symlinked destination (operators symlink configs) must have the
+        // write land on the REAL file — a bare rename would replace the
+        // symlink itself with a regular file and orphan the target.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.toml");
+        fs::write(&real, "old").unwrap();
+        let link = dir.path().join("config.toml");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        write_atomic(&link, b"new").unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive the write"
+        );
+        assert_eq!(fs::read_to_string(&real).unwrap(), "new");
+        assert_eq!(fs::read_to_string(&link).unwrap(), "new");
+    }
+
+    #[test]
+    fn journal_roundtrips_rollback_failed_and_defaults_it_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = journal_path(dir.path());
+        write(
+            &path,
+            &ConfirmJournal {
+                rollback_failed: true,
+                ..journal()
+            },
+        )
+        .unwrap();
+        let read: ConfirmJournal =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(read.rollback_failed);
+
+        // A journal written before the field existed still parses (false).
+        let legacy: ConfirmJournal = serde_json::from_str(
+            &serde_json::to_string(&serde_json::json!({
+                "confirm_id": "deploy-1",
+                "deadline_unix_seconds": 1234,
+                "rollback_toml": PREVIOUS_TOML,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(!legacy.rollback_failed);
+    }
+
+    #[test]
+    fn boot_check_notice_carries_rollback_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rustbgpd.toml");
+        fs::write(&config_path, "candidate").unwrap();
+        let path = journal_path(dir.path());
+        write(
+            &path,
+            &ConfirmJournal {
+                rollback_failed: true,
+                ..journal()
+            },
+        )
+        .unwrap();
+
+        let revert = boot_revert_check(&path, &config_path).unwrap().unwrap();
+        assert!(revert.notice.rollback_failed);
+        // The revert itself still applies — the journaled snapshot is the
+        // proven pre-transaction config.
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), PREVIOUS_TOML);
+    }
+
+    #[test]
+    fn boot_check_reverts_through_symlinked_config() {
+        // A symlinked config file survives the boot revert: the save-aside
+        // and restore operate on the real file, next to which the
+        // `.unconfirmed` candidate is preserved.
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        fs::create_dir_all(&real_dir).unwrap();
+        let real = real_dir.join("rustbgpd.toml");
+        fs::write(&real, "unconfirmed candidate bytes").unwrap();
+        let link = dir.path().join("config.toml");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let path = journal_path(dir.path());
+        write(&path, &journal()).unwrap();
+
+        let revert = boot_revert_check(&path, &link).unwrap().unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the config symlink must survive the revert"
+        );
+        assert_eq!(fs::read_to_string(&real).unwrap(), PREVIOUS_TOML);
+        assert_eq!(fs::read_to_string(&link).unwrap(), PREVIOUS_TOML);
+        // Candidate saved aside next to the REAL file.
+        assert_eq!(
+            revert.notice.backup_path,
+            real_dir.join("rustbgpd.toml.unconfirmed")
+        );
+        assert_eq!(
+            fs::read_to_string(&revert.notice.backup_path).unwrap(),
+            "unconfirmed candidate bytes"
+        );
+        assert!(!path.exists(), "journal consumed");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1431,12 +1431,21 @@ async fn run<T>(
         error!(
             confirm_id = %notice.confirm_id,
             unconfirmed_candidate = %notice.backup_path.display(),
+            rollback_failed = notice.rollback_failed,
             "commit-confirmed transaction was never confirmed before the last shutdown — reverted to the pre-transaction config at boot; the unconfirmed candidate config was saved aside"
         );
         eprintln!(
             "!! commit-confirm boot revert: transaction {:?} was never confirmed before the last shutdown.",
             notice.confirm_id
         );
+        if notice.rollback_failed {
+            // The journal recorded a live rollback FAILURE for this
+            // transaction: before this restart the runtime, the on-disk
+            // config, and the journal were three-way inconsistent.
+            eprintln!(
+                "!! A live rollback of this transaction FAILED before the restart, so the pre-restart on-disk state was uncertain."
+            );
+        }
         eprintln!(
             "!! Booted from the pre-transaction config; the unconfirmed candidate was saved to {}.",
             notice.backup_path.display()

--- a/tests/lib_module_mirror.rs
+++ b/tests/lib_module_mirror.rs
@@ -1,0 +1,101 @@
+//! Guard for the `src/lib.rs` module mirror (LAN-198 class).
+//!
+//! The library target re-declares the subset of `src/main.rs` modules that
+//! `config`'s dependency closure needs under the `bench-internals` feature.
+//! A module added to `main.rs` without a deliberate mirror decision breaks
+//! `cargo check -p rustbgpd --all-features --lib` only when someone happens
+//! to build that combination — this test makes the decision explicit at
+//! ordinary `cargo test` time instead.
+//!
+//! The files are parsed at test run time, never rewritten, so concurrent
+//! module additions only ever fail this test with instructions.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// `main.rs` modules deliberately NOT mirrored in `lib.rs`: they are outside
+/// the dependency closure of the lib-exposed modules. Adding a module to
+/// `main.rs` requires either mirroring it in `lib.rs` (if anything the lib
+/// exposes reaches it) or listing it here — that forced choice is the guard.
+const NOT_MIRRORED: &[&str] = &[
+    "bfd_runtime",
+    "blackhole",
+    "config_persister",
+    "config_transaction_control",
+    "confirm_journal",
+    "fib_runtime",
+    "fib_table_control",
+    "gnmi_set_bridge",
+    "kernel_route_notify",
+    "metrics_server",
+    "peer_manager",
+    "policy_admin",
+    "reload",
+];
+
+/// Collect file-backed `mod name;` declarations (any visibility, any cfg
+/// attributes). Inline `mod name { .. }` blocks are not mirror candidates.
+fn mod_declarations(path: &Path) -> BTreeSet<String> {
+    let source = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    source
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let rest = line
+                .strip_prefix("pub(crate) ")
+                .or_else(|| line.strip_prefix("pub "))
+                .unwrap_or(line);
+            let name = rest.strip_prefix("mod ")?.strip_suffix(';')?.trim();
+            name.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+                .then(|| name.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn lib_rs_mirrors_main_rs_modules() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let main_mods = mod_declarations(&src.join("main.rs"));
+    let lib_mods = mod_declarations(&src.join("lib.rs"));
+    let exceptions: BTreeSet<&str> = NOT_MIRRORED.iter().copied().collect();
+
+    // Every lib.rs module must exist in main.rs — the lib is a mirror, not
+    // an independent module tree.
+    let lib_only: Vec<_> = lib_mods
+        .iter()
+        .filter(|name| !main_mods.contains(*name))
+        .collect();
+    assert!(
+        lib_only.is_empty(),
+        "src/lib.rs declares modules absent from src/main.rs: {lib_only:?}"
+    );
+
+    // Every main.rs module must be mirrored in lib.rs or deliberately listed
+    // in NOT_MIRRORED above.
+    let unaccounted: Vec<_> = main_mods
+        .iter()
+        .filter(|name| !lib_mods.contains(*name) && !exceptions.contains(name.as_str()))
+        .collect();
+    assert!(
+        unaccounted.is_empty(),
+        "src/main.rs modules neither mirrored in src/lib.rs nor listed in \
+         NOT_MIRRORED (tests/lib_module_mirror.rs): {unaccounted:?}. If the \
+         module is reachable from the lib-exposed modules, mirror it in \
+         src/lib.rs (see the LAN-198 comment there); otherwise add it to \
+         NOT_MIRRORED."
+    );
+
+    // Keep the exception list honest: every entry must still be a real,
+    // unmirrored main.rs module.
+    let stale: Vec<_> = exceptions
+        .iter()
+        .filter(|name| !main_mods.contains(**name) || lib_mods.contains(**name))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "stale NOT_MIRRORED entries (removed from src/main.rs or now \
+         mirrored in src/lib.rs): {stale:?}"
+    );
+}


### PR DESCRIPTION
- Create the atomic-write temp file with mode 0o600 so the commit-confirm
  journal (which embeds config snapshots, potentially with TCP-MD5 secrets)
  and persisted configs are never world-readable under a permissive umask;
  the rename preserves the mode.
- Resolve symlinks before durable writes: the temp file and rename target
  the canonicalized real file, so writing through a symlinked config
  updates the target instead of replacing the symlink with a regular file.
  boot_revert_check canonicalizes the config path up front so a symlinked
  config survives a boot revert with its candidate saved aside next to the
  real file. Plain paths are unchanged.
- Record a failed live abort/timeout rollback in the retained revert
  journal (rollback_failed, serde-defaulted for older journals) and state
  in the boot-revert banner that the pre-restart on-disk state was
  uncertain, instead of only the generic never-confirmed message.
- Add tests/lib_module_mirror.rs: parses the mod declarations of
  src/main.rs and src/lib.rs at test time and fails when a new main.rs
  module is neither mirrored nor added to the documented not-mirrored
  list (LAN-198 class), without ever rewriting either file.

Closes LAN-205.