### PR TITLE
refactor(transport): centralize exact session export encoding

### DIFF
--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -254,6 +254,7 @@ impl PeerSession {
                 self.config.gr_stale_routes_time = gr_stale_routes_time;
                 self.config.local_ipv6_nexthop = local_ipv6_nexthop;
                 self.config.remove_private_as = remove_private_as;
+                self.publish_export_profile();
                 info!(peer = %self.peer_label, "hot-applied runtime config knobs");
                 let _ = reply.send(Ok(()));
                 ControlFlow::Continue(())
@@ -264,6 +265,7 @@ impl PeerSession {
                 // RFC 8326 §5 expects the operator to follow this with
                 // a re-advertise so peers see the tagged routes.
                 self.advertise_graceful_shutdown = enabled;
+                self.publish_export_profile();
                 info!(
                     peer = %self.peer_label,
                     enabled,

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -1,0 +1,1735 @@
+//! Authoritative per-session outbound encoding profile and message builder.
+//!
+//! The RIB-facing exportability gate is deliberately deferred to LAN-361.
+//! This module establishes its prerequisite: live emission and exact probes
+//! consume one immutable snapshot of every negotiated, socket, configured,
+//! and runtime input that can change the outbound wire form.
+
+use super::{
+    Afi, AsPath, AsPathSegment, BgpLsRibRoute, BgpLsRouteKey, BgpRole, EvpnRibRoute, EvpnRoute,
+    EvpnRouteKey, FlowSpecKey, FlowSpecRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry,
+    Ipv4UnicastMode, Ipv6Addr, LabeledRibRoute, LabeledRibRouteKey, MpReachNlri, MpUnreachNlri,
+    NlriEntry, PathAttribute, PeerSession, Prefix, RemovePrivateAs, Route, RtcRibRoute,
+    RtcRibRouteKey, Safi, TransportConfig, UpdateMessage, VpnRibRoute, VpnRibRouteKey,
+    is_ipv6_link_local, is_private_asn,
+};
+use std::sync::{Arc, RwLock};
+
+use rustbgpd_wire::EncodeError;
+
+/// Immutable inputs that determine one established session's outbound wire
+/// representation. A complete replacement is published for runtime changes;
+/// readers never observe a mixture of old and new fields.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "the immutable wire profile records independent negotiated capabilities and runtime flags"
+)]
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct SessionExportProfile {
+    generation: u64,
+    local_asn: u32,
+    local_router_id: Ipv4Addr,
+    local_role: Option<BgpRole>,
+    route_server_client: bool,
+    remove_private_as: RemovePrivateAs,
+    cluster_id: Option<Ipv4Addr>,
+    configured_local_ipv6_nexthop: Option<Ipv6Addr>,
+    peer_asn: Option<u32>,
+    four_octet_as: bool,
+    extended_messages: bool,
+    extended_nexthop_ipv4: bool,
+    add_path_send_families: Arc<[(Afi, Safi)]>,
+    peer_llgr_families: Arc<[(Afi, Safi)]>,
+    local_addr: Option<IpAddr>,
+    scoped_link_local_peer: bool,
+    advertise_graceful_shutdown: bool,
+}
+
+impl std::fmt::Debug for SessionExportProfile {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SessionExportProfile")
+            .field("generation", &self.generation)
+            .field("local_asn", &self.local_asn)
+            .field("local_router_id", &self.local_router_id)
+            .field("local_role", &self.local_role)
+            .field("route_server_client", &self.route_server_client)
+            .field("remove_private_as", &self.remove_private_as)
+            .field("cluster_id", &self.cluster_id)
+            .field(
+                "configured_local_ipv6_nexthop",
+                &self.configured_local_ipv6_nexthop,
+            )
+            .field("peer_asn", &self.peer_asn)
+            .field("four_octet_as", &self.four_octet_as)
+            .field("extended_messages", &self.extended_messages)
+            .field("extended_nexthop_ipv4", &self.extended_nexthop_ipv4)
+            .field("add_path_send_families", &self.add_path_send_families)
+            .field("peer_llgr_families", &self.peer_llgr_families)
+            .field("local_addr", &self.local_addr)
+            .field("scoped_link_local_peer", &self.scoped_link_local_peer)
+            .field(
+                "advertise_graceful_shutdown",
+                &self.advertise_graceful_shutdown,
+            )
+            .finish()
+    }
+}
+
+impl SessionExportProfile {
+    pub(super) fn capture(session: &PeerSession) -> Self {
+        let local_addr = session
+            .read_half
+            .as_ref()
+            .and_then(|half| half.local_addr().ok())
+            .map(|addr| addr.ip());
+        let scoped_link_local_peer = matches!(session.peer_ip, IpAddr::V6(v6) if is_ipv6_link_local(&v6))
+            && session.config.peer_interface.is_some()
+            && session.config.peer_scope_id.is_some();
+        Self {
+            generation: 0,
+            local_asn: session.config.peer.local_asn,
+            local_router_id: session.config.peer.local_router_id,
+            local_role: session.config.peer.local_role,
+            route_server_client: session.config.route_server_client,
+            remove_private_as: session.config.remove_private_as,
+            cluster_id: session.config.cluster_id,
+            configured_local_ipv6_nexthop: session.config.local_ipv6_nexthop,
+            peer_asn: session.negotiated.as_ref().map(|neg| neg.peer_asn),
+            four_octet_as: session
+                .negotiated
+                .as_ref()
+                .is_some_and(|neg| neg.four_octet_as),
+            extended_messages: session
+                .negotiated
+                .as_ref()
+                .is_some_and(|neg| neg.peer_extended_message),
+            extended_nexthop_ipv4: session.negotiated.as_ref().is_some_and(|neg| {
+                neg.extended_nexthop_families
+                    .get(&(Afi::Ipv4, Safi::Unicast))
+                    .is_some_and(|afi| *afi == Afi::Ipv6)
+            }),
+            add_path_send_families: Arc::from(
+                session
+                    .negotiated
+                    .as_ref()
+                    .map(|neg| {
+                        neg.add_path_families
+                            .iter()
+                            .filter_map(|(&family, mode)| {
+                                matches!(
+                                    mode,
+                                    rustbgpd_wire::AddPathMode::Send
+                                        | rustbgpd_wire::AddPathMode::Both
+                                )
+                                .then_some(family)
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+            ),
+            peer_llgr_families: Arc::from(
+                session
+                    .negotiated
+                    .as_ref()
+                    .filter(|neg| neg.peer_llgr_capable)
+                    .map(|neg| {
+                        neg.peer_llgr_families
+                            .iter()
+                            .map(|entry| (entry.afi, entry.safi))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+            ),
+            local_addr,
+            scoped_link_local_peer,
+            advertise_graceful_shutdown: session.advertise_graceful_shutdown,
+        }
+    }
+
+    pub(super) fn initial(
+        config: &TransportConfig,
+        local_addr: Option<IpAddr>,
+        advertise_graceful_shutdown: bool,
+    ) -> Self {
+        let peer_ip = config.remote_addr.ip();
+        Self {
+            generation: 0,
+            local_asn: config.peer.local_asn,
+            local_router_id: config.peer.local_router_id,
+            local_role: config.peer.local_role,
+            route_server_client: config.route_server_client,
+            remove_private_as: config.remove_private_as,
+            cluster_id: config.cluster_id,
+            configured_local_ipv6_nexthop: config.local_ipv6_nexthop,
+            peer_asn: None,
+            four_octet_as: false,
+            extended_messages: false,
+            extended_nexthop_ipv4: false,
+            add_path_send_families: Arc::from(Vec::new()),
+            peer_llgr_families: Arc::from(Vec::new()),
+            local_addr,
+            scoped_link_local_peer: matches!(peer_ip, IpAddr::V6(v6) if is_ipv6_link_local(&v6))
+                && config.peer_interface.is_some()
+                && config.peer_scope_id.is_some(),
+            advertise_graceful_shutdown,
+        }
+    }
+
+    pub(crate) const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(super) fn four_octet_as(&self) -> bool {
+        self.four_octet_as
+    }
+
+    pub(super) fn is_ebgp(&self) -> bool {
+        self.peer_asn
+            .is_some_and(|peer_asn| peer_asn != self.local_asn)
+    }
+
+    pub(super) fn add_path_send(&self, family: (Afi, Safi)) -> bool {
+        self.add_path_send_families.contains(&family)
+    }
+
+    pub(crate) fn max_message_len(&self) -> usize {
+        usize::from(if self.extended_messages {
+            rustbgpd_wire::EXTENDED_MAX_MESSAGE_LEN
+        } else {
+            rustbgpd_wire::MAX_MESSAGE_LEN
+        })
+    }
+
+    pub(super) fn use_extended_nexthop_ipv4(&self) -> bool {
+        self.extended_nexthop_ipv4
+    }
+
+    pub(super) const fn is_scoped_link_local_peer(&self) -> bool {
+        self.scoped_link_local_peer
+    }
+
+    pub(super) fn local_ipv4(&self) -> Ipv4Addr {
+        self.local_addr
+            .and_then(|addr| match addr {
+                IpAddr::V4(v4) => Some(v4),
+                IpAddr::V6(_) => None,
+            })
+            .unwrap_or(self.local_router_id)
+    }
+
+    pub(super) fn local_ipv6(&self) -> Option<Ipv6Addr> {
+        self.local_addr.and_then(|addr| match addr {
+            IpAddr::V6(v6) => Some(v6),
+            IpAddr::V4(_) => None,
+        })
+    }
+
+    pub(super) fn usable_ipv4_extended_nexthop_ipv6(
+        &self,
+        candidate: Option<Ipv6Addr>,
+    ) -> Option<Ipv6Addr> {
+        candidate.filter(|addr| {
+            rustbgpd_wire::is_valid_ipv6_nexthop(addr)
+                || (self.scoped_link_local_peer && is_ipv6_link_local(addr))
+        })
+    }
+
+    pub(super) fn usable_ipv6_unicast_next_hop(candidate: Option<Ipv6Addr>) -> Option<Ipv6Addr> {
+        candidate.filter(rustbgpd_wire::is_valid_ipv6_nexthop)
+    }
+
+    pub(super) fn ipv4_mp_reach_link_local_next_hop(
+        &self,
+        next_hop: IpAddr,
+        route: &Route,
+    ) -> Option<Ipv6Addr> {
+        match next_hop {
+            IpAddr::V6(v6) if self.scoped_link_local_peer && is_ipv6_link_local(&v6) => Some(v6),
+            _ if next_hop == route.next_hop => route.link_local_next_hop,
+            _ => None,
+        }
+    }
+
+    pub(super) fn route_link_local_next_hop_for_selected_primary(
+        next_hop: IpAddr,
+        route: &Route,
+    ) -> Option<Ipv6Addr> {
+        (next_hop == route.next_hop)
+            .then_some(route.link_local_next_hop)
+            .flatten()
+    }
+
+    fn peer_accepts_llgr_stale(&self, family: (Afi, Safi)) -> bool {
+        self.peer_llgr_families.contains(&family)
+    }
+
+    fn apply_llgr_stale_export_form(
+        &self,
+        attrs: &mut Vec<PathAttribute>,
+        family: (Afi, Safi),
+        is_ebgp: bool,
+    ) {
+        if is_ebgp || self.peer_accepts_llgr_stale(family) {
+            return;
+        }
+        let is_llgr_stale = attrs.iter().any(|attr| {
+            matches!(attr, PathAttribute::Communities(comms)
+                if comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
+        });
+        if !is_llgr_stale {
+            return;
+        }
+        let mut has_local_pref = false;
+        for attr in attrs.iter_mut() {
+            match attr {
+                PathAttribute::LocalPref(local_pref) => {
+                    *local_pref = 0;
+                    has_local_pref = true;
+                }
+                PathAttribute::Communities(comms)
+                    if !comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT) =>
+                {
+                    comms.push(rustbgpd_wire::COMMUNITY_NO_EXPORT);
+                }
+                _ => {}
+            }
+        }
+        if !has_local_pref {
+            attrs.push(PathAttribute::LocalPref(0));
+        }
+    }
+
+    fn attach_graceful_shutdown_if_enabled(&self, attrs: &mut Vec<PathAttribute>) {
+        if !self.advertise_graceful_shutdown {
+            return;
+        }
+        for attr in attrs.iter_mut() {
+            if let PathAttribute::Communities(comms) = attr {
+                if !comms.contains(&rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN) {
+                    comms.push(rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN);
+                }
+                return;
+            }
+        }
+        attrs.push(PathAttribute::Communities(vec![
+            rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN,
+        ]));
+    }
+
+    /// Prepare the classic unicast attribute set using only this immutable
+    /// profile and the post-policy route candidate.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "keeps the ordered outbound attribute transformation in one auditable pass"
+    )]
+    pub(super) fn prepare_unicast_attributes(
+        &self,
+        route: &Route,
+        local_ipv4: Ipv4Addr,
+        nh_override: Option<&rustbgpd_policy::NextHopAction>,
+    ) -> Vec<PathAttribute> {
+        let is_ebgp = self.is_ebgp();
+        let force_next_hop_self =
+            matches!(nh_override, Some(rustbgpd_policy::NextHopAction::Self_));
+        let policy_set_specific = matches!(
+            nh_override,
+            Some(rustbgpd_policy::NextHopAction::Specific(_))
+        );
+        let route_server_client = self.route_server_client;
+        let mut attrs = Vec::new();
+        for attr in route.attributes.iter() {
+            match attr {
+                PathAttribute::AsPath(as_path) if is_ebgp && !route_server_client => {
+                    let cleaned =
+                        remove_private_asns(as_path, self.remove_private_as, self.local_asn);
+                    let mut new_segments = vec![AsPathSegment::AsSequence(vec![self.local_asn])];
+                    for segment in &cleaned.segments {
+                        match segment {
+                            AsPathSegment::AsSequence(asns) => {
+                                if let Some(AsPathSegment::AsSequence(first)) =
+                                    new_segments.first_mut()
+                                {
+                                    first.extend(asns);
+                                }
+                            }
+                            AsPathSegment::AsSet(asns) => {
+                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
+                            }
+                        }
+                    }
+                    attrs.push(PathAttribute::AsPath(AsPath {
+                        segments: new_segments,
+                    }));
+                }
+                PathAttribute::NextHop(_) => {
+                    if policy_set_specific {
+                        attrs.push(attr.clone());
+                    } else if force_next_hop_self || (is_ebgp && !route_server_client) {
+                        attrs.push(PathAttribute::NextHop(local_ipv4));
+                    } else {
+                        attrs.push(attr.clone());
+                    }
+                }
+                PathAttribute::LocalPref(_) => {
+                    if !is_ebgp {
+                        attrs.push(attr.clone());
+                    }
+                }
+                PathAttribute::MpReachNlri(_) | PathAttribute::MpUnreachNlri(_) => {}
+                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
+                _ => attrs.push(attr.clone()),
+            }
+        }
+        if !is_ebgp
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
+        {
+            attrs.push(PathAttribute::LocalPref(100));
+        }
+        if is_ebgp
+            && matches!(
+                self.local_role,
+                Some(BgpRole::Provider | BgpRole::Peer | BgpRole::RouteServer)
+            )
+            && !has_otc(&attrs)
+        {
+            attrs.push(PathAttribute::OnlyToCustomer(self.local_asn));
+        }
+        if matches!(route.prefix, Prefix::V4(_))
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::NextHop(_)))
+        {
+            let next_hop = match nh_override {
+                Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V4(next_hop))) => {
+                    Some(*next_hop)
+                }
+                Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V6(_))) => {
+                    tracing::warn!(
+                        prefix = %route.prefix,
+                        "export policy set IPv6 next-hop for classic IPv4 NLRI; \
+                         requires Extended Next Hop (RFC 8950) — using default next-hop instead"
+                    );
+                    if is_ebgp && !route_server_client {
+                        Some(local_ipv4)
+                    } else {
+                        match route.next_hop {
+                            IpAddr::V4(next_hop) => Some(next_hop),
+                            IpAddr::V6(_) => None,
+                        }
+                    }
+                }
+                Some(rustbgpd_policy::NextHopAction::Self_) => Some(local_ipv4),
+                _ if is_ebgp && !route_server_client => Some(local_ipv4),
+                _ => match route.next_hop {
+                    IpAddr::V4(next_hop) => Some(next_hop),
+                    IpAddr::V6(_) => None,
+                },
+            };
+            if let Some(next_hop) = next_hop {
+                attrs.push(PathAttribute::NextHop(next_hop));
+            }
+        }
+        if is_ebgp
+            && !route_server_client
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
+        {
+            attrs.push(PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![self.local_asn])],
+            }));
+        }
+        self.apply_reflector_attributes(
+            &mut attrs,
+            route.origin_type,
+            route.peer_router_id,
+            is_ebgp,
+        );
+        let family = match route.prefix {
+            Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
+            Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
+        };
+        self.attach_graceful_shutdown_if_enabled(&mut attrs);
+        self.apply_llgr_stale_export_form(&mut attrs, family, is_ebgp);
+        attrs
+    }
+
+    fn prepare_mp_attributes(
+        &self,
+        attributes: &[PathAttribute],
+        origin_type: rustbgpd_rib::RouteOrigin,
+        peer_router_id: Ipv4Addr,
+        family: (Afi, Safi),
+    ) -> Vec<PathAttribute> {
+        let is_ebgp = self.is_ebgp();
+        let mut attrs = Vec::new();
+        for attr in attributes {
+            match attr {
+                PathAttribute::AsPath(as_path) if is_ebgp && !self.route_server_client => {
+                    let cleaned =
+                        remove_private_asns(as_path, self.remove_private_as, self.local_asn);
+                    let mut new_segments = vec![AsPathSegment::AsSequence(vec![self.local_asn])];
+                    for segment in &cleaned.segments {
+                        match segment {
+                            AsPathSegment::AsSequence(asns) => {
+                                if let Some(AsPathSegment::AsSequence(first)) =
+                                    new_segments.first_mut()
+                                {
+                                    first.extend(asns);
+                                }
+                            }
+                            AsPathSegment::AsSet(asns) => {
+                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
+                            }
+                        }
+                    }
+                    attrs.push(PathAttribute::AsPath(AsPath {
+                        segments: new_segments,
+                    }));
+                }
+                PathAttribute::NextHop(_)
+                | PathAttribute::MpReachNlri(_)
+                | PathAttribute::MpUnreachNlri(_) => {}
+                PathAttribute::LocalPref(_) => {
+                    if !is_ebgp {
+                        attrs.push(attr.clone());
+                    }
+                }
+                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
+                _ => attrs.push(attr.clone()),
+            }
+        }
+        if !is_ebgp
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
+        {
+            attrs.push(PathAttribute::LocalPref(100));
+        }
+        if is_ebgp
+            && !self.route_server_client
+            && !attrs
+                .iter()
+                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
+        {
+            attrs.push(PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![self.local_asn])],
+            }));
+        }
+        self.apply_reflector_attributes(&mut attrs, origin_type, peer_router_id, is_ebgp);
+        self.attach_graceful_shutdown_if_enabled(&mut attrs);
+        self.apply_llgr_stale_export_form(&mut attrs, family, is_ebgp);
+        attrs
+    }
+
+    fn apply_reflector_attributes(
+        &self,
+        attrs: &mut Vec<PathAttribute>,
+        origin_type: rustbgpd_rib::RouteOrigin,
+        peer_router_id: Ipv4Addr,
+        is_ebgp: bool,
+    ) {
+        if is_ebgp || origin_type != rustbgpd_rib::RouteOrigin::Ibgp {
+            return;
+        }
+        let Some(cluster_id) = self.cluster_id else {
+            return;
+        };
+        if !attrs
+            .iter()
+            .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
+        {
+            attrs.push(PathAttribute::OriginatorId(peer_router_id));
+        }
+        if let Some(ids) = attrs.iter_mut().find_map(|attr| match attr {
+            PathAttribute::ClusterList(ids) => Some(ids),
+            _ => None,
+        }) {
+            ids.insert(0, cluster_id);
+        } else {
+            attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
+        }
+    }
+
+    pub(super) fn prepare_flowspec_attributes(&self, route: &FlowSpecRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            (route.afi, Safi::FlowSpec),
+        )
+    }
+
+    pub(super) fn prepare_evpn_attributes(&self, route: &EvpnRibRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            (Afi::L2Vpn, Safi::Evpn),
+        )
+    }
+
+    pub(super) fn prepare_bgpls_attributes(&self, route: &BgpLsRibRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            route.family.to_afi_safi(),
+        )
+    }
+
+    pub(super) fn prepare_vpn_attributes(&self, route: &VpnRibRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            route.afi_safi(),
+        )
+    }
+
+    pub(super) fn prepare_labeled_attributes(&self, route: &LabeledRibRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            route.afi_safi(),
+        )
+    }
+
+    pub(super) fn prepare_rtc_attributes(&self, route: &RtcRibRoute) -> Vec<PathAttribute> {
+        self.prepare_mp_attributes(
+            &route.attributes,
+            route.origin_type,
+            route.peer_router_id,
+            (Afi::Ipv4, Safi::RtConstrain),
+        )
+    }
+
+    pub(super) fn rtc_next_hop(&self, route: &RtcRibRoute) -> IpAddr {
+        if route.next_hop.is_unspecified() {
+            self.local_addr.unwrap_or(IpAddr::V4(self.local_ipv4()))
+        } else {
+            route.next_hop
+        }
+    }
+
+    pub(super) fn prepare_flowspec_candidate(
+        &self,
+        route: &FlowSpecRoute,
+    ) -> PreparedMpCandidate<FlowSpecRule> {
+        PreparedMpCandidate {
+            afi: route.afi,
+            safi: Safi::FlowSpec,
+            next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            link_local_next_hop: None,
+            attrs: self.prepare_flowspec_attributes(route),
+            nlri: route.rule.clone(),
+        }
+    }
+
+    pub(super) fn prepare_evpn_candidate(
+        &self,
+        route: &EvpnRibRoute,
+    ) -> PreparedMpCandidate<EvpnRoute> {
+        PreparedMpCandidate {
+            afi: Afi::L2Vpn,
+            safi: Safi::Evpn,
+            next_hop: route.next_hop,
+            link_local_next_hop: None,
+            attrs: self.prepare_evpn_attributes(route),
+            nlri: route.route.clone(),
+        }
+    }
+
+    pub(super) fn prepare_bgpls_candidate(
+        &self,
+        route: &BgpLsRibRoute,
+    ) -> PreparedMpCandidate<rustbgpd_wire::bgpls::BgpLsNlri> {
+        let (afi, safi) = route.family.to_afi_safi();
+        PreparedMpCandidate {
+            afi,
+            safi,
+            next_hop: route.next_hop,
+            link_local_next_hop: None,
+            attrs: self.prepare_bgpls_attributes(route),
+            nlri: route.nlri.clone(),
+        }
+    }
+
+    pub(super) fn prepare_vpn_candidate(
+        &self,
+        route: &VpnRibRoute,
+    ) -> PreparedMpCandidate<rustbgpd_wire::VpnNlriEntry> {
+        let (afi, safi) = route.afi_safi();
+        PreparedMpCandidate {
+            afi,
+            safi,
+            next_hop: route.next_hop,
+            link_local_next_hop: route.link_local_next_hop,
+            attrs: self.prepare_vpn_attributes(route),
+            nlri: rustbgpd_wire::VpnNlriEntry {
+                path_id: route.path_id,
+                nlri: route.nlri.clone(),
+            },
+        }
+    }
+
+    pub(super) fn prepare_labeled_candidate(
+        &self,
+        route: &LabeledRibRoute,
+    ) -> PreparedMpCandidate<rustbgpd_wire::LabeledNlriEntry> {
+        let (afi, safi) = route.afi_safi();
+        PreparedMpCandidate {
+            afi,
+            safi,
+            next_hop: route.next_hop,
+            link_local_next_hop: route.link_local_next_hop,
+            attrs: self.prepare_labeled_attributes(route),
+            nlri: rustbgpd_wire::LabeledNlriEntry {
+                path_id: route.path_id,
+                nlri: route.nlri.clone(),
+            },
+        }
+    }
+
+    pub(super) fn prepare_rtc_candidate(
+        &self,
+        route: &RtcRibRoute,
+    ) -> PreparedMpCandidate<rustbgpd_wire::RtcNlri> {
+        PreparedMpCandidate {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            next_hop: self.rtc_next_hop(route),
+            link_local_next_hop: None,
+            attrs: self.prepare_rtc_attributes(route),
+            nlri: route.nlri,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_test_ebgp(mut self, is_ebgp: bool) -> Self {
+        self.peer_asn = Some(if is_ebgp {
+            self.local_asn.wrapping_add(1)
+        } else {
+            self.local_asn
+        });
+        self
+    }
+
+    /// Prepare one post-policy unicast route from this profile. Live grouping
+    /// and exact preflight both consume this result, including policy next-hop
+    /// override, socket/config next-hop selection, ENHE, and link-local form.
+    #[allow(dead_code, reason = "crate-private high-level LAN-361 probe bridge")]
+    pub(crate) fn prepare_unicast_candidate(
+        &self,
+        route: &Route,
+        next_hop_override: Option<&rustbgpd_policy::NextHopAction>,
+    ) -> Result<PreparedUnicastCandidate, ExportProbeError> {
+        let attrs =
+            self.prepare_unicast_attribute_bundle(route, self.local_ipv4(), next_hop_override);
+        self.finish_unicast_candidate(route, next_hop_override, attrs)
+    }
+
+    pub(super) fn prepare_unicast_attribute_bundle(
+        &self,
+        route: &Route,
+        local_ipv4: Ipv4Addr,
+        next_hop_override: Option<&rustbgpd_policy::NextHopAction>,
+    ) -> PreparedUnicastAttributes {
+        let with_next_hop =
+            Arc::new(self.prepare_unicast_attributes(route, local_ipv4, next_hop_override));
+        let without_next_hop = Arc::new(
+            with_next_hop
+                .iter()
+                .filter(|attr| !matches!(attr, PathAttribute::NextHop(_)))
+                .cloned()
+                .collect(),
+        );
+        PreparedUnicastAttributes {
+            with_next_hop,
+            without_next_hop,
+        }
+    }
+
+    pub(super) fn finish_unicast_candidate(
+        &self,
+        route: &Route,
+        next_hop_override: Option<&rustbgpd_policy::NextHopAction>,
+        attrs: PreparedUnicastAttributes,
+    ) -> Result<PreparedUnicastCandidate, ExportProbeError> {
+        let local_ipv4 = self.local_ipv4();
+        match route.prefix {
+            Prefix::V4(_prefix) if self.use_extended_nexthop_ipv4() => {
+                let force_self = matches!(
+                    next_hop_override,
+                    Some(rustbgpd_policy::NextHopAction::Self_)
+                );
+                let ebgp_ipv6 = self.usable_ipv4_extended_nexthop_ipv6(
+                    self.configured_local_ipv6_nexthop.or(self.local_ipv6()),
+                );
+                let next_hop = match next_hop_override {
+                    Some(rustbgpd_policy::NextHopAction::Specific(addr)) => *addr,
+                    _ if force_self => self.local_addr.unwrap_or(IpAddr::V4(local_ipv4)),
+                    _ if self.is_ebgp() && !self.route_server_client => {
+                        IpAddr::V6(ebgp_ipv6.ok_or(ExportProbeError::MissingIpv6NextHop)?)
+                    }
+                    _ => route.next_hop,
+                };
+                Ok(PreparedUnicastCandidate::Mp {
+                    afi: Afi::Ipv4,
+                    next_hop,
+                    link_local_next_hop: self.ipv4_mp_reach_link_local_next_hop(next_hop, route),
+                    attrs: attrs.without_next_hop,
+                    entry: NlriEntry {
+                        path_id: route.path_id,
+                        prefix: route.prefix,
+                    },
+                    ipv4_mode: Ipv4UnicastMode::MpReach,
+                })
+            }
+            Prefix::V4(prefix) => {
+                if self.scoped_link_local_peer {
+                    return Err(ExportProbeError::Ipv4RequiresExtendedNextHop);
+                }
+                Ok(PreparedUnicastCandidate::Ipv4Body {
+                    attrs: attrs.with_next_hop,
+                    entry: Ipv4NlriEntry {
+                        path_id: route.path_id,
+                        prefix,
+                    },
+                })
+            }
+            Prefix::V6(_) => {
+                let usable_local = Self::usable_ipv6_unicast_next_hop(
+                    self.configured_local_ipv6_nexthop.or(self.local_ipv6()),
+                );
+                let force_self = matches!(
+                    next_hop_override,
+                    Some(rustbgpd_policy::NextHopAction::Self_)
+                );
+                let next_hop = match next_hop_override {
+                    Some(rustbgpd_policy::NextHopAction::Specific(addr)) => *addr,
+                    _ if self.is_ebgp() && !self.route_server_client => {
+                        IpAddr::V6(usable_local.ok_or(ExportProbeError::MissingIpv6NextHop)?)
+                    }
+                    _ if force_self => usable_local.map_or(route.next_hop, IpAddr::V6),
+                    _ => route.next_hop,
+                };
+                Ok(PreparedUnicastCandidate::Mp {
+                    afi: Afi::Ipv6,
+                    next_hop,
+                    link_local_next_hop: Self::route_link_local_next_hop_for_selected_primary(
+                        next_hop, route,
+                    ),
+                    attrs: attrs.with_next_hop,
+                    entry: NlriEntry {
+                        path_id: route.path_id,
+                        prefix: route.prefix,
+                    },
+                    ipv4_mode: Ipv4UnicastMode::Body,
+                })
+            }
+        }
+    }
+
+    #[allow(
+        dead_code,
+        clippy::too_many_lines,
+        reason = "crate-private high-level LAN-361 probe bridge enumerates every supported family"
+    )]
+    pub(crate) fn probe_announcement(
+        &self,
+        candidate: ExportCandidate<'_>,
+    ) -> Result<ExactExportProbe, ExportProbeError> {
+        match candidate {
+            ExportCandidate::Unicast {
+                route,
+                next_hop_override,
+            } => match self.prepare_unicast_candidate(route, next_hop_override)? {
+                PreparedUnicastCandidate::Ipv4Body { attrs, entry } => self
+                    .probe_ipv4_body(std::slice::from_ref(&entry), &[], &attrs)
+                    .map_err(Into::into),
+                PreparedUnicastCandidate::Mp {
+                    afi,
+                    next_hop,
+                    link_local_next_hop,
+                    attrs,
+                    entry,
+                    ipv4_mode,
+                } => self
+                    .probe_mp_reach(
+                        afi,
+                        Safi::Unicast,
+                        next_hop,
+                        link_local_next_hop,
+                        &attrs,
+                        ReachNlri::Unicast(std::slice::from_ref(&entry)),
+                        ipv4_mode,
+                    )
+                    .map_err(Into::into),
+            },
+            ExportCandidate::FlowSpec(route) => {
+                let prepared = self.prepare_flowspec_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::FlowSpec(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+            ExportCandidate::Evpn(route) => {
+                let prepared = self.prepare_evpn_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::Evpn(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+            ExportCandidate::BgpLs(route) => {
+                let prepared = self.prepare_bgpls_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::BgpLs(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+            ExportCandidate::Vpn(route) => {
+                let prepared = self.prepare_vpn_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::Vpn(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+            ExportCandidate::Labeled(route) => {
+                let prepared = self.prepare_labeled_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::Labeled(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+            ExportCandidate::Rtc(route) => {
+                let prepared = self.prepare_rtc_candidate(route);
+                self.probe_mp_reach(
+                    prepared.afi,
+                    prepared.safi,
+                    prepared.next_hop,
+                    prepared.link_local_next_hop,
+                    &prepared.attrs,
+                    ReachNlri::Rtc(std::slice::from_ref(&prepared.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into)
+            }
+        }
+    }
+
+    #[allow(dead_code, reason = "crate-private high-level LAN-361 probe bridge")]
+    pub(crate) fn probe_withdrawal(
+        &self,
+        withdrawal: ExportWithdrawal<'_>,
+    ) -> Result<ExactExportProbe, ExportProbeError> {
+        match withdrawal {
+            ExportWithdrawal::Unicast { prefix, path_id } => match prefix {
+                Prefix::V4(prefix) if self.use_extended_nexthop_ipv4() => {
+                    let entry = NlriEntry {
+                        path_id,
+                        prefix: Prefix::V4(prefix),
+                    };
+                    self.probe_mp_unreach(
+                        Afi::Ipv4,
+                        Safi::Unicast,
+                        UnreachNlri::Unicast(std::slice::from_ref(&entry)),
+                        Ipv4UnicastMode::MpReach,
+                    )
+                    .map_err(Into::into)
+                }
+                Prefix::V4(prefix) => {
+                    if self.scoped_link_local_peer {
+                        return Err(ExportProbeError::Ipv4RequiresExtendedNextHop);
+                    }
+                    self.probe_ipv4_body(
+                        &[],
+                        std::slice::from_ref(&Ipv4NlriEntry { path_id, prefix }),
+                        &[],
+                    )
+                    .map_err(Into::into)
+                }
+                Prefix::V6(_) => {
+                    let entry = NlriEntry { path_id, prefix };
+                    self.probe_mp_unreach(
+                        Afi::Ipv6,
+                        Safi::Unicast,
+                        UnreachNlri::Unicast(std::slice::from_ref(&entry)),
+                        Ipv4UnicastMode::Body,
+                    )
+                    .map_err(Into::into)
+                }
+            },
+            ExportWithdrawal::FlowSpec(key) => self
+                .probe_mp_unreach(
+                    key.afi,
+                    Safi::FlowSpec,
+                    UnreachNlri::FlowSpec(std::slice::from_ref(&key.rule)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+            ExportWithdrawal::Evpn(key) => self
+                .probe_mp_unreach(
+                    Afi::L2Vpn,
+                    Safi::Evpn,
+                    UnreachNlri::Evpn(std::slice::from_ref(&evpn_route_from_key(*key))),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+            ExportWithdrawal::BgpLs(key) => self
+                .probe_mp_unreach(
+                    Afi::BgpLs,
+                    key.family.to_afi_safi().1,
+                    UnreachNlri::BgpLs(std::slice::from_ref(&bgpls_nlri_from_key(key))),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+            ExportWithdrawal::Vpn(key) => self
+                .probe_mp_unreach(
+                    key.afi_safi().0,
+                    Safi::MplsVpn,
+                    UnreachNlri::Vpn(std::slice::from_ref(&vpn_withdraw_entry(key))),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+            ExportWithdrawal::Labeled(key) => self
+                .probe_mp_unreach(
+                    key.afi_safi().0,
+                    Safi::LabeledUnicast,
+                    UnreachNlri::Labeled(std::slice::from_ref(&labeled_withdraw_entry(key))),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+            ExportWithdrawal::Rtc(key) => self
+                .probe_mp_unreach(
+                    Afi::Ipv4,
+                    Safi::RtConstrain,
+                    UnreachNlri::Rtc(std::slice::from_ref(&key.nlri)),
+                    Ipv4UnicastMode::Body,
+                )
+                .map_err(Into::into),
+        }
+    }
+
+    pub(super) fn build_ipv4_body(
+        &self,
+        announced: &[Ipv4NlriEntry],
+        withdrawn: &[Ipv4NlriEntry],
+        attrs: &[PathAttribute],
+    ) -> Result<UpdateMessage, EncodeError> {
+        self.probe_ipv4_body(announced, withdrawn, attrs)
+            .map(ExactExportProbe::into_message)
+    }
+
+    pub(crate) fn probe_ipv4_body(
+        &self,
+        announced: &[Ipv4NlriEntry],
+        withdrawn: &[Ipv4NlriEntry],
+        attrs: &[PathAttribute],
+    ) -> Result<ExactExportProbe, EncodeError> {
+        let message = UpdateMessage::try_build(
+            announced,
+            withdrawn,
+            attrs,
+            self.four_octet_as(),
+            self.add_path_send((Afi::Ipv4, Safi::Unicast)),
+            Ipv4UnicastMode::Body,
+        )?;
+        Ok(self.exact_probe(message))
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "MP_REACH wire framing has independent family, next-hop, attribute, and NLRI inputs"
+    )]
+    pub(super) fn build_mp_reach(
+        &self,
+        afi: Afi,
+        safi: Safi,
+        next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
+        base_attrs: &[PathAttribute],
+        nlri: ReachNlri<'_>,
+        ipv4_mode: Ipv4UnicastMode,
+    ) -> Result<UpdateMessage, EncodeError> {
+        self.probe_mp_reach(
+            afi,
+            safi,
+            next_hop,
+            link_local_next_hop,
+            base_attrs,
+            nlri,
+            ipv4_mode,
+        )
+        .map(ExactExportProbe::into_message)
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "MP_REACH exact probe mirrors the authoritative builder inputs"
+    )]
+    pub(crate) fn probe_mp_reach(
+        &self,
+        afi: Afi,
+        safi: Safi,
+        next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
+        base_attrs: &[PathAttribute],
+        nlri: ReachNlri<'_>,
+        ipv4_mode: Ipv4UnicastMode,
+    ) -> Result<ExactExportProbe, EncodeError> {
+        let mut attrs = base_attrs.to_vec();
+        attrs.push(PathAttribute::MpReachNlri(nlri.into_mp_reach(
+            afi,
+            safi,
+            next_hop,
+            link_local_next_hop,
+        )));
+        let message = UpdateMessage::try_build(
+            &[],
+            &[],
+            &attrs,
+            self.four_octet_as(),
+            self.add_path_send((afi, safi)),
+            ipv4_mode,
+        )?;
+        Ok(self.exact_probe(message))
+    }
+
+    pub(super) fn build_mp_unreach(
+        &self,
+        afi: Afi,
+        safi: Safi,
+        nlri: UnreachNlri<'_>,
+        ipv4_mode: Ipv4UnicastMode,
+    ) -> Result<UpdateMessage, EncodeError> {
+        self.probe_mp_unreach(afi, safi, nlri, ipv4_mode)
+            .map(ExactExportProbe::into_message)
+    }
+
+    pub(crate) fn probe_mp_unreach(
+        &self,
+        afi: Afi,
+        safi: Safi,
+        nlri: UnreachNlri<'_>,
+        ipv4_mode: Ipv4UnicastMode,
+    ) -> Result<ExactExportProbe, EncodeError> {
+        let attrs = vec![PathAttribute::MpUnreachNlri(
+            nlri.into_mp_unreach(afi, safi),
+        )];
+        let message = UpdateMessage::try_build(
+            &[],
+            &[],
+            &attrs,
+            self.four_octet_as(),
+            self.add_path_send((afi, safi)),
+            ipv4_mode,
+        )?;
+        Ok(self.exact_probe(message))
+    }
+
+    fn exact_probe(&self, message: UpdateMessage) -> ExactExportProbe {
+        ExactExportProbe {
+            encoded_len: message.encoded_len(),
+            max_len: self.max_message_len(),
+            generation: self.generation,
+            message,
+        }
+    }
+
+    pub(super) fn build_end_of_rib(
+        &self,
+        afi: Afi,
+        safi: Safi,
+    ) -> Result<UpdateMessage, EncodeError> {
+        if (afi, safi) == (Afi::Ipv4, Safi::Unicast) {
+            self.build_ipv4_body(&[], &[], &[])
+        } else {
+            self.build_mp_unreach(afi, safi, UnreachNlri::Unicast(&[]), Ipv4UnicastMode::Body)
+        }
+    }
+}
+
+/// Real post-policy announcement inputs accepted by the exact probe bridge.
+#[allow(dead_code, reason = "crate-private high-level LAN-361 probe bridge")]
+#[derive(Clone, Copy)]
+pub(crate) enum ExportCandidate<'a> {
+    Unicast {
+        route: &'a Route,
+        next_hop_override: Option<&'a rustbgpd_policy::NextHopAction>,
+    },
+    FlowSpec(&'a FlowSpecRoute),
+    Evpn(&'a EvpnRibRoute),
+    BgpLs(&'a BgpLsRibRoute),
+    Vpn(&'a VpnRibRoute),
+    Labeled(&'a LabeledRibRoute),
+    Rtc(&'a RtcRibRoute),
+}
+
+/// Real Adj-RIB-Out withdrawal identities accepted by the exact probe bridge.
+#[allow(dead_code, reason = "crate-private high-level LAN-361 probe bridge")]
+#[derive(Clone, Copy)]
+pub(crate) enum ExportWithdrawal<'a> {
+    Unicast { prefix: Prefix, path_id: u32 },
+    FlowSpec(&'a FlowSpecKey),
+    Evpn(&'a EvpnRouteKey),
+    BgpLs(&'a BgpLsRouteKey),
+    Vpn(&'a VpnRibRouteKey),
+    Labeled(&'a LabeledRibRouteKey),
+    Rtc(&'a RtcRibRouteKey),
+}
+
+#[allow(
+    dead_code,
+    reason = "high-level probe consumes metadata beyond live grouping"
+)]
+pub(crate) enum PreparedUnicastCandidate {
+    Ipv4Body {
+        attrs: Arc<Vec<PathAttribute>>,
+        entry: Ipv4NlriEntry,
+    },
+    Mp {
+        afi: Afi,
+        next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
+        attrs: Arc<Vec<PathAttribute>>,
+        entry: NlriEntry,
+        ipv4_mode: Ipv4UnicastMode,
+    },
+}
+
+#[derive(Clone)]
+pub(super) struct PreparedUnicastAttributes {
+    pub(super) with_next_hop: Arc<Vec<PathAttribute>>,
+    pub(super) without_next_hop: Arc<Vec<PathAttribute>>,
+}
+
+pub(super) struct PreparedMpCandidate<T> {
+    pub(super) afi: Afi,
+    pub(super) safi: Safi,
+    pub(super) next_hop: IpAddr,
+    pub(super) link_local_next_hop: Option<Ipv6Addr>,
+    pub(super) attrs: Vec<PathAttribute>,
+    pub(super) nlri: T,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExportProbeError {
+    Encode(EncodeError),
+    MissingIpv6NextHop,
+    Ipv4RequiresExtendedNextHop,
+}
+
+impl From<EncodeError> for ExportProbeError {
+    fn from(error: EncodeError) -> Self {
+        Self::Encode(error)
+    }
+}
+
+impl std::fmt::Display for ExportProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Encode(error) => error.fmt(formatter),
+            Self::MissingIpv6NextHop => formatter.write_str("no usable local IPv6 next-hop"),
+            Self::Ipv4RequiresExtendedNextHop => formatter
+                .write_str("IPv4 on a scoped link-local session requires Extended Next Hop"),
+        }
+    }
+}
+
+pub(super) fn vpn_withdraw_entry(key: &VpnRibRouteKey) -> rustbgpd_wire::VpnNlriEntry {
+    rustbgpd_wire::VpnNlriEntry {
+        path_id: key.path_id,
+        nlri: rustbgpd_wire::VpnNlri {
+            labels: vec![],
+            route_distinguisher: key.nlri_key.route_distinguisher,
+            prefix: key.nlri_key.prefix,
+        },
+    }
+}
+
+pub(super) fn labeled_withdraw_entry(key: &LabeledRibRouteKey) -> rustbgpd_wire::LabeledNlriEntry {
+    rustbgpd_wire::LabeledNlriEntry {
+        path_id: key.path_id,
+        nlri: rustbgpd_wire::LabeledNlri {
+            labels: vec![],
+            prefix: key.prefix,
+        },
+    }
+}
+
+pub(super) fn bgpls_nlri_from_key(key: &BgpLsRouteKey) -> rustbgpd_wire::bgpls::BgpLsNlri {
+    rustbgpd_wire::bgpls::BgpLsNlri {
+        nlri_type: key.nlri.nlri_type,
+        route_distinguisher: key.nlri.route_distinguisher,
+        payload: key.nlri.payload.clone(),
+    }
+}
+
+pub(super) fn evpn_route_from_key(key: EvpnRouteKey) -> EvpnRoute {
+    use rustbgpd_wire::{
+        EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnImet, EvpnIpPrefixRoute, EvpnMacIp, MplsLabel,
+    };
+    let zero_label = MplsLabel::new(0);
+    match key {
+        EvpnRouteKey::EadPerEs {
+            rd,
+            esi,
+            ethernet_tag,
+        } => EvpnRoute::EadPerEs(EvpnEadPerEs {
+            rd,
+            esi,
+            ethernet_tag,
+            label: zero_label,
+        }),
+        EvpnRouteKey::EadPerEvi {
+            rd,
+            esi,
+            ethernet_tag,
+        } => EvpnRoute::EadPerEvi(EvpnEadPerEvi {
+            rd,
+            esi,
+            ethernet_tag,
+            label: zero_label,
+        }),
+        EvpnRouteKey::MacIp {
+            rd,
+            ethernet_tag,
+            mac,
+            ip,
+        } => EvpnRoute::MacIp(EvpnMacIp {
+            rd,
+            esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
+            ethernet_tag,
+            mac,
+            ip,
+            label1: zero_label,
+            label2: None,
+        }),
+        EvpnRouteKey::Imet {
+            rd,
+            ethernet_tag,
+            originator_ip,
+        } => EvpnRoute::Imet(EvpnImet {
+            rd,
+            ethernet_tag,
+            originator_ip,
+        }),
+        EvpnRouteKey::Es {
+            rd,
+            esi,
+            originator_ip,
+        } => EvpnRoute::Es(EvpnEs {
+            rd,
+            esi,
+            originator_ip,
+        }),
+        EvpnRouteKey::IpPrefix {
+            rd,
+            ethernet_tag,
+            prefix,
+        } => {
+            let gateway = match prefix {
+                rustbgpd_wire::EvpnIpPrefixValue::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                rustbgpd_wire::EvpnIpPrefixValue::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            };
+            EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
+                rd,
+                esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
+                ethernet_tag,
+                prefix,
+                gateway,
+                label: zero_label,
+            })
+        }
+    }
+}
+
+/// Exact result consumed by live builders now and the RIB precommit gate in
+/// LAN-361. Length is measured from the same constructed message, never from
+/// an estimator.
+pub(crate) struct ExactExportProbe {
+    pub(crate) message: UpdateMessage,
+    pub(crate) encoded_len: usize,
+    pub(crate) max_len: usize,
+    pub(crate) generation: u64,
+}
+
+impl ExactExportProbe {
+    fn into_message(self) -> UpdateMessage {
+        debug_assert_eq!(self.encoded_len, self.message.encoded_len());
+        debug_assert!(matches!(self.max_len, 4_096 | 65_535));
+        let _generation = self.generation;
+        self.message
+    }
+}
+
+/// The single `MP_REACH` builder accepts every outbound family so live chunks
+/// and future one-NLRI exportability probes cannot diverge by construction.
+pub(crate) enum ReachNlri<'a> {
+    Unicast(&'a [NlriEntry]),
+    FlowSpec(&'a [FlowSpecRule]),
+    Evpn(&'a [EvpnRoute]),
+    BgpLs(&'a [rustbgpd_wire::bgpls::BgpLsNlri]),
+    Labeled(&'a [rustbgpd_wire::LabeledNlriEntry]),
+    Vpn(&'a [rustbgpd_wire::VpnNlriEntry]),
+    Rtc(&'a [rustbgpd_wire::RtcNlri]),
+}
+
+impl ReachNlri<'_> {
+    fn into_mp_reach(
+        self,
+        afi: Afi,
+        safi: Safi,
+        next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
+    ) -> MpReachNlri {
+        let mut value = MpReachNlri {
+            afi,
+            safi,
+            next_hop,
+            link_local_next_hop,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        };
+        match self {
+            Self::Unicast(entries) => value.announced = entries.to_vec(),
+            Self::FlowSpec(entries) => value.flowspec_announced = entries.to_vec(),
+            Self::Evpn(entries) => value.evpn_announced = entries.to_vec(),
+            Self::BgpLs(entries) => value.bgpls_announced = entries.to_vec(),
+            Self::Labeled(entries) => value.labeled_announced = entries.to_vec(),
+            Self::Vpn(entries) => value.vpn_announced = entries.to_vec(),
+            Self::Rtc(entries) => value.rtc_announced = entries.to_vec(),
+        }
+        value
+    }
+}
+
+/// The withdrawal sibling of [`ReachNlri`].
+pub(crate) enum UnreachNlri<'a> {
+    Unicast(&'a [NlriEntry]),
+    FlowSpec(&'a [FlowSpecRule]),
+    Evpn(&'a [EvpnRoute]),
+    BgpLs(&'a [rustbgpd_wire::bgpls::BgpLsNlri]),
+    Labeled(&'a [rustbgpd_wire::LabeledNlriEntry]),
+    Vpn(&'a [rustbgpd_wire::VpnNlriEntry]),
+    Rtc(&'a [rustbgpd_wire::RtcNlri]),
+}
+
+impl UnreachNlri<'_> {
+    fn into_mp_unreach(self, afi: Afi, safi: Safi) -> MpUnreachNlri {
+        let mut value = MpUnreachNlri {
+            afi,
+            safi,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            labeled_withdrawn: vec![],
+            vpn_withdrawn: vec![],
+            rtc_withdrawn: vec![],
+        };
+        match self {
+            Self::Unicast(entries) => value.withdrawn = entries.to_vec(),
+            Self::FlowSpec(entries) => value.flowspec_withdrawn = entries.to_vec(),
+            Self::Evpn(entries) => value.evpn_withdrawn = entries.to_vec(),
+            Self::BgpLs(entries) => value.bgpls_withdrawn = entries.to_vec(),
+            Self::Labeled(entries) => value.labeled_withdrawn = entries.to_vec(),
+            Self::Vpn(entries) => value.vpn_withdrawn = entries.to_vec(),
+            Self::Rtc(entries) => value.rtc_withdrawn = entries.to_vec(),
+        }
+        value
+    }
+}
+
+/// Replaceable owner of immutable export-profile snapshots.
+pub(crate) struct SessionExportEncoder {
+    current: RwLock<Arc<SessionExportProfile>>,
+}
+
+impl SessionExportEncoder {
+    pub(super) fn new(profile: SessionExportProfile) -> Self {
+        Self {
+            current: RwLock::new(Arc::new(profile)),
+        }
+    }
+
+    pub(super) fn publish(&self, mut profile: SessionExportProfile) -> Arc<SessionExportProfile> {
+        let mut current = self
+            .current
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        profile.generation = current.generation();
+        if **current == profile {
+            return Arc::clone(&current);
+        }
+        profile.generation = current.generation().saturating_add(1);
+        let profile = Arc::new(profile);
+        *current = Arc::clone(&profile);
+        profile
+    }
+
+    pub(crate) fn snapshot(&self) -> Arc<SessionExportProfile> {
+        Arc::clone(
+            &self
+                .current
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
+}
+
+impl PeerSession {
+    /// Publish a complete profile replacement and return the immutable
+    /// snapshot that the next outbound envelope must use throughout.
+    pub(super) fn publish_export_profile(&self) -> Arc<SessionExportProfile> {
+        self.export_encoder
+            .publish(SessionExportProfile::capture(self))
+    }
+}
+
+pub(super) fn has_otc(attrs: &[PathAttribute]) -> bool {
+    attrs.iter().any(|attr| match attr {
+        PathAttribute::OnlyToCustomer(_) => true,
+        PathAttribute::Unknown(raw) => {
+            raw.type_code == rustbgpd_wire::constants::attr_type::ONLY_TO_CUSTOMER
+        }
+        _ => false,
+    })
+}
+
+/// Remove private ASNs from an `AS_PATH` according to the configured mode.
+pub(super) fn remove_private_asns(
+    as_path: &AsPath,
+    mode: RemovePrivateAs,
+    local_asn: u32,
+) -> AsPath {
+    match mode {
+        RemovePrivateAs::Disabled => as_path.clone(),
+        RemovePrivateAs::Remove => {
+            if as_path.all_private() {
+                AsPath {
+                    segments: as_path
+                        .segments
+                        .iter()
+                        .filter_map(|segment| {
+                            let filtered: Vec<u32> = match segment {
+                                AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => {
+                                    asns.iter()
+                                        .copied()
+                                        .filter(|asn| !is_private_asn(*asn))
+                                        .collect()
+                                }
+                            };
+                            (!filtered.is_empty()).then_some(match segment {
+                                AsPathSegment::AsSequence(_) => AsPathSegment::AsSequence(filtered),
+                                AsPathSegment::AsSet(_) => AsPathSegment::AsSet(filtered),
+                            })
+                        })
+                        .collect(),
+                }
+            } else {
+                as_path.clone()
+            }
+        }
+        RemovePrivateAs::All => AsPath {
+            segments: as_path
+                .segments
+                .iter()
+                .filter_map(|segment| {
+                    let filtered: Vec<u32> = match segment {
+                        AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => asns
+                            .iter()
+                            .copied()
+                            .filter(|asn| !is_private_asn(*asn))
+                            .collect(),
+                    };
+                    (!filtered.is_empty()).then_some(match segment {
+                        AsPathSegment::AsSequence(_) => AsPathSegment::AsSequence(filtered),
+                        AsPathSegment::AsSet(_) => AsPathSegment::AsSet(filtered),
+                    })
+                })
+                .collect(),
+        },
+        RemovePrivateAs::Replace => AsPath {
+            segments: as_path
+                .segments
+                .iter()
+                .map(|segment| match segment {
+                    AsPathSegment::AsSequence(asns) => AsPathSegment::AsSequence(
+                        asns.iter()
+                            .map(|asn| {
+                                if is_private_asn(*asn) {
+                                    local_asn
+                                } else {
+                                    *asn
+                                }
+                            })
+                            .collect(),
+                    ),
+                    AsPathSegment::AsSet(asns) => AsPathSegment::AsSet(
+                        asns.iter()
+                            .map(|asn| {
+                                if is_private_asn(*asn) {
+                                    local_asn
+                                } else {
+                                    *asn
+                                }
+                            })
+                            .collect(),
+                    ),
+                })
+                .collect(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{TcpAoAlgorithm, TcpAoConfig};
+    use rustbgpd_fsm::PeerConfig;
+    use rustbgpd_wire::{Ipv4Prefix, encode_message};
+
+    fn config_with_auth_secret(secret: &str) -> TransportConfig {
+        let peer = PeerConfig::new(65_001, 65_002, Ipv4Addr::new(10, 0, 0, 1));
+        let mut config = TransportConfig::new(peer, "10.0.0.2:179".parse().unwrap());
+        config.md5_password = Some(secret.to_string());
+        config.tcp_ao = Some(TcpAoConfig {
+            key: secret.to_string(),
+            send_id: 7,
+            recv_id: 9,
+            algorithm: TcpAoAlgorithm::HmacSha256,
+            preferred: true,
+            deprecated: false,
+        });
+        config
+    }
+
+    #[test]
+    fn export_profile_never_retains_or_formats_transport_auth_secrets() {
+        const SENTINEL: &str = "lan-380-profile-must-not-retain-this-secret";
+        let config = config_with_auth_secret(SENTINEL);
+        let profile = SessionExportProfile::initial(&config, None, false);
+
+        let rendered = format!("{profile:?}");
+        assert!(!rendered.contains(SENTINEL));
+        assert!(!rendered.contains("tcp_ao"));
+        assert!(!rendered.contains("md5"));
+    }
+
+    #[test]
+    fn profile_publish_is_complete_immutable_and_generation_stable() {
+        let config = config_with_auth_secret("not-retained");
+        let encoder =
+            SessionExportEncoder::new(SessionExportProfile::initial(&config, None, false));
+        let old = encoder.snapshot();
+        assert_eq!(old.generation(), 0);
+
+        let mut replacement = SessionExportProfile::initial(&config, None, true);
+        replacement.remove_private_as = RemovePrivateAs::All;
+        replacement.configured_local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
+        let published = encoder.publish(replacement);
+        let current = encoder.snapshot();
+
+        assert_eq!(published.generation(), 1);
+        assert!(Arc::ptr_eq(&published, &current));
+        assert_eq!(old.generation(), 0, "old Arc remains immutable");
+        assert!(!old.advertise_graceful_shutdown);
+        assert!(current.advertise_graceful_shutdown);
+        assert_eq!(current.remove_private_as, RemovePrivateAs::All);
+        assert_eq!(
+            current.configured_local_ipv6_nexthop,
+            Some("2001:db8::1".parse().unwrap())
+        );
+
+        let same = encoder.publish((*current).clone());
+        assert!(Arc::ptr_eq(&same, &current));
+        assert_eq!(same.generation(), 1, "wire-equal publish is idempotent");
+
+        let mut changed = (*same).clone();
+        changed.remove_private_as = RemovePrivateAs::Replace;
+        let changed = encoder.publish(changed);
+        assert_eq!(changed.generation(), 2, "one wire change increments once");
+    }
+
+    #[test]
+    fn old_snapshot_remains_exact_while_new_generation_publishes() {
+        let config = config_with_auth_secret("not-retained");
+        let encoder = Arc::new(SessionExportEncoder::new(SessionExportProfile::initial(
+            &config, None, false,
+        )));
+        let old = encoder.snapshot();
+        let entry = [Ipv4NlriEntry {
+            path_id: 0x0102_0304,
+            prefix: Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        }];
+        let old_before = encoded(old.build_ipv4_body(&entry, &[], &[]).unwrap());
+
+        let mut replacement = (*old).clone();
+        replacement.add_path_send_families = Arc::from(vec![(Afi::Ipv4, Safi::Unicast)]);
+        let publisher = Arc::clone(&encoder);
+        let new = std::thread::spawn(move || publisher.publish(replacement))
+            .join()
+            .unwrap();
+
+        let old_after = encoded(old.build_ipv4_body(&entry, &[], &[]).unwrap());
+        let new_bytes = encoded(new.build_ipv4_body(&entry, &[], &[]).unwrap());
+        assert_eq!(old.generation(), 0);
+        assert_eq!(new.generation(), 1);
+        assert_eq!(
+            old_before, old_after,
+            "one envelope stays pinned to old Arc"
+        );
+        assert_ne!(
+            old_after, new_bytes,
+            "new Add-Path profile changes wire bytes"
+        );
+        assert!(Arc::ptr_eq(&new, &encoder.snapshot()));
+    }
+
+    fn encoded(message: UpdateMessage) -> Vec<u8> {
+        encode_message(&super::super::Message::Update(message))
+            .unwrap()
+            .to_vec()
+    }
+}

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -957,92 +957,132 @@ impl SessionExportProfile {
         &self,
         withdrawal: ExportWithdrawal<'_>,
     ) -> Result<ExactExportProbe, ExportProbeError> {
-        match withdrawal {
+        match self.prepare_withdrawal(withdrawal)? {
+            PreparedWithdrawal::Ipv4Body(entry) => self
+                .probe_ipv4_body(&[], std::slice::from_ref(&entry), &[])
+                .map_err(Into::into),
+            PreparedWithdrawal::Unicast(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::Unicast(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::FlowSpec(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::FlowSpec(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::Evpn(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::Evpn(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::BgpLs(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::BgpLs(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::Vpn(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::Vpn(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::Labeled(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::Labeled(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+            PreparedWithdrawal::Rtc(prepared) => self
+                .probe_mp_unreach(
+                    prepared.afi,
+                    prepared.safi,
+                    UnreachNlri::Rtc(std::slice::from_ref(&prepared.nlri)),
+                    prepared.ipv4_mode,
+                )
+                .map_err(Into::into),
+        }
+    }
+
+    /// Resolve one real Adj-RIB-Out identity into its authoritative wire
+    /// family, encoding mode, and NLRI representation. Live batching and the
+    /// exact one-route probe both consume this typed result.
+    pub(super) fn prepare_withdrawal(
+        &self,
+        withdrawal: ExportWithdrawal<'_>,
+    ) -> Result<PreparedWithdrawal, ExportProbeError> {
+        Ok(match withdrawal {
             ExportWithdrawal::Unicast { prefix, path_id } => match prefix {
                 Prefix::V4(prefix) if self.use_extended_nexthop_ipv4() => {
-                    let entry = NlriEntry {
-                        path_id,
-                        prefix: Prefix::V4(prefix),
-                    };
-                    self.probe_mp_unreach(
-                        Afi::Ipv4,
-                        Safi::Unicast,
-                        UnreachNlri::Unicast(std::slice::from_ref(&entry)),
-                        Ipv4UnicastMode::MpReach,
-                    )
-                    .map_err(Into::into)
+                    PreparedWithdrawal::Unicast(PreparedMpWithdrawal {
+                        afi: Afi::Ipv4,
+                        safi: Safi::Unicast,
+                        ipv4_mode: Ipv4UnicastMode::MpReach,
+                        nlri: NlriEntry {
+                            path_id,
+                            prefix: Prefix::V4(prefix),
+                        },
+                    })
                 }
                 Prefix::V4(prefix) => {
                     if self.scoped_link_local_peer {
                         return Err(ExportProbeError::Ipv4RequiresExtendedNextHop);
                     }
-                    self.probe_ipv4_body(
-                        &[],
-                        std::slice::from_ref(&Ipv4NlriEntry { path_id, prefix }),
-                        &[],
-                    )
-                    .map_err(Into::into)
+                    PreparedWithdrawal::Ipv4Body(Ipv4NlriEntry { path_id, prefix })
                 }
-                Prefix::V6(_) => {
-                    let entry = NlriEntry { path_id, prefix };
-                    self.probe_mp_unreach(
-                        Afi::Ipv6,
-                        Safi::Unicast,
-                        UnreachNlri::Unicast(std::slice::from_ref(&entry)),
-                        Ipv4UnicastMode::Body,
-                    )
-                    .map_err(Into::into)
-                }
+                Prefix::V6(_) => PreparedWithdrawal::Unicast(PreparedMpWithdrawal::new(
+                    Afi::Ipv6,
+                    Safi::Unicast,
+                    NlriEntry { path_id, prefix },
+                )),
             },
-            ExportWithdrawal::FlowSpec(key) => self
-                .probe_mp_unreach(
-                    key.afi,
-                    Safi::FlowSpec,
-                    UnreachNlri::FlowSpec(std::slice::from_ref(&key.rule)),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-            ExportWithdrawal::Evpn(key) => self
-                .probe_mp_unreach(
-                    Afi::L2Vpn,
-                    Safi::Evpn,
-                    UnreachNlri::Evpn(std::slice::from_ref(&evpn_route_from_key(*key))),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-            ExportWithdrawal::BgpLs(key) => self
-                .probe_mp_unreach(
-                    Afi::BgpLs,
-                    key.family.to_afi_safi().1,
-                    UnreachNlri::BgpLs(std::slice::from_ref(&bgpls_nlri_from_key(key))),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-            ExportWithdrawal::Vpn(key) => self
-                .probe_mp_unreach(
-                    key.afi_safi().0,
-                    Safi::MplsVpn,
-                    UnreachNlri::Vpn(std::slice::from_ref(&vpn_withdraw_entry(key))),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-            ExportWithdrawal::Labeled(key) => self
-                .probe_mp_unreach(
+            ExportWithdrawal::FlowSpec(key) => PreparedWithdrawal::FlowSpec(
+                PreparedMpWithdrawal::new(key.afi, Safi::FlowSpec, key.rule.clone()),
+            ),
+            ExportWithdrawal::Evpn(key) => PreparedWithdrawal::Evpn(PreparedMpWithdrawal::new(
+                Afi::L2Vpn,
+                Safi::Evpn,
+                evpn_route_from_key(*key),
+            )),
+            ExportWithdrawal::BgpLs(key) => PreparedWithdrawal::BgpLs(PreparedMpWithdrawal::new(
+                Afi::BgpLs,
+                key.family.to_afi_safi().1,
+                bgpls_nlri_from_key(key),
+            )),
+            ExportWithdrawal::Vpn(key) => PreparedWithdrawal::Vpn(PreparedMpWithdrawal::new(
+                key.afi_safi().0,
+                Safi::MplsVpn,
+                vpn_withdraw_entry(key),
+            )),
+            ExportWithdrawal::Labeled(key) => {
+                PreparedWithdrawal::Labeled(PreparedMpWithdrawal::new(
                     key.afi_safi().0,
                     Safi::LabeledUnicast,
-                    UnreachNlri::Labeled(std::slice::from_ref(&labeled_withdraw_entry(key))),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-            ExportWithdrawal::Rtc(key) => self
-                .probe_mp_unreach(
-                    Afi::Ipv4,
-                    Safi::RtConstrain,
-                    UnreachNlri::Rtc(std::slice::from_ref(&key.nlri)),
-                    Ipv4UnicastMode::Body,
-                )
-                .map_err(Into::into),
-        }
+                    labeled_withdraw_entry(key),
+                ))
+            }
+            ExportWithdrawal::Rtc(key) => PreparedWithdrawal::Rtc(PreparedMpWithdrawal::new(
+                Afi::Ipv4,
+                Safi::RtConstrain,
+                key.nlri,
+            )),
+        })
     }
 
     pub(super) fn build_ipv4_body(
@@ -1211,6 +1251,35 @@ pub(crate) enum ExportWithdrawal<'a> {
     Vpn(&'a VpnRibRouteKey),
     Labeled(&'a LabeledRibRouteKey),
     Rtc(&'a RtcRibRouteKey),
+}
+
+pub(super) struct PreparedMpWithdrawal<T> {
+    pub(super) afi: Afi,
+    pub(super) safi: Safi,
+    pub(super) ipv4_mode: Ipv4UnicastMode,
+    pub(super) nlri: T,
+}
+
+impl<T> PreparedMpWithdrawal<T> {
+    fn new(afi: Afi, safi: Safi, nlri: T) -> Self {
+        Self {
+            afi,
+            safi,
+            ipv4_mode: Ipv4UnicastMode::Body,
+            nlri,
+        }
+    }
+}
+
+pub(super) enum PreparedWithdrawal {
+    Ipv4Body(Ipv4NlriEntry),
+    Unicast(PreparedMpWithdrawal<NlriEntry>),
+    FlowSpec(PreparedMpWithdrawal<FlowSpecRule>),
+    Evpn(PreparedMpWithdrawal<EvpnRoute>),
+    BgpLs(PreparedMpWithdrawal<rustbgpd_wire::bgpls::BgpLsNlri>),
+    Vpn(PreparedMpWithdrawal<rustbgpd_wire::VpnNlriEntry>),
+    Labeled(PreparedMpWithdrawal<rustbgpd_wire::LabeledNlriEntry>),
+    Rtc(PreparedMpWithdrawal<rustbgpd_wire::RtcNlri>),
 }
 
 #[allow(

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -428,6 +428,7 @@ impl PeerSession {
                         .collect();
 
                     self.negotiated = Some(*neg);
+                    self.publish_export_profile();
                     self.established_at = Some(Instant::now());
 
                     // Emit BMP Peer Up event — reliable (awaited): losing

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -1,4 +1,5 @@
 mod commands;
+pub(crate) mod export;
 mod fsm;
 pub mod import_decision_cache;
 pub(crate) mod inbound;
@@ -50,9 +51,10 @@ use crate::timer::{Timers, poll_timer};
 use self::io::read_tcp;
 
 #[cfg(test)]
-use self::fsm::{hard_reset_notification_in_actions, notification_teardown_event};
+use self::export::remove_private_asns;
+use self::export::{SessionExportEncoder, SessionExportProfile};
 #[cfg(test)]
-use self::outbound::remove_private_asns;
+use self::fsm::{hard_reset_notification_in_actions, notification_teardown_event};
 
 /// Runtime for a single BGP peer session.
 ///
@@ -161,6 +163,9 @@ pub(crate) struct PeerSession {
     import_needs_as_path_string: bool,
     /// Export policy (sent to RIB manager on `PeerUp` for per-peer filtering).
     export_policy: Option<PolicyChain>,
+    /// Authoritative immutable snapshot owner for outbound wire encoding.
+    /// Each RIB envelope captures one snapshot before any preparation/build.
+    export_encoder: SessionExportEncoder,
     /// RFC 8326 graceful-shutdown initiator toggle: when `true`, every
     /// outbound update gets `COMMUNITY_GRACEFUL_SHUTDOWN` (`0xFFFF_0000`)
     /// added to its Communities attribute (creating one if absent).
@@ -500,6 +505,11 @@ impl PeerSession {
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
+        let export_encoder = SessionExportEncoder::new(SessionExportProfile::initial(
+            &config,
+            None,
+            advertise_graceful_shutdown,
+        ));
         Self {
             config,
             fsm,
@@ -528,6 +538,7 @@ impl PeerSession {
             import_policy,
             import_needs_as_path_string,
             export_policy,
+            export_encoder,
             advertise_graceful_shutdown,
             session_notify_tx,
             session_lifecycle_tx,
@@ -603,6 +614,11 @@ impl PeerSession {
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
+        let export_encoder = SessionExportEncoder::new(SessionExportProfile::initial(
+            &config,
+            stream.local_addr().ok().map(|addr| addr.ip()),
+            advertise_graceful_shutdown,
+        ));
         // Split the inbound stream and spawn the writer immediately —
         // we're in async context here (inside `tokio::spawn` from
         // `PeerHandle::spawn_inbound`), so `tokio::spawn` inside
@@ -643,6 +659,7 @@ impl PeerSession {
             import_policy,
             import_needs_as_path_string,
             export_policy,
+            export_encoder,
             advertise_graceful_shutdown,
             session_notify_tx,
             session_lifecycle_tx,

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1,7 +1,6 @@
 use super::export::{
-    PreparedUnicastAttributes, PreparedUnicastCandidate, ReachNlri, SessionExportProfile,
-    UnreachNlri, bgpls_nlri_from_key, evpn_route_from_key, has_otc, labeled_withdraw_entry,
-    vpn_withdraw_entry,
+    ExportWithdrawal, PreparedUnicastAttributes, PreparedUnicastCandidate, PreparedWithdrawal,
+    ReachNlri, SessionExportProfile, UnreachNlri, has_otc,
 };
 use super::{
     Afi, BgpRole, EvpnRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
@@ -262,82 +261,73 @@ impl PeerSession {
         let mut prepared_attr_cache: HashMap<PreparedAttrCacheKey, PreparedUnicastAttributes> =
             HashMap::default();
         // Split withdrawals by address family, filtering by negotiated families
-        let mut v4_withdraw: Vec<Ipv4NlriEntry> = Vec::new();
+        let mut v4_body_withdraw: Vec<Ipv4NlriEntry> = Vec::new();
+        let mut v4_mp_withdraw: Vec<NlriEntry> = Vec::new();
+        let mut v4_mp_wire = None;
         let mut v6_withdraw: Vec<NlriEntry> = Vec::new();
+        let mut v6_wire = None;
         for &(ref prefix, path_id) in &update.withdraw {
             if !self.is_family_negotiated(prefix) {
                 continue;
             }
-            match prefix {
-                Prefix::V4(v4) => v4_withdraw.push(Ipv4NlriEntry {
-                    path_id,
-                    prefix: *v4,
-                }),
-                v6 @ Prefix::V6(_) => v6_withdraw.push(NlriEntry {
-                    path_id,
-                    prefix: *v6,
-                }),
+            match export.prepare_withdrawal(ExportWithdrawal::Unicast {
+                prefix: *prefix,
+                path_id,
+            }) {
+                Ok(PreparedWithdrawal::Ipv4Body(entry)) => v4_body_withdraw.push(entry),
+                Ok(PreparedWithdrawal::Unicast(prepared)) => {
+                    let wire = (prepared.afi, prepared.safi, prepared.ipv4_mode);
+                    if prepared.afi == Afi::Ipv4 {
+                        v4_mp_wire = Some(wire);
+                        v4_mp_withdraw.push(prepared.nlri);
+                    } else {
+                        v6_wire = Some(wire);
+                        v6_withdraw.push(prepared.nlri);
+                    }
+                }
+                Ok(_) => unreachable!("unicast withdrawal must prepare as unicast"),
+                Err(error) => warn!(
+                    peer = %self.peer_label,
+                    %prefix,
+                    %error,
+                    "not sending unicast withdrawal: exact export preparation failed"
+                ),
             }
         }
-        // Send IPv4 withdrawals via body NLRI or IPv4 MP_UNREACH_NLRI,
-        // depending on Extended Next Hop negotiation.
-        if !v4_withdraw.is_empty() {
-            if export.is_scoped_link_local_peer() && !use_extended_nexthop_ipv4 {
-                warn!(
-                    peer = %self.peer_label,
-                    "not sending IPv4 withdrawals to scoped link-local peer without negotiated Extended Next Hop"
-                );
-            } else {
-                let max_len = export.max_message_len();
-                let ok = if use_extended_nexthop_ipv4 {
-                    self.send_v4_chunked(&v4_withdraw, max_len, "withdraw", |chunk| {
-                        let entries: Vec<_> = chunk
-                            .iter()
-                            .map(|entry| NlriEntry {
-                                path_id: entry.path_id,
-                                prefix: Prefix::V4(entry.prefix),
-                            })
-                            .collect();
-                        export
-                            .build_mp_unreach(
-                                Afi::Ipv4,
-                                Safi::Unicast,
-                                UnreachNlri::Unicast(&entries),
-                                Ipv4UnicastMode::MpReach,
-                            )
-                            .expect("IPv4 MP_UNREACH construction was previously infallible")
-                    })
-                } else {
-                    self.send_v4_chunked(&v4_withdraw, max_len, "withdraw", |chunk| {
-                        export
-                            .build_ipv4_body(&[], chunk, &[])
-                            .expect("IPv4 body withdrawal construction was previously infallible")
-                    })
-                };
-                if !ok {
-                    return;
-                }
+        if !v4_body_withdraw.is_empty() {
+            let max_len = export.max_message_len();
+            if !self.send_v4_chunked(&v4_body_withdraw, max_len, "withdraw", |chunk| {
+                export
+                    .build_ipv4_body(&[], chunk, &[])
+                    .expect("IPv4 body withdrawal construction was previously infallible")
+            }) {
+                return;
+            }
+        }
+        if let Some((afi, safi, ipv4_mode)) = v4_mp_wire {
+            let max_len = export.max_message_len();
+            if !self.send_mp_chunked(
+                &v4_mp_withdraw,
+                max_len,
+                "IPv4 unicast",
+                "withdrawal",
+                |chunk| export.build_mp_unreach(afi, safi, UnreachNlri::Unicast(chunk), ipv4_mode),
+            ) {
+                return;
             }
         }
         // Send IPv6 withdrawals via `MP_UNREACH_NLRI`, chunked to the
         // negotiated message ceiling just like IPv4. A large Add-Path
         // withdrawal set must not be handed to `enqueue_bulk` as one
         // oversized message after the RIB has already committed it.
-        if !v6_withdraw.is_empty() {
+        if let Some((afi, safi, ipv4_mode)) = v6_wire {
             let max_len = export.max_message_len();
             if !self.send_mp_chunked(
                 &v6_withdraw,
                 max_len,
                 "IPv6 unicast",
                 "withdrawal",
-                |chunk| {
-                    export.build_mp_unreach(
-                        Afi::Ipv6,
-                        Safi::Unicast,
-                        UnreachNlri::Unicast(chunk),
-                        Ipv4UnicastMode::Body,
-                    )
-                },
+                |chunk| export.build_mp_unreach(afi, safi, UnreachNlri::Unicast(chunk), ipv4_mode),
             ) {
                 return;
             }
@@ -572,30 +562,39 @@ impl PeerSession {
         }
         // Send FlowSpec withdrawals via MP_UNREACH_NLRI, grouped by AFI
         if !update.flowspec_withdraw.is_empty() {
-            let mut fs_withdrawals = [
-                (Afi::Ipv4, Vec::<FlowSpecRule>::new()),
-                (Afi::Ipv6, Vec::<FlowSpecRule>::new()),
-            ];
+            type FlowSpecWithdrawalGroup = Option<(Afi, Safi, Ipv4UnicastMode, Vec<FlowSpecRule>)>;
+            // Preserve the established deterministic wire order: IPv4, then IPv6.
+            let mut fs_withdrawals: [FlowSpecWithdrawalGroup; 2] = [None, None];
             for key in &update.flowspec_withdraw {
-                let Some((_, rules)) = fs_withdrawals.iter_mut().find(|(afi, _)| *afi == key.afi)
+                let PreparedWithdrawal::FlowSpec(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::FlowSpec(key))
+                    .expect("FlowSpec withdrawal preparation is infallible")
                 else {
-                    warn!(afi = ?key.afi, "ignoring FlowSpec withdrawal with non-IP AFI");
-                    continue;
+                    unreachable!("FlowSpec key must prepare as FlowSpec")
                 };
-                rules.push(key.rule.clone());
-            }
-            for (afi, rules) in fs_withdrawals {
-                if rules.is_empty() {
-                    continue;
+                let slot = match prepared.afi {
+                    Afi::Ipv4 => &mut fs_withdrawals[0],
+                    Afi::Ipv6 => &mut fs_withdrawals[1],
+                    Afi::L2Vpn | Afi::BgpLs => {
+                        warn!(afi = ?prepared.afi, "ignoring FlowSpec withdrawal with non-IP AFI");
+                        continue;
+                    }
+                };
+                if let Some((_, _, _, rules)) = slot {
+                    rules.push(prepared.nlri);
+                } else {
+                    *slot = Some((
+                        prepared.afi,
+                        prepared.safi,
+                        prepared.ipv4_mode,
+                        vec![prepared.nlri],
+                    ));
                 }
+            }
+            for (afi, safi, ipv4_mode, rules) in fs_withdrawals.into_iter().flatten() {
                 let max_len = export.max_message_len();
                 if !self.send_mp_chunked(&rules, max_len, "FlowSpec", "withdrawal", |chunk| {
-                    export.build_mp_unreach(
-                        afi,
-                        Safi::FlowSpec,
-                        UnreachNlri::FlowSpec(chunk),
-                        Ipv4UnicastMode::Body,
-                    )
+                    export.build_mp_unreach(afi, safi, UnreachNlri::FlowSpec(chunk), ipv4_mode)
                 }) {
                     return;
                 }
@@ -607,13 +606,21 @@ impl PeerSession {
         // can otherwise exceed the limit and `enqueue_bulk` returns
         // `MessageTooLong`, dropping the rest of the update.
         if !update.evpn_withdraw.is_empty() {
-            let routes: Vec<EvpnRoute> = update
-                .evpn_withdraw
-                .iter()
-                .map(|key| evpn_route_from_key(*key))
-                .collect();
+            let mut routes = Vec::with_capacity(update.evpn_withdraw.len());
+            let mut wire = None;
+            for key in &update.evpn_withdraw {
+                let PreparedWithdrawal::Evpn(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::Evpn(key))
+                    .expect("EVPN withdrawal preparation is infallible")
+                else {
+                    unreachable!("EVPN key must prepare as EVPN")
+                };
+                wire = Some((prepared.afi, prepared.safi, prepared.ipv4_mode));
+                routes.push(prepared.nlri);
+            }
             let max_len = export.max_message_len();
-            if !self.send_evpn_unreach_chunked(&export, &routes, max_len) {
+            let (afi, safi, ipv4_mode) = wire.expect("non-empty EVPN withdrawal batch");
+            if !self.send_evpn_unreach_chunked(&export, afi, safi, ipv4_mode, &routes, max_len) {
                 return;
             }
         }
@@ -621,38 +628,49 @@ impl PeerSession {
         // chunked so the RIB never commits a route that transport could not
         // enqueue.
         if !update.bgpls_withdraw.is_empty() {
-            let mut base_routes = Vec::new();
-            let mut vpn_routes = Vec::new();
+            let mut groups = Vec::<(
+                Afi,
+                Safi,
+                Ipv4UnicastMode,
+                Vec<rustbgpd_wire::bgpls::BgpLsNlri>,
+            )>::new();
             for key in &update.bgpls_withdraw {
-                let nlri = bgpls_nlri_from_key(key);
-                match key.family {
-                    rustbgpd_rib::BgpLsFamily::LinkState
-                        if self
-                            .negotiated_families
-                            .contains(&(Afi::BgpLs, Safi::BgpLs)) =>
-                    {
-                        base_routes.push(nlri);
-                    }
-                    rustbgpd_rib::BgpLsFamily::LinkStateVpn
-                        if self
-                            .negotiated_families
-                            .contains(&(Afi::BgpLs, Safi::BgpLsVpn)) =>
-                    {
-                        vpn_routes.push(nlri);
-                    }
-                    _ => {}
+                let PreparedWithdrawal::BgpLs(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::BgpLs(key))
+                    .expect("BGP-LS withdrawal preparation is infallible")
+                else {
+                    unreachable!("BGP-LS key must prepare as BGP-LS")
+                };
+                if !self
+                    .negotiated_families
+                    .contains(&(prepared.afi, prepared.safi))
+                {
+                    continue;
+                }
+                if let Some((_, _, _, routes)) = groups.iter_mut().find(|(afi, safi, mode, _)| {
+                    (*afi, *safi, *mode) == (prepared.afi, prepared.safi, prepared.ipv4_mode)
+                }) {
+                    routes.push(prepared.nlri);
+                } else {
+                    groups.push((
+                        prepared.afi,
+                        prepared.safi,
+                        prepared.ipv4_mode,
+                        vec![prepared.nlri],
+                    ));
                 }
             }
             let max_len = export.max_message_len();
-            if !base_routes.is_empty()
-                && !self.send_bgpls_unreach_chunked(Safi::BgpLs, &base_routes, &export, max_len)
-            {
-                return;
-            }
-            if !vpn_routes.is_empty()
-                && !self.send_bgpls_unreach_chunked(Safi::BgpLsVpn, &vpn_routes, &export, max_len)
-            {
-                return;
+            groups.sort_by_key(|(_, safi, _, _)| match safi {
+                Safi::BgpLs => 0,
+                Safi::BgpLsVpn => 1,
+                _ => 2,
+            });
+            for (afi, safi, ipv4_mode, routes) in groups {
+                if !self.send_bgpls_unreach_chunked(afi, safi, ipv4_mode, &routes, &export, max_len)
+                {
+                    return;
+                }
             }
         }
         // Send VPNv4/VPNv6 withdrawals via MP_UNREACH_NLRI, grouped by AFI
@@ -660,25 +678,40 @@ impl PeerSession {
         // compatibility field instead of a label stack, so the rebuilt NLRI
         // carries no labels (the withdraw encoder ignores them).
         if !update.vpn_withdraw.is_empty() {
-            let mut v4_routes = Vec::new();
-            let mut v6_routes = Vec::new();
+            let mut groups =
+                Vec::<(Afi, Safi, Ipv4UnicastMode, Vec<rustbgpd_wire::VpnNlriEntry>)>::new();
             for key in &update.vpn_withdraw {
-                let entry = vpn_withdraw_entry(key);
-                let family = key.afi_safi();
+                let PreparedWithdrawal::Vpn(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::Vpn(key))
+                    .expect("VPN withdrawal preparation is infallible")
+                else {
+                    unreachable!("VPN key must prepare as VPN")
+                };
+                let family = (prepared.afi, prepared.safi);
                 if !self.negotiated_families.contains(&family) {
                     continue;
                 }
-                match family.0 {
-                    Afi::Ipv4 => v4_routes.push(entry),
-                    Afi::Ipv6 => v6_routes.push(entry),
-                    Afi::L2Vpn | Afi::BgpLs => {}
+                if let Some((_, _, _, routes)) = groups.iter_mut().find(|(afi, safi, mode, _)| {
+                    (*afi, *safi, *mode) == (prepared.afi, prepared.safi, prepared.ipv4_mode)
+                }) {
+                    routes.push(prepared.nlri);
+                } else {
+                    groups.push((
+                        prepared.afi,
+                        prepared.safi,
+                        prepared.ipv4_mode,
+                        vec![prepared.nlri],
+                    ));
                 }
             }
             let max_len = export.max_message_len();
-            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
-                if !routes.is_empty()
-                    && !self.send_vpn_unreach_chunked(afi, &routes, &export, max_len)
-                {
+            groups.sort_by_key(|(afi, _, _, _)| match afi {
+                Afi::Ipv4 => 0,
+                Afi::Ipv6 => 1,
+                Afi::L2Vpn | Afi::BgpLs => 2,
+            });
+            for (afi, safi, ipv4_mode, routes) in groups {
+                if !self.send_vpn_unreach_chunked(afi, safi, ipv4_mode, &routes, &export, max_len) {
                     return;
                 }
             }
@@ -689,24 +722,45 @@ impl PeerSession {
         // rebuilt NLRI carries no labels (the withdraw encoder ignores
         // them).
         if !update.labeled_withdraw.is_empty() {
-            let mut v4_routes = Vec::new();
-            let mut v6_routes = Vec::new();
+            let mut groups = Vec::<(
+                Afi,
+                Safi,
+                Ipv4UnicastMode,
+                Vec<rustbgpd_wire::LabeledNlriEntry>,
+            )>::new();
             for key in &update.labeled_withdraw {
-                let entry = labeled_withdraw_entry(key);
-                let family = key.afi_safi();
+                let PreparedWithdrawal::Labeled(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::Labeled(key))
+                    .expect("labeled withdrawal preparation is infallible")
+                else {
+                    unreachable!("labeled key must prepare as labeled unicast")
+                };
+                let family = (prepared.afi, prepared.safi);
                 if !self.negotiated_families.contains(&family) {
                     continue;
                 }
-                match family.0 {
-                    Afi::Ipv4 => v4_routes.push(entry),
-                    Afi::Ipv6 => v6_routes.push(entry),
-                    Afi::L2Vpn | Afi::BgpLs => {}
+                if let Some((_, _, _, routes)) = groups.iter_mut().find(|(afi, safi, mode, _)| {
+                    (*afi, *safi, *mode) == (prepared.afi, prepared.safi, prepared.ipv4_mode)
+                }) {
+                    routes.push(prepared.nlri);
+                } else {
+                    groups.push((
+                        prepared.afi,
+                        prepared.safi,
+                        prepared.ipv4_mode,
+                        vec![prepared.nlri],
+                    ));
                 }
             }
             let max_len = export.max_message_len();
-            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
-                if !routes.is_empty()
-                    && !self.send_labeled_unreach_chunked(afi, &routes, &export, max_len)
+            groups.sort_by_key(|(afi, _, _, _)| match afi {
+                Afi::Ipv4 => 0,
+                Afi::Ipv6 => 1,
+                Afi::L2Vpn | Afi::BgpLs => 2,
+            });
+            for (afi, safi, ipv4_mode, routes) in groups {
+                if !self
+                    .send_labeled_unreach_chunked(afi, safi, ipv4_mode, &routes, &export, max_len)
                 {
                     return;
                 }
@@ -720,10 +774,21 @@ impl PeerSession {
                 .negotiated_families
                 .contains(&(Afi::Ipv4, Safi::RtConstrain))
         {
-            let routes: Vec<rustbgpd_wire::RtcNlri> =
-                update.rtc_withdraw.iter().map(|key| key.nlri).collect();
+            let mut routes = Vec::with_capacity(update.rtc_withdraw.len());
+            let mut wire = None;
+            for key in &update.rtc_withdraw {
+                let PreparedWithdrawal::Rtc(prepared) = export
+                    .prepare_withdrawal(ExportWithdrawal::Rtc(key))
+                    .expect("RTC withdrawal preparation is infallible")
+                else {
+                    unreachable!("RTC key must prepare as RTC")
+                };
+                wire = Some((prepared.afi, prepared.safi, prepared.ipv4_mode));
+                routes.push(prepared.nlri);
+            }
             let max_len = export.max_message_len();
-            if !self.send_rtc_unreach_chunked(&export, &routes, max_len) {
+            let (afi, safi, ipv4_mode) = wire.expect("non-empty RTC withdrawal batch");
+            if !self.send_rtc_unreach_chunked(&export, afi, safi, ipv4_mode, &routes, max_len) {
                 return;
             }
         }
@@ -1257,6 +1322,9 @@ impl PeerSession {
     fn send_evpn_unreach_chunked(
         &mut self,
         profile: &SessionExportProfile,
+        afi: Afi,
+        safi: Safi,
+        ipv4_mode: Ipv4UnicastMode,
         routes: &[EvpnRoute],
         max_len: usize,
     ) -> bool {
@@ -1265,12 +1333,7 @@ impl PeerSession {
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
             let msg = profile
-                .build_mp_unreach(
-                    Afi::L2Vpn,
-                    Safi::Evpn,
-                    UnreachNlri::Evpn(&routes[idx..end]),
-                    Ipv4UnicastMode::Body,
-                )
+                .build_mp_unreach(afi, safi, UnreachNlri::Evpn(&routes[idx..end]), ipv4_mode)
                 .expect("EVPN MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
@@ -1352,7 +1415,9 @@ impl PeerSession {
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     fn send_bgpls_unreach_chunked(
         &mut self,
+        afi: Afi,
         safi: Safi,
+        ipv4_mode: Ipv4UnicastMode,
         routes: &[rustbgpd_wire::bgpls::BgpLsNlri],
         profile: &SessionExportProfile,
         max_len: usize,
@@ -1362,12 +1427,7 @@ impl PeerSession {
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
             let msg = profile
-                .build_mp_unreach(
-                    Afi::BgpLs,
-                    safi,
-                    UnreachNlri::BgpLs(&routes[idx..end]),
-                    Ipv4UnicastMode::Body,
-                )
+                .build_mp_unreach(afi, safi, UnreachNlri::BgpLs(&routes[idx..end]), ipv4_mode)
                 .expect("BGP-LS MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
@@ -1464,6 +1524,8 @@ impl PeerSession {
     fn send_vpn_unreach_chunked(
         &mut self,
         afi: Afi,
+        safi: Safi,
+        ipv4_mode: Ipv4UnicastMode,
         routes: &[rustbgpd_wire::VpnNlriEntry],
         profile: &SessionExportProfile,
         max_len: usize,
@@ -1473,12 +1535,7 @@ impl PeerSession {
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
             let msg = profile
-                .build_mp_unreach(
-                    afi,
-                    Safi::MplsVpn,
-                    UnreachNlri::Vpn(&routes[idx..end]),
-                    Ipv4UnicastMode::Body,
-                )
+                .build_mp_unreach(afi, safi, UnreachNlri::Vpn(&routes[idx..end]), ipv4_mode)
                 .expect("VPN MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
@@ -1570,6 +1627,8 @@ impl PeerSession {
     fn send_labeled_unreach_chunked(
         &mut self,
         afi: Afi,
+        safi: Safi,
+        ipv4_mode: Ipv4UnicastMode,
         routes: &[rustbgpd_wire::LabeledNlriEntry],
         profile: &SessionExportProfile,
         max_len: usize,
@@ -1581,9 +1640,9 @@ impl PeerSession {
             let msg = profile
                 .build_mp_unreach(
                     afi,
-                    Safi::LabeledUnicast,
+                    safi,
                     UnreachNlri::Labeled(&routes[idx..end]),
-                    Ipv4UnicastMode::Body,
+                    ipv4_mode,
                 )
                 .expect("labeled-unicast MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
@@ -1668,6 +1727,9 @@ impl PeerSession {
     fn send_rtc_unreach_chunked(
         &mut self,
         profile: &SessionExportProfile,
+        afi: Afi,
+        safi: Safi,
+        ipv4_mode: Ipv4UnicastMode,
         routes: &[rustbgpd_wire::RtcNlri],
         max_len: usize,
     ) -> bool {
@@ -1676,12 +1738,7 @@ impl PeerSession {
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
             let msg = profile
-                .build_mp_unreach(
-                    Afi::Ipv4,
-                    Safi::RtConstrain,
-                    UnreachNlri::Rtc(&routes[idx..end]),
-                    Ipv4UnicastMode::Body,
-                )
+                .build_mp_unreach(afi, safi, UnreachNlri::Rtc(&routes[idx..end]), ipv4_mode)
                 .expect("RTC MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
@@ -1855,7 +1912,14 @@ mod tests {
                     1,
                 )
             } else {
-                session.send_evpn_unreach_chunked(&profile, std::slice::from_ref(&route), 1)
+                session.send_evpn_unreach_chunked(
+                    &profile,
+                    Afi::L2Vpn,
+                    Safi::Evpn,
+                    Ipv4UnicastMode::Body,
+                    std::slice::from_ref(&route),
+                    1,
+                )
             };
             assert!(!sent, "overflowing EVPN send must fail closed");
             assert!(session.read_half.is_none());

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1,11 +1,15 @@
-use super::{
-    Afi, AsPath, AsPathSegment, BgpLsRibRoute, BgpLsRouteKey, BgpRole, EvpnRibRoute, EvpnRoute,
-    EvpnRouteKey, FlowSpecRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
-    Ipv6Addr, LabeledRibRoute, Message, MpReachNlri, MpUnreachNlri, NlriEntry, OutboundRouteUpdate,
-    PathAttribute, PeerSession, Prefix, RemovePrivateAs, Route, RouteRefreshMessage,
-    RouteRefreshSubtype, RtcRibRoute, Safi, UpdateMessage, VpnRibRoute, debug, info,
-    is_ipv6_link_local, is_private_asn, warn,
+use super::export::{
+    PreparedUnicastAttributes, PreparedUnicastCandidate, ReachNlri, SessionExportProfile,
+    UnreachNlri, bgpls_nlri_from_key, evpn_route_from_key, has_otc, labeled_withdraw_entry,
+    vpn_withdraw_entry,
 };
+use super::{
+    Afi, BgpRole, EvpnRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
+    Ipv6Addr, Message, NlriEntry, OutboundRouteUpdate, PathAttribute, PeerSession, Prefix, Route,
+    RouteRefreshMessage, RouteRefreshSubtype, Safi, UpdateMessage, debug, info, warn,
+};
+#[cfg(test)]
+use super::{FlowSpecRoute, LabeledRibRoute, RtcRibRoute, VpnRibRoute};
 use std::sync::Arc;
 
 // The per-batch outbound maps (`PreparedAttrCacheKey` cache + the
@@ -21,15 +25,6 @@ use std::sync::Arc;
 // capped. A peer able to craft colliding attribute sets already has
 // strictly higher-impact vectors (churn flood, hijack).
 use rustc_hash::FxHashMap as HashMap;
-fn has_otc(attrs: &[PathAttribute]) -> bool {
-    attrs.iter().any(|attr| match attr {
-        PathAttribute::OnlyToCustomer(_) => true,
-        PathAttribute::Unknown(raw) => {
-            raw.type_code == rustbgpd_wire::constants::attr_type::ONLY_TO_CUSTOMER
-        }
-        _ => false,
-    })
-}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum NextHopOverrideKey {
     None,
@@ -56,11 +51,6 @@ struct PreparedAttrCacheKey {
     local_ipv4: Ipv4Addr,
     nh_override: NextHopOverrideKey,
 }
-#[derive(Clone)]
-struct PreparedAttrCacheValue {
-    with_next_hop: Arc<Vec<PathAttribute>>,
-    without_next_hop: Arc<Vec<PathAttribute>>,
-}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct AttrGroupKey {
     attrs_ptr: usize,
@@ -78,128 +68,6 @@ struct MpGroup {
     prefixes: Vec<NlriEntry>,
 }
 impl PeerSession {
-    fn usable_ipv4_extended_nexthop_ipv6(&self, candidate: Option<Ipv6Addr>) -> Option<Ipv6Addr> {
-        // The link-local relaxation is only valid for IPv4-over-IPv6 ENHE on a
-        // configured scoped peer. IPv6 unicast keeps using
-        // `usable_ipv6_unicast_next_hop`, which rejects link-local primaries.
-        candidate.filter(|addr| {
-            rustbgpd_wire::is_valid_ipv6_nexthop(addr)
-                || (self.is_scoped_link_local_peer() && is_ipv6_link_local(addr))
-        })
-    }
-    fn usable_ipv6_unicast_next_hop(candidate: Option<Ipv6Addr>) -> Option<Ipv6Addr> {
-        candidate.filter(rustbgpd_wire::is_valid_ipv6_nexthop)
-    }
-    fn ipv4_mp_reach_link_local_next_hop(
-        &self,
-        next_hop: IpAddr,
-        route: &Route,
-    ) -> Option<Ipv6Addr> {
-        match next_hop {
-            IpAddr::V6(v6) if self.is_scoped_link_local_peer() && is_ipv6_link_local(&v6) => {
-                Some(v6)
-            }
-            _ if next_hop == route.next_hop => route.link_local_next_hop,
-            _ => None,
-        }
-    }
-    fn route_link_local_next_hop_for_selected_primary(
-        next_hop: IpAddr,
-        route: &Route,
-    ) -> Option<Ipv6Addr> {
-        if next_hop == route.next_hop {
-            route.link_local_next_hop
-        } else {
-            None
-        }
-    }
-    fn peer_accepts_llgr_stale(&self, family: (Afi, Safi)) -> bool {
-        self.negotiated.as_ref().is_some_and(|neg| {
-            neg.peer_llgr_capable
-                && neg
-                    .peer_llgr_families
-                    .iter()
-                    .any(|f| (f.afi, f.safi) == family)
-        })
-    }
-    /// RFC 9494 §4.6 outbound form for an LLGR-stale route toward a peer
-    /// that did NOT advertise the LLGR capability for the family. The RIB
-    /// staging gate suppresses such routes toward eBGP peers entirely, so
-    /// the only LLGR-stale routes that legitimately arrive here for a
-    /// non-LLGR peer are iBGP — permitted by the §4.6 intra-AS exception
-    /// only with `NO_EXPORT` attached and `LOCAL_PREF` set to zero. The
-    /// `LLGR_STALE` community itself "MUST NOT be removed when the route
-    /// is further advertised", so it rides through unchanged (toward
-    /// LLGR peers too). This lives beside the other per-peer attribute
-    /// rewrites (eBGP `LOCAL_PREF` strip, `ORIGINATOR_ID`/`CLUSTER_LIST`,
-    /// `GShut` attach) rather than at RIB staging.
-    ///
-    /// Detection is by the `LLGR_STALE` community rather than the RIB's
-    /// `is_llgr_stale` flag — deliberately: the community is the superset.
-    /// A route *received* already tagged by an upstream LLGR helper carries
-    /// only the community (the local flag is never set for it), yet §4.6
-    /// applies to it all the same. For locally promoted routes the flag and
-    /// community are coupled by construction (promotion injects the
-    /// community; the flag is never set anywhere else), and that coupling
-    /// is pinned by `llgr_stale_flag_implies_community_across_mutations` in
-    /// `rustbgpd-rib::adj_rib_in`.
-    fn apply_llgr_stale_export_form(
-        &self,
-        attrs: &mut Vec<PathAttribute>,
-        family: (Afi, Safi),
-        is_ebgp: bool,
-    ) {
-        if is_ebgp || self.peer_accepts_llgr_stale(family) {
-            return;
-        }
-        let is_llgr_stale = attrs.iter().any(|attr| {
-            matches!(attr, PathAttribute::Communities(comms)
-                if comms.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
-        });
-        if !is_llgr_stale {
-            return;
-        }
-        let mut has_local_pref = false;
-        for attr in attrs.iter_mut() {
-            match attr {
-                PathAttribute::LocalPref(local_pref) => {
-                    *local_pref = 0;
-                    has_local_pref = true;
-                }
-                PathAttribute::Communities(comms)
-                    if !comms.contains(&rustbgpd_wire::COMMUNITY_NO_EXPORT) =>
-                {
-                    comms.push(rustbgpd_wire::COMMUNITY_NO_EXPORT);
-                }
-                _ => {}
-            }
-        }
-        if !has_local_pref {
-            attrs.push(PathAttribute::LocalPref(0));
-        }
-    }
-    /// RFC 8326 initiator: when `advertise_graceful_shutdown` is set
-    /// (via gRPC `SetGracefulShutdown`), ensure every outbound update
-    /// carries the `GRACEFUL_SHUTDOWN` community. If the route already
-    /// has a `Communities` attribute, the value is folded in; otherwise
-    /// a new `Communities` attribute is added. Idempotent — re-applying
-    /// to an already-tagged route is a no-op.
-    fn attach_graceful_shutdown_if_enabled(&self, attrs: &mut Vec<PathAttribute>) {
-        if !self.advertise_graceful_shutdown {
-            return;
-        }
-        for attr in attrs.iter_mut() {
-            if let PathAttribute::Communities(comms) = attr {
-                if !comms.contains(&rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN) {
-                    comms.push(rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN);
-                }
-                return;
-            }
-        }
-        attrs.push(PathAttribute::Communities(vec![
-            rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN,
-        ]));
-    }
     fn route_origin_key(origin: rustbgpd_rib::RouteOrigin) -> u8 {
         match origin {
             rustbgpd_rib::RouteOrigin::Ebgp => 0,
@@ -225,28 +93,16 @@ impl PeerSession {
         }
     }
     fn prepared_outbound_attributes_cached<'a>(
-        &'a self,
-        cache: &'a mut HashMap<PreparedAttrCacheKey, PreparedAttrCacheValue>,
+        profile: &'a SessionExportProfile,
+        cache: &'a mut HashMap<PreparedAttrCacheKey, PreparedUnicastAttributes>,
         route: &Route,
-        is_ebgp: bool,
         local_ipv4: Ipv4Addr,
         nh_override: Option<&rustbgpd_policy::NextHopAction>,
-    ) -> &'a PreparedAttrCacheValue {
+    ) -> &'a PreparedUnicastAttributes {
+        let is_ebgp = profile.is_ebgp();
         let key = Self::prepared_attr_cache_key(route, is_ebgp, local_ipv4, nh_override);
         cache.entry(key).or_insert_with(|| {
-            let with_next_hop =
-                Arc::new(self.prepare_outbound_attributes(route, is_ebgp, local_ipv4, nh_override));
-            let without_next_hop = Arc::new(
-                with_next_hop
-                    .iter()
-                    .filter(|attr| !matches!(attr, PathAttribute::NextHop(_)))
-                    .cloned()
-                    .collect(),
-            );
-            PreparedAttrCacheValue {
-                with_next_hop,
-                without_next_hop,
-            }
+            profile.prepare_unicast_attribute_bundle(route, local_ipv4, nh_override)
         })
     }
     pub(super) fn otc_egress_blocks_unicast(&self, route: &Route) -> bool {
@@ -323,85 +179,18 @@ impl PeerSession {
         reason = "export pipeline keeps policy, ORF, and advertisement ordering in one pass"
     )]
     pub(super) fn send_route_update(&mut self, update: OutboundRouteUpdate) {
+        // Production only reads the profile published by lifecycle/runtime
+        // seams, so its generation remains stable between real changes.
+        #[cfg(test)]
+        self.publish_export_profile();
+        let export = self.export_encoder.snapshot();
         for route in &update.otc_blocked {
             self.record_otc_egress_block(route);
         }
-        let four_octet_as = self.negotiated.as_ref().is_some_and(|n| n.four_octet_as);
-        let is_ebgp = self
-            .negotiated
-            .as_ref()
-            .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
         let peer_err = self
             .negotiated
             .as_ref()
             .is_some_and(|n| n.peer_enhanced_route_refresh);
-        // Check if Add-Path send is negotiated (we can send path IDs to this peer)
-        let add_path_ipv4_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv4, Safi::Unicast))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
-        let add_path_ipv6_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv6, Safi::Unicast))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
-        // VPNv4/VPNv6 (SAFI 128) negotiate Add-Path per family (RFC 7911);
-        // when send is negotiated, EVERY VPN NLRI to this peer carries the
-        // 4-octet path ID — announcements and withdrawals alike.
-        let add_path_vpnv4_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv4, Safi::MplsVpn))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
-        let add_path_vpnv6_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv6, Safi::MplsVpn))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
-        // Labeled-unicast (SAFI 4) negotiates Add-Path per family the same
-        // way; when send is negotiated, EVERY labeled NLRI to this peer
-        // carries the 4-octet path ID — announcements and withdrawals alike.
-        let add_path_labeled_v4_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv4, Safi::LabeledUnicast))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
-        let add_path_labeled_v6_send = self.negotiated.as_ref().is_some_and(|n| {
-            n.add_path_families
-                .get(&(Afi::Ipv6, Safi::LabeledUnicast))
-                .is_some_and(|m| {
-                    matches!(
-                        m,
-                        rustbgpd_wire::AddPathMode::Send | rustbgpd_wire::AddPathMode::Both
-                    )
-                })
-        });
         // ROUTE-REFRESH *requests* toward the peer (RFC 2918), asked for by
         // the RIB manager (outbound-registration failover: the survivor's
         // Adj-RIB-In must be re-learned from the peer). The manager only
@@ -468,24 +257,9 @@ impl PeerSession {
                     .record_message_sent(&self.peer_label, "route_refresh");
             }
         }
-        let use_extended_nexthop_ipv4 = self.use_extended_nexthop_ipv4();
-        // Extract TCP local addresses for NEXT_HOP rewrite
-        let local_addr = self
-            .read_half
-            .as_ref()
-            .and_then(|h| h.local_addr().ok())
-            .map(|a| a.ip());
-        let local_ipv4 = local_addr
-            .and_then(|a| match a {
-                IpAddr::V4(v4) => Some(v4),
-                IpAddr::V6(_) => None,
-            })
-            .unwrap_or(self.config.peer.local_router_id);
-        let local_ipv6 = local_addr.and_then(|a| match a {
-            IpAddr::V6(v6) => Some(v6),
-            IpAddr::V4(_) => None,
-        });
-        let mut prepared_attr_cache: HashMap<PreparedAttrCacheKey, PreparedAttrCacheValue> =
+        let use_extended_nexthop_ipv4 = export.use_extended_nexthop_ipv4();
+        let local_ipv4 = export.local_ipv4();
+        let mut prepared_attr_cache: HashMap<PreparedAttrCacheKey, PreparedUnicastAttributes> =
             HashMap::default();
         // Split withdrawals by address family, filtering by negotiated families
         let mut v4_withdraw: Vec<Ipv4NlriEntry> = Vec::new();
@@ -508,51 +282,36 @@ impl PeerSession {
         // Send IPv4 withdrawals via body NLRI or IPv4 MP_UNREACH_NLRI,
         // depending on Extended Next Hop negotiation.
         if !v4_withdraw.is_empty() {
-            if self.is_scoped_link_local_peer() && !use_extended_nexthop_ipv4 {
+            if export.is_scoped_link_local_peer() && !use_extended_nexthop_ipv4 {
                 warn!(
                     peer = %self.peer_label,
                     "not sending IPv4 withdrawals to scoped link-local peer without negotiated Extended Next Hop"
                 );
             } else {
-                let max_len = usize::from(self.outbound_max_message_len());
+                let max_len = export.max_message_len();
                 let ok = if use_extended_nexthop_ipv4 {
                     self.send_v4_chunked(&v4_withdraw, max_len, "withdraw", |chunk| {
-                        let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                            afi: Afi::Ipv4,
-                            safi: Safi::Unicast,
-                            withdrawn: chunk
-                                .iter()
-                                .map(|entry| NlriEntry {
-                                    path_id: entry.path_id,
-                                    prefix: Prefix::V4(entry.prefix),
-                                })
-                                .collect(),
-                            flowspec_withdrawn: vec![],
-                            evpn_withdrawn: vec![],
-                            bgpls_withdrawn: vec![],
-                            labeled_withdrawn: vec![],
-                            vpn_withdrawn: vec![],
-                            rtc_withdrawn: vec![],
-                        })];
-                        UpdateMessage::build(
-                            &[],
-                            &[],
-                            &attrs,
-                            four_octet_as,
-                            add_path_ipv4_send,
-                            Ipv4UnicastMode::MpReach,
-                        )
+                        let entries: Vec<_> = chunk
+                            .iter()
+                            .map(|entry| NlriEntry {
+                                path_id: entry.path_id,
+                                prefix: Prefix::V4(entry.prefix),
+                            })
+                            .collect();
+                        export
+                            .build_mp_unreach(
+                                Afi::Ipv4,
+                                Safi::Unicast,
+                                UnreachNlri::Unicast(&entries),
+                                Ipv4UnicastMode::MpReach,
+                            )
+                            .expect("IPv4 MP_UNREACH construction was previously infallible")
                     })
                 } else {
                     self.send_v4_chunked(&v4_withdraw, max_len, "withdraw", |chunk| {
-                        UpdateMessage::build(
-                            &[],
-                            chunk,
-                            &[],
-                            four_octet_as,
-                            add_path_ipv4_send,
-                            Ipv4UnicastMode::Body,
-                        )
+                        export
+                            .build_ipv4_body(&[], chunk, &[])
+                            .expect("IPv4 body withdrawal construction was previously infallible")
                     })
                 };
                 if !ok {
@@ -565,30 +324,17 @@ impl PeerSession {
         // withdrawal set must not be handed to `enqueue_bulk` as one
         // oversized message after the RIB has already committed it.
         if !v6_withdraw.is_empty() {
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             if !self.send_mp_chunked(
                 &v6_withdraw,
                 max_len,
                 "IPv6 unicast",
                 "withdrawal",
                 |chunk| {
-                    let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                        afi: Afi::Ipv6,
-                        safi: Safi::Unicast,
-                        withdrawn: chunk.to_vec(),
-                        flowspec_withdrawn: vec![],
-                        evpn_withdrawn: vec![],
-                        bgpls_withdrawn: vec![],
-                        labeled_withdrawn: vec![],
-                        vpn_withdrawn: vec![],
-                        rtc_withdrawn: vec![],
-                    })];
-                    UpdateMessage::try_build(
-                        &[],
-                        &[],
-                        &attrs,
-                        four_octet_as,
-                        add_path_ipv6_send,
+                    export.build_mp_unreach(
+                        Afi::Ipv6,
+                        Safi::Unicast,
+                        UnreachNlri::Unicast(chunk),
                         Ipv4UnicastMode::Body,
                     )
                 },
@@ -619,46 +365,41 @@ impl PeerSession {
         // Send IPv4 announcements via body NLRI or IPv4 MP_REACH_NLRI,
         // depending on Extended Next Hop negotiation.
         if use_extended_nexthop_ipv4 {
-            let ebgp_ipv6_nh = self
-                .usable_ipv4_extended_nexthop_ipv6(self.config.local_ipv6_nexthop.or(local_ipv6));
             let mut v4_group_index: HashMap<AttrGroupKey, usize> = HashMap::default();
             let mut v4_groups: Vec<MpGroup> = Vec::new();
             for (route, nh_override_ref) in &v4_routes {
                 let nh_override = *nh_override_ref;
-                let attrs = Arc::clone(
-                    &self
-                        .prepared_outbound_attributes_cached(
-                            &mut prepared_attr_cache,
-                            route,
-                            is_ebgp,
-                            local_ipv4,
-                            nh_override,
-                        )
-                        .without_next_hop,
-                );
-                let force_nh_self =
-                    matches!(nh_override, Some(rustbgpd_policy::NextHopAction::Self_));
-                let next_hop = match nh_override {
-                    Some(rustbgpd_policy::NextHopAction::Specific(addr)) => *addr,
-                    _ if force_nh_self => local_addr.unwrap_or(IpAddr::V4(local_ipv4)),
-                    _ if is_ebgp && !self.config.route_server_client => {
-                        let Some(v6) = ebgp_ipv6_nh else {
+                let cached_attrs = Self::prepared_outbound_attributes_cached(
+                    &export,
+                    &mut prepared_attr_cache,
+                    route,
+                    local_ipv4,
+                    nh_override,
+                )
+                .clone();
+                let prepared =
+                    match export.finish_unicast_candidate(route, nh_override, cached_attrs) {
+                        Ok(PreparedUnicastCandidate::Mp {
+                            next_hop,
+                            link_local_next_hop,
+                            attrs,
+                            entry,
+                            ..
+                        }) => (attrs, next_hop, link_local_next_hop, entry),
+                        Ok(PreparedUnicastCandidate::Ipv4Body { .. }) => {
+                            unreachable!("ENHE profile must prepare IPv4 as MP_REACH")
+                        }
+                        Err(error) => {
                             warn!(
                                 peer = %self.peer_label,
                                 prefix = %route.prefix,
-                                "cannot send IPv4 route with Extended Next Hop: no usable local IPv6 next-hop"
+                                %error,
+                                "cannot prepare IPv4 route with Extended Next Hop"
                             );
                             continue;
-                        };
-                        IpAddr::V6(v6)
-                    }
-                    _ => route.next_hop,
-                };
-                let entry = NlriEntry {
-                    path_id: route.path_id,
-                    prefix: route.prefix,
-                };
-                let link_local_next_hop = self.ipv4_mp_reach_link_local_next_hop(next_hop, route);
+                        }
+                    };
+                let (attrs, next_hop, link_local_next_hop, entry) = prepared;
                 let key = AttrGroupKey {
                     attrs_ptr: Arc::as_ptr(&attrs) as usize,
                     next_hop: Some(next_hop),
@@ -676,39 +417,28 @@ impl PeerSession {
                     });
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for group in &v4_groups {
                 let base_attrs = group.attrs.as_ref();
                 let next_hop = group.next_hop;
                 let link_local_next_hop = group.link_local_next_hop;
                 if !self.send_v4_chunked(&group.prefixes, max_len, "announce", |chunk| {
-                    let mut attrs = base_attrs.clone();
-                    attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                        afi: Afi::Ipv4,
-                        safi: Safi::Unicast,
-                        next_hop,
-                        link_local_next_hop,
-                        announced: chunk.to_vec(),
-                        flowspec_announced: vec![],
-                        evpn_announced: vec![],
-                        bgpls_announced: vec![],
-                        labeled_announced: vec![],
-                        vpn_announced: vec![],
-                        rtc_announced: vec![],
-                    }));
-                    UpdateMessage::build(
-                        &[],
-                        &[],
-                        &attrs,
-                        four_octet_as,
-                        add_path_ipv4_send,
-                        Ipv4UnicastMode::MpReach,
-                    )
+                    export
+                        .build_mp_reach(
+                            Afi::Ipv4,
+                            Safi::Unicast,
+                            next_hop,
+                            link_local_next_hop,
+                            base_attrs,
+                            ReachNlri::Unicast(chunk),
+                            Ipv4UnicastMode::MpReach,
+                        )
+                        .expect("IPv4 MP_REACH construction was previously infallible")
                 }) {
                     return;
                 }
             }
-        } else if self.is_scoped_link_local_peer() {
+        } else if export.is_scoped_link_local_peer() {
             if !v4_routes.is_empty() {
                 warn!(
                     peer = %self.peer_label,
@@ -719,22 +449,17 @@ impl PeerSession {
             let mut v4_group_index: HashMap<AttrGroupKey, usize> = HashMap::default();
             let mut v4_groups: Vec<V4BodyGroup> = Vec::new();
             for (route, nh_override) in &v4_routes {
-                let attrs = Arc::clone(
-                    &self
-                        .prepared_outbound_attributes_cached(
-                            &mut prepared_attr_cache,
-                            route,
-                            is_ebgp,
-                            local_ipv4,
-                            *nh_override,
-                        )
-                        .with_next_hop,
-                );
-                if let Prefix::V4(v4) = route.prefix {
-                    let entry = Ipv4NlriEntry {
-                        path_id: route.path_id,
-                        prefix: v4,
-                    };
+                let cached_attrs = Self::prepared_outbound_attributes_cached(
+                    &export,
+                    &mut prepared_attr_cache,
+                    route,
+                    local_ipv4,
+                    *nh_override,
+                )
+                .clone();
+                if let Ok(PreparedUnicastCandidate::Ipv4Body { attrs, entry }) =
+                    export.finish_unicast_candidate(route, *nh_override, cached_attrs)
+                {
                     let key = AttrGroupKey {
                         attrs_ptr: Arc::as_ptr(&attrs) as usize,
                         next_hop: None,
@@ -751,18 +476,13 @@ impl PeerSession {
                     }
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for group in &v4_groups {
                 let attrs = group.attrs.as_ref();
                 if !self.send_v4_chunked(&group.prefixes, max_len, "announce", |chunk| {
-                    UpdateMessage::build(
-                        chunk,
-                        &[],
-                        attrs,
-                        four_octet_as,
-                        add_path_ipv4_send,
-                        Ipv4UnicastMode::Body,
-                    )
+                    export
+                        .build_ipv4_body(chunk, &[], attrs)
+                        .expect("IPv4 body announcement construction was previously infallible")
                 }) {
                     return;
                 }
@@ -772,68 +492,46 @@ impl PeerSession {
         // The RIB already filters unsendable families via sendable_families, so
         // v6_routes should be empty here for eBGP peers without a valid IPv6 NH.
         // The is_family_negotiated filter above is retained as a safety net.
-        let ebgp_ipv6_nh: Option<Ipv6Addr> =
-            Self::usable_ipv6_unicast_next_hop(self.config.local_ipv6_nexthop.or(local_ipv6));
         // Group by (attributes, next-hop) so routes with different next-hops
         // get separate UPDATEs with correct MP_REACH_NLRI next-hop values.
         let mut v6_group_index: HashMap<AttrGroupKey, usize> = HashMap::default();
         let mut v6_groups: Vec<MpGroup> = Vec::new();
         for (route, nh_override_ref) in &v6_routes {
             let nh_override = *nh_override_ref;
-            let attrs = Arc::clone(
-                &self
-                    .prepared_outbound_attributes_cached(
-                        &mut prepared_attr_cache,
-                        route,
-                        is_ebgp,
-                        local_ipv4,
-                        nh_override,
-                    )
-                    .with_next_hop,
-            );
-            let force_nh_self = matches!(nh_override, Some(rustbgpd_policy::NextHopAction::Self_));
-            let nh = if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh_override {
-                // Policy explicitly set a next-hop — use it
-                *addr
-            } else if is_ebgp && !self.config.route_server_client {
-                // Non-transparent eBGP uses next-hop-self unless policy set
-                // an explicit next-hop. If no usable local IPv6 next-hop is
-                // available, drop the route rather than advertising the peer's
-                // original next-hop by mistake.
-                let Some(v6) = ebgp_ipv6_nh else {
-                    debug_assert!(
-                        false,
-                        "RIB sent IPv6 route to eBGP peer with no valid IPv6 next-hop and no explicit policy override"
-                    );
+            let cached_attrs = Self::prepared_outbound_attributes_cached(
+                &export,
+                &mut prepared_attr_cache,
+                route,
+                local_ipv4,
+                nh_override,
+            )
+            .clone();
+            let prepared = match export.finish_unicast_candidate(route, nh_override, cached_attrs) {
+                Ok(PreparedUnicastCandidate::Mp {
+                    next_hop,
+                    link_local_next_hop,
+                    attrs,
+                    entry,
+                    ..
+                }) => (attrs, next_hop, link_local_next_hop, entry),
+                Ok(PreparedUnicastCandidate::Ipv4Body { .. }) => {
+                    unreachable!("IPv6 must prepare as MP_REACH")
+                }
+                Err(error) => {
                     warn!(
                         peer = %self.peer_label,
                         prefix = %route.prefix,
-                        "dropping IPv6 route: no usable local IPv6 next-hop and no explicit export next-hop override"
+                        %error,
+                        "dropping IPv6 route: exact export preparation failed"
                     );
                     continue;
-                };
-                IpAddr::V6(v6)
-            } else if force_nh_self {
-                // For next-hop-self on non-eBGP paths, use local IPv6 address
-                // when available; otherwise leave the stored next-hop in place.
-                if let Some(v6) = ebgp_ipv6_nh {
-                    IpAddr::V6(v6)
-                } else {
-                    route.next_hop
                 }
-            } else {
-                route.next_hop
             };
-            let nlri_entry = NlriEntry {
-                path_id: route.path_id,
-                prefix: route.prefix,
-            };
+            let (attrs, nh, link_local_next_hop, nlri_entry) = prepared;
             let key = AttrGroupKey {
                 attrs_ptr: Arc::as_ptr(&attrs) as usize,
                 next_hop: Some(nh),
-                link_local_next_hop: Self::route_link_local_next_hop_for_selected_primary(
-                    nh, route,
-                ),
+                link_local_next_hop,
             };
             if let Some(&idx) = v6_group_index.get(&key) {
                 v6_groups[idx].prefixes.push(nlri_entry);
@@ -842,14 +540,12 @@ impl PeerSession {
                 v6_groups.push(MpGroup {
                     attrs,
                     next_hop: nh,
-                    link_local_next_hop: Self::route_link_local_next_hop_for_selected_primary(
-                        nh, route,
-                    ),
+                    link_local_next_hop,
                     prefixes: vec![nlri_entry],
                 });
             }
         }
-        let max_len = usize::from(self.outbound_max_message_len());
+        let max_len = export.max_message_len();
         for group in &v6_groups {
             let base_attrs = group.attrs.as_ref();
             let next_hop = group.next_hop;
@@ -860,26 +556,13 @@ impl PeerSession {
                 "IPv6 unicast",
                 "announcement",
                 |chunk| {
-                    let mut attrs = base_attrs.clone();
-                    attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                        afi: Afi::Ipv6,
-                        safi: Safi::Unicast,
+                    export.build_mp_reach(
+                        Afi::Ipv6,
+                        Safi::Unicast,
                         next_hop,
                         link_local_next_hop,
-                        announced: chunk.to_vec(),
-                        flowspec_announced: vec![],
-                        evpn_announced: vec![],
-                        bgpls_announced: vec![],
-                        labeled_announced: vec![],
-                        vpn_announced: vec![],
-                        rtc_announced: vec![],
-                    }));
-                    UpdateMessage::try_build(
-                        &[],
-                        &[],
-                        &attrs,
-                        four_octet_as,
-                        add_path_ipv6_send,
+                        base_attrs,
+                        ReachNlri::Unicast(chunk),
                         Ipv4UnicastMode::Body,
                     )
                 },
@@ -905,25 +588,12 @@ impl PeerSession {
                 if rules.is_empty() {
                     continue;
                 }
-                let max_len = usize::from(self.outbound_max_message_len());
+                let max_len = export.max_message_len();
                 if !self.send_mp_chunked(&rules, max_len, "FlowSpec", "withdrawal", |chunk| {
-                    let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                    export.build_mp_unreach(
                         afi,
-                        safi: Safi::FlowSpec,
-                        withdrawn: vec![],
-                        flowspec_withdrawn: chunk.to_vec(),
-                        evpn_withdrawn: vec![],
-                        bgpls_withdrawn: vec![],
-                        labeled_withdrawn: vec![],
-                        vpn_withdrawn: vec![],
-                        rtc_withdrawn: vec![],
-                    })];
-                    UpdateMessage::try_build(
-                        &[],
-                        &[],
-                        &attrs,
-                        four_octet_as,
-                        false,
+                        Safi::FlowSpec,
+                        UnreachNlri::FlowSpec(chunk),
                         Ipv4UnicastMode::Body,
                     )
                 }) {
@@ -942,8 +612,8 @@ impl PeerSession {
                 .iter()
                 .map(|key| evpn_route_from_key(*key))
                 .collect();
-            let max_len = usize::from(self.outbound_max_message_len());
-            if !self.send_evpn_unreach_chunked(&routes, four_octet_as, max_len) {
+            let max_len = export.max_message_len();
+            if !self.send_evpn_unreach_chunked(&export, &routes, max_len) {
                 return;
             }
         }
@@ -973,24 +643,14 @@ impl PeerSession {
                     _ => {}
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             if !base_routes.is_empty()
-                && !self.send_bgpls_unreach_chunked(
-                    Safi::BgpLs,
-                    &base_routes,
-                    four_octet_as,
-                    max_len,
-                )
+                && !self.send_bgpls_unreach_chunked(Safi::BgpLs, &base_routes, &export, max_len)
             {
                 return;
             }
             if !vpn_routes.is_empty()
-                && !self.send_bgpls_unreach_chunked(
-                    Safi::BgpLsVpn,
-                    &vpn_routes,
-                    four_octet_as,
-                    max_len,
-                )
+                && !self.send_bgpls_unreach_chunked(Safi::BgpLsVpn, &vpn_routes, &export, max_len)
             {
                 return;
             }
@@ -1003,14 +663,7 @@ impl PeerSession {
             let mut v4_routes = Vec::new();
             let mut v6_routes = Vec::new();
             for key in &update.vpn_withdraw {
-                let entry = rustbgpd_wire::VpnNlriEntry {
-                    path_id: key.path_id,
-                    nlri: rustbgpd_wire::VpnNlri {
-                        labels: vec![],
-                        route_distinguisher: key.nlri_key.route_distinguisher,
-                        prefix: key.nlri_key.prefix,
-                    },
-                };
+                let entry = vpn_withdraw_entry(key);
                 let family = key.afi_safi();
                 if !self.negotiated_families.contains(&family) {
                     continue;
@@ -1021,19 +674,10 @@ impl PeerSession {
                     Afi::L2Vpn | Afi::BgpLs => {}
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
-            for (afi, routes, add_path) in [
-                (Afi::Ipv4, v4_routes, add_path_vpnv4_send),
-                (Afi::Ipv6, v6_routes, add_path_vpnv6_send),
-            ] {
+            let max_len = export.max_message_len();
+            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
                 if !routes.is_empty()
-                    && !self.send_vpn_unreach_chunked(
-                        afi,
-                        &routes,
-                        four_octet_as,
-                        add_path,
-                        max_len,
-                    )
+                    && !self.send_vpn_unreach_chunked(afi, &routes, &export, max_len)
                 {
                     return;
                 }
@@ -1048,13 +692,7 @@ impl PeerSession {
             let mut v4_routes = Vec::new();
             let mut v6_routes = Vec::new();
             for key in &update.labeled_withdraw {
-                let entry = rustbgpd_wire::LabeledNlriEntry {
-                    path_id: key.path_id,
-                    nlri: rustbgpd_wire::LabeledNlri {
-                        labels: vec![],
-                        prefix: key.prefix,
-                    },
-                };
+                let entry = labeled_withdraw_entry(key);
                 let family = key.afi_safi();
                 if !self.negotiated_families.contains(&family) {
                     continue;
@@ -1065,19 +703,10 @@ impl PeerSession {
                     Afi::L2Vpn | Afi::BgpLs => {}
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
-            for (afi, routes, add_path) in [
-                (Afi::Ipv4, v4_routes, add_path_labeled_v4_send),
-                (Afi::Ipv6, v6_routes, add_path_labeled_v6_send),
-            ] {
+            let max_len = export.max_message_len();
+            for (afi, routes) in [(Afi::Ipv4, v4_routes), (Afi::Ipv6, v6_routes)] {
                 if !routes.is_empty()
-                    && !self.send_labeled_unreach_chunked(
-                        afi,
-                        &routes,
-                        four_octet_as,
-                        add_path,
-                        max_len,
-                    )
+                    && !self.send_labeled_unreach_chunked(afi, &routes, &export, max_len)
                 {
                     return;
                 }
@@ -1093,8 +722,8 @@ impl PeerSession {
         {
             let routes: Vec<rustbgpd_wire::RtcNlri> =
                 update.rtc_withdraw.iter().map(|key| key.nlri).collect();
-            let max_len = usize::from(self.outbound_max_message_len());
-            if !self.send_rtc_unreach_chunked(&routes, four_octet_as, max_len) {
+            let max_len = export.max_message_len();
+            if !self.send_rtc_unreach_chunked(&export, &routes, max_len) {
                 return;
             }
         }
@@ -1107,24 +736,21 @@ impl PeerSession {
             )]
             let mut evpn_groups: Vec<(IpAddr, Vec<PathAttribute>, Vec<EvpnRoute>)> = Vec::new();
             for evpn_route in &update.evpn_announce {
-                let attrs = self.prepare_outbound_attributes_evpn(evpn_route, is_ebgp);
-                // Determine the next-hop for the reflected route. In RR mode
-                // we preserve the originating VTEP's loopback as next-hop so
-                // downstream VTEPs can build the VXLAN tunnel correctly.
-                let nh = evpn_route.next_hop;
+                let prepared = export.prepare_evpn_candidate(evpn_route);
+                let attrs = prepared.attrs;
+                let nh = prepared.next_hop;
                 if let Some(group) = evpn_groups
                     .iter_mut()
                     .find(|(g_nh, g_attrs, _)| *g_nh == nh && *g_attrs == attrs)
                 {
-                    group.2.push(evpn_route.route.clone());
+                    group.2.push(prepared.nlri);
                 } else {
-                    evpn_groups.push((nh, attrs, vec![evpn_route.route.clone()]));
+                    evpn_groups.push((nh, attrs, vec![prepared.nlri]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for (next_hop, attrs, routes) in evpn_groups {
-                if !self.send_evpn_reach_chunked(next_hop, &attrs, &routes, four_octet_as, max_len)
-                {
+                if !self.send_evpn_reach_chunked(&export, next_hop, &attrs, &routes, max_len) {
                     return;
                 }
             }
@@ -1147,29 +773,25 @@ impl PeerSession {
                 if !self.negotiated_families.contains(&(Afi::BgpLs, safi)) {
                     continue;
                 }
-                let attrs = self.prepare_outbound_attributes_bgpls(bgpls_route, is_ebgp);
-                let nh = bgpls_route.next_hop;
+                let prepared = export.prepare_bgpls_candidate(bgpls_route);
+                let attrs = prepared.attrs;
+                let nh = prepared.next_hop;
                 if let Some(group) = bgpls_groups.iter_mut().find(|(family, g_nh, g_attrs, _)| {
                     *family == bgpls_route.family && *g_nh == nh && *g_attrs == attrs
                 }) {
-                    group.3.push(bgpls_route.nlri.clone());
+                    group.3.push(prepared.nlri);
                 } else {
-                    bgpls_groups.push((
-                        bgpls_route.family,
-                        nh,
-                        attrs,
-                        vec![bgpls_route.nlri.clone()],
-                    ));
+                    bgpls_groups.push((bgpls_route.family, nh, attrs, vec![prepared.nlri]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for (family, next_hop, attrs, routes) in bgpls_groups {
                 if !self.send_bgpls_reach_chunked(
                     family.to_afi_safi().1,
                     next_hop,
                     &attrs,
                     &routes,
-                    four_octet_as,
+                    &export,
                     max_len,
                 ) {
                     return;
@@ -1197,16 +819,11 @@ impl PeerSession {
                 if !self.negotiated_families.contains(&family) {
                     continue;
                 }
-                let attrs = self.prepare_outbound_attributes_vpn(vpn_route, is_ebgp);
-                let nh = vpn_route.next_hop;
-                // RFC 4659 two-address IPv6 next-hop: the link-local half
-                // is grouped alongside the global next-hop so it survives
-                // reflection (LAN-217).
-                let ll = vpn_route.link_local_next_hop;
-                let entry = rustbgpd_wire::VpnNlriEntry {
-                    path_id: vpn_route.path_id,
-                    nlri: vpn_route.nlri.clone(),
-                };
+                let prepared = export.prepare_vpn_candidate(vpn_route);
+                let attrs = prepared.attrs;
+                let nh = prepared.next_hop;
+                let ll = prepared.link_local_next_hop;
+                let entry = prepared.nlri;
                 if let Some(group) =
                     vpn_groups
                         .iter_mut()
@@ -1219,20 +836,15 @@ impl PeerSession {
                     vpn_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in vpn_groups {
-                let add_path = match afi {
-                    Afi::Ipv4 => add_path_vpnv4_send,
-                    _ => add_path_vpnv6_send,
-                };
                 if !self.send_vpn_reach_chunked(
                     afi,
                     next_hop,
                     link_local_next_hop,
                     &attrs,
                     &routes,
-                    four_octet_as,
-                    add_path,
+                    &export,
                     max_len,
                 ) {
                     return;
@@ -1260,16 +872,11 @@ impl PeerSession {
                 if !self.negotiated_families.contains(&family) {
                     continue;
                 }
-                let attrs = self.prepare_outbound_attributes_labeled(labeled_route, is_ebgp);
-                let nh = labeled_route.next_hop;
-                // RFC 8950 two-address IPv6 next-hop: the link-local half
-                // is grouped alongside the global next-hop so it survives
-                // reflection (LAN-190).
-                let ll = labeled_route.link_local_next_hop;
-                let entry = rustbgpd_wire::LabeledNlriEntry {
-                    path_id: labeled_route.path_id,
-                    nlri: labeled_route.nlri.clone(),
-                };
+                let prepared = export.prepare_labeled_candidate(labeled_route);
+                let attrs = prepared.attrs;
+                let nh = prepared.next_hop;
+                let ll = prepared.link_local_next_hop;
+                let entry = prepared.nlri;
                 if let Some(group) =
                     labeled_groups
                         .iter_mut()
@@ -1282,20 +889,15 @@ impl PeerSession {
                     labeled_groups.push((family, nh, ll, attrs, vec![entry]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for ((afi, _), next_hop, link_local_next_hop, attrs, routes) in labeled_groups {
-                let add_path = match afi {
-                    Afi::Ipv4 => add_path_labeled_v4_send,
-                    _ => add_path_labeled_v6_send,
-                };
                 if !self.send_labeled_reach_chunked(
                     afi,
                     next_hop,
                     link_local_next_hop,
                     &attrs,
                     &routes,
-                    four_octet_as,
-                    add_path,
+                    &export,
                     max_len,
                 ) {
                     return;
@@ -1315,24 +917,21 @@ impl PeerSession {
             let mut rtc_groups: Vec<(IpAddr, Vec<PathAttribute>, Vec<rustbgpd_wire::RtcNlri>)> =
                 Vec::new();
             for rtc_route in &update.rtc_announce {
-                let attrs = self.prepare_outbound_attributes_rtc(rtc_route, is_ebgp);
-                let nh = if rtc_route.next_hop.is_unspecified() {
-                    local_addr.unwrap_or(IpAddr::V4(local_ipv4))
-                } else {
-                    rtc_route.next_hop
-                };
+                let prepared = export.prepare_rtc_candidate(rtc_route);
+                let attrs = prepared.attrs;
+                let nh = prepared.next_hop;
                 if let Some(group) = rtc_groups
                     .iter_mut()
                     .find(|(g_nh, g_attrs, _)| *g_nh == nh && *g_attrs == attrs)
                 {
-                    group.2.push(rtc_route.nlri);
+                    group.2.push(prepared.nlri);
                 } else {
-                    rtc_groups.push((nh, attrs, vec![rtc_route.nlri]));
+                    rtc_groups.push((nh, attrs, vec![prepared.nlri]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for (next_hop, attrs, routes) in rtc_groups {
-                if !self.send_rtc_reach_chunked(next_hop, &attrs, &routes, four_octet_as, max_len) {
+                if !self.send_rtc_reach_chunked(&export, next_hop, &attrs, &routes, max_len) {
                     return;
                 }
             }
@@ -1341,39 +940,27 @@ impl PeerSession {
         if !update.flowspec_announce.is_empty() {
             let mut fs_groups: Vec<(Afi, Vec<PathAttribute>, Vec<FlowSpecRule>)> = Vec::new();
             for fs_route in &update.flowspec_announce {
-                let attrs = self.prepare_outbound_attributes_flowspec(fs_route, is_ebgp);
+                let prepared = export.prepare_flowspec_candidate(fs_route);
+                let attrs = prepared.attrs;
                 if let Some(group) = fs_groups
                     .iter_mut()
-                    .find(|(a, ga, _)| *a == fs_route.afi && *ga == attrs)
+                    .find(|(a, ga, _)| *a == prepared.afi && *ga == attrs)
                 {
-                    group.2.push(fs_route.rule.clone());
+                    group.2.push(prepared.nlri);
                 } else {
-                    fs_groups.push((fs_route.afi, attrs, vec![fs_route.rule.clone()]));
+                    fs_groups.push((prepared.afi, attrs, vec![prepared.nlri]));
                 }
             }
-            let max_len = usize::from(self.outbound_max_message_len());
+            let max_len = export.max_message_len();
             for (afi, attrs, rules) in &fs_groups {
                 if !self.send_mp_chunked(rules, max_len, "FlowSpec", "announcement", |chunk| {
-                    let mut attrs = attrs.clone();
-                    attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                        afi: *afi,
-                        safi: Safi::FlowSpec,
-                        next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED), // NH len = 0 for FlowSpec
-                        link_local_next_hop: None,
-                        announced: vec![],
-                        flowspec_announced: chunk.to_vec(),
-                        evpn_announced: vec![],
-                        bgpls_announced: vec![],
-                        labeled_announced: vec![],
-                        vpn_announced: vec![],
-                        rtc_announced: vec![],
-                    }));
-                    UpdateMessage::try_build(
-                        &[],
-                        &[],
-                        &attrs,
-                        four_octet_as,
-                        false,
+                    export.build_mp_reach(
+                        *afi,
+                        Safi::FlowSpec,
+                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                        None,
+                        attrs,
+                        ReachNlri::FlowSpec(chunk),
                         Ipv4UnicastMode::Body,
                     )
                 }) {
@@ -1420,31 +1007,9 @@ impl PeerSession {
             {
                 continue;
             }
-            let msg = if let (Afi::Ipv4, Safi::Unicast) = (afi, safi) {
-                // IPv4 Unicast EoR: empty UPDATE (no NLRI, no withdrawn, no attrs)
-                UpdateMessage::build(&[], &[], &[], four_octet_as, false, Ipv4UnicastMode::Body)
-            } else {
-                // MP EoR: UPDATE with empty MP_UNREACH_NLRI (IPv6 unicast, FlowSpec, etc.)
-                let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                    afi: *afi,
-                    safi: *safi,
-                    withdrawn: vec![],
-                    flowspec_withdrawn: vec![],
-                    evpn_withdrawn: vec![],
-                    bgpls_withdrawn: vec![],
-                    labeled_withdrawn: vec![],
-                    vpn_withdrawn: vec![],
-                    rtc_withdrawn: vec![],
-                })];
-                UpdateMessage::build(
-                    &[],
-                    &[],
-                    &attrs,
-                    four_octet_as,
-                    false,
-                    Ipv4UnicastMode::Body,
-                )
-            };
+            let msg = export
+                .build_end_of_rib(*afi, *safi)
+                .expect("empty End-of-RIB construction is infallible");
             let wire_msg = Message::Update(msg);
             if let Err(e) = self.enqueue_bulk(&wire_msg) {
                 warn!(peer = %self.peer_label, error = %e, "failed to send End-of-RIB for {afi:?}/{safi:?}");
@@ -1457,7 +1022,7 @@ impl PeerSession {
     }
     /// Split `entries` into as many wire UPDATEs as needed so each
     /// `build`-produced message fits `max_len`, enqueueing each in order.
-    /// `UpdateMessage::build` emits one message regardless of size, so a large
+    /// The exact profile builder emits one message regardless of size, so a large
     /// same-attribute IPv4 group (e.g. 1000 /24s ≈ 4114 bytes) exceeds the
     /// 4096-byte limit: `enqueue_bulk` rejects it and the session logs and
     /// abandons the rest of the batch, and — the actual defect — that partial
@@ -1628,10 +1193,10 @@ impl PeerSession {
     /// can abort the whole route batch the same way the unicast path does.
     fn send_evpn_reach_chunked(
         &mut self,
+        profile: &SessionExportProfile,
         next_hop: IpAddr,
         base_attrs: &[PathAttribute],
         routes: &[EvpnRoute],
-        four_octet_as: bool,
         max_len: usize,
     ) -> bool {
         // Initial chunk size: 1000 fits comfortably under the 65535-byte
@@ -1641,28 +1206,17 @@ impl PeerSession {
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let mut attrs = base_attrs.to_vec();
-            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                afi: Afi::L2Vpn,
-                safi: Safi::Evpn,
-                next_hop,
-                link_local_next_hop: None,
-                announced: vec![],
-                flowspec_announced: vec![],
-                evpn_announced: routes[idx..end].to_vec(),
-                bgpls_announced: vec![],
-                labeled_announced: vec![],
-                vpn_announced: vec![],
-                rtc_announced: vec![],
-            }));
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_reach(
+                    Afi::L2Vpn,
+                    Safi::Evpn,
+                    next_hop,
+                    None,
+                    base_attrs,
+                    ReachNlri::Evpn(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("EVPN MP_REACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     // Single-route oversize: a single EVPN route plus its
@@ -1702,33 +1256,22 @@ impl PeerSession {
     /// UPDATEs, splitting so each encoded message fits `max_len` bytes.
     fn send_evpn_unreach_chunked(
         &mut self,
+        profile: &SessionExportProfile,
         routes: &[EvpnRoute],
-        four_octet_as: bool,
         max_len: usize,
     ) -> bool {
         let mut chunk_size = routes.len().clamp(1, 1000);
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                afi: Afi::L2Vpn,
-                safi: Safi::Evpn,
-                withdrawn: vec![],
-                flowspec_withdrawn: vec![],
-                evpn_withdrawn: routes[idx..end].to_vec(),
-                bgpls_withdrawn: vec![],
-                labeled_withdrawn: vec![],
-                vpn_withdrawn: vec![],
-                rtc_withdrawn: vec![],
-            })];
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_unreach(
+                    Afi::L2Vpn,
+                    Safi::Evpn,
+                    UnreachNlri::Evpn(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("EVPN MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -1762,35 +1305,24 @@ impl PeerSession {
         next_hop: IpAddr,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::bgpls::BgpLsNlri],
-        four_octet_as: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let mut attrs = base_attrs.to_vec();
-            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                afi: Afi::BgpLs,
-                safi,
-                next_hop,
-                link_local_next_hop: None,
-                announced: vec![],
-                flowspec_announced: vec![],
-                evpn_announced: vec![],
-                bgpls_announced: routes[idx..end].to_vec(),
-                labeled_announced: vec![],
-                vpn_announced: vec![],
-                rtc_announced: vec![],
-            }));
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_reach(
+                    Afi::BgpLs,
+                    safi,
+                    next_hop,
+                    None,
+                    base_attrs,
+                    ReachNlri::BgpLs(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("BGP-LS MP_REACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -1822,32 +1354,21 @@ impl PeerSession {
         &mut self,
         safi: Safi,
         routes: &[rustbgpd_wire::bgpls::BgpLsNlri],
-        four_octet_as: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                afi: Afi::BgpLs,
-                safi,
-                withdrawn: vec![],
-                flowspec_withdrawn: vec![],
-                evpn_withdrawn: vec![],
-                bgpls_withdrawn: routes[idx..end].to_vec(),
-                labeled_withdrawn: vec![],
-                vpn_withdrawn: vec![],
-                rtc_withdrawn: vec![],
-            })];
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_unreach(
+                    Afi::BgpLs,
+                    safi,
+                    UnreachNlri::BgpLs(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("BGP-LS MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -1883,9 +1404,9 @@ impl PeerSession {
     /// default rewrite) is deliberately inert for this family — rewriting it
     /// would break the remote PE's transport-label resolution toward the
     /// originating PE.
-    #[expect(
+    #[allow(
         clippy::too_many_arguments,
-        reason = "VPN chunked sender adds the RFC 7911 add_path flag to the shared chunking shape"
+        reason = "the MP_REACH chunker receives each wire component explicitly"
     )]
     fn send_vpn_reach_chunked(
         &mut self,
@@ -1894,36 +1415,24 @@ impl PeerSession {
         link_local_next_hop: Option<Ipv6Addr>,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::VpnNlriEntry],
-        four_octet_as: bool,
-        add_path: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let mut attrs = base_attrs.to_vec();
-            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                afi,
-                safi: Safi::MplsVpn,
-                next_hop,
-                link_local_next_hop,
-                announced: vec![],
-                flowspec_announced: vec![],
-                evpn_announced: vec![],
-                bgpls_announced: vec![],
-                labeled_announced: vec![],
-                vpn_announced: routes[idx..end].to_vec(),
-                rtc_announced: vec![],
-            }));
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                add_path,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_reach(
+                    afi,
+                    Safi::MplsVpn,
+                    next_hop,
+                    link_local_next_hop,
+                    base_attrs,
+                    ReachNlri::Vpn(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("VPN MP_REACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -1956,33 +1465,21 @@ impl PeerSession {
         &mut self,
         afi: Afi,
         routes: &[rustbgpd_wire::VpnNlriEntry],
-        four_octet_as: bool,
-        add_path: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                afi,
-                safi: Safi::MplsVpn,
-                withdrawn: vec![],
-                flowspec_withdrawn: vec![],
-                evpn_withdrawn: vec![],
-                bgpls_withdrawn: vec![],
-                labeled_withdrawn: vec![],
-                vpn_withdrawn: routes[idx..end].to_vec(),
-                rtc_withdrawn: vec![],
-            })];
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                add_path,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_unreach(
+                    afi,
+                    Safi::MplsVpn,
+                    UnreachNlri::Vpn(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("VPN MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -2012,9 +1509,9 @@ impl PeerSession {
     /// `MP_REACH_NLRI` UPDATEs, splitting so each encoded message fits
     /// `max_len` bytes. Mirrors the VPN sender minus the RD-prefixed
     /// next-hop (RFC 8277 uses the ordinary host next-hop forms).
-    #[expect(
+    #[allow(
         clippy::too_many_arguments,
-        reason = "chunked family senders keep family, next-hop, attrs, and Add-Path mode explicit"
+        reason = "the MP_REACH chunker receives each wire component explicitly"
     )]
     fn send_labeled_reach_chunked(
         &mut self,
@@ -2023,36 +1520,24 @@ impl PeerSession {
         link_local_next_hop: Option<Ipv6Addr>,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::LabeledNlriEntry],
-        four_octet_as: bool,
-        add_path: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let mut attrs = base_attrs.to_vec();
-            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                afi,
-                safi: Safi::LabeledUnicast,
-                next_hop,
-                link_local_next_hop,
-                announced: vec![],
-                flowspec_announced: vec![],
-                evpn_announced: vec![],
-                bgpls_announced: vec![],
-                vpn_announced: vec![],
-                labeled_announced: routes[idx..end].to_vec(),
-                rtc_announced: vec![],
-            }));
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                add_path,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_reach(
+                    afi,
+                    Safi::LabeledUnicast,
+                    next_hop,
+                    link_local_next_hop,
+                    base_attrs,
+                    ReachNlri::Labeled(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("labeled-unicast MP_REACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -2086,33 +1571,21 @@ impl PeerSession {
         &mut self,
         afi: Afi,
         routes: &[rustbgpd_wire::LabeledNlriEntry],
-        four_octet_as: bool,
-        add_path: bool,
+        profile: &SessionExportProfile,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                afi,
-                safi: Safi::LabeledUnicast,
-                withdrawn: vec![],
-                flowspec_withdrawn: vec![],
-                evpn_withdrawn: vec![],
-                bgpls_withdrawn: vec![],
-                vpn_withdrawn: vec![],
-                labeled_withdrawn: routes[idx..end].to_vec(),
-                rtc_withdrawn: vec![],
-            })];
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                add_path,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_unreach(
+                    afi,
+                    Safi::LabeledUnicast,
+                    UnreachNlri::Labeled(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("labeled-unicast MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -2143,38 +1616,27 @@ impl PeerSession {
     /// `max_len` bytes. Mirrors the VPN sender minus label handling.
     fn send_rtc_reach_chunked(
         &mut self,
+        profile: &SessionExportProfile,
         next_hop: IpAddr,
         base_attrs: &[PathAttribute],
         routes: &[rustbgpd_wire::RtcNlri],
-        four_octet_as: bool,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let mut attrs = base_attrs.to_vec();
-            attrs.push(PathAttribute::MpReachNlri(MpReachNlri {
-                afi: Afi::Ipv4,
-                safi: Safi::RtConstrain,
-                next_hop,
-                link_local_next_hop: None,
-                announced: vec![],
-                flowspec_announced: vec![],
-                evpn_announced: vec![],
-                bgpls_announced: vec![],
-                labeled_announced: vec![],
-                vpn_announced: vec![],
-                rtc_announced: routes[idx..end].to_vec(),
-            }));
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_reach(
+                    Afi::Ipv4,
+                    Safi::RtConstrain,
+                    next_hop,
+                    None,
+                    base_attrs,
+                    ReachNlri::Rtc(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("RTC MP_REACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -2205,33 +1667,22 @@ impl PeerSession {
     /// `max_len` bytes.
     fn send_rtc_unreach_chunked(
         &mut self,
+        profile: &SessionExportProfile,
         routes: &[rustbgpd_wire::RtcNlri],
-        four_octet_as: bool,
         max_len: usize,
     ) -> bool {
         let mut chunk_size: usize = 1000;
         let mut idx: usize = 0;
         while idx < routes.len() {
             let end = (idx + chunk_size).min(routes.len());
-            let attrs = vec![PathAttribute::MpUnreachNlri(MpUnreachNlri {
-                afi: Afi::Ipv4,
-                safi: Safi::RtConstrain,
-                withdrawn: vec![],
-                flowspec_withdrawn: vec![],
-                evpn_withdrawn: vec![],
-                bgpls_withdrawn: vec![],
-                labeled_withdrawn: vec![],
-                vpn_withdrawn: vec![],
-                rtc_withdrawn: routes[idx..end].to_vec(),
-            })];
-            let msg = UpdateMessage::build(
-                &[],
-                &[],
-                &attrs,
-                four_octet_as,
-                false,
-                Ipv4UnicastMode::Body,
-            );
+            let msg = profile
+                .build_mp_unreach(
+                    Afi::Ipv4,
+                    Safi::RtConstrain,
+                    UnreachNlri::Rtc(&routes[idx..end]),
+                    Ipv4UnicastMode::Body,
+                )
+                .expect("RTC MP_UNREACH construction was previously infallible");
             if msg.encoded_len() > max_len {
                 if chunk_size <= 1 {
                     warn!(
@@ -2257,16 +1708,10 @@ impl PeerSession {
         }
         true
     }
-    /// Prepare path attributes for outbound advertisement.
-    ///
-    /// For standard eBGP: prepend our ASN, set `NEXT_HOP` to local addr, strip
-    /// `LOCAL_PREF`. For route-server clients, preserve `AS_PATH` and
-    /// `NEXT_HOP` by default. For iBGP: ensure `LOCAL_PREF` present (default
-    /// 100), pass `NEXT_HOP` through.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "route-refresh helper keeps per-family replay and EoR emission ordering explicit"
-    )]
+    // Test-facing compatibility helpers delegate to the same immutable
+    // profile preparation used by live emission. They republish first because
+    // focused fixtures intentionally mutate config/negotiation fields directly.
+    #[cfg(test)]
     pub(super) fn prepare_outbound_attributes(
         &self,
         route: &Route,
@@ -2274,940 +1719,55 @@ impl PeerSession {
         local_ipv4: Ipv4Addr,
         nh_override: Option<&rustbgpd_policy::NextHopAction>,
     ) -> Vec<PathAttribute> {
-        let force_next_hop_self =
-            matches!(nh_override, Some(rustbgpd_policy::NextHopAction::Self_));
-        let policy_set_specific = matches!(
-            nh_override,
-            Some(rustbgpd_policy::NextHopAction::Specific(_))
-        );
-        let route_server_client = self.config.route_server_client;
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !route_server_client => {
-                    // Apply private AS removal before prepending our ASN
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    // Prepend our ASN
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                // Merge into first sequence if possible
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                PathAttribute::NextHop(_) => {
-                    if policy_set_specific {
-                        // Policy explicitly set a next-hop — preserve it
-                        attrs.push(attr.clone());
-                    } else if force_next_hop_self || (is_ebgp && !route_server_client) {
-                        attrs.push(PathAttribute::NextHop(local_ipv4));
-                    } else {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                    // Strip LOCAL_PREF for eBGP
-                }
-                // Strip MP_REACH/MP_UNREACH — rebuilt per-UPDATE, not copied
-                PathAttribute::MpReachNlri(_) | PathAttribute::MpUnreachNlri(_) => {}
-                // Strip ORIGINATOR_ID and CLUSTER_LIST on eBGP outbound
-                // (optional non-transitive, must not leave the AS)
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        // For iBGP, ensure LOCAL_PREF is present (default 100)
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && matches!(
-                self.config.peer.local_role,
-                Some(BgpRole::Provider | BgpRole::Peer | BgpRole::RouteServer)
-            )
-            && !has_otc(&attrs)
-        {
-            attrs.push(PathAttribute::OnlyToCustomer(self.config.peer.local_asn));
-        }
-        // Ensure classic IPv4 body-NLRI exports carry a NEXT_HOP. This also
-        // preserves the route's original next hop for transparent route-server
-        // clients when the attribute was absent on the stored route.
-        if matches!(route.prefix, Prefix::V4(_))
-            && !attrs.iter().any(|a| matches!(a, PathAttribute::NextHop(_)))
-        {
-            let next_hop = match nh_override {
-                Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V4(nh))) => Some(*nh),
-                Some(rustbgpd_policy::NextHopAction::Specific(IpAddr::V6(_))) => {
-                    // IPv6 next-hop is not encodable in classic IPv4 NEXT_HOP
-                    // attribute. Requires RFC 8950 Extended Next Hop negotiation.
-                    // Fall through to default next-hop selection.
-                    tracing::warn!(
-                        prefix = %route.prefix,
-                        "export policy set IPv6 next-hop for classic IPv4 NLRI; \
-                         requires Extended Next Hop (RFC 8950) — using default next-hop instead"
-                    );
-                    if is_ebgp && !route_server_client {
-                        Some(local_ipv4)
-                    } else {
-                        match route.next_hop {
-                            IpAddr::V4(nh) => Some(nh),
-                            IpAddr::V6(_) => None,
-                        }
-                    }
-                }
-                Some(rustbgpd_policy::NextHopAction::Self_) => Some(local_ipv4),
-                _ if is_ebgp && !route_server_client => Some(local_ipv4),
-                _ => match route.next_hop {
-                    IpAddr::V4(nh) => Some(nh),
-                    IpAddr::V6(_) => None,
-                },
-            };
-            if let Some(next_hop) = next_hop {
-                attrs.push(PathAttribute::NextHop(next_hop));
-            }
-        }
-        // For standard eBGP, ensure AS_PATH is present (even if empty).
-        if is_ebgp
-            && !route_server_client
-            && !attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        // Route reflector attribute manipulation (RFC 4456 §8):
-        // Only when reflecting an iBGP-learned route to an iBGP target do we
-        // set ORIGINATOR_ID and prepend CLUSTER_LIST. Locally originated and
-        // eBGP-learned routes are advertised normally and are not "reflected"
-        // in the RFC 4456 sense.
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            // ORIGINATOR_ID: set to source peer's router-id if not already present
-            if !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            // CLUSTER_LIST: prepend our cluster_id
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        let family = match route.prefix {
-            Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
-            Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
-        };
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, family, is_ebgp);
-        attrs
+        SessionExportProfile::capture(self)
+            .with_test_ebgp(is_ebgp)
+            .prepare_unicast_attributes(route, local_ipv4, nh_override)
     }
-    /// Prepare path attributes for outbound `FlowSpec` advertisement.
-    ///
-    /// `FlowSpec` has no `NEXT_HOP`. For eBGP: prepend ASN, strip `LOCAL_PREF`.
-    /// For iBGP: ensure `LOCAL_PREF`. Route reflector attributes handled same
-    /// as unicast. Route-server clients skip automatic eBGP `AS_PATH` rewriting,
-    /// matching transparent unicast behavior.
+
+    #[cfg(test)]
     pub(super) fn prepare_outbound_attributes_flowspec(
         &self,
         route: &FlowSpecRoute,
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in &route.attributes {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    // Apply private AS removal before prepending our ASN
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                // No NEXT_HOP for FlowSpec — skip; also skip MP framing attrs
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        // Route reflector attribute manipulation for FlowSpec (same as unicast)
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, (route.afi, Safi::FlowSpec), is_ebgp);
-        attrs
-    }
-    /// Prepare outbound attributes for a reflected EVPN route. Mirrors
-    /// [`Self::prepare_outbound_attributes_flowspec`] — route reflectors
-    /// don't rewrite the `NEXT_HOP` (that's what preserves the VTEP loopback
-    /// for VXLAN tunnel construction), don't strip `LOCAL_PREF` across iBGP,
-    /// and add `ORIGINATOR_ID` / `CLUSTER_LIST` per RFC 4456 when reflecting.
-    pub(super) fn prepare_outbound_attributes_evpn(
-        &self,
-        route: &EvpnRibRoute,
-        is_ebgp: bool,
-    ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                // NEXT_HOP is carried in MP_REACH_NLRI for EVPN; strip the
-                // legacy NEXT_HOP attribute if present. Strip MP framing too.
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs.iter().any(|a| matches!(a, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        // RFC 4456 RR attribute manipulation — ORIGINATOR_ID + CLUSTER_LIST
-        // when reflecting iBGP routes.
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|a| matches!(a, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, (Afi::L2Vpn, Safi::Evpn), is_ebgp);
-        attrs
-    }
-    /// Prepare outbound attributes for a reflected BGP-LS route. Mirrors
-    /// EVPN/FlowSpec: `NEXT_HOP` and MP framing live in `MP_REACH_NLRI`, not in
-    /// the attribute set, while RR attributes are added for iBGP reflection.
-    pub(super) fn prepare_outbound_attributes_bgpls(
-        &self,
-        route: &BgpLsRibRoute,
-        is_ebgp: bool,
-    ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, route.family.to_afi_safi(), is_ebgp);
-        attrs
+        SessionExportProfile::capture(self)
+            .with_test_ebgp(is_ebgp)
+            .prepare_flowspec_attributes(route)
     }
 
-    /// Prepare outbound attributes for a reflected VPNv4/VPNv6 route. Mirrors
-    /// EVPN/BGP-LS: `NEXT_HOP` and MP framing live in `MP_REACH_NLRI`, not in
-    /// the attribute set, while RR attributes are added for iBGP reflection.
-    ///
-    /// ADR-0077 §6: the VPN next-hop is never rewritten here — any
-    /// next-hop-self configuration is deliberately inert for SAFI 128, since
-    /// the reflected next-hop must stay the originating PE for transport-label
-    /// resolution. Route Targets ride through untouched as extended
-    /// communities in the generic pass-through arm.
+    #[cfg(test)]
     pub(super) fn prepare_outbound_attributes_vpn(
         &self,
         route: &VpnRibRoute,
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, route.afi_safi(), is_ebgp);
-        attrs
+        SessionExportProfile::capture(self)
+            .with_test_ebgp(is_ebgp)
+            .prepare_vpn_attributes(route)
     }
 
-    /// Prepare outbound attributes for a reflected labeled-unicast route.
-    /// Mirrors the VPN version: RFC 4456 `ORIGINATOR_ID`/`CLUSTER_LIST`
-    /// reflection semantics are identical, and the next-hop lives in
-    /// `MP_REACH_NLRI` (chosen by the caller), never in the attribute set.
-    ///
-    /// ADR-0077 §4/§6: the labeled next-hop is never rewritten here — any
-    /// next-hop-self configuration is deliberately inert for SAFI 4, since
-    /// the reflected next-hop must stay the originating speaker for
-    /// transport-label resolution. The MPLS label stack rides in the NLRI
-    /// and passes through verbatim.
+    #[cfg(test)]
     pub(super) fn prepare_outbound_attributes_labeled(
         &self,
         route: &LabeledRibRoute,
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, route.afi_safi(), is_ebgp);
-        attrs
+        SessionExportProfile::capture(self)
+            .with_test_ebgp(is_ebgp)
+            .prepare_labeled_attributes(route)
     }
 
-    /// Prepare outbound attributes for a reflected RT-Constrain route.
-    /// Mirrors the VPN version: RFC 4456 `ORIGINATOR_ID`/`CLUSTER_LIST`
-    /// reflection semantics are identical, and the next-hop lives in
-    /// `MP_REACH_NLRI` (chosen by the caller), never in the attribute set.
+    #[cfg(test)]
     pub(super) fn prepare_outbound_attributes_rtc(
         &self,
         route: &RtcRibRoute,
         is_ebgp: bool,
     ) -> Vec<PathAttribute> {
-        let mut attrs = Vec::new();
-        for attr in route.attributes.iter() {
-            match attr {
-                PathAttribute::AsPath(as_path) if is_ebgp && !self.config.route_server_client => {
-                    let cleaned = remove_private_asns(
-                        as_path,
-                        self.config.remove_private_as,
-                        self.config.peer.local_asn,
-                    );
-                    let mut new_segments =
-                        vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])];
-                    for seg in &cleaned.segments {
-                        match seg {
-                            AsPathSegment::AsSequence(asns) => {
-                                if let Some(AsPathSegment::AsSequence(first)) =
-                                    new_segments.first_mut()
-                                {
-                                    first.extend(asns);
-                                }
-                            }
-                            AsPathSegment::AsSet(asns) => {
-                                new_segments.push(AsPathSegment::AsSet(asns.clone()));
-                            }
-                        }
-                    }
-                    attrs.push(PathAttribute::AsPath(AsPath {
-                        segments: new_segments,
-                    }));
-                }
-                PathAttribute::NextHop(_)
-                | PathAttribute::MpReachNlri(_)
-                | PathAttribute::MpUnreachNlri(_) => {}
-                PathAttribute::LocalPref(_) => {
-                    if !is_ebgp {
-                        attrs.push(attr.clone());
-                    }
-                }
-                PathAttribute::OriginatorId(_) | PathAttribute::ClusterList(_) if is_ebgp => {}
-                _ => {
-                    attrs.push(attr.clone());
-                }
-            }
-        }
-        if !is_ebgp
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::LocalPref(_)))
-        {
-            attrs.push(PathAttribute::LocalPref(100));
-        }
-        if is_ebgp
-            && !self.config.route_server_client
-            && !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::AsPath(_)))
-        {
-            attrs.push(PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![self.config.peer.local_asn])],
-            }));
-        }
-        if !is_ebgp
-            && route.origin_type == rustbgpd_rib::RouteOrigin::Ibgp
-            && let Some(cluster_id) = self.config.cluster_id
-        {
-            if !attrs
-                .iter()
-                .any(|attr| matches!(attr, PathAttribute::OriginatorId(_)))
-            {
-                attrs.push(PathAttribute::OriginatorId(route.peer_router_id));
-            }
-            let mut found = false;
-            for attr in &mut attrs {
-                if let PathAttribute::ClusterList(ids) = attr {
-                    ids.insert(0, cluster_id);
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                attrs.push(PathAttribute::ClusterList(vec![cluster_id]));
-            }
-        }
-        self.attach_graceful_shutdown_if_enabled(&mut attrs);
-        self.apply_llgr_stale_export_form(&mut attrs, route.afi_safi(), is_ebgp);
-        attrs
+        SessionExportProfile::capture(self)
+            .with_test_ebgp(is_ebgp)
+            .prepare_rtc_attributes(route)
     }
 }
-/// Build a BGP-LS NLRI from an Adj-RIB-Out key, used when emitting
-/// `MP_UNREACH_NLRI` withdrawals. The key stores the opaque bytes required by
-/// RFC 9552, including the optional VPN Route Distinguisher.
-fn bgpls_nlri_from_key(key: &BgpLsRouteKey) -> rustbgpd_wire::bgpls::BgpLsNlri {
-    rustbgpd_wire::bgpls::BgpLsNlri {
-        nlri_type: key.nlri.nlri_type,
-        route_distinguisher: key.nlri.route_distinguisher,
-        payload: key.nlri.payload.clone(),
-    }
-}
-/// Build a minimal `EvpnRoute` from a key, used when emitting `MP_UNREACH_NLRI`
-/// withdrawals. The receiver identifies the route by its key fields; any
-/// labels / optional fields the key doesn't capture are zeroed.
-fn evpn_route_from_key(key: EvpnRouteKey) -> EvpnRoute {
-    use rustbgpd_wire::{
-        EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnImet, EvpnIpPrefixRoute, EvpnMacIp, MplsLabel,
-    };
-    let zero_label = MplsLabel::new(0);
-    match key {
-        EvpnRouteKey::EadPerEs {
-            rd,
-            esi,
-            ethernet_tag,
-        } => EvpnRoute::EadPerEs(EvpnEadPerEs {
-            rd,
-            esi,
-            ethernet_tag,
-            label: zero_label,
-        }),
-        EvpnRouteKey::EadPerEvi {
-            rd,
-            esi,
-            ethernet_tag,
-        } => EvpnRoute::EadPerEvi(EvpnEadPerEvi {
-            rd,
-            esi,
-            ethernet_tag,
-            label: zero_label,
-        }),
-        EvpnRouteKey::MacIp {
-            rd,
-            ethernet_tag,
-            mac,
-            ip,
-        } => EvpnRoute::MacIp(EvpnMacIp {
-            rd,
-            esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
-            ethernet_tag,
-            mac,
-            ip,
-            label1: zero_label,
-            label2: None,
-        }),
-        EvpnRouteKey::Imet {
-            rd,
-            ethernet_tag,
-            originator_ip,
-        } => EvpnRoute::Imet(EvpnImet {
-            rd,
-            ethernet_tag,
-            originator_ip,
-        }),
-        EvpnRouteKey::Es {
-            rd,
-            esi,
-            originator_ip,
-        } => EvpnRoute::Es(EvpnEs {
-            rd,
-            esi,
-            originator_ip,
-        }),
-        EvpnRouteKey::IpPrefix {
-            rd,
-            ethernet_tag,
-            prefix,
-        } => {
-            let gateway = match prefix {
-                rustbgpd_wire::EvpnIpPrefixValue::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                rustbgpd_wire::EvpnIpPrefixValue::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            };
-            EvpnRoute::IpPrefix(EvpnIpPrefixRoute {
-                rd,
-                esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
-                ethernet_tag,
-                prefix,
-                gateway,
-                label: zero_label,
-            })
-        }
-    }
-}
-/// Remove private ASNs from an `AS_PATH` according to the given mode.
-///
-/// - `Remove` — strip all ASNs only if every ASN in the path is private.
-/// - `All` — unconditionally remove all private ASNs; drop empty segments.
-/// - `Replace` — replace each private ASN with `local_asn`.
-/// - `Disabled` — return the path unchanged.
-pub(super) fn remove_private_asns(
-    as_path: &AsPath,
-    mode: RemovePrivateAs,
-    local_asn: u32,
-) -> AsPath {
-    match mode {
-        RemovePrivateAs::Disabled => as_path.clone(),
-        RemovePrivateAs::Remove => {
-            if as_path.all_private() {
-                // Strip all private ASNs (produces empty path)
-                let segments: Vec<_> = as_path
-                    .segments
-                    .iter()
-                    .filter_map(|seg| {
-                        let filtered: Vec<u32> = match seg {
-                            AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => asns
-                                .iter()
-                                .copied()
-                                .filter(|a| !is_private_asn(*a))
-                                .collect(),
-                        };
-                        if filtered.is_empty() {
-                            None
-                        } else {
-                            Some(match seg {
-                                AsPathSegment::AsSequence(_) => AsPathSegment::AsSequence(filtered),
-                                AsPathSegment::AsSet(_) => AsPathSegment::AsSet(filtered),
-                            })
-                        }
-                    })
-                    .collect();
-                AsPath { segments }
-            } else {
-                as_path.clone()
-            }
-        }
-        RemovePrivateAs::All => {
-            let segments: Vec<_> = as_path
-                .segments
-                .iter()
-                .filter_map(|seg| {
-                    let filtered: Vec<u32> = match seg {
-                        AsPathSegment::AsSequence(asns) | AsPathSegment::AsSet(asns) => asns
-                            .iter()
-                            .copied()
-                            .filter(|a| !is_private_asn(*a))
-                            .collect(),
-                    };
-                    if filtered.is_empty() {
-                        None
-                    } else {
-                        Some(match seg {
-                            AsPathSegment::AsSequence(_) => AsPathSegment::AsSequence(filtered),
-                            AsPathSegment::AsSet(_) => AsPathSegment::AsSet(filtered),
-                        })
-                    }
-                })
-                .collect();
-            AsPath { segments }
-        }
-        RemovePrivateAs::Replace => {
-            let segments = as_path
-                .segments
-                .iter()
-                .map(|seg| match seg {
-                    AsPathSegment::AsSequence(asns) => AsPathSegment::AsSequence(
-                        asns.iter()
-                            .map(|a| if is_private_asn(*a) { local_asn } else { *a })
-                            .collect(),
-                    ),
-                    AsPathSegment::AsSet(asns) => AsPathSegment::AsSet(
-                        asns.iter()
-                            .map(|a| if is_private_asn(*a) { local_asn } else { *a })
-                            .collect(),
-                    ),
-                })
-                .collect();
-            AsPath { segments }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3284,17 +1844,18 @@ mod tests {
             let mut session = make_test_session();
             let (client, mut server) = connected_stream_pair().await;
             session.test_install_stream(client);
+            let profile = SessionExportProfile::capture(&session).with_test_ebgp(true);
 
             let sent = if announce {
                 session.send_evpn_reach_chunked(
+                    &profile,
                     IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
                     &[PathAttribute::Origin(Origin::Igp)],
                     std::slice::from_ref(&route),
-                    true,
                     1,
                 )
             } else {
-                session.send_evpn_unreach_chunked(std::slice::from_ref(&route), true, 1)
+                session.send_evpn_unreach_chunked(&profile, std::slice::from_ref(&route), 1)
             };
             assert!(!sent, "overflowing EVPN send must fail closed");
             assert!(session.read_half.is_none());

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1,3 +1,4 @@
+use super::export::{ExportCandidate, ExportWithdrawal};
 use super::*;
 use bytes::Bytes;
 use rustbgpd_fsm::PeerConfig;
@@ -9448,5 +9449,350 @@ async fn outbound_extended_message_gated_on_peer_capability() {
     assert!(
         session.enqueue_priority(&big).is_ok(),
         "the peer advertised Extended Messages — the extended limit applies"
+    );
+}
+
+/// LAN-380: the high-level exact probe must be byte-identical to the real
+/// `OutboundRouteUpdate -> send_route_update -> writer -> TCP` path. This is
+/// intentionally a socket receipt rather than a probe-vs-builder unit test:
+/// it catches drift in grouping, next-hop selection, withdrawal-key rebuild,
+/// Add-Path, ENHE, and the profile generation held by one envelope.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one matrix pins every outbound subfamily and both directions against real writer bytes"
+)]
+#[expect(
+    clippy::items_after_statements,
+    reason = "local helper and macros keep the full wire matrix readable"
+)]
+#[tokio::test]
+async fn exact_export_probe_matches_real_writer_for_every_family_and_limit() {
+    for extended_messages in [false, true] {
+        for extended_nexthop in [false, true] {
+            let (mut session, _rib_rx) = make_test_session_with_rib(65_001, 65_002);
+            let (client, mut server) = connected_stream_pair().await;
+            session.test_install_stream(client);
+            session.config.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
+
+            let families = vec![
+                (Afi::Ipv4, Safi::Unicast),
+                (Afi::Ipv6, Safi::Unicast),
+                (Afi::Ipv4, Safi::FlowSpec),
+                (Afi::Ipv6, Safi::FlowSpec),
+                (Afi::L2Vpn, Safi::Evpn),
+                (Afi::BgpLs, Safi::BgpLs),
+                (Afi::BgpLs, Safi::BgpLsVpn),
+                (Afi::Ipv4, Safi::MplsVpn),
+                (Afi::Ipv6, Safi::MplsVpn),
+                (Afi::Ipv4, Safi::LabeledUnicast),
+                (Afi::Ipv6, Safi::LabeledUnicast),
+                (Afi::Ipv4, Safi::RtConstrain),
+            ];
+            let mut negotiated = negotiated_session(65_002, extended_nexthop);
+            negotiated.peer_extended_message = extended_messages;
+            negotiated.negotiated_families.clone_from(&families);
+            for family in [
+                (Afi::Ipv4, Safi::Unicast),
+                (Afi::Ipv6, Safi::Unicast),
+                (Afi::Ipv4, Safi::MplsVpn),
+                (Afi::Ipv6, Safi::MplsVpn),
+                (Afi::Ipv4, Safi::LabeledUnicast),
+                (Afi::Ipv6, Safi::LabeledUnicast),
+            ] {
+                negotiated
+                    .add_path_families
+                    .insert(family, AddPathMode::Send);
+            }
+            install_test_negotiated_session(&mut session, negotiated);
+            let held = session.publish_export_profile();
+            assert_eq!(
+                held.max_message_len(),
+                if extended_messages { 65_535 } else { 4_096 }
+            );
+            let held_generation = held.generation();
+
+            let mut v4 = make_route(100);
+            v4.path_id = 101;
+            let mut v6 = make_v6_unicast_route("2001:db8:ffff::1".parse().unwrap());
+            v6.path_id = 102;
+
+            let fs_v4 = make_flowspec_route();
+            let mut fs_v6 = make_flowspec_route();
+            fs_v6.afi = Afi::Ipv6;
+            fs_v6.rule = FlowSpecRule {
+                components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V6(
+                    Ipv6PrefixOffset {
+                        prefix: Ipv6Prefix::new("2001:db8:100::".parse().unwrap(), 64),
+                        offset: 0,
+                    },
+                ))],
+            };
+
+            let evpn = rustbgpd_rib::EvpnRibRoute {
+                route: EvpnRoute::MacIp(rustbgpd_wire::EvpnMacIp {
+                    rd: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 100]),
+                    esi: rustbgpd_wire::EthernetSegmentIdentifier::ZERO,
+                    ethernet_tag: rustbgpd_wire::EthernetTagId(100),
+                    mac: rustbgpd_wire::MacAddress([0x02, 0, 0, 0xaa, 0xbb, 0xcc]),
+                    ip: Some(IpAddr::V6("2001:db8::10".parse().unwrap())),
+                    label1: rustbgpd_wire::MplsLabel::new(10_000),
+                    label2: None,
+                }),
+                next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+                link_local_next_hop: None,
+                peer: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                attributes: Arc::new(vec![
+                    PathAttribute::Origin(Origin::Igp),
+                    PathAttribute::AsPath(AsPath {
+                        segments: vec![AsPathSegment::AsSequence(vec![65_002])],
+                    }),
+                ]),
+                received_at: Instant::now(),
+                origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+                peer_router_id: Ipv4Addr::new(10, 0, 0, 2),
+                is_stale: false,
+                is_llgr_stale: false,
+            };
+
+            let bgpls = make_bgpls_route(0xcc);
+            let mut bgpls_vpn = make_bgpls_route(0xdd);
+            bgpls_vpn.family = rustbgpd_rib::BgpLsFamily::LinkStateVpn;
+            bgpls_vpn.nlri.route_distinguisher = Some([0, 0, 0xfd, 0xe8, 0, 0, 0, 2]);
+
+            let mut vpn_v4 = make_vpn_rib_route(20_000);
+            vpn_v4.path_id = 103;
+            let mut vpn_v6 = make_vpn_rib_route(20_001);
+            vpn_v6.path_id = 104;
+            vpn_v6.nlri.prefix = VpnPrefix::v6("2001:db8:200::".parse().unwrap(), 64).unwrap();
+            vpn_v6.next_hop = IpAddr::V6("2001:db8::20".parse().unwrap());
+            vpn_v6.link_local_next_hop = Some("fe80::20".parse().unwrap());
+
+            let mut labeled_v4 = make_labeled_rib_route(20_002);
+            labeled_v4.path_id = 105;
+            let mut labeled_v6 = make_labeled_rib_route(20_003);
+            labeled_v6.path_id = 106;
+            labeled_v6.nlri.prefix =
+                Prefix::V6(Ipv6Prefix::new("2001:db8:300::".parse().unwrap(), 64));
+            labeled_v6.next_hop = IpAddr::V6("2001:db8::30".parse().unwrap());
+            labeled_v6.link_local_next_hop = Some("fe80::30".parse().unwrap());
+
+            let rtc = make_rtc_rib_route(100);
+
+            assert_eq!(
+                matches!(
+                    held.prepare_unicast_candidate(&v4, None).unwrap(),
+                    super::export::PreparedUnicastCandidate::Mp { .. }
+                ),
+                extended_nexthop,
+                "matrix must exercise both IPv4 body and IPv4-over-IPv6 ENHE"
+            );
+
+            async fn assert_frame(
+                session: &mut PeerSession,
+                server: &mut TcpStream,
+                probe: super::export::ExactExportProbe,
+                update: OutboundRouteUpdate,
+                generation: u64,
+            ) {
+                assert_eq!(probe.generation, generation);
+                let expected = rustbgpd_wire::encode_message(&Message::Update(probe.message))
+                    .unwrap()
+                    .to_vec();
+                session.send_route_update(update);
+                let actual = read_single_raw_bgp_message(server).await;
+                assert_eq!(actual, expected);
+                assert_eq!(session.export_encoder.snapshot().generation(), generation);
+            }
+
+            macro_rules! announce {
+                ($candidate:expr, $field:ident, $route:expr) => {{
+                    let probe = held.probe_announcement($candidate).unwrap();
+                    let mut update = empty_outbound_update();
+                    update.$field = vec![$route.clone()];
+                    assert_frame(&mut session, &mut server, probe, update, held_generation).await;
+                }};
+            }
+            macro_rules! withdraw {
+                ($withdrawal:expr, $field:ident, $key:expr) => {{
+                    let probe = held.probe_withdrawal($withdrawal).unwrap();
+                    let mut update = empty_outbound_update();
+                    update.$field = vec![$key.clone()];
+                    assert_frame(&mut session, &mut server, probe, update, held_generation).await;
+                }};
+            }
+
+            for route in [&v4, &v6] {
+                let probe = held
+                    .probe_announcement(ExportCandidate::Unicast {
+                        route,
+                        next_hop_override: None,
+                    })
+                    .unwrap();
+                let mut update = empty_outbound_update();
+                update.announce = vec![route.clone()].into();
+                update.next_hop_override = vec![None].into();
+                assert_frame(&mut session, &mut server, probe, update, held_generation).await;
+            }
+            announce!(ExportCandidate::FlowSpec(&fs_v4), flowspec_announce, fs_v4);
+            announce!(ExportCandidate::FlowSpec(&fs_v6), flowspec_announce, fs_v6);
+            announce!(ExportCandidate::Evpn(&evpn), evpn_announce, evpn);
+            announce!(ExportCandidate::BgpLs(&bgpls), bgpls_announce, bgpls);
+            announce!(
+                ExportCandidate::BgpLs(&bgpls_vpn),
+                bgpls_announce,
+                bgpls_vpn
+            );
+            announce!(ExportCandidate::Vpn(&vpn_v4), vpn_announce, vpn_v4);
+            announce!(ExportCandidate::Vpn(&vpn_v6), vpn_announce, vpn_v6);
+            announce!(
+                ExportCandidate::Labeled(&labeled_v4),
+                labeled_announce,
+                labeled_v4
+            );
+            announce!(
+                ExportCandidate::Labeled(&labeled_v6),
+                labeled_announce,
+                labeled_v6
+            );
+            announce!(ExportCandidate::Rtc(&rtc), rtc_announce, rtc);
+
+            for route in [&v4, &v6] {
+                let probe = held
+                    .probe_withdrawal(ExportWithdrawal::Unicast {
+                        prefix: route.prefix,
+                        path_id: route.path_id,
+                    })
+                    .unwrap();
+                let mut update = empty_outbound_update();
+                update.withdraw = vec![(route.prefix, route.path_id)];
+                assert_frame(&mut session, &mut server, probe, update, held_generation).await;
+            }
+
+            let fs_v4_key = fs_v4.selection_key();
+            let fs_v6_key = fs_v6.selection_key();
+            let evpn_key = evpn.route.key();
+            let bgpls_key = bgpls.key();
+            let bgpls_vpn_key = bgpls_vpn.key();
+            let vpn_v4_key = vpn_v4.key();
+            let vpn_v6_key = vpn_v6.key();
+            let labeled_v4_key = labeled_v4.key();
+            let labeled_v6_key = labeled_v6.key();
+            let rtc_key = rtc.key();
+            withdraw!(
+                ExportWithdrawal::FlowSpec(&fs_v4_key),
+                flowspec_withdraw,
+                fs_v4_key
+            );
+            withdraw!(
+                ExportWithdrawal::FlowSpec(&fs_v6_key),
+                flowspec_withdraw,
+                fs_v6_key
+            );
+            withdraw!(ExportWithdrawal::Evpn(&evpn_key), evpn_withdraw, evpn_key);
+            withdraw!(
+                ExportWithdrawal::BgpLs(&bgpls_key),
+                bgpls_withdraw,
+                bgpls_key
+            );
+            withdraw!(
+                ExportWithdrawal::BgpLs(&bgpls_vpn_key),
+                bgpls_withdraw,
+                bgpls_vpn_key
+            );
+            withdraw!(ExportWithdrawal::Vpn(&vpn_v4_key), vpn_withdraw, vpn_v4_key);
+            withdraw!(ExportWithdrawal::Vpn(&vpn_v6_key), vpn_withdraw, vpn_v6_key);
+            withdraw!(
+                ExportWithdrawal::Labeled(&labeled_v4_key),
+                labeled_withdraw,
+                labeled_v4_key
+            );
+            withdraw!(
+                ExportWithdrawal::Labeled(&labeled_v6_key),
+                labeled_withdraw,
+                labeled_v6_key
+            );
+            withdraw!(ExportWithdrawal::Rtc(&rtc_key), rtc_withdraw, rtc_key);
+        }
+    }
+}
+
+#[tokio::test]
+#[allow(
+    clippy::items_after_statements,
+    reason = "local async helpers keep the generation transition assertions compact"
+)]
+async fn export_profile_generation_changes_once_per_wire_runtime_mutation() {
+    let mut session = make_test_session(65_001, 65_002);
+    install_test_negotiated_session(&mut session, negotiated_session(65_002, false));
+    let initial = session.publish_export_profile();
+    let generation = initial.generation();
+
+    async fn runtime_update(
+        session: &mut PeerSession,
+        local_ipv6_nexthop: Option<Ipv6Addr>,
+        remove_private_as: RemovePrivateAs,
+    ) {
+        let (reply, done) = oneshot::channel();
+        assert_eq!(
+            session
+                .handle_command(PeerCommand::UpdateRuntimeConfig {
+                    max_prefixes: Some(123),
+                    gr_stale_routes_time: 999,
+                    local_ipv6_nexthop,
+                    remove_private_as,
+                    reply,
+                })
+                .await,
+            ControlFlow::Continue(())
+        );
+        done.await.unwrap().unwrap();
+    }
+
+    async fn gshut(session: &mut PeerSession, enabled: bool) {
+        let (reply, done) = oneshot::channel();
+        assert_eq!(
+            session
+                .handle_command(PeerCommand::UpdateGracefulShutdown { enabled, reply })
+                .await,
+            ControlFlow::Continue(())
+        );
+        done.await.unwrap().unwrap();
+    }
+
+    runtime_update(&mut session, None, RemovePrivateAs::Disabled).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation,
+        "non-wire/equal runtime fields must not republish"
+    );
+    gshut(&mut session, false).await;
+    assert_eq!(session.export_encoder.snapshot().generation(), generation);
+
+    let local_v6 = Some("2001:db8::1".parse().unwrap());
+    runtime_update(&mut session, local_v6, RemovePrivateAs::Disabled).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation + 1
+    );
+    runtime_update(&mut session, local_v6, RemovePrivateAs::Disabled).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation + 1
+    );
+
+    runtime_update(&mut session, local_v6, RemovePrivateAs::All).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation + 2
+    );
+    gshut(&mut session, true).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation + 3
+    );
+    gshut(&mut session, true).await;
+    assert_eq!(
+        session.export_encoder.snapshot().generation(),
+        generation + 3
     );
 }


### PR DESCRIPTION
## Summary

- introduce a transport-owned `SessionExportEncoder` with immutable, replaceable `SessionExportProfile` snapshots
- centralize outbound attribute preparation, next-hop selection, NLRI conversion, and exact UPDATE construction for every supported family
- make live emission and exact single-route probes consume the same typed announcement and withdrawal preparation seams
- publish profile generations only for wire-affecting establishment or hot-runtime changes, with no secret-bearing config retained

## Motivation

Exact pre-commit exportability cannot be implemented safely in the RIB while final wire bytes are assembled from session-local negotiated, socket, configured, and runtime state. Duplicating that logic or estimating encoded length would allow the probe and live writer to disagree.

This PR establishes the prerequisite for LAN-361 without adding RIB gating. The session owns one immutable profile generation, every outbound envelope captures one snapshot, and future preflight can use the same high-level candidate/key probe that live batching consumes.

## Behavior preservation

The shared profile covers negotiated message ceiling, four-octet AS, Add-Path, Extended Next Hop, socket/config next hops, eBGP and route-server behavior, route reflection, RFC 9234 OTC preparation, private-AS removal, LLGR, and runtime Graceful Shutdown.

Typed prepared candidates now own family/mode, attribute and next-hop preparation, link-local handling, and route/key-to-wire conversion for IPv4/IPv6 unicast, FlowSpec, EVPN, BGP-LS base/VPN, VPNv4/v6, labeled-unicast v4/v6, and RTC. EoR and all live chunk builders use the same fallible exact builders. Existing selection, batching order, adaptive chunking, diagnostics, and Cease/8 fail-closed behavior remain unchanged.

The profile stores no `TransportConfig`, TCP-AO key, MD5 password, or serializable secret-bearing state. Equal runtime publications preserve the generation; each real wire-affecting change advances it once while existing readers retain the old immutable snapshot.

## Validation

- real connected-writer byte receipts against exact probes for every family, announcement and withdrawal, IPv4 body and ENHE, Add-Path, 4096 and 65535 limits
- immutable generation, concurrent old-reader/new-publication, hot-runtime idempotency, secret-exclusion, EoR, chunking, and overflow regressions
- complete transport suite: 254 passed, 1 kernel-dependent test ignored
- locked workspace tests with no fail-fast
- transport all-target/all-feature check and Clippy with warnings denied
- workspace rustdoc with warnings denied
- formatting, hooks, and diff checks
- independent adversarial review, including a typed withdrawal-preparation follow-up

Linear: [LAN-380](https://linear.app/lance0/issue/LAN-380/shared-exact-sessionexportencoder-and-immutable-profile-prerequisite)
