### PR TITLE
fix(api): populate GR stale flags on unicast route conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Unicast routes now carry their graceful-restart stale flags
+  through the API.** The unicast RIB conversion was the only family
+  that dropped `is_stale`/`is_llgr_stale` when building the gRPC
+  `Route` (VPN, labeled, RTC, and BGP-LS entries have always carried
+  them), so `rbgp rib received` showed GR-preserved routes as normal
+  during a restart window. The proto `Route` message gains
+  `stale`/`llgr_stale` fields, the JSON output emits them when set
+  (matching the other families), and the human route table marks
+  flagged rows with a red `S` (stale, RFC 4724) or `L` (LLGR stale,
+  RFC 9494) next to the best marker — the column only appears when a
+  flagged route is present, so the everyday table is unchanged.
+  (LAN-347)
 - **Update-group withdraw residue now drains on the per-peer resync
   path.** A grouped member that went dirty, missed withdrawals (group
   tombstones), and then moved off the grouped path (e.g. its export

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1047,6 +1047,11 @@ fn route_to_proto(route: &Route, best: bool) -> proto::Route {
         path_id: route.path_id,
         validation_state: route.validation_state.to_string(),
         aspa_state: route.aspa_state.to_string(),
+        // GR stale flags, same population as the VPN/labeled/RTC/BGP-LS
+        // route entries (LAN-347: unicast was the only family that
+        // dropped them on conversion).
+        stale: route.is_stale,
+        llgr_stale: route.is_llgr_stale,
         // Distinguishes "explicit LOCAL_PREF attribute" from "no
         // attribute" — required for the M35 interop test to assert
         // that the RFC 8326 implicit demotion actually fired on a
@@ -2565,6 +2570,48 @@ mod tests {
         assert!(entry.stale);
         assert!(!entry.llgr_stale);
         assert_eq!(entry.path_id, 0);
+    }
+
+    /// LAN-347: the unicast conversion dropped the GR stale flags, so
+    /// `rbgp rib received` showed stale routes as normal during a
+    /// graceful-restart window.
+    #[test]
+    fn route_to_proto_populates_gr_stale_flags() {
+        let mut route = Route {
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24)),
+            next_hop: "192.0.2.1".parse().unwrap(),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: "192.0.2.2".parse().unwrap(),
+            attributes: Arc::new(vec![]),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: true,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        };
+
+        let entry = route_to_proto(&route, true);
+        assert_eq!(entry.prefix, "10.0.0.0");
+        assert_eq!(entry.prefix_length, 24);
+        assert!(entry.best);
+        assert!(entry.stale);
+        assert!(!entry.llgr_stale);
+
+        route.is_llgr_stale = true;
+        let entry = route_to_proto(&route, false);
+        assert!(entry.stale);
+        assert!(entry.llgr_stale);
+
+        route.is_stale = false;
+        route.is_llgr_stale = false;
+        let entry = route_to_proto(&route, false);
+        assert!(!entry.stale);
+        assert!(!entry.llgr_stale);
     }
 
     #[test]

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -701,6 +701,12 @@ impl Serialize for JsonRouteRef<'_> {
         if !route.validation_state.is_empty() {
             len += 1;
         }
+        if route.stale {
+            len += 1;
+        }
+        if route.llgr_stale {
+            len += 1;
+        }
 
         let mut map = serializer.serialize_map(Some(len))?;
         map.serialize_entry("prefix", &JsonRoutePrefix(route))?;
@@ -722,6 +728,12 @@ impl Serialize for JsonRouteRef<'_> {
         }
         if !route.validation_state.is_empty() {
             map.serialize_entry("validation_state", &route.validation_state)?;
+        }
+        if route.stale {
+            map.serialize_entry("stale", &route.stale)?;
+        }
+        if route.llgr_stale {
+            map.serialize_entry("llgr_stale", &route.llgr_stale)?;
         }
         map.end()
     }
@@ -2489,6 +2501,26 @@ mod tests {
             serde_json::to_value(JsonRoutes(&[with_med, zero_med])).unwrap();
         assert_eq!(value[0]["med"], 50);
         assert_eq!(value[1]["med"], 0);
+    }
+
+    /// GR stale flags serialize only when set, matching the VPN /
+    /// labeled / RTC / BGP-LS route JSON convention (LAN-347).
+    #[test]
+    fn route_list_json_emits_stale_flags_only_when_set() {
+        let fresh = route_for_json(0, "");
+        let mut stale = route_for_json(0, "");
+        stale.stale = true;
+        let mut llgr = route_for_json(0, "");
+        llgr.stale = true;
+        llgr.llgr_stale = true;
+        let value: serde_json::Value =
+            serde_json::to_value(JsonRoutes(&[fresh, stale, llgr])).unwrap();
+        assert!(value[0].get("stale").is_none());
+        assert!(value[0].get("llgr_stale").is_none());
+        assert_eq!(value[1]["stale"], true);
+        assert!(value[1].get("llgr_stale").is_none());
+        assert_eq!(value[2]["stale"], true);
+        assert_eq!(value[2]["llgr_stale"], true);
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -612,6 +612,12 @@ fn format_med(med: u32, med_attr: Option<u32>, med_attr_supported: bool) -> Stri
 
 /// Print route table with dynamic column widths and colored best marker.
 pub fn print_route_table(routes: &[proto::Route]) {
+    print!("{}", render_route_table(routes));
+}
+
+fn render_route_table(routes: &[proto::Route]) -> String {
+    use std::fmt::Write as _;
+
     struct Row {
         marker_colored: String,
         marker_plain_len: usize,
@@ -624,6 +630,10 @@ pub fn print_route_table(routes: &[proto::Route]) {
         path_id: String,
     }
 
+    // GR stale flag column ("S" = stale per RFC 4724, "L" = LLGR stale
+    // per RFC 9494), prepended to the best marker only when some route
+    // carries a flag so the everyday table is unchanged.
+    let any_stale = routes.iter().any(|r| r.stale || r.llgr_stale);
     // A daemon that populates `med_attr` anywhere in the response is
     // MED-absence-aware: render an absent MED as "-". Older daemons
     // never set it, so fall back to the bare (0-defaulted) `med` field.
@@ -636,9 +646,30 @@ pub fn print_route_table(routes: &[proto::Route]) {
             } else {
                 String::new()
             };
+            let mut marker_colored = String::new();
+            let mut marker_plain_len = 2;
+            if any_stale {
+                marker_plain_len = 3;
+                if r.llgr_stale {
+                    let _ = write!(
+                        marker_colored,
+                        "{}",
+                        "L".if_supports_color(Stdout, |s| s.red())
+                    );
+                } else if r.stale {
+                    let _ = write!(
+                        marker_colored,
+                        "{}",
+                        "S".if_supports_color(Stdout, |s| s.red())
+                    );
+                } else {
+                    marker_colored.push(' ');
+                }
+            }
+            marker_colored.push_str(&colored_best_marker(r.best));
             Row {
-                marker_colored: colored_best_marker(r.best),
-                marker_plain_len: 2,
+                marker_colored,
+                marker_plain_len,
                 prefix: format!("{}/{}", r.prefix, r.prefix_length),
                 next_hop: r.next_hop.clone(),
                 as_path: format_as_path(&r.as_path),
@@ -677,15 +708,19 @@ pub fn print_route_table(routes: &[proto::Route]) {
         .unwrap_or(0)
         .max(6);
 
-    println!(
-        "   {:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} PathID",
+    let mut out = String::new();
+    let header_pad = if any_stale { "    " } else { "   " };
+    let _ = writeln!(
+        out,
+        "{header_pad}{:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} PathID",
         "Prefix", "Next Hop", "AS Path", "LP", "MED", "Origin",
     );
 
     for row in &rows {
         let overhead = ansi_overhead(&row.marker_colored, row.marker_plain_len);
-        let marker_width = 2 + overhead;
-        println!(
+        let marker_width = row.marker_plain_len + overhead;
+        let _ = writeln!(
+            out,
             "{:<marker_width$} {:<w_pfx$} {:<w_nh$} {:<w_asp$} {:>w_lp$} {:>w_med$}  {:<w_orig$} {}",
             row.marker_colored,
             row.prefix,
@@ -697,6 +732,7 @@ pub fn print_route_table(routes: &[proto::Route]) {
             row.path_id,
         );
     }
+    out
 }
 
 /// Print a mutating command result, either as JSON or plain text.
@@ -1076,5 +1112,63 @@ Neighbor    AS    State       Uptime   Rx Pfx Tx Pfx Description    MsgRcvd MsgS
         let first_row = rendered.lines().nth(1).expect("row rendered");
         assert!(first_row.ends_with("Stale"), "got: {first_row:?}");
         assert!(!first_row.ends_with("100"));
+    }
+
+    fn route_fixture(stale: bool, llgr_stale: bool) -> proto::Route {
+        proto::Route {
+            prefix: "10.0.0.0".to_string(),
+            prefix_length: 24,
+            next_hop: "192.0.2.1".to_string(),
+            as_path: vec![65001],
+            local_pref: 100,
+            best: true,
+            stale,
+            llgr_stale,
+            ..Default::default()
+        }
+    }
+
+    /// Without any GR-stale route the table keeps its classic 2-char
+    /// marker column — unchanged from the pre-LAN-347 layout.
+    #[test]
+    fn route_table_no_stale_layout_unchanged() {
+        owo_colors::set_override(false);
+        let rendered = render_route_table(&[route_fixture(false, false)]);
+        let mut lines = rendered.lines();
+        assert!(lines.next().unwrap().starts_with("   Prefix"));
+        assert!(lines.next().unwrap().starts_with("*> 10.0.0.0/24"));
+    }
+
+    /// A GR-stale route widens the marker column with an "S" (stale,
+    /// RFC 4724) or "L" (LLGR stale, RFC 9494) flag; unflagged rows
+    /// stay aligned (LAN-347).
+    #[test]
+    fn route_table_marks_stale_routes() {
+        owo_colors::set_override(false);
+        let mut llgr = route_fixture(true, true);
+        llgr.best = false;
+        let routes = [
+            route_fixture(false, false),
+            route_fixture(true, false),
+            llgr,
+        ];
+        let rendered = render_route_table(&routes);
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert!(lines[0].starts_with("    Prefix"), "got: {:?}", lines[0]);
+        assert!(
+            lines[1].starts_with(" *> 10.0.0.0/24"),
+            "got: {:?}",
+            lines[1]
+        );
+        assert!(
+            lines[2].starts_with("S*> 10.0.0.0/24"),
+            "got: {:?}",
+            lines[2]
+        );
+        assert!(
+            lines[3].starts_with("L   10.0.0.0/24"),
+            "got: {:?}",
+            lines[3]
+        );
     }
 }

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1750,6 +1750,13 @@ message Route {
   // distinction `med = 0` could mean either "MED zero" or "no
   // attribute". Mirrors `local_pref_attr`.
   optional uint32 med_attr = 18;
+  // True while this route is retained as stale during a peer graceful
+  // restart (RFC 4724). Mirrors the per-family route entries
+  // (VpnRouteEntry etc.), which have always carried these flags.
+  bool stale = 19;
+  // True while this route is in the RFC 9494 long-lived graceful
+  // restart stale phase.
+  bool llgr_stale = 20;
 }
 
 message WatchRoutesRequest {


### PR DESCRIPTION
The unicast route_to_proto conversion was the only per-family
conversion that dropped is_stale/is_llgr_stale when building the gRPC
Route message (VPN, labeled, RTC, and BGP-LS entries have always
carried them), so 'rbgp rib received' showed GR-preserved routes as
normal during a graceful-restart window.

- Add stale/llgr_stale fields (19/20) to the proto Route message and
  populate them from the internal route, matching the other families.
- Emit stale/llgr_stale in the unicast route JSON only when set,
  the same convention as the VPN/labeled/RTC/BGP-LS route JSON.
- Mark flagged rows in the human route table with a red S (stale,
  RFC 4724) or L (LLGR stale, RFC 9494) ahead of the best marker;
  the flag column only appears when some route carries a flag, so
  the everyday table layout is unchanged.

Closes LAN-347.