### PR TITLE
docs: teach the canonical CLI spellings from the consistency sweep

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -23,13 +23,13 @@ rbgp top          # live terminal dashboard
 ### Config Transactions
 
 ```bash
-rbgp config diff --from-file config.toml
-rbgp config plan --from-file config.toml
-rbgp config apply --from-file config.toml \
+rbgp config diff config.toml
+rbgp config plan config.toml
+rbgp config apply config.toml \
   --expected-runtime-snapshot-token kv1:...
 
 # Confirmed apply: rolls back unless confirmed before the timeout.
-rbgp config apply --from-file config.toml \
+rbgp config apply config.toml \
   --expected-runtime-snapshot-token kv1:... \
   --confirm-id deploy-123 \
   --confirm-timeout 120
@@ -92,9 +92,9 @@ rbgp policy chain clear-import [--neighbor <addr>]
 rbgp policy chain clear-export [--neighbor <addr>]
 rbgp policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>]
 rbgp policy check <file.rpol>                          # parse + typecheck an .rpol file in-process (no daemon)
-rbgp policy test <file.rpol> --policy <name> --direction import|export [--peer <addr>]   # dry-run over the live RIB
-rbgp policy stats [--peer <addr>]                     # live per-term hit counters
-rbgp policy counters [--peer <addr>]                  # alias
+rbgp policy test <file.rpol> --policy <name> --direction import|export [--neighbor <addr>]   # dry-run over the live RIB
+rbgp policy stats [--neighbor <addr>]                     # live per-term hit counters
+rbgp policy counters [--neighbor <addr>]                  # alias
 
 rbgp flowspec
 rbgp fib-table list
@@ -131,7 +131,7 @@ rbgp watch              # legacy route-update stream
 
 rbgp topology           # RFC 9107 ORR topology graph from BGP-LS
 rbgp orr                # RFC 9107 ORR per-vantage status
-rbgp gshut [--peer <addr>] [--clear]   # RFC 8326 graceful-shutdown toggle
+rbgp gshut [--neighbor <addr>] [--clear]   # RFC 8326 graceful-shutdown toggle
 rbgp mrt-dump
 rbgp shutdown
 rbgp completions bash

--- a/docs/API.md
+++ b/docs/API.md
@@ -496,12 +496,12 @@ outside the reshape family (ADR-0086).
 CLI equivalent:
 
 ```bash
-rbgp config diff --from-file /tmp/new-config.toml
-rbgp --json config diff --from-file /tmp/new-config.toml
-rbgp config plan --from-file /tmp/new-config.toml
-rbgp config apply --from-file /tmp/new-config.toml \
+rbgp config diff /tmp/new-config.toml
+rbgp --json config diff /tmp/new-config.toml
+rbgp config plan /tmp/new-config.toml
+rbgp config apply /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
-rbgp config apply --from-file /tmp/new-config.toml \
+rbgp config apply /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:... \
   --client-request-id deploy-2026-06-03-003 \
   --confirm-id deploy-2026-06-03-003 \
@@ -1078,7 +1078,7 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 rbgp rib fib          # human table
 rbgp rib fib --json   # JSON array for scripts
 rbgp rib fib --table edge --state rejected --reason route_limit_exceeded
-rbgp rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rbgp rib fib --prefix 203.0.113.0/24 --neighbor 198.51.100.2
 rbgp rib fib --page-size 100
 ```
 
@@ -1100,7 +1100,7 @@ longest-prefix or containment matching, so `203.0.113.0/24` does not match
 `203.0.113.128/25`. Empty strings and `FIB_ROUTE_STATE_UNSPECIFIED` mean "no
 filter"; for direct gRPC callers, `prefix_length` must be `0` when `prefix` is
 empty. `rbgp rib fib` exposes the same filters as `--table`, `--state`,
-`--reason`, `--prefix`, and `--peer`. `page_size` and `page_token` enable
+`--reason`, `--prefix`, and `--neighbor`. `page_size` and `page_token` enable
 optional pagination over the filtered status rows; `page_size = 0` keeps the
 legacy full-snapshot response, and `page_token` is valid only when
 `page_size > 0`. The response includes `next_page_token` and `total_count`;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -897,7 +897,7 @@ the static TOML form above:
 
 ```sh
 rbgp dynamic-neighbor list
-rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members [--asn 65010] [--description "..."]
+rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members [--remote-asn 65010] [--description "..."]
 rbgp dynamic-neighbor delete 10.0.0.0/24
 ```
 
@@ -2250,15 +2250,15 @@ executors exist.
 Like SIGHUP and FIB CRUD, FIB transaction apply requires the FIB reconciler to
 already be running: a daemon that started with no `[[fib_tables]]` still needs a
 restart to enable the subsystem.
-Operators can drive the workflow through `rbgp config plan --from-file`
-and `rbgp config apply --from-file --expected-runtime-snapshot-token`;
+Operators can drive the workflow through `rbgp config plan <config.toml>`
+and `rbgp config apply <config.toml> --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
 mode: add `--confirm-id <id>` (and optionally `--confirm-timeout <seconds>`) to
-the normal apply invocation — `rbgp config apply --from-file <config.toml>
+the normal apply invocation — `rbgp config apply <config.toml>
 --expected-runtime-snapshot-token <token> --confirm-id <id> --confirm-timeout
 <seconds>` — or set the matching gRPC fields directly. The confirm flags are
-additions; `--from-file` and `--expected-runtime-snapshot-token` are still
+additions; the candidate file and `--expected-runtime-snapshot-token` are still
 required. The timeout defaults to 600 seconds
 and is capped at 86400. The change applies immediately, then remains pending
 until `rbgp config confirm <id>` (or `ConfirmConfigTransaction`) makes it

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -97,13 +97,13 @@ transaction with an optimistic runtime snapshot token:
 rbgp config effective
 rbgp -j config effective
 
-rbgp config diff --from-file /tmp/new-config.toml
-rbgp --json config diff --from-file /tmp/new-config.toml
+rbgp config diff /tmp/new-config.toml
+rbgp --json config diff /tmp/new-config.toml
 
-rbgp config plan --from-file /tmp/new-config.toml
-rbgp --json config plan --from-file /tmp/new-config.toml
+rbgp config plan /tmp/new-config.toml
+rbgp --json config plan /tmp/new-config.toml
 
-rbgp config apply --from-file /tmp/new-config.toml \
+rbgp config apply /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:...
 ```
 
@@ -113,7 +113,7 @@ immediately, starts the timer, and rolls back when the timer expires unless the
 same handle is confirmed:
 
 ```bash
-rbgp config apply --from-file /tmp/new-config.toml \
+rbgp config apply /tmp/new-config.toml \
   --expected-runtime-snapshot-token kv1:... \
   --confirm-id deploy-20260605-1 \
   --confirm-timeout 120
@@ -943,8 +943,8 @@ prefixes received). Display-only: `-j` output always carries every field.
 ### Add a peer at runtime
 
 ```bash
-rbgp neighbor 10.0.0.5 add --asn 65005 --description "new-peer"
-rbgp neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
+rbgp neighbor 10.0.0.5 add --remote-asn 65005 --description "new-peer"
+rbgp neighbor 203.0.113.2 add --remote-asn 65002 --role provider --strict-role
 ```
 
 The peer is persisted to the config file automatically. `--role` enables RFC
@@ -973,7 +973,7 @@ restart (`AddDynamicNeighbor` / `DeleteDynamicNeighbor`, tier `mutating`).
 not enable BFD, the prefix must be valid, and the effective prefix must not
 duplicate an existing range. `delete` stops *future* accepts only —
 already-established dynamic peers keep running and drain when they next
-return to Idle. Omitting `--asn` uses the accept-any sentinel (`remote_asn = 0`);
+return to Idle. Omitting `--remote-asn` uses the accept-any sentinel (`remote_asn = 0`);
 once a peer is accepted, operational state surfaces the ASN learned from the
 peer's OPEN. When the daemon was started with `--config`, changes persist to the
 TOML file (atomic write) before the RPC returns and survive a restart.
@@ -1229,7 +1229,7 @@ rbgp rib
 rbgp rib fib
 rbgp -j rib fib
 rbgp rib fib --table edge --state rejected --reason route_limit_exceeded
-rbgp rib fib --prefix 203.0.113.0/24 --peer 198.51.100.2
+rbgp rib fib --prefix 203.0.113.0/24 --neighbor 198.51.100.2
 rbgp rib fib --page-size 100
 ```
 
@@ -1422,7 +1422,7 @@ already moved.
 
 ```bash
 # Start the drain on one peer
-rbgp gshut --peer 10.0.0.2
+rbgp gshut --neighbor 10.0.0.2
 
 # Or drain every currently-managed peer at once
 rbgp gshut
@@ -1432,7 +1432,7 @@ rbgp gshut
 # the actual maintenance — restart, config edit, etc.
 
 # Clear the community when maintenance ends
-rbgp gshut --peer 10.0.0.2 --clear
+rbgp gshut --neighbor 10.0.0.2 --clear
 rbgp gshut --clear
 ```
 
@@ -1589,7 +1589,7 @@ own `cluster_id` (under `[global]`) drives the RFC 4456 ORIGINATOR_ID
 rbgp evpn                             # all EVPN routes
 rbgp evpn --route-type 2              # MAC/IP only
 rbgp evpn --rd 65000:100              # filter by RD
-rbgp evpn --peer 10.0.1.1             # filter by source peer
+rbgp evpn --neighbor 10.0.1.1         # filter by source peer
 rbgp evpn diagnose                    # alpha VTEP summary
 rbgp evpn runtime                     # committed EVPN generation / mutation state
 rbgp evpn clear-duplicate-mac --vni 100 --mac aa:bb:cc:dd:ee:ff

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -88,9 +88,9 @@ With the systemd unit, the default CLI address is already
 ```bash
 # Add static peers at runtime; persisted to config when the daemon was started
 # with --config.
-rbgp neighbor 10.0.0.5 add --asn 65005
-rbgp neighbor 203.0.113.2 add --asn 65002 --role provider --strict-role
-rbgp neighbor fe80::5054:ff:fe00:1%eth1 add --asn 65101
+rbgp neighbor 10.0.0.5 add --remote-asn 65005
+rbgp neighbor 203.0.113.2 add --remote-asn 65002 --role provider --strict-role
+rbgp neighbor fe80::5054:ff:fe00:1%eth1 add --remote-asn 65101
 
 # Add a dynamic-neighbor accept range.
 rbgp dynamic-neighbor add 10.0.0.0/24 --peer-group ix-members

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -208,7 +208,7 @@ IXP member C (AS 64503) ──┘
 
 ```bash
 # Add member at runtime (persisted to config automatically)
-rbgp neighbor 198.51.100.10 add --asn 64510 \
+rbgp neighbor 198.51.100.10 add --remote-asn 64510 \
   --description "new-member" \
   --families ipv4_unicast,ipv6_unicast \
   --max-prefixes 10000

--- a/docs/cookbook/evpn-fabric-rr.md
+++ b/docs/cookbook/evpn-fabric-rr.md
@@ -87,7 +87,7 @@ $ rbgp evpn                          # all reflected EVPN routes
 $ rbgp evpn --route-type 2           # MAC/IP advertisements only
 $ rbgp evpn --route-type 3           # IMET (BUM flooding) entries
 $ rbgp evpn --rd 65000:100           # one EVI's view
-$ rbgp evpn --peer 10.0.0.1          # what leaf-01 contributed
+$ rbgp evpn --neighbor 10.0.0.1      # what leaf-01 contributed
 ```
 
 Expected shape: one row per (RD, route-type, key) with the originating
@@ -126,7 +126,7 @@ number.
 **A leaf's routes aren't reaching another leaf.** (The
 `rbgp rib advertised --explain` gate ladder covers the unicast and
 VPN families, not EVPN — for EVPN, walk the gates by hand; they fail
-in this order.) First `rbgp evpn --peer 10.0.0.1` — did the RR accept
+in this order.) First `rbgp evpn --neighbor 10.0.0.1` — did the RR accept
 the routes from the source leaf at all? Then the two common
 reflection stops: *family* — the quiet leaf didn't negotiate
 `l2vpn_evpn` (check its row in `rbgp neighbor`; an FRR leaf missing

--- a/docs/cookbook/l3vpn-route-reflector.md
+++ b/docs/cookbook/l3vpn-route-reflector.md
@@ -110,7 +110,7 @@ The VPN table and the membership driving the filter:
 $ rbgp rib vpn                          # VPNv4/VPNv6: RD, prefix, label, RTs
 $ rbgp rib vpn -a vpnv6                 # VPNv6 only
 $ rbgp rib rtc                          # RT-Constrain NLRIs per peer
-$ rbgp rib rtc --peer 10.0.0.11         # what pe-1 says it imports
+$ rbgp rib rtc --neighbor 10.0.0.11     # what pe-1 says it imports
 $ rbgp rib advertised 10.0.0.12 -a l3vpn_ipv4_unicast   # what pe-2 gets
 ```
 
@@ -142,7 +142,7 @@ First suspect: empty RTC membership — strict fail-closed is the
 designed behavior, not a bug. Check what the PE has advertised:
 
 ```console
-$ rbgp rib rtc --peer 10.0.0.11
+$ rbgp rib rtc --neighbor 10.0.0.11
 ```
 
 Empty output = the PE negotiated SAFI 132 but announced no RT
@@ -170,5 +170,5 @@ returns, both the routes and its membership expire with LLGR.
 
 **A VRF is torn down on a PE but its routes linger on other PEs.**
 Check the withdraw actually arrived: `rbgp events --prefix <pfx>`
-shows the per-prefix route-event history, and `rbgp rib vpn --peer
+shows the per-prefix route-event history, and `rbgp rib vpn --neighbor
 <pe>` shows what the RR still holds from that PE.

--- a/docs/cookbook/peer-flap-triage.md
+++ b/docs/cookbook/peer-flap-triage.md
@@ -83,5 +83,5 @@ rbgp neighbor 10.0.0.2 disable --reason "flap triage $(date -u +%F)"
 ```
 
 Disabling keeps the neighbor's config, counters, and history; `enable`
-brings it back. For planned drains prefer `rbgp gshut --peer 10.0.0.2`
+brings it back. For planned drains prefer `rbgp gshut --neighbor 10.0.0.2`
 (RFC 8326) so traffic moves before the session does.

--- a/docs/cookbook/policy-quickstart.md
+++ b/docs/cookbook/policy-quickstart.md
@@ -176,7 +176,7 @@ against the live RIB — read-only, no route state or session touched:
 
 ```console
 $ rbgp policy test edge.rpol --policy "customer-in(150)" \
-    --direction import --peer 192.0.2.10
+    --direction import --neighbor 192.0.2.10
 ```
 
 Output: accept/reject counts, per-term hit counters, and before/after
@@ -215,7 +215,7 @@ And the live counters — which terms are actually doing work since the
 chain was installed (counters reset on chain replace):
 
 ```console
-$ rbgp policy stats --peer 192.0.2.20
+$ rbgp policy stats --neighbor 192.0.2.20
 ```
 
 ## 6. The update-group footnote
@@ -246,5 +246,5 @@ by design.
 composition — another member of the effective chain rejected first —
 or a peer-context mismatch between the test's `peer` fixture and the
 real neighbor. `rbgp policy chain show --neighbor <addr>` prints the
-effective chain order; `rbgp policy test` with `--peer` reproduces
+effective chain order; `rbgp policy test` with `--neighbor` reproduces
 the live evaluation against the real peer context.

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -348,7 +348,7 @@ cutover blockers.
 
    ```bash
    rbgp diff advertised --against incumbent.ndjson          # all snapshot members
-   rbgp diff advertised --peer <member> --against incumbent.ndjson
+   rbgp diff advertised --neighbor <member> --against incumbent.ndjson
    ```
 
    Exit code 0 means complete inputs with no semantic differences, 1

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -174,7 +174,7 @@ it, followed by the runner-up actually advertised — instead of the false
 Members can be added and removed at runtime:
 
 ```console
-$ rbgp neighbor 198.51.100.4 add --asn 64503 \
+$ rbgp neighbor 198.51.100.4 add --remote-asn 64503 \
     --route-server-client --per-client-best --role rs
 ```
 

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -36,7 +36,7 @@ If the fleet auto-accepts via a `[[dynamic_neighbors]]` range, a new
 client inside the range needs nothing. Otherwise:
 
 ```bash
-rbgp neighbor 10.0.0.42 add --asn 65000 --description "new-client"
+rbgp neighbor 10.0.0.42 add --remote-asn 65000 --description "new-client"
 # or widen the accept range:
 rbgp dynamic-neighbor add 10.0.9.0/24 --peer-group rr-clients
 ```
@@ -53,7 +53,7 @@ Before touching a live RR, classify the edit — the
 oracle:
 
 ```bash
-rbgp config diff --from-file /etc/rustbgpd/candidate.toml
+rbgp config diff /etc/rustbgpd/candidate.toml
 ```
 
 Not sure what a value on the live RR *currently* is (an inherited
@@ -87,9 +87,9 @@ For anything you would want auto-rolled-back if you cut yourself off,
 use a config transaction with a confirm timer instead of SIGHUP:
 
 ```bash
-rbgp config plan --from-file /etc/rustbgpd/candidate.toml
+rbgp config plan /etc/rustbgpd/candidate.toml
 # plan prints the runtime snapshot token; apply requires it:
-rbgp config apply --from-file /etc/rustbgpd/candidate.toml \
+rbgp config apply /etc/rustbgpd/candidate.toml \
   --expected-runtime-snapshot-token kv1:... \
   --confirm-id rr1-edit-$(date -u +%Y%m%d-%H%M) \
   --confirm-timeout 120

--- a/docs/ribdiff.md
+++ b/docs/ribdiff.md
@@ -12,7 +12,7 @@ are the only RPCs issued) and fail-closed: **equality is never asserted
 from incomplete, truncated, over-limit, stale, or malformed input.**
 
 ```console
-$ rbgp diff advertised --peer 192.0.2.1 --against incumbent.ndjson
+$ rbgp diff advertised --neighbor 192.0.2.1 --against incumbent.ndjson
 $ echo $?
 0
 ```
@@ -29,7 +29,7 @@ $ echo $?
 
 | Flag | Default | Meaning |
 |------|---------|---------|
-| `--peer <IP>` | all snapshot peers | Peer to compare; repeatable |
+| `--neighbor <IP>` | all snapshot peers | Peer to compare; repeatable |
 | `--against <PATH>` | required | Incumbent `rbgp-ribsnap/1` NDJSON snapshot |
 | `--family <F>` | ipv4\_unicast + ipv6\_unicast | Family filter; repeatable |
 | `--ignore-attribute <A>` | none | Exclude an attribute from comparison on both sides; repeatable (`origin`, `as_path`, `next_hop`, `med`, `local_pref`, `communities`, `extended_communities`, `large_communities`, `unknown`) |

--- a/docs/rpol-language.md
+++ b/docs/rpol-language.md
@@ -1405,7 +1405,7 @@ move (`SensitiveRead` authorization).
 
 ```console
 $ rbgp policy test policies/core.rpol --policy "customer-in(200)" \
-    --direction import --peer 10.0.0.2 --show-changes 2
+    --direction import --neighbor 10.0.0.2 --show-changes 2
 policy "customer-in(200)" (import) over 1204 routes:
   accepted 990  rejected 214  modified 990
 Term hits:
@@ -1422,8 +1422,8 @@ Changes (up to 2):
 ```
 
 - `--direction import` evaluates Adj-RIB-In routes (all peers, or one
-  with `--peer`); `--direction export` evaluates Loc-RIB best routes,
-  with `--peer` setting the peer context guards see (`peer.address`,
+  with `--neighbor`); `--direction export` evaluates Loc-RIB best routes,
+  with `--neighbor` setting the peer context guards see (`peer.address`,
   `peer.asn`, `peer.group`).
 - `--family ipv4_unicast|ipv6_unicast` filters the snapshot; V1 scope
   is IPv4/IPv6 unicast routes (other families are not walked).
@@ -1478,7 +1478,7 @@ cost), and the query snapshots them without resetting anything
 (`SensitiveRead`).
 
 ```console
-$ rbgp policy stats --peer 10.0.0.2 --direction both
+$ rbgp policy stats --neighbor 10.0.0.2 --direction both
 10.0.0.2 export chain — 1204 routes evaluated since install
   POLICY                           TERM                     HITS
   customer-in(200)                 rpki-guard               3

--- a/examples/route-server/README.md
+++ b/examples/route-server/README.md
@@ -38,5 +38,5 @@ ladder with per-candidate export-policy verdicts (which candidates were
 denied by which policy term, and which one was advertised).
 
 Members are managed dynamically via gRPC as they join and leave — see
-`rbgp neighbor <addr> add --asn <asn> --route-server-client \
+`rbgp neighbor <addr> add --remote-asn <asn> --route-server-client \
 --per-client-best --role rs`.


### PR DESCRIPTION
Closes LAN-343. Rewrites rbgp invocations across 16 docs to the #806 canonical forms (--neighbor, --remote-asn, positional config candidates); deliberate leave-alones (snapshot-header --peer metadata, JSON --from-file payloads, historical ADRs) preserved. Every rewritten command shape verified against the built CLI's --help (14/14).