### PR TITLE
fix(rib): drain update-group withdraw residue on the per-peer resync path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -668,6 +668,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Update-group withdraw residue now drains on the per-peer resync
+  path.** A grouped member that went dirty, missed withdrawals (group
+  tombstones), and then moved off the grouped path (e.g. its export
+  chain became peer-context-dependent) carried those tombstones as
+  pending extra withdraws that the per-peer resync never consumed —
+  the keys were in neither the Loc-RIB nor the seeded Adj-RIB-Out, so
+  the stale routes stayed on the peer's wire until a regroup or
+  session bounce, and the residue gauge floored at a nonzero value.
+  Relatedly, a resync whose enumeration came up empty in every family
+  (a full-withdraw moment after a regroup-while-dirty) dropped the
+  carried residue without emitting the withdraws. Pending extra
+  withdraws now feed the resync enumerations (so an empty enumeration
+  proves there is nothing owed), the per-peer resync appends the
+  residue keys as (over-)withdraws — skipping keys announced in the
+  same pass or genuinely advertised in Adj-RIB-Out — and the residue
+  is dropped only after a successful send. A still-dirty member moving
+  to the per-peer path also folds its retained regroup baseline into
+  the seeded Adj-RIB-Out (wire values win), matching the union rule
+  already used for grouped→grouped moves. (LAN-344)
 - **`TestPolicy` no longer panics on a candidate source that probes a
   dataset.** A dry-run source declaring and referencing a `dataset`
   compiles per the language (LAN-305) but has no file bindings inside

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1288,6 +1288,14 @@ impl RibManager {
                         all.extend(rib_out.iter().map(|r| r.prefix));
                     }
                 }
+                // Extra (over-)withdraw residue keys can be in NONE of
+                // the sources above (withdrawn while the peer was
+                // dirty, then carried across a regroup): without them
+                // a resync can enumerate empty — or skip the keys
+                // entirely — and the owed withdraws are never emitted.
+                if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
+                    all.extend(extras.unicast.iter().map(|(prefix, _)| *prefix));
+                }
                 Cow::Owned(all)
             } else if member_of.is_some() {
                 // Grouped peers have no ORR / Add-Path extras (both are
@@ -1406,6 +1414,10 @@ impl RibManager {
                         all.extend(rib_out.iter_vpn().map(|route| route.nlri.key()));
                     }
                 }
+                // Same residue rule as the unicast enumeration above.
+                if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
+                    all.extend(extras.vpn.iter().copied());
+                }
                 all
             } else {
                 HashSet::new()
@@ -1462,11 +1474,12 @@ impl RibManager {
                 // RefreshPeerOutbound for a different reason) would
                 // accidentally inherit the bypass-equality-suppression
                 // semantics. Same shape for `dirty_peers` for symmetry.
+                // The residue drop is safe here: pending extra
+                // withdraws feed the enumerations above, so an empty
+                // enumeration proves there is no residue to emit.
                 if is_dirty {
                     self.dirty_peers.remove(&peer);
-                    if member_of.is_some() {
-                        self.clear_grouped_member_synced(peer);
-                    }
+                    self.clear_grouped_member_synced(peer);
                 }
                 if is_force {
                     self.force_outbound_peers.remove(&peer);
@@ -1953,6 +1966,57 @@ impl RibManager {
                 );
             }
 
+            // A dirty peer on the per-peer path may carry extra
+            // (over-)withdraw residue: group tombstones that rode a
+            // grouped→per-peer move while the peer was dirty. Those
+            // keys are in neither the Loc-RIB nor the Adj-RIB-Out
+            // seeded from the regroup baseline, so the equality diff
+            // above cannot emit them — append them here (the per-peer
+            // twin of the grouped resync assembly's extras term). A key
+            // staged for announce this pass or still present in
+            // Adj-RIB-Out (genuinely advertised — commit-after-send)
+            // is not stale and must not be withdrawn; one already
+            // staged for withdraw needs no duplicate. The residue is
+            // dropped only after a successful send (the unconditional
+            // `clear_grouped_member_synced` below).
+            if is_dirty
+                && member_of.is_none()
+                && let Some(extras) = self.pending_extra_withdraws.get(&peer)
+            {
+                let announced: HashSet<(Prefix, u32)> =
+                    announce.iter().map(|r| (r.prefix, r.path_id)).collect();
+                let staged: HashSet<(Prefix, u32)> = withdraw.iter().copied().collect();
+                withdraw.extend(extras.unicast.iter().copied().filter(|key| {
+                    !announced.contains(key)
+                        && !staged.contains(key)
+                        && rib_out.get(&key.0, key.1).is_none()
+                }));
+                let vpn_announced: HashSet<rustbgpd_wire::VpnRouteKey> =
+                    vpn_announce.iter().map(|r| r.nlri.key()).collect();
+                let vpn_staged: HashSet<rustbgpd_wire::VpnRouteKey> =
+                    vpn_withdraw.iter().map(|key| key.nlri_key).collect();
+                vpn_withdraw.extend(
+                    extras
+                        .vpn
+                        .iter()
+                        .copied()
+                        .filter(|key| {
+                            !vpn_announced.contains(key)
+                                && !vpn_staged.contains(key)
+                                && rib_out
+                                    .get_vpn(&crate::route::VpnRibRouteKey {
+                                        nlri_key: *key,
+                                        path_id: 0,
+                                    })
+                                    .is_none()
+                        })
+                        .map(|nlri_key| crate::route::VpnRibRouteKey {
+                            nlri_key,
+                            path_id: 0,
+                        }),
+                );
+            }
+
             // The outbound payload: the group-shared Arc for a covered
             // member, otherwise this peer's own staged vectors. A shared
             // member never stages per-peer unicast (grouped + in-sync),
@@ -2034,9 +2098,7 @@ impl RibManager {
                         );
                         if is_dirty {
                             self.dirty_peers.remove(&peer);
-                            if member_of.is_some() {
-                                self.clear_grouped_member_synced(peer);
-                            }
+                            self.clear_grouped_member_synced(peer);
                             if pending_eor.is_empty() {
                                 self.flush_pending_eor(peer);
                             } else {
@@ -2092,9 +2154,7 @@ impl RibManager {
                     debug!(%peer, "outbound routes unchanged after resync");
                     if is_dirty {
                         self.dirty_peers.remove(&peer);
-                        if member_of.is_some() {
-                            self.clear_grouped_member_synced(peer);
-                        }
+                        self.clear_grouped_member_synced(peer);
                         self.flush_pending_eor(peer);
                         self.retry_pending_refresh(peer);
                     }

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -597,6 +597,129 @@ async fn residue_gauge_tracks_tombstones_and_clears_on_resync() {
     handle.await.unwrap();
 }
 
+/// The withdrawal-residue gauge across a grouped→per-peer move while
+/// dirty: the carried extra withdraws keep the gauge nonzero until the
+/// per-peer resync EMITS them; a successful resync must then drain the
+/// residue (gauge back to zero) — it must not floor at nonzero because
+/// the per-peer path never consumes the carried extras.
+#[tokio::test]
+async fn residue_gauge_clears_after_dirty_leaver_moves_to_per_peer_path() {
+    tokio::time::pause();
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let handle = tokio::spawn(manager.run());
+
+    let residue = || gauge_metric_value(&metrics, "bgp_update_group_residue_entries", &[]);
+    let quiesce = async || {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RibUpdate::QueryBestRoutes { reply: reply_tx })
+            .await
+            .unwrap();
+        let _ = reply_rx.await.unwrap();
+    };
+    let send_routes = async |announced: Vec<crate::route::Route>, withdrawn: Vec<(Prefix, u32)>| {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(Ipv4Addr::new(10, 0, 5, 9)),
+            announced,
+            withdrawn,
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    };
+
+    // Grouped member with a capacity-1 outbound channel so a second
+    // update jams it.
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 5, 1));
+    let (out_tx, mut out_rx) = mpsc::channel(1);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    assert_eq!(query_update_group(&tx, peer).await, "group:0");
+
+    let p1 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let p2 = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 101, 0), 24);
+    let mk = |p: Ipv4Prefix| crate::test_support::make_route(p, Ipv4Addr::new(10, 0, 5, 9));
+
+    // p1 fills the channel; p2's emission fails → member goes dirty;
+    // p1 withdrawn WHILE dirty → tombstone.
+    send_routes(vec![mk(p1)], vec![]).await;
+    send_routes(vec![mk(p2)], vec![]).await;
+    send_routes(vec![], vec![(Prefix::V4(p1), 0)]).await;
+    quiesce().await;
+    assert_metric(
+        residue(),
+        1.0,
+        "tombstone recorded while a member is dirty must show in the residue gauge",
+    );
+
+    // The member's chain becomes peer-context-dependent: it moves to
+    // the per-peer path while dirty, carrying the tombstone as an
+    // extra withdraw — still residue.
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer,
+        export_policy: Some(peer_context_chain()),
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    assert_eq!(reply_rx.await.unwrap(), Ok(()));
+    assert_eq!(query_update_group(&tx, peer).await, "policy_peer_context");
+    assert_metric(
+        residue(),
+        1.0,
+        "the extra withdraw carried across the move must stay in the residue gauge",
+    );
+
+    // Free the channel and let the resync timer drain the residue.
+    let jammed = out_rx.recv().await.unwrap();
+    assert_eq!(jammed.announce.len(), 1, "p1 was delivered before the jam");
+    tokio::time::advance(std::time::Duration::from_secs(2)).await;
+    quiesce().await;
+    let resync = out_rx
+        .try_recv()
+        .expect("the per-peer resync must emit the residue withdraw");
+    assert!(
+        resync
+            .withdraw
+            .iter()
+            .any(|(prefix, _)| *prefix == Prefix::V4(p1)),
+        "the per-peer resync must (over-)withdraw the carried tombstoned prefix"
+    );
+    quiesce().await;
+    assert_metric(
+        residue(),
+        0.0,
+        "a completed per-peer resync must drain the carried residue",
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// LAN-311 item 3 (the term-hit freeze): a content-equal chain
 /// reinstall must keep the INSTALLED chain instance, not just the
 /// group key. The group's staging handle shares the installed

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -17,7 +17,8 @@
 use std::collections::BTreeMap;
 
 use rustbgpd_policy::{
-    NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+    NeighborSetMatch, NextHopAction, Policy, PolicyAction, PolicyChain, PolicyStatement,
+    RouteModifications,
 };
 use rustbgpd_wire::RtcNlri;
 
@@ -1199,6 +1200,171 @@ async fn oracle_second_regroup_while_dirty_unions_baseline_no_leak() {
         fold(&grouped),
         fold(&ungrouped),
         "grouped final advertised state must converge with the per-peer oracle"
+    );
+}
+
+/// A permit-everything chain carrying a peer-context guard: the
+/// neighbor-set deny matches an ASN no test peer uses, so verdicts are
+/// unchanged, but `requires_peer_context` moves the peer off the
+/// grouped path — the grouped→per-peer membership transition.
+fn peer_context_permit_chain() -> PolicyChain {
+    PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: PolicyAction::Deny,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: Some(NeighborSetMatch {
+                addresses: vec![],
+                remote_asns: vec![65099],
+                peer_groups: vec![],
+            }),
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications::default(),
+        }],
+        default_action: PolicyAction::Permit,
+    }])
+}
+
+/// A grouped member that goes dirty, misses a withdraw (recorded as a
+/// group tombstone), and then moves to the per-peer path (its chain
+/// becomes peer-context-dependent) carries the tombstone as extra
+/// (over-)withdraw residue. The withdrawn key is in neither the
+/// Loc-RIB nor the Adj-RIB-Out seeded from the regroup baseline, so
+/// the residue is the ONLY record of the stale route — the per-peer
+/// resync must emit its withdraw, or the route strands on the wire
+/// until the session bounces.
+#[tokio::test]
+async fn oracle_dirty_leaver_extras_withdraw_on_per_peer_path() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        // C gets a capacity-1 channel so a jammed send fails try_reserve.
+        o.peer_up(C, false, true, None, 1).await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Sync C to wire {p1, p2}: each lands and is drained, so the
+        // channel empties between sends and C never goes dirty here.
+        for n in 1..=2u8 {
+            o.routes(A, vec![ibgp_route(pfx(n, 0), A, 100, vec![])], vec![])
+                .await;
+            o.drain_one(C).await;
+        }
+        // Jam: p3 lands in the cap-1 channel and is NOT drained.
+        o.routes(A, vec![ibgp_route(pfx(3, 0), A, 100, vec![])], vec![])
+            .await;
+        // p1 withdrawn: C's emission fails against the full channel →
+        // dirty, with the withdrawal recorded as a group tombstone.
+        o.routes(A, vec![], vec![pfx(1, 0)]).await;
+        // C's chain becomes peer-context-dependent (verdicts
+        // unchanged): a grouped→per-peer move while dirty — the
+        // tombstone rides C's extra-withdraw residue across it.
+        o.replace_policy(C, Some(peer_context_permit_chain())).await;
+
+        // Free the channel and let the resync timer fire.
+        o.drain_one(C).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)),
+        "the withdraw missed while dirty must reach the wire after the move to the per-peer path"
+    );
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
+        "p2 (still best) must stay advertised"
+    );
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(3, 0)), 0)),
+        "p3 (still best) must stay advertised"
+    );
+}
+
+/// Regroup-while-dirty where the tombstoned keys survive ONLY in the
+/// carried extra-withdraw residue and every family's resync
+/// enumeration is empty: the Loc-RIB emptied while the member was
+/// dirty, the destination group's table is therefore empty, and the
+/// regroup baseline snapshot is empty. The resync must still emit the
+/// residue withdraws instead of dropping them on the empty-enumeration
+/// early exit.
+#[tokio::test]
+async fn oracle_regroup_while_dirty_empty_enumeration_emits_residue_withdraws() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        // C gets a capacity-1 channel so a jammed send fails try_reserve.
+        o.peer_up(C, false, true, None, 1).await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Sync C to wire {p1}.
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        o.drain_one(C).await;
+        // Jam: p2 lands in the cap-1 channel and is NOT drained.
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+        // p1 withdrawn: C's emission fails → dirty; tombstone {p1}.
+        o.routes(A, vec![], vec![pfx(1, 0)]).await;
+        // p2 withdrawn too: the Loc-RIB and the group table are now
+        // both empty; tombstones {p1, p2}. C's resync attempt fails
+        // against the still-full channel.
+        o.routes(A, vec![], vec![pfx(2, 0)]).await;
+        // Regroup while dirty: the baseline snapshot and the new
+        // group's table are both empty — the tombstones survive only
+        // as C's carried extra-withdraw residue.
+        o.replace_policy(C, Some(deny_prefix_chain(pfx(9, 0))))
+            .await;
+
+        // Free the channel and let the resync timer fire.
+        o.drain_one(C).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)),
+        "the residue withdraw of p1 must be emitted, not dropped on the empty-enumeration exit"
+    );
+    assert!(
+        !c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
+        "the residue withdraw of p2 must be emitted, not dropped on the empty-enumeration exit"
     );
 }
 

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -947,9 +947,13 @@ impl RibManager {
             .set_update_group_residue_entries(i64::try_from(residue).unwrap_or(i64::MAX));
     }
 
-    /// A grouped member's resync succeeded (or had nothing to send):
+    /// A member's resync succeeded (or provably had nothing to send):
     /// drop its regroup residue and its group dirty flag; the last
-    /// dirty member syncing clears the tombstones.
+    /// dirty member syncing clears the tombstones. Also the drain
+    /// point for a peer on the per-peer path whose residue rode a
+    /// grouped→ungrouped move — the group half is a no-op for it.
+    /// Callers must have emitted the pending extra withdraws (or shown
+    /// them empty/retained) before calling: this drops them.
     pub(in crate::manager) fn clear_grouped_member_synced(&mut self, peer: IpAddr) {
         self.pending_regroup_baseline.remove(&peer);
         self.pending_extra_withdraws.remove(&peer);
@@ -1730,6 +1734,10 @@ impl RibManager {
     /// (per-peer gRPC edits, ADR-0076 live-impact txns, SIGHUP rpol
     /// overlays). A key-stable recompute (content-equal chain
     /// reinstall) is a strict no-op.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the membership lifecycle keeps every residue-carry rule at one seam"
+    )]
     pub(super) fn recompute_update_group(&mut self, peer: IpAddr) {
         let membership = self.compute_update_group_membership(peer);
         let previous = self.update_groups.members.get(&peer).cloned();
@@ -1849,10 +1857,22 @@ impl RibManager {
                     }
                     self.pending_regroup_baseline.insert(peer, base);
                 }
-                (Some(base), None) => {
+                (Some(mut base), None) => {
                     // Back on the per-peer path: seed Adj-RIB-Out with
                     // the old advertised view so the dirty resync diffs
                     // against it instead of re-flooding the table.
+                    // Same union rule as the grouped arm above: a
+                    // still-dirty leaver's retained baseline is the
+                    // only record of its true wire state — fold it
+                    // into the seed (wire values win on conflict) and
+                    // consume the entry, or its keys could never be
+                    // withdrawn from the per-peer path.
+                    if self.dirty_peers.contains(&peer)
+                        && let Some(prev) = self.pending_regroup_baseline.remove(&peer)
+                    {
+                        base.unicast.extend(prev.unicast);
+                        base.vpn.extend(prev.vpn);
+                    }
                     let loc_rib_len = self.loc_rib.len();
                     let rib_out = self
                         .adj_ribs_out


### PR DESCRIPTION
A grouped member that went dirty, missed withdrawals (group
tombstones), and then moved off the grouped path carried those
tombstones as pending extra withdraws that only the grouped resync
arm consumed: the per-peer resync enumerated Loc-RIB and Adj-RIB-Out
only, neither of which can contain a key withdrawn while the member
was dirty, so the stale route stayed on the peer's wire until a
regroup or session bounce and the residue gauge floored at nonzero
(the residue was also never dropped, since the drain point was gated
on current group membership). Separately, a resync whose enumeration
came up empty in every family — the full-withdraw moment after a
regroup-while-dirty, where the tombstoned keys survive only in the
carried residue — took the empty-enumeration early exit, which
dropped the residue without emitting the withdraws.

Fix:

- Pending extra withdraws now feed the resync enumerations (unicast
  and VPN, grouped and per-peer destinations alike), so an empty
  enumeration proves there is no residue owed and the early exit's
  drop is safe.
- The per-peer resync appends the residue keys as (over-)withdraws,
  mirroring the grouped resync assembly's extras term: keys announced
  in the same pass, already staged for withdraw, or still genuinely
  advertised in Adj-RIB-Out (commit-after-send) are skipped.
- The residue drain on resync success is now unconditional instead of
  grouped-only, and still happens only after the withdraws were sent
  (or proven empty/retained).
- A still-dirty member moving to the per-peer path folds its retained
  regroup baseline into the seeded Adj-RIB-Out (wire values win on
  conflict), the same union rule the grouped destination already
  applied, so wire keys recorded only there stay withdrawable.

New differential-oracle scenarios cover both shapes (dirty leaver to
the per-peer path; regroup-while-dirty with an all-families-empty
enumeration), and a residue-gauge test pins the gauge returning to
zero once the carried residue drains. (LAN-344)

Closes LAN-344.