### PR TITLE
test(rib): add replayable update-group fault corpus

### DIFF
--- a/.github/workflows/update-group-fault.yml
+++ b/.github/workflows/update-group-fault.yml
@@ -1,0 +1,30 @@
+name: Update-group fault corpus
+
+on:
+  schedule:
+    - cron: "30 3 * * 1" # Mondays at 03:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-group-fault-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  extended-corpus:
+    if: github.repository == 'lance0/rustbgpd'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: update-group-fault
+      - name: Run hard-capped deterministic corpus
+        run: >-
+          cargo test -p rustbgpd-rib
+          deterministic_fault_corpus_extended
+          -- --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,16 +48,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **Update-group correctness now has a deterministic differential fault
-  corpus.** The grouped manager path and forced-per-peer oracle are compared
-  with explicit exact-stream or folded-state semantics across bounded channel
+- **Update-group correctness now has a parameterized fixed-scenario
+  differential corpus.** The grouped manager path and forced-per-peer oracle
+  are compared with explicit exact-stream or normalized semantic-effect plus
+  folded-state semantics across bounded channel
   saturation and virtual-time retry, repeated policy regroup while dirty, stale
   session generations, and RT-Constrain membership churn. Every path must emit
   non-empty traffic, deliver a terminal sentinel, finish its manager task, and
   clear dirty/force/regroup/residue state. A hard-capped 24-seed extension runs
-  weekly and by manual dispatch on GitHub-hosted runners; validated seed-start,
-  seed-count, and max-operation controls replay an individual failure without
-  allowing an unbounded run. (LAN-357)
+  weekly and by manual dispatch on GitHub-hosted runners. Seeds vary fixture
+  identities, not schedule order or length; validated seed-start, seed-count,
+  and max-operation controls replay an individual failure without allowing an
+  unbounded run. (LAN-357)
 
 - **Reload UPDATE-stall receipt re-run and re-validated.**
   `docs/perf/reload-stall-2026-07.md` replaces the July run that was withdrawn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   session generations, and RT-Constrain membership churn. Every path must emit
   non-empty traffic, deliver a terminal sentinel, finish its manager task, and
   clear dirty/force/regroup/residue state. A hard-capped 24-seed extension runs
-  weekly and by manual dispatch on GitHub-hosted runners. (LAN-357)
+  weekly and by manual dispatch on GitHub-hosted runners; validated seed-start,
+  seed-count, and max-operation controls replay an individual failure without
+  allowing an unbounded run. (LAN-357)
 
 - **Reload UPDATE-stall receipt re-run and re-validated.**
   `docs/perf/reload-stall-2026-07.md` replaces the July run that was withdrawn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Update-group correctness now has a deterministic differential fault
+  corpus.** The grouped manager path and forced-per-peer oracle are compared
+  with explicit exact-stream or folded-state semantics across bounded channel
+  saturation and virtual-time retry, repeated policy regroup while dirty, stale
+  session generations, and RT-Constrain membership churn. Every path must emit
+  non-empty traffic, deliver a terminal sentinel, finish its manager task, and
+  clear dirty/force/regroup/residue state. A hard-capped 24-seed extension runs
+  weekly and by manual dispatch on GitHub-hosted runners. (LAN-357)
+
 - **Reload UPDATE-stall receipt re-run and re-validated.**
   `docs/perf/reload-stall-2026-07.md` replaces the July run that was withdrawn
   as not-acceptance evidence. The corrected harness counts unique re-advertised

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,27 @@ All PRs must pass (enforced by CI in `.github/workflows/ci.yml`):
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
 
+### Replaying update-group faults
+
+The PR-sized deterministic corpus compares the grouped manager path with the
+forced-per-peer oracle under bounded channel saturation, dirty policy regroup,
+stale session generations, and RT-Constrain membership churn:
+
+```bash
+cargo test -p rustbgpd-rib deterministic_fault_corpus -- --nocapture
+```
+
+Failure output includes the scenario name, seed, comparison mode, and ordered
+operation log. To run the hard-capped 24-seed corpus used by the weekly
+GitHub-hosted workflow:
+
+```bash
+cargo test -p rustbgpd-rib deterministic_fault_corpus_extended -- --ignored --nocapture
+```
+
+The extended corpus uses virtual time and fixed operation caps; it is not a
+replacement for a live or multi-day soak.
+
 The clippy-reason ratchet currently covers the paths listed in
 `DEFAULT_PATHS` in `scripts/check-clippy-reasons.py`. Any
 `#[allow(clippy::...)]` or `#[expect(clippy::...)]` in a ratcheted path must

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,20 @@ GitHub-hosted workflow:
 cargo test -p rustbgpd-rib deterministic_fault_corpus_extended -- --ignored --nocapture
 ```
 
-The extended corpus uses virtual time and fixed operation caps; it is not a
-replacement for a live or multi-day soak.
+The defaults are seed start `0x35700000`, 24 seeds, and at most 64 operations
+per schedule. Replay one failing seed with:
+
+```bash
+RUSTBGPD_UPDATE_GROUP_SEED_START=0x35700007 \
+RUSTBGPD_UPDATE_GROUP_SEED_COUNT=1 \
+RUSTBGPD_UPDATE_GROUP_MAX_OPS=64 \
+cargo test -p rustbgpd-rib deterministic_fault_corpus_extended -- --ignored --nocapture
+```
+
+`RUSTBGPD_UPDATE_GROUP_SEED_COUNT` must be `1..=64`; max operations must also
+be `1..=64`. Invalid values and overflowing seed ranges fail before a manager
+starts. The corpus uses virtual time and hard caps; it is not a replacement for
+a live or multi-day soak.
 
 The clippy-reason ratchet currently covers the paths listed in
 `DEFAULT_PATHS` in `scripts/check-clippy-reasons.py`. Any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ All PRs must pass (enforced by CI in `.github/workflows/ci.yml`):
 
 ### Replaying update-group faults
 
-The PR-sized deterministic corpus compares the grouped manager path with the
-forced-per-peer oracle under bounded channel saturation, dirty policy regroup,
-stale session generations, and RT-Constrain membership churn:
+The PR-sized parameterized fixed-scenario corpus compares the grouped manager
+path with the forced-per-peer oracle under bounded channel saturation, dirty
+policy regroup, stale session generations, and RT-Constrain membership churn:
 
 ```bash
 cargo test -p rustbgpd-rib deterministic_fault_corpus -- --nocapture
@@ -49,8 +49,9 @@ GitHub-hosted workflow:
 cargo test -p rustbgpd-rib deterministic_fault_corpus_extended -- --ignored --nocapture
 ```
 
-The defaults are seed start `0x35700000`, 24 seeds, and at most 64 operations
-per schedule. Replay one failing seed with:
+Seeds vary valid fixture identities; they do not randomize operation ordering
+or scenario length. The defaults are seed start `0x35700000`, 24 fixture sets,
+and at most 64 operations per schedule. Replay one failing fixture set with:
 
 ```bash
 RUSTBGPD_UPDATE_GROUP_SEED_START=0x35700007 \
@@ -59,10 +60,11 @@ RUSTBGPD_UPDATE_GROUP_MAX_OPS=64 \
 cargo test -p rustbgpd-rib deterministic_fault_corpus_extended -- --ignored --nocapture
 ```
 
-`RUSTBGPD_UPDATE_GROUP_SEED_COUNT` must be `1..=64`; max operations must also
-be `1..=64`. Invalid values and overflowing seed ranges fail before a manager
-starts. The corpus uses virtual time and hard caps; it is not a replacement for
-a live or multi-day soak.
+`RUSTBGPD_UPDATE_GROUP_SEED_COUNT` must be `1..=64`; max operations must be
+`18..=64`, where 18 is the longest fixed schedule and is test-ratcheted when a
+schedule changes. Invalid values and overflowing seed ranges fail before a
+manager starts. The corpus uses virtual time and hard caps; it is not a
+replacement for a live or multi-day soak.
 
 The clippy-reason ratchet currently covers the paths listed in
 `DEFAULT_PATHS` in `scripts/check-clippy-reasons.py`. Any

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,11 +233,14 @@ new AFI/SAFI and EVPN dataplane expansion.
   peers/families, private outbound-view count, regroup/full-resync scope, and a
   bounded capacity class. Do not present byte-precise memory or time estimates
   until a calibrated model exists.
-- **Keep update-group correctness as a permanent fault program.** Differentially
-  compare grouped and forced-per-peer output under channel saturation, policy
-  swaps, repeated regrouping, dirty-member recovery, session loss, and restart;
-  add long-running folded-state comparison rather than relying only on happy-
-  path convergence receipts.
+- **Keep update-group correctness as a permanent fault program.** The bounded
+  deterministic foundation is shipped: grouped and forced-per-peer output are
+  compared under channel saturation/virtual retry, dirty policy swaps and
+  repeated regrouping, stale session generations, and RTC membership churn,
+  with a fixed PR corpus plus a hard-capped weekly 24-seed extension. Remaining:
+  automated failure minimization, a broader fault matrix, restart/persistence,
+  growth measurement, and long-running folded-state comparison (LAN-18) rather
+  than relying only on bounded convergence receipts.
 - **Turn shipped shadow tooling into external evidence.** The canonical semantic
   diff engine, `rbgp diff`, incumbent snapshot adapters, and BMP Adj-RIB-Out
   importer are shipped. The remaining adoption gate is a real BIRD/FRR/GoBGP

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -237,7 +237,8 @@ new AFI/SAFI and EVPN dataplane expansion.
   deterministic foundation is shipped: grouped and forced-per-peer output are
   compared under channel saturation/virtual retry, dirty policy swaps and
   repeated regrouping, stale session generations, and RTC membership churn,
-  with a fixed PR corpus plus a hard-capped weekly 24-seed extension. Remaining:
+  with fixed PR schedules plus a hard-capped weekly 24-fixture parameter sweep.
+  Seeds vary identities, not operation ordering or scenario length. Remaining:
   automated failure minimization, a broader fault matrix, restart/persistence,
   growth measurement, and long-running folded-state comparison (LAN-18) rather
   than relying only on bounded convergence receipts.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1193,6 +1193,15 @@ impl RibManager {
             RibUpdate::TestQueryVpnAdvertised { peer, reply } => {
                 self.handle_test_query_vpn_advertised(peer, reply);
             }
+            #[cfg(test)]
+            RibUpdate::TestQueryOutboundHealth { reply } => {
+                let _ = reply.send((
+                    self.dirty_peers.len(),
+                    self.force_outbound_peers.len(),
+                    self.pending_regroup_baseline.len(),
+                    self.pending_extra_withdraws.len(),
+                ));
+            }
             RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
                 self.handle_query_export_policy_term_hits(peer, reply);
             }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1195,9 +1195,21 @@ impl RibManager {
             }
             #[cfg(test)]
             RibUpdate::TestQueryOutboundHealth { reply } => {
+                let group_dirty = self
+                    .group_ribs
+                    .values()
+                    .map(|group| group.dirty_members.len())
+                    .sum();
+                let group_tombstones = self
+                    .group_ribs
+                    .values()
+                    .map(|group| group.tombstones.len() + group.vpn_tombstones.len())
+                    .sum();
                 let _ = reply.send((
                     self.dirty_peers.len(),
                     self.force_outbound_peers.len(),
+                    group_dirty,
+                    group_tombstones,
                     self.pending_regroup_baseline.len(),
                     self.pending_extra_withdraws.len(),
                 ));

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -945,5 +945,6 @@ mod rpki;
 mod rtc;
 mod unicast;
 mod update_groups;
+mod update_groups_fault_corpus;
 mod update_groups_oracle;
 mod vpn;

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -4,14 +4,15 @@
 //! same replayable schedules with a hard seed/operation cap; it is exercised by
 //! the weekly GitHub-hosted workflow, never by a live soak runner.
 
+use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use rustbgpd_wire::{Afi, Ipv4Prefix, Prefix, RtcNlri, Safi};
 
 use super::update_groups_oracle::{
-    Oracle, Streams, deny_prefix_chain, deny_prefixes_chain, fold, ibgp_route, pfx, rtc_default,
-    vpn_rtc_sendable,
+    Oracle, Streams, deny_prefix_chain, deny_prefixes_chain, fold, fold_vpn, ibgp_route, pfx,
+    rtc_default, vpn_nlri, vpn_route, vpn_rtc_sendable,
 };
 use crate::route::RtcRibRouteKey;
 
@@ -19,8 +20,72 @@ const SOURCE: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 const LEFT: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
 const RIGHT: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 3);
 const PR_SEEDS: [u64; 3] = [0x51_7A, 0xC0_FF_EE, 0x05EE_D357];
-const EXTENDED_SEEDS: usize = 24;
-const MAX_OPS: usize = 64;
+const DEFAULT_SEED_START: u64 = 0x3570_0000;
+const DEFAULT_SEED_COUNT: usize = 24;
+const DEFAULT_MAX_OPS: usize = 64;
+const SEED_COUNT_CAP: usize = 64;
+const MAX_OPS_CAP: usize = 64;
+const SEED_START_ENV: &str = "RUSTBGPD_UPDATE_GROUP_SEED_START";
+const SEED_COUNT_ENV: &str = "RUSTBGPD_UPDATE_GROUP_SEED_COUNT";
+const MAX_OPS_ENV: &str = "RUSTBGPD_UPDATE_GROUP_MAX_OPS";
+const TEST_RT: u64 = 0x0002_FDE8_0000_002A;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ExtendedConfig {
+    seed_start: u64,
+    seed_count: usize,
+    max_ops: usize,
+}
+
+fn parse_u64(name: &str, value: &str) -> Result<u64, String> {
+    let parsed = value.strip_prefix("0x").unwrap_or(value);
+    if value.starts_with("0x") {
+        u64::from_str_radix(parsed, 16)
+    } else {
+        value.parse()
+    }
+    .map_err(|error| format!("invalid {name}={value:?}: {error}"))
+}
+
+fn parse_extended_config(get: impl Fn(&str) -> Option<String>) -> Result<ExtendedConfig, String> {
+    let seed_start = get(SEED_START_ENV)
+        .map(|value| parse_u64(SEED_START_ENV, &value))
+        .transpose()?
+        .unwrap_or(DEFAULT_SEED_START);
+    let seed_count = get(SEED_COUNT_ENV)
+        .map(|value| parse_u64(SEED_COUNT_ENV, &value))
+        .transpose()?
+        .map_or(Ok(DEFAULT_SEED_COUNT), |value| {
+            usize::try_from(value)
+                .map_err(|error| format!("invalid {SEED_COUNT_ENV}={value}: {error}"))
+        })?;
+    let max_ops = get(MAX_OPS_ENV)
+        .map(|value| parse_u64(MAX_OPS_ENV, &value))
+        .transpose()?
+        .map_or(Ok(DEFAULT_MAX_OPS), |value| {
+            usize::try_from(value)
+                .map_err(|error| format!("invalid {MAX_OPS_ENV}={value}: {error}"))
+        })?;
+    if !(1..=SEED_COUNT_CAP).contains(&seed_count) {
+        return Err(format!(
+            "{SEED_COUNT_ENV} must be in 1..={SEED_COUNT_CAP}, got {seed_count}"
+        ));
+    }
+    if !(1..=MAX_OPS_CAP).contains(&max_ops) {
+        return Err(format!(
+            "{MAX_OPS_ENV} must be in 1..={MAX_OPS_CAP}, got {max_ops}"
+        ));
+    }
+    let last_offset = u64::try_from(seed_count - 1).expect("seed count is capped at 64");
+    seed_start
+        .checked_add(last_offset)
+        .ok_or_else(|| format!("{SEED_START_ENV} + {SEED_COUNT_ENV} overflows u64"))?;
+    Ok(ExtendedConfig {
+        seed_start,
+        seed_count,
+        max_ops,
+    })
+}
 
 #[derive(Clone, Copy, Debug)]
 enum ComparisonMode {
@@ -64,6 +129,11 @@ enum Op {
         generation: u64,
         prefix: Ipv4Prefix,
     },
+    VpnAnnounce {
+        peer: Ipv4Addr,
+        generation: u64,
+        id: u8,
+    },
     ReplacePolicy {
         peer: Ipv4Addr,
         policy: PolicySpec,
@@ -87,6 +157,7 @@ struct Schedule {
     name: &'static str,
     seed: u64,
     comparison: ComparisonMode,
+    require_vpn_churn: bool,
     ops: Vec<Op>,
 }
 
@@ -118,12 +189,37 @@ fn seed_octet(seed: u64, byte: usize) -> u8 {
     seed.to_le_bytes()[byte] | 1
 }
 
+fn distinct_seed_octet(seed: u64, byte: usize, other: u8) -> u8 {
+    let candidate = seed_octet(seed, byte);
+    if candidate == other {
+        candidate.wrapping_add(2)
+    } else {
+        candidate
+    }
+}
+
 fn policy(spec: &PolicySpec) -> Option<rustbgpd_policy::PolicyChain> {
     match spec {
         PolicySpec::Permit => None,
         PolicySpec::DenyOne(prefix) => Some(deny_prefix_chain(*prefix)),
         PolicySpec::DenyMany(prefixes) => Some(deny_prefixes_chain(prefixes)),
     }
+}
+
+async fn apply_vpn_announce(oracle: &mut Oracle, peer: Ipv4Addr, generation: u64, id: u8) {
+    oracle
+        .vpn_routes_generation(
+            peer,
+            generation,
+            vec![vpn_route(
+                vpn_nlri(id, 16_000 + u32::from(id)),
+                peer,
+                100,
+                vec![TEST_RT],
+            )],
+            vec![],
+        )
+        .await;
 }
 
 async fn apply(oracle: &mut Oracle, op: &Op) {
@@ -177,6 +273,13 @@ async fn apply(oracle: &mut Oracle, op: &Op) {
                 .routes_generation(*peer, *generation, vec![], vec![*prefix])
                 .await;
         }
+        Op::VpnAnnounce {
+            peer,
+            generation,
+            id,
+        } => {
+            apply_vpn_announce(oracle, *peer, *generation, *id).await;
+        }
         Op::ReplacePolicy { peer, policy: spec } => {
             oracle.replace_policy(*peer, policy(spec)).await;
         }
@@ -212,10 +315,10 @@ async fn apply(oracle: &mut Oracle, op: &Op) {
     }
 }
 
-async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
+async fn run_path(schedule: &Schedule, force_ungrouped: bool, max_ops: usize) -> Streams {
     assert!(
-        schedule.ops.len() <= MAX_OPS,
-        "operation cap exceeded: {}",
+        schedule.ops.len() <= max_ops,
+        "operation cap {max_ops} exceeded: {}",
         schedule.replay()
     );
     let mut oracle = Oracle::spawn(force_ungrouped, Some(Ipv4Addr::new(192, 0, 2, 1)));
@@ -225,6 +328,15 @@ async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
             schedule.name, schedule.seed
         );
         apply(&mut oracle, op).await;
+    }
+    if !force_ungrouped {
+        let left = oracle.group_label(LEFT).await;
+        let right = oracle.group_label(RIGHT).await;
+        assert!(
+            left.starts_with("group:") && left == right,
+            "scenario did not exercise a shared update group ({left:?}/{right:?}): {}",
+            schedule.replay()
+        );
     }
 
     // Every schedule ends with a current-generation sentinel from SOURCE.
@@ -251,6 +363,24 @@ async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
         "schedule emitted no traffic: {}",
         schedule.replay()
     );
+    if schedule.require_vpn_churn {
+        let left = streams
+            .get(&IpAddr::V4(LEFT))
+            .expect("LEFT is registered in every schedule");
+        assert!(
+            left.iter().any(|message| !message.vpn_announce.is_empty())
+                && left.iter().any(|message| !message.vpn_withdraw.is_empty()),
+            "RTC membership did not produce both VPN announce and withdraw traffic: {}",
+            schedule.replay()
+        );
+        assert!(
+            fold_vpn(&streams)
+                .get(&IpAddr::V4(LEFT))
+                .is_none_or(std::collections::HashMap::is_empty),
+            "final RTC withdrawal must leave LEFT with no advertised VPN route: {}",
+            schedule.replay()
+        );
+    }
     for peer in [LEFT, RIGHT] {
         let delivered = streams
             .get(&IpAddr::V4(peer))
@@ -271,9 +401,9 @@ async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
     streams
 }
 
-async fn run_schedule(schedule: Schedule) {
-    let grouped = run_path(&schedule, false).await;
-    let ungrouped = run_path(&schedule, true).await;
+async fn run_schedule(schedule: Schedule, max_ops: usize) {
+    let grouped = run_path(&schedule, false, max_ops).await;
+    let ungrouped = run_path(&schedule, true, max_ops).await;
     match schedule.comparison {
         ComparisonMode::ExactStream => assert_eq!(
             grouped,
@@ -288,15 +418,22 @@ async fn run_schedule(schedule: Schedule) {
             schedule.replay()
         ),
     }
+    assert_eq!(
+        fold_vpn(&grouped),
+        fold_vpn(&ungrouped),
+        "folded VPN advertised-state mismatch: {}",
+        schedule.replay()
+    );
 }
 
 fn saturation_schedule(seed: u64) -> Schedule {
     let first = pfx(seed_octet(seed, 0), 0);
-    let second = pfx(seed_octet(seed, 1), 1);
+    let second = pfx(distinct_seed_octet(seed, 1, seed_octet(seed, 0)), 1);
     Schedule {
         name: "saturation-drain-virtual-retry",
         seed,
         comparison: ComparisonMode::SemanticFold,
+        require_vpn_churn: false,
         ops: vec![
             Op::PeerUp {
                 peer: SOURCE,
@@ -343,11 +480,12 @@ fn saturation_schedule(seed: u64) -> Schedule {
 
 fn dirty_policy_schedule(seed: u64) -> Schedule {
     let first = pfx(seed_octet(seed, 2), 2);
-    let second = pfx(seed_octet(seed, 3), 3);
+    let second = pfx(distinct_seed_octet(seed, 3, seed_octet(seed, 2)), 3);
     Schedule {
         name: "dirty-policy-regroup-transitions",
         seed,
         comparison: ComparisonMode::SemanticFold,
+        require_vpn_churn: false,
         ops: vec![
             Op::PeerUp {
                 peer: SOURCE,
@@ -406,6 +544,7 @@ fn stale_generation_rtc_schedule(seed: u64) -> Schedule {
         name: "stale-generation-rtc-membership-churn",
         seed,
         comparison: ComparisonMode::ExactStream,
+        require_vpn_churn: true,
         ops: vec![
             Op::PeerUp {
                 peer: SOURCE,
@@ -429,7 +568,7 @@ fn stale_generation_rtc_schedule(seed: u64) -> Schedule {
                 peer: SOURCE,
                 generation: 2,
                 capacity: 64,
-                families: FamilySet::Unicast,
+                families: FamilySet::VpnRtc,
             },
             Op::Announce {
                 peer: SOURCE,
@@ -465,6 +604,11 @@ fn stale_generation_rtc_schedule(seed: u64) -> Schedule {
                 peer: LEFT,
                 generation: 2,
             },
+            Op::VpnAnnounce {
+                peer: SOURCE,
+                generation: 2,
+                id: seed_octet(seed, 6),
+            },
             Op::RtcDefaultWithdraw {
                 peer: LEFT,
                 generation: 2,
@@ -487,19 +631,71 @@ async fn deterministic_fault_corpus() {
     tokio::time::pause();
     for seed in PR_SEEDS {
         for schedule in schedules(seed) {
-            run_schedule(schedule).await;
+            run_schedule(schedule, DEFAULT_MAX_OPS).await;
         }
     }
+}
+
+#[test]
+fn extended_config_defaults_and_boundaries() {
+    assert_eq!(
+        parse_extended_config(|_| None).unwrap(),
+        ExtendedConfig {
+            seed_start: DEFAULT_SEED_START,
+            seed_count: DEFAULT_SEED_COUNT,
+            max_ops: DEFAULT_MAX_OPS,
+        }
+    );
+
+    let get = |name: &str| match name {
+        SEED_START_ENV => Some("0xffffffffffffffff".to_owned()),
+        SEED_COUNT_ENV | MAX_OPS_ENV => Some("1".to_owned()),
+        _ => None,
+    };
+    assert_eq!(
+        parse_extended_config(get).unwrap(),
+        ExtendedConfig {
+            seed_start: u64::MAX,
+            seed_count: 1,
+            max_ops: 1,
+        }
+    );
+
+    for (name, value, expected) in [
+        (
+            SEED_START_ENV,
+            "wat",
+            "invalid RUSTBGPD_UPDATE_GROUP_SEED_START",
+        ),
+        (SEED_COUNT_ENV, "0", "must be in 1..=64"),
+        (SEED_COUNT_ENV, "65", "must be in 1..=64"),
+        (MAX_OPS_ENV, "0", "must be in 1..=64"),
+        (MAX_OPS_ENV, "65", "must be in 1..=64"),
+    ] {
+        let error = parse_extended_config(|key| (key == name).then(|| value.to_owned()))
+            .expect_err("invalid boundary must fail");
+        assert!(error.contains(expected), "unexpected error: {error}");
+    }
+
+    let overflow = parse_extended_config(|name| match name {
+        SEED_START_ENV => Some(u64::MAX.to_string()),
+        SEED_COUNT_ENV => Some("2".to_owned()),
+        _ => None,
+    })
+    .expect_err("seed range overflow must fail");
+    assert!(overflow.contains("overflows u64"));
 }
 
 #[tokio::test]
 #[ignore = "bounded extended corpus; run explicitly or via weekly workflow"]
 async fn deterministic_fault_corpus_extended() {
     tokio::time::pause();
-    for index in 0..EXTENDED_SEEDS {
-        let seed = 0x3570_0000_u64.wrapping_add(index as u64);
+    let config = parse_extended_config(|name| env::var(name).ok())
+        .unwrap_or_else(|error| panic!("invalid extended fault-corpus controls: {error}"));
+    for index in 0..config.seed_count {
+        let seed = config.seed_start + u64::try_from(index).expect("seed count is capped at 64");
         for schedule in schedules(seed) {
-            run_schedule(schedule).await;
+            run_schedule(schedule, config.max_ops).await;
         }
     }
 }

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -241,7 +241,7 @@ async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
     let health = oracle.terminal_health().await;
     assert_eq!(
         health,
-        (0, 0, 0, 0),
+        (0, 0, 0, 0, 0, 0),
         "terminal dirty/force/regroup/residue health is not clean: {}",
         schedule.replay()
     );

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -77,6 +77,7 @@ enum Op {
         generation: u64,
     },
     DrainOne(Ipv4Addr),
+    DrainAvailable,
     AdvanceRetry,
     Quiesce,
 }
@@ -202,6 +203,7 @@ async fn apply(oracle: &mut Oracle, op: &Op) {
         Op::DrainOne(peer) => {
             let _ = oracle.drain_one(*peer).await;
         }
+        Op::DrainAvailable => oracle.drain_available(),
         Op::AdvanceRetry => {
             tokio::time::advance(Duration::from_secs(2)).await;
             oracle.quiesce().await;
@@ -334,7 +336,7 @@ fn saturation_schedule(seed: u64) -> Schedule {
             },
             Op::DrainOne(RIGHT),
             Op::AdvanceRetry,
-            Op::DrainOne(RIGHT),
+            Op::DrainAvailable,
         ],
     }
 }
@@ -392,7 +394,7 @@ fn dirty_policy_schedule(seed: u64) -> Schedule {
             },
             Op::DrainOne(RIGHT),
             Op::AdvanceRetry,
-            Op::DrainOne(RIGHT),
+            Op::DrainAvailable,
         ],
     }
 }

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -1,9 +1,10 @@
-//! Deterministic differential fault corpus for update-group distribution.
+//! Parameterized fixed-scenario differential corpus for update groups.
 //!
-//! The small corpus runs in normal PR CI. The ignored extended corpus uses the
-//! same replayable schedules with a hard seed/operation cap; it is exercised by
-//! the weekly GitHub-hosted workflow, never by a live soak runner.
+//! The small corpus runs fixed schedules in normal PR CI. Seeds vary fixture
+//! identities, not operation ordering. The ignored extension sweeps those same
+//! schedules under hard parameter/operation caps on a weekly hosted runner.
 
+use std::collections::HashMap;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
@@ -11,8 +12,9 @@ use std::time::Duration;
 use rustbgpd_wire::{Afi, Ipv4Prefix, Prefix, RtcNlri, Safi};
 
 use super::update_groups_oracle::{
-    Oracle, Streams, deny_prefix_chain, deny_prefixes_chain, fold, fold_vpn, ibgp_route, pfx,
-    rtc_default, vpn_nlri, vpn_route, vpn_rtc_sendable,
+    NormAnnounce, NormMsg, NormVpnAnnounce, Oracle, Streams, deny_prefix_chain,
+    deny_prefixes_chain, fold, fold_vpn, ibgp_route, peer_context_permit_chain, pfx, rtc_default,
+    vpn_nlri, vpn_route, vpn_rtc_sendable,
 };
 use crate::route::RtcRibRouteKey;
 
@@ -24,6 +26,7 @@ const DEFAULT_SEED_START: u64 = 0x3570_0000;
 const DEFAULT_SEED_COUNT: usize = 24;
 const DEFAULT_MAX_OPS: usize = 64;
 const SEED_COUNT_CAP: usize = 64;
+const MIN_MAX_OPS: usize = 18;
 const MAX_OPS_CAP: usize = 64;
 const SEED_START_ENV: &str = "RUSTBGPD_UPDATE_GROUP_SEED_START";
 const SEED_COUNT_ENV: &str = "RUSTBGPD_UPDATE_GROUP_SEED_COUNT";
@@ -71,9 +74,9 @@ fn parse_extended_config(get: impl Fn(&str) -> Option<String>) -> Result<Extende
             "{SEED_COUNT_ENV} must be in 1..={SEED_COUNT_CAP}, got {seed_count}"
         ));
     }
-    if !(1..=MAX_OPS_CAP).contains(&max_ops) {
+    if !(MIN_MAX_OPS..=MAX_OPS_CAP).contains(&max_ops) {
         return Err(format!(
-            "{MAX_OPS_ENV} must be in 1..={MAX_OPS_CAP}, got {max_ops}"
+            "{MAX_OPS_ENV} must be in {MIN_MAX_OPS}..={MAX_OPS_CAP}, got {max_ops}"
         ));
     }
     let last_offset = u64::try_from(seed_count - 1).expect("seed count is capped at 64");
@@ -104,6 +107,13 @@ enum PolicySpec {
     Permit,
     DenyOne(Ipv4Prefix),
     DenyMany(Vec<Ipv4Prefix>),
+    PeerContext,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MembershipExpectation {
+    SharedGroup,
+    PeerContextFallback,
 }
 
 #[derive(Clone, Debug)]
@@ -137,6 +147,10 @@ enum Op {
     ReplacePolicy {
         peer: Ipv4Addr,
         policy: PolicySpec,
+    },
+    AssertMembership {
+        peer: Ipv4Addr,
+        expectation: MembershipExpectation,
     },
     RtcDefaultAnnounce {
         peer: Ipv4Addr,
@@ -203,7 +217,100 @@ fn policy(spec: &PolicySpec) -> Option<rustbgpd_policy::PolicyChain> {
         PolicySpec::Permit => None,
         PolicySpec::DenyOne(prefix) => Some(deny_prefix_chain(*prefix)),
         PolicySpec::DenyMany(prefixes) => Some(deny_prefixes_chain(prefixes)),
+        PolicySpec::PeerContext => Some(peer_context_permit_chain()),
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum SemanticEffect {
+    Announce {
+        peer: IpAddr,
+        route: NormAnnounce,
+    },
+    Withdraw {
+        peer: IpAddr,
+        key: (Prefix, u32),
+    },
+    UnknownWithdrawBeforeTerminalRoute {
+        peer: IpAddr,
+        key: (Prefix, u32),
+    },
+    VpnAnnounce {
+        peer: IpAddr,
+        route: NormVpnAnnounce,
+    },
+    VpnWithdraw {
+        peer: IpAddr,
+        key: (String, u32),
+    },
+    UnknownVpnWithdrawBeforeTerminalRoute {
+        peer: IpAddr,
+        key: (String, u32),
+    },
+}
+
+fn semantic_effects(streams: &Streams) -> Vec<SemanticEffect> {
+    let terminal = fold(streams);
+    let terminal_vpn = fold_vpn(streams);
+    let mut effects = Vec::new();
+    for (peer, messages) in streams {
+        let mut state: HashMap<(Prefix, u32), NormAnnounce> = HashMap::new();
+        let mut vpn_state: HashMap<String, NormVpnAnnounce> = HashMap::new();
+        for message in messages {
+            for key in &message.withdraw {
+                if state.remove(key).is_some() {
+                    effects.push(SemanticEffect::Withdraw {
+                        peer: *peer,
+                        key: *key,
+                    });
+                } else if terminal
+                    .get(peer)
+                    .is_some_and(|routes| routes.contains_key(key))
+                {
+                    effects.push(SemanticEffect::UnknownWithdrawBeforeTerminalRoute {
+                        peer: *peer,
+                        key: *key,
+                    });
+                }
+            }
+            for route in &message.announce {
+                let key = (route.0, route.1);
+                if state.get(&key) != Some(route) {
+                    state.insert(key, route.clone());
+                    effects.push(SemanticEffect::Announce {
+                        peer: *peer,
+                        route: route.clone(),
+                    });
+                }
+            }
+            for key in &message.vpn_withdraw {
+                if vpn_state.remove(&key.0).is_some() {
+                    effects.push(SemanticEffect::VpnWithdraw {
+                        peer: *peer,
+                        key: key.clone(),
+                    });
+                } else if terminal_vpn
+                    .get(peer)
+                    .is_some_and(|routes| routes.contains_key(&key.0))
+                {
+                    effects.push(SemanticEffect::UnknownVpnWithdrawBeforeTerminalRoute {
+                        peer: *peer,
+                        key: key.clone(),
+                    });
+                }
+            }
+            for route in &message.vpn_announce {
+                if vpn_state.get(&route.0) != Some(route) {
+                    vpn_state.insert(route.0.clone(), route.clone());
+                    effects.push(SemanticEffect::VpnAnnounce {
+                        peer: *peer,
+                        route: route.clone(),
+                    });
+                }
+            }
+        }
+    }
+    effects
 }
 
 async fn apply_vpn_announce(oracle: &mut Oracle, peer: Ipv4Addr, generation: u64, id: u8) {
@@ -222,7 +329,30 @@ async fn apply_vpn_announce(oracle: &mut Oracle, peer: Ipv4Addr, generation: u64
         .await;
 }
 
-async fn apply(oracle: &mut Oracle, op: &Op) {
+async fn assert_membership(
+    oracle: &mut Oracle,
+    peer: Ipv4Addr,
+    expectation: MembershipExpectation,
+    force_ungrouped: bool,
+) {
+    let label = oracle.group_label(peer).await;
+    match expectation {
+        MembershipExpectation::SharedGroup if force_ungrouped => assert!(
+            !label.starts_with("group:"),
+            "forced oracle unexpectedly grouped {peer}: {label}"
+        ),
+        MembershipExpectation::SharedGroup => assert!(
+            label.starts_with("group:"),
+            "grouped path did not group {peer}: {label}"
+        ),
+        MembershipExpectation::PeerContextFallback => assert!(
+            !label.starts_with("group:") && (force_ungrouped || label == "policy_peer_context"),
+            "peer-context transition did not reach per-peer path for {peer}: {label}"
+        ),
+    }
+}
+
+async fn apply(oracle: &mut Oracle, op: &Op, force_ungrouped: bool) {
     match op {
         Op::PeerUp {
             peer,
@@ -283,6 +413,9 @@ async fn apply(oracle: &mut Oracle, op: &Op) {
         Op::ReplacePolicy { peer, policy: spec } => {
             oracle.replace_policy(*peer, policy(spec)).await;
         }
+        Op::AssertMembership { peer, expectation } => {
+            assert_membership(oracle, *peer, *expectation, force_ungrouped).await;
+        }
         Op::RtcDefaultAnnounce { peer, generation } => {
             oracle
                 .rtc_routes_full_generation(*peer, *generation, vec![rtc_default(*peer)], vec![])
@@ -327,7 +460,7 @@ async fn run_path(schedule: &Schedule, force_ungrouped: bool, max_ops: usize) ->
             "update-group replay: scenario={} seed={:#x} op={index} {op:?}",
             schedule.name, schedule.seed
         );
-        apply(&mut oracle, op).await;
+        apply(&mut oracle, op, force_ungrouped).await;
     }
     if !force_ungrouped {
         let left = oracle.group_label(LEFT).await;
@@ -412,12 +545,18 @@ async fn run_schedule(schedule: Schedule, max_ops: usize) {
             schedule.replay()
         ),
         ComparisonMode::SemanticFold => assert_eq!(
-            fold(&grouped),
-            fold(&ungrouped),
-            "folded advertised-state mismatch: {}",
+            semantic_effects(&grouped),
+            semantic_effects(&ungrouped),
+            "normalized semantic-effect mismatch: {}",
             schedule.replay()
         ),
     }
+    assert_eq!(
+        fold(&grouped),
+        fold(&ungrouped),
+        "folded advertised-state mismatch: {}",
+        schedule.replay()
+    );
     assert_eq!(
         fold_vpn(&grouped),
         fold_vpn(&ungrouped),
@@ -452,6 +591,10 @@ fn saturation_schedule(seed: u64) -> Schedule {
                 generation: 2,
                 capacity: 1,
                 families: FamilySet::Unicast,
+            },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::SharedGroup,
             },
             Op::DrainOne(RIGHT),
             Op::Announce {
@@ -518,17 +661,41 @@ fn dirty_policy_schedule(seed: u64) -> Schedule {
                 prefix: second,
                 local_pref: 100,
             },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::SharedGroup,
+            },
             Op::ReplacePolicy {
                 peer: RIGHT,
                 policy: PolicySpec::DenyOne(first),
+            },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::SharedGroup,
             },
             Op::ReplacePolicy {
                 peer: RIGHT,
                 policy: PolicySpec::DenyMany(vec![first, second]),
             },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::SharedGroup,
+            },
+            Op::ReplacePolicy {
+                peer: RIGHT,
+                policy: PolicySpec::PeerContext,
+            },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::PeerContextFallback,
+            },
             Op::ReplacePolicy {
                 peer: RIGHT,
                 policy: PolicySpec::Permit,
+            },
+            Op::AssertMembership {
+                peer: RIGHT,
+                expectation: MembershipExpectation::SharedGroup,
             },
             Op::DrainOne(RIGHT),
             Op::AdvanceRetry,
@@ -626,6 +793,82 @@ fn schedules(seed: u64) -> [Schedule; 3] {
     ]
 }
 
+fn norm_announce(prefix: Ipv4Prefix, local_pref: u32) -> NormAnnounce {
+    let route = ibgp_route(prefix, SOURCE, local_pref, vec![]);
+    (
+        route.prefix,
+        route.path_id,
+        route.next_hop,
+        route.peer,
+        (*route.attributes).clone(),
+        None,
+    )
+}
+
+fn norm_message(announce: Vec<NormAnnounce>, withdraw: Vec<(Prefix, u32)>) -> NormMsg {
+    NormMsg {
+        announce,
+        withdraw,
+        end_of_rib: vec![],
+        vpn_announce: vec![],
+        vpn_withdraw: vec![],
+    }
+}
+
+fn one_peer_stream(messages: Vec<NormMsg>) -> Streams {
+    [(IpAddr::V4(LEFT), messages)].into_iter().collect()
+}
+
+#[test]
+fn semantic_effects_reject_transient_announces_and_attribute_changes() {
+    let first = pfx(41, 0);
+    let extra = pfx(43, 0);
+    let baseline = one_peer_stream(vec![norm_message(vec![norm_announce(first, 100)], vec![])]);
+
+    let extra_transient = one_peer_stream(vec![
+        norm_message(vec![norm_announce(first, 100)], vec![]),
+        norm_message(vec![norm_announce(extra, 100)], vec![]),
+        norm_message(vec![], vec![(Prefix::V4(extra), 0)]),
+    ]);
+    assert_ne!(
+        semantic_effects(&baseline),
+        semantic_effects(&extra_transient)
+    );
+
+    let wrong_attributes = one_peer_stream(vec![
+        norm_message(vec![norm_announce(first, 100)], vec![]),
+        norm_message(vec![norm_announce(first, 200)], vec![]),
+        norm_message(vec![norm_announce(first, 100)], vec![]),
+    ]);
+    assert_ne!(
+        semantic_effects(&baseline),
+        semantic_effects(&wrong_attributes)
+    );
+}
+
+#[test]
+fn semantic_effects_allow_only_terminally_absent_unknown_withdraws() {
+    let prefix = pfx(45, 0);
+    let empty = one_peer_stream(vec![]);
+    let safe_over_withdraw =
+        one_peer_stream(vec![norm_message(vec![], vec![(Prefix::V4(prefix), 0)])]);
+    assert_eq!(
+        semantic_effects(&empty),
+        semantic_effects(&safe_over_withdraw)
+    );
+
+    let terminal_route =
+        one_peer_stream(vec![norm_message(vec![norm_announce(prefix, 100)], vec![])]);
+    let withdraw_before_terminal_route = one_peer_stream(vec![
+        norm_message(vec![], vec![(Prefix::V4(prefix), 0)]),
+        norm_message(vec![norm_announce(prefix, 100)], vec![]),
+    ]);
+    assert_ne!(
+        semantic_effects(&terminal_route),
+        semantic_effects(&withdraw_before_terminal_route)
+    );
+}
+
 #[tokio::test]
 async fn deterministic_fault_corpus() {
     tokio::time::pause();
@@ -638,6 +881,15 @@ async fn deterministic_fault_corpus() {
 
 #[test]
 fn extended_config_defaults_and_boundaries() {
+    let longest = schedules(DEFAULT_SEED_START)
+        .iter()
+        .map(|schedule| schedule.ops.len())
+        .max()
+        .unwrap();
+    assert_eq!(
+        MIN_MAX_OPS, longest,
+        "minimum cap must track longest schedule"
+    );
     assert_eq!(
         parse_extended_config(|_| None).unwrap(),
         ExtendedConfig {
@@ -649,7 +901,8 @@ fn extended_config_defaults_and_boundaries() {
 
     let get = |name: &str| match name {
         SEED_START_ENV => Some("0xffffffffffffffff".to_owned()),
-        SEED_COUNT_ENV | MAX_OPS_ENV => Some("1".to_owned()),
+        SEED_COUNT_ENV => Some("1".to_owned()),
+        MAX_OPS_ENV => Some(MIN_MAX_OPS.to_string()),
         _ => None,
     };
     assert_eq!(
@@ -657,7 +910,7 @@ fn extended_config_defaults_and_boundaries() {
         ExtendedConfig {
             seed_start: u64::MAX,
             seed_count: 1,
-            max_ops: 1,
+            max_ops: MIN_MAX_OPS,
         }
     );
 
@@ -669,8 +922,8 @@ fn extended_config_defaults_and_boundaries() {
         ),
         (SEED_COUNT_ENV, "0", "must be in 1..=64"),
         (SEED_COUNT_ENV, "65", "must be in 1..=64"),
-        (MAX_OPS_ENV, "0", "must be in 1..=64"),
-        (MAX_OPS_ENV, "65", "must be in 1..=64"),
+        (MAX_OPS_ENV, "17", "must be in 18..=64"),
+        (MAX_OPS_ENV, "65", "must be in 18..=64"),
     ] {
         let error = parse_extended_config(|key| (key == name).then(|| value.to_owned()))
             .expect_err("invalid boundary must fail");

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -1,0 +1,503 @@
+//! Deterministic differential fault corpus for update-group distribution.
+//!
+//! The small corpus runs in normal PR CI. The ignored extended corpus uses the
+//! same replayable schedules with a hard seed/operation cap; it is exercised by
+//! the weekly GitHub-hosted workflow, never by a live soak runner.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use rustbgpd_wire::{Afi, Ipv4Prefix, Prefix, RtcNlri, Safi};
+
+use super::update_groups_oracle::{
+    Oracle, Streams, deny_prefix_chain, deny_prefixes_chain, fold, ibgp_route, pfx, rtc_default,
+    vpn_rtc_sendable,
+};
+use crate::route::RtcRibRouteKey;
+
+const SOURCE: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+const LEFT: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
+const RIGHT: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 3);
+const PR_SEEDS: [u64; 3] = [0x51_7A, 0xC0_FF_EE, 0x05EE_D357];
+const EXTENDED_SEEDS: usize = 24;
+const MAX_OPS: usize = 64;
+
+#[derive(Clone, Copy, Debug)]
+enum ComparisonMode {
+    ExactStream,
+    SemanticFold,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FamilySet {
+    Unicast,
+    VpnRtc,
+}
+
+#[derive(Clone, Debug)]
+enum PolicySpec {
+    Permit,
+    DenyOne(Ipv4Prefix),
+    DenyMany(Vec<Ipv4Prefix>),
+}
+
+#[derive(Clone, Debug)]
+enum Op {
+    PeerUp {
+        peer: Ipv4Addr,
+        generation: u64,
+        capacity: usize,
+        families: FamilySet,
+    },
+    PeerDown {
+        peer: Ipv4Addr,
+        generation: u64,
+    },
+    Announce {
+        peer: Ipv4Addr,
+        generation: u64,
+        prefix: Ipv4Prefix,
+        local_pref: u32,
+    },
+    Withdraw {
+        peer: Ipv4Addr,
+        generation: u64,
+        prefix: Ipv4Prefix,
+    },
+    ReplacePolicy {
+        peer: Ipv4Addr,
+        policy: PolicySpec,
+    },
+    RtcDefaultAnnounce {
+        peer: Ipv4Addr,
+        generation: u64,
+    },
+    RtcDefaultWithdraw {
+        peer: Ipv4Addr,
+        generation: u64,
+    },
+    DrainOne(Ipv4Addr),
+    AdvanceRetry,
+    Quiesce,
+}
+
+#[derive(Clone, Debug)]
+struct Schedule {
+    name: &'static str,
+    seed: u64,
+    comparison: ComparisonMode,
+    ops: Vec<Op>,
+}
+
+impl Schedule {
+    fn replay(&self) -> String {
+        let ops = self
+            .ops
+            .iter()
+            .enumerate()
+            .map(|(index, op)| format!("{index}:{op:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "scenario={} seed={:#x} mode={:?} ops=[{}]",
+            self.name, self.seed, self.comparison, ops
+        )
+    }
+}
+
+fn unicast() -> Vec<(Afi, Safi)> {
+    vec![(Afi::Ipv4, Safi::Unicast)]
+}
+
+fn sentinel() -> Ipv4Prefix {
+    Ipv4Prefix::new(Ipv4Addr::new(10, 255, 255, 0), 24)
+}
+
+fn seed_octet(seed: u64, byte: usize) -> u8 {
+    seed.to_le_bytes()[byte] | 1
+}
+
+fn policy(spec: &PolicySpec) -> Option<rustbgpd_policy::PolicyChain> {
+    match spec {
+        PolicySpec::Permit => None,
+        PolicySpec::DenyOne(prefix) => Some(deny_prefix_chain(*prefix)),
+        PolicySpec::DenyMany(prefixes) => Some(deny_prefixes_chain(prefixes)),
+    }
+}
+
+async fn apply(oracle: &mut Oracle, op: &Op) {
+    match op {
+        Op::PeerUp {
+            peer,
+            generation,
+            capacity,
+            families,
+        } => {
+            let sendable = match families {
+                FamilySet::Unicast => unicast(),
+                FamilySet::VpnRtc => vpn_rtc_sendable(),
+            };
+            oracle
+                .peer_up_families_generation(
+                    *peer,
+                    *generation,
+                    false,
+                    true,
+                    None,
+                    *capacity,
+                    sendable,
+                )
+                .await;
+        }
+        Op::PeerDown { peer, generation } => {
+            oracle.peer_down_generation(*peer, *generation).await;
+        }
+        Op::Announce {
+            peer,
+            generation,
+            prefix,
+            local_pref,
+        } => {
+            oracle
+                .routes_generation(
+                    *peer,
+                    *generation,
+                    vec![ibgp_route(*prefix, *peer, *local_pref, vec![])],
+                    vec![],
+                )
+                .await;
+        }
+        Op::Withdraw {
+            peer,
+            generation,
+            prefix,
+        } => {
+            oracle
+                .routes_generation(*peer, *generation, vec![], vec![*prefix])
+                .await;
+        }
+        Op::ReplacePolicy { peer, policy: spec } => {
+            oracle.replace_policy(*peer, policy(spec)).await;
+        }
+        Op::RtcDefaultAnnounce { peer, generation } => {
+            oracle
+                .rtc_routes_full_generation(*peer, *generation, vec![rtc_default(*peer)], vec![])
+                .await;
+            oracle.quiesce().await;
+        }
+        Op::RtcDefaultWithdraw { peer, generation } => {
+            oracle
+                .rtc_routes_full_generation(
+                    *peer,
+                    *generation,
+                    vec![],
+                    vec![RtcRibRouteKey {
+                        nlri: RtcNlri::DEFAULT,
+                        path_id: 0,
+                    }],
+                )
+                .await;
+            oracle.quiesce().await;
+        }
+        Op::DrainOne(peer) => {
+            let _ = oracle.drain_one(*peer).await;
+        }
+        Op::AdvanceRetry => {
+            tokio::time::advance(Duration::from_secs(2)).await;
+            oracle.quiesce().await;
+        }
+        Op::Quiesce => oracle.quiesce().await,
+    }
+}
+
+async fn run_path(schedule: &Schedule, force_ungrouped: bool) -> Streams {
+    assert!(
+        schedule.ops.len() <= MAX_OPS,
+        "operation cap exceeded: {}",
+        schedule.replay()
+    );
+    let mut oracle = Oracle::spawn(force_ungrouped, Some(Ipv4Addr::new(192, 0, 2, 1)));
+    for (index, op) in schedule.ops.iter().enumerate() {
+        eprintln!(
+            "update-group replay: scenario={} seed={:#x} op={index} {op:?}",
+            schedule.name, schedule.seed
+        );
+        apply(&mut oracle, op).await;
+    }
+
+    // Every schedule ends with a current-generation sentinel from SOURCE.
+    // Its delivery proves that the manager remains live after the injected
+    // faults rather than merely comparing two empty or prematurely-ended runs.
+    oracle
+        .routes_generation(
+            SOURCE,
+            2,
+            vec![ibgp_route(sentinel(), SOURCE, 250, vec![])],
+            vec![],
+        )
+        .await;
+    let health = oracle.terminal_health().await;
+    assert_eq!(
+        health,
+        (0, 0, 0, 0),
+        "terminal dirty/force/regroup/residue health is not clean: {}",
+        schedule.replay()
+    );
+    let streams = oracle.finish().await; // Awaiting the handle proves manager completion.
+    assert!(
+        streams.values().any(|messages| !messages.is_empty()),
+        "schedule emitted no traffic: {}",
+        schedule.replay()
+    );
+    for peer in [LEFT, RIGHT] {
+        let delivered = streams
+            .get(&IpAddr::V4(peer))
+            .into_iter()
+            .flatten()
+            .any(|message| {
+                message
+                    .announce
+                    .iter()
+                    .any(|(prefix, ..)| *prefix == Prefix::V4(sentinel()))
+            });
+        assert!(
+            delivered,
+            "terminal sentinel missing for {peer}: {}",
+            schedule.replay()
+        );
+    }
+    streams
+}
+
+async fn run_schedule(schedule: Schedule) {
+    let grouped = run_path(&schedule, false).await;
+    let ungrouped = run_path(&schedule, true).await;
+    match schedule.comparison {
+        ComparisonMode::ExactStream => assert_eq!(
+            grouped,
+            ungrouped,
+            "exact stream mismatch: {}",
+            schedule.replay()
+        ),
+        ComparisonMode::SemanticFold => assert_eq!(
+            fold(&grouped),
+            fold(&ungrouped),
+            "folded advertised-state mismatch: {}",
+            schedule.replay()
+        ),
+    }
+}
+
+fn saturation_schedule(seed: u64) -> Schedule {
+    let first = pfx(seed_octet(seed, 0), 0);
+    let second = pfx(seed_octet(seed, 1), 1);
+    Schedule {
+        name: "saturation-drain-virtual-retry",
+        seed,
+        comparison: ComparisonMode::SemanticFold,
+        ops: vec![
+            Op::PeerUp {
+                peer: SOURCE,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::PeerUp {
+                peer: LEFT,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::PeerUp {
+                peer: RIGHT,
+                generation: 2,
+                capacity: 1,
+                families: FamilySet::Unicast,
+            },
+            Op::DrainOne(RIGHT),
+            Op::Announce {
+                peer: SOURCE,
+                generation: 2,
+                prefix: first,
+                local_pref: 100,
+            },
+            Op::Announce {
+                peer: SOURCE,
+                generation: 2,
+                prefix: second,
+                local_pref: 110,
+            },
+            Op::Withdraw {
+                peer: SOURCE,
+                generation: 2,
+                prefix: first,
+            },
+            Op::DrainOne(RIGHT),
+            Op::AdvanceRetry,
+            Op::DrainOne(RIGHT),
+        ],
+    }
+}
+
+fn dirty_policy_schedule(seed: u64) -> Schedule {
+    let first = pfx(seed_octet(seed, 2), 2);
+    let second = pfx(seed_octet(seed, 3), 3);
+    Schedule {
+        name: "dirty-policy-regroup-transitions",
+        seed,
+        comparison: ComparisonMode::SemanticFold,
+        ops: vec![
+            Op::PeerUp {
+                peer: SOURCE,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::PeerUp {
+                peer: LEFT,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::PeerUp {
+                peer: RIGHT,
+                generation: 2,
+                capacity: 1,
+                families: FamilySet::Unicast,
+            },
+            Op::DrainOne(RIGHT),
+            Op::Announce {
+                peer: SOURCE,
+                generation: 2,
+                prefix: first,
+                local_pref: 100,
+            },
+            Op::Announce {
+                peer: SOURCE,
+                generation: 2,
+                prefix: second,
+                local_pref: 100,
+            },
+            Op::ReplacePolicy {
+                peer: RIGHT,
+                policy: PolicySpec::DenyOne(first),
+            },
+            Op::ReplacePolicy {
+                peer: RIGHT,
+                policy: PolicySpec::DenyMany(vec![first, second]),
+            },
+            Op::ReplacePolicy {
+                peer: RIGHT,
+                policy: PolicySpec::Permit,
+            },
+            Op::DrainOne(RIGHT),
+            Op::AdvanceRetry,
+            Op::DrainOne(RIGHT),
+        ],
+    }
+}
+
+fn stale_generation_rtc_schedule(seed: u64) -> Schedule {
+    let live = pfx(seed_octet(seed, 4), 4);
+    let stale = pfx(seed_octet(seed, 5), 5);
+    Schedule {
+        name: "stale-generation-rtc-membership-churn",
+        seed,
+        comparison: ComparisonMode::ExactStream,
+        ops: vec![
+            Op::PeerUp {
+                peer: SOURCE,
+                generation: 1,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::PeerUp {
+                peer: LEFT,
+                generation: 1,
+                capacity: 64,
+                families: FamilySet::VpnRtc,
+            },
+            Op::PeerUp {
+                peer: RIGHT,
+                generation: 1,
+                capacity: 64,
+                families: FamilySet::VpnRtc,
+            },
+            Op::PeerUp {
+                peer: SOURCE,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::Unicast,
+            },
+            Op::Announce {
+                peer: SOURCE,
+                generation: 1,
+                prefix: stale,
+                local_pref: 200,
+            },
+            Op::PeerDown {
+                peer: SOURCE,
+                generation: 1,
+            },
+            Op::Announce {
+                peer: SOURCE,
+                generation: 2,
+                prefix: live,
+                local_pref: 100,
+            },
+            Op::RtcDefaultAnnounce {
+                peer: LEFT,
+                generation: 1,
+            },
+            Op::PeerUp {
+                peer: LEFT,
+                generation: 2,
+                capacity: 64,
+                families: FamilySet::VpnRtc,
+            },
+            Op::RtcDefaultWithdraw {
+                peer: LEFT,
+                generation: 2,
+            },
+            Op::RtcDefaultAnnounce {
+                peer: LEFT,
+                generation: 2,
+            },
+            Op::RtcDefaultWithdraw {
+                peer: LEFT,
+                generation: 2,
+            },
+            Op::Quiesce,
+        ],
+    }
+}
+
+fn schedules(seed: u64) -> [Schedule; 3] {
+    [
+        saturation_schedule(seed),
+        dirty_policy_schedule(seed),
+        stale_generation_rtc_schedule(seed),
+    ]
+}
+
+#[tokio::test]
+async fn deterministic_fault_corpus() {
+    tokio::time::pause();
+    for seed in PR_SEEDS {
+        for schedule in schedules(seed) {
+            run_schedule(schedule).await;
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "bounded extended corpus; run explicitly or via weekly workflow"]
+async fn deterministic_fault_corpus_extended() {
+    tokio::time::pause();
+    for index in 0..EXTENDED_SEEDS {
+        let seed = 0x3570_0000_u64.wrapping_add(index as u64);
+        for schedule in schedules(seed) {
+            run_schedule(schedule).await;
+        }
+    }
+}

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -779,7 +779,7 @@ impl Oracle {
     /// Collect every message every peer has received so far, including
     /// those drained mid-scenario by `drain_one` and the invariant
     /// checker — the returned streams are the complete emission history.
-    pub(super) async fn terminal_health(&mut self) -> (usize, usize, usize, usize) {
+    pub(super) async fn terminal_health(&mut self) -> (usize, usize, usize, usize, usize, usize) {
         self.quiesce().await;
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -25,11 +25,16 @@ use rustbgpd_wire::RtcNlri;
 use super::*;
 use crate::route::{RouteOrigin, RtcRibRoute, VpnRibRouteKey};
 
-const SESSION: u64 = 1;
+pub(super) const SESSION: u64 = 1;
 
 /// An iBGP-learned route fixture: `LOCAL_PREF` ranks it, optional
 /// communities ride along (e.g. `COMMUNITY_LLGR_STALE`).
-fn ibgp_route(prefix: Ipv4Prefix, src: Ipv4Addr, local_pref: u32, communities: Vec<u32>) -> Route {
+pub(super) fn ibgp_route(
+    prefix: Ipv4Prefix,
+    src: Ipv4Addr,
+    local_pref: u32,
+    communities: Vec<u32>,
+) -> Route {
     let mut attributes = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath { segments: vec![] }),
@@ -57,7 +62,7 @@ fn ibgp_route(prefix: Ipv4Prefix, src: Ipv4Addr, local_pref: u32, communities: V
     }
 }
 
-fn pfx(a: u8, b: u8) -> Ipv4Prefix {
+pub(super) fn pfx(a: u8, b: u8) -> Ipv4Prefix {
     Ipv4Prefix::new(Ipv4Addr::new(10, 200, a, b), 24)
 }
 
@@ -117,7 +122,7 @@ fn vpn_route(
 
 /// RT-Constrain default-NLRI advertisement from a peer (RFC 4684
 /// wildcard interest — membership passes every RT).
-fn rtc_default(src: Ipv4Addr) -> RtcRibRoute {
+pub(super) fn rtc_default(src: Ipv4Addr) -> RtcRibRoute {
     RtcRibRoute {
         nlri: RtcNlri::DEFAULT,
         next_hop: IpAddr::V4(src),
@@ -139,7 +144,7 @@ fn vpn_sendable() -> Vec<(Afi, Safi)> {
     vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv4, Safi::MplsVpn)]
 }
 
-fn vpn_rtc_sendable() -> Vec<(Afi, Safi)> {
+pub(super) fn vpn_rtc_sendable() -> Vec<(Afi, Safi)> {
     vec![
         (Afi::Ipv4, Safi::Unicast),
         (Afi::Ipv4, Safi::MplsVpn),
@@ -174,7 +179,7 @@ fn permit_all_with(modifications: RouteModifications) -> PolicyChain {
     }])
 }
 
-fn deny_prefix_chain(prefix: Ipv4Prefix) -> PolicyChain {
+pub(super) fn deny_prefix_chain(prefix: Ipv4Prefix) -> PolicyChain {
     PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: Some(Prefix::V4(prefix)),
@@ -204,7 +209,7 @@ fn deny_prefix_chain(prefix: Ipv4Prefix) -> PolicyChain {
 /// Deny several prefixes, permit the rest — a multi-statement variant of
 /// [`deny_prefix_chain`] so a second regroup lands on a *different* chain
 /// (a content-equal reinstall is key-stable and would not regroup).
-fn deny_prefixes_chain(prefixes: &[Ipv4Prefix]) -> PolicyChain {
+pub(super) fn deny_prefixes_chain(prefixes: &[Ipv4Prefix]) -> PolicyChain {
     PolicyChain::new(vec![Policy {
         entries: prefixes
             .iter()
@@ -239,7 +244,7 @@ fn deny_prefixes_chain(prefixes: &[Ipv4Prefix]) -> PolicyChain {
 /// aligned next-hop-override flag), sorted so intra-message iteration
 /// order is not compared.
 /// (prefix, path id, next hop, source peer, attributes, nh-override).
-type NormAnnounce = (
+pub(super) type NormAnnounce = (
     Prefix,
     u32,
     IpAddr,
@@ -252,15 +257,15 @@ type NormAnnounce = (
 /// stack, next hop, source peer, attributes). Keys/NLRI are `Debug`
 /// strings — `VpnRouteKey` has no `Display` and only sort stability
 /// matters here.
-type NormVpnAnnounce = (String, String, IpAddr, IpAddr, Vec<PathAttribute>);
+pub(super) type NormVpnAnnounce = (String, String, IpAddr, IpAddr, Vec<PathAttribute>);
 
 #[derive(Debug, PartialEq, Clone)]
-struct NormMsg {
-    announce: Vec<NormAnnounce>,
-    withdraw: Vec<(Prefix, u32)>,
-    end_of_rib: Vec<(Afi, Safi)>,
-    vpn_announce: Vec<NormVpnAnnounce>,
-    vpn_withdraw: Vec<(String, u32)>,
+pub(super) struct NormMsg {
+    pub(super) announce: Vec<NormAnnounce>,
+    pub(super) withdraw: Vec<(Prefix, u32)>,
+    pub(super) end_of_rib: Vec<(Afi, Safi)>,
+    pub(super) vpn_announce: Vec<NormVpnAnnounce>,
+    pub(super) vpn_withdraw: Vec<(String, u32)>,
 }
 
 fn normalize(update: &OutboundRouteUpdate) -> NormMsg {
@@ -315,15 +320,15 @@ fn normalize(update: &OutboundRouteUpdate) -> NormMsg {
     }
 }
 
-type Streams = BTreeMap<IpAddr, Vec<NormMsg>>;
+pub(super) type Streams = BTreeMap<IpAddr, Vec<NormMsg>>;
 
 /// Fold a stream into the final advertised state (announce replaces,
 /// withdraw removes; unknown withdraws are RFC 4271 no-ops).
 /// (next hop, source peer, attributes, nh-override).
-type FoldedEntry = (IpAddr, IpAddr, Vec<PathAttribute>, Option<NextHopAction>);
-type FoldedState = BTreeMap<IpAddr, HashMap<(Prefix, u32), FoldedEntry>>;
+pub(super) type FoldedEntry = (IpAddr, IpAddr, Vec<PathAttribute>, Option<NextHopAction>);
+pub(super) type FoldedState = BTreeMap<IpAddr, HashMap<(Prefix, u32), FoldedEntry>>;
 
-fn fold(streams: &Streams) -> FoldedState {
+pub(super) fn fold(streams: &Streams) -> FoldedState {
     let mut state = FoldedState::new();
     for (peer, msgs) in streams {
         let table = state.entry(*peer).or_default();
@@ -363,7 +368,7 @@ fn fold_vpn(streams: &Streams) -> FoldedVpnState {
     state
 }
 
-struct Oracle {
+pub(super) struct Oracle {
     tx: mpsc::Sender<RibUpdate>,
     outs: BTreeMap<IpAddr, mpsc::Receiver<OutboundRouteUpdate>>,
     handle: tokio::task::JoinHandle<()>,
@@ -374,7 +379,7 @@ struct Oracle {
 }
 
 impl Oracle {
-    fn spawn(force_ungrouped: bool, cluster_id: Option<Ipv4Addr>) -> Self {
+    pub(super) fn spawn(force_ungrouped: bool, cluster_id: Option<Ipv4Addr>) -> Self {
         let (tx, rx) = mpsc::channel(512);
         let mut manager =
             RibManager::new(rx, dummy_query_rx(), None, cluster_id, BgpMetrics::new());
@@ -407,9 +412,34 @@ impl Oracle {
         .await;
     }
 
-    async fn peer_up_families(
+    pub(super) async fn peer_up_families(
         &mut self,
         peer: Ipv4Addr,
+        is_ebgp: bool,
+        route_reflector_client: bool,
+        export_policy: Option<PolicyChain>,
+        capacity: usize,
+        sendable_families: Vec<(Afi, Safi)>,
+    ) {
+        self.peer_up_families_generation(
+            peer,
+            SESSION,
+            is_ebgp,
+            route_reflector_client,
+            export_policy,
+            capacity,
+            sendable_families,
+        )
+        .await;
+    }
+
+    // Mirrors the production PeerUp event so schedules can state every
+    // grouping input and the session generation at the call site.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn peer_up_families_generation(
+        &mut self,
+        peer: Ipv4Addr,
+        session_id: u64,
         is_ebgp: bool,
         route_reflector_client: bool,
         export_policy: Option<PolicyChain>,
@@ -420,7 +450,7 @@ impl Oracle {
         self.tx
             .send(RibUpdate::PeerUp {
                 per_client_best: false,
-                session_id: SESSION,
+                session_id,
                 peer: IpAddr::V4(peer),
                 peer_asn: if is_ebgp { 65010 } else { 65000 },
                 peer_router_id: peer,
@@ -449,21 +479,41 @@ impl Oracle {
         self.quiesce().await;
     }
 
-    async fn peer_down(&mut self, peer: Ipv4Addr) {
+    pub(super) async fn peer_down(&mut self, peer: Ipv4Addr) {
+        self.peer_down_generation(peer, SESSION).await;
+    }
+
+    pub(super) async fn peer_down_generation(&mut self, peer: Ipv4Addr, session_id: u64) {
         self.tx
             .send(RibUpdate::PeerDown {
                 peer: IpAddr::V4(peer),
-                session_id: SESSION,
+                session_id,
             })
             .await
             .unwrap();
         self.quiesce().await;
     }
 
-    async fn routes(&mut self, from: Ipv4Addr, announce: Vec<Route>, withdraw: Vec<Ipv4Prefix>) {
+    pub(super) async fn routes(
+        &mut self,
+        from: Ipv4Addr,
+        announce: Vec<Route>,
+        withdraw: Vec<Ipv4Prefix>,
+    ) {
+        self.routes_generation(from, SESSION, announce, withdraw)
+            .await;
+    }
+
+    pub(super) async fn routes_generation(
+        &mut self,
+        from: Ipv4Addr,
+        session_id: u64,
+        announce: Vec<Route>,
+        withdraw: Vec<Ipv4Prefix>,
+    ) {
         self.tx
             .send(RibUpdate::RoutesReceived {
-                session_id: SESSION,
+                session_id,
                 peer: IpAddr::V4(from),
                 announced: announce,
                 withdrawn: withdraw.into_iter().map(|p| (Prefix::V4(p), 0)).collect(),
@@ -497,23 +547,35 @@ impl Oracle {
 
     /// RFC 4684 RT-Constrain advertisement from a peer — rebuilds the
     /// peer's RT membership (the per-peer VPN filter).
-    async fn rtc_routes(&mut self, from: Ipv4Addr, announce: Vec<RtcRibRoute>) {
-        self.rtc_routes_full(from, announce, vec![]).await;
+    pub(super) async fn rtc_routes(&mut self, from: Ipv4Addr, announce: Vec<RtcRibRoute>) {
+        self.rtc_routes_full_generation(from, SESSION, announce, vec![])
+            .await;
         self.quiesce().await;
     }
 
     /// RTC announce + withdraw, WITHOUT quiescing — racing scenarios
     /// queue this back-to-back with route updates.
-    async fn rtc_routes_full(
+    pub(super) async fn rtc_routes_full(
         &mut self,
         from: Ipv4Addr,
+        announce: Vec<RtcRibRoute>,
+        withdraw: Vec<crate::route::RtcRibRouteKey>,
+    ) {
+        self.rtc_routes_full_generation(from, SESSION, announce, withdraw)
+            .await;
+    }
+
+    pub(super) async fn rtc_routes_full_generation(
+        &mut self,
+        from: Ipv4Addr,
+        session_id: u64,
         announce: Vec<RtcRibRoute>,
         withdraw: Vec<crate::route::RtcRibRouteKey>,
     ) {
         self.tx
             .send(RibUpdate::RtcRoutesReceived {
                 peer: IpAddr::V4(from),
-                session_id: SESSION,
+                session_id,
                 announced: announce,
                 withdrawn: withdraw,
             })
@@ -617,7 +679,7 @@ impl Oracle {
 
     /// The peer's update-group membership label (`group:N` or the
     /// ungrouped reason).
-    async fn group_label(&mut self, peer: Ipv4Addr) -> String {
+    pub(super) async fn group_label(&mut self, peer: Ipv4Addr) -> String {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
             .send(RibUpdate::QueryPeerUpdateGroup {
@@ -629,7 +691,11 @@ impl Oracle {
         reply_rx.await.unwrap()
     }
 
-    async fn replace_policy(&mut self, peer: Ipv4Addr, export_policy: Option<PolicyChain>) {
+    pub(super) async fn replace_policy(
+        &mut self,
+        peer: Ipv4Addr,
+        export_policy: Option<PolicyChain>,
+    ) {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
             .send(RibUpdate::ReplacePeerExportPolicy {
@@ -673,7 +739,7 @@ impl Oracle {
     /// handles it after every prior update (and its route chunks) has
     /// been fully processed, so all resulting outbound sends have
     /// happened by the time the reply arrives.
-    async fn quiesce(&mut self) {
+    pub(super) async fn quiesce(&mut self) {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
             .send(RibUpdate::QueryBestRoutes { reply: reply_tx })
@@ -685,7 +751,7 @@ impl Oracle {
     /// Drain one pending message from a peer's channel (channel-fill
     /// scenarios). The message stays in the collected stream so folded
     /// comparisons and the VPN invariant checker see the whole history.
-    async fn drain_one(&mut self, peer: Ipv4Addr) -> OutboundRouteUpdate {
+    pub(super) async fn drain_one(&mut self, peer: Ipv4Addr) -> OutboundRouteUpdate {
         let update = self
             .outs
             .get_mut(&IpAddr::V4(peer))
@@ -703,7 +769,17 @@ impl Oracle {
     /// Collect every message every peer has received so far, including
     /// those drained mid-scenario by `drain_one` and the invariant
     /// checker — the returned streams are the complete emission history.
-    async fn finish(mut self) -> Streams {
+    pub(super) async fn terminal_health(&mut self) -> (usize, usize, usize, usize) {
+        self.quiesce().await;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::TestQueryOutboundHealth { reply: reply_tx })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap()
+    }
+
+    pub(super) async fn finish(mut self) -> Streams {
         self.quiesce().await;
         self.drain_collected();
         for peer in self.outs.keys() {

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -1521,7 +1521,7 @@ async fn oracle_clean_member_regroup_suppresses_unchanged_announces() {
 /// neighbor-set deny matches an ASN no test peer uses, so verdicts are
 /// unchanged, but `requires_peer_context` moves the peer off the
 /// grouped path — the grouped→per-peer membership transition.
-fn peer_context_permit_chain() -> PolicyChain {
+pub(super) fn peer_context_permit_chain() -> PolicyChain {
     PolicyChain::new(vec![Policy {
         entries: vec![PolicyStatement {
             prefix: None,

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -69,7 +69,7 @@ pub(super) fn pfx(a: u8, b: u8) -> Ipv4Prefix {
 /// A `VPNv4` NLRI fixture: RD 65000:n, inner prefix 10.210.n.0/24, one
 /// BOS label. The label is route *data* (not key), so a relabel of the
 /// same `n` is the ADR-0077 same-peer-relabel re-advertise case.
-fn vpn_nlri(n: u8, label: u32) -> VpnNlri {
+pub(super) fn vpn_nlri(n: u8, label: u32) -> VpnNlri {
     VpnNlri {
         labels: vec![MplsLabelEntry::try_new(label, 0, true).unwrap()],
         route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, n]),
@@ -86,7 +86,7 @@ fn vpn_key(n: u8, label: u32) -> VpnRibRouteKey {
 
 /// An iBGP-learned VPN route fixture; `LOCAL_PREF` ranks it in the VPN
 /// selection chain, extended communities (RTs) ride along when given.
-fn vpn_route(
+pub(super) fn vpn_route(
     nlri: VpnNlri,
     src: Ipv4Addr,
     local_pref: u32,
@@ -349,10 +349,10 @@ pub(super) fn fold(streams: &Streams) -> FoldedState {
 
 /// VPN counterpart of [`fold`]: final advertised VPN state per peer,
 /// keyed by RD+prefix identity (`path_id` 0 only in these scenarios).
-type FoldedVpnState =
+pub(super) type FoldedVpnState =
     BTreeMap<IpAddr, HashMap<String, (String, IpAddr, IpAddr, Vec<PathAttribute>)>>;
 
-fn fold_vpn(streams: &Streams) -> FoldedVpnState {
+pub(super) fn fold_vpn(streams: &Streams) -> FoldedVpnState {
     let mut state = FoldedVpnState::new();
     for (peer, msgs) in streams {
         let table = state.entry(*peer).or_default();
@@ -536,10 +536,21 @@ impl Oracle {
         announce: Vec<VpnRibRoute>,
         withdraw: Vec<VpnRibRouteKey>,
     ) {
+        self.vpn_routes_generation(from, SESSION, announce, withdraw)
+            .await;
+    }
+
+    pub(super) async fn vpn_routes_generation(
+        &mut self,
+        from: Ipv4Addr,
+        session_id: u64,
+        announce: Vec<VpnRibRoute>,
+        withdraw: Vec<VpnRibRouteKey>,
+    ) {
         self.tx
             .send(RibUpdate::VpnRoutesReceived {
                 peer: IpAddr::V4(from),
-                session_id: SESSION,
+                session_id,
                 announced: announce,
                 withdrawn: withdraw,
             })

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -435,7 +435,10 @@ impl Oracle {
 
     // Mirrors the production PeerUp event so schedules can state every
     // grouping input and the session generation at the call site.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "mirrors every grouping input in the production PeerUp event"
+    )]
     pub(super) async fn peer_up_families_generation(
         &mut self,
         peer: Ipv4Addr,

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -766,6 +766,13 @@ impl Oracle {
         update
     }
 
+    /// Drain every currently available message without waiting for a send.
+    /// Fault schedules use this after a virtual-time retry because a correct
+    /// no-op resync is also allowed to emit nothing.
+    pub(super) fn drain_available(&mut self) {
+        self.drain_collected();
+    }
+
     /// Collect every message every peer has received so far, including
     /// those drained mid-scenario by `drain_one` and the invariant
     /// checker — the returned streams are the complete emission history.

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -808,6 +808,14 @@ pub enum RibUpdate {
         /// Response channel: `(Debug-formatted VpnRouteKey, source peer)`.
         reply: oneshot::Sender<Vec<(String, IpAddr)>>,
     },
+    /// TEST ONLY: transient outbound-distribution state that must be
+    /// empty after a differential-oracle scenario reaches quiescence.
+    #[cfg(test)]
+    TestQueryOutboundHealth {
+        /// Response channel: dirty peers, forced peers, regroup baselines,
+        /// and pending extra-withdraw residue, respectively.
+        reply: oneshot::Sender<(usize, usize, usize, usize)>,
+    },
     /// Query: snapshot the live per-term guard-hit counters of the
     /// installed export chains (ADR-0096 Decision 3.3). Counters
     /// accumulate since a chain instance was installed and reset when

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -812,9 +812,10 @@ pub enum RibUpdate {
     /// empty after a differential-oracle scenario reaches quiescence.
     #[cfg(test)]
     TestQueryOutboundHealth {
-        /// Response channel: dirty peers, forced peers, regroup baselines,
-        /// and pending extra-withdraw residue, respectively.
-        reply: oneshot::Sender<(usize, usize, usize, usize)>,
+        /// Response channel: dirty peers, forced peers, group-dirty members,
+        /// group tombstones, regroup baselines, and carried extra-withdraw
+        /// residue, respectively.
+        reply: oneshot::Sender<(usize, usize, usize, usize, usize, usize)>,
     },
     /// Query: snapshot the live per-term guard-hit counters of the
     /// installed export chains (ADR-0096 Decision 3.3). Counters

--- a/docs/OPERATIONAL_PROOF.md
+++ b/docs/OPERATIONAL_PROOF.md
@@ -10,6 +10,7 @@ operator-facing index that answers "what has actually been proved?"
 | Surface | Current receipt | Primary source |
 |---------|-----------------|----------------|
 | Workspace correctness | Unit, integration, async, and policy tests run through `cargo test --workspace`. | `cargo test --workspace`; release notes in [`../CHANGELOG.md`](../CHANGELOG.md) |
+| Update-group fault differential | A fixed PR corpus compares grouped and forced-per-peer output under saturation/retry, dirty regroup, stale generations, and RTC membership churn; a hard-capped 24-seed extension runs weekly and on manual dispatch on GitHub-hosted runners. | `cargo test -p rustbgpd-rib deterministic_fault_corpus`; [replay instructions](../CONTRIBUTING.md#replaying-update-group-faults); [workflow](../.github/workflows/update-group-fault.yml) |
 | Wire robustness | libFuzzer harnesses cover message and attribute decoding, with CI smoke and nightly extended jobs. | [`../README.md`](../README.md#testing-and-correctness) |
 | Foundation interop | PR-gated containerlab coverage for core RIB, refresh, policy, MP-BGP, RR, multipath, BMP, security, FlowSpec, EVPN sanity, graceful shutdown, BLACKHOLE FIB discard, gRPC/gNMI, and ORF/gNMI Set smokes. | [`INTEROP.md`](INTEROP.md#ci-coverage) |
 | Privileged dataplane interop | Hosted GitHub `kernel-dataplane` workflow covers EVPN VTEP/IRB, FIB, BFD, TCP-AO where supported, and Linux netns dataplane selectors. | [`kernel-dataplane-runner.md`](kernel-dataplane-runner.md), [`INTEROP.md`](INTEROP.md#ci-coverage) |
@@ -87,6 +88,7 @@ Useful commands and entry points:
 cargo test --workspace --no-fail-fast
 cargo clippy --workspace --all-targets -- -D warnings
 cargo doc --workspace --no-deps  # -D warnings pinned in .cargo/config.toml
+cargo test -p rustbgpd-rib deterministic_fault_corpus
 
 bench/compare-criterion.sh --package rustbgpd-rib --bench rib_ops
 bench/compare-rib-memory.sh --base origin/main --head HEAD --profile quick


### PR DESCRIPTION
## Summary

- extract reusable generation-aware controls from the grouped-versus-forced-per-peer oracle
- add fixed PR scenarios for channel saturation/retry, dirty policy regroup and peer-context fallback, and stale generations with observable RTC/VPN churn
- compare exact streams where contractual and normalized transient semantic effects plus terminal unicast/VPN folds otherwise
- require non-empty traffic, terminal sentinel delivery, manager completion, shared-group exercise, and clean dirty/force/regroup/tombstone/residue health on both paths
- add validated single-fixture replay controls and a hard-capped 24-fixture weekly/manual GitHub-hosted sweep

## Review order

1. reusable oracle generation, replay, and terminal-health primitives
2. three bounded fault scenario families and comparison modes
3. hosted extended-corpus workflow
4. contributor replay instructions, operational-proof index, changelog, and ROADMAP truth
5. self-review fixes for nonblocking drains, group residue, observable RTC/VPN effects, transient semantic comparison, and real fallback checkpoints

## Verification

- fixed PR corpus repeated three times
- explicit one-fixture replay at seed `0x35700007` and minimum operation cap
- default hard-capped 24-fixture extended corpus
- all 22 legacy update-group oracle tests
- semantic comparator and config-boundary tests
- full workspace tests
- RIB and workspace all-target Clippy
- Rust 1.95 locked all-target check
- rustdoc warnings-as-errors and Clippy-reason ratchet
- per-commit and full-diff review; independent adversarial re-review

## Documentation and remaining scope

Updated `CONTRIBUTING.md`, `docs/OPERATIONAL_PROOF.md`, the Unreleased changelog, and ROADMAP. This is a parameterized fixed-scenario corpus: fixture seeds vary route identities, not operation ordering or length. LAN-357 remains open for automated minimization, the broader fault matrix, restart/persistence, growth measurements, and LAN-18 long-duration soak coverage.

Linear: LAN-357