### PR TITLE
fix(rib): heal announces missed while dirty across a regroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -687,6 +687,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to the per-peer path also folds its retained regroup baseline into
   the seeded Adj-RIB-Out (wire values win), matching the union rule
   already used for grouped→grouped moves. (LAN-344)
+- **Announces missed while dirty are no longer equality-suppressed
+  against the regroup baseline.** A grouped member's regroup baseline
+  is a snapshot of the group table — intended state, not wire state:
+  the table advances before the send that then fails, so a member that
+  went dirty and then regrouped had its missed announces already in
+  the baseline, the one-shot resync diff suppressed them as
+  "unchanged", and the peer was left permanently missing the routes
+  (an under-advertise invisible to the residue gauge). The same
+  suppression hit the per-peer destination through the Adj-RIB-Out
+  seeded from that baseline on a grouped→ungrouped move. A member that
+  is dirty when it regroups now takes the suppression-free dirty
+  resync (full-table over-announce — announces are idempotent, the
+  same safe direction as the existing plain-dirty arm) with the
+  baseline keys riding its extra-(over-)withdraw residue, so the
+  baseline's withdraw duty — including the retained-baseline union
+  across a second regroup — is preserved exactly and nothing is
+  suppressed against unconfirmed state. Clean members' regroup diffs
+  are untouched and still suppress redundant announces. (LAN-346)
 - **`TestPolicy` no longer panics on a candidate source that probes a
   dataset.** A dry-run source declaring and referencing a `dataset`
   compiles per the language (LAN-305) but has no file bindings inside

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -688,10 +688,14 @@ async fn residue_gauge_clears_after_dirty_leaver_moves_to_per_peer_path() {
     .unwrap();
     assert_eq!(reply_rx.await.unwrap(), Ok(()));
     assert_eq!(query_update_group(&tx, peer).await, "policy_peer_context");
+    // Two entries: the carried tombstone (p1) plus the dirty leaver's
+    // baseline key (p2) — a dirty mover's baseline rides the residue as
+    // (over-)withdraw candidates instead of seeding the Adj-RIB-Out
+    // (its snapshot is intended state, not wire state — LAN-346).
     assert_metric(
         residue(),
-        1.0,
-        "the extra withdraw carried across the move must stay in the residue gauge",
+        2.0,
+        "the extra withdraws carried across the move must stay in the residue gauge",
     );
 
     // Free the channel and let the resync timer drain the residue.

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -1203,6 +1203,165 @@ async fn oracle_second_regroup_while_dirty_unions_baseline_no_leak() {
     );
 }
 
+/// Under-advertise heal (LAN-346), grouped→grouped: a member misses an
+/// ANNOUNCE while dirty (the group table gains p3 but the send fails),
+/// then regroups. The regroup baseline is a snapshot of the group table
+/// — INTENDED state, which already contains p3 — so an equality diff
+/// against it suppresses the p3 announce the member never received and
+/// the route goes permanently missing. The successful resync after the
+/// regroup must put p3 on the member's wire.
+#[tokio::test]
+async fn oracle_announce_missed_while_dirty_heals_across_regroup() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        // C gets a capacity-1 channel so a jammed send fails try_reserve.
+        o.peer_up(C, false, true, None, 1).await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Sync C to wire {p1}.
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        o.drain_one(C).await;
+        // Jam: p2 lands in the cap-1 channel and is NOT drained.
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+        // p3 announce fails for C → dirty; the group table holds p3 but
+        // C's wire never saw it. The regroup baseline snapshot below
+        // will contain p3 anyway (intended state, not wire state).
+        o.routes(A, vec![ibgp_route(pfx(3, 0), A, 100, vec![])], vec![])
+            .await;
+        // Regroup C while dirty (grouped→grouped).
+        o.replace_policy(C, Some(deny_prefix_chain(pfx(9, 0))))
+            .await;
+
+        // Free the channel and let the resync timer fire.
+        o.drain_one(C).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(3, 0)), 0)),
+        "the announce missed while dirty must not be equality-suppressed \
+         against the regroup baseline — p3 must reach the wire"
+    );
+}
+
+/// Under-advertise heal (LAN-346), grouped→ungrouped: same missed
+/// announce, but the dirty member's membership flips to the per-peer
+/// path. The baseline seeded into the Adj-RIB-Out contains the never-
+/// sent p3, so the per-peer equality diff suppresses it the same way.
+/// The per-peer resync must put p3 on the wire.
+#[tokio::test]
+async fn oracle_announce_missed_while_dirty_heals_across_move_to_per_peer_path() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        // C gets a capacity-1 channel so a jammed send fails try_reserve.
+        o.peer_up(C, false, true, None, 1).await;
+        // Drain the initial-dump EoR so the channel starts empty.
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // Sync C to wire {p1}.
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        o.drain_one(C).await;
+        // Jam: p2 lands in the cap-1 channel and is NOT drained.
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+        // p3 announce fails for C → dirty; C's wire never saw p3.
+        o.routes(A, vec![ibgp_route(pfx(3, 0), A, 100, vec![])], vec![])
+            .await;
+        // C's chain becomes peer-context-dependent (verdicts unchanged):
+        // a grouped→per-peer move while dirty.
+        o.replace_policy(C, Some(peer_context_permit_chain())).await;
+
+        // Free the channel and let the resync timer fire.
+        o.drain_one(C).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(3, 0)), 0)),
+        "the announce missed while dirty must not be equality-suppressed \
+         against the seeded Adj-RIB-Out — p3 must reach the wire"
+    );
+    assert!(
+        c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0))
+            && c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
+        "routes already delivered must stay advertised"
+    );
+}
+
+/// Suppression pin: a CLEAN member's regroup one-shot diff must keep
+/// equality-suppressing unchanged routes — the dirty-member announce
+/// heal must not regress the clean path into a full-table re-announce.
+#[tokio::test]
+async fn oracle_clean_member_regroup_suppresses_unchanged_announces() {
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        o.peer_up(C, false, true, None, 64).await;
+
+        // C in sync on wire {p1, p2} — never dirty (ample capacity).
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 100, vec![])], vec![])
+            .await;
+
+        // Clean regroup: the one-shot diff must assemble empty.
+        o.replace_policy(C, Some(deny_prefix_chain(pfx(9, 0))))
+            .await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "final advertised state must converge on both paths"
+    );
+    let c_msgs = &grouped[&IpAddr::V4(C)];
+    for prefix in [pfx(1, 0), pfx(2, 0)] {
+        let announces = c_msgs
+            .iter()
+            .flat_map(|msg| &msg.announce)
+            .filter(|(p, _, _, _, _, _)| *p == Prefix::V4(prefix))
+            .count();
+        assert_eq!(
+            announces, 1,
+            "clean member must not re-announce unchanged {prefix} across a regroup"
+        );
+    }
+    assert!(
+        c_msgs.iter().all(|msg| msg.withdraw.is_empty()),
+        "clean regroup with no verdict change must not withdraw anything"
+    );
+}
+
 /// A permit-everything chain carrying a peer-context guard: the
 /// neighbor-set deny matches an ASN no test peer uses, so verdicts are
 /// unchanged, but `requires_peer_context` moves the peer off the

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -1836,6 +1836,31 @@ impl RibManager {
                 self.join_group(gid, peer);
             }
             match (baseline, new_gid) {
+                // A member leaving a group DIRTY has a baseline that is
+                // INTENDED state, not wire state: the group table
+                // advances before the send that then fails, so the
+                // snapshot can hold announces the member never received.
+                // Using it for equality suppression would silently drop
+                // those announces from the resync — an under-advertise
+                // that nothing later heals (LAN-346). Keep only the
+                // baseline's withdraw duty: ride its keys (plus any
+                // retained baseline from an earlier unfinished regroup)
+                // as extra (over-)withdraw residue — the resync's
+                // retention guards filter them exactly — and let the
+                // dirty resync take the suppression-free arm
+                // (over-announce, the plain-dirty safe direction;
+                // announces are idempotent). Applies to both grouped and
+                // per-peer destinations: neither gets a baseline /
+                // seeded Adj-RIB-Out to suppress against.
+                (Some(base), _) if prev_gid.is_some() && self.dirty_peers.contains(&peer) => {
+                    let extras = self.pending_extra_withdraws.entry(peer).or_default();
+                    if let Some(prev) = self.pending_regroup_baseline.remove(&peer) {
+                        extras.unicast.extend(prev.unicast.into_keys());
+                        extras.vpn.extend(prev.vpn.into_keys());
+                    }
+                    extras.unicast.extend(base.unicast.into_keys());
+                    extras.vpn.extend(base.vpn.into_keys());
+                }
                 (Some(mut base), Some(_)) => {
                     // A grouped member keeps no per-family record of its
                     // unicast/VPN wire state in `adj_ribs_out` (join clears


### PR DESCRIPTION
A dirty update-group member's regroup baseline is a snapshot of the
group table -- intended state, not wire state: the table advances
before the send that then fails. The one-shot resync diff
equality-suppressed announces the member never received against that
baseline, leaving the peer permanently missing the routes; the
grouped->ungrouped move had the same defect through the Adj-RIB-Out
seeded from the baseline. Invisible to the residue gauge.

A member that is dirty when it regroups now takes the suppression-free
dirty resync (full-table over-announce, the plain-dirty safe
direction) with the baseline keys riding its extra-(over-)withdraw
residue, so the baseline's withdraw duty -- including the
retained-baseline union across a second regroup -- is preserved by the
resyncs' existing retention guards. Clean members' regroup diffs are
untouched and still suppress redundant announces exactly.

Closes LAN-346

Closes LAN-346.