### PR TITLE
fix(policy): guard rpol cost passes against duplicate-name underflow

### DIFF
--- a/crates/policy/src/rpol/tests.rs
+++ b/crates/policy/src/rpol/tests.rs
@@ -4185,6 +4185,36 @@ fn fn_declaration_diagnostics() {
     assert!(rendered.contains("apply"), "{rendered}");
 }
 
+/// A duplicate `fn` whose bodies call a shared function must not
+/// underflow the cost-pass Kahn accounting. The duplicate name is
+/// diagnosed, but the cost pass still runs: `edges`/`defs` key by name
+/// (one entry), so seeding `pending`/`dependents` per `file.fns` entry
+/// would push the reverse-edge twice while `pending` counted once, and
+/// the shared callee's completion would decrement past zero.
+#[test]
+fn duplicate_fn_calling_shared_does_not_underflow() {
+    let (_, rendered) = diagnostics_of(
+        "fn base(x: u32) -> u32 { x + 1 }
+         fn dup(x: u32) -> u32 { base(x) }
+         fn dup(x: u32) -> u32 { base(x) }
+         policy p { term t { if dup(route.med) >= 1 { reject } accept } }",
+    );
+    assert!(rendered.contains("duplicate fn `dup`"), "{rendered}");
+}
+
+/// The apply-bounds pass has the same Kahn shape over policies: a
+/// duplicate `policy` that applies a shared policy must not underflow
+/// it either (mirror of `duplicate_fn_calling_shared_does_not_underflow`).
+#[test]
+fn duplicate_policy_applying_shared_does_not_underflow() {
+    let (_, rendered) = diagnostics_of(
+        "policy base { term t { reject } }
+         policy dup { term t { if apply(base) { reject } accept } }
+         policy dup { term t { if apply(base) { reject } accept } }",
+    );
+    assert!(rendered.contains("duplicate policy `dup`"), "{rendered}");
+}
+
 /// Functions get their own namespace: a set and a policy may share a
 /// function's name — every reference position is disjoint.
 #[test]

--- a/crates/policy/src/rpol/typeck.rs
+++ b/crates/policy/src/rpol/typeck.rs
@@ -490,8 +490,17 @@ impl<'a> Checker<'a> {
         let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
         let mut pending: HashMap<&str, usize> = HashMap::new();
         let mut ready: VecDeque<&str> = VecDeque::new();
+        // Seed each name once. A duplicate `fn` is diagnosed elsewhere but
+        // the cost pass still runs; `edges`/`defs` key by name (last def
+        // wins), so seeding per `file.fns` entry would push a reverse-edge
+        // for every duplicate while `pending.insert` kept only one count —
+        // and the decrement below would then underflow.
+        let mut seeded: HashSet<&str> = HashSet::new();
         for def in &file.fns {
             let name = def.name.node.as_str();
+            if !seeded.insert(name) {
+                continue;
+            }
             let known: Vec<&str> = edges[name]
                 .iter()
                 .map(|&(target, _)| target)
@@ -1944,8 +1953,17 @@ impl<'a> Checker<'a> {
         let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
         let mut pending: HashMap<&str, usize> = HashMap::new();
         let mut ready: VecDeque<&str> = VecDeque::new();
+        // Seed each name once — a duplicate `policy` is diagnosed
+        // elsewhere but this pass still runs, and `edges`/`defs` key by
+        // name; seeding per `file.policies` entry would push a duplicate
+        // reverse-edge while `pending.insert` kept one count, underflowing
+        // the decrement below (mirrors the `check_fns` guard).
+        let mut seeded: HashSet<&str> = HashSet::new();
         for policy in &file.policies {
             let name = policy.name.node.as_str();
+            if !seeded.insert(name) {
+                continue;
+            }
             let known: Vec<&str> = edges[name]
                 .iter()
                 .map(|&(target, _)| target)


### PR DESCRIPTION
The nightly `rpol_compile` fuzz target found a panic in the `.rpol`
typechecker: `typeck.rs` "attempt to subtract with overflow" on a
policy file with a duplicate `fn` (and a duplicate `policy`) whose
bodies call/apply a shared symbol.

## Root cause

One bug, two passes. The LAN-304 function-cost pass (`check_fns`) and
the LAN-290 apply-bounds pass (`check_apply_bounds`) both run a Kahn
topological sort. Each builds its `pending` / `dependents` accounting
by iterating `file.fns` / `file.policies` — which hold **every**
duplicate definition — while the `edges` / `defs` maps they consume
are keyed by name and collapse duplicates to a single entry.

So a duplicate `fn dup` that calls `base` pushes the reverse-edge
`dependents["base"] = ["dup", "dup"]` while `pending.insert("dup", ..)`
keeps only the last count (`1`). When the shared callee `base`
completes, `pending["dup"]` is decremented once per reverse-edge —
twice — driving the count `1 -> 0 -> underflow`.

## Impact

The duplicate name is already an error, so `compile_rpol` returns
`Err` and the file never lowers. The shipped `[profile.release]` has
no `overflow-checks`, so the daemon wraps harmlessly rather than
panicking — this is **not a production crash**. But debug and fuzz
builds panic, which breaks the frontend contract that the whole
pipeline always returns `Diagnostics` and never panics.

## Fix

Seed each name once in both passes, so `pending` / `dependents` stay
consistent with the deduped `edges` / `defs` maps.

## Verification

- The exact overnight crash artifact replays through the fuzz target
  clean (2 ms, no crash); it panicked before.
- Both new regression tests panic on the pre-fix code and pass with
  the fix. The existing duplicate-`fn` test missed this because its
  bodies call nothing — the new tests call a shared symbol, which is
  what lands the name in the accounting twice.
- Full policy suite green (386 passed); `clippy -D warnings` and
  `fmt` clean.