### PR TITLE
feat(neighbor): expose effective live session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Neighbor state reports live effective transport and distribution truth.**
+  TCP-AO health is refreshed read-only from the connected socket for every
+  state query, clears rather than serving stale data when inspection fails,
+  and retains Linux's cumulative-per-socket degraded semantics. The API and
+  CLI report the RIB's live effective distribution mode independently of
+  update-group diagnostic labels. Paths-Limit rows use stable numeric AFI/SAFI
+  order and an explicit active bit, allowing active unlimited, inactive, and
+  finite effective send caps to render without a zero-value ambiguity.
+  (LAN-225, LAN-364, LAN-366)
+
 - **Neighbor diagnostics expose transport authentication health.** Neighbor
   API, JSON, and human output identify plaintext, TCP-MD5, and TCP-AO sessions;
-  connected TCP-AO peers include connection-time current/RNext KeyIDs and
-  verification counters when socket inspection succeeds. Connect setup
+  connected TCP-AO peers include current/RNext KeyIDs and verification
+  counters when live socket inspection succeeds. Connect setup
   failures remain visible in `last_error`;
   `rbgp doctor` flags configured AO peers on unsupported kernels, and the
   configuration guide documents directional KeyID cross-mapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   update-group diagnostic labels. Paths-Limit rows use stable numeric AFI/SAFI
   order and an optional normalized limit, allowing active unlimited, inactive,
   and finite effective send caps to render without a zero-value ambiguity while
-  preserving the legacy raw sentinel for rolling clients.
+  preserving the legacy raw sentinel for rolling protobuf and JSON clients.
   (LAN-225, LAN-364, LAN-366)
 
 - **Neighbor diagnostics expose transport authentication health.** Neighbor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and retains Linux's cumulative-per-socket degraded semantics. The API and
   CLI report the RIB's live effective distribution mode independently of
   update-group diagnostic labels. Paths-Limit rows use stable numeric AFI/SAFI
-  order and an explicit active bit, allowing active unlimited, inactive, and
-  finite effective send caps to render without a zero-value ambiguity.
+  order and an optional normalized limit, allowing active unlimited, inactive,
+  and finite effective send caps to render without a zero-value ambiguity while
+  preserving the legacy raw sentinel for rolling clients.
   (LAN-225, LAN-364, LAN-366)
 
 - **Neighbor diagnostics expose transport authentication health.** Neighbor

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ evolving API.**
 | **Runtime** | Rust 1.95+ (workspace MSRV — set by the bundled SQLite build), single binary, no external dependencies except optional RPKI/BMP/MRT backends |
 | **Config stability** | TOML format may change between minor versions; migrations documented in CHANGELOG |
 | **API stability** | gRPC proto may add fields/RPCs; breaking changes documented in CHANGELOG |
-| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design), true RFC VLAN-aware bundle VTEP origination + dataplane (non-zero Ethernet Tag RR receive/reflect shipped, M82), EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, BGP-LS local topology production, Confederation, TCP-AO dynamic-neighbor / runtime-rotation / multi-key rollover |
+| **Not yet supported** | EVPN runtime L3VNI/device/table IP-VRF identity changes (restart-required by design), true RFC VLAN-aware bundle VTEP origination + dataplane (non-zero Ethernet Tag RR receive/reflect shipped, M82), EVPN route types 6-11 / PBB / MVPN / MPLS/SRv6 service encapsulation, BGP-LS local topology production, Confederation, TCP-AO runtime rotation / multi-key rollover / runtime protected-range CRUD |
 | **Tests** | Workspace test suite, fuzz targets, an automated interop suite (see `docs/INTEROP.md`) primarily against FRR plus GoBGP / StayRTR / documented BIRD coverage, and an in-tree EVPN load generator (foundation tier gated on every PR; privileged kernel dataplane smokes run on GitHub-hosted CI) |
 
 ## Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1213,10 +1213,10 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
 
 ### Maybe / demand-shaped
 
-- **TCP-AO dynamic / rotation polish.** Static TCP-AO + BIRD interop (M43) are
-  shipped. Dynamic-neighbor wildcard-MKT design, runtime key rotation /
-  multi-key rollover, and public accepted-socket inspection / observability
-  matter to some route-server / security operators but are demand-shaped, not
+- **TCP-AO rotation polish.** Static TCP-AO + BIRD interop (M43), direct
+  dynamic-prefix listener MKTs, fail-closed accepted-socket validation, and
+  live neighbor API/CLI inspection are shipped. Runtime key rotation,
+  multi-key rollover, and per-socket metrics remain demand-shaped rather than
   core-feature blockers.
 - **Dataplane-aware readiness.** The shipped `/readyz` (and the bounded
   `GetHealth`) probe scopes readiness to the **control-plane core** — PeerManager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,7 @@ input from the network. It runs under continuous fuzzing in CI.
 
 - **TCP MD5 (RFC 2385):** Supported. Linux only.
 - **GTSM (RFC 5082):** Supported. Configurable per peer.
-- **TCP-AO (RFC 5925):** Supported for static neighbors on Linux (ADR-0062, startup key install). Dynamic-neighbor, runtime key rotation, and multi-key rollover remain roadmap items.
+- **TCP-AO (RFC 5925):** Supported for static neighbors and direct dynamic-prefix listener keys on Linux (ADR-0062), with fail-closed accepted-socket validation and live API/CLI health. Runtime key rotation and multi-key rollover remain roadmap items.
 - **gRPC:** Unix domain socket by default (local-only). TCP listeners
   are opt-in via config. Per-listener bearer-token authentication is
   available via `token_file`. Native mTLS terminates in-process on TCP

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -18,7 +18,7 @@ use crate::server::{
     AccessMode, ConfigMutationGateFn, check_config_mutation_gate, persist_runtime_config_event,
     read_only_rejection,
 };
-use rustbgpd_rib::RibUpdate;
+use rustbgpd_rib::{EffectiveDistributionMode, PeerOutboundState, RibUpdate};
 
 const CONFIG_PERSIST_RESERVE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -169,13 +169,13 @@ async fn query_export_policy_stats(
         .map_err(|_| Status::internal("RIB manager dropped reply"))
 }
 
-async fn query_update_group(
+async fn query_peer_outbound_state(
     rib_tx: &mpsc::Sender<RibUpdate>,
     peer: std::net::IpAddr,
-) -> Result<String, Status> {
+) -> Result<PeerOutboundState, Status> {
     let (reply_tx, reply_rx) = oneshot::channel();
     rib_tx
-        .send(RibUpdate::QueryPeerUpdateGroup {
+        .send(RibUpdate::QueryPeerOutboundState {
             peer,
             reply: reply_tx,
         })
@@ -424,6 +424,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
                 paths_limit_families.push(*family);
             }
         }
+        paths_limit_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
         paths_limit_families
             .iter()
             .filter_map(|family| {
@@ -437,8 +438,10 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
                 let effective = info
                     .effective_add_path_send_limits
                     .iter()
-                    .find_map(|(candidate, value)| (candidate == family).then_some(*value))
-                    .unwrap_or(0);
+                    .find_map(|(candidate, value)| (candidate == family).then_some(*value));
+                let effective_send_active = effective.is_some();
+                let effective_send_max =
+                    effective.map_or(0, |value| if value == u32::MAX { 0 } else { value });
                 let advertised = if info.add_path_receive
                     && matches!(
                         family.1,
@@ -448,13 +451,14 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
                 } else {
                     0
                 };
-                (advertised != 0 || received != 0 || effective != 0).then(|| {
+                (advertised != 0 || received != 0 || effective_send_active).then(|| {
                     proto::PathsLimitState {
                         family: family_to_string(family.0, family.1),
                         configured_receive_max: u32::from(info.paths_limit_receive_max),
                         advertised_receive_max: advertised,
                         received_receive_max: received,
-                        effective_send_max: effective,
+                        effective_send_max,
+                        effective_send_active,
                     }
                 })
             })
@@ -531,6 +535,19 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
             packets_dropped_icmp: ao.pkt_dropped_icmp,
         }),
         tcp_ao_health: tcp_ao_health.into(),
+        effective_distribution_mode: proto::EffectiveDistributionMode::Unknown.into(),
+    }
+}
+
+fn effective_distribution_mode_to_proto(
+    mode: EffectiveDistributionMode,
+) -> proto::EffectiveDistributionMode {
+    match mode {
+        EffectiveDistributionMode::Unknown => proto::EffectiveDistributionMode::Unknown,
+        EffectiveDistributionMode::SingleBest => proto::EffectiveDistributionMode::SingleBest,
+        EffectiveDistributionMode::AddPath => proto::EffectiveDistributionMode::AddPath,
+        EffectiveDistributionMode::Orr => proto::EffectiveDistributionMode::Orr,
+        EffectiveDistributionMode::PerClientBest => proto::EffectiveDistributionMode::PerClientBest,
     }
 }
 
@@ -842,7 +859,10 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             let policy_stats = query_export_policy_stats(&self.rib_tx, info.address).await?;
             state.export_policy_routes_permitted = policy_stats.export_policy_routes_permitted;
             state.export_policy_routes_denied = policy_stats.export_policy_routes_denied;
-            state.update_group = query_update_group(&self.rib_tx, info.address).await?;
+            let outbound = query_peer_outbound_state(&self.rib_tx, info.address).await?;
+            state.update_group = outbound.update_group;
+            state.effective_distribution_mode =
+                effective_distribution_mode_to_proto(outbound.effective_distribution_mode).into();
             neighbors.push(state);
         }
 
@@ -875,7 +895,10 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         let policy_stats = query_export_policy_stats(&self.rib_tx, info.address).await?;
         state.export_policy_routes_permitted = policy_stats.export_policy_routes_permitted;
         state.export_policy_routes_denied = policy_stats.export_policy_routes_denied;
-        state.update_group = query_update_group(&self.rib_tx, info.address).await?;
+        let outbound = query_peer_outbound_state(&self.rib_tx, info.address).await?;
+        state.update_group = outbound.update_group;
+        state.effective_distribution_mode =
+            effective_distribution_mode_to_proto(outbound.effective_distribution_mode).into();
         Ok(Response::new(state))
     }
 
@@ -1201,6 +1224,16 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let (rib_tx, _rib_rx) = mpsc::channel(16);
         NeighborService::new(65001, AccessMode::ReadWrite, tx, rib_tx, None)
+    }
+
+    #[test]
+    fn neighbor_observability_proto_fields_are_append_only() {
+        let source = include_str!("../../../proto/rustbgpd.proto");
+        assert!(source.contains("AuthenticationMode authentication = 27;"));
+        assert!(source.contains("TcpAoState tcp_ao = 28;"));
+        assert!(source.contains("TcpAoHealth tcp_ao_health = 29;"));
+        assert!(source.contains("EffectiveDistributionMode effective_distribution_mode = 30;"));
+        assert!(source.contains("bool effective_send_active = 6;"));
     }
 
     fn test_static_peer_config() -> PeerManagerNeighborConfig {
@@ -1896,8 +1929,11 @@ mod tests {
                             ..Default::default()
                         });
                     }
-                    RibUpdate::QueryPeerUpdateGroup { reply, .. } => {
-                        let _ = reply.send("group:0".to_string());
+                    RibUpdate::QueryPeerOutboundState { reply, .. } => {
+                        let _ = reply.send(PeerOutboundState {
+                            update_group: "group:0".to_string(),
+                            effective_distribution_mode: EffectiveDistributionMode::AddPath,
+                        });
                     }
                     _ => {}
                 }
@@ -1917,6 +1953,10 @@ mod tests {
         assert_eq!(resp.export_policy_routes_permitted, 3);
         assert_eq!(resp.export_policy_routes_denied, 4);
         assert_eq!(resp.update_group, "group:0");
+        assert_eq!(
+            resp.effective_distribution_mode,
+            proto::EffectiveDistributionMode::AddPath as i32
+        );
     }
 
     #[test]
@@ -1962,6 +2002,37 @@ mod tests {
         assert_eq!(state.messages_received, 4321);
         assert_eq!(state.messages_sent, 1234);
         assert!(state.route_reflector_client);
+    }
+
+    #[test]
+    fn paths_limit_output_is_numeric_ordered_and_normalizes_active_unlimited() {
+        let mut info = peer_info("10.0.0.1".parse().unwrap());
+        info.families = vec![(Afi::Ipv6, Safi::Unicast), (Afi::Ipv4, Safi::Unicast)];
+        info.paths_limit_receive_max = 3;
+        info.peer_paths_limits = vec![
+            ((Afi::L2Vpn, Safi::Evpn), 9),
+            ((Afi::Ipv6, Safi::Unicast), 4),
+        ];
+        info.effective_add_path_send_limits = vec![
+            ((Afi::Ipv6, Safi::Unicast), 2),
+            ((Afi::Ipv4, Safi::Unicast), u32::MAX),
+        ];
+
+        let paths = peer_info_to_proto(&info).paths_limits;
+
+        assert_eq!(
+            paths
+                .iter()
+                .map(|row| row.family.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ipv4_unicast", "ipv6_unicast", "L2Vpn_Evpn"]
+        );
+        assert!(paths[0].effective_send_active);
+        assert_eq!(paths[0].effective_send_max, 0);
+        assert!(paths[1].effective_send_active);
+        assert_eq!(paths[1].effective_send_max, 2);
+        assert!(!paths[2].effective_send_active);
+        assert_eq!(paths[2].effective_send_max, 0);
     }
 
     #[test]

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -428,6 +428,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
         paths_limit_families
             .iter()
             .filter_map(|family| {
+                let locally_configured = info.families.contains(family);
                 let received = info
                     .peer_paths_limits
                     .iter()
@@ -439,10 +440,16 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
                     .effective_add_path_send_limits
                     .iter()
                     .find_map(|(candidate, value)| (candidate == family).then_some(*value));
-                let effective_send_active = effective.is_some();
-                let effective_send_max =
-                    effective.map_or(0, |value| if value == u32::MAX { 0 } else { value });
-                let advertised = if info.add_path_receive
+                let effective_send_limit =
+                    effective.map(|value| if value == u32::MAX { 0 } else { value });
+                let effective_send_max = effective.unwrap_or(0);
+                let configured_receive_max = if locally_configured {
+                    u32::from(info.paths_limit_receive_max)
+                } else {
+                    0
+                };
+                let advertised = if locally_configured
+                    && info.add_path_receive
                     && matches!(
                         family.1,
                         Safi::Unicast | Safi::MplsVpn | Safi::LabeledUnicast
@@ -451,14 +458,14 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
                 } else {
                     0
                 };
-                (advertised != 0 || received != 0 || effective_send_active).then(|| {
+                (advertised != 0 || received != 0 || effective.is_some()).then(|| {
                     proto::PathsLimitState {
                         family: family_to_string(family.0, family.1),
-                        configured_receive_max: u32::from(info.paths_limit_receive_max),
+                        configured_receive_max,
                         advertised_receive_max: advertised,
                         received_receive_max: received,
                         effective_send_max,
-                        effective_send_active,
+                        effective_send_limit,
                     }
                 })
             })
@@ -477,7 +484,9 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
     let tcp_ao_health = if info.authentication != "tcp_ao" {
         proto::TcpAoHealth::NotApplicable
     } else if let Some(ao) = info.tcp_ao_info {
-        if ao.pkt_bad > 0
+        if !ao.has_current_key
+            || !ao.has_rnext_key
+            || ao.pkt_bad > 0
             || ao.pkt_key_not_found > 0
             || ao.pkt_ao_required > 0
             || ao.pkt_dropped_icmp > 0
@@ -1233,7 +1242,7 @@ mod tests {
         assert!(source.contains("TcpAoState tcp_ao = 28;"));
         assert!(source.contains("TcpAoHealth tcp_ao_health = 29;"));
         assert!(source.contains("EffectiveDistributionMode effective_distribution_mode = 30;"));
-        assert!(source.contains("bool effective_send_active = 6;"));
+        assert!(source.contains("optional uint32 effective_send_limit = 6;"));
     }
 
     fn test_static_peer_config() -> PeerManagerNeighborConfig {
@@ -2027,12 +2036,14 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["ipv4_unicast", "ipv6_unicast", "L2Vpn_Evpn"]
         );
-        assert!(paths[0].effective_send_active);
-        assert_eq!(paths[0].effective_send_max, 0);
-        assert!(paths[1].effective_send_active);
+        assert_eq!(paths[0].effective_send_max, u32::MAX);
+        assert_eq!(paths[0].effective_send_limit, Some(0));
         assert_eq!(paths[1].effective_send_max, 2);
-        assert!(!paths[2].effective_send_active);
+        assert_eq!(paths[1].effective_send_limit, Some(2));
         assert_eq!(paths[2].effective_send_max, 0);
+        assert_eq!(paths[2].effective_send_limit, None);
+        assert_eq!(paths[2].configured_receive_max, 0);
+        assert_eq!(paths[2].advertised_receive_max, 0);
     }
 
     #[test]
@@ -2082,6 +2093,52 @@ mod tests {
         );
         assert_eq!(state.tcp_ao_health, proto::TcpAoHealth::Unavailable as i32);
         assert!(state.tcp_ao.is_none());
+    }
+
+    #[test]
+    fn tcp_ao_missing_current_key_degrades_clean_counters() {
+        let mut info = peer_info("10.0.0.1".parse().unwrap());
+        info.authentication = "tcp_ao".to_string();
+        info.tcp_ao_info = Some(rustbgpd_transport::TcpAoInfoSnapshot {
+            has_current_key: false,
+            has_rnext_key: true,
+            ao_required: false,
+            accept_icmps: false,
+            current_key: 0,
+            rnext_key: 9,
+            pkt_good: 20,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        });
+        assert_eq!(
+            peer_info_to_proto(&info).tcp_ao_health,
+            proto::TcpAoHealth::Degraded as i32
+        );
+    }
+
+    #[test]
+    fn tcp_ao_missing_rnext_key_degrades_clean_counters() {
+        let mut info = peer_info("10.0.0.1".parse().unwrap());
+        info.authentication = "tcp_ao".to_string();
+        info.tcp_ao_info = Some(rustbgpd_transport::TcpAoInfoSnapshot {
+            has_current_key: true,
+            has_rnext_key: false,
+            ao_required: false,
+            accept_icmps: false,
+            current_key: 7,
+            rnext_key: 0,
+            pkt_good: 20,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        });
+        assert_eq!(
+            peer_info_to_proto(&info).tcp_ao_health,
+            proto::TcpAoHealth::Degraded as i32
+        );
     }
 
     #[test]

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1822,9 +1822,13 @@ pub struct PeerInfo {
     pub uptime_secs: u64,
     /// Human-readable last error description.
     pub last_error: String,
-    /// Configured transport authentication: plaintext, MD5, or `tcp_ao`.
+    /// Effective transport authentication: plaintext, MD5, or `tcp_ao`.
+    /// Protected accepted dynamic sessions derive this from durable live
+    /// transport identity rather than a per-neighbor key configuration.
     pub authentication: String,
-    /// Query-time TCP-AO health for the currently owned stream.
+    /// Query-time TCP-AO inspection snapshot for the currently owned stream,
+    /// including `KeyID` validity flags and cumulative verification counters.
+    /// Health classification is derived at the protobuf/API boundary.
     pub tcp_ao_info: Option<TcpAoInfoSnapshot>,
     /// True for peers auto-created from a `[[dynamic_neighbors]]` range.
     pub is_dynamic: bool,

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -853,7 +853,8 @@ pub enum PeerManagerCommand {
         stream: TcpStream,
         /// Remote peer socket address, including IPv6 scope for link-local.
         peer_addr: std::net::SocketAddr,
-        /// Connection-time TCP-AO inspection tied to this accepted stream.
+        /// Initial TCP-AO inspection tied to this accepted stream. The session
+        /// refreshes it when state is queried.
         tcp_ao_info: Option<rustbgpd_transport::TcpAoInfoSnapshot>,
     },
     /// Reconcile peers after config reload (add/remove/change).
@@ -1823,7 +1824,7 @@ pub struct PeerInfo {
     pub last_error: String,
     /// Configured transport authentication: plaintext, MD5, or `tcp_ao`.
     pub authentication: String,
-    /// Connection-time TCP-AO health for the currently owned stream.
+    /// Query-time TCP-AO health for the currently owned stream.
     pub tcp_ao_info: Option<TcpAoInfoSnapshot>,
     /// True for peers auto-created from a `[[dynamic_neighbors]]` range.
     pub is_dynamic: bool,

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -121,13 +121,17 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             paths_limits: n
                 .paths_limits
                 .iter()
-                .map(|limit| JsonPathsLimit {
-                    family: limit.family.clone(),
-                    configured_receive_max: limit.configured_receive_max,
-                    advertised_receive_max: limit.advertised_receive_max,
-                    received_receive_max: limit.received_receive_max,
-                    effective_send_max: limit.effective_send_max,
-                    effective_send_active: limit.effective_send_active,
+                .map(|limit| {
+                    let (effective_send_active, effective_send_max) =
+                        normalized_effective_send(limit);
+                    JsonPathsLimit {
+                        family: limit.family.clone(),
+                        configured_receive_max: limit.configured_receive_max,
+                        advertised_receive_max: limit.advertised_receive_max,
+                        received_receive_max: limit.received_receive_max,
+                        effective_send_max,
+                        effective_send_active,
+                    }
                 })
                 .collect(),
             role: cfg.map(|c| c.role.clone()).unwrap_or_default(),
@@ -215,10 +219,9 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             println!("Add-Path Send Max:     {add_path_send_max}");
         }
         for limit in &n.paths_limits {
-            let effective_send = paths_limit_effective_send_label(
-                limit.effective_send_active,
-                limit.effective_send_max,
-            );
+            let (effective_send_active, effective_send_max) = normalized_effective_send(limit);
+            let effective_send =
+                paths_limit_effective_send_label(effective_send_active, effective_send_max);
             println!(
                 "Paths-Limit {}: configured={} advertised={} received={} effective-send={}",
                 limit.family,
@@ -329,6 +332,17 @@ fn paths_limit_effective_send_label(active: bool, max: u32) -> String {
         "unlimited".to_string()
     } else {
         max.to_string()
+    }
+}
+
+fn normalized_effective_send(limit: &crate::proto::PathsLimitState) -> (bool, u32) {
+    if let Some(normalized) = limit.effective_send_limit {
+        return (true, normalized);
+    }
+    match limit.effective_send_max {
+        0 => (false, 0),
+        u32::MAX => (true, 0),
+        finite => (true, finite),
     }
 }
 
@@ -551,6 +565,25 @@ mod tests {
         assert_eq!(paths_limit_effective_send_label(false, 0), "inactive");
         assert_eq!(paths_limit_effective_send_label(true, 0), "unlimited");
         assert_eq!(paths_limit_effective_send_label(true, 4), "4");
+    }
+
+    #[test]
+    fn paths_limit_new_and_legacy_servers_normalize_bidirectionally() {
+        let row = |raw, normalized| crate::proto::PathsLimitState {
+            effective_send_max: raw,
+            effective_send_limit: normalized,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            normalized_effective_send(&row(u32::MAX, Some(0))),
+            (true, 0)
+        );
+        assert_eq!(normalized_effective_send(&row(4, Some(4))), (true, 4));
+        assert_eq!(normalized_effective_send(&row(0, None)), (false, 0));
+        assert_eq!(normalized_effective_send(&row(u32::MAX, None)), (true, 0));
+        assert_eq!(normalized_effective_send(&row(3, None)), (true, 3));
+        assert_eq!(normalized_effective_send(&row(0, Some(0))), (true, 0));
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -74,26 +74,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         .into_inner();
 
     let cfg = n.config.as_ref();
-    // Unicast distribution mode, mirroring the RIB's mode ladder
-    // (negotiated Add-Path send outranks the per-client-best fallback).
-    // An ORR vantage is not on the runtime NeighborConfig surface, so
-    // it is recognized via the update-group ungrouped reason.
-    //
-    // LAN-211 #6: this reads the *configured* add_path_send/per_client_best
-    // bits echoed on NeighborConfig, so a peer that configured Add-Path but
-    // never negotiated it still prints "add-path". A negotiated/effective
-    // mode is not surfaced on NeighborState (update_group is a shadow-mode
-    // grouping string, "group:N" when grouped), so fixing this needs new
-    // plumbing; deferred.
-    let distribution_mode = if cfg.map(|c| c.add_path_send).unwrap_or(false) {
-        "add-path"
-    } else if cfg.map(|c| c.per_client_best).unwrap_or(false) {
-        "per-client-best"
-    } else if n.update_group == "orr_vantage" {
-        "orr"
-    } else {
-        "single-best"
-    };
+    let distribution_mode = effective_distribution_mode_label(n.effective_distribution_mode);
     if json {
         let out = JsonNeighborDetail {
             address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
@@ -146,6 +127,7 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
                     advertised_receive_max: limit.advertised_receive_max,
                     received_receive_max: limit.received_receive_max,
                     effective_send_max: limit.effective_send_max,
+                    effective_send_active: limit.effective_send_active,
                 })
                 .collect(),
             role: cfg.map(|c| c.role.clone()).unwrap_or_default(),
@@ -233,13 +215,17 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             println!("Add-Path Send Max:     {add_path_send_max}");
         }
         for limit in &n.paths_limits {
+            let effective_send = paths_limit_effective_send_label(
+                limit.effective_send_active,
+                limit.effective_send_max,
+            );
             println!(
                 "Paths-Limit {}: configured={} advertised={} received={} effective-send={}",
                 limit.family,
                 limit.configured_receive_max,
                 limit.advertised_receive_max,
                 limit.received_receive_max,
-                limit.effective_send_max
+                effective_send
             );
         }
         println!(
@@ -321,6 +307,28 @@ fn tcp_ao_health_label(value: i32) -> &'static str {
         Ok(crate::proto::TcpAoHealth::Healthy) => "healthy",
         Ok(crate::proto::TcpAoHealth::Degraded) => "degraded",
         Ok(crate::proto::TcpAoHealth::Unspecified) | Err(_) => "unknown",
+    }
+}
+
+fn effective_distribution_mode_label(value: i32) -> &'static str {
+    match crate::proto::EffectiveDistributionMode::try_from(value) {
+        Ok(crate::proto::EffectiveDistributionMode::SingleBest) => "single-best",
+        Ok(crate::proto::EffectiveDistributionMode::AddPath) => "add-path",
+        Ok(crate::proto::EffectiveDistributionMode::Orr) => "orr",
+        Ok(crate::proto::EffectiveDistributionMode::PerClientBest) => "per-client-best",
+        Ok(crate::proto::EffectiveDistributionMode::Unknown)
+        | Ok(crate::proto::EffectiveDistributionMode::Unspecified)
+        | Err(_) => "unknown",
+    }
+}
+
+fn paths_limit_effective_send_label(active: bool, max: u32) -> String {
+    if !active {
+        "inactive".to_string()
+    } else if max == 0 {
+        "unlimited".to_string()
+    } else {
+        max.to_string()
     }
 }
 
@@ -519,6 +527,31 @@ mod tests {
     use super::*;
     use crate::connection::connect;
     use crate::test_support::spawn_mock_server;
+
+    #[test]
+    fn effective_distribution_mode_is_live_and_backward_compatible() {
+        assert_eq!(
+            effective_distribution_mode_label(
+                crate::proto::EffectiveDistributionMode::AddPath as i32
+            ),
+            "add-path"
+        );
+        assert_eq!(
+            effective_distribution_mode_label(
+                crate::proto::EffectiveDistributionMode::PerClientBest as i32
+            ),
+            "per-client-best"
+        );
+        assert_eq!(effective_distribution_mode_label(0), "unknown");
+        assert_eq!(effective_distribution_mode_label(i32::MAX), "unknown");
+    }
+
+    #[test]
+    fn paths_limit_effective_send_distinguishes_inactive_and_unlimited() {
+        assert_eq!(paths_limit_effective_send_label(false, 0), "inactive");
+        assert_eq!(paths_limit_effective_send_label(true, 0), "unlimited");
+        assert_eq!(paths_limit_effective_send_label(true, 4), "4");
+    }
 
     #[tokio::test]
     async fn add_sends_route_server_and_add_path_fields() {

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -74,7 +74,12 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         .into_inner();
 
     let cfg = n.config.as_ref();
-    let distribution_mode = effective_distribution_mode_label(n.effective_distribution_mode);
+    let distribution_mode = effective_distribution_mode_label(
+        n.effective_distribution_mode,
+        cfg.map(|c| c.add_path_send).unwrap_or(false),
+        cfg.map(|c| c.per_client_best).unwrap_or(false),
+        &n.update_group,
+    );
     if json {
         let out = JsonNeighborDetail {
             address: cfg.map(|c| c.address.clone()).unwrap_or_default(),
@@ -129,7 +134,8 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
                         configured_receive_max: limit.configured_receive_max,
                         advertised_receive_max: limit.advertised_receive_max,
                         received_receive_max: limit.received_receive_max,
-                        effective_send_max,
+                        effective_send_max: limit.effective_send_max,
+                        effective_send_limit: effective_send_active.then_some(effective_send_max),
                         effective_send_active,
                     }
                 })
@@ -313,15 +319,29 @@ fn tcp_ao_health_label(value: i32) -> &'static str {
     }
 }
 
-fn effective_distribution_mode_label(value: i32) -> &'static str {
+fn effective_distribution_mode_label(
+    value: i32,
+    legacy_add_path_send: bool,
+    legacy_per_client_best: bool,
+    legacy_update_group: &str,
+) -> &'static str {
     match crate::proto::EffectiveDistributionMode::try_from(value) {
         Ok(crate::proto::EffectiveDistributionMode::SingleBest) => "single-best",
         Ok(crate::proto::EffectiveDistributionMode::AddPath) => "add-path",
         Ok(crate::proto::EffectiveDistributionMode::Orr) => "orr",
         Ok(crate::proto::EffectiveDistributionMode::PerClientBest) => "per-client-best",
-        Ok(crate::proto::EffectiveDistributionMode::Unknown)
-        | Ok(crate::proto::EffectiveDistributionMode::Unspecified)
-        | Err(_) => "unknown",
+        Ok(crate::proto::EffectiveDistributionMode::Unknown) | Err(_) => "unknown",
+        Ok(crate::proto::EffectiveDistributionMode::Unspecified) => {
+            if legacy_add_path_send {
+                "add-path"
+            } else if legacy_per_client_best {
+                "per-client-best"
+            } else if legacy_update_group == "orr_vantage" {
+                "orr"
+            } else {
+                "single-best"
+            }
+        }
     }
 }
 
@@ -546,18 +566,47 @@ mod tests {
     fn effective_distribution_mode_is_live_and_backward_compatible() {
         assert_eq!(
             effective_distribution_mode_label(
-                crate::proto::EffectiveDistributionMode::AddPath as i32
+                crate::proto::EffectiveDistributionMode::AddPath as i32,
+                false,
+                false,
+                ""
             ),
             "add-path"
         );
         assert_eq!(
             effective_distribution_mode_label(
-                crate::proto::EffectiveDistributionMode::PerClientBest as i32
+                crate::proto::EffectiveDistributionMode::PerClientBest as i32,
+                false,
+                false,
+                ""
             ),
             "per-client-best"
         );
-        assert_eq!(effective_distribution_mode_label(0), "unknown");
-        assert_eq!(effective_distribution_mode_label(i32::MAX), "unknown");
+        assert_eq!(
+            effective_distribution_mode_label(0, true, false, ""),
+            "add-path"
+        );
+        assert_eq!(
+            effective_distribution_mode_label(0, false, true, ""),
+            "per-client-best"
+        );
+        assert_eq!(
+            effective_distribution_mode_label(0, false, false, "orr_vantage"),
+            "orr"
+        );
+        assert_eq!(
+            effective_distribution_mode_label(
+                crate::proto::EffectiveDistributionMode::Unknown as i32,
+                true,
+                true,
+                "orr_vantage"
+            ),
+            "unknown"
+        );
+        assert_eq!(
+            effective_distribution_mode_label(i32::MAX, true, true, "orr_vantage"),
+            "unknown"
+        );
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -254,8 +254,7 @@ pub struct JsonNeighborDetail {
     pub route_server_client: bool,
     #[serde(skip_serializing_if = "is_false")]
     pub per_client_best: bool,
-    /// Unicast distribution mode: `single-best`, `add-path`, `orr`, or
-    /// `per-client-best`.
+    /// Effective live unicast distribution mode, or `unknown` while down.
     pub distribution_mode: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub role: String,
@@ -306,6 +305,7 @@ pub struct JsonPathsLimit {
     pub advertised_receive_max: u32,
     pub received_receive_max: u32,
     pub effective_send_max: u32,
+    pub effective_send_active: bool,
 }
 
 #[cfg(test)]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -304,7 +304,11 @@ pub struct JsonPathsLimit {
     pub configured_receive_max: u32,
     pub advertised_receive_max: u32,
     pub received_receive_max: u32,
+    /// Legacy raw value: zero inactive, `u32::MAX` unlimited.
     pub effective_send_max: u32,
+    /// Normalized active limit: zero unlimited, finite otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_send_limit: Option<u32>,
     pub effective_send_active: bool,
 }
 
@@ -847,6 +851,23 @@ pub fn parse_prefix(s: &str) -> Result<(String, u32), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn paths_limit_json_preserves_raw_and_adds_normalized_limit() {
+        let row = JsonPathsLimit {
+            family: "ipv4_unicast".to_string(),
+            configured_receive_max: 3,
+            advertised_receive_max: 3,
+            received_receive_max: 0,
+            effective_send_max: u32::MAX,
+            effective_send_limit: Some(0),
+            effective_send_active: true,
+        };
+        let value = serde_json::to_value(row).unwrap();
+        assert_eq!(value["effective_send_max"], u64::from(u32::MAX));
+        assert_eq!(value["effective_send_limit"], 0);
+        assert_eq!(value["effective_send_active"], true);
+    }
     use serde_json::Value;
     use std::collections::BTreeMap;
 

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -737,6 +737,7 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
             messages_sent: 8,
             route_reflector_client: false,
             paths_limits: Vec::new(),
+            effective_distribution_mode: server_proto::EffectiveDistributionMode::AddPath.into(),
         }))
     }
 

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -62,11 +62,12 @@ pub use route::{
     RouteOrigin, RtcRibRoute, RtcRibRouteKey, VpnRibRoute, VpnRibRouteKey,
 };
 pub use update::{
-    AdjRibOutCounts, BestPathCandidate, ExplainAdvertisedRoute, ExplainBestPath, ExplainDecision,
-    ExplainReason, ExportGateStep, ExportGateVerdict, MrtPeerEntry, MrtSnapshotData,
-    NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, PlannedGroupability,
-    RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
-    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupFamilyImpact,
-    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
-    UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group, route_query_key,
+    AdjRibOutCounts, BestPathCandidate, EffectiveDistributionMode, ExplainAdvertisedRoute,
+    ExplainBestPath, ExplainDecision, ExplainReason, ExportGateStep, ExportGateVerdict,
+    MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate,
+    PeerOutboundState, PlannedGroupability, RibCommandError, RibUpdate, RoutePage,
+    RouteQueryFilter, RouteQueryKey, RouteQueryScope, UpdateGroupClassification,
+    UpdateGroupClassifierInput, UpdateGroupFamilyImpact, UpdateGroupFingerprint,
+    UpdateGroupImpactPlan, UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot,
+    classify_update_group, route_query_key,
 };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1210,6 +1210,9 @@ impl RibManager {
             RibUpdate::QueryPeerUpdateGroup { peer, reply } => {
                 self.handle_query_peer_update_group(peer, reply);
             }
+            RibUpdate::QueryPeerOutboundState { peer, reply } => {
+                self.handle_query_peer_outbound_state(peer, reply);
+            }
             RibUpdate::QueryUpdateGroupSnapshot { reply } => {
                 self.handle_query_update_group_snapshot(reply);
             }

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -137,6 +137,20 @@ async fn query_update_group(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Strin
     reply_rx.await.unwrap()
 }
 
+async fn query_peer_outbound_state(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+) -> crate::PeerOutboundState {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryPeerOutboundState {
+        peer,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
 fn regroups_total(metrics: &BgpMetrics) -> f64 {
     metrics
         .registry()
@@ -168,6 +182,12 @@ async fn identical_peers_group_together_and_gauges_track_membership() {
 
     assert_eq!(query_update_group(&tx, a).await, "group:0");
     assert_eq!(query_update_group(&tx, b).await, "group:0");
+    assert_eq!(
+        query_peer_outbound_state(&tx, a)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::SingleBest
+    );
     assert_metric(
         gauge_metric_value(&metrics, "bgp_update_groups", &[]),
         1.0,
@@ -210,6 +230,12 @@ async fn identical_peers_group_together_and_gauges_track_membership() {
     .await
     .unwrap();
     assert_eq!(query_update_group(&tx, a).await, "");
+    assert_eq!(
+        query_peer_outbound_state(&tx, a)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::Unknown
+    );
     assert_metric(
         gauge_metric_value(&metrics, "bgp_update_group_members", &[("group", "0")]),
         0.0,
@@ -297,6 +323,30 @@ async fn ungrouped_reasons_surface_per_disqualifier() {
     assert_eq!(
         query_update_group(&tx, orf_negotiated_peer).await,
         "orf_installed"
+    );
+    assert_eq!(
+        query_peer_outbound_state(&tx, policy_peer)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::SingleBest
+    );
+    assert_eq!(
+        query_peer_outbound_state(&tx, add_path_peer)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::AddPath
+    );
+    assert_eq!(
+        query_peer_outbound_state(&tx, per_client_best_peer)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::PerClientBest
+    );
+    assert_eq!(
+        query_peer_outbound_state(&tx, orf_negotiated_peer)
+            .await
+            .effective_distribution_mode,
+        crate::EffectiveDistributionMode::SingleBest
     );
     assert_metric(
         gauge_metric_value(&metrics, "bgp_update_group_fallback_peers", &[]),

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2244,6 +2244,60 @@ impl RibManager {
             .unwrap_or_default();
         let _ = reply.send(label);
     }
+
+    /// Answer the neighbor API's combined outbound-state query atomically.
+    pub(super) fn handle_query_peer_outbound_state(
+        &mut self,
+        peer: IpAddr,
+        reply: tokio::sync::oneshot::Sender<crate::update::PeerOutboundState>,
+    ) {
+        use crate::update::PeerOutboundState;
+
+        let update_group = self
+            .update_groups
+            .membership(peer)
+            .map(GroupMembership::label)
+            .unwrap_or_default();
+        let orr_resolved = self
+            .peer_orr_vantage
+            .get(&peer)
+            .is_some_and(|vantage| self.orr.spf.contains_key(vantage));
+        let effective_distribution_mode = classify_effective_distribution_mode(
+            self.outbound_peers.contains_key(&peer),
+            self.peer_has_any_add_path_send(peer),
+            self.peer_per_client_best.contains(&peer),
+            orr_resolved,
+        );
+        let _ = reply.send(PeerOutboundState {
+            update_group,
+            effective_distribution_mode,
+        });
+    }
+}
+
+#[expect(
+    clippy::fn_params_excessive_bools,
+    reason = "pure classifier mirrors four independent live RIB membership predicates"
+)]
+fn classify_effective_distribution_mode(
+    registered: bool,
+    add_path: bool,
+    per_client_best: bool,
+    orr_resolved: bool,
+) -> crate::update::EffectiveDistributionMode {
+    use crate::update::EffectiveDistributionMode;
+
+    if !registered {
+        EffectiveDistributionMode::Unknown
+    } else if add_path {
+        EffectiveDistributionMode::AddPath
+    } else if per_client_best {
+        EffectiveDistributionMode::PerClientBest
+    } else if orr_resolved {
+        EffectiveDistributionMode::Orr
+    } else {
+        EffectiveDistributionMode::SingleBest
+    }
 }
 
 #[cfg(test)]
@@ -2256,6 +2310,32 @@ mod tests {
 
     use super::*;
     use crate::test_support::make_route;
+
+    #[test]
+    fn effective_distribution_mode_precedence_is_deterministic() {
+        use crate::EffectiveDistributionMode;
+
+        assert_eq!(
+            classify_effective_distribution_mode(false, true, true, true),
+            EffectiveDistributionMode::Unknown
+        );
+        assert_eq!(
+            classify_effective_distribution_mode(true, true, true, true),
+            EffectiveDistributionMode::AddPath
+        );
+        assert_eq!(
+            classify_effective_distribution_mode(true, false, true, true),
+            EffectiveDistributionMode::PerClientBest
+        );
+        assert_eq!(
+            classify_effective_distribution_mode(true, false, false, true),
+            EffectiveDistributionMode::Orr
+        );
+        assert_eq!(
+            classify_effective_distribution_mode(true, false, false, false),
+            EffectiveDistributionMode::SingleBest
+        );
+    }
 
     const MEMBER: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1));
     const OTHER1: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 2));

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -655,6 +655,30 @@ pub struct RoutePage {
     pub has_more: bool,
 }
 
+/// Effective live unicast distribution mode for a registered peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveDistributionMode {
+    /// The peer has no active outbound registration.
+    Unknown,
+    /// Ordinary Loc-RIB single-best distribution.
+    SingleBest,
+    /// Negotiated Add-Path send is active for at least one family.
+    AddPath,
+    /// RFC 9107 ORR is active with a resolved vantage.
+    Orr,
+    /// RFC 7947 per-client-best export is active.
+    PerClientBest,
+}
+
+/// Atomic neighbor-facing snapshot of live outbound RIB state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerOutboundState {
+    /// Update-group membership label, or empty when unregistered.
+    pub update_group: String,
+    /// Effective live distribution mode.
+    pub effective_distribution_mode: EffectiveDistributionMode,
+}
+
 /// Messages sent from peer sessions to the RIB manager.
 pub enum RibUpdate {
     /// Peer session sent us routes.
@@ -1083,6 +1107,13 @@ pub enum RibUpdate {
         peer: IpAddr,
         /// Response channel.
         reply: oneshot::Sender<String>,
+    },
+    /// Query: atomically return neighbor-facing live outbound state.
+    QueryPeerOutboundState {
+        /// The target peer.
+        peer: IpAddr,
+        /// Response channel.
+        reply: oneshot::Sender<PeerOutboundState>,
     },
     /// Side-effect-free snapshot used by config impact planning.
     QueryUpdateGroupSnapshot {

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -450,6 +450,9 @@ pub struct PeerSessionState {
     /// Query-time TCP-AO socket inspection. Refreshed by `QueryState` and
     /// cleared on disconnect or inspection failure.
     pub tcp_ao_info: Option<Box<crate::TcpAoInfoSnapshot>>,
+    /// Whether this session is TCP-AO protected, independent of whether the
+    /// latest read-only socket inspection succeeded.
+    pub tcp_ao_protected: bool,
     /// Number of unicast route announcements blocked by RFC 9234 OTC rules.
     pub otc_routes_blocked: u64,
     /// Import policy evaluations that permitted a route.

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -447,7 +447,8 @@ pub struct PeerSessionState {
     pub uptime_secs: u64,
     /// Human-readable description of the last error (empty if none).
     pub last_error: String,
-    /// Connection-time TCP-AO socket inspection. Cleared on disconnect.
+    /// Query-time TCP-AO socket inspection. Refreshed by `QueryState` and
+    /// cleared on disconnect or inspection failure.
     pub tcp_ao_info: Option<Box<crate::TcpAoInfoSnapshot>>,
     /// Number of unicast route announcements blocked by RFC 9234 OTC rules.
     pub otc_routes_blocked: u64,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1,11 +1,50 @@
 use super::{
     ControlFlow, Event, Message, NotificationCode, PeerCommand, PeerSession, PeerSessionState,
     RibUpdate, RouteRefreshMessage, SessionNotificationDirection, SessionState, cease_subcode,
-    info,
+    debug, info, warn,
 };
 use crate::handle::PeerCommandError;
 
 impl PeerSession {
+    fn refresh_tcp_ao_info(&mut self) {
+        self.refresh_tcp_ao_info_with(crate::socket_opts::get_tcp_ao_info);
+    }
+
+    pub(super) fn refresh_tcp_ao_info_with<F>(&mut self, inspect: F)
+    where
+        F: FnOnce(&tokio::net::TcpStream) -> std::io::Result<crate::TcpAoInfoSnapshot>,
+    {
+        if self.config.tcp_ao.is_none() {
+            self.tcp_ao_info = None;
+            return;
+        }
+        let Some(read_half) = self.read_half.as_ref() else {
+            self.tcp_ao_info = None;
+            return;
+        };
+        match inspect(read_half.as_ref()) {
+            Ok(snapshot) => self.tcp_ao_info = Some(snapshot),
+            Err(error) => {
+                if self.tcp_ao_info.is_some() {
+                    warn!(
+                        peer = %self.peer_label,
+                        %error,
+                        "live TCP-AO inspection became unavailable"
+                    );
+                } else {
+                    debug!(
+                        peer = %self.peer_label,
+                        %error,
+                        "live TCP-AO inspection unavailable"
+                    );
+                }
+                // Never fall back to a connection-time snapshot: a stale
+                // healthy value would be more dangerous than UNAVAILABLE.
+                self.tcp_ao_info = None;
+            }
+        }
+    }
+
     /// Map external commands to FSM events.
     #[expect(
         clippy::too_many_lines,
@@ -37,6 +76,9 @@ impl PeerSession {
                 ControlFlow::Break(())
             }
             PeerCommand::QueryState { reply } => {
+                // TCP_AO_INFO is cumulative for this socket. Refresh at the
+                // query boundary so operators see current verification health.
+                self.refresh_tcp_ao_info();
                 let uptime_secs = self.established_at.map_or(0, |t| t.elapsed().as_secs());
                 // Prefer FSM's negotiated (available at OpenConfirm) over
                 // self.negotiated (set later at SessionEstablished). This is

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -14,7 +14,7 @@ impl PeerSession {
     where
         F: FnOnce(&tokio::net::TcpStream) -> std::io::Result<crate::TcpAoInfoSnapshot>,
     {
-        if self.config.tcp_ao.is_none() {
+        if !self.tcp_ao_protected {
             self.tcp_ao_info = None;
             return;
         }
@@ -123,6 +123,7 @@ impl PeerSession {
                     uptime_secs,
                     last_error: self.last_error.clone(),
                     tcp_ao_info: self.tcp_ao_info.map(Box::new),
+                    tcp_ao_protected: self.tcp_ao_protected,
                 };
                 let _ = reply.send(state);
                 ControlFlow::Continue(())

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -258,7 +258,7 @@ pub(crate) struct PeerSession {
     flap_count: u64,
     established_at: Option<Instant>,
     last_error: String,
-    /// Connection-time TCP-AO inspection for the currently owned stream.
+    /// Latest query-time TCP-AO inspection for the currently owned stream.
     tcp_ao_info: Option<crate::TcpAoInfoSnapshot>,
     /// Teardown was triggered by NOTIFICATION semantics (inbound or outbound).
     /// RFC 8538: only preserves routes when Notification GR was negotiated.

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -260,6 +260,10 @@ pub(crate) struct PeerSession {
     last_error: String,
     /// Latest query-time TCP-AO inspection for the currently owned stream.
     tcp_ao_info: Option<crate::TcpAoInfoSnapshot>,
+    /// Durable protection identity for this session. Unlike `tcp_ao_info`,
+    /// inspection failure never clears this bit, so a protected accepted
+    /// session keeps retrying read-only inspection on later queries.
+    tcp_ao_protected: bool,
     /// Teardown was triggered by NOTIFICATION semantics (inbound or outbound).
     /// RFC 8538: only preserves routes when Notification GR was negotiated.
     notification_teardown: bool,
@@ -492,6 +496,7 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let tcp_ao_protected = config.tcp_ao.is_some();
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
@@ -554,6 +559,7 @@ impl PeerSession {
             established_at: None,
             last_error: String::new(),
             tcp_ao_info: None,
+            tcp_ao_protected,
             notification_teardown: false,
             received_hard_reset: false,
             sent_hard_reset: false,
@@ -593,6 +599,7 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let tcp_ao_protected = config.tcp_ao.is_some() || tcp_ao_info.is_some();
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
@@ -667,6 +674,7 @@ impl PeerSession {
             established_at: None,
             last_error: String::new(),
             tcp_ao_info,
+            tcp_ao_protected,
             notification_teardown: false,
             received_hard_reset: false,
             sent_hard_reset: false,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1064,6 +1064,9 @@ async fn tcp_ao_query_test_session() -> PeerSession {
         preferred: true,
         deprecated: false,
     });
+    // The test mutates config after construction; production constructors
+    // seed this durable bit from config before the session starts.
+    session.tcp_ao_protected = true;
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let connect = TcpStream::connect(listener.local_addr().unwrap());
     let accept = listener.accept();

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1073,6 +1073,37 @@ async fn tcp_ao_query_test_session() -> PeerSession {
     session
 }
 
+async fn accepted_query_test_session(tcp_ao_info: Option<crate::TcpAoInfoSnapshot>) -> PeerSession {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    let config = TransportConfig::new(peer_config, "127.0.0.1:179".parse().unwrap());
+    assert!(config.tcp_ao.is_none());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let connect = TcpStream::connect(listener.local_addr().unwrap());
+    let accept = listener.accept();
+    let (client, accepted) = tokio::join!(connect, accept);
+    let (_server, _) = accepted.unwrap();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    PeerSession::new_inbound_with_identity_and_lifecycle(
+        config,
+        BgpMetrics::new(),
+        cmd_rx,
+        rib_tx,
+        None,
+        None,
+        client.unwrap(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        crate::SessionIdentity::default(),
+        tcp_ao_info,
+    )
+}
+
 #[tokio::test]
 async fn tcp_ao_query_refreshes_degraded_cumulative_counters() {
     let mut session = tcp_ao_query_test_session().await;
@@ -1091,6 +1122,34 @@ async fn tcp_ao_query_clears_stale_snapshot_and_recovers() {
 
     session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(44, 0)));
     assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 44);
+}
+
+#[tokio::test]
+async fn accepted_tcp_ao_snapshot_seeds_durable_refresh_across_failure_and_recovery() {
+    let mut session = accepted_query_test_session(Some(tcp_ao_snapshot(20, 0))).await;
+    assert!(session.config.tcp_ao.is_none());
+    assert!(session.tcp_ao_protected);
+
+    session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(43, 0)));
+    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 43);
+    session.refresh_tcp_ao_info_with(|_| Err(std::io::Error::other("inspection failed")));
+    assert!(session.tcp_ao_info.is_none());
+    assert!(
+        session.tcp_ao_protected,
+        "inspection failure must not erase protection identity"
+    );
+    session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(44, 0)));
+    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 44);
+}
+
+#[tokio::test]
+async fn plaintext_accepted_session_does_not_inherit_tcp_ao_protection() {
+    let mut session = accepted_query_test_session(None).await;
+    assert!(!session.tcp_ao_protected);
+    session.refresh_tcp_ao_info_with(|_| -> std::io::Result<crate::TcpAoInfoSnapshot> {
+        panic!("plaintext accepted session must not inspect TCP_AO_INFO")
+    });
+    assert!(session.tcp_ao_info.is_none());
 }
 
 #[test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1038,6 +1038,71 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
     );
 }
 
+fn tcp_ao_snapshot(good: u64, bad: u64) -> crate::TcpAoInfoSnapshot {
+    crate::TcpAoInfoSnapshot {
+        has_current_key: true,
+        has_rnext_key: true,
+        ao_required: true,
+        accept_icmps: false,
+        current_key: 7,
+        rnext_key: 9,
+        pkt_good: good,
+        pkt_bad: bad,
+        pkt_key_not_found: 0,
+        pkt_ao_required: 0,
+        pkt_dropped_icmp: 0,
+    }
+}
+
+async fn tcp_ao_query_test_session() -> PeerSession {
+    let mut session = make_test_session(65001, 65002);
+    session.config.tcp_ao = Some(crate::TcpAoConfig {
+        key: "test-secret".to_string(),
+        send_id: 7,
+        recv_id: 9,
+        algorithm: crate::TcpAoAlgorithm::HmacSha256,
+        preferred: true,
+        deprecated: false,
+    });
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let connect = TcpStream::connect(listener.local_addr().unwrap());
+    let accept = listener.accept();
+    let (client, accepted) = tokio::join!(connect, accept);
+    let (_server, _) = accepted.unwrap();
+    session.test_install_stream(client.unwrap());
+    session
+}
+
+#[tokio::test]
+async fn tcp_ao_query_refreshes_degraded_cumulative_counters() {
+    let mut session = tcp_ao_query_test_session().await;
+    session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(43, 1)));
+    let snapshot = session.tcp_ao_info.unwrap();
+    assert_eq!(snapshot.pkt_good, 43);
+    assert_eq!(snapshot.pkt_bad, 1);
+}
+
+#[tokio::test]
+async fn tcp_ao_query_clears_stale_snapshot_and_recovers() {
+    let mut session = tcp_ao_query_test_session().await;
+    session.tcp_ao_info = Some(tcp_ao_snapshot(12, 0));
+    session.refresh_tcp_ao_info_with(|_| Err(std::io::Error::other("inspection failed")));
+    assert!(session.tcp_ao_info.is_none());
+
+    session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(44, 0)));
+    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 44);
+}
+
+#[test]
+fn non_tcp_ao_query_does_not_invoke_inspector() {
+    let mut session = make_test_session(65001, 65002);
+    session.tcp_ao_info = Some(tcp_ao_snapshot(12, 0));
+    session.refresh_tcp_ao_info_with(|_| -> std::io::Result<crate::TcpAoInfoSnapshot> {
+        panic!("non-AO session must not inspect TCP_AO_INFO")
+    });
+    assert!(session.tcp_ao_info.is_none());
+}
+
 #[test]
 fn connect_failure_is_retained_for_neighbor_diagnostics() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);

--- a/docs/API.md
+++ b/docs/API.md
@@ -247,14 +247,28 @@ Runtime key rotation is not exposed.
 
 `NeighborState.authentication` reports `PLAINTEXT`, `MD5`, or `TCP_AO` from
 the effective transport configuration. When socket inspection succeeds for a
-connected TCP-AO session, `NeighborState.tcp_ao` contains the connection-time
-current/RNext KeyIDs and Linux verification/error counters. The best-effort
-message is cleared on disconnect; counters are not continuously refreshed.
+connected TCP-AO session, `NeighborState.tcp_ao` contains current/RNext KeyIDs
+and Linux verification/error counters. The daemon refreshes this read-only
+snapshot from the live socket for each neighbor state query and clears it on
+disconnect or inspection failure; it never serves an older healthy snapshot as
+a fallback. The counters are cumulative for the lifetime of that TCP socket,
+so any non-zero error counter keeps the socket `DEGRADED` until reconnect.
 `NeighborState.tcp_ao_health` is `NOT_APPLICABLE` for plaintext and MD5 peers,
 `UNAVAILABLE` when TCP-AO is configured but there is no socket snapshot
 (including disconnect and inspection failure), `HEALTHY` when the snapshot has
 no error counters, and `DEGRADED` when any bad, key-not-found,
 unsigned-required, or dropped-ICMP counter is non-zero.
+
+`NeighborState.effective_distribution_mode` reports the live RIB selection
+surface: `SINGLE_BEST`, `ADD_PATH`, `ORR`, or `PER_CLIENT_BEST`. It is `UNKNOWN`
+when the peer has no active outbound registration; `UNSPECIFIED` remains the
+backward-compatible value returned by older servers. This field is independent
+of the diagnostic `update_group` label.
+
+`NeighborState.paths_limits` is sorted by numeric AFI then SAFI. Each row's
+`effective_send_active` distinguishes an inactive family from active unlimited
+Add-Path send: when active, `effective_send_max = 0` means unlimited; when
+inactive, the zero is only a placeholder.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -265,10 +265,11 @@ when the peer has no active outbound registration; `UNSPECIFIED` remains the
 backward-compatible value returned by older servers. This field is independent
 of the diagnostic `update_group` label.
 
-`NeighborState.paths_limits` is sorted by numeric AFI then SAFI. Each row's
-`effective_send_active` distinguishes an inactive family from active unlimited
-Add-Path send: when active, `effective_send_max = 0` means unlimited; when
-inactive, the zero is only a placeholder.
+`NeighborState.paths_limits` is sorted by numeric AFI then SAFI. Legacy field
+`effective_send_max` retains raw semantics (`UINT32_MAX` unlimited, zero
+inactive). Optional `effective_send_limit` is the normalized view: presence
+means active, with zero unlimited and non-zero finite; absence means inactive.
+New clients fall back to the legacy field when reading an older server.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -245,9 +245,11 @@ attempt without falling back to unauthenticated TCP. Dynamic-range keys are
 config-file-only: runtime range CRUD rejects protected ranges and overlaps.
 Runtime key rotation is not exposed.
 
-`NeighborState.authentication` reports `PLAINTEXT`, `MD5`, or `TCP_AO` from
-the effective transport configuration. When socket inspection succeeds for a
-connected TCP-AO session, `NeighborState.tcp_ao` contains current/RNext KeyIDs
+`NeighborState.authentication` reports the effective protected transport as
+`PLAINTEXT`, `MD5`, or `TCP_AO`. For direct dynamic-prefix TCP-AO sessions,
+that identity comes from the validated accepted socket rather than a synthesized
+per-neighbor key configuration. When socket inspection succeeds for a connected
+TCP-AO session, `NeighborState.tcp_ao` contains current/RNext KeyIDs
 and Linux verification/error counters. The daemon refreshes this read-only
 snapshot from the live socket for each neighbor state query and clears it on
 disconnect or inspection failure; it never serves an older healthy snapshot as

--- a/docs/API.md
+++ b/docs/API.md
@@ -254,9 +254,10 @@ disconnect or inspection failure; it never serves an older healthy snapshot as
 a fallback. The counters are cumulative for the lifetime of that TCP socket,
 so any non-zero error counter keeps the socket `DEGRADED` until reconnect.
 `NeighborState.tcp_ao_health` is `NOT_APPLICABLE` for plaintext and MD5 peers,
-`UNAVAILABLE` when TCP-AO is configured but there is no socket snapshot
+`UNAVAILABLE` when TCP-AO protects the session but there is no socket snapshot
 (including disconnect and inspection failure), `HEALTHY` when the snapshot has
-no error counters, and `DEGRADED` when any bad, key-not-found,
+both current/RNext key-validity flags and no error counters, and `DEGRADED`
+when either key-validity flag is absent or any bad, key-not-found,
 unsigned-required, or dropped-ICMP counter is non-zero.
 
 `NeighborState.effective_distribution_mode` reports the live RIB selection

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1021,7 +1021,7 @@ receive_max = 3   # experimental Paths-Limit preference sent to this peer
 | `receive`  | bool    | no       | false   | Accept multiple paths per prefix from peer  |
 | `send`     | bool    | no       | false   | Advertise multiple paths per prefix to peer |
 | `send_max` | integer | no       | —       | Max paths per prefix (omit for unlimited)   |
-| `receive_max` | integer | no    | —       | Experimental preferred maximum received paths per family (1..=65535) |
+| `receive_max` | integer | no    | —       | Experimental preferred maximum received paths per family (1..=65535); omit or set 0 to disable |
 
 When `receive` is true, the Add-Path capability (code 69) is advertised in
 OPEN with `Receive` mode. When `send` is true, `Send` mode is advertised.
@@ -1035,7 +1035,9 @@ the peer's value; it does not affect other families and never rejects excess
 inbound paths. Zero tuples and tuples without matching Add-Path negotiation are
 ignored. Because the draft expired without IETF adoption, deploy this only
 after confirming peer support. `rbgp neighbor <address>` reports configured,
-advertised, received, and effective values per family.
+advertised, received, and effective values per family in stable numeric
+AFI/SAFI order. Effective send renders as `inactive`, `unlimited`, or a finite
+cap; JSON carries `effective_send_active` so zero is never ambiguous.
 
 **Multi-path send (route server mode):** When `send = true`, the RIB
 distributes multiple candidate paths per prefix to this peer, sorted by

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1038,6 +1038,8 @@ after confirming peer support. `rbgp neighbor <address>` reports configured,
 advertised, received, and effective values per family in stable numeric
 AFI/SAFI order. Effective send renders as `inactive`, `unlimited`, or a finite
 cap; JSON carries `effective_send_active` so zero is never ambiguous.
+The protobuf preserves the legacy raw `effective_send_max` sentinel for rolling
+clients and adds optional `effective_send_limit` as the normalized active view.
 
 **Multi-path send (route server mode):** When `send = true`, the RIB
 distributes multiple candidate paths per prefix to this peer, sorted by

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1037,7 +1037,9 @@ ignored. Because the draft expired without IETF adoption, deploy this only
 after confirming peer support. `rbgp neighbor <address>` reports configured,
 advertised, received, and effective values per family in stable numeric
 AFI/SAFI order. Effective send renders as `inactive`, `unlimited`, or a finite
-cap; JSON carries `effective_send_active` so zero is never ambiguous.
+cap; JSON preserves raw `effective_send_max` and adds
+`effective_send_active` plus optional normalized `effective_send_limit` so zero
+is never ambiguous.
 The protobuf preserves the legacy raw `effective_send_max` sentinel for rolling
 clients and adds optional `effective_send_limit` as the normalized active view.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -562,8 +562,10 @@ This section defines the security stance for rustbgpd. Not all items are v1 impl
 **TCP-AO (RFC 5925):** Staged via ADR-0062. Static-neighbor `tcp_ao` TOML is
 validated and installed on Linux startup sockets: active-open sessions install
 the key before `connect()`, and the passive BGP listener installs configured
-peer keys before `listen()`. Runtime key rotation, dynamic-neighbor wildcard
-MKTs, multi-key rollover, and protected interop smoke remain follow-up work.
+static-peer and direct dynamic-prefix MKTs before `listen()`. Accepted protected
+sockets are validated fail-closed, live KeyIDs/counters are queryable through
+the neighbor API/CLI, and M43 covers BIRD interop. Runtime key rotation and
+multi-key rollover remain follow-up work.
 
 **GTSM (RFC 5082):** Supported in v1 as a configurable option (`ttl_security = true` per neighbor). Sets `IP_TTL` to 255 on outbound and checks inbound TTL >= 254. Simple, effective, and prevents most remote session hijacking.
 
@@ -672,7 +674,7 @@ This matrix tracks every protocol behavior: its RFC basis, implementation status
 | FlowSpec | 8955 | post-v0.3.0 | — | IPv4/IPv6 unicast FlowSpec implemented; speaker-mode hardening continues |
 | Graceful restart (receiving speaker) | 4724 | v0.3.0 | FRR | Stale demotion, per-family EoR, two-phase timer (ADR-0024) |
 | LLGR (two-phase GR timer) | 9494 | post-v0.3.0 | FRR | Implemented; GR-stale → LLGR-stale promotion, configurable stale time |
-| TCP-AO | 5925 | Post-v1 | — | Static-neighbor startup install; dynamic / rollover follow-ups deferred |
+| TCP-AO | 5925 | Post-v1 | BIRD | Static and direct dynamic-prefix startup install; fail-closed accept validation and live API/CLI health; rollover deferred |
 | BMP exporter | 7854 | post-v0.3.0 | — | Implemented (ADR-0041); reconnect replay + periodic stats + coordinated-shutdown termination |
 | MRT dump export | 6396 | post-v0.3.0 | — | Implemented (ADR-0044); TABLE_DUMP_V2 periodic + on-demand, gzip optional |
 | RPKI / RTR client | 8210 | post-v0.3.0 | — | Implemented (ADR-0034); runtime gRPC management deferred |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -905,9 +905,10 @@ For live inspection, `rbgp neighbor <address>` reports the configured
 authentication mode and an explicit TCP-AO health state. `unavailable` means
 TCP-AO is configured but no socket inspection snapshot is available (the peer
 may be disconnected, connecting, or socket inspection may have failed).
-`healthy` means the live snapshot has no authentication error counters;
-`degraded` means at least one cumulative socket-lifetime error counter is
-non-zero. When socket
+`healthy` means the live snapshot has valid current/RNext keys and no
+authentication error counters; `degraded` means either key-validity flag is
+missing or at least one cumulative socket-lifetime error counter is non-zero.
+When socket
 inspection succeeds, connected sessions also show current/RNext KeyIDs and
 packet verification counters.
 Counters are refreshed from the socket for each query; inspect `last_error` for

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -901,10 +901,12 @@ more checks are red. A doctor run against a down daemon still produces a
 bundle (system facts + crash reports) and the manifest records which
 sections are missing.
 
-For live inspection, `rbgp neighbor <address>` reports the configured
-authentication mode and an explicit TCP-AO health state. `unavailable` means
-TCP-AO is configured but no socket inspection snapshot is available (the peer
-may be disconnected, connecting, or socket inspection may have failed).
+For live inspection, `rbgp neighbor <address>` reports the effective protected
+transport and an explicit TCP-AO health state. Direct dynamic-prefix sessions
+derive TCP-AO identity from their validated accepted socket rather than a
+per-neighbor key configuration. `unavailable` means TCP-AO protection is
+expected but no socket inspection snapshot is available (the peer may be
+disconnected, connecting, or socket inspection may have failed).
 `healthy` means the live snapshot has valid current/RNext keys and no
 authentication error counters; `degraded` means either key-validity flag is
 missing or at least one cumulative socket-lifetime error counter is non-zero.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -905,12 +905,13 @@ For live inspection, `rbgp neighbor <address>` reports the configured
 authentication mode and an explicit TCP-AO health state. `unavailable` means
 TCP-AO is configured but no socket inspection snapshot is available (the peer
 may be disconnected, connecting, or socket inspection may have failed).
-`healthy` means the connection-time snapshot has no authentication error
-counters; `degraded` means at least one error counter is non-zero. When socket
+`healthy` means the live snapshot has no authentication error counters;
+`degraded` means at least one cumulative socket-lifetime error counter is
+non-zero. When socket
 inspection succeeds, connected sessions also show current/RNext KeyIDs and
 packet verification counters.
-Counters are captured when the socket connects and are not continuously
-refreshed; inspect `last_error` for setup or connect failures.
+Counters are refreshed from the socket for each query; inspect `last_error` for
+setup or connect failures.
 
 What is never collected: the raw daemon config file (the config section is
 the daemon's own secret-redacted effective dump — the same document as
@@ -1222,6 +1223,18 @@ unauthenticated sessions: listener failures abort startup, while active-open
 failures reject that connect attempt and retry later. TCP-AO key additions,
 removals, and rotations are restart-required because Linux requires the keys to
 exist when active-open or passive-listener sockets are created.
+
+`rbgp neighbor <address>` reads TCP-AO KeyIDs and verification counters from
+the live connected socket on every query. Inspection failure is reported as
+`unavailable` without falling back to an older snapshot or disturbing the BGP
+session. Linux counters are cumulative for the socket lifetime, so `degraded`
+means at least one verification, missing-key, unsigned-required, or dropped-ICMP
+error has occurred since that TCP connection was created.
+
+The same neighbor view reports the RIB's effective live distribution mode,
+rather than inferring it from configuration or update-group fallback labels.
+Down peers show `unknown`. Paths-Limit rows are numeric AFI/SAFI ordered, and
+their effective send value is explicitly `inactive`, `unlimited`, or finite.
 
 ### View received routes from a peer
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1229,8 +1229,9 @@ exist when active-open or passive-listener sockets are created.
 the live connected socket on every query. Inspection failure is reported as
 `unavailable` without falling back to an older snapshot or disturbing the BGP
 session. Linux counters are cumulative for the socket lifetime, so `degraded`
-means at least one verification, missing-key, unsigned-required, or dropped-ICMP
-error has occurred since that TCP connection was created.
+means either the current/RNext key-validity flag is missing or at least one
+verification, missing-key, unsigned-required, or dropped-ICMP error has occurred
+since that TCP connection was created.
 
 The same neighbor view reports the RIB's effective live distribution mode,
 rather than inferring it from configuration or update-group fallback labels.

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -547,9 +547,9 @@ Capability code 76 implements the tuple format from the expired
 `draft-abraitis-idr-addpath-paths-limit-04`. Each AFI/SAFI receiver preference
 is applied only to the matching negotiated Add-Path send direction. This is an
 experimental interoperability feature, not an adopted IETF standard.
-Neighbor output orders rows by numeric AFI/SAFI and carries a separate active
-bit so API zero can represent active unlimited without being confused with an
-inactive family.
+Neighbor output orders rows by numeric AFI/SAFI and carries an optional
+normalized limit whose presence distinguishes active unlimited from inactive,
+while retaining the legacy raw unlimited sentinel for rolling compatibility.
 
 - Capability code 69. Per-family Send/Receive/Both modes.
 - Adj-RIB-In/Out keyed by `(Prefix, u32)` for multi-path storage.

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -547,6 +547,9 @@ Capability code 76 implements the tuple format from the expired
 `draft-abraitis-idr-addpath-paths-limit-04`. Each AFI/SAFI receiver preference
 is applied only to the matching negotiated Add-Path send direction. This is an
 experimental interoperability feature, not an adopted IETF standard.
+Neighbor output orders rows by numeric AFI/SAFI and carries a separate active
+bit so API zero can represent active unlimited without being confused with an
+inactive family.
 
 - Capability code 69. Per-family Send/Receive/Both modes.
 - Adj-RIB-In/Out keyed by `(Prefix, u32)` for multi-path storage.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -199,8 +199,10 @@ listener-wide `ao_required` bit. Protected accepted sockets are discarded unless
 `TCP_AO_INFO` confirms the expected current/RNext IDs and clean authentication
 counters. Protected
 ranges must be disjoint from all other ranges and static peers; reload and
-runtime CRUD cannot mutate them. Runtime key rotation, multi-key rollover, and
-public API/CLI/metrics exposure of accepted-socket inspection remain deferred.
+runtime CRUD cannot mutate them. Neighbor API/CLI queries refresh read-only
+TCP-AO KeyIDs and cumulative verification counters from the live connected
+socket without exposing key material. Runtime key rotation, multi-key rollover,
+and metrics exposure of per-socket inspection remain deferred.
 
 ## Linux EVPN VTEP — `CAP_NET_ADMIN` requirement
 
@@ -298,8 +300,7 @@ the roadmap:
   only the durable in-daemon sink remains deferred until file/syslog
   backpressure and failure semantics are designed.
 - TCP-AO (RFC 5925) dynamic-neighbor support, runtime key rotation,
-  multi-key rollover, and public accepted-socket inspection for BGP session
-  protection
+  multi-key rollover, and per-socket metrics for BGP session protection
 
 ## Current gaps
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -299,8 +299,8 @@ the roadmap:
   [`docs/OPERATIONS.md`](OPERATIONS.md#grpc-authorization-audit-and-resource-guardrails);
   only the durable in-daemon sink remains deferred until file/syslog
   backpressure and failure semantics are designed.
-- TCP-AO (RFC 5925) dynamic-neighbor support, runtime key rotation,
-  multi-key rollover, and per-socket metrics for BGP session protection
+- TCP-AO (RFC 5925) runtime key rotation, multi-key rollover, and per-socket
+  metrics for BGP session protection
 
 ## Current gaps
 

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -105,5 +105,7 @@ slices have now shipped static-neighbor and startup-only dynamic-range support:
   restart. Runtime range CRUD cannot mutate or overlap a protected range.
 
 Still deferred: runtime key rotation / deletion on an already-listening socket,
-multi-key rollover, peer-group inheritance, and API/CLI exposure of
-accepted-socket inspection results.
+multi-key rollover, and peer-group inheritance. API/CLI neighbor state exposes
+redacted live inspection results (KeyIDs, validity flags, and counters) for
+static and direct dynamic-prefix protected sessions; runtime protected-range
+CRUD remains restart-gated.

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -183,7 +183,7 @@
           "default": false
         },
         "receive_max": {
-          "description": "Experimental Paths-Limit preference per received Add-Path family.",
+          "description": "Experimental Paths-Limit preference per received Add-Path family.\nZero or absent disables Paths-Limit advertisement.",
           "type": [
             "integer",
             "null"

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -461,10 +461,10 @@ message NeighborState {
   repeated PathsLimitState paths_limits = 26;
   // Configured transport authentication for this session.
   AuthenticationMode authentication = 27;
-  // Best-effort connection-time Linux TCP-AO inspection; absent when not AO
-  // or when no snapshot is available (including disconnect or inspection failure).
+  // Best-effort query-time Linux TCP-AO inspection; absent when not AO or when
+  // no live snapshot is available (including disconnect or inspection failure).
   TcpAoState tcp_ao = 28;
-  // Health derived from the configured mode and connection-time inspection.
+  // Health derived from the configured mode and query-time inspection.
   // UNAVAILABLE means TCP-AO is configured but no socket snapshot is available
   // (disconnected, still connecting, or inspection failed).
   TcpAoHealth tcp_ao_health = 29;

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -395,12 +395,13 @@ message PathsLimitState {
   uint32 configured_receive_max = 2;
   uint32 advertised_receive_max = 3;
   uint32 received_receive_max = 4;
-  // Normalized effective send cap. Zero means unlimited only when
-  // effective_send_active is true.
+  // Legacy raw effective send cap: 0 = inactive, UINT32_MAX = unlimited,
+  // any other value = finite. Preserved for rolling compatibility.
   uint32 effective_send_max = 5;
-  // True when Add-Path send is active for this family. Distinguishes an
-  // active unlimited cap from an inactive family.
-  bool effective_send_active = 6;
+  // Normalized effective send cap. Presence means Add-Path send is active:
+  // 0 = unlimited, non-zero = finite. Absence means inactive. New clients
+  // fall back to effective_send_max when reading an older server.
+  optional uint32 effective_send_limit = 6;
 }
 
 message NeighborState {

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -395,7 +395,12 @@ message PathsLimitState {
   uint32 configured_receive_max = 2;
   uint32 advertised_receive_max = 3;
   uint32 received_receive_max = 4;
+  // Normalized effective send cap. Zero means unlimited only when
+  // effective_send_active is true.
   uint32 effective_send_max = 5;
+  // True when Add-Path send is active for this family. Distinguishes an
+  // active unlimited cap from an inactive family.
+  bool effective_send_active = 6;
 }
 
 message NeighborState {
@@ -463,6 +468,18 @@ message NeighborState {
   // UNAVAILABLE means TCP-AO is configured but no socket snapshot is available
   // (disconnected, still connecting, or inspection failed).
   TcpAoHealth tcp_ao_health = 29;
+  // Effective live unicast distribution mode reported by the RIB. This is
+  // UNKNOWN while the peer has no active outbound registration.
+  EffectiveDistributionMode effective_distribution_mode = 30;
+}
+
+enum EffectiveDistributionMode {
+  EFFECTIVE_DISTRIBUTION_MODE_UNSPECIFIED = 0;
+  EFFECTIVE_DISTRIBUTION_MODE_UNKNOWN = 1;
+  EFFECTIVE_DISTRIBUTION_MODE_SINGLE_BEST = 2;
+  EFFECTIVE_DISTRIBUTION_MODE_ADD_PATH = 3;
+  EFFECTIVE_DISTRIBUTION_MODE_ORR = 4;
+  EFFECTIVE_DISTRIBUTION_MODE_PER_CLIENT_BEST = 5;
 }
 
 enum AuthenticationMode {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -925,6 +925,7 @@ pub struct AddPathConfig {
     /// Maximum number of paths to advertise per prefix (0 or absent = unlimited).
     pub send_max: Option<u32>,
     /// Experimental Paths-Limit preference per received Add-Path family.
+    /// Zero or absent disables Paths-Limit advertisement.
     pub receive_max: Option<u16>,
 }
 

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -195,6 +195,7 @@ impl PeerManager {
                     .dead_lettered_pending
                     .get(&peer_ip)
                     .is_some_and(|pending| pending.graceful_shutdown);
+                let tcp_ao_protected = tcp_ao_info.is_some();
 
                 let session_id = self.allocate_session_id();
                 let handle = PeerHandle::spawn_inbound_with_event_sink_and_identity_and_lifecycle(
@@ -244,6 +245,7 @@ impl PeerManager {
                     export_policy,
                     pending_inbound: None,
                     is_dynamic: true,
+                    tcp_ao_protected,
                     accepted_dynamic_range: Some(accepted_dynamic_range),
                     pending_refresh: false,
                     pending_export_apply: false,

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -226,6 +226,7 @@ impl PeerManager {
         }
 
         info!(%address, %remote_asn, "peer added dynamically");
+        let tcp_ao_protected = transport.tcp_ao.is_some();
         self.peers.insert(
             peer_key.clone(),
             ManagedPeer {
@@ -242,6 +243,7 @@ impl PeerManager {
                 export_policy,
                 pending_inbound: None,
                 is_dynamic: false,
+                tcp_ao_protected,
                 accepted_dynamic_range: None,
                 pending_refresh: false,
                 pending_export_apply: false,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -113,6 +113,9 @@ struct ManagedPeer {
     /// True for peers auto-created from a `[[dynamic_neighbors]]` range.
     /// Dynamic peers are ephemeral: removed when session falls to Idle.
     is_dynamic: bool,
+    /// Durable, non-secret TCP-AO protection identity used when the bounded
+    /// session-state query times out or the task has exited.
+    tcp_ao_protected: bool,
     /// Canonical `[[dynamic_neighbors]]` range that accepted this peer.
     ///
     /// Static peers are `None`. Dynamic peers keep the accepted range even if

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -67,7 +67,9 @@ fn build_peer_info(
         flap_count: session_state.map_or(0, |s| s.flap_count),
         uptime_secs: session_state.map_or(0, |s| s.uptime_secs),
         last_error: session_state.map_or_else(String::new, |s| s.last_error.clone()),
-        authentication: if managed.transport_config.tcp_ao.is_some() {
+        authentication: if session_state.is_some_and(|state| state.tcp_ao_protected)
+            || managed.transport_config.tcp_ao.is_some()
+        {
             "tcp_ao"
         } else if managed.transport_config.md5_password.is_some() {
             "md5"

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -14,7 +14,7 @@ use super::{ManagedPeer, PEER_QUERY_TIMEOUT, PeerManager};
 /// `query_state` either timed out (peer parked on TCP write) or its task
 /// has already exited; in both cases we surface `state = Idle, stale =
 /// true` so consumers know the field isn't authoritative.
-fn build_peer_info(
+pub(super) fn build_peer_info(
     peer: &PeerKey,
     managed: &ManagedPeer,
     session_state: Option<&PeerSessionState>,
@@ -67,8 +67,8 @@ fn build_peer_info(
         flap_count: session_state.map_or(0, |s| s.flap_count),
         uptime_secs: session_state.map_or(0, |s| s.uptime_secs),
         last_error: session_state.map_or_else(String::new, |s| s.last_error.clone()),
-        authentication: if session_state.is_some_and(|state| state.tcp_ao_protected)
-            || managed.transport_config.tcp_ao.is_some()
+        authentication: if session_state
+            .map_or(managed.tcp_ao_protected, |state| state.tcp_ao_protected)
         {
             "tcp_ao"
         } else if managed.transport_config.md5_password.is_some() {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -514,6 +514,68 @@ fn runtime_dynamic_crud_rejects_startup_pinned_tcp_ao_ranges_and_overlaps() {
     assert!(delete_err.to_string().contains("startup-pinned"));
 }
 
+#[tokio::test]
+async fn dynamic_tcp_ao_snapshot_reports_protected_without_synthesized_key_config() {
+    let (tx, rx) = mpsc::channel(16);
+    let (_internal_tx, internal_rx) = mpsc::unbounded_channel();
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mut config = make_dynamic_manager_config();
+    config.dynamic_neighbors[0].tcp_ao = Some(test_tcp_ao());
+    let manager = PeerManager::new_with_config(
+        rx,
+        internal_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+        None,
+        config,
+    );
+    let handle = tokio::spawn(manager.run());
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let connect = TcpStream::connect(listener.local_addr().unwrap());
+    let accept = listener.accept();
+    let (client, accepted) = tokio::join!(connect, accept);
+    let client = client.unwrap();
+    let (server, remote_addr) = accepted.unwrap();
+    tx.send(PeerManagerCommand::AcceptInbound {
+        stream: server,
+        peer_addr: remote_addr,
+        tcp_ao_info: Some(rustbgpd_transport::TcpAoInfoSnapshot {
+            has_current_key: true,
+            has_rnext_key: true,
+            ao_required: false,
+            accept_icmps: false,
+            current_key: 1,
+            rnext_key: 1,
+            pkt_good: 1,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        }),
+    })
+    .await
+    .unwrap();
+
+    let (list_tx, list_rx) = oneshot::channel();
+    tx.send(PeerManagerCommand::ListPeers { reply: list_tx })
+        .await
+        .unwrap();
+    let peers = list_rx.await.unwrap();
+    assert_eq!(peers.len(), 1);
+    assert!(peers[0].is_dynamic);
+    assert_eq!(peers[0].authentication, "tcp_ao");
+
+    drop(client);
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    handle.await.unwrap();
+}
+
 #[test]
 fn delete_dynamic_range_removes_and_stops_future_match() {
     let mut mgr = dynamic_test_manager();
@@ -1129,6 +1191,7 @@ fn fake_peer_handle_with_route_refresh_reply(
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -4444,6 +4507,7 @@ fn acking_counted_policy_handle(peer_addr: IpAddr, counters: Arc<FakePeerCounter
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -5308,6 +5372,7 @@ fn acking_policy_handle(peer_addr: IpAddr, state: SessionState) -> PeerHandle {
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::UpdateImportPolicy { reply, .. }
@@ -5374,6 +5439,7 @@ fn export_fails_once_policy_handle(peer_addr: IpAddr, state: SessionState) -> Pe
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::UpdateImportPolicy { reply, .. }
@@ -5437,6 +5503,7 @@ fn route_refresh_failing_handle(peer_addr: IpAddr, state: SessionState) -> PeerH
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::UpdateImportPolicy { reply, .. }
@@ -5498,6 +5565,7 @@ fn route_refresh_failing_after_first_handle(peer_addr: IpAddr, state: SessionSta
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::UpdateImportPolicy { reply, .. }
@@ -6053,6 +6121,7 @@ async fn back_to_back_updates_do_not_lose_pending_refresh() {
                         uptime_secs: u64::from(state == SessionState::Established),
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -6166,6 +6235,7 @@ async fn peer_deletion_after_failed_update_drops_pending_retry_cleanly() {
                         uptime_secs: 1,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::Shutdown => break,
@@ -6297,6 +6367,7 @@ async fn content_equal_policy_fanout_skips_unaffected_peers() {
                             uptime_secs: 1,
                             last_error: String::new(),
                             tcp_ao_info: None,
+                            tcp_ao_protected: false,
                         });
                     }
                     PeerCommand::Shutdown => break,
@@ -6518,6 +6589,7 @@ async fn export_policy_apply_times_out_when_rib_reply_wedges() {
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 _ => {}
@@ -6635,6 +6707,7 @@ async fn honor_graceful_shutdown_hot_apply_targets_ebgp_only() {
                             uptime_secs: 1,
                             last_error: String::new(),
                             tcp_ao_info: None,
+                            tcp_ao_protected: false,
                         });
                     }
                     PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -6811,6 +6884,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
                         uptime_secs: 1,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -6987,6 +7061,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -7157,6 +7232,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -7358,6 +7434,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
                         uptime_secs: 1,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -7582,6 +7659,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
                         uptime_secs: 1,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::SendRouteRefresh { reply, .. } => {
@@ -7916,6 +7994,7 @@ async fn simultaneous_active_open_runs_inbound_candidate_before_primary_idle() {
                         uptime_secs: 0,
                         last_error: String::new(),
                         tcp_ao_info: None,
+                        tcp_ao_protected: false,
                     });
                 }
                 PeerCommand::CollisionDump => {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1083,6 +1083,7 @@ fn insert_test_managed_peer_with_asn(
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh,
             pending_export_apply: false,
@@ -1122,6 +1123,7 @@ fn insert_test_scoped_managed_peer(
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -1220,6 +1222,53 @@ fn fake_peer_handle_with_route_refresh_reply(
         Ok(())
     });
     PeerHandle::from_parts(session_tx, task)
+}
+
+#[tokio::test]
+async fn unavailable_session_authentication_uses_durable_managed_protection() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "10.0.0.44".parse().unwrap();
+    let handle = fake_peer_handle(
+        addr,
+        SessionState::Idle,
+        None,
+        Arc::new(FakePeerCounters::default()),
+    );
+    insert_test_managed_peer(&mut mgr, addr, handle, false);
+    let peer_key = key(addr);
+
+    {
+        let managed = mgr.peers.get_mut(&peer_key).unwrap();
+        managed.is_dynamic = true;
+        managed.tcp_ao_protected = true;
+        assert!(managed.transport_config.tcp_ao.is_none());
+        let info = super::snapshot::build_peer_info(&peer_key, managed, None);
+        assert_eq!(info.authentication, "tcp_ao");
+        assert!(info.tcp_ao_info.is_none());
+        assert!(info.stale);
+
+        managed.is_dynamic = false;
+        managed.tcp_ao_protected = true;
+        assert_eq!(
+            super::snapshot::build_peer_info(&peer_key, managed, None).authentication,
+            "tcp_ao"
+        );
+
+        managed.tcp_ao_protected = false;
+        assert_eq!(
+            super::snapshot::build_peer_info(&peer_key, managed, None).authentication,
+            "plaintext"
+        );
+
+        managed.transport_config.md5_password = Some("test-password".to_string());
+        assert_eq!(
+            super::snapshot::build_peer_info(&peer_key, managed, None).authentication,
+            "md5"
+        );
+    }
+
+    let managed = mgr.peers.remove(&peer_key).unwrap();
+    managed.handle.shutdown().await.unwrap().unwrap();
 }
 
 fn attach_test_pending_inbound(
@@ -1738,6 +1787,7 @@ fn insert_test_dynamic_managed_peer(
             export_policy: None,
             pending_inbound: None,
             is_dynamic: true,
+            tcp_ao_protected: false,
             accepted_dynamic_range: Some(AcceptedDynamicRange {
                 addr: range_addr,
                 prefix_len: range_prefix_len,
@@ -5132,6 +5182,7 @@ async fn pending_refresh_re_arms_when_peer_still_not_established() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: true,
             pending_export_apply: false,
@@ -6936,6 +6987,7 @@ async fn import_apply_failure_on_established_peer_bails_without_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -7108,6 +7160,7 @@ async fn import_apply_failure_on_idle_peer_bails_and_sets_pending_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -7290,6 +7343,7 @@ async fn export_apply_failure_bails_without_advancing_bookkeeping() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -7491,6 +7545,7 @@ async fn import_succeeds_export_fails_then_retry_fires_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -7717,6 +7772,7 @@ async fn rib_failure_preserves_pending_refresh_for_retry() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,
@@ -7873,6 +7929,7 @@ async fn stale_query_state_re_arms_pending_refresh() {
             export_policy: None,
             pending_inbound: None,
             is_dynamic: false,
+            tcp_ao_protected: false,
             accepted_dynamic_range: None,
             pending_refresh: false,
             pending_export_apply: false,


### PR DESCRIPTION
## Summary

- refresh TCP-AO KeyID and verification counters from the live socket on neighbor queries, including protected dynamic sessions and unavailable-state identity
- expose the RIB-applied distribution mode through an append-only API field instead of inferring it from configuration or update-group labels
- make Paths-Limit output deterministic and rolling-compatible, with raw legacy values preserved and additive normalized state for unlimited versus inactive
- reconcile operator, API, security, design, roadmap, and configuration documentation with shipped behavior

## Correctness and compatibility

- TCP-AO inspection stays read-only and off the UPDATE hot path; failures report unavailable without serving a stale healthy snapshot or weakening the session
- protected dynamic peers retain only a non-secret boolean identity outside the session actor; no key bytes are exposed or logged
- NeighborState field 30 and PathsLimitState optional field 6 are append-only; existing field numbers and raw field 5 semantics are unchanged
- new clients fall back correctly against old daemons, while explicit runtime Unknown remains distinct from an absent legacy field
- locally unconfigured families cannot claim locally advertised Paths-Limit values

## Linear

- closes LAN-364
- closes LAN-225
- partially addresses LAN-366 output ordering, normalized presentation, and receive_max documentation; the wire 0.15.0 release bump and redundant resync optimization remain open

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --all-targets --locked
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --locked
- focused TCP-AO success/failure/recovery and dynamic timeout tests
- focused RIB effective-mode precedence, API/protobuf compatibility, CLI JSON/legacy fallback, and Paths-Limit ordering tests
- schema freshness, protobuf field assertions, diff checks, and stale-documentation scans
- independent adversarial review of the final range

The branch is independent of PR #849; a synthetic merge-tree check is conflict-free.