### PR TITLE
docs: correct documentation drift against HEAD

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,7 +237,6 @@ gRPC request
 | Config loading + validation | `src/config/` |
 | Scoped link-local / unnumbered neighbor identity | `src/config/validation.rs` + `src/config/mod.rs` (`interface` / `scope_id` parse + resolve), `crates/api/src/peer_types.rs` (`PeerKey`), `crates/transport/src/config.rs` (`peer_interface` / `peer_scope_id`), `crates/transport/src/socket_opts.rs` (scoped connect, AF-aware GTSM), `src/peer_manager/inbound.rs` (passive scope match) — ADR-0069 |
 | Startup wiring | `src/main.rs` |
-| Looking glass (REST API) | `src/looking_glass.rs` |
 | Prometheus metrics | `crates/telemetry/src/lib.rs` |
 
 ---
@@ -251,7 +250,7 @@ gRPC request
 3. Spawns RibManager task (owns all routing state).
 4. Spawns PeerManager task (owns neighbor lifecycle).
 5. Spawns BgpListener (accepts inbound TCP on port 179).
-6. Spawns gRPC API server. Optionally spawns Prometheus metrics server (if `prometheus_addr` configured) and looking glass HTTP server (if `[global.telemetry.looking_glass]` configured).
+6. Spawns gRPC API server. Optionally spawns Prometheus metrics server (if `prometheus_addr` configured).
 7. Optionally spawns BMP manager + per-collector clients, MRT manager, RPKI VRP manager + RTR clients.
 8. For each configured neighbor, sends `AddPeer` to PeerManager → PeerManager spawns a PeerSession task.
 
@@ -295,8 +294,7 @@ gRPC request
    refresh time, transient mpsc backpressure).
 6. Global config changes that are not hot-reloadable
    (`[global]` ASN/router-id/families, `[rpki]`, `[bmp]`, `[mrt]`,
-   `[global.telemetry.grpc_*]` listener config, inline
-   `policy.import` / `policy.export` legacy global-fallback statements)
+   `[global.telemetry.grpc_*]` listener config)
    are surfaced under "Restart-required" in `rustbgpd --diff` and logged
    at reload time. The runtime listener config for `grpc_tcp` / `grpc_uds`
    is pinned back to the live values so subsequent diffs keep flagging

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -240,16 +240,6 @@ resolved.
   (replaying reverse commands to undo successful steps) is still
   out of scope — peer-group changes flap sessions, and unwinding
   flap them again.
-- **Inline `policy.import` / `policy.export` reload requires restart.**
-  Named-definition / chain edits hot-reload now (as of v0.12.0), but
-  the legacy inline global-fallback statements at `[policy.import]` /
-  `[policy.export]` are evaluated at session start and have no
-  runtime swap surface yet. `rustbgpd --diff` flags them under
-  "Restart-required" with a migration hint to named definitions plus
-  `import_chain` / `export_chain`. Adding a runtime swap is tractable
-  follow-up work — would need a new `ConfigEvent` variant and a
-  `PeerManagerCommand` that re-runs `effective_policy_chains_for_neighbor`
-  for every peer.
 - **MRT snapshot encoding is allocation-heavy at large scale.** The
   `TABLE_DUMP_V2` encoder groups routes by prefix and synthesizes
   per-entry attributes, which is correct but can create extra allocation

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ transaction-backed config subset:
 
 | Service | RPCs | Purpose |
 |---------|------|---------|
-| `GlobalService` | `GetGlobal`, `SetGlobal` | Daemon identity and configuration |
+| `GlobalService` | `GetGlobal` | Daemon identity |
 | `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction`, `ApplyConfigTransaction`, `ConfirmConfigTransaction`, `AbortConfigTransaction`, `GetConfigTransactionStatus` | Candidate-vs-live config diff, plus the v1 config-transaction lifecycle: validate/plan, commit/apply (incl. commit-confirmed), confirm, abort, and status |
 | `NeighborService` | `AddNeighbor`, `DeleteNeighbor`, `ListNeighbors`, `GetNeighborState`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `SetGracefulShutdown`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `ListDynamicNeighbors` | Peer lifecycle, inbound soft reset, RFC 8326 graceful-shutdown toggle, and dynamic-neighbor CRUD — `AddDynamicNeighbor` / `DeleteDynamicNeighbor` add and remove `[[dynamic_neighbors]]` prefix ranges at runtime (queued to config when started with `--config`), `ListDynamicNeighbors` for visibility |
 | `PolicyService` | `ListPolicies`, `GetPolicy`, `SetPolicy`, `DeletePolicy`, `List/Get/Set/DeleteNeighborSet`, `Get*Chain`, `Set*Chain`, `Clear*Chain`, `ExplainImportPolicy`, `TestPolicy`, `GetPolicyStats` | Named policy CRUD, neighbor sets, global/per-neighbor chain attachment, import-policy decision explain (per-term traces for `.rpol` members), read-only candidate-policy dry runs over the live RIB, and live per-term hit counters |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ those.
 |------|--------|-------|
 | BGP core (RFC 4271 FSM, 4-byte ASN, capabilities, collision detection) | Shipped | All 6 states, property-tested |
 | Address families: IPv4/IPv6 unicast (MP-BGP, RFC 4760) | Shipped | Dual-stack, FRR-interop validated |
-| Extensions: Add-Path (7911), Extended Messages (8654), Extended Nexthop (8950) | Partial | Extended Message send/receive directionality correction queued from the post-v0.50 audit |
+| Extensions: Add-Path (7911), Extended Messages (8654), Extended Nexthop (8950) | Partial | Extended Message send/receive directionality and per-type size-limit correction shipped |
 | Graceful Restart (4724) + LLGR (9494) + Notification GR (8538) | Partial | GR helper + minimal restarting speaker shipped; LLGR reconnect/consecutive-reset/per-AFI/SAFI timer corrections shipped; interop re-proof queued |
 | Route Refresh (2918) + Enhanced Route Refresh (7313) | Shipped | |
 | BGP Roles + Only-to-Customer (9234) | Shipped | Static eBGP, IPv4/IPv6 unicast (ADR-0071, M55) |
@@ -43,8 +43,8 @@ those.
 | EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side GW-IP overlay-index recursion shipped; native GW-IP + ESI overlay-index origination shipped; single-active ESI overlay-index receive v1 shipped; all-active ESI overlay-index Type 5 writer shipped with same-host netns proof and M72 real-peer proof (ADR-0087/0090, FRR consume-side M68 for GW-IP, GoBGP receive-side M71 for single-active ESI recursion, GoBGP ×2 receive-side M72 for all-active ESI recursion) |
 | FIB / dataplane: unicast Linux FIB install, ECMP, weighted multipath, BLACKHOLE discard | Shipped | Opt-in `[[fib_tables]]` (ADR-0061/0066/0068) |
 | Security: TCP MD5, GTSM, static TCP-AO, native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop (M43); ADR-0064 authz |
-| RPKI origin validation (6811 + 8210) | Partial | VRP table and policy match shipped; RTR epoch/reconnect-retention/identity/transaction-bound corrections shipped; multi-cache interop proof queued |
-| ASPA verification | Partial | Role-aware verification and policy match shipped; RTR v2 replacement/withdrawal semantics shipped; interop proof queued |
+| RPKI origin validation (6811 + 8210) | Partial | VRP table and policy match shipped; RTR epoch/reconnect-retention/identity/transaction-bound corrections shipped; M84 multi-cache RTR/ASPA epoch conformance lab shipped |
+| ASPA verification | Partial | Role-aware verification and policy match shipped; RTR v2 replacement/withdrawal semantics shipped; M84 RTR/ASPA epoch conformance lab shipped |
 | Policy: prefix lists, named chains, actions, community/AS_PATH/validation match | Shipped | GoBGP-style chain evaluation |
 | Policy: `.rpol` typed compiled language (ADR-0096) | Shipped | Named sets, `u32` parameters, in-language tests (`rbgp policy check`), live-RIB dry run (`rbgp policy test`), per-term explain traces + live hit counters (`rbgp policy stats`); M80 FRR route-map parity receipt |
 | BFD single-hop async + RFC 5882 coupling | Partial | M51 base receipt; receive-work budgeting and remote-AdminDown coupling corrections shipped; re-receipt queued |
@@ -173,7 +173,7 @@ and the research-shaped queue below.
   resumable RIB actor queries with cancellation; stop `rbgp best`, `received`,
   and `advertised` from silently truncating at 100 rows; skip canceled MRT
   requests before snapshot/encoding/file creation.
-- [ ] **FlowSpec policy context.** Represent a legal FlowSpec rule without a
+- [x] **FlowSpec policy context.** Represent a legal FlowSpec rule without a
   destination-prefix component as `prefix = None`, never fabricated IPv4
   `0.0.0.0/0`, and prove IPv4/IPv6 import/export policy behavior.
 - [x] **BMP connection-generation synchronization.** Fence/cancel stale dump
@@ -182,20 +182,20 @@ and the research-shaped queue below.
 
 **Contained hardening and design follow-ups:**
 
-- [ ] Bound rpol `apply()` DAG depth, expansion, and evaluation work; remove the
+- [x] Bound rpol `apply()` DAG depth, expansion, and evaluation work; remove the
   unconditional policy-name allocation from the non-attributed hot path.
-- [ ] Make managed-netdev partial creation converge: roll back known in-process
+- [x] Make managed-netdev partial creation converge: roll back known in-process
   pre-stamp failures, retry safely stamped incomplete bindings, and prune stale
   managed/NHG permanent-suppression entries after intent withdrawal.
-- [ ] Make Type-1/2/4 EVPN origination acknowledgement-aware, with explicit
+- [x] Make Type-1/2/4 EVPN origination acknowledgement-aware, with explicit
   desired/pending/confirmed state and idempotent retry. Separately bound
   unmatched pending IP bindings; design a safe-forget contract before pruning
   MAC-mobility ratchet history.
-- [ ] Define NHID ownership authority. Numeric ranges plus `NHA_FDB` are not
+- [x] Define NHID ownership authority. Numeric ranges plus `NHA_FDB` are not
   kernel-enforced proof against arbitrary co-resident writers; either document
   and validate a single-writer reserved-range deployment contract or stamp and
   verify `nh_protocol` with a fail-closed fallback.
-- [ ] Correct Extended Message directionality and custom-limit encoding for
+- [x] Correct Extended Message directionality and custom-limit encoding for
   NOTIFICATION/ROUTE-REFRESH; rustbgpd's advertised capability controls inbound
   acceptance, while the peer's capability controls outbound size.
 - [ ] Add CI compilation for transport `bench-internals`; make fuzz target

--- a/bench/README.md
+++ b/bench/README.md
@@ -126,10 +126,15 @@ non-zero only when a row is a confident regression:
 - `min..max` is entirely above zero
 - `stddev` is below `--regression-max-stddev-pct` (default: 10)
 - `mean delta` is at least `--regression-threshold-pct` (default: 3)
+- the last run's propagated 95% CI is entirely above zero (all-positive
+  across-attempt deltas whose last-run CI straddles zero stay advisory)
 
 Verdict labels are:
 
 - `regression`: confident regression; `--fail-on-regression` exits non-zero.
+- `ci-straddles-zero`: all-positive deltas clearing the mean-delta threshold,
+  but the last run's own 95% CI straddles zero — advisory, does **not** fail
+  `--fail-on-regression`.
 - `noise`: `min..max` brackets zero, so the sign is not reliable.
 - `improvement`: the completed attempts are consistently faster.
 - `positive-under-threshold`: consistently slower, but below the configured

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -36,6 +36,7 @@ rbgp config apply config.toml \
 rbgp config status
 rbgp config confirm deploy-123
 rbgp config abort deploy-123
+rbgp config effective                       # dump running post-defaults config (redacted TOML; -j for JSON)
 ```
 
 ### Peers and BFD
@@ -80,6 +81,7 @@ rbgp rib bgpls    # BGP-LS routes learned from peers (RFC 9552)
 rbgp rib vpn      # VPNv4/VPNv6 routes (RFC 4364/4659, SAFI 128)
 rbgp rib labeled  # labeled-unicast routes (RFC 8277, SAFI 4)
 rbgp rib rtc      # RT-Constrain membership NLRI (RFC 4684, SAFI 132)
+rbgp diff advertised   # compare live Adj-RIB-Out against an incumbent NDJSON snapshot (read-only; own 0/1/2 exit contract)
 
 rbgp policy list
 rbgp policy get <name>
@@ -92,6 +94,7 @@ rbgp policy chain clear-import [--neighbor <addr>]
 rbgp policy chain clear-export [--neighbor <addr>]
 rbgp policy explain --neighbor <addr> --prefix <cidr> [--path-id <n>]
 rbgp policy check <file.rpol>                          # parse + typecheck an .rpol file in-process (no daemon)
+rbgp policy fmt <file.rpol>... [--check]               # canonical .rpol formatter (in-place; --check for CI; - = stdin)
 rbgp policy test <file.rpol> --policy <name> --direction import|export [--neighbor <addr>]   # dry-run over the live RIB
 rbgp policy stats [--neighbor <addr>]                     # live per-term hit counters
 rbgp policy counters [--neighbor <addr>]                  # alias

--- a/crates/mrt/README.md
+++ b/crates/mrt/README.md
@@ -1,6 +1,6 @@
 # rustbgpd-mrt
 
-MRT dump export implementing RFC 6396 TABLE_DUMP_V2.
+MRT TABLE_DUMP_V2 export and read-back implementing RFC 6396.
 
 Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 
@@ -14,6 +14,10 @@ Part of [rustbgpd](https://github.com/lance0/rustbgpd).
 - **Atomic writes** — temp file + rename to prevent partial dumps
 - **NH synthesis** — IPv4 routes get NEXT_HOP attribute, IPv6 get
   MP_REACH_NLRI, RFC 8950 IPv4-with-IPv6-NH get MP_REACH_NLRI
+- **TABLE_DUMP_V2 reader** — `SnapshotReader` parses `PEER_INDEX_TABLE` +
+  `RIB_IPV4_UNICAST` / `RIB_IPV6_UNICAST` records into
+  `SnapshotEntry` / `SnapshotNlri`, with gzip auto-detection
+  (`decompress_if_gzip`)
 
 ## License
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -196,7 +196,7 @@ these columns:
 | `stddev` | spread of the per-attempt deltas | **The confidence signal.** Single-digit-% stddev → the mean delta is trustworthy. Large stddev → the host was noisy; the mean is soft. |
 | `min..max` | range of per-attempt deltas | If this brackets `0` (e.g. `-3%..+4%`), the sign of the mean delta is not reliable — it's inside the noise. |
 | `last-run 95% CI` | conservatively propagated from the last attempt's saved median CIs | Wider than Criterion's own change CI by construction; a sanity bound, not the primary signal. |
-| `verdict` | optional script classifier for CI tripwires | `regression` only when enough attempts completed, `min..max` is entirely positive, stddev is below the configured ceiling, and mean delta crosses the configured threshold. Other informational labels are `noise`, `improvement`, `positive-under-threshold`, `inconclusive-noisy`, `insufficient-attempts`, and `missing`. |
+| `verdict` | optional script classifier for CI tripwires | `regression` only when enough attempts completed, `min..max` is entirely positive, stddev is below the configured ceiling, mean delta crosses the configured threshold, and the last run's propagated 95% CI is entirely above zero. Other informational labels are `ci-straddles-zero` (all-positive deltas above threshold but the last-run CI straddles zero — advisory, does not fail the gate), `noise`, `improvement`, `positive-under-threshold`, `inconclusive-noisy`, `insufficient-attempts`, and `missing`. |
 
 ### The grading rule (reviewer guidance, not a CI gate)
 
@@ -247,8 +247,10 @@ regression branch for unattended use. The nightly release-baseline workflow
 enables it with the default `--verdict-min-attempts 3` and
 `--regression-threshold-pct 3` plus `--regression-max-stddev-pct 10`: rows
 whose `min..max` straddles zero remain advisory/noise, high-stddev rows remain
-inconclusive, and a confirmed row at or above the threshold makes the workflow
-fail for human review.
+inconclusive, all-positive rows whose last-run 95% CI straddles zero stay
+advisory (`ci-straddles-zero`), and a confirmed row at or above the threshold
+whose last-run 95% CI is entirely above zero makes the workflow fail for human
+review.
 
 **Worked example** — the first multi-attempt comparison on the VPS
 runner (`rib_ops`, `v0.30.0` → `main`, 3 attempts; the span includes

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1092,7 +1092,7 @@ Notes:
   rejects it otherwise. It is mutually exclusive with `orr_vantage` by
   construction (ORR requires an iBGP route-reflector client).
 - Per-client-best peers are excluded from update-group sharing (their
-  selected route is per-member); `rbgp neighbor show` reports the
+  selected route is per-member); `rbgp neighbor <peer>` reports the
   `per_client_best` ungrouped reason and the peer counts toward
   `bgp_update_group_fallback_peers`. Prefer Add-Path for large fleets.
 - Selection cost is O(candidate paths × export-policy evaluations) per
@@ -1298,7 +1298,7 @@ v2 it is part of the group key, not a fallback reason. Add-Path send
 remains a fallback for all families (ADR-0099 records why per-member
 path-id correction is unsound without per-member state).
 
-`rbgp neighbor show <peer>` prints the membership (`group:N`) or the
+`rbgp neighbor <peer>` prints the membership (`group:N`) or the
 fallback reason on its `Update Group` line. Metrics:
 `bgp_update_groups`, `bgp_update_group_members{group}`,
 `bgp_update_group_regroups_total`, `bgp_update_group_fallback_peers`,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -601,8 +601,10 @@ If the global limit is hit, it means either the limit is configured too low or t
 ### gRPC Security (v1)
 
 - gRPC listens on a configurable address (default: localhost only).
-- No built-in TLS in v1. For non-loopback exposure, front rustbgpd with an
-  mTLS/TLS-authenticated proxy.
+- Native gRPC mTLS is supported on TCP listeners via `tls_cert_file` /
+  `tls_key_file` / `tls_client_ca_file` (all three required together; no
+  TLS-without-mTLS half-mode) — see docs/CONFIGURATION.md "Native gRPC mTLS".
+  UDS listeners and bearer-token auth are also available.
 - Per-listener access mode (`read_only` / `read_write`) controls which RPCs
   are available. The eleven-service split supports per-service auth policies
   when finer-grained authorization is added.

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -35,6 +35,7 @@ matrix below runs on the hosted kernel-dataplane workflow or manual gates).
 - **Outbound Route Filtering** — RFC 5291/5292 receive-side prefix ORF against an FRR 10.3.1 peer: **M57**.
 - **EVPN + SIGHUP** — control-plane sanity, MAC reflection, policy soft-reset, VLAN-aware-bundle (non-zero Ethernet Tag) reflection: **M29**, **M30**, **M34**, **M82** (synthetic leg; the SR Linux vendor leg is local-only).
 - **Route-server profile** — RFC 7947 transparency at byte level, per-member policy views, ROV at import, RFC 9234 OTC toward members, and the §2.3 path-hiding contrast (single-best / `per_client_best` / Add-Path, ADR-0101) against BIRD 2 + GoBGP + FRR at once: **M83**.
+- **Core RR against incumbents** — RFC 4456 reflection + RFC 4724 GR helper-truth against BIRD 2 clients and OpenBGPD 9.1 clients: **M85**, **M86**.
 - **Graceful Shutdown** — receiver/initiator coverage across unicast, FlowSpec, and EVPN: **M35**, **M35b**, **M35c**.
 - **BLACKHOLE FIB discard** — RFC 7999 receiver scoping plus opt-in kernel discard install / withdraw: **M41**.
 - **gRPC/gNMI + EVPN injection** — ADR-0064 mTLS tier enforcement, ADR-0070 gNMI / OpenConfig telemetry + Set, gNMI Subscribe ON_CHANGE, and EVPN Type 5 control-plane injection: **M44**, **M54**, **M56**, **M45**.

--- a/docs/adr/0073-import-policy-explain.md
+++ b/docs/adr/0073-import-policy-explain.md
@@ -11,7 +11,7 @@ evaluation is `evaluate_export_chain` in
 `crates/rib/src/manager/distribution/mod.rs`, and `ExplainAdvertisedRoute`
 assembly lives in `crates/rib/src/manager/distribution/unicast.rs`), and
 the RPC surface hangs off the route-explain group at
-`proto/rustbgpd.proto:1113` (`RibService.ExplainAdvertisedRoute`).
+`proto/rustbgpd.proto:1189` (`RibService.ExplainAdvertisedRoute`).
 
 There is no equivalent for **import**. The operator question
 "why didn't this route come in?" cannot be answered today, because:
@@ -27,7 +27,7 @@ There is no equivalent for **import**. The operator question
   prefix that was *rejected* on arrival.
 - `bgp_policy_import_routes_{permitted,denied}_total{peer}`
   counters answer "how many," not "which prefix and why."
-- `PolicyEvaluation` (`crates/policy/src/engine.rs:896`) carries
+- `PolicyEvaluation` (`crates/policy/src/engine.rs:1133`) carries
   the terminal-decision policy + action, which is what an explain
   surface should report — but it is consumed and discarded at the
   eval site.
@@ -154,7 +154,7 @@ rpc ExplainImportPolicy(ExplainImportPolicyRequest)
 Authorization tier: **`SensitiveRead`**, matching the existing
 route-explain surfaces (`crates/api/src/authz.rs`).
 
-Response carries one of six outcomes:
+Response carries one of eight outcomes:
 
 | Outcome | Meaning |
 |---|---|
@@ -164,6 +164,11 @@ Response carries one of six outcomes:
 | `WITHDRAWN` | Was permitted, withdrawn after; entry retained for visibility |
 | `EVICTED` | Was in the cache; pushed out by the per-peer bound |
 | `STALE` | Cached entry's `policy_generation` is older than current; result no longer represents current policy |
+| `CACHE_DISABLED` | The daemon has `[policy.explain] enabled = false`, so no decisions are cached to consult (distinct from `NOT_SEEN`) |
+| `NO_SESSION` | No live session with the neighbor |
+
+The CLI renders `CACHE_DISABLED` and `NO_SESSION` as errors (nonzero
+exit) rather than as answers.
 
 The query is a **read** — it must not increment policy counters,
 must not touch RIB, must not log a new policy decision.
@@ -308,11 +313,11 @@ built in stages but is not split across PRs:
 - Eval call sites: `evaluate_chain_with_attribution` in
   `crates/transport/src/session/inbound.rs` (body IPv4, FlowSpec, EVPN,
   and MP-unicast paths)
-- `PolicyEvaluation`: `crates/policy/src/engine.rs:896`
+- `PolicyEvaluation`: `crates/policy/src/engine.rs:1133`
 - Export-explain reference: `evaluate_export_chain` in
   `crates/rib/src/manager/distribution/mod.rs` (assembly in
   `crates/rib/src/manager/distribution/unicast.rs`),
-  RPC at `proto/rustbgpd.proto:1113`
+  RPC at `proto/rustbgpd.proto:1189`
 - Existing import counters: `record_import_policy_eval` at
   `crates/transport/src/session/inbound.rs:21`
 - Authz tier reference: `crates/api/src/authz.rs`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -528,7 +528,7 @@ sanity-check on the labelled Prometheus counter:
 Both directions reset together on the next session establishment, so
 "how many routes did this session permit / deny in total" is straight
 subtraction; "how many across reconnects" requires Prometheus history.
-The CLI surfaces these in `rbgp neighbor show` as a Policy Stats
+The CLI surfaces these in `rbgp neighbor <peer>` as a Policy Stats
 block:
 
 ```
@@ -537,7 +537,7 @@ Policy Stats:
   Export — permitted: 892    denied: 0
 ```
 
-JSON output (`rbgp --json neighbor show`) carries the same
+JSON output (`rbgp --json neighbor <peer>`) carries the same
 fields under `import_policy_routes_permitted` / `import_policy_routes_denied`
 / `export_policy_routes_permitted` / `export_policy_routes_denied`,
 elided when zero.

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -298,7 +298,7 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 97-method classification
+`crates/api/src/authz.rs` contains the same 98-method classification
 as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added


### PR DESCRIPTION
Pre-tag documentation-drift corrections. Dominant theme: #796's removals never propagated past the CHANGELOG — the in-daemon looking glass, the global inline policy.import/export fallback, and the SetGlobal RPC are removed from README/ARCHITECTURE/KNOWN_ISSUES. Plus 8 stale ROADMAP checkboxes flipped (each cross-checked to a shipped CHANGELOG entry), the invalid `rbgp neighbor show` command corrected to `rbgp neighbor <peer>` in two operator guides, stale ADR-0073 code anchors (proto 1113→1189, engine 896→1133) and the six→eight ImportExplainOutcome drift, the bench regression-verdict docs synced to compare-criterion.sh (ci-straddles-zero), the false 'no built-in TLS' claim in DESIGN.md corrected to the shipped native mTLS, M85/M86 added to INTEROP CI coverage, and the 97→98 method-count typo. Every claim verified against HEAD before editing. GoBGP competitive cells deliberately excluded (handled separately with primary-source verification).