### PR TITLE
fix(bench): validate and accurately pace EVPN workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **EVPN load generation validates unsafe workloads and honors exact event
   budgets.** The development-only `evpn-tester` now rejects zero-sized batches,
   zero-route or zero-rate churn, and hold times of 1-2 seconds before opening a
-  session. Hold time zero correctly disables both periodic keepalives and the
-  receive timer instead of constructing a zero-duration Tokio interval. Initial
-  injection and withdraw/re-advertise churn now pace against cumulative route
-  events, avoiding integer batch-rate rounding and preserving configured rates
-  when a batch is larger than the per-second budget or a route-set chunk is
-  partial. Session-only `--count 0` and unlimited injection with `--rate 0`
-  remain supported. (LAN-84)
+  session. It also rejects out-of-range 24-bit VNIs, MAC/IP counts that would
+  reuse the synthetic MAC space, and initial/churn chunks that do not encode
+  within a standard 4096-byte BGP message. Hold time zero correctly disables
+  both periodic keepalives and the receive timer instead of constructing a
+  zero-duration Tokio interval. Initial injection and withdraw/re-advertise
+  churn now wait before sending against cumulative route events, avoiding both
+  an initial low-rate burst and integer batch-rate rounding. Configured rates
+  hold when a batch exceeds the per-second budget or a route-set chunk is
+  partial, and churn does not emit a pair scheduled beyond its duration.
+  Session-only `--count 0` and unlimited injection with `--rate 0` remain
+  supported. (LAN-84)
 
 - **Peer-supplied `LOCAL_PREF` is ignored on eBGP ingress.** Per RFC 4271,
   external peers can no longer influence import policy, explain output,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **EVPN load generation validates unsafe workloads and honors exact event
+  budgets.** The development-only `evpn-tester` now rejects zero-sized batches,
+  zero-route or zero-rate churn, and hold times of 1-2 seconds before opening a
+  session. Hold time zero correctly disables both periodic keepalives and the
+  receive timer instead of constructing a zero-duration Tokio interval. Initial
+  injection and withdraw/re-advertise churn now pace against cumulative route
+  events, avoiding integer batch-rate rounding and preserving configured rates
+  when a batch is larger than the per-second budget or a route-set chunk is
+  partial. Session-only `--count 0` and unlimited injection with `--rate 0`
+  remain supported. (LAN-84)
+
 - **Peer-supplied `LOCAL_PREF` is ignored on eBGP ingress.** Per RFC 4271,
   external peers can no longer influence import policy, explain output,
   Adj-RIB-In storage, or best-path selection by sending `LOCAL_PREF`. iBGP

--- a/bench/README.md
+++ b/bench/README.md
@@ -17,6 +17,20 @@ RR benchmarking and the soak gates. It is not a BGP implementation and
 not an operator tool; see the crate docs in `evpn-load/src/lib.rs` for
 scope.
 
+The tester validates the workload before listening for BGP. `--batch` must
+be non-zero, and an enabled churn phase requires both a non-zero `--count`
+and `--churn-rate`. A zero count remains useful for a session-only peer, and
+`--rate 0` retains its historical meaning of unlimited initial injection.
+`--hold-time 0` disables both the hold timer and periodic keepalives; non-zero
+values must be at least 3 seconds so the hold/3 keepalive cadence is valid.
+
+Both injection and churn pacing use a cumulative route-event budget rather
+than rounding to whole batches per second. Churn counts each withdrawal and
+re-advertisement as one event, so `--churn-rate 1000` means 1000 total route
+events per second regardless of `--batch` and partial chunks at the end of the
+route set. The M32b/M33 route-type, count, rate, batch, and churn arguments are
+otherwise unchanged.
+
 ## Criterion compare
 
 `compare-criterion.sh` runs the same Criterion bench target at two git refs,

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,14 +22,22 @@ be non-zero, and an enabled churn phase requires both a non-zero `--count`
 and `--churn-rate`. A zero count remains useful for a session-only peer, and
 `--rate 0` retains its historical meaning of unlimited initial injection.
 `--hold-time 0` disables both the hold timer and periodic keepalives; non-zero
-values must be at least 3 seconds so the hold/3 keepalive cadence is valid.
+values must be at least 3 seconds so the hold/3 keepalive cadence is valid. The
+VNI must fit its 24-bit wire field, and MAC/IP workloads are limited to the
+16,777,216 unique synthetic MAC addresses. EAD-per-EVI workloads do not have
+that MAC-space limit. The largest initial advertisement and active-churn
+withdrawal chunks are encoded before bind and rejected if they exceed the
+standard 4096-byte BGP message limit.
 
 Both injection and churn pacing use a cumulative route-event budget rather
-than rounding to whole batches per second. Churn counts each withdrawal and
-re-advertisement as one event, so `--churn-rate 1000` means 1000 total route
-events per second regardless of `--batch` and partial chunks at the end of the
-route set. The M32b/M33 route-type, count, rate, batch, and churn arguments are
-otherwise unchanged.
+than rounding to whole batches per second. Each chunk waits for its cumulative
+budget before it is sent, and the effective chunk size is capped by the rate so
+a low configured rate cannot escape as an initial batch burst. Churn counts
+each withdrawal and re-advertisement as one event, so `--churn-rate 1000` means
+1000 total route events per second regardless of `--batch` and partial chunks
+at the end of the route set. A pair scheduled after the churn-duration deadline
+is not emitted. The M32b/M33 route-type, count, rate, batch, and churn arguments
+are otherwise unchanged.
 
 ## Criterion compare
 

--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -348,19 +348,8 @@ async fn inject_phase(
     is_withdraw: bool,
 ) -> anyhow::Result<()> {
     let start = Instant::now();
-    let batch_per_sec = if phase_params.rate == 0 {
-        u32::MAX
-    } else {
-        phase_params.rate / phase_params.batch.max(1)
-    };
     let mut sent = 0u32;
     let mut idx = 0u32;
-    let mut next_tick = Instant::now();
-    let tick = if batch_per_sec == 0 {
-        Duration::from_millis(1)
-    } else {
-        Duration::from_millis(1000 / u64::from(batch_per_sec.max(1)))
-    };
 
     while idx < phase_params.count {
         let end = idx
@@ -394,7 +383,7 @@ async fn inject_phase(
         idx = end;
 
         if phase_params.rate > 0 {
-            next_tick += tick;
+            let next_tick = start + pacing_offset(u64::from(sent), phase_params.rate);
             let now = Instant::now();
             if next_tick > now {
                 tokio::time::sleep(next_tick - now).await;
@@ -418,17 +407,10 @@ async fn run_churn(
     anyhow::ensure!(phase_params.count > 0, "cannot churn a zero-route workload");
     anyhow::ensure!(phase_params.batch > 0, "churn batch must be non-zero");
     anyhow::ensure!(phase_params.rate > 0, "churn rate must be non-zero");
-    let deadline = Instant::now() + total;
-    // `rate` is route-events per second. Each tick of this loop emits
-    // 2 * batch events (one withdraw + one re-advertise of the same chunk),
-    // so the per-tick budget is `rate / (2 * batch)` ticks per second.
-    // Without the factor of 2 the effective churn rate is doubled — the
-    // RR sees 2x what the operator configured, which is fine for the
-    // M33 reflection-throughput shape but misleading in the report.
-    let ops_per_tick = u64::from(phase_params.batch.max(1)) * 2;
-    let ticks_per_sec = u64::from(phase_params.rate.max(1)) / ops_per_tick;
-    let tick = Duration::from_millis(1000 / ticks_per_sec.max(1));
+    let start_time = Instant::now();
+    let deadline = start_time + total;
     let mut idx = 0u32;
+    let mut emitted_events = 0u64;
 
     while Instant::now() < deadline {
         let start = idx % phase_params.count;
@@ -457,10 +439,22 @@ async fn run_churn(
         if tx.send(withdraw).await.is_err() || tx.send(advertise).await.is_err() {
             anyhow::bail!("send channel closed during churn");
         }
+        emitted_events += u64::from(end - start) * 2;
         idx = end;
-        tokio::time::sleep(tick).await;
+        let next_tick = start_time + pacing_offset(emitted_events, phase_params.rate);
+        let now = Instant::now();
+        if next_tick > now {
+            tokio::time::sleep(next_tick - now).await;
+        }
     }
     Ok(())
+}
+
+fn pacing_offset(events: u64, rate: u32) -> Duration {
+    if rate == 0 {
+        return Duration::ZERO;
+    }
+    Duration::from_nanos(events.saturating_mul(1_000_000_000) / u64::from(rate))
 }
 
 #[allow(dead_code)]
@@ -521,5 +515,18 @@ mod tests {
         input.churn_duration_sec = 1;
         input.churn_rate = 0;
         assert!(validate_workload(&input).is_err());
+    }
+
+    #[test]
+    fn pacing_uses_the_cumulative_event_budget() {
+        assert_eq!(pacing_offset(0, 1_000), Duration::ZERO);
+        assert_eq!(pacing_offset(40, 1_000), Duration::from_millis(40));
+        assert_eq!(pacing_offset(80, 1_000), Duration::from_millis(80));
+        assert_eq!(pacing_offset(100, 25), Duration::from_secs(4));
+    }
+
+    #[test]
+    fn zero_rate_has_no_pacing_delay() {
+        assert_eq!(pacing_offset(u64::MAX, 0), Duration::ZERO);
     }
 }

--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -129,6 +129,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
+    validate_workload(&args)?;
     tracing::info!(
         listen = %args.listen,
         local_as = args.local_as,
@@ -222,6 +223,25 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tokio::time::sleep(Duration::from_secs(args.linger_sec)).await;
+    Ok(())
+}
+
+fn validate_workload(args: &Args) -> anyhow::Result<()> {
+    anyhow::ensure!(args.batch > 0, "--batch must be greater than zero");
+    anyhow::ensure!(
+        args.hold_time == 0 || args.hold_time >= 3,
+        "--hold-time must be 0 (disabled) or at least 3 seconds"
+    );
+    if args.churn_duration_sec > 0 {
+        anyhow::ensure!(
+            args.count > 0,
+            "--count must be greater than zero when churn is enabled"
+        );
+        anyhow::ensure!(
+            args.churn_rate > 0,
+            "--churn-rate must be greater than zero when churn is enabled"
+        );
+    }
     Ok(())
 }
 
@@ -343,7 +363,9 @@ async fn inject_phase(
     };
 
     while idx < phase_params.count {
-        let end = (idx + phase_params.batch).min(phase_params.count);
+        let end = idx
+            .saturating_add(phase_params.batch)
+            .min(phase_params.count);
         let chunk: Vec<EvpnRoute> = (idx..end)
             .map(|i| match route_params.route_type {
                 RouteType::MacIp => build_type2(
@@ -393,6 +415,9 @@ async fn run_churn(
     route_params: RouteParams,
     total: Duration,
 ) -> anyhow::Result<()> {
+    anyhow::ensure!(phase_params.count > 0, "cannot churn a zero-route workload");
+    anyhow::ensure!(phase_params.batch > 0, "churn batch must be non-zero");
+    anyhow::ensure!(phase_params.rate > 0, "churn rate must be non-zero");
     let deadline = Instant::now() + total;
     // `rate` is route-events per second. Each tick of this loop emits
     // 2 * batch events (one withdraw + one re-advertise of the same chunk),
@@ -407,7 +432,9 @@ async fn run_churn(
 
     while Instant::now() < deadline {
         let start = idx % phase_params.count;
-        let end = (start + phase_params.batch).min(phase_params.count);
+        let end = start
+            .saturating_add(phase_params.batch)
+            .min(phase_params.count);
         let chunk: Vec<EvpnRoute> = (start..end)
             .map(|i| match route_params.route_type {
                 RouteType::MacIp => build_type2(
@@ -439,4 +466,60 @@ async fn run_churn(
 #[allow(dead_code)]
 fn _unused_ipaddr() -> IpAddr {
     IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> Args {
+        Args {
+            listen: "127.0.0.1:1179".parse().unwrap(),
+            local_as: 65_000,
+            router_id: Ipv4Addr::new(192, 0, 2, 1),
+            count: 10_000,
+            rate: 1_000,
+            batch: 40,
+            vni: 100,
+            ethernet_tag: 0,
+            churn_duration_sec: 0,
+            churn_rate: 1_000,
+            linger_sec: 30,
+            hold_time: 180,
+            route_type: RouteType::MacIp,
+        }
+    }
+
+    #[test]
+    fn validates_session_only_and_unlimited_injection_modes() {
+        let mut input = args();
+        input.count = 0;
+        input.rate = 0;
+        input.hold_time = 0;
+        assert!(validate_workload(&input).is_ok());
+    }
+
+    #[test]
+    fn rejects_unsafe_workload_shapes_before_session_setup() {
+        let mut input = args();
+        input.batch = 0;
+        assert_eq!(
+            validate_workload(&input).unwrap_err().to_string(),
+            "--batch must be greater than zero"
+        );
+
+        input = args();
+        input.hold_time = 2;
+        assert!(validate_workload(&input).is_err());
+
+        input = args();
+        input.count = 0;
+        input.churn_duration_sec = 1;
+        assert!(validate_workload(&input).is_err());
+
+        input = args();
+        input.churn_duration_sec = 1;
+        input.churn_rate = 0;
+        assert!(validate_workload(&input).is_err());
+    }
 }

--- a/bench/evpn-load/src/bin/tester.rs
+++ b/bench/evpn-load/src/bin/tester.rs
@@ -19,11 +19,12 @@ use clap::{Parser, ValueEnum};
 use rustbgpd_evpn_load::{PeerConfig, establish, synth_esi, synth_mac, v4_next_hop};
 use rustbgpd_wire::attribute::{AsPath, MpReachNlri, Origin, PathAttribute};
 use rustbgpd_wire::capability::{Afi, Safi};
+use rustbgpd_wire::constants::MAX_MESSAGE_LEN;
 use rustbgpd_wire::evpn::{
     EthernetSegmentIdentifier, EthernetTagId, EvpnEadPerEvi, EvpnMacIp, EvpnRoute, MacAddress,
     MplsLabel, RouteDistinguisher,
 };
-use rustbgpd_wire::message::Message;
+use rustbgpd_wire::message::{Message, encode_message};
 use rustbgpd_wire::update::UpdateMessage;
 
 /// Which RFC 7432 route type the tester originates.
@@ -130,6 +131,15 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
     validate_workload(&args)?;
+    let rd = make_rd(args.router_id);
+    let route_params = RouteParams {
+        vni: args.vni,
+        ethernet_tag: args.ethernet_tag,
+        router_id: args.router_id,
+        rd,
+        route_type: args.route_type,
+    };
+    preflight_workload(&args, route_params)?;
     tracing::info!(
         listen = %args.listen,
         local_as = args.local_as,
@@ -175,15 +185,6 @@ async fn main() -> anyhow::Result<()> {
     // Build shared attribute set — identical across all routes except for
     // the NLRI payload itself. That keeps per-route CPU to a minimum on
     // the generator side so the RR's scale is what we measure.
-    let rd = make_rd(args.router_id);
-    let route_params = RouteParams {
-        vni: args.vni,
-        ethernet_tag: args.ethernet_tag,
-        router_id: args.router_id,
-        rd,
-        route_type: args.route_type,
-    };
-
     inject_phase(
         &handle.tx,
         PhaseParams {
@@ -229,6 +230,16 @@ async fn main() -> anyhow::Result<()> {
 fn validate_workload(args: &Args) -> anyhow::Result<()> {
     anyhow::ensure!(args.batch > 0, "--batch must be greater than zero");
     anyhow::ensure!(
+        args.vni <= 0x00ff_ffff,
+        "--vni must fit the 24-bit MPLS label field (maximum 16777215)"
+    );
+    if args.route_type == RouteType::MacIp {
+        anyhow::ensure!(
+            args.count <= 0x0100_0000,
+            "--count exceeds the 16777216 unique MAC addresses available to --route-type mac-ip"
+        );
+    }
+    anyhow::ensure!(
         args.hold_time == 0 || args.hold_time >= 3,
         "--hold-time must be 0 (disabled) or at least 3 seconds"
     );
@@ -240,6 +251,54 @@ fn validate_workload(args: &Args) -> anyhow::Result<()> {
         anyhow::ensure!(
             args.churn_rate > 0,
             "--churn-rate must be greater than zero when churn is enabled"
+        );
+    }
+    Ok(())
+}
+
+fn preflight_workload(args: &Args, route_params: RouteParams) -> anyhow::Result<()> {
+    if args.count == 0 {
+        return Ok(());
+    }
+
+    let inject_chunk = effective_chunk_size(args.batch, args.rate, 1).min(args.count);
+    let churn_chunk = (args.churn_duration_sec > 0)
+        .then(|| effective_chunk_size(args.batch, args.churn_rate, 2).min(args.count));
+    let advertised_chunk = churn_chunk.map_or(inject_chunk, |chunk| chunk.max(inject_chunk));
+    validate_encoded_chunk(advertised_chunk, route_params, false, "advertisement")?;
+
+    if let Some(churn_chunk) = churn_chunk {
+        validate_encoded_chunk(churn_chunk, route_params, true, "churn withdrawal")?;
+    }
+    Ok(())
+}
+
+fn validate_encoded_chunk(
+    chunk_count: u32,
+    route_params: RouteParams,
+    withdraw: bool,
+    phase: &str,
+) -> anyhow::Result<()> {
+    let mut routes = Vec::new();
+    for index in 0..chunk_count {
+        routes.push(build_route(index, route_params));
+        let message = if withdraw {
+            build_update(vec![], routes.clone(), route_params)
+        } else {
+            build_update(routes.clone(), vec![], route_params)
+        };
+        let encoded_len = encode_message(&message)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "{phase} chunk configured for {chunk_count} routes exceeds the standard 4096-byte BGP message limit at route {}: {error}; reduce --batch or the phase rate",
+                    routes.len()
+                )
+            })?
+            .len();
+        anyhow::ensure!(
+            encoded_len <= usize::from(MAX_MESSAGE_LEN),
+            "{phase} chunk configured for {chunk_count} routes exceeds the standard 4096-byte BGP message limit at route {} ({encoded_len} bytes); reduce --batch or the phase rate",
+            routes.len()
         );
     }
     Ok(())
@@ -287,6 +346,23 @@ fn build_ead_per_evi(
         ethernet_tag: EthernetTagId(tag),
         label: MplsLabel::new(vni),
     })
+}
+
+fn build_route(index: u32, route_params: RouteParams) -> EvpnRoute {
+    match route_params.route_type {
+        RouteType::MacIp => build_type2(
+            index,
+            route_params.rd,
+            route_params.ethernet_tag,
+            route_params.vni,
+        ),
+        RouteType::EadPerEvi => build_ead_per_evi(
+            index,
+            route_params.rd,
+            route_params.ethernet_tag,
+            route_params.vni,
+        ),
+    }
 }
 
 fn build_update(
@@ -348,47 +424,28 @@ async fn inject_phase(
     is_withdraw: bool,
 ) -> anyhow::Result<()> {
     let start = Instant::now();
-    let mut sent = 0u32;
+    let mut sent = 0u64;
     let mut idx = 0u32;
+    let chunk_size = effective_chunk_size(phase_params.batch, phase_params.rate, 1);
 
     while idx < phase_params.count {
-        let end = idx
-            .saturating_add(phase_params.batch)
-            .min(phase_params.count);
-        let chunk: Vec<EvpnRoute> = (idx..end)
-            .map(|i| match route_params.route_type {
-                RouteType::MacIp => build_type2(
-                    i,
-                    route_params.rd,
-                    route_params.ethernet_tag,
-                    route_params.vni,
-                ),
-                RouteType::EadPerEvi => build_ead_per_evi(
-                    i,
-                    route_params.rd,
-                    route_params.ethernet_tag,
-                    route_params.vni,
-                ),
-            })
-            .collect();
+        let end = chunk_end(idx, phase_params.count, chunk_size);
+        let chunk: Vec<EvpnRoute> = (idx..end).map(|i| build_route(i, route_params)).collect();
         let msg = if is_withdraw {
             build_update(vec![], chunk, route_params)
         } else {
             build_update(chunk, vec![], route_params)
         };
+
+        sent += u64::from(end - idx);
+        if phase_params.rate > 0 {
+            let send_at = start + pacing_offset(sent, phase_params.rate);
+            tokio::time::sleep_until(send_at.into()).await;
+        }
         if tx.send(msg).await.is_err() {
             anyhow::bail!("send channel closed before inject complete");
         }
-        sent += end - idx;
         idx = end;
-
-        if phase_params.rate > 0 {
-            let next_tick = start + pacing_offset(u64::from(sent), phase_params.rate);
-            let now = Instant::now();
-            if next_tick > now {
-                tokio::time::sleep(next_tick - now).await;
-            }
-        }
     }
     tracing::info!(
         sent,
@@ -411,41 +468,27 @@ async fn run_churn(
     let deadline = start_time + total;
     let mut idx = 0u32;
     let mut emitted_events = 0u64;
+    let chunk_size = effective_chunk_size(phase_params.batch, phase_params.rate, 2);
 
-    while Instant::now() < deadline {
+    loop {
         let start = idx % phase_params.count;
-        let end = start
-            .saturating_add(phase_params.batch)
-            .min(phase_params.count);
-        let chunk: Vec<EvpnRoute> = (start..end)
-            .map(|i| match route_params.route_type {
-                RouteType::MacIp => build_type2(
-                    i,
-                    route_params.rd,
-                    route_params.ethernet_tag,
-                    route_params.vni,
-                ),
-                RouteType::EadPerEvi => build_ead_per_evi(
-                    i,
-                    route_params.rd,
-                    route_params.ethernet_tag,
-                    route_params.vni,
-                ),
-            })
-            .collect();
+        let end = chunk_end(start, phase_params.count, chunk_size);
+        let chunk: Vec<EvpnRoute> = (start..end).map(|i| build_route(i, route_params)).collect();
+        let next_event_count = emitted_events + u64::from(end - start) * 2;
+        if !scheduled_within_deadline(next_event_count, phase_params.rate, total) {
+            break;
+        }
+        let send_at = start_time + pacing_offset(next_event_count, phase_params.rate);
+        debug_assert!(send_at <= deadline);
+        tokio::time::sleep_until(send_at.into()).await;
         // Withdraw + re-advertise as two UPDATEs back-to-back.
         let withdraw = build_update(vec![], chunk.clone(), route_params);
         let advertise = build_update(chunk, vec![], route_params);
         if tx.send(withdraw).await.is_err() || tx.send(advertise).await.is_err() {
             anyhow::bail!("send channel closed during churn");
         }
-        emitted_events += u64::from(end - start) * 2;
+        emitted_events = next_event_count;
         idx = end;
-        let next_tick = start_time + pacing_offset(emitted_events, phase_params.rate);
-        let now = Instant::now();
-        if next_tick > now {
-            tokio::time::sleep(next_tick - now).await;
-        }
     }
     Ok(())
 }
@@ -454,7 +497,26 @@ fn pacing_offset(events: u64, rate: u32) -> Duration {
     if rate == 0 {
         return Duration::ZERO;
     }
-    Duration::from_nanos(events.saturating_mul(1_000_000_000) / u64::from(rate))
+    let numerator = u128::from(events) * 1_000_000_000;
+    let denominator = u128::from(rate);
+    let nanos = numerator.div_ceil(denominator).min(u128::from(u64::MAX));
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+fn effective_chunk_size(batch: u32, rate: u32, events_per_route: u32) -> u32 {
+    if rate == 0 {
+        batch
+    } else {
+        batch.min((rate / events_per_route).max(1))
+    }
+}
+
+fn chunk_end(start: u32, count: u32, chunk_size: u32) -> u32 {
+    start.saturating_add(chunk_size).min(count)
+}
+
+fn scheduled_within_deadline(events: u64, rate: u32, total: Duration) -> bool {
+    pacing_offset(events, rate) <= total
 }
 
 #[allow(dead_code)]
@@ -481,6 +543,17 @@ mod tests {
             linger_sec: 30,
             hold_time: 180,
             route_type: RouteType::MacIp,
+        }
+    }
+
+    fn route_params(route_type: RouteType) -> RouteParams {
+        let router_id = Ipv4Addr::new(192, 0, 2, 1);
+        RouteParams {
+            vni: 100,
+            ethernet_tag: 0,
+            router_id,
+            rd: make_rd(router_id),
+            route_type,
         }
     }
 
@@ -518,15 +591,110 @@ mod tests {
     }
 
     #[test]
+    fn validates_vni_boundaries() {
+        let mut input = args();
+        input.vni = 0;
+        assert!(validate_workload(&input).is_ok());
+        input.vni = 0x00ff_ffff;
+        assert!(validate_workload(&input).is_ok());
+        input.vni = 0x0100_0000;
+        assert!(validate_workload(&input).is_err());
+    }
+
+    #[test]
+    fn mac_ip_count_is_bounded_by_unique_mac_space() {
+        let mut input = args();
+        input.count = 0x0100_0000;
+        assert!(validate_workload(&input).is_ok());
+        input.count = 0x0100_0001;
+        assert!(validate_workload(&input).is_err());
+
+        input.route_type = RouteType::EadPerEvi;
+        input.count = u32::MAX;
+        assert!(validate_workload(&input).is_ok());
+    }
+
+    #[test]
+    fn encoded_chunk_preflight_accepts_defaults_and_rejects_oversize() {
+        let input = args();
+        assert!(preflight_workload(&input, route_params(RouteType::MacIp)).is_ok());
+        assert!(preflight_workload(&input, route_params(RouteType::EadPerEvi)).is_ok());
+
+        let mut oversized = args();
+        oversized.count = 1_000;
+        oversized.batch = 1_000;
+        oversized.rate = 0;
+        let error = preflight_workload(&oversized, route_params(RouteType::MacIp))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("advertisement chunk configured for 1000 routes"));
+        assert!(error.contains("4096-byte BGP message limit"));
+    }
+
+    #[test]
+    fn encoded_chunk_preflight_checks_active_churn_withdrawals() {
+        let mut input = args();
+        input.churn_duration_sec = 1;
+        assert!(preflight_workload(&input, route_params(RouteType::MacIp)).is_ok());
+
+        let error = validate_encoded_chunk(
+            1_000,
+            route_params(RouteType::MacIp),
+            true,
+            "churn withdrawal",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("churn withdrawal chunk configured for 1000 routes"));
+    }
+
+    #[test]
+    fn zero_count_skips_encoded_chunk_preflight() {
+        let mut input = args();
+        input.count = 0;
+        input.batch = u32::MAX;
+        assert!(preflight_workload(&input, route_params(RouteType::MacIp)).is_ok());
+    }
+
+    #[test]
+    fn chunk_end_handles_partial_and_u32_boundary_chunks() {
+        assert_eq!(chunk_end(80, 100, 40), 100);
+        assert_eq!(chunk_end(40, 100, 40), 80);
+        assert_eq!(chunk_end(u32::MAX - 5, u32::MAX, 40), u32::MAX);
+        assert_eq!(chunk_end(0, u32::MAX, u32::MAX), u32::MAX);
+    }
+
+    #[test]
     fn pacing_uses_the_cumulative_event_budget() {
         assert_eq!(pacing_offset(0, 1_000), Duration::ZERO);
         assert_eq!(pacing_offset(40, 1_000), Duration::from_millis(40));
         assert_eq!(pacing_offset(80, 1_000), Duration::from_millis(80));
         assert_eq!(pacing_offset(100, 25), Duration::from_secs(4));
+        assert_eq!(pacing_offset(1, 3), Duration::from_nanos(333_333_334));
+        assert_eq!(pacing_offset(2, 3), Duration::from_nanos(666_666_667));
+        assert_eq!(pacing_offset(3, 3), Duration::from_secs(1));
+        assert_eq!(pacing_offset(40, 100_000), Duration::from_micros(400));
     }
 
     #[test]
     fn zero_rate_has_no_pacing_delay() {
         assert_eq!(pacing_offset(u64::MAX, 0), Duration::ZERO);
+    }
+
+    #[test]
+    fn effective_chunks_prevent_low_rate_bursts() {
+        assert_eq!(effective_chunk_size(40, 10, 1), 10);
+        assert_eq!(effective_chunk_size(40, 1, 1), 1);
+        assert_eq!(effective_chunk_size(40, 1_000, 1), 40);
+        assert_eq!(effective_chunk_size(40, 10, 2), 5);
+        assert_eq!(effective_chunk_size(40, 1, 2), 1);
+        assert_eq!(effective_chunk_size(40, 0, 1), 40);
+    }
+
+    #[test]
+    fn churn_suppresses_pairs_beyond_the_total_deadline() {
+        assert!(scheduled_within_deadline(2, 2, Duration::from_secs(1)));
+        assert!(!scheduled_within_deadline(4, 2, Duration::from_secs(1)));
+        assert!(scheduled_within_deadline(1, 0, Duration::ZERO));
     }
 }

--- a/bench/evpn-load/src/lib.rs
+++ b/bench/evpn-load/src/lib.rs
@@ -164,35 +164,50 @@ pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
     let (mut reader, mut writer) = stream.into_split();
 
     let hold = cfg.hold_time;
-    let ka_interval = Duration::from_secs(u64::from(hold) / 3);
+    let ka_interval = keepalive_interval(hold);
 
     // Writer task: pulls from tx, writes to socket, injects periodic KEEPALIVE.
     tokio::spawn(async move {
-        let mut ka_tick = tokio::time::interval(ka_interval);
-        ka_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ka_tick.tick().await; // fire immediately, then cadence
-        loop {
-            tokio::select! {
-                Some(msg) = tx_rx.recv() => {
-                    match encode_message(&msg) {
-                        Ok(bytes) => {
-                            if writer.write_all(&bytes).await.is_err() {
+        if let Some(interval) = ka_interval {
+            let mut ka_tick = tokio::time::interval(interval);
+            ka_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            ka_tick.tick().await; // fire immediately, then cadence
+            loop {
+                tokio::select! {
+                    Some(msg) = tx_rx.recv() => {
+                        match encode_message(&msg) {
+                            Ok(bytes) => {
+                                if writer.write_all(&bytes).await.is_err() {
+                                    return;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!(?e, "encode failed in writer task");
                                 return;
                             }
                         }
-                        Err(e) => {
-                            tracing::error!(?e, "encode failed in writer task");
-                            return;
+                    }
+                    _ = ka_tick.tick() => {
+                        if let Ok(bytes) = encode_message(&Message::Keepalive)
+                            && writer.write_all(&bytes).await.is_err() {
+                                return;
                         }
                     }
+                    else => return,
                 }
-                _ = ka_tick.tick() => {
-                    if let Ok(bytes) = encode_message(&Message::Keepalive)
-                        && writer.write_all(&bytes).await.is_err() {
-                            return;
+            }
+        } else {
+            while let Some(msg) = tx_rx.recv().await {
+                let bytes = match encode_message(&msg) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::error!(?e, "encode failed in writer task");
+                        return;
                     }
+                };
+                if writer.write_all(&bytes).await.is_err() {
+                    return;
                 }
-                else => return,
             }
         }
     });
@@ -277,6 +292,14 @@ pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
         rx: rx_out,
         established_at,
     })
+}
+
+fn keepalive_interval(hold_time: u16) -> Option<Duration> {
+    if hold_time == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(u64::from(hold_time) / 3))
+    }
 }
 
 fn build_open(cfg: &PeerConfig) -> OpenMessage {
@@ -393,5 +416,12 @@ mod tests {
         let cfg = PeerConfig::evpn_only(addr, 65000, Ipv4Addr::new(10, 0, 0, 2));
         assert_eq!(cfg.hold_time, 90);
         assert_eq!(cfg.families, vec![(Afi::L2Vpn, Safi::Evpn)]);
+    }
+
+    #[test]
+    fn hold_zero_disables_periodic_keepalives() {
+        assert_eq!(keepalive_interval(0), None);
+        assert_eq!(keepalive_interval(3), Some(Duration::from_secs(1)));
+        assert_eq!(keepalive_interval(180), Some(Duration::from_mins(1)));
     }
 }

--- a/bench/evpn-load/src/lib.rs
+++ b/bench/evpn-load/src/lib.rs
@@ -47,6 +47,8 @@ pub enum PeerError {
     Notification { code: String, subcode: u8 },
     #[error("send channel closed")]
     SendChannelClosed,
+    #[error("hold time must be 0 (disabled) or at least 3 seconds, got {0}")]
+    InvalidHoldTime(u16),
 }
 
 /// Peer session configuration.
@@ -132,6 +134,7 @@ pub struct PeerHandle {
 /// KEEPALIVE fails.
 #[expect(clippy::too_many_lines, reason = "reader task body is the bulk")]
 pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
+    validate_hold_time(cfg.hold_time)?;
     let listener = TcpListener::bind(cfg.listen).await?;
     tracing::info!(listen = %cfg.listen, "evpn-load peer listening for BGP session");
     let (mut stream, remote) = listener.accept().await?;
@@ -302,6 +305,14 @@ fn keepalive_interval(hold_time: u16) -> Option<Duration> {
     }
 }
 
+fn validate_hold_time(hold_time: u16) -> Result<(), PeerError> {
+    if hold_time == 0 || hold_time >= 3 {
+        Ok(())
+    } else {
+        Err(PeerError::InvalidHoldTime(hold_time))
+    }
+}
+
 fn build_open(cfg: &PeerConfig) -> OpenMessage {
     let mut caps: Vec<Capability> = cfg
         .families
@@ -423,5 +434,19 @@ mod tests {
         assert_eq!(keepalive_interval(0), None);
         assert_eq!(keepalive_interval(3), Some(Duration::from_secs(1)));
         assert_eq!(keepalive_interval(180), Some(Duration::from_mins(1)));
+    }
+
+    #[test]
+    fn rejects_hold_times_without_a_safe_keepalive_interval() {
+        assert!(validate_hold_time(0).is_ok());
+        assert!(matches!(
+            validate_hold_time(1),
+            Err(PeerError::InvalidHoldTime(1))
+        ));
+        assert!(matches!(
+            validate_hold_time(2),
+            Err(PeerError::InvalidHoldTime(2))
+        ));
+        assert!(validate_hold_time(3).is_ok());
     }
 }

--- a/bench/evpn-load/src/lib.rs
+++ b/bench/evpn-load/src/lib.rs
@@ -177,7 +177,13 @@ pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
             ka_tick.tick().await; // fire immediately, then cadence
             loop {
                 tokio::select! {
-                    Some(msg) = tx_rx.recv() => {
+                    msg = tx_rx.recv() => {
+                        // `None` means every sender dropped (run finished). Bind
+                        // the whole Option and exit on close: with the always-armed
+                        // keepalive tick, a `Some(msg) =` pattern arm would just be
+                        // disabled on close and `else` never reached, so the task
+                        // would send KEEPALIVEs forever after the run ends.
+                        let Some(msg) = msg else { return };
                         match encode_message(&msg) {
                             Ok(bytes) => {
                                 if writer.write_all(&bytes).await.is_err() {
@@ -196,7 +202,6 @@ pub async fn establish(cfg: PeerConfig) -> Result<PeerHandle, PeerError> {
                                 return;
                         }
                     }
-                    else => return,
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

- reject invalid zero-batch/churn, VNI, synthetic-MAC, hold-time, and oversized UPDATE workloads before binding
- make hold time zero disable periodic keepalive and receive timers without constructing a zero-duration interval
- pace injection and churn against cumulative route-event budgets, including low/sub-millisecond rates and churn deadlines
- add validation, wire-size, chunk-boundary, hold-time, and deterministic pacing regression tests

## Behavior contract

- `--count 0` remains valid for a session-only run when churn is disabled
- initial `--rate 0` remains unpaced
- active churn requires positive count and churn rate
- churn counts withdrawal and re-advertisement as separate route events
- VNI is bounded to its 24-bit field and Type-2 workloads to the unique synthetic MAC space
- actual initial/churn chunks are preflighted against the standard 4096-byte BGP message limit

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p rustbgpd-evpn-load` (16 tests)
- `cargo clippy -p rustbgpd-evpn-load --all-targets -- -D warnings`
- `cargo check -p rustbgpd-evpn-load --bins`
- `cargo clippy --workspace --all-targets -- -D warnings`
- per-commit and full-branch diff review
- independent adversarial review

## Documentation

Updated `bench/README.md` and the Unreleased changelog. ROADMAP, ADRs, and interop scripts are unchanged because this corrects development-harness measurement behavior without changing product scope or topology.

Linear: LAN-362