### PR TITLE
chore: regenerate shell completions from the current CLI

### DIFF
--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -68,7 +68,7 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (diff)
 _arguments "${_arguments_options[@]}" : \
-'--from-file=[Candidate TOML file to validate and compare]:PATH:_default' \
+'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -77,11 +77,12 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
+'::candidate -- Candidate TOML file to validate and compare:_default' \
 && ret=0
 ;;
 (plan)
 _arguments "${_arguments_options[@]}" : \
-'--from-file=[Candidate TOML file to validate and classify]:PATH:_default' \
+'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '--expected-runtime-snapshot-token=[Optional runtime snapshot token to check while planning]:TOKEN:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -91,11 +92,12 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
+'::candidate -- Candidate TOML file to validate and classify:_default' \
 && ret=0
 ;;
 (apply)
 _arguments "${_arguments_options[@]}" : \
-'--from-file=[Candidate TOML file to validate and commit]:PATH:_default' \
+'()--from-file=[Hidden compatibility alias for the positional \`CANDIDATE\`]:PATH:_default' \
 '--expected-runtime-snapshot-token=[Runtime snapshot token returned by config plan]:TOKEN:_default' \
 '--client-request-id=[Optional audit/correlation identifier]:ID:_default' \
 '--comment=[Optional human change note; not logged verbatim by the daemon]:TEXT:_default' \
@@ -109,6 +111,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
+'::candidate -- Candidate TOML file to validate and commit:_default' \
 && ret=0
 ;;
 (confirm)
@@ -138,6 +141,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (status)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(effective)
 _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -185,6 +200,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(effective)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -202,6 +221,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'()--wide[Append the classic summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), and State/PfxRcd (prefix count when Established). Display-only; -j already carries every field]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -220,9 +240,11 @@ _arguments "${_arguments_options[@]}" : \
         case $line[2] in
             (add)
 _arguments "${_arguments_options[@]}" : \
-'--asn=[Remote AS number]:ASN:_default' \
+'--remote-asn=[Remote AS number of the peer (the local AS is \`rbgp global\`)]:ASN:_default' \
+'--asn=[Remote AS number of the peer (the local AS is \`rbgp global\`)]:ASN:_default' \
 '--description=[Description]:DESCRIPTION:_default' \
 '--hold-time=[Hold time in seconds]:HOLD_TIME:_default' \
+'--send-hold-time=[RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default\: max(480, 2 x hold time))]:SEND_HOLD_TIME:_default' \
 '--max-prefixes=[Max prefix limit]:MAX_PREFIXES:_default' \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
@@ -231,6 +253,150 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
+'--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client]' \
+'--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
+'--add-path-receive[Enable Add-Path receive]' \
+'--add-path-send[Enable Add-Path send]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(enable)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(disable)
+_arguments "${_arguments_options[@]}" : \
+'--reason=[Disable reason]:REASON:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(softreset)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family to refresh]:FAMILY:_default' \
+'--family=[Address family to refresh]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__neighbor__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-help-command-$line[1]:"
+        case $line[1] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(enable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(disable)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(softreset)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(summary)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'()--wide[Append the classic summary columns to the list\: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), and State/PfxRcd (prefix count when Established). Display-only; -j already carries every field]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'::address -- Neighbor address (omit to list all):_default' \
+":: :_rbgp__subcmd__neighbor_commands" \
+"*::: :->neighbor" \
+&& ret=0
+
+    case $state in
+    (neighbor)
+        words=($line[2] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-neighbor-command-$line[2]:"
+        case $line[2] in
+            (add)
+_arguments "${_arguments_options[@]}" : \
+'--remote-asn=[Remote AS number of the peer (the local AS is \`rbgp global\`)]:ASN:_default' \
+'--asn=[Remote AS number of the peer (the local AS is \`rbgp global\`)]:ASN:_default' \
+'--description=[Description]:DESCRIPTION:_default' \
+'--hold-time=[Hold time in seconds]:HOLD_TIME:_default' \
+'--send-hold-time=[RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default\: max(480, 2 x hold time))]:SEND_HOLD_TIME:_default' \
+'--max-prefixes=[Max prefix limit]:MAX_PREFIXES:_default' \
+'*--families=[Address families (comma-separated)]:FAMILIES:_default' \
+'--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
+'--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--route-server-client[Enable transparent route-server client mode (eBGP only)]' \
+'--per-client-best[RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client]' \
 '--strict-role[Require the peer to advertise a compatible BGP Role capability]' \
 '--add-path-receive[Enable Add-Path receive]' \
 '--add-path-send[Enable Add-Path send]' \
@@ -460,10 +626,43 @@ _arguments "${_arguments_options[@]}" : \
 ':address -- Neighbor address:_default' \
 && ret=0
 ;;
+(recv)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
 (advertised)
 _arguments "${_arguments_options[@]}" : \
 '-a+[Address family filter]:FAMILY:_default' \
 '--family=[Address family filter]:FAMILY:_default' \
+'--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':address -- Neighbor address:_default' \
+&& ret=0
+;;
+(sent)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Address family filter]:FAMILY:_default' \
+'--family=[Address family filter]:FAMILY:_default' \
+'--rd=[Route Distinguisher ("asn\:nn" or "ip\:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate]:RD:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -494,9 +693,90 @@ _arguments "${_arguments_options[@]}" : \
 '--state=[FIB route state filter\: installed, rejected, failed]:STATE:_default' \
 '--reason=[Exact reason-code filter, e.g. owned or route_limit_exceeded]:REASON:_default' \
 '--prefix=[Exact prefix filter, e.g. 203.0.113.0/24]:PREFIX:_default' \
-'--peer=[Source peer-address filter]:PEER:_default' \
+'--neighbor=[Source neighbor-address filter]:NEIGHBOR:_default' \
+'--peer=[Source neighbor-address filter]:NEIGHBOR:_default' \
 '--page-size=[Maximum FIB status rows to return; omitted returns the full snapshot]:PAGE_SIZE:_default' \
 '--page-token=[Page token returned by a previous paginated FIB status query]:PAGE_TOKEN:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(bgpls)
+_arguments "${_arguments_options[@]}" : \
+'-a+[BGP-LS family filter\: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)]:FAMILY:_default' \
+'--family=[BGP-LS family filter\: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)]:FAMILY:_default' \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--nlri-type=[NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)]:NLRI_TYPE:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(bgp-ls)
+_arguments "${_arguments_options[@]}" : \
+'-a+[BGP-LS family filter\: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)]:FAMILY:_default' \
+'--family=[BGP-LS family filter\: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)]:FAMILY:_default' \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--nlri-type=[NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)]:NLRI_TYPE:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(vpn)
+_arguments "${_arguments_options[@]}" : \
+'-a+[VPN family filter\: l3vpn_ipv4_unicast (alias vpnv4) or l3vpn_ipv6_unicast (alias vpnv6)]:FAMILY:_default' \
+'--family=[VPN family filter\: l3vpn_ipv4_unicast (alias vpnv4) or l3vpn_ipv6_unicast (alias vpnv6)]:FAMILY:_default' \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(labeled)
+_arguments "${_arguments_options[@]}" : \
+'-a+[Labeled family filter\: ipv4_labeled_unicast (alias labeled-v4) or ipv6_labeled_unicast (alias labeled-v6)]:FAMILY:_default' \
+'--family=[Labeled family filter\: ipv4_labeled_unicast (alias labeled-v4) or ipv6_labeled_unicast (alias labeled-v6)]:FAMILY:_default' \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(rtc)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -570,6 +850,22 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(bgpls)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(vpn)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(labeled)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(rtc)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (add)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -577,6 +873,274 @@ _arguments "${_arguments_options[@]}" : \
 (delete)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(topology)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__topology_commands" \
+"*::: :->topology" \
+&& ret=0
+
+    case $state in
+    (topology)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-topology-command-$line[1]:"
+        case $line[1] in
+            (nodes)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(links)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__topology__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-topology-help-command-$line[1]:"
+        case $line[1] in
+            (nodes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(links)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(orr)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(diff)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__diff_commands" \
+"*::: :->diff" \
+&& ret=0
+
+    case $state in
+    (diff)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-diff-command-$line[1]:"
+        case $line[1] in
+            (advertised)
+_arguments "${_arguments_options[@]}" : \
+'*--neighbor=[Neighbor address to compare; may be repeated. Omit to compare every peer present in the snapshot]:NEIGHBOR:_default' \
+'*--peer=[Neighbor address to compare; may be repeated. Omit to compare every peer present in the snapshot]:NEIGHBOR:_default' \
+'--against=[Path to the incumbent \`rbgp-ribsnap/1\` NDJSON snapshot]:PATH:_default' \
+'*-a+[Address family filter (ipv4_unicast, ipv6_unicast); may be repeated]:FAMILY:_default' \
+'*--family=[Address family filter (ipv4_unicast, ipv6_unicast); may be repeated]:FAMILY:_default' \
+'--max-routes=[Maximum retained routes per side; exceeding it refuses the comparison (exit 2)]:MAX_ROUTES:_default' \
+'--max-input-bytes=[Maximum snapshot bytes read; exceeding it refuses the comparison (exit 2)]:MAX_INPUT_BYTES:_default' \
+'*--ignore-attribute=[Attribute to exclude from comparison on both sides (origin, as_path, next_hop, med, local_pref, communities, extended_communities, large_communities, unknown); may be repeated]:IGNORE_ATTRIBUTE:_default' \
+'--detail=[Maximum detailed difference rows in human output (--json is always complete)]:DETAIL:_default' \
+'--deadline=[Overall wall-clock budget in seconds; expiry refuses the comparison (exit 2)]:DEADLINE:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(snapshot)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_rbgp__subcmd__diff__subcmd__snapshot_commands" \
+"*::: :->snapshot" \
+&& ret=0
+
+    case $state in
+    (snapshot)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-diff-snapshot-command-$line[1]:"
+        case $line[1] in
+            (from-mrt)
+_arguments "${_arguments_options[@]}" : \
+'--view=[Attestation of what the dump is\: adj-rib-out-capture (a per-client post-policy capture; accepted), loc-rib, or adj-rib-in (both refused as non-comparable)]:VIEW:_default' \
+'--peer=[Peer address the captured routes were advertised to]:PEER:_default' \
+'--peer-asn=[ASN of that peer]:PEER_ASN:_default' \
+'--source=[Free-form provenance label appended to the header \`source\`]:SOURCE:_default' \
+'--generation=[Capture-round generation stamped into the header]:GENERATION:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':file -- Path to the MRT TABLE_DUMP_V2 file:_files' \
+&& ret=0
+;;
+(from-bmp)
+_arguments "${_arguments_options[@]}" : \
+'*--peer=[Peer address to emit; may be repeated. Omit to emit every complete global-instance peer (all of which must then be complete)]:PEER:_default' \
+'--source=[Free-form provenance label appended to the header \`source\`]:SOURCE:_default' \
+'--generation=[Capture-round generation stamped into the header]:GENERATION:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':file -- Path to the captured BMP byte stream:_files' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-diff-snapshot-help-command-$line[1]:"
+        case $line[1] in
+            (from-mrt)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(from-bmp)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__diff__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-diff-help-command-$line[1]:"
+        case $line[1] in
+            (advertised)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(snapshot)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot_commands" \
+"*::: :->snapshot" \
+&& ret=0
+
+    case $state in
+    (snapshot)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-diff-help-snapshot-command-$line[1]:"
+        case $line[1] in
+            (from-mrt)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(from-bmp)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
@@ -678,7 +1242,8 @@ esac
 (evpn)
 _arguments "${_arguments_options[@]}" : \
 '--route-type=[Route type filter (1..=5) — applies when no subcommand is given]:ROUTE_TYPE:_default' \
-'--peer=[Peer IP address filter (list mode only)]:PEER:_default' \
+'--neighbor=[Neighbor IP address filter (list mode only)]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter (list mode only)]:NEIGHBOR:_default' \
 '--rd=[Route Distinguisher filter (list mode only), e.g. "65000\:100"]:RD:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -701,7 +1266,8 @@ _arguments "${_arguments_options[@]}" : \
             (list)
 _arguments "${_arguments_options[@]}" : \
 '--route-type=[]:ROUTE_TYPE:_default' \
-'--peer=[]:PEER:_default' \
+'--neighbor=[Neighbor IP address filter]:NEIGHBOR:_default' \
+'--peer=[Neighbor IP address filter]:NEIGHBOR:_default' \
 '--rd=[]:RD:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -1272,6 +1838,20 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(doctor)
+_arguments "${_arguments_options[@]}" : \
+'--output=[Output tarball path. Defaults to \`rustbgpd-doctor-<unix-seconds>.tar.gz\`]:FILE:_files' \
+'--log-file=[Daemon log file to tail (last 1000 lines) into the bundle. Without it the manifest records that the daemon logs to stdout/journald]:FILE:_files' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (metrics)
 _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -1311,7 +1891,8 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (gshut)
 _arguments "${_arguments_options[@]}" : \
-'--peer=[Peer address; omit to toggle for all peers]:PEER:_default' \
+'--neighbor=[Neighbor address; omit to toggle for all peers]:NEIGHBOR:_default' \
+'--peer=[Neighbor address; omit to toggle for all peers]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1367,6 +1948,58 @@ _arguments "${_arguments_options[@]}" : \
 '--no-color[Disable colored output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(check)
+_arguments "${_arguments_options[@]}" : \
+'*--root=[Additional policy root for \`import\` resolution (repeatable; the main file'\''s directory is always a root) — mirror of the daemon'\''s \`\[policy\] rpol_roots\`]:ROOTS:_default' \
+'--coverage-min=[Minimum acceptable exercised-term percentage (implies --coverage)\: exit 3 when coverage falls below PCT (CI gate). Diagnostics (1) and test failures (2) take precedence]:PCT:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--list-deps[Print the resolved import graph — each module'\''s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)]' \
+'--coverage[Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':file -- Path to the main `.rpol` file:_default' \
+&& ret=0
+;;
+(fmt)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--check[Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)]' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'*::files -- `.rpol` files to format; `-` reads stdin and writes the formatted source to stdout (editor integration):_default' \
+&& ret=0
+;;
+(test)
+_arguments "${_arguments_options[@]}" : \
+'--policy=[Policy to evaluate\: a name, or a call-form with u32 arguments for parameterized policies, e.g. "customer-in(200)"]:POLICY:_default' \
+'--direction=[Evaluation direction\: import (Adj-RIB-In) or export (Loc-RIB best routes)]:DIRECTION:_default' \
+'--neighbor=[Neighbor address\: restricts the import snapshot to one peer'\''s Adj-RIB-In, or sets the export evaluation target]:NEIGHBOR:_default' \
+'--peer=[Neighbor address\: restricts the import snapshot to one peer'\''s Adj-RIB-In, or sets the export evaluation target]:NEIGHBOR:_default' \
+'-a+[Address family filter (ipv4_unicast, ipv6_unicast)]:FAMILY:_default' \
+'--family=[Address family filter (ipv4_unicast, ipv6_unicast)]:FAMILY:_default' \
+'--limit=[Maximum routes to evaluate (0 = all)]:LIMIT:_default' \
+'--show-changes=[Maximum before/after attribute diffs to show]:SHOW_CHANGES:_default' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':file -- Path to the `.rpol` file:_default' \
 && ret=0
 ;;
 (get)
@@ -1432,6 +2065,7 @@ _arguments "${_arguments_options[@]}" : \
             (show)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[Neighbor address (omit for the global chains)]:NEIGHBOR:_default' \
+'--peer=[Neighbor address (omit for the global chains)]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1445,6 +2079,7 @@ _arguments "${_arguments_options[@]}" : \
 (set-import)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[Neighbor address (omit for global)]:NEIGHBOR:_default' \
+'--peer=[Neighbor address (omit for global)]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1459,6 +2094,7 @@ _arguments "${_arguments_options[@]}" : \
 (set-export)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[]:NEIGHBOR:_default' \
+'--peer=[]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1473,6 +2109,7 @@ _arguments "${_arguments_options[@]}" : \
 (clear-import)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[]:NEIGHBOR:_default' \
+'--peer=[]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1486,6 +2123,7 @@ _arguments "${_arguments_options[@]}" : \
 (clear-export)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[]:NEIGHBOR:_default' \
+'--peer=[]:NEIGHBOR:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -1540,9 +2178,40 @@ esac
     ;;
 esac
 ;;
+(stats)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Restrict to one neighbor'\''s installed chain]:NEIGHBOR:_default' \
+'--peer=[Restrict to one neighbor'\''s installed chain]:NEIGHBOR:_default' \
+'--direction=[Direction\: export (default), import, or both]:DIRECTION:(import export both)' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(counters)
+_arguments "${_arguments_options[@]}" : \
+'--neighbor=[Restrict to one neighbor'\''s installed chain]:NEIGHBOR:_default' \
+'--peer=[Restrict to one neighbor'\''s installed chain]:NEIGHBOR:_default' \
+'--direction=[Direction\: export (default), import, or both]:DIRECTION:(import export both)' \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (explain)
 _arguments "${_arguments_options[@]}" : \
 '--neighbor=[Neighbor (peer) address whose import-decision cache to read]:NEIGHBOR:_default' \
+'--peer=[Neighbor (peer) address whose import-decision cache to read]:NEIGHBOR:_default' \
 '--prefix=[Prefix in CIDR form, e.g. \`192.0.2.0/24\` or \`2001\:db8\:\:/32\`]:PREFIX:_default' \
 '--path-id=[Add-Path identifier; omit to show every matching path]:PATH_ID:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -1568,6 +2237,18 @@ _arguments "${_arguments_options[@]}" : \
         curcontext="${curcontext%:*:*}:rbgp-policy-help-command-$line[1]:"
         case $line[1] in
             (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(check)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fmt)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(test)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1618,6 +2299,10 @@ _arguments "${_arguments_options[@]}" : \
         esac
     ;;
 esac
+;;
+(stats)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
 ;;
 (explain)
 _arguments "${_arguments_options[@]}" : \
@@ -1929,6 +2614,7 @@ _arguments "${_arguments_options[@]}" : \
 (add)
 _arguments "${_arguments_options[@]}" : \
 '--peer-group=[Peer group the dynamic peers inherit]:PEER_GROUP:_default' \
+'--remote-asn=[Expected remote ASN (0 = accept any ASN from OPEN)]:ASN:_default' \
 '--asn=[Expected remote ASN (0 = accept any ASN from OPEN)]:ASN:_default' \
 '--description=[Optional description]:DESCRIPTION:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
@@ -2107,6 +2793,18 @@ _arguments "${_arguments_options[@]}" : \
 ':shell -- Shell to generate completions for:(bash elvish fish powershell zsh)' \
 && ret=0
 ;;
+(man)
+_arguments "${_arguments_options[@]}" : \
+'-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
+'--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'-j[Output in JSON format]' \
+'--json[Output in JSON format]' \
+'--no-color[Disable colored output]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 ":: :_rbgp__subcmd__help_commands" \
@@ -2156,6 +2854,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(effective)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2251,6 +2953,22 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(bgpls)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(vpn)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(labeled)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(rtc)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (add)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -2258,6 +2976,78 @@ _arguments "${_arguments_options[@]}" : \
 (delete)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(topology)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__topology_commands" \
+"*::: :->topology" \
+&& ret=0
+
+    case $state in
+    (topology)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-topology-command-$line[1]:"
+        case $line[1] in
+            (nodes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(links)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(orr)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(diff)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__diff_commands" \
+"*::: :->diff" \
+&& ret=0
+
+    case $state in
+    (diff)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-diff-command-$line[1]:"
+        case $line[1] in
+            (advertised)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(snapshot)
+_arguments "${_arguments_options[@]}" : \
+":: :_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot_commands" \
+"*::: :->snapshot" \
+&& ret=0
+
+    case $state in
+    (snapshot)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:rbgp-help-diff-snapshot-command-$line[1]:"
+        case $line[1] in
+            (from-mrt)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(from-bmp)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
         esac
     ;;
@@ -2427,6 +3217,10 @@ esac
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(doctor)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (metrics)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -2460,6 +3254,18 @@ _arguments "${_arguments_options[@]}" : \
         curcontext="${curcontext%:*:*}:rbgp-help-policy-command-$line[1]:"
         case $line[1] in
             (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(check)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fmt)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(test)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2510,6 +3316,10 @@ _arguments "${_arguments_options[@]}" : \
         esac
     ;;
 esac
+;;
+(stats)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
 ;;
 (explain)
 _arguments "${_arguments_options[@]}" : \
@@ -2651,6 +3461,10 @@ esac
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(man)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -2670,24 +3484,30 @@ _rbgp_commands() {
 'global:Show daemon global configuration' \
 'config:Runtime config diagnostics' \
 'neighbor:Manage BGP neighbors' \
+'summary:Manage BGP neighbors' \
 'bfd:Inspect single-hop BFD sessions (ADR-0067)' \
 'rib:Query and manage the RIB' \
+'topology:Show the RFC 9107 ORR topology graph derived from BGP-LS' \
+'orr:Show RFC 9107 ORR per-vantage status (resolution, SPF reach, peers)' \
+'diff:Compare live RIB views against an external snapshot (read-only)' \
 'flowspec:Manage FlowSpec routes' \
 'evpn:Manage EVPN routes (list, add, delete — RFC 7432)' \
 'watch:Watch route updates (streaming)' \
 'events:Show recent route update events' \
 'health:Check daemon health' \
+'doctor:Run red/green triage checks and write a redacted support bundle' \
 'metrics:Show Prometheus metrics' \
 'shutdown:Request daemon shutdown' \
 'mrt-dump:Trigger an on-demand MRT dump' \
-'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (\`--peer X\`) or every currently-managed peer (omit \`--peer\`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance' \
+'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates' \
 'top:Live TUI dashboard' \
-'policy:Manage named \`\[\[policy_definitions\]\]\` entries and the global / per-neighbor import/export chains. Backed by PolicyService' \
-'neighbor-set:Manage named \`\[\[neighbor_sets\]\]\` entries used by policy \`match_neighbor_set\`. Backed by PolicyService' \
-'peer-group:Manage named \`\[\[peer_groups\]\]\` entries and bind/unbind neighbors to them. Backed by PeerGroupService' \
-'dynamic-neighbor:Manage \`\[\[dynamic_neighbors\]\]\` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService' \
-'fib-table:Manage \`\[\[fib_tables\]\]\` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config' \
+'policy:Manage policy definitions and import/export chains' \
+'neighbor-set:Manage named neighbor sets used by policy' \
+'peer-group:Manage peer groups and neighbor membership' \
+'dynamic-neighbor:Manage dynamic-neighbor prefix ranges' \
+'fib-table:Manage general unicast FIB export tables at runtime' \
 'completions:Generate shell completions' \
+'man:Print the rbgp man page (roff) to stdout' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp commands' commands "$@"
@@ -2749,6 +3569,7 @@ _rbgp__subcmd__config_commands() {
 'confirm:Confirm a pending confirmed config transaction' \
 'abort:Abort a pending confirmed config transaction and roll back immediately' \
 'status:Show pending or last confirmed-transaction lifecycle state' \
+'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp config commands' commands "$@"
@@ -2773,6 +3594,11 @@ _rbgp__subcmd__config__subcmd__diff_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp config diff commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__config__subcmd__effective_commands] )) ||
+_rbgp__subcmd__config__subcmd__effective_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config effective commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__config__subcmd__help_commands] )) ||
 _rbgp__subcmd__config__subcmd__help_commands() {
     local commands; commands=(
@@ -2782,6 +3608,7 @@ _rbgp__subcmd__config__subcmd__help_commands() {
 'confirm:Confirm a pending confirmed config transaction' \
 'abort:Abort a pending confirmed config transaction and roll back immediately' \
 'status:Show pending or last confirmed-transaction lifecycle state' \
+'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp config help commands' commands "$@"
@@ -2805,6 +3632,11 @@ _rbgp__subcmd__config__subcmd__help__subcmd__confirm_commands() {
 _rbgp__subcmd__config__subcmd__help__subcmd__diff_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp config help diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__effective_commands] )) ||
+_rbgp__subcmd__config__subcmd__help__subcmd__effective_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp config help effective commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__config__subcmd__help__subcmd__help_commands] )) ||
 _rbgp__subcmd__config__subcmd__help__subcmd__help_commands() {
@@ -2830,6 +3662,105 @@ _rbgp__subcmd__config__subcmd__plan_commands() {
 _rbgp__subcmd__config__subcmd__status_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp config status commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff_commands] )) ||
+_rbgp__subcmd__diff_commands() {
+    local commands; commands=(
+'advertised:Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot' \
+'snapshot:Produce an \`rbgp-ribsnap/1\` snapshot from an incumbent'\''s own output (offline; no daemon connection)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__diff__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help_commands() {
+    local commands; commands=(
+'advertised:Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot' \
+'snapshot:Produce an \`rbgp-ribsnap/1\` snapshot from an incumbent'\''s own output (offline; no daemon connection)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp diff help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff help advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot_commands() {
+    local commands; commands=(
+'from-mrt:Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot' \
+'from-bmp:Convert a captured RFC 7854/8671 BMP byte stream into a snapshot' \
+    )
+    _describe -t commands 'rbgp diff help snapshot commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from-bmp_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from-bmp_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff help snapshot from-bmp commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from-mrt_commands] )) ||
+_rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from-mrt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff help snapshot from-mrt commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot_commands() {
+    local commands; commands=(
+'from-mrt:Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot' \
+'from-bmp:Convert a captured RFC 7854/8671 BMP byte stream into a snapshot' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp diff snapshot commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__from-bmp_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__from-bmp_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff snapshot from-bmp commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__from-mrt_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__from-mrt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff snapshot from-mrt commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help_commands() {
+    local commands; commands=(
+'from-mrt:Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot' \
+'from-bmp:Convert a captured RFC 7854/8671 BMP byte stream into a snapshot' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp diff snapshot help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from-bmp_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from-bmp_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff snapshot help from-bmp commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from-mrt_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from-mrt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff snapshot help from-mrt commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp diff snapshot help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__doctor_commands] )) ||
+_rbgp__subcmd__doctor_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp doctor commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__dynamic-neighbor_commands] )) ||
 _rbgp__subcmd__dynamic-neighbor_commands() {
@@ -2966,10 +3897,10 @@ _rbgp__subcmd__evpn_commands() {
 'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
 'es:Ethernet Segment runtime controls and diagnose state' \
 'runtime:Show the committed ADR-0063 EVPN runtime generation' \
-'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'instances:List local EVPN instances configured on this VTEP' \
 'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
 'managed-netdevs:List managed EVPN netdev ownership/status rows (ADR-0091)' \
-'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'vrfs:List configured IP-VRFs and their readiness verdict' \
 'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -3018,9 +3949,9 @@ _rbgp__subcmd__evpn__subcmd__diagnose_commands() {
 (( $+functions[_rbgp__subcmd__evpn__subcmd__es_commands] )) ||
 _rbgp__subcmd__evpn__subcmd__es_commands() {
     local commands; commands=(
-'list:List configured Ethernet Segments joined with live drain, DF/AC-gate, same-ESI bias, and FDB-NHG state' \
-'drain:Drain an Ethernet Segment before access-circuit maintenance\: withdraw its Type 4 + EAD routes (exiting DF election) and the member VNIs'\'' local Type 2 routes, and suppress new local-MAC origination. In-memory only — a daemon restart clears the drain' \
-'undrain:Undrain an Ethernet Segment\: re-originate its Type 4 + EAD routes, re-run DF election, and replay cached local MAC state' \
+'list:List configured Ethernet Segments' \
+'drain:Drain an Ethernet Segment before access-circuit maintenance' \
+'undrain:Undrain an Ethernet Segment' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp evpn es commands' commands "$@"
@@ -3033,9 +3964,9 @@ _rbgp__subcmd__evpn__subcmd__es__subcmd__drain_commands() {
 (( $+functions[_rbgp__subcmd__evpn__subcmd__es__subcmd__help_commands] )) ||
 _rbgp__subcmd__evpn__subcmd__es__subcmd__help_commands() {
     local commands; commands=(
-'list:List configured Ethernet Segments joined with live drain, DF/AC-gate, same-ESI bias, and FDB-NHG state' \
-'drain:Drain an Ethernet Segment before access-circuit maintenance\: withdraw its Type 4 + EAD routes (exiting DF election) and the member VNIs'\'' local Type 2 routes, and suppress new local-MAC origination. In-memory only — a daemon restart clears the drain' \
-'undrain:Undrain an Ethernet Segment\: re-originate its Type 4 + EAD routes, re-run DF election, and replay cached local MAC state' \
+'list:List configured Ethernet Segments' \
+'drain:Drain an Ethernet Segment before access-circuit maintenance' \
+'undrain:Undrain an Ethernet Segment' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp evpn es help commands' commands "$@"
@@ -3083,10 +4014,10 @@ _rbgp__subcmd__evpn__subcmd__help_commands() {
 'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
 'es:Ethernet Segment runtime controls and diagnose state' \
 'runtime:Show the committed ADR-0063 EVPN runtime generation' \
-'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'instances:List local EVPN instances configured on this VTEP' \
 'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
 'managed-netdevs:List managed EVPN netdev ownership/status rows (ADR-0091)' \
-'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'vrfs:List configured IP-VRFs and their readiness verdict' \
 'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -3135,9 +4066,9 @@ _rbgp__subcmd__evpn__subcmd__help__subcmd__diagnose_commands() {
 (( $+functions[_rbgp__subcmd__evpn__subcmd__help__subcmd__es_commands] )) ||
 _rbgp__subcmd__evpn__subcmd__help__subcmd__es_commands() {
     local commands; commands=(
-'list:List configured Ethernet Segments joined with live drain, DF/AC-gate, same-ESI bias, and FDB-NHG state' \
-'drain:Drain an Ethernet Segment before access-circuit maintenance\: withdraw its Type 4 + EAD routes (exiting DF election) and the member VNIs'\'' local Type 2 routes, and suppress new local-MAC origination. In-memory only — a daemon restart clears the drain' \
-'undrain:Undrain an Ethernet Segment\: re-originate its Type 4 + EAD routes, re-run DF election, and replay cached local MAC state' \
+'list:List configured Ethernet Segments' \
+'drain:Drain an Ethernet Segment before access-circuit maintenance' \
+'undrain:Undrain an Ethernet Segment' \
     )
     _describe -t commands 'rbgp evpn help es commands' commands "$@"
 }
@@ -3342,22 +4273,27 @@ _rbgp__subcmd__help_commands() {
 'neighbor:Manage BGP neighbors' \
 'bfd:Inspect single-hop BFD sessions (ADR-0067)' \
 'rib:Query and manage the RIB' \
+'topology:Show the RFC 9107 ORR topology graph derived from BGP-LS' \
+'orr:Show RFC 9107 ORR per-vantage status (resolution, SPF reach, peers)' \
+'diff:Compare live RIB views against an external snapshot (read-only)' \
 'flowspec:Manage FlowSpec routes' \
 'evpn:Manage EVPN routes (list, add, delete — RFC 7432)' \
 'watch:Watch route updates (streaming)' \
 'events:Show recent route update events' \
 'health:Check daemon health' \
+'doctor:Run red/green triage checks and write a redacted support bundle' \
 'metrics:Show Prometheus metrics' \
 'shutdown:Request daemon shutdown' \
 'mrt-dump:Trigger an on-demand MRT dump' \
-'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (\`--peer X\`) or every currently-managed peer (omit \`--peer\`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance' \
+'gshut:Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates' \
 'top:Live TUI dashboard' \
-'policy:Manage named \`\[\[policy_definitions\]\]\` entries and the global / per-neighbor import/export chains. Backed by PolicyService' \
-'neighbor-set:Manage named \`\[\[neighbor_sets\]\]\` entries used by policy \`match_neighbor_set\`. Backed by PolicyService' \
-'peer-group:Manage named \`\[\[peer_groups\]\]\` entries and bind/unbind neighbors to them. Backed by PeerGroupService' \
-'dynamic-neighbor:Manage \`\[\[dynamic_neighbors\]\]\` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService' \
-'fib-table:Manage \`\[\[fib_tables\]\]\` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config' \
+'policy:Manage policy definitions and import/export chains' \
+'neighbor-set:Manage named neighbor sets used by policy' \
+'peer-group:Manage peer groups and neighbor membership' \
+'dynamic-neighbor:Manage dynamic-neighbor prefix ranges' \
+'fib-table:Manage general unicast FIB export tables at runtime' \
 'completions:Generate shell completions' \
+'man:Print the rbgp man page (roff) to stdout' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp help commands' commands "$@"
@@ -3394,6 +4330,7 @@ _rbgp__subcmd__help__subcmd__config_commands() {
 'confirm:Confirm a pending confirmed config transaction' \
 'abort:Abort a pending confirmed config transaction and roll back immediately' \
 'status:Show pending or last confirmed-transaction lifecycle state' \
+'effective:Dump the daemon'\''s effective running config (defaults materialized)' \
     )
     _describe -t commands 'rbgp help config commands' commands "$@"
 }
@@ -3417,6 +4354,11 @@ _rbgp__subcmd__help__subcmd__config__subcmd__diff_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help config diff commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__effective_commands] )) ||
+_rbgp__subcmd__help__subcmd__config__subcmd__effective_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help config effective commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__config__subcmd__plan_commands] )) ||
 _rbgp__subcmd__help__subcmd__config__subcmd__plan_commands() {
     local commands; commands=()
@@ -3426,6 +4368,42 @@ _rbgp__subcmd__help__subcmd__config__subcmd__plan_commands() {
 _rbgp__subcmd__help__subcmd__config__subcmd__status_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help config status commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__diff_commands] )) ||
+_rbgp__subcmd__help__subcmd__diff_commands() {
+    local commands; commands=(
+'advertised:Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot' \
+'snapshot:Produce an \`rbgp-ribsnap/1\` snapshot from an incumbent'\''s own output (offline; no daemon connection)' \
+    )
+    _describe -t commands 'rbgp help diff commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__diff__subcmd__advertised_commands] )) ||
+_rbgp__subcmd__help__subcmd__diff__subcmd__advertised_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help diff advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot_commands] )) ||
+_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot_commands() {
+    local commands; commands=(
+'from-mrt:Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot' \
+'from-bmp:Convert a captured RFC 7854/8671 BMP byte stream into a snapshot' \
+    )
+    _describe -t commands 'rbgp help diff snapshot commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from-bmp_commands] )) ||
+_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from-bmp_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help diff snapshot from-bmp commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from-mrt_commands] )) ||
+_rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from-mrt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help diff snapshot from-mrt commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__doctor_commands] )) ||
+_rbgp__subcmd__help__subcmd__doctor_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help doctor commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__dynamic-neighbor_commands] )) ||
 _rbgp__subcmd__help__subcmd__dynamic-neighbor_commands() {
@@ -3494,10 +4472,10 @@ _rbgp__subcmd__help__subcmd__evpn_commands() {
 'clear-duplicate-mac:Clear one duplicate-MAC local-origin quarantine' \
 'es:Ethernet Segment runtime controls and diagnose state' \
 'runtime:Show the committed ADR-0063 EVPN runtime generation' \
-'instances:List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector' \
+'instances:List local EVPN instances configured on this VTEP' \
 'nexthops:List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)' \
 'managed-netdevs:List managed EVPN netdev ownership/status rows (ADR-0091)' \
-'vrfs:List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass' \
+'vrfs:List configured IP-VRFs and their readiness verdict' \
 'diagnose:Summarize EVPN VTEP alpha state and key metrics' \
     )
     _describe -t commands 'rbgp help evpn commands' commands "$@"
@@ -3545,9 +4523,9 @@ _rbgp__subcmd__help__subcmd__evpn__subcmd__diagnose_commands() {
 (( $+functions[_rbgp__subcmd__help__subcmd__evpn__subcmd__es_commands] )) ||
 _rbgp__subcmd__help__subcmd__evpn__subcmd__es_commands() {
     local commands; commands=(
-'list:List configured Ethernet Segments joined with live drain, DF/AC-gate, same-ESI bias, and FDB-NHG state' \
-'drain:Drain an Ethernet Segment before access-circuit maintenance\: withdraw its Type 4 + EAD routes (exiting DF election) and the member VNIs'\'' local Type 2 routes, and suppress new local-MAC origination. In-memory only — a daemon restart clears the drain' \
-'undrain:Undrain an Ethernet Segment\: re-originate its Type 4 + EAD routes, re-run DF election, and replay cached local MAC state' \
+'list:List configured Ethernet Segments' \
+'drain:Drain an Ethernet Segment before access-circuit maintenance' \
+'undrain:Undrain an Ethernet Segment' \
     )
     _describe -t commands 'rbgp help evpn es commands' commands "$@"
 }
@@ -3658,6 +4636,11 @@ _rbgp__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help help commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__man_commands] )) ||
+_rbgp__subcmd__help__subcmd__man_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help man commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__metrics_commands] )) ||
 _rbgp__subcmd__help__subcmd__metrics_commands() {
     local commands; commands=()
@@ -3734,6 +4717,11 @@ _rbgp__subcmd__help__subcmd__neighbor-set__subcmd__set_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help neighbor-set set commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__orr_commands] )) ||
+_rbgp__subcmd__help__subcmd__orr_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help orr commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__peer-group_commands] )) ||
 _rbgp__subcmd__help__subcmd__peer-group_commands() {
     local commands; commands=(
@@ -3780,19 +4768,23 @@ _rbgp__subcmd__help__subcmd__peer-group__subcmd__set_commands() {
 _rbgp__subcmd__help__subcmd__policy_commands() {
     local commands; commands=(
 'list:List configured policies (names + statement counts)' \
+'check:Check an \`.rpol\` policy file locally (parse, typecheck, tests)' \
+'fmt:Format \`.rpol\` files in the one canonical style' \
+'test:Dry-run a candidate \`.rpol\` policy against the live RIB' \
 'get:Show one policy by name' \
 'set:Set (create or replace) a policy from a JSON file' \
 'delete:Delete a policy by name' \
 'chain:Manage global / per-neighbor import/export chains' \
-'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+'stats:Show live per-term policy hit counters' \
+'explain:Explain the import-policy decision for a prefix on a neighbor' \
     )
     _describe -t commands 'rbgp help policy commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__chain_commands] )) ||
 _rbgp__subcmd__help__subcmd__policy__subcmd__chain_commands() {
     local commands; commands=(
-'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
-'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'show:Show the global or per-neighbor chains' \
+'set-import:Replace the import chain' \
 'set-export:Replace the export chain' \
 'clear-import:Clear the import chain entirely' \
 'clear-export:Clear the export chain entirely' \
@@ -3824,6 +4816,11 @@ _rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__show_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help policy chain show commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__check_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__check_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy check commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__delete_commands] )) ||
 _rbgp__subcmd__help__subcmd__policy__subcmd__delete_commands() {
     local commands; commands=()
@@ -3833,6 +4830,11 @@ _rbgp__subcmd__help__subcmd__policy__subcmd__delete_commands() {
 _rbgp__subcmd__help__subcmd__policy__subcmd__explain_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help policy explain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__fmt_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__fmt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy fmt commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__get_commands] )) ||
 _rbgp__subcmd__help__subcmd__policy__subcmd__get_commands() {
@@ -3849,6 +4851,16 @@ _rbgp__subcmd__help__subcmd__policy__subcmd__set_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help policy set commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__stats_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__stats_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy stats commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__policy__subcmd__test_commands] )) ||
+_rbgp__subcmd__help__subcmd__policy__subcmd__test_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help policy test commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__rib_commands] )) ||
 _rbgp__subcmd__help__subcmd__rib_commands() {
     local commands; commands=(
@@ -3856,6 +4868,10 @@ _rbgp__subcmd__help__subcmd__rib_commands() {
 'advertised:Show advertised routes to a neighbor' \
 'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
 'fib:Show ADR-0061 general FIB route install status' \
+'bgpls:Show BGP-LS routes learned from peers (RFC 9552)' \
+'vpn:Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)' \
+'labeled:Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)' \
+'rtc:Show RT-Constrain routes (RFC 4684, single IPv4 family)' \
 'add:Inject a route' \
 'delete:Withdraw a route' \
     )
@@ -3870,6 +4886,11 @@ _rbgp__subcmd__help__subcmd__rib__subcmd__add_commands() {
 _rbgp__subcmd__help__subcmd__rib__subcmd__advertised_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help rib advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__bgpls_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__bgpls_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib bgpls commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__blackholes_commands] )) ||
 _rbgp__subcmd__help__subcmd__rib__subcmd__blackholes_commands() {
@@ -3886,10 +4907,25 @@ _rbgp__subcmd__help__subcmd__rib__subcmd__fib_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help rib fib commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__labeled_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__labeled_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib labeled commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__received_commands] )) ||
 _rbgp__subcmd__help__subcmd__rib__subcmd__received_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help rib received commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__rtc_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__rtc_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib rtc commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__rib__subcmd__vpn_commands] )) ||
+_rbgp__subcmd__help__subcmd__rib__subcmd__vpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help rib vpn commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__help__subcmd__shutdown_commands] )) ||
 _rbgp__subcmd__help__subcmd__shutdown_commands() {
@@ -3901,10 +4937,33 @@ _rbgp__subcmd__help__subcmd__top_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help top commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__help__subcmd__topology_commands] )) ||
+_rbgp__subcmd__help__subcmd__topology_commands() {
+    local commands; commands=(
+'nodes:List topology nodes (BGP-LS node identities across all peers)' \
+'links:List usable directed topology links (with IGP metrics)' \
+    )
+    _describe -t commands 'rbgp help topology commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__topology__subcmd__links_commands] )) ||
+_rbgp__subcmd__help__subcmd__topology__subcmd__links_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help topology links commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__help__subcmd__topology__subcmd__nodes_commands] )) ||
+_rbgp__subcmd__help__subcmd__topology__subcmd__nodes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp help topology nodes commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__help__subcmd__watch_commands] )) ||
 _rbgp__subcmd__help__subcmd__watch_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp help watch commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__man_commands] )) ||
+_rbgp__subcmd__man_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp man commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__metrics_commands] )) ||
 _rbgp__subcmd__metrics_commands() {
@@ -4062,6 +5121,11 @@ _rbgp__subcmd__neighbor-set__subcmd__set_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp neighbor-set set commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__orr_commands] )) ||
+_rbgp__subcmd__orr_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp orr commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__peer-group_commands] )) ||
 _rbgp__subcmd__peer-group_commands() {
     local commands; commands=(
@@ -4157,11 +5221,16 @@ _rbgp__subcmd__peer-group__subcmd__set_commands() {
 _rbgp__subcmd__policy_commands() {
     local commands; commands=(
 'list:List configured policies (names + statement counts)' \
+'check:Check an \`.rpol\` policy file locally (parse, typecheck, tests)' \
+'fmt:Format \`.rpol\` files in the one canonical style' \
+'test:Dry-run a candidate \`.rpol\` policy against the live RIB' \
 'get:Show one policy by name' \
 'set:Set (create or replace) a policy from a JSON file' \
 'delete:Delete a policy by name' \
 'chain:Manage global / per-neighbor import/export chains' \
-'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+'stats:Show live per-term policy hit counters' \
+'counters:Show live per-term policy hit counters' \
+'explain:Explain the import-policy decision for a prefix on a neighbor' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp policy commands' commands "$@"
@@ -4169,8 +5238,8 @@ _rbgp__subcmd__policy_commands() {
 (( $+functions[_rbgp__subcmd__policy__subcmd__chain_commands] )) ||
 _rbgp__subcmd__policy__subcmd__chain_commands() {
     local commands; commands=(
-'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
-'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'show:Show the global or per-neighbor chains' \
+'set-import:Replace the import chain' \
 'set-export:Replace the export chain' \
 'clear-import:Clear the import chain entirely' \
 'clear-export:Clear the export chain entirely' \
@@ -4191,8 +5260,8 @@ _rbgp__subcmd__policy__subcmd__chain__subcmd__clear-import_commands() {
 (( $+functions[_rbgp__subcmd__policy__subcmd__chain__subcmd__help_commands] )) ||
 _rbgp__subcmd__policy__subcmd__chain__subcmd__help_commands() {
     local commands; commands=(
-'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
-'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'show:Show the global or per-neighbor chains' \
+'set-import:Replace the import chain' \
 'set-export:Replace the export chain' \
 'clear-import:Clear the import chain entirely' \
 'clear-export:Clear the export chain entirely' \
@@ -4245,6 +5314,11 @@ _rbgp__subcmd__policy__subcmd__chain__subcmd__show_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy chain show commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__policy__subcmd__check_commands] )) ||
+_rbgp__subcmd__policy__subcmd__check_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy check commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__policy__subcmd__delete_commands] )) ||
 _rbgp__subcmd__policy__subcmd__delete_commands() {
     local commands; commands=()
@@ -4255,6 +5329,11 @@ _rbgp__subcmd__policy__subcmd__explain_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy explain commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__policy__subcmd__fmt_commands] )) ||
+_rbgp__subcmd__policy__subcmd__fmt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy fmt commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__policy__subcmd__get_commands] )) ||
 _rbgp__subcmd__policy__subcmd__get_commands() {
     local commands; commands=()
@@ -4264,11 +5343,15 @@ _rbgp__subcmd__policy__subcmd__get_commands() {
 _rbgp__subcmd__policy__subcmd__help_commands() {
     local commands; commands=(
 'list:List configured policies (names + statement counts)' \
+'check:Check an \`.rpol\` policy file locally (parse, typecheck, tests)' \
+'fmt:Format \`.rpol\` files in the one canonical style' \
+'test:Dry-run a candidate \`.rpol\` policy against the live RIB' \
 'get:Show one policy by name' \
 'set:Set (create or replace) a policy from a JSON file' \
 'delete:Delete a policy by name' \
 'chain:Manage global / per-neighbor import/export chains' \
-'explain:Explain the import-policy decision for a prefix on a neighbor (ADR-0073)\: why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires \`\[policy.explain\].enabled\` on the daemon' \
+'stats:Show live per-term policy hit counters' \
+'explain:Explain the import-policy decision for a prefix on a neighbor' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'rbgp policy help commands' commands "$@"
@@ -4276,8 +5359,8 @@ _rbgp__subcmd__policy__subcmd__help_commands() {
 (( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__chain_commands] )) ||
 _rbgp__subcmd__policy__subcmd__help__subcmd__chain_commands() {
     local commands; commands=(
-'show:Show the global chains, or the per-neighbor chains when \`--neighbor\` is given' \
-'set-import:Replace the import chain. Empty list is rejected — use \`clear-import\` instead. Apply globally by omitting \`--neighbor\`' \
+'show:Show the global or per-neighbor chains' \
+'set-import:Replace the import chain' \
 'set-export:Replace the export chain' \
 'clear-import:Clear the import chain entirely' \
 'clear-export:Clear the export chain entirely' \
@@ -4309,6 +5392,11 @@ _rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__show_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy help chain show commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__check_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__check_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help check commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__delete_commands] )) ||
 _rbgp__subcmd__policy__subcmd__help__subcmd__delete_commands() {
     local commands; commands=()
@@ -4318,6 +5406,11 @@ _rbgp__subcmd__policy__subcmd__help__subcmd__delete_commands() {
 _rbgp__subcmd__policy__subcmd__help__subcmd__explain_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy help explain commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__fmt_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__fmt_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help fmt commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__get_commands] )) ||
 _rbgp__subcmd__policy__subcmd__help__subcmd__get_commands() {
@@ -4339,6 +5432,16 @@ _rbgp__subcmd__policy__subcmd__help__subcmd__set_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy help set commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__stats_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__stats_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help stats commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__help__subcmd__test_commands] )) ||
+_rbgp__subcmd__policy__subcmd__help__subcmd__test_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy help test commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__policy__subcmd__list_commands] )) ||
 _rbgp__subcmd__policy__subcmd__list_commands() {
     local commands; commands=()
@@ -4349,13 +5452,30 @@ _rbgp__subcmd__policy__subcmd__set_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp policy set commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__policy__subcmd__stats_commands] )) ||
+_rbgp__subcmd__policy__subcmd__stats_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy stats commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__policy__subcmd__test_commands] )) ||
+_rbgp__subcmd__policy__subcmd__test_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp policy test commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__rib_commands] )) ||
 _rbgp__subcmd__rib_commands() {
     local commands; commands=(
 'received:Show received routes from a neighbor' \
+'recv:Show received routes from a neighbor' \
 'advertised:Show advertised routes to a neighbor' \
+'sent:Show advertised routes to a neighbor' \
 'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
 'fib:Show ADR-0061 general FIB route install status' \
+'bgpls:Show BGP-LS routes learned from peers (RFC 9552)' \
+'bgp-ls:Show BGP-LS routes learned from peers (RFC 9552)' \
+'vpn:Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)' \
+'labeled:Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)' \
+'rtc:Show RT-Constrain routes (RFC 4684, single IPv4 family)' \
 'add:Inject a route' \
 'delete:Withdraw a route' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -4371,6 +5491,11 @@ _rbgp__subcmd__rib__subcmd__add_commands() {
 _rbgp__subcmd__rib__subcmd__advertised_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp rib advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__bgpls_commands] )) ||
+_rbgp__subcmd__rib__subcmd__bgpls_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib bgpls commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__rib__subcmd__blackholes_commands] )) ||
 _rbgp__subcmd__rib__subcmd__blackholes_commands() {
@@ -4394,6 +5519,10 @@ _rbgp__subcmd__rib__subcmd__help_commands() {
 'advertised:Show advertised routes to a neighbor' \
 'blackholes:Show RFC 7999 BLACKHOLE discard install status' \
 'fib:Show ADR-0061 general FIB route install status' \
+'bgpls:Show BGP-LS routes learned from peers (RFC 9552)' \
+'vpn:Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)' \
+'labeled:Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)' \
+'rtc:Show RT-Constrain routes (RFC 4684, single IPv4 family)' \
 'add:Inject a route' \
 'delete:Withdraw a route' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -4409,6 +5538,11 @@ _rbgp__subcmd__rib__subcmd__help__subcmd__add_commands() {
 _rbgp__subcmd__rib__subcmd__help__subcmd__advertised_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp rib help advertised commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__bgpls_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__bgpls_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help bgpls commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__blackholes_commands] )) ||
 _rbgp__subcmd__rib__subcmd__help__subcmd__blackholes_commands() {
@@ -4430,15 +5564,45 @@ _rbgp__subcmd__rib__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp rib help help commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__labeled_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__labeled_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help labeled commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__received_commands] )) ||
 _rbgp__subcmd__rib__subcmd__help__subcmd__received_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp rib help received commands' commands "$@"
 }
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__rtc_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__rtc_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help rtc commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__help__subcmd__vpn_commands] )) ||
+_rbgp__subcmd__rib__subcmd__help__subcmd__vpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib help vpn commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__labeled_commands] )) ||
+_rbgp__subcmd__rib__subcmd__labeled_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib labeled commands' commands "$@"
+}
 (( $+functions[_rbgp__subcmd__rib__subcmd__received_commands] )) ||
 _rbgp__subcmd__rib__subcmd__received_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp rib received commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__rtc_commands] )) ||
+_rbgp__subcmd__rib__subcmd__rtc_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib rtc commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__rib__subcmd__vpn_commands] )) ||
+_rbgp__subcmd__rib__subcmd__vpn_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp rib vpn commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__shutdown_commands] )) ||
 _rbgp__subcmd__shutdown_commands() {
@@ -4449,6 +5613,49 @@ _rbgp__subcmd__shutdown_commands() {
 _rbgp__subcmd__top_commands() {
     local commands; commands=()
     _describe -t commands 'rbgp top commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology_commands] )) ||
+_rbgp__subcmd__topology_commands() {
+    local commands; commands=(
+'nodes:List topology nodes (BGP-LS node identities across all peers)' \
+'links:List usable directed topology links (with IGP metrics)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp topology commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__help_commands] )) ||
+_rbgp__subcmd__topology__subcmd__help_commands() {
+    local commands; commands=(
+'nodes:List topology nodes (BGP-LS node identities across all peers)' \
+'links:List usable directed topology links (with IGP metrics)' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'rbgp topology help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__help__subcmd__help_commands] )) ||
+_rbgp__subcmd__topology__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp topology help help commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__help__subcmd__links_commands] )) ||
+_rbgp__subcmd__topology__subcmd__help__subcmd__links_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp topology help links commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__help__subcmd__nodes_commands] )) ||
+_rbgp__subcmd__topology__subcmd__help__subcmd__nodes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp topology help nodes commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__links_commands] )) ||
+_rbgp__subcmd__topology__subcmd__links_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp topology links commands' commands "$@"
+}
+(( $+functions[_rbgp__subcmd__topology__subcmd__nodes_commands] )) ||
+_rbgp__subcmd__topology__subcmd__nodes_commands() {
+    local commands; commands=()
+    _describe -t commands 'rbgp topology nodes commands' commands "$@"
 }
 (( $+functions[_rbgp__subcmd__watch_commands] )) ||
 _rbgp__subcmd__watch_commands() {

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -25,6 +25,12 @@ _rbgp() {
             rbgp,config)
                 cmd="rbgp__subcmd__config"
                 ;;
+            rbgp,diff)
+                cmd="rbgp__subcmd__diff"
+                ;;
+            rbgp,doctor)
+                cmd="rbgp__subcmd__doctor"
+                ;;
             rbgp,dynamic-neighbor)
                 cmd="rbgp__subcmd__dynamic__subcmd__neighbor"
                 ;;
@@ -52,6 +58,9 @@ _rbgp() {
             rbgp,help)
                 cmd="rbgp__subcmd__help"
                 ;;
+            rbgp,man)
+                cmd="rbgp__subcmd__man"
+                ;;
             rbgp,metrics)
                 cmd="rbgp__subcmd__metrics"
                 ;;
@@ -63,6 +72,9 @@ _rbgp() {
                 ;;
             rbgp,neighbor-set)
                 cmd="rbgp__subcmd__neighbor__subcmd__set"
+                ;;
+            rbgp,orr)
+                cmd="rbgp__subcmd__orr"
                 ;;
             rbgp,peer-group)
                 cmd="rbgp__subcmd__peer__subcmd__group"
@@ -76,8 +88,14 @@ _rbgp() {
             rbgp,shutdown)
                 cmd="rbgp__subcmd__shutdown"
                 ;;
+            rbgp,summary)
+                cmd="rbgp__subcmd__neighbor"
+                ;;
             rbgp,top)
                 cmd="rbgp__subcmd__top"
+                ;;
+            rbgp,topology)
+                cmd="rbgp__subcmd__topology"
                 ;;
             rbgp,watch)
                 cmd="rbgp__subcmd__watch"
@@ -112,6 +130,9 @@ _rbgp() {
             rbgp__subcmd__config,diff)
                 cmd="rbgp__subcmd__config__subcmd__diff"
                 ;;
+            rbgp__subcmd__config,effective)
+                cmd="rbgp__subcmd__config__subcmd__effective"
+                ;;
             rbgp__subcmd__config,help)
                 cmd="rbgp__subcmd__config__subcmd__help"
                 ;;
@@ -133,6 +154,9 @@ _rbgp() {
             rbgp__subcmd__config__subcmd__help,diff)
                 cmd="rbgp__subcmd__config__subcmd__help__subcmd__diff"
                 ;;
+            rbgp__subcmd__config__subcmd__help,effective)
+                cmd="rbgp__subcmd__config__subcmd__help__subcmd__effective"
+                ;;
             rbgp__subcmd__config__subcmd__help,help)
                 cmd="rbgp__subcmd__config__subcmd__help__subcmd__help"
                 ;;
@@ -141,6 +165,48 @@ _rbgp() {
                 ;;
             rbgp__subcmd__config__subcmd__help,status)
                 cmd="rbgp__subcmd__config__subcmd__help__subcmd__status"
+                ;;
+            rbgp__subcmd__diff,advertised)
+                cmd="rbgp__subcmd__diff__subcmd__advertised"
+                ;;
+            rbgp__subcmd__diff,help)
+                cmd="rbgp__subcmd__diff__subcmd__help"
+                ;;
+            rbgp__subcmd__diff,snapshot)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot"
+                ;;
+            rbgp__subcmd__diff__subcmd__help,advertised)
+                cmd="rbgp__subcmd__diff__subcmd__help__subcmd__advertised"
+                ;;
+            rbgp__subcmd__diff__subcmd__help,help)
+                cmd="rbgp__subcmd__diff__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__diff__subcmd__help,snapshot)
+                cmd="rbgp__subcmd__diff__subcmd__help__subcmd__snapshot"
+                ;;
+            rbgp__subcmd__diff__subcmd__help__subcmd__snapshot,from-bmp)
+                cmd="rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from__subcmd__bmp"
+                ;;
+            rbgp__subcmd__diff__subcmd__help__subcmd__snapshot,from-mrt)
+                cmd="rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from__subcmd__mrt"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot,from-bmp)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot,from-mrt)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot,help)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__help"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot__subcmd__help,from-bmp)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from__subcmd__bmp"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot__subcmd__help,from-mrt)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from__subcmd__mrt"
+                ;;
+            rbgp__subcmd__diff__subcmd__snapshot__subcmd__help,help)
+                cmd="rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__help"
                 ;;
             rbgp__subcmd__dynamic__subcmd__neighbor,add)
                 cmd="rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add"
@@ -376,6 +442,12 @@ _rbgp() {
             rbgp__subcmd__help,config)
                 cmd="rbgp__subcmd__help__subcmd__config"
                 ;;
+            rbgp__subcmd__help,diff)
+                cmd="rbgp__subcmd__help__subcmd__diff"
+                ;;
+            rbgp__subcmd__help,doctor)
+                cmd="rbgp__subcmd__help__subcmd__doctor"
+                ;;
             rbgp__subcmd__help,dynamic-neighbor)
                 cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor"
                 ;;
@@ -403,6 +475,9 @@ _rbgp() {
             rbgp__subcmd__help,help)
                 cmd="rbgp__subcmd__help__subcmd__help"
                 ;;
+            rbgp__subcmd__help,man)
+                cmd="rbgp__subcmd__help__subcmd__man"
+                ;;
             rbgp__subcmd__help,metrics)
                 cmd="rbgp__subcmd__help__subcmd__metrics"
                 ;;
@@ -414,6 +489,9 @@ _rbgp() {
                 ;;
             rbgp__subcmd__help,neighbor-set)
                 cmd="rbgp__subcmd__help__subcmd__neighbor__subcmd__set"
+                ;;
+            rbgp__subcmd__help,orr)
+                cmd="rbgp__subcmd__help__subcmd__orr"
                 ;;
             rbgp__subcmd__help,peer-group)
                 cmd="rbgp__subcmd__help__subcmd__peer__subcmd__group"
@@ -429,6 +507,9 @@ _rbgp() {
                 ;;
             rbgp__subcmd__help,top)
                 cmd="rbgp__subcmd__help__subcmd__top"
+                ;;
+            rbgp__subcmd__help,topology)
+                cmd="rbgp__subcmd__help__subcmd__topology"
                 ;;
             rbgp__subcmd__help,watch)
                 cmd="rbgp__subcmd__help__subcmd__watch"
@@ -451,11 +532,26 @@ _rbgp() {
             rbgp__subcmd__help__subcmd__config,diff)
                 cmd="rbgp__subcmd__help__subcmd__config__subcmd__diff"
                 ;;
+            rbgp__subcmd__help__subcmd__config,effective)
+                cmd="rbgp__subcmd__help__subcmd__config__subcmd__effective"
+                ;;
             rbgp__subcmd__help__subcmd__config,plan)
                 cmd="rbgp__subcmd__help__subcmd__config__subcmd__plan"
                 ;;
             rbgp__subcmd__help__subcmd__config,status)
                 cmd="rbgp__subcmd__help__subcmd__config__subcmd__status"
+                ;;
+            rbgp__subcmd__help__subcmd__diff,advertised)
+                cmd="rbgp__subcmd__help__subcmd__diff__subcmd__advertised"
+                ;;
+            rbgp__subcmd__help__subcmd__diff,snapshot)
+                cmd="rbgp__subcmd__help__subcmd__diff__subcmd__snapshot"
+                ;;
+            rbgp__subcmd__help__subcmd__diff__subcmd__snapshot,from-bmp)
+                cmd="rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp"
+                ;;
+            rbgp__subcmd__help__subcmd__diff__subcmd__snapshot,from-mrt)
+                cmd="rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt"
                 ;;
             rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor,add)
                 cmd="rbgp__subcmd__help__subcmd__dynamic__subcmd__neighbor__subcmd__add"
@@ -595,11 +691,17 @@ _rbgp() {
             rbgp__subcmd__help__subcmd__policy,chain)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain"
                 ;;
+            rbgp__subcmd__help__subcmd__policy,check)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__check"
+                ;;
             rbgp__subcmd__help__subcmd__policy,delete)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__delete"
                 ;;
             rbgp__subcmd__help__subcmd__policy,explain)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__explain"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,fmt)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__fmt"
                 ;;
             rbgp__subcmd__help__subcmd__policy,get)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__get"
@@ -609,6 +711,12 @@ _rbgp() {
                 ;;
             rbgp__subcmd__help__subcmd__policy,set)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__set"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,stats)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__stats"
+                ;;
+            rbgp__subcmd__help__subcmd__policy,test)
+                cmd="rbgp__subcmd__help__subcmd__policy__subcmd__test"
                 ;;
             rbgp__subcmd__help__subcmd__policy__subcmd__chain,clear-export)
                 cmd="rbgp__subcmd__help__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export"
@@ -631,6 +739,9 @@ _rbgp() {
             rbgp__subcmd__help__subcmd__rib,advertised)
                 cmd="rbgp__subcmd__help__subcmd__rib__subcmd__advertised"
                 ;;
+            rbgp__subcmd__help__subcmd__rib,bgpls)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__bgpls"
+                ;;
             rbgp__subcmd__help__subcmd__rib,blackholes)
                 cmd="rbgp__subcmd__help__subcmd__rib__subcmd__blackholes"
                 ;;
@@ -640,8 +751,23 @@ _rbgp() {
             rbgp__subcmd__help__subcmd__rib,fib)
                 cmd="rbgp__subcmd__help__subcmd__rib__subcmd__fib"
                 ;;
+            rbgp__subcmd__help__subcmd__rib,labeled)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__labeled"
+                ;;
             rbgp__subcmd__help__subcmd__rib,received)
                 cmd="rbgp__subcmd__help__subcmd__rib__subcmd__received"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,rtc)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__rtc"
+                ;;
+            rbgp__subcmd__help__subcmd__rib,vpn)
+                cmd="rbgp__subcmd__help__subcmd__rib__subcmd__vpn"
+                ;;
+            rbgp__subcmd__help__subcmd__topology,links)
+                cmd="rbgp__subcmd__help__subcmd__topology__subcmd__links"
+                ;;
+            rbgp__subcmd__help__subcmd__topology,nodes)
+                cmd="rbgp__subcmd__help__subcmd__topology__subcmd__nodes"
                 ;;
             rbgp__subcmd__neighbor,add)
                 cmd="rbgp__subcmd__neighbor__subcmd__add"
@@ -754,11 +880,20 @@ _rbgp() {
             rbgp__subcmd__policy,chain)
                 cmd="rbgp__subcmd__policy__subcmd__chain"
                 ;;
+            rbgp__subcmd__policy,check)
+                cmd="rbgp__subcmd__policy__subcmd__check"
+                ;;
+            rbgp__subcmd__policy,counters)
+                cmd="rbgp__subcmd__policy__subcmd__stats"
+                ;;
             rbgp__subcmd__policy,delete)
                 cmd="rbgp__subcmd__policy__subcmd__delete"
                 ;;
             rbgp__subcmd__policy,explain)
                 cmd="rbgp__subcmd__policy__subcmd__explain"
+                ;;
+            rbgp__subcmd__policy,fmt)
+                cmd="rbgp__subcmd__policy__subcmd__fmt"
                 ;;
             rbgp__subcmd__policy,get)
                 cmd="rbgp__subcmd__policy__subcmd__get"
@@ -771,6 +906,12 @@ _rbgp() {
                 ;;
             rbgp__subcmd__policy,set)
                 cmd="rbgp__subcmd__policy__subcmd__set"
+                ;;
+            rbgp__subcmd__policy,stats)
+                cmd="rbgp__subcmd__policy__subcmd__stats"
+                ;;
+            rbgp__subcmd__policy,test)
+                cmd="rbgp__subcmd__policy__subcmd__test"
                 ;;
             rbgp__subcmd__policy__subcmd__chain,clear-export)
                 cmd="rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export"
@@ -811,11 +952,17 @@ _rbgp() {
             rbgp__subcmd__policy__subcmd__help,chain)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain"
                 ;;
+            rbgp__subcmd__policy__subcmd__help,check)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__check"
+                ;;
             rbgp__subcmd__policy__subcmd__help,delete)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__delete"
                 ;;
             rbgp__subcmd__policy__subcmd__help,explain)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__explain"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,fmt)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__fmt"
                 ;;
             rbgp__subcmd__policy__subcmd__help,get)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__get"
@@ -828,6 +975,12 @@ _rbgp() {
                 ;;
             rbgp__subcmd__policy__subcmd__help,set)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__set"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,stats)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__stats"
+                ;;
+            rbgp__subcmd__policy__subcmd__help,test)
+                cmd="rbgp__subcmd__policy__subcmd__help__subcmd__test"
                 ;;
             rbgp__subcmd__policy__subcmd__help__subcmd__chain,clear-export)
                 cmd="rbgp__subcmd__policy__subcmd__help__subcmd__chain__subcmd__clear__subcmd__export"
@@ -850,6 +1003,12 @@ _rbgp() {
             rbgp__subcmd__rib,advertised)
                 cmd="rbgp__subcmd__rib__subcmd__advertised"
                 ;;
+            rbgp__subcmd__rib,bgp-ls)
+                cmd="rbgp__subcmd__rib__subcmd__bgpls"
+                ;;
+            rbgp__subcmd__rib,bgpls)
+                cmd="rbgp__subcmd__rib__subcmd__bgpls"
+                ;;
             rbgp__subcmd__rib,blackholes)
                 cmd="rbgp__subcmd__rib__subcmd__blackholes"
                 ;;
@@ -862,14 +1021,32 @@ _rbgp() {
             rbgp__subcmd__rib,help)
                 cmd="rbgp__subcmd__rib__subcmd__help"
                 ;;
+            rbgp__subcmd__rib,labeled)
+                cmd="rbgp__subcmd__rib__subcmd__labeled"
+                ;;
             rbgp__subcmd__rib,received)
                 cmd="rbgp__subcmd__rib__subcmd__received"
+                ;;
+            rbgp__subcmd__rib,recv)
+                cmd="rbgp__subcmd__rib__subcmd__received"
+                ;;
+            rbgp__subcmd__rib,rtc)
+                cmd="rbgp__subcmd__rib__subcmd__rtc"
+                ;;
+            rbgp__subcmd__rib,sent)
+                cmd="rbgp__subcmd__rib__subcmd__advertised"
+                ;;
+            rbgp__subcmd__rib,vpn)
+                cmd="rbgp__subcmd__rib__subcmd__vpn"
                 ;;
             rbgp__subcmd__rib__subcmd__help,add)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__add"
                 ;;
             rbgp__subcmd__rib__subcmd__help,advertised)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__advertised"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,bgpls)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__bgpls"
                 ;;
             rbgp__subcmd__rib__subcmd__help,blackholes)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__blackholes"
@@ -883,8 +1060,35 @@ _rbgp() {
             rbgp__subcmd__rib__subcmd__help,help)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__help"
                 ;;
+            rbgp__subcmd__rib__subcmd__help,labeled)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__labeled"
+                ;;
             rbgp__subcmd__rib__subcmd__help,received)
                 cmd="rbgp__subcmd__rib__subcmd__help__subcmd__received"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,rtc)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__rtc"
+                ;;
+            rbgp__subcmd__rib__subcmd__help,vpn)
+                cmd="rbgp__subcmd__rib__subcmd__help__subcmd__vpn"
+                ;;
+            rbgp__subcmd__topology,help)
+                cmd="rbgp__subcmd__topology__subcmd__help"
+                ;;
+            rbgp__subcmd__topology,links)
+                cmd="rbgp__subcmd__topology__subcmd__links"
+                ;;
+            rbgp__subcmd__topology,nodes)
+                cmd="rbgp__subcmd__topology__subcmd__nodes"
+                ;;
+            rbgp__subcmd__topology__subcmd__help,help)
+                cmd="rbgp__subcmd__topology__subcmd__help__subcmd__help"
+                ;;
+            rbgp__subcmd__topology__subcmd__help,links)
+                cmd="rbgp__subcmd__topology__subcmd__help__subcmd__links"
+                ;;
+            rbgp__subcmd__topology__subcmd__help,nodes)
+                cmd="rbgp__subcmd__topology__subcmd__help__subcmd__nodes"
                 ;;
             *)
                 ;;
@@ -893,7 +1097,7 @@ _rbgp() {
 
     case "${cmd}" in
         rbgp)
-            opts="-s -j -h -V --addr --token-file --json --no-color --help --version global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help"
+            opts="-s -j -h -V --addr --token-file --json --no-color --help --version global config neighbor summary bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1027,7 +1231,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__bfd__subcmd__show)
-            opts="-s -j -h --addr --token-file --json --no-color --help <ADDRESS>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1079,7 +1283,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config)
-            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply confirm abort status help"
+            opts="-s -j -h --addr --token-file --json --no-color --help diff plan apply confirm abort status effective help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1105,7 +1309,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__abort)
-            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1181,7 +1385,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__confirm)
-            opts="-s -j -h --addr --token-file --json --no-color --help <CONFIRM_ID>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1236,8 +1440,34 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__config__subcmd__effective)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__config__subcmd__help)
-            opts="diff plan apply confirm abort status help"
+            opts="diff plan apply confirm abort status effective help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1293,6 +1523,20 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__config__subcmd__help__subcmd__diff)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__config__subcmd__help__subcmd__effective)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1408,6 +1652,382 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__diff)
+            opts="-s -j -h --addr --token-file --json --no-color --help advertised snapshot help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__advertised)
+            opts="-a -s -j -h --peer --neighbor --against --family --max-routes --max-input-bytes --ignore-attribute --detail --deadline --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --against)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-routes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-input-bytes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ignore-attribute)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --detail)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --deadline)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help)
+            opts="advertised snapshot help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help__subcmd__snapshot)
+            opts="from-mrt from-bmp"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from__subcmd__bmp)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__help__subcmd__snapshot__subcmd__from__subcmd__mrt)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot)
+            opts="-s -j -h --addr --token-file --json --no-color --help from-mrt from-bmp help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp)
+            opts="-s -j -h --peer --source --generation --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --generation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt)
+            opts="-s -j -h --view --peer --peer-asn --source --generation --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --view)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer-asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --generation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__help)
+            opts="from-mrt from-bmp help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from__subcmd__bmp)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__from__subcmd__mrt)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__diff__subcmd__snapshot__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__doctor)
+            opts="-s -j -h --output --log-file --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --log-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__dynamic__subcmd__neighbor)
             opts="-s -j -h --addr --token-file --json --no-color --help list add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -1435,13 +2055,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --peer-group --asn --description --addr --token-file --json --no-color --help <PREFIX>"
+            opts="-s -j -h --peer-group --asn --remote-asn --description --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --peer-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --remote-asn)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -1473,7 +2097,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__dynamic__subcmd__neighbor__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help <PREFIX>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1921,13 +2545,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn)
-            opts="-s -j -h --route-type --peer --rd --addr --token-file --json --no-color --help list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help"
+            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --no-color --help list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --route-type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2325,7 +2953,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__drain)
-            opts="-s -j -h --addr --token-file --json --no-color --help <ESI>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2421,7 +3049,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__list)
-            opts="-s -j -h --addr --token-file --json --no-color --help [ESI]"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2447,7 +3075,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__es__subcmd__undrain)
-            opts="-s -j -h --addr --token-file --json --no-color --help <ESI>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2779,13 +3407,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__list)
-            opts="-s -j -h --route-type --peer --rd --addr --token-file --json --no-color --help"
+            opts="-s -j -h --route-type --peer --neighbor --rd --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --route-type)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2895,7 +3527,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__evpn__subcmd__vrfs)
-            opts="-s -j -h --addr --token-file --json --no-color --help [NAME]"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2947,7 +3579,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3069,7 +3701,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__fib__subcmd__table__subcmd__set)
-            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --table-id --metric --families --allowed-peer-group --allowed-neighbor --max-routes --maximum-paths --maximum-paths-ebgp --maximum-paths-ibgp --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3327,12 +3959,16 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__gshut)
-            opts="-s -j -h --peer --clear --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --clear --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -3383,7 +4019,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help)
-            opts="global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help"
+            opts="global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3453,7 +4089,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help__subcmd__config)
-            opts="diff plan apply confirm abort status"
+            opts="diff plan apply confirm abort status effective"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3522,6 +4158,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__config__subcmd__effective)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__config__subcmd__plan)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -3539,6 +4189,90 @@ _rbgp() {
         rbgp__subcmd__help__subcmd__config__subcmd__status)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__diff)
+            opts="advertised snapshot"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__diff__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__diff__subcmd__snapshot)
+            opts="from-mrt from-bmp"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__bmp)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__diff__subcmd__snapshot__subcmd__from__subcmd__mrt)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__doctor)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -4096,6 +4830,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__man)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__metrics)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -4278,6 +5026,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__orr)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__peer__subcmd__group)
             opts="list get set delete attach detach"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -4377,7 +5139,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help__subcmd__policy)
-            opts="list get set delete chain explain"
+            opts="list check fmt test get set delete chain stats explain"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4474,6 +5236,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__check)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__policy__subcmd__delete)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -4489,6 +5265,20 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help__subcmd__policy__subcmd__explain)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__fmt)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4544,8 +5334,36 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__stats)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__policy__subcmd__test)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__rib)
-            opts="received advertised blackholes fib add delete"
+            opts="received advertised blackholes fib bgpls vpn labeled rtc add delete"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4573,6 +5391,20 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__help__subcmd__rib__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__bgpls)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4628,7 +5460,49 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__labeled)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__rib__subcmd__received)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__rtc)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__rib__subcmd__vpn)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4670,6 +5544,48 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__help__subcmd__topology)
+            opts="nodes links"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__topology__subcmd__links)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__help__subcmd__topology__subcmd__nodes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__help__subcmd__watch)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -4677,6 +5593,32 @@ _rbgp() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__man)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -4737,7 +5679,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor)
-            opts="-s -j -h --addr --token-file --json --no-color --help [ADDRESS] add delete enable disable softreset help"
+            opts="-s -j -h --wide --addr --token-file --json --no-color --help add delete enable disable softreset help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4789,7 +5731,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4815,7 +5757,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4951,7 +5893,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__set__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4981,12 +5923,16 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --description --hold-time --max-prefixes --families --route-server-client --role --strict-role --add-path-receive --add-path-send --add-path-send-max --addr --token-file --json --no-color --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --send-hold-time --max-prefixes --families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --remote-asn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --asn)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -4996,6 +5942,10 @@ _rbgp() {
                     return 0
                     ;;
                 --hold-time)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --send-hold-time)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5248,6 +6198,32 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__orr)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__peer__subcmd__group)
             opts="-s -j -h --addr --token-file --json --no-color --help list get set delete attach detach help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -5275,7 +6251,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__attach)
-            opts="-s -j -h --group --addr --token-file --json --no-color --help <ADDRESS>"
+            opts="-s -j -h --group --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5305,7 +6281,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5331,7 +6307,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__detach)
-            opts="-s -j -h --addr --token-file --json --no-color --help <ADDRESS>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5357,7 +6333,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5521,7 +6497,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__peer__subcmd__group__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5551,7 +6527,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy)
-            opts="-s -j -h --addr --token-file --json --no-color --help list get set delete chain explain help"
+            opts="-s -j -h --addr --token-file --json --no-color --help list check fmt test get set delete chain stats counters explain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5603,13 +6579,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__export)
-            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5633,13 +6613,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__clear__subcmd__import)
-            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5761,13 +6745,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__export)
-            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help [POLICIES]..."
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5791,13 +6779,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__set__subcmd__import)
-            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help [POLICIES]..."
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5821,13 +6813,51 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__chain__subcmd__show)
-            opts="-s -j -h --neighbor --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__check)
+            opts="-s -j -h --root --list-deps --coverage --coverage-min --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --root)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --coverage-min)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5851,7 +6881,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__delete)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5877,13 +6907,17 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__explain)
-            opts="-s -j -h --neighbor --prefix --path-id --addr --token-file --json --no-color --help"
+            opts="-s -j -h --peer --neighbor --prefix --path-id --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5914,8 +6948,34 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__policy__subcmd__fmt)
+            opts="-s -j -h --check --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__policy__subcmd__get)
-            opts="-s -j -h --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5941,7 +7001,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__help)
-            opts="list get set delete chain explain help"
+            opts="list check fmt test get set delete chain stats explain help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6038,6 +7098,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__check)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__policy__subcmd__help__subcmd__delete)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -6053,6 +7127,20 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__help__subcmd__explain)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__fmt)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -6122,6 +7210,34 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__stats)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__help__subcmd__test)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__policy__subcmd__list)
             opts="-s -j -h --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -6149,7 +7265,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__policy__subcmd__set)
-            opts="-s -j -h --from-file --addr --token-file --json --no-color --help <NAME>"
+            opts="-s -j -h --from-file --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6178,8 +7294,104 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__policy__subcmd__stats)
+            opts="-s -j -h --peer --neighbor --direction --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --direction)
+                    COMPREPLY=($(compgen -W "import export both" -- "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__policy__subcmd__test)
+            opts="-a -s -j -h --policy --direction --peer --neighbor --family --limit --show-changes --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --policy)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --direction)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --show-changes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__rib)
-            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received advertised blackholes fib add delete help"
+            opts="-a -p -l -c -s -j -h --family --prefix --longer --explain --explain-peer --origin-asn --community --large-community --addr --token-file --json --no-color --help received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6241,7 +7453,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__add)
-            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --help <PREFIX>"
+            opts="-s -j -h --nexthop --origin --local-pref --med --as-path --communities --large-communities --path-id --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6299,7 +7511,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -s -j -h --family --explain --addr --token-file --json --no-color --help <ADDRESS>"
+            opts="-a -s -j -h --family --explain --rd --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6310,6 +7522,56 @@ _rbgp() {
                     return 0
                     ;;
                 -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --rd)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__bgpls)
+            opts="-a -s -j -h --family --peer --neighbor --nlri-type --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --nlri-type)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -6359,7 +7621,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__delete)
-            opts="-s -j -h --path-id --addr --token-file --json --no-color --help <PREFIX>"
+            opts="-s -j -h --path-id --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6389,7 +7651,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__fib)
-            opts="-s -j -h --table --state --reason --prefix --peer --page-size --page-token --addr --token-file --json --no-color --help"
+            opts="-s -j -h --table --state --reason --prefix --peer --neighbor --page-size --page-token --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6408,6 +7670,10 @@ _rbgp() {
                     return 0
                     ;;
                 --prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -6443,7 +7709,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__help)
-            opts="received advertised blackholes fib add delete help"
+            opts="received advertised blackholes fib bgpls vpn labeled rtc add delete help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6471,6 +7737,20 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__help__subcmd__advertised)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__bgpls)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -6540,6 +7820,20 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__labeled)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__rib__subcmd__help__subcmd__received)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -6554,8 +7848,36 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        rbgp__subcmd__rib__subcmd__received)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help <ADDRESS>"
+        rbgp__subcmd__rib__subcmd__help__subcmd__rtc)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__help__subcmd__vpn)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__labeled)
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -6566,6 +7888,124 @@ _rbgp() {
                     return 0
                     ;;
                 -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__received)
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__rtc)
+            opts="-s -j -h --peer --neighbor --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__rib__subcmd__vpn)
+            opts="-a -s -j -h --family --peer --neighbor --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --family)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --neighbor)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -6652,8 +8092,142 @@ _rbgp() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        rbgp__subcmd__topology)
+            opts="-s -j -h --addr --token-file --json --no-color --help nodes links help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__help)
+            opts="nodes links help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__help__subcmd__links)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__help__subcmd__nodes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__links)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        rbgp__subcmd__topology__subcmd__nodes)
+            opts="-s -j -h --addr --token-file --json --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --addr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --token-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         rbgp__subcmd__watch)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help [ADDRESS]"
+            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_rbgp_global_optspecs
-	string join \n s/addr= token-file= j/json no-color h/help V/version
+    string join \n s/addr= token-file= j/json no-color h/help V/version
 end
 
 function __fish_rbgp_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_rbgp_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_rbgp_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_rbgp_using_subcommand
-	set -l cmd (__fish_rbgp_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_rbgp_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c rbgp -n "__fish_rbgp_needs_command" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -33,56 +33,63 @@ complete -c rbgp -n "__fish_rbgp_needs_command" -s V -l version -d 'Print versio
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "global" -d 'Show daemon global configuration'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "config" -d 'Runtime config diagnostics'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "neighbor" -d 'Manage BGP neighbors'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "summary" -d 'Manage BGP neighbors'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "bfd" -d 'Inspect single-hop BFD sessions (ADR-0067)'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "rib" -d 'Query and manage the RIB'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "topology" -d 'Show the RFC 9107 ORR topology graph derived from BGP-LS'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "orr" -d 'Show RFC 9107 ORR per-vantage status (resolution, SPF reach, peers)'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "diff" -d 'Compare live RIB views against an external snapshot (read-only)'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "flowspec" -d 'Manage FlowSpec routes'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "evpn" -d 'Manage EVPN routes (list, add, delete — RFC 7432)'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "watch" -d 'Watch route updates (streaming)'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "events" -d 'Show recent route update events'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "health" -d 'Check daemon health'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "doctor" -d 'Run red/green triage checks and write a redacted support bundle'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "metrics" -d 'Show Prometheus metrics'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "shutdown" -d 'Request daemon shutdown'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "mrt-dump" -d 'Trigger an on-demand MRT dump'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (`--peer X`) or every currently-managed peer (omit `--peer`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "top" -d 'Live TUI dashboard'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "policy" -d 'Manage named `[[policy_definitions]]` entries and the global / per-neighbor import/export chains. Backed by PolicyService'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "neighbor-set" -d 'Manage named `[[neighbor_sets]]` entries used by policy `match_neighbor_set`. Backed by PolicyService'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "peer-group" -d 'Manage named `[[peer_groups]]` entries and bind/unbind neighbors to them. Backed by PeerGroupService'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "dynamic-neighbor" -d 'Manage `[[dynamic_neighbors]]` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService'
-complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "fib-table" -d 'Manage `[[fib_tables]]` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "policy" -d 'Manage policy definitions and import/export chains'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "neighbor-set" -d 'Manage named neighbor sets used by policy'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "peer-group" -d 'Manage peer groups and neighbor membership'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "dynamic-neighbor" -d 'Manage dynamic-neighbor prefix ranges'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "fib-table" -d 'Manage general unicast FIB export tables at runtime'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "completions" -d 'Generate shell completions'
+complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "man" -d 'Print the rbgp man page (roff) to stdout'
 complete -c rbgp -n "__fish_rbgp_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand global" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s j -l json -d 'Output in JSON format'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -l no-color -d 'Disable colored output'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Candidate TOML file to validate and compare' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and not __fish_seen_subcommand_from diff plan apply confirm abort status effective help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from diff" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l from-file -d 'Candidate TOML file to validate and classify' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l expected-runtime-snapshot-token -d 'Optional runtime snapshot token to check while planning' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from plan" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l from-file -d 'Candidate TOML file to validate and commit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l from-file -d 'Hidden compatibility alias for the positional `CANDIDATE`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l expected-runtime-snapshot-token -d 'Runtime snapshot token returned by config plan' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l client-request-id -d 'Optional audit/correlation identifier' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from apply" -l comment -d 'Optional human change note; not logged verbatim by the daemon' -r
@@ -108,15 +115,22 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from status" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from effective" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "apply" -d 'Commit a previously planned candidate transaction'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand config; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l wide -d 'Append the classic summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), and State/PfxRcd (prefix count when Established). Display-only; -j already carries every field'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -126,9 +140,10 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "disable" -d 'Disable this neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "softreset" -d 'Trigger soft reset (inbound)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l asn -d 'Remote AS number' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l remote-asn -l asn -d 'Remote AS number of the peer (the local AS is `rbgp global`)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l description -d 'Description' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l hold-time -d 'Hold time in seconds' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l send-hold-time -d 'RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default: max(480, 2 x hold time))' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l max-prefixes -d 'Max prefix limit' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
@@ -136,6 +151,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l strict-role -d 'Require the peer to advertise a compatible BGP Role capability'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-receive -d 'Enable Add-Path receive'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
@@ -170,6 +186,64 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "disable" -d 'Disable this neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "softreset" -d 'Trigger soft reset (inbound)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l wide -d 'Append the classic summary columns to the list: MsgRcvd, MsgSent, Flaps, RRC (route-reflector client), and State/PfxRcd (prefix count when Established). Display-only; -j already carries every field'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "add" -d 'Add a new neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "delete" -d 'Delete this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "enable" -d 'Enable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "disable" -d 'Disable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "softreset" -d 'Trigger soft reset (inbound)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and not __fish_seen_subcommand_from add delete enable disable softreset help" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l remote-asn -l asn -d 'Remote AS number of the peer (the local AS is `rbgp global`)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l description -d 'Description' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l hold-time -d 'Hold time in seconds' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l send-hold-time -d 'RFC 9687 send hold time in seconds (0 disables; must exceed the hold time; default: max(480, 2 x hold time))' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l max-prefixes -d 'Max prefix limit' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-send-max -d 'Max paths per prefix for Add-Path send' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l per-client-best -d 'RFC 7947 per-client best-path (path-hiding mitigation); requires --route-server-client'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l strict-role -d 'Require the peer to advertise a compatible BGP Role capability'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-receive -d 'Enable Add-Path receive'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-send -d 'Enable Add-Path send'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from delete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from enable" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l reason -d 'Disable reason' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from disable" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s a -l family -d 'Address family to refresh' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from softreset" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "enable" -d 'Enable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "disable" -d 'Disable this neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "softreset" -d 'Trigger soft reset (inbound)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and not __fish_seen_subcommand_from list show help" -s j -l json -d 'Output in JSON format'
@@ -191,39 +265,61 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all BFD sessions (default)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "show" -d 'Show a single BFD session by peer address'
 complete -c rbgp -n "__fish_rbgp_using_subcommand bfd; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast)' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l explain-peer -d 'Scope --explain to a specific peer\'s Add-Path send view. When set, candidates are filtered by the peer\'s export policy + sendable families and the top `add_path_send_max` are tagged with their advertised rank. Omit for the global Loc-RIB view' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s j -l json -d 'Output in JSON format'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -l no-color -d 'Disable colored output'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "received" -d 'Show received routes from a neighbor'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "advertised" -d 'Show advertised routes to a neighbor'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "add" -d 'Inject a route'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "delete" -d 'Withdraw a route'
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received advertised blackholes fib add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s p -l prefix -d 'Prefix filter (e.g., 10.0.0.0/24)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l explain-peer -d 'Scope --explain to a specific peer\'s Add-Path send view. When set, candidates are filtered by the peer\'s export policy + sendable families and the top `add_path_send_max` are tagged with their advertised rank. Omit for the global Loc-RIB view' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l origin-asn -d 'Filter by origin ASN (last ASN in AS_PATH)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s c -l community -d 'Filter by community (e.g., 65001:100 or BLACKHOLE); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l large-community -d 'Filter by large community (e.g., 65001:100:200); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s l -l longer -d 'Show longer (more specific) prefixes matching --prefix'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l explain -d 'Show why the best route was selected (requires --prefix)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "received" -d 'Show received routes from a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "recv" -d 'Show received routes from a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "advertised" -d 'Show advertised routes to a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "sent" -d 'Show advertised routes to a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "bgpls" -d 'Show BGP-LS routes learned from peers (RFC 9552)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "bgp-ls" -d 'Show BGP-LS routes learned from peers (RFC 9552)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "vpn" -d 'Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "labeled" -d 'Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "rtc" -d 'Show RT-Constrain routes (RFC 4684, single IPv4 family)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "add" -d 'Inject a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "delete" -d 'Withdraw a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subcommand_from received recv advertised sent blackholes fib bgpls bgp-ls vpn labeled rtc add delete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s a -l family -d 'Address family filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l rd -d 'Route Distinguisher ("asn:nn" or "ip:nn") - explain the VPNv4/VPNv6 export ladder for the (RD, prefix) identity, including the RFC 4684 RT-Constrain membership gate' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from blackholes" -s j -l json -d 'Output in JSON format'
@@ -233,7 +329,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l state -d 'FIB route state filter: installed, rejected, failed' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l reason -d 'Exact reason-code filter, e.g. owned or route_limit_exceeded' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l prefix -d 'Exact prefix filter, e.g. 203.0.113.0/24' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l peer -d 'Source peer-address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l neighbor -l peer -d 'Source neighbor-address filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l page-size -d 'Maximum FIB status rows to return; omitted returns the full snapshot' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l page-token -d 'Page token returned by a previous paginated FIB status query' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -241,6 +337,42 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from fib" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s a -l family -d 'BGP-LS family filter: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l neighbor -l peer -d 'Neighbor IP address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l nlri-type -d 'NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgpls" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s a -l family -d 'BGP-LS family filter: linkstate (aliases bgpls, bgp-ls) or linkstate_vpn (aliases bgpls-vpn, bgp-ls-vpn)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l neighbor -l peer -d 'Neighbor IP address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l nlri-type -d 'NLRI type filter (1=node, 2=link, 3=IPv4 prefix, 4=IPv6 prefix)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from bgp-ls" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s a -l family -d 'VPN family filter: l3vpn_ipv4_unicast (alias vpnv4) or l3vpn_ipv6_unicast (alias vpnv6)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l neighbor -l peer -d 'Neighbor IP address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from vpn" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s a -l family -d 'Labeled family filter: ipv4_labeled_unicast (alias labeled-v4) or ipv6_labeled_unicast (alias labeled-v6)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l neighbor -l peer -d 'Neighbor IP address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from labeled" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l neighbor -l peer -d 'Neighbor IP address filter' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from rtc" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l nexthop -d 'Next hop address' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l origin -d 'Origin (0=igp, 1=egp, 2=incomplete)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from add" -l local-pref -d 'Local preference' -r
@@ -264,9 +396,71 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "advertised" -d 'Show advertised routes to a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "bgpls" -d 'Show BGP-LS routes learned from peers (RFC 9552)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "vpn" -d 'Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "labeled" -d 'Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "rtc" -d 'Show RT-Constrain routes (RFC 4684, single IPv4 family)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "add" -d 'Inject a route'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Withdraw a route'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -f -a "nodes" -d 'List topology nodes (BGP-LS node identities across all peers)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -f -a "links" -d 'List usable directed topology links (with IGP metrics)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and not __fish_seen_subcommand_from nodes links help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from nodes" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from links" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from help" -f -a "nodes" -d 'List topology nodes (BGP-LS node identities across all peers)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from help" -f -a "links" -d 'List usable directed topology links (with IGP metrics)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand topology; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand orr" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -f -a "advertised" -d 'Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -f -a "snapshot" -d 'Produce an `rbgp-ribsnap/1` snapshot from an incumbent\'s own output (offline; no daemon connection)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and not __fish_seen_subcommand_from advertised snapshot help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l neighbor -l peer -d 'Neighbor address to compare; may be repeated. Omit to compare every peer present in the snapshot' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l against -d 'Path to the incumbent `rbgp-ribsnap/1` NDJSON snapshot' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l max-routes -d 'Maximum retained routes per side; exceeding it refuses the comparison (exit 2)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l max-input-bytes -d 'Maximum snapshot bytes read; exceeding it refuses the comparison (exit 2)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l ignore-attribute -d 'Attribute to exclude from comparison on both sides (origin, as_path, next_hop, med, local_pref, communities, extended_communities, large_communities, unknown); may be repeated' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l detail -d 'Maximum detailed difference rows in human output (--json is always complete)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l deadline -d 'Overall wall-clock budget in seconds; expiry refuses the comparison (exit 2)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -f -a "from-mrt" -d 'Convert an RFC 6396 TABLE_DUMP_V2 MRT dump into a snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -f -a "from-bmp" -d 'Convert a captured RFC 7854/8671 BMP byte stream into a snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from snapshot" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from help" -f -a "advertised" -d 'Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from help" -f -a "snapshot" -d 'Produce an `rbgp-ribsnap/1` snapshot from an incumbent\'s own output (offline; no daemon connection)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand diff; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s a -l family -d 'Address family (ipv4_flowspec, ipv6_flowspec)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and not __fish_seen_subcommand_from add delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -295,7 +489,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a FlowSpec rule'
 complete -c rbgp -n "__fish_rbgp_using_subcommand flowspec; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -l route-type -d 'Route type filter (1..=5) — applies when no subcommand is given' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -l peer -d 'Peer IP address filter (list mode only)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -l neighbor -l peer -d 'Neighbor IP address filter (list mode only)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -l rd -d 'Route Distinguisher filter (list mode only), e.g. "65000:100"' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -312,14 +506,14 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "es" -d 'Ethernet Segment runtime controls and diagnose state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "managed-netdevs" -d 'List managed EVPN netdev ownership/status rows (ADR-0091)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "vrfs" -d 'List configured IP-VRFs and their readiness verdict'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and not __fish_seen_subcommand_from list add-mac-ip add-imet add-ip-prefix delete-mac-ip delete-imet delete-ip-prefix clear-duplicate-mac es runtime instances nexthops managed-netdevs vrfs diagnose help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l route-type -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l peer -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l neighbor -l peer -d 'Neighbor IP address filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l rd -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -402,9 +596,9 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "list" -d 'List configured Ethernet Segments joined with live drain, DF/AC-gate, same-ESI bias, and FDB-NHG state'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "drain" -d 'Drain an Ethernet Segment before access-circuit maintenance: withdraw its Type 4 + EAD routes (exiting DF election) and the member VNIs\' local Type 2 routes, and suppress new local-MAC origination. In-memory only — a daemon restart clears the drain'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "undrain" -d 'Undrain an Ethernet Segment: re-originate its Type 4 + EAD routes, re-run DF election, and replay cached local MAC state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "list" -d 'List configured Ethernet Segments'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "drain" -d 'Drain an Ethernet Segment before access-circuit maintenance'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "undrain" -d 'Undrain an Ethernet Segment'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from es" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from runtime" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -446,10 +640,10 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "es" -d 'Ethernet Segment runtime controls and diagnose state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "instances" -d 'List local EVPN instances configured on this VTEP'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "managed-netdevs" -d 'List managed EVPN netdev ownership/status rows (ADR-0091)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "vrfs" -d 'List configured IP-VRFs and their readiness verdict'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
 complete -c rbgp -n "__fish_rbgp_using_subcommand evpn; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand watch" -s a -l family -d 'Address family filter' -r
@@ -520,6 +714,13 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l token-file -d 'Bear
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand health" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l output -d 'Output tarball path. Defaults to `rustbgpd-doctor-<unix-seconds>.tar.gz`' -r -F
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l log-file -d 'Daemon log file to tail (last 1000 lines) into the bundle. Without it the manifest records that the daemon logs to stdout/journald' -r -F
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand doctor" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand metrics" -s j -l json -d 'Output in JSON format'
@@ -536,7 +737,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l token-file -d 'Be
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand mrt-dump" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l peer -d 'Peer address; omit to toggle for all peers' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l neighbor -l peer -d 'Neighbor address; omit to toggle for all peers' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand gshut" -l clear -d 'Clear instead of enabling'
@@ -549,23 +750,54 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l token-file -d 'Bearer 
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand top" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s j -l json -d 'Output in JSON format'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -l no-color -d 'Disable colored output'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "list" -d 'List configured policies (names + statement counts)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "get" -d 'Show one policy by name'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "delete" -d 'Delete a policy by name'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list get set delete chain explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "check" -d 'Check an `.rpol` policy file locally (parse, typecheck, tests)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "fmt" -d 'Format `.rpol` files in the one canonical style'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "test" -d 'Dry-run a candidate `.rpol` policy against the live RIB'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "get" -d 'Show one policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "delete" -d 'Delete a policy by name'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "stats" -d 'Show live per-term policy hit counters'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "counters" -d 'Show live per-term policy hit counters'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and not __fish_seen_subcommand_from list check fmt test get set delete chain stats counters explain help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l root -d 'Additional policy root for `import` resolution (repeatable; the main file\'s directory is always a root) — mirror of the daemon\'s `[policy] rpol_roots`' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l coverage-min -d 'Minimum acceptable exercised-term percentage (implies --coverage): exit 3 when coverage falls below PCT (CI gate). Diagnostics (1) and test failures (2) take precedence' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l list-deps -d 'Print the resolved import graph — each module\'s path, SHA-256 content hash, and imports — instead of running tests (audit/packaging aid)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l coverage -d 'Report which policy terms the in-language tests exercised (evaluated vs. matched, per term) plus static lints (unused sets/datasets/fns, unreachable terms, unreferenced policies). A report only — it never changes the exit code by itself'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from check" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l check -d 'Rewrite nothing; print a diff and exit 1 when any file is not canonically formatted (CI mode)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from fmt" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l policy -d 'Policy to evaluate: a name, or a call-form with u32 arguments for parameterized policies, e.g. "customer-in(200)"' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l direction -d 'Evaluation direction: import (Adj-RIB-In) or export (Loc-RIB best routes)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l neighbor -l peer -d 'Neighbor address: restricts the import snapshot to one peer\'s Adj-RIB-In, or sets the export evaluation target' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s a -l family -d 'Address family filter (ipv4_unicast, ipv6_unicast)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l limit -d 'Maximum routes to evaluate (0 = all)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l show-changes -d 'Maximum before/after attribute diffs to show' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from test" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from get" -s j -l json -d 'Output in JSON format'
@@ -587,13 +819,31 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "show" -d 'Show the global chains, or the per-neighbor chains when `--neighbor` is given'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "set-import" -d 'Replace the import chain. Empty list is rejected — use `clear-import` instead. Apply globally by omitting `--neighbor`'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "show" -d 'Show the global or per-neighbor chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "set-import" -d 'Replace the import chain'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "set-export" -d 'Replace the export chain'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "clear-import" -d 'Clear the import chain entirely'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "clear-export" -d 'Clear the export chain entirely'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from chain" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -d 'Neighbor (peer) address whose import-decision cache to read' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l neighbor -l peer -d 'Restrict to one neighbor\'s installed chain' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l direction -d 'Direction: export (default), import, or both' -r -f -a "import\t''
+export\t''
+both\t''"
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from stats" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l neighbor -l peer -d 'Restrict to one neighbor\'s installed chain' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l direction -d 'Direction: export (default), import, or both' -r -f -a "import\t''
+export\t''
+both\t''"
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from counters" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l neighbor -l peer -d 'Neighbor (peer) address whose import-decision cache to read' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l prefix -d 'Prefix in CIDR form, e.g. `192.0.2.0/24` or `2001:db8::/32`' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l path-id -d 'Add-Path identifier; omit to show every matching path' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
@@ -602,11 +852,15 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcom
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from explain" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "check" -d 'Check an `.rpol` policy file locally (parse, typecheck, tests)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "fmt" -d 'Format `.rpol` files in the one canonical style'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "test" -d 'Dry-run a candidate `.rpol` policy against the live RIB'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "get" -d 'Show one policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "delete" -d 'Delete a policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
-complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "stats" -d 'Show live per-term policy hit counters'
+complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand policy; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor-set; and not __fish_seen_subcommand_from list get set delete help" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -710,7 +964,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_s
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l peer-group -d 'Peer group the dynamic peers inherit' -r
-complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l asn -d 'Expected remote ASN (0 = accept any ASN from OPEN)' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l remote-asn -l asn -d 'Expected remote ASN (0 = accept any ASN from OPEN)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l description -d 'Optional description' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand dynamic-neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
@@ -768,34 +1022,45 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l token-file -d 
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand completions" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "global" -d 'Show daemon global configuration'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "config" -d 'Runtime config diagnostics'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "neighbor" -d 'Manage BGP neighbors'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "bfd" -d 'Inspect single-hop BFD sessions (ADR-0067)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "rib" -d 'Query and manage the RIB'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "flowspec" -d 'Manage FlowSpec routes'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "evpn" -d 'Manage EVPN routes (list, add, delete — RFC 7432)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "watch" -d 'Watch route updates (streaming)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "events" -d 'Show recent route update events'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "health" -d 'Check daemon health'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "metrics" -d 'Show Prometheus metrics'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "shutdown" -d 'Request daemon shutdown'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "mrt-dump" -d 'Trigger an on-demand MRT dump'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates for one peer (`--peer X`) or every currently-managed peer (omit `--peer`). Receivers that honor RFC 8326 will set local_pref = 0 on tagged paths, draining traffic ahead of planned maintenance'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "top" -d 'Live TUI dashboard'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "policy" -d 'Manage named `[[policy_definitions]]` entries and the global / per-neighbor import/export chains. Backed by PolicyService'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "neighbor-set" -d 'Manage named `[[neighbor_sets]]` entries used by policy `match_neighbor_set`. Backed by PolicyService'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "peer-group" -d 'Manage named `[[peer_groups]]` entries and bind/unbind neighbors to them. Backed by PeerGroupService'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "dynamic-neighbor" -d 'Manage `[[dynamic_neighbors]]` prefix ranges that auto-accept inbound peers into a peer group. Backed by NeighborService'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "fib-table" -d 'Manage `[[fib_tables]]` (ADR-0061 general unicast FIB export) at runtime. Hot-applies through the FIB reconciler and persists to the config'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "completions" -d 'Generate shell completions'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib flowspec evpn watch events health metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s j -l json -d 'Output in JSON format'
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -l no-color -d 'Disable colored output'
+complete -c rbgp -n "__fish_rbgp_using_subcommand man" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "global" -d 'Show daemon global configuration'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "config" -d 'Runtime config diagnostics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "neighbor" -d 'Manage BGP neighbors'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "bfd" -d 'Inspect single-hop BFD sessions (ADR-0067)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "rib" -d 'Query and manage the RIB'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "topology" -d 'Show the RFC 9107 ORR topology graph derived from BGP-LS'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "orr" -d 'Show RFC 9107 ORR per-vantage status (resolution, SPF reach, peers)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "diff" -d 'Compare live RIB views against an external snapshot (read-only)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "flowspec" -d 'Manage FlowSpec routes'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "evpn" -d 'Manage EVPN routes (list, add, delete — RFC 7432)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "watch" -d 'Watch route updates (streaming)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "events" -d 'Show recent route update events'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "health" -d 'Check daemon health'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "doctor" -d 'Run red/green triage checks and write a redacted support bundle'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "metrics" -d 'Show Prometheus metrics'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "shutdown" -d 'Request daemon shutdown'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "mrt-dump" -d 'Trigger an on-demand MRT dump'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "gshut" -d 'Toggle the RFC 8326 GRACEFUL_SHUTDOWN community on outbound updates'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "top" -d 'Live TUI dashboard'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "policy" -d 'Manage policy definitions and import/export chains'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "neighbor-set" -d 'Manage named neighbor sets used by policy'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "peer-group" -d 'Manage peer groups and neighbor membership'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "dynamic-neighbor" -d 'Manage dynamic-neighbor prefix ranges'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "fib-table" -d 'Manage general unicast FIB export tables at runtime'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "completions" -d 'Generate shell completions'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "man" -d 'Print the rbgp man page (roff) to stdout'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and not __fish_seen_subcommand_from global config neighbor bfd rib topology orr diff flowspec evpn watch events health doctor metrics shutdown mrt-dump gshut top policy neighbor-set peer-group dynamic-neighbor fib-table completions man help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "diff" -d 'Diff a candidate TOML file against the daemon\'s live runtime snapshot'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "plan" -d 'Validate and classify a candidate transaction without mutation'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "apply" -d 'Commit a previously planned candidate transaction'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "confirm" -d 'Confirm a pending confirmed config transaction'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "abort" -d 'Abort a pending confirmed config transaction and roll back immediately'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "status" -d 'Show pending or last confirmed-transaction lifecycle state'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from config" -f -a "effective" -d 'Dump the daemon\'s effective running config (defaults materialized)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "add" -d 'Add a new neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "delete" -d 'Delete this neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor" -f -a "enable" -d 'Enable this neighbor'
@@ -807,8 +1072,16 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "advertised" -d 'Show advertised routes to a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "blackholes" -d 'Show RFC 7999 BLACKHOLE discard install status'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "fib" -d 'Show ADR-0061 general FIB route install status'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "bgpls" -d 'Show BGP-LS routes learned from peers (RFC 9552)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "vpn" -d 'Show VPNv4/VPNv6 routes learned from peers (RFC 4364/4659)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "labeled" -d 'Show IPv4/IPv6 labeled-unicast routes learned from peers (RFC 8277)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "rtc" -d 'Show RT-Constrain routes (RFC 4684, single IPv4 family)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "add" -d 'Inject a route'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from rib" -f -a "delete" -d 'Withdraw a route'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from topology" -f -a "nodes" -d 'List topology nodes (BGP-LS node identities across all peers)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from topology" -f -a "links" -d 'List usable directed topology links (with IGP metrics)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from diff" -f -a "advertised" -d 'Compare the live Adj-RIB-Out against an incumbent NDJSON snapshot'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from diff" -f -a "snapshot" -d 'Produce an `rbgp-ribsnap/1` snapshot from an incumbent\'s own output (offline; no daemon connection)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from flowspec" -f -a "add" -d 'Add a FlowSpec rule'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from flowspec" -f -a "delete" -d 'Delete a FlowSpec rule'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "list" -d 'List EVPN routes (default action — same as omitting the subcommand)'
@@ -821,21 +1094,25 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcomma
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "clear-duplicate-mac" -d 'Clear one duplicate-MAC local-origin quarantine'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "es" -d 'Ethernet Segment runtime controls and diagnose state'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "runtime" -d 'Show the committed ADR-0063 EVPN runtime generation'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "instances" -d 'List local EVPN instances configured on this VTEP. Empty when the daemon is acting purely as an EVPN route reflector'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "instances" -d 'List local EVPN instances configured on this VTEP'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "nexthops" -d 'List rustbgpd-owned FDB nexthop groups (ADR-0059 aliasing ECMP)'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "managed-netdevs" -d 'List managed EVPN netdev ownership/status rows (ADR-0091)'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "vrfs" -d 'List configured IP-VRFs (Gate 9, ADR-0058) and their readiness verdict from the most recent reconcile pass'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "vrfs" -d 'List configured IP-VRFs and their readiness verdict'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from evpn" -f -a "diagnose" -d 'Summarize EVPN VTEP alpha state and key metrics'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "watch" -d 'Watch the unified live event stream'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "sessions" -d 'Show recent session lifecycle events'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "policy" -d 'Show recent policy / neighbor-set / peer-group / chain mutation events'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from events" -f -a "evpn" -d 'Show recent EVPN route events'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "list" -d 'List configured policies (names + statement counts)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "check" -d 'Check an `.rpol` policy file locally (parse, typecheck, tests)'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "fmt" -d 'Format `.rpol` files in the one canonical style'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "test" -d 'Dry-run a candidate `.rpol` policy against the live RIB'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "get" -d 'Show one policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "set" -d 'Set (create or replace) a policy from a JSON file'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "delete" -d 'Delete a policy by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "chain" -d 'Manage global / per-neighbor import/export chains'
-complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor (ADR-0073): why it was permitted / denied / withdrawn, or not-seen / evicted / stale. Reads the per-session decision cache; requires `[policy.explain].enabled` on the daemon'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "stats" -d 'Show live per-term policy hit counters'
+complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from policy" -f -a "explain" -d 'Explain the import-policy decision for a prefix on a neighbor'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "list" -d 'List configured neighbor sets'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "get" -d 'Show one neighbor set by name'
 complete -c rbgp -n "__fish_rbgp_using_subcommand help; and __fish_seen_subcommand_from neighbor-set" -f -a "set" -d 'Set (create or replace) a neighbor set from a JSON file'


### PR DESCRIPTION
The checked-in completions were last generated at #589 and predate the CLI consistency sweep (#806) plus every subcommand added since (diff toolchain, policy fmt/coverage, config effective, doctor v2 flags). Regenerated all three via `rbgp completions <shell>`; they now complete --neighbor/--remote-asn/positional candidates and the current subcommand set. Follow-up from the LAN-343 docs sweep.