### PR TITLE
chore: inherit shared workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ clap_mangen = "0.2"
 serde_json = "1"
 owo-colors = { version = "4", features = ["supports-colors"] }
 criterion = { version = "0.8", features = ["html_reports"] }
+proptest = "1"
 smallvec = "1"
 rustc-hash = "2"
 # Lock-free snapshot swap for policy dataset handles (LAN-305,
@@ -95,6 +96,7 @@ tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 dhat = "0.3"
 rcgen = "0.14"
 tempfile = "3"
+flate2 = "1"
 # Embedded SQLite for the durable event history outbox (ADR-0072).
 # Bundled libsqlite avoids per-distro packaging variance — the outbox
 # is a daemon-local file, not something operators expect to inspect

--- a/crates/bfd/Cargo.toml
+++ b/crates/bfd/Cargo.toml
@@ -16,4 +16,4 @@ bytes.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,14 +31,14 @@ tokio.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 clap_mangen.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
-tower = { version = "0.5", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 # `rbgp doctor` bundle output (one gzipped tarball).
 tar = "0.4"
-flate2 = "1"
+flate2.workspace = true
 owo-colors.workspace = true
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["event-stream"] }
@@ -49,7 +49,7 @@ rustbgpd-wire.workspace = true
 tonic-prost-build.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }
 rustbgpd-api.workspace = true
 rustbgpd-evpn.workspace = true

--- a/crates/event-history/Cargo.toml
+++ b/crates/event-history/Cargo.toml
@@ -23,4 +23,4 @@ serde.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -16,4 +16,4 @@ thiserror.workspace = true
 bytes.workspace = true
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true

--- a/crates/mrt/Cargo.toml
+++ b/crates/mrt/Cargo.toml
@@ -18,9 +18,9 @@ tokio.workspace = true
 tracing.workspace = true
 rustbgpd-wire = { workspace = true }
 rustbgpd-rib = { workspace = true }
-flate2 = "1"
+flate2.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/rib/Cargo.toml
+++ b/crates/rib/Cargo.toml
@@ -36,7 +36,7 @@ tokio-stream.workspace = true
 bench-internals = []
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 criterion.workspace = true
 

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -15,7 +15,7 @@ bytes.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-proptest = "1"
+proptest.workspace = true
 criterion.workspace = true
 
 [[bench]]


### PR DESCRIPTION
## Summary

- centralize `proptest` and `flate2` in workspace dependencies
- inherit duplicated `proptest`, `flate2`, and `tempfile` declarations across the approved consumers
- make the CLI inherit workspace `serde` and `tower` while preserving the existing `derive` and `util` feature resolution

## Invariants

- exactly eight manifest files changed; no source, docs, proto, or excluded dependency changes
- `Cargo.lock` is byte-identical to `main`
- the complete before/after `cargo tree -e features --workspace --locked` output is identical (`111c94f45511f3ebadd196279a4f799f63eb718365f5c9f804b2f190e3c59fb7`)
- `futures`, `tokio-util`, netlink dependencies, and PR #538 manifests remain untouched

## Validation

- `cargo check --workspace --all-targets --locked`
- workspace all-target/all-feature Clippy with warnings denied
- rustdoc with warnings denied
- all seven changed consumer packages tested with all targets/features
- independent manifest review: CLEAN

The full all-feature workspace run exposed one existing concurrency-sensitive EVPN-originator test failure. It reproduces unchanged on pristine `main` at `aac0138f` and passes in isolation; the default-feature root suite passes all 1,411 tests.

Linear: LAN-86
