### PR TITLE
chore: audit production unwrap/expect in transport, rpki, bmp, evpn crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -643,6 +643,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`unwrap()`/`expect()` audit of the transport, rpki, bmp, evpn, and
+  evpn-linux crates.** Every non-test site was reviewed: none are
+  reachable from network input or runtime IO — all remaining `expect()`
+  calls guard compile-time-certain conversions or locally provable
+  invariants, and the terse invariant messages were expanded to state
+  what guarantees them. (LAN-8)
 - **Durable config/journal writes are owner-only and symlink-safe.**
   The shared atomic-write primitive behind the config persister and the
   commit-confirm revert journal now creates its temp file with mode

--- a/crates/evpn-linux/src/reconcile.rs
+++ b/crates/evpn-linux/src/reconcile.rs
@@ -6530,7 +6530,13 @@ where
 
     let member_ids: Vec<u32> = members
         .iter()
-        .map(|ip| state.l3_groups.vtep_nh(ip).expect("just installed").id)
+        .map(|ip| {
+            state
+                .l3_groups
+                .vtep_nh(ip)
+                .expect("every member is pre-existing or was recorded by the install loop above")
+                .id
+        })
         .collect();
     let existing = state
         .l3_groups
@@ -6753,7 +6759,13 @@ where
     // Step 2: ensure group exists with the desired member set.
     let member_ids: Vec<u32> = members
         .iter()
-        .map(|ip| state.groups.vtep_nh(ip).expect("just installed").id)
+        .map(|ip| {
+            state
+                .groups
+                .vtep_nh(ip)
+                .expect("every member is pre-existing or was recorded by the install loop above")
+                .id
+        })
         .collect();
     // Snapshot the existing group ID + member set before the
     // mutable replace call (which re-borrows `state.groups`).
@@ -6938,7 +6950,13 @@ where
     // Compute new member-id list and REPLACE the group.
     let member_ids: Vec<u32> = members
         .iter()
-        .map(|ip| state.groups.vtep_nh(ip).expect("just installed").id)
+        .map(|ip| {
+            state
+                .groups
+                .vtep_nh(ip)
+                .expect("every member is pre-existing or was recorded by the install loop above")
+                .id
+        })
         .collect();
     let existing = state
         .groups


### PR DESCRIPTION
Slice 1 of LAN-8 (transport, rpki, bmp, evpn, evpn-linux). Result: zero bare unwrap() in non-test code; rpki and bmp — the network-reachable tier — carry zero non-test sites at all. The 30 surviving expect() calls guard compile-time-certain conversions or locally provable invariants (inventory verified by both a cfg(test)-aware scan and clippy's unwrap_used/expect_used lints). Three vague expect messages in evpn-linux reconcile now state the guaranteeing invariant. No behavior changes.