### PR TITLE
chore: document remaining production unwraps in daemon binary

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -134,10 +134,18 @@ impl Config {
                 });
             }
             if tls_count == 3 {
-                // SAFETY: all three are Some — checked above.
-                let cert = cfg.tls_cert_file.as_deref().unwrap();
-                let key = cfg.tls_key_file.as_deref().unwrap();
-                let ca = cfg.tls_client_ca_file.as_deref().unwrap();
+                let cert = cfg
+                    .tls_cert_file
+                    .as_deref()
+                    .expect("tls_count == 3 means all three TLS paths are Some");
+                let key = cfg
+                    .tls_key_file
+                    .as_deref()
+                    .expect("tls_count == 3 means all three TLS paths are Some");
+                let ca = cfg
+                    .tls_client_ca_file
+                    .as_deref()
+                    .expect("tls_count == 3 means all three TLS paths are Some");
                 validate_grpc_pem_file(cert, "grpc_tcp.tls_cert_file", PemKind::Certificate)?;
                 validate_grpc_pem_file(key, "grpc_tcp.tls_key_file", PemKind::PrivateKey)?;
                 validate_grpc_pem_file(ca, "grpc_tcp.tls_client_ca_file", PemKind::Certificate)?;

--- a/src/fib.rs
+++ b/src/fib.rs
@@ -767,7 +767,8 @@ fn push_route_limit_drop_for_route(
         sampled_rows: 0,
         suppressed_rows: 0,
         total_rows: 0,
-        sample_limit: u32::try_from(MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE).unwrap(),
+        sample_limit: u32::try_from(MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE)
+            .expect("MAX_ROUTE_LIMIT_EXCEEDED_DROPS_PER_TABLE (128) fits u32"),
     });
     counters.sampled += 1;
 }


### PR DESCRIPTION
Slice 2 of LAN-8 (src/, the daemon binary). 28 non-test sites inventoried (clippy unwrap_used/expect_used and a cfg(test)-aware scan agree exactly); zero reachable panics found — every validated-at-load expect was traced to its actual validator, and all non-test Config construction funnels through the validating loader, including SIGHUP reload and the gNMI candidate path. The four bare unwraps (TLS path triple, one const conversion) become invariant-stating expects; src/ is now at zero bare unwraps. Note: the issue's prefix_map.rs reference is stale for src/ — that file lives in crates/rib (rib slice, pending).