### PR TITLE
feat(config): plan update-group impact before apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   negotiation remain explicitly indeterminate; no memory or time estimate is
   implied. Policy-lint integration and post-renegotiation projection remain in
   LAN-356.
+  The transaction token covers the negotiated live-session snapshot as well as
+  config, private fallbacks retain policy-content identity, and capacity labels
+  apply only to the exact measured topologies; intervening session changes are
+  rejected at apply re-plan rather than silently changing the accepted impact.
 
 - **Management-plane credentials rotate atomically on SIGHUP.** Bearer tokens,
   mTLS server identity, and client CA material behind unchanged configured paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   expose one deterministic schema-v1 structure with established-peer
   current/candidate groupability, exact fallback reasons, plan-local group IDs,
   transition and resync rollups, projected shared/private totals, and only
-  conservative published-receipt capacity classes. Session reshape and future
-  negotiation remain explicitly indeterminate; no memory or time estimate is
-  implied. Policy-lint integration and post-renegotiation projection remain in
-  LAN-356.
+  conservative capacity classes: exact labels for published receipt topologies
+  plus a structural, explicitly unmeasured `fully_shared` label for other
+  one-group shapes. Session reshape and future negotiation remain explicitly
+  indeterminate; no memory or time estimate or extrapolation is implied.
+  Policy-lint integration and post-renegotiation projection remain in LAN-356.
   The transaction token covers the negotiated live-session snapshot as well as
-  config, private fallbacks retain policy-content identity, and capacity labels
-  apply only to the exact measured topologies; intervening session changes are
-  rejected at the apply-time re-plan rather than silently changing the accepted
-  impact. The token does not freeze sessions after that re-plan.
+  config, private fallbacks retain policy-content identity, and measured
+  capacity labels apply only to the exact receipt topologies; intervening
+  session changes are rejected at the apply-time re-plan rather than silently
+  changing the accepted impact. The token does not freeze sessions after that
+  re-plan.
 
 - **Management-plane credentials rotate atomically on SIGHUP.** Bearer tokens,
   mTLS server identity, and client CA material behind unchanged configured paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The transaction token covers the negotiated live-session snapshot as well as
   config, private fallbacks retain policy-content identity, and capacity labels
   apply only to the exact measured topologies; intervening session changes are
-  rejected at apply re-plan rather than silently changing the accepted impact.
+  rejected at the apply-time re-plan rather than silently changing the accepted
+  impact. The token does not freeze sessions after that re-plan.
 
 - **Management-plane credentials rotate atomically on SIGHUP.** Bearer tokens,
   mTLS server identity, and client CA material behind unchanged configured paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Config plans project update-group impact before apply.** Plan and apply
+  expose one deterministic schema-v1 structure with established-peer
+  current/candidate groupability, exact fallback reasons, plan-local group IDs,
+  transition and resync rollups, projected shared/private totals, and only
+  conservative published-receipt capacity classes. Session reshape and future
+  negotiation remain explicitly indeterminate; no memory or time estimate is
+  implied. Policy-lint integration and post-renegotiation projection remain in
+  LAN-356.
+
 - **Management-plane credentials rotate atomically on SIGHUP.** Bearer tokens,
   mTLS server identity, and client CA material behind unchanged configured paths
   are staged for every gRPC/gNMI listener and published as one immutable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,11 +228,13 @@ new AFI/SAFI and EVPN dataplane expansion.
   reloads on completion time, control-query latency, session continuity, and
   folded advertised-state equivalence. The withdrawn historical `< 1 s` claim
   is not evidence until the corrected run replaces it.
-- **Expose groupability before apply.** Extend config planning and policy linting
-  with projected update-group membership, exact fallback reasons, affected
-  peers/families, private outbound-view count, regroup/full-resync scope, and a
-  bounded capacity class. Do not present byte-precise memory or time estimates
-  until a calibrated model exists.
+- **Expose groupability before apply.** Config transaction planning now projects
+  established-peer update-group membership with exact fallback reasons,
+  affected peers/families, shared/private totals, resync scope, and bounded
+  receipt-envelope capacity classes. Remaining: surface the same classifier in
+  policy linting and add a post-renegotiation projection; until then session
+  reshape stays explicitly indeterminate. Do not present byte-precise memory or
+  time estimates until a calibrated model exists.
 - **Keep update-group correctness as a permanent fault program.** The bounded
   deterministic foundation is shipped: grouped and forced-per-peer output are
   compared under channel saturation/virtual retry, dirty policy swaps and

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -28,6 +28,7 @@ pub struct ConfigService {
 }
 
 impl ConfigService {
+    #[must_use]
     pub fn new(peer_mgr_tx: mpsc::Sender<PeerManagerCommand>) -> Self {
         Self {
             peer_mgr_tx,
@@ -88,6 +89,48 @@ fn transaction_plan_to_proto(
         unsupported_sections: plan.unsupported_sections,
         restart_required_sections: plan.restart_required_sections,
         human_text: plan.human_text,
+        update_group_impact: Some(update_group_impact_to_proto(plan.update_group_impact)),
+    }
+}
+
+#[must_use]
+pub fn update_group_impact_to_proto(
+    plan: rustbgpd_rib::UpdateGroupImpactPlan,
+) -> proto::UpdateGroupImpactPlan {
+    let rollup = plan.rollup;
+    proto::UpdateGroupImpactPlan {
+        schema_version: plan.schema_version,
+        entries: plan
+            .entries
+            .into_iter()
+            .map(|row| proto::UpdateGroupFamilyImpact {
+                peer: row.peer.to_string(),
+                afi: u32::from(row.afi),
+                safi: u32::from(row.safi),
+                current: row.current.label(),
+                candidate: row.candidate.label(),
+                transition: row.transition,
+                reason: row.reason,
+                provenance: row.provenance,
+                local_resync: row.local_resync,
+                remote_route_refresh: row.remote_route_refresh,
+            })
+            .collect(),
+        rollup: Some(proto::UpdateGroupImpactRollup {
+            affected_peers: rollup.affected_peers,
+            affected_families: rollup.affected_families,
+            no_op: rollup.no_op,
+            regroup: rollup.regroup,
+            shared_migration: rollup.shared_migration,
+            private_resync: rollup.private_resync,
+            indeterminate: rollup.indeterminate,
+            projected_shared_groups: rollup.projected_shared_groups,
+            projected_private_views: rollup.projected_private_views,
+            local_resyncs: rollup.local_resyncs,
+            remote_route_refreshes: rollup.remote_route_refreshes,
+        }),
+        capacity_class: plan.capacity_class,
+        capacity_basis: plan.capacity_basis,
     }
 }
 
@@ -408,6 +451,7 @@ mod tests {
                 unsupported_sections: Vec::new(),
                 restart_required_sections: Vec::new(),
                 human_text: "Config transaction is committable by v1.\n".to_string(),
+                update_group_impact: rustbgpd_rib::UpdateGroupImpactPlan::default(),
             }));
         });
 
@@ -509,6 +553,7 @@ mod tests {
                 unsupported_sections: Vec::new(),
                 restart_required_sections: Vec::new(),
                 human_text: "No changes.\n".to_string(),
+                update_group_impact: rustbgpd_rib::UpdateGroupImpactPlan::default(),
             }));
         });
 
@@ -575,6 +620,7 @@ mod tests {
                         committed_sections: vec!["[[fib_tables]]".to_string()],
                         human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
                         confirmation: None,
+                        update_group_impact: None,
                     })
                 })
             })),

--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -424,6 +424,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn plan_response_uses_the_canonical_impact_projection() {
+        let impact = rustbgpd_rib::UpdateGroupImpactPlan {
+            schema_version: 1,
+            capacity_class: "fully_shared".to_string(),
+            capacity_basis: "fixture".to_string(),
+            ..rustbgpd_rib::UpdateGroupImpactPlan::default()
+        };
+        let expected = update_group_impact_to_proto(impact.clone());
+        let response = transaction_plan_to_proto(RuntimeConfigTransactionPlan {
+            status: RuntimeConfigTransactionStatus::Committable,
+            runtime_snapshot_token: "before".to_string(),
+            post_commit_runtime_snapshot_token: "after".to_string(),
+            diff: sample_runtime_diff(),
+            supported_sections: vec!["[policy]".to_string()],
+            unsupported_sections: vec![],
+            restart_required_sections: vec![],
+            human_text: String::new(),
+            update_group_impact: impact,
+        });
+        assert_eq!(response.update_group_impact, Some(expected));
+    }
+
     #[tokio::test]
     async fn plan_config_transaction_forwards_candidate_and_token() {
         let (tx, mut rx) = mpsc::channel(1);

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -14,7 +14,7 @@ pub mod authz;
 pub mod authz_principal;
 pub mod authz_runtime;
 pub mod bfd_service;
-pub mod config_service;
+mod config_service;
 mod connect_info;
 mod control_service;
 pub mod credentials;
@@ -36,6 +36,7 @@ pub mod server;
 #[cfg(test)]
 mod test_support;
 
+pub use config_service::update_group_impact_to_proto;
 pub use evpn_service::EvpnService;
 
 /// Public-facing alias for the proto-encoding helpers used by the

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -14,7 +14,7 @@ pub mod authz;
 pub mod authz_principal;
 pub mod authz_runtime;
 pub mod bfd_service;
-mod config_service;
+pub mod config_service;
 mod connect_info;
 mod control_service;
 pub mod credentials;

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -385,9 +385,10 @@ pub struct RuntimeConfigTransactionPlan {
     pub status: RuntimeConfigTransactionStatus,
     pub runtime_snapshot_token: String,
     /// Keyed token the live runtime config would carry once this candidate is
-    /// committed. The apply path returns it so a client can chain a follow-up
-    /// apply without re-planning. Computed under the same peer-manager key as
-    /// `runtime_snapshot_token`; not surfaced in the gRPC plan response.
+    /// committed if the negotiated snapshot is unchanged. Live policy apply
+    /// refreshes the authoritative token after RIB convergence before returning
+    /// it, so clients can safely chain a follow-up plan. Not surfaced in the
+    /// gRPC plan response.
     pub post_commit_runtime_snapshot_token: String,
     pub diff: RuntimeConfigDiff,
     pub supported_sections: Vec<String>,

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -394,6 +394,8 @@ pub struct RuntimeConfigTransactionPlan {
     pub unsupported_sections: Vec<String>,
     pub restart_required_sections: Vec<String>,
     pub human_text: String,
+    /// Side-effect-free update-group projection from the same runtime snapshot.
+    pub update_group_impact: rustbgpd_rib::UpdateGroupImpactPlan,
 }
 
 /// Validate-only transaction planning error returned by the peer manager.

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -7,6 +7,7 @@ use crate::proto::{
     ConfigTransactionPlanResponse, ConfigTransactionPlanStatus, ConfigTransactionStatusResponse,
     ConfirmConfigTransactionRequest, DiffRuntimeConfigRequest, DiffRuntimeConfigResponse,
     GetConfigTransactionStatusRequest, GetEffectiveConfigRequest, PlanConfigTransactionRequest,
+    UpdateGroupImpactPlan,
 };
 
 const MAX_CONFIRM_ID_CHARS: usize = 128;
@@ -331,6 +332,7 @@ fn plan_to_json(resp: &ConfigTransactionPlanResponse) -> serde_json::Value {
         "unsupported_sections": resp.unsupported_sections,
         "restart_required_sections": resp.restart_required_sections,
         "human_text": resp.human_text,
+        "update_group_impact": update_group_impact_to_json(resp.update_group_impact.as_ref()),
     })
 }
 
@@ -341,7 +343,72 @@ fn apply_to_json(resp: &ConfigTransactionApplyResponse) -> serde_json::Value {
         "committed_sections": resp.committed_sections,
         "human_text": resp.human_text,
         "confirmation": confirmation_to_json(resp.confirmation.as_ref()),
+        "update_group_impact": update_group_impact_to_json(resp.update_group_impact.as_ref()),
     })
+}
+
+fn update_group_impact_to_json(plan: Option<&UpdateGroupImpactPlan>) -> serde_json::Value {
+    let Some(plan) = plan else {
+        return serde_json::Value::Null;
+    };
+    let rollup = plan.rollup.as_ref();
+    serde_json::json!({
+        "schema_version": plan.schema_version,
+        "entries": plan.entries.iter().map(|row| serde_json::json!({
+            "peer": row.peer, "afi": row.afi, "safi": row.safi,
+            "current": row.current, "candidate": row.candidate,
+            "transition": row.transition, "reason": row.reason,
+            "provenance": row.provenance, "local_resync": row.local_resync,
+            "remote_route_refresh": row.remote_route_refresh,
+        })).collect::<Vec<_>>(),
+        "rollup": rollup.map(|value| serde_json::json!({
+            "affected_peers": value.affected_peers,
+            "affected_families": value.affected_families,
+            "no_op": value.no_op, "regroup": value.regroup,
+            "shared_migration": value.shared_migration,
+            "private_resync": value.private_resync,
+            "indeterminate": value.indeterminate,
+            "projected_shared_groups": value.projected_shared_groups,
+            "projected_private_views": value.projected_private_views,
+            "local_resyncs": value.local_resyncs,
+            "remote_route_refreshes": value.remote_route_refreshes,
+        })),
+        "capacity_class": plan.capacity_class,
+        "capacity_basis": plan.capacity_basis,
+    })
+}
+
+fn print_update_group_impact(plan: Option<&UpdateGroupImpactPlan>) {
+    let Some(plan) = plan else {
+        return;
+    };
+    if let Some(rollup) = &plan.rollup {
+        println!(
+            "update_group_impact_v{}: affected_peers={} affected_families={} shared_groups={} private_views={} capacity={} ({})",
+            plan.schema_version,
+            rollup.affected_peers,
+            rollup.affected_families,
+            rollup.projected_shared_groups,
+            rollup.projected_private_views,
+            plan.capacity_class,
+            plan.capacity_basis
+        );
+    }
+    for row in &plan.entries {
+        if row.transition != "no_op" {
+            println!(
+                "  {} afi/safi {}/{}: {} -> {} [{}; local_resync={}; route_refresh={}]",
+                row.peer,
+                row.afi,
+                row.safi,
+                row.current,
+                row.candidate,
+                row.transition,
+                row.local_resync,
+                row.remote_route_refresh
+            );
+        }
+    }
 }
 
 fn confirmation_to_json(confirmation: Option<&ConfigTransactionConfirmation>) -> serde_json::Value {
@@ -377,6 +444,7 @@ fn print_plan_human(resp: &ConfigTransactionPlanResponse) {
             ("restart_required_sections", &resp.restart_required_sections),
         ],
     );
+    print_update_group_impact(resp.update_group_impact.as_ref());
 }
 
 fn print_apply_human(resp: &ConfigTransactionApplyResponse) {
@@ -387,6 +455,7 @@ fn print_apply_human(resp: &ConfigTransactionApplyResponse) {
         &[("committed_sections", &resp.committed_sections)],
     );
     print_confirmation(resp.confirmation.as_ref());
+    print_update_group_impact(resp.update_group_impact.as_ref());
 }
 
 fn print_confirmation(confirmation: Option<&ConfigTransactionConfirmation>) {
@@ -1007,12 +1076,47 @@ mod tests {
             unsupported_sections: vec!["[policy]".to_string()],
             restart_required_sections: vec!["[global]".to_string()],
             human_text: "Config transaction is rejected.\n".to_string(),
+            update_group_impact: Some(UpdateGroupImpactPlan {
+                schema_version: 1,
+                entries: vec![crate::proto::UpdateGroupFamilyImpact {
+                    peer: "192.0.2.1".to_string(),
+                    afi: 1,
+                    safi: 1,
+                    current: "plan-group-001".to_string(),
+                    candidate: "policy_peer_context".to_string(),
+                    transition: "private_resync".to_string(),
+                    reason: "policy_peer_context".to_string(),
+                    provenance: "runtime_groupability_classifier".to_string(),
+                    local_resync: true,
+                    remote_route_refresh: false,
+                }],
+                rollup: Some(crate::proto::UpdateGroupImpactRollup {
+                    affected_peers: 1,
+                    affected_families: 1,
+                    no_op: 0,
+                    regroup: 0,
+                    shared_migration: 0,
+                    private_resync: 1,
+                    indeterminate: 0,
+                    projected_shared_groups: 0,
+                    projected_private_views: 1,
+                    local_resyncs: 1,
+                    remote_route_refreshes: 0,
+                }),
+                capacity_class: "within_mixed".to_string(),
+                capacity_basis: "receipt envelope".to_string(),
+            }),
         });
 
         assert_eq!(value["status"], "committable");
         assert_eq!(value["runtime_snapshot_token"], "kv1:planned:1");
         assert_eq!(value["supported_sections"][0], "[[fib_tables]]");
         assert_eq!(value["unsupported_sections"][0], "[policy]");
+        assert_eq!(value["update_group_impact"]["schema_version"], 1);
+        assert_eq!(
+            value["update_group_impact"]["entries"][0]["transition"],
+            "private_resync"
+        );
         assert_eq!(value["restart_required_sections"][0], "[global]");
         assert_eq!(
             value["diff"]["diff_json"]["reload_applied"],
@@ -1036,6 +1140,7 @@ mod tests {
                 runtime_snapshot_token: "kv1:committed:2".to_string(),
                 human_text: "Confirmed config transaction is pending confirmation.".to_string(),
             }),
+            update_group_impact: None,
         });
 
         assert_eq!(value["status"], "committable");

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -403,6 +403,7 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
                 unsupported_sections: Vec::new(),
                 restart_required_sections: Vec::new(),
                 human_text: "Config transaction is a noop.\n".to_string(),
+                update_group_impact: None,
             }));
         }
         Ok(Response::new(server_proto::ConfigTransactionPlanResponse {
@@ -421,6 +422,7 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
             unsupported_sections: Vec::new(),
             restart_required_sections: Vec::new(),
             human_text: "Config transaction is committable by v1.\n".to_string(),
+            update_group_impact: None,
         }))
     }
 
@@ -437,6 +439,7 @@ impl rustbgpd_api::proto::config_service_server::ConfigService for MockConfigSer
                 committed_sections: vec!["[[fib_tables]]".to_string()],
                 human_text: "Committed [[fib_tables]] transaction.\n".to_string(),
                 confirmation: None,
+                update_group_impact: None,
             },
         ))
     }

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1209,6 +1209,16 @@ impl fmt::Debug for PolicyChain {
 }
 
 impl PolicyChain {
+    /// Stable origin label for update-group planning diagnostics.
+    #[must_use]
+    pub fn groupability_provenance(&self) -> &'static str {
+        if self.policies.iter().any(|policy| policy.rpol.is_some()) {
+            "rpol_compiled_ir"
+        } else {
+            "toml_compiled_ir"
+        }
+    }
+
     /// Create a chain from an ordered list of (unnamed) policies. Each
     /// becomes a `NamedPolicy` with `name = None`. Callers that have
     /// names in hand (the config resolver) build `NamedPolicy` values

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -67,6 +67,6 @@ pub use update::{
     NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, PlannedGroupability,
     RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
     UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupFamilyImpact,
-    UpdateGroupImpactPlan, UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot,
-    classify_update_group, route_query_key,
+    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
+    UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group, route_query_key,
 };

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -64,6 +64,9 @@ pub use route::{
 pub use update::{
     AdjRibOutCounts, BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision,
     ExplainReason, ExportGateStep, ExportGateVerdict, MrtPeerEntry, MrtSnapshotData,
-    NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, RibCommandError, RibUpdate,
-    RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope, route_query_key,
+    NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, PlannedGroupability,
+    RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
+    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupFamilyImpact,
+    UpdateGroupImpactPlan, UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot,
+    classify_update_group, route_query_key,
 };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1189,6 +1189,9 @@ impl RibManager {
             RibUpdate::QueryPeerUpdateGroup { peer, reply } => {
                 self.handle_query_peer_update_group(peer, reply);
             }
+            RibUpdate::QueryUpdateGroupSnapshot { reply } => {
+                self.handle_query_update_group_snapshot(reply);
+            }
             #[cfg(test)]
             RibUpdate::TestQueryVpnAdvertised { peer, reply } => {
                 self.handle_test_query_vpn_advertised(peer, reply);

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -880,6 +880,24 @@ async fn update_group_snapshot_is_side_effect_free_and_runtime_exact() {
     oracle.finish().await;
 }
 
+#[tokio::test]
+async fn runtime_group_key_ignores_non_staging_families() {
+    let mut oracle = Oracle::spawn(false, None);
+    oracle
+        .peer_up_families(
+            A,
+            false,
+            true,
+            None,
+            64,
+            vec![(Afi::Ipv4, Safi::Unicast), (Afi::L2Vpn, Safi::Evpn)],
+        )
+        .await;
+    oracle.peer_up(B, false, true, None, 64).await;
+    assert_eq!(oracle.group_label(A).await, oracle.group_label(B).await);
+    oracle.finish().await;
+}
+
 /// The kitchen-sink exact-stream scenario: initial dump, best change,
 /// best withdraw, split horizon (source inside the group), source-flip
 /// X→Y→X, policy-modified attributes, next-hop-override flags,

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -705,6 +705,24 @@ impl Oracle {
         reply_rx.await.unwrap()
     }
 
+    async fn group_snapshot(&mut self) -> crate::update::UpdateGroupSnapshot {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::QueryUpdateGroupSnapshot { reply: reply_tx })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap()
+    }
+
+    async fn outbound_health(&mut self) -> (usize, usize, usize, usize, usize, usize) {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::TestQueryOutboundHealth { reply: reply_tx })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap()
+    }
+
     pub(super) async fn replace_policy(
         &mut self,
         peer: Ipv4Addr,
@@ -833,6 +851,33 @@ where
     scenario(&mut ungrouped).await;
     let ungrouped = ungrouped.finish().await;
     (grouped, ungrouped)
+}
+
+#[tokio::test]
+async fn update_group_snapshot_is_side_effect_free_and_runtime_exact() {
+    let mut oracle = Oracle::spawn(false, None);
+    oracle.peer_up(A, false, true, None, 64).await;
+    oracle.peer_up(B, false, true, None, 64).await;
+    let labels_before = (oracle.group_label(A).await, oracle.group_label(B).await);
+    let evals_before = oracle.export_policy_evals().await;
+    let health_before = oracle.outbound_health().await;
+
+    let first = oracle.group_snapshot().await;
+    let second = oracle.group_snapshot().await;
+
+    assert_eq!(first, second, "snapshot must be deterministic");
+    assert_eq!(first.peers.len(), 2);
+    assert!(first.peers.iter().all(|row| {
+        row.runtime_membership.starts_with("group:")
+            && row.classification == crate::update::classify_update_group(row.input.clone())
+    }));
+    assert_eq!(
+        labels_before,
+        (oracle.group_label(A).await, oracle.group_label(B).await)
+    );
+    assert_eq!(evals_before, oracle.export_policy_evals().await);
+    assert_eq!(health_before, oracle.outbound_health().await);
+    oracle.finish().await;
 }
 
 /// The kitchen-sink exact-stream scenario: initial dump, best change,

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -41,6 +41,10 @@ use super::helpers::{LOCAL_PEER, routes_equal, vpn_routes_equal};
 use super::{PolicyFilteredRouteKey, RibManager, RtcMembership};
 use crate::adj_rib_out::AdjRibOut;
 use crate::route::{Route, VpnRibRoute, VpnRibRouteKey};
+use crate::update::{
+    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupPeerSnapshot,
+    UpdateGroupSnapshot, classify_update_group,
+};
 use rustbgpd_wire::{ExtendedCommunity, VpnAddressFamily, VpnRouteKey};
 
 /// Fingerprint of every RIB-staging input that makes per-peer staged
@@ -2008,21 +2012,6 @@ impl RibManager {
         if self.test_force_ungrouped {
             return GroupMembership::PolicyPeerContext;
         }
-        if self
-            .export_policy_for(peer)
-            .is_some_and(PolicyChain::requires_peer_context)
-        {
-            return GroupMembership::PolicyPeerContext;
-        }
-        if self.peer_has_any_add_path_send(peer) {
-            return GroupMembership::AddPathSend;
-        }
-        if self.peer_per_client_best.contains(&peer) {
-            return GroupMembership::PerClientBest;
-        }
-        if self.peer_orr_vantage.contains_key(&peer) {
-            return GroupMembership::OrrVantage;
-        }
         // ORF-receive negotiated ⇒ ungrouped from the start (the RFC
         // 5291 §6 gate never meets grouping). Read from the live
         // session record — `peer_orf_pending` drains as gates lift, so
@@ -2032,13 +2021,25 @@ impl RibManager {
             .get(&peer)
             .and_then(|sessions| sessions.last())
             .is_some_and(|record| !record.negotiated_orf_recv.is_empty());
-        if orf_negotiated || self.peer_orf_filters.contains_key(&peer) {
-            return GroupMembership::OrfInstalled;
+        let chain = self.export_policy_for(peer).cloned();
+        let input = self.update_group_classifier_input(
+            peer,
+            chain.as_ref(),
+            orf_negotiated || self.peer_orf_filters.contains_key(&peer),
+        );
+        match classify_update_group(input) {
+            UpdateGroupClassification::PolicyPeerContext => {
+                return GroupMembership::PolicyPeerContext;
+            }
+            UpdateGroupClassification::AddPathSend => return GroupMembership::AddPathSend,
+            UpdateGroupClassification::PerClientBest => return GroupMembership::PerClientBest,
+            UpdateGroupClassification::OrrVantage => return GroupMembership::OrrVantage,
+            UpdateGroupClassification::OrfInstalled => return GroupMembership::OrfInstalled,
+            UpdateGroupClassification::Groupable(_) => {}
         }
 
         // Clone released before the &mut intern below; chains are small
         // and this runs at config/session-lifecycle frequency only.
-        let chain = self.export_policy_for(peer).cloned();
         let chain_idx = chain
             .as_ref()
             .map(|chain| self.update_groups.intern_chain(chain));
@@ -2068,6 +2069,76 @@ impl RibManager {
             llgr_families,
         };
         GroupMembership::Grouped(self.update_groups.group_for(key))
+    }
+
+    fn update_group_classifier_input(
+        &self,
+        peer: IpAddr,
+        chain: Option<&PolicyChain>,
+        orf_installed: bool,
+    ) -> UpdateGroupClassifierInput {
+        let sendable = self.peer_sendable_families.get(&peer);
+        let mut sendable_families = sendable
+            .into_iter()
+            .flatten()
+            .map(|&(afi, safi)| (afi as u16, safi as u8))
+            .collect::<Vec<_>>();
+        sendable_families.sort_unstable();
+        let mut llgr_families = self
+            .peer_advertised_llgr_families
+            .get(&peer)
+            .into_iter()
+            .flatten()
+            .map(|&(afi, safi)| (afi as u16, safi as u8))
+            .collect::<Vec<_>>();
+        llgr_families.sort_unstable();
+        UpdateGroupClassifierInput {
+            policy_fingerprint: chain.map(|value| format!("{value:?}")),
+            policy_requires_peer_context: chain.is_some_and(PolicyChain::requires_peer_context),
+            target_is_ebgp: self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
+            target_is_rr_client: self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),
+            sendable_families,
+            llgr_families,
+            add_path_send: self.peer_has_any_add_path_send(peer),
+            per_client_best: self.peer_per_client_best.contains(&peer),
+            orr_vantage: self.peer_orr_vantage.contains_key(&peer),
+            orf_installed,
+        }
+    }
+
+    pub(super) fn handle_query_update_group_snapshot(
+        &self,
+        reply: tokio::sync::oneshot::Sender<UpdateGroupSnapshot>,
+    ) {
+        let mut peers = self
+            .update_groups
+            .members
+            .iter()
+            .map(|(&peer, membership)| {
+                let chain = self.export_policy_for(peer);
+                let orf_negotiated = self
+                    .live_sessions
+                    .get(&peer)
+                    .and_then(|sessions| sessions.last())
+                    .is_some_and(|record| !record.negotiated_orf_recv.is_empty());
+                let input = self.update_group_classifier_input(
+                    peer,
+                    chain,
+                    orf_negotiated || self.peer_orf_filters.contains_key(&peer),
+                );
+                UpdateGroupPeerSnapshot {
+                    peer,
+                    classification: classify_update_group(input.clone()),
+                    input,
+                    runtime_membership: membership.label(),
+                }
+            })
+            .collect::<Vec<_>>();
+        peers.sort_by_key(|row| match row.peer {
+            IpAddr::V4(addr) => (0, addr.octets().to_vec()),
+            IpAddr::V6(addr) => (1, addr.octets().to_vec()),
+        });
+        let _ = reply.send(UpdateGroupSnapshot { peers });
     }
 
     /// Re-derive every update-group gauge from the membership map.

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2094,6 +2094,7 @@ impl RibManager {
         llgr_families.sort_unstable();
         UpdateGroupClassifierInput {
             policy_fingerprint: chain.map(|value| format!("{value:?}")),
+            policy_provenance: chain.map(|value| value.groupability_provenance().to_string()),
             policy_requires_peer_context: chain.is_some_and(PolicyChain::requires_peer_context),
             target_is_ebgp: self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
             target_is_rr_client: self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2027,7 +2027,7 @@ impl RibManager {
             chain.as_ref(),
             orf_negotiated || self.peer_orf_filters.contains_key(&peer),
         );
-        match classify_update_group(input) {
+        let fingerprint = match classify_update_group(input) {
             UpdateGroupClassification::PolicyPeerContext => {
                 return GroupMembership::PolicyPeerContext;
             }
@@ -2035,38 +2035,24 @@ impl RibManager {
             UpdateGroupClassification::PerClientBest => return GroupMembership::PerClientBest,
             UpdateGroupClassification::OrrVantage => return GroupMembership::OrrVantage,
             UpdateGroupClassification::OrfInstalled => return GroupMembership::OrfInstalled,
-            UpdateGroupClassification::Groupable(_) => {}
-        }
+            UpdateGroupClassification::Groupable(fingerprint) => fingerprint,
+        };
 
         // Clone released before the &mut intern below; chains are small
         // and this runs at config/session-lifecycle frequency only.
         let chain_idx = chain
             .as_ref()
             .map(|chain| self.update_groups.intern_chain(chain));
-        let sendable = self.peer_sendable_families.get(&peer);
-        let contains = |family: (Afi, Safi)| sendable.is_some_and(|f| f.contains(&family));
-        let mut llgr_families: Vec<(u16, u8)> = self
-            .peer_advertised_llgr_families
-            .get(&peer)
-            .map(|families| {
-                families
-                    .iter()
-                    .map(|&(afi, safi)| (afi as u16, safi as u8))
-                    .collect()
-            })
-            .unwrap_or_default();
-        llgr_families.sort_unstable();
-        llgr_families.dedup();
         let key = GroupKey {
             chain: chain_idx,
-            target_is_ebgp: self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
-            target_is_rr_client: self.peer_is_rr_client.get(&peer).copied().unwrap_or(false),
-            sendable_ipv4_unicast: contains((Afi::Ipv4, Safi::Unicast)),
-            sendable_ipv6_unicast: contains((Afi::Ipv6, Safi::Unicast)),
-            sendable_vpnv4: contains((Afi::Ipv4, Safi::MplsVpn)),
-            sendable_vpnv6: contains((Afi::Ipv6, Safi::MplsVpn)),
-            rtc_negotiated: contains((Afi::Ipv4, Safi::RtConstrain)),
-            llgr_families,
+            target_is_ebgp: fingerprint.target_is_ebgp,
+            target_is_rr_client: fingerprint.target_is_rr_client,
+            sendable_ipv4_unicast: fingerprint.sendable_ipv4_unicast,
+            sendable_ipv6_unicast: fingerprint.sendable_ipv6_unicast,
+            sendable_vpnv4: fingerprint.sendable_vpnv4,
+            sendable_vpnv6: fingerprint.sendable_vpnv6,
+            rtc_negotiated: fingerprint.rtc_negotiated,
+            llgr_families: fingerprint.llgr_families,
         };
         GroupMembership::Grouped(self.update_groups.group_for(key))
     }

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2070,6 +2070,7 @@ impl RibManager {
             .map(|&(afi, safi)| (afi as u16, safi as u8))
             .collect::<Vec<_>>();
         sendable_families.sort_unstable();
+        sendable_families.dedup();
         let mut llgr_families = self
             .peer_advertised_llgr_families
             .get(&peer)
@@ -2078,6 +2079,7 @@ impl RibManager {
             .map(|&(afi, safi)| (afi as u16, safi as u8))
             .collect::<Vec<_>>();
         llgr_families.sort_unstable();
+        llgr_families.dedup();
         UpdateGroupClassifierInput {
             policy_fingerprint: chain.map(|value| format!("{value:?}")),
             policy_provenance: chain.map(|value| value.groupability_provenance().to_string()),

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2088,7 +2088,7 @@ impl RibManager {
             llgr_families,
             add_path_send: self.peer_has_any_add_path_send(peer),
             per_client_best: self.peer_per_client_best.contains(&peer),
-            orr_vantage: self.peer_orr_vantage.contains_key(&peer),
+            orr_vantage: self.peer_orr_vantage.get(&peer).copied(),
             orf_installed,
         }
     }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -26,7 +26,7 @@ pub struct UpdateGroupClassifierInput {
     pub llgr_families: Vec<(u16, u8)>,
     pub add_path_send: bool,
     pub per_client_best: bool,
-    pub orr_vantage: bool,
+    pub orr_vantage: Option<IpAddr>,
     pub orf_installed: bool,
 }
 
@@ -86,7 +86,7 @@ pub fn classify_update_group(mut input: UpdateGroupClassifierInput) -> UpdateGro
         UpdateGroupClassification::AddPathSend
     } else if input.per_client_best {
         UpdateGroupClassification::PerClientBest
-    } else if input.orr_vantage {
+    } else if input.orr_vantage.is_some() {
         UpdateGroupClassification::OrrVantage
     } else if input.orf_installed {
         UpdateGroupClassification::OrfInstalled
@@ -192,7 +192,7 @@ mod update_group_classifier_tests {
             llgr_families: vec![],
             add_path_send: false,
             per_client_best: false,
-            orr_vantage: false,
+            orr_vantage: None,
             orf_installed: false,
         }
     }
@@ -249,7 +249,7 @@ mod update_group_classifier_tests {
             (
                 "orr",
                 UpdateGroupClassifierInput {
-                    orr_vantage: true,
+                    orr_vantage: Some("192.0.2.9".parse().unwrap()),
                     ..input()
                 },
                 Some("orr_vantage"),

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -10,6 +10,183 @@ use rustbgpd_wire::{
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 
+/// Canonical, side-effect-free input to update-group eligibility.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors the independent runtime update-group predicates"
+)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UpdateGroupClassifierInput {
+    pub policy_fingerprint: Option<String>,
+    pub policy_requires_peer_context: bool,
+    pub target_is_ebgp: bool,
+    pub target_is_rr_client: bool,
+    pub sendable_families: Vec<(u16, u8)>,
+    pub llgr_families: Vec<(u16, u8)>,
+    pub add_path_send: bool,
+    pub per_client_best: bool,
+    pub orr_vantage: bool,
+    pub orf_installed: bool,
+}
+
+/// Stable classifier result shared by live registration and config planning.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UpdateGroupClassification {
+    Groupable(UpdateGroupClassifierInput),
+    PolicyPeerContext,
+    AddPathSend,
+    PerClientBest,
+    OrrVantage,
+    OrfInstalled,
+}
+
+impl UpdateGroupClassification {
+    #[must_use]
+    pub const fn reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Groupable(_) => None,
+            Self::PolicyPeerContext => Some("policy_peer_context"),
+            Self::AddPathSend => Some("add_path_send"),
+            Self::PerClientBest => Some("per_client_best"),
+            Self::OrrVantage => Some("orr_vantage"),
+            Self::OrfInstalled => Some("orf_installed"),
+        }
+    }
+}
+
+/// Apply the runtime eligibility precedence without reading or mutating RIB state.
+#[must_use]
+pub fn classify_update_group(mut input: UpdateGroupClassifierInput) -> UpdateGroupClassification {
+    input.sendable_families.sort_unstable();
+    input.sendable_families.dedup();
+    input.llgr_families.sort_unstable();
+    input.llgr_families.dedup();
+    if input.policy_requires_peer_context {
+        UpdateGroupClassification::PolicyPeerContext
+    } else if input.add_path_send {
+        UpdateGroupClassification::AddPathSend
+    } else if input.per_client_best {
+        UpdateGroupClassification::PerClientBest
+    } else if input.orr_vantage {
+        UpdateGroupClassification::OrrVantage
+    } else if input.orf_installed {
+        UpdateGroupClassification::OrfInstalled
+    } else {
+        UpdateGroupClassification::Groupable(input)
+    }
+}
+
+/// One established peer in the side-effect-free planner snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpdateGroupPeerSnapshot {
+    pub peer: IpAddr,
+    pub input: UpdateGroupClassifierInput,
+    pub classification: UpdateGroupClassification,
+    pub runtime_membership: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UpdateGroupSnapshot {
+    pub peers: Vec<UpdateGroupPeerSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PlannedGroupability {
+    Group { id: String },
+    Private { reason: String },
+    Indeterminate { reason: String },
+    Absent,
+}
+
+impl PlannedGroupability {
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self {
+            Self::Group { id } => id.clone(),
+            Self::Private { reason } | Self::Indeterminate { reason } => reason.clone(),
+            Self::Absent => "absent".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UpdateGroupFamilyImpact {
+    pub peer: IpAddr,
+    pub afi: u16,
+    pub safi: u8,
+    pub current: PlannedGroupability,
+    pub candidate: PlannedGroupability,
+    pub transition: String,
+    pub reason: String,
+    pub provenance: String,
+    pub local_resync: bool,
+    pub remote_route_refresh: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UpdateGroupImpactRollup {
+    pub affected_peers: u32,
+    pub affected_families: u32,
+    pub no_op: u32,
+    pub regroup: u32,
+    pub shared_migration: u32,
+    pub private_resync: u32,
+    pub indeterminate: u32,
+    pub projected_shared_groups: u32,
+    pub projected_private_views: u32,
+    pub local_resyncs: u32,
+    pub remote_route_refreshes: u32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UpdateGroupImpactPlan {
+    pub schema_version: u32,
+    pub entries: Vec<UpdateGroupFamilyImpact>,
+    pub rollup: UpdateGroupImpactRollup,
+    pub capacity_class: String,
+    pub capacity_basis: String,
+}
+
+#[cfg(test)]
+mod update_group_classifier_tests {
+    use super::*;
+
+    fn input() -> UpdateGroupClassifierInput {
+        UpdateGroupClassifierInput {
+            policy_fingerprint: Some("permit-all".to_string()),
+            policy_requires_peer_context: false,
+            target_is_ebgp: false,
+            target_is_rr_client: true,
+            sendable_families: vec![(2, 1), (1, 1), (1, 1)],
+            llgr_families: vec![],
+            add_path_send: false,
+            per_client_best: false,
+            orr_vantage: false,
+            orf_installed: false,
+        }
+    }
+
+    #[test]
+    fn classifier_canonicalizes_families() {
+        let UpdateGroupClassification::Groupable(result) = classify_update_group(input()) else {
+            panic!("uniform input must group");
+        };
+        assert_eq!(result.sendable_families, vec![(1, 1), (2, 1)]);
+    }
+
+    #[test]
+    fn classifier_uses_runtime_fallback_precedence() {
+        let mut value = input();
+        value.policy_requires_peer_context = true;
+        value.add_path_send = true;
+        value.orf_installed = true;
+        assert_eq!(
+            classify_update_group(value),
+            UpdateGroupClassification::PolicyPeerContext
+        );
+    }
+}
+
 use crate::best_path::BestPathReason;
 use crate::event::{EvpnRouteEvent, RouteEvent};
 use crate::route::{
@@ -795,6 +972,10 @@ pub enum RibUpdate {
         peer: IpAddr,
         /// Response channel.
         reply: oneshot::Sender<String>,
+    },
+    /// Side-effect-free snapshot used by config impact planning.
+    QueryUpdateGroupSnapshot {
+        reply: oneshot::Sender<UpdateGroupSnapshot>,
     },
     /// TEST ONLY: a peer's advertised VPN view recomputed from manager
     /// state — the Φ-filtered group table for a VPN-grouped member, the

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -18,6 +18,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UpdateGroupClassifierInput {
     pub policy_fingerprint: Option<String>,
+    pub policy_provenance: Option<String>,
     pub policy_requires_peer_context: bool,
     pub target_is_ebgp: bool,
     pub target_is_rr_client: bool,
@@ -154,6 +155,7 @@ mod update_group_classifier_tests {
     fn input() -> UpdateGroupClassifierInput {
         UpdateGroupClassifierInput {
             policy_fingerprint: Some("permit-all".to_string()),
+            policy_provenance: Some("toml_compiled_ir".to_string()),
             policy_requires_peer_context: false,
             target_is_ebgp: false,
             target_is_rr_client: true,
@@ -184,6 +186,67 @@ mod update_group_classifier_tests {
             classify_update_group(value),
             UpdateGroupClassification::PolicyPeerContext
         );
+    }
+
+    #[test]
+    fn classifier_golden_groupability_scenarios() {
+        let cases: Vec<(&str, UpdateGroupClassifierInput, Option<&str>)> = vec![
+            ("uniform", input(), None),
+            (
+                "rtc_membership",
+                UpdateGroupClassifierInput {
+                    sendable_families: vec![(1, 132), (1, 128)],
+                    ..input()
+                },
+                None,
+            ),
+            (
+                "per_client_best",
+                UpdateGroupClassifierInput {
+                    per_client_best: true,
+                    ..input()
+                },
+                Some("per_client_best"),
+            ),
+            (
+                "orf",
+                UpdateGroupClassifierInput {
+                    orf_installed: true,
+                    ..input()
+                },
+                Some("orf_installed"),
+            ),
+            (
+                "orr",
+                UpdateGroupClassifierInput {
+                    orr_vantage: true,
+                    ..input()
+                },
+                Some("orr_vantage"),
+            ),
+            (
+                "toml_peer_context",
+                UpdateGroupClassifierInput {
+                    policy_requires_peer_context: true,
+                    policy_provenance: Some("toml_compiled_ir".to_string()),
+                    ..input()
+                },
+                Some("policy_peer_context"),
+            ),
+            (
+                "rpol_peer_context",
+                UpdateGroupClassifierInput {
+                    policy_requires_peer_context: true,
+                    policy_provenance: Some("rpol_compiled_ir".to_string()),
+                    ..input()
+                },
+                Some("policy_peer_context"),
+            ),
+        ];
+        for (name, value, expected_reason) in cases {
+            let result = classify_update_group(value);
+            assert_eq!(result.reason(), expected_reason, "scenario {name}");
+        }
     }
 }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -30,10 +30,28 @@ pub struct UpdateGroupClassifierInput {
     pub orf_installed: bool,
 }
 
+/// Exact runtime grouping key, excluding diagnostics and non-staging families.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors the independent fields of the runtime GroupKey"
+)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UpdateGroupFingerprint {
+    pub policy_fingerprint: Option<String>,
+    pub target_is_ebgp: bool,
+    pub target_is_rr_client: bool,
+    pub sendable_ipv4_unicast: bool,
+    pub sendable_ipv6_unicast: bool,
+    pub sendable_vpnv4: bool,
+    pub sendable_vpnv6: bool,
+    pub rtc_negotiated: bool,
+    pub llgr_families: Vec<(u16, u8)>,
+}
+
 /// Stable classifier result shared by live registration and config planning.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UpdateGroupClassification {
-    Groupable(UpdateGroupClassifierInput),
+    Groupable(UpdateGroupFingerprint),
     PolicyPeerContext,
     AddPathSend,
     PerClientBest,
@@ -73,7 +91,18 @@ pub fn classify_update_group(mut input: UpdateGroupClassifierInput) -> UpdateGro
     } else if input.orf_installed {
         UpdateGroupClassification::OrfInstalled
     } else {
-        UpdateGroupClassification::Groupable(input)
+        let contains = |family| input.sendable_families.contains(&family);
+        UpdateGroupClassification::Groupable(UpdateGroupFingerprint {
+            policy_fingerprint: input.policy_fingerprint,
+            target_is_ebgp: input.target_is_ebgp,
+            target_is_rr_client: input.target_is_rr_client,
+            sendable_ipv4_unicast: contains((1, 1)),
+            sendable_ipv6_unicast: contains((2, 1)),
+            sendable_vpnv4: contains((1, 128)),
+            sendable_vpnv6: contains((2, 128)),
+            rtc_negotiated: contains((1, 132)),
+            llgr_families: input.llgr_families,
+        })
     }
 }
 
@@ -94,7 +123,7 @@ pub struct UpdateGroupSnapshot {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PlannedGroupability {
     Group { id: String },
-    Private { reason: String },
+    Private { reason: String, fingerprint: String },
     Indeterminate { reason: String },
     Absent,
 }
@@ -104,7 +133,7 @@ impl PlannedGroupability {
     pub fn label(&self) -> String {
         match self {
             Self::Group { id } => id.clone(),
-            Self::Private { reason } | Self::Indeterminate { reason } => reason.clone(),
+            Self::Private { reason, .. } | Self::Indeterminate { reason } => reason.clone(),
             Self::Absent => "absent".to_string(),
         }
     }
@@ -173,7 +202,8 @@ mod update_group_classifier_tests {
         let UpdateGroupClassification::Groupable(result) = classify_update_group(input()) else {
             panic!("uniform input must group");
         };
-        assert_eq!(result.sendable_families, vec![(1, 1), (2, 1)]);
+        assert!(result.sendable_ipv4_unicast);
+        assert!(result.sendable_ipv6_unicast);
     }
 
     #[test]
@@ -247,6 +277,15 @@ mod update_group_classifier_tests {
             let result = classify_update_group(value);
             assert_eq!(result.reason(), expected_reason, "scenario {name}");
         }
+    }
+
+    #[test]
+    fn canonical_fingerprint_ignores_non_key_family_and_provenance() {
+        let left = input();
+        let mut right = left.clone();
+        right.sendable_families.push((25, 70));
+        right.policy_provenance = Some("rpol_compiled_ir".to_string());
+        assert_eq!(classify_update_group(left), classify_update_group(right));
     }
 }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -15,7 +15,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
     clippy::struct_excessive_bools,
     reason = "mirrors the independent runtime update-group predicates"
 )]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UpdateGroupClassifierInput {
     pub policy_fingerprint: Option<String>,
     pub policy_provenance: Option<String>,
@@ -35,7 +35,7 @@ pub struct UpdateGroupClassifierInput {
     clippy::struct_excessive_bools,
     reason = "mirrors the independent fields of the runtime GroupKey"
 )]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UpdateGroupFingerprint {
     pub policy_fingerprint: Option<String>,
     pub target_is_ebgp: bool,
@@ -49,7 +49,7 @@ pub struct UpdateGroupFingerprint {
 }
 
 /// Stable classifier result shared by live registration and config planning.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UpdateGroupClassification {
     Groupable(UpdateGroupFingerprint),
     PolicyPeerContext,
@@ -107,7 +107,7 @@ pub fn classify_update_group(mut input: UpdateGroupClassifierInput) -> UpdateGro
 }
 
 /// One established peer in the side-effect-free planner snapshot.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UpdateGroupPeerSnapshot {
     pub peer: IpAddr,
     pub input: UpdateGroupClassifierInput,
@@ -115,7 +115,7 @@ pub struct UpdateGroupPeerSnapshot {
     pub runtime_membership: String,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct UpdateGroupSnapshot {
     pub peers: Vec<UpdateGroupPeerSnapshot>,
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2272,6 +2272,12 @@ re-evaluation, while `remote_route_refresh` is separate and remains false for
 this outbound-only projection. Capacity is a receipt-envelope class
 (`fully_shared`, `within_uniform`, `within_mixed`, `outside_measured`, or
 `unknown`), not a byte, memory, or completion-time estimate.
+Only the exact published 1,000-peer uniform and 900-shared/100-private
+topologies receive measured capacity labels; smaller or otherwise different
+shapes are `outside_measured`, not extrapolated. The optimistic transaction
+token is also bound to the live negotiated update-group snapshot, so a session
+flap, capability change, or membership change after Plan makes Apply fail with
+`FAILED_PRECONDITION` and requires a fresh plan.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
 mode: add `--confirm-id <id>` (and optionally `--confirm-timeout <seconds>`) to
 the normal apply invocation — `rbgp config apply <config.toml>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2276,8 +2276,9 @@ Only the exact published 1,000-peer uniform and 900-shared/100-private
 topologies receive measured capacity labels; smaller or otherwise different
 shapes are `outside_measured`, not extrapolated. The optimistic transaction
 token is also bound to the live negotiated update-group snapshot, so a session
-flap, capability change, or membership change after Plan makes Apply fail with
-`FAILED_PRECONDITION` and requires a fresh plan.
+flap, capability change, or membership change observed by Apply's mandatory
+re-plan makes Apply fail with `FAILED_PRECONDITION` and requires a fresh plan.
+The token is optimistic concurrency, not a session freeze after that re-plan.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
 mode: add `--confirm-id <id>` (and optionally `--confirm-timeout <seconds>`) to
 the normal apply invocation — `rbgp config apply <config.toml>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2265,16 +2265,19 @@ Plan and apply responses also carry `update_group_impact` schema version 1.
 It projects each established peer and negotiated AFI/SAFI through the same
 groupability classifier used by live update-group registration, assigns
 deterministic plan-local group IDs, and distinguishes regroup, shared migration,
-private resync, and no-op transitions. New, down, deleted, or session-reshaped
-peers are reported as `indeterminate_session_negotiation`; the planner never
-guesses future capabilities. `local_resync` describes local outbound
+private resync, and no-op transitions. Deleted peers have an explicit `absent`
+candidate state and do not count toward the projected topology or local resyncs.
+New, down, or session-reshaped peers are reported as
+`indeterminate_session_negotiation`; the planner never guesses future
+capabilities. `local_resync` describes local outbound
 re-evaluation, while `remote_route_refresh` is separate and remains false for
 this outbound-only projection. Capacity is a receipt-envelope class
 (`fully_shared`, `within_uniform`, `within_mixed`, `outside_measured`, or
 `unknown`), not a byte, memory, or completion-time estimate.
 Only the exact published 1,000-peer uniform and 900-shared/100-private
-topologies receive measured capacity labels; smaller or otherwise different
-shapes are `outside_measured`, not extrapolated. The optimistic transaction
+topologies receive measured capacity labels. `fully_shared` is a structural,
+explicitly unmeasured label for other one-group topologies; remaining shapes are
+`outside_measured`, not extrapolated. The optimistic transaction
 token is also bound to the live negotiated update-group snapshot, so a session
 flap, capability change, or membership change observed by Apply's mandatory
 re-plan makes Apply fail with `FAILED_PRECONDITION` and requires a fresh plan.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2261,6 +2261,17 @@ restart to enable the subsystem.
 Operators can drive the workflow through `rbgp config plan <config.toml>`
 and `rbgp config apply <config.toml> --expected-runtime-snapshot-token`;
 `--json` returns the same status, section, and token fields for automation.
+Plan and apply responses also carry `update_group_impact` schema version 1.
+It projects each established peer and negotiated AFI/SAFI through the same
+groupability classifier used by live update-group registration, assigns
+deterministic plan-local group IDs, and distinguishes regroup, shared migration,
+private resync, and no-op transitions. New, down, deleted, or session-reshaped
+peers are reported as `indeterminate_session_negotiation`; the planner never
+guesses future capabilities. `local_resync` describes local outbound
+re-evaluation, while `remote_route_refresh` is separate and remains false for
+this outbound-only projection. Capacity is a receipt-envelope class
+(`fully_shared`, `within_uniform`, `within_mixed`, `outside_measured`, or
+`unknown`), not a byte, memory, or completion-time estimate.
 For safe deploys, `ApplyConfigTransaction` also supports a confirmed-commit
 mode: add `--confirm-id <id>` (and optionally `--confirm-timeout <seconds>`) to
 the normal apply invocation — `rbgp config apply <config.toml>

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -204,6 +204,42 @@ message ConfigTransactionPlanResponse {
   repeated string restart_required_sections = 6;
   // Short operator-facing summary of the transaction classification.
   string human_text = 7;
+  UpdateGroupImpactPlan update_group_impact = 8;
+}
+
+message UpdateGroupImpactPlan {
+  uint32 schema_version = 1;
+  repeated UpdateGroupFamilyImpact entries = 2;
+  UpdateGroupImpactRollup rollup = 3;
+  string capacity_class = 4;
+  string capacity_basis = 5;
+}
+
+message UpdateGroupFamilyImpact {
+  string peer = 1;
+  uint32 afi = 2;
+  uint32 safi = 3;
+  string current = 4;
+  string candidate = 5;
+  string transition = 6;
+  string reason = 7;
+  string provenance = 8;
+  bool local_resync = 9;
+  bool remote_route_refresh = 10;
+}
+
+message UpdateGroupImpactRollup {
+  uint32 affected_peers = 1;
+  uint32 affected_families = 2;
+  uint32 no_op = 3;
+  uint32 regroup = 4;
+  uint32 shared_migration = 5;
+  uint32 private_resync = 6;
+  uint32 indeterminate = 7;
+  uint32 projected_shared_groups = 8;
+  uint32 projected_private_views = 9;
+  uint32 local_resyncs = 10;
+  uint32 remote_route_refreshes = 11;
 }
 
 message ApplyConfigTransactionRequest {
@@ -234,6 +270,7 @@ message ConfigTransactionApplyResponse {
   repeated string committed_sections = 3;
   string human_text = 4;
   ConfigTransactionConfirmation confirmation = 5;
+  UpdateGroupImpactPlan update_group_impact = 6;
 }
 
 enum ConfigTransactionConfirmationStatus {

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -187,7 +187,9 @@ enum ConfigTransactionPlanStatus {
 message ConfigTransactionPlanResponse {
   ConfigTransactionPlanStatus status = 1;
   // Opaque process-local optimistic-concurrency token for the live runtime
-  // config snapshot used to produce this plan. It is not a cryptographic
+  // config and negotiated update-group snapshot observed while producing this
+  // plan. Apply performs the same observation before mutation; the token does
+  // not freeze sessions after that apply-time re-plan. It is not a cryptographic
   // commitment or authorization credential; clients must re-plan after daemon
   // restart.
   string runtime_snapshot_token = 2;

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -219,6 +219,8 @@ message UpdateGroupImpactPlan {
 
 message UpdateGroupFamilyImpact {
   string peer = 1;
+  // Negotiated address-family identifiers. Both are zero only for the single
+  // synthetic indeterminate row emitted when no negotiated family is known.
   uint32 afi = 2;
   uint32 safi = 3;
   string current = 4;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2650,7 +2650,13 @@ impl RuntimeSnapshotKey {
     /// serialization under this key, so the token changes when any config byte
     /// relevant to a candidate changes (secrets included) but cannot be
     /// reproduced by a caller who does not hold the key.
+    #[cfg(test)]
     pub fn token(&self, config: &Config) -> Result<String, String> {
+        self.token_with_context(config, &[])
+    }
+
+    /// Keyed token additionally bound to a canonical live-runtime context.
+    pub fn token_with_context(&self, config: &Config, context: &[u8]) -> Result<String, String> {
         use std::hash::{BuildHasher, Hasher};
         // Canonical because `toml::Value::Table` is `BTreeMap`-backed (keys
         // sorted) unless toml's `preserve_order` feature is enabled, which it is
@@ -2665,7 +2671,18 @@ impl RuntimeSnapshotKey {
             .map_err(|error| format!("failed to serialize runtime config snapshot: {error}"))?;
         let mut hasher = self.0.build_hasher();
         hasher.write(normalized.as_bytes());
-        Ok(format!("kv1:{:016x}:{}", hasher.finish(), normalized.len()))
+        hasher.write_usize(context.len());
+        hasher.write(context);
+        let digest = hasher.finish();
+        if context.is_empty() {
+            Ok(format!("kv1:{digest:016x}:{}", normalized.len()))
+        } else {
+            Ok(format!(
+                "kv2:{digest:016x}:{}:{}",
+                normalized.len(),
+                context.len()
+            ))
+        }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2646,6 +2646,17 @@ impl RuntimeSnapshotKey {
         Self(std::collections::hash_map::RandomState::new())
     }
 
+    /// Compact, process-local identity for a canonical hashable context.
+    ///
+    /// Uses the same secret per-process key material as runtime snapshot
+    /// tokens, so config-controlled context fields cannot cheaply construct a
+    /// collision in an unkeyed pre-hash. The fixed-width result avoids
+    /// materializing large debug or serialization strings.
+    pub(crate) fn digest_context<T: std::hash::Hash>(&self, context: &T) -> [u8; 8] {
+        use std::hash::BuildHasher;
+        self.0.hash_one(context).to_be_bytes()
+    }
+
     /// Keyed change-detector token for `config`. Hashes the canonical TOML
     /// serialization under this key, so the token changes when any config byte
     /// relevant to a candidate changes (secrets included) but cannot be

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -7061,4 +7061,21 @@ families = ["ipv4_unicast"]
             ConfigTransactionApplyError::Unavailable("busy".to_string())
         );
     }
+
+    #[test]
+    fn apply_response_preserves_the_accepted_plan_impact_exactly() {
+        let impact = proto::UpdateGroupImpactPlan {
+            schema_version: 1,
+            capacity_class: "within_mixed".to_string(),
+            capacity_basis: "fixture".to_string(),
+            ..proto::UpdateGroupImpactPlan::default()
+        };
+        let response = committable_response(
+            "after".to_string(),
+            vec!["[policy]".to_string()],
+            "committed".to_string(),
+            Some(impact.clone()),
+        );
+        assert_eq!(response.update_group_impact, Some(impact));
+    }
 }

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1239,11 +1239,9 @@ async fn apply_config_transaction_locked(
                 committed_sections: Vec::new(),
                 human_text: "No changes.\n".to_string(),
                 confirmation: None,
-                update_group_impact: Some(
-                    rustbgpd_api::config_service::update_group_impact_to_proto(
-                        plan.update_group_impact,
-                    ),
-                ),
+                update_group_impact: Some(rustbgpd_api::update_group_impact_to_proto(
+                    plan.update_group_impact,
+                )),
             });
         }
         RuntimeConfigTransactionStatus::Rejected => {
@@ -1268,8 +1266,7 @@ async fn apply_config_transaction_locked(
     // Post-commit token comes from the plan (computed under the peer-manager's
     // key); the apply path can't recompute a key-consistent token itself.
     let post_commit_runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
-    let update_group_impact =
-        rustbgpd_api::config_service::update_group_impact_to_proto(plan.update_group_impact);
+    let update_group_impact = rustbgpd_api::update_group_impact_to_proto(plan.update_group_impact);
     let committed_candidate_toml = request.candidate_toml.clone();
     let mut response = commit_apply_family(
         deps,

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1239,6 +1239,11 @@ async fn apply_config_transaction_locked(
                 committed_sections: Vec::new(),
                 human_text: "No changes.\n".to_string(),
                 confirmation: None,
+                update_group_impact: Some(
+                    rustbgpd_api::config_service::update_group_impact_to_proto(
+                        plan.update_group_impact,
+                    ),
+                ),
             });
         }
         RuntimeConfigTransactionStatus::Rejected => {
@@ -1263,6 +1268,8 @@ async fn apply_config_transaction_locked(
     // Post-commit token comes from the plan (computed under the peer-manager's
     // key); the apply path can't recompute a key-consistent token itself.
     let post_commit_runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
+    let update_group_impact =
+        rustbgpd_api::config_service::update_group_impact_to_proto(plan.update_group_impact);
     commit_apply_family(
         deps,
         &config_tx,
@@ -1271,10 +1278,15 @@ async fn apply_config_transaction_locked(
         candidate,
         plan.supported_sections,
         post_commit_runtime_snapshot_token,
+        update_group_impact,
     )
     .await
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the transaction executor carries candidate, receipt, and commit-token state"
+)]
 async fn commit_apply_family(
     deps: &FibTableControlDeps,
     config_tx: &mpsc::Sender<ConfigEvent>,
@@ -1283,6 +1295,7 @@ async fn commit_apply_family(
     candidate: Config,
     supported_sections: Vec<String>,
     post_commit_runtime_snapshot_token: String,
+    update_group_impact: proto::UpdateGroupImpactPlan,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     match family {
         ApplyFamily::FibTables => {
@@ -1291,6 +1304,7 @@ async fn commit_apply_family(
                 config_tx,
                 &candidate,
                 post_commit_runtime_snapshot_token,
+                update_group_impact,
             )
             .await
         }
@@ -1303,6 +1317,7 @@ async fn commit_apply_family(
                     "Committed [[dynamic_neighbors]] transaction.\n{} range(s) active.\n",
                     candidate.dynamic_neighbors.len()
                 ),
+                Some(update_group_impact),
             ))
         }
         ApplyFamily::CatalogSnapshot => {
@@ -1316,6 +1331,7 @@ async fn commit_apply_family(
                     candidate.policy.neighbor_sets.len(),
                     candidate.peer_groups.len(),
                 ),
+                Some(update_group_impact),
             ))
         }
         ApplyFamily::LivePolicyImpact => {
@@ -1332,6 +1348,7 @@ async fn commit_apply_family(
                 format!(
                     "Committed live policy-impact runtime config transaction.\n{refreshed} live session(s) re-evaluated under the new resolved policy.\n"
                 ),
+                Some(update_group_impact),
             ))
         }
         ApplyFamily::PeerSessionReshape => {
@@ -1346,6 +1363,7 @@ async fn commit_apply_family(
                 post_commit_runtime_snapshot_token,
                 supported_sections,
                 peer_session_reshape_commit_message(&commit),
+                Some(update_group_impact),
             ))
         }
         ApplyFamily::StaticNeighbors => {
@@ -1361,6 +1379,7 @@ async fn commit_apply_family(
                 post_commit_runtime_snapshot_token,
                 supported_sections,
                 "Committed [[neighbors]] add/delete/modify transaction.\n".to_string(),
+                Some(update_group_impact),
             ))
         }
     }
@@ -1371,6 +1390,7 @@ async fn commit_fib_transaction(
     config_tx: &mpsc::Sender<ConfigEvent>,
     candidate: &Config,
     post_commit_runtime_snapshot_token: String,
+    update_group_impact: proto::UpdateGroupImpactPlan,
 ) -> Result<proto::ConfigTransactionApplyResponse, ApplyFailure> {
     let fib_cmd_tx = deps.fib_cmd_tx.clone().ok_or_else(|| {
         fib_error_to_apply_error(runtime_unavailable_error(!deps.startup_tables.is_empty()))
@@ -1393,6 +1413,7 @@ async fn commit_fib_transaction(
             "Committed [[fib_tables]] transaction.\n{} table(s) active.\n",
             response.tables.len()
         ),
+        Some(update_group_impact),
     ))
 }
 
@@ -2457,6 +2478,7 @@ fn committable_response(
     runtime_snapshot_token: String,
     committed_sections: Vec<String>,
     human_text: String,
+    update_group_impact: Option<proto::UpdateGroupImpactPlan>,
 ) -> proto::ConfigTransactionApplyResponse {
     proto::ConfigTransactionApplyResponse {
         status: proto::ConfigTransactionPlanStatus::Committable.into(),
@@ -2464,6 +2486,7 @@ fn committable_response(
         committed_sections,
         human_text,
         confirmation: None,
+        update_group_impact,
     }
 }
 
@@ -2583,6 +2606,7 @@ fn rejected_response(runtime_snapshot_token: String) -> proto::ConfigTransaction
         committed_sections: Vec::new(),
         human_text: "Config transaction is not committable by the current apply executor.\nRun PlanConfigTransaction for section classification.\n".to_string(),
         confirmation: None,
+        update_group_impact: None,
     }
 }
 
@@ -3062,6 +3086,7 @@ peer_group = "edge"
             unsupported_sections: Vec::new(),
             restart_required_sections: Vec::new(),
             human_text: String::new(),
+            update_group_impact: rustbgpd_rib::UpdateGroupImpactPlan::default(),
         }
     }
 

--- a/src/config_transaction_control.rs
+++ b/src/config_transaction_control.rs
@@ -1270,7 +1270,8 @@ async fn apply_config_transaction_locked(
     let post_commit_runtime_snapshot_token = plan.post_commit_runtime_snapshot_token;
     let update_group_impact =
         rustbgpd_api::config_service::update_group_impact_to_proto(plan.update_group_impact);
-    commit_apply_family(
+    let committed_candidate_toml = request.candidate_toml.clone();
+    let mut response = commit_apply_family(
         deps,
         &config_tx,
         family,
@@ -1280,7 +1281,13 @@ async fn apply_config_transaction_locked(
         post_commit_runtime_snapshot_token,
         update_group_impact,
     )
-    .await
+    .await?;
+    if family == ApplyFamily::LivePolicyImpact {
+        let authoritative =
+            plan_candidate(&deps.peer_mgr_tx, committed_candidate_toml, String::new()).await?;
+        response.runtime_snapshot_token = authoritative.runtime_snapshot_token;
+    }
+    Ok(response)
 }
 
 #[expect(
@@ -3633,10 +3640,31 @@ peer_group = "{group}"
         apply_calls: Arc<Mutex<Vec<Vec<ResolvedPeerPolicy>>>>,
         dynamic_calls: Arc<Mutex<Vec<Vec<DynamicRangeTarget>>>>,
     ) {
+        let mut plan_calls = 0usize;
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                PeerManagerCommand::PlanConfigTransaction { reply, .. } => {
-                    let _ = reply.send(Ok(plan.clone()));
+                PeerManagerCommand::PlanConfigTransaction {
+                    expected_runtime_snapshot_token,
+                    reply,
+                    ..
+                } => {
+                    let mut response = plan.clone();
+                    if plan_calls > 0 {
+                        response.runtime_snapshot_token =
+                            plan.post_commit_runtime_snapshot_token.clone();
+                    }
+                    plan_calls += 1;
+                    if let Some(expected) =
+                        expected_runtime_snapshot_token.filter(|value| !value.is_empty())
+                        && expected != response.runtime_snapshot_token
+                    {
+                        let _ = reply.send(Err(RuntimeConfigTransactionPlanError::StaleSnapshot {
+                            expected,
+                            current: response.runtime_snapshot_token,
+                        }));
+                    } else {
+                        let _ = reply.send(Ok(response));
+                    }
                 }
                 PeerManagerCommand::StageConfigSnapshot {
                     candidate_toml,
@@ -3838,7 +3866,7 @@ remote_asn = 65010
         });
 
         let response = apply_config_transaction(
-            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            deps(None, peer_tx.clone(), Some(config_tx), Vec::new()),
             proto::ApplyConfigTransactionRequest {
                 candidate_toml: candidate_toml.clone(),
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
@@ -5265,7 +5293,7 @@ default_action = "permit"
         });
 
         let response = apply_config_transaction(
-            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            deps(None, peer_tx.clone(), Some(config_tx), Vec::new()),
             proto::ApplyConfigTransactionRequest {
                 candidate_toml: candidate_toml.clone(),
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
@@ -5387,7 +5415,7 @@ default_action = "permit"
         });
 
         let response = apply_config_transaction(
-            deps(None, peer_tx, Some(config_tx), Vec::new()),
+            deps(None, peer_tx.clone(), Some(config_tx), Vec::new()),
             proto::ApplyConfigTransactionRequest {
                 candidate_toml: candidate_toml.clone(),
                 expected_runtime_snapshot_token: "kv1:old:1".to_string(),
@@ -5410,6 +5438,18 @@ default_action = "permit"
         );
         assert_eq!(*snapshot_toml.lock().await, candidate_toml);
         assert!(response.human_text.contains("live policy-impact"));
+        assert_eq!(response.runtime_snapshot_token, "kv1:new:2");
+        let chained = plan_candidate(
+            &peer_tx,
+            candidate_toml.clone(),
+            response.runtime_snapshot_token.clone(),
+        )
+        .await
+        .expect("returned post-commit token must chain into a second plan");
+        assert_eq!(
+            chained.runtime_snapshot_token,
+            response.runtime_snapshot_token
+        );
         let calls = apply_calls.lock().await;
         assert_eq!(calls.len(), 1, "exactly one apply call");
         assert_eq!(calls[0].len(), 1, "one impacted static neighbor");

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -37,6 +37,7 @@ mod notifications;
 mod policy;
 mod reconcile;
 mod snapshot;
+mod update_group_plan;
 
 use dynamic::{AcceptedDynamicRange, DeadLetteredPending, DynamicRange};
 
@@ -650,7 +651,7 @@ impl PeerManager {
                             let result = self.plan_config_transaction(
                                 &candidate_toml,
                                 expected_runtime_snapshot_token.as_deref(),
-                            );
+                            ).await;
                             let _ = reply.send(result);
                         }
                         PeerManagerCommand::StageConfigSnapshot {

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -160,7 +160,14 @@ impl PeerManager {
                 .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
         let update_group_impact = self
             .plan_update_group_impact(&candidate, live_snapshot)
-            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
+            .map_err(|error| match error {
+                super::update_group_plan::UpdateGroupImpactPlanError::InvalidCandidate(message) => {
+                    RuntimeConfigTransactionPlanError::InvalidCandidate(message)
+                }
+                super::update_group_plan::UpdateGroupImpactPlanError::Internal(message) => {
+                    RuntimeConfigTransactionPlanError::Internal(message)
+                }
+            })?;
         // Token the resulting live config would carry once this candidate is
         // committed. The apply path returns it so a client can chain a follow-up
         // apply without re-planning; computing it here keeps every token under

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -134,9 +134,16 @@ impl PeerManager {
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
+        let candidate =
+            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
+                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        let (update_group_impact, live_snapshot_identity) = self
+            .plan_update_group_impact(&candidate)
+            .await
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         let runtime_snapshot_token = self
             .snapshot_key
-            .token(&self.current_config)
+            .token_with_context(&self.current_config, live_snapshot_identity.as_bytes())
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         if let Some(expected) = expected_runtime_snapshot_token.filter(|token| !token.is_empty())
             && expected != runtime_snapshot_token
@@ -146,14 +153,6 @@ impl PeerManager {
                 current: runtime_snapshot_token,
             });
         }
-
-        let candidate =
-            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
-                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
-        let update_group_impact = self
-            .plan_update_group_impact(&candidate)
-            .await
-            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         // Token the resulting live config would carry once this candidate is
         // committed. The apply path returns it so a client can chain a follow-up
         // apply without re-planning; computing it here keeps every token under
@@ -162,7 +161,7 @@ impl PeerManager {
         // the one staged family (FIB), which the candidate already reflects.
         let post_commit_runtime_snapshot_token = self
             .snapshot_key
-            .token(&candidate)
+            .token_with_context(&candidate, live_snapshot_identity.as_bytes())
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         let diff = crate::config::diff_config(&self.current_config, &candidate);
         let classification = crate::config::classify_config_transaction_v1(&diff);

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -129,7 +129,7 @@ impl PeerManager {
         runtime_config_diff_from_config_diff(&diff)
     }
 
-    pub(super) fn plan_config_transaction(
+    pub(super) async fn plan_config_transaction(
         &self,
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
@@ -150,6 +150,10 @@ impl PeerManager {
         let candidate =
             Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
                 .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        let update_group_impact = self
+            .plan_update_group_impact(&candidate)
+            .await
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         // Token the resulting live config would carry once this candidate is
         // committed. The apply path returns it so a client can chain a follow-up
         // apply without re-planning; computing it here keeps every token under
@@ -187,6 +191,7 @@ impl PeerManager {
             unsupported_sections: classification.unsupported_sections,
             restart_required_sections: classification.restart_required_sections,
             human_text,
+            update_group_impact,
         })
     }
 

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -142,7 +142,7 @@ impl PeerManager {
             .query_update_group_snapshot()
             .await
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
-        let live_snapshot_identity = super::update_group_plan::snapshot_identity(&live_snapshot);
+        let live_snapshot_identity = self.snapshot_key.digest_context(&live_snapshot);
         let runtime_snapshot_token = self
             .snapshot_key
             .token_with_context(&self.current_config, &live_snapshot_identity)

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -134,16 +134,18 @@ impl PeerManager {
         candidate_toml: &str,
         expected_runtime_snapshot_token: Option<&str>,
     ) -> Result<RuntimeConfigTransactionPlan, RuntimeConfigTransactionPlanError> {
-        let candidate =
-            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
-                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
-        let (update_group_impact, live_snapshot_identity) = self
-            .plan_update_group_impact(&candidate)
+        // Query once and retain the exact snapshot used for both optimistic
+        // concurrency and impact planning. This lets stale callers fail before
+        // candidate parsing and the per-peer planning pass without introducing
+        // a second RIB query or a check/use race.
+        let live_snapshot = self
+            .query_update_group_snapshot()
             .await
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
+        let live_snapshot_identity = super::update_group_plan::snapshot_identity(&live_snapshot);
         let runtime_snapshot_token = self
             .snapshot_key
-            .token_with_context(&self.current_config, live_snapshot_identity.as_bytes())
+            .token_with_context(&self.current_config, &live_snapshot_identity)
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         if let Some(expected) = expected_runtime_snapshot_token.filter(|token| !token.is_empty())
             && expected != runtime_snapshot_token
@@ -153,6 +155,12 @@ impl PeerManager {
                 current: runtime_snapshot_token,
             });
         }
+        let candidate =
+            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
+                .map_err(RuntimeConfigTransactionPlanError::InvalidCandidate)?;
+        let update_group_impact = self
+            .plan_update_group_impact(&candidate, live_snapshot)
+            .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         // Token the resulting live config would carry once this candidate is
         // committed. The apply path returns it so a client can chain a follow-up
         // apply without re-planning; computing it here keeps every token under
@@ -161,7 +169,7 @@ impl PeerManager {
         // the one staged family (FIB), which the candidate already reflects.
         let post_commit_runtime_snapshot_token = self
             .snapshot_key
-            .token_with_context(&candidate, live_snapshot_identity.as_bytes())
+            .token_with_context(&candidate, &live_snapshot_identity)
             .map_err(RuntimeConfigTransactionPlanError::Internal)?;
         let diff = crate::config::diff_config(&self.current_config, &candidate);
         let classification = crate::config::classify_config_transaction_v1(&diff);

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -125,7 +125,7 @@ fn test_peer_manager() -> PeerManager {
 }
 
 #[tokio::test]
-async fn config_apply_replan_rejects_intervening_live_session_snapshot() {
+async fn stale_live_snapshot_is_rejected_before_candidate_validation() {
     let config = load_test_config(
         r#"
 [global]
@@ -202,7 +202,10 @@ log_format = "json"
     });
     let planned = mgr.plan_config_transaction(&candidate, None).await.unwrap();
     let error = mgr
-        .plan_config_transaction(&candidate, Some(&planned.runtime_snapshot_token))
+        .plan_config_transaction(
+            "this is not valid TOML =",
+            Some(&planned.runtime_snapshot_token),
+        )
         .await
         .unwrap_err();
     assert!(matches!(

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -124,6 +124,94 @@ fn test_peer_manager() -> PeerManager {
     )
 }
 
+#[tokio::test]
+async fn config_apply_replan_rejects_intervening_live_session_snapshot() {
+    let config = load_test_config(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+"#,
+    );
+    let candidate = toml::to_string_pretty(&config).unwrap();
+    let (_tx, rx) = mpsc::channel(4);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, mut rib_rx) = mpsc::channel(4);
+    let mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let responder = tokio::spawn(async move {
+        let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+            panic!("first plan snapshot query missing");
+        };
+        reply
+            .send(rustbgpd_rib::UpdateGroupSnapshot::default())
+            .unwrap();
+        let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+            panic!("apply re-plan snapshot query missing");
+        };
+        reply
+            .send(rustbgpd_rib::UpdateGroupSnapshot {
+                peers: vec![rustbgpd_rib::UpdateGroupPeerSnapshot {
+                    peer: "192.0.2.1".parse().unwrap(),
+                    input: rustbgpd_rib::UpdateGroupClassifierInput {
+                        policy_fingerprint: None,
+                        policy_provenance: None,
+                        policy_requires_peer_context: false,
+                        target_is_ebgp: false,
+                        target_is_rr_client: true,
+                        sendable_families: vec![(1, 1)],
+                        llgr_families: vec![],
+                        add_path_send: false,
+                        per_client_best: false,
+                        orr_vantage: false,
+                        orf_installed: false,
+                    },
+                    classification: rustbgpd_rib::UpdateGroupClassification::Groupable(
+                        rustbgpd_rib::UpdateGroupFingerprint {
+                            policy_fingerprint: None,
+                            target_is_ebgp: false,
+                            target_is_rr_client: true,
+                            sendable_ipv4_unicast: true,
+                            sendable_ipv6_unicast: false,
+                            sendable_vpnv4: false,
+                            sendable_vpnv6: false,
+                            rtc_negotiated: false,
+                            llgr_families: vec![],
+                        },
+                    ),
+                    runtime_membership: "group:0".to_string(),
+                }],
+            })
+            .unwrap();
+    });
+    let planned = mgr.plan_config_transaction(&candidate, None).await.unwrap();
+    let error = mgr
+        .plan_config_transaction(&candidate, Some(&planned.runtime_snapshot_token))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionPlanError::StaleSnapshot { .. }
+    ));
+    responder.await.unwrap();
+}
+
 async fn query_session_event_history(
     mgr: &PeerManager,
     peer: Option<IpAddr>,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -215,6 +215,66 @@ log_format = "json"
     responder.await.unwrap();
 }
 
+#[tokio::test]
+async fn candidate_neighbor_resolution_failure_is_invalid_candidate() {
+    let config = load_test_config(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+"#,
+    );
+    let mut candidate = toml::to_string_pretty(&config).unwrap();
+    candidate.push_str(
+        r#"
+[[neighbors]]
+address = "fe80::2"
+interface = "rustbgpd-interface-that-does-not-exist"
+remote_asn = 65002
+"#,
+    );
+    let (_tx, rx) = mpsc::channel(4);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, mut rib_rx) = mpsc::channel(4);
+    let mgr = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let responder = tokio::spawn(async move {
+        let Some(RibUpdate::QueryUpdateGroupSnapshot { reply }) = rib_rx.recv().await else {
+            panic!("plan snapshot query missing");
+        };
+        reply
+            .send(rustbgpd_rib::UpdateGroupSnapshot::default())
+            .unwrap();
+    });
+
+    let error = mgr
+        .plan_config_transaction(&candidate, None)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        rustbgpd_api::peer_types::RuntimeConfigTransactionPlanError::InvalidCandidate(_)
+    ));
+    responder.await.unwrap();
+}
+
 async fn query_session_event_history(
     mgr: &PeerManager,
     peer: Option<IpAddr>,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -179,7 +179,7 @@ log_format = "json"
                         llgr_families: vec![],
                         add_path_send: false,
                         per_client_best: false,
-                        orr_vantage: false,
+                        orr_vantage: None,
                         orf_installed: false,
                     },
                     classification: rustbgpd_rib::UpdateGroupClassification::Groupable(

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -58,13 +58,17 @@ fn candidate_input(
     }
 }
 
-fn raw_state(classification: &UpdateGroupClassification) -> PlannedGroupability {
+fn raw_state(
+    classification: &UpdateGroupClassification,
+    private_fingerprint: &str,
+) -> PlannedGroupability {
     match classification {
         UpdateGroupClassification::Groupable(input) => PlannedGroupability::Group {
             id: format!("raw:{input:?}"),
         },
         other => PlannedGroupability::Private {
             reason: other.reason().expect("fallback has a reason").to_string(),
+            fingerprint: private_fingerprint.to_string(),
         },
     }
 }
@@ -95,7 +99,16 @@ fn transition(current: &PlannedGroupability, candidate: &PlannedGroupability) ->
     use PlannedGroupability::{Absent, Group, Indeterminate, Private};
     match (current, candidate) {
         (Group { id: a }, Group { id: b }) if a == b => "no_op",
-        (Private { reason: a }, Private { reason: b }) if a == b => "no_op",
+        (
+            Private {
+                reason: ar,
+                fingerprint: af,
+            },
+            Private {
+                reason: br,
+                fingerprint: bf,
+            },
+        ) if ar == br && af == bf => "no_op",
         (Absent, Absent) => "no_op",
         (Group { .. }, Group { .. }) | (_, Absent) | (Absent, Group { .. }) => "regroup",
         (Private { .. }, Group { .. }) => "shared_migration",
@@ -112,14 +125,9 @@ fn capacity_class(
 ) -> (&'static str, &'static str) {
     if indeterminate > 0 {
         ("unknown", "future session negotiation is not projected")
-    } else if private_views == 0 && shared_groups == 1 {
+    } else if projected_peers == 1_000 && private_views == 0 && shared_groups == 1 {
         ("fully_shared", "one shared group and no private views")
-    } else if private_views == 0 && projected_peers <= 1_000 {
-        (
-            "within_uniform",
-            "inside the measured 1000-peer uniform envelope",
-        )
-    } else if private_views <= 100 && projected_peers <= 1_000 {
+    } else if projected_peers == 1_000 && private_views == 100 && shared_groups == 1 {
         (
             "within_mixed",
             "inside the measured 900-shared/100-private envelope",
@@ -140,7 +148,7 @@ impl PeerManager {
     pub(super) async fn plan_update_group_impact(
         &self,
         candidate: &Config,
-    ) -> Result<UpdateGroupImpactPlan, String> {
+    ) -> Result<(UpdateGroupImpactPlan, String), String> {
         let (reply, recv) = oneshot::channel();
         self.rib_tx
             .send(RibUpdate::QueryUpdateGroupSnapshot { reply })
@@ -150,6 +158,7 @@ impl PeerManager {
             .await
             .map_err(|_| "RIB update-group snapshot timed out".to_string())?
             .map_err(|_| "RIB dropped update-group snapshot reply".to_string())?;
+        let snapshot_identity = format!("{snapshot:?}");
 
         let current = by_peer(&self.current_config)?;
         let candidate = by_peer(candidate)?;
@@ -174,17 +183,26 @@ impl PeerManager {
                 || PlannedGroupability::Indeterminate {
                     reason: "indeterminate_session_negotiation".to_string(),
                 },
-                |row| raw_state(&row.classification),
+                |row| {
+                    raw_state(
+                        &row.classification,
+                        row.input
+                            .policy_fingerprint
+                            .as_deref()
+                            .unwrap_or("no-policy"),
+                    )
+                },
             );
             let candidate_state = match (live, current_cfg, candidate_cfg) {
                 (Some(live), Some(current), Some(candidate))
                     if preserves_negotiation(current, candidate) =>
                 {
-                    raw_state(&classify_update_group(candidate_input(
-                        live,
-                        candidate,
-                        self.local_asn,
-                    )))
+                    let input = candidate_input(live, candidate, self.local_asn);
+                    let fingerprint = input
+                        .policy_fingerprint
+                        .clone()
+                        .unwrap_or_else(|| "no-policy".to_string());
+                    raw_state(&classify_update_group(input), &fingerprint)
                 }
                 _ => PlannedGroupability::Indeterminate {
                     reason: "indeterminate_session_negotiation".to_string(),
@@ -207,15 +225,17 @@ impl PeerManager {
             let mut families = live.map_or_else(BTreeSet::new, |row| {
                 row.input.sendable_families.iter().copied().collect()
             });
-            for config in [current_cfg, candidate_cfg].into_iter().flatten() {
-                families.extend(
-                    config
-                        .transport_config
-                        .peer
-                        .families
-                        .iter()
-                        .map(|&(afi, safi)| (afi as u16, safi as u8)),
-                );
+            if live.is_none() {
+                for config in [current_cfg, candidate_cfg].into_iter().flatten() {
+                    families.extend(
+                        config
+                            .transport_config
+                            .peer
+                            .families
+                            .iter()
+                            .map(|&(afi, safi)| (afi as u16, safi as u8)),
+                    );
+                }
             }
             for (afi, safi) in families {
                 rows.push((
@@ -301,13 +321,16 @@ impl PeerManager {
             candidate_private.len(),
             rollup.indeterminate,
         );
-        Ok(UpdateGroupImpactPlan {
-            schema_version: 1,
-            entries,
-            rollup,
-            capacity_class: capacity_class.to_string(),
-            capacity_basis: capacity_basis.to_string(),
-        })
+        Ok((
+            UpdateGroupImpactPlan {
+                schema_version: 1,
+                entries,
+                rollup,
+                capacity_class: capacity_class.to_string(),
+                capacity_basis: capacity_basis.to_string(),
+            },
+            snapshot_identity,
+        ))
     }
 }
 
@@ -325,6 +348,7 @@ mod tests {
         };
         let private = PlannedGroupability::Private {
             reason: "policy_peer_context".to_string(),
+            fingerprint: "policy-a".to_string(),
         };
         let unknown = PlannedGroupability::Indeterminate {
             reason: "indeterminate_session_negotiation".to_string(),
@@ -334,6 +358,11 @@ mod tests {
         assert_eq!(transition(&private, &shared_a), "shared_migration");
         assert_eq!(transition(&shared_a, &private), "private_resync");
         assert_eq!(transition(&shared_a, &unknown), "indeterminate");
+        let changed_private = PlannedGroupability::Private {
+            reason: "policy_peer_context".to_string(),
+            fingerprint: "policy-b".to_string(),
+        };
+        assert_eq!(transition(&private, &changed_private), "private_resync");
     }
 
     #[test]
@@ -369,9 +398,10 @@ mod tests {
     #[test]
     fn uniform_and_mixed_fleet_capacity_goldens() {
         assert_eq!(capacity_class(1_000, 1, 0, 0).0, "fully_shared");
-        assert_eq!(capacity_class(1_000, 2, 0, 0).0, "within_uniform");
+        assert_eq!(capacity_class(1_000, 2, 0, 0).0, "outside_measured");
         assert_eq!(capacity_class(1_000, 1, 100, 0).0, "within_mixed");
         assert_eq!(capacity_class(1_000, 1, 101, 0).0, "outside_measured");
+        assert_eq!(capacity_class(10, 1, 0, 0).0, "outside_measured");
         assert_eq!(capacity_class(10, 1, 0, 1).0, "unknown");
     }
 
@@ -434,9 +464,20 @@ mod tests {
             ("rtc_membership_stable", rtc.clone(), rtc, "no_op"),
         ];
         for (name, current_input, candidate_input, expected) in cases {
-            let current = raw_state(&classify_update_group(current_input));
-            let planned = raw_state(&classify_update_group(candidate_input.clone()));
-            let observed_after_apply = raw_state(&classify_update_group(candidate_input));
+            let current_fingerprint = current_input.policy_fingerprint.clone().unwrap_or_default();
+            let candidate_fingerprint = candidate_input
+                .policy_fingerprint
+                .clone()
+                .unwrap_or_default();
+            let current = raw_state(&classify_update_group(current_input), &current_fingerprint);
+            let planned = raw_state(
+                &classify_update_group(candidate_input.clone()),
+                &candidate_fingerprint,
+            );
+            let observed_after_apply = raw_state(
+                &classify_update_group(candidate_input),
+                &candidate_fingerprint,
+            );
             assert_eq!(transition(&current, &planned), expected, "plan {name}");
             assert_eq!(observed_after_apply, planned, "runtime parity {name}");
         }

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -1,16 +1,49 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rib::{
     PlannedGroupability, RibUpdate, UpdateGroupClassification, UpdateGroupClassifierInput,
     UpdateGroupFamilyImpact, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
-    UpdateGroupPeerSnapshot, classify_update_group,
+    UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group,
 };
 use tokio::sync::oneshot;
 
 use super::{PeerManager, RIB_REPLY_TIMEOUT};
 use crate::config::{Config, ResolvedNeighbor};
+
+/// Fixed-width, allocation-free identity for a canonical RIB snapshot.
+///
+/// Snapshot tokens are process-local, so this hash only needs to remain stable
+/// for one daemon lifetime. FNV-1a gives `Hash` a deterministic byte sink; the
+/// result is subsequently protected by the peer manager's keyed token hash.
+struct SnapshotIdentityHasher(u64);
+
+impl Default for SnapshotIdentityHasher {
+    fn default() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+}
+
+impl Hasher for SnapshotIdentityHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.0 ^= u64::from(*byte);
+            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+}
+
+pub(super) fn snapshot_identity(snapshot: &UpdateGroupSnapshot) -> [u8; 8] {
+    let mut hasher = SnapshotIdentityHasher::default();
+    snapshot.hash(&mut hasher);
+    hasher.finish().to_be_bytes()
+}
 
 fn by_peer(config: &Config) -> Result<BTreeMap<IpAddr, ResolvedNeighbor>, String> {
     config
@@ -171,25 +204,27 @@ fn capacity_class(
 }
 
 impl PeerManager {
-    #[expect(
-        clippy::too_many_lines,
-        reason = "keeps snapshot classification, canonical IDs, and rollup in one auditable pure planning pass"
-    )]
-    pub(super) async fn plan_update_group_impact(
-        &self,
-        candidate: &Config,
-    ) -> Result<(UpdateGroupImpactPlan, String), String> {
+    pub(super) async fn query_update_group_snapshot(&self) -> Result<UpdateGroupSnapshot, String> {
         let (reply, recv) = oneshot::channel();
         self.rib_tx
             .send(RibUpdate::QueryUpdateGroupSnapshot { reply })
             .await
             .map_err(|_| "RIB unavailable while planning update-group impact".to_string())?;
-        let snapshot = tokio::time::timeout(RIB_REPLY_TIMEOUT, recv)
+        tokio::time::timeout(RIB_REPLY_TIMEOUT, recv)
             .await
             .map_err(|_| "RIB update-group snapshot timed out".to_string())?
-            .map_err(|_| "RIB dropped update-group snapshot reply".to_string())?;
-        let snapshot_identity = format!("{snapshot:?}");
+            .map_err(|_| "RIB dropped update-group snapshot reply".to_string())
+    }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "keeps snapshot classification, canonical IDs, and rollup in one auditable pure planning pass"
+    )]
+    pub(super) fn plan_update_group_impact(
+        &self,
+        candidate: &Config,
+        snapshot: UpdateGroupSnapshot,
+    ) -> Result<UpdateGroupImpactPlan, String> {
         let current = by_peer(&self.current_config)?;
         let candidate = by_peer(candidate)?;
         let live = snapshot
@@ -328,22 +363,57 @@ impl PeerManager {
             candidate_private.len(),
             rollup.indeterminate,
         );
-        Ok((
-            UpdateGroupImpactPlan {
-                schema_version: 1,
-                entries,
-                rollup,
-                capacity_class: capacity_class.to_string(),
-                capacity_basis: capacity_basis.to_string(),
-            },
-            snapshot_identity,
-        ))
+        Ok(UpdateGroupImpactPlan {
+            schema_version: 1,
+            entries,
+            rollup,
+            capacity_class: capacity_class.to_string(),
+            capacity_basis: capacity_basis.to_string(),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn snapshot_fixture() -> UpdateGroupSnapshot {
+        let input = UpdateGroupClassifierInput {
+            policy_fingerprint: Some("policy-a".to_string()),
+            policy_provenance: Some("toml_compiled_ir".to_string()),
+            policy_requires_peer_context: false,
+            target_is_ebgp: true,
+            target_is_rr_client: false,
+            sendable_families: vec![(1, 1)],
+            llgr_families: vec![],
+            add_path_send: false,
+            per_client_best: false,
+            orr_vantage: None,
+            orf_installed: false,
+        };
+        UpdateGroupSnapshot {
+            peers: vec![UpdateGroupPeerSnapshot {
+                peer: "192.0.2.1".parse().unwrap(),
+                classification: classify_update_group(input.clone()),
+                input,
+                runtime_membership: "group:1".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn snapshot_identity_is_fixed_width_deterministic_and_state_sensitive() {
+        let snapshot = snapshot_fixture();
+        assert_eq!(snapshot_identity(&snapshot).len(), 8);
+        assert_eq!(snapshot_identity(&snapshot), snapshot_identity(&snapshot));
+
+        let mut changed = snapshot;
+        changed.peers[0].runtime_membership = "private:orf_installed".to_string();
+        assert_ne!(
+            snapshot_identity(&changed),
+            snapshot_identity(&snapshot_fixture())
+        );
+    }
 
     #[test]
     fn transitions_keep_resync_and_indeterminate_distinct() {

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -27,7 +27,7 @@ fn preserves_negotiation(current: &ResolvedNeighbor, candidate: &ResolvedNeighbo
     let left = &current.transport_config;
     let right = &candidate.transport_config;
     left.peer.remote_asn == right.peer.remote_asn
-        && left.peer.families == right.peer.families
+        && same_families(&left.peer.families, &right.peer.families)
         && left.peer.add_path_send == right.peer.add_path_send
         && left.peer.add_path_receive == right.peer.add_path_receive
         && left.peer.graceful_restart == right.peer.graceful_restart
@@ -35,6 +35,11 @@ fn preserves_negotiation(current: &ResolvedNeighbor, candidate: &ResolvedNeighbo
         && left.peer.prefix_orf_receive == right.peer.prefix_orf_receive
         && left.peer.disable_ipv4_unicast == right.peer.disable_ipv4_unicast
         && left.llgr_stale_time == right.llgr_stale_time
+}
+
+fn same_families<T: Eq>(left: &[T], right: &[T]) -> bool {
+    left.iter().all(|family| right.contains(family))
+        && right.iter().all(|family| left.contains(family))
 }
 
 fn candidate_input(
@@ -187,13 +192,18 @@ impl PeerManager {
             let current_cfg = current.get(&peer);
             let candidate_cfg = candidate.get(&peer);
             let live = live.get(&peer);
-            let current_state = live.map_or_else(
-                || PlannedGroupability::Indeterminate {
-                    reason: "indeterminate_session_negotiation".to_string(),
-                },
-                |row| raw_state(&row.classification, &format!("{:?}", row.input)),
-            );
+            let current_state = if current_cfg.is_none() {
+                PlannedGroupability::Absent
+            } else {
+                live.map_or_else(
+                    || PlannedGroupability::Indeterminate {
+                        reason: "indeterminate_session_negotiation".to_string(),
+                    },
+                    |row| raw_state(&row.classification, &format!("{:?}", row.input)),
+                )
+            };
             let candidate_state = match (live, current_cfg, candidate_cfg) {
+                (_, _, None) => PlannedGroupability::Absent,
                 (Some(live), Some(current), Some(candidate))
                     if preserves_negotiation(current, candidate) =>
                 {
@@ -219,21 +229,9 @@ impl PeerManager {
                     raw_groups.insert(id.clone());
                 }
             }
-            let mut families = live.map_or_else(BTreeSet::new, |row| {
+            let families = live.map_or_else(BTreeSet::new, |row| {
                 row.input.sendable_families.iter().copied().collect()
             });
-            if live.is_none() {
-                for config in [current_cfg, candidate_cfg].into_iter().flatten() {
-                    families.extend(
-                        config
-                            .transport_config
-                            .peer
-                            .families
-                            .iter()
-                            .map(|&(afi, safi)| (afi as u16, safi as u8)),
-                    );
-                }
-            }
             for (afi, safi) in families {
                 rows.push((
                     peer,
@@ -360,6 +358,20 @@ mod tests {
             fingerprint: "policy-b".to_string(),
         };
         assert_eq!(transition(&private, &changed_private), "private_resync");
+        assert_eq!(
+            transition(&shared_a, &PlannedGroupability::Absent),
+            "regroup"
+        );
+        assert_eq!(
+            transition(&PlannedGroupability::Absent, &unknown),
+            "indeterminate"
+        );
+    }
+
+    #[test]
+    fn negotiation_family_comparison_is_order_and_duplicate_independent() {
+        assert!(same_families(&[(1, 1), (2, 1), (1, 1)], &[(2, 1), (1, 1)]));
+        assert!(!same_families(&[(1, 1)], &[(1, 1), (2, 1)]));
     }
 
     #[test]

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -45,6 +45,7 @@ fn candidate_input(
     let policy = candidate.export_policy.as_ref();
     UpdateGroupClassifierInput {
         policy_fingerprint: policy.map(|chain| format!("{chain:?}")),
+        policy_provenance: policy.map(|chain| chain.groupability_provenance().to_string()),
         policy_requires_peer_context: policy.is_some_and(PolicyChain::requires_peer_context),
         target_is_ebgp: candidate.transport_config.peer.remote_asn != local_asn,
         target_is_rr_client: candidate.transport_config.route_reflector_client,
@@ -80,6 +81,16 @@ fn canonicalize_group(
     }
 }
 
+fn plan_local_ids(raw_groups: impl IntoIterator<Item = String>) -> BTreeMap<String, String> {
+    raw_groups
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .enumerate()
+        .map(|(index, raw)| (raw, format!("plan-group-{:03}", index + 1)))
+        .collect()
+}
+
 fn transition(current: &PlannedGroupability, candidate: &PlannedGroupability) -> &'static str {
     use PlannedGroupability::{Absent, Group, Indeterminate, Private};
     match (current, candidate) {
@@ -90,6 +101,34 @@ fn transition(current: &PlannedGroupability, candidate: &PlannedGroupability) ->
         (Private { .. }, Group { .. }) => "shared_migration",
         (_, Private { .. }) => "private_resync",
         (_, Indeterminate { .. }) | (Indeterminate { .. }, _) => "indeterminate",
+    }
+}
+
+fn capacity_class(
+    projected_peers: usize,
+    shared_groups: usize,
+    private_views: usize,
+    indeterminate: u32,
+) -> (&'static str, &'static str) {
+    if indeterminate > 0 {
+        ("unknown", "future session negotiation is not projected")
+    } else if private_views == 0 && shared_groups == 1 {
+        ("fully_shared", "one shared group and no private views")
+    } else if private_views == 0 && projected_peers <= 1_000 {
+        (
+            "within_uniform",
+            "inside the measured 1000-peer uniform envelope",
+        )
+    } else if private_views <= 100 && projected_peers <= 1_000 {
+        (
+            "within_mixed",
+            "inside the measured 900-shared/100-private envelope",
+        )
+    } else {
+        (
+            "outside_measured",
+            "outside published update-group receipt envelopes",
+        )
     }
 }
 
@@ -151,6 +190,15 @@ impl PeerManager {
                     reason: "indeterminate_session_negotiation".to_string(),
                 },
             };
+            let provenance = match (&candidate_state, candidate_cfg) {
+                (PlannedGroupability::Indeterminate { .. }, _) => "session_negotiation".to_string(),
+                (_, Some(candidate)) => candidate
+                    .export_policy
+                    .as_ref()
+                    .map_or("no_export_policy", PolicyChain::groupability_provenance)
+                    .to_string(),
+                _ => "session_negotiation".to_string(),
+            };
             for state in [&current_state, &candidate_state] {
                 if let PlannedGroupability::Group { id } = state {
                     raw_groups.insert(id.clone());
@@ -176,22 +224,19 @@ impl PeerManager {
                     safi,
                     current_state.clone(),
                     candidate_state.clone(),
+                    provenance.clone(),
                 ));
             }
             if live.is_none() || rows.last().is_none_or(|row| row.0 != peer) {
-                rows.push((peer, 0, 0, current_state, candidate_state));
+                rows.push((peer, 0, 0, current_state, candidate_state, provenance));
             }
         }
 
-        let ids = raw_groups
-            .into_iter()
-            .enumerate()
-            .map(|(index, raw)| (raw, format!("plan-group-{:03}", index + 1)))
-            .collect::<BTreeMap<_, _>>();
+        let ids = plan_local_ids(raw_groups);
         let mut entries = Vec::with_capacity(rows.len());
         let mut rollup = UpdateGroupImpactRollup::default();
         let mut affected = BTreeSet::new();
-        for (peer, afi, safi, current, candidate) in rows {
+        for (peer, afi, safi, current, candidate, provenance) in rows {
             let current = canonicalize_group(current, &ids);
             let candidate = canonicalize_group(candidate, &ids);
             let class = transition(&current, &candidate).to_string();
@@ -224,7 +269,7 @@ impl PeerManager {
                 candidate,
                 transition: class,
                 reason,
-                provenance: "runtime_groupability_classifier".to_string(),
+                provenance,
                 local_resync,
                 remote_route_refresh: false,
             });
@@ -250,26 +295,12 @@ impl PeerManager {
             .map(|row| row.peer)
             .collect::<BTreeSet<_>>()
             .len();
-        let (capacity_class, capacity_basis) = if rollup.indeterminate > 0 {
-            ("unknown", "future session negotiation is not projected")
-        } else if candidate_private.is_empty() && candidate_groups.len() == 1 {
-            ("fully_shared", "one shared group and no private views")
-        } else if candidate_private.is_empty() && projected_peers <= 1_000 {
-            (
-                "within_uniform",
-                "inside the measured 1000-peer uniform envelope",
-            )
-        } else if candidate_private.len() <= 100 && projected_peers <= 1_000 {
-            (
-                "within_mixed",
-                "inside the measured 900-shared/100-private envelope",
-            )
-        } else {
-            (
-                "outside_measured",
-                "outside published update-group receipt envelopes",
-            )
-        };
+        let (capacity_class, capacity_basis) = capacity_class(
+            projected_peers,
+            candidate_groups.len(),
+            candidate_private.len(),
+            rollup.indeterminate,
+        );
         Ok(UpdateGroupImpactPlan {
             schema_version: 1,
             entries,
@@ -317,5 +348,97 @@ mod tests {
                 id: "plan-group-001".to_string()
             }
         );
+    }
+
+    #[test]
+    fn plan_local_ids_are_insertion_order_independent() {
+        let forward = plan_local_ids([
+            "raw:c".to_string(),
+            "raw:a".to_string(),
+            "raw:b".to_string(),
+        ]);
+        let reverse = plan_local_ids([
+            "raw:b".to_string(),
+            "raw:a".to_string(),
+            "raw:c".to_string(),
+        ]);
+        assert_eq!(forward, reverse);
+        assert_eq!(forward["raw:a"], "plan-group-001");
+    }
+
+    #[test]
+    fn uniform_and_mixed_fleet_capacity_goldens() {
+        assert_eq!(capacity_class(1_000, 1, 0, 0).0, "fully_shared");
+        assert_eq!(capacity_class(1_000, 2, 0, 0).0, "within_uniform");
+        assert_eq!(capacity_class(1_000, 1, 100, 0).0, "within_mixed");
+        assert_eq!(capacity_class(1_000, 1, 101, 0).0, "outside_measured");
+        assert_eq!(capacity_class(10, 1, 0, 1).0, "unknown");
+    }
+
+    #[test]
+    fn runtime_after_apply_parity_transition_matrix() {
+        fn fixture(policy: &str) -> UpdateGroupClassifierInput {
+            UpdateGroupClassifierInput {
+                policy_fingerprint: Some(policy.to_string()),
+                policy_provenance: Some("toml_compiled_ir".to_string()),
+                policy_requires_peer_context: false,
+                target_is_ebgp: false,
+                target_is_rr_client: true,
+                sendable_families: vec![(1, 1)],
+                llgr_families: vec![],
+                add_path_send: false,
+                per_client_best: false,
+                orr_vantage: false,
+                orf_installed: false,
+            }
+        }
+        let shared_a = fixture("a");
+        let shared_b = fixture("b");
+        let mut private_peer = fixture("peer");
+        private_peer.policy_requires_peer_context = true;
+        let mut private_orf = fixture("orf");
+        private_orf.orf_installed = true;
+        let mut rtc = fixture("rtc");
+        rtc.sendable_families = vec![(1, 128), (1, 132)];
+        let cases = [
+            (
+                "shared_to_shared",
+                shared_a.clone(),
+                shared_b.clone(),
+                "regroup",
+            ),
+            (
+                "shared_to_private",
+                shared_a.clone(),
+                private_peer.clone(),
+                "private_resync",
+            ),
+            (
+                "private_to_shared",
+                private_peer.clone(),
+                shared_a.clone(),
+                "shared_migration",
+            ),
+            (
+                "private_to_private",
+                private_peer.clone(),
+                private_orf,
+                "private_resync",
+            ),
+            (
+                "content_identical_reinstall",
+                shared_a.clone(),
+                shared_a.clone(),
+                "no_op",
+            ),
+            ("rtc_membership_stable", rtc.clone(), rtc, "no_op"),
+        ];
+        for (name, current_input, candidate_input, expected) in cases {
+            let current = raw_state(&classify_update_group(current_input));
+            let planned = raw_state(&classify_update_group(candidate_input.clone()));
+            let observed_after_apply = raw_state(&classify_update_group(candidate_input));
+            assert_eq!(transition(&current, &planned), expected, "plan {name}");
+            assert_eq!(observed_after_apply, planned, "runtime parity {name}");
+        }
     }
 }

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -12,6 +12,12 @@ use tokio::sync::oneshot;
 use super::{PeerManager, RIB_REPLY_TIMEOUT};
 use crate::config::{Config, ResolvedNeighbor};
 
+#[derive(Debug)]
+pub(super) enum UpdateGroupImpactPlanError {
+    InvalidCandidate(String),
+    Internal(String),
+}
+
 fn by_peer(config: &Config) -> Result<BTreeMap<IpAddr, ResolvedNeighbor>, String> {
     config
         .resolved_neighbors()
@@ -191,9 +197,10 @@ impl PeerManager {
         &self,
         candidate: &Config,
         snapshot: UpdateGroupSnapshot,
-    ) -> Result<UpdateGroupImpactPlan, String> {
-        let current = by_peer(&self.current_config)?;
-        let candidate = by_peer(candidate)?;
+    ) -> Result<UpdateGroupImpactPlan, UpdateGroupImpactPlanError> {
+        let current =
+            by_peer(&self.current_config).map_err(UpdateGroupImpactPlanError::Internal)?;
+        let candidate = by_peer(candidate).map_err(UpdateGroupImpactPlanError::InvalidCandidate)?;
         let live = snapshot
             .peers
             .into_iter()

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
 use rustbgpd_policy::PolicyChain;
@@ -12,38 +11,6 @@ use tokio::sync::oneshot;
 
 use super::{PeerManager, RIB_REPLY_TIMEOUT};
 use crate::config::{Config, ResolvedNeighbor};
-
-/// Fixed-width, allocation-free identity for a canonical RIB snapshot.
-///
-/// Snapshot tokens are process-local, so this hash only needs to remain stable
-/// for one daemon lifetime. FNV-1a gives `Hash` a deterministic byte sink; the
-/// result is subsequently protected by the peer manager's keyed token hash.
-struct SnapshotIdentityHasher(u64);
-
-impl Default for SnapshotIdentityHasher {
-    fn default() -> Self {
-        Self(0xcbf2_9ce4_8422_2325)
-    }
-}
-
-impl Hasher for SnapshotIdentityHasher {
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        for byte in bytes {
-            self.0 ^= u64::from(*byte);
-            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-    }
-}
-
-pub(super) fn snapshot_identity(snapshot: &UpdateGroupSnapshot) -> [u8; 8] {
-    let mut hasher = SnapshotIdentityHasher::default();
-    snapshot.hash(&mut hasher);
-    hasher.finish().to_be_bytes()
-}
 
 fn by_peer(config: &Config) -> Result<BTreeMap<IpAddr, ResolvedNeighbor>, String> {
     config
@@ -403,15 +370,16 @@ mod tests {
 
     #[test]
     fn snapshot_identity_is_fixed_width_deterministic_and_state_sensitive() {
+        let key = crate::config::RuntimeSnapshotKey::random();
         let snapshot = snapshot_fixture();
-        assert_eq!(snapshot_identity(&snapshot).len(), 8);
-        assert_eq!(snapshot_identity(&snapshot), snapshot_identity(&snapshot));
+        assert_eq!(key.digest_context(&snapshot).len(), 8);
+        assert_eq!(key.digest_context(&snapshot), key.digest_context(&snapshot));
 
         let mut changed = snapshot;
         changed.peers[0].runtime_membership = "private:orf_installed".to_string();
         assert_ne!(
-            snapshot_identity(&changed),
-            snapshot_identity(&snapshot_fixture())
+            key.digest_context(&changed),
+            key.digest_context(&snapshot_fixture())
         );
     }
 

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -35,9 +35,6 @@ fn preserves_negotiation(current: &ResolvedNeighbor, candidate: &ResolvedNeighbo
         && left.peer.prefix_orf_receive == right.peer.prefix_orf_receive
         && left.peer.disable_ipv4_unicast == right.peer.disable_ipv4_unicast
         && left.llgr_stale_time == right.llgr_stale_time
-        && left.route_reflector_client == right.route_reflector_client
-        && left.orr_vantage == right.orr_vantage
-        && left.per_client_best == right.per_client_best
 }
 
 fn candidate_input(
@@ -159,9 +156,19 @@ impl PeerManager {
                     raw_groups.insert(id.clone());
                 }
             }
-            let families = live.map_or_else(BTreeSet::new, |row| {
+            let mut families = live.map_or_else(BTreeSet::new, |row| {
                 row.input.sendable_families.iter().copied().collect()
             });
+            for config in [current_cfg, candidate_cfg].into_iter().flatten() {
+                families.extend(
+                    config
+                        .transport_config
+                        .peer
+                        .families
+                        .iter()
+                        .map(|&(afi, safi)| (afi as u16, safi as u8)),
+                );
+            }
             for (afi, safi) in families {
                 rows.push((
                     peer,
@@ -270,5 +277,45 @@ impl PeerManager {
             capacity_class: capacity_class.to_string(),
             capacity_basis: capacity_basis.to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitions_keep_resync_and_indeterminate_distinct() {
+        let shared_a = PlannedGroupability::Group {
+            id: "plan-group-001".to_string(),
+        };
+        let shared_b = PlannedGroupability::Group {
+            id: "plan-group-002".to_string(),
+        };
+        let private = PlannedGroupability::Private {
+            reason: "policy_peer_context".to_string(),
+        };
+        let unknown = PlannedGroupability::Indeterminate {
+            reason: "indeterminate_session_negotiation".to_string(),
+        };
+        assert_eq!(transition(&shared_a, &shared_a), "no_op");
+        assert_eq!(transition(&shared_a, &shared_b), "regroup");
+        assert_eq!(transition(&private, &shared_a), "shared_migration");
+        assert_eq!(transition(&shared_a, &private), "private_resync");
+        assert_eq!(transition(&shared_a, &unknown), "indeterminate");
+    }
+
+    #[test]
+    fn plan_local_group_ids_are_not_runtime_ids() {
+        let raw = PlannedGroupability::Group {
+            id: "raw:fingerprint".to_string(),
+        };
+        let ids = BTreeMap::from([("raw:fingerprint".to_string(), "plan-group-001".to_string())]);
+        assert_eq!(
+            canonicalize_group(raw, &ids),
+            PlannedGroupability::Group {
+                id: "plan-group-001".to_string()
+            }
+        );
     }
 }

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -122,6 +122,23 @@ fn transition(current: &PlannedGroupability, candidate: &PlannedGroupability) ->
     }
 }
 
+fn requires_local_resync(candidate: &PlannedGroupability, changed: bool) -> bool {
+    changed
+        && !matches!(
+            candidate,
+            PlannedGroupability::Indeterminate { .. } | PlannedGroupability::Absent
+        )
+}
+
+fn projected_peer_count(entries: &[UpdateGroupFamilyImpact]) -> usize {
+    entries
+        .iter()
+        .filter(|row| !matches!(row.candidate, PlannedGroupability::Absent))
+        .map(|row| row.peer)
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
 fn capacity_class(
     projected_peers: usize,
     shared_groups: usize,
@@ -267,8 +284,7 @@ impl PeerManager {
                 "private_resync" => rollup.private_resync += 1,
                 _ => rollup.indeterminate += 1,
             }
-            let local_resync =
-                changed && !matches!(candidate, PlannedGroupability::Indeterminate { .. });
+            let local_resync = requires_local_resync(&candidate, changed);
             if local_resync {
                 rollup.local_resyncs += 1;
             }
@@ -305,11 +321,7 @@ impl PeerManager {
             .collect::<BTreeSet<_>>();
         rollup.projected_shared_groups = u32::try_from(candidate_groups.len()).unwrap_or(u32::MAX);
         rollup.projected_private_views = u32::try_from(candidate_private.len()).unwrap_or(u32::MAX);
-        let projected_peers = entries
-            .iter()
-            .map(|row| row.peer)
-            .collect::<BTreeSet<_>>()
-            .len();
+        let projected_peers = projected_peer_count(&entries);
         let (capacity_class, capacity_basis) = capacity_class(
             projected_peers,
             candidate_groups.len(),
@@ -372,6 +384,37 @@ mod tests {
     fn negotiation_family_comparison_is_order_and_duplicate_independent() {
         assert!(same_families(&[(1, 1), (2, 1), (1, 1)], &[(2, 1), (1, 1)]));
         assert!(!same_families(&[(1, 1)], &[(1, 1), (2, 1)]));
+    }
+
+    #[test]
+    fn deletion_is_not_a_projected_peer_or_local_resync() {
+        let deleted = PlannedGroupability::Absent;
+        assert_eq!(
+            transition(
+                &PlannedGroupability::Group {
+                    id: "plan-group-001".to_string()
+                },
+                &deleted
+            ),
+            "regroup"
+        );
+        assert!(!requires_local_resync(&deleted, true));
+
+        let entries = [UpdateGroupFamilyImpact {
+            peer: "192.0.2.1".parse().unwrap(),
+            afi: 1,
+            safi: 1,
+            current: PlannedGroupability::Group {
+                id: "plan-group-001".to_string(),
+            },
+            candidate: deleted,
+            transition: "regroup".to_string(),
+            reason: "absent".to_string(),
+            provenance: "session_negotiation".to_string(),
+            local_resync: false,
+            remote_route_refresh: false,
+        }];
+        assert_eq!(projected_peer_count(&entries), 0);
     }
 
     #[test]

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -1,0 +1,274 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::IpAddr;
+
+use rustbgpd_policy::PolicyChain;
+use rustbgpd_rib::{
+    PlannedGroupability, RibUpdate, UpdateGroupClassification, UpdateGroupClassifierInput,
+    UpdateGroupFamilyImpact, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
+    UpdateGroupPeerSnapshot, classify_update_group,
+};
+use tokio::sync::oneshot;
+
+use super::{PeerManager, RIB_REPLY_TIMEOUT};
+use crate::config::{Config, ResolvedNeighbor};
+
+fn by_peer(config: &Config) -> Result<BTreeMap<IpAddr, ResolvedNeighbor>, String> {
+    config
+        .resolved_neighbors()
+        .map_err(|error| error.to_string())
+        .map(|rows| {
+            rows.into_iter()
+                .map(|row| (row.transport_config.remote_addr.ip(), row))
+                .collect()
+        })
+}
+
+fn preserves_negotiation(current: &ResolvedNeighbor, candidate: &ResolvedNeighbor) -> bool {
+    let left = &current.transport_config;
+    let right = &candidate.transport_config;
+    left.peer.remote_asn == right.peer.remote_asn
+        && left.peer.families == right.peer.families
+        && left.peer.add_path_send == right.peer.add_path_send
+        && left.peer.add_path_receive == right.peer.add_path_receive
+        && left.peer.graceful_restart == right.peer.graceful_restart
+        && left.peer.gr_restart_time == right.peer.gr_restart_time
+        && left.peer.prefix_orf_receive == right.peer.prefix_orf_receive
+        && left.peer.disable_ipv4_unicast == right.peer.disable_ipv4_unicast
+        && left.llgr_stale_time == right.llgr_stale_time
+        && left.route_reflector_client == right.route_reflector_client
+        && left.orr_vantage == right.orr_vantage
+        && left.per_client_best == right.per_client_best
+}
+
+fn candidate_input(
+    live: &UpdateGroupPeerSnapshot,
+    candidate: &ResolvedNeighbor,
+    local_asn: u32,
+) -> UpdateGroupClassifierInput {
+    let policy = candidate.export_policy.as_ref();
+    UpdateGroupClassifierInput {
+        policy_fingerprint: policy.map(|chain| format!("{chain:?}")),
+        policy_requires_peer_context: policy.is_some_and(PolicyChain::requires_peer_context),
+        target_is_ebgp: candidate.transport_config.peer.remote_asn != local_asn,
+        target_is_rr_client: candidate.transport_config.route_reflector_client,
+        sendable_families: live.input.sendable_families.clone(),
+        llgr_families: live.input.llgr_families.clone(),
+        add_path_send: live.input.add_path_send,
+        per_client_best: candidate.transport_config.per_client_best,
+        orr_vantage: candidate.transport_config.orr_vantage.is_some(),
+        orf_installed: live.input.orf_installed,
+    }
+}
+
+fn raw_state(classification: &UpdateGroupClassification) -> PlannedGroupability {
+    match classification {
+        UpdateGroupClassification::Groupable(input) => PlannedGroupability::Group {
+            id: format!("raw:{input:?}"),
+        },
+        other => PlannedGroupability::Private {
+            reason: other.reason().expect("fallback has a reason").to_string(),
+        },
+    }
+}
+
+fn canonicalize_group(
+    state: PlannedGroupability,
+    ids: &BTreeMap<String, String>,
+) -> PlannedGroupability {
+    match state {
+        PlannedGroupability::Group { id } => PlannedGroupability::Group {
+            id: ids.get(&id).expect("collected group fingerprint").clone(),
+        },
+        other => other,
+    }
+}
+
+fn transition(current: &PlannedGroupability, candidate: &PlannedGroupability) -> &'static str {
+    use PlannedGroupability::{Absent, Group, Indeterminate, Private};
+    match (current, candidate) {
+        (Group { id: a }, Group { id: b }) if a == b => "no_op",
+        (Private { reason: a }, Private { reason: b }) if a == b => "no_op",
+        (Absent, Absent) => "no_op",
+        (Group { .. }, Group { .. }) | (_, Absent) | (Absent, Group { .. }) => "regroup",
+        (Private { .. }, Group { .. }) => "shared_migration",
+        (_, Private { .. }) => "private_resync",
+        (_, Indeterminate { .. }) | (Indeterminate { .. }, _) => "indeterminate",
+    }
+}
+
+impl PeerManager {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "keeps snapshot classification, canonical IDs, and rollup in one auditable pure planning pass"
+    )]
+    pub(super) async fn plan_update_group_impact(
+        &self,
+        candidate: &Config,
+    ) -> Result<UpdateGroupImpactPlan, String> {
+        let (reply, recv) = oneshot::channel();
+        self.rib_tx
+            .send(RibUpdate::QueryUpdateGroupSnapshot { reply })
+            .await
+            .map_err(|_| "RIB unavailable while planning update-group impact".to_string())?;
+        let snapshot = tokio::time::timeout(RIB_REPLY_TIMEOUT, recv)
+            .await
+            .map_err(|_| "RIB update-group snapshot timed out".to_string())?
+            .map_err(|_| "RIB dropped update-group snapshot reply".to_string())?;
+
+        let current = by_peer(&self.current_config)?;
+        let candidate = by_peer(candidate)?;
+        let live = snapshot
+            .peers
+            .into_iter()
+            .map(|row| (row.peer, row))
+            .collect::<BTreeMap<_, _>>();
+        let peers = current
+            .keys()
+            .chain(candidate.keys())
+            .copied()
+            .collect::<BTreeSet<_>>();
+
+        let mut rows = Vec::new();
+        let mut raw_groups = BTreeSet::new();
+        for peer in peers {
+            let current_cfg = current.get(&peer);
+            let candidate_cfg = candidate.get(&peer);
+            let live = live.get(&peer);
+            let current_state = live.map_or_else(
+                || PlannedGroupability::Indeterminate {
+                    reason: "indeterminate_session_negotiation".to_string(),
+                },
+                |row| raw_state(&row.classification),
+            );
+            let candidate_state = match (live, current_cfg, candidate_cfg) {
+                (Some(live), Some(current), Some(candidate))
+                    if preserves_negotiation(current, candidate) =>
+                {
+                    raw_state(&classify_update_group(candidate_input(
+                        live,
+                        candidate,
+                        self.local_asn,
+                    )))
+                }
+                _ => PlannedGroupability::Indeterminate {
+                    reason: "indeterminate_session_negotiation".to_string(),
+                },
+            };
+            for state in [&current_state, &candidate_state] {
+                if let PlannedGroupability::Group { id } = state {
+                    raw_groups.insert(id.clone());
+                }
+            }
+            let families = live.map_or_else(BTreeSet::new, |row| {
+                row.input.sendable_families.iter().copied().collect()
+            });
+            for (afi, safi) in families {
+                rows.push((
+                    peer,
+                    afi,
+                    safi,
+                    current_state.clone(),
+                    candidate_state.clone(),
+                ));
+            }
+            if live.is_none() || rows.last().is_none_or(|row| row.0 != peer) {
+                rows.push((peer, 0, 0, current_state, candidate_state));
+            }
+        }
+
+        let ids = raw_groups
+            .into_iter()
+            .enumerate()
+            .map(|(index, raw)| (raw, format!("plan-group-{:03}", index + 1)))
+            .collect::<BTreeMap<_, _>>();
+        let mut entries = Vec::with_capacity(rows.len());
+        let mut rollup = UpdateGroupImpactRollup::default();
+        let mut affected = BTreeSet::new();
+        for (peer, afi, safi, current, candidate) in rows {
+            let current = canonicalize_group(current, &ids);
+            let candidate = canonicalize_group(candidate, &ids);
+            let class = transition(&current, &candidate).to_string();
+            let changed = class != "no_op";
+            if changed {
+                affected.insert(peer);
+                rollup.affected_families += 1;
+            }
+            match class.as_str() {
+                "no_op" => rollup.no_op += 1,
+                "regroup" => rollup.regroup += 1,
+                "shared_migration" => rollup.shared_migration += 1,
+                "private_resync" => rollup.private_resync += 1,
+                _ => rollup.indeterminate += 1,
+            }
+            let local_resync =
+                changed && !matches!(candidate, PlannedGroupability::Indeterminate { .. });
+            if local_resync {
+                rollup.local_resyncs += 1;
+            }
+            let reason = match &candidate {
+                PlannedGroupability::Group { .. } => "groupable".to_string(),
+                other => other.label(),
+            };
+            entries.push(UpdateGroupFamilyImpact {
+                peer,
+                afi,
+                safi,
+                current,
+                candidate,
+                transition: class,
+                reason,
+                provenance: "runtime_groupability_classifier".to_string(),
+                local_resync,
+                remote_route_refresh: false,
+            });
+        }
+        rollup.affected_peers = u32::try_from(affected.len()).unwrap_or(u32::MAX);
+        let candidate_groups = entries
+            .iter()
+            .filter_map(|row| match &row.candidate {
+                PlannedGroupability::Group { id } => Some(id),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        let candidate_private = entries
+            .iter()
+            .filter_map(|row| {
+                matches!(row.candidate, PlannedGroupability::Private { .. }).then_some(row.peer)
+            })
+            .collect::<BTreeSet<_>>();
+        rollup.projected_shared_groups = u32::try_from(candidate_groups.len()).unwrap_or(u32::MAX);
+        rollup.projected_private_views = u32::try_from(candidate_private.len()).unwrap_or(u32::MAX);
+        let projected_peers = entries
+            .iter()
+            .map(|row| row.peer)
+            .collect::<BTreeSet<_>>()
+            .len();
+        let (capacity_class, capacity_basis) = if rollup.indeterminate > 0 {
+            ("unknown", "future session negotiation is not projected")
+        } else if candidate_private.is_empty() && candidate_groups.len() == 1 {
+            ("fully_shared", "one shared group and no private views")
+        } else if candidate_private.is_empty() && projected_peers <= 1_000 {
+            (
+                "within_uniform",
+                "inside the measured 1000-peer uniform envelope",
+            )
+        } else if candidate_private.len() <= 100 && projected_peers <= 1_000 {
+            (
+                "within_mixed",
+                "inside the measured 900-shared/100-private envelope",
+            )
+        } else {
+            (
+                "outside_measured",
+                "outside published update-group receipt envelopes",
+            )
+        };
+        Ok(UpdateGroupImpactPlan {
+            schema_version: 1,
+            entries,
+            rollup,
+            capacity_class: capacity_class.to_string(),
+            capacity_basis: capacity_basis.to_string(),
+        })
+    }
+}

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -53,7 +53,7 @@ fn candidate_input(
         llgr_families: live.input.llgr_families.clone(),
         add_path_send: live.input.add_path_send,
         per_client_best: candidate.transport_config.per_client_best,
-        orr_vantage: candidate.transport_config.orr_vantage.is_some(),
+        orr_vantage: candidate.transport_config.orr_vantage,
         orf_installed: live.input.orf_installed,
     }
 }
@@ -126,7 +126,15 @@ fn capacity_class(
     if indeterminate > 0 {
         ("unknown", "future session negotiation is not projected")
     } else if projected_peers == 1_000 && private_views == 0 && shared_groups == 1 {
-        ("fully_shared", "one shared group and no private views")
+        (
+            "within_uniform",
+            "exact measured 1000-peer uniform topology",
+        )
+    } else if private_views == 0 && shared_groups == 1 {
+        (
+            "fully_shared",
+            "structurally one shared group; no measured capacity claim",
+        )
     } else if projected_peers == 1_000 && private_views == 100 && shared_groups == 1 {
         (
             "within_mixed",
@@ -183,25 +191,14 @@ impl PeerManager {
                 || PlannedGroupability::Indeterminate {
                     reason: "indeterminate_session_negotiation".to_string(),
                 },
-                |row| {
-                    raw_state(
-                        &row.classification,
-                        row.input
-                            .policy_fingerprint
-                            .as_deref()
-                            .unwrap_or("no-policy"),
-                    )
-                },
+                |row| raw_state(&row.classification, &format!("{:?}", row.input)),
             );
             let candidate_state = match (live, current_cfg, candidate_cfg) {
                 (Some(live), Some(current), Some(candidate))
                     if preserves_negotiation(current, candidate) =>
                 {
                     let input = candidate_input(live, candidate, self.local_asn);
-                    let fingerprint = input
-                        .policy_fingerprint
-                        .clone()
-                        .unwrap_or_else(|| "no-policy".to_string());
+                    let fingerprint = format!("{input:?}");
                     raw_state(&classify_update_group(input), &fingerprint)
                 }
                 _ => PlannedGroupability::Indeterminate {
@@ -397,11 +394,11 @@ mod tests {
 
     #[test]
     fn uniform_and_mixed_fleet_capacity_goldens() {
-        assert_eq!(capacity_class(1_000, 1, 0, 0).0, "fully_shared");
+        assert_eq!(capacity_class(1_000, 1, 0, 0).0, "within_uniform");
         assert_eq!(capacity_class(1_000, 2, 0, 0).0, "outside_measured");
         assert_eq!(capacity_class(1_000, 1, 100, 0).0, "within_mixed");
         assert_eq!(capacity_class(1_000, 1, 101, 0).0, "outside_measured");
-        assert_eq!(capacity_class(10, 1, 0, 0).0, "outside_measured");
+        assert_eq!(capacity_class(10, 1, 0, 0).0, "fully_shared");
         assert_eq!(capacity_class(10, 1, 0, 1).0, "unknown");
     }
 
@@ -418,7 +415,7 @@ mod tests {
                 llgr_families: vec![],
                 add_path_send: false,
                 per_client_best: false,
-                orr_vantage: false,
+                orr_vantage: None,
                 orf_installed: false,
             }
         }
@@ -428,6 +425,10 @@ mod tests {
         private_peer.policy_requires_peer_context = true;
         let mut private_orf = fixture("orf");
         private_orf.orf_installed = true;
+        let mut orr_a = fixture("orr");
+        orr_a.orr_vantage = Some("192.0.2.10".parse().unwrap());
+        let mut orr_b = orr_a.clone();
+        orr_b.orr_vantage = Some("192.0.2.11".parse().unwrap());
         let mut rtc = fixture("rtc");
         rtc.sendable_families = vec![(1, 128), (1, 132)];
         let cases = [
@@ -456,6 +457,12 @@ mod tests {
                 "private_resync",
             ),
             (
+                "same_reason_orr_vantage_change",
+                orr_a,
+                orr_b,
+                "private_resync",
+            ),
+            (
                 "content_identical_reinstall",
                 shared_a.clone(),
                 shared_a.clone(),
@@ -464,11 +471,8 @@ mod tests {
             ("rtc_membership_stable", rtc.clone(), rtc, "no_op"),
         ];
         for (name, current_input, candidate_input, expected) in cases {
-            let current_fingerprint = current_input.policy_fingerprint.clone().unwrap_or_default();
-            let candidate_fingerprint = candidate_input
-                .policy_fingerprint
-                .clone()
-                .unwrap_or_default();
+            let current_fingerprint = format!("{current_input:?}");
+            let candidate_fingerprint = format!("{candidate_input:?}");
             let current = raw_state(&classify_update_group(current_input), &current_fingerprint);
             let planned = raw_state(
                 &classify_update_group(candidate_input.clone()),


### PR DESCRIPTION
## Summary

- share the exact update-group classifier and fingerprint between runtime membership and config planning
- expose deterministic schema-v1 update-group impact details through Config Plan/Apply and `rbgp config plan`
- bind transaction tokens to live session/group state and return an authoritative post-commit token
- classify measured capacity envelopes conservatively and mark negotiation-dependent changes indeterminate
- document accuracy, race, and receipt boundaries

Linear: LAN-356

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 check --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- focused RIB classifier, update-group planning, and live-policy transaction tests

## Docs

Updated `docs/CONFIGURATION.md`, `CHANGELOG.md`, and `ROADMAP.md` with the planning model, measured-envelope limits, and remaining LAN-356 scope.