### PR TITLE
feat(api): rotate management credentials without restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Management-plane credentials rotate atomically on SIGHUP.** Bearer tokens,
+  mTLS server identity, and client CA material behind unchanged configured paths
+  are staged for every gRPC/gNMI listener and published as one immutable
+  process-wide generation. New RPCs on an existing HTTP/2 connection use the
+  new bearer token; existing streams survive. New TLS accepts use the new
+  identity/CA while established TLS connections survive. Invalid or partial
+  material preserves the complete last-known-good generation, and confirmed
+  config transactions fence reload through the existing runtime lock. Listener
+  shape, paths, authorization roles, and access policy remain restart-required.
+  A bounded success/failure metric and redacted logs expose outcomes. (LAN-359)
+
 ### Fixed
 
 - **EVPN load generation validates unsafe workloads and honors exact event

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,6 @@ dependencies = [
  "rustbgpd-telemetry",
  "rustbgpd-transport",
  "rustbgpd-wire",
- "rustls-pemfile",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -3115,15 +3114,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,7 @@ version = "0.51.0"
 dependencies = [
  "arc-swap",
  "bytes",
+ "futures",
  "prometheus",
  "prost",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
 name = "rustbgpd-api"
 version = "0.51.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "prometheus",
  "prost",
@@ -2836,6 +2837,7 @@ dependencies = [
  "rustbgpd-telemetry",
  "rustbgpd-transport",
  "rustbgpd-wire",
+ "rustls-pemfile",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -3112,6 +3114,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ socket2 = { version = "0.6", features = ["all"] }
 nix = { version = "0.31", features = ["socket", "net", "uio"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+rustls-pemfile = "2"
 axum = "0.8"
 tower = "0.5"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ socket2 = { version = "0.6", features = ["all"] }
 nix = { version = "0.31", features = ["socket", "net", "uio"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-rustls-pemfile = "2"
 axum = "0.8"
 tower = "0.5"
 libc = "0.2"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -32,6 +32,7 @@ tokio-stream.workspace = true
 tokio-rustls.workspace = true
 rustls-pemfile.workspace = true
 arc-swap.workspace = true
+futures = "0.3"
 prometheus.workspace = true
 bytes.workspace = true
 x509-parser.workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -29,6 +29,9 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true
+tokio-rustls.workspace = true
+rustls-pemfile.workspace = true
+arc-swap.workspace = true
 prometheus.workspace = true
 bytes.workspace = true
 x509-parser.workspace = true
@@ -40,5 +43,4 @@ protoc-bin-vendored = "3"
 
 [dev-dependencies]
 rcgen.workspace = true
-tokio-rustls.workspace = true
 tempfile.workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -30,7 +30,6 @@ tracing.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true
 tokio-rustls.workspace = true
-rustls-pemfile.workspace = true
 arc-swap.workspace = true
 futures = "0.3"
 prometheus.workspace = true

--- a/crates/api/src/authz_runtime/context.rs
+++ b/crates/api/src/authz_runtime/context.rs
@@ -177,7 +177,7 @@ impl GrpcAuthAuditContext {
             .map_or("unmapped", |role| role.as_str())
     }
 
-    pub(super) fn principal_for_extensions<'a>(
+    pub(crate) fn principal_for_extensions<'a>(
         &'a self,
         extensions: &http::Extensions,
     ) -> Cow<'a, str> {

--- a/crates/api/src/authz_runtime/context.rs
+++ b/crates/api/src/authz_runtime/context.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
 use crate::connect_info::RustbgpdTcpConnectInfo;
+use crate::credentials::{CredentialStore, PinnedCredentialGeneration};
 
 use super::decision::RoleDenial;
 
@@ -52,6 +53,7 @@ pub struct GrpcAuthAuditContext {
     roles: Arc<BTreeMap<String, PrincipalRole>>,
     resolve_mtls_principal: bool,
     expected_bearer_header: Option<BearerAuthSecret>,
+    dynamic_bearer: Option<(CredentialStore, usize)>,
 }
 
 impl GrpcAuthAuditContext {
@@ -74,6 +76,7 @@ impl GrpcAuthAuditContext {
             roles: Arc::new(BTreeMap::new()),
             resolve_mtls_principal: false,
             expected_bearer_header: None,
+            dynamic_bearer: None,
         }
     }
 
@@ -103,6 +106,12 @@ impl GrpcAuthAuditContext {
         self
     }
 
+    #[must_use]
+    pub fn with_dynamic_bearer(mut self, store: CredentialStore, listener: usize) -> Self {
+        self.dynamic_bearer = Some((store, listener));
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn authn(&self) -> GrpcAuthnKind {
         self.authn
@@ -118,7 +127,30 @@ impl GrpcAuthAuditContext {
         self.max_tier
     }
 
-    pub(super) fn bearer_auth_error(&self, headers: &http::HeaderMap) -> Option<Status> {
+    pub(super) fn pin_credentials(&self, extensions: &mut http::Extensions) {
+        if let Some((store, listener)) = &self.dynamic_bearer {
+            extensions.insert(PinnedCredentialGeneration::new(store.load(), *listener));
+        }
+    }
+
+    pub(super) fn bearer_auth_error(
+        &self,
+        headers: &http::HeaderMap,
+        extensions: &http::Extensions,
+    ) -> Option<Status> {
+        if let Some(pinned) = extensions.get::<PinnedCredentialGeneration>() {
+            return pinned
+                .bearer()
+                .and_then(|expected| expected.auth_error_from_http_headers(headers));
+        }
+        if let Some((store, listener)) = &self.dynamic_bearer {
+            let generation = store.load();
+            return generation
+                .listener(*listener)
+                .bearer
+                .as_ref()
+                .and_then(|expected| expected.auth_error_from_http_headers(headers));
+        }
         let expected = self.expected_bearer_header.as_ref()?;
         expected.auth_error_from_http_headers(headers)
     }
@@ -170,6 +202,14 @@ impl GrpcAuthAuditContext {
 fn mtls_principal_from_extensions(
     extensions: &http::Extensions,
 ) -> Result<String, PrincipalExtractionError> {
+    if let Some(info) = extensions.get::<RustbgpdTcpConnectInfo>() {
+        let certs = info
+            .peer_certs()
+            .ok_or(PrincipalExtractionError::MissingPeerCertificate)?;
+        return info
+            .mtls_principal(certs)
+            .map(|principal| principal.to_string());
+    }
     if let Some(connect_info) = extensions.get::<TlsConnectInfo<RustbgpdTcpConnectInfo>>() {
         let certs = connect_info
             .peer_certs()

--- a/crates/api/src/authz_runtime/layer.rs
+++ b/crates/api/src/authz_runtime/layer.rs
@@ -65,6 +65,7 @@ where
     }
 
     fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        self.context.pin_credentials(req.extensions_mut());
         let path = req.uri().path().to_string();
         let lookup = audit_lookup_for_path(&path);
         let decision = lookup.decision;
@@ -74,7 +75,10 @@ where
             // over-cap bearer-token request, authenticate first so
             // invalid callers still receive UNAUTHENTICATED instead of
             // learning listener tier details via PERMISSION_DENIED.
-            if let Some(status) = self.context.bearer_auth_error(req.headers()) {
+            if let Some(status) = self
+                .context
+                .bearer_auth_error(req.headers(), req.extensions())
+            {
                 record_audit_decision(
                     &path,
                     &lookup,
@@ -105,7 +109,10 @@ where
             return Box::pin(async move { Ok(response) });
         }
         if let Some(denial) = self.context.role_denial(principal.as_ref(), decision.tier) {
-            if let Some(status) = self.context.bearer_auth_error(req.headers()) {
+            if let Some(status) = self
+                .context
+                .bearer_auth_error(req.headers(), req.extensions())
+            {
                 record_audit_decision(
                     &path,
                     &lookup,

--- a/crates/api/src/connect_info.rs
+++ b/crates/api/src/connect_info.rs
@@ -7,6 +7,8 @@ use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
+use tokio_rustls::rustls::pki_types::CertificateDer;
+use tokio_rustls::server::TlsStream;
 use tonic::transport::server::Connected;
 
 use crate::authz_principal::{PrincipalExtractionError, principal_from_peer_certs};
@@ -38,12 +40,14 @@ impl MtlsPrincipalCache {
 #[derive(Clone, Debug)]
 pub(crate) struct RustbgpdTcpConnectInfo {
     mtls_principal: MtlsPrincipalCache,
+    peer_certs: Option<Arc<[CertificateDer<'static>]>>,
 }
 
 impl RustbgpdTcpConnectInfo {
     fn new() -> Self {
         Self {
             mtls_principal: MtlsPrincipalCache::default(),
+            peer_certs: None,
         }
     }
 
@@ -56,20 +60,49 @@ impl RustbgpdTcpConnectInfo {
     {
         self.mtls_principal.resolve(certs)
     }
+
+    pub(crate) fn peer_certs(&self) -> Option<&[CertificateDer<'static>]> {
+        self.peer_certs.as_deref()
+    }
 }
 
 /// TCP stream wrapper that carries rustbgpd-specific connect info through
 /// tonic's `Connected` extension path.
 #[derive(Debug)]
 pub(crate) struct RustbgpdTcpStream {
-    inner: TcpStream,
+    inner: RustbgpdTcpStreamInner,
     info: RustbgpdTcpConnectInfo,
+}
+
+#[derive(Debug)]
+enum RustbgpdTcpStreamInner {
+    Plain(TcpStream),
+    Tls(Box<TlsStream<TcpStream>>),
 }
 
 impl RustbgpdTcpStream {
     pub(crate) fn new(inner: TcpStream) -> Self {
         let info = RustbgpdTcpConnectInfo::new();
-        Self { inner, info }
+        Self {
+            inner: RustbgpdTcpStreamInner::Plain(inner),
+            info,
+        }
+    }
+
+    pub(crate) fn from_tls(inner: TlsStream<TcpStream>) -> Self {
+        let peer_certs = inner
+            .get_ref()
+            .1
+            .peer_certificates()
+            .map(|certs| Arc::<[CertificateDer<'static>]>::from(certs.to_vec()));
+        let info = RustbgpdTcpConnectInfo {
+            mtls_principal: MtlsPrincipalCache::default(),
+            peer_certs,
+        };
+        Self {
+            inner: RustbgpdTcpStreamInner::Tls(Box::new(inner)),
+            info,
+        }
     }
 }
 
@@ -87,7 +120,10 @@ impl AsyncRead for RustbgpdTcpStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_read(cx, buf)
+        match &mut self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            RustbgpdTcpStreamInner::Tls(s) => Pin::new(s).poll_read(cx, buf),
+        }
     }
 }
 
@@ -97,19 +133,31 @@ impl AsyncWrite for RustbgpdTcpStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
+        match &mut self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            RustbgpdTcpStreamInner::Tls(s) => Pin::new(s).poll_write(cx, buf),
+        }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
+        match &mut self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => Pin::new(s).poll_flush(cx),
+            RustbgpdTcpStreamInner::Tls(s) => Pin::new(s).poll_flush(cx),
+        }
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+        match &mut self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            RustbgpdTcpStreamInner::Tls(s) => Pin::new(s).poll_shutdown(cx),
+        }
     }
 
     fn is_write_vectored(&self) -> bool {
-        self.inner.is_write_vectored()
+        match &self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => s.is_write_vectored(),
+            RustbgpdTcpStreamInner::Tls(s) => s.is_write_vectored(),
+        }
     }
 
     fn poll_write_vectored(
@@ -117,7 +165,10 @@ impl AsyncWrite for RustbgpdTcpStream {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+        match &mut self.inner {
+            RustbgpdTcpStreamInner::Plain(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            RustbgpdTcpStreamInner::Tls(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+        }
     }
 }
 

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -1,11 +1,11 @@
 //! Atomic management-plane credential generations.
 
 use std::fs;
-use std::io::{BufReader, Cursor};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
@@ -196,7 +196,7 @@ fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, Stri
     let cert_bytes = read_file(index, "certificate", &source.cert_file)?;
     let key_bytes = read_file(index, "private key", &source.key_file)?;
     let ca_bytes = read_file(index, "client CA", &source.client_ca_file)?;
-    let certs = rustls_pemfile::certs(&mut BufReader::new(Cursor::new(cert_bytes)))
+    let certs = CertificateDer::pem_slice_iter(&cert_bytes)
         .collect::<Result<Vec<CertificateDer<'static>>, _>>()
         .map_err(|e| format!("listener {index}: invalid certificate PEM: {e}"))?;
     if certs.is_empty() {
@@ -204,11 +204,9 @@ fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, Stri
             "listener {index}: certificate PEM contains no certificates"
         ));
     }
-    let key: PrivateKeyDer<'static> =
-        rustls_pemfile::private_key(&mut BufReader::new(Cursor::new(key_bytes)))
-            .map_err(|e| format!("listener {index}: invalid private-key PEM: {e}"))?
-            .ok_or_else(|| format!("listener {index}: private-key PEM contains no key"))?;
-    let ca_certs = rustls_pemfile::certs(&mut BufReader::new(Cursor::new(ca_bytes)))
+    let key = PrivateKeyDer::from_pem_slice(&key_bytes)
+        .map_err(|e| format!("listener {index}: invalid private-key PEM: {e}"))?;
+    let ca_certs = CertificateDer::pem_slice_iter(&ca_bytes)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("listener {index}: invalid client-CA PEM: {e}"))?;
     let mut roots = RootCertStore::empty();
@@ -221,10 +219,14 @@ fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, Stri
     let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
         .build()
         .map_err(|e| format!("listener {index}: invalid client-CA verifier: {e}"))?;
-    let config = ServerConfig::builder()
+    let mut config = ServerConfig::builder()
         .with_client_cert_verifier(verifier)
         .with_single_cert(certs, key)
         .map_err(|e| format!("listener {index}: certificate/private-key mismatch: {e}"))?;
+    // tonic's `ServerTlsConfig` advertises HTTP/2 over ALPN; the manual
+    // rustls config must do the same, or ALPN-strict gRPC clients
+    // (grpc-go: gnmic, gobgp) refuse to negotiate h2 on the TLS session.
+    config.alpn_protocols = vec![b"h2".to_vec()];
     Ok(Arc::new(config))
 }
 
@@ -497,6 +499,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let old_server_config = store.load().listener(0).tls.clone().unwrap();
+        assert_eq!(old_server_config.alpn_protocols, vec![b"h2".to_vec()]);
         let old_server = tokio::spawn(async move {
             let (tcp, _) = listener.accept().await.unwrap();
             TlsAcceptor::from(old_server_config)

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -1,0 +1,541 @@
+//! Atomic management-plane credential generations.
+
+use std::fs;
+use std::io::{BufReader, Cursor};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::server::WebPkiClientVerifier;
+use tokio_rustls::rustls::{RootCertStore, ServerConfig};
+
+use crate::authz_runtime::BearerAuthSecret;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CredentialSource {
+    pub token_file: Option<PathBuf>,
+    pub tls: Option<TlsSource>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TlsSource {
+    pub cert_file: PathBuf,
+    pub key_file: PathBuf,
+    pub client_ca_file: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct ListenerCredentials {
+    pub(crate) bearer: Option<BearerAuthSecret>,
+    pub(crate) tls: Option<Arc<ServerConfig>>,
+}
+
+impl std::fmt::Debug for ListenerCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ListenerCredentials")
+            .field("bearer", &self.bearer.is_some())
+            .field("tls", &self.tls.is_some())
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CredentialGeneration {
+    sequence: u64,
+    listeners: Arc<[ListenerCredentials]>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PinnedCredentialGeneration {
+    generation: Arc<CredentialGeneration>,
+    listener: usize,
+}
+
+impl PinnedCredentialGeneration {
+    pub(crate) fn new(generation: Arc<CredentialGeneration>, listener: usize) -> Self {
+        Self {
+            generation,
+            listener,
+        }
+    }
+
+    pub(crate) fn bearer(&self) -> Option<&BearerAuthSecret> {
+        self.generation.listener(self.listener).bearer.as_ref()
+    }
+}
+
+impl CredentialGeneration {
+    #[must_use]
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub(crate) fn listener(&self, index: usize) -> &ListenerCredentials {
+        &self.listeners[index]
+    }
+}
+
+#[derive(Clone)]
+pub struct CredentialStore {
+    sources: Arc<[CredentialSource]>,
+    active: Arc<ArcSwap<CredentialGeneration>>,
+}
+
+impl std::fmt::Debug for CredentialStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialStore")
+            .field("listeners", &self.sources.len())
+            .field("sequence", &self.load().sequence())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for CredentialStore {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.active, &other.active)
+    }
+}
+
+impl Eq for CredentialStore {}
+
+impl CredentialStore {
+    /// Load and validate the initial immutable generation.
+    ///
+    /// # Errors
+    /// Returns a redacted error when any configured file cannot be read or its
+    /// credential material is invalid.
+    pub fn stage(sources: Vec<CredentialSource>) -> Result<Self, String> {
+        let sources: Arc<[CredentialSource]> = sources.into();
+        let generation = Arc::new(stage_generation(&sources, 1)?);
+        Ok(Self {
+            sources,
+            active: Arc::new(ArcSwap::from(generation)),
+        })
+    }
+
+    #[must_use]
+    pub fn load(&self) -> Arc<CredentialGeneration> {
+        self.active.load_full()
+    }
+
+    /// Stage all configured files, then atomically publish one generation.
+    ///
+    /// # Errors
+    /// Returns a redacted error when any listener fails staging. The active
+    /// generation is left unchanged.
+    pub fn reload(&self) -> Result<u64, String> {
+        let sequence = self.load().sequence.saturating_add(1);
+        let candidate = Arc::new(stage_generation(&self.sources, sequence)?);
+        self.active.store(candidate);
+        Ok(sequence)
+    }
+}
+
+fn stage_generation(
+    sources: &[CredentialSource],
+    sequence: u64,
+) -> Result<CredentialGeneration, String> {
+    let listeners = sources
+        .iter()
+        .enumerate()
+        .map(|(index, source)| stage_listener(index, source))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(CredentialGeneration {
+        sequence,
+        listeners: listeners.into(),
+    })
+}
+
+fn stage_listener(index: usize, source: &CredentialSource) -> Result<ListenerCredentials, String> {
+    let bearer = source
+        .token_file
+        .as_ref()
+        .map(|path| {
+            let token = fs::read_to_string(path).map_err(|e| {
+                format!(
+                    "listener {index}: failed to read token file {}: {e}",
+                    path.display()
+                )
+            })?;
+            let token = token.trim_end();
+            if token.is_empty() {
+                return Err(format!(
+                    "listener {index}: token file {} is empty",
+                    path.display()
+                ));
+            }
+            Ok(BearerAuthSecret::from_token(token))
+        })
+        .transpose()?;
+    let tls = source
+        .tls
+        .as_ref()
+        .map(|source| build_tls(index, source))
+        .transpose()?;
+    Ok(ListenerCredentials { bearer, tls })
+}
+
+fn read_file(index: usize, label: &str, path: &Path) -> Result<Vec<u8>, String> {
+    let bytes = fs::read(path).map_err(|e| {
+        format!(
+            "listener {index}: failed to read {label} file {}: {e}",
+            path.display()
+        )
+    })?;
+    if bytes.is_empty() {
+        return Err(format!(
+            "listener {index}: {label} file {} is empty",
+            path.display()
+        ));
+    }
+    Ok(bytes)
+}
+
+fn build_tls(index: usize, source: &TlsSource) -> Result<Arc<ServerConfig>, String> {
+    let cert_bytes = read_file(index, "certificate", &source.cert_file)?;
+    let key_bytes = read_file(index, "private key", &source.key_file)?;
+    let ca_bytes = read_file(index, "client CA", &source.client_ca_file)?;
+    let certs = rustls_pemfile::certs(&mut BufReader::new(Cursor::new(cert_bytes)))
+        .collect::<Result<Vec<CertificateDer<'static>>, _>>()
+        .map_err(|e| format!("listener {index}: invalid certificate PEM: {e}"))?;
+    if certs.is_empty() {
+        return Err(format!(
+            "listener {index}: certificate PEM contains no certificates"
+        ));
+    }
+    let key: PrivateKeyDer<'static> =
+        rustls_pemfile::private_key(&mut BufReader::new(Cursor::new(key_bytes)))
+            .map_err(|e| format!("listener {index}: invalid private-key PEM: {e}"))?
+            .ok_or_else(|| format!("listener {index}: private-key PEM contains no key"))?;
+    let ca_certs = rustls_pemfile::certs(&mut BufReader::new(Cursor::new(ca_bytes)))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("listener {index}: invalid client-CA PEM: {e}"))?;
+    let mut roots = RootCertStore::empty();
+    let (accepted, rejected) = roots.add_parsable_certificates(ca_certs);
+    if accepted == 0 || rejected != 0 {
+        return Err(format!(
+            "listener {index}: client-CA PEM contains invalid certificates"
+        ));
+    }
+    let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+        .build()
+        .map_err(|e| format!("listener {index}: invalid client-CA verifier: {e}"))?;
+    let config = ServerConfig::builder()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .map_err(|e| format!("listener {index}: certificate/private-key mismatch: {e}"))?;
+    Ok(Arc::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, Write};
+    use std::sync::Barrier;
+    use std::thread;
+
+    use rcgen::{
+        BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
+        Issuer, KeyPair, KeyUsagePurpose, SanType,
+    };
+    use tempfile::NamedTempFile;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_rustls::rustls::ClientConfig;
+    use tokio_rustls::{TlsAcceptor, TlsConnector};
+    use tonic::metadata::MetadataMap;
+
+    use super::*;
+
+    fn token_file(value: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(value.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn metadata(token: &str) -> MetadataMap {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("authorization", format!("Bearer {token}").parse().unwrap());
+        metadata
+    }
+
+    struct TlsBundle {
+        ca_pem: String,
+        server_pem: String,
+        server_key_pem: String,
+        client: Arc<ClientConfig>,
+    }
+
+    fn signed_leaf(
+        issuer: &Issuer<'static, KeyPair>,
+        name: &str,
+        eku: ExtendedKeyUsagePurpose,
+    ) -> (Certificate, KeyPair) {
+        let mut params = CertificateParams::new(Vec::new()).unwrap();
+        params.subject_alt_names = vec![SanType::DnsName("localhost".try_into().unwrap())];
+        params.distinguished_name.push(DnType::CommonName, name);
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+        params.extended_key_usages.push(eku);
+        let key = KeyPair::generate().unwrap();
+        (params.signed_by(&key, issuer).unwrap(), key)
+    }
+
+    fn tls_bundle(name: &str) -> TlsBundle {
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+        let mut params = CertificateParams::new(Vec::new()).unwrap();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params
+            .distinguished_name
+            .push(DnType::CommonName, format!("{name} CA"));
+        params.key_usages.extend([
+            KeyUsagePurpose::DigitalSignature,
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+        ]);
+        let ca_key = KeyPair::generate().unwrap();
+        let ca = params.self_signed(&ca_key).unwrap();
+        let issuer = Issuer::new(params, ca_key);
+        let (server, server_key) = signed_leaf(&issuer, name, ExtendedKeyUsagePurpose::ServerAuth);
+        let (client, client_key) = signed_leaf(&issuer, name, ExtendedKeyUsagePurpose::ClientAuth);
+        let mut roots = RootCertStore::empty();
+        roots.add(ca.der().clone()).unwrap();
+        let client_config = ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_client_auth_cert(
+                vec![client.der().clone()],
+                PrivateKeyDer::Pkcs8(client_key.serialize_der().into()),
+            )
+            .unwrap();
+        TlsBundle {
+            ca_pem: ca.pem(),
+            server_pem: server.pem(),
+            server_key_pem: server_key.serialize_pem(),
+            client: Arc::new(client_config),
+        }
+    }
+
+    fn overwrite(file: &mut NamedTempFile, bytes: &[u8]) {
+        file.as_file_mut().set_len(0).unwrap();
+        file.rewind().unwrap();
+        file.write_all(bytes).unwrap();
+        file.flush().unwrap();
+    }
+
+    async fn connect(
+        config: Arc<ClientConfig>,
+        addr: std::net::SocketAddr,
+    ) -> std::io::Result<tokio_rustls::client::TlsStream<TcpStream>> {
+        let stream = TcpStream::connect(addr).await.unwrap();
+        TlsConnector::from(config)
+            .connect("localhost".to_string().try_into().unwrap(), stream)
+            .await
+    }
+
+    #[test]
+    fn bearer_reload_is_new_rpc_visible_and_old_snapshot_survives() {
+        let mut token = token_file("old\n");
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: Some(token.path().to_path_buf()),
+            tls: None,
+        }])
+        .unwrap();
+        let old_generation = store.load();
+        old_generation
+            .listener(0)
+            .bearer
+            .as_ref()
+            .unwrap()
+            .authenticate_metadata(&metadata("old"))
+            .unwrap();
+
+        token.as_file_mut().set_len(0).unwrap();
+        token.rewind().unwrap();
+        token.write_all(b"new\n").unwrap();
+        token.flush().unwrap();
+        assert_eq!(store.reload().unwrap(), 2);
+
+        let new_generation = store.load();
+        assert!(
+            new_generation
+                .listener(0)
+                .bearer
+                .as_ref()
+                .unwrap()
+                .authenticate_metadata(&metadata("old"))
+                .is_err()
+        );
+        new_generation
+            .listener(0)
+            .bearer
+            .as_ref()
+            .unwrap()
+            .authenticate_metadata(&metadata("new"))
+            .unwrap();
+        old_generation
+            .listener(0)
+            .bearer
+            .as_ref()
+            .unwrap()
+            .authenticate_metadata(&metadata("old"))
+            .unwrap();
+    }
+
+    #[test]
+    fn partial_stage_failure_preserves_complete_last_known_good() {
+        let mut first = token_file("first-old");
+        let mut second = token_file("second-old");
+        let store = CredentialStore::stage(vec![
+            CredentialSource {
+                token_file: Some(first.path().to_path_buf()),
+                tls: None,
+            },
+            CredentialSource {
+                token_file: Some(second.path().to_path_buf()),
+                tls: None,
+            },
+        ])
+        .unwrap();
+        first.as_file_mut().set_len(0).unwrap();
+        first.rewind().unwrap();
+        first.write_all(b"first-new").unwrap();
+        first.flush().unwrap();
+        second.as_file_mut().set_len(0).unwrap();
+        second.rewind().unwrap();
+        second.flush().unwrap();
+
+        assert!(store.reload().is_err());
+        assert_eq!(store.load().sequence(), 1);
+        store
+            .load()
+            .listener(0)
+            .bearer
+            .as_ref()
+            .unwrap()
+            .authenticate_metadata(&metadata("first-old"))
+            .unwrap();
+        store
+            .load()
+            .listener(1)
+            .bearer
+            .as_ref()
+            .unwrap()
+            .authenticate_metadata(&metadata("second-old"))
+            .unwrap();
+    }
+
+    #[test]
+    fn concurrent_readers_observe_only_complete_generations() {
+        let mut first = token_file("a-old");
+        let mut second = token_file("b-old");
+        let store = CredentialStore::stage(vec![
+            CredentialSource {
+                token_file: Some(first.path().to_path_buf()),
+                tls: None,
+            },
+            CredentialSource {
+                token_file: Some(second.path().to_path_buf()),
+                tls: None,
+            },
+        ])
+        .unwrap();
+        first.as_file_mut().set_len(0).unwrap();
+        first.rewind().unwrap();
+        first.write_all(b"a-new").unwrap();
+        first.flush().unwrap();
+        second.as_file_mut().set_len(0).unwrap();
+        second.rewind().unwrap();
+        second.write_all(b"b-new").unwrap();
+        second.flush().unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let reader_store = store.clone();
+        let reader_barrier = barrier.clone();
+        let reader = thread::spawn(move || {
+            reader_barrier.wait();
+            for _ in 0..10_000 {
+                let generation = reader_store.load();
+                let old = generation
+                    .listener(0)
+                    .bearer
+                    .as_ref()
+                    .unwrap()
+                    .authenticate_metadata(&metadata("a-old"))
+                    .is_ok();
+                let other_old = generation
+                    .listener(1)
+                    .bearer
+                    .as_ref()
+                    .unwrap()
+                    .authenticate_metadata(&metadata("b-old"))
+                    .is_ok();
+                assert_eq!(old, other_old);
+            }
+        });
+        barrier.wait();
+        store.reload().unwrap();
+        reader.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn mtls_rotation_applies_to_new_handshakes_and_keeps_old_connection_alive() {
+        let old = tls_bundle("old");
+        let new = tls_bundle("new");
+        let mut cert = token_file(&old.server_pem);
+        let mut key = token_file(&old.server_key_pem);
+        let mut ca = token_file(&old.ca_pem);
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: None,
+            tls: Some(TlsSource {
+                cert_file: cert.path().to_path_buf(),
+                key_file: key.path().to_path_buf(),
+                client_ca_file: ca.path().to_path_buf(),
+            }),
+        }])
+        .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let old_server_config = store.load().listener(0).tls.clone().unwrap();
+        let old_server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            TlsAcceptor::from(old_server_config)
+                .accept(tcp)
+                .await
+                .unwrap()
+        });
+        let mut old_client = connect(old.client.clone(), addr).await.unwrap();
+        let mut old_server = old_server.await.unwrap();
+
+        overwrite(&mut cert, new.server_pem.as_bytes());
+        overwrite(&mut key, new.server_key_pem.as_bytes());
+        overwrite(&mut ca, new.ca_pem.as_bytes());
+        store.reload().unwrap();
+        old_client.write_all(b"x").await.unwrap();
+        let mut byte = [0];
+        old_server.read_exact(&mut byte).await.unwrap();
+        assert_eq!(byte, *b"x");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let new_server_config = store.load().listener(0).tls.clone().unwrap();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            TlsAcceptor::from(new_server_config).accept(tcp).await
+        });
+        assert!(connect(old.client.clone(), addr).await.is_err());
+        assert!(server.await.unwrap().is_err());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let new_server_config = store.load().listener(0).tls.clone().unwrap();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            TlsAcceptor::from(new_server_config)
+                .accept(tcp)
+                .await
+                .unwrap()
+        });
+        let _new_client = connect(new.client, addr).await.unwrap();
+        let _new_server = server.await.unwrap();
+    }
+}

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -244,6 +244,7 @@ mod tests {
     use tokio_rustls::rustls::ClientConfig;
     use tokio_rustls::{TlsAcceptor, TlsConnector};
     use tonic::metadata::MetadataMap;
+    use tonic::transport::server::Connected;
 
     use super::*;
 
@@ -504,7 +505,20 @@ mod tests {
                 .unwrap()
         });
         let mut old_client = connect(old.client.clone(), addr).await.unwrap();
-        let mut old_server = old_server.await.unwrap();
+        let old_server = old_server.await.unwrap();
+        let wrapped = crate::connect_info::RustbgpdTcpStream::from_tls(old_server);
+        let mut extensions = tonic::codegen::http::Extensions::new();
+        extensions.insert(wrapped.connect_info());
+        let context = crate::authz_runtime::GrpcAuthAuditContext::new(
+            "tcp://127.0.0.1:0",
+            "read_write",
+            crate::authz::AuthTier::OperatorOnly,
+            crate::authz_runtime::GrpcAuthnKind::Mtls,
+            "mtls-unresolved",
+        )
+        .with_mtls_peer_principal();
+        assert_eq!(context.principal_for_extensions(&extensions), "old");
+        let mut old_server = wrapped;
 
         overwrite(&mut cert, new.server_pem.as_bytes());
         overwrite(&mut key, new.server_key_pem.as_bytes());

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bfd_service;
 mod config_service;
 mod connect_info;
 mod control_service;
+pub mod credentials;
 pub mod event_history_sinks;
 mod event_service;
 pub mod evpn_service;

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -6,15 +6,15 @@ use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
+use futures::StreamExt as FuturesStreamExt;
+use futures::{Future, Stream};
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 use tokio_rustls::TlsAcceptor;
-use tokio_stream::{
-    StreamExt,
-    wrappers::{TcpListenerStream, UnixListenerStream},
-};
+use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::service::Interceptor;
 use tonic::transport::Server;
 use tonic::{Request, Status};
@@ -56,6 +56,20 @@ use crate::proto::rib_service_server::RibServiceServer;
 use crate::rib_service::RibService;
 use rustbgpd_rib::RibUpdate;
 use rustbgpd_telemetry::BgpMetrics;
+
+const MAX_CONCURRENT_GRPC_TLS_HANDSHAKES: usize = 64;
+const GRPC_TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn bounded_handshakes<S, F, T, E>(incoming: S) -> impl Stream<Item = Result<T, E>>
+where
+    S: Stream<Item = F>,
+    F: Future<Output = Option<Result<T, E>>>,
+{
+    FuturesStreamExt::filter_map(
+        FuturesStreamExt::buffer_unordered(incoming, MAX_CONCURRENT_GRPC_TLS_HANDSHAKES),
+        std::future::ready,
+    )
+}
 
 /// Error returned by the daemon-owned config transaction apply hook.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1099,29 +1113,39 @@ async fn run_tcp_listener(
     let interceptor = AuthInterceptor::new(credential_store.clone(), credential_index);
     let builder = Server::builder();
     let mut builder = builder.layer(GrpcAuthzLayer::new(audit_context, metrics.clone()));
-    let incoming = TcpListenerStream::new(tcp_listener)
-        .then(move |accepted| {
-            let credential_store = credential_store.clone();
-            async move {
-                let stream = match accepted {
-                    Ok(stream) => stream,
-                    Err(error) => return Some(Err(error)),
-                };
-                let generation = credential_store.load();
-                if let Some(tls) = generation.listener(credential_index).tls.clone() {
-                    match TlsAcceptor::from(tls).accept(stream).await {
-                        Ok(stream) => Some(Ok(RustbgpdTcpStream::from_tls(stream))),
-                        Err(error) => {
-                            warn!(%error, "rejected gRPC mTLS handshake");
-                            None
-                        }
+    let incoming = FuturesStreamExt::map(TcpListenerStream::new(tcp_listener), move |accepted| {
+        let generation = credential_store.load();
+        async move {
+            let stream = match accepted {
+                Ok(stream) => stream,
+                Err(error) => return Some(Err(error)),
+            };
+            if let Some(tls) = generation.listener(credential_index).tls.clone() {
+                match tokio::time::timeout(
+                    GRPC_TLS_HANDSHAKE_TIMEOUT,
+                    TlsAcceptor::from(tls).accept(stream),
+                )
+                .await
+                {
+                    Ok(Ok(stream)) => Some(Ok(RustbgpdTcpStream::from_tls(stream))),
+                    Ok(Err(error)) => {
+                        warn!(%error, "rejected gRPC mTLS handshake");
+                        None
                     }
-                } else {
-                    Some(Ok(RustbgpdTcpStream::new(stream)))
+                    Err(_) => {
+                        warn!(
+                            timeout_seconds = GRPC_TLS_HANDSHAKE_TIMEOUT.as_secs(),
+                            "timed out gRPC mTLS handshake"
+                        );
+                        None
+                    }
                 }
+            } else {
+                Some(Ok(RustbgpdTcpStream::new(stream)))
             }
-        })
-        .filter_map(std::convert::identity);
+        }
+    });
+    let incoming = bounded_handshakes(incoming);
     let mut routes = tonic::service::Routes::builder();
     routes.add_service(RibServiceServer::with_interceptor(
         RibService::with_status_snapshots_and_metrics(
@@ -1532,6 +1556,12 @@ mod tests {
 
     use super::*;
     use crate::credentials::CredentialSource;
+    use crate::peer_types::SessionLifecycleEventType;
+    use crate::proto::GetGlobalRequest;
+    use crate::proto::event_service_client::EventServiceClient;
+    use crate::proto::global_service_client::GlobalServiceClient;
+    use crate::proto::{EventCategory, WatchEventsRequest};
+    use crate::test_support::{session_event, spawn_fake_peer_manager, spawn_fake_rib};
 
     fn empty_roles() -> Arc<BTreeMap<String, PrincipalRole>> {
         Arc::new(BTreeMap::new())
@@ -1641,6 +1671,121 @@ mod tests {
         new.metadata_mut()
             .insert("authorization", "Bearer new".parse().unwrap());
         assert!(interceptor.call(new).is_ok());
+    }
+
+    #[tokio::test]
+    async fn bounded_handshakes_do_not_serialize_behind_stalled_client() {
+        type TestHandshake = Pin<Box<dyn Future<Output = Option<Result<u8, ()>>> + Send>>;
+        let stalled = Box::pin(std::future::pending::<Option<Result<u8, ()>>>());
+        let ready = Box::pin(std::future::ready(Some(Ok(7))));
+        let futures: Vec<TestHandshake> = vec![stalled, ready];
+        let mut admitted = bounded_handshakes(tokio_stream::iter(futures));
+        let result = tokio::time::timeout(Duration::from_millis(100), admitted.next())
+            .await
+            .expect("ready handshake must not queue behind stalled handshake");
+        assert_eq!(result, Some(Ok(7)));
+    }
+
+    #[tokio::test]
+    async fn live_http2_channel_uses_rotated_token_on_each_rpc() {
+        let mut token = tempfile::NamedTempFile::new().unwrap();
+        token.write_all(b"old").unwrap();
+        token.flush().unwrap();
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: Some(token.path().to_path_buf()),
+            tls: None,
+        }])
+        .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = FuturesStreamExt::map(TcpListenerStream::new(listener), |stream| {
+            stream.map(RustbgpdTcpStream::new)
+        });
+        let (rib_tx, _) = spawn_fake_rib();
+        let (peer_tx, session_events, _) = spawn_fake_peer_manager();
+        let context = tcp_audit_context(
+            addr,
+            AccessMode::ReadOnly,
+            AuthTier::SensitiveRead,
+            legacy_authz(),
+            None,
+            false,
+            Some("test"),
+        )
+        .with_dynamic_bearer(store.clone(), 0);
+        let interceptor = AuthInterceptor::new(store.clone(), 0);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .layer(GrpcAuthzLayer::new(context, BgpMetrics::new()))
+                .add_service(GlobalServiceServer::with_interceptor(
+                    GlobalService::new(65000, "192.0.2.1".into(), 179),
+                    interceptor.clone(),
+                ))
+                .add_service(EventServiceServer::with_interceptor(
+                    EventService::new(rib_tx, peer_tx),
+                    interceptor,
+                ))
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        let channel = tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let mut client = GlobalServiceClient::new(channel.clone());
+        let mut request = Request::new(GetGlobalRequest {});
+        request
+            .metadata_mut()
+            .insert("authorization", "Bearer old".parse().unwrap());
+        client.get_global(request).await.unwrap();
+        let mut events = EventServiceClient::new(channel);
+        let mut watch = Request::new(WatchEventsRequest {
+            categories: vec![EventCategory::Session as i32],
+            ..Default::default()
+        });
+        watch
+            .metadata_mut()
+            .insert("authorization", "Bearer old".parse().unwrap());
+        let mut stream = events.watch_events(watch).await.unwrap().into_inner();
+
+        token.as_file_mut().set_len(0).unwrap();
+        token.rewind().unwrap();
+        token.write_all(b"new").unwrap();
+        token.flush().unwrap();
+        store.reload().unwrap();
+        let mut old = Request::new(GetGlobalRequest {});
+        old.metadata_mut()
+            .insert("authorization", "Bearer old".parse().unwrap());
+        assert_eq!(
+            client.get_global(old).await.unwrap_err().code(),
+            tonic::Code::Unauthenticated
+        );
+        let mut new = Request::new(GetGlobalRequest {});
+        new.metadata_mut()
+            .insert("authorization", "Bearer new".parse().unwrap());
+        client.get_global(new).await.unwrap();
+        session_events
+            .send(session_event(
+                "192.0.2.9".parse().unwrap(),
+                SessionLifecycleEventType::Established,
+            ))
+            .unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(1), stream.message())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.peer_address, "192.0.2.9");
+        drop(stream);
+        drop(events);
+        drop(client);
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
     }
 
     #[test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinSet;
+use tokio_rustls::TlsAcceptor;
 use tokio_stream::{
     StreamExt,
     wrappers::{TcpListenerStream, UnixListenerStream},
@@ -20,11 +21,13 @@ use tonic::{Request, Status};
 use tracing::{error, info, warn};
 
 use crate::authz::{AuthEnforcement, AuthTier, PrincipalRole};
-use crate::authz_runtime::{BearerAuthSecret, GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
+use crate::authz_runtime::{GrpcAuthAuditContext, GrpcAuthnKind, GrpcAuthzLayer};
 use crate::bfd_service::BfdService;
 use crate::config_service::ConfigService;
 use crate::connect_info::RustbgpdTcpStream;
 use crate::control_service::{ControlService, MrtTriggerTx};
+use crate::credentials::CredentialStore;
+use crate::credentials::PinnedCredentialGeneration;
 use crate::event_service::{DataplaneEventBroadcaster, EventService, dataplane_event_broadcaster};
 use crate::evpn_service::{
     BumEnforcementSnapshotFn, DuplicateMacClearFn, EthernetSegmentDrainReasonsFn,
@@ -545,29 +548,29 @@ pub struct ListenerConfig {
     pub enforcement: AuthEnforcement,
     /// Global principal-to-role map used when `enforcement = tier`.
     pub roles: Arc<BTreeMap<String, PrincipalRole>>,
-    pub auth_token: Option<String>,
+    pub credential_store: CredentialStore,
+    pub credential_index: usize,
     /// Optional stable principal label for audit records. Bearer-token
     /// and UDS listeners may use it to avoid placeholder identities in
     /// `grpc_authz` logs; mTLS listeners derive their audit principal
     /// from the peer certificate instead.
     pub principal: Option<String>,
-    /// Optional native mTLS for TCP listeners. The server presents
-    /// `cert_pem` and accepts client connections that present a
-    /// certificate signed by `client_ca_pem`. Ignored on UDS
-    /// endpoints — file-system permissions are the auth surface there.
-    pub tls: Option<TlsParams>,
 }
 
-/// PEM-encoded TLS material for a gRPC listener (server identity +
-/// client-authentication CA root). Loaded from disk by the daemon
-/// before the listener spawns; storing the bytes inline rather than
-/// the paths means a config reload that changes the path doesn't
-/// silently keep using stale material.
-#[derive(Clone, Debug)]
-pub struct TlsParams {
-    pub cert_pem: Vec<u8>,
-    pub key_pem: Vec<u8>,
-    pub client_ca_pem: Vec<u8>,
+impl ListenerConfig {
+    #[must_use]
+    pub fn auth_enabled(&self) -> bool {
+        self.credential_store
+            .load()
+            .listener(self.credential_index)
+            .bearer
+            .is_some()
+    }
+
+    #[must_use]
+    pub fn credential_store(&self) -> CredentialStore {
+        self.credential_store.clone()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -670,13 +673,27 @@ fn uds_audit_context(
 
 #[derive(Clone, Debug)]
 struct AuthInterceptor {
-    bearer_auth: Option<BearerAuthSecret>,
+    credential_store: Option<CredentialStore>,
+    credential_index: usize,
+    static_bearer: Option<crate::authz_runtime::BearerAuthSecret>,
 }
 
 impl AuthInterceptor {
-    fn new(token: Option<&str>) -> Self {
-        let bearer_auth = token.map(BearerAuthSecret::from_token);
-        Self { bearer_auth }
+    fn new(credential_store: CredentialStore, credential_index: usize) -> Self {
+        Self {
+            credential_store: Some(credential_store),
+            credential_index,
+            static_bearer: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn from_token(token: Option<&str>) -> Self {
+        Self {
+            credential_store: None,
+            credential_index: 0,
+            static_bearer: token.map(crate::authz_runtime::BearerAuthSecret::from_token),
+        }
     }
 }
 
@@ -692,10 +709,26 @@ pub(crate) fn read_only_rejection(access_mode: AccessMode) -> Option<Status> {
 
 impl Interceptor for AuthInterceptor {
     fn call(&mut self, request: Request<()>) -> Result<Request<()>, Status> {
-        let Some(bearer_auth) = self.bearer_auth.as_ref() else {
-            return Ok(request);
-        };
-        bearer_auth.authenticate_metadata(request.metadata())?;
+        if let Some(store) = &self.credential_store {
+            let pinned = request
+                .extensions()
+                .get::<PinnedCredentialGeneration>()
+                .cloned();
+            let generation = pinned.is_none().then(|| store.load());
+            let bearer_auth = pinned
+                .as_ref()
+                .and_then(PinnedCredentialGeneration::bearer)
+                .or_else(|| {
+                    generation.as_ref().and_then(|generation| {
+                        generation.listener(self.credential_index).bearer.as_ref()
+                    })
+                });
+            if let Some(bearer_auth) = bearer_auth {
+                bearer_auth.authenticate_metadata(request.metadata())?;
+            }
+        } else if let Some(bearer_auth) = &self.static_bearer {
+            bearer_auth.authenticate_metadata(request.metadata())?;
+        }
         Ok(request)
     }
 }
@@ -859,22 +892,22 @@ async fn run_listener(
         max_tier,
         enforcement,
         roles,
-        auth_token,
+        credential_store,
+        credential_index,
         principal,
-        tls,
     } = listener;
 
     match endpoint {
         ListenerEndpoint::Tcp(addr) => {
-            run_tcp_listener(
+            Box::pin(run_tcp_listener(
                 addr,
                 access_mode,
                 max_tier,
                 enforcement,
                 roles,
-                auth_token,
+                credential_store,
+                credential_index,
                 principal,
-                tls,
                 rib_tx,
                 rib_query_tx,
                 peer_mgr_tx,
@@ -917,7 +950,7 @@ async fn run_listener(
                 shutdown_rx,
                 rpc_shutdown_tx,
                 config_tx,
-            )
+            ))
             .await
         }
         ListenerEndpoint::Uds { path, mode } => {
@@ -928,7 +961,8 @@ async fn run_listener(
                 max_tier,
                 enforcement,
                 roles,
-                auth_token,
+                credential_store,
+                credential_index,
                 principal,
                 rib_tx,
                 rib_query_tx,
@@ -989,9 +1023,9 @@ async fn run_tcp_listener(
     max_tier: AuthTier,
     enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
-    auth_token: Option<String>,
+    credential_store: CredentialStore,
+    credential_index: usize,
     principal: Option<String>,
-    tls: Option<TlsParams>,
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
@@ -1035,7 +1069,10 @@ async fn run_tcp_listener(
     rpc_shutdown_tx: watch::Sender<bool>,
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
 ) -> Result<(), String> {
-    let tls_enabled = tls.is_some();
+    let initial_generation = credential_store.load();
+    let credentials = initial_generation.listener(credential_index);
+    let tls_enabled = credentials.tls.is_some();
+    let auth_enabled = credentials.bearer.is_some();
     let tcp_listener = TcpListener::bind(addr)
         .await
         .map_err(|e| format!("failed to bind gRPC TCP listener {addr}: {e}"))?;
@@ -1044,7 +1081,7 @@ async fn run_tcp_listener(
         %bound_addr,
         requested_addr = %addr,
         access_mode = ?access_mode,
-        auth_enabled = auth_token.is_some(),
+        auth_enabled,
         tls_enabled,
         "starting gRPC TCP listener"
     );
@@ -1053,25 +1090,38 @@ async fn run_tcp_listener(
         access_mode,
         max_tier,
         RuntimeAuthzConfig { enforcement, roles },
-        auth_token.as_deref(),
+        None,
         tls_enabled,
         principal.as_deref(),
     );
-    let interceptor = AuthInterceptor::new(auth_token.as_deref());
-    let mut builder = Server::builder();
-    if let Some(tls) = tls {
-        let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
-        let client_ca = tonic::transport::Certificate::from_pem(&tls.client_ca_pem);
-        let tls_cfg = tonic::transport::ServerTlsConfig::new()
-            .identity(identity)
-            .client_ca_root(client_ca);
-        builder = builder
-            .tls_config(tls_cfg)
-            .map_err(|e| format!("TCP listener {addr} TLS config invalid: {e}"))?;
-    }
+    let audit_context =
+        audit_context.with_dynamic_bearer(credential_store.clone(), credential_index);
+    let interceptor = AuthInterceptor::new(credential_store.clone(), credential_index);
+    let builder = Server::builder();
     let mut builder = builder.layer(GrpcAuthzLayer::new(audit_context, metrics.clone()));
-    let incoming =
-        TcpListenerStream::new(tcp_listener).map(|accepted| accepted.map(RustbgpdTcpStream::new));
+    let incoming = TcpListenerStream::new(tcp_listener)
+        .then(move |accepted| {
+            let credential_store = credential_store.clone();
+            async move {
+                let stream = match accepted {
+                    Ok(stream) => stream,
+                    Err(error) => return Some(Err(error)),
+                };
+                let generation = credential_store.load();
+                if let Some(tls) = generation.listener(credential_index).tls.clone() {
+                    match TlsAcceptor::from(tls).accept(stream).await {
+                        Ok(stream) => Some(Ok(RustbgpdTcpStream::from_tls(stream))),
+                        Err(error) => {
+                            warn!(%error, "rejected gRPC mTLS handshake");
+                            None
+                        }
+                    }
+                } else {
+                    Some(Ok(RustbgpdTcpStream::new(stream)))
+                }
+            }
+        })
+        .filter_map(std::convert::identity);
     let mut routes = tonic::service::Routes::builder();
     routes.add_service(RibServiceServer::with_interceptor(
         RibService::with_status_snapshots_and_metrics(
@@ -1194,11 +1244,13 @@ async fn run_tcp_listener(
             interceptor.clone(),
         ));
     }
-    builder
-        .add_routes(routes.routes())
-        .serve_with_incoming_shutdown(incoming, await_shutdown(shutdown_rx))
-        .await
-        .map_err(|e| format!("TCP listener {bound_addr} failed: {e}"))
+    Box::pin(
+        builder
+            .add_routes(routes.routes())
+            .serve_with_incoming_shutdown(incoming, await_shutdown(shutdown_rx)),
+    )
+    .await
+    .map_err(|e| format!("TCP listener {bound_addr} failed: {e}"))
 }
 
 #[expect(
@@ -1213,7 +1265,8 @@ async fn run_uds_listener(
     max_tier: AuthTier,
     enforcement: AuthEnforcement,
     roles: Arc<BTreeMap<String, PrincipalRole>>,
-    auth_token: Option<String>,
+    credential_store: CredentialStore,
+    credential_index: usize,
     principal: Option<String>,
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
@@ -1259,13 +1312,17 @@ async fn run_uds_listener(
     config_tx: Option<mpsc::Sender<ConfigEvent>>,
 ) -> Result<(), String> {
     let uds_listener = bind_uds_listener(&path, mode)?;
-    let auth_enabled = auth_token.is_some();
+    let auth_enabled = credential_store
+        .load()
+        .listener(credential_index)
+        .bearer
+        .is_some();
     let audit_context = uds_audit_context(
         &path,
         access_mode,
         max_tier,
         RuntimeAuthzConfig { enforcement, roles },
-        auth_token.as_deref(),
+        None,
         principal.as_deref(),
     );
     info!(
@@ -1274,7 +1331,9 @@ async fn run_uds_listener(
         auth_enabled,
         "starting gRPC UDS listener"
     );
-    let interceptor = AuthInterceptor::new(auth_token.as_deref());
+    let audit_context =
+        audit_context.with_dynamic_bearer(credential_store.clone(), credential_index);
+    let interceptor = AuthInterceptor::new(credential_store, credential_index);
     let mut routes = tonic::service::Routes::builder();
     routes.add_service(RibServiceServer::with_interceptor(
         RibService::with_status_snapshots_and_metrics(
@@ -1469,7 +1528,10 @@ async fn await_shutdown(mut shutdown_rx: watch::Receiver<bool>) {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Seek, Write};
+
     use super::*;
+    use crate::credentials::CredentialSource;
 
     fn empty_roles() -> Arc<BTreeMap<String, PrincipalRole>> {
         Arc::new(BTreeMap::new())
@@ -1518,20 +1580,20 @@ mod tests {
 
     #[test]
     fn auth_interceptor_allows_unprotected_requests() {
-        let mut interceptor = AuthInterceptor::new(None);
+        let mut interceptor = AuthInterceptor::from_token(None);
         assert!(interceptor.call(Request::new(())).is_ok());
     }
 
     #[test]
     fn auth_interceptor_rejects_missing_token() {
-        let mut interceptor = AuthInterceptor::new(Some("secret"));
+        let mut interceptor = AuthInterceptor::from_token(Some("secret"));
         let err = interceptor.call(Request::new(())).unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 
     #[test]
     fn auth_interceptor_accepts_matching_token() {
-        let mut interceptor = AuthInterceptor::new(Some("secret"));
+        let mut interceptor = AuthInterceptor::from_token(Some("secret"));
         let mut request = Request::new(());
         request
             .metadata_mut()
@@ -1541,13 +1603,44 @@ mod tests {
 
     #[test]
     fn auth_interceptor_rejects_wrong_token() {
-        let mut interceptor = AuthInterceptor::new(Some("secret"));
+        let mut interceptor = AuthInterceptor::from_token(Some("secret"));
         let mut request = Request::new(());
         request
             .metadata_mut()
             .insert("authorization", "Bearer wrong".parse().unwrap());
         let err = interceptor.call(request).unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn dynamic_interceptor_applies_rotation_to_next_rpc_on_same_instance() {
+        let mut token = tempfile::NamedTempFile::new().unwrap();
+        token.write_all(b"old").unwrap();
+        token.flush().unwrap();
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: Some(token.path().to_path_buf()),
+            tls: None,
+        }])
+        .unwrap();
+        let mut interceptor = AuthInterceptor::new(store.clone(), 0);
+        let mut old = Request::new(());
+        old.metadata_mut()
+            .insert("authorization", "Bearer old".parse().unwrap());
+        assert!(interceptor.call(old).is_ok());
+
+        token.as_file_mut().set_len(0).unwrap();
+        token.rewind().unwrap();
+        token.write_all(b"new").unwrap();
+        token.flush().unwrap();
+        store.reload().unwrap();
+        let mut old = Request::new(());
+        old.metadata_mut()
+            .insert("authorization", "Bearer old".parse().unwrap());
+        assert!(interceptor.call(old).is_err());
+        let mut new = Request::new(());
+        new.metadata_mut()
+            .insert("authorization", "Bearer new".parse().unwrap());
+        assert!(interceptor.call(new).is_ok());
     }
 
     #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -104,6 +104,7 @@ pub struct BgpMetrics {
     event_stream_lagged: IntCounterVec,
     event_stream_subscribers: IntGaugeVec,
     grpc_authz_decisions: IntCounterVec,
+    grpc_credential_reloads: IntCounterVec,
     config_transaction_lifecycle: IntCounterVec,
 
     // ── Policy ──────────────────────────────────────────────────
@@ -442,6 +443,14 @@ impl BgpMetrics {
                 "ADR-0064 gRPC authorization tier decisions by bounded listener and decision labels.",
             ),
             &["tier", "result", "authn", "access_mode"],
+        )
+        .expect("valid metric definition");
+        let grpc_credential_reloads = IntCounterVec::new(
+            Opts::new(
+                "bgp_grpc_credential_reloads_total",
+                "Management-plane credential reload attempts by bounded outcome label.",
+            ),
+            &["outcome"],
         )
         .expect("valid metric definition");
 
@@ -1394,6 +1403,9 @@ impl BgpMetrics {
             .register(Box::new(grpc_authz_decisions.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(grpc_credential_reloads.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(config_transaction_lifecycle.clone()))
             .expect("metric not already registered");
         registry
@@ -1722,6 +1734,7 @@ impl BgpMetrics {
             event_stream_lagged,
             event_stream_subscribers,
             grpc_authz_decisions,
+            grpc_credential_reloads,
             config_transaction_lifecycle,
             max_prefix_exceeded,
             outbound_route_drops,
@@ -2162,6 +2175,15 @@ impl BgpMetrics {
     ) {
         self.grpc_authz_decisions
             .with_label_values(&[tier, result, authn, access_mode])
+            .inc();
+    }
+
+    /// Record a credential-generation reload attempt. The only labels are
+    /// `success` and `failure`; listener paths and errors remain in logs.
+    pub fn record_grpc_credential_reload(&self, outcome: &str) {
+        debug_assert!(matches!(outcome, "success" | "failure"));
+        self.grpc_credential_reloads
+            .with_label_values(&[outcome])
             .inc();
     }
 
@@ -3457,6 +3479,16 @@ mod tests {
         let text = gather_text(&m);
         assert!(text.contains("bgp_grpc_authz_decisions_total"));
         assert!(!text.contains("rustbgpd.v1.ControlService"));
+    }
+
+    #[test]
+    fn grpc_credential_reload_counter_uses_only_outcome() {
+        let m = BgpMetrics::new();
+        m.record_grpc_credential_reload("success");
+        m.record_grpc_credential_reload("failure");
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_grpc_credential_reloads_total{outcome=\"success\"} 1"));
+        assert!(text.contains("bgp_grpc_credential_reloads_total{outcome=\"failure\"} 1"));
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -356,11 +356,12 @@ rejected at `Config::load`. There is no "TLS-without-mTLS" half-mode by
 design. When enabled, the daemon presents the server certificate, requires
 every client to present a certificate signed by `tls_client_ca_file`, and
 rejects unverified clients at the TLS layer before any gRPC handler runs.
-PEM material is pre-flight-validated at config load and `--check` time so a
-successful `--check` rules out cert-rotation surprises at startup. Listener
-config (including any TLS field) is **restart-required** — SIGHUP reload
-pins the runtime listener back to the live values and surfaces the drift
-in `rustbgpd --diff` until the daemon is restarted.
+PEM material is pre-flight-validated at config load and `--check` time. SIGHUP
+re-reads the bytes behind the three unchanged paths, validates the complete
+server identity and client CA for every listener, then atomically publishes one
+process-wide credential generation. A malformed or partial rotation leaves the
+last-known-good generation active. Changing a path or TLS/auth mode remains
+**restart-required** and stays visible as drift until restart.
 
 Native gNMI / OpenConfig telemetry (`gnmi.gNMI`) is registered on TCP only when
 this native mTLS config is present. Plaintext or bearer-token-only TCP listeners
@@ -390,11 +391,11 @@ cap is the stricter of the two, so `access_mode = "read_only"` cannot be
 weakened by `max_tier = "operator_only"`.
 
 **Token file lifecycle:** When `token_file` is configured, the file must exist
-and contain a non-empty token at daemon startup. The token is read once during
-config validation and kept in memory for the daemon's lifetime. Token rotation
-requires a daemon restart. In orchestrated environments where secrets are
-mounted after config files, ensure the token file is available before starting
-the daemon.
+and contain a non-empty token at daemon startup. SIGHUP re-reads the bytes behind
+the unchanged path as part of the all-listener credential generation. New RPCs
+on existing HTTP/2 connections use the new token; already-admitted streaming
+RPCs continue. Invalid or missing material rejects the whole credential reload.
+Changing the path or enabling/disabling token auth remains restart-required.
 
 **ADR-0064 audit principals:** `principal` gives the audit-only
 `grpc_authz` log line a stable operator-controlled identity. On UDS listeners

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -94,11 +94,11 @@ Preferred posture:
 - Even with mTLS in place, treat the API as privileged. Read-only RPCs still
   reveal peer topology, route state, and policy results.
 
-> **Listener config is restart-required.** Adding, removing, or
-> rotating `tls_cert_file` / `tls_key_file` / `tls_client_ca_file`
-> takes effect only on a daemon restart, not on SIGHUP. SIGHUP
-> reload pins the runtime listener config back to the live values
-> and surfaces the drift in `rustbgpd --diff` until restart.
+> **Listener shape is restart-required; credential bytes rotate live.** SIGHUP
+> atomically reloads token and mTLS material behind unchanged configured paths.
+> Existing TLS connections and admitted streams continue; new TLS connections
+> and new bearer-authenticated RPCs use the new generation. Path, listener,
+> auth-mode, principal, role, and access changes still require restart.
 
 ### Direct TCP on a non-loopback address
 
@@ -312,4 +312,7 @@ the roadmap:
   neighbors, live key rotation, and multi-key rollover remain follow-up work.
   Protected static-neighbor interop is covered by M43 against BIRD 3.2.1 on
   Linux with `CONFIG_TCP_AO=y`.
-- Cert rotation on the gRPC TLS listener requires a daemon restart (not SIGHUP)
+- gRPC token and mTLS material behind unchanged paths rotate on SIGHUP as one
+  all-listener generation. Alert on
+  `bgp_grpc_credential_reloads_total{outcome="failure"}`; failures retain the
+  last-known-good generation and logs never include secret bytes.

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -221,7 +221,8 @@ rebind on reload.
 | Field | Class | Notes |
 |---|---|---|
 | `address` | restart-required | Listener address. |
-| `tls.*` (mTLS material) | restart-required | All TLS/mTLS fields pinned. |
+| credential bytes behind unchanged token/TLS paths | reload-applied | Staged for all listeners, then one atomic generation; existing connections/streams survive. |
+| token/TLS paths or auth mode | restart-required | Listener shape and configured paths remain pinned. |
 | `path` (`grpc_uds`) | restart-required | UDS path bound at startup. |
 | `mode` (`grpc_uds`) | restart-required | Permissions set at bind time. |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,64 +502,53 @@ fn write_gr_restart_marker(path: &Path, expires_at: SystemTime) -> std::io::Resu
     std::fs::write(path, encoded)
 }
 
-fn load_grpc_token(path: &Path) -> Result<String, String> {
-    let token = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read gRPC token file {}: {e}", path.display()))?;
-    let token = token.trim_end().to_string();
-    if token.is_empty() {
-        return Err(format!(
-            "gRPC token file {} must contain a non-empty token",
-            path.display()
-        ));
-    }
-    Ok(token)
-}
-
-fn load_grpc_pem(path: &Path, label: &str) -> Result<Vec<u8>, String> {
-    let bytes = std::fs::read(path)
-        .map_err(|e| format!("failed to read gRPC {label} file {}: {e}", path.display()))?;
-    if bytes.is_empty() {
-        return Err(format!("gRPC {label} file {} is empty", path.display()));
-    }
-    Ok(bytes)
-}
-
 fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, String> {
+    use rustbgpd_api::credentials::{CredentialSource, CredentialStore, TlsSource};
     let enforcement = grpc_enforcement_to_auth_enforcement(config.security.grpc.enforcement);
     let roles = Arc::new(grpc_principal_roles(config));
-    config
-        .grpc_listeners()
-        .into_iter()
+    let declared = config.grpc_listeners();
+    let sources = declared
+        .iter()
         .map(|listener| match listener {
+            GrpcListener::Tcp {
+                token_file, tls, ..
+            } => CredentialSource {
+                token_file: token_file.clone(),
+                tls: tls.as_ref().map(|paths| TlsSource {
+                    cert_file: paths.cert_file.clone(),
+                    key_file: paths.key_file.clone(),
+                    client_ca_file: paths.client_ca_file.clone(),
+                }),
+            },
+            GrpcListener::Uds { token_file, .. } => CredentialSource {
+                token_file: token_file.clone(),
+                tls: None,
+            },
+        })
+        .collect();
+    let credential_store = CredentialStore::stage(sources)?;
+    declared
+        .into_iter()
+        .enumerate()
+        .map(|(credential_index, listener)| match listener {
             GrpcListener::Tcp {
                 addr,
                 access_mode,
                 max_tier,
-                token_file,
+                token_file: _,
                 principal,
                 tls,
             } => {
-                let tls_params = tls
-                    .map(|paths| {
-                        Ok::<_, String>(rustbgpd_api::server::TlsParams {
-                            cert_pem: load_grpc_pem(&paths.cert_file, "tls_cert_file")?,
-                            key_pem: load_grpc_pem(&paths.key_file, "tls_key_file")?,
-                            client_ca_pem: load_grpc_pem(
-                                &paths.client_ca_file,
-                                "tls_client_ca_file",
-                            )?,
-                        })
-                    })
-                    .transpose()?;
+                let _ = tls;
                 Ok(GrpcListenerConfig {
                     endpoint: ListenerEndpoint::Tcp(addr),
                     access_mode: access_mode.into(),
                     max_tier: grpc_max_tier_to_auth_tier(max_tier),
                     enforcement,
                     roles: Arc::clone(&roles),
-                    auth_token: token_file.as_deref().map(load_grpc_token).transpose()?,
+                    credential_store: credential_store.clone(),
+                    credential_index,
                     principal,
-                    tls: tls_params,
                 })
             }
             GrpcListener::Uds {
@@ -567,7 +556,7 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                 mode,
                 access_mode,
                 max_tier,
-                token_file,
+                token_file: _,
                 principal,
             } => Ok(GrpcListenerConfig {
                 endpoint: ListenerEndpoint::Uds { path, mode },
@@ -575,9 +564,9 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
                 max_tier: grpc_max_tier_to_auth_tier(max_tier),
                 enforcement,
                 roles: Arc::clone(&roles),
-                auth_token: token_file.as_deref().map(load_grpc_token).transpose()?,
+                credential_store: credential_store.clone(),
+                credential_index,
                 principal,
-                tls: None,
             }),
         })
         .collect()
@@ -731,7 +720,7 @@ fn print_startup_banner(config: &Config, grpc_listeners: &[GrpcListenerConfig]) 
             ListenerEndpoint::Tcp(addr) => format!("grpc: tcp://{addr}"),
             ListenerEndpoint::Uds { path, .. } => format!("grpc: unix://{}", path.display()),
         };
-        let auth = if listener.auth_token.is_some() {
+        let auth = if listener.auth_enabled() {
             " (token auth)"
         } else {
             ""
@@ -1421,6 +1410,9 @@ async fn run<T>(
         error!(error = %e, "invalid gRPC listener configuration");
         process::exit(1);
     });
+    let grpc_credentials = grpc_listeners
+        .first()
+        .map(GrpcListenerConfig::credential_store);
 
     // Startup banner — human-friendly topology summary on stderr.
     print_startup_banner(&config, &grpc_listeners);
@@ -1865,10 +1857,10 @@ async fn run<T>(
             ListenerEndpoint::Tcp(addr) => {
                 info!(
                     %addr,
-                    auth_enabled = listener.auth_token.is_some(),
+                    auth_enabled = listener.auth_enabled(),
                     "configured gRPC TCP listener"
                 );
-                if !addr.ip().is_loopback() && listener.auth_token.is_none() {
+                if !addr.ip().is_loopback() && !listener.auth_enabled() {
                     warn!(
                         %addr,
                         "gRPC TCP listener bound to a non-loopback address without authentication; prefer UDS for local administration or a proxy with mTLS for remote access"
@@ -1884,7 +1876,7 @@ async fn run<T>(
                 info!(
                     path = %path.display(),
                     mode = format_args!("{mode:o}"),
-                    auth_enabled = listener.auth_token.is_some(),
+                    auth_enabled = listener.auth_enabled(),
                     "configured gRPC UDS listener"
                 );
             }
@@ -3017,6 +3009,8 @@ async fn run<T>(
                 let config_transaction_controller = config_transaction_controller.clone();
                 let pm_internal = peer_mgr_internal_tx.clone();
                 let bridge_replace = bridge_replace_tx.clone();
+                let grpc_credentials = grpc_credentials.clone();
+                let reload_metrics = metrics.clone();
                 reload_in_flight = Some(tokio::spawn(async move {
                     let _runtime_config_guard = runtime_config_lock.lock().await;
                     if let Err(error) = config_transaction_controller
@@ -3028,6 +3022,18 @@ async fn run<T>(
                             "SIGHUP reload ignored while confirmed config transaction is applying or pending"
                         );
                         return None;
+                    }
+                    if let Some(credentials) = grpc_credentials {
+                        match credentials.reload() {
+                            Ok(generation) => {
+                                reload_metrics.record_grpc_credential_reload("success");
+                                info!(generation, "gRPC credential generation reloaded");
+                            }
+                            Err(error) => {
+                                reload_metrics.record_grpc_credential_reload("failure");
+                                error!(error = %error, "gRPC credential reload rejected; last-known-good generation remains active");
+                            }
+                        }
                     }
                     let snapshot = match runtime_config_snapshot(&pm_tx).await {
                         Ok(snapshot) => snapshot,

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -538,9 +538,9 @@ pub(crate) async fn reload_config(
         error!(
             "[global.telemetry.grpc_tcp] differs from the live listener \
              (address / token / TLS): live listener is unchanged. \
-             Restart rustbgpd to apply. Adding, removing, or rotating \
-             tls_cert_file / tls_key_file / tls_client_ca_file does NOT \
-             take effect on SIGHUP."
+             Restart rustbgpd to apply path/auth-mode changes. Credential \
+             bytes behind unchanged token/TLS paths rotate independently \
+             on SIGHUP."
         );
         new_config.global.telemetry.grpc_tcp = live_grpc_tcp.cloned();
     }


### PR DESCRIPTION
## Summary

- atomically stage and publish one immutable credential generation across all configured management listeners
- rotate bearer-token and mTLS certificate/key/client-CA material behind unchanged configured paths on SIGHUP while preserving last-known-good state on failure
- make new RPCs on existing HTTP/2 connections observe the new bearer token while admitted streams continue
- snapshot mTLS generations per accepted connection with bounded concurrent handshakes, timeout isolation, and preserved certificate principal extraction
- fence credential publication with confirmed config transactions and document the exact connection, filesystem, and restart-required boundaries

## Verification

- live tonic same-channel token rotation and admitted `WatchEvents` stream survival
- two independently rooted mTLS generations, old-connection survival, old-client rejection on new handshake, and new-client acceptance
- production `RustbgpdTcpStream`/`Connected` certificate-principal propagation
- stalled-first/ready-second bounded TLS admission regression
- complete-stage failure and 10,000-observation atomic-generation concurrency tests
- `cargo test --workspace --all-targets`
- workspace Clippy with warnings denied
- Rust 1.95 locked workspace all-target check
- workspace rustdoc with warnings denied
- repository hooks and `git diff --check`

Linear: LAN-359
