### PR TITLE
fix: reject dataset-probing candidate sources in TestPolicy instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,6 +651,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`TestPolicy` no longer panics on a candidate source that probes a
+  dataset.** A dry-run source declaring and referencing a `dataset`
+  compiles per the language (LAN-305) but has no file bindings inside
+  the RPC; the handler previously hit the dataset-free
+  `compile_policy` convenience and panicked. It now returns
+  `INVALID_ARGUMENT` naming the unbindable datasets, mirroring the
+  inline-compilation diagnostic. Found by the LAN-8 `unwrap()`/
+  `expect()` audit of the wire, policy, api, cli, fsm, mrt, telemetry,
+  bfd, and event-history crates — every other non-test site guards a
+  compile-time-certain conversion or a locally provable, documented
+  invariant. (LAN-8)
 - **`unwrap()`/`expect()` audit of the transport, rpki, bmp, evpn, and
   evpn-linux crates.** Every non-test site was reviewed: none are
   reachable from network input or runtime IO — all remaining `expect()`

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1467,9 +1467,21 @@ impl proto::policy_service_server::PolicyService for PolicyService {
             )));
         }
         let mut store = SetStore::new();
+        // Dry runs have no dataset file bindings — a candidate source
+        // referencing one is rejected, not panicked on (LAN-305).
         let chain = file
-            .compile_policy(base, &args, &mut store)
-            .expect("existence checked above");
+            .compile_policy_bound(
+                base,
+                &args,
+                &mut store,
+                &rustbgpd_policy::datasets::DatasetBindings::new(),
+            )
+            .expect("existence checked above")
+            .map_err(|missing| {
+                Status::invalid_argument(format!(
+                    "policy {base:?} probes datasets, which TestPolicy cannot bind: {missing}"
+                ))
+            })?;
 
         // Read-only route snapshot via the existing RIB query
         // machinery. Import evaluates Adj-RIB-In (optionally one
@@ -2782,6 +2794,39 @@ policy customer-in(peer_lp: u32) {
             resp.diagnostics
         );
         assert_eq!(resp.routes_evaluated, 0);
+    }
+
+    /// A candidate source that references a dataset compiles per the
+    /// language (LAN-305) but has no file bindings in a dry run — the
+    /// RPC must reject it, not panic in `compile_policy`.
+    #[tokio::test]
+    async fn test_policy_rejects_dataset_referencing_source() {
+        let svc = test_policy_service(Vec::new());
+        let source = "dataset asn-set customers\n\n\
+                      policy origin-guard {\n\
+                          term members { if route.origin-as in customers { accept } }\n\
+                          term rest { reject }\n\
+                      }\n";
+        let status = PolicyServiceRpc::test_policy(
+            &svc,
+            Request::new(proto::TestPolicyRequest {
+                rpol_source: source.to_string(),
+                policy: "origin-guard".to_string(),
+                direction: "import".to_string(),
+                peer: String::new(),
+                afi_safi: 0,
+                limit: 0,
+                show_changes: 0,
+            }),
+        )
+        .await
+        .expect_err("dataset-referencing source must be rejected");
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(
+            status.message().contains("customers"),
+            "{}",
+            status.message()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Slice 3 of LAN-8 (wire, policy, api, cli, fsm, mrt, telemetry, bfd, event-history). One real finding, fixed: the TestPolicy gRPC handler compiled operator-submitted rpol via the panicking compile_policy convenience, so a dry-run candidate that probes a dataset (parses and typechecks cleanly) panicked the handler — reproduced, then fixed to compile_policy_bound with empty bindings returning INVALID_ARGUMENT naming the datasets, with a regression test. The nightly rpol_compile fuzzer misses this path because the fuzzed entry point already handles missing datasets. Remaining ~340 sites across the nine crates verified LEAVE/DOCUMENT (full inventory in the report); fsm, bfd, event-history are clean.