### PR TITLE
feat(transport): protect dynamic neighbors with TCP-AO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,6 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Dynamic-neighbor TCP-AO can protect a whole inbound prefix at startup.**
-  Direct `[[dynamic_neighbors]].tcp_ao` installs IPv4 or IPv6 prefix MKTs before
-  the BGP listener enters `listen(2)` without enabling listener-wide
-  `ao_required`. Configuration rejects overlapping dynamic/static authentication
-  boundaries and inherited MD5; protected accepts fail closed unless
-  `TCP_AO_INFO` confirms the expected key IDs and clean authentication counters. SIGHUP pins
-  protected range/key edits to the startup snapshot, and runtime CRUD rejects
-  protected ranges and overlaps. Runtime rotation remains deferred. (#158)
-
 - **EVPN load generation validates unsafe workloads and honors exact event
   budgets.** The development-only `evpn-tester` now rejects zero-sized batches,
   zero-route or zero-rate churn, and hold times of 1-2 seconds before opening a
@@ -93,6 +84,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   verifiably received the full re-advertised table under the new policy. The
   daemon-side scenario generator is committed at
   `bench/scale/reloadstall/gen-scenario.py`.
+
+### Added
+
+- **Dynamic-neighbor TCP-AO can protect a whole inbound prefix at startup.**
+  Direct `[[dynamic_neighbors]].tcp_ao` installs IPv4 or IPv6 prefix MKTs before
+  the BGP listener enters `listen(2)` without enabling listener-wide
+  `ao_required`. Configuration rejects overlapping dynamic/static authentication
+  boundaries and inherited MD5; protected accepts fail closed unless
+  `TCP_AO_INFO` confirms the expected key IDs and clean authentication counters. SIGHUP pins
+  protected range/key edits to the startup snapshot, and runtime CRUD rejects
+  protected ranges and overlaps. Runtime rotation remains deferred. (#158)
 
 ## [0.51.0] — 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Dynamic-neighbor TCP-AO can protect a whole inbound prefix at startup.**
+  Direct `[[dynamic_neighbors]].tcp_ao` installs IPv4 or IPv6 prefix MKTs before
+  the BGP listener enters `listen(2)` without enabling listener-wide
+  `ao_required`. Configuration rejects overlapping dynamic/static authentication
+  boundaries and inherited MD5; protected accepts fail closed unless
+  `TCP_AO_INFO` confirms the expected key IDs and clean authentication counters. SIGHUP pins
+  protected range/key edits to the startup snapshot, and runtime CRUD rejects
+  protected ranges and overlaps. Runtime rotation remains deferred. (#158)
+
 - **EVPN load generation validates unsafe workloads and honors exact event
   budgets.** The development-only `evpn-tester` now rejects zero-sized batches,
   zero-route or zero-rate churn, and hold times of 1-2 seconds before opening a

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -1,6 +1,5 @@
 //! BGP inbound TCP listener.
 
-use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 
 use crate::config::TcpAoConfig;
@@ -27,8 +26,10 @@ pub struct AcceptedConnection {
 /// TCP-AO key to install on the inbound listener socket.
 #[derive(Clone)]
 pub struct TcpAoListenerKey {
-    /// Remote peer address matched by this listener MKT.
+    /// Remote network address matched by this listener MKT.
     pub peer: IpAddr,
+    /// Prefix length for the remote network.
+    pub prefix_len: u8,
     /// TCP-AO key configuration for the peer.
     pub config: TcpAoConfig,
 }
@@ -45,7 +46,7 @@ pub struct ListenerSocketOptions {
 pub struct BgpListener {
     listener: TcpListener,
     accept_tx: mpsc::Sender<AcceptedConnection>,
-    tcp_ao_peers: HashSet<IpAddr>,
+    tcp_ao_keys: Vec<TcpAoListenerKey>,
 }
 
 impl BgpListener {
@@ -80,7 +81,7 @@ impl BgpListener {
         options: ListenerSocketOptions,
     ) -> std::io::Result<Self> {
         let tcp_ao_keys = options.tcp_ao_keys.len();
-        let tcp_ao_peers = options.tcp_ao_keys.iter().map(|key| key.peer).collect();
+        let installed_tcp_ao_keys = options.tcp_ao_keys.clone();
         let listener = bind_socket2_listener(addr, &options)?;
         let bound_addr = listener.local_addr().unwrap_or(addr);
         info!(
@@ -92,7 +93,7 @@ impl BgpListener {
         Ok(Self {
             listener,
             accept_tx,
-            tcp_ao_peers,
+            tcp_ao_keys: installed_tcp_ao_keys,
         })
     }
 
@@ -115,7 +116,13 @@ impl BgpListener {
                 Ok((stream, peer_addr)) => {
                     let peer_ip = peer_addr.ip();
                     debug!(%peer_ip, "inbound TCP connection");
-                    let tcp_ao_info = self.inspect_tcp_ao_accept(&stream, peer_ip);
+                    let tcp_ao_info = match self.inspect_tcp_ao_accept(&stream, peer_ip) {
+                        Ok(info) => info,
+                        Err(err) => {
+                            warn!(peer = %peer_ip, error = %err, "rejecting TCP-AO-protected inbound connection");
+                            continue;
+                        }
+                    };
                     let conn = AcceptedConnection {
                         stream,
                         peer_addr,
@@ -137,10 +144,10 @@ impl BgpListener {
         &self,
         stream: &TcpStream,
         peer_ip: IpAddr,
-    ) -> Option<TcpAoInfoSnapshot> {
-        if !self.tcp_ao_peers.contains(&peer_ip) {
-            return None;
-        }
+    ) -> std::io::Result<Option<TcpAoInfoSnapshot>> {
+        let Some(key) = self.tcp_ao_keys.iter().find(|key| key.covers(peer_ip)) else {
+            return Ok(None);
+        };
 
         match crate::socket_opts::get_tcp_ao_info(stream) {
             Ok(info) => {
@@ -159,7 +166,19 @@ impl BgpListener {
                     pkt_dropped_icmp = info.pkt_dropped_icmp,
                     "TCP-AO accepted socket inspected"
                 );
-                Some(info)
+                if !accepted_tcp_ao_info_is_valid(&info, key.config.send_id) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        format!(
+                            "TCP-AO accepted socket state is inconsistent: expected current key {} and at least one verified packet, got has_current_key={}, current_key={}, pkt_good={}",
+                            key.config.send_id,
+                            info.has_current_key,
+                            info.current_key,
+                            info.pkt_good
+                        ),
+                    ));
+                }
+                Ok(Some(info))
             }
             Err(err) => {
                 warn!(
@@ -167,8 +186,36 @@ impl BgpListener {
                     error = %err,
                     "failed to inspect TCP-AO accepted socket"
                 );
-                None
+                Err(err)
             }
+        }
+    }
+}
+
+fn accepted_tcp_ao_info_is_valid(info: &TcpAoInfoSnapshot, expected_send_id: u8) -> bool {
+    info.has_current_key && info.current_key == expected_send_id && info.pkt_good > 0
+}
+
+impl TcpAoListenerKey {
+    fn covers(&self, addr: IpAddr) -> bool {
+        match (self.peer, addr) {
+            (IpAddr::V4(network), IpAddr::V4(addr)) if self.prefix_len <= 32 => {
+                let mask = if self.prefix_len == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - self.prefix_len)
+                };
+                u32::from(network) & mask == u32::from(addr) & mask
+            }
+            (IpAddr::V6(network), IpAddr::V6(addr)) if self.prefix_len <= 128 => {
+                let mask = if self.prefix_len == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - self.prefix_len)
+                };
+                u128::from(network) & mask == u128::from(addr) & mask
+            }
+            _ => false,
         }
     }
 }
@@ -215,6 +262,7 @@ fn install_listener_tcp_ao_key(socket: &Socket, key: &TcpAoListenerKey) -> std::
     crate::socket_opts::set_tcp_ao_config(
         socket,
         key.peer,
+        key.prefix_len,
         &key.config,
         crate::socket_opts::TcpAoSocketRole::Listener,
     )
@@ -224,9 +272,10 @@ fn listener_tcp_ao_error(key: &TcpAoListenerKey, err: &std::io::Error) -> std::i
     std::io::Error::new(
         err.kind(),
         format!(
-            "failed to install TCP-AO listener key for peer {} \
+            "failed to install TCP-AO listener key for peer {}/{} \
              (send_id={}, recv_id={}, algorithm={}): {err}",
             key.peer,
+            key.prefix_len,
             key.config.send_id,
             key.config.recv_id,
             key.config.algorithm.linux_name()
@@ -252,12 +301,59 @@ mod tests {
         }
     }
 
+    fn tcp_ao_info(current_key: u8, pkt_good: u64) -> TcpAoInfoSnapshot {
+        TcpAoInfoSnapshot {
+            has_current_key: true,
+            has_rnext_key: false,
+            ao_required: false,
+            accept_icmps: false,
+            current_key,
+            rnext_key: 0,
+            pkt_good,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        }
+    }
+
+    #[test]
+    fn prefix_mkt_matching_covers_v4_and_v6_without_cross_family_matches() {
+        let config = tcp_ao_config();
+        let v4 = TcpAoListenerKey {
+            peer: "192.0.2.0".parse().unwrap(),
+            prefix_len: 24,
+            config: config.clone(),
+        };
+        let v6 = TcpAoListenerKey {
+            peer: "2001:db8::".parse().unwrap(),
+            prefix_len: 32,
+            config,
+        };
+        assert!(v4.covers("192.0.2.200".parse().unwrap()));
+        assert!(!v4.covers("192.0.3.1".parse().unwrap()));
+        assert!(v6.covers("2001:db8:ffff::1".parse().unwrap()));
+        assert!(!v6.covers("2001:db9::1".parse().unwrap()));
+        assert!(!v6.covers("192.0.2.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn protected_accept_requires_verified_packet_and_expected_current_key() {
+        assert!(accepted_tcp_ao_info_is_valid(&tcp_ao_info(7, 1), 7));
+        assert!(!accepted_tcp_ao_info_is_valid(&tcp_ao_info(8, 1), 7));
+        assert!(!accepted_tcp_ao_info_is_valid(&tcp_ao_info(7, 0), 7));
+        let mut missing = tcp_ao_info(7, 1);
+        missing.has_current_key = false;
+        assert!(!accepted_tcp_ao_info_is_valid(&missing, 7));
+    }
+
     #[tokio::test]
     async fn bind_socket2_listener_installs_tcp_ao_keys_before_listen() {
         let installed = RefCell::new(Vec::new());
         let options = ListenerSocketOptions {
             tcp_ao_keys: vec![TcpAoListenerKey {
                 peer: IpAddr::from(Ipv4Addr::new(192, 0, 2, 1)),
+                prefix_len: 32,
                 config: tcp_ao_config(),
             }],
         };
@@ -283,6 +379,7 @@ mod tests {
         let options = ListenerSocketOptions {
             tcp_ao_keys: vec![TcpAoListenerKey {
                 peer: IpAddr::from(Ipv4Addr::new(192, 0, 2, 1)),
+                prefix_len: 32,
                 config: tcp_ao_config(),
             }],
         };

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -1,5 +1,6 @@
 //! BGP inbound TCP listener.
 
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 
 use crate::config::TcpAoConfig;
@@ -46,7 +47,88 @@ pub struct ListenerSocketOptions {
 pub struct BgpListener {
     listener: TcpListener,
     accept_tx: mpsc::Sender<AcceptedConnection>,
-    tcp_ao_keys: Vec<TcpAoListenerKey>,
+    tcp_ao_keys: TcpAoListenerKeyIndex,
+}
+
+/// Immutable, family-split prefix-length index for listener MKTs.
+///
+/// Lookup performs at most 33 IPv4 or 129 IPv6 hash probes regardless of the
+/// configured key count. When validated overlapping ranges are present, the
+/// lowest original index wins, preserving the previous linear-scan semantics.
+struct TcpAoListenerKeyIndex {
+    keys: Vec<TcpAoListenerKey>,
+    v4: Vec<HashMap<u32, usize>>,
+    v6: Vec<HashMap<u128, usize>>,
+}
+
+impl TcpAoListenerKeyIndex {
+    fn new(keys: Vec<TcpAoListenerKey>) -> Self {
+        let mut index = Self {
+            v4: (0..=32).map(|_| HashMap::new()).collect(),
+            v6: (0..=128).map(|_| HashMap::new()).collect(),
+            keys,
+        };
+        for (key_index, key) in index.keys.iter().enumerate() {
+            match key.peer {
+                IpAddr::V4(addr) if key.prefix_len <= 32 => {
+                    index.v4[usize::from(key.prefix_len)]
+                        .entry(mask_v4(addr.into(), key.prefix_len))
+                        .or_insert(key_index);
+                }
+                IpAddr::V6(addr) if key.prefix_len <= 128 => {
+                    index.v6[usize::from(key.prefix_len)]
+                        .entry(mask_v6(addr.into(), key.prefix_len))
+                        .or_insert(key_index);
+                }
+                _ => {}
+            }
+        }
+        index
+    }
+
+    fn find(&self, addr: IpAddr) -> Option<&TcpAoListenerKey> {
+        let key_index = match addr {
+            IpAddr::V4(addr) => self
+                .v4
+                .iter()
+                .enumerate()
+                .filter_map(|(prefix_len, bucket)| {
+                    bucket.get(&mask_v4(
+                        addr.into(),
+                        u8::try_from(prefix_len).expect("IPv4 index is bounded to 32"),
+                    ))
+                })
+                .min(),
+            IpAddr::V6(addr) => self
+                .v6
+                .iter()
+                .enumerate()
+                .filter_map(|(prefix_len, bucket)| {
+                    bucket.get(&mask_v6(
+                        addr.into(),
+                        u8::try_from(prefix_len).expect("IPv6 index is bounded to 128"),
+                    ))
+                })
+                .min(),
+        }?;
+        self.keys.get(*key_index)
+    }
+}
+
+fn mask_v4(addr: u32, prefix_len: u8) -> u32 {
+    if prefix_len == 0 {
+        0
+    } else {
+        addr & (u32::MAX << (32 - prefix_len))
+    }
+}
+
+fn mask_v6(addr: u128, prefix_len: u8) -> u128 {
+    if prefix_len == 0 {
+        0
+    } else {
+        addr & (u128::MAX << (128 - prefix_len))
+    }
 }
 
 impl BgpListener {
@@ -81,7 +163,6 @@ impl BgpListener {
         options: ListenerSocketOptions,
     ) -> std::io::Result<Self> {
         let tcp_ao_keys = options.tcp_ao_keys.len();
-        let installed_tcp_ao_keys = options.tcp_ao_keys.clone();
         let listener = bind_socket2_listener(addr, &options)?;
         let bound_addr = listener.local_addr().unwrap_or(addr);
         info!(
@@ -93,7 +174,7 @@ impl BgpListener {
         Ok(Self {
             listener,
             accept_tx,
-            tcp_ao_keys: installed_tcp_ao_keys,
+            tcp_ao_keys: TcpAoListenerKeyIndex::new(options.tcp_ao_keys),
         })
     }
 
@@ -145,7 +226,7 @@ impl BgpListener {
         stream: &TcpStream,
         peer_ip: IpAddr,
     ) -> std::io::Result<Option<TcpAoInfoSnapshot>> {
-        let Some(key) = self.tcp_ao_keys.iter().find(|key| key.covers(peer_ip)) else {
+        let Some(key) = self.tcp_ao_keys.find(peer_ip) else {
             return Ok(None);
         };
 
@@ -185,14 +266,7 @@ impl BgpListener {
                 }
                 Ok(Some(info))
             }
-            Err(err) => {
-                warn!(
-                    peer = %peer_ip,
-                    error = %err,
-                    "failed to inspect TCP-AO accepted socket"
-                );
-                Err(err)
-            }
+            Err(err) => Err(err),
         }
     }
 }
@@ -211,24 +285,15 @@ fn accepted_tcp_ao_info_is_valid(
         && info.pkt_ao_required == 0
 }
 
+#[cfg(test)]
 impl TcpAoListenerKey {
     fn covers(&self, addr: IpAddr) -> bool {
         match (self.peer, addr) {
             (IpAddr::V4(network), IpAddr::V4(addr)) if self.prefix_len <= 32 => {
-                let mask = if self.prefix_len == 0 {
-                    0
-                } else {
-                    u32::MAX << (32 - self.prefix_len)
-                };
-                u32::from(network) & mask == u32::from(addr) & mask
+                mask_v4(network.into(), self.prefix_len) == mask_v4(addr.into(), self.prefix_len)
             }
             (IpAddr::V6(network), IpAddr::V6(addr)) if self.prefix_len <= 128 => {
-                let mask = if self.prefix_len == 0 {
-                    0
-                } else {
-                    u128::MAX << (128 - self.prefix_len)
-                };
-                u128::from(network) & mask == u128::from(addr) & mask
+                mask_v6(network.into(), self.prefix_len) == mask_v6(addr.into(), self.prefix_len)
             }
             _ => false,
         }
@@ -350,6 +415,78 @@ mod tests {
         assert!(v6.covers("2001:db8:ffff::1".parse().unwrap()));
         assert!(!v6.covers("2001:db9::1".parse().unwrap()));
         assert!(!v6.covers("192.0.2.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn listener_key_index_matches_linear_lookup_for_exact_prefix_miss_and_families() {
+        let config = tcp_ao_config();
+        let keys = vec![
+            TcpAoListenerKey {
+                peer: "192.0.2.9".parse().unwrap(),
+                prefix_len: 32,
+                config: config.clone(),
+            },
+            TcpAoListenerKey {
+                peer: "198.51.100.0".parse().unwrap(),
+                prefix_len: 24,
+                config: config.clone(),
+            },
+            TcpAoListenerKey {
+                peer: "2001:db8:1::".parse().unwrap(),
+                prefix_len: 48,
+                config,
+            },
+        ];
+        let probes = [
+            "192.0.2.9",
+            "192.0.2.10",
+            "198.51.100.254",
+            "198.51.101.1",
+            "2001:db8:1::1234",
+            "2001:db8:2::1",
+        ];
+        let index = TcpAoListenerKeyIndex::new(keys.clone());
+
+        for probe in probes.map(|probe| probe.parse::<IpAddr>().unwrap()) {
+            let linear = keys.iter().position(|key| key.covers(probe));
+            let indexed = index
+                .find(probe)
+                .and_then(|found| index.keys.iter().position(|key| std::ptr::eq(key, found)));
+            assert_eq!(indexed, linear, "{probe}");
+        }
+    }
+
+    #[test]
+    fn listener_key_index_preserves_first_match_across_many_keys() {
+        let config = tcp_ao_config();
+        let mut keys = vec![TcpAoListenerKey {
+            peer: "10.0.0.0".parse().unwrap(),
+            prefix_len: 8,
+            config: config.clone(),
+        }];
+        keys.extend((0_u32..5_000).map(|offset| TcpAoListenerKey {
+            peer: IpAddr::V4(Ipv4Addr::from(
+                u32::from(Ipv4Addr::new(10, 0, 0, 0)) + offset,
+            )),
+            prefix_len: 32,
+            config: config.clone(),
+        }));
+        keys.push(TcpAoListenerKey {
+            peer: "2001:db8::".parse().unwrap(),
+            prefix_len: 32,
+            config,
+        });
+        let index = TcpAoListenerKeyIndex::new(keys.clone());
+
+        for probe in ["10.0.0.0", "10.0.19.135", "10.255.255.255", "2001:db8::5"] {
+            let probe = probe.parse::<IpAddr>().unwrap();
+            let linear = keys.iter().position(|key| key.covers(probe));
+            let indexed = index
+                .find(probe)
+                .and_then(|found| index.keys.iter().position(|key| std::ptr::eq(key, found)));
+            assert_eq!(indexed, linear, "{probe}");
+        }
+        assert!(index.find("203.0.113.1".parse().unwrap()).is_none());
     }
 
     #[test]

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -166,15 +166,20 @@ impl BgpListener {
                     pkt_dropped_icmp = info.pkt_dropped_icmp,
                     "TCP-AO accepted socket inspected"
                 );
-                if !accepted_tcp_ao_info_is_valid(&info, key.config.send_id) {
+                if !accepted_tcp_ao_info_is_valid(&info, key.config.send_id, key.config.recv_id) {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::PermissionDenied,
                         format!(
-                            "TCP-AO accepted socket state is inconsistent: expected current key {} and at least one verified packet, got has_current_key={}, current_key={}, pkt_good={}",
+                            "TCP-AO accepted socket state is inconsistent: expected current/rnext keys {}/{}, got has_current_key={}, current_key={}, has_rnext_key={}, rnext_key={}, pkt_bad={}, pkt_key_not_found={}, pkt_ao_required={}",
                             key.config.send_id,
+                            key.config.recv_id,
                             info.has_current_key,
                             info.current_key,
-                            info.pkt_good
+                            info.has_rnext_key,
+                            info.rnext_key,
+                            info.pkt_bad,
+                            info.pkt_key_not_found,
+                            info.pkt_ao_required
                         ),
                     ));
                 }
@@ -192,8 +197,18 @@ impl BgpListener {
     }
 }
 
-fn accepted_tcp_ao_info_is_valid(info: &TcpAoInfoSnapshot, expected_send_id: u8) -> bool {
-    info.has_current_key && info.current_key == expected_send_id && info.pkt_good > 0
+fn accepted_tcp_ao_info_is_valid(
+    info: &TcpAoInfoSnapshot,
+    expected_send_id: u8,
+    expected_recv_id: u8,
+) -> bool {
+    info.has_current_key
+        && info.current_key == expected_send_id
+        && info.has_rnext_key
+        && info.rnext_key == expected_recv_id
+        && info.pkt_bad == 0
+        && info.pkt_key_not_found == 0
+        && info.pkt_ao_required == 0
 }
 
 impl TcpAoListenerKey {
@@ -338,13 +353,19 @@ mod tests {
     }
 
     #[test]
-    fn protected_accept_requires_verified_packet_and_expected_current_key() {
-        assert!(accepted_tcp_ao_info_is_valid(&tcp_ao_info(7, 1), 7));
-        assert!(!accepted_tcp_ao_info_is_valid(&tcp_ao_info(8, 1), 7));
-        assert!(!accepted_tcp_ao_info_is_valid(&tcp_ao_info(7, 0), 7));
-        let mut missing = tcp_ao_info(7, 1);
-        missing.has_current_key = false;
-        assert!(!accepted_tcp_ao_info_is_valid(&missing, 7));
+    fn protected_accept_requires_expected_keys_and_clean_auth_counters() {
+        let mut valid = tcp_ao_info(7, 0);
+        valid.has_rnext_key = true;
+        valid.rnext_key = 9;
+        assert!(accepted_tcp_ao_info_is_valid(&valid, 7, 9));
+        assert!(!accepted_tcp_ao_info_is_valid(&valid, 8, 9));
+        assert!(!accepted_tcp_ao_info_is_valid(&valid, 7, 8));
+        let mut bad = valid;
+        bad.pkt_bad = 1;
+        assert!(!accepted_tcp_ao_info_is_valid(&bad, 7, 9));
+        let mut missing = valid;
+        missing.pkt_key_not_found = 1;
+        assert!(!accepted_tcp_ao_info_is_valid(&missing, 7, 9));
     }
 
     #[tokio::test]
@@ -402,5 +423,100 @@ mod tests {
             vec![IpAddr::from(Ipv4Addr::new(192, 0, 2, 1))]
         );
         tokio::task::yield_now().await;
+    }
+
+    /// Bounded privileged/kernel receipt for GitHub #158. Run on a Linux host
+    /// with `CONFIG_TCP_AO=y`:
+    /// `cargo test -p rustbgpd-transport dynamic_prefix_tcp_ao_kernel_receipt -- --ignored`
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[ignore = "requires a Linux kernel with CONFIG_TCP_AO=y"]
+    async fn dynamic_prefix_tcp_ao_kernel_receipt() {
+        use std::time::Duration;
+
+        fn connect_from(
+            source: Ipv4Addr,
+            destination: SocketAddr,
+            tcp_ao: Option<&TcpAoConfig>,
+        ) -> std::io::Result<Socket> {
+            let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+            socket.bind(&SockAddr::from(SocketAddr::new(source.into(), 0)))?;
+            if let Some(config) = tcp_ao {
+                crate::socket_opts::set_tcp_ao_config(
+                    &socket,
+                    destination.ip(),
+                    32,
+                    config,
+                    crate::socket_opts::TcpAoSocketRole::ActiveOpen,
+                )?;
+            }
+            socket.connect_timeout(&SockAddr::from(destination), Duration::from_secs(2))?;
+            Ok(socket)
+        }
+
+        let config = tcp_ao_config();
+        let (accept_tx, mut accept_rx) = mpsc::channel(4);
+        let listener = BgpListener::bind_with_options(
+            "127.0.0.1:0".parse().unwrap(),
+            accept_tx,
+            ListenerSocketOptions {
+                tcp_ao_keys: vec![TcpAoListenerKey {
+                    peer: "127.0.0.0".parse().unwrap(),
+                    prefix_len: 24,
+                    config: config.clone(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        let destination = listener.local_addr().unwrap();
+        let task = tokio::spawn(listener.run());
+
+        let signed_config = config.clone();
+        let signed = tokio::task::spawn_blocking(move || {
+            connect_from(
+                "127.0.0.2".parse().unwrap(),
+                destination,
+                Some(&signed_config),
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        let accepted = tokio::time::timeout(Duration::from_secs(2), accept_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            accepted.peer_addr.ip(),
+            "127.0.0.2".parse::<IpAddr>().unwrap()
+        );
+        assert!(accepted.tcp_ao_info.is_some());
+
+        let protected_unsigned = tokio::task::spawn_blocking(move || {
+            connect_from("127.0.0.3".parse().unwrap(), destination, None)
+        })
+        .await
+        .unwrap();
+        assert!(protected_unsigned.is_err());
+
+        let unprotected = tokio::task::spawn_blocking(move || {
+            connect_from("127.0.1.2".parse().unwrap(), destination, None)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        let accepted = tokio::time::timeout(Duration::from_secs(2), accept_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            accepted.peer_addr.ip(),
+            "127.0.1.2".parse::<IpAddr>().unwrap()
+        );
+        assert!(accepted.tcp_ao_info.is_none());
+
+        drop((signed, unprotected));
+        task.abort();
     }
 }

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -645,6 +645,7 @@ async fn create_and_connect(
         crate::socket_opts::set_tcp_ao_config(
             &socket,
             config.remote_addr.ip(),
+            if config.remote_addr.is_ipv4() { 32 } else { 128 },
             tcp_ao,
             crate::socket_opts::TcpAoSocketRole::ActiveOpen,
         )

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -232,23 +232,21 @@ const TCP_AO_INFO_ACCEPT_ICMPS: u32 = 1 << 4;
 pub(crate) fn set_tcp_ao_config(
     socket: &Socket,
     peer: IpAddr,
+    prefix_len: u8,
     config: &TcpAoConfig,
     role: TcpAoSocketRole,
 ) -> io::Result<()> {
-    let key = tcp_ao_key_from_config(peer, config, role);
+    let key = tcp_ao_key_from_config(peer, prefix_len, config, role);
     set_tcp_ao_key(socket, &key)
 }
 
 #[cfg(target_os = "linux")]
 fn tcp_ao_key_from_config(
     peer: IpAddr,
+    prefix_len: u8,
     config: &TcpAoConfig,
     role: TcpAoSocketRole,
 ) -> TcpAoKey<'_> {
-    let prefix_len = match peer {
-        IpAddr::V4(_) => 32,
-        IpAddr::V6(_) => 128,
-    };
     TcpAoKey {
         peer,
         scope_id: 0,
@@ -268,6 +266,7 @@ fn tcp_ao_key_from_config(
 pub(crate) fn set_tcp_ao_config(
     _socket: &Socket,
     _peer: std::net::IpAddr,
+    _prefix_len: u8,
     _config: &crate::config::TcpAoConfig,
     _role: TcpAoSocketRole,
 ) -> io::Result<()> {
@@ -777,11 +776,12 @@ mod tests {
 
         let key = tcp_ao_key_from_config(
             IpAddr::from([198, 51, 100, 1]),
+            24,
             &config,
             TcpAoSocketRole::ActiveOpen,
         );
 
-        assert_eq!(key.prefix_len, 32);
+        assert_eq!(key.prefix_len, 24);
         assert_eq!(key.send_id, 10);
         assert_eq!(key.recv_id, 11);
         assert_eq!(key.algorithm, TcpAoAlgorithm::HmacSha1);
@@ -803,11 +803,12 @@ mod tests {
 
         let key = tcp_ao_key_from_config(
             "2001:db8::1".parse().unwrap(),
+            48,
             &config,
             TcpAoSocketRole::Listener,
         );
 
-        assert_eq!(key.prefix_len, 128);
+        assert_eq!(key.prefix_len, 48);
         assert_eq!(key.algorithm, TcpAoAlgorithm::HmacSha256);
         assert!(!key.set_current);
         assert!(!key.set_rnext);

--- a/docs/API.md
+++ b/docs/API.md
@@ -238,11 +238,12 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
 
 `tcp_ao_support` is a read-only Linux capability probe for RFC 5925 TCP-AO. It
 reports whether the host kernel accepts the TCP-AO socket primitive that
-rustbgpd uses for static-neighbor startup key installation. If a static
-`[[neighbors]].tcp_ao` key is configured on a host where the primitive fails,
+rustbgpd uses for static-neighbor and dynamic-prefix startup key installation.
+If a `tcp_ao` key is configured on a host where the primitive fails,
 listener setup aborts startup, and active-open setup rejects that connect
-attempt without falling back to unauthenticated TCP. Runtime key rotation and
-dynamic neighbor wildcard-MKT support are not exposed through the API yet.
+attempt without falling back to unauthenticated TCP. Dynamic-range keys are
+config-file-only: runtime range CRUD rejects protected ranges and overlaps.
+Runtime key rotation is not exposed.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -562,7 +562,8 @@ remote_asn = 65101
 families = ["ipv4_unicast"]
 ```
 
-TCP-AO (RFC 5925) `tcp_ao` is accepted for static `[[neighbors]]` only. On
+TCP-AO (RFC 5925) `tcp_ao` is accepted directly on static `[[neighbors]]` and
+on `[[dynamic_neighbors]]` ranges. On
 Linux, rustbgpd installs the configured key on outbound active-open sockets
 before `connect()` and on the passive BGP listener before `listen()` when the
 peer address family matches the configured listener socket. If a configured
@@ -590,8 +591,8 @@ restart. Runtime deletion of a configured TCP-AO neighbor is also rejected
 until listener MKT deletion / key rotation support lands.
 
 `tcp_ao` is mutually exclusive with `md5_password`, including an inherited
-peer-group MD5 password. It is not available in `[peer_groups.*]` because
-dynamic-neighbor TCP-AO needs a separate wildcard-MKT design. Example:
+peer-group MD5 password. It is not available in `[peer_groups.*]`; dynamic
+ranges configure their prefix MKT directly. Example:
 
 ```toml
 [[neighbors]]
@@ -792,8 +793,8 @@ Peer-group fields mirror inheritable neighbor settings: timers, families,
 GR/LLGR, Add-Path, route-server / RR flags, BGP Role / strict-role defaults,
 receive-side Prefix ORF, private-AS handling, MD5/GTSM,
 `local_ipv6_nexthop`, `log_level`, and import/export inline policy or named
-chains. TCP-AO is intentionally not inherited through peer groups because
-dynamic-neighbor TCP-AO needs a separate wildcard-MKT design.
+chains. TCP-AO is intentionally not inherited through peer groups; static
+neighbors and dynamic ranges configure their startup key directly.
 
 ```toml
 # IPv4 peer with dual-stack
@@ -848,6 +849,7 @@ Dynamic peers:
 | `peer_group`  | string | yes      | --      | Peer group whose settings dynamic peers inherit |
 | `remote_asn`  | u32    | no       | `0`     | Expected remote ASN. `0` means accept any ASN from the peer's OPEN |
 | `description` | string | no       | --      | Optional description applied to accepted dynamic peers |
+| `tcp_ao`      | table  | no       | --      | Direct TCP-AO prefix MKT; Linux startup-only and restart-required |
 
 When `remote_asn = 0`, the accepted peer keeps the configured range as
 accept-any, but the ephemeral peer's session state uses the ASN learned from the
@@ -875,6 +877,7 @@ prefix = "10.0.0.0/24"
 peer_group = "ix-members"
 remote_asn = 0
 description = "IXP auto-accept"
+tcp_ao = { key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }
 
 [[dynamic_neighbors]]
 prefix = "2001:db8::/32"
@@ -889,6 +892,8 @@ Validation rules:
 - two ranges covering the **identical** effective prefix (same masked network
   and length) are rejected; overlapping ranges of *different* lengths are
   allowed and resolve by longest-prefix-match at accept time
+- a TCP-AO-protected range must be disjoint from every other dynamic range and
+  static neighbor, and its peer group must not configure MD5
 
 ### Runtime management (gRPC / `rbgp`)
 
@@ -917,6 +922,8 @@ rbgp dynamic-neighbor delete 10.0.0.0/24
   or a duplicate effective prefix. Delete matches by effective prefix, so a
   host-bit variant of the same network (e.g. `10.0.0.7/24`) removes the
   `10.0.0.0/24` range.
+- Protected ranges cannot be added or deleted through runtime CRUD. Adds that
+  overlap a protected range are also rejected; edit TOML and restart instead.
 
 Operational note:
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -59,8 +59,8 @@ full gate ladder.
 
 ## Transport and session features
 
-- TCP-AO supports static-neighbor startup keys on Linux. Dynamic-neighbor
-  TCP-AO, runtime key rotation, and multi-key rollover remain follow-up work.
+- TCP-AO supports static-neighbor and direct dynamic-prefix startup keys on
+  Linux. Runtime key rotation and multi-key rollover remain follow-up work.
 - TCP MD5 and GTSM are supported.
 - BFD supports IPv4/IPv6 global-address single-hop asynchronous sessions for
   static neighbors. Multihop, echo, demand mode, authentication,

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -24,7 +24,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |
 | EVPN (Linux/VXLAN alpha) | RFC 7432, RFC 9135/9136 (symmetric IRB), RFC 9012/8365 (VXLAN encap) | Route types 1-5; RR + VTEP + multi-homing building blocks |
 | Origin / path security | RFC 6811 + RFC 8210 (RPKI/RTR), ASPA, RFC 9234 (Roles + OTC, ADR-0071) | Origin validation, AS-path verification, leak prevention |
-| Transport security | RFC 5925 (TCP-AO), TCP MD5, RFC 5082 (GTSM) | TCP-AO: static-neighbor startup keys on Linux only |
+| Transport security | RFC 5925 (TCP-AO), TCP MD5, RFC 5082 (GTSM) | TCP-AO: static-neighbor and direct dynamic-prefix startup keys on Linux |
 | FlowSpec / blackhole | RFC 8955/8956 (FlowSpec, SAFI 133), RFC 7999 (BLACKHOLE) | Receiver scoping + opt-in Linux FIB discard |
 | Liveness | RFC 5880/5881/5882 (BFD), RFC 9687 (Send Hold Timer) | Single-hop async BFD for static neighbors |
 | Maintenance | RFC 8326 (Graceful Shutdown), RFC 8203 (Admin Shutdown Communication) | Receiver gating + initiator toggle |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -180,8 +180,8 @@ These protect BGP transport sessions, not the gRPC management surface.
 
 TCP-AO (RFC 5925) is the intended successor to TCP MD5. rustbgpd now has
 an internal Linux socket primitive and capability probe for TCP-AO
-(ADR-0062), plus static-neighbor `tcp_ao` TOML parsing/validation and startup
-runtime installation. Outbound active-open sockets install the key before
+(ADR-0062), plus static-neighbor and direct dynamic-range `tcp_ao` TOML
+parsing/validation and startup runtime installation. Outbound active-open sockets install the key before
 `connect()`, and the passive BGP listener installs configured peer keys before
 `listen()`. Listener key-install failures abort startup rather than running a
 partially protected listener; active-open key-install failures fail the
@@ -194,8 +194,13 @@ the route and does not re-establish within the fail-closed window. The
 hosted `kernel-dataplane` workflow includes M43, and the current hosted
 runner advertises `CONFIG_TCP_AO=y` and runs the topology. The workflow keeps a
 warning-only skip guard for future runner kernels without TCP-AO support.
-Dynamic-neighbor TCP-AO, runtime key rotation, multi-key rollover, and public
-API/CLI/metrics exposure of accepted-socket inspection remain deferred.
+Dynamic prefix MKTs are installed before `listen()` without setting the
+listener-wide `ao_required` bit. Protected accepted sockets are discarded unless
+`TCP_AO_INFO` confirms the expected current/RNext IDs and clean authentication
+counters. Protected
+ranges must be disjoint from all other ranges and static peers; reload and
+runtime CRUD cannot mutate them. Runtime key rotation, multi-key rollover, and
+public API/CLI/metrics exposure of accepted-socket inspection remain deferred.
 
 ## Linux EVPN VTEP — `CAP_NET_ADMIN` requirement
 
@@ -308,8 +313,8 @@ the roadmap:
   the daemon. Use listener tier caps, role enforcement, management-network
   controls, client deadlines, and the documented `grpc_authz` / stream metrics
   to detect or constrain accepted-client abuse in v1.
-- TCP-AO currently supports static-neighbor startup keys only; dynamic
-  neighbors, live key rotation, and multi-key rollover remain follow-up work.
+- TCP-AO supports static-neighbor and direct dynamic-prefix startup keys; live
+  key rotation and multi-key rollover remain follow-up work.
   Protected static-neighbor interop is covered by M43 against BIRD 3.2.1 on
   Linux with `CONFIG_TCP_AO=y`.
 - Cert rotation on the gRPC TLS listener requires a daemon restart (not SIGHUP)

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -78,7 +78,7 @@ apply it would be a silent security footgun.
 ## Implementation Status
 
 The foundation decision above describes the first ADR-0062 slice. Subsequent
-slices have now shipped static-neighbor startup support:
+slices have now shipped static-neighbor and startup-only dynamic-range support:
 
 - `[[neighbors]].tcp_ao` is parsed and validated, mutually exclusive with TCP
   MD5, and redacted in config diffs.
@@ -99,7 +99,11 @@ slices have now shipped static-neighbor startup support:
   `kernel-dataplane` workflow on the current TCP-AO-capable runner. The
   workflow keeps a `CONFIG_TCP_AO` probe so future runner kernels without the
   feature skip M43 with a warning instead of failing unrelated dataplane gates.
+- Direct `[[dynamic_neighbors]].tcp_ao` installs a prefix MKT before listen,
+  rejects overlapping authentication boundaries, fails closed when accepted
+  socket inspection is missing or inconsistent, and pins protected edits until
+  restart. Runtime range CRUD cannot mutate or overlap a protected range.
 
-Still deferred: dynamic-neighbor wildcard MKTs, runtime key rotation / deletion
-on an already-listening socket, multi-key rollover, and API/CLI exposure of
+Still deferred: runtime key rotation / deletion on an already-listening socket,
+multi-key rollover, peer-group inheritance, and API/CLI exposure of
 accepted-socket inspection results.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -146,7 +146,7 @@ Verified 2026-07 against GoBGP `master`.
 | Feature | GoBGP | rustbgpd | Notes |
 |---------|:-----:|:--------:|-------|
 | TCP MD5 (RFC 2385) | Yes | Yes | |
-| TCP-AO (RFC 5925) | No | Static startup | rustbgpd applies static-neighbor TCP-AO keys on Linux startup active-open and passive-listener sockets; dynamic neighbors, live rotation, and multi-key rollover remain follow-ups |
+| TCP-AO (RFC 5925) | No | Startup | rustbgpd applies static-neighbor and direct dynamic-prefix TCP-AO keys on Linux startup sockets; live rotation and multi-key rollover remain follow-ups |
 | GTSM / TTL Security (RFC 5082) | Yes | Yes | |
 | BFD (RFC 5880/5881/5882) | Yes | Yes | GoBGP now documents native single-hop async BFD for BGP neighbors with config-file and gRPC API support. rustbgpd ships single-hop async BFD with IPv4 + IPv6 global static neighbors, `[[bfd_profiles]]` / `[neighbors.bfd]`, `GetBfdSessions`, `rbgp bfd`, Prometheus/events, and RFC 5882 strict + non-strict BGP coupling. M51 validates non-strict failover/recovery against FRR `bfdd`. Deferred: multihop, echo/demand, auth, dynamic-neighbor BFD, and IPv6 link-local / unnumbered |
 | RPKI/RTR (RFC 6811/8210) | Yes | Yes | Persistent RTR session with `SerialNotify`, fallback serial polling, and enforced expiry |

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -126,8 +126,8 @@ reload).
 Peer-group fields mirror `[[neighbors]]` minus the identity triple
 (`address`, `interface`, `remote_asn`) and TCP-AO. Inheritance is resolved at
 each reconcile. Neighbor-level policy fields override inherited peer-group
-policy fields. TCP-AO remains a static-neighbor-only field because
-dynamic-neighbor TCP-AO needs a separate wildcard-MKT design.
+policy fields. TCP-AO is never inherited: static neighbors and dynamic ranges
+configure their startup key directly.
 
 | Field | Class | Notes |
 |---|---|---|
@@ -173,12 +173,18 @@ started with `--config`. Runtime CRUD and SIGHUP reload share a coordinator
 lock, held through the persistence acknowledgement, so reload sees either the
 pre-mutation TOML or the committed post-mutation TOML.
 
+The exception is direct `tcp_ao` on a dynamic range. Prefix MKTs are installed
+before the listener enters `listen(2)`, so adding, removing, moving, or rotating
+a protected range is restart-required and remains pinned to the startup
+snapshot. Disjoint unprotected range edits can still reload normally.
+
 | Field | Class | Notes |
 |---|---|---|
 | `prefix` | reload-applied | Consulted on every inbound TCP accept. |
 | `peer_group` | reload-applied | Inheritance resolves when a passive session promotes to a managed peer. |
 | `remote_asn` | reload-applied | Validated against the OPEN's `my_as` at promotion. |
 | `description` | reload-applied | Metadata. |
+| `tcp_ao` | restart-required | Direct prefix MKT installed before listen; protected range/auth edits are pinned until restart. |
 
 ## `[global]`
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -447,6 +447,18 @@
           "format": "uint32",
           "default": 0,
           "minimum": 0
+        },
+        "tcp_ao": {
+          "description": "TCP-AO key installed as a prefix MKT on the passive listener at startup.\nDynamic ranges never inherit authentication from their peer group.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TcpAoConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "additionalProperties": false,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2252,6 +2252,9 @@ pub struct ConfigDiff {
     /// new. Reload-applied by replacing the peer-manager config snapshot and
     /// rebuilding the live longest-prefix matcher.
     pub dynamic_neighbors_changed: bool,
+    /// The portion of a dynamic-neighbor edit that remains after startup-only
+    /// TCP-AO ranges are pinned back to the live listener snapshot.
+    pub dynamic_neighbors_reload_applied_changed: bool,
     /// The startup-pinned dynamic TCP-AO protected range set changed. Any
     /// add/remove/move, protected-row edit, or key-material rotation requires
     /// a daemon restart before the listener and matcher can advance together.
@@ -2461,7 +2464,7 @@ impl ConfigDiff {
             || self.policy.rpol_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
-            || (self.dynamic_neighbors_changed && !self.dynamic_neighbor_tcp_ao_changed)
+            || self.dynamic_neighbors_reload_applied_changed
             || (self.fib_tables_changed && !self.fib_tables_requires_restart)
             || self.evpn_runtime_change_class.is_reload_applied()
     }
@@ -3150,7 +3153,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "rpol_changed": diff.policy.rpol_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
-            "dynamic_neighbors_changed": diff.dynamic_neighbors_changed && !diff.dynamic_neighbor_tcp_ao_changed,
+            "dynamic_neighbors_changed": diff.dynamic_neighbors_reload_applied_changed,
             "fib_tables_changed": diff.fib_tables_changed && !diff.fib_tables_requires_restart,
             "evpn_runtime_changed": diff.evpn_runtime_change_class.is_reload_applied(),
             "evpn_instances_changed": diff.evpn_runtime_change_class.is_reload_applied() && diff.evpn_instances_changed,
@@ -3359,7 +3362,7 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
                 style.change_marker
             );
         }
-        if diff.dynamic_neighbors_changed && !diff.dynamic_neighbor_tcp_ao_changed {
+        if diff.dynamic_neighbors_reload_applied_changed {
             let _ = writeln!(
                 out,
                 "  {} [[dynamic_neighbors]] matcher rebuilt",
@@ -3455,6 +3458,10 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
     let neighbor_tcp_ao_changed = neighbor_tcp_ao_restart_required_changed(old, new);
     let dynamic_neighbor_tcp_ao_changed =
         dynamic_neighbor_tcp_ao_restart_required_changed(old, new);
+    let mut dynamic_reload_new = new.clone();
+    pin_dynamic_tcp_ao_startup_only(&mut dynamic_reload_new, old);
+    let dynamic_neighbors_reload_applied_changed =
+        old.dynamic_neighbors != dynamic_reload_new.dynamic_neighbors;
     let bfd_changed = bfd_restart_required_changed(old, new);
     let mut reload_new = new.clone();
     pin_tcp_ao_startup_only_runtime(&mut reload_new, old);
@@ -3547,6 +3554,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         fib_tables_changed: old.fib_tables != new.fib_tables,
         fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
         dynamic_neighbors_changed: old.dynamic_neighbors != new.dynamic_neighbors,
+        dynamic_neighbors_reload_applied_changed,
         dynamic_neighbor_tcp_ao_changed,
         apply_bum_enforcement_changed: old.apply_bum_enforcement != new.apply_bum_enforcement,
         blackhole_fib_discard_changed,
@@ -4309,6 +4317,47 @@ fn dynamic_neighbor_tcp_ao_restart_required_changed(old: &Config, new: &Config) 
             .collect::<Vec<_>>()
     };
     protected(old) != protected(new)
+}
+
+/// Pin dynamic TCP-AO listener state to the startup snapshot while preserving
+/// disjoint unprotected range edits that the live matcher can safely apply.
+pub(crate) fn pin_dynamic_tcp_ao_startup_only(new_config: &mut Config, current: &Config) -> usize {
+    let current_protected: Vec<_> = current
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .cloned()
+        .collect();
+    let new_protected: Vec<_> = new_config
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .cloned()
+        .collect();
+    if current_protected == new_protected {
+        return 0;
+    }
+
+    let current_prefixes: Vec<_> = current_protected
+        .iter()
+        .filter_map(|range| effective_prefix_str(&range.prefix))
+        .collect();
+    new_config.dynamic_neighbors.retain(|range| {
+        let Some(prefix) = effective_prefix_str(&range.prefix) else {
+            return true;
+        };
+        !current_prefixes
+            .iter()
+            .any(|protected| dynamic_prefixes_intersect(prefix, *protected))
+            && range.tcp_ao.is_none()
+    });
+    new_config.dynamic_neighbors.extend(current_protected);
+    new_protected.len().max(current_prefixes.len())
+}
+
+fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
+    let min_len = left.1.min(right.1);
+    effective_prefix(left.0, min_len).0 == effective_prefix(right.0, min_len).0
 }
 
 /// Pin TCP-AO runtime state to the live startup snapshot.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4435,7 +4435,11 @@ pub(crate) fn pin_dynamic_tcp_ao_startup_only(new_config: &mut Config, current: 
     affected_ranges
 }
 
-fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
+/// Return whether two validated effective IP prefixes cover any common address.
+///
+/// Shared by config validation, reload pinning, and runtime dynamic-range CRUD
+/// so TCP-AO authentication boundaries use one intersection definition.
+pub(crate) fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
     let min_len = left.1.min(right.1);
     effective_prefix(left.0, min_len).0 == effective_prefix(right.0, min_len).0
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4342,16 +4342,45 @@ pub(crate) fn pin_dynamic_tcp_ao_startup_only(new_config: &mut Config, current: 
         .iter()
         .filter_map(|range| effective_prefix_str(&range.prefix))
         .collect();
-    new_config.dynamic_neighbors.retain(|range| {
+    let mut restored = vec![false; current_protected.len()];
+    new_config.dynamic_neighbors.retain_mut(|range| {
         let Some(prefix) = effective_prefix_str(&range.prefix) else {
             return true;
         };
+        if range.tcp_ao.is_some() {
+            if let Some((index, startup_range)) =
+                current_protected
+                    .iter()
+                    .enumerate()
+                    .find(|(index, startup_range)| {
+                        !restored[*index]
+                            && effective_prefix_str(&startup_range.prefix) == Some(prefix)
+                    })
+            {
+                *range = startup_range.clone();
+                restored[index] = true;
+                return true;
+            }
+            return false;
+        }
+
         !current_prefixes
             .iter()
             .any(|protected| dynamic_prefixes_intersect(prefix, *protected))
-            && range.tcp_ao.is_none()
     });
-    new_config.dynamic_neighbors.extend(current_protected);
+    for (index, startup_range) in current_protected.into_iter().enumerate() {
+        if !restored[index] {
+            let startup_index = current
+                .dynamic_neighbors
+                .iter()
+                .position(|range| range == &startup_range)
+                .unwrap_or(new_config.dynamic_neighbors.len());
+            new_config.dynamic_neighbors.insert(
+                startup_index.min(new_config.dynamic_neighbors.len()),
+                startup_range,
+            );
+        }
+    }
     new_protected.len().max(current_prefixes.len())
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2252,6 +2252,10 @@ pub struct ConfigDiff {
     /// new. Reload-applied by replacing the peer-manager config snapshot and
     /// rebuilding the live longest-prefix matcher.
     pub dynamic_neighbors_changed: bool,
+    /// The startup-pinned dynamic TCP-AO protected range set changed. Any
+    /// add/remove/move, protected-row edit, or key-material rotation requires
+    /// a daemon restart before the listener and matcher can advance together.
+    pub dynamic_neighbor_tcp_ao_changed: bool,
     /// Top-level Gate 8b kernel-enforcement opt-in changed. The
     /// dataplane actor reads this once at startup, so SIGHUP must not
     /// silently advance the in-memory snapshot.
@@ -2457,7 +2461,7 @@ impl ConfigDiff {
             || self.policy.rpol_changed
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
-            || self.dynamic_neighbors_changed
+            || (self.dynamic_neighbors_changed && !self.dynamic_neighbor_tcp_ao_changed)
             || (self.fib_tables_changed && !self.fib_tables_requires_restart)
             || self.evpn_runtime_change_class.is_reload_applied()
     }
@@ -2472,6 +2476,7 @@ impl ConfigDiff {
             || self.apply_bum_enforcement_changed
             || self.blackhole_fib_discard_changed
             || self.neighbor_tcp_ao_changed
+            || self.dynamic_neighbor_tcp_ao_changed
             || self.bfd_changed
             || self.policy_explain_changed
             || self.fib_tables_requires_restart
@@ -2793,7 +2798,8 @@ impl Config {
         }
 
         // Redact secret material everywhere it appears in the schema:
-        // neighbor md5_password / tcp_ao.key and peer-group md5_password.
+        // neighbor/dynamic-range tcp_ao.key, neighbor md5_password, and
+        // peer-group md5_password.
         for neighbor in &mut effective.neighbors {
             if neighbor.md5_password.is_some() {
                 neighbor.md5_password = Some(REDACTED_SECRET.to_string());
@@ -2805,6 +2811,11 @@ impl Config {
         for group in effective.peer_groups.values_mut() {
             if group.md5_password.is_some() {
                 group.md5_password = Some(REDACTED_SECRET.to_string());
+            }
+        }
+        for range in &mut effective.dynamic_neighbors {
+            if let Some(tcp_ao) = &mut range.tcp_ao {
+                tcp_ao.key = REDACTED_SECRET.to_string();
             }
         }
 
@@ -2851,7 +2862,7 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .supported_sections
             .push(TRANSACTION_NEIGHBOR_MODIFY_SECTION.to_string());
     }
-    if diff.dynamic_neighbors_changed {
+    if diff.dynamic_neighbors_changed && !diff.dynamic_neighbor_tcp_ao_changed {
         class
             .supported_sections
             .push(TRANSACTION_DYNAMIC_SECTION.to_string());
@@ -3013,6 +3024,11 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .restart_required_sections
             .push("[[neighbors]].tcp_ao".to_string());
     }
+    if diff.dynamic_neighbor_tcp_ao_changed {
+        class
+            .restart_required_sections
+            .push("[[dynamic_neighbors]].tcp_ao".to_string());
+    }
     if diff.bfd_changed {
         class
             .restart_required_sections
@@ -3134,7 +3150,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "rpol_changed": diff.policy.rpol_changed,
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
-            "dynamic_neighbors_changed": diff.dynamic_neighbors_changed,
+            "dynamic_neighbors_changed": diff.dynamic_neighbors_changed && !diff.dynamic_neighbor_tcp_ao_changed,
             "fib_tables_changed": diff.fib_tables_changed && !diff.fib_tables_requires_restart,
             "evpn_runtime_changed": diff.evpn_runtime_change_class.is_reload_applied(),
             "evpn_instances_changed": diff.evpn_runtime_change_class.is_reload_applied() && diff.evpn_instances_changed,
@@ -3157,6 +3173,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "apply_bum_enforcement_changed": diff.apply_bum_enforcement_changed,
             "blackhole_fib_discard_changed": diff.blackhole_fib_discard_changed,
             "neighbor_tcp_ao_changed": diff.neighbor_tcp_ao_changed,
+            "dynamic_neighbor_tcp_ao_changed": diff.dynamic_neighbor_tcp_ao_changed,
             "bfd_changed": diff.bfd_changed,
             "policy_explain_changed": diff.policy_explain_changed,
         },
@@ -3342,7 +3359,7 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
                 style.change_marker
             );
         }
-        if diff.dynamic_neighbors_changed {
+        if diff.dynamic_neighbors_changed && !diff.dynamic_neighbor_tcp_ao_changed {
             let _ = writeln!(
                 out,
                 "  {} [[dynamic_neighbors]] matcher rebuilt",
@@ -3408,6 +3425,9 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     if diff.neighbor_tcp_ao_changed {
         restart_sections.push("[[neighbors]].tcp_ao");
     }
+    if diff.dynamic_neighbor_tcp_ao_changed {
+        restart_sections.push("[[dynamic_neighbors]].tcp_ao");
+    }
     if diff.bfd_changed {
         restart_sections.push("[[bfd_profiles]] / [neighbors.bfd] / [peer_groups.*.bfd]");
     }
@@ -3433,6 +3453,8 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
 /// Compare two full configurations and return a structured diff.
 pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
     let neighbor_tcp_ao_changed = neighbor_tcp_ao_restart_required_changed(old, new);
+    let dynamic_neighbor_tcp_ao_changed =
+        dynamic_neighbor_tcp_ao_restart_required_changed(old, new);
     let bfd_changed = bfd_restart_required_changed(old, new);
     let mut reload_new = new.clone();
     pin_tcp_ao_startup_only_runtime(&mut reload_new, old);
@@ -3525,6 +3547,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         fib_tables_changed: old.fib_tables != new.fib_tables,
         fib_tables_requires_restart: old.fib_tables.is_empty() && !new.fib_tables.is_empty(),
         dynamic_neighbors_changed: old.dynamic_neighbors != new.dynamic_neighbors,
+        dynamic_neighbor_tcp_ao_changed,
         apply_bum_enforcement_changed: old.apply_bum_enforcement != new.apply_bum_enforcement,
         blackhole_fib_discard_changed,
         neighbor_tcp_ao_changed,
@@ -4274,6 +4297,18 @@ fn neighbor_tcp_ao_restart_required_changed(old: &Config, new: &Config) -> bool 
     old.neighbors.iter().any(|old_neighbor| {
         old_neighbor.tcp_ao.is_some() && !new_by_addr.contains_key(old_neighbor.address.as_str())
     })
+}
+
+fn dynamic_neighbor_tcp_ao_restart_required_changed(old: &Config, new: &Config) -> bool {
+    let protected = |config: &Config| {
+        config
+            .dynamic_neighbors
+            .iter()
+            .filter(|range| range.tcp_ao.is_some())
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    protected(old) != protected(new)
 }
 
 /// Pin TCP-AO runtime state to the live startup snapshot.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4324,7 +4324,11 @@ fn protected_dynamic_ranges_equal(old: &Config, new: &Config) -> bool {
         .collect();
     old_protected.sort_unstable_by(|left, right| protected_dynamic_range_cmp(left, right));
     new_protected.sort_unstable_by(|left, right| protected_dynamic_range_cmp(left, right));
-    old_protected == new_protected
+    old_protected.len() == new_protected.len()
+        && old_protected
+            .iter()
+            .zip(new_protected)
+            .all(|(old, new)| protected_dynamic_range_cmp(old, new).is_eq())
 }
 
 fn protected_dynamic_range_cmp(
@@ -4333,8 +4337,8 @@ fn protected_dynamic_range_cmp(
 ) -> std::cmp::Ordering {
     let left_ao = left.tcp_ao.as_ref().expect("protected range");
     let right_ao = right.tcp_ao.as_ref().expect("protected range");
-    left.prefix
-        .cmp(&right.prefix)
+    effective_prefix_str(&left.prefix)
+        .cmp(&effective_prefix_str(&right.prefix))
         .then_with(|| left.peer_group.cmp(&right.peer_group))
         .then_with(|| left.remote_asn.cmp(&right.remote_asn))
         .then_with(|| left.description.cmp(&right.description))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4308,15 +4308,42 @@ fn neighbor_tcp_ao_restart_required_changed(old: &Config, new: &Config) -> bool 
 }
 
 fn dynamic_neighbor_tcp_ao_restart_required_changed(old: &Config, new: &Config) -> bool {
-    let protected = |config: &Config| {
-        config
-            .dynamic_neighbors
-            .iter()
-            .filter(|range| range.tcp_ao.is_some())
-            .cloned()
-            .collect::<Vec<_>>()
-    };
-    protected(old) != protected(new)
+    !protected_dynamic_ranges_equal(old, new)
+}
+
+fn protected_dynamic_ranges_equal(old: &Config, new: &Config) -> bool {
+    let mut old_protected: Vec<_> = old
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .collect();
+    let mut new_protected: Vec<_> = new
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .collect();
+    old_protected.sort_unstable_by(|left, right| protected_dynamic_range_cmp(left, right));
+    new_protected.sort_unstable_by(|left, right| protected_dynamic_range_cmp(left, right));
+    old_protected == new_protected
+}
+
+fn protected_dynamic_range_cmp(
+    left: &DynamicNeighborConfig,
+    right: &DynamicNeighborConfig,
+) -> std::cmp::Ordering {
+    let left_ao = left.tcp_ao.as_ref().expect("protected range");
+    let right_ao = right.tcp_ao.as_ref().expect("protected range");
+    left.prefix
+        .cmp(&right.prefix)
+        .then_with(|| left.peer_group.cmp(&right.peer_group))
+        .then_with(|| left.remote_asn.cmp(&right.remote_asn))
+        .then_with(|| left.description.cmp(&right.description))
+        .then_with(|| left_ao.key.cmp(&right_ao.key))
+        .then_with(|| left_ao.send_id.cmp(&right_ao.send_id))
+        .then_with(|| left_ao.recv_id.cmp(&right_ao.recv_id))
+        .then_with(|| left_ao.algorithm.cmp(&right_ao.algorithm))
+        .then_with(|| left_ao.preferred.cmp(&right_ao.preferred))
+        .then_with(|| left_ao.deprecated.cmp(&right_ao.deprecated))
 }
 
 /// Pin dynamic TCP-AO listener state to the startup snapshot while preserving
@@ -4334,9 +4361,29 @@ pub(crate) fn pin_dynamic_tcp_ao_startup_only(new_config: &mut Config, current: 
         .filter(|range| range.tcp_ao.is_some())
         .cloned()
         .collect();
-    if current_protected == new_protected {
+    if protected_dynamic_ranges_equal(current, new_config) {
         return 0;
     }
+
+    let mut current_by_prefix = BTreeMap::new();
+    for range in &current_protected {
+        if let Some(prefix) = effective_prefix_str(&range.prefix) {
+            current_by_prefix.insert(prefix, range);
+        }
+    }
+    let mut new_by_prefix = BTreeMap::new();
+    for range in &new_protected {
+        if let Some(prefix) = effective_prefix_str(&range.prefix) {
+            new_by_prefix.insert(prefix, range);
+        }
+    }
+    let affected_ranges = current_by_prefix
+        .keys()
+        .chain(new_by_prefix.keys())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|prefix| current_by_prefix.get(prefix) != new_by_prefix.get(prefix))
+        .count();
 
     let current_prefixes: Vec<_> = current_protected
         .iter()
@@ -4381,7 +4428,7 @@ pub(crate) fn pin_dynamic_tcp_ao_startup_only(new_config: &mut Config, current: 
             );
         }
     }
-    new_protected.len().max(current_prefixes.len())
+    affected_ranges
 }
 
 fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -279,6 +279,10 @@ pub struct DynamicNeighborConfig {
     /// Description applied to dynamic peers from this range.
     #[serde(default)]
     pub description: Option<String>,
+    /// TCP-AO key installed as a prefix MKT on the passive listener at startup.
+    /// Dynamic ranges never inherit authentication from their peer group.
+    #[serde(default)]
+    pub tcp_ao: Option<TcpAoConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9299,6 +9299,69 @@ metric = 200
     );
 }
 
+fn dynamic_tcp_ao_transaction_config(protected: Option<(&str, &str)>, extra: &str) -> Config {
+    let protected = protected.map_or_else(String::new, |(prefix, key)| {
+        format!(
+            "[[dynamic_neighbors]]\nprefix = \"{prefix}\"\npeer_group = \"dynamic\"\ntcp_ao = {{ key = \"{key}\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }}\n"
+        )
+    });
+    parse(&format!(
+        "{}\n[peer_groups.dynamic]\nhold_time = 90\n{protected}{extra}",
+        valid_toml()
+    ))
+    .unwrap()
+}
+
+#[test]
+fn transaction_v1_rejects_dynamic_tcp_ao_add_remove_rotate_and_move() {
+    let absent = dynamic_tcp_ao_transaction_config(None, "");
+    let original = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "old-secret")), "");
+    let rotated = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "new-secret")), "");
+    let moved = dynamic_tcp_ao_transaction_config(Some(("192.0.3.0/24", "old-secret")), "");
+
+    for (label, old, new) in [
+        ("add", &absent, &original),
+        ("remove", &original, &absent),
+        ("rotate", &original, &rotated),
+        ("move", &original, &moved),
+    ] {
+        let diff = diff_config(old, new);
+        let class = classify_config_transaction_v1(&diff);
+        assert!(diff.dynamic_neighbor_tcp_ao_changed, "{label}");
+        assert!(!diff.has_reload_applied_changes(), "{label}");
+        assert!(!class.is_committable(), "{label}");
+        assert!(class.supported_sections.is_empty(), "{label}: {class:?}");
+        assert_eq!(
+            class.restart_required_sections,
+            vec!["[[dynamic_neighbors]].tcp_ao"],
+            "{label}"
+        );
+        let json = config_diff_json_value(&diff);
+        assert_eq!(json["reload_applied"]["dynamic_neighbors_changed"], false);
+        assert_eq!(
+            json["restart_required"]["dynamic_neighbor_tcp_ao_changed"],
+            true
+        );
+    }
+}
+
+#[test]
+fn transaction_v1_allows_disjoint_unprotected_dynamic_edit_beside_tcp_ao_range() {
+    let old = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "secret")), "");
+    let new = dynamic_tcp_ao_transaction_config(
+        Some(("192.0.2.0/24", "secret")),
+        "[[dynamic_neighbors]]\nprefix = \"198.51.100.0/24\"\npeer_group = \"dynamic\"\n",
+    );
+    let diff = diff_config(&old, &new);
+    let class = classify_config_transaction_v1(&diff);
+
+    assert!(!diff.dynamic_neighbor_tcp_ao_changed);
+    assert!(diff.has_reload_applied_changes());
+    assert!(class.is_committable(), "{class:?}");
+    assert_eq!(class.supported_sections, vec!["[[dynamic_neighbors]]"]);
+    assert!(class.restart_required_sections.is_empty());
+}
+
 #[test]
 fn runtime_snapshot_token_is_stable_and_changes_with_config() {
     let old = parse(valid_toml()).unwrap();
@@ -13150,6 +13213,14 @@ log_format = "json"
 [peer_groups.md5-group]
 md5_password = "group-hunter2-seed"
 
+[peer_groups.dynamic]
+hold_time = 90
+
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "dynamic"
+tcp_ao = { key = "dynamic-hunter2-seed", send_id = 3, recv_id = 4, algorithm = "hmac(sha256)" }
+
 [[neighbors]]
 address = "10.0.0.2"
 remote_asn = 65002
@@ -13240,6 +13311,10 @@ fn redacted_placeholder_fails_validation_loudly() {
         (
             "peer group md5",
             "[peer_groups.g]\nmd5_password = \"<redacted>\"\n",
+        ),
+        (
+            "dynamic tcp_ao key",
+            "[peer_groups.g]\nhold_time = 90\n[[dynamic_neighbors]]\nprefix = \"192.0.2.0/24\"\npeer_group = \"g\"\ntcp_ao = { key = \"<redacted>\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }\n",
         ),
     ] {
         let toml_str = format!(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9383,6 +9383,16 @@ fn protected_dynamic_range_reorder_is_not_a_tcp_ao_restart_change() {
 }
 
 #[test]
+fn protected_dynamic_range_effective_prefix_identity_avoids_restart_change() {
+    let canonical = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "secret")), "");
+    let host_bits = dynamic_tcp_ao_transaction_config(Some(("192.0.2.1/24", "secret")), "");
+
+    let diff = diff_config(&canonical, &host_bits);
+    assert!(!diff.dynamic_neighbor_tcp_ao_changed);
+    assert!(diff.dynamic_neighbors_reload_applied_changed);
+}
+
+#[test]
 fn mixed_dynamic_tcp_ao_and_disjoint_unprotected_diff_reports_both_portions() {
     let old = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "old-secret")), "");
     let new = dynamic_tcp_ao_transaction_config(

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9363,6 +9363,44 @@ fn transaction_v1_allows_disjoint_unprotected_dynamic_edit_beside_tcp_ao_range()
 }
 
 #[test]
+fn mixed_dynamic_tcp_ao_and_disjoint_unprotected_diff_reports_both_portions() {
+    let old = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "old-secret")), "");
+    let new = dynamic_tcp_ao_transaction_config(
+        Some(("192.0.2.0/24", "new-secret")),
+        "[[dynamic_neighbors]]\nprefix = \"198.51.100.0/24\"\npeer_group = \"dynamic\"\n",
+    );
+    let diff = diff_config(&old, &new);
+    let json = config_diff_json_value(&diff);
+    let text = format_config_diff(&diff);
+
+    assert!(diff.dynamic_neighbor_tcp_ao_changed);
+    assert!(diff.dynamic_neighbors_reload_applied_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(diff.has_reload_applied_changes());
+    assert_eq!(
+        json["restart_required"]["dynamic_neighbor_tcp_ao_changed"],
+        true
+    );
+    assert_eq!(json["reload_applied"]["dynamic_neighbors_changed"], true);
+    assert!(
+        text.contains("[[dynamic_neighbors]] matcher rebuilt"),
+        "{text}"
+    );
+    assert!(
+        text.contains("[[dynamic_neighbors]].tcp_ao changed"),
+        "{text}"
+    );
+
+    let class = classify_config_transaction_v1(&diff);
+    assert!(!class.is_committable());
+    assert!(class.supported_sections.is_empty(), "{class:?}");
+    assert_eq!(
+        class.restart_required_sections,
+        vec!["[[dynamic_neighbors]].tcp_ao"]
+    );
+}
+
+#[test]
 fn runtime_snapshot_token_is_stable_and_changes_with_config() {
     let old = parse(valid_toml()).unwrap();
     let mut new = old.clone();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5409,6 +5409,104 @@ description = "IXP auto-accept"
     assert_eq!(config.dynamic_neighbors[0].remote_asn, 0);
 }
 
+fn dynamic_tcp_ao_toml(ranges_and_neighbors: &str) -> String {
+    format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[peer_groups.ix-members]
+hold_time = 90
+
+{ranges_and_neighbors}
+"#
+    )
+}
+
+#[test]
+fn dynamic_neighbor_tcp_ao_parses_directly_and_redacts_debug() {
+    let config = parse(&dynamic_tcp_ao_toml(
+        r#"
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "ix-members"
+tcp_ao = { key = "dynamic-secret", send_id = 7, recv_id = 9, algorithm = "hmac(sha256)" }
+"#,
+    ))
+    .unwrap();
+    let tcp_ao = config.dynamic_neighbors[0].tcp_ao.as_ref().unwrap();
+    assert_eq!(tcp_ao.send_id, 7);
+    assert_eq!(tcp_ao.recv_id, 9);
+    let rendered = format!("{tcp_ao:?}");
+    assert!(rendered.contains("<redacted>"));
+    assert!(!rendered.contains("dynamic-secret"));
+}
+
+#[test]
+fn dynamic_neighbor_tcp_ao_rejects_overlapping_dynamic_auth_boundaries() {
+    let err = parse(&dynamic_tcp_ao_toml(
+        r#"
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "ix-members"
+tcp_ao = { key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }
+
+[[dynamic_neighbors]]
+prefix = "10.0.0.128/25"
+peer_group = "ix-members"
+"#,
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("protected ranges must be disjoint")
+    );
+}
+
+#[test]
+fn dynamic_neighbor_tcp_ao_rejects_static_peer_inside_prefix() {
+    let err = parse(&dynamic_tcp_ao_toml(
+        r#"
+[[dynamic_neighbors]]
+prefix = "2001:db8::/32"
+peer_group = "ix-members"
+tcp_ao = { key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }
+
+[[neighbors]]
+address = "2001:db8::42"
+remote_asn = 65002
+"#,
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("static and dynamic authentication boundaries must be disjoint")
+    );
+}
+
+#[test]
+fn dynamic_neighbor_tcp_ao_rejects_peer_group_md5_inheritance() {
+    let mut source = dynamic_tcp_ao_toml(
+        r#"
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "ix-members"
+tcp_ao = { key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }
+"#,
+    );
+    source = source.replace(
+        "hold_time = 90",
+        "hold_time = 90\nmd5_password = \"legacy\"",
+    );
+    let err = parse(&source).unwrap_err();
+    assert!(err.to_string().contains("never inherited"));
+}
+
 #[test]
 fn dynamic_neighbor_invalid_prefix_rejected() {
     let toml = r#"

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -9363,6 +9363,26 @@ fn transaction_v1_allows_disjoint_unprotected_dynamic_edit_beside_tcp_ao_range()
 }
 
 #[test]
+fn protected_dynamic_range_reorder_is_not_a_tcp_ao_restart_change() {
+    let first = dynamic_tcp_ao_transaction_config(
+        Some(("192.0.2.0/24", "first-secret")),
+        "[[dynamic_neighbors]]\nprefix = \"198.51.100.0/24\"\npeer_group = \"dynamic\"\ntcp_ao = { key = \"second-secret\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }\n",
+    );
+    let second = dynamic_tcp_ao_transaction_config(
+        Some(("198.51.100.0/24", "second-secret")),
+        "[[dynamic_neighbors]]\nprefix = \"192.0.2.0/24\"\npeer_group = \"dynamic\"\ntcp_ao = { key = \"first-secret\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }\n",
+    );
+
+    let diff = diff_config(&first, &second);
+    let class = classify_config_transaction_v1(&diff);
+    assert!(!diff.dynamic_neighbor_tcp_ao_changed);
+    assert!(diff.dynamic_neighbors_reload_applied_changed);
+    assert!(class.is_committable(), "{class:?}");
+    assert_eq!(class.supported_sections, vec!["[[dynamic_neighbors]]"]);
+    assert!(class.restart_required_sections.is_empty());
+}
+
+#[test]
 fn mixed_dynamic_tcp_ao_and_disjoint_unprotected_diff_reports_both_portions() {
     let old = dynamic_tcp_ao_transaction_config(Some(("192.0.2.0/24", "old-secret")), "");
     let new = dynamic_tcp_ao_transaction_config(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -792,6 +792,7 @@ impl Config {
 
         // Validate dynamic neighbor ranges
         let mut seen_prefixes = std::collections::HashSet::new();
+        let mut parsed_dynamic_prefixes = Vec::with_capacity(self.dynamic_neighbors.len());
         for (i, dn) in self.dynamic_neighbors.iter().enumerate() {
             // Prefix must parse as addr/len
             let parts: Vec<&str> = dn.prefix.split('/').collect();
@@ -855,6 +856,7 @@ impl Config {
                     ),
                 });
             }
+            parsed_dynamic_prefixes.push((key.0, key.1));
 
             // Peer group must exist
             let Some(group) = self.peer_groups.get(&dn.peer_group) else {
@@ -880,6 +882,63 @@ impl Config {
                         dn.peer_group
                     ),
                 });
+            }
+
+            if let Some(tcp_ao) = &dn.tcp_ao {
+                if group.md5_password.is_some() {
+                    return Err(ConfigError::InvalidDynamicNeighbor {
+                        reason: format!(
+                            "dynamic_neighbors[{i}]: tcp_ao is mutually exclusive with \
+                             md5_password on peer group {:?}; dynamic authentication is direct \
+                             and never inherited",
+                            dn.peer_group
+                        ),
+                    });
+                }
+                validate_tcp_ao_config(&dn.prefix, tcp_ao).map_err(|err| {
+                    ConfigError::InvalidDynamicNeighbor {
+                        reason: format!("dynamic_neighbors[{i}]: {err}"),
+                    }
+                })?;
+            }
+        }
+
+        // A prefix MKT creates an authentication boundary in the kernel. Until
+        // Linux precedence for overlapping MKTs is proven and modeled, every
+        // protected dynamic range must be disjoint from all other dynamic
+        // ranges and static peers. This prevents longest-prefix application
+        // matching from disagreeing with listener authentication.
+        for (i, protected) in self.dynamic_neighbors.iter().enumerate() {
+            if protected.tcp_ao.is_none() {
+                continue;
+            }
+            let protected_prefix = parsed_dynamic_prefixes[i];
+            for (j, other_prefix) in parsed_dynamic_prefixes.iter().copied().enumerate() {
+                if i != j && prefixes_intersect(protected_prefix, other_prefix) {
+                    return Err(ConfigError::InvalidDynamicNeighbor {
+                        reason: format!(
+                            "dynamic_neighbors[{i}]: TCP-AO range {:?} overlaps \
+                             dynamic_neighbors[{j}] {:?}; protected ranges must be disjoint",
+                            protected.prefix, self.dynamic_neighbors[j].prefix
+                        ),
+                    });
+                }
+            }
+            for neighbor in &self.neighbors {
+                let Ok(address) = neighbor.address.parse::<IpAddr>() else {
+                    continue;
+                };
+                let host_prefix = (address, if address.is_ipv4() { 32 } else { 128 });
+                if prefixes_intersect(protected_prefix, host_prefix) {
+                    return Err(ConfigError::InvalidDynamicNeighbor {
+                        reason: format!(
+                            "dynamic_neighbors[{i}]: TCP-AO range {:?} contains static \
+                             neighbor {:?}; static and dynamic authentication boundaries \
+                             must be disjoint",
+                            protected.prefix, neighbor.address
+                        ),
+                    });
+                }
             }
         }
 
@@ -959,6 +1018,11 @@ impl Config {
             effective.iter().any(|f| f == "linkstate")
         })
     }
+}
+
+fn prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
+    let min_len = left.1.min(right.1);
+    effective_prefix(left.0, min_len).0 == effective_prefix(right.0, min_len).0
 }
 
 impl Config {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1052,6 +1052,18 @@ impl Config {
                 return Err(placeholder_error(&neighbor.address, "tcp_ao.key"));
             }
         }
+        for range in &self.dynamic_neighbors {
+            if range
+                .tcp_ao
+                .as_ref()
+                .is_some_and(|tcp_ao| tcp_ao.key == super::REDACTED_SECRET)
+            {
+                return Err(placeholder_error(
+                    &format!("dynamic_neighbors.{}", range.prefix),
+                    "tcp_ao.key",
+                ));
+            }
+        }
         for (name, group) in &self.peer_groups {
             if group.md5_password.as_deref() == Some(super::REDACTED_SECRET) {
                 return Err(placeholder_error(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -13,7 +13,8 @@ use super::schema::{
 };
 use super::{
     Config, ConfigError, DEFAULT_HOLD_TIME, EventHistoryConfig, GrpcEnforcementConfig,
-    PeerGroupConfig, SecurityConfig, TcpAoConfig, is_unicast_nonzero_mac, parse_mac_address,
+    PeerGroupConfig, SecurityConfig, TcpAoConfig, dynamic_prefixes_intersect,
+    is_unicast_nonzero_mac, parse_mac_address,
 };
 
 /// Canonical key for a dynamic-neighbor prefix: the network address with all
@@ -914,7 +915,7 @@ impl Config {
             }
             let protected_prefix = parsed_dynamic_prefixes[i];
             for (j, other_prefix) in parsed_dynamic_prefixes.iter().copied().enumerate() {
-                if i != j && prefixes_intersect(protected_prefix, other_prefix) {
+                if i != j && dynamic_prefixes_intersect(protected_prefix, other_prefix) {
                     return Err(ConfigError::InvalidDynamicNeighbor {
                         reason: format!(
                             "dynamic_neighbors[{i}]: TCP-AO range {:?} overlaps \
@@ -929,7 +930,7 @@ impl Config {
                     continue;
                 };
                 let host_prefix = (address, if address.is_ipv4() { 32 } else { 128 });
-                if prefixes_intersect(protected_prefix, host_prefix) {
+                if dynamic_prefixes_intersect(protected_prefix, host_prefix) {
                     return Err(ConfigError::InvalidDynamicNeighbor {
                         reason: format!(
                             "dynamic_neighbors[{i}]: TCP-AO range {:?} contains static \
@@ -1018,11 +1019,6 @@ impl Config {
             effective.iter().any(|f| f == "linkstate")
         })
     }
-}
-
-fn prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
-    let min_len = left.1.min(right.1);
-    effective_prefix(left.0, min_len).0 == effective_prefix(right.0, min_len).0
 }
 
 impl Config {

--- a/src/gnmi_set_bridge.rs
+++ b/src/gnmi_set_bridge.rs
@@ -434,6 +434,7 @@ fn empty_dynamic_neighbor(prefix: &str) -> DynamicNeighborConfig {
         peer_group: String::new(),
         remote_asn: 0,
         description: None,
+        tcp_ao: None,
     }
 }
 
@@ -1449,6 +1450,7 @@ description = "old"
             peer_group: "old".to_string(),
             remote_asn: 65010,
             description: Some("existing".to_string()),
+            tcp_ao: None,
         });
 
         let candidate = apply_transaction_to_config(
@@ -1475,6 +1477,7 @@ description = "old"
             peer_group: "ix-members".to_string(),
             remote_asn: 0,
             description: None,
+            tcp_ao: None,
         });
 
         let candidate = apply_transaction_to_config(
@@ -1515,6 +1518,7 @@ description = "old"
             peer_group: "old".to_string(),
             remote_asn: 65010,
             description: Some("existing".to_string()),
+            tcp_ao: None,
         });
 
         let candidate = apply_transaction_to_config(
@@ -1542,6 +1546,7 @@ description = "old"
             peer_group: "ix-members".to_string(),
             remote_asn: 0,
             description: None,
+            tcp_ao: None,
         });
 
         let candidate = apply_transaction_to_config(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3566,6 +3566,43 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
     }
 
     #[test]
+    fn tcp_ao_listener_key_preserves_dynamic_v4_and_v6_prefix_lengths() {
+        let range = |prefix: &str| config::DynamicNeighborConfig {
+            prefix: prefix.to_string(),
+            peer_group: "dynamic".to_string(),
+            remote_asn: 0,
+            description: None,
+            tcp_ao: Some(config::TcpAoConfig {
+                key: "secret".to_string(),
+                send_id: 7,
+                recv_id: 9,
+                algorithm: "hmac(sha256)".to_string(),
+                preferred: false,
+                deprecated: false,
+            }),
+        };
+
+        let v4 = tcp_ao_listener_key_for_dynamic_range(
+            "0.0.0.0:179".parse().unwrap(),
+            &range("192.0.2.0/24"),
+        )
+        .unwrap();
+        let v6 = tcp_ao_listener_key_for_dynamic_range(
+            "[::]:179".parse().unwrap(),
+            &range("2001:db8::/48"),
+        )
+        .unwrap();
+        assert_eq!(
+            (v4.peer.to_string(), v4.prefix_len),
+            ("192.0.2.0".to_string(), 24)
+        );
+        assert_eq!(
+            (v6.peer.to_string(), v6.prefix_len),
+            ("2001:db8::".to_string(), 48)
+        );
+    }
+
+    #[test]
     #[expect(clippy::too_many_lines)]
     fn max_gr_restart_time_uses_largest_enabled_peer() {
         let config = crate::config::Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,10 @@ use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
 
 use rustbgpd_rib::{RibManager, RibUpdate};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
-use rustbgpd_transport::{BgpListener, ListenerSocketOptions, TcpAoListenerKey};
+use rustbgpd_transport::{
+    BgpListener, ListenerSocketOptions, TcpAoAlgorithm, TcpAoConfig as TransportTcpAoConfig,
+    TcpAoListenerKey,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
@@ -602,7 +605,32 @@ fn tcp_ao_listener_key_for_neighbor(
     }
     Some(TcpAoListenerKey {
         peer,
+        prefix_len: if peer.is_ipv4() { 32 } else { 128 },
         config: tcp_ao.clone(),
+    })
+}
+
+fn tcp_ao_listener_key_for_dynamic_range(
+    listen_addr: SocketAddr,
+    range: &config::DynamicNeighborConfig,
+) -> Option<TcpAoListenerKey> {
+    let tcp_ao = range.tcp_ao.as_ref()?;
+    let (peer, prefix_len) = config::effective_prefix_str(&range.prefix)?;
+    if listen_addr.is_ipv4() != peer.is_ipv4() {
+        return None;
+    }
+    Some(TcpAoListenerKey {
+        peer,
+        prefix_len,
+        config: TransportTcpAoConfig {
+            key: tcp_ao.key.clone(),
+            send_id: tcp_ao.send_id,
+            recv_id: tcp_ao.recv_id,
+            algorithm: TcpAoAlgorithm::from_linux_name(&tcp_ao.algorithm)
+                .expect("validated in Config::load"),
+            preferred: tcp_ao.preferred,
+            deprecated: tcp_ao.deprecated,
+        },
     })
 }
 
@@ -2813,6 +2841,12 @@ async fn run<T>(
         tcp_ao_keys: peer_configs
             .iter()
             .filter_map(|neighbor| tcp_ao_listener_key_for_neighbor(listen_addr, neighbor))
+            .chain(
+                config
+                    .dynamic_neighbors
+                    .iter()
+                    .filter_map(|range| tcp_ao_listener_key_for_dynamic_range(listen_addr, range)),
+            )
             .collect(),
     };
 

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -182,6 +182,17 @@ impl PeerManager {
         }
 
         let key = crate::config::effective_prefix(addr, prefix_len);
+        if self.current_config.dynamic_neighbors.iter().any(|range| {
+            range.tcp_ao.is_some()
+                && crate::config::effective_prefix_str(&range.prefix)
+                    .is_some_and(|protected| dynamic_prefixes_intersect(key, protected))
+        }) {
+            return Err(DynamicRangeError::Invalid(format!(
+                "dynamic range {}/{} overlaps a startup-pinned TCP-AO range; restart \
+                 rustbgpd with an updated configuration instead",
+                key.0, key.1
+            )));
+        }
         if self
             .dynamic_ranges
             .iter()
@@ -207,6 +218,7 @@ impl PeerManager {
                 peer_group,
                 remote_asn,
                 description,
+                tcp_ao: None,
             });
         Ok(())
     }
@@ -225,6 +237,16 @@ impl PeerManager {
         let (addr, prefix_len) =
             parse_dynamic_prefix(prefix).map_err(DynamicRangeError::Invalid)?;
         let key = crate::config::effective_prefix(addr, prefix_len);
+
+        if self.current_config.dynamic_neighbors.iter().any(|range| {
+            range.tcp_ao.is_some()
+                && crate::config::effective_prefix_str(&range.prefix) == Some(key)
+        }) {
+            return Err(DynamicRangeError::Invalid(format!(
+                "dynamic TCP-AO range {}/{} is startup-pinned; restart rustbgpd to remove it",
+                key.0, key.1
+            )));
+        }
 
         // Snapshot the config entry being removed (owned) before mutating, so
         // rollback can restore the exact range. dynamic_ranges and
@@ -408,6 +430,12 @@ impl PeerManager {
             "restored dead-lettered hot-apply intent on dynamic peer re-establishment"
         );
     }
+}
+
+fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
+    let min_len = left.1.min(right.1);
+    crate::config::effective_prefix(left.0, min_len).0
+        == crate::config::effective_prefix(right.0, min_len).0
 }
 
 #[cfg(test)]

--- a/src/peer_manager/dynamic.rs
+++ b/src/peer_manager/dynamic.rs
@@ -184,8 +184,9 @@ impl PeerManager {
         let key = crate::config::effective_prefix(addr, prefix_len);
         if self.current_config.dynamic_neighbors.iter().any(|range| {
             range.tcp_ao.is_some()
-                && crate::config::effective_prefix_str(&range.prefix)
-                    .is_some_and(|protected| dynamic_prefixes_intersect(key, protected))
+                && crate::config::effective_prefix_str(&range.prefix).is_some_and(|protected| {
+                    crate::config::dynamic_prefixes_intersect(key, protected)
+                })
         }) {
             return Err(DynamicRangeError::Invalid(format!(
                 "dynamic range {}/{} overlaps a startup-pinned TCP-AO range; restart \
@@ -430,12 +431,6 @@ impl PeerManager {
             "restored dead-lettered hot-apply intent on dynamic peer re-establishment"
         );
     }
-}
-
-fn dynamic_prefixes_intersect(left: (IpAddr, u8), right: (IpAddr, u8)) -> bool {
-    let min_len = left.1.min(right.1);
-    crate::config::effective_prefix(left.0, min_len).0
-        == crate::config::effective_prefix(right.0, min_len).0
 }
 
 #[cfg(test)]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -241,6 +241,7 @@ fn make_dynamic_manager_config() -> Config {
             peer_group: "ix-members".to_string(),
             remote_asn: 0,
             description: Some("ix-auto".to_string()),
+            tcp_ao: None,
         }],
         rpki: None,
         bmp: None,
@@ -334,6 +335,33 @@ fn add_dynamic_range_rejects_unknown_peer_group() {
     );
 }
 
+fn test_tcp_ao() -> crate::config::TcpAoConfig {
+    crate::config::TcpAoConfig {
+        key: "secret".to_string(),
+        send_id: 1,
+        recv_id: 1,
+        algorithm: "hmac(sha256)".to_string(),
+        preferred: false,
+        deprecated: false,
+    }
+}
+
+#[test]
+fn runtime_dynamic_crud_rejects_startup_pinned_tcp_ao_ranges_and_overlaps() {
+    let mut mgr = dynamic_test_manager();
+    mgr.current_config.dynamic_neighbors[0].tcp_ao = Some(test_tcp_ao());
+
+    let add_err = mgr
+        .add_dynamic_range("127.0.1.0/24".into(), "ix-members".into(), 0, None)
+        .expect_err("runtime add overlapping protected prefix must fail");
+    assert!(add_err.to_string().contains("startup-pinned TCP-AO"));
+
+    let delete_err = mgr
+        .delete_dynamic_range("127.0.0.0/8")
+        .expect_err("runtime delete of protected prefix must fail");
+    assert!(delete_err.to_string().contains("startup-pinned"));
+}
+
 #[test]
 fn delete_dynamic_range_removes_and_stops_future_match() {
     let mut mgr = dynamic_test_manager();
@@ -385,6 +413,7 @@ async fn replace_config_snapshot_rebuilds_dynamic_range_matcher() {
         peer_group: "ix-members".to_string(),
         remote_asn: 65010,
         description: Some("reload range".to_string()),
+        tcp_ao: None,
     }];
 
     let manager = PeerManager::new_with_config(
@@ -437,6 +466,7 @@ async fn stage_config_snapshot_rebuilds_matcher_and_returns_previous_toml() {
         peer_group: "ix-members".to_string(),
         remote_asn: 65020,
         description: Some("transaction range".to_string()),
+        tcp_ao: None,
     }];
     let candidate_toml = toml::to_string_pretty(&replacement).unwrap();
 
@@ -494,6 +524,7 @@ async fn staged_snapshot_fences_dynamic_accept_and_restore_reaps_candidate_dynam
         peer_group: "ix-members".to_string(),
         remote_asn: 0,
         description: Some("candidate-only".to_string()),
+        tcp_ao: None,
     }];
     let candidate_toml = toml::to_string_pretty(&candidate).unwrap();
 
@@ -606,6 +637,7 @@ async fn runtime_config_snapshot_returns_current_staged_config() {
         peer_group: "ix-members".to_string(),
         remote_asn: 65030,
         description: Some("transaction range".to_string()),
+        tcp_ao: None,
     }];
     let candidate_toml = toml::to_string_pretty(&replacement).unwrap();
 
@@ -1548,6 +1580,7 @@ async fn rollback_reap_keeps_dynamic_peer_for_host_bit_range_prefix() {
         peer_group: "ix-members".to_string(),
         remote_asn: 0,
         description: Some("host-bit range".to_string()),
+        tcp_ao: None,
     }];
     mgr.dynamic_ranges = PeerManager::parse_dynamic_ranges(&config);
     assert_eq!(
@@ -8468,12 +8501,14 @@ async fn dynamic_inbound_peer_records_most_specific_accepted_range() {
             peer_group: "ix-members".to_string(),
             remote_asn: 0,
             description: Some("wide".to_string()),
+            tcp_ao: None,
         },
         crate::config::DynamicNeighborConfig {
             prefix: "127.0.0.9/24".to_string(),
             peer_group: "narrow-members".to_string(),
             remote_asn: 0,
             description: Some("narrow".to_string()),
+            tcp_ao: None,
         },
     ];
     let mut mgr = PeerManager::new_with_config(
@@ -8531,6 +8566,7 @@ async fn inbound_link_local_is_not_accepted_as_dynamic_peer() {
         peer_group: "ix-members".to_string(),
         remote_asn: 0,
         description: Some("ll-auto".to_string()),
+        tcp_ao: None,
     }];
     let mut mgr = PeerManager::new_with_config(
         rx,

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -493,6 +493,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                         peer_group: peer_group.clone(),
                         remote_asn: *remote_asn,
                         description: description.clone(),
+                        tcp_ao: None,
                     });
             }
         }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -667,7 +667,7 @@ pub(crate) async fn reload_config(
         );
     }
 
-    let pinned_dynamic_tcp_ao = pin_dynamic_tcp_ao_startup_only(&mut new_config, current);
+    let pinned_dynamic_tcp_ao = config::pin_dynamic_tcp_ao_startup_only(&mut new_config, current);
     if pinned_dynamic_tcp_ao > 0 {
         error!(
             ranges = pinned_dynamic_tcp_ao,
@@ -1763,48 +1763,6 @@ pub(crate) async fn reload_config(
 
     info!("config reload complete");
     Some(ReloadedConfig::new(working_config, desired_config))
-}
-
-fn pin_dynamic_tcp_ao_startup_only(
-    new_config: &mut config::Config,
-    current: &config::Config,
-) -> usize {
-    let current_protected: Vec<_> = current
-        .dynamic_neighbors
-        .iter()
-        .filter(|range| range.tcp_ao.is_some())
-        .cloned()
-        .collect();
-    let new_protected: Vec<_> = new_config
-        .dynamic_neighbors
-        .iter()
-        .filter(|range| range.tcp_ao.is_some())
-        .cloned()
-        .collect();
-    if current_protected == new_protected {
-        return 0;
-    }
-
-    let current_prefixes: Vec<_> = current_protected
-        .iter()
-        .filter_map(|range| config::effective_prefix_str(&range.prefix))
-        .collect();
-    new_config.dynamic_neighbors.retain(|range| {
-        let Some(prefix) = config::effective_prefix_str(&range.prefix) else {
-            return true;
-        };
-        !current_prefixes
-            .iter()
-            .any(|protected| reload_prefixes_intersect(prefix, *protected))
-            && range.tcp_ao.is_none()
-    });
-    new_config.dynamic_neighbors.extend(current_protected);
-    new_protected.len().max(current_prefixes.len())
-}
-
-fn reload_prefixes_intersect(left: (std::net::IpAddr, u8), right: (std::net::IpAddr, u8)) -> bool {
-    let min_len = left.1.min(right.1);
-    config::effective_prefix(left.0, min_len).0 == config::effective_prefix(right.0, min_len).0
 }
 
 /// Halt a SIGHUP reload at the first failed step. Logs the failure
@@ -4635,7 +4593,10 @@ tcp_ao = {{ key = "{key}", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" 
         )
         .unwrap();
 
-        assert_eq!(pin_dynamic_tcp_ao_startup_only(&mut candidate, &current), 1);
+        assert_eq!(
+            config::pin_dynamic_tcp_ao_startup_only(&mut candidate, &current),
+            1
+        );
         assert_eq!(candidate.dynamic_neighbors.len(), 2);
         let protected = candidate
             .dynamic_neighbors

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -4676,6 +4676,15 @@ peer_group = "dynamic"
 
         for (label, ranges, expected) in [
             (
+                "equivalent host bits",
+                vec![
+                    ("192.0.2.1/24", "one"),
+                    ("198.51.100.0/24", "two"),
+                    ("203.0.113.0/24", "three"),
+                ],
+                0,
+            ),
+            (
                 "reorder",
                 vec![
                     ("203.0.113.0/24", "three"),
@@ -4720,6 +4729,8 @@ peer_group = "dynamic"
                     candidate.dynamic_neighbors, current.dynamic_neighbors,
                     "{label}"
                 );
+            } else if label == "equivalent host bits" {
+                assert_eq!(candidate.dynamic_neighbors[0].prefix, "192.0.2.1/24");
             }
         }
     }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -667,6 +667,16 @@ pub(crate) async fn reload_config(
         );
     }
 
+    let pinned_dynamic_tcp_ao = pin_dynamic_tcp_ao_startup_only(&mut new_config, current);
+    if pinned_dynamic_tcp_ao > 0 {
+        error!(
+            ranges = pinned_dynamic_tcp_ao,
+            "[[dynamic_neighbors]].tcp_ao differs from the live listener prefix MKTs: \
+             protected ranges and overlapping replacements remain pinned to the startup \
+             snapshot. Restart rustbgpd to add, remove, move, or rotate a dynamic TCP-AO key."
+        );
+    }
+
     if config::pin_bfd_startup_only_runtime(&mut new_config, current) {
         error!(
             "BFD config differs from the live session set: the ADR-0067 BFD actor \
@@ -1753,6 +1763,48 @@ pub(crate) async fn reload_config(
 
     info!("config reload complete");
     Some(ReloadedConfig::new(working_config, desired_config))
+}
+
+fn pin_dynamic_tcp_ao_startup_only(
+    new_config: &mut config::Config,
+    current: &config::Config,
+) -> usize {
+    let current_protected: Vec<_> = current
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .cloned()
+        .collect();
+    let new_protected: Vec<_> = new_config
+        .dynamic_neighbors
+        .iter()
+        .filter(|range| range.tcp_ao.is_some())
+        .cloned()
+        .collect();
+    if current_protected == new_protected {
+        return 0;
+    }
+
+    let current_prefixes: Vec<_> = current_protected
+        .iter()
+        .filter_map(|range| config::effective_prefix_str(&range.prefix))
+        .collect();
+    new_config.dynamic_neighbors.retain(|range| {
+        let Some(prefix) = config::effective_prefix_str(&range.prefix) else {
+            return true;
+        };
+        !current_prefixes
+            .iter()
+            .any(|protected| reload_prefixes_intersect(prefix, *protected))
+            && range.tcp_ao.is_none()
+    });
+    new_config.dynamic_neighbors.extend(current_protected);
+    new_protected.len().max(current_prefixes.len())
+}
+
+fn reload_prefixes_intersect(left: (std::net::IpAddr, u8), right: (std::net::IpAddr, u8)) -> bool {
+    let min_len = left.1.min(right.1);
+    config::effective_prefix(left.0, min_len).0 == config::effective_prefix(right.0, min_len).0
 }
 
 /// Halt a SIGHUP reload at the first failed step. Logs the failure
@@ -4549,6 +4601,53 @@ hold_time = 90
             returned.desired.neighbors[0].tcp_ao.as_ref().unwrap().key,
             "new-secret",
             "desired TOML must preserve the operator's edit for restart"
+        );
+    }
+
+    #[test]
+    fn reload_pins_dynamic_tcp_ao_range_and_allows_disjoint_unprotected_edit() {
+        let base = |key: &str, extra: &str| {
+            format!(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+[peer_groups.dynamic]
+hold_time = 90
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "dynamic"
+tcp_ao = {{ key = "{key}", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }}
+{extra}
+"#
+            )
+        };
+        let current = config::Config::load_toml_with_diagnostics(&base("old", ""), "old").unwrap();
+        let mut candidate = config::Config::load_toml_with_diagnostics(
+            &base(
+                "new",
+                "[[dynamic_neighbors]]\nprefix = \"192.0.2.0/24\"\npeer_group = \"dynamic\"",
+            ),
+            "new",
+        )
+        .unwrap();
+
+        assert_eq!(pin_dynamic_tcp_ao_startup_only(&mut candidate, &current), 1);
+        assert_eq!(candidate.dynamic_neighbors.len(), 2);
+        let protected = candidate
+            .dynamic_neighbors
+            .iter()
+            .find(|range| range.tcp_ao.is_some())
+            .unwrap();
+        assert_eq!(protected.tcp_ao.as_ref().unwrap().key, "old");
+        assert!(
+            candidate
+                .dynamic_neighbors
+                .iter()
+                .any(|range| range.prefix == "192.0.2.0/24")
         );
     }
 

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1797,6 +1797,7 @@ fn halt_partial(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -4647,6 +4648,80 @@ peer_group = "dynamic"
             1
         );
         assert_eq!(candidate.dynamic_neighbors, current.dynamic_neighbors);
+    }
+
+    #[test]
+    fn dynamic_tcp_ao_pin_count_reports_only_affected_ranges() {
+        let config = |ranges: &[(&str, &str)]| {
+            let ranges = ranges.iter().fold(String::new(), |mut output, (prefix, key)| {
+                write!(
+                    output,
+                    "[[dynamic_neighbors]]\nprefix = \"{prefix}\"\npeer_group = \"dynamic\"\ntcp_ao = {{ key = \"{key}\", send_id = 1, recv_id = 2, algorithm = \"hmac(sha256)\" }}\n"
+                )
+                .expect("writing to a String cannot fail");
+                output
+            });
+            format!(
+                "[global]\nasn = 65001\nrouter_id = \"10.0.0.1\"\nlisten_port = 179\n[global.telemetry]\nlog_format = \"json\"\n[peer_groups.dynamic]\nhold_time = 90\n{ranges}"
+            )
+        };
+        let load = |ranges: &[(&str, &str)]| {
+            config::Config::load_toml_with_diagnostics(&config(ranges), "test").unwrap()
+        };
+        let current = load(&[
+            ("192.0.2.0/24", "one"),
+            ("198.51.100.0/24", "two"),
+            ("203.0.113.0/24", "three"),
+        ]);
+
+        for (label, ranges, expected) in [
+            (
+                "reorder",
+                vec![
+                    ("203.0.113.0/24", "three"),
+                    ("192.0.2.0/24", "one"),
+                    ("198.51.100.0/24", "two"),
+                ],
+                0,
+            ),
+            (
+                "rotate subset",
+                vec![
+                    ("192.0.2.0/24", "one"),
+                    ("198.51.100.0/24", "changed"),
+                    ("203.0.113.0/24", "three"),
+                ],
+                1,
+            ),
+            (
+                "remove",
+                vec![("192.0.2.0/24", "one"), ("198.51.100.0/24", "two")],
+                1,
+            ),
+            (
+                "add",
+                vec![
+                    ("192.0.2.0/24", "one"),
+                    ("198.51.100.0/24", "two"),
+                    ("203.0.113.0/24", "three"),
+                    ("10.0.0.0/24", "four"),
+                ],
+                1,
+            ),
+        ] {
+            let mut candidate = load(&ranges);
+            assert_eq!(
+                config::pin_dynamic_tcp_ao_startup_only(&mut candidate, &current),
+                expected,
+                "{label}"
+            );
+            if expected > 0 {
+                assert_eq!(
+                    candidate.dynamic_neighbors, current.dynamic_neighbors,
+                    "{label}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -4612,6 +4612,43 @@ tcp_ao = {{ key = "{key}", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" 
         );
     }
 
+    #[test]
+    fn reload_pins_dynamic_tcp_ao_range_without_reordering_unchanged_ranges() {
+        let config = |key: &str| {
+            format!(
+                r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+[global.telemetry]
+log_format = "json"
+[peer_groups.dynamic]
+hold_time = 90
+[[dynamic_neighbors]]
+prefix = "192.0.2.0/24"
+peer_group = "dynamic"
+[[dynamic_neighbors]]
+prefix = "10.0.0.0/24"
+peer_group = "dynamic"
+tcp_ao = {{ key = "{key}", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)" }}
+[[dynamic_neighbors]]
+prefix = "198.51.100.0/24"
+peer_group = "dynamic"
+"#
+            )
+        };
+        let current = config::Config::load_toml_with_diagnostics(&config("old"), "old").unwrap();
+        let mut candidate =
+            config::Config::load_toml_with_diagnostics(&config("new"), "new").unwrap();
+
+        assert_eq!(
+            config::pin_dynamic_tcp_ao_startup_only(&mut candidate, &current),
+            1
+        );
+        assert_eq!(candidate.dynamic_neighbors, current.dynamic_neighbors);
+    }
+
     #[tokio::test]
     async fn reload_pins_tcp_ao_dependency_edits_to_startup_snapshot() {
         let initial = r#"


### PR DESCRIPTION
## Summary

- add direct, startup-only `tcp_ao` configuration for dynamic-neighbor prefixes
- install IPv4/IPv6 prefix MKTs before the listener starts and fail closed when protected accepted sockets lack consistent TCP-AO state
- reject ambiguous static/dynamic authentication overlaps, inherited MD5, runtime CRUD, and config transactions that would diverge from startup listener keys
- keep mixed SIGHUP edits truthful by pinning protected ranges while applying and reporting disjoint unprotected changes
- document the security, reload, API, and operational boundaries

## Verification

- live Linux TCP-AO receipt: signed in-range accepted, unsigned in-range rejected, unsigned out-of-range accepted
- focused transport, config, reload, transaction, CRUD, schema, and secret-redaction tests
- `cargo test --workspace`
- workspace all-target Clippy with warnings denied
- Rust 1.95 workspace all-target check
- workspace rustdoc with warnings denied
- repository commit hooks and `git diff --check`

Runtime key rotation and listener MKT mutation remain deferred to #159.

Closes #158
