### PR TITLE
fix(orr): isolate BGP-LS topology inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for both IPv4 and IPv6; the primary pre-commit RIB policy is unchanged.
   (LAN-375)
 
+- **ORR isolates its SPF graph to the RFC 9552 default topology.** BGP-LS
+  Node, Link, and Prefix inputs are classified before deduplication or graph
+  insertion: valid non-default MT-ID objects and malformed topology/Attribute
+  29 inputs are excluded fail-closed, so they cannot claim nodes, addresses,
+  links, or reachability. Flex-Algorithm data remains inert while the base
+  default object and classic IGP/Prefix Metric stay usable. `rbgp orr`, the
+  status API, aggregate transition logs, export explain, and five fixed-label
+  Prometheus series expose the bounded input diagnostics. (LAN-373)
+
 - **RFC 9234 OTC suppression now precedes Adj-RIB-Out commit.** IPv4/IPv6
   unicast routes carrying OTC toward a Provider, Peer, or Route Server are
   rejected while staging grouped and private export views, including ORR,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -387,9 +387,12 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   via SPF over the BGP-LS-sourced topology; typed topology accessors, graph +
   hand-rolled Dijkstra + NH-cost resolution, `orr_vantage` config, the
   interior-cost tiebreak at RFC 4271's step-(e) slot, `rbgp topology`/`rbgp
-  orr`. M76 proves live divergent bests, topology-driven flips with zero
-  churn to unaffected clients, and clean fallback. **No other open-source
-  BGP daemon ships ORR.** The M76 lab also surfaced and fixed a latent
+  orr`. The SPF graph is default-topology-only: non-default/malformed inputs
+  are isolated before graph insertion, with aggregate API/CLI/metric/explain
+  diagnostics; Flex-Algorithm data is inert. M76 proves live divergent bests,
+  topology-driven flips with zero churn to unaffected clients, and clean
+  fallback. **No other open-source BGP daemon ships ORR.** The M76 lab also
+  surfaced and fixed a latent
   negotiation bug: implicit IPv4 unicast was added against explicit MP
   capability sets, leaking classic NLRI onto linkstate/VPN/RTC-only
   sessions (#632; capability-less-legacy-peers-only now).
@@ -1231,8 +1234,8 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   flapping pods), so the stricter probe should be opt-in, not a redefinition.
 - ~~**Optimal Route Reflection (RFC 9107).**~~ **Shipped 2026-07-02**
   (ADR-0095, M76) — see "Recently shipped" under Next. The remaining ORR
-  tail (backup vantages, inter-RR Add-Path for multi-cluster, VPN-ORR,
-  TE/multi-topology metrics, §3.2 per-policy Decision Processes) is
+  tail (backup vantages, inter-RR Add-Path for multi-cluster, selectable
+  TE/non-default/Flex-Algorithm SPF, §3.2 per-policy Decision Processes) is
   recorded in ADR-0095's deferral register with un-defer triggers.
 - **ORF / Outbound Route Filtering follow-ups.** Receive-side Address-Prefix ORF
   (capability code 3, type 64; ADR-0075) is shipped and closes the IX

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1745,6 +1745,15 @@ impl proto::rib_service_server::RibService for RibService {
                 .collect(),
             topology_nodes: snapshot.topology_nodes,
             topology_links: snapshot.topology_links,
+            input_diagnostics: Some(proto::OrrInputDiagnostics {
+                included_default: snapshot.input_diagnostics.included_default,
+                excluded_nondefault: snapshot.input_diagnostics.excluded_nondefault,
+                malformed_topology: snapshot.input_diagnostics.malformed_topology,
+                malformed_attribute_29: snapshot.input_diagnostics.malformed_attribute_29,
+                default_with_ignored_flex_algo: snapshot
+                    .input_diagnostics
+                    .default_with_ignored_flex_algo,
+            }),
         }))
     }
 
@@ -2764,6 +2773,13 @@ mod tests {
                     ],
                     topology_nodes: 4,
                     topology_links: 4,
+                    input_diagnostics: rustbgpd_rib::orr::OrrInputDiagnostics {
+                        included_default: 8,
+                        excluded_nondefault: 2,
+                        malformed_topology: 1,
+                        malformed_attribute_29: 3,
+                        default_with_ignored_flex_algo: 4,
+                    },
                 });
             }
         });
@@ -2775,6 +2791,16 @@ mod tests {
             .into_inner();
         assert_eq!(resp.topology_nodes, 4);
         assert_eq!(resp.topology_links, 4);
+        assert_eq!(
+            resp.input_diagnostics,
+            Some(proto::OrrInputDiagnostics {
+                included_default: 8,
+                excluded_nondefault: 2,
+                malformed_topology: 1,
+                malformed_attribute_29: 3,
+                default_with_ignored_flex_algo: 4,
+            })
+        );
         assert_eq!(resp.vantages.len(), 2);
 
         let resolved = &resp.vantages[0];

--- a/crates/cli/src/commands/orr.rs
+++ b/crates/cli/src/commands/orr.rs
@@ -5,7 +5,9 @@ use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output;
 use crate::proto::rib_service_client::RibServiceClient;
-use crate::proto::{ListOrrStatusRequest, ListOrrStatusResponse, OrrVantageStatusEntry};
+use crate::proto::{
+    ListOrrStatusRequest, ListOrrStatusResponse, OrrInputDiagnostics, OrrVantageStatusEntry,
+};
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 
@@ -63,7 +65,22 @@ fn print_orr_status(resp: &ListOrrStatusResponse, json: bool) -> Result<(), CliE
             resp.topology_nodes, resp.topology_links
         );
     }
+    if !json {
+        let diagnostics = input_diagnostics(resp);
+        println!(
+            "Topology inputs: included_default={} excluded_nondefault={} malformed_topology={} malformed_attribute_29={} default_with_ignored_flex_algo={}",
+            diagnostics.included_default,
+            diagnostics.excluded_nondefault,
+            diagnostics.malformed_topology,
+            diagnostics.malformed_attribute_29,
+            diagnostics.default_with_ignored_flex_algo,
+        );
+    }
     Ok(())
+}
+
+fn input_diagnostics(resp: &ListOrrStatusResponse) -> OrrInputDiagnostics {
+    resp.input_diagnostics.unwrap_or_default()
 }
 
 struct JsonOrrStatus<'a>(&'a ListOrrStatusResponse);
@@ -73,10 +90,34 @@ impl Serialize for JsonOrrStatus<'_> {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(3))?;
+        let mut map = serializer.serialize_map(Some(4))?;
         map.serialize_entry("vantages", &JsonVantages(&self.0.vantages))?;
         map.serialize_entry("topology_nodes", &self.0.topology_nodes)?;
         map.serialize_entry("topology_links", &self.0.topology_links)?;
+        map.serialize_entry(
+            "input_diagnostics",
+            &JsonInputDiagnostics(&input_diagnostics(self.0)),
+        )?;
+        map.end()
+    }
+}
+
+struct JsonInputDiagnostics<'a>(&'a OrrInputDiagnostics);
+
+impl Serialize for JsonInputDiagnostics<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(5))?;
+        map.serialize_entry("included_default", &self.0.included_default)?;
+        map.serialize_entry("excluded_nondefault", &self.0.excluded_nondefault)?;
+        map.serialize_entry("malformed_topology", &self.0.malformed_topology)?;
+        map.serialize_entry("malformed_attribute_29", &self.0.malformed_attribute_29)?;
+        map.serialize_entry(
+            "default_with_ignored_flex_algo",
+            &self.0.default_with_ignored_flex_algo,
+        )?;
         map.end()
     }
 }
@@ -167,6 +208,13 @@ mod tests {
                 vantages: vec![resolved, unresolved],
                 topology_nodes: 4,
                 topology_links: 4,
+                input_diagnostics: Some(OrrInputDiagnostics {
+                    included_default: 7,
+                    excluded_nondefault: 2,
+                    malformed_topology: 1,
+                    malformed_attribute_29: 3,
+                    default_with_ignored_flex_algo: 4,
+                }),
             },
             false,
         )
@@ -195,6 +243,13 @@ mod tests {
             }],
             topology_nodes: 4,
             topology_links: 6,
+            input_diagnostics: Some(OrrInputDiagnostics {
+                included_default: 7,
+                excluded_nondefault: 2,
+                malformed_topology: 1,
+                malformed_attribute_29: 3,
+                default_with_ignored_flex_algo: 4,
+            }),
         };
 
         let value = serde_json::to_value(JsonOrrStatus(&resp)).unwrap();
@@ -214,6 +269,35 @@ mod tests {
                 }],
                 "topology_nodes": 4,
                 "topology_links": 6,
+                "input_diagnostics": {
+                    "included_default": 7,
+                    "excluded_nondefault": 2,
+                    "malformed_topology": 1,
+                    "malformed_attribute_29": 3,
+                    "default_with_ignored_flex_algo": 4,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn older_server_missing_input_diagnostics_renders_zero_object() {
+        let resp = ListOrrStatusResponse {
+            vantages: Vec::new(),
+            topology_nodes: 0,
+            topology_links: 0,
+            input_diagnostics: None,
+        };
+        assert_eq!(input_diagnostics(&resp), OrrInputDiagnostics::default());
+        let value = serde_json::to_value(JsonOrrStatus(&resp)).unwrap();
+        assert_eq!(
+            value["input_diagnostics"],
+            serde_json::json!({
+                "included_default": 0,
+                "excluded_nondefault": 0,
+                "malformed_topology": 0,
+                "malformed_attribute_29": 0,
+                "default_with_ignored_flex_algo": 0,
             })
         );
     }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1399,6 +1399,13 @@ impl rustbgpd_api::proto::rib_service_server::RibService for MockRibService {
             }],
             topology_nodes: 4,
             topology_links: 4,
+            input_diagnostics: Some(server_proto::OrrInputDiagnostics {
+                included_default: 4,
+                excluded_nondefault: 0,
+                malformed_topology: 0,
+                malformed_attribute_29: 0,
+                default_with_ignored_flex_algo: 0,
+            }),
         }))
     }
 

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -248,6 +248,16 @@ impl RibManager {
         // Loc-RIB best, unchanged.
         let best = if let Some((topology, spf, vantage)) = orr {
             explain.orr_vantage = Some(vantage);
+            let input_diagnostics = topology.input_diagnostics();
+            if input_diagnostics.noteworthy() {
+                explain.reasons.push(ExplainReason {
+                    code: "orr_topology_input_diagnostics",
+                    message: format!(
+                        "aggregate non-decisive ORR input diagnostics; winner and decisive cost are unchanged; default-topology SPF uses {}",
+                        input_diagnostics.summary()
+                    ),
+                });
+            }
             let mut ranked: Vec<&crate::route::Route> = orr_candidates(
                 ribs,
                 prefix_peers,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -701,6 +701,42 @@ impl PendingRoutesReceived {
     }
 }
 
+fn log_orr_input_transition(
+    previous: crate::orr::OrrInputDiagnostics,
+    current: crate::orr::OrrInputDiagnostics,
+) {
+    match crate::orr::input_diagnostics_transition(previous, current) {
+        Some(crate::orr::OrrInputTransition::ExclusionsActivated) => warn!(
+            included_default = current.included_default,
+            excluded_nondefault = current.excluded_nondefault,
+            malformed_topology = current.malformed_topology,
+            malformed_attribute_29 = current.malformed_attribute_29,
+            default_with_ignored_flex_algo = current.default_with_ignored_flex_algo,
+            "ORR BGP-LS exclusions became active for the supported default topology"
+        ),
+        Some(crate::orr::OrrInputTransition::ExclusionsCleared) => info!(
+            included_default = current.included_default,
+            excluded_nondefault = current.excluded_nondefault,
+            malformed_topology = current.malformed_topology,
+            malformed_attribute_29 = current.malformed_attribute_29,
+            default_with_ignored_flex_algo = current.default_with_ignored_flex_algo,
+            "one or more ORR BGP-LS exclusion categories cleared; other diagnostics remain active"
+        ),
+        Some(crate::orr::OrrInputTransition::FlexChanged) => info!(
+            included_default = current.included_default,
+            excluded_nondefault = current.excluded_nondefault,
+            malformed_topology = current.malformed_topology,
+            malformed_attribute_29 = current.malformed_attribute_29,
+            default_with_ignored_flex_algo = current.default_with_ignored_flex_algo,
+            "ORR ignored Flex-Algorithm input changed; classic default-topology metrics remain active"
+        ),
+        Some(crate::orr::OrrInputTransition::Cleared) => {
+            info!("ORR BGP-LS input filtering is no longer active");
+        }
+        None => {}
+    }
+}
+
 impl RibManager {
     /// Sweep the global attribute intern table (drop entries no route
     /// references any more) and refresh its gauge. Run after any batch
@@ -3013,11 +3049,17 @@ impl RibManager {
     pub(super) fn recompute_orr(&mut self) -> HashSet<IpAddr> {
         if self.peer_orr_vantage.is_empty() {
             if !self.orr.is_empty() {
+                log_orr_input_transition(
+                    self.orr.topology.input_diagnostics(),
+                    crate::orr::OrrInputDiagnostics::default(),
+                );
                 self.orr = crate::orr::OrrState::default();
-                self.metrics.set_orr_topology_nodes(0);
-                self.metrics.set_orr_topology_links(0);
-                self.metrics.set_orr_unresolved_vantages(0);
             }
+            self.metrics.set_orr_topology_nodes(0);
+            self.metrics.set_orr_topology_links(0);
+            self.metrics.set_orr_unresolved_vantages(0);
+            self.metrics
+                .set_orr_input_diagnostics(crate::orr::OrrInputDiagnostics::default().values());
             return HashSet::new();
         }
 
@@ -3026,6 +3068,8 @@ impl RibManager {
                 .values()
                 .flat_map(crate::adj_rib_in::AdjRibIn::iter_bgpls),
         );
+        let input_diagnostics = topology.input_diagnostics();
+        log_orr_input_transition(self.orr.topology.input_diagnostics(), input_diagnostics);
         let vantages: HashSet<IpAddr> = self.peer_orr_vantage.values().copied().collect();
         let mut changed = HashSet::new();
         let mut spf = HashMap::new();
@@ -3070,6 +3114,8 @@ impl RibManager {
             .set_orr_topology_links(i64::try_from(topology.link_count()).unwrap_or(i64::MAX));
         self.metrics
             .set_orr_unresolved_vantages(i64::try_from(unresolved).unwrap_or(i64::MAX));
+        self.metrics
+            .set_orr_input_diagnostics(input_diagnostics.values());
         self.orr = crate::orr::OrrState {
             topology,
             spf,
@@ -3127,6 +3173,7 @@ impl RibManager {
             vantages,
             topology_nodes: u32::try_from(self.orr.topology.node_count()).unwrap_or(u32::MAX),
             topology_links: u32::try_from(self.orr.topology.link_count()).unwrap_or(u32::MAX),
+            input_diagnostics: self.orr.topology.input_diagnostics(),
         });
     }
 

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -39,8 +39,47 @@ async fn peer_up_registers_orr_vantage_and_teardown_clears() {
     assert_eq!(status.vantages[0].peers, vec![client]);
     assert_eq!(status.topology_nodes, 4);
     assert_eq!(status.topology_links, 4);
+    assert_eq!(status.input_diagnostics.included_default, 4);
+    assert_eq!(status.input_diagnostics.excluded_nondefault, 0);
     assert!(
         (gauge_metric_value(&metrics, "bgp_orr_topology_nodes", &[]) - 4.0).abs() < f64::EPSILON
+    );
+    let input_family = metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "bgp_orr_input_objects")
+        .expect("ORR input diagnostic metric registered");
+    let classifications: std::collections::BTreeSet<_> = input_family
+        .metric
+        .iter()
+        .map(|metric| {
+            assert_eq!(metric.get_label().len(), 1, "only classification label");
+            assert_eq!(metric.get_label()[0].name(), "classification");
+            metric.get_label()[0].value().to_owned()
+        })
+        .collect();
+    assert_eq!(
+        classifications,
+        [
+            "default_with_ignored_flex_algo",
+            "excluded_nondefault",
+            "included_default",
+            "malformed_attribute_29",
+            "malformed_topology",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
+    );
+    assert!(
+        (gauge_metric_value(
+            &metrics,
+            "bgp_orr_input_objects",
+            &[("classification", "included_default")],
+        ) - 4.0)
+            .abs()
+            < f64::EPSILON
     );
 
     tx.send(RibUpdate::PeerDown {
@@ -56,7 +95,23 @@ async fn peer_up_registers_orr_vantage_and_teardown_clears() {
         "teardown clears the vantage registry"
     );
     assert_eq!(status.topology_nodes, 0, "cached state emptied");
+    assert_eq!(
+        status.input_diagnostics,
+        crate::orr::OrrInputDiagnostics::default()
+    );
     assert!(gauge_metric_value(&metrics, "bgp_orr_topology_nodes", &[]).abs() < f64::EPSILON);
+    for classification in classifications {
+        assert!(
+            gauge_metric_value(
+                &metrics,
+                "bgp_orr_input_objects",
+                &[("classification", classification.as_str())],
+            )
+            .abs()
+                < f64::EPSILON,
+            "{classification} resets when the last vantage is removed"
+        );
+    }
 
     drop(tx);
     handle.await.unwrap();
@@ -592,6 +647,59 @@ async fn topology_metric_flip_marks_only_affected_vantage_peers_dirty_and_flips_
     );
 }
 
+/// A non-default topology object is observable but cannot perturb the
+/// cached default graph, SPF signatures, or any client's advertised state.
+#[tokio::test]
+async fn excluded_topology_mutation_does_not_dirty_or_stage_outbound() {
+    use crate::orr::fixtures::{A, X, link_route, mt_id_tlv, v4_interface, v4_neighbor};
+
+    let (tx, handle) = orr_rr_manager().await;
+    let client_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let client_c = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4));
+    let mut out_a = orr_client_peer_up(&tx, client_a, Some(vantage_at_node_a())).await;
+    let mut out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
+    let mut out_c = orr_client_peer_up(&tx, client_c, None).await;
+
+    announce_divergent_bests(&tx).await;
+    let _ = drain_final_unicast(&mut out_a);
+    let _ = drain_final_unicast(&mut out_b);
+    let _ = drain_final_unicast(&mut out_c);
+
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(ORR_FEED),
+        announced: vec![link_route(
+            ORR_FEED,
+            A,
+            X,
+            Some(0),
+            &[
+                v4_interface(Ipv4Addr::new(10, 0, A, X)),
+                v4_neighbor(Ipv4Addr::new(10, 0, X, A)),
+                mt_id_tlv(&[2]),
+            ],
+        )],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let status = query_orr_status(&tx).await;
+    assert_eq!(status.topology_nodes, 4);
+    assert_eq!(status.topology_links, 4);
+    assert_eq!(status.input_diagnostics.included_default, 4);
+    assert_eq!(status.input_diagnostics.excluded_nondefault, 1);
+
+    drop(tx);
+    handle.await.unwrap();
+    assert!(out_a.try_recv().is_err(), "vantage A must not be restaged");
+    assert!(out_b.try_recv().is_err(), "vantage B must not be restaged");
+    assert!(
+        out_c.try_recv().is_err(),
+        "plain client must not be restaged"
+    );
+}
+
 /// A vantage that does not resolve to a topology node silently falls
 /// back to the standard single-best: the ORR client's advertisement is
 /// identical to a vantage-less peer's.
@@ -746,6 +854,8 @@ async fn route_refresh_replays_vantage_best() {
 /// interior-cost reason with the compared costs.
 #[tokio::test]
 async fn explain_advertised_route_reports_orr_vantage_and_costs() {
+    use crate::orr::fixtures::{A, X, link_route, mt_id_tlv};
+
     let (tx, handle) = orr_rr_manager().await;
     let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
     let _out_b = orr_client_peer_up(&tx, client_b, Some(vantage_at_node_b())).await;
@@ -761,6 +871,14 @@ async fn explain_advertised_route_reports_orr_vantage_and_costs() {
         vec![ibgp_route(orr_prefix(), src_unknown, nh_unknown)],
     )
     .await;
+    tx.send(RibUpdate::BgpLsRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(ORR_FEED),
+        announced: vec![link_route(ORR_FEED, A, X, Some(0), &[mt_id_tlv(&[2])])],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
 
     let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
     assert_eq!(explain.decision, crate::update::ExplainDecision::Advertise);
@@ -795,6 +913,27 @@ async fn explain_advertised_route_reports_orr_vantage_and_costs() {
         orr_reason.message.contains("orr_cost 1 < 10"),
         "compared vantage costs rendered: {}",
         orr_reason.message
+    );
+    let diagnostic_reason = explain
+        .reasons
+        .iter()
+        .find(|reason| reason.code == "orr_topology_input_diagnostics")
+        .expect("aggregate filtered-input diagnostics are explained");
+    assert!(diagnostic_reason.message.contains("aggregate non-decisive"));
+    assert!(
+        diagnostic_reason
+            .message
+            .contains("winner and decisive cost are unchanged")
+    );
+    assert!(diagnostic_reason.message.contains("excluded_nondefault=1"));
+    assert_eq!(
+        explain
+            .reasons
+            .iter()
+            .filter(|reason| reason.code == "orr_interior_cost")
+            .count(),
+        1,
+        "the aggregate diagnostic does not replace the decisive cost reason"
     );
 
     drop(tx);

--- a/crates/rib/src/orr.rs
+++ b/crates/rib/src/orr.rs
@@ -34,8 +34,8 @@ use lru::LruCache;
 use prefix_trie::PrefixMap;
 use rustbgpd_wire::{
     BGP_LS_TLV_AUTONOMOUS_SYSTEM, BGP_LS_TLV_BGP_LS_IDENTIFIER, BGP_LS_TLV_IGP_ROUTER_ID,
-    BgpLsNlri, BgpLsNlriType, BgpLsNodeKey, BgpLsTlv, PathAttribute, Prefix, bgp_ls_attribute_tlvs,
-    decode_bgpls_tlvs, igp_metric, prefix_metric,
+    BGP_LS_TLV_MULTI_TOPOLOGY_ID, BgpLsNlri, BgpLsNlriType, BgpLsNodeKey, BgpLsTlv, PathAttribute,
+    Prefix, bgp_ls_attribute_tlvs, decode_bgpls_tlvs, igp_metric, prefix_metric,
 };
 
 use crate::route::BgpLsRibRoute;
@@ -44,6 +44,20 @@ use crate::route::BgpLsRibRoute;
 /// stores it as `PathAttribute::Unknown(RawAttribute)` on purpose; this is
 /// the only place that needs the code point.
 const BGP_LS_ATTRIBUTE_TYPE_CODE: u8 = 29;
+
+/// RFC 9085 SR-Algorithm Node Attribute TLV.
+const BGP_LS_TLV_SR_ALGORITHM: u16 = 1035;
+/// RFC 9351 Flexible Algorithm Definition Node Attribute TLV.
+const BGP_LS_TLV_FLEX_ALGO_DEFINITION: u16 = 1039;
+/// RFC 9351 Flexible Algorithm Prefix Metric Attribute TLV.
+const BGP_LS_TLV_FLEX_ALGO_PREFIX_METRIC: u16 = 1044;
+/// RFC 9085 Prefix-SID Attribute TLV.
+const BGP_LS_TLV_PREFIX_SID: u16 = 1158;
+
+const PROTOCOL_ISIS_LEVEL_1: u8 = 1;
+const PROTOCOL_ISIS_LEVEL_2: u8 = 2;
+const PROTOCOL_OSPFV2: u8 = 3;
+const PROTOCOL_OSPFV3: u8 = 6;
 
 /// Next-hop cost LRU capacity per [`SpfResult`]. A fresh cache is created
 /// per SPF run, so a topology rebuild invalidates it by construction.
@@ -118,18 +132,306 @@ impl NodeDescriptors {
 }
 
 /// The route's BGP-LS Attribute TLVs, parsed lazily from the raw
-/// `PathAttribute::Unknown` bytes. Absent or malformed attributes yield no
-/// TLVs (the route then simply carries no metrics).
-fn attribute_tlvs(route: &BgpLsRibRoute) -> Vec<BgpLsTlv> {
-    route
-        .attributes
-        .iter()
-        .find_map(|attr| match attr {
-            PathAttribute::Unknown(raw) if raw.type_code == BGP_LS_ATTRIBUTE_TYPE_CODE => Some(raw),
-            _ => None,
+/// `PathAttribute::Unknown` bytes. Absence is distinct from malformed or
+/// duplicate Attribute 29: malformed input must not become an implicit
+/// zero-metric topology object.
+fn attribute_tlvs(route: &BgpLsRibRoute) -> Result<Option<Vec<BgpLsTlv>>, ()> {
+    let mut matching = route.attributes.iter().filter_map(|attr| match attr {
+        PathAttribute::Unknown(raw) if raw.type_code == BGP_LS_ATTRIBUTE_TYPE_CODE => Some(raw),
+        _ => None,
+    });
+    let Some(raw) = matching.next() else {
+        return Ok(None);
+    };
+    if matching.next().is_some() {
+        return Err(());
+    }
+    bgp_ls_attribute_tlvs(&raw.data).map(Some).map_err(|_| ())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TopologyScope {
+    Default,
+    NonDefault,
+    Malformed,
+}
+
+fn decode_mt_ids(protocol_id: u8, value: &[u8]) -> Result<Vec<u16>, ()> {
+    if value.is_empty() || !value.len().is_multiple_of(2) {
+        return Err(());
+    }
+    value
+        .chunks_exact(2)
+        .map(|raw| {
+            let raw = u16::from_be_bytes([raw[0], raw[1]]);
+            match protocol_id {
+                PROTOCOL_ISIS_LEVEL_1 | PROTOCOL_ISIS_LEVEL_2 => Ok(raw & 0x0fff),
+                PROTOCOL_OSPFV2 | PROTOCOL_OSPFV3 if raw <= 127 => Ok(raw),
+                _ => Err(()),
+            }
         })
-        .and_then(|raw| bgp_ls_attribute_tlvs(&raw.data).ok())
-        .unwrap_or_default()
+        .collect()
+}
+
+fn descriptor_topology_scope(nlri: &BgpLsNlri) -> TopologyScope {
+    let Ok(Some(tlvs)) = nlri.descriptor_tlvs() else {
+        return TopologyScope::Malformed;
+    };
+    let mut mt = tlvs
+        .iter()
+        .filter(|tlv| tlv.type_code == BGP_LS_TLV_MULTI_TOPOLOGY_ID);
+    let Some(tlv) = mt.next() else {
+        return TopologyScope::Default;
+    };
+    if nlri.nlri_type == BgpLsNlriType::Node {
+        // Node MT membership belongs in Attribute 29, never the Node NLRI
+        // descriptor. Accepting it here would mix two identity surfaces.
+        return TopologyScope::Malformed;
+    }
+    if mt.next().is_some() || tlv.value.len() != 2 {
+        return TopologyScope::Malformed;
+    }
+    let Some(protocol_id) = nlri.protocol_id() else {
+        return TopologyScope::Malformed;
+    };
+    match decode_mt_ids(protocol_id, &tlv.value) {
+        Ok(ids) if ids == [0] => TopologyScope::Default,
+        Ok(_) => TopologyScope::NonDefault,
+        Err(()) => TopologyScope::Malformed,
+    }
+}
+
+fn node_topology_scope(protocol_id: u8, attributes: &[BgpLsTlv]) -> TopologyScope {
+    let mut mt = attributes
+        .iter()
+        .filter(|tlv| tlv.type_code == BGP_LS_TLV_MULTI_TOPOLOGY_ID);
+    let Some(tlv) = mt.next() else {
+        return TopologyScope::Default;
+    };
+    if mt.next().is_some() {
+        return TopologyScope::Malformed;
+    }
+    match decode_mt_ids(protocol_id, &tlv.value) {
+        Ok(ids) if ids.contains(&0) => TopologyScope::Default,
+        Ok(_) => TopologyScope::NonDefault,
+        Err(()) => TopologyScope::Malformed,
+    }
+}
+
+fn has_ignored_flex(nlri_type: BgpLsNlriType, attributes: &[BgpLsTlv]) -> bool {
+    attributes.iter().any(|tlv| match nlri_type {
+        BgpLsNlriType::Node => match tlv.type_code {
+            BGP_LS_TLV_FLEX_ALGO_DEFINITION => true,
+            BGP_LS_TLV_SR_ALGORITHM => tlv.value.iter().any(|algorithm| *algorithm >= 128),
+            _ => false,
+        },
+        BgpLsNlriType::Ipv4TopologyPrefix | BgpLsNlriType::Ipv6TopologyPrefix => {
+            match tlv.type_code {
+                BGP_LS_TLV_FLEX_ALGO_PREFIX_METRIC => true,
+                BGP_LS_TLV_PREFIX_SID => {
+                    matches!(tlv.value.len(), 7 | 8)
+                        && tlv.value.get(1).is_some_and(|algorithm| *algorithm >= 128)
+                }
+                _ => false,
+            }
+        }
+        BgpLsNlriType::Link | BgpLsNlriType::Unknown(_) => false,
+    })
+}
+
+/// Aggregate classification of BGP-LS inputs considered by one ORR topology
+/// build. Counts are per Adj-RIB-In input before NLRI deduplication and
+/// saturate instead of wrapping.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OrrInputDiagnostics {
+    pub included_default: u64,
+    pub excluded_nondefault: u64,
+    pub malformed_topology: u64,
+    pub malformed_attribute_29: u64,
+    /// Subset of `included_default` carrying inert Flex-Algorithm data.
+    pub default_with_ignored_flex_algo: u64,
+}
+
+impl OrrInputDiagnostics {
+    fn record(&mut self, classification: InputClassification) {
+        match classification {
+            InputClassification::IncludedDefault => {
+                self.included_default = self.included_default.saturating_add(1);
+            }
+            InputClassification::ExcludedNonDefault => {
+                self.excluded_nondefault = self.excluded_nondefault.saturating_add(1);
+            }
+            InputClassification::MalformedTopology => {
+                self.malformed_topology = self.malformed_topology.saturating_add(1);
+            }
+            InputClassification::MalformedAttribute29 => {
+                self.malformed_attribute_29 = self.malformed_attribute_29.saturating_add(1);
+            }
+            InputClassification::DefaultWithIgnoredFlexAlgo => {
+                self.included_default = self.included_default.saturating_add(1);
+                self.default_with_ignored_flex_algo =
+                    self.default_with_ignored_flex_algo.saturating_add(1);
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn values(self) -> [u64; 5] {
+        [
+            self.included_default,
+            self.excluded_nondefault,
+            self.malformed_topology,
+            self.malformed_attribute_29,
+            self.default_with_ignored_flex_algo,
+        ]
+    }
+
+    #[must_use]
+    pub fn noteworthy(self) -> bool {
+        self.excluded_nondefault != 0
+            || self.malformed_topology != 0
+            || self.malformed_attribute_29 != 0
+            || self.default_with_ignored_flex_algo != 0
+    }
+
+    #[must_use]
+    pub fn summary(self) -> String {
+        format!(
+            "included_default={} excluded_nondefault={} malformed_topology={} \
+             malformed_attribute_29={} default_with_ignored_flex_algo={}",
+            self.included_default,
+            self.excluded_nondefault,
+            self.malformed_topology,
+            self.malformed_attribute_29,
+            self.default_with_ignored_flex_algo
+        )
+    }
+
+    fn exclusion_presence(self) -> [bool; 3] {
+        [
+            self.excluded_nondefault != 0,
+            self.malformed_topology != 0,
+            self.malformed_attribute_29 != 0,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputClassification {
+    IncludedDefault,
+    ExcludedNonDefault,
+    MalformedTopology,
+    MalformedAttribute29,
+    DefaultWithIgnoredFlexAlgo,
+}
+
+impl InputClassification {
+    fn included(self) -> bool {
+        matches!(
+            self,
+            Self::IncludedDefault | Self::DefaultWithIgnoredFlexAlgo
+        )
+    }
+}
+
+fn classify_input(
+    nlri: &BgpLsNlri,
+    attributes: Result<Option<&[BgpLsTlv]>, ()>,
+) -> InputClassification {
+    // Descriptor/topology framing takes precedence over Attribute 29. This
+    // keeps one stable classification when both independent surfaces are bad.
+    let descriptor_scope = descriptor_topology_scope(nlri);
+    if descriptor_scope == TopologyScope::Malformed {
+        return InputClassification::MalformedTopology;
+    }
+    let attributes = match attributes {
+        Ok(attributes) => attributes.unwrap_or_default(),
+        Err(()) => return InputClassification::MalformedAttribute29,
+    };
+
+    let scope = match nlri.nlri_type {
+        BgpLsNlriType::Node => {
+            if attributes
+                .iter()
+                .any(|tlv| tlv.type_code == BGP_LS_TLV_MULTI_TOPOLOGY_ID)
+            {
+                let Some(protocol_id) = nlri.protocol_id() else {
+                    return InputClassification::MalformedTopology;
+                };
+                node_topology_scope(protocol_id, attributes)
+            } else {
+                TopologyScope::Default
+            }
+        }
+        BgpLsNlriType::Link
+        | BgpLsNlriType::Ipv4TopologyPrefix
+        | BgpLsNlriType::Ipv6TopologyPrefix => {
+            if attributes
+                .iter()
+                .any(|tlv| tlv.type_code == BGP_LS_TLV_MULTI_TOPOLOGY_ID)
+            {
+                TopologyScope::Malformed
+            } else {
+                descriptor_scope
+            }
+        }
+        BgpLsNlriType::Unknown(_) => return InputClassification::MalformedTopology,
+    };
+    match scope {
+        TopologyScope::NonDefault => InputClassification::ExcludedNonDefault,
+        TopologyScope::Malformed => InputClassification::MalformedTopology,
+        TopologyScope::Default if has_ignored_flex(nlri.nlri_type, attributes) => {
+            InputClassification::DefaultWithIgnoredFlexAlgo
+        }
+        TopologyScope::Default => InputClassification::IncludedDefault,
+    }
+}
+
+/// Aggregate log transition for ORR input classifications. Non-zero count
+/// changes do not retrigger logs; only entering or clearing noteworthy input
+/// does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrrInputTransition {
+    ExclusionsActivated,
+    ExclusionsCleared,
+    FlexChanged,
+    Cleared,
+}
+
+#[must_use]
+pub(crate) fn input_diagnostics_transition(
+    previous: OrrInputDiagnostics,
+    current: OrrInputDiagnostics,
+) -> Option<OrrInputTransition> {
+    let previous_exclusions = previous.exclusion_presence();
+    let current_exclusions = current.exclusion_presence();
+    let previous_flex = previous.default_with_ignored_flex_algo != 0;
+    let current_flex = current.default_with_ignored_flex_algo != 0;
+    let exclusion_activated = previous_exclusions
+        .iter()
+        .zip(current_exclusions)
+        .any(|(previous, current)| !previous && current);
+    let exclusion_cleared = previous_exclusions
+        .iter()
+        .zip(current_exclusions)
+        .any(|(previous, current)| *previous && !current);
+    if exclusion_activated {
+        Some(OrrInputTransition::ExclusionsActivated)
+    } else if exclusion_cleared {
+        if current_exclusions.into_iter().any(|present| present) || current_flex {
+            Some(OrrInputTransition::ExclusionsCleared)
+        } else {
+            Some(OrrInputTransition::Cleared)
+        }
+    } else if previous_flex != current_flex {
+        if current_flex || current_exclusions.iter().any(|present| *present) {
+            Some(OrrInputTransition::FlexChanged)
+        } else {
+            Some(OrrInputTransition::Cleared)
+        }
+    } else {
+        None
+    }
 }
 
 /// Directed weighted topology graph built from BGP-LS routes.
@@ -152,6 +454,7 @@ pub struct OrrTopology {
     /// (TLV 1155, 0 when absent).
     prefix_v4: PrefixMap<Ipv4Net, Vec<(NodeIx, u32)>>,
     prefix_v6: PrefixMap<Ipv6Net, Vec<(NodeIx, u32)>>,
+    input_diagnostics: OrrInputDiagnostics,
 }
 
 impl Default for OrrTopology {
@@ -189,15 +492,33 @@ impl OrrTopology {
         // preserving first-seen order for deterministic node indexes.
         let mut order: Vec<(&'a BgpLsNlri, Element)> = Vec::new();
         let mut seen: HashMap<&'a BgpLsNlri, usize> = HashMap::new();
+        let mut input_diagnostics = OrrInputDiagnostics::default();
         for route in routes {
+            if matches!(route.nlri.nlri_type, BgpLsNlriType::Unknown(_)) {
+                continue;
+            }
+            let attribute_tlvs = attribute_tlvs(route);
+            let classification_attributes = match &attribute_tlvs {
+                Ok(tlvs) => Ok(tlvs.as_deref()),
+                Err(()) => Err(()),
+            };
+            let classification = classify_input(&route.nlri, classification_attributes);
+            input_diagnostics.record(classification);
+            if !classification.included() {
+                continue;
+            }
+            let Ok(attributes) = attribute_tlvs else {
+                continue;
+            };
+            let attributes = attributes.unwrap_or_default();
             let element = match route.nlri.nlri_type {
                 BgpLsNlriType::Node => Element::Node,
                 BgpLsNlriType::Link => Element::Link {
-                    metric: igp_metric(&attribute_tlvs(route)),
+                    metric: igp_metric(&attributes),
                 },
                 BgpLsNlriType::Ipv4TopologyPrefix | BgpLsNlriType::Ipv6TopologyPrefix => {
                     Element::IpPrefix {
-                        metric: prefix_metric(&attribute_tlvs(route)).unwrap_or(0),
+                        metric: prefix_metric(&attributes).unwrap_or(0),
                     }
                 }
                 BgpLsNlriType::Unknown(_) => continue,
@@ -231,6 +552,7 @@ impl OrrTopology {
             addr_index: HashMap::new(),
             prefix_v4: PrefixMap::new(),
             prefix_v6: PrefixMap::new(),
+            input_diagnostics,
         };
         for (nlri, element) in order {
             match element {
@@ -325,6 +647,12 @@ impl OrrTopology {
     #[must_use]
     pub fn links(&self) -> &[OrrLink] {
         &self.links
+    }
+
+    /// Aggregate classification of inputs considered by this topology build.
+    #[must_use]
+    pub fn input_diagnostics(&self) -> OrrInputDiagnostics {
+        self.input_diagnostics
     }
 
     /// The canonical key of an interned node.
@@ -667,6 +995,8 @@ pub struct OrrStatusSnapshot {
     pub topology_nodes: u32,
     /// Topology usable-directed-link total.
     pub topology_links: u32,
+    /// Default-topology input classification for the cached graph.
+    pub input_diagnostics: OrrInputDiagnostics,
 }
 
 /// Status of one configured ORR vantage.
@@ -720,6 +1050,7 @@ pub(crate) mod fixtures {
         BgpLsNodeKey, BgpLsTlv, PathAttribute, RawAttribute, encode_bgpls_tlvs,
     };
 
+    use super::{BGP_LS_TLV_MULTI_TOPOLOGY_ID, PROTOCOL_ISIS_LEVEL_2};
     use crate::route::{BgpLsFamily, BgpLsRibRoute, RouteOrigin};
 
     fn sub_tlvs(tlvs: &[BgpLsTlv]) -> Bytes {
@@ -743,11 +1074,19 @@ pub(crate) mod fixtures {
         ])
     }
 
-    fn build_nlri(nlri_type: BgpLsNlriType, tlvs: &[BgpLsTlv]) -> BgpLsNlri {
-        let mut payload = vec![2]; // protocol-id: IS-IS L2
+    pub(crate) fn build_nlri_protocol(
+        nlri_type: BgpLsNlriType,
+        protocol_id: u8,
+        tlvs: &[BgpLsTlv],
+    ) -> BgpLsNlri {
+        let mut payload = vec![protocol_id];
         payload.extend_from_slice(&0_u64.to_be_bytes()); // identifier
         encode_bgpls_tlvs(tlvs, &mut payload).expect("fixture TLVs encode");
         BgpLsNlri::try_new(nlri_type, None, Bytes::from(payload)).expect("fixture NLRI fits")
+    }
+
+    fn build_nlri(nlri_type: BgpLsNlriType, tlvs: &[BgpLsTlv]) -> BgpLsNlri {
+        build_nlri_protocol(nlri_type, PROTOCOL_ISIS_LEVEL_2, tlvs)
     }
 
     /// The canonical key of fixture node `id`.
@@ -821,7 +1160,11 @@ pub(crate) mod fixtures {
         )
     }
 
-    fn rib_route(peer: Ipv4Addr, nlri: BgpLsNlri, attributes: Vec<PathAttribute>) -> BgpLsRibRoute {
+    pub(crate) fn rib_route(
+        peer: Ipv4Addr,
+        nlri: BgpLsNlri,
+        attributes: Vec<PathAttribute>,
+    ) -> BgpLsRibRoute {
         BgpLsRibRoute {
             family: BgpLsFamily::LinkState,
             nlri,
@@ -835,6 +1178,18 @@ pub(crate) mod fixtures {
             is_llgr_stale: false,
             path_id: 0,
         }
+    }
+
+    /// Multi-Topology Identifier TLV 263 with the supplied raw 16-bit values.
+    pub(crate) fn mt_id_tlv(ids: &[u16]) -> BgpLsTlv {
+        BgpLsTlv::new(
+            BGP_LS_TLV_MULTI_TOPOLOGY_ID,
+            Bytes::from(
+                ids.iter()
+                    .flat_map(|id| id.to_be_bytes())
+                    .collect::<Vec<_>>(),
+            ),
+        )
     }
 
     /// A Link NLRI route `local -> remote` with optional IGP metric and
@@ -925,6 +1280,11 @@ mod tests {
 
     use super::fixtures::*;
     use super::*;
+    use bytes::Bytes;
+    use rustbgpd_wire::{
+        BGP_LS_TLV_IP_REACHABILITY, BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS, BGP_LS_TLV_PREFIX_METRIC,
+        BGP_LS_TLV_REMOTE_NODE_DESCRIPTORS, RawAttribute,
+    };
 
     const PEER1: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 1);
     const PEER2: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 2);
@@ -936,6 +1296,657 @@ mod tests {
 
     fn ix(topo: &OrrTopology, id: u8) -> NodeIx {
         topo.node_ix(&node_key(id)).expect("fixture node interned")
+    }
+
+    fn link_nlri(protocol_id: u8, mt_tlvs: &[BgpLsTlv]) -> BgpLsNlri {
+        let mut descriptors = vec![
+            BgpLsTlv::new(BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS, node_container(A)),
+            BgpLsTlv::new(BGP_LS_TLV_REMOTE_NODE_DESCRIPTORS, node_container(X)),
+        ];
+        descriptors.extend_from_slice(mt_tlvs);
+        build_nlri_protocol(BgpLsNlriType::Link, protocol_id, &descriptors)
+    }
+
+    fn node_nlri_with_descriptors(protocol_id: u8, extra: &[BgpLsTlv]) -> BgpLsNlri {
+        let mut descriptors = vec![BgpLsTlv::new(
+            BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS,
+            node_container(A),
+        )];
+        descriptors.extend_from_slice(extra);
+        build_nlri_protocol(BgpLsNlriType::Node, protocol_id, &descriptors)
+    }
+
+    fn prefix_nlri(protocol_id: u8, node: u8, mt: Option<BgpLsTlv>) -> BgpLsNlri {
+        let mut descriptors = vec![BgpLsTlv::new(
+            BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS,
+            node_container(node),
+        )];
+        if let Some(mt) = mt {
+            descriptors.push(mt);
+        }
+        descriptors.push(BgpLsTlv::new(
+            BGP_LS_TLV_IP_REACHABILITY,
+            Bytes::from_static(&[24, 203, 0, 113]),
+        ));
+        build_nlri_protocol(BgpLsNlriType::Ipv4TopologyPrefix, protocol_id, &descriptors)
+    }
+
+    fn mt_link_route(
+        peer: Ipv4Addr,
+        local: u8,
+        remote: u8,
+        metric: u32,
+        mt_id: u16,
+        extra_descriptors: &[BgpLsTlv],
+    ) -> BgpLsRibRoute {
+        let mut descriptors = vec![
+            BgpLsTlv::new(BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS, node_container(local)),
+            BgpLsTlv::new(BGP_LS_TLV_REMOTE_NODE_DESCRIPTORS, node_container(remote)),
+        ];
+        descriptors.extend_from_slice(extra_descriptors);
+        descriptors.push(mt_id_tlv(&[mt_id]));
+        rib_route(
+            peer,
+            build_nlri_protocol(BgpLsNlriType::Link, PROTOCOL_ISIS_LEVEL_2, &descriptors),
+            vec![bgp_ls_attribute(&[igp_metric_tlv(metric)])],
+        )
+    }
+
+    fn mt_prefix_route(
+        peer: Ipv4Addr,
+        node: u8,
+        prefix: Ipv4Addr,
+        prefix_len: u8,
+        metric: u32,
+        mt_id: u16,
+    ) -> BgpLsRibRoute {
+        let mut reach = vec![prefix_len];
+        reach.extend_from_slice(&prefix.octets()[..usize::from(prefix_len.div_ceil(8))]);
+        rib_route(
+            peer,
+            build_nlri_protocol(
+                BgpLsNlriType::Ipv4TopologyPrefix,
+                PROTOCOL_ISIS_LEVEL_2,
+                &[
+                    BgpLsTlv::new(BGP_LS_TLV_LOCAL_NODE_DESCRIPTORS, node_container(node)),
+                    mt_id_tlv(&[mt_id]),
+                    BgpLsTlv::new(BGP_LS_TLV_IP_REACHABILITY, Bytes::from(reach)),
+                ],
+            ),
+            vec![bgp_ls_attribute(&[BgpLsTlv::new(
+                BGP_LS_TLV_PREFIX_METRIC,
+                Bytes::from(metric.to_be_bytes().to_vec()),
+            )])],
+        )
+    }
+
+    fn malformed_attribute() -> PathAttribute {
+        PathAttribute::Unknown(RawAttribute {
+            flags: 0x80,
+            type_code: BGP_LS_ATTRIBUTE_TYPE_CODE,
+            data: Bytes::from_static(&[0x01, 0x07, 0x00]),
+        })
+    }
+
+    fn classify(nlri: BgpLsNlri, attributes: Vec<PathAttribute>) -> InputClassification {
+        let route = rib_route(PEER1, nlri, attributes);
+        let attributes = attribute_tlvs(&route);
+        let attributes = match &attributes {
+            Ok(tlvs) => Ok(tlvs.as_deref()),
+            Err(()) => Err(()),
+        };
+        classify_input(&route.nlri, attributes)
+    }
+
+    fn raw_tlv(type_code: u16, value: &[u8]) -> BgpLsTlv {
+        BgpLsTlv::new(type_code, Bytes::copy_from_slice(value))
+    }
+
+    #[test]
+    fn link_and_prefix_mt_id_classification_is_protocol_strict() {
+        assert_eq!(
+            classify(link_nlri(99, &[]), vec![]),
+            InputClassification::IncludedDefault,
+            "absent MT-ID is default without interpreting protocol-id"
+        );
+        for protocol in [PROTOCOL_ISIS_LEVEL_1, PROTOCOL_ISIS_LEVEL_2] {
+            assert_eq!(
+                classify(link_nlri(protocol, &[mt_id_tlv(&[0xf000])]), vec![]),
+                InputClassification::IncludedDefault,
+                "IS-IS reserved bits are ignored"
+            );
+            assert_eq!(
+                classify(link_nlri(protocol, &[mt_id_tlv(&[2])]), vec![]),
+                InputClassification::ExcludedNonDefault
+            );
+        }
+        for protocol in [PROTOCOL_OSPFV2, PROTOCOL_OSPFV3] {
+            assert_eq!(
+                classify(link_nlri(protocol, &[mt_id_tlv(&[0])]), vec![]),
+                InputClassification::IncludedDefault
+            );
+            assert_eq!(
+                classify(link_nlri(protocol, &[mt_id_tlv(&[2])]), vec![]),
+                InputClassification::ExcludedNonDefault
+            );
+            assert_eq!(
+                classify(link_nlri(protocol, &[mt_id_tlv(&[128])]), vec![]),
+                InputClassification::MalformedTopology
+            );
+        }
+        assert_eq!(
+            classify(link_nlri(99, &[mt_id_tlv(&[0])]), vec![]),
+            InputClassification::MalformedTopology
+        );
+        assert_eq!(
+            classify(
+                prefix_nlri(PROTOCOL_ISIS_LEVEL_2, A, Some(mt_id_tlv(&[3]))),
+                vec![]
+            ),
+            InputClassification::ExcludedNonDefault
+        );
+        assert_eq!(
+            classify(prefix_nlri(99, A, None), vec![]),
+            InputClassification::IncludedDefault
+        );
+        assert_eq!(
+            classify(
+                prefix_nlri(PROTOCOL_ISIS_LEVEL_2, A, Some(mt_id_tlv(&[0]))),
+                vec![]
+            ),
+            InputClassification::IncludedDefault
+        );
+    }
+
+    #[test]
+    fn link_mt_id_shape_and_placement_fail_closed() {
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[mt_id_tlv(&[0]), mt_id_tlv(&[0])]),
+                vec![]
+            ),
+            InputClassification::MalformedTopology
+        );
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[mt_id_tlv(&[0, 2])]),
+                vec![]
+            ),
+            InputClassification::MalformedTopology
+        );
+        assert_eq!(
+            classify(
+                link_nlri(
+                    PROTOCOL_ISIS_LEVEL_2,
+                    &[raw_tlv(BGP_LS_TLV_MULTI_TOPOLOGY_ID, &[0])]
+                ),
+                vec![]
+            ),
+            InputClassification::MalformedTopology
+        );
+        for value in [&[][..], &[0, 0, 0][..]] {
+            assert_eq!(
+                classify(
+                    link_nlri(
+                        PROTOCOL_ISIS_LEVEL_2,
+                        &[raw_tlv(BGP_LS_TLV_MULTI_TOPOLOGY_ID, value)]
+                    ),
+                    vec![]
+                ),
+                InputClassification::MalformedTopology
+            );
+        }
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[]),
+                vec![bgp_ls_attribute(&[mt_id_tlv(&[0])])]
+            ),
+            InputClassification::MalformedTopology,
+            "TLV 263 belongs in Link/Prefix descriptors, not Attribute 29"
+        );
+    }
+
+    #[test]
+    fn node_mt_id_uses_only_attribute_29_and_accepts_default_membership() {
+        let node = node_nlri_with_descriptors(99, &[]);
+        assert_eq!(
+            classify(node.clone(), vec![]),
+            InputClassification::IncludedDefault,
+            "absent Node MT-ID is default without interpreting protocol-id"
+        );
+        let node = node_nlri_with_descriptors(PROTOCOL_ISIS_LEVEL_2, &[]);
+        assert_eq!(
+            classify(node.clone(), vec![bgp_ls_attribute(&[mt_id_tlv(&[0, 2])])]),
+            InputClassification::IncludedDefault
+        );
+        assert_eq!(
+            classify(node.clone(), vec![bgp_ls_attribute(&[mt_id_tlv(&[2, 3])])]),
+            InputClassification::ExcludedNonDefault
+        );
+        assert_eq!(
+            classify(
+                node.clone(),
+                vec![bgp_ls_attribute(&[mt_id_tlv(&[0]), mt_id_tlv(&[2])])]
+            ),
+            InputClassification::MalformedTopology
+        );
+        assert_eq!(
+            classify(
+                node_nlri_with_descriptors(PROTOCOL_ISIS_LEVEL_2, &[mt_id_tlv(&[0])]),
+                vec![]
+            ),
+            InputClassification::MalformedTopology,
+            "Node descriptor MT-ID is invalid placement"
+        );
+        for malformed in [
+            raw_tlv(BGP_LS_TLV_MULTI_TOPOLOGY_ID, &[]),
+            raw_tlv(BGP_LS_TLV_MULTI_TOPOLOGY_ID, &[0]),
+        ] {
+            assert_eq!(
+                classify(
+                    node.clone(),
+                    vec![bgp_ls_attribute(std::slice::from_ref(&malformed))]
+                ),
+                InputClassification::MalformedTopology
+            );
+        }
+        assert_eq!(
+            classify(
+                node_nlri_with_descriptors(99, &[]),
+                vec![bgp_ls_attribute(&[mt_id_tlv(&[0])])]
+            ),
+            InputClassification::MalformedTopology,
+            "an unknown protocol cannot interpret Node MT membership"
+        );
+        assert_eq!(
+            classify(
+                node_nlri_with_descriptors(PROTOCOL_OSPFV2, &[]),
+                vec![bgp_ls_attribute(&[mt_id_tlv(&[128])])]
+            ),
+            InputClassification::MalformedTopology,
+            "OSPF Node membership rejects reserved high bits"
+        );
+    }
+
+    #[test]
+    fn malformed_descriptor_precedes_malformed_attribute_29() {
+        let mut payload = vec![PROTOCOL_ISIS_LEVEL_2];
+        payload.extend_from_slice(&0_u64.to_be_bytes());
+        payload.extend_from_slice(&[0x01, 0x00, 0x00]);
+        let nlri = BgpLsNlri::try_new(BgpLsNlriType::Link, None, Bytes::from(payload)).unwrap();
+        assert_eq!(
+            classify(nlri, vec![malformed_attribute()]),
+            InputClassification::MalformedTopology
+        );
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[]),
+                vec![malformed_attribute()]
+            ),
+            InputClassification::MalformedAttribute29
+        );
+        let valid_attribute = bgp_ls_attribute(&[]);
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[]),
+                vec![valid_attribute.clone(), valid_attribute]
+            ),
+            InputClassification::MalformedAttribute29,
+            "duplicate Attribute 29 is fail-closed"
+        );
+    }
+
+    #[test]
+    fn ignored_flex_is_kind_aware_and_prefix_sid_shape_strict() {
+        let node = node_nlri_with_descriptors(PROTOCOL_ISIS_LEVEL_2, &[]);
+        assert_eq!(
+            classify(
+                node.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_FLEX_ALGO_DEFINITION,
+                    &[128, 0, 0, 0]
+                )])]
+            ),
+            InputClassification::DefaultWithIgnoredFlexAlgo
+        );
+        assert_eq!(
+            classify(
+                node.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_SR_ALGORITHM,
+                    &[0, 1]
+                )])]
+            ),
+            InputClassification::IncludedDefault,
+            "standard SR algorithms are not Flex-Algorithm input"
+        );
+        assert_eq!(
+            classify(
+                node.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_SR_ALGORITHM,
+                    &[0, 128]
+                )])]
+            ),
+            InputClassification::DefaultWithIgnoredFlexAlgo
+        );
+        assert_eq!(
+            classify(
+                node.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_FLEX_ALGO_PREFIX_METRIC,
+                    &[128, 0, 0, 0, 0, 0, 0, 1]
+                )])]
+            ),
+            InputClassification::IncludedDefault,
+            "FAPM is a Prefix attribute, not a Node Flex signal"
+        );
+
+        let prefix = prefix_nlri(PROTOCOL_ISIS_LEVEL_2, A, None);
+        assert_eq!(
+            classify(
+                prefix.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_FLEX_ALGO_PREFIX_METRIC,
+                    &[128, 0, 0, 0, 0, 0, 0, 1]
+                )])]
+            ),
+            InputClassification::DefaultWithIgnoredFlexAlgo
+        );
+        for len in [7_usize, 8] {
+            let mut value = vec![0; len];
+            value[1] = 128;
+            assert_eq!(
+                classify(
+                    prefix.clone(),
+                    vec![bgp_ls_attribute(&[raw_tlv(BGP_LS_TLV_PREFIX_SID, &value)])]
+                ),
+                InputClassification::DefaultWithIgnoredFlexAlgo
+            );
+        }
+        assert_eq!(
+            classify(
+                prefix.clone(),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_PREFIX_SID,
+                    &[0, 128]
+                )])]
+            ),
+            InputClassification::IncludedDefault,
+            "short Prefix-SID values are not interpreted"
+        );
+        assert_eq!(
+            classify(
+                link_nlri(PROTOCOL_ISIS_LEVEL_2, &[]),
+                vec![bgp_ls_attribute(&[raw_tlv(
+                    BGP_LS_TLV_FLEX_ALGO_DEFINITION,
+                    &[128, 0, 0, 0]
+                )])]
+            ),
+            InputClassification::IncludedDefault,
+            "Link objects do not own FAD/FAPM/SR-Algorithm/Prefix-SID"
+        );
+    }
+
+    #[test]
+    fn diagnostics_are_input_level_saturating_and_flex_is_subset() {
+        let nlri = node_nlri_with_descriptors(PROTOCOL_ISIS_LEVEL_2, &[]);
+        let attributes = vec![bgp_ls_attribute(&[raw_tlv(
+            BGP_LS_TLV_FLEX_ALGO_DEFINITION,
+            &[128, 0, 0, 0],
+        )])];
+        let routes = [
+            rib_route(PEER1, nlri.clone(), attributes.clone()),
+            rib_route(PEER2, nlri, attributes),
+        ];
+        let diagnostics = OrrTopology::build(routes.iter()).input_diagnostics();
+        assert_eq!(diagnostics.included_default, 2, "counted before dedup");
+        assert_eq!(diagnostics.default_with_ignored_flex_algo, 2);
+
+        let mut diagnostics = OrrInputDiagnostics {
+            included_default: u64::MAX,
+            ..OrrInputDiagnostics::default()
+        };
+        diagnostics.record(InputClassification::IncludedDefault);
+        assert_eq!(diagnostics.included_default, u64::MAX);
+    }
+
+    #[test]
+    fn diagnostic_transitions_are_presence_based_and_severity_aware() {
+        let baseline = OrrInputDiagnostics {
+            excluded_nondefault: 2,
+            ..OrrInputDiagnostics::default()
+        };
+        assert_eq!(
+            input_diagnostics_transition(
+                baseline,
+                OrrInputDiagnostics {
+                    excluded_nondefault: 9,
+                    ..OrrInputDiagnostics::default()
+                }
+            ),
+            None,
+            "positive count changes do not retrigger a transition"
+        );
+        assert_eq!(
+            input_diagnostics_transition(
+                OrrInputDiagnostics {
+                    excluded_nondefault: 1,
+                    malformed_topology: 1,
+                    ..OrrInputDiagnostics::default()
+                },
+                OrrInputDiagnostics {
+                    excluded_nondefault: 1,
+                    ..OrrInputDiagnostics::default()
+                }
+            ),
+            Some(OrrInputTransition::ExclusionsCleared),
+            "a partial exclusion recovery is informational"
+        );
+        assert_eq!(
+            input_diagnostics_transition(
+                OrrInputDiagnostics {
+                    excluded_nondefault: 1,
+                    ..OrrInputDiagnostics::default()
+                },
+                OrrInputDiagnostics {
+                    malformed_topology: 1,
+                    ..OrrInputDiagnostics::default()
+                }
+            ),
+            Some(OrrInputTransition::ExclusionsActivated),
+            "an activation wins when another bucket clears in the same rebuild"
+        );
+        assert_eq!(
+            input_diagnostics_transition(
+                OrrInputDiagnostics {
+                    excluded_nondefault: 1,
+                    ..OrrInputDiagnostics::default()
+                },
+                OrrInputDiagnostics {
+                    excluded_nondefault: 1,
+                    default_with_ignored_flex_algo: 1,
+                    ..OrrInputDiagnostics::default()
+                }
+            ),
+            Some(OrrInputTransition::FlexChanged),
+            "Flex transitions remain informational while exclusions are active"
+        );
+    }
+
+    #[test]
+    fn nondefault_link_cannot_compete_with_default_topology() {
+        for excluded_first in [true, false] {
+            let excluded = mt_link_route(PEER1, A, X, 1, 2, &[]);
+            let default = link_route(PEER2, A, X, Some(50), &[]);
+            let routes = if excluded_first {
+                vec![excluded, default]
+            } else {
+                vec![default, excluded]
+            };
+            let topology = OrrTopology::build(routes.iter());
+            assert_eq!(topology.node_count(), 2);
+            assert_eq!(topology.link_count(), 1);
+            assert_eq!(topology.links()[0].cost, 50);
+            assert_eq!(
+                topology.spf(ix(&topology, A)).dist_to(ix(&topology, X)),
+                Some(50)
+            );
+            assert_eq!(
+                topology.input_diagnostics(),
+                OrrInputDiagnostics {
+                    included_default: 1,
+                    excluded_nondefault: 1,
+                    ..OrrInputDiagnostics::default()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn nondefault_prefix_cannot_compete_with_default_topology() {
+        let mut routes = square_topology(PEER1);
+        routes.push(mt_prefix_route(
+            PEER1,
+            Y,
+            Ipv4Addr::new(192, 0, 2, 0),
+            24,
+            1,
+            2,
+        ));
+        routes.push(prefix_route(
+            PEER2,
+            X,
+            Ipv4Addr::new(192, 0, 2, 0),
+            24,
+            Some(50),
+        ));
+        let topology = OrrTopology::build(routes.iter());
+        let address = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99));
+        assert_eq!(topology.resolve_node(address), Some(ix(&topology, X)));
+        assert_eq!(
+            topology.spf(ix(&topology, A)).cost_to(&topology, address),
+            Some(51),
+            "only A-to-X default cost plus the classic default prefix metric applies"
+        );
+        assert_eq!(topology.input_diagnostics().excluded_nondefault, 1);
+    }
+
+    #[test]
+    fn excluded_link_never_claims_nodes_or_addresses_regardless_of_order() {
+        let shared = Ipv4Addr::new(10, 255, 0, 1);
+        for excluded_first in [true, false] {
+            let excluded = mt_link_route(PEER1, A, X, 1, 2, &[v4_interface(shared)]);
+            let default = link_route(PEER2, B, Y, Some(10), &[v4_interface(shared)]);
+            let routes = if excluded_first {
+                vec![excluded, default]
+            } else {
+                vec![default, excluded]
+            };
+            let topology = OrrTopology::build(routes.iter());
+            assert_eq!(topology.node_count(), 2);
+            assert!(topology.node_ix(&node_key(A)).is_none());
+            assert!(topology.node_ix(&node_key(X)).is_none());
+            assert_eq!(
+                topology.resolve_node(IpAddr::V4(shared)),
+                Some(ix(&topology, B))
+            );
+        }
+    }
+
+    #[test]
+    fn nondefault_only_input_builds_an_empty_graph() {
+        let routes = [
+            mt_link_route(
+                PEER1,
+                A,
+                X,
+                1,
+                2,
+                &[v4_interface(Ipv4Addr::new(10, 255, 0, 2))],
+            ),
+            mt_prefix_route(PEER1, X, Ipv4Addr::new(192, 0, 2, 0), 24, 0, 2),
+        ];
+        let topology = OrrTopology::build(routes.iter());
+        assert_eq!(topology.node_count(), 0);
+        assert_eq!(topology.link_count(), 0);
+        assert_eq!(
+            topology.resolve_node(IpAddr::V4(Ipv4Addr::new(10, 255, 0, 2))),
+            None
+        );
+        assert_eq!(topology.input_diagnostics().excluded_nondefault, 2);
+        assert_eq!(
+            topology.resolve_node(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_attribute_29_never_contributes_any_graph_surface() {
+        let link = rib_route(
+            PEER1,
+            link_nlri(
+                PROTOCOL_ISIS_LEVEL_2,
+                &[v4_interface(Ipv4Addr::new(10, 255, 0, 3))],
+            ),
+            vec![malformed_attribute()],
+        );
+        let routes = [
+            rib_route(
+                PEER1,
+                node_nlri_with_descriptors(PROTOCOL_ISIS_LEVEL_2, &[]),
+                vec![malformed_attribute()],
+            ),
+            link,
+            rib_route(
+                PEER1,
+                prefix_nlri(PROTOCOL_ISIS_LEVEL_2, X, None),
+                vec![malformed_attribute()],
+            ),
+        ];
+        let topology = OrrTopology::build(routes.iter());
+        assert_eq!(topology.node_count(), 0);
+        assert_eq!(topology.link_count(), 0);
+        assert_eq!(
+            topology.resolve_node(IpAddr::V4(Ipv4Addr::new(10, 255, 0, 3))),
+            None
+        );
+        assert_eq!(
+            topology.resolve_node(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+            None
+        );
+        assert_eq!(topology.input_diagnostics().malformed_attribute_29, 3);
+    }
+
+    #[test]
+    fn flex_prefix_metric_is_inert_but_classic_metric_remains_usable() {
+        let mut routes = square_topology(PEER1);
+        let nlri = prefix_nlri(PROTOCOL_ISIS_LEVEL_2, X, None);
+        routes.push(rib_route(
+            PEER1,
+            nlri,
+            vec![bgp_ls_attribute(&[
+                BgpLsTlv::new(
+                    BGP_LS_TLV_PREFIX_METRIC,
+                    Bytes::from(50_u32.to_be_bytes().to_vec()),
+                ),
+                raw_tlv(
+                    BGP_LS_TLV_FLEX_ALGO_PREFIX_METRIC,
+                    &[128, 0, 0, 0, 0, 0, 0, 1],
+                ),
+            ])],
+        ));
+        let topology = OrrTopology::build(routes.iter());
+        let address = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+        assert_eq!(
+            topology.spf(ix(&topology, A)).cost_to(&topology, address),
+            Some(51)
+        );
+        assert_eq!(topology.input_diagnostics().included_default, 5);
+        assert_eq!(
+            topology.input_diagnostics().default_with_ignored_flex_algo,
+            1
+        );
     }
 
     #[test]

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -470,7 +470,8 @@ pub struct ExplainAdvertisedRoute {
     pub route_peer: Option<IpAddr>,
     /// Selected best route type.
     pub route_type: Option<rustbgpd_policy::RouteType>,
-    /// Decisive explanation reasons, in order.
+    /// Explanation reasons, in order. Most entries are decisive; stable
+    /// aggregate diagnostics may be non-decisive and say so explicitly.
     pub reasons: Vec<ExplainReason>,
     /// Export modifications that would be applied.
     pub modifications: rustbgpd_policy::RouteModifications,
@@ -571,7 +572,8 @@ pub enum ExplainDecision {
     UnsupportedFamily,
 }
 
-/// One decisive reason in an advertised-route explanation.
+/// One reason in an advertised-route explanation. A reason may be an
+/// explicitly labeled aggregate/non-decisive diagnostic.
 #[derive(Debug, Clone)]
 pub struct ExplainReason {
     pub code: &'static str,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -19,6 +19,15 @@ static NEXT_METRICS_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 /// recreating, from zero) the series like `with_label_values` does.
 static POLICY_ROUTES_REAP_EPOCH: AtomicU64 = AtomicU64::new(0);
 
+/// Bounded label contract for aggregate ORR topology-input diagnostics.
+const ORR_INPUT_CLASSIFICATIONS: [&str; 5] = [
+    "included_default",
+    "excluded_nondefault",
+    "malformed_topology",
+    "malformed_attribute_29",
+    "default_with_ignored_flex_algo",
+];
+
 /// One memoized `bgp_policy_routes_total` child handle.
 ///
 /// `record_policy_routes` fires once per route × policy evaluation —
@@ -99,6 +108,7 @@ pub struct BgpMetrics {
     orr_topology_nodes: IntGauge,
     orr_topology_links: IntGauge,
     orr_unresolved_vantages: IntGauge,
+    orr_input_objects: IntGaugeVec,
 
     // ── Event streams ───────────────────────────────────────────
     event_stream_lagged: IntCounterVec,
@@ -418,6 +428,20 @@ impl BgpMetrics {
             "Configured RFC 9107 ORR vantages that do not resolve to a BGP-LS topology node (their peers fall back to the standard best path).",
         )
         .expect("valid metric definition");
+
+        let orr_input_objects = IntGaugeVec::new(
+            Opts::new(
+                "bgp_orr_input_objects",
+                "BGP-LS inputs considered by the RFC 9107 ORR default-topology builder, by one of five fixed classifications. Flex-Algorithm inputs remain included in the default total and are also counted by their ignored-data subset label.",
+            ),
+            &["classification"],
+        )
+        .expect("valid metric definition");
+        for classification in ORR_INPUT_CLASSIFICATIONS {
+            orr_input_objects
+                .with_label_values(&[classification])
+                .set(0);
+        }
 
         let event_stream_lagged = IntCounterVec::new(
             Opts::new(
@@ -1394,6 +1418,9 @@ impl BgpMetrics {
             .register(Box::new(orr_unresolved_vantages.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(orr_input_objects.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(event_stream_lagged.clone()))
             .expect("metric not already registered");
         registry
@@ -1731,6 +1758,7 @@ impl BgpMetrics {
             orr_topology_nodes,
             orr_topology_links,
             orr_unresolved_vantages,
+            orr_input_objects,
             event_stream_lagged,
             event_stream_subscribers,
             grpc_authz_decisions,
@@ -2119,6 +2147,16 @@ impl BgpMetrics {
     /// a topology node.
     pub fn set_orr_unresolved_vantages(&self, count: i64) {
         self.orr_unresolved_vantages.set(count);
+    }
+
+    /// Set all five fixed ORR input-classification series. Calling this with
+    /// the default diagnostics resets every series to zero when ORR is idle.
+    pub fn set_orr_input_diagnostics(&self, values: [u64; 5]) {
+        for (classification, value) in ORR_INPUT_CLASSIFICATIONS.iter().zip(values) {
+            self.orr_input_objects
+                .with_label_values(&[classification])
+                .set(i64::try_from(value).unwrap_or(i64::MAX));
+        }
     }
 
     /// Record events missed by a slow live event-stream subscriber.
@@ -3302,9 +3340,40 @@ mod tests {
     fn new_creates_metrics_at_zero() {
         let m = BgpMetrics::new();
         let text = gather_text(&m);
-        // Metrics should be registered but no label vectors initialized yet
-        // (prometheus only emits metrics once a label combination is observed)
+        // Dynamic peer-label vectors remain absent until observed.
         assert!(!text.contains("bgp_session_state_transitions_total"));
+    }
+
+    #[test]
+    fn new_materializes_exactly_five_zero_orr_input_series() {
+        let m = BgpMetrics::new();
+        let family = m
+            .registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "bgp_orr_input_objects")
+            .expect("ORR input diagnostic metric registered");
+        let observed: std::collections::BTreeMap<_, _> = family
+            .metric
+            .iter()
+            .map(|metric| {
+                assert_eq!(metric.get_label().len(), 1, "only classification label");
+                assert_eq!(metric.get_label()[0].name(), "classification");
+                (
+                    metric.get_label()[0].value().to_owned(),
+                    metric.get_gauge().value(),
+                )
+            })
+            .collect();
+        assert_eq!(observed.len(), ORR_INPUT_CLASSIFICATIONS.len());
+        for classification in ORR_INPUT_CLASSIFICATIONS {
+            assert!(
+                observed
+                    .get(classification)
+                    .is_some_and(|value| value.abs() < f64::EPSILON),
+                "{classification} starts at zero"
+            );
+        }
     }
 
     /// LAN-322: the per-peer totals sum every message type in both

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -15,7 +15,10 @@ operator is comfortable with an evolving config and gRPC API.
 - VPNv4 / VPNv6 support is route-reflector / controller-feed only. VRF import,
   MPLS label forwarding, and CE-facing attachment are out of scope.
 - BGP-LS support is receive, reflection, API export, and ORR topology input.
-  rustbgpd does not synthesize local BGP-LS objects.
+  rustbgpd does not synthesize local BGP-LS objects. ORR computes only the
+  RFC 9552 default topology: non-default MT-ID and malformed topology inputs
+  are excluded fail-closed, while Flex-Algorithm data is ignored and no
+  selectable non-default/Flex SPF is implemented.
 - Confederations are not implemented.
 
 ## EVPN

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -456,6 +456,7 @@ authenticated sensitive-read surface.
 | `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The survivor is re-registered, re-sent the initial table, and asked for an inbound ROUTE-REFRESH |
 | `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
 | `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
+| `bgp_orr_input_objects{classification}` | Inputs considered by the ORR default-topology builder before NLRI deduplication. Exactly five classifications exist: `included_default`, `excluded_nondefault`, `malformed_topology`, `malformed_attribute_29`, and `default_with_ignored_flex_algo`. The Flex series is a subset of included default objects: its base object and classic metric remain usable. All series reset to zero when no vantage is configured |
 
 ### Ingress rejection / route-leak detection
 
@@ -1397,7 +1398,12 @@ peer's export is group-staged. Explain queries never count toward
 `bgp_policy_routes_total` or per-term policy hit counters.
 
 An RFC 9107 ORR peer's explain ranks the per-vantage candidate set the
-ORR export uses (with per-candidate cost output); an Add-Path-send
+ORR export uses (with per-candidate cost output). When filtered or ignored
+topology inputs are present, the stable
+`orr_topology_input_diagnostics` reason is explicitly aggregate and
+non-decisive; it does not replace the winner's decisive interior-cost reason.
+`rbgp orr` always prints a `Topology inputs:` aggregate line; JSON and
+`ListOrrStatus` expose the same five counters. An Add-Path-send
 peer's explain covers the best path -- per-rank advertisement detail
 lives in `rbgp rib --prefix X --explain --explain-peer`.
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -32,6 +32,24 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ---
 
+## RFC 9552 and RFC 9107 — ORR topology scope
+
+- ORR builds only the default BGP-LS topology. Link and Prefix NLRIs use a
+  single descriptor MT-ID; Node membership comes only from Multi-Topology TLV
+  263 inside BGP-LS Attribute 29. IS-IS interprets the lower 12 bits, while
+  OSPF requires the reserved high bits clear and a value in `0..=127`.
+- Absent MT-ID is default. A Node list containing zero is default even when it
+  also advertises non-zero memberships. Valid non-zero-only objects are
+  excluded; duplicate, wrongly placed, structurally invalid, or
+  protocol-uninterpretable topology data is excluded fail-closed before graph
+  insertion.
+- Flex-Algorithm definition/prefix inputs and Flex Prefix-SID/SR-Algorithm
+  values do not select another SPF. They are reported as ignored aggregate
+  input while the valid base default object and classic IGP/Prefix Metric stay
+  active.
+
+---
+
 ## RFC 9234 — Roles and Only-to-Customer
 
 - The configured local Role is session-stamped into the RIB before `PeerUp`,

--- a/docs/adr/0095-optimal-route-reflection.md
+++ b/docs/adr/0095-optimal-route-reflection.md
@@ -39,8 +39,12 @@ BIRD/GoBGP/OpenBGPd lack it); only commercial routers do.
    it verbatim (the fidelity M73 pins). The topology builder parses the raw
    bytes lazily and locally: IGP Metric (TLV 1095, 1/2/3-byte forms) as link
    cost — a link without it contributes no edge; Prefix Metric (TLV 1155)
-   for reachability cost; TE Default Metric (1092) parsed but unused;
-   Multi-Topology deferred.
+   for reachability cost; TE Default Metric (1092) parsed but unused. The SPF
+   graph is strictly the default topology. Valid non-default Multi-Topology
+   objects and malformed descriptor/Attribute-29 inputs are classified before
+   deduplication and excluded before they can intern nodes or claim addresses,
+   links, or prefixes. Flex-Algorithm attributes are diagnostic-only: the base
+   default object and classic metric remain usable, but no Flex SPF is run.
 
 3. **Next-hop resolution**: exact match on link interface/neighbor addresses
    (TLVs 259–262) wins outright — an unreachable owner is a real
@@ -102,7 +106,9 @@ BIRD/GoBGP/OpenBGPd lack it); only commercial routers do.
   cost to each candidate's next-hop, exactly like unicast
   (`vpn_tiebreak_orr`, same slot in the chain; the RFC 4684 RTC gate
   applies to the vantage winner).
-- **TE / Multi-Topology metrics** — operator demand.
+- **Selectable non-default Multi-Topology, TE, or Flex-Algorithm SPF** —
+  operator demand. Aggregate default-topology input diagnostics are shipped;
+  selection and per-object diagnostics remain deliberately out of scope.
 - **RFC 9107 §3.2 per-policy multiple Decision Processes** — policy
   divergence below step (e) is out of scope until a concrete case appears.
 

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1527,7 +1527,9 @@ message ExplainAdvertisedRouteResponse {
   // the same candidate set and order distribution would use. The
   // decisive step for the winner is reported through reasons (code
   // orr_interior_cost when the vantage cost decided, with the compared
-  // costs in the message). Empty for non-ORR explains.
+  // costs in the message). Reasons may also contain the explicitly
+  // non-decisive aggregate code orr_topology_input_diagnostics. Empty for
+  // non-ORR explains.
   repeated OrrExplainCandidate orr_candidates = 12;
   // The full export gate ladder in the exact order the live export
   // path evaluates it, one step per gate. A Stop step names the gate
@@ -2729,12 +2731,27 @@ message OrrVantageStatusEntry {
   repeated string peers = 8;
 }
 
+// Aggregate BGP-LS input classification for the cached default-topology ORR
+// graph. Counts are per Adj-RIB-In input before NLRI deduplication.
+message OrrInputDiagnostics {
+  uint64 included_default = 1;
+  uint64 excluded_nondefault = 2;
+  uint64 malformed_topology = 3;
+  uint64 malformed_attribute_29 = 4;
+  // Subset of included_default whose Flex-Algorithm data was ignored while
+  // the base object and classic metric remained usable.
+  uint64 default_with_ignored_flex_algo = 5;
+}
+
 message ListOrrStatusResponse {
   repeated OrrVantageStatusEntry vantages = 1;
   // Cached ORR topology node total.
   uint32 topology_nodes = 2;
   // Cached ORR topology usable-directed-link total.
   uint32 topology_links = 3;
+  // Default-topology input classification. Absent only when talking to an
+  // older server that predates this additive field.
+  OrrInputDiagnostics input_diagnostics = 4;
 }
 
 // Controller-injected EVPN route. Supports Type 2 (MAC/IP), Type 3


### PR DESCRIPTION
## Summary

- classify BGP-LS Node, Link, and Prefix inputs before ORR graph insertion and isolate SPF to the RFC 9552 default topology
- exclude non-default and malformed topology inputs fail closed without changing raw BGP-LS storage, reflection, or API fidelity
- keep Flex-Algorithm data inert while preserving the valid default object and classic IGP/Prefix Metric
- expose bounded aggregate diagnostics through ORR status, CLI JSON/text, fixed-cardinality metrics, transition logs, and non-decisive explain output

## Root cause

The ORR topology builder previously consumed every BGP-LS Link and Prefix NLRI into one graph. MT-ID domains could therefore contribute competing edges, address ownership, and prefix reachability to the same SPF calculation. Malformed BGP-LS Attribute 29 also fell back to an empty attribute set, which could create implicit zero-metric inputs.

## Behavior

Known topology inputs are now classified before deduplication or graph insertion. Absent or explicit MT0 input remains usable; valid non-default input is excluded; malformed descriptor, protocol, placement, or Attribute 29 data is excluded in deterministic categories. Excluded objects cannot intern nodes, claim addresses, affect SPF signatures, dirty ORR peers, or stage outbound changes.

Flex-Algorithm FAD/FAPM and Flex-valued SR attributes are reported as ignored aggregate input while the base default object remains usable. No Flex, TE, or selectable non-default SPF is introduced.

`ListOrrStatusResponse` gains additive field 4. Older-server absence renders as five zero counters in the CLI. Metrics always materialize exactly five fixed label values, including at fresh startup with no configured vantage.

## Validation

- 27 focused ORR classifier/graph tests
- 30 manager ORR integration tests
- API and CLI status/compatibility tests
- fresh five-series telemetry regression
- workspace all-target tests
- workspace all-target Clippy with warnings denied
- rustdoc with warnings denied
- formatting and diff checks
- independent pre- and post-rebase reviews

Linear: [LAN-373](https://linear.app/lance0/issue/LAN-373/orr-must-not-mix-bgp-ls-multi-topology-or-flex-algo-inputs)
