### PR TITLE
docs: normalize host-specific paths in published soak evidence

### DIFF
--- a/docs/artifacts/soak/README.md
+++ b/docs/artifacts/soak/README.md
@@ -1,0 +1,13 @@
+# Soak evidence artifacts
+
+Frozen run evidence for the long-running soak and scale gates: per-run
+`soak.log`, `run.json`/`report.json` summaries, and `samples.csv` time
+series. Each directory is a single run, named `<gate>-<UTC-timestamp>`.
+
+## Normalization note
+
+Host-specific absolute paths were normalized before publication;
+measurements and command output are otherwise unchanged. Absolute run
+paths that embedded a host home directory were rewritten to the
+`<SOAK_HOME>` placeholder — only the path prefix was substituted, and no
+sample value, threshold, timing, or verdict was altered.

--- a/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/report.json
+++ b/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/report.json
@@ -1,5 +1,5 @@
 {
-  "samples_csv": "/home/lance/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z/samples.csv",
+  "samples_csv": "<SOAK_HOME>/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z/samples.csv",
   "row_count": 591,
   "runtime_hours": 10.088888888888889,
   "pe1_memory_slope_mb_per_h": 0.12462185291014867,

--- a/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/run.json
+++ b/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/run.json
@@ -17,6 +17,6 @@
   "pool_max": 384,
   "ce_port": "ce100a",
   "vni": 100,
-  "topology": "/home/lance/projects/rustbgpd/tests/soak/gate8b-soak.clab.yml",
-  "run_dir": "/home/lance/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z"
+  "topology": "<SOAK_HOME>/projects/rustbgpd/tests/soak/gate8b-soak.clab.yml",
+  "run_dir": "<SOAK_HOME>/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z"
 }

--- a/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/soak.log
+++ b/docs/artifacts/soak/gate8b-mac-churn-20260701T014434Z/soak.log
@@ -1,9 +1,9 @@
-acquired host lock: /home/lance/.local/state/rustbgpd-host.lock
+acquired host lock: <SOAK_HOME>/.local/state/rustbgpd-host.lock
 [2026-07-01T01:44:34Z] Gate 8b MAC-churn soak starting
 [2026-07-01T01:44:34Z]   duration=24h  sample=60s  flip=600s
 [2026-07-01T01:44:34Z]   churn_interval=5s  batch=16  pool=512 (target=256)
 [2026-07-01T01:44:34Z]   mobility=25%  ce_port=ce100a  vni=100
-[2026-07-01T01:44:34Z]   run_dir=/home/lance/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z
+[2026-07-01T01:44:34Z]   run_dir=<SOAK_HOME>/projects/rustbgpd/tests/soak/runs/gate8b-mac-churn-20260701T014434Z
 [2026-07-01T01:44:34Z]   git_rev=c273118e49dcbac46d174c869dcf9626dbacca76 dirty=true kernel=6.8.0-117-generic
 [2026-07-01T01:44:34Z] warmup: waiting 120s for initial dataplane discovery
 [2026-07-01T01:46:34Z] waiting up to 300s for both PEs to reach BGP Established

--- a/docs/artifacts/soak/m33-evpn-scale-20260701T014045Z/soak.log
+++ b/docs/artifacts/soak/m33-evpn-scale-20260701T014045Z/soak.log
@@ -1,11 +1,11 @@
-acquired host lock: /home/lance/.local/state/rustbgpd-host.lock
+acquired host lock: <SOAK_HOME>/.local/state/rustbgpd-host.lock
 [1;34m[21:40:45 TEST][0m M33 soak run 20260701T014045Z
 [1;34m[21:40:45 TEST][0m   duration:   24.00h (86400s)
 [1;34m[21:40:45 TEST][0m   warmup:     600s
 [1;34m[21:40:45 TEST][0m   sample:     every 60s
 [1;34m[21:40:45 TEST][0m   health:     every 300s
 [1;34m[21:40:45 TEST][0m   churn rate: 1000 rps
-[1;34m[21:40:45 TEST][0m   output:     /home/lance/projects/rustbgpd/tests/soak/runs/20260701T014045Z
+[1;34m[21:40:45 TEST][0m   output:     <SOAK_HOME>/projects/rustbgpd/tests/soak/runs/20260701T014045Z
 [1;34m[21:40:45 TEST][0m gRPC endpoint: 172.20.20.4:50051
 [1;34m[21:40:45 TEST][0m Starting rustbgpd daemon...
 [1;34m[21:40:45 TEST][0m rustbgpd is running (after 1s)


### PR DESCRIPTION
Rewrites the host home-directory prefix (`/home/<user>`) to a stable `<SOAK_HOME>` placeholder in the four soak-evidence files that leaked it — the only such leaks in the tree. Prefix-only substitution: no sample value, threshold, timing, or verdict changed (diff is 7 path lines). Adds a normalization disclosure note to a new `docs/artifacts/soak/README.md`. Raw originals retained privately off-repo.