### PR TITLE
perf(rib): store route bodies in slabs behind u32 handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -573,6 +573,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     top-level and nested help lists are now terse one-liners with
     details moved to each subcommand's `--help`.
 - Removed the deprecated `bgp_aspa_records_total` gauge alias; `bgp_aspa_records` is the only exported name
+- **Compact route storage: slab-backed route bodies behind `u32`
+  handles.** Adj-RIB-In and Adj-RIB-Out (which also backs the shared
+  update-group RIB-Out table — the largest heap component in the
+  2026-07 memory re-baseline) no longer keep ~130-byte `Route` values
+  inline in hashbrown bucket arrays. Route bodies live densely in a
+  per-table slab; the existing prefix-trie index carries
+  `(path_id, handle)` pairs, and the separate
+  `(prefix, path_id)`-keyed hash maps are gone entirely. Withdrawals
+  free slab slots onto a free list, so steady-state churn does not
+  grow the tables. The Loc-RIB best-path map deliberately keeps its
+  inline route bodies: a slab handle measurably regressed its
+  lookup-hot recompute (see the field note in `loc_rib.rs`).
+  Allocator-tracked `memory_profile` at the 2-peer × 100k-prefix
+  shape: Full-RIB 65.6 MiB → 51.8 MiB (−21.1%), RR-fanout
+  110.1 MiB → 82.5 MiB (−25.1%); `rib_ops` insert / pipeline / churn
+  benchmarks improved 18–72% from the removed per-route hashing.
+  (LAN-335)
 - **Docs reorganized by task shape (Diátaxis).** `docs/README.md` now
   indexes every doc under tutorials / how-to guides / reference /
   explanation; archived soak postmortems moved from `docs/soak-*.md`

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -30,6 +30,7 @@ use crate::route::{
     BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, LabeledRibRoute,
     LabeledRibRouteKey, Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
+use crate::slab::RouteSlab;
 
 /// Per-peer Adj-RIB-In: stores the routes received from a single peer.
 ///
@@ -46,13 +47,18 @@ use crate::route::{
 #[derive(Debug)]
 pub struct AdjRibIn {
     peer: IpAddr,
-    routes: HashMap<(Prefix, u32), Route>,
-    /// Secondary index: prefix → path IDs stored for that prefix, backed by a
-    /// family-split prefix trie. `SmallVec<[u32; 1]>` inlines the single-path
-    /// case (`path_id=0`, no Add-Path) without a per-prefix heap allocation;
-    /// Add-Path multi-path spills to the heap transparently. Mirrors
-    /// `AdjRibOut::prefix_path_ids`.
-    prefix_index: FamilyPrefixMap<SmallVec<[u32; 1]>>,
+    /// Unicast route bodies, stored densely behind `u32` handles (LAN-335).
+    /// The `(prefix, path_id)` identity lives on the routes themselves and in
+    /// `prefix_index`; there is no separate keyed route map — a hashbrown
+    /// bucket array carrying inline `Route` values was the dominant heap cost
+    /// at high N (docs/perf/rebaseline-2026-07.md).
+    routes: RouteSlab<Route>,
+    /// Primary index: prefix → `(path_id, slab handle)` pairs stored for that
+    /// prefix, backed by a family-split prefix trie. `SmallVec<[(u32, u32); 1]>`
+    /// inlines the single-path case (`path_id=0`, no Add-Path) without a
+    /// per-prefix heap allocation; Add-Path multi-path spills to the heap
+    /// transparently. Mirrors `AdjRibOut::prefix_path_ids`.
+    prefix_index: FamilyPrefixMap<SmallVec<[(u32, u32); 1]>>,
     /// Route keys where `LLGR_STALE` was injected locally by this daemon.
     llgr_stale_local_tags: HashSet<(Prefix, u32)>,
     /// `FlowSpec` routes keyed by `(rule, path_id)`.
@@ -115,7 +121,7 @@ impl AdjRibIn {
         let flowspec_capacity = flowspec_capacity.max(4);
         Self {
             peer,
-            routes: HashMap::with_capacity_and_hasher(route_capacity, FxBuildHasher),
+            routes: RouteSlab::with_capacity(route_capacity),
             prefix_index: FamilyPrefixMap::default(),
             llgr_stale_local_tags: HashSet::default(),
             flowspec_routes: HashMap::with_capacity_and_hasher(flowspec_capacity, FxBuildHasher),
@@ -158,12 +164,8 @@ impl AdjRibIn {
     /// `true` (see the unicast announce path in the RIB manager). A first-time
     /// insert orphans nothing, so the initial-load flood skips the GC.
     pub fn insert(&mut self, mut route: Route) -> bool {
-        let key = (route.prefix, route.path_id);
-        let ids = self.prefix_index.entry_or_default(route.prefix);
-        if !ids.contains(&route.path_id) {
-            ids.push(route.path_id);
-        }
-        self.llgr_stale_local_tags.remove(&key);
+        self.llgr_stale_local_tags
+            .remove(&(route.prefix, route.path_id));
 
         // Intern: reuse an existing Arc if one matches
         if let Some(existing) = self.attr_intern.get(&route.attributes) {
@@ -172,18 +174,44 @@ impl AdjRibIn {
             self.attr_intern.insert(route.attributes.clone());
         }
 
-        self.routes.insert(key, route).is_some()
+        let path_id = route.path_id;
+        let ids = self.prefix_index.entry_or_default(route.prefix);
+        if let Some((_, handle)) = ids.iter().find(|(id, _)| *id == path_id) {
+            self.routes.set(*handle, route);
+            true
+        } else {
+            let handle = self.routes.insert(route);
+            ids.push((path_id, handle));
+            false
+        }
     }
 
     /// Withdraw a route by prefix and path ID. Returns `true` if it existed.
     pub fn withdraw(&mut self, prefix: &Prefix, path_id: u32) -> bool {
-        let key = (*prefix, path_id);
-        self.llgr_stale_local_tags.remove(&key);
-        let removed = self.routes.remove(&key).is_some();
-        if removed {
-            self.remove_from_prefix_index(prefix, path_id);
+        self.llgr_stale_local_tags.remove(&(*prefix, path_id));
+        self.remove_route_entry(prefix, path_id).is_some()
+    }
+
+    /// Slab handle for the route stored at `(prefix, path_id)`, if any.
+    fn route_handle(&self, prefix: &Prefix, path_id: u32) -> Option<u32> {
+        self.prefix_index
+            .get(prefix)?
+            .iter()
+            .find(|(id, _)| *id == path_id)
+            .map(|&(_, handle)| handle)
+    }
+
+    /// Remove a route from both the prefix index and the slab, freeing its
+    /// slot. Every unicast removal path routes through here so the index and
+    /// slab can never disagree.
+    fn remove_route_entry(&mut self, prefix: &Prefix, path_id: u32) -> Option<Route> {
+        let ids = self.prefix_index.get_mut(prefix)?;
+        let pos = ids.iter().position(|(id, _)| *id == path_id)?;
+        let (_, handle) = ids.swap_remove(pos);
+        if ids.is_empty() {
+            self.prefix_index.remove(prefix);
         }
-        removed
+        self.routes.remove(handle)
     }
 
     /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
@@ -265,32 +293,33 @@ impl AdjRibIn {
 
     /// Iterate over all stored routes.
     pub fn iter(&self) -> impl Iterator<Item = &Route> {
-        self.routes.values()
+        self.routes.iter()
     }
 
     /// Iterate mutably over all stored routes.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Route> {
-        self.routes.values_mut()
+        self.routes.iter_mut()
     }
 
     /// Look up a route by prefix and path ID.
     #[must_use]
     pub fn get(&self, prefix: &Prefix, path_id: u32) -> Option<&Route> {
-        self.routes.get(&(*prefix, path_id))
+        self.routes.get(self.route_handle(prefix, path_id)?)
     }
 
     /// Iterate over all routes for a given prefix (all path IDs).
     ///
-    /// Uses a secondary prefix index for O(candidates) lookup instead of
-    /// scanning the entire RIB.
+    /// Uses the prefix index for O(candidates) lookup instead of an O(N)
+    /// full scan.
     pub fn iter_prefix(&self, prefix: &Prefix) -> impl Iterator<Item = &Route> {
-        let path_ids = self.prefix_index.get(prefix);
-        let target = *prefix;
         let routes = &self.routes;
-        path_ids.into_iter().flat_map(move |ids| {
-            ids.iter()
-                .filter_map(move |&pid| routes.get(&(target, pid)))
-        })
+        self.prefix_index
+            .get(prefix)
+            .into_iter()
+            .flat_map(move |ids| {
+                ids.iter()
+                    .filter_map(move |&(_, handle)| routes.get(handle))
+            })
     }
 
     /// Mark all routes matching the given address family as stale
@@ -309,17 +338,16 @@ impl AdjRibIn {
         let already_stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| r.is_stale && route_matches_family(r, family))
-            .map(|(k, _)| *k)
+            .filter(|r| r.is_stale && route_matches_family(r, family))
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut deleted = Vec::new();
         for key in &already_stale {
             deleted.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
-        for route in self.routes.values_mut() {
+        for route in self.routes.iter_mut() {
             if route_matches_family(route, family) && !route.is_llgr_stale {
                 route.is_stale = true;
             }
@@ -330,12 +358,13 @@ impl AdjRibIn {
     /// Clear the stale flag on routes matching the given address family.
     pub fn clear_stale(&mut self, family: (Afi, Safi)) {
         let mut clear_local_llgr = Vec::new();
-        for (key, route) in &mut self.routes {
+        for route in self.routes.iter_mut() {
             if route_matches_family(route, family) {
                 route.is_stale = false;
                 route.is_llgr_stale = false;
-                if self.llgr_stale_local_tags.contains(key) {
-                    clear_local_llgr.push(*key);
+                let key = (route.prefix, route.path_id);
+                if self.llgr_stale_local_tags.contains(&key) {
+                    clear_local_llgr.push(key);
                 }
             }
         }
@@ -349,15 +378,14 @@ impl AdjRibIn {
         let to_remove: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| !keep.iter().any(|&fam| route_matches_family(r, fam)))
-            .map(|(k, _)| *k)
+            .filter(|r| !keep.iter().any(|&fam| route_matches_family(r, fam)))
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut prefixes = Vec::new();
         for key in &to_remove {
             prefixes.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
         prefixes
     }
@@ -367,15 +395,14 @@ impl AdjRibIn {
         let stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| r.is_stale)
-            .map(|(k, _)| *k)
+            .filter(|r| r.is_stale)
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut prefixes = Vec::new();
         for key in &stale {
             prefixes.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
         prefixes
     }
@@ -386,15 +413,14 @@ impl AdjRibIn {
         let stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| r.is_stale && route_matches_family(r, family))
-            .map(|(k, _)| *k)
+            .filter(|r| r.is_stale && route_matches_family(r, family))
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut prefixes = Vec::new();
         for key in &stale {
             prefixes.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
         prefixes
     }
@@ -413,22 +439,21 @@ impl AdjRibIn {
         let no_llgr_keys: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| {
+            .filter(|r| {
                 r.is_stale
                     && route_matches_family(r, family)
                     && r.communities().contains(&COMMUNITY_NO_LLGR)
             })
-            .map(|(k, _)| *k)
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut affected: Vec<Prefix> = no_llgr_keys.iter().map(|(p, _)| *p).collect();
         for key in &no_llgr_keys {
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
 
         // Second pass: promote remaining stale routes to LLGR-stale
-        for route in self.routes.values_mut() {
+        for route in self.routes.iter_mut() {
             if route.is_stale && route_matches_family(route, family) {
                 route.is_stale = false;
                 route.is_llgr_stale = true;
@@ -460,15 +485,14 @@ impl AdjRibIn {
         let stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| r.is_llgr_stale)
-            .map(|(k, _)| *k)
+            .filter(|r| r.is_llgr_stale)
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut prefixes = Vec::new();
         for key in &stale {
             prefixes.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
         prefixes
     }
@@ -480,15 +504,14 @@ impl AdjRibIn {
         let stale: Vec<(Prefix, u32)> = self
             .routes
             .iter()
-            .filter(|(_, r)| r.is_llgr_stale && route_matches_family(r, family))
-            .map(|(k, _)| *k)
+            .filter(|r| r.is_llgr_stale && route_matches_family(r, family))
+            .map(|r| (r.prefix, r.path_id))
             .collect();
         let mut prefixes = Vec::new();
         for key in &stale {
             prefixes.push(key.0);
             self.llgr_stale_local_tags.remove(key);
-            self.routes.remove(key);
-            self.remove_from_prefix_index(&key.0, key.1);
+            self.remove_route_entry(&key.0, key.1);
         }
         prefixes
     }
@@ -497,11 +520,12 @@ impl AdjRibIn {
     /// Called when `EoR` is received during LLGR phase.
     pub fn clear_llgr_stale(&mut self, family: (Afi, Safi)) {
         let mut clear_local_llgr = Vec::new();
-        for (key, route) in &mut self.routes {
+        for route in self.routes.iter_mut() {
             if route_matches_family(route, family) {
                 route.is_llgr_stale = false;
-                if self.llgr_stale_local_tags.contains(key) {
-                    clear_local_llgr.push(*key);
+                let key = (route.prefix, route.path_id);
+                if self.llgr_stale_local_tags.contains(&key) {
+                    clear_local_llgr.push(key);
                 }
             }
         }
@@ -2112,19 +2136,11 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_flowspec_community(&clear_local_llgr);
     }
 
-    /// Remove a `path_id` from the prefix index, cleaning up empty entries.
-    fn remove_from_prefix_index(&mut self, prefix: &Prefix, path_id: u32) {
-        if let Some(ids) = self.prefix_index.get_mut(prefix) {
-            ids.retain(|id| *id != path_id);
-            if ids.is_empty() {
-                self.prefix_index.remove(prefix);
-            }
-        }
-    }
-
     fn clear_local_llgr_stale_community(&mut self, keys: &[(Prefix, u32)]) {
         for key in keys {
-            if let Some(route) = self.routes.get_mut(key) {
+            if let Some(handle) = self.route_handle(&key.0, key.1)
+                && let Some(route) = self.routes.get_mut(handle)
+            {
                 remove_llgr_stale_community(route);
             }
             self.llgr_stale_local_tags.remove(key);
@@ -2744,7 +2760,7 @@ mod tests {
         assert_eq!(rib.len(), 1);
         // The secondary prefix index is maintained through the deletion.
         assert_eq!(rib.iter_prefix(&Prefix::V4(gr_prefix)).count(), 0);
-        let retained = rib.routes.get(&(Prefix::V4(llgr_prefix), 0)).unwrap();
+        let retained = rib.get(&Prefix::V4(llgr_prefix), 0).unwrap();
         assert!(retained.is_llgr_stale);
         assert!(!retained.is_stale, "LLGR-stale must not be re-marked");
         assert!(
@@ -4571,5 +4587,33 @@ mod tests {
         assert!(rib.bgpls_llgr_stale_local_tags.is_empty());
         assert!(rib.rtc_llgr_stale_local_tags.is_empty());
         assert!(rib.labeled_llgr_stale_local_tags.is_empty());
+    }
+
+    /// LAN-335 slab-storage leak gate: withdraw must free the route's slab
+    /// slot and re-insert must reuse it, so sustained insert/withdraw churn
+    /// keeps the slot vector at the steady-state size instead of growing
+    /// without bound.
+    #[test]
+    fn withdraw_reinsert_churn_reuses_slab_slots() {
+        let mut rib = AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let prefixes: Vec<Ipv4Prefix> = (0..100u8)
+            .map(|i| Ipv4Prefix::new(Ipv4Addr::new(10, 1, i, 0), 24))
+            .collect();
+
+        for cycle in 0..5 {
+            for p in &prefixes {
+                rib.insert(make_route(*p, Ipv4Addr::new(192, 0, 2, 1)));
+            }
+            assert_eq!(rib.len(), prefixes.len(), "cycle {cycle}");
+            assert_eq!(
+                rib.routes.slot_count(),
+                prefixes.len(),
+                "cycle {cycle}: churn must reuse freed slots, not grow the slab"
+            );
+            for p in &prefixes {
+                assert!(rib.withdraw(&Prefix::V4(*p), 0), "cycle {cycle}");
+            }
+            assert!(rib.is_empty(), "cycle {cycle}");
+        }
     }
 }

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -4,7 +4,7 @@ use rustbgpd_wire::{Afi, EvpnRouteKey, FlowSpecRule, Prefix, Safi};
 // FxHash (rustc-hash) on the route-bearing maps — see `adj_rib_in` for the
 // rationale (internal keys, faster hasher on the convergence hot path).
 // Aliased to the std name so the storage types read unchanged.
-use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
+use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 
 use crate::prefix_map::FamilyPrefixMap;
@@ -12,6 +12,7 @@ use crate::route::{
     BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecRoute, LabeledRibRoute, LabeledRibRouteKey,
     Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
+use crate::slab::RouteSlab;
 
 /// Per-peer Adj-RIB-Out: routes advertised to a specific peer.
 ///
@@ -19,12 +20,17 @@ use crate::route::{
 /// In single-best mode, `path_id` is always 0.
 pub struct AdjRibOut {
     peer: IpAddr,
-    routes: HashMap<(Prefix, u32), Route>,
-    /// Secondary index: prefix → path IDs for fast per-prefix lookup, backed by
-    /// a family-split prefix trie. `SmallVec<[u32; 1]>` inlines the single-best
-    /// case (`path_id=0`) without heap allocation; Add-Path multi-path spills to
-    /// heap transparently.
-    prefix_path_ids: FamilyPrefixMap<SmallVec<[u32; 1]>>,
+    /// Unicast route bodies, stored densely behind `u32` handles (LAN-335).
+    /// The `(prefix, path_id)` identity lives on the routes themselves and in
+    /// `prefix_path_ids`; there is no separate keyed route map — this struct
+    /// also backs the group RIB-Out table (`GroupRibOut`), whose route map
+    /// was the largest heap component in docs/perf/rebaseline-2026-07.md.
+    routes: RouteSlab<Route>,
+    /// Primary index: prefix → `(path_id, slab handle)` pairs, backed by a
+    /// family-split prefix trie. `SmallVec<[(u32, u32); 1]>` inlines the
+    /// single-best case (`path_id=0`) without heap allocation; Add-Path
+    /// multi-path spills to heap transparently.
+    prefix_path_ids: FamilyPrefixMap<SmallVec<[(u32, u32); 1]>>,
     /// `FlowSpec` routes advertised to this peer (always single-best, `path_id=0`).
     flowspec_routes: HashMap<FlowSpecRule, FlowSpecRoute>,
     /// EVPN routes advertised to this peer, keyed by RFC 7432 route identity.
@@ -63,7 +69,7 @@ impl AdjRibOut {
     pub fn with_capacity(peer: IpAddr, capacity: usize) -> Self {
         Self {
             peer,
-            routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
+            routes: RouteSlab::with_capacity(capacity),
             prefix_path_ids: FamilyPrefixMap::default(),
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
@@ -84,59 +90,66 @@ impl AdjRibOut {
 
     /// Insert or replace an advertised route.
     pub fn insert(&mut self, route: Route) {
-        let prefix = route.prefix;
         let path_id = route.path_id;
-        self.routes.insert((prefix, path_id), route);
-        let ids = self.prefix_path_ids.entry_or_default(prefix);
-        if !ids.contains(&path_id) {
-            ids.push(path_id);
+        let ids = self.prefix_path_ids.entry_or_default(route.prefix);
+        if let Some((_, handle)) = ids.iter().find(|(id, _)| *id == path_id) {
+            self.routes.set(*handle, route);
+        } else {
+            let handle = self.routes.insert(route);
+            ids.push((path_id, handle));
         }
     }
 
     /// Withdraw a route by prefix and path ID. Returns `true` if it existed.
     pub fn withdraw(&mut self, prefix: &Prefix, path_id: u32) -> bool {
-        if self.routes.remove(&(*prefix, path_id)).is_some() {
-            if let Some(ids) = self.prefix_path_ids.get_mut(prefix) {
-                ids.retain(|id| *id != path_id);
-                if ids.is_empty() {
-                    self.prefix_path_ids.remove(prefix);
-                }
-            }
-            true
-        } else {
-            false
+        let Some(ids) = self.prefix_path_ids.get_mut(prefix) else {
+            return false;
+        };
+        let Some(pos) = ids.iter().position(|(id, _)| *id == path_id) else {
+            return false;
+        };
+        let (_, handle) = ids.swap_remove(pos);
+        if ids.is_empty() {
+            self.prefix_path_ids.remove(prefix);
         }
+        self.routes.remove(handle).is_some()
     }
 
     /// Look up a route by prefix and path ID.
     #[must_use]
     pub fn get(&self, prefix: &Prefix, path_id: u32) -> Option<&Route> {
-        self.routes.get(&(*prefix, path_id))
+        let (_, handle) = self
+            .prefix_path_ids
+            .get(prefix)?
+            .iter()
+            .find(|(id, _)| *id == path_id)?;
+        self.routes.get(*handle)
     }
 
     /// Iterate over all advertised routes.
     pub fn iter(&self) -> impl Iterator<Item = &Route> {
-        self.routes.values()
+        self.routes.iter()
     }
 
     /// Iterate over all routes for a given prefix (all path IDs).
     pub fn iter_prefix(&self, prefix: &Prefix) -> impl Iterator<Item = &Route> + '_ {
-        let prefix = *prefix;
+        let routes = &self.routes;
         self.prefix_path_ids
-            .get(&prefix)
+            .get(prefix)
             .into_iter()
             .flat_map(move |ids| {
                 ids.iter()
-                    .filter_map(move |&id| self.routes.get(&(prefix, id)))
+                    .filter_map(move |&(_, handle)| routes.get(handle))
             })
     }
 
     /// Return all path IDs currently advertised for a given prefix.
     #[must_use]
-    pub fn path_ids_for_prefix(&self, prefix: &Prefix) -> &[u32] {
+    pub fn path_ids_for_prefix(&self, prefix: &Prefix) -> SmallVec<[u32; 1]> {
         self.prefix_path_ids
             .get(prefix)
-            .map_or(&[], SmallVec::as_slice)
+            .map(|ids| ids.iter().map(|&(id, _)| id).collect())
+            .unwrap_or_default()
     }
 
     /// Remove only the unicast routes and their secondary prefix index,
@@ -452,8 +465,8 @@ impl AdjRibOut {
                 counts.push((family, 1));
             }
         };
-        for (prefix, _) in self.routes.keys() {
-            let afi = match prefix {
+        for route in self.routes.iter() {
+            let afi = match route.prefix {
                 Prefix::V4(_) => Afi::Ipv4,
                 Prefix::V6(_) => Afi::Ipv6,
             };
@@ -708,7 +721,7 @@ mod tests {
 
         assert!(rib.path_ids_for_prefix(&p).is_empty());
         rib.insert(make_route(p, 0));
-        assert_eq!(rib.path_ids_for_prefix(&p), [0]);
+        assert_eq!(rib.path_ids_for_prefix(&p).as_slice(), [0]);
 
         assert!(rib.withdraw(&p, 0));
         assert!(rib.path_ids_for_prefix(&p).is_empty());
@@ -741,7 +754,7 @@ mod tests {
 
         rib.insert(make_route(p, 0));
         rib.insert(make_route(p, 0)); // replace, not duplicate
-        assert_eq!(rib.path_ids_for_prefix(&p), [0]);
+        assert_eq!(rib.path_ids_for_prefix(&p).as_slice(), [0]);
         assert_eq!(rib.len(), 1);
     }
 
@@ -755,7 +768,7 @@ mod tests {
         rib.insert(make_route(pb, 0));
         rib.insert(make_route(pb, 1));
 
-        assert_eq!(rib.path_ids_for_prefix(&pa), [0]);
+        assert_eq!(rib.path_ids_for_prefix(&pa).as_slice(), [0]);
         let mut ids_b = rib.path_ids_for_prefix(&pb).to_vec();
         ids_b.sort_unstable();
         assert_eq!(ids_b, [0, 1]);

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -33,6 +33,8 @@ pub mod orr;
 mod prefix_map;
 /// Route and `FlowSpec` route data types.
 pub mod route;
+/// Slab storage for route bodies behind `u32` handles (LAN-335).
+mod slab;
 /// Shared unit-test fixtures (canonical test route builders).
 #[cfg(test)]
 mod test_support;

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -25,6 +25,14 @@ pub struct LocRib {
     /// reads the stored stamp (not a reconstruction from the monotonic
     /// clock), so an NTP step between install and dump cannot skew the
     /// per-peer header timestamp (LAN-193).
+    ///
+    /// Deliberately NOT slab-backed (LAN-335): this map keeps its route
+    /// bodies inline. Both compact-storage candidates were measured and
+    /// rejected on this lookup-hot recompute path — the prefix trie
+    /// regressed it (see `prefix_map`), and a `u32` slab handle regressed
+    /// `loc_rib_recompute/1` by ~14% (extra indirection + a second probe
+    /// per hit) for only ~4 MiB of the ~19 MiB the Adj-RIB slab conversion
+    /// saved at the 2p×100k profile shape.
     routes: HashMap<Prefix, (Route, SystemTime)>,
     /// `FlowSpec` Loc-RIB: best route per `FlowSpec` rule.
     flowspec_routes: HashMap<FlowSpecRule, FlowSpecRoute>,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1020,7 +1020,7 @@ impl RibManager {
         };
         if !sendable.is_some_and(|f| f.contains(&family)) {
             // Withdraw all previously advertised paths for this prefix
-            for &path_id in rib_out.path_ids_for_prefix(prefix) {
+            for path_id in rib_out.path_ids_for_prefix(prefix) {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1029,7 +1029,7 @@ impl RibManager {
         // ORF check (RFC 5291): filters the prefix, not individual Add-Path
         // path-ids — gate the whole prefix once, before collecting candidates.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
-            for &path_id in rib_out.path_ids_for_prefix(prefix) {
+            for path_id in rib_out.path_ids_for_prefix(prefix) {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1148,14 +1148,14 @@ impl RibManager {
             // permitted — an implicit replace otherwise (no spurious
             // withdraw+announce pair when the filtered best flips).
             let staged_winner = next_rank > 1;
-            for &path_id in rib_out.path_ids_for_prefix(prefix) {
+            for path_id in rib_out.path_ids_for_prefix(prefix) {
                 if path_id != 0 || !staged_winner {
                     withdraw.push((*prefix, path_id));
                 }
             }
         } else {
             // Withdraw any previously advertised path_ids beyond the new set
-            for &path_id in rib_out.path_ids_for_prefix(prefix) {
+            for path_id in rib_out.path_ids_for_prefix(prefix) {
                 if path_id >= next_rank {
                     withdraw.push((*prefix, path_id));
                 }
@@ -1202,7 +1202,7 @@ impl RibManager {
             target.gate("best_route", "no_best_route", Stop, || {
                 "no best route exists for this prefix".to_string()
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1230,7 +1230,7 @@ impl RibManager {
                 "route is suppressed by split horizon because it originated from the target peer"
                     .to_string()
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1257,7 +1257,7 @@ impl RibManager {
                 );
                 trace.push("rr_reflection", code, Stop, detail.to_string());
             }
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1272,7 +1272,7 @@ impl RibManager {
             target.gate("family", "family_not_sendable", Stop, || {
                 format!("peer cannot receive {} routes", family_label(family))
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1295,7 +1295,7 @@ impl RibManager {
                  Long-Lived Graceful Restart capability for this family (RFC 9494 §4.4)"
                     .to_string()
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1323,7 +1323,7 @@ impl RibManager {
                     "peer-pushed Outbound Route Filter (RFC 5291) does not permit this prefix"
                         .to_string()
                 });
-                for &path_id in existing_path_ids {
+                for &path_id in &existing_path_ids {
                     withdraw.push((*prefix, path_id));
                 }
                 return;
@@ -1395,7 +1395,7 @@ impl RibManager {
                 prefix: *prefix,
                 path_id: best.path_id,
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1477,7 +1477,7 @@ impl RibManager {
 
         // Clean up any stale multi-path entries if this prefix was previously
         // advertised via Add-Path and is now single-best.
-        for &path_id in existing_path_ids {
+        for &path_id in &existing_path_ids {
             if path_id != 0 {
                 withdraw.push((*prefix, path_id));
             }
@@ -1542,7 +1542,7 @@ impl RibManager {
         // Sendable family check
         let family = prefix_family(prefix);
         if !sendable.is_some_and(|f| f.contains(&family)) {
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1551,7 +1551,7 @@ impl RibManager {
         // Outbound Route Filter check (RFC 5291): silent withdraw, not a
         // policy denial — see `distribute_single_best_prefix`.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1582,7 +1582,7 @@ impl RibManager {
                 orr_spf.cost_to(orr_topology, b.next_hop),
             )
         }) else {
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1599,7 +1599,7 @@ impl RibManager {
             target_is_ebgp,
             llgr,
         ) {
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1641,7 +1641,7 @@ impl RibManager {
                 prefix: *prefix,
                 path_id: best.path_id,
             });
-            for &path_id in existing_path_ids {
+            for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
             return;
@@ -1669,7 +1669,7 @@ impl RibManager {
 
         // Clean up any stale multi-path entries if this prefix was
         // previously advertised via Add-Path and is now single-best.
-        for &path_id in existing_path_ids {
+        for &path_id in &existing_path_ids {
             if path_id != 0 {
                 withdraw.push((*prefix, path_id));
             }

--- a/crates/rib/src/slab.rs
+++ b/crates/rib/src/slab.rs
@@ -1,0 +1,186 @@
+//! Compact slab storage for route bodies (LAN-335).
+//!
+//! The route-bearing maps used to store ~130-byte route values inline in
+//! hashbrown bucket arrays, paying the table's power-of-two capacity slack
+//! per value (the dominant heap cost in the 2026-07 dhat re-baseline).
+//! [`RouteSlab`] stores the bodies densely in a `Vec` behind `u32` handles,
+//! so the maps and prefix-trie indexes only carry 4-byte handles.
+//!
+//! `Option<T>` costs nothing for the stored route types: they all carry a
+//! non-null `Arc`, so the niche optimization folds the vacancy discriminant
+//! into the payload (asserted by `option_is_niche_free_for_route_types`).
+//!
+//! Freed slots are pushed onto a free list and reused by later inserts, so
+//! sustained insert/withdraw churn does not grow the slot vector.
+
+/// Dense storage for route bodies addressed by `u32` handles.
+///
+/// Not a general-purpose slab: handles are only valid until `remove` or
+/// `clear`, and the owner (a RIB table) is responsible for never holding a
+/// stale handle — its map/index and this slab are mutated together.
+#[derive(Debug)]
+pub(crate) struct RouteSlab<T> {
+    slots: Vec<Option<T>>,
+    free: Vec<u32>,
+}
+
+impl<T> Default for RouteSlab<T> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<T> RouteSlab<T> {
+    /// Create a slab with pre-sized slot capacity.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            slots: Vec::with_capacity(capacity),
+            free: Vec::new(),
+        }
+    }
+
+    /// Store a value, returning its handle. Reuses a freed slot when one
+    /// is available.
+    pub(crate) fn insert(&mut self, value: T) -> u32 {
+        if let Some(handle) = self.free.pop() {
+            self.slots[handle as usize] = Some(value);
+            handle
+        } else {
+            let handle =
+                u32::try_from(self.slots.len()).expect("route slab exceeds u32 handle space");
+            self.slots.push(Some(value));
+            handle
+        }
+    }
+
+    /// Remove and return the value at `handle`, freeing the slot for reuse.
+    pub(crate) fn remove(&mut self, handle: u32) -> Option<T> {
+        let value = self.slots.get_mut(handle as usize)?.take();
+        if value.is_some() {
+            self.free.push(handle);
+        }
+        value
+    }
+
+    /// Replace the value in an occupied slot.
+    pub(crate) fn set(&mut self, handle: u32, value: T) {
+        let slot = &mut self.slots[handle as usize];
+        debug_assert!(slot.is_some(), "RouteSlab::set on a vacant slot");
+        *slot = Some(value);
+    }
+
+    pub(crate) fn get(&self, handle: u32) -> Option<&T> {
+        self.slots.get(handle as usize)?.as_ref()
+    }
+
+    pub(crate) fn get_mut(&mut self, handle: u32) -> Option<&mut T> {
+        self.slots.get_mut(handle as usize)?.as_mut()
+    }
+
+    /// Number of occupied slots.
+    pub(crate) fn len(&self) -> usize {
+        self.slots.len() - self.free.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Backing slot capacity (the memory-profile analog of
+    /// `HashMap::capacity` on the maps this replaces).
+    #[cfg(feature = "bench-internals")]
+    pub(crate) fn capacity(&self) -> usize {
+        self.slots.capacity()
+    }
+
+    /// Total slots ever allocated (occupied + free). Test-only leak probe:
+    /// steady-state churn must not grow this.
+    #[cfg(test)]
+    pub(crate) fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Drop every value. Keeps the slot allocation, like `HashMap::clear`.
+    pub(crate) fn clear(&mut self) {
+        self.slots.clear();
+        self.free.clear();
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
+        self.slots.iter().filter_map(Option::as_ref)
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.slots.iter_mut().filter_map(Option::as_mut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_get_remove_round_trip() {
+        let mut slab: RouteSlab<String> = RouteSlab::default();
+        let a = slab.insert("a".to_string());
+        let b = slab.insert("b".to_string());
+        assert_ne!(a, b);
+        assert_eq!(slab.len(), 2);
+        assert_eq!(slab.get(a).unwrap(), "a");
+        assert_eq!(slab.get_mut(b).unwrap(), "b");
+        assert_eq!(slab.remove(a), Some("a".to_string()));
+        assert_eq!(slab.remove(a), None, "double-remove is a no-op");
+        assert_eq!(slab.get(a), None);
+        assert_eq!(slab.len(), 1);
+    }
+
+    #[test]
+    fn removed_slots_are_reused_so_churn_does_not_grow_the_slab() {
+        let mut slab: RouteSlab<u64> = RouteSlab::default();
+        let handles: Vec<u32> = (0..1000).map(|i| slab.insert(i)).collect();
+        assert_eq!(slab.slots.len(), 1000);
+        for h in &handles {
+            slab.remove(*h);
+        }
+        assert!(slab.is_empty());
+        for i in 0..1000 {
+            slab.insert(i);
+        }
+        assert_eq!(slab.len(), 1000);
+        assert_eq!(
+            slab.slots.len(),
+            1000,
+            "withdraw/re-insert churn must reuse freed slots, not grow"
+        );
+    }
+
+    #[test]
+    fn set_replaces_in_place() {
+        let mut slab: RouteSlab<u64> = RouteSlab::default();
+        let h = slab.insert(1);
+        slab.set(h, 2);
+        assert_eq!(slab.get(h), Some(&2));
+        assert_eq!(slab.len(), 1);
+    }
+
+    #[test]
+    fn clear_empties_and_invalidates_handles() {
+        let mut slab: RouteSlab<u64> = RouteSlab::default();
+        let h = slab.insert(7);
+        slab.clear();
+        assert!(slab.is_empty());
+        assert_eq!(slab.get(h), None);
+        // Fresh inserts after clear start from slot zero again.
+        assert_eq!(slab.insert(8), 0);
+    }
+
+    /// The whole point of the slab is compactness: `Option<Route>` must not
+    /// pay a discriminant word — the non-null `Arc` inside `Route` provides
+    /// the niche.
+    #[test]
+    fn option_is_niche_free_for_route_types() {
+        use crate::route::Route;
+        use std::mem::size_of;
+        assert_eq!(size_of::<Option<Route>>(), size_of::<Route>());
+    }
+}


### PR DESCRIPTION
Adj-RIB-In and Adj-RIB-Out (the substrate of the shared update-group
RIB-Out table) kept ~130-byte Route values inline in hashbrown bucket
arrays — the dominant tracked-heap cost in the 2026-07 re-baseline
(group table 32%, Loc-RIB 19%, Adj-RIB-In 13%, all resize_inner bucket
arrays). Route bodies now live densely in a per-table slab (Vec slots +
free list; Option<Route> is niche-free via the attributes Arc) and the
existing prefix-trie index carries (path_id, handle) pairs, replacing
the (prefix, path_id)-keyed hash maps outright. Handles are private to
each table: every public accessor still returns &Route borrows or owned
clones, so Arc-identity contracts (ExportMemo pointer keys, routes_equal
ptr_eq fast paths, clone-before-commit snapshots) are untouched.

Withdrawals free slots onto the free list; a churn test asserts
steady-state insert/withdraw does not grow the slot vector.

The Loc-RIB best-path map deliberately keeps inline bodies: a u32
handle measurably regressed its lookup-hot recompute microbench (~14%
on the hit path) for only ~4 MiB of the ~19 MiB won here — recorded in
the loc_rib.rs field note next to the earlier trie rejection.

memory_profile (allocator-tracked, 2p x 100k): full_rib 65.6 -> 51.8
MiB (-21.1%), rr_fanout 110.1 -> 82.5 MiB (-25.1%). rib_ops:
adj_rib_in_insert -56..72%, rib_pipeline -21..40%, bulk_initial_load
-15..46%, route_churn -19.6%; remaining cells within run-to-run noise
(loc_rib_recompute source is byte-identical to base; its base runs
span 31% run-to-run).

LAN-335

Closes LAN-335.