### PR TITLE
test(rib): harden update-group invariants

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -721,6 +721,14 @@ impl RibManager {
             )));
             return;
         }
+        // ORF is arbitrary per-peer outbound state and therefore a grouping
+        // disqualifier. Assert before installing the filter: inserting it
+        // first would make a later membership recompute hide an invalid
+        // pre-existing grouped registration.
+        debug_assert!(
+            self.grouped_member_of(peer).is_none(),
+            "an ORF-receive peer must never be registered in an update group"
+        );
         let family = (afi, safi);
         // The ORF message is itself a ROUTE-REFRESH (RFC 5291 §6) — lift the gate.
         if let Some(pending) = self.peer_orf_pending.get_mut(&peer) {
@@ -1259,6 +1267,16 @@ impl RibManager {
             // helpers — see `RibUpdate::RefreshPeerOutbound` rationale on
             // `force_outbound_peers`.
             let is_force = self.force_outbound_peers.contains(&peer);
+            // A grouped force-only resync intentionally re-announces the
+            // current group table and ignores pass tombstones/deltas. Its
+            // setters synchronously run an empty distribution pass, so it
+            // cannot meet a genuine best-change pass. A failed force send is
+            // also dirty and is valid here: dirty assembly includes the
+            // tombstones needed to heal subsequent churn.
+            debug_assert!(
+                member_of.is_none() || !is_force || is_dirty || best_changed.is_empty(),
+                "a grouped force-only resync cannot share a nonempty best-change pass"
+            );
             let resync = is_dirty || is_force;
             let effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
                 let mut all: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2800,6 +2800,16 @@ impl RibManager {
     /// machinery yields the RFC 4684 minimal update set, no session
     /// reset). An unchanged membership is a strict no-op.
     fn set_rt_membership(&mut self, peer: IpAddr, membership: Option<RtcMembership>) {
+        // Removing Φ is valid only before outbound registration (a new
+        // session that did not negotiate RTC) or after deregistration during
+        // teardown. On a live registration it would silently change the peer
+        // from RT-filtered to unfiltered without a corrective VPN emission.
+        // Keep this before the equality early-return so an already-absent
+        // entry cannot conceal an invalid live call.
+        debug_assert!(
+            membership.is_some() || !self.outbound_peers.contains_key(&peer),
+            "RT membership may be cleared only before outbound registration or after deregistration"
+        );
         // Capture BEFORE the write (design §2.3): under the invariant
         // adv(m) = Φ-filtered group table, `old` is the true prior
         // advertised state.
@@ -2909,7 +2919,12 @@ impl RibManager {
         if bound.is_empty() {
             return;
         }
-        self.dirty_peers.extend(bound);
+        // Preserve the single dirty-marking seam: ORR currently disqualifies
+        // grouping, but routing through the helper also marks group state if
+        // that eligibility rule changes later.
+        for peer in bound {
+            self.mark_outbound_dirty(peer);
+        }
         self.distribute_changes(&HashSet::new(), &HashSet::new());
     }
 

--- a/crates/rib/src/manager/tests/lifecycle.rs
+++ b/crates/rib/src/manager/tests/lifecycle.rs
@@ -1517,16 +1517,24 @@ async fn stale_orf_update_from_superseded_session_is_discarded() {
     let handle = tokio::spawn(manager.run());
 
     let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let orf_peer_up = |session_id, outbound_tx| {
+        let mut update = session_peer_up(peer, session_id, outbound_tx, ipv4_sendable());
+        let RibUpdate::PeerUp {
+            negotiated_orf_recv,
+            ..
+        } = &mut update
+        else {
+            unreachable!("session_peer_up always constructs PeerUp")
+        };
+        *negotiated_orf_recv = vec![(Afi::Ipv4, Safi::Unicast)];
+        update
+    };
 
     let (loser_tx, mut loser_rx) = mpsc::channel(8);
-    tx.send(session_peer_up(peer, 1, loser_tx, ipv4_sendable()))
-        .await
-        .unwrap();
+    tx.send(orf_peer_up(1, loser_tx)).await.unwrap();
     drain_eor(&mut loser_rx).await;
     let (winner_tx, mut winner_rx) = mpsc::channel(8);
-    tx.send(session_peer_up(peer, 2, winner_tx, ipv4_sendable()))
-        .await
-        .unwrap();
+    tx.send(orf_peer_up(2, winner_tx)).await.unwrap();
     drain_eor(&mut winner_rx).await;
 
     let entry = AddressPrefixOrf {

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -824,6 +824,13 @@ async fn oracle_streams_identical_across_rr_mix() {
 
         // GShut-style forced re-emission (RefreshPeerOutbound).
         o.refresh_outbound(D).await;
+
+        // A genuine best change immediately after the acknowledged force
+        // proves the force-only pass was consumed synchronously. Grouped
+        // force assembly deliberately ignores pass deltas; allowing the flag
+        // to leak into this pass would violate that invariant (LAN-345).
+        o.routes(A, vec![ibgp_route(pfx(2, 0), A, 175, vec![])], vec![])
+            .await;
     };
     let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
     assert_eq!(
@@ -892,6 +899,57 @@ async fn oracle_dirty_resync_converges_to_identical_state() {
         c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)),
         "the update lost to the full channel must be recovered by the resync"
     );
+}
+
+/// A failed forced refresh is retained for retry and marks the peer dirty.
+/// Genuine churn can arrive before that retry, so this deliberately exercises
+/// the allowed `force && dirty && !best_changed.is_empty()` state: dirty group
+/// assembly must include the pass tombstones while force still replays the
+/// current table.
+#[tokio::test]
+async fn oracle_failed_force_then_churn_converges_to_identical_state() {
+    tokio::time::pause();
+    let cluster = Some(Ipv4Addr::new(192, 0, 2, 1));
+    let scenario = async |o: &mut Oracle| {
+        o.peer_up(A, false, true, None, 64).await;
+        o.peer_up(B, false, true, None, 64).await;
+        o.peer_up(C, false, true, None, 1).await;
+        let eor = o.drain_one(C).await;
+        assert!(eor.announce.is_empty() && !eor.end_of_rib.is_empty());
+
+        // The standing p1 announce fills C's only queue slot.
+        o.routes(A, vec![ibgp_route(pfx(1, 0), A, 100, vec![])], vec![])
+            .await;
+        // Forced replay fails against the full channel, retaining force and
+        // marking C dirty for the timer retry.
+        o.refresh_outbound(C).await;
+        // Before retry, p1 is withdrawn and p2 becomes best. This is the
+        // nonempty best-change pass that force-only assembly may never see,
+        // but force+dirty must heal.
+        o.routes(
+            A,
+            vec![ibgp_route(pfx(2, 0), A, 100, vec![])],
+            vec![pfx(1, 0)],
+        )
+        .await;
+
+        let first = o.drain_one(C).await;
+        assert_eq!(first.announce.len(), 1, "p1 was delivered before the jam");
+        tokio::time::advance(Duration::from_secs(2)).await;
+        o.quiesce().await;
+    };
+    let (grouped, ungrouped) = run_grouped_and_ungrouped(cluster, scenario).await;
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "failed force plus churn must converge on both paths"
+    );
+    let c_final = fold(&grouped)
+        .get(&IpAddr::V4(C))
+        .cloned()
+        .unwrap_or_default();
+    assert!(!c_final.contains_key(&(Prefix::V4(pfx(1, 0)), 0)));
+    assert!(c_final.contains_key(&(Prefix::V4(pfx(2, 0)), 0)));
 }
 
 /// A source-flip member-scoped withdraw lost to a full channel: the


### PR DESCRIPTION
## Summary

- route ORR-triggered dirty peers through the canonical update-group dirty-marking seam
- assert that live RTC membership is never silently cleared and ORF-receive peers are never grouped
- assert the grouped force-only resync ordering while preserving valid forced+dirty recovery after a failed send
- extend the differential oracle across successful force consumption and failed-force-plus-churn recovery
- correct the stale-session ORF fixture to negotiate ORF explicitly

## Why

The current states are unreachable through valid production flows, but several invariants were implicit and could become correctness bugs if grouping eligibility or call ordering changes. In particular, grouped force-only assembly intentionally ignores pass tombstones and therefore depends on its empty distribution pass being consumed synchronously. Failed forced sends are the important exception: they also mark the peer dirty, and dirty assembly must heal later churn.

This change makes those boundaries executable in debug/test builds and pins the failure-recovery exception in the grouped-versus-ungrouped differential oracle.

## Validation

- `cargo test -p rustbgpd-rib --all-features` (728 unit tests; integration/profile tests passed or remained explicitly ignored)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push format, Clippy, test, and rustdoc hooks passed

Linear: [LAN-345](https://linear.app/lance0/issue/LAN-345/update-groups-hardening-asserts-and-test-gaps-from-the-adversarial)
