### PR TITLE
docs(rib): pin the batch-purge pairing behind the chunk-processing expects

### DIFF
--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -451,6 +451,12 @@ impl RibManager {
         self.gr_deferred_eor.remove(&peer);
         self.dirty_peers.remove(&peer);
         self.pending_eor.remove(&peer);
+        // Purge the peer's queued route batches. This upholds the
+        // "peer rib must exist before chunk processing" expectation in
+        // the distribution chunk handlers: `enqueue_routes_received`
+        // creates the Adj-RIB-In if absent, and the only removal path
+        // (`clear_peer_adj_rib_in`) is followed by this purge in every
+        // caller, so a queued chunk can never outlive its rib.
         self.pending_route_batches.retain(|prb| prb.peer() != peer);
         // Drop per-peer export-policy counters alongside the rest of the
         // per-peer state. Without this the HashMap grows unbounded as


### PR DESCRIPTION
Final slice of LAN-8 (crates/rib). Zero reachable panics: all 19 non-test sites verified as documented invariants or compile-time-certain, including the fresh slab/intern/residue code. The issue's named target prefix_map.rs is already panic-free in release (debug_assert + clamped fallback). The one non-local invariant — chunk-processing expects depending on teardown always purging pending_route_batches — is traced sound (single-threaded actor, purge follows every ribs.remove) and now pinned with a comment at the purge site. Closes LAN-8.