### PR TITLE
perf(rib): intern path attributes globally across peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Global cross-peer path-attribute interning (LAN-336).** The
+  attribute intern table moved from one-per-peer (`AdjRibIn`) to a
+  single daemon-wide table owned by the RIB manager — the analog of
+  BIRD's refcounted `rta` cache. Identical attribute sets from
+  different peers (the common RR/RS reality: reflection preserves
+  `NEXT_HOP`, so dual-fed clients advertise byte-identical attribute
+  vectors) now share one allocation instead of one copy per peer.
+  Measured on the allocator-tracked `memory_profile` harness at
+  2 peers × 100k with per-prefix-unique, cross-peer-identical
+  attributes (`full_rib_diverse`, new shape): live heap
+  310.4 -> 181.1 MiB (-41.7%), intern entries 200k -> 100k. The
+  pre-existing `full_rib` / `rr_fanout` / `adj_rib_in` shapes carry one
+  attribute set per peer by construction (their entire attribute heap
+  is ~1 KiB), so they are byte-neutral — the intern dimension is
+  degenerate there, not measured as a win.
+  Reclaim is unchanged in kind — `Arc` strong-count sweeps at the same
+  batch seams that swept the per-peer tables, plus the peer-teardown
+  seam — and is pinned by a cross-peer churn test (steady-state
+  replace churn holds the table flat; removing one of two sharing
+  peers reclaims nothing; removing the last empties it). New gauge
+  `bgp_rib_attr_intern_global_size` (entries), refreshed at every
+  insert/remove batch seam.
+
 - **M85/M86 core-RR interop labs against BIRD and OpenBGPD.** Two new
   hosted-CI containerlab jobs pair a rustbgpd route reflector with the
   route-server incumbents: **M85** (two BIRD 2.0.12 clients + a
@@ -562,6 +585,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   both corpora now report full term coverage. (LAN-342)
 
 ### Changed
+- **Per-peer `bgp_rib_attr_intern_size{peer}` gauge replaced by
+  `bgp_rib_attr_intern_global_size`** (LAN-336): the per-peer intern
+  tables it measured no longer exist. The GR-restart/hot-reload/
+  inject-churn soak harnesses, the Grafana attribute-intern panel, and
+  OPERATIONS.md now read the global gauge; the soak slope gates are
+  unchanged in meaning (flat under steady-state churn or the gate
+  fails).
 - **CLI consistency sweep (LAN-329).** One noun, one file-arg style, one
   empty-state shape across `rbgp`; every old spelling keeps working as
   an alias, so existing scripts are unaffected.

--- a/crates/rib/benches/rib_ops.rs
+++ b/crates/rib/benches/rib_ops.rs
@@ -7,6 +7,7 @@ use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_ma
 use rustbgpd_policy::{PolicyChain, RouteContext, evaluate_chain};
 use rustbgpd_rib::adj_rib_in::AdjRibIn;
 use rustbgpd_rib::adj_rib_out::AdjRibOut;
+use rustbgpd_rib::attr_intern::AttrInternTable;
 use rustbgpd_rib::best_path::best_path_cmp;
 use rustbgpd_rib::loc_rib::LocRib;
 use rustbgpd_rib::route::{Route, RouteOrigin};
@@ -147,12 +148,19 @@ fn bench_adj_rib_in_insert(c: &mut Criterion) {
         let routes: Vec<Route> = prefixes.iter().map(|p| make_route(*p, 1)).collect();
         group.bench_with_input(BenchmarkId::from_parameter(count), &routes, |b, routes| {
             b.iter_batched(
-                || AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1))),
-                |mut rib| {
+                || {
+                    (
+                        AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1))),
+                        AttrInternTable::new(),
+                    )
+                },
+                |(mut rib, mut intern)| {
                     for route in routes {
-                        rib.insert(route.clone());
+                        let mut route = route.clone();
+                        intern.intern(&mut route.attributes);
+                        rib.insert(route);
                     }
-                    rib
+                    (rib, intern)
                 },
                 BatchSize::LargeInput,
             );
@@ -207,15 +215,20 @@ fn bench_rib_pipeline(c: &mut Criterion) {
                             AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1))),
                             LocRib::new(),
                             AdjRibOut::new(IpAddr::V4(Ipv4Addr::new(10, 0, 3, 1))),
+                            AttrInternTable::new(),
                         )
                     },
-                    |(mut rib1, mut rib2, mut loc, mut out)| {
+                    |(mut rib1, mut rib2, mut loc, mut out, mut intern)| {
                         // Insert into Adj-RIB-In from two peers
                         for route in *p1_routes {
-                            rib1.insert(route.clone());
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib1.insert(route);
                         }
                         for route in *p2_routes {
-                            rib2.insert(route.clone());
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib2.insert(route);
                         }
                         // Recompute best path for each prefix
                         for prefix in *prefixes {
@@ -227,7 +240,7 @@ fn bench_rib_pipeline(c: &mut Criterion) {
                                 out.insert(best.clone());
                             }
                         }
-                        (rib1, rib2, loc, out)
+                        (rib1, rib2, loc, out, intern)
                     },
                     BatchSize::LargeInput,
                 );
@@ -265,11 +278,14 @@ fn bench_bulk_initial_load(c: &mut Criterion) {
                                 IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
                                 routes.len(),
                             ),
+                            AttrInternTable::new(),
                         )
                     },
-                    |(mut rib, mut loc, mut out)| {
+                    |(mut rib, mut loc, mut out, mut intern)| {
                         for route in *routes {
-                            rib.insert(route.clone());
+                            let mut route = route.clone();
+                            intern.intern(&mut route.attributes);
+                            rib.insert(route);
                         }
 
                         for prefix in *prefixes {
@@ -280,7 +296,7 @@ fn bench_bulk_initial_load(c: &mut Criterion) {
                             }
                         }
 
-                        (rib, loc, out)
+                        (rib, loc, out, intern)
                     },
                     BatchSize::LargeInput,
                 );
@@ -310,18 +326,23 @@ fn bench_route_churn(c: &mut Criterion) {
                 let mut rib = AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)));
                 let rib2 = AdjRibIn::new(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)));
                 let mut loc = LocRib::new();
+                let mut intern = AttrInternTable::new();
                 for route in &base_routes {
-                    rib.insert(route.clone());
+                    let mut route = route.clone();
+                    intern.intern(&mut route.attributes);
+                    rib.insert(route);
                 }
                 for prefix in &prefixes {
                     loc.recompute(*prefix, rib.iter_prefix(prefix));
                 }
-                (rib, rib2, loc)
+                (rib, rib2, loc, intern)
             },
-            |(rib, mut rib2, mut loc)| {
+            |(rib, mut rib2, mut loc, mut intern)| {
                 // Announce churn routes from peer 2
                 for route in &churn_routes {
-                    rib2.insert(route.clone());
+                    let mut route = route.clone();
+                    intern.intern(&mut route.attributes);
+                    rib2.insert(route);
                 }
                 for prefix in &prefixes[..churn_count] {
                     let candidates = rib.iter_prefix(prefix).chain(rib2.iter_prefix(prefix));
@@ -334,7 +355,10 @@ fn bench_route_churn(c: &mut Criterion) {
                 for prefix in &prefixes[..churn_count] {
                     loc.recompute(*prefix, rib.iter_prefix(prefix));
                 }
-                (rib, rib2, loc)
+                // Reclaim the withdrawn churn attrs — the manager gc's at
+                // this seam, so the benched pipeline does too.
+                intern.gc();
+                (rib, rib2, loc, intern)
             },
             BatchSize::LargeInput,
         );

--- a/crates/rib/src/adj_rib_in.rs
+++ b/crates/rib/src/adj_rib_in.rs
@@ -40,10 +40,10 @@ use crate::slab::RouteSlab;
 /// A secondary `prefix_index` maps each prefix to its path IDs,
 /// enabling O(candidates) `iter_prefix()` lookups instead of O(N) full scans.
 ///
-/// Path attribute interning: routes from the same peer that share identical
-/// attributes reuse a single `Arc<Vec<PathAttribute>>` allocation.  This is
-/// common in bulk advertisements where every prefix has the same ORIGIN,
-/// `AS_PATH`, `NEXT_HOP`, `LOCAL_PREF`, MED, and communities.
+/// Path attribute interning happens *before* routes reach this table: the
+/// RIB manager deduplicates identical `Arc<Vec<PathAttribute>>` allocations
+/// across ALL peers through its global [`crate::attr_intern::AttrInternTable`]
+/// (LAN-336), so this struct only stores whatever `Arc`s it is handed.
 #[derive(Debug)]
 pub struct AdjRibIn {
     peer: IpAddr,
@@ -100,11 +100,6 @@ pub struct AdjRibIn {
     /// RTC route keys where `LLGR_STALE` was injected locally (see
     /// `evpn_llgr_stale_local_tags`).
     rtc_llgr_stale_local_tags: HashSet<RtcRibRouteKey>,
-    /// Intern table: deduplicates identical attribute sets across routes.
-    /// Lookup by content returns the shared `Arc`.  Entries with
-    /// `strong_count == 1` (only the intern table itself) are garbage-
-    /// collected on `gc_intern_table()`.
-    attr_intern: HashSet<Arc<Vec<rustbgpd_wire::PathAttribute>>>,
 }
 
 impl AdjRibIn {
@@ -138,10 +133,6 @@ impl AdjRibIn {
             vpn_llgr_stale_local_tags: HashSet::default(),
             labeled_llgr_stale_local_tags: HashSet::default(),
             rtc_llgr_stale_local_tags: HashSet::default(),
-            attr_intern: HashSet::with_capacity_and_hasher(
-                route_capacity.clamp(16, 64),
-                FxBuildHasher,
-            ),
         }
     }
 
@@ -153,26 +144,20 @@ impl AdjRibIn {
 
     /// Insert or replace a route. Clears any stale tag on the key.
     ///
-    /// The route's attributes are interned: if an identical attribute set
-    /// already exists from a previous route, the existing `Arc` is reused
-    /// instead of keeping a separate allocation.
+    /// Attribute interning is the caller's job: the RIB manager interns
+    /// `route.attributes` through its global
+    /// [`crate::attr_intern::AttrInternTable`] before insertion.
     ///
     /// Returns `true` if an existing route at the same `(prefix, path_id)` was
     /// replaced. A replacement may strand the previous route's interned
     /// attribute set, so a caller processing a batch should run
-    /// [`Self::gc_intern_table`] once afterwards when any insert returned
-    /// `true` (see the unicast announce path in the RIB manager). A first-time
-    /// insert orphans nothing, so the initial-load flood skips the GC.
-    pub fn insert(&mut self, mut route: Route) -> bool {
+    /// [`crate::attr_intern::AttrInternTable::gc`] once afterwards when any
+    /// insert returned `true` (see the unicast announce path in the RIB
+    /// manager). A first-time insert orphans nothing, so the initial-load
+    /// flood skips the GC.
+    pub fn insert(&mut self, route: Route) -> bool {
         self.llgr_stale_local_tags
             .remove(&(route.prefix, route.path_id));
-
-        // Intern: reuse an existing Arc if one matches
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
 
         let path_id = route.path_id;
         let ids = self.prefix_index.entry_or_default(route.prefix);
@@ -215,10 +200,11 @@ impl AdjRibIn {
     }
 
     /// Remove every route from this Adj-RIB-In — unicast, `FlowSpec`, EVPN,
-    /// BGP-LS, VPN, labeled-unicast, and RTC — plus all secondary indices,
-    /// stale tags, and the attribute intern table. Used when the per-peer
-    /// Adj-RIB-In needs to be wiped without also dropping the [`AdjRibIn`]
-    /// struct itself.
+    /// BGP-LS, VPN, labeled-unicast, and RTC — plus all secondary indices
+    /// and stale tags. Used when the per-peer Adj-RIB-In needs to be wiped
+    /// without also dropping the [`AdjRibIn`] struct itself. The caller must
+    /// follow up with [`crate::attr_intern::AttrInternTable::gc`] to reclaim
+    /// attribute sets the dropped routes were the last users of.
     pub fn clear(&mut self) {
         self.routes.clear();
         self.prefix_index.clear();
@@ -237,7 +223,6 @@ impl AdjRibIn {
         self.vpn_llgr_stale_local_tags.clear();
         self.labeled_llgr_stale_local_tags.clear();
         self.rtc_llgr_stale_local_tags.clear();
-        self.attr_intern.clear();
     }
 
     /// Return the number of unicast routes stored.
@@ -269,20 +254,6 @@ impl AdjRibIn {
     #[must_use]
     pub fn bench_prefix_index_mem_size(&self) -> usize {
         self.prefix_index.mem_size()
-    }
-
-    /// Return the number of interned attribute sets.
-    #[cfg(feature = "bench-internals")]
-    #[must_use]
-    pub fn bench_attr_intern_len(&self) -> usize {
-        self.attr_intern.len()
-    }
-
-    /// Return the backing capacity of the attribute intern table.
-    #[cfg(feature = "bench-internals")]
-    #[must_use]
-    pub fn bench_attr_intern_capacity(&self) -> usize {
-        self.attr_intern.capacity()
     }
 
     /// Return `true` if no unicast routes are stored.
@@ -532,18 +503,6 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_community(&clear_local_llgr);
     }
 
-    /// Garbage-collect interned attribute sets that are no longer referenced
-    /// by any route (only the intern table itself holds the `Arc`).
-    pub fn gc_intern_table(&mut self) {
-        self.attr_intern.retain(|arc| Arc::strong_count(arc) > 1);
-    }
-
-    /// Return the number of unique interned attribute sets.
-    #[must_use]
-    pub fn intern_len(&self) -> usize {
-        self.attr_intern.len()
-    }
-
     // --- FlowSpec methods ---
 
     /// Insert or replace a `FlowSpec` route.
@@ -580,12 +539,13 @@ impl AdjRibIn {
     ///
     /// Re-advertising the same key with a new attribute set (notably RFC 7432
     /// §7.7 MAC Mobility, which increments a sequence number on every move)
-    /// strands the previous interned set. Callers must run [`Self::gc_intern_table`]
-    /// after a batch of inserts/withdraws to reclaim it — see the EVPN
+    /// strands the previous interned set. Callers must run
+    /// [`crate::attr_intern::AttrInternTable::gc`] after a batch of
+    /// inserts/withdraws to reclaim it — see the EVPN
     /// announce/withdraw/inject paths in the RIB manager.
     ///
     /// Returns `true` if an existing route at the same key was replaced.
-    pub fn insert_evpn(&mut self, mut route: EvpnRibRoute) -> bool {
+    pub fn insert_evpn(&mut self, route: EvpnRibRoute) -> bool {
         let key = route.key();
         // Re-advertising a key drops any record that *we* locally injected
         // LLGR_STALE on the prior version of it — exactly as unicast `insert`
@@ -593,12 +553,6 @@ impl AdjRibIn {
         // a later EoR (`clear_llgr_stale_evpn`) would treat this fresh route as
         // locally tagged and strip a peer-originated LLGR_STALE off it.
         self.evpn_llgr_stale_local_tags.remove(&key);
-        // Intern attributes so identical attribute sets share one Arc.
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
         self.evpn_routes.insert(key, route).is_some()
     }
 
@@ -807,20 +761,15 @@ impl AdjRibIn {
     ///
     /// Returns `true` if an existing route at the same opaque key was replaced.
     /// A replacement may strand the previous route's interned attribute set.
-    /// BGP-LS batch callers run [`Self::gc_intern_table`] once after any
-    /// replacement or real withdrawal, after Loc-RIB recomputation has dropped
-    /// any selected-route clone.
-    pub fn insert_bgpls(&mut self, mut route: BgpLsRibRoute) -> bool {
+    /// BGP-LS batch callers run [`crate::attr_intern::AttrInternTable::gc`]
+    /// once after any replacement or real withdrawal, after Loc-RIB
+    /// recomputation has dropped any selected-route clone.
+    pub fn insert_bgpls(&mut self, route: BgpLsRibRoute) -> bool {
         let key = route.key();
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
         self.bgpls_llgr_stale_local_tags.remove(&key);
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
         self.bgpls_routes.insert(key, route).is_some()
     }
 
@@ -1071,24 +1020,19 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_bgpls_community(&clear_local_llgr);
     }
 
-    /// Insert or replace a VPNv4/VPNv6 route, interning its attribute set.
+    /// Insert or replace a VPNv4/VPNv6 route.
     ///
     /// Returns `true` if an existing route at the same RD + prefix + path-id was
     /// replaced. A replacement may strand the previous route's interned attribute
-    /// set; VPN batch callers run [`Self::gc_intern_table`] once after any
-    /// replacement or real withdrawal, after Loc-RIB recomputation has dropped
-    /// any selected-route clone.
-    pub fn insert_vpn(&mut self, mut route: VpnRibRoute) -> bool {
+    /// set; VPN batch callers run [`crate::attr_intern::AttrInternTable::gc`]
+    /// once after any replacement or real withdrawal, after Loc-RIB
+    /// recomputation has dropped any selected-route clone.
+    pub fn insert_vpn(&mut self, route: VpnRibRoute) -> bool {
         let key = route.key();
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
         self.vpn_llgr_stale_local_tags.remove(&key);
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
         let ids = self.vpn_key_index.entry(key.nlri_key).or_default();
         if !ids.contains(&key.path_id) {
             ids.push(key.path_id);
@@ -1372,26 +1316,21 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_vpn_community(&clear_local_llgr);
     }
 
-    /// Insert or replace a labeled-unicast route, interning its attribute set.
+    /// Insert or replace a labeled-unicast route.
     ///
     /// Returns `true` if an existing route at the same prefix + path-id was
     /// replaced (RFC 8277 §2.3 implicit-replace: a relabel of the same prefix
     /// lands on the same key). A replacement may strand the previous route's
     /// interned attribute set; labeled batch callers run
-    /// [`Self::gc_intern_table`] once after any replacement or real
-    /// withdrawal, after Loc-RIB recomputation has dropped any selected-route
-    /// clone.
-    pub fn insert_labeled(&mut self, mut route: LabeledRibRoute) -> bool {
+    /// [`crate::attr_intern::AttrInternTable::gc`] once after any replacement
+    /// or real withdrawal, after Loc-RIB recomputation has dropped any
+    /// selected-route clone.
+    pub fn insert_labeled(&mut self, route: LabeledRibRoute) -> bool {
         let key = route.key();
         // Mirror unicast `insert` / `insert_vpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
         self.labeled_llgr_stale_local_tags.remove(&key);
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
         let ids = self.labeled_key_index.entry(key.prefix).or_default();
         if !ids.contains(&key.path_id) {
             ids.push(key.path_id);
@@ -1677,24 +1616,20 @@ impl AdjRibIn {
         self.clear_local_llgr_stale_labeled_community(&clear_local_llgr);
     }
 
-    /// Insert or replace an RT-Constrain route, interning its attribute set.
+    /// Insert or replace an RT-Constrain route.
     ///
     /// Returns `true` if an existing route at the same NLRI + path-id was
     /// replaced. A replacement may strand the previous route's interned
-    /// attribute set; RTC batch callers run [`Self::gc_intern_table`] once
-    /// after any replacement or real withdrawal, after Loc-RIB recomputation
-    /// has dropped any selected-route clone.
-    pub fn insert_rtc(&mut self, mut route: RtcRibRoute) -> bool {
+    /// attribute set; RTC batch callers run
+    /// [`crate::attr_intern::AttrInternTable::gc`] once after any replacement
+    /// or real withdrawal, after Loc-RIB recomputation has dropped any
+    /// selected-route clone.
+    pub fn insert_rtc(&mut self, route: RtcRibRoute) -> bool {
         let key = route.key();
         // Mirror unicast `insert` / `insert_evpn`: a re-advertised key drops
         // any record that *we* locally injected LLGR_STALE on its prior
         // version, so a later EoR never strips a peer-originated community.
         self.rtc_llgr_stale_local_tags.remove(&key);
-        if let Some(existing) = self.attr_intern.get(&route.attributes) {
-            route.attributes = existing.clone();
-        } else {
-            self.attr_intern.insert(route.attributes.clone());
-        }
         self.rtc_routes.insert(key, route).is_some()
     }
 
@@ -2395,23 +2330,27 @@ mod tests {
     fn vpn_insert_reports_replacement_for_intern_gc() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = crate::attr_intern::AttrInternTable::new();
         let nlri = vpn_nlri([10, 0, 1, 0], 24, 100);
 
-        assert!(!rib.insert_vpn(make_vpn_route(nlri.clone(), 1)));
-        assert_eq!(rib.intern_len(), 1);
+        let mut first = make_vpn_route(nlri.clone(), 1);
+        intern.intern(&mut first.attributes);
+        assert!(!rib.insert_vpn(first));
+        assert_eq!(intern.len(), 1);
 
         let mut replacement = make_vpn_route(nlri, 2);
         replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+        intern.intern(&mut replacement.attributes);
 
         assert!(rib.insert_vpn(replacement));
         assert_eq!(
-            rib.intern_len(),
+            intern.len(),
             2,
             "replacement strands the previous interned attribute set before GC"
         );
 
-        rib.gc_intern_table();
-        assert_eq!(rib.intern_len(), 1);
+        intern.gc();
+        assert_eq!(intern.len(), 1);
     }
 
     #[test]
@@ -2510,23 +2449,27 @@ mod tests {
     fn rtc_insert_reports_replacement_for_intern_gc() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = crate::attr_intern::AttrInternTable::new();
         let nlri = rtc_nlri(100);
 
-        assert!(!rib.insert_rtc(make_rtc_route(nlri, 1)));
-        assert_eq!(rib.intern_len(), 1);
+        let mut first = make_rtc_route(nlri, 1);
+        intern.intern(&mut first.attributes);
+        assert!(!rib.insert_rtc(first));
+        assert_eq!(intern.len(), 1);
 
         let mut replacement = make_rtc_route(nlri, 2);
         replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+        intern.intern(&mut replacement.attributes);
 
         assert!(rib.insert_rtc(replacement));
         assert_eq!(
-            rib.intern_len(),
+            intern.len(),
             2,
             "replacement strands the previous interned attribute set before GC"
         );
 
-        rib.gc_intern_table();
-        assert_eq!(rib.intern_len(), 1);
+        intern.gc();
+        assert_eq!(intern.len(), 1);
     }
 
     #[test]
@@ -2644,23 +2587,27 @@ mod tests {
     fn bgpls_insert_reports_replacement_for_intern_gc() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = crate::attr_intern::AttrInternTable::new();
         let nlri = bgpls_nlri(8);
 
-        assert!(!rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1)));
-        assert_eq!(rib.intern_len(), 1);
+        let mut first = make_bgpls_route(BgpLsFamily::LinkState, nlri.clone(), 1);
+        intern.intern(&mut first.attributes);
+        assert!(!rib.insert_bgpls(first));
+        assert_eq!(intern.len(), 1);
 
         let mut replacement = make_bgpls_route(BgpLsFamily::LinkState, nlri, 2);
         replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+        intern.intern(&mut replacement.attributes);
 
         assert!(rib.insert_bgpls(replacement));
         assert_eq!(
-            rib.intern_len(),
+            intern.len(),
             2,
             "replacement strands the previous interned attribute set before GC"
         );
 
-        rib.gc_intern_table();
-        assert_eq!(rib.intern_len(), 1);
+        intern.gc();
+        assert_eq!(intern.len(), 1);
     }
 
     #[test]
@@ -3095,11 +3042,14 @@ mod tests {
     }
 
     #[test]
-    fn intern_deduplicates_identical_attributes() {
+    fn interned_routes_share_one_arc_in_storage() {
         use rustbgpd_wire::Origin;
+
+        use crate::attr_intern::AttrInternTable;
 
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = AttrInternTable::new();
 
         let attrs = vec![
             PathAttribute::Origin(Origin::Igp),
@@ -3110,16 +3060,16 @@ mod tests {
         let p2 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
         let p3 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 3, 0), 24);
 
-        let mut r1 = make_route(p1, Ipv4Addr::new(10, 0, 0, 1));
-        r1.attributes = Arc::new(attrs.clone());
-        let mut r2 = make_route(p2, Ipv4Addr::new(10, 0, 0, 1));
-        r2.attributes = Arc::new(attrs.clone());
-        let mut r3 = make_route(p3, Ipv4Addr::new(10, 0, 0, 1));
-        r3.attributes = Arc::new(attrs);
-
-        rib.insert(r1);
-        rib.insert(r2);
-        rib.insert(r3);
+        for (prefix, set) in [
+            (p1, attrs.clone()),
+            (p2, attrs.clone()),
+            (p3, attrs.clone()),
+        ] {
+            let mut route = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+            route.attributes = Arc::new(set);
+            intern.intern(&mut route.attributes);
+            rib.insert(route);
+        }
 
         // All three routes should share the same Arc
         let a1 = &rib.get(&Prefix::V4(p1), 0).unwrap().attributes;
@@ -3129,59 +3079,39 @@ mod tests {
         assert!(Arc::ptr_eq(a2, a3));
 
         // Only one unique entry in the intern table
-        assert_eq!(rib.intern_len(), 1);
+        assert_eq!(intern.len(), 1);
     }
 
     #[test]
-    fn intern_separates_different_attributes() {
+    fn gc_after_withdraw_removes_orphaned_intern_entries() {
         use rustbgpd_wire::Origin;
+
+        use crate::attr_intern::AttrInternTable;
 
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = AttrInternTable::new();
 
         let p1 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
         let p2 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
 
         let mut r1 = make_route(p1, Ipv4Addr::new(10, 0, 0, 1));
         r1.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Igp)]);
+        intern.intern(&mut r1.attributes);
         let mut r2 = make_route(p2, Ipv4Addr::new(10, 0, 0, 1));
         r2.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+        intern.intern(&mut r2.attributes);
 
         rib.insert(r1);
         rib.insert(r2);
-
-        let a1 = &rib.get(&Prefix::V4(p1), 0).unwrap().attributes;
-        let a2 = &rib.get(&Prefix::V4(p2), 0).unwrap().attributes;
-        assert!(!Arc::ptr_eq(a1, a2));
-        assert_eq!(rib.intern_len(), 2);
-    }
-
-    #[test]
-    fn gc_intern_table_removes_orphaned_entries() {
-        use rustbgpd_wire::Origin;
-
-        let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        let mut rib = AdjRibIn::new(peer);
-
-        let p1 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
-        let p2 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
-
-        let attrs = vec![PathAttribute::Origin(Origin::Igp)];
-        let mut r1 = make_route(p1, Ipv4Addr::new(10, 0, 0, 1));
-        r1.attributes = Arc::new(attrs.clone());
-        let mut r2 = make_route(p2, Ipv4Addr::new(10, 0, 0, 1));
-        r2.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
-
-        rib.insert(r1);
-        rib.insert(r2);
-        assert_eq!(rib.intern_len(), 2);
+        assert_eq!(intern.len(), 2);
 
         // Withdraw p2 — its unique attrs become orphaned
         rib.withdraw(&Prefix::V4(p2), 0);
-        assert_eq!(rib.intern_len(), 2); // still there before GC
+        assert_eq!(intern.len(), 2); // still there before GC
 
-        rib.gc_intern_table();
-        assert_eq!(rib.intern_len(), 1); // orphan cleaned up
+        intern.gc();
+        assert_eq!(intern.len(), 1); // orphan cleaned up
     }
 
     #[test]
@@ -3448,23 +3378,23 @@ mod tests {
 
     #[test]
     fn promote_to_llgr_stale_evpn_arc_make_mut_preserves_other_routes() {
-        // Two routes share an Arc<Vec<PathAttribute>> via the intern table.
+        // Two routes share an Arc<Vec<PathAttribute>> — in production the
+        // manager's global intern table produces this sharing (LAN-336).
         // Promoting one must only mutate that route's copy, not the shared
         // Arc — otherwise both routes would gain LLGR_STALE when only one
         // is being promoted.
         let peer_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer_ip);
-        // Both routes get identical attrs → interned to the same Arc
         let key_a = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 100, vec![]);
         let key_b = insert_evpn_imet(&mut rib, Ipv4Addr::new(10, 0, 0, 1), 200, vec![]);
+        // Share the allocation explicitly, as the intern table would.
+        let shared = Arc::clone(&rib.evpn_routes[&key_a].attributes);
+        rib.evpn_routes.get_mut(&key_b).unwrap().attributes = shared;
 
         // Confirm they actually share the Arc pre-promotion
         let before_a = Arc::as_ptr(&rib.evpn_routes[&key_a].attributes);
         let before_b = Arc::as_ptr(&rib.evpn_routes[&key_b].attributes);
-        assert_eq!(
-            before_a, before_b,
-            "intern table should have shared the Arc"
-        );
+        assert_eq!(before_a, before_b, "routes must share the Arc");
 
         // Mark only route A stale, promote — route B must NOT gain LLGR_STALE
         rib.evpn_routes.get_mut(&key_a).unwrap().is_stale = true;
@@ -3901,23 +3831,27 @@ mod tests {
     fn labeled_insert_reports_replacement_for_intern_gc() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let mut rib = AdjRibIn::new(peer);
+        let mut intern = crate::attr_intern::AttrInternTable::new();
         let nlri = labeled_nlri([10, 0, 1, 0], 24, 100);
 
-        assert!(!rib.insert_labeled(make_labeled_route(nlri.clone(), 1)));
-        assert_eq!(rib.intern_len(), 1);
+        let mut first = make_labeled_route(nlri.clone(), 1);
+        intern.intern(&mut first.attributes);
+        assert!(!rib.insert_labeled(first));
+        assert_eq!(intern.len(), 1);
 
         let mut replacement = make_labeled_route(nlri, 2);
         replacement.attributes = Arc::new(vec![PathAttribute::Origin(Origin::Egp)]);
+        intern.intern(&mut replacement.attributes);
 
         assert!(rib.insert_labeled(replacement));
         assert_eq!(
-            rib.intern_len(),
+            intern.len(),
             2,
             "replacement strands the previous interned attribute set before GC"
         );
 
-        rib.gc_intern_table();
-        assert_eq!(rib.intern_len(), 1);
+        intern.gc();
+        assert_eq!(intern.len(), 1);
     }
 
     #[test]

--- a/crates/rib/src/attr_intern.rs
+++ b/crates/rib/src/attr_intern.rs
@@ -1,0 +1,145 @@
+//! Global cross-peer path-attribute interning (LAN-336).
+//!
+//! One table for the whole daemon, owned by the `RibManager` actor —
+//! the analog of BIRD's refcounted `rta`/`ea_list` cache and OpenBGPD's
+//! attribute hash. Interning used to live per `AdjRibIn` (one table per
+//! peer), which deduplicated identical attribute sets *within* a peer
+//! but stored one copy *per peer* when many peers carry the same set —
+//! the common route-reflector / route-server reality (reflection
+//! preserves `NEXT_HOP`, so dual-fed clients advertise byte-identical
+//! attribute vectors).
+//!
+//! Ownership makes this lock-free: the manager task is the only writer,
+//! so the table is a plain field threaded by `&mut` — no `Mutex`, no
+//! atomics beyond the `Arc` counters that already exist.
+//!
+//! Reclaim is the `Arc::strong_count` sweep the per-peer tables already
+//! used: an entry whose only reference is the table itself is dropped by
+//! [`AttrInternTable::gc`], which the manager runs at the same batch
+//! seams that previously swept the per-peer tables (announce-replace,
+//! withdraw, GR/LLGR sweeps, route-refresh, peer teardown). `Arc`'s
+//! reference count *is* the refcount; there is no separate bookkeeping
+//! to drift out of sync.
+//
+// ponytail: gc is an O(table) sweep per dirty batch — same policy the
+// per-peer tables had, now over one global table. If a fleet with
+// per-peer-unique attribute churn ever makes this visible in profiles,
+// the upgrade path is generation-tagged incremental sweeping.
+
+use std::sync::Arc;
+
+use rustbgpd_wire::PathAttribute;
+use rustc_hash::FxHashSet;
+
+/// Deduplicates identical `Arc<Vec<PathAttribute>>` allocations across
+/// all peers and route families. See the module docs for ownership and
+/// reclaim rules.
+#[derive(Debug, Default)]
+pub struct AttrInternTable {
+    set: FxHashSet<Arc<Vec<PathAttribute>>>,
+}
+
+impl AttrInternTable {
+    /// Create an empty intern table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Intern `attrs` in place: if identical content is already in the
+    /// table, `attrs` is rewritten to the shared allocation and the
+    /// caller's copy drops; otherwise this allocation is recorded as the
+    /// canonical one.
+    ///
+    /// Callers intern *before* storing a route, never after — an `Arc`
+    /// already stored in a RIB is never swapped out from under it, so
+    /// pointer-identity contracts downstream (`ExportMemo` keys on
+    /// `Arc::as_ptr`, the `routes_equal` `ptr_eq` fast paths) hold.
+    pub fn intern(&mut self, attrs: &mut Arc<Vec<PathAttribute>>) {
+        if let Some(existing) = self.set.get(attrs) {
+            *attrs = Arc::clone(existing);
+        } else {
+            self.set.insert(Arc::clone(attrs));
+        }
+    }
+
+    /// Drop entries whose only remaining reference is the table itself
+    /// (`strong_count == 1`): no route in any RIB, Loc-RIB clone, or
+    /// in-flight export still uses them.
+    pub fn gc(&mut self) {
+        self.set.retain(|a| Arc::strong_count(a) > 1);
+    }
+
+    /// Number of unique interned attribute sets.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    /// `true` if the table holds no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    /// Backing capacity of the table, for memory-profile harnesses.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.set.capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustbgpd_wire::Origin;
+
+    use super::*;
+
+    fn attrs(med: u32) -> Arc<Vec<PathAttribute>> {
+        Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::Med(med),
+        ])
+    }
+
+    #[test]
+    fn intern_deduplicates_identical_content() {
+        let mut table = AttrInternTable::new();
+        let mut a = attrs(1);
+        let mut b = attrs(1);
+        assert!(!Arc::ptr_eq(&a, &b));
+        table.intern(&mut a);
+        table.intern(&mut b);
+        assert!(Arc::ptr_eq(&a, &b));
+        assert_eq!(table.len(), 1);
+    }
+
+    #[test]
+    fn intern_separates_different_content() {
+        let mut table = AttrInternTable::new();
+        let mut a = attrs(1);
+        let mut b = attrs(2);
+        table.intern(&mut a);
+        table.intern(&mut b);
+        assert!(!Arc::ptr_eq(&a, &b));
+        assert_eq!(table.len(), 2);
+    }
+
+    #[test]
+    fn gc_removes_unreferenced_entries_only() {
+        let mut table = AttrInternTable::new();
+        let mut a = attrs(1);
+        let mut b = attrs(2);
+        table.intern(&mut a);
+        table.intern(&mut b);
+        drop(b);
+        assert_eq!(table.len(), 2, "entries persist until gc");
+        table.gc();
+        assert_eq!(table.len(), 1, "unreferenced entry reclaimed");
+        table.gc();
+        assert_eq!(table.len(), 1, "referenced entry survives repeated gc");
+        drop(a);
+        table.gc();
+        assert!(table.is_empty());
+    }
+}

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -12,6 +12,8 @@
 pub mod adj_rib_in;
 /// Per-peer outbound RIB storage.
 pub mod adj_rib_out;
+/// Global cross-peer path-attribute interning (LAN-336).
+pub mod attr_intern;
 /// Best-path selection algorithm (RFC 4271 §9.1.2).
 pub mod best_path;
 /// RFC 9069 Loc-RIB BMP synthesis (UPDATE PDUs + fabricated OPEN).
@@ -41,6 +43,7 @@ mod test_support;
 /// RIB update messages and outbound route structures.
 pub mod update;
 
+pub use attr_intern::AttrInternTable;
 pub use best_path::{
     BestPathReason, MultipathEligibility, best_path_cmp, best_path_reason_detail,
     multipath_eligibility, multipath_equal,

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -88,8 +88,9 @@ impl RibManager {
             .entry(source)
             .or_insert_with(|| AdjRibIn::new(source));
         let mut affected = HashSet::with_capacity(routes.len());
-        for route in routes {
+        for mut route in routes {
             affected.insert(route.prefix);
+            self.attr_intern.intern(&mut route.attributes);
             rib.insert(route);
         }
         for prefix in &affected {

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -44,11 +44,7 @@ impl RibManager {
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
             self.recompute_and_distribute_evpn(&affected);
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
     }
 
@@ -71,10 +67,11 @@ impl RibManager {
                 .ribs
                 .get_mut(&peer)
                 .expect("peer rib must exist before chunk processing");
-            for route in evpn_announced {
+            for mut route in evpn_announced {
                 debug!(%peer, route_type = route.route_type(), "evpn announced");
                 let key = route.key();
                 affected.insert(key);
+                self.attr_intern.intern(&mut route.attributes);
                 any_replaced |= rib.insert_evpn(route);
                 // Enhanced Route Refresh: re-advertised key removes from
                 // the stale set so EoRR's sweep doesn't withdraw it.
@@ -93,13 +90,10 @@ impl RibManager {
         self.update_peer_refresh_metrics(peer);
         if !affected.is_empty() {
             self.recompute_and_distribute_evpn(&affected);
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                if any_replaced {
-                    rib.gc_intern_table();
-                }
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            if any_replaced {
+                self.attr_intern.gc();
             }
+            self.sync_attr_intern_gauge();
         }
     }
 
@@ -109,6 +103,8 @@ impl RibManager {
         reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let key = route.key();
+        let mut route = route;
+        self.attr_intern.intern(&mut route.attributes);
         let rib = self
             .ribs
             .entry(LOCAL_PEER)
@@ -118,13 +114,10 @@ impl RibManager {
         let mut evpn_affected = HashSet::new();
         evpn_affected.insert(key);
         self.recompute_and_distribute_evpn(&evpn_affected);
-        if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-            if replaced {
-                rib.gc_intern_table();
-            }
-            self.metrics
-                .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
+        if replaced {
+            self.attr_intern.gc();
         }
+        self.sync_attr_intern_gauge();
         let _ = reply.send(Ok(()));
     }
 
@@ -142,11 +135,7 @@ impl RibManager {
             let mut evpn_affected = HashSet::new();
             evpn_affected.insert(key);
             self.recompute_and_distribute_evpn(&evpn_affected);
-            if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
             let _ = reply.send(Ok(()));
         } else {
             let _ = reply.send(Err(RibCommandError::not_found(format!(

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -813,11 +813,7 @@ impl RibManager {
             let changed = self.recompute_best_after_withdraw(&affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
     }
 
@@ -853,6 +849,7 @@ impl RibManager {
                 affected.insert(route.prefix);
                 let prefix = route.prefix;
                 let path_id = route.path_id;
+                self.attr_intern.intern(&mut route.attributes);
                 any_replaced |= rib.insert(route);
                 let family = prefix_family(&prefix);
                 if active_refresh.contains(&family)
@@ -891,13 +888,10 @@ impl RibManager {
             let changed = self.recompute_best_after_announce(peer, &affected);
             self.pending_distribute_changed.extend(changed);
             self.pending_distribute_affected.extend(affected);
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                if any_replaced {
-                    rib.gc_intern_table();
-                }
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            if any_replaced {
+                self.attr_intern.gc();
             }
+            self.sync_attr_intern_gauge();
         }
     }
 
@@ -907,6 +901,8 @@ impl RibManager {
         reply: tokio::sync::oneshot::Sender<Result<(), RibCommandError>>,
     ) {
         let prefix = route.prefix;
+        let mut route = route;
+        self.attr_intern.intern(&mut route.attributes);
         let rib = self
             .ribs
             .entry(LOCAL_PEER)
@@ -922,13 +918,10 @@ impl RibManager {
         affected.insert(prefix);
         let changed = self.recompute_best(&affected);
         self.distribute_changes(&changed, &affected);
-        if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-            if replaced {
-                rib.gc_intern_table();
-            }
-            self.metrics
-                .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
+        if replaced {
+            self.attr_intern.gc();
         }
+        self.sync_attr_intern_gauge();
 
         let _ = reply.send(Ok(()));
     }
@@ -951,11 +944,7 @@ impl RibManager {
             affected.insert(prefix);
             let changed = self.recompute_best(&affected);
             self.distribute_changes(&changed, &affected);
-            if let Some(rib) = self.ribs.get_mut(&LOCAL_PEER) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&LOCAL_PEER.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
             let _ = reply.send(Ok(()));
         } else {
             let _ = reply.send(Err(RibCommandError::not_found(format!(

--- a/crates/rib/src/manager/graceful_restart.rs
+++ b/crates/rib/src/manager/graceful_restart.rs
@@ -170,9 +170,9 @@ impl RibManager {
             // the peer Adj-RIB-In shell alive for preserved families. Reclaim
             // attribute sets stranded by those removals now rather than
             // waiting for an unrelated future withdraw on this peer.
-            rib.gc_intern_table();
+            self.attr_intern.gc();
             self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
         }
 
         if let Some(rib) = self.ribs.get(&peer) {
@@ -232,44 +232,28 @@ impl RibManager {
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(&bgpls_affected);
             // Reclaim attribute sets stranded by the BGP-LS withdrawals above.
-            // The gc_intern_table() earlier in this method ran before this
+            // The intern gc earlier in this method ran before this
             // recompute, while the Loc-RIB still held the selected-route Arc
             // clones, so those orphans survived (gc only frees a set whose sole
             // remaining holder is the intern table). Now that recompute_bgpls_keys
             // has dropped the Loc-RIB clones, gc reclaims them — mirroring the
             // receive path's recompute-then-gc ordering.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !vpn_affected.is_empty() {
             self.recompute_vpn_keys(&vpn_affected);
             // Same recompute-then-gc ordering rationale as BGP-LS above.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !labeled_affected.is_empty() {
             self.recompute_labeled_keys(&labeled_affected);
             // Same recompute-then-gc ordering rationale as BGP-LS above.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !rtc_affected.is_empty() {
             self.recompute_rtc_keys(&rtc_affected);
             // Same recompute-then-gc ordering rationale as BGP-LS above.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         // No RTC membership rebuild here even when routes were deleted:
         // `clear_outbound_peer_state` below drops this peer's
@@ -502,9 +486,9 @@ impl RibManager {
                 // sweeps). A second GC below runs after Loc-RIB recompute
                 // drops selected-route clones that were still holding old
                 // Arcs alive here.
-                rib.gc_intern_table();
+                self.attr_intern.gc();
                 self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                    .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
             }
             if !non_llgr_families.is_empty() {
                 info!(%peer, families = ?non_llgr_families, "swept stale routes for non-LLGR families");
@@ -533,18 +517,15 @@ impl RibManager {
             if rtc_changed {
                 self.recompute_rtc_keys(&rtc_affected);
             }
-            if (!affected.is_empty()
+            if !affected.is_empty()
                 || !fs_affected.is_empty()
                 || !evpn_affected.is_empty()
                 || !bgpls_affected.is_empty()
                 || !vpn_affected.is_empty()
                 || !labeled_affected.is_empty()
-                || rtc_changed)
-                && let Some(rib) = self.ribs.get_mut(&peer)
+                || rtc_changed
             {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                self.gc_attr_intern();
             }
             if rtc_changed {
                 // A non-LLGR purge (or a NO_LLGR removal during promotion)
@@ -619,9 +600,9 @@ impl RibManager {
             l3vpn_swept = rib.sweep_stale_vpn();
             labeled_swept = rib.sweep_stale_labeled();
             rtc_swept = rib.sweep_stale_rtc();
-            rib.gc_intern_table();
+            self.attr_intern.gc();
             self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
         }
@@ -672,18 +653,15 @@ impl RibManager {
                 rtc_swept.into_iter().collect();
             self.recompute_rtc_keys(&rtc_affected);
         }
-        if (had_swept
+        if had_swept
             || had_fs_swept
             || had_evpn_swept
             || had_bgpls_swept
             || had_l3vpn_swept
             || had_labeled_swept
-            || had_rtc_swept)
-            && let Some(rib) = self.ribs.get_mut(&peer)
+            || had_rtc_swept
         {
-            rib.gc_intern_table();
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.gc_attr_intern();
         }
         if had_rtc_swept {
             // Same obligation as the LLGR branch: a re-established peer whose
@@ -756,9 +734,9 @@ impl RibManager {
                 labeled_swept.extend(rib.sweep_llgr_stale_family_labeled(family));
                 rtc_swept.extend(rib.sweep_llgr_stale_family_rtc(family));
             }
-            rib.gc_intern_table();
+            self.attr_intern.gc();
             self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
             rib_len = rib.len();
             evpn_len = rib.evpn_len();
             llgr_stale_remaining = rib.iter().filter(|r| r.is_llgr_stale).count()
@@ -817,18 +795,15 @@ impl RibManager {
                 rtc_swept.into_iter().collect();
             self.recompute_rtc_keys(&rtc_affected);
         }
-        if (had_swept
+        if had_swept
             || had_fs_swept
             || had_evpn_swept
             || had_bgpls_swept
             || had_l3vpn_swept
             || had_labeled_swept
-            || had_rtc_swept)
-            && let Some(rib) = self.ribs.get_mut(&peer)
+            || had_rtc_swept
         {
-            rib.gc_intern_table();
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.gc_attr_intern();
         }
         if had_rtc_swept {
             // Same obligation as the GR-expiry sweeps: the down peer's

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -89,6 +89,12 @@ impl RtcMembership {
 /// No `Arc<RwLock>` — all state is owned by this task.
 pub struct RibManager {
     ribs: HashMap<IpAddr, AdjRibIn>,
+    /// Global cross-peer attribute intern table (LAN-336). Owned by this
+    /// task like everything else — lock-free by construction. Every route
+    /// insertion seam interns `route.attributes` here BEFORE storing the
+    /// route; every removal seam runs [`RibManager::gc_attr_intern`]
+    /// afterwards (see `crate::attr_intern` for the reclaim rules).
+    attr_intern: crate::attr_intern::AttrInternTable,
     /// See [`UnicastPrefixPeers`] for the maintenance contract.
     unicast_prefix_peers: UnicastPrefixPeers,
     loc_rib: LocRib,
@@ -685,6 +691,25 @@ impl PendingRoutesReceived {
 }
 
 impl RibManager {
+    /// Sweep the global attribute intern table (drop entries no route
+    /// references any more) and refresh its gauge. Run after any batch
+    /// that removed or replaced routes — the same seams that swept the
+    /// per-peer tables before LAN-336.
+    fn gc_attr_intern(&mut self) {
+        self.attr_intern.gc();
+        self.sync_attr_intern_gauge();
+    }
+
+    /// Refresh the global intern-table gauge without sweeping. Run after
+    /// insert-only batches so growth is visible at every mutation seam
+    /// (a gauge a scenario never updates cannot gate anything).
+    fn sync_attr_intern_gauge(&self) {
+        self.metrics
+            .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
+    }
+}
+
+impl RibManager {
     /// Create a new RIB manager with the given update channel and optional export policy.
     #[must_use]
     pub fn new(
@@ -726,6 +751,7 @@ impl RibManager {
         }
         Self {
             ribs: HashMap::new(),
+            attr_intern: crate::attr_intern::AttrInternTable::new(),
             unicast_prefix_peers: UnicastPrefixPeers::default(),
             loc_rib: LocRib::new(),
             adj_ribs_out: HashMap::new(),
@@ -2524,9 +2550,10 @@ impl RibManager {
                 }
             }
 
-            for route in announced {
+            for mut route in announced {
                 let key = route.key();
                 let family = route.family.to_afi_safi();
+                self.attr_intern.intern(&mut route.attributes);
                 needs_intern_gc |= rib.insert_bgpls(route);
                 affected.insert(key.clone());
                 if active_refresh.contains(&family)
@@ -2543,14 +2570,11 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_bgpls_keys(&affected);
-        if !affected.is_empty()
-            && let Some(rib) = self.ribs.get_mut(&peer)
-        {
+        if !affected.is_empty() {
             if needs_intern_gc {
-                rib.gc_intern_table();
+                self.attr_intern.gc();
             }
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.sync_attr_intern_gauge();
         }
     }
 
@@ -2585,9 +2609,10 @@ impl RibManager {
                 }
             }
 
-            for route in announced {
+            for mut route in announced {
                 let key = route.key();
                 let family = route.afi_safi();
+                self.attr_intern.intern(&mut route.attributes);
                 needs_intern_gc |= rib.insert_vpn(route);
                 affected.insert(key.clone());
                 if active_refresh.contains(&family)
@@ -2604,14 +2629,11 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_vpn_keys(&affected);
-        if !affected.is_empty()
-            && let Some(rib) = self.ribs.get_mut(&peer)
-        {
+        if !affected.is_empty() {
             if needs_intern_gc {
-                rib.gc_intern_table();
+                self.attr_intern.gc();
             }
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.sync_attr_intern_gauge();
         }
     }
 
@@ -2656,9 +2678,10 @@ impl RibManager {
                 }
             }
 
-            for route in announced {
+            for mut route in announced {
                 let key = route.key();
                 let family = route.afi_safi();
+                self.attr_intern.intern(&mut route.attributes);
                 needs_intern_gc |= rib.insert_labeled(route);
                 affected.insert(key);
                 if active_refresh.contains(&family)
@@ -2675,14 +2698,11 @@ impl RibManager {
         }
         self.update_peer_refresh_metrics(peer);
         self.recompute_labeled_keys(&affected);
-        if !affected.is_empty()
-            && let Some(rib) = self.ribs.get_mut(&peer)
-        {
+        if !affected.is_empty() {
             if needs_intern_gc {
-                rib.gc_intern_table();
+                self.attr_intern.gc();
             }
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.sync_attr_intern_gauge();
         }
     }
 
@@ -2725,8 +2745,9 @@ impl RibManager {
                     removed_stale += 1;
                 }
             }
-            for route in announced {
+            for mut route in announced {
                 let key = route.key();
+                self.attr_intern.intern(&mut route.attributes);
                 needs_intern_gc |= rib.insert_rtc(route);
                 if active_refresh
                     && let Some(stale) = self.refresh_stale_rtc.get_mut(&peer)
@@ -2741,14 +2762,11 @@ impl RibManager {
         self.decrement_refresh_stale_count(peer, family.0, family.1, removed_stale);
         self.update_peer_refresh_metrics(peer);
         self.recompute_rtc_keys(&affected);
-        if !affected.is_empty()
-            && let Some(rib) = self.ribs.get_mut(&peer)
-        {
+        if !affected.is_empty() {
             if needs_intern_gc {
-                rib.gc_intern_table();
+                self.attr_intern.gc();
             }
-            self.metrics
-                .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+            self.sync_attr_intern_gauge();
         }
         self.rebuild_rtc_membership_and_restage_vpn(peer);
     }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -362,6 +362,13 @@ impl RibManager {
         if !rtc_affected.is_empty() {
             self.recompute_rtc_keys(&rtc_affected);
         }
+        // The removed Adj-RIB-In held the peer's route bodies; dropping it
+        // releases their attribute Arcs. Sweep the global intern table now
+        // (after the recomputes above dropped any Loc-RIB selected-route
+        // clones) so a departed peer cannot leave stranded attribute sets —
+        // the reclaim the per-peer tables used to get for free on drop.
+        drop(rib);
+        self.gc_attr_intern();
     }
 
     /// Handle a peer *deletion* (the neighbor was removed from the

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -255,11 +255,7 @@ impl RibManager {
             if !rtc_affected.is_empty() {
                 self.recompute_rtc_keys(&rtc_affected);
             }
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
             if rtc_swept {
                 // The EoR sweep removed RT interest the peer did not
                 // re-advertise: shrink its membership so no-longer-covered
@@ -430,11 +426,7 @@ impl RibManager {
             if !rtc_affected.is_empty() {
                 self.recompute_rtc_keys(&rtc_affected);
             }
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
             if rtc_swept {
                 // The EoR sweep removed LLGR-stale RT interest the peer did
                 // not re-advertise: shrink its membership so no-longer-
@@ -1392,9 +1384,9 @@ impl RibManager {
                 || !labeled_affected.is_empty()
                 || !rtc_affected.is_empty()
             {
-                rib.gc_intern_table();
+                self.attr_intern.gc();
                 self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
+                    .set_rib_attr_intern_global_size(gauge_val(self.attr_intern.len()));
             }
             self.metrics
                 .set_rib_prefixes(&peer.to_string(), "all", gauge_val(rib.len()));
@@ -1494,45 +1486,29 @@ impl RibManager {
         if !bgpls_affected.is_empty() {
             self.recompute_bgpls_keys(&bgpls_affected);
             // Reclaim attribute sets stranded by the stale-BGP-LS withdrawals
-            // above. The earlier gc_intern_table() ran before this recompute,
+            // above. The earlier intern gc ran before this recompute,
             // while the Loc-RIB still held the selected-route Arc clones, so
             // those orphans survived (gc only frees a set whose sole remaining
             // holder is the intern table). Now that recompute_bgpls_keys has
             // dropped the Loc-RIB clones, gc reclaims them — mirroring the
             // receive path's recompute-then-gc ordering.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !vpn_affected.is_empty() {
             self.recompute_vpn_keys(&vpn_affected);
             // Same gc-after-recompute ordering as BGP-LS above: the swept VPN
             // routes' interned attribute sets stay alive in the Loc-RIB clone
             // until recompute_vpn_keys drops it, so gc must run after it.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !labeled_affected.is_empty() {
             self.recompute_labeled_keys(&labeled_affected);
             // Same gc-after-recompute ordering as VPN above.
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
         }
         if !rtc_affected.is_empty() {
             self.recompute_rtc_keys(&rtc_affected);
-            if let Some(rib) = self.ribs.get_mut(&peer) {
-                rib.gc_intern_table();
-                self.metrics
-                    .set_rib_attr_intern_size(&peer.to_string(), gauge_val(rib.intern_len()));
-            }
+            self.gc_attr_intern();
             // The sweep just mutated this peer's RTC Adj-RIB-In — its RT
             // membership shrank, so VPN routes no longer covered must be
             // withdrawn from this peer's Adj-RIB-Out.

--- a/crates/rib/src/manager/tests/attr_intern.rs
+++ b/crates/rib/src/manager/tests/attr_intern.rs
@@ -29,7 +29,7 @@ fn evpn_withdraw_gcs_attr_intern_under_mac_mobility() {
         manager.process_evpn_withdraw_chunk(peer, vec![key]);
     }
 
-    let intern = manager.ribs[&peer].intern_len();
+    let intern = manager.attr_intern.len();
     assert!(
         intern <= EVPN_ROUTE_EVENT_HISTORY_CAPACITY,
         "EVPN attribute intern table grew unbounded under MAC-mobility churn: \
@@ -62,7 +62,7 @@ fn evpn_announce_replace_reclaims_attr_intern() {
         manager.process_evpn_announce_chunk(peer, vec![route]);
     }
 
-    let intern = manager.ribs[&peer].intern_len();
+    let intern = manager.attr_intern.len();
     // Bounded by the event-history ring plus the single live route and the
     // in-flight event (~ring + 2); pre-fix this grew to `moves` (6096).
     let bound = EVPN_ROUTE_EVENT_HISTORY_CAPACITY + 16;
@@ -92,6 +92,7 @@ fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
         let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100);
         route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
         let key = route.key();
+        manager.attr_intern.intern(&mut route.attributes);
         manager
             .ribs
             .entry(LOCAL_PEER)
@@ -101,7 +102,7 @@ fn handle_withdraw_evpn_gcs_attr_intern_for_injected_routes() {
         manager.handle_withdraw_evpn(key, reply_tx);
     }
 
-    let intern = manager.ribs[&LOCAL_PEER].intern_len();
+    let intern = manager.attr_intern.len();
     assert!(
         intern <= 1,
         "injected EVPN re-origination leaked the intern table: {intern} sets (expected <= 1)"
@@ -126,7 +127,7 @@ fn unicast_withdraw_reclaims_selected_attr_intern_after_loc_rib_recompute() {
         manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
         Some(peer)
     );
-    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+    assert_eq!(manager.attr_intern.len(), 1);
 
     manager.handle_update(RibUpdate::RoutesReceived {
         session_id: 0,
@@ -150,7 +151,7 @@ fn unicast_withdraw_reclaims_selected_attr_intern_after_loc_rib_recompute() {
         "withdraw recompute must remove the selected Loc-RIB clone"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         0,
         "post-recompute GC must reclaim the withdrawn route's interned attributes"
     );
@@ -179,7 +180,7 @@ fn unicast_inject_replace_reclaims_attr_intern_after_loc_rib_recompute() {
         Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
     );
     assert_eq!(
-        manager.ribs[&LOCAL_PEER].intern_len(),
+        manager.attr_intern.len(),
         1,
         "injected unicast re-originations must leave only the live route's interned attrs"
     );
@@ -198,7 +199,7 @@ fn unicast_withdraw_injected_reclaims_attr_intern_after_loc_rib_recompute() {
     route.attributes = Arc::new(vec![PathAttribute::Med(100)]);
     let (reply_tx, _reply_rx) = oneshot::channel();
     manager.handle_inject_route(route, reply_tx);
-    assert_eq!(manager.ribs[&LOCAL_PEER].intern_len(), 1);
+    assert_eq!(manager.attr_intern.len(), 1);
 
     let (reply_tx, _reply_rx) = oneshot::channel();
     manager.handle_withdraw_injected(Prefix::V4(prefix), 0, reply_tx);
@@ -208,7 +209,7 @@ fn unicast_withdraw_injected_reclaims_attr_intern_after_loc_rib_recompute() {
         "withdrawing the injected route must recompute it out of the Loc-RIB"
     );
     assert_eq!(
-        manager.ribs[&LOCAL_PEER].intern_len(),
+        manager.attr_intern.len(),
         0,
         "withdraw-injected must reclaim the selected route's interned attrs"
     );
@@ -234,7 +235,7 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
         manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
         Some(peer)
     );
-    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+    assert_eq!(manager.attr_intern.len(), 1);
 
     manager.handle_update(RibUpdate::PeerGracefulRestart {
         session_id: 0,
@@ -261,7 +262,7 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
         "GR expiry should promote the retained route into LLGR stale state"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         0,
         "GR expiry must reclaim the pre-promotion interned set after Loc-RIB recompute"
     );
@@ -290,7 +291,7 @@ fn llgr_eor_reclaims_stale_clear_attr_intern_after_loc_rib_recompute() {
         "End-of-RIB should clear LLGR stale on the retained route"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         1,
         "only the re-advertised route's live interned set survives EoR — the \
          orphaned pre-promotion set stays reclaimed"
@@ -316,7 +317,7 @@ fn gr_expiry_reclaims_stale_attr_intern_after_loc_rib_recompute() {
         manager.loc_rib.get(&Prefix::V4(prefix)).map(|r| r.peer),
         Some(peer)
     );
-    assert_eq!(manager.ribs[&peer].intern_len(), 1);
+    assert_eq!(manager.attr_intern.len(), 1);
 
     manager.handle_update(RibUpdate::PeerGracefulRestart {
         session_id: 0,
@@ -337,7 +338,7 @@ fn gr_expiry_reclaims_stale_attr_intern_after_loc_rib_recompute() {
         "GR expiry should remove the stale route from the Loc-RIB"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         0,
         "GR expiry must reclaim the selected route's interned attrs after recompute"
     );
@@ -365,7 +366,7 @@ fn unicast_announce_replace_reclaims_attr_intern() {
         manager.process_announce_chunk(peer, vec![route]);
     }
 
-    let intern = manager.ribs[&peer].intern_len();
+    let intern = manager.attr_intern.len();
     assert_eq!(
         intern, 1,
         "unicast re-advertise (replace, no withdraw) churn leaked the intern table: \
@@ -400,9 +401,8 @@ fn bgpls_withdraw_reclaims_attr_intern_after_loc_rib_recompute() {
         manager.handle_bgpls_routes_received(peer, vec![], vec![key]);
     }
 
-    let rib = &manager.ribs[&peer];
     assert_eq!(
-        rib.bgpls_len(),
+        manager.ribs[&peer].bgpls_len(),
         0,
         "every churned BGP-LS route was withdrawn from the Adj-RIB-In"
     );
@@ -412,16 +412,16 @@ fn bgpls_withdraw_reclaims_attr_intern_after_loc_rib_recompute() {
         "every churned BGP-LS route was removed from the Loc-RIB"
     );
     assert_eq!(
-        rib.intern_len(),
+        manager.attr_intern.len(),
         0,
         "BGP-LS pure-withdraw churn leaked the intern table: {} interned sets after {moves} withdraws",
-        rib.intern_len()
+        manager.attr_intern.len()
     );
 }
 
 #[test]
-fn bgpls_pure_add_records_peer_attr_intern_size() {
-    // Per-peer intern-size telemetry must move on growth, not only on later
+fn bgpls_pure_add_records_global_attr_intern_size() {
+    // Intern-size telemetry must move on growth, not only on later
     // replacement/withdraw GC. BGP-LS is representative of the RR-only
     // families handled in manager/mod.rs: insert_* returns "replaced", so a
     // first-time route add grows the intern table while `needs_intern_gc`
@@ -437,18 +437,14 @@ fn bgpls_pure_add_records_peer_attr_intern_size() {
     manager.handle_bgpls_routes_received(peer, vec![route], vec![]);
 
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         1,
-        "the pure add should grow the peer's intern table"
+        "the pure add should grow the global intern table"
     );
-    let gauge = gauge_metric_value(
-        &metrics,
-        "bgp_rib_attr_intern_size",
-        &[("peer", &peer.to_string())],
-    );
+    let gauge = gauge_metric_value(&metrics, "bgp_rib_attr_intern_global_size", &[]);
     assert!(
         (gauge - 1.0).abs() < f64::EPSILON,
-        "pure-add growth must be visible in the exported per-peer gauge"
+        "pure-add growth must be visible in the exported global gauge"
     );
 }
 
@@ -470,9 +466,10 @@ fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
     for seq in 0..64u32 {
         let mut route = make_evpn_imet(Ipv4Addr::new(10, 0, 0, 1), 100 + seq);
         route.attributes = Arc::new(vec![PathAttribute::Med(seq)]);
+        manager.attr_intern.intern(&mut route.attributes);
         rib.insert_evpn(route);
     }
-    assert_eq!(manager.ribs[&peer].intern_len(), 64);
+    assert_eq!(manager.attr_intern.len(), 64);
 
     manager.handle_update(RibUpdate::PeerGracefulRestart {
         peer,
@@ -491,7 +488,7 @@ fn graceful_restart_entry_gcs_attr_intern_after_family_prune() {
         .expect("GR-preserved peer shell should stay alive");
     assert_eq!(rib.evpn_len(), 0, "EVPN was not GR-preserved");
     assert_eq!(
-        rib.intern_len(),
+        manager.attr_intern.len(),
         0,
         "GR family pruning must reclaim EVPN attribute intern entries"
     );
@@ -521,7 +518,7 @@ fn graceful_restart_entry_gcs_attr_intern_for_loc_rib_selected_bgpls() {
         let route = make_bgpls_route(peer_addr, u8::try_from(seq).unwrap(), 100 + seq);
         manager.handle_bgpls_routes_received(peer, vec![route], vec![]);
     }
-    assert_eq!(manager.ribs[&peer].intern_len(), count as usize);
+    assert_eq!(manager.attr_intern.len(), count as usize);
     assert_eq!(manager.loc_rib.iter_bgpls().count(), count as usize);
 
     manager.handle_update(RibUpdate::PeerGracefulRestart {
@@ -546,7 +543,7 @@ fn graceful_restart_entry_gcs_attr_intern_for_loc_rib_selected_bgpls() {
         "GR entry withdraws BGP-LS from the Loc-RIB"
     );
     assert_eq!(
-        rib.intern_len(),
+        manager.attr_intern.len(),
         0,
         "GR entry must reclaim the interned attribute sets of the Loc-RIB-selected \
          BGP-LS routes it withdraws (gc must run after the Loc-RIB recompute)"
@@ -571,7 +568,7 @@ fn enhanced_route_refresh_bgpls_eorr_gcs_attr_intern_for_swept_route() {
     let survivor = make_bgpls_route(peer_addr, 21, 100);
     let omitted = make_bgpls_route(peer_addr, 22, 200);
     manager.handle_bgpls_routes_received(peer, vec![survivor.clone(), omitted], vec![]);
-    assert_eq!(manager.ribs[&peer].intern_len(), 2);
+    assert_eq!(manager.attr_intern.len(), 2);
 
     manager.handle_update(RibUpdate::BeginRouteRefresh {
         session_id: 0,
@@ -594,7 +591,7 @@ fn enhanced_route_refresh_bgpls_eorr_gcs_attr_intern_for_swept_route() {
         "EoRR sweeps the omitted BGP-LS route, leaving only the survivor"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         1,
         "EoRR sweep must reclaim the swept route's interned attribute set \
          (gc must run after finish_route_refresh's Loc-RIB recompute)"
@@ -617,7 +614,7 @@ fn enhanced_route_refresh_vpn_eorr_gcs_attr_intern_for_swept_route() {
     let survivor = make_vpn_rib_route(peer_addr, 21, 100, 100);
     let omitted = make_vpn_rib_route(peer_addr, 22, 100, 200);
     manager.handle_vpn_routes_received(peer, vec![survivor.clone(), omitted], vec![]);
-    assert_eq!(manager.ribs[&peer].intern_len(), 2);
+    assert_eq!(manager.attr_intern.len(), 2);
 
     manager.handle_update(RibUpdate::BeginRouteRefresh {
         session_id: 0,
@@ -640,9 +637,116 @@ fn enhanced_route_refresh_vpn_eorr_gcs_attr_intern_for_swept_route() {
         "EoRR sweeps the omitted VPN route, leaving only the survivor"
     );
     assert_eq!(
-        manager.ribs[&peer].intern_len(),
+        manager.attr_intern.len(),
         1,
         "EoRR sweep must reclaim the swept VPN route's interned attribute set \
          (gc must run after finish_route_refresh's Loc-RIB recompute)"
+    );
+}
+
+#[test]
+fn cross_peer_identical_attrs_share_one_global_intern_entry() {
+    // The LAN-336 premise: two RR clients advertising the same route carry
+    // byte-identical attribute sets (reflection preserves NEXT_HOP). The
+    // global table must collapse both peers' allocations to ONE entry, and
+    // both stored routes must share that allocation (Arc pointer equality
+    // across Adj-RIB-Ins — per-peer tables could never produce this).
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    manager.ribs.insert(peer1, AdjRibIn::new(peer1));
+    manager.ribs.insert(peer2, AdjRibIn::new(peer2));
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let attrs = vec![PathAttribute::Med(100), PathAttribute::LocalPref(200)];
+
+    let mut r1 = make_route(prefix, Ipv4Addr::new(10, 0, 0, 1));
+    r1.attributes = Arc::new(attrs.clone());
+    let mut r2 = make_route(prefix, Ipv4Addr::new(10, 0, 0, 2));
+    r2.attributes = Arc::new(attrs);
+    assert!(!Arc::ptr_eq(&r1.attributes, &r2.attributes));
+
+    manager.process_announce_chunk(peer1, vec![r1]);
+    manager.process_announce_chunk(peer2, vec![r2]);
+
+    assert_eq!(
+        manager.attr_intern.len(),
+        1,
+        "identical attribute sets from two peers must intern to one entry"
+    );
+    let a1 = &manager.ribs[&peer1]
+        .get(&Prefix::V4(prefix), 0)
+        .unwrap()
+        .attributes;
+    let a2 = &manager.ribs[&peer2]
+        .get(&Prefix::V4(prefix), 0)
+        .unwrap()
+        .attributes;
+    assert!(
+        Arc::ptr_eq(a1, a2),
+        "both peers' stored routes must share one allocation"
+    );
+    // Referenced by: intern table + peer1 route + peer2 route + the
+    // Loc-RIB selected clone. The point: >= 3 proves cross-peer sharing.
+    assert!(Arc::strong_count(a1) >= 3);
+}
+
+#[test]
+fn cross_peer_churn_keeps_global_intern_table_flat_and_teardown_reclaims() {
+    // Reclaim proof for the global table (same discipline as the slab
+    // slot-reuse test): steady-state replace churn across two peers must
+    // hold the table at exactly one entry per live attribute set — a table
+    // that only grows is a soak-killer. Afterwards, tearing down one peer
+    // keeps the shared entries alive (the other peer still references
+    // them); tearing down the last peer drops the table to zero.
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    manager.ribs.insert(peer1, AdjRibIn::new(peer1));
+    manager.ribs.insert(peer2, AdjRibIn::new(peer2));
+
+    let n = 64u8;
+    let cycles = 10u32;
+    for cycle in 0..cycles {
+        for (peer, nh) in [
+            (peer1, Ipv4Addr::new(10, 0, 0, 1)),
+            (peer2, Ipv4Addr::new(10, 0, 0, 2)),
+        ] {
+            let routes: Vec<_> = (0..n)
+                .map(|i| {
+                    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, i, 0), 24);
+                    let mut route = make_route(prefix, nh);
+                    // Per-prefix-unique, cross-peer-identical, rotated
+                    // every cycle so each cycle replaces every set.
+                    route.attributes = Arc::new(vec![
+                        PathAttribute::Med(u32::from(i)),
+                        PathAttribute::LocalPref(cycle),
+                    ]);
+                    route
+                })
+                .collect();
+            manager.process_announce_chunk(peer, routes);
+        }
+        assert_eq!(
+            manager.attr_intern.len(),
+            usize::from(n),
+            "cycle {cycle}: one global entry per live attribute set — \
+             replaced sets must be reclaimed, cross-peer duplicates merged"
+        );
+    }
+
+    manager.handle_peer_deleted(peer2);
+    assert_eq!(
+        manager.attr_intern.len(),
+        usize::from(n),
+        "peer2 teardown must NOT reclaim sets peer1's routes still share"
+    );
+    manager.handle_peer_deleted(peer1);
+    assert_eq!(
+        manager.attr_intern.len(),
+        0,
+        "tearing down the last referencing peer must empty the table"
     );
 }

--- a/crates/rib/tests/memory_profile.rs
+++ b/crates/rib/tests/memory_profile.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 
 use rustbgpd_rib::adj_rib_in::AdjRibIn;
 use rustbgpd_rib::adj_rib_out::AdjRibOut;
+use rustbgpd_rib::attr_intern::AttrInternTable;
 use rustbgpd_rib::loc_rib::LocRib;
 use rustbgpd_rib::route::{Route, RouteOrigin};
 use rustbgpd_wire::{
@@ -204,6 +205,30 @@ fn typical_attributes(peer_idx: u32) -> Vec<PathAttribute> {
     ]
 }
 
+/// Per-prefix-unique attribute set, identical across peers for the same
+/// prefix index. Models the LAN-336 RR dual-feed shape: two clients
+/// advertising the same routes carry byte-identical attribute sets
+/// (NEXT_HOP preserved by reflection), while attribute diversity across
+/// prefixes matches a real table (unique AS_PATH tails / MED / community
+/// values per route) instead of `typical_attributes`' single set per peer.
+fn diverse_attributes(idx: u32) -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![
+                64512 + (idx % 1024),
+                65100 + (idx % 7),
+                65200 + (idx % 3),
+                idx,
+            ])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 255, 0, 1)),
+        PathAttribute::LocalPref(100),
+        PathAttribute::Med(idx % 16),
+        PathAttribute::Communities(vec![0xFFFF_0001, idx]),
+    ]
+}
+
 fn make_route(prefix: Prefix, peer_idx: u32, attrs: &[PathAttribute]) -> Route {
     Route {
         prefix,
@@ -266,24 +291,6 @@ fn adj_in_prefix_index_mem_size(_rib: &AdjRibIn) -> usize {
 }
 
 #[cfg(feature = "bench-internals")]
-fn adj_in_attr_intern_len(rib: &AdjRibIn) -> usize {
-    rib.bench_attr_intern_len()
-}
-#[cfg(not(feature = "bench-internals"))]
-fn adj_in_attr_intern_len(_rib: &AdjRibIn) -> usize {
-    0
-}
-
-#[cfg(feature = "bench-internals")]
-fn adj_in_attr_intern_capacity(rib: &AdjRibIn) -> usize {
-    rib.bench_attr_intern_capacity()
-}
-#[cfg(not(feature = "bench-internals"))]
-fn adj_in_attr_intern_capacity(_rib: &AdjRibIn) -> usize {
-    0
-}
-
-#[cfg(feature = "bench-internals")]
 fn loc_route_capacity(rib: &LocRib) -> usize {
     rib.bench_route_capacity()
 }
@@ -319,16 +326,18 @@ fn adj_out_prefix_index_mem_size(_rib: &AdjRibOut) -> usize {
     0
 }
 
-fn adj_in_stats(ribs: &[&AdjRibIn]) -> ComponentStats {
-    ribs.iter().fold(ComponentStats::ZERO, |mut stats, rib| {
+fn adj_in_stats(ribs: &[&AdjRibIn], intern: &AttrInternTable) -> ComponentStats {
+    let mut stats = ribs.iter().fold(ComponentStats::ZERO, |mut stats, rib| {
         stats.adj_in_routes += rib.len();
         stats.adj_in_capacity += adj_in_route_capacity(rib);
         stats.adj_in_prefix_index_entries += adj_in_prefix_index_len(rib);
         stats.adj_in_prefix_index_bytes += adj_in_prefix_index_mem_size(rib);
-        stats.adj_in_attr_intern_entries += adj_in_attr_intern_len(rib);
-        stats.adj_in_attr_intern_capacity += adj_in_attr_intern_capacity(rib);
         stats
-    })
+    });
+    // One global cross-peer table (LAN-336), not a per-rib sum.
+    stats.adj_in_attr_intern_entries = intern.len();
+    stats.adj_in_attr_intern_capacity = intern.capacity();
+    stats
 }
 
 fn loc_stats(rib: &LocRib) -> ComponentStats {
@@ -373,18 +382,22 @@ fn measure_adj_rib_in(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     ALLOC.reset_peak();
     let start = Instant::now();
 
+    let mut intern = AttrInternTable::new();
     let mut rib =
         AdjRibIn::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)), prefixes.len(), 0);
     for prefix in prefixes {
-        rib.insert(make_route(*prefix, 1, &attrs));
+        let mut route = make_route(*prefix, 1, &attrs);
+        intern.intern(&mut route.attributes);
+        rib.insert(route);
     }
 
     let elapsed_ms = start.elapsed().as_millis();
     let live_bytes = ALLOC.allocated() - baseline;
     let peak_bytes = ALLOC.peak() - baseline;
-    let stats = adj_in_stats(&[&rib]);
+    let stats = adj_in_stats(&[&rib], &intern);
     let route_copies = stats.adj_in_routes;
     drop(rib);
+    drop(intern);
 
     MemoryRow {
         profile,
@@ -407,6 +420,7 @@ fn measure_full_rib(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     ALLOC.reset_peak();
     let start = Instant::now();
 
+    let mut intern = AttrInternTable::new();
     let mut rib1 =
         AdjRibIn::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)), prefixes.len(), 0);
     let mut rib2 =
@@ -414,8 +428,12 @@ fn measure_full_rib(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     let mut loc = LocRib::with_capacity(prefixes.len());
 
     for prefix in prefixes {
-        rib1.insert(make_route(*prefix, 1, &attrs1));
-        rib2.insert(make_route(*prefix, 2, &attrs2));
+        let mut r1 = make_route(*prefix, 1, &attrs1);
+        intern.intern(&mut r1.attributes);
+        rib1.insert(r1);
+        let mut r2 = make_route(*prefix, 2, &attrs2);
+        intern.intern(&mut r2.attributes);
+        rib2.insert(r2);
     }
     for prefix in prefixes {
         let candidates = rib1.iter_prefix(prefix).chain(rib2.iter_prefix(prefix));
@@ -425,15 +443,72 @@ fn measure_full_rib(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     let elapsed_ms = start.elapsed().as_millis();
     let live_bytes = ALLOC.allocated() - baseline;
     let peak_bytes = ALLOC.peak() - baseline;
-    let stats = merge_stats(&[adj_in_stats(&[&rib1, &rib2]), loc_stats(&loc)]);
+    let stats = merge_stats(&[adj_in_stats(&[&rib1, &rib2], &intern), loc_stats(&loc)]);
     let route_copies = stats.adj_in_routes + stats.loc_routes;
     drop(loc);
     drop(rib1);
     drop(rib2);
+    drop(intern);
 
     MemoryRow {
         profile,
         shape: "full_rib",
+        prefixes: prefixes.len(),
+        input_peers: 2,
+        output_peers: 0,
+        route_copies,
+        live_bytes,
+        peak_bytes,
+        elapsed_ms,
+        stats,
+    }
+}
+
+/// `full_rib` with per-prefix-diverse, cross-peer-identical attributes
+/// (see [`diverse_attributes`]). This is the shape where attribute-set
+/// heap is a first-order cost and where cross-peer interning can act;
+/// the plain `full_rib` shape carries one attribute set per peer by
+/// construction, so its intern dimension is degenerate (2 entries).
+fn measure_full_rib_diverse(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
+    let baseline = ALLOC.allocated();
+    ALLOC.reset_peak();
+    let start = Instant::now();
+
+    let mut intern = AttrInternTable::new();
+    let mut rib1 =
+        AdjRibIn::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)), prefixes.len(), 0);
+    let mut rib2 =
+        AdjRibIn::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)), prefixes.len(), 0);
+    let mut loc = LocRib::with_capacity(prefixes.len());
+
+    for (idx, prefix) in prefixes.iter().enumerate() {
+        #[expect(clippy::cast_possible_truncation, reason = "profile sizes fit u32")]
+        let attrs = diverse_attributes(idx as u32);
+        let mut r1 = make_route(*prefix, 1, &attrs);
+        intern.intern(&mut r1.attributes);
+        rib1.insert(r1);
+        let mut r2 = make_route(*prefix, 2, &attrs);
+        intern.intern(&mut r2.attributes);
+        rib2.insert(r2);
+    }
+    for prefix in prefixes {
+        let candidates = rib1.iter_prefix(prefix).chain(rib2.iter_prefix(prefix));
+        loc.recompute(*prefix, candidates);
+    }
+
+    let elapsed_ms = start.elapsed().as_millis();
+    let live_bytes = ALLOC.allocated() - baseline;
+    let peak_bytes = ALLOC.peak() - baseline;
+    let stats = merge_stats(&[adj_in_stats(&[&rib1, &rib2], &intern), loc_stats(&loc)]);
+    let route_copies = stats.adj_in_routes + stats.loc_routes;
+    drop(loc);
+    drop(rib1);
+    drop(rib2);
+    drop(intern);
+
+    MemoryRow {
+        profile,
+        shape: "full_rib_diverse",
         prefixes: prefixes.len(),
         input_peers: 2,
         output_peers: 0,
@@ -452,6 +527,7 @@ fn measure_rr_fanout(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     ALLOC.reset_peak();
     let start = Instant::now();
 
+    let mut intern = AttrInternTable::new();
     let mut rib1 =
         AdjRibIn::with_capacity(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)), prefixes.len(), 0);
     let mut rib2 =
@@ -459,8 +535,12 @@ fn measure_rr_fanout(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     let mut loc = LocRib::with_capacity(prefixes.len());
 
     for prefix in prefixes {
-        rib1.insert(make_route(*prefix, 1, &attrs1));
-        rib2.insert(make_route(*prefix, 2, &attrs2));
+        let mut r1 = make_route(*prefix, 1, &attrs1);
+        intern.intern(&mut r1.attributes);
+        rib1.insert(r1);
+        let mut r2 = make_route(*prefix, 2, &attrs2);
+        intern.intern(&mut r2.attributes);
+        rib2.insert(r2);
     }
     for prefix in prefixes {
         let candidates = rib1.iter_prefix(prefix).chain(rib2.iter_prefix(prefix));
@@ -481,7 +561,7 @@ fn measure_rr_fanout(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     let live_bytes = ALLOC.allocated() - baseline;
     let peak_bytes = ALLOC.peak() - baseline;
     let stats = merge_stats(&[
-        adj_in_stats(&[&rib1, &rib2]),
+        adj_in_stats(&[&rib1, &rib2], &intern),
         loc_stats(&loc),
         adj_out_stats(&[&out1, &out2]),
     ]);
@@ -491,6 +571,7 @@ fn measure_rr_fanout(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
     drop(loc);
     drop(rib1);
     drop(rib2);
+    drop(intern);
 
     MemoryRow {
         profile,
@@ -507,11 +588,12 @@ fn measure_rr_fanout(profile: &'static str, prefixes: &[Prefix]) -> MemoryRow {
 }
 
 fn profile_rows(profile: &'static str, sizes: &[usize]) -> Vec<MemoryRow> {
-    let mut rows = Vec::with_capacity(sizes.len() * 3);
+    let mut rows = Vec::with_capacity(sizes.len() * 4);
     for &size in sizes {
         let prefixes = generate_prefixes(size);
         rows.push(measure_adj_rib_in(profile, &prefixes));
         rows.push(measure_full_rib(profile, &prefixes));
+        rows.push(measure_full_rib_diverse(profile, &prefixes));
         rows.push(measure_rr_fanout(profile, &prefixes));
         drop(prefixes);
     }
@@ -549,7 +631,7 @@ fn configured_profile() -> (&'static str, Vec<usize>) {
 #[test]
 fn memory_profile_schema_quick() {
     let rows = profile_rows("schema", &[512]);
-    assert_eq!(rows.len(), 3);
+    assert_eq!(rows.len(), 4);
 
     let adj = rows.iter().find(|row| row.shape == "adj_rib_in").unwrap();
     assert_eq!(adj.prefixes, 512);
@@ -567,6 +649,14 @@ fn memory_profile_schema_quick() {
     assert_eq!(full.route_copies, 512 * 3);
     assert_eq!(full.stats.adj_in_routes, 512 * 2);
     assert_eq!(full.stats.loc_routes, 512);
+
+    let diverse = rows
+        .iter()
+        .find(|row| row.shape == "full_rib_diverse")
+        .unwrap();
+    assert_eq!(diverse.input_peers, 2);
+    assert_eq!(diverse.route_copies, 512 * 3);
+    assert_eq!(diverse.stats.adj_in_routes, 512 * 2);
 
     let rr = rows.iter().find(|row| row.shape == "rr_fanout").unwrap();
     assert_eq!(rr.input_peers, 2);

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -90,7 +90,7 @@ pub struct BgpMetrics {
     rib_prefixes: IntGaugeVec,
     rib_adj_out_prefixes: IntGaugeVec,
     rib_loc_prefixes: IntGaugeVec,
-    rib_attr_intern_size: IntGaugeVec,
+    rib_attr_intern_global_size: IntGauge,
     route_event_history_depth: IntGauge,
     route_event_history_capacity: IntGauge,
 
@@ -376,12 +376,9 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
-        let rib_attr_intern_size = IntGaugeVec::new(
-            Opts::new(
-                "bgp_rib_attr_intern_size",
-                "Unique interned attribute sets in a peer's Adj-RIB-In intern table (gc_intern_table reclaims unreferenced entries). Sum across peers for the daemon-wide total.",
-            ),
-            &["peer"],
+        let rib_attr_intern_global_size = IntGauge::new(
+            "bgp_rib_attr_intern_global_size",
+            "Unique attribute sets in the daemon-wide cross-peer intern table (LAN-336). Reclaim sweeps drop entries no route references; refreshed at every insert/remove batch seam.",
         )
         .expect("valid metric definition");
 
@@ -1367,7 +1364,7 @@ impl BgpMetrics {
             .register(Box::new(rib_loc_prefixes.clone()))
             .expect("metric not already registered");
         registry
-            .register(Box::new(rib_attr_intern_size.clone()))
+            .register(Box::new(rib_attr_intern_global_size.clone()))
             .expect("metric not already registered");
         registry
             .register(Box::new(route_event_history_depth.clone()))
@@ -1715,7 +1712,7 @@ impl BgpMetrics {
             rib_prefixes,
             rib_adj_out_prefixes,
             rib_loc_prefixes,
-            rib_attr_intern_size,
+            rib_attr_intern_global_size,
             route_event_history_depth,
             route_event_history_capacity,
             orr_spf_runs_total,
@@ -1865,7 +1862,6 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.messages_sent, peer);
         Self::reap_peer_series_from_vec(&self.messages_received, peer);
         Self::reap_peer_series_from_vec(&self.rib_prefixes, peer);
-        Self::reap_peer_series_from_vec(&self.rib_attr_intern_size, peer);
         Self::reap_peer_series_from_vec(&self.rib_adj_out_prefixes, peer);
         Self::reap_peer_series_from_vec(&self.max_prefix_exceeded, peer);
         Self::reap_peer_series_from_vec(&self.outbound_route_drops, peer);
@@ -2071,14 +2067,12 @@ impl BgpMetrics {
             .set(count);
     }
 
-    /// Set the number of unique interned attribute sets in one peer's
-    /// Adj-RIB-In intern table. O(1); sum across peers for the daemon-wide
-    /// total. Monitors `gc_intern_table` reclamation and live growth under
-    /// injection / route churn.
-    pub fn set_rib_attr_intern_size(&self, peer: &str, count: i64) {
-        self.rib_attr_intern_size
-            .with_label_values(&[peer])
-            .set(count);
+    /// Set the number of unique attribute sets in the daemon-wide
+    /// cross-peer intern table (LAN-336). O(1). Refreshed at every
+    /// insert/remove batch seam so reclaim regressions surface as a
+    /// monotonic slope, never a stale flat line.
+    pub fn set_rib_attr_intern_global_size(&self, count: i64) {
+        self.rib_attr_intern_global_size.set(count);
     }
 
     /// Set the number of retained events in the bounded route-event
@@ -3876,38 +3870,12 @@ mod tests {
     }
 
     #[test]
-    fn rib_attr_intern_size_gauge_is_per_peer() {
+    fn rib_attr_intern_global_size_gauge_is_daemon_wide() {
         let m = BgpMetrics::new();
-        m.set_rib_attr_intern_size("10.0.0.1", 7);
-        m.set_rib_attr_intern_size("10.0.0.2", 3);
-
-        assert_eq!(
-            m.rib_attr_intern_size
-                .with_label_values(&["10.0.0.1"])
-                .get(),
-            7
-        );
-        assert_eq!(
-            m.rib_attr_intern_size
-                .with_label_values(&["10.0.0.2"])
-                .get(),
-            3
-        );
-
-        m.reap_peer_series("10.0.0.1");
-        assert!(
-            !series_for_peer(&m, "10.0.0.1")
-                .iter()
-                .any(|name| name == "bgp_rib_attr_intern_size"),
-            "reaped peer's intern-size series should be gone"
-        );
-        // The other peer's series survives.
-        assert_eq!(
-            m.rib_attr_intern_size
-                .with_label_values(&["10.0.0.2"])
-                .get(),
-            3
-        );
+        m.set_rib_attr_intern_global_size(7);
+        assert_eq!(m.rib_attr_intern_global_size.get(), 7);
+        m.set_rib_attr_intern_global_size(3);
+        assert_eq!(m.rib_attr_intern_global_size.get(), 3);
     }
 
     #[test]
@@ -4434,7 +4402,6 @@ mod tests {
         m.record_message_sent(peer, "keepalive");
         m.record_message_received(peer, "update");
         m.set_rib_prefixes(peer, "ipv4_unicast", 42);
-        m.set_rib_attr_intern_size(peer, 11);
         m.set_adj_rib_out_prefixes(peer, "ipv4_unicast", 7);
         m.record_max_prefix_exceeded(peer);
         m.record_outbound_route_drop(peer);
@@ -4491,8 +4458,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 34 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 35);
+        // 33 peer-labeled families; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 34);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -4502,7 +4469,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 35);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 34);
     }
 
     #[test]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -514,19 +514,20 @@ bench/compare-rib-memory.sh --base origin/main --head HEAD --profile quick
 | `LocRib` | 96 bytes |
 
 `PathAttribute` grew from 72 to 112 bytes since the v0.30-era figures (new
-attribute variants). It is interned per peer, so the per-route impact is
-amortized to near zero (see below), but it does raise the per-unique-attribute-
-set heap cost.
+attribute variants). It is interned (globally, across all peers — LAN-336),
+so the per-route impact is amortized to near zero (see below), but it does
+raise the per-unique-attribute-set heap cost.
 
 `Route.attributes` is `Arc<Vec<PathAttribute>>` — cloning a route between
 Adj-RIB-In, Loc-RIB, and Adj-RIB-Out shares the attribute allocation via
 reference counting. Mutation uses `Arc::make_mut()` (copy-on-write).
 
-Path attribute interning in `AdjRibIn` deduplicates identical attribute sets
-across routes from the same peer. A `HashSet<Arc<Vec<PathAttribute>>>` intern
-table maps each unique attribute set to a shared `Arc`. Routes with identical
-attributes (common in bulk advertisements) share one heap allocation instead of
-each having their own copy.
+Path attribute interning deduplicates identical attribute sets across routes
+from ALL peers: a single RIB-manager-owned `AttrInternTable` (LAN-336, the
+analog of BIRD's `rta` cache) maps each unique attribute set to a shared
+`Arc`. Routes with identical attributes — bulk advertisements from one peer,
+or the same route re-advertised by multiple RR clients — share one heap
+allocation instead of one copy per route or per peer.
 
 ### Per-Route Heap Allocation
 
@@ -565,8 +566,8 @@ can separate those cliffs from real storage regressions.
 *prefix-index migration* note below.) This is the **RIB-only, allocator-tracked**
 structural memory (2× Adj-RIB-In +
 Loc-RIB); each prefix stores Route instances with `Arc` sharing of attributes
-across copies, and attribute interning within each `AdjRibIn` shares one
-allocation across routes with identical attributes. It is **distinct from the
+across copies, and global attribute interning shares one allocation across
+routes with identical attributes, whichever peers they came from. It is **distinct from the
 full-process RSS** below — it excludes the daemon's operational surfaces
 (event-history, gRPC, telemetry, BFD, the tokio runtime, allocator arenas).
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -444,7 +444,7 @@ authenticated sensitive-read surface.
 | `bgp_rib_loc_prefixes{afi_safi}` | Loc-RIB size (best paths) per AFI/SAFI |
 | `bgp_rib_prefixes{peer,afi_safi}` | Adj-RIB-In size per peer + AFI/SAFI (received) |
 | `bgp_rib_adj_out_prefixes{peer,afi_safi}` | Adj-RIB-Out size per peer + AFI/SAFI (advertised) |
-| `bgp_rib_attr_intern_size{peer}` | Unique interned attribute sets in a peer's Adj-RIB-In (attribute-memory dedup). Sum across peers for the daemon-wide total; tracks `gc_intern_table` reclamation and growth under churn |
+| `bgp_rib_attr_intern_global_size` | Unique attribute sets in the daemon-wide cross-peer intern table (attribute-memory dedup across ALL peers). Tracks reclaim sweeps and growth under churn; a monotonic slope under steady-state churn indicates an intern leak. Replaces the per-peer `bgp_rib_attr_intern_size{peer}` gauge |
 | `bgp_messages_received_total` | Inbound BGP messages by type |
 | `bgp_messages_sent_total` | Outbound BGP messages by type |
 | `bgp_route_refresh_in_progress{peer,afi_safi}` | Active inbound Enhanced Route Refresh window for a peer/family (1 = active, 0 = inactive) |

--- a/docs/adr/0048-rib-memory-optimizations.md
+++ b/docs/adr/0048-rib-memory-optimizations.md
@@ -4,6 +4,12 @@
 
 Accepted
 
+> **Update (LAN-336):** the per-`AdjRibIn` intern table described below was
+> replaced by a single daemon-wide cross-peer table owned by the RIB manager
+> (`crates/rib/src/attr_intern.rs`). The interning mechanics (content-hash
+> lookup, `Arc` strong-count GC) are unchanged; only the scope moved from
+> one-table-per-peer to one table for all peers and families.
+
 ## Context
 
 With a full Internet routing table (~900k IPv4 prefixes), memory consumption is

--- a/docs/grafana/rustbgpd-overview.json
+++ b/docs/grafana/rustbgpd-overview.json
@@ -1049,8 +1049,8 @@
     {
       "id": 39,
       "type": "timeseries",
-      "title": "Attribute intern table size (per peer)",
-      "description": "bgp_rib_attr_intern_size: interned path-attribute entries per peer's Adj-RIB-In. Updated on growth and reclaim; a monotonically climbing series under steady churn indicates an intern leak.",
+      "title": "Attribute intern table size (global)",
+      "description": "Unique attribute sets in the daemon-wide cross-peer intern table (LAN-336). Flat under steady-state churn; a monotonic slope means reclaim is broken.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -1090,8 +1090,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (peer) (bgp_rib_attr_intern_size{instance=~\"$instance\",peer=~\"$peer\"})",
-          "legendFormat": "{{peer}}",
+          "expr": "bgp_rib_attr_intern_global_size{instance=~\"$instance\"}",
+          "legendFormat": "interned attribute sets",
           "refId": "A"
         }
       ]

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -814,7 +814,7 @@ per-cycle events recorded in `churn.log`.
 
 | Harness | Proves | Topology / analyzer |
 |---------|--------|---------------------|
-| `run-soak-gr-restart-intern-gc.sh` | The attribute intern table does not grow across GR-restart → EoR → stale-clear cycles: `sum(bgp_rib_attr_intern_size)` slope `< 1.0`/hr | containerlab topology + post-hoc slope analyzer |
+| `run-soak-gr-restart-intern-gc.sh` | The attribute intern table does not grow across GR-restart → EoR → stale-clear cycles: `bgp_rib_attr_intern_global_size` slope `< 1.0`/hr | containerlab topology + post-hoc slope analyzer |
 | `run-soak-hot-reload.sh` | Sustained SIGHUP / live-apply config churn leaks no state | containerlab topology + post-hoc analyzer |
 | `run-soak-inject-churn.sh` | Sustained gRPC AddPath/DeletePath churn holds RSS + intern-table size flat | containerlab topology + post-hoc analyzer |
 

--- a/tests/soak/analyze-soak-gr-restart.py
+++ b/tests/soak/analyze-soak-gr-restart.py
@@ -4,7 +4,7 @@
 Reads the CSV emitted by run-soak-gr-restart-intern-gc.sh and emits a
 JSON verdict against the soak-specific gates:
 
-  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
+  - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
     (the intern table should not grow across restart cycles; a positive
     slope indicates gc_intern_table is not reclaiming stranded sets)
   - RSS slope (steady state, MB/hour) < 1.0

--- a/tests/soak/analyze-soak-hot-reload.py
+++ b/tests/soak/analyze-soak-hot-reload.py
@@ -5,7 +5,7 @@ Reads the CSV emitted by run-soak-hot-reload.sh and emits a JSON
 verdict against the soak-specific gates:
 
   - RSS slope (steady state, MB/hour) < 1.0
-  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
+  - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap from live-apply)
   - at least one apply cycle recorded

--- a/tests/soak/analyze-soak-inject-churn.py
+++ b/tests/soak/analyze-soak-inject-churn.py
@@ -5,7 +5,7 @@ Reads the CSV emitted by run-soak-inject-churn.sh and emits a JSON
 verdict against the soak-specific gates:
 
   - RSS slope (steady state, MB/hour) < 1.0
-  - intern table size (bgp_rib_attr_intern_size) slope per hour < 1.0
+  - intern table size (bgp_rib_attr_intern_global_size) slope per hour < 1.0
   - peak RSS < 512 MB
   - session established in final 3 samples (no flap)
   - at least one churn cycle recorded

--- a/tests/soak/run-soak-gr-restart-intern-gc.sh
+++ b/tests/soak/run-soak-gr-restart-intern-gc.sh
@@ -4,7 +4,7 @@
 # Repeatedly restarts FRR's bgpd to drive rustbgpd through the
 # Graceful Restart state machine: session down → stale-mark →
 # reconnect → EoR → stale-clear → gc_intern_table. Samples RSS and
-# the bgp_rib_attr_intern_size Prometheus gauge each cycle to prove
+# the bgp_rib_attr_intern_global_size Prometheus gauge each cycle to prove
 # the interned-attribute table does not grow across restart cycles
 # (the leak class fixed in #603 and unsoaked at HEAD until now).
 #
@@ -201,7 +201,7 @@ sample_row() {
     local prom rss intern_size gr_active established
     prom=$(prom_scrape)
     rss=$(container_rss_mb)
-    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
     gr_active=$(prom_extract_or_zero "$prom" bgp_gr_active_peers)
     if frr_established_seen; then
         established=1

--- a/tests/soak/run-soak-hot-reload.sh
+++ b/tests/soak/run-soak-hot-reload.sh
@@ -250,7 +250,7 @@ sample_row() {
     local prom rss intern_size established
     prom=$(prom_scrape)
     rss=$(container_rss_mb)
-    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
     if frr_established_seen; then
         established=1
     else

--- a/tests/soak/run-soak-inject-churn.sh
+++ b/tests/soak/run-soak-inject-churn.sh
@@ -285,7 +285,7 @@ sample_row() {
     else
         established=0
     fi
-    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_size)
+    intern_size=$(prom_extract_sum "$prom" bgp_rib_attr_intern_global_size)
     printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         "$elapsed" \

--- a/tests/soak/soak-gr-restart-intern-gc.clab.yml
+++ b/tests/soak/soak-gr-restart-intern-gc.clab.yml
@@ -8,8 +8,8 @@
 # rustbgpd has gr_restart_time=15, gr_stale_routes_time=20,
 # llgr_stale_time=60. The soak harness cyclically restarts FRR's
 # bgpd to drive the rustbgpd GR-restart → stale-mark → EoR →
-# stale-clear → gc_intern_table path repeatedly, sampling RSS and
-# the bgp_rib_attr_intern_size gauge to prove the intern table
+# stale-clear → attribute-intern gc path repeatedly, sampling RSS and
+# the bgp_rib_attr_intern_global_size gauge to prove the intern table
 # does not grow across restart cycles.
 #
 # Usage:


### PR DESCRIPTION
Attribute interning moves from one table per AdjRibIn to a single
cross-peer table owned by the RibManager actor (lock-free by
ownership) - the analog of BIRD's refcounted rta cache. Peers carrying
byte-identical attribute sets (the RR/RS reality: reflection preserves
NEXT_HOP, so dual-fed clients advertise identical vectors) now share
one allocation instead of one copy per peer. Interning happens in the
manager BEFORE a route is stored, so a stored route's Arc is never
swapped: ExportMemo's Arc::as_ptr keys and the routes_equal ptr_eq
fast paths are untouched (cross-peer sharing makes both HIT more).

Reclaim is the same Arc strong-count sweep the per-peer tables used,
run at the same batch seams plus peer teardown; a cross-peer churn
test holds the table flat over replace cycles and proves teardown of
one sharing peer reclaims nothing while the last teardown empties it.

The per-peer bgp_rib_attr_intern_size{peer} gauge is replaced by
bgp_rib_attr_intern_global_size, refreshed at every insert/remove
batch seam; soak harnesses, Grafana, and OPERATIONS.md follow.

memory_profile (allocator-tracked, 2p x 100k, medians of 3):
full_rib_diverse (new shape: per-prefix-unique, cross-peer-identical
attrs) 310.4 -> 181.1 MiB (-41.7%), intern entries 200k -> 100k;
full_rib 51.80 -> 51.79 MiB (-0.00%), rr_fanout/adj_rib_in neutral -
those shapes carry one attribute set per peer by construction, so
their intern dimension is degenerate (~1 KiB total attr heap).

CPU (criterion A/B vs base, 3 alternating core-pinned attempts):
rib_ops - no confident regressions, worst mean +2.25%
(rib_pipeline/10000, inside noise), route_churn -0.10%;
distribute_fanout - all cells within +/-1.7% median-of-3.

LAN-336

Closes LAN-336.