### PR TITLE
fix(transport): fail closed on outbound overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Outbound transport hardening closes EVPN overflow and bounded-probe
+  gaps.** A single EVPN announcement or withdrawal that cannot fit the
+  negotiated message ceiling now invokes the established Cease/8 outbound
+  saturation teardown, so an Established stream cannot survive with logical
+  Adj-RIB-Out ahead of the wire. IPv6-unicast and FlowSpec Extended Message
+  batches start with a bounded 1,024-entry probe, grow through exactly built
+  candidates up to a 4,096-entry probe ceiling, and remember successful and
+  failed bounds without losing, duplicating, or reordering NLRI. The
+  transport's defense-only RFC 9234 OTC gate is test-pinned as family-neutral
+  for both IPv4 and IPv6; the primary pre-commit RIB policy is unchanged.
+  (LAN-375)
+
 - **RFC 9234 OTC suppression now precedes Adj-RIB-Out commit.** IPv4/IPv6
   unicast routes carrying OTC toward a Provider, Peer, or Route Server are
   rejected while staging grouped and private export views, including ORR,
@@ -118,7 +130,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   where every route is re-advertised at once). IPv4 body/MP_REACH,
   IPv4 MP_UNREACH, IPv6 MP_REACH/MP_UNREACH, and IPv4/IPv6 FlowSpec
   MP_REACH/MP_UNREACH now chunk to the negotiated maximum message size,
-  filling Extended Messages when negotiated. FlowSpec uses fallible structured
+  using bounded, exactly encoded probes that can grow beyond 1,024 entries
+  when Extended Messages are negotiated. FlowSpec uses fallible structured
   encoding throughout. Its RIB and withdrawal identity now carries AFI
   explicitly, so destination-less IPv4 and IPv6 rules can coexist and withdraw
   independently. A lone entry that still cannot fit tears the session down so

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1545,21 +1545,41 @@ impl PeerSession {
     where
         F: FnMut(&[E]) -> Result<UpdateMessage, rustbgpd_wire::EncodeError>,
     {
-        // `max_len` is a byte budget, not an entry count. Keep the first
-        // clone/encode probe bounded, then let the exact encoded-size check
-        // halve it for large or variable-length NLRI. This avoids a 32K-entry
-        // speculative allocation when Extended Messages are negotiated.
+        // `max_len` is a byte budget, not an entry count. Keep every
+        // clone/encode probe bounded even when Extended Messages are
+        // negotiated, but grow beyond the conservative first 1,024 entries
+        // after an exact build proves that candidate fits. Remember the
+        // successful lower and failed upper bounds: after 1,024 succeeds and
+        // 2,048 fails, for example, probe 1,536, then binary-search between
+        // the proven bounds rather than retrying 2,048 or regressing below
+        // 1,024. Exact build/length checks still guard every enqueue.
+        const MAX_PROBE_ENTRIES: usize = 4096;
         let mut chunk_size = entries.len().clamp(1, 1024);
+        let max_probe = entries.len().clamp(1, MAX_PROBE_ENTRIES);
+        let mut successful_lower: usize = 0;
+        let mut failed_upper: Option<usize> = None;
         let mut idx = 0;
         while idx < entries.len() {
             let end = (idx + chunk_size).min(entries.len());
+            let probe_size = end - idx;
             let candidate = build(&entries[idx..end]);
             let needs_smaller = candidate
                 .as_ref()
                 .map_or(true, |message| message.encoded_len() > max_len);
             if needs_smaller {
-                if chunk_size > 1 {
-                    chunk_size = (chunk_size / 2).max(1);
+                if probe_size > 1 {
+                    failed_upper =
+                        Some(failed_upper.map_or(probe_size, |upper| upper.min(probe_size)));
+                    if successful_lower.saturating_add(1) >= probe_size {
+                        // Entry sizes can vary within a family. A count that
+                        // fitted an earlier slice is not proof for this one.
+                        successful_lower = 0;
+                    }
+                    chunk_size = if successful_lower + 1 < probe_size {
+                        successful_lower + (probe_size - successful_lower) / 2
+                    } else {
+                        (probe_size / 2).max(1)
+                    };
                     continue;
                 }
                 match candidate {
@@ -1587,6 +1607,16 @@ impl PeerSession {
             self.updates_sent += 1;
             self.metrics.record_message_sent(&self.peer_label, "update");
             idx = end;
+            if idx < entries.len() {
+                successful_lower = successful_lower.max(probe_size);
+                chunk_size = match failed_upper {
+                    Some(upper) if successful_lower + 1 < upper => {
+                        successful_lower + (upper - successful_lower) / 2
+                    }
+                    Some(_) => successful_lower,
+                    None => successful_lower.saturating_mul(2).min(max_probe),
+                };
+            }
         }
         true
     }
@@ -1607,7 +1637,7 @@ impl PeerSession {
         // Initial chunk size: 1000 fits comfortably under the 65535-byte
         // Extended Messages limit even for Type 5/IPv6 routes (~60 B each)
         // and shrinks on overflow for the standard 4096-byte limit.
-        let mut chunk_size: usize = 1000;
+        let mut chunk_size = routes.len().clamp(1, 1000);
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
@@ -1641,16 +1671,17 @@ impl PeerSession {
                     // and continued, returning `true` — a silent desync
                     // because RIB has already committed the route to
                     // Adj-RIB-Out and now believes the peer holds it.
-                    // Failing the send path lets the dirty-resync mechanism
-                    // notice and retry; if the route is structurally
-                    // un-sendable the peer will observe the discrepancy
-                    // rather than rustbgpd lying about the advertise state.
+                    // The caller cannot report this synchronous failure back
+                    // across the RIB/session boundary. Use the established
+                    // Cease/8 hard teardown so the stream cannot remain
+                    // Established with Adj-RIB-Out ahead of the wire.
                     warn!(
                         peer = %self.peer_label,
                         size = msg.encoded_len(),
                         max = max_len,
-                        "single EVPN route exceeds maximum message length — failing send so resync can retry"
+                        "single EVPN route exceeds maximum message length — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     );
+                    self.trigger_outbound_saturation_teardown();
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -1675,7 +1706,7 @@ impl PeerSession {
         four_octet_as: bool,
         max_len: usize,
     ) -> bool {
-        let mut chunk_size: usize = 1000;
+        let mut chunk_size = routes.len().clamp(1, 1000);
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
@@ -1704,8 +1735,9 @@ impl PeerSession {
                         peer = %self.peer_label,
                         size = msg.encoded_len(),
                         max = max_len,
-                        "single EVPN withdrawal exceeds maximum message length — failing send so resync can retry"
+                        "single EVPN withdrawal exceeds maximum message length — tearing down the session so Adj-RIB-Out is rebuilt on reconnect"
                     );
+                    self.trigger_outbound_saturation_teardown();
                     return false;
                 }
                 chunk_size = (chunk_size / 2).max(1);
@@ -3172,6 +3204,130 @@ pub(super) fn remove_private_asns(
                 })
                 .collect();
             AsPath { segments }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use rustbgpd_fsm::PeerConfig;
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, MacAddress, MplsLabel, Origin,
+        RouteDistinguisher, notification::NotificationCode, notification::cease_subcode,
+    };
+    use tokio::io::AsyncReadExt;
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::mpsc;
+    use tokio::time::{Duration, timeout};
+
+    fn make_test_session() -> PeerSession {
+        let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+        peer_config.families = vec![(Afi::L2Vpn, Safi::Evpn)];
+        let config =
+            crate::config::TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+        let (_command_tx, command_rx) = mpsc::channel(8);
+        let (rib_tx, _rib_rx) = mpsc::channel(8);
+        PeerSession::new(
+            config,
+            rustbgpd_telemetry::BgpMetrics::new(),
+            command_rx,
+            rib_tx,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+    }
+
+    async fn connected_stream_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = TcpStream::connect(address).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        (client, server)
+    }
+
+    async fn read_message(stream: &mut TcpStream) -> Message {
+        let mut header = [0_u8; 19];
+        stream.read_exact(&mut header).await.unwrap();
+        let message_len = usize::from(u16::from_be_bytes([header[16], header[17]]));
+        let mut body = vec![0_u8; message_len - header.len()];
+        stream.read_exact(&mut body).await.unwrap();
+        let mut complete = header.to_vec();
+        complete.extend_from_slice(&body);
+        let mut bytes = Bytes::from(complete);
+        rustbgpd_wire::decode_message(&mut bytes, rustbgpd_wire::MAX_MESSAGE_LEN).unwrap()
+    }
+
+    /// A single EVPN NLRI that cannot fit the negotiated message ceiling is
+    /// not a recoverable batch error: the RIB has already committed the
+    /// logical advertisement or withdrawal. Pin both private helper branches
+    /// with an artificial ceiling so even the otherwise-unreachable valid
+    /// withdrawal overflow emits a final Cease/8 and hard-closes the stream.
+    #[tokio::test]
+    async fn evpn_single_entry_overflow_tears_down_announce_and_withdraw() {
+        let route = EvpnRoute::MacIp(EvpnMacIp {
+            rd: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 100]),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(100),
+            mac: MacAddress([0x02, 0, 0, 0xaa, 0xbb, 0xcc]),
+            ip: Some(IpAddr::V6("2001:db8::1".parse().unwrap())),
+            label1: MplsLabel::new(10_000),
+            label2: None,
+        });
+
+        for announce in [true, false] {
+            let mut session = make_test_session();
+            let (client, mut server) = connected_stream_pair().await;
+            session.test_install_stream(client);
+
+            let sent = if announce {
+                session.send_evpn_reach_chunked(
+                    IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                    &[PathAttribute::Origin(Origin::Igp)],
+                    std::slice::from_ref(&route),
+                    true,
+                    1,
+                )
+            } else {
+                session.send_evpn_unreach_chunked(std::slice::from_ref(&route), true, 1)
+            };
+            assert!(!sent, "overflowing EVPN send must fail closed");
+            assert!(session.read_half.is_none());
+            assert!(session.writer_bulk_tx.is_none());
+            assert!(session.writer_priority_tx.is_none());
+
+            let Message::Notification(notification) = read_message(&mut server).await else {
+                panic!("overflowing EVPN send must emit a NOTIFICATION");
+            };
+            assert_eq!(notification.code, NotificationCode::Cease);
+            assert_eq!(notification.subcode, cease_subcode::OUT_OF_RESOURCES);
+
+            let join = session
+                .writer_join
+                .take()
+                .expect("teardown keeps writer join handle for run-loop observation");
+            let result = timeout(Duration::from_secs(2), join)
+                .await
+                .expect("writer exits after EVPN overflow")
+                .expect("writer task must not panic");
+            assert!(matches!(
+                result,
+                Err(super::super::writer::WriterExit::TornDown)
+            ));
+            let mut trailing = [0_u8; 1];
+            assert_eq!(
+                timeout(Duration::from_secs(1), server.read(&mut trailing))
+                    .await
+                    .expect("writer hard-close reaches EOF")
+                    .unwrap(),
+                0,
+                "Cease/8 must be the final frame"
+            );
         }
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1360,23 +1360,29 @@ fn otc_egress_preserves_existing_otc() {
 #[test]
 fn otc_egress_blocks_unicast_to_provider_peer_or_route_server_client() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
-        let mut session = make_test_session(65001, 65002);
-        session.config.peer.local_role = Some(role);
-        let route = replace_route_attrs(
-            &make_route(100),
-            vec![
-                PathAttribute::Origin(Origin::Igp),
-                PathAttribute::AsPath(AsPath {
-                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
-                }),
-                PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
-                PathAttribute::OnlyToCustomer(65002),
-            ],
-        );
-        assert!(
-            session.otc_egress_blocks_unicast(&route),
-            "role {role:?} must not propagate an OTC-tagged unicast route"
-        );
+        for prefix in [
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+            Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 64)),
+        ] {
+            let mut session = make_test_session(65001, 65002);
+            session.config.peer.local_role = Some(role);
+            let mut route = replace_route_attrs(
+                &make_route(100),
+                vec![
+                    PathAttribute::Origin(Origin::Igp),
+                    PathAttribute::AsPath(AsPath {
+                        segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                    }),
+                    PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+                    PathAttribute::OnlyToCustomer(65002),
+                ],
+            );
+            route.prefix = prefix;
+            assert!(
+                session.otc_egress_blocks_unicast(&route),
+                "role {role:?} must not propagate an OTC-tagged {prefix} route"
+            );
+        }
     }
 }
 #[test]
@@ -3629,6 +3635,213 @@ async fn send_route_update_chunks_ipv6_at_negotiated_message_limit() {
         .await
         .is_err(),
         "Extended Message peer should receive this withdrawal in one UPDATE"
+    );
+}
+
+/// Extended Messages should not freeze MP batches at the conservative 1,024
+/// entry first probe. Use a large shared attribute so 1,024 entries fit while
+/// 2,048 do not; the sender must remember that failed upper bound, make
+/// monotonic progress with a later in-between probe, and preserve exact order.
+#[tokio::test]
+async fn extended_ipv6_chunk_probe_grows_bounded_without_reordering() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    session.config.route_server_client = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+    negotiated.peer_extended_message = true;
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let padding = Bytes::from(vec![0x5a; 36_000]);
+    let attrs = Arc::new(vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::Unknown(rustbgpd_wire::RawAttribute {
+            flags: rustbgpd_wire::constants::attr_flags::OPTIONAL
+                | rustbgpd_wire::constants::attr_flags::TRANSITIVE,
+            type_code: 99,
+            data: padding,
+        }),
+    ]);
+    let count = 3_500_u32;
+    let expected: Vec<Prefix> = (0..count)
+        .map(|i| {
+            Prefix::V6(Ipv6Prefix::new(
+                Ipv6Addr::from(0x2001_0db8_0003_0000_0000_0000_0000_0000_u128 + u128::from(i)),
+                128,
+            ))
+        })
+        .collect();
+    let routes: Vec<Route> = expected
+        .iter()
+        .copied()
+        .map(|prefix| Route {
+            prefix,
+            next_hop: IpAddr::V6("2001:db8::2".parse().unwrap()),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: IpAddr::V6("2001:db8::2".parse().unwrap()),
+            attributes: Arc::clone(&attrs),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        })
+        .collect();
+    session.send_route_update(OutboundRouteUpdate {
+        announce: routes.into(),
+        next_hop_override: vec![None; count as usize].into(),
+        ..empty_outbound_update()
+    });
+
+    let mut actual = Vec::new();
+    let mut chunk_sizes = Vec::new();
+    while let Ok(raw) = tokio::time::timeout(
+        Duration::from_millis(500),
+        read_single_raw_bgp_message(&mut server),
+    )
+    .await
+    {
+        assert!(
+            raw.len() <= 65_535,
+            "Extended UPDATE is {} bytes",
+            raw.len()
+        );
+        let mut buf = Bytes::from(raw);
+        let Message::Update(update) =
+            rustbgpd_wire::decode_message(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)
+                .unwrap()
+        else {
+            continue;
+        };
+        let parsed = update.parse(true, false, &[]).unwrap();
+        let announced = parsed
+            .attributes
+            .iter()
+            .find_map(|attribute| match attribute {
+                PathAttribute::MpReachNlri(mp) => Some(&mp.announced),
+                _ => None,
+            })
+            .expect("IPv6 announcement uses MP_REACH");
+        chunk_sizes.push(announced.len());
+        actual.extend(announced.iter().map(|entry| entry.prefix));
+    }
+    assert_eq!(
+        actual, expected,
+        "IPv6 NLRI must be emitted exactly once in order"
+    );
+    assert_eq!(chunk_sizes.first(), Some(&1024));
+    assert!(
+        chunk_sizes.iter().any(|size| *size > 1024),
+        "a proven Extended Message candidate must grow beyond 1,024: {chunk_sizes:?}"
+    );
+}
+
+/// Pin the same bounded-growth invariant for the fallible `FlowSpec` encoder.
+#[tokio::test]
+async fn extended_flowspec_chunk_probe_grows_and_preserves_exact_order() {
+    let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![(Afi::Ipv6, Safi::FlowSpec)];
+    negotiated.peer_extended_message = true;
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let padding = Bytes::from(vec![0xa5; 36_000]);
+    let count = 3_500_u32;
+    let rules: Vec<FlowSpecRule> = (0..count)
+        .map(|i| FlowSpecRule {
+            components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(
+                Ipv6PrefixOffset {
+                    prefix: Ipv6Prefix::new(
+                        Ipv6Addr::from(
+                            0x2001_0db8_0004_0000_0000_0000_0000_0000_u128 + u128::from(i),
+                        ),
+                        128,
+                    ),
+                    offset: 0,
+                },
+            ))],
+        })
+        .collect();
+    let routes = rules
+        .iter()
+        .cloned()
+        .map(|rule| FlowSpecRoute {
+            rule,
+            afi: Afi::Ipv6,
+            peer: IpAddr::V6("2001:db8::2".parse().unwrap()),
+            attributes: vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::Unknown(rustbgpd_wire::RawAttribute {
+                    flags: rustbgpd_wire::constants::attr_flags::OPTIONAL
+                        | rustbgpd_wire::constants::attr_flags::TRANSITIVE,
+                    type_code: 99,
+                    data: padding.clone(),
+                }),
+            ],
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+        })
+        .collect();
+    session.send_route_update(OutboundRouteUpdate {
+        flowspec_announce: routes,
+        ..empty_outbound_update()
+    });
+
+    let mut actual = Vec::new();
+    let mut chunk_sizes = Vec::new();
+    while let Ok(raw) = tokio::time::timeout(
+        Duration::from_millis(500),
+        read_single_raw_bgp_message(&mut server),
+    )
+    .await
+    {
+        assert!(
+            raw.len() <= 65_535,
+            "Extended UPDATE is {} bytes",
+            raw.len()
+        );
+        let mut buf = Bytes::from(raw);
+        let Message::Update(update) =
+            rustbgpd_wire::decode_message(&mut buf, rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN)
+                .unwrap()
+        else {
+            continue;
+        };
+        let parsed = update.parse(true, false, &[]).unwrap();
+        let announced = parsed
+            .attributes
+            .iter()
+            .find_map(|attribute| match attribute {
+                PathAttribute::MpReachNlri(mp) => Some(&mp.flowspec_announced),
+                _ => None,
+            })
+            .expect("FlowSpec announcement uses MP_REACH");
+        chunk_sizes.push(announced.len());
+        actual.extend(announced.iter().cloned());
+    }
+    assert_eq!(
+        actual, rules,
+        "FlowSpec rules must be emitted exactly once in order"
+    );
+    assert_eq!(chunk_sizes.first(), Some(&1024));
+    assert!(
+        chunk_sizes.iter().any(|size| *size > 1024),
+        "a proven Extended Message candidate must grow beyond 1,024: {chunk_sizes:?}"
     );
 }
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1360,24 +1360,31 @@ fn otc_egress_preserves_existing_otc() {
 #[test]
 fn otc_egress_blocks_unicast_to_provider_peer_or_route_server_client() {
     for role in [BgpRole::Customer, BgpRole::Peer, BgpRole::RouteServerClient] {
-        for prefix in [
-            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
-            Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 64)),
+        for (prefix, route_next_hop) in [
+            (
+                Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24)),
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            ),
+            (
+                Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 64)),
+                IpAddr::V6("2001:db8::2".parse().unwrap()),
+            ),
         ] {
             let mut session = make_test_session(65001, 65002);
             session.config.peer.local_role = Some(role);
-            let mut route = replace_route_attrs(
-                &make_route(100),
-                vec![
-                    PathAttribute::Origin(Origin::Igp),
-                    PathAttribute::AsPath(AsPath {
-                        segments: vec![AsPathSegment::AsSequence(vec![65002])],
-                    }),
-                    PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
-                    PathAttribute::OnlyToCustomer(65002),
-                ],
-            );
+            let mut attributes = vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                }),
+                PathAttribute::OnlyToCustomer(65002),
+            ];
+            if let IpAddr::V4(next_hop) = route_next_hop {
+                attributes.push(PathAttribute::NextHop(next_hop));
+            }
+            let mut route = replace_route_attrs(&make_route(100), attributes);
             route.prefix = prefix;
+            route.next_hop = route_next_hop;
             assert!(
                 session.otc_egress_blocks_unicast(&route),
                 "role {role:?} must not propagate an OTC-tagged {prefix} route"

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -86,8 +86,15 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   validation (is the attribute set RFC-compliant?). See ADR-0012.
 - Outbound IPv4/IPv6 unicast and IPv4/IPv6 FlowSpec announcements and
   withdrawals are chunked by the peer's negotiated 4096/65535-byte message
-  limit. Structured FlowSpec construction is fallible; an individually
+  limit. MP chunking starts with at most 1,024 entries, grows through exactly
+  built and size-checked candidates up to a 4,096-entry probe ceiling, and
+  retains successful/failed bounds; it does not promise to fill every Extended
+  Message. Structured FlowSpec construction is fallible; an individually
   unencodable NLRI fails the session rather than partially committing a batch.
+- EVPN MP_REACH/MP_UNREACH is likewise chunked to the negotiated ceiling. A
+  single announcement or withdrawal that still cannot fit invokes the
+  Cease/8 outbound-saturation teardown, preventing a live session from
+  retaining logical Adj-RIB-Out state that never reached the wire.
 - FlowSpec identity is `(AFI, rule)` throughout Adj-RIB-In, Loc-RIB,
   Adj-RIB-Out, recompute, distribution, and withdrawal. AFI is never inferred
   from an optional destination-prefix component: legal destination-less IPv4


### PR DESCRIPTION
## Summary

- fail closed with Cease/8 when a single EVPN announcement or withdrawal cannot fit the negotiated message ceiling
- let IPv6-unicast and FlowSpec MP chunk probes grow beyond 1,024 entries through bounded, exactly checked candidates
- pin the existing family-neutral OTC encoder defense for both IPv4 and IPv6
- correct documentation that previously implied Extended Messages were always filled

## Root cause

The EVPN chunk helpers returned a local failure for a single oversized route, but that result could not reach the RIB. The session therefore remained active while logical Adj-RIB-Out was ahead of the wire. Separately, MP chunking started at 1,024 entries and could only shrink, leaving negotiated Extended Messages systematically under-filled for large batches.

## Behavior

EVPN overflow now uses the existing outbound-saturation teardown, sends Cease/Out of Resources, and forces the session to rebuild rather than serving false advertised state. Adaptive MP probing retains exact build and encoded-length checks, caps speculative candidates at 4,096 entries, remembers successful and failed bounds, and advances only after successful enqueue.

The suspected IPv6 OTC asymmetry was already resolved by the shared pre-AFI-split guard on current main, so this PR adds regression coverage without a duplicate code path or diagnostic.

## Validation

- focused EVPN overflow, IPv6 growth/order, FlowSpec growth/order, and IPv4/IPv6 OTC tests
- complete `rustbgpd-transport` suite: 249 unit tests passed, 1 kernel-dependent test ignored; listener, lifecycle, and doc tests passed
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`

Linear: [LAN-375](https://linear.app/lance0/issue/LAN-375/outbound-hardening-fail-closed-on-oversized-evpn-and-improve-mp-chunk)
