### PR TITLE
feat(tcp-ao): expose redacted kernel MKT inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tempfile = "3"
 rusqlite = { version = "0.40", features = ["bundled"] }
 # Daemon boot ID stamping for restart detection (ADR-0072).
 uuid = { version = "1", features = ["v4"] }
+zeroize = "1"
 
 [package]
 name = "rustbgpd"

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -483,13 +483,26 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
 
     let tcp_ao_health = if info.authentication != "tcp_ao" {
         proto::TcpAoHealth::NotApplicable
-    } else if let Some(ao) = info.tcp_ao_info {
+    } else if let Some(ao) = info.tcp_ao_info.as_ref() {
         if !ao.has_current_key
             || !ao.has_rnext_key
             || ao.pkt_bad > 0
             || ao.pkt_key_not_found > 0
             || ao.pkt_ao_required > 0
             || ao.pkt_dropped_icmp > 0
+            || ao.keys.is_empty()
+            || ao
+                .keys
+                .iter()
+                .any(|key| key.pkt_bad > 0 || key.deprecated && (key.is_current || key.is_rnext))
+            || !ao
+                .keys
+                .iter()
+                .any(|key| key.is_current && key.send_id == ao.current_key)
+            || !ao
+                .keys
+                .iter()
+                .any(|key| key.is_rnext && key.recv_id == ao.rnext_key)
         {
             proto::TcpAoHealth::Degraded
         } else {
@@ -532,7 +545,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
             "plaintext" => proto::AuthenticationMode::Plaintext.into(),
             _ => proto::AuthenticationMode::Unspecified.into(),
         },
-        tcp_ao: info.tcp_ao_info.map(|ao| proto::TcpAoState {
+        tcp_ao: info.tcp_ao_info.as_ref().map(|ao| proto::TcpAoState {
             current_key_id: ao.has_current_key.then_some(u32::from(ao.current_key)),
             rnext_key_id: ao.has_rnext_key.then_some(u32::from(ao.rnext_key)),
             ao_required: ao.ao_required,
@@ -542,6 +555,24 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
             packets_key_not_found: ao.pkt_key_not_found,
             packets_ao_required: ao.pkt_ao_required,
             packets_dropped_icmp: ao.pkt_dropped_icmp,
+            keys: ao
+                .keys
+                .iter()
+                .map(|key| proto::TcpAoKeyState {
+                    peer_address: key.peer.to_string(),
+                    prefix_length: u32::from(key.prefix_len),
+                    send_id: u32::from(key.send_id),
+                    recv_id: u32::from(key.recv_id),
+                    algorithm: key.algorithm.linux_name().to_string(),
+                    is_current: key.is_current,
+                    is_rnext: key.is_rnext,
+                    preferred: key.preferred,
+                    deprecated: key.deprecated,
+                    packets_good: key.pkt_good,
+                    packets_bad: key.pkt_bad,
+                    vrf_ifindex: key.vrf_ifindex,
+                })
+                .collect(),
         }),
         tcp_ao_health: tcp_ao_health.into(),
         effective_distribution_mode: proto::EffectiveDistributionMode::Unknown.into(),
@@ -1241,6 +1272,8 @@ mod tests {
         assert!(source.contains("AuthenticationMode authentication = 27;"));
         assert!(source.contains("TcpAoState tcp_ao = 28;"));
         assert!(source.contains("TcpAoHealth tcp_ao_health = 29;"));
+        assert!(source.contains("repeated TcpAoKeyState keys = 10;"));
+        assert!(source.contains("message TcpAoKeyState {"));
         assert!(source.contains("EffectiveDistributionMode effective_distribution_mode = 30;"));
         assert!(source.contains("optional uint32 effective_send_limit = 6;"));
     }
@@ -2062,6 +2095,20 @@ mod tests {
             pkt_key_not_found: 2,
             pkt_ao_required: 3,
             pkt_dropped_icmp: 4,
+            keys: vec![rustbgpd_transport::TcpAoKeyState {
+                peer: "10.0.0.1".parse().unwrap(),
+                prefix_len: 32,
+                send_id: 7,
+                recv_id: 9,
+                algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+                is_current: true,
+                is_rnext: false,
+                preferred: true,
+                deprecated: false,
+                vrf_ifindex: None,
+                pkt_good: 21,
+                pkt_bad: 1,
+            }],
         });
         let state = peer_info_to_proto(&info);
         assert_eq!(
@@ -2076,6 +2123,11 @@ mod tests {
         assert_eq!(ao.packets_key_not_found, 2);
         assert_eq!(ao.packets_ao_required, 3);
         assert_eq!(ao.packets_dropped_icmp, 4);
+        assert_eq!(ao.keys.len(), 1);
+        assert_eq!(ao.keys[0].peer_address, "10.0.0.1");
+        assert_eq!(ao.keys[0].algorithm, "hmac(sha256)");
+        assert!(ao.keys[0].preferred);
+        assert_eq!(ao.keys[0].vrf_ifindex, None);
         assert_eq!(state.tcp_ao_health, proto::TcpAoHealth::Degraded as i32);
     }
 
@@ -2111,6 +2163,7 @@ mod tests {
             pkt_key_not_found: 0,
             pkt_ao_required: 0,
             pkt_dropped_icmp: 0,
+            keys: Vec::new(),
         });
         assert_eq!(
             peer_info_to_proto(&info).tcp_ao_health,
@@ -2134,6 +2187,7 @@ mod tests {
             pkt_key_not_found: 0,
             pkt_ao_required: 0,
             pkt_dropped_icmp: 0,
+            keys: Vec::new(),
         });
         assert_eq!(
             peer_info_to_proto(&info).tcp_ao_health,
@@ -2182,11 +2236,70 @@ mod tests {
             pkt_key_not_found: 0,
             pkt_ao_required: 0,
             pkt_dropped_icmp: 0,
+            keys: vec![rustbgpd_transport::TcpAoKeyState {
+                peer: "10.0.0.1".parse().unwrap(),
+                prefix_len: 32,
+                send_id: 7,
+                recv_id: 9,
+                algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+                is_current: true,
+                is_rnext: true,
+                preferred: true,
+                deprecated: false,
+                vrf_ifindex: None,
+                pkt_good: 20,
+                pkt_bad: 0,
+            }],
         });
 
         let state = peer_info_to_proto(&info);
 
         assert_eq!(state.tcp_ao_health, proto::TcpAoHealth::Healthy as i32);
+    }
+
+    #[test]
+    fn active_deprecated_tcp_ao_key_is_degraded() {
+        let mut info = peer_info("10.0.0.1".parse().unwrap());
+        info.authentication = "tcp_ao".to_string();
+        let mut snapshot = rustbgpd_transport::TcpAoInfoSnapshot {
+            has_current_key: true,
+            has_rnext_key: true,
+            ao_required: true,
+            accept_icmps: false,
+            current_key: 7,
+            rnext_key: 9,
+            pkt_good: 20,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+            keys: vec![rustbgpd_transport::TcpAoKeyState {
+                peer: "10.0.0.1".parse().unwrap(),
+                prefix_len: 32,
+                send_id: 7,
+                recv_id: 9,
+                algorithm: rustbgpd_transport::TcpAoAlgorithm::HmacSha256,
+                is_current: true,
+                is_rnext: true,
+                preferred: false,
+                deprecated: true,
+                vrf_ifindex: None,
+                pkt_good: 20,
+                pkt_bad: 0,
+            }],
+        };
+        info.tcp_ao_info = Some(snapshot.clone());
+        assert_eq!(
+            peer_info_to_proto(&info).tcp_ao_health,
+            proto::TcpAoHealth::Degraded as i32
+        );
+        snapshot.keys[0].deprecated = false;
+        snapshot.pkt_dropped_icmp = 1;
+        info.tcp_ao_info = Some(snapshot);
+        assert_eq!(
+            peer_info_to_proto(&info).tcp_ao_health,
+            proto::TcpAoHealth::Degraded as i32
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -1,6 +1,8 @@
 use crate::connection::Connection;
 use crate::error::CliError;
-use crate::output::{self, JsonNeighbor, JsonNeighborDetail, JsonPathsLimit, JsonTcpAoState};
+use crate::output::{
+    self, JsonNeighbor, JsonNeighborDetail, JsonPathsLimit, JsonTcpAoKeyState, JsonTcpAoState,
+};
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
     AddNeighborRequest, DeleteNeighborRequest, DisableNeighborRequest, EnableNeighborRequest,
@@ -110,6 +112,24 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
                 packets_key_not_found: ao.packets_key_not_found,
                 packets_ao_required: ao.packets_ao_required,
                 packets_dropped_icmp: ao.packets_dropped_icmp,
+                keys: ao
+                    .keys
+                    .iter()
+                    .map(|key| JsonTcpAoKeyState {
+                        peer_address: key.peer_address.clone(),
+                        prefix_length: key.prefix_length,
+                        send_id: key.send_id,
+                        recv_id: key.recv_id,
+                        algorithm: key.algorithm.clone(),
+                        is_current: key.is_current,
+                        is_rnext: key.is_rnext,
+                        preferred: key.preferred,
+                        deprecated: key.deprecated,
+                        vrf_ifindex: key.vrf_ifindex,
+                        packets_good: key.packets_good,
+                        packets_bad: key.packets_bad,
+                    })
+                    .collect(),
             }),
             description: cfg.map(|c| c.description.clone()).unwrap_or_default(),
             hold_time: cfg.map(|c| c.hold_time).unwrap_or(0),
@@ -278,6 +298,24 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
                 "TCP-AO Packets:        good={} bad={} key-not-found={} unsigned-required={}",
                 ao.packets_good, ao.packets_bad, ao.packets_key_not_found, ao.packets_ao_required
             );
+            for key in &ao.keys {
+                println!(
+                    "  MKT {}/{}: send={} recv={} algorithm={} current={} rnext={} preferred={} deprecated={} vrf-ifindex={} good={} bad={}",
+                    key.peer_address,
+                    key.prefix_length,
+                    key.send_id,
+                    key.recv_id,
+                    key.algorithm,
+                    key.is_current,
+                    key.is_rnext,
+                    key.preferred,
+                    key.deprecated,
+                    key.vrf_ifindex
+                        .map_or_else(|| "unbound".to_string(), |value| value.to_string()),
+                    key.packets_good,
+                    key.packets_bad
+                );
+            }
         }
         println!("OTC Routes Blocked:    {}", n.otc_routes_blocked);
         println!("Policy Stats:");

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -296,6 +296,24 @@ pub struct JsonTcpAoState {
     pub packets_key_not_found: u64,
     pub packets_ao_required: u64,
     pub packets_dropped_icmp: u64,
+    pub keys: Vec<JsonTcpAoKeyState>,
+}
+
+#[derive(Serialize)]
+pub struct JsonTcpAoKeyState {
+    pub peer_address: String,
+    pub prefix_length: u32,
+    pub send_id: u32,
+    pub recv_id: u32,
+    pub algorithm: String,
+    pub is_current: bool,
+    pub is_rnext: bool,
+    pub preferred: bool,
+    pub deprecated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vrf_ifindex: Option<u32>,
+    pub packets_good: u64,
+    pub packets_bad: u64,
 }
 
 #[derive(Serialize)]
@@ -1049,7 +1067,31 @@ mod tests {
             last_error: String::new(),
             authentication: "tcp_ao".to_string(),
             tcp_ao_health: "unavailable".to_string(),
-            tcp_ao: None,
+            tcp_ao: Some(JsonTcpAoState {
+                current_key_id: Some(7),
+                rnext_key_id: Some(9),
+                ao_required: true,
+                accept_icmps: false,
+                packets_good: 12,
+                packets_bad: 0,
+                packets_key_not_found: 0,
+                packets_ao_required: 0,
+                packets_dropped_icmp: 0,
+                keys: vec![JsonTcpAoKeyState {
+                    peer_address: "10.0.0.2".to_string(),
+                    prefix_length: 32,
+                    send_id: 7,
+                    recv_id: 9,
+                    algorithm: "hmac(sha256)".to_string(),
+                    is_current: true,
+                    is_rnext: true,
+                    preferred: true,
+                    deprecated: false,
+                    vrf_ifindex: None,
+                    packets_good: 12,
+                    packets_bad: 0,
+                }],
+            }),
             description: "peer-2".to_string(),
             hold_time: 90,
             send_hold_time: 480,
@@ -1087,6 +1129,8 @@ mod tests {
         assert_eq!(value["role_negotiated"], true);
         assert_eq!(value["authentication"], "tcp_ao");
         assert_eq!(value["tcp_ao_health"], "unavailable");
+        assert_eq!(value["tcp_ao"]["keys"][0]["algorithm"], "hmac(sha256)");
+        assert!(value.to_string().find("secret").is_none());
         assert_eq!(value["otc_routes_blocked"], 3);
         assert_eq!(value["import_policy_routes_permitted"], 8);
         assert_eq!(value["import_policy_routes_denied"], 1);

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -28,6 +28,7 @@ socket2.workspace = true
 libc.workspace = true
 lru.workspace = true
 rustc-hash.workspace = true
+zeroize.workspace = true
 
 [features]
 # Exposes `RouteAttrBundle` + `materialize_attrs` (inbound attribute

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -42,4 +42,4 @@ pub use session::import_decision_cache::{
     CachedDecision, CachedOutcome, CachedPolicyContext, ImportExplainReply, LookupResult,
     ResolvedMatch,
 };
-pub use socket_opts::{TcpAoInfoSnapshot, TcpAoSupport, probe_tcp_ao_support};
+pub use socket_opts::{TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support};

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -230,7 +230,13 @@ impl BgpListener {
             return Ok(None);
         };
 
-        match crate::socket_opts::get_tcp_ao_info(stream) {
+        match crate::socket_opts::get_tcp_ao_info_for_config(
+            stream,
+            key.peer,
+            key.prefix_len,
+            &key.config,
+            true,
+        ) {
             Ok(info) => {
                 info!(
                     peer = %peer_ip,
@@ -283,6 +289,10 @@ fn accepted_tcp_ao_info_is_valid(
         && info.pkt_bad == 0
         && info.pkt_key_not_found == 0
         && info.pkt_ao_required == 0
+        && info.keys.len() == 1
+        && info.keys[0].is_current
+        && info.keys[0].is_rnext
+        && info.keys[0].pkt_bad == 0
 }
 
 #[cfg(test)]
@@ -394,6 +404,20 @@ mod tests {
             pkt_key_not_found: 0,
             pkt_ao_required: 0,
             pkt_dropped_icmp: 0,
+            keys: vec![crate::TcpAoKeyState {
+                peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+                prefix_len: 32,
+                send_id: current_key,
+                recv_id: 9,
+                algorithm: TcpAoAlgorithm::HmacSha256,
+                is_current: true,
+                is_rnext: true,
+                preferred: false,
+                deprecated: false,
+                vrf_ifindex: None,
+                pkt_good,
+                pkt_bad: 0,
+            }],
         }
     }
 
@@ -497,7 +521,7 @@ mod tests {
         assert!(accepted_tcp_ao_info_is_valid(&valid, 7, 9));
         assert!(!accepted_tcp_ao_info_is_valid(&valid, 8, 9));
         assert!(!accepted_tcp_ao_info_is_valid(&valid, 7, 8));
-        let mut bad = valid;
+        let mut bad = valid.clone();
         bad.pkt_bad = 1;
         assert!(!accepted_tcp_ao_info_is_valid(&bad, 7, 9));
         let mut missing = valid;
@@ -628,7 +652,16 @@ mod tests {
             accepted.peer_addr.ip(),
             "127.0.0.2".parse::<IpAddr>().unwrap()
         );
-        assert!(accepted.tcp_ao_info.is_some());
+        let info = accepted.tcp_ao_info.as_ref().expect("accepted AO snapshot");
+        assert_eq!(info.keys.len(), 1);
+        let key = &info.keys[0];
+        assert_eq!(key.peer, "127.0.0.0".parse::<IpAddr>().unwrap());
+        assert_eq!(key.prefix_len, 24);
+        assert_eq!(key.send_id, config.send_id);
+        assert_eq!(key.recv_id, config.recv_id);
+        assert_eq!(key.algorithm, config.algorithm);
+        assert!(key.is_current);
+        assert!(key.is_rnext);
 
         let protected_unsigned = tokio::task::spawn_blocking(move || {
             connect_from("127.0.0.3".parse().unwrap(), destination, None)

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -23,7 +23,24 @@ impl PeerSession {
             return;
         };
         match inspect(read_half.as_ref()) {
-            Ok(snapshot) => self.tcp_ao_info = Some(snapshot),
+            Ok(mut snapshot) => {
+                if self.tcp_ao_key_metadata.is_empty() {
+                    self.tcp_ao_key_metadata = super::tcp_ao_key_metadata(&self.config, None);
+                }
+                for key in &mut snapshot.keys {
+                    if let Some(metadata) = self.tcp_ao_key_metadata.iter().find(|metadata| {
+                        metadata.peer == key.peer
+                            && metadata.prefix_len == key.prefix_len
+                            && metadata.send_id == key.send_id
+                            && metadata.recv_id == key.recv_id
+                            && metadata.algorithm == key.algorithm
+                    }) {
+                        key.preferred = metadata.preferred;
+                        key.deprecated = metadata.deprecated;
+                    }
+                }
+                self.tcp_ao_info = Some(snapshot);
+            }
             Err(error) => {
                 if self.tcp_ao_info.is_some() {
                     warn!(
@@ -122,7 +139,7 @@ impl PeerSession {
                     flap_count: self.flap_count,
                     uptime_secs,
                     last_error: self.last_error.clone(),
-                    tcp_ao_info: self.tcp_ao_info.map(Box::new),
+                    tcp_ao_info: self.tcp_ao_info.clone().map(Box::new),
                     tcp_ao_protected: self.tcp_ao_protected,
                 };
                 let _ = reply.send(state);

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -702,42 +702,57 @@ async fn create_and_connect(
         return Err(err);
     }
 
-    let tcp_ao_info = if config.tcp_ao.is_some() {
-        match crate::socket_opts::get_tcp_ao_info(&stream) {
-            Ok(info) => {
-                info!(
-                    peer = %peer_label,
-                    addr = %config.remote_addr,
-                    current_key = info.current_key,
-                    rnext_key = info.rnext_key,
-                    has_current_key = info.has_current_key,
-                    has_rnext_key = info.has_rnext_key,
-                    ao_required = info.ao_required,
-                    accept_icmps = info.accept_icmps,
-                    pkt_good = info.pkt_good,
-                    pkt_bad = info.pkt_bad,
-                    pkt_key_not_found = info.pkt_key_not_found,
-                    pkt_ao_required = info.pkt_ao_required,
-                    pkt_dropped_icmp = info.pkt_dropped_icmp,
-                    "TCP-AO active-open socket inspected"
-                );
-                Some(info)
-            }
-            Err(err) => {
-                warn!(
-                    peer = %peer_label,
-                    addr = %config.remote_addr,
-                    error = %err,
-                    "failed to inspect TCP-AO active-open socket"
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let tcp_ao_info = inspect_active_tcp_ao(&stream, &config, &peer_label);
 
     Ok((stream, tcp_ao_info))
+}
+
+fn inspect_active_tcp_ao(
+    stream: &TcpStream,
+    config: &TransportConfig,
+    peer_label: &str,
+) -> Option<crate::TcpAoInfoSnapshot> {
+    let tcp_ao = config.tcp_ao.as_ref()?;
+    match crate::socket_opts::get_tcp_ao_info_for_config(
+        stream,
+        config.remote_addr.ip(),
+        if config.remote_addr.is_ipv4() {
+            32
+        } else {
+            128
+        },
+        tcp_ao,
+        false,
+    ) {
+        Ok(info) => {
+            info!(
+                peer = %peer_label,
+                addr = %config.remote_addr,
+                current_key = info.current_key,
+                rnext_key = info.rnext_key,
+                has_current_key = info.has_current_key,
+                has_rnext_key = info.has_rnext_key,
+                ao_required = info.ao_required,
+                accept_icmps = info.accept_icmps,
+                pkt_good = info.pkt_good,
+                pkt_bad = info.pkt_bad,
+                pkt_key_not_found = info.pkt_key_not_found,
+                pkt_ao_required = info.pkt_ao_required,
+                pkt_dropped_icmp = info.pkt_dropped_icmp,
+                "TCP-AO active-open socket inspected"
+            );
+            Some(info)
+        }
+        Err(err) => {
+            warn!(
+                peer = %peer_label,
+                addr = %config.remote_addr,
+                error = %err,
+                "failed to inspect TCP-AO active-open socket"
+            );
+            None
+        }
+    }
 }
 
 /// Read from the TCP read half into the buffer. Extracted as a

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -265,6 +265,9 @@ pub(crate) struct PeerSession {
     last_error: String,
     /// Latest query-time TCP-AO inspection for the currently owned stream.
     tcp_ao_info: Option<crate::TcpAoInfoSnapshot>,
+    /// Secret-free configured MKT identity/rollover metadata. This survives
+    /// inspection failures so recovered snapshots retain their annotations.
+    tcp_ao_key_metadata: Vec<TcpAoKeyMetadata>,
     /// Durable protection identity for this session. Unlike `tcp_ao_info`,
     /// inspection failure never clears this bit, so a protected accepted
     /// session keeps retrying read-only inspection on later queries.
@@ -305,6 +308,51 @@ pub(crate) struct PeerSession {
     /// rather than a global registry counter so a policy edit to an
     /// unrelated peer can't false-`STALE` this peer's decisions.
     import_policy_generation: u64,
+}
+
+#[derive(Clone)]
+struct TcpAoKeyMetadata {
+    peer: IpAddr,
+    prefix_len: u8,
+    send_id: u8,
+    recv_id: u8,
+    algorithm: crate::TcpAoAlgorithm,
+    preferred: bool,
+    deprecated: bool,
+}
+
+fn tcp_ao_key_metadata(
+    config: &TransportConfig,
+    initial: Option<&crate::TcpAoInfoSnapshot>,
+) -> Vec<TcpAoKeyMetadata> {
+    if let Some(key) = config.tcp_ao.as_ref() {
+        return vec![TcpAoKeyMetadata {
+            peer: config.remote_addr.ip(),
+            prefix_len: if config.remote_addr.is_ipv4() {
+                32
+            } else {
+                128
+            },
+            send_id: key.send_id,
+            recv_id: key.recv_id,
+            algorithm: key.algorithm,
+            preferred: key.preferred,
+            deprecated: key.deprecated,
+        }];
+    }
+    initial
+        .into_iter()
+        .flat_map(|snapshot| &snapshot.keys)
+        .map(|key| TcpAoKeyMetadata {
+            peer: key.peer,
+            prefix_len: key.prefix_len,
+            send_id: key.send_id,
+            recv_id: key.recv_id,
+            algorithm: key.algorithm,
+            preferred: key.preferred,
+            deprecated: key.deprecated,
+        })
+        .collect()
 }
 
 /// Outbound channel buffer size.
@@ -502,6 +550,7 @@ impl PeerSession {
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
         let tcp_ao_protected = config.tcp_ao.is_some();
+        let tcp_ao_key_metadata = tcp_ao_key_metadata(&config, None);
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
@@ -570,6 +619,7 @@ impl PeerSession {
             established_at: None,
             last_error: String::new(),
             tcp_ao_info: None,
+            tcp_ao_key_metadata,
             tcp_ao_protected,
             notification_teardown: false,
             received_hard_reset: false,
@@ -611,6 +661,7 @@ impl PeerSession {
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
         let tcp_ao_protected = config.tcp_ao.is_some() || tcp_ao_info.is_some();
+        let tcp_ao_key_metadata = tcp_ao_key_metadata(&config, tcp_ao_info.as_ref());
         let import_needs_as_path_string =
             Self::import_chain_needs_as_path_string(import_policy.as_ref(), explain_enabled);
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_BUFFER);
@@ -691,6 +742,7 @@ impl PeerSession {
             established_at: None,
             last_error: String::new(),
             tcp_ao_info,
+            tcp_ao_key_metadata,
             tcp_ao_protected,
             notification_teardown: false,
             received_hard_reset: false,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -1007,6 +1007,7 @@ async fn tcp_disconnect_clears_bmp_repair_latch() {
         pkt_key_not_found: 0,
         pkt_ao_required: 0,
         pkt_dropped_icmp: 0,
+        keys: Vec::new(),
     });
     // Latch divergence + arm the repair timer via a dropped RM on a full
     // channel.
@@ -1061,6 +1062,20 @@ fn tcp_ao_snapshot(good: u64, bad: u64) -> crate::TcpAoInfoSnapshot {
         pkt_key_not_found: 0,
         pkt_ao_required: 0,
         pkt_dropped_icmp: 0,
+        keys: vec![crate::TcpAoKeyState {
+            peer: "10.0.0.2".parse().unwrap(),
+            prefix_len: 32,
+            send_id: 7,
+            recv_id: 9,
+            algorithm: crate::TcpAoAlgorithm::HmacSha256,
+            is_current: true,
+            is_rnext: true,
+            preferred: false,
+            deprecated: false,
+            vrf_ifindex: None,
+            pkt_good: good,
+            pkt_bad: bad,
+        }],
     }
 }
 
@@ -1130,21 +1145,30 @@ async fn tcp_ao_query_refreshes_degraded_cumulative_counters() {
 async fn tcp_ao_query_clears_stale_snapshot_and_recovers() {
     let mut session = tcp_ao_query_test_session().await;
     session.tcp_ao_info = Some(tcp_ao_snapshot(12, 0));
-    session.refresh_tcp_ao_info_with(|_| Err(std::io::Error::other("inspection failed")));
+    session.refresh_tcp_ao_info_with(|_| {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "TCP-AO INFO and key inventory remained inconsistent",
+        ))
+    });
     assert!(session.tcp_ao_info.is_none());
 
     session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(44, 0)));
-    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 44);
+    assert_eq!(session.tcp_ao_info.as_ref().unwrap().pkt_good, 44);
+    assert!(session.tcp_ao_info.as_ref().unwrap().keys[0].preferred);
 }
 
 #[tokio::test]
 async fn accepted_tcp_ao_snapshot_seeds_durable_refresh_across_failure_and_recovery() {
-    let mut session = accepted_query_test_session(Some(tcp_ao_snapshot(20, 0))).await;
+    let mut initial = tcp_ao_snapshot(20, 0);
+    initial.keys[0].preferred = true;
+    let mut session = accepted_query_test_session(Some(initial)).await;
     assert!(session.config.tcp_ao.is_none());
     assert!(session.tcp_ao_protected);
 
     session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(43, 0)));
-    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 43);
+    assert_eq!(session.tcp_ao_info.as_ref().unwrap().pkt_good, 43);
+    assert!(session.tcp_ao_info.as_ref().unwrap().keys[0].preferred);
     session.refresh_tcp_ao_info_with(|_| Err(std::io::Error::other("inspection failed")));
     assert!(session.tcp_ao_info.is_none());
     assert!(
@@ -1152,7 +1176,8 @@ async fn accepted_tcp_ao_snapshot_seeds_durable_refresh_across_failure_and_recov
         "inspection failure must not erase protection identity"
     );
     session.refresh_tcp_ao_info_with(|_| Ok(tcp_ao_snapshot(44, 0)));
-    assert_eq!(session.tcp_ao_info.unwrap().pkt_good, 44);
+    assert_eq!(session.tcp_ao_info.as_ref().unwrap().pkt_good, 44);
+    assert!(session.tcp_ao_info.as_ref().unwrap().keys[0].preferred);
 }
 
 #[tokio::test]

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -716,6 +716,21 @@ pub(crate) fn get_tcp_ao_info_for_config(
 }
 
 #[cfg(target_os = "linux")]
+fn tcp_ao_secret_eq(lhs: &[u8], rhs: &[u8]) -> bool {
+    // Mirror the bearer-token comparison contract: include the length in the
+    // accumulated difference and walk the longer input so neither the first
+    // mismatching byte nor a length mismatch short-circuits comparison.
+    let max_len = lhs.len().max(rhs.len());
+    let mut diff = lhs.len() ^ rhs.len();
+    for index in 0..max_len {
+        let left = lhs.get(index).copied().unwrap_or(0);
+        let right = rhs.get(index).copied().unwrap_or(0);
+        diff |= usize::from(left ^ right);
+    }
+    diff == 0
+}
+
+#[cfg(target_os = "linux")]
 fn annotate_tcp_ao_config(
     info: &mut TcpAoInfoSnapshot,
     keys: &[TcpAoGetSockOpt],
@@ -741,7 +756,7 @@ fn annotate_tcp_ao_config(
                 && state.vrf_ifindex.is_none()
                 && raw.keyflags == 0
                 && usize::from(raw.keylen) == config.key.len()
-                && raw.key[..usize::from(raw.keylen)] == config.key.as_bytes()[..]
+                && tcp_ao_secret_eq(&raw.key[..usize::from(raw.keylen)], config.key.as_bytes())
         })
         .map(|(index, _)| index)
         .collect::<Vec<_>>();
@@ -1221,6 +1236,14 @@ mod tests {
         assert!(raw.alg_name.iter().all(|byte| *byte == 0));
         assert!(raw.key.iter().all(|byte| *byte == 0));
         assert_eq!(raw.keylen, 0);
+    }
+
+    #[test]
+    fn tcp_ao_secret_comparison_covers_content_and_length() {
+        assert!(tcp_ao_secret_eq(b"shared secret", b"shared secret"));
+        assert!(!tcp_ao_secret_eq(b"shared secret", b"shared secreu"));
+        assert!(!tcp_ao_secret_eq(b"shared secret", b"shared secret!"));
+        assert!(!tcp_ao_secret_eq(b"shared secret!", b"shared secret"));
     }
 
     #[test]

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -14,9 +14,12 @@ use std::net::SocketAddr;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 
+use crate::config::TcpAoAlgorithm;
 #[cfg(target_os = "linux")]
-use crate::config::{TcpAoAlgorithm, TcpAoConfig};
+use crate::config::TcpAoConfig;
 use socket2::Socket;
+#[cfg(target_os = "linux")]
+use zeroize::Zeroize;
 
 /// Set TCP MD5 signature on a socket for a specific peer.
 ///
@@ -110,7 +113,6 @@ pub(crate) enum TcpAoSocketRole {
 
 /// A single Linux TCP-AO Master Key Tuple for a peer address.
 #[cfg(target_os = "linux")]
-#[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub(crate) struct TcpAoKey<'a> {
     pub(crate) peer: IpAddr,
@@ -143,6 +145,22 @@ struct TcpAoAdd {
 }
 
 #[cfg(target_os = "linux")]
+impl Drop for TcpAoAdd {
+    fn drop(&mut self) {
+        self.scrub();
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl TcpAoAdd {
+    fn scrub(&mut self) {
+        self.alg_name.zeroize();
+        self.key.zeroize();
+        self.keylen.zeroize();
+    }
+}
+
+#[cfg(target_os = "linux")]
 #[repr(C, align(8))]
 #[allow(dead_code)]
 struct TcpAoInfoOpt {
@@ -157,8 +175,78 @@ struct TcpAoInfoOpt {
     pkt_dropped_icmp: u64,
 }
 
+/// Linux `tcp_ao_getsockopt`. This raw type contains the MKT secret copied
+/// back by the kernel, so it deliberately implements neither formatting nor
+/// cloning and scrubs every secret-bearing byte on drop.
+#[cfg(target_os = "linux")]
+#[repr(C, align(8))]
+struct TcpAoGetSockOpt {
+    addr: libc::sockaddr_storage,
+    alg_name: [u8; 64],
+    key: [u8; 80],
+    nkeys: u32,
+    flags: u16,
+    sndid: u8,
+    rcvid: u8,
+    prefix: u8,
+    maclen: u8,
+    keyflags: u8,
+    keylen: u8,
+    ifindex: libc::c_int,
+    pkt_good: u64,
+    pkt_bad: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl TcpAoGetSockOpt {
+    fn zeroed() -> Self {
+        // SAFETY: this is a C UAPI record made entirely of integer/byte fields.
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for TcpAoGetSockOpt {
+    fn drop(&mut self) {
+        self.scrub();
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl TcpAoGetSockOpt {
+    fn scrub(&mut self) {
+        self.alg_name.zeroize();
+        self.key.zeroize();
+        self.keylen.zeroize();
+    }
+}
+
+/// Redacted per-MKT Linux TCP-AO state. No key material, key length, or
+/// key-derived identifier is retained in this projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors independent Linux selection and local rollover flags"
+)]
+pub struct TcpAoKeyState {
+    pub peer: std::net::IpAddr,
+    pub prefix_len: u8,
+    pub send_id: u8,
+    pub recv_id: u8,
+    pub algorithm: TcpAoAlgorithm,
+    pub is_current: bool,
+    pub is_rnext: bool,
+    pub preferred: bool,
+    pub deprecated: bool,
+    /// VRF L3-master ifindex when Linux marks this MKT `TCP_AO_KEYF_IFINDEX`.
+    /// This is not an IPv6 link-local scope ID.
+    pub vrf_ifindex: Option<u32>,
+    pub pkt_good: u64,
+    pub pkt_bad: u64,
+}
+
 /// Runtime TCP-AO socket state returned by Linux `getsockopt(TCP_AO_INFO)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "mirrors independent Linux TCP_AO_INFO flag bits"
@@ -186,6 +274,8 @@ pub struct TcpAoInfoSnapshot {
     pub pkt_ao_required: u64,
     /// ICMPs dropped by TCP-AO policy.
     pub pkt_dropped_icmp: u64,
+    /// Ordered, redacted kernel MKT inventory for this socket.
+    pub keys: Vec<TcpAoKeyState>,
 }
 
 /// Result of probing whether the running host supports Linux TCP-AO.
@@ -202,6 +292,8 @@ const TCP_AO_ADD_KEY: libc::c_int = 38;
 #[allow(dead_code)]
 const TCP_AO_INFO: libc::c_int = 40;
 #[cfg(target_os = "linux")]
+const TCP_AO_GET_KEYS: libc::c_int = 41;
+#[cfg(target_os = "linux")]
 const TCP_AO_MAXKEYLEN: usize = 80;
 #[cfg(target_os = "linux")]
 const TCP_AO_ADD_SET_CURRENT: u32 = 1 << 0;
@@ -215,6 +307,20 @@ const TCP_AO_INFO_SET_RNEXT: u32 = 1 << 1;
 const TCP_AO_INFO_AO_REQUIRED: u32 = 1 << 2;
 #[cfg(target_os = "linux")]
 const TCP_AO_INFO_ACCEPT_ICMPS: u32 = 1 << 4;
+#[cfg(target_os = "linux")]
+const TCP_AO_GET_IS_CURRENT: u16 = 1 << 0;
+#[cfg(target_os = "linux")]
+const TCP_AO_GET_IS_RNEXT: u16 = 1 << 1;
+#[cfg(target_os = "linux")]
+const TCP_AO_GET_ALL: u16 = 1 << 2;
+#[cfg(target_os = "linux")]
+const TCP_AO_KEYF_IFINDEX: u8 = 1 << 0;
+#[cfg(target_os = "linux")]
+const TCP_AO_KEYF_EXCLUDE_OPT: u8 = 1 << 1;
+#[cfg(target_os = "linux")]
+const TCP_AO_KEY_QUERY_ATTEMPTS: usize = 3;
+#[cfg(target_os = "linux")]
+const TCP_AO_MAX_DUMP_KEYS: usize = 4096;
 
 /// Add a TCP-AO key to a socket.
 ///
@@ -303,7 +409,7 @@ pub(crate) fn set_tcp_ao_key(socket: &Socket, key: &TcpAoKey<'_>) -> io::Result<
             fd,
             libc::IPPROTO_TCP,
             TCP_AO_ADD_KEY,
-            (&raw const add).cast(),
+            std::ptr::from_ref(add.as_ref()).cast(),
             std::mem::size_of::<TcpAoAdd>() as libc::socklen_t,
         )
     };
@@ -322,7 +428,7 @@ pub(crate) fn set_tcp_ao_key(socket: &Socket, key: &TcpAoKey<'_>) -> io::Result<
     clippy::cast_possible_truncation,
     reason = "TCP-AO inspection uses raw Linux getsockopt ABI structs"
 )]
-pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnapshot> {
+fn get_tcp_ao_info_only(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnapshot> {
     let mut info: TcpAoInfoOpt = unsafe { std::mem::zeroed() };
     let mut len = std::mem::size_of::<TcpAoInfoOpt>() as libc::socklen_t;
 
@@ -357,9 +463,319 @@ pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnap
     Ok(TcpAoInfoSnapshot::from_raw(&info))
 }
 
+#[cfg(target_os = "linux")]
+#[allow(
+    unsafe_code,
+    reason = "TCP-AO key inventory uses the raw Linux getsockopt ABI"
+)]
+fn query_tcp_ao_keys(socket: &impl AsRawFd, entries: &mut [TcpAoGetSockOpt]) -> io::Result<usize> {
+    let capacity = entries.len();
+    let Some(first) = entries.first_mut() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "empty TCP-AO key dump buffer",
+        ));
+    };
+    first.nkeys = u32::try_from(capacity).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "TCP-AO key dump capacity exceeds u32",
+        )
+    })?;
+    first.flags = TCP_AO_GET_ALL;
+    let mut len = libc::socklen_t::try_from(std::mem::size_of::<TcpAoGetSockOpt>())
+        .expect("TCP-AO key record size fits socklen_t");
+    let ret = unsafe {
+        libc::getsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_TCP,
+            TCP_AO_GET_KEYS,
+            entries.as_mut_ptr().cast(),
+            &raw mut len,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let returned_len = usize::try_from(len).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TCP-AO key record length does not fit usize",
+        )
+    })?;
+    validate_tcp_ao_key_record_len(returned_len)?;
+    usize::try_from(entries[0].nkeys).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TCP-AO key count does not fit usize",
+        )
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn validate_tcp_ao_key_record_len(returned_len: usize) -> io::Result<()> {
+    let known_len = std::mem::size_of::<TcpAoGetSockOpt>();
+    if returned_len < known_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("short TCP-AO key record: {returned_len} < {known_len}"),
+        ));
+    }
+    // Linux returns its current structure size for version negotiation. A
+    // newer kernel may append fields; all fields consumed here are in the
+    // known prefix and the input stride remains our userspace structure size.
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn get_tcp_ao_keys_with<F>(mut query: F) -> io::Result<Vec<TcpAoGetSockOpt>>
+where
+    F: FnMut(&mut [TcpAoGetSockOpt]) -> io::Result<usize>,
+{
+    let mut capacity = 1;
+    for _ in 0..TCP_AO_KEY_QUERY_ATTEMPTS {
+        // Allocate the complete zero-only buffer before the syscall. Once the
+        // kernel writes secrets, records remain stationary: retries drop this
+        // Vec in place, and ordering is applied only to redacted projections.
+        let mut raw = (0..capacity)
+            .map(|_| TcpAoGetSockOpt::zeroed())
+            .collect::<Vec<_>>();
+        let matched = query(&mut raw)?;
+        if matched > TCP_AO_MAX_DUMP_KEYS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("TCP-AO key count {matched} exceeds safety limit {TCP_AO_MAX_DUMP_KEYS}"),
+            ));
+        }
+        if matched > capacity {
+            capacity = matched;
+            continue;
+        }
+        raw.truncate(matched);
+        for record in &raw {
+            decode_tcp_ao_key_state(record)?;
+        }
+        return Ok(raw);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::WouldBlock,
+        "TCP-AO key inventory changed during bounded query",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn decode_tcp_ao_key_state(raw: &TcpAoGetSockOpt) -> io::Result<TcpAoKeyState> {
+    let peer = read_sockaddr(&raw.addr)?;
+    let max_prefix = if peer.is_ipv4() { 32 } else { 128 };
+    if raw.prefix > max_prefix {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid TCP-AO key prefix",
+        ));
+    }
+    let key_len = usize::from(raw.keylen);
+    if key_len == 0 || key_len > TCP_AO_MAXKEYLEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid TCP-AO key length",
+        ));
+    }
+    let nul = raw
+        .alg_name
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unterminated TCP-AO algorithm name",
+            )
+        })?;
+    let name = std::str::from_utf8(&raw.alg_name[..nul])
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid TCP-AO algorithm name"))?;
+    let canonical = if name == "cmac(aes)" {
+        "cmac(aes128)"
+    } else {
+        name
+    };
+    let algorithm = TcpAoAlgorithm::from_linux_name(canonical)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "unknown TCP-AO algorithm"))?;
+    if raw.keyflags & !(TCP_AO_KEYF_IFINDEX | TCP_AO_KEYF_EXCLUDE_OPT) != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unknown TCP-AO key flags",
+        ));
+    }
+    let vrf_ifindex = if raw.keyflags & TCP_AO_KEYF_IFINDEX != 0 {
+        Some(u32::try_from(raw.ifindex).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "invalid TCP-AO VRF ifindex")
+        })?)
+    } else {
+        if raw.ifindex != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "TCP-AO ifindex lacks TCP_AO_KEYF_IFINDEX",
+            ));
+        }
+        None
+    };
+    Ok(TcpAoKeyState {
+        peer,
+        prefix_len: raw.prefix,
+        send_id: raw.sndid,
+        recv_id: raw.rcvid,
+        algorithm,
+        is_current: raw.flags & TCP_AO_GET_IS_CURRENT != 0,
+        is_rnext: raw.flags & TCP_AO_GET_IS_RNEXT != 0,
+        preferred: false,
+        deprecated: false,
+        vrf_ifindex,
+        pkt_good: raw.pkt_good,
+        pkt_bad: raw.pkt_bad,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn redacted_tcp_ao_keys(keys: &[TcpAoGetSockOpt]) -> io::Result<Vec<TcpAoKeyState>> {
+    let mut states = keys
+        .iter()
+        .map(decode_tcp_ao_key_state)
+        .collect::<io::Result<Vec<_>>>()?;
+    states.sort_by_key(|key| (key.peer, key.prefix_len, key.send_id, key.recv_id));
+    Ok(states)
+}
+
+#[cfg(target_os = "linux")]
+fn tcp_ao_inventory_consistent(info: &TcpAoInfoSnapshot, keys: &[TcpAoGetSockOpt]) -> bool {
+    let current = keys
+        .iter()
+        .filter(|key| key.flags & TCP_AO_GET_IS_CURRENT != 0)
+        .collect::<Vec<_>>();
+    let rnext = keys
+        .iter()
+        .filter(|key| key.flags & TCP_AO_GET_IS_RNEXT != 0)
+        .collect::<Vec<_>>();
+    (!info.has_current_key || (current.len() == 1 && current[0].sndid == info.current_key))
+        && (!info.has_rnext_key || (rnext.len() == 1 && rnext[0].rcvid == info.rnext_key))
+        && (info.has_current_key || current.is_empty())
+        && (info.has_rnext_key || rnext.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn get_tcp_ao_snapshot_with<I, K>(
+    mut info_query: I,
+    mut key_query: K,
+) -> io::Result<(TcpAoInfoSnapshot, Vec<TcpAoGetSockOpt>)>
+where
+    I: FnMut() -> io::Result<TcpAoInfoSnapshot>,
+    K: FnMut() -> io::Result<Vec<TcpAoGetSockOpt>>,
+{
+    for _ in 0..TCP_AO_KEY_QUERY_ATTEMPTS {
+        let info = info_query()?;
+        let keys = key_query()?;
+        if tcp_ao_inventory_consistent(&info, &keys) {
+            return Ok((info, keys));
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::WouldBlock,
+        "TCP-AO INFO and key inventory remained inconsistent",
+    ))
+}
+
+/// Inspect socket-wide and per-key TCP-AO state as one all-or-none freshness
+/// result. The two Linux syscalls are cross-checked and retried on a transition.
+#[cfg(target_os = "linux")]
+pub(crate) fn get_tcp_ao_info(socket: &impl AsRawFd) -> io::Result<TcpAoInfoSnapshot> {
+    let (mut info, keys) = get_tcp_ao_snapshot_with(
+        || get_tcp_ao_info_only(socket),
+        || get_tcp_ao_keys_with(|entries| query_tcp_ao_keys(socket, entries)),
+    )?;
+    info.keys = redacted_tcp_ao_keys(&keys)?;
+    drop(keys);
+    Ok(info)
+}
+
+/// Inspect and annotate the singleton MKT installed from configuration.
+/// `exact` is used for accepted sockets, where any missing/unexpected key or
+/// transient secret mismatch must fail closed.
+#[cfg(target_os = "linux")]
+pub(crate) fn get_tcp_ao_info_for_config(
+    socket: &impl AsRawFd,
+    peer: IpAddr,
+    prefix_len: u8,
+    config: &TcpAoConfig,
+    exact: bool,
+) -> io::Result<TcpAoInfoSnapshot> {
+    let (mut info, keys) = get_tcp_ao_snapshot_with(
+        || get_tcp_ao_info_only(socket),
+        || get_tcp_ao_keys_with(|entries| query_tcp_ao_keys(socket, entries)),
+    )?;
+    annotate_tcp_ao_config(&mut info, &keys, peer, prefix_len, config, exact)?;
+    drop(keys);
+    Ok(info)
+}
+
+#[cfg(target_os = "linux")]
+fn annotate_tcp_ao_config(
+    info: &mut TcpAoInfoSnapshot,
+    keys: &[TcpAoGetSockOpt],
+    peer: IpAddr,
+    prefix_len: u8,
+    config: &TcpAoConfig,
+    exact: bool,
+) -> io::Result<()> {
+    let states = keys
+        .iter()
+        .map(decode_tcp_ao_key_state)
+        .collect::<io::Result<Vec<_>>>()?;
+    let matching = keys
+        .iter()
+        .zip(&states)
+        .enumerate()
+        .filter(|(_, (raw, state))| {
+            state.peer == peer
+                && state.prefix_len == prefix_len
+                && state.send_id == config.send_id
+                && state.recv_id == config.recv_id
+                && state.algorithm == config.algorithm
+                && state.vrf_ifindex.is_none()
+                && raw.keyflags == 0
+                && usize::from(raw.keylen) == config.key.len()
+                && raw.key[..usize::from(raw.keylen)] == config.key.as_bytes()[..]
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if matching.len() != 1 || (exact && keys.len() != 1) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "TCP-AO kernel MKT inventory does not exactly match configured singleton",
+        ));
+    }
+    let mut states = states;
+    states[matching[0]].preferred = config.preferred;
+    states[matching[0]].deprecated = config.deprecated;
+    states.sort_by_key(|key| (key.peer, key.prefix_len, key.send_id, key.recv_id));
+    info.keys = states;
+    Ok(())
+}
+
 /// Inspect runtime TCP-AO socket state.
 #[cfg(not(target_os = "linux"))]
 pub(crate) fn get_tcp_ao_info<T>(_socket: &T) -> io::Result<TcpAoInfoSnapshot> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP-AO inspection is only supported on Linux",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn get_tcp_ao_info_for_config<T>(
+    _socket: &T,
+    _peer: std::net::IpAddr,
+    _prefix_len: u8,
+    _config: &crate::config::TcpAoConfig,
+    _exact: bool,
+) -> io::Result<TcpAoInfoSnapshot> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP-AO inspection is only supported on Linux",
@@ -381,6 +797,7 @@ impl TcpAoInfoSnapshot {
             pkt_key_not_found: info.pkt_key_not_found,
             pkt_ao_required: info.pkt_ao_required,
             pkt_dropped_icmp: info.pkt_dropped_icmp,
+            keys: Vec::new(),
         }
     }
 }
@@ -429,7 +846,7 @@ pub fn probe_tcp_ao_support() -> TcpAoSupport {
 }
 
 #[cfg(target_os = "linux")]
-fn build_tcp_ao_add(key: &TcpAoKey<'_>) -> io::Result<TcpAoAdd> {
+fn build_tcp_ao_add(key: &TcpAoKey<'_>) -> io::Result<Box<TcpAoAdd>> {
     let max_prefix = match key.peer {
         IpAddr::V4(_) => 32,
         IpAddr::V6(_) => 128,
@@ -453,7 +870,9 @@ fn build_tcp_ao_add(key: &TcpAoKey<'_>) -> io::Result<TcpAoAdd> {
         ));
     }
 
-    let mut add: TcpAoAdd = unsafe { std::mem::zeroed() };
+    // Allocate before copying the secret so the initialized raw record never
+    // moves between stack/heap locations before its zeroizing Drop runs.
+    let mut add = Box::new(unsafe { std::mem::zeroed::<TcpAoAdd>() });
     write_sockaddr(&mut add.addr, key.peer, key.scope_id);
     write_alg_name(&mut add.alg_name, key.algorithm.linux_name())?;
     if key.set_current {
@@ -505,6 +924,27 @@ fn write_sockaddr(storage: &mut libc::sockaddr_storage, peer: IpAddr, scope_id: 
             };
             sin6.sin6_scope_id = scope_id;
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+fn read_sockaddr(storage: &libc::sockaddr_storage) -> io::Result<IpAddr> {
+    match libc::c_int::from(storage.ss_family) {
+        libc::AF_INET => {
+            let sin = unsafe { &*(std::ptr::from_ref(storage).cast::<libc::sockaddr_in>()) };
+            Ok(IpAddr::V4(std::net::Ipv4Addr::from(u32::from_be(
+                sin.sin_addr.s_addr,
+            ))))
+        }
+        libc::AF_INET6 => {
+            let sin6 = unsafe { &*(std::ptr::from_ref(storage).cast::<libc::sockaddr_in6>()) };
+            Ok(IpAddr::V6(std::net::Ipv6Addr::from(sin6.sin6_addr.s6_addr)))
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid TCP-AO key address family",
+        )),
     }
 }
 
@@ -639,12 +1079,24 @@ mod tests {
         assert_eq!(mem::offset_of!(TcpAoInfoOpt, current_key), 6);
         assert_eq!(mem::offset_of!(TcpAoInfoOpt, rnext), 7);
         assert_eq!(mem::offset_of!(TcpAoInfoOpt, pkt_good), 8);
+
+        assert_eq!(mem::size_of::<TcpAoGetSockOpt>(), 304);
+        assert_eq!(mem::align_of::<TcpAoGetSockOpt>(), 8);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, addr), 0);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, alg_name), 128);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, key), 192);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, nkeys), 272);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, flags), 276);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, sndid), 278);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, ifindex), 284);
+        assert_eq!(mem::offset_of!(TcpAoGetSockOpt, pkt_good), 288);
     }
 
     #[test]
     fn tcp_ao_constants_match_linux_header() {
         assert_eq!(TCP_AO_ADD_KEY, 38);
         assert_eq!(TCP_AO_INFO, 40);
+        assert_eq!(TCP_AO_GET_KEYS, 41);
         assert_eq!(TCP_AO_MAXKEYLEN, 80);
         assert_eq!(TCP_AO_ADD_SET_CURRENT, 1);
         assert_eq!(TCP_AO_ADD_SET_RNEXT, 2);
@@ -652,6 +1104,232 @@ mod tests {
         assert_eq!(TCP_AO_INFO_SET_RNEXT, 2);
         assert_eq!(TCP_AO_INFO_AO_REQUIRED, 4);
         assert_eq!(TCP_AO_INFO_ACCEPT_ICMPS, 16);
+    }
+
+    #[test]
+    fn tcp_ao_get_keys_accepts_extended_kernel_record_size() {
+        let known = mem::size_of::<TcpAoGetSockOpt>();
+        assert!(validate_tcp_ao_key_record_len(known).is_ok());
+        assert!(validate_tcp_ao_key_record_len(known + 16).is_ok());
+        assert_eq!(
+            validate_tcp_ao_key_record_len(known - 1)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    fn raw_dump_key(peer: IpAddr, algorithm: &str, secret: &[u8]) -> TcpAoGetSockOpt {
+        let mut raw = TcpAoGetSockOpt::zeroed();
+        write_sockaddr(&mut raw.addr, peer, 0);
+        write_alg_name(&mut raw.alg_name, algorithm).unwrap();
+        raw.key[..secret.len()].copy_from_slice(secret);
+        raw.keylen = u8::try_from(secret.len()).unwrap();
+        raw.prefix = if peer.is_ipv4() { 32 } else { 128 };
+        raw.sndid = 7;
+        raw.rcvid = 9;
+        raw.flags = TCP_AO_GET_IS_CURRENT | TCP_AO_GET_IS_RNEXT;
+        raw.pkt_good = 11;
+        raw
+    }
+
+    #[test]
+    fn tcp_ao_get_keys_retries_count_growth_and_orders_projection() {
+        let mut calls = 0;
+        let keys = get_tcp_ao_keys_with(|entries| {
+            calls += 1;
+            if calls == 1 {
+                return Ok(2);
+            }
+            entries[0] = raw_dump_key("2001:db8::2".parse().unwrap(), "hmac(sha256)", b"two");
+            entries[1] = raw_dump_key("192.0.2.1".parse().unwrap(), "hmac(sha1)", b"one");
+            Ok(2)
+        })
+        .unwrap();
+        assert_eq!(calls, 2);
+        let states = redacted_tcp_ao_keys(&keys).unwrap();
+        assert_eq!(states[0].peer, "192.0.2.1".parse::<IpAddr>().unwrap());
+        assert_eq!(states[1].peer, "2001:db8::2".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn tcp_ao_get_keys_bounds_growth_and_retries() {
+        let err = get_tcp_ao_keys_with(|_| Ok(TCP_AO_MAX_DUMP_KEYS + 1))
+            .err()
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+
+        let err = get_tcp_ao_keys_with(|entries| Ok(entries.len() + 1))
+            .err()
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn tcp_ao_get_keys_canonicalizes_cmac_and_rejects_bad_records() {
+        let raw = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "cmac(aes)", b"secret");
+        assert_eq!(
+            decode_tcp_ao_key_state(&raw).unwrap().algorithm,
+            TcpAoAlgorithm::CmacAes128
+        );
+
+        let mut bad = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha1)", b"secret");
+        bad.keylen = 0;
+        assert_eq!(
+            decode_tcp_ao_key_state(&bad).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let mut vrf = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha1)", b"secret");
+        vrf.keyflags = TCP_AO_KEYF_IFINDEX;
+        vrf.ifindex = 9;
+        assert_eq!(decode_tcp_ao_key_state(&vrf).unwrap().vrf_ifindex, Some(9));
+        vrf.keyflags = 0;
+        assert_eq!(
+            decode_tcp_ao_key_state(&vrf).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+        vrf.keyflags = 1 << 7;
+        assert_eq!(
+            decode_tcp_ao_key_state(&vrf).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+        bad.keylen = 6;
+        bad.alg_name.fill(b'x');
+        assert_eq!(
+            decode_tcp_ao_key_state(&bad).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+        bad.alg_name.fill(0);
+        write_alg_name(&mut bad.alg_name, "unknown").unwrap();
+        assert_eq!(
+            decode_tcp_ao_key_state(&bad).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn tcp_ao_secret_buffers_scrub_without_formatting() {
+        let mut add = build_tcp_ao_add(&base_key()).unwrap();
+        add.scrub();
+        assert!(add.alg_name.iter().all(|byte| *byte == 0));
+        assert!(add.key.iter().all(|byte| *byte == 0));
+        assert_eq!(add.keylen, 0);
+
+        let mut raw = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha256)", b"secret");
+        raw.scrub();
+        assert!(raw.alg_name.iter().all(|byte| *byte == 0));
+        assert!(raw.key.iter().all(|byte| *byte == 0));
+        assert_eq!(raw.keylen, 0);
+    }
+
+    #[test]
+    fn tcp_ao_config_annotation_requires_transient_secret_and_exact_singleton() {
+        let peer = IpAddr::from([192, 0, 2, 1]);
+        let config = TcpAoConfig {
+            key: "secret".to_string(),
+            send_id: 7,
+            recv_id: 9,
+            algorithm: TcpAoAlgorithm::HmacSha256,
+            preferred: true,
+            deprecated: false,
+        };
+        let info_raw = TcpAoInfoOpt {
+            flags: TCP_AO_INFO_SET_CURRENT | TCP_AO_INFO_SET_RNEXT,
+            reserved2: 0,
+            current_key: 7,
+            rnext: 9,
+            pkt_good: 1,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        };
+        let mut info = TcpAoInfoSnapshot::from_raw(&info_raw);
+        let raw = raw_dump_key(peer, "hmac(sha256)", b"secret");
+        let keys = vec![raw];
+        annotate_tcp_ao_config(&mut info, &keys, peer, 32, &config, true).unwrap();
+        assert!(info.keys[0].preferred);
+
+        let wrong_secret = vec![raw_dump_key(peer, "hmac(sha256)", b"wrong")];
+        assert_eq!(
+            annotate_tcp_ao_config(&mut info, &wrong_secret, peer, 32, &config, true)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+
+        let extra = vec![
+            raw_dump_key(peer, "hmac(sha256)", b"secret"),
+            raw_dump_key(IpAddr::from([192, 0, 2, 2]), "hmac(sha256)", b"other"),
+        ];
+        assert_eq!(
+            annotate_tcp_ao_config(&mut info, &extra, peer, 32, &config, true)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+
+        for mut wrong in [
+            raw_dump_key(IpAddr::from([192, 0, 2, 2]), "hmac(sha256)", b"secret"),
+            raw_dump_key(peer, "hmac(sha1)", b"secret"),
+            raw_dump_key(peer, "hmac(sha256)", b"secret"),
+        ] {
+            if wrong.alg_name.starts_with(b"hmac(sha256)")
+                && read_sockaddr(&wrong.addr).unwrap() == peer
+            {
+                wrong.sndid = 8;
+            }
+            let wrong = vec![wrong];
+            assert_eq!(
+                annotate_tcp_ao_config(&mut info, &wrong, peer, 32, &config, true)
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::PermissionDenied
+            );
+        }
+    }
+
+    #[test]
+    fn tcp_ao_composite_snapshot_retries_inconsistent_key_selection() {
+        let info = TcpAoInfoSnapshot::from_raw(&TcpAoInfoOpt {
+            flags: TCP_AO_INFO_SET_CURRENT | TCP_AO_INFO_SET_RNEXT,
+            reserved2: 0,
+            current_key: 7,
+            rnext: 9,
+            pkt_good: 1,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        });
+        let mut calls = 0;
+        let (_, keys) = get_tcp_ao_snapshot_with(
+            || Ok(info.clone()),
+            || {
+                calls += 1;
+                let mut raw = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha256)", b"secret");
+                if calls == 1 {
+                    raw.sndid = 8;
+                }
+                Ok(vec![raw])
+            },
+        )
+        .unwrap();
+        assert_eq!(calls, 2);
+        assert_eq!(decode_tcp_ao_key_state(&keys[0]).unwrap().send_id, 7);
+
+        let err = get_tcp_ao_snapshot_with(
+            || Ok(info.clone()),
+            || {
+                let mut raw = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha256)", b"secret");
+                raw.sndid = 8;
+                Ok(vec![raw])
+            },
+        )
+        .err()
+        .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -249,18 +249,28 @@ Runtime key rotation is not exposed.
 `PLAINTEXT`, `MD5`, or `TCP_AO`. For direct dynamic-prefix TCP-AO sessions,
 that identity comes from the validated accepted socket rather than a synthesized
 per-neighbor key configuration. When socket inspection succeeds for a connected
-TCP-AO session, `NeighborState.tcp_ao` contains current/RNext KeyIDs
-and Linux verification/error counters. The daemon refreshes this read-only
-snapshot from the live socket for each neighbor state query and clears it on
-disconnect or inspection failure; it never serves an older healthy snapshot as
+TCP-AO session, `NeighborState.tcp_ao` contains current/RNext KeyIDs,
+Linux verification/error counters, and an ordered `keys` inventory. Each key
+row is deliberately redacted: it contains only peer/prefix, directional IDs,
+algorithm, current/RNext and local rollover flags, optional Linux VRF
+L3-master ifindex, and per-key counters. The VRF ifindex is not an IPv6
+link-local scope ID; absence means the MKT is VRF-unbound, not default-VRF
+bound. The inventory never contains key material, key length, a hash, or a
+fingerprint. The daemon
+refreshes `TCP_AO_INFO` and `TCP_AO_GET_KEYS` from the live socket for each
+neighbor state query, publishes them only as one internally consistent result,
+and clears it on disconnect or inspection failure; it never serves an older healthy snapshot as
 a fallback. The counters are cumulative for the lifetime of that TCP socket,
 so any non-zero error counter keeps the socket `DEGRADED` until reconnect.
 `NeighborState.tcp_ao_health` is `NOT_APPLICABLE` for plaintext and MD5 peers,
 `UNAVAILABLE` when TCP-AO protects the session but there is no socket snapshot
-(including disconnect and inspection failure), `HEALTHY` when the snapshot has
-both current/RNext key-validity flags and no error counters, and `DEGRADED`
-when either key-validity flag is absent or any bad, key-not-found,
-unsigned-required, or dropped-ICMP counter is non-zero.
+(including disconnect, inspection failure, or persistent INFO/inventory
+inconsistency), `HEALTHY` when the published snapshot has
+both current/RNext key-validity flags, a matching nondeprecated key inventory,
+and no error counters, and `DEGRADED` when either key-validity flag is absent,
+an active key is deprecated, or any bad, key-not-found, unsigned-required, or
+dropped-ICMP counter is non-zero. An inconsistent INFO/inventory pair is never
+published as degraded state.
 
 `NeighborState.effective_distribution_mode` reports the live RIB selection
 surface: `SINGLE_BEST`, `ADD_PATH`, `ORR`, or `PER_CLIENT_BEST`. It is `UNKNOWN`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -910,14 +910,29 @@ derive TCP-AO identity from their validated accepted socket rather than a
 per-neighbor key configuration. `unavailable` means TCP-AO protection is
 expected but no socket inspection snapshot is available (the peer may be
 disconnected, connecting, or socket inspection may have failed).
-`healthy` means the live snapshot has valid current/RNext keys and no
-authentication error counters; `degraded` means either key-validity flag is
-missing or at least one cumulative socket-lifetime error counter is non-zero.
-When socket
-inspection succeeds, connected sessions also show current/RNext KeyIDs and
-packet verification counters.
-Counters are refreshed from the socket for each query; inspect `last_error` for
-setup or connect failures.
+Persistent disagreement between `TCP_AO_INFO` and `TCP_AO_GET_KEYS` is also
+`unavailable`: rustbgpd clears the whole snapshot instead of publishing an
+inconsistent degraded value. `healthy` means the published live snapshot has valid current/RNext keys, a consistent
+nondeprecated kernel MKT inventory, and no authentication error counters;
+`degraded` means a key-validity flag is missing, an active key is deprecated,
+or at least one cumulative socket-lifetime error counter is non-zero. When socket inspection succeeds, connected sessions
+also show current/RNext KeyIDs,
+packet verification counters, and redacted per-key peer/prefix, directional
+IDs, algorithm, selection flags, rollover metadata, and counters. Key bytes,
+lengths, hashes, and fingerprints are never returned. `TCP_AO_GET_KEYS` does
+copy raw key bytes into a private temporary buffer; rustbgpd compares accepted
+sockets against the configured singleton without logging the bytes and
+zeroizes every temporary on success, error, retry, and unwind.
+
+The optional per-key `vrf_ifindex` is Linux's VRF L3-master key selector, not
+an IPv6 link-local interface scope. rustbgpd currently installs VRF-unbound
+TCP-AO MKTs (`TCP_AO_KEYF_IFINDEX` clear), so Linux may match them in any L3
+master. Scoped link-local routing remains attached to the TCP socket,
+and configuration validation forbids reusing the same link-local neighbor
+address across interfaces.
+
+Counters and the key inventory are refreshed from the socket for each query;
+inspect `last_error` for setup or connect failures.
 
 What is never collected: the raw daemon config file (the config section is
 the daemon's own secret-redacted effective dump — the same document as

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -93,8 +93,17 @@ slices have now shipped static-neighbor and startup-only dynamic-range support:
 - Runtime deletion of a configured TCP-AO neighbor is rejected until listener
   MKT deletion / key rotation support exists.
 - Protected active-open and accepted passive sockets are inspected with
-  `getsockopt(TCP_AO_INFO)` after connection setup; logs include current and
-  RNext key IDs plus Linux TCP-AO packet counters when inspection succeeds.
+  `getsockopt(TCP_AO_INFO)` plus a bounded `TCP_AO_GET_KEYS` dump after
+  connection setup. Raw GET_KEYS records are non-formatting, non-cloning
+  temporaries that are zeroized on drop; only peer/prefix, IDs, algorithm,
+  selection metadata, optional VRF L3-master ifindex, and counters leave the
+  transport boundary. The Linux AO ifindex selector is a VRF identity rather
+  than an IPv6 link-local scope; current rustbgpd AO MKTs are VRF-unbound and
+  may match any L3 master because `TCP_AO_KEYF_IFINDEX` is clear. Active-open
+  inspection is best effort. Accepted static and dynamic-prefix sockets fail
+  closed unless the full singleton inventory, including transient key-byte
+  equality, matches configuration. Dropped-ICMP counters degrade health but do
+  not by themselves reject an accepted authenticated socket.
 - Protected M43 interop against BIRD 3.2.1 runs in the self-hosted
   `kernel-dataplane` workflow on the current TCP-AO-capable runner. The
   workflow keeps a `CONFIG_TCP_AO` probe so future runner kernels without the
@@ -106,6 +115,7 @@ slices have now shipped static-neighbor and startup-only dynamic-range support:
 
 Still deferred: runtime key rotation / deletion on an already-listening socket,
 multi-key rollover, and peer-group inheritance. API/CLI neighbor state exposes
-redacted live inspection results (KeyIDs, validity flags, and counters) for
+redacted live inspection results (KeyIDs, validity flags, per-key inventory,
+and counters) for
 static and direct dynamic-prefix protected sessions; runtime protected-range
 CRUD remains restart-gated.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -508,6 +508,26 @@ message TcpAoState {
   uint64 packets_key_not_found = 7;
   uint64 packets_ao_required = 8;
   uint64 packets_dropped_icmp = 9;
+  // Redacted kernel MKT inventory. Never contains key material, key length,
+  // hashes, fingerprints, or other key-derived identifiers.
+  repeated TcpAoKeyState keys = 10;
+}
+
+message TcpAoKeyState {
+  string peer_address = 1;
+  uint32 prefix_length = 2;
+  uint32 send_id = 3;
+  uint32 recv_id = 4;
+  string algorithm = 5;
+  bool is_current = 6;
+  bool is_rnext = 7;
+  bool preferred = 8;
+  bool deprecated = 9;
+  uint64 packets_good = 10;
+  uint64 packets_bad = 11;
+  // Linux VRF L3-master ifindex (`TCP_AO_KEYF_IFINDEX`), when present.
+  // This is not an IPv6 link-local scope ID.
+  optional uint32 vrf_ifindex = 12;
 }
 
 message DynamicNeighborRange {

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -77,7 +77,7 @@ pub(super) fn build_peer_info(
             "plaintext"
         }
         .to_string(),
-        tcp_ao_info: session_state.and_then(|s| s.tcp_ao_info.as_deref().copied()),
+        tcp_ao_info: session_state.and_then(|s| s.tcp_ao_info.as_deref().cloned()),
         is_dynamic: managed.is_dynamic,
         stale,
     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -559,6 +559,7 @@ async fn dynamic_tcp_ao_snapshot_reports_protected_without_synthesized_key_confi
             pkt_key_not_found: 0,
             pkt_ao_required: 0,
             pkt_dropped_icmp: 0,
+            keys: Vec::new(),
         }),
     })
     .await


### PR DESCRIPTION
## Summary

- query Linux `TCP_AO_GET_KEYS` with an exact, bounded, forward-compatible UAPI buffer contract
- keep raw kernel MKT secrets stationary, non-formatable, non-cloneable, and zeroized on every drop path
- publish one redacted, deterministically ordered INFO plus key-inventory snapshot through the neighbor API and CLI
- fail closed for accepted static and dynamic sockets unless the kernel contains exactly the configured singleton MKT
- preserve durable secret-free protection metadata across transient inspection failures

## Correctness and security

Accepted-socket reconciliation compares peer/prefix, send and receive KeyIDs, canonical algorithm, and transient secret equality without retaining or exporting key material. INFO and GET_KEYS are cross-checked with bounded retry; persistent mismatch makes inspection unavailable. Bad, key-not-found, and unsigned-required counters fail health, while dropped ICMP degrades health without falsely rejecting authenticated traffic.

This advances the inspection and reconciliation prerequisite for multi-key rollover; it does not add multi-key configuration or live ADD/DEL mutation and does not close LAN-16 or GitHub #159.

LAN-381: https://linear.app/lance0/issue/LAN-381/tcp-ao-secret-safe-kernel-mkt-inventory-and-accepted-socket

## Validation

- `cargo test -p rustbgpd-transport tcp_ao` (25 passed, 1 privileged kernel receipt ignored)
- privileged `dynamic_prefix_tcp_ao_kernel_receipt --ignored` on a CONFIG_TCP_AO host
- `cargo test -p rustbgpd-api tcp_ao`
- `cargo test -p rustbgpctl tcp_ao`
- exact CLI neighbor JSON regression
- transport all-target check and Clippy with warnings denied
- `cargo fmt --all -- --check`
- `cargo test --workspace` (complete rerun passed after one unrelated transient event-history failure)
- workspace docs with warnings denied
- repository pre-push format, Clippy, test, and docs hooks