### PR TITLE
fix(session): stabilize live paths-limit state

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1132,10 +1132,33 @@ impl RibManager {
                 session_id,
                 limits,
             } => {
+                // Transport emits this once per session from the immutable
+                // OPEN negotiation, immediately after PeerUp. Idempotency
+                // suppresses duplicate delivery; this is not a runtime cap
+                // reconfiguration surface (a decrease requires a new session
+                // so excess advertised path IDs are withdrawn by teardown).
                 if self.outbound_session_ids.get(&peer).copied() == Some(session_id) {
-                    self.peer_add_path_send_limits
-                        .insert(peer, limits.into_iter().collect());
-                    self.send_initial_table(peer);
+                    let new_limits: HashMap<_, _> = limits.into_iter().collect();
+                    let scalar_limit = self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0);
+                    let effective_limit_changed = self
+                        .peer_add_path_send_families
+                        .get(&peer)
+                        .is_some_and(|families| {
+                            families.iter().any(|family| {
+                                let old = self
+                                    .peer_add_path_send_limits
+                                    .get(&peer)
+                                    .and_then(|limits| limits.get(family))
+                                    .copied()
+                                    .unwrap_or(scalar_limit);
+                                let new = new_limits.get(family).copied().unwrap_or(scalar_limit);
+                                old != new
+                            })
+                        });
+                    self.peer_add_path_send_limits.insert(peer, new_limits);
+                    if effective_limit_changed {
+                        self.send_initial_table(peer);
+                    }
                 }
             }
             RibUpdate::PeerOrfUpdate {

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -336,25 +336,104 @@ async fn grouped_otc_source_withdraw_clears_pending_diagnostic_before_recovery()
     handle.await.unwrap();
 }
 
+fn assert_one_dual_stack_eor(out_rx: &mut mpsc::Receiver<OutboundRouteUpdate>) {
+    let update = out_rx
+        .try_recv()
+        .expect("effective limit change triggers one resync");
+    assert!(update.announce.is_empty());
+    assert!(update.withdraw.is_empty());
+    assert_eq!(
+        update.end_of_rib,
+        vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)]
+    );
+    assert!(
+        matches!(out_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "effective limit change must trigger exactly one resync"
+    );
+}
+
 #[test]
-fn paths_limit_is_applied_per_unicast_family_and_rejects_stale_session() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "one lifecycle pins stale, idempotent, changed, and reverted family-limit updates"
+)]
+fn paths_limit_updates_resync_only_for_effective_unicast_changes() {
     let (_tx, rx) = mpsc::channel(1);
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     let peer: IpAddr = "192.0.2.1".parse().unwrap();
-    manager.outbound_session_ids.insert(peer, 7);
-    manager.peer_add_path_send_max.insert(peer, 8);
-    manager.peer_add_path_send_families.insert(
-        peer,
-        vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
-    );
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24));
+    let v6 = Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32));
 
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id: 7,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: dual_stack_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        add_path_send_families: dual_stack_sendable(),
+        add_path_send_max: 8,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    });
+    assert_one_dual_stack_eor(&mut out_rx);
+
+    // A stale session must neither alter stored limits nor trigger a resync.
     manager.handle_update(RibUpdate::PeerAddPathLimits {
         peer,
         session_id: 6,
         limits: vec![((Afi::Ipv4, Safi::Unicast), 1)],
     });
     assert!(!manager.peer_add_path_send_limits.contains_key(&peer));
+    assert!(matches!(
+        out_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
 
+    // Explicit scalar-equivalent limits are stored but do not change the
+    // effective caps, so the PeerUp EoR is not repeated.
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 8),
+            ((Afi::Ipv6, Safi::Unicast), 8),
+        ],
+    });
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 8);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 8);
+    assert!(matches!(
+        out_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    // An empty exact map also means scalar fallback for every negotiated
+    // send family and remains idempotent while replacing the stored map.
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![],
+    });
+    assert!(
+        manager
+            .peer_add_path_send_limits
+            .get(&peer)
+            .is_some_and(HashMap::is_empty)
+    );
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 8);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 8);
+    assert!(matches!(
+        out_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    // A family divergence installs the exact map and performs one resync.
     manager.handle_update(RibUpdate::PeerAddPathLimits {
         peer,
         session_id: 7,
@@ -363,20 +442,54 @@ fn paths_limit_is_applied_per_unicast_family_and_rejects_stale_session() {
             ((Afi::Ipv6, Safi::Unicast), 5),
         ],
     });
-    assert_eq!(
-        manager.add_path_send_max_for_prefix(
-            peer,
-            &Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24))
-        ),
-        2
+    assert_one_dual_stack_eor(&mut out_rx);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 2);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 5);
+
+    // An identical retransmission replaces the map without another resync.
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 2),
+            ((Afi::Ipv6, Safi::Unicast), 5),
+        ],
+    });
+    assert!(matches!(
+        out_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    // Synthetic differing same-session maps pin the comparison and storage
+    // guard only; production emits one immutable map per negotiation. Each
+    // effective change still requests exactly one replay, and reverting an
+    // override restores scalar fallback in the stored/effective view.
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 3),
+            ((Afi::Ipv6, Safi::Unicast), 5),
+        ],
+    });
+    assert_one_dual_stack_eor(&mut out_rx);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 3);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 5);
+
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![],
+    });
+    assert_one_dual_stack_eor(&mut out_rx);
+    assert!(
+        manager
+            .peer_add_path_send_limits
+            .get(&peer)
+            .is_some_and(HashMap::is_empty)
     );
-    assert_eq!(
-        manager.add_path_send_max_for_prefix(
-            peer,
-            &Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32))
-        ),
-        5
-    );
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 8);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 8);
 }
 
 #[tokio::test]

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2338,6 +2338,9 @@ fn classify_effective_distribution_mode(
 ) -> crate::update::EffectiveDistributionMode {
     use crate::update::EffectiveDistributionMode;
 
+    // This scalar reports the dominant live selection surface. An inactive
+    // registration is always UNKNOWN; for an active peer, ADD_PATH outranks
+    // PER_CLIENT_BEST, which outranks ORR, then ordinary SINGLE_BEST.
     if !registered {
         EffectiveDistributionMode::Unknown
     } else if add_path {

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1,9 +1,17 @@
 use super::{
-    ControlFlow, Event, Message, NotificationCode, PeerCommand, PeerSession, PeerSessionState,
-    RibUpdate, RouteRefreshMessage, SessionNotificationDirection, SessionState, cease_subcode,
-    debug, info, warn,
+    Afi, ControlFlow, Event, Message, NotificationCode, PeerCommand, PeerSession, PeerSessionState,
+    RibUpdate, RouteRefreshMessage, Safi, SessionNotificationDirection, SessionState,
+    cease_subcode, debug, info, warn,
 };
 use crate::handle::PeerCommandError;
+
+fn sorted_family_limits<T>(
+    limits: impl Iterator<Item = ((Afi, Safi), T)>,
+) -> Vec<((Afi, Safi), T)> {
+    let mut limits: Vec<_> = limits.collect();
+    limits.sort_by_key(|((afi, safi), _)| (*afi as u16, *safi as u8));
+    limits
+}
 
 impl PeerSession {
     fn refresh_tcp_ao_info(&mut self) {
@@ -76,8 +84,9 @@ impl PeerSession {
                 ControlFlow::Break(())
             }
             PeerCommand::QueryState { reply } => {
-                // TCP_AO_INFO is cumulative for this socket. Refresh at the
-                // query boundary so operators see current verification health.
+                // TCP_AO_INFO is cumulative for this socket. Its in-actor
+                // getsockopt is a bounded, nonblocking kernel-memory read, so
+                // refresh at the query boundary for current operator health.
                 self.refresh_tcp_ao_info();
                 let uptime_secs = self.established_at.map_or(0, |t| t.elapsed().as_secs());
                 // Prefer FSM's negotiated (available at OpenConfirm) over
@@ -100,14 +109,21 @@ impl PeerSession {
                     remote_role: neg.and_then(|n| n.remote_role),
                     role_negotiated: neg.is_some_and(|n| n.role_negotiated),
                     peer_paths_limits: neg
-                        .map(|n| n.peer_paths_limits.iter().map(|(f, v)| (*f, *v)).collect())
+                        .map(|n| {
+                            sorted_family_limits(
+                                n.peer_paths_limits
+                                    .iter()
+                                    .map(|(family, limit)| (*family, *limit)),
+                            )
+                        })
                         .unwrap_or_default(),
                     effective_add_path_send_limits: neg
                         .map(|n| {
-                            n.effective_add_path_send_limits
-                                .iter()
-                                .map(|(f, v)| (*f, *v))
-                                .collect()
+                            sorted_family_limits(
+                                n.effective_add_path_send_limits
+                                    .iter()
+                                    .map(|(family, limit)| (*family, *limit)),
+                            )
                         })
                         .unwrap_or_default(),
                     updates_received: self.updates_received,

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -410,8 +410,9 @@ impl PeerSession {
                             // following family map reaches the RIB. Seed it
                             // with the strictest effective family limit so it
                             // can never transiently exceed a peer preference;
-                            // PeerAddPathLimits immediately installs exact
-                            // family-local values and resynchronizes.
+                            // PeerAddPathLimits then installs exact family-local
+                            // values and resynchronizes only when that changes
+                            // an effective cap.
                             neg.effective_add_path_send_limits
                                 .values()
                                 .copied()

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -118,6 +118,53 @@ fn install_test_negotiated_session(session: &mut PeerSession, negotiated: Negoti
         .collect();
     session.negotiated = Some(negotiated);
 }
+
+#[tokio::test]
+async fn query_state_sorts_both_paths_limit_vectors_by_numeric_family() {
+    let mut session = make_test_session(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    for (family, peer_limit, effective_limit) in [
+        ((Afi::BgpLs, Safi::BgpLs), 11_u16, 21_u32),
+        ((Afi::Ipv4, Safi::FlowSpec), 12, 22),
+        ((Afi::Ipv6, Safi::Unicast), 13, 23),
+        ((Afi::Ipv4, Safi::Unicast), 14, 24),
+    ] {
+        negotiated.peer_paths_limits.insert(family, peer_limit);
+        negotiated
+            .effective_add_path_send_limits
+            .insert(family, effective_limit);
+    }
+    session.negotiated = Some(negotiated);
+
+    let (reply, state) = oneshot::channel();
+    assert!(matches!(
+        session
+            .handle_command(PeerCommand::QueryState { reply })
+            .await,
+        ControlFlow::Continue(())
+    ));
+    let state = state.await.unwrap();
+
+    assert_eq!(
+        state.peer_paths_limits,
+        vec![
+            ((Afi::Ipv4, Safi::Unicast), 14),
+            ((Afi::Ipv4, Safi::FlowSpec), 12),
+            ((Afi::Ipv6, Safi::Unicast), 13),
+            ((Afi::BgpLs, Safi::BgpLs), 11),
+        ]
+    );
+    assert_eq!(
+        state.effective_add_path_send_limits,
+        vec![
+            ((Afi::Ipv4, Safi::Unicast), 24),
+            ((Afi::Ipv4, Safi::FlowSpec), 22),
+            ((Afi::Ipv6, Safi::Unicast), 23),
+            ((Afi::BgpLs, Safi::BgpLs), 21),
+        ]
+    );
+}
+
 fn make_bgpls_route(payload_tag: u8) -> rustbgpd_rib::BgpLsRibRoute {
     let nlri = decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_tag])
         .expect("fixture BGP-LS NLRI decodes")

--- a/docs/API.md
+++ b/docs/API.md
@@ -263,8 +263,9 @@ when either key-validity flag is absent or any bad, key-not-found,
 unsigned-required, or dropped-ICMP counter is non-zero.
 
 `NeighborState.effective_distribution_mode` reports the live RIB selection
-surface: `SINGLE_BEST`, `ADD_PATH`, `ORR`, or `PER_CLIENT_BEST`. It is `UNKNOWN`
-when the peer has no active outbound registration; `UNSPECIFIED` remains the
+surface. When multiple mechanisms apply, its primary-label precedence is
+`ADD_PATH` > `PER_CLIENT_BEST` > `ORR` > `SINGLE_BEST`. It is `UNKNOWN` when the
+peer has no active outbound registration; `UNSPECIFIED` remains the
 backward-compatible value returned by older servers. This field is independent
 of the diagnostic `update_group` label.
 


### PR DESCRIPTION
## Summary

- sort both negotiated Paths-Limit vectors by numeric AFI/SAFI before API and CLI export
- install exact per-family Add-Path limits without redundant initial-table dumps when effective caps are unchanged
- document the live distribution-mode precedence and intentional in-actor TCP-AO health read
- add direct ordering and live resynchronization regressions, including stale, empty, identical, changed, and reverted updates

## Correctness notes

The RIB keeps the scalar negotiated limit as the fallback for omitted families and only replays the initial table when an effective family cap actually changes. Session IDs still fence stale updates, and negotiation remains immutable for the lifetime of a session.

LAN-376: https://linear.app/lance0/issue/LAN-376/rustbgpd-pr-850-follow-ups-effective-mode-label-orrpcb-combination-in
LAN-366: https://linear.app/lance0/issue/LAN-366/add-path-paths-limit-follow-ups-output-normalization-deterministic

LAN-376 is fully covered here. LAN-366 retains only its explicit wire 0.15.0 and README ship-time work.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p rustbgpd-transport -p rustbgpd-rib --all-targets -- -D warnings`
- `cargo test -p rustbgpd-transport query_state_sorts_both_paths_limit_vectors_by_numeric_family`
- `cargo test -p rustbgpd-rib paths_limit_updates_resync_only_for_effective_unicast_changes`
- `cargo test --workspace --all-targets` (one unrelated event-history timeout flaked; isolated rerun passed)
- `cargo test -p rustbgpd-event-history --test byte_equality payload_bytes_identical_persisted_and_broadcast`
- `cargo doc --workspace --no-deps`
- repository pre-push format, Clippy, test, and docs hooks