### PR TITLE
feat(rib): defer selection during planned restart

### DIFF
--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -576,6 +576,7 @@ fn peer_info_to_proto(info: &PeerInfo) -> proto::NeighborState {
         }),
         tcp_ao_health: tcp_ao_health.into(),
         effective_distribution_mode: proto::EffectiveDistributionMode::Unknown.into(),
+        selection_deferral: Vec::new(),
     }
 }
 
@@ -589,6 +590,23 @@ fn effective_distribution_mode_to_proto(
         EffectiveDistributionMode::Orr => proto::EffectiveDistributionMode::Orr,
         EffectiveDistributionMode::PerClientBest => proto::EffectiveDistributionMode::PerClientBest,
     }
+}
+
+fn selection_deferral_to_proto(
+    rows: Vec<rustbgpd_rib::SelectionDeferralPeerFamilyState>,
+) -> Vec<proto::SelectionDeferralFamilyState> {
+    rows.into_iter()
+        .map(|row| proto::SelectionDeferralFamilyState {
+            afi: row.afi as u32,
+            safi: row.safi as u32,
+            active: row.active,
+            waiter_state: row.waiter_state,
+            waiter_session_id: row.waiter_session_id,
+            blocking_waiters: row.blocking_waiters,
+            remaining_millis: row.remaining_millis,
+            release_reason: row.release_reason,
+        })
+        .collect()
 }
 
 fn peer_key(address: &str, interface: &str) -> Result<PeerKey, Status> {
@@ -903,6 +921,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
             state.update_group = outbound.update_group;
             state.effective_distribution_mode =
                 effective_distribution_mode_to_proto(outbound.effective_distribution_mode).into();
+            state.selection_deferral = selection_deferral_to_proto(outbound.selection_deferral);
             neighbors.push(state);
         }
 
@@ -939,6 +958,7 @@ impl proto::neighbor_service_server::NeighborService for NeighborService {
         state.update_group = outbound.update_group;
         state.effective_distribution_mode =
             effective_distribution_mode_to_proto(outbound.effective_distribution_mode).into();
+        state.selection_deferral = selection_deferral_to_proto(outbound.selection_deferral);
         Ok(Response::new(state))
     }
 
@@ -1275,6 +1295,8 @@ mod tests {
         assert!(source.contains("repeated TcpAoKeyState keys = 10;"));
         assert!(source.contains("message TcpAoKeyState {"));
         assert!(source.contains("EffectiveDistributionMode effective_distribution_mode = 30;"));
+        assert!(source.contains("repeated SelectionDeferralFamilyState selection_deferral = 31;"));
+        assert!(source.contains("message SelectionDeferralFamilyState {"));
         assert!(source.contains("optional uint32 effective_send_limit = 6;"));
     }
 
@@ -1975,6 +1997,18 @@ mod tests {
                         let _ = reply.send(PeerOutboundState {
                             update_group: "group:0".to_string(),
                             effective_distribution_mode: EffectiveDistributionMode::AddPath,
+                            selection_deferral: vec![
+                                rustbgpd_rib::SelectionDeferralPeerFamilyState {
+                                    afi: Afi::Ipv4,
+                                    safi: Safi::Unicast,
+                                    active: true,
+                                    waiter_state: "awaiting_eor".to_string(),
+                                    waiter_session_id: Some(42),
+                                    blocking_waiters: 2,
+                                    remaining_millis: 1_500,
+                                    release_reason: String::new(),
+                                },
+                            ],
                         });
                     }
                     _ => {}
@@ -1999,6 +2033,14 @@ mod tests {
             resp.effective_distribution_mode,
             proto::EffectiveDistributionMode::AddPath as i32
         );
+        assert_eq!(resp.selection_deferral.len(), 1);
+        assert_eq!(resp.selection_deferral[0].afi, Afi::Ipv4 as u32);
+        assert_eq!(resp.selection_deferral[0].safi, Safi::Unicast as u32);
+        assert!(resp.selection_deferral[0].active);
+        assert_eq!(resp.selection_deferral[0].waiter_state, "awaiting_eor");
+        assert_eq!(resp.selection_deferral[0].waiter_session_id, Some(42));
+        assert_eq!(resp.selection_deferral[0].blocking_waiters, 2);
+        assert_eq!(resp.selection_deferral[0].remaining_millis, 1_500);
     }
 
     #[test]

--- a/crates/cli/src/commands/neighbor.rs
+++ b/crates/cli/src/commands/neighbor.rs
@@ -1,7 +1,8 @@
 use crate::connection::Connection;
 use crate::error::CliError;
 use crate::output::{
-    self, JsonNeighbor, JsonNeighborDetail, JsonPathsLimit, JsonTcpAoKeyState, JsonTcpAoState,
+    self, JsonNeighbor, JsonNeighborDetail, JsonPathsLimit, JsonSelectionDeferralFamily,
+    JsonTcpAoKeyState, JsonTcpAoState,
 };
 use crate::proto::neighbor_service_client::NeighborServiceClient;
 use crate::proto::{
@@ -170,6 +171,20 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
             export_policy_routes_permitted: n.export_policy_routes_permitted,
             export_policy_routes_denied: n.export_policy_routes_denied,
             update_group: n.update_group.clone(),
+            selection_deferral: n
+                .selection_deferral
+                .iter()
+                .map(|row| JsonSelectionDeferralFamily {
+                    afi: row.afi,
+                    safi: row.safi,
+                    active: row.active,
+                    waiter_state: row.waiter_state.clone(),
+                    waiter_session_id: row.waiter_session_id,
+                    blocking_waiters: row.blocking_waiters,
+                    remaining_millis: row.remaining_millis,
+                    release_reason: row.release_reason.clone(),
+                })
+                .collect(),
         };
         output::print_json_pretty(&out)?;
     } else {
@@ -329,6 +344,30 @@ pub async fn show(connection: Connection, address: &str, json: bool) -> Result<(
         );
         if !n.update_group.is_empty() {
             println!("Update Group:          {}", n.update_group);
+        }
+        if !n.selection_deferral.is_empty() {
+            println!("Selection Deferral:");
+            for row in &n.selection_deferral {
+                let state = if row.active {
+                    format!(
+                        "active; waiter={}; session={}; blocking={}; remaining={}ms",
+                        row.waiter_state,
+                        row.waiter_session_id
+                            .map_or_else(|| "none".to_string(), |id| id.to_string()),
+                        row.blocking_waiters,
+                        row.remaining_millis
+                    )
+                } else {
+                    format!(
+                        "released={}; waiter={}; session={}",
+                        row.release_reason,
+                        row.waiter_state,
+                        row.waiter_session_id
+                            .map_or_else(|| "none".to_string(), |id| id.to_string())
+                    )
+                };
+                println!("  AFI {}/SAFI {} — {state}", row.afi, row.safi);
+            }
         }
         println!("Flap Count:            {}", n.flap_count);
         if !n.last_error.is_empty() {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -281,6 +281,23 @@ pub struct JsonNeighborDetail {
     /// Update-group membership: `group:N` or the ungrouped reason.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub update_group: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub selection_deferral: Vec<JsonSelectionDeferralFamily>,
+}
+
+#[derive(Serialize)]
+pub struct JsonSelectionDeferralFamily {
+    pub afi: u32,
+    pub safi: u32,
+    pub active: bool,
+    pub waiter_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waiter_session_id: Option<u64>,
+    pub blocking_waiters: u64,
+    #[serde(skip_serializing_if = "is_zero_u64")]
+    pub remaining_millis: u64,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub release_reason: String,
 }
 
 #[derive(Serialize)]
@@ -1115,6 +1132,16 @@ mod tests {
             add_path_send_max: 4,
             paths_limits: Vec::new(),
             update_group: "group:0".to_string(),
+            selection_deferral: vec![JsonSelectionDeferralFamily {
+                afi: 1,
+                safi: 1,
+                active: true,
+                waiter_state: "awaiting_eor".to_string(),
+                waiter_session_id: Some(42),
+                blocking_waiters: 2,
+                remaining_millis: 1_500,
+                release_reason: String::new(),
+            }],
         };
 
         let value: Value =
@@ -1142,6 +1169,13 @@ mod tests {
         assert_eq!(value["messages_received"], 20);
         assert_eq!(value["messages_sent"], 21);
         assert_eq!(value["route_reflector_client"], false);
+        assert_eq!(value["selection_deferral"][0]["afi"], 1);
+        assert_eq!(
+            value["selection_deferral"][0]["waiter_state"],
+            "awaiting_eor"
+        );
+        assert_eq!(value["selection_deferral"][0]["waiter_session_id"], 42);
+        assert_eq!(value["selection_deferral"][0]["blocking_waiters"], 2);
     }
 
     fn table_fixture() -> Vec<proto::NeighborState> {

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -738,6 +738,7 @@ impl rustbgpd_api::proto::neighbor_service_server::NeighborService for MockNeigh
             route_reflector_client: false,
             paths_limits: Vec::new(),
             effective_distribution_mode: server_proto::EffectiveDistributionMode::AddPath.into(),
+            selection_deferral: Vec::new(),
         }))
     }
 

--- a/crates/fsm/src/config.rs
+++ b/crates/fsm/src/config.rs
@@ -17,7 +17,8 @@ use rustbgpd_wire::{
 /// and RT-Constrain (SAFI 132). A family absent here is excluded from the
 /// GR/LLGR capability sets and therefore withdrawn (not retained stale) on
 /// session drop.
-pub(crate) fn graceful_restart_preserves_family((afi, safi): (Afi, Safi)) -> bool {
+#[must_use]
+pub fn graceful_restart_preserves_family((afi, safi): (Afi, Safi)) -> bool {
     matches!(
         (afi, safi),
         (

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -38,7 +38,9 @@ pub mod session;
 pub mod state;
 
 pub use action::{Action, NegotiatedSession, TimerType};
-pub use config::{DEFAULT_HOLD_TIME, PeerConfig, default_send_hold_time};
+pub use config::{
+    DEFAULT_HOLD_TIME, PeerConfig, default_send_hold_time, graceful_restart_preserves_family,
+};
 pub use event::Event;
 pub use session::Session;
 pub use state::SessionState;

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -52,6 +52,7 @@ pub use event::{EvpnRouteEvent, RouteEvent, RouteEventType};
 pub use event_sink::{NoopRibEventSink, RibEventSink};
 pub use loc_rib::LocRib;
 pub use manager::RibManager;
+pub use manager::{SelectionDeferralConfig, SelectionDeferralWaiterConfig};
 pub use orr::{
     NodeDescriptors, NodeIx, OrrLink, OrrLinkSnapshot, OrrNodeSnapshot, OrrPrefixSnapshot,
     OrrState, OrrStatusSnapshot, OrrTopology, OrrTopologySnapshot, OrrVantageStatus, SpfResult,
@@ -69,7 +70,8 @@ pub use update::{
     ExportGateStep, ExportGateVerdict, MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats,
     OrrExplainCandidate, OutboundRouteUpdate, PeerOutboundState, PlannedGroupability,
     RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
-    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupFamilyImpact,
-    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
-    UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group, route_query_key,
+    SelectionDeferralPeerFamilyState, UpdateGroupClassification, UpdateGroupClassifierInput,
+    UpdateGroupFamilyImpact, UpdateGroupFingerprint, UpdateGroupImpactPlan,
+    UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group,
+    route_query_key,
 };

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -173,14 +173,28 @@ impl RibManager {
     ///
     /// BGP-LS remains opaque: the selected route is reflected as received with
     /// ordinary BGP attribute handling, and no LSDB/TLV semantics are parsed.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "typed BGP-LS recompute stages every outbound distribution mode"
+    )]
     pub(in crate::manager) fn recompute_and_distribute_bgpls(
         &mut self,
         affected: &HashSet<crate::route::BgpLsRouteKey>,
     ) {
         use crate::route::BgpLsRibRoute;
 
+        self.record_deferred_bgpls(affected);
+        let affected: HashSet<_> = affected
+            .iter()
+            .filter(|key| !self.selection_deferred(key.family.to_afi_safi()))
+            .cloned()
+            .collect();
+        if affected.is_empty() {
+            return;
+        }
+
         let mut changed_keys: HashSet<crate::route::BgpLsRouteKey> = HashSet::new();
-        for key in affected {
+        for key in &affected {
             let candidates: Vec<BgpLsRibRoute> = self
                 .ribs
                 .values()

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -371,6 +371,11 @@ impl RibManager {
     ) {
         use crate::route::EvpnRibRoute;
 
+        self.record_deferred_evpn(affected);
+        if self.selection_deferred((Afi::L2Vpn, Safi::Evpn)) {
+            return;
+        }
+
         let mut changed_keys: HashSet<rustbgpd_wire::EvpnRouteKey> = HashSet::new();
         for key in affected {
             let candidates: Vec<&EvpnRibRoute> = self

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -306,15 +306,29 @@ impl RibManager {
 
     /// Recompute `FlowSpec` Loc-RIB best routes for affected rules and
     /// distribute changes to all outbound peers.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "FlowSpec recompute stages policy-aware changes for every outbound peer"
+    )]
     pub(in crate::manager) fn recompute_and_distribute_flowspec(
         &mut self,
         affected: &HashSet<FlowSpecKey>,
     ) {
         use crate::route::FlowSpecRoute;
 
+        self.record_deferred_flowspec(affected);
+        let affected: HashSet<_> = affected
+            .iter()
+            .filter(|key| !self.selection_deferred((key.afi, Safi::FlowSpec)))
+            .cloned()
+            .collect();
+        if affected.is_empty() {
+            return;
+        }
+
         let mut changed_keys: HashSet<FlowSpecKey> = HashSet::new();
 
-        for key in affected {
+        for key in &affected {
             let candidates: Vec<&FlowSpecRoute> = self
                 .ribs
                 .values()

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -436,7 +436,12 @@ impl RibManager {
         &mut self,
         affected: &HashSet<LabeledRibRouteKey>,
     ) {
-        let affected_nlri: HashSet<Prefix> = affected.iter().map(|key| key.prefix).collect();
+        self.record_deferred_labeled(affected);
+        let affected_nlri: HashSet<Prefix> = affected
+            .iter()
+            .filter(|key| !self.selection_deferred(key.afi_safi()))
+            .map(|key| key.prefix)
+            .collect();
 
         let mut changed_keys: HashSet<Prefix> = HashSet::new();
         for key in &affected_nlri {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -791,6 +791,50 @@ impl RibManager {
         group_prior: HashSet<crate::update::ExactExportKey>,
         mut shared_unicast_probe_cache: Option<(usize, &mut SharedUnicastProbeCache)>,
     ) -> bool {
+        let gated = announce
+            .iter()
+            .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
+            || withdraw
+                .iter()
+                .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
+            || end_of_rib
+                .iter()
+                .any(|family| self.selection_deferred(*family))
+            || refresh_markers
+                .iter()
+                .any(|(afi, safi, _)| self.selection_deferred((*afi, *safi)))
+            || flowspec_announce
+                .iter()
+                .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
+            || flowspec_withdraw
+                .iter()
+                .any(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
+            || ((!evpn_announce.is_empty() || !evpn_withdraw.is_empty())
+                && self.selection_deferred((Afi::L2Vpn, Safi::Evpn)))
+            || bgpls_announce
+                .iter()
+                .any(|route| self.selection_deferred(route.family.to_afi_safi()))
+            || bgpls_withdraw
+                .iter()
+                .any(|key| self.selection_deferred(key.family.to_afi_safi()))
+            || vpn_announce
+                .iter()
+                .any(|route| self.selection_deferred(route.afi_safi()))
+            || vpn_withdraw
+                .iter()
+                .any(|key| self.selection_deferred(key.afi_safi()))
+            || labeled_announce
+                .iter()
+                .any(|route| self.selection_deferred(route.afi_safi()))
+            || labeled_withdraw
+                .iter()
+                .any(|key| self.selection_deferred(key.afi_safi()))
+            || ((!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
+                && self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()));
+        if gated {
+            warn!(%peer, "outbound transaction intersected an active RFC 4724 selection gate; failing closed");
+            return false;
+        }
         let Some(tx) = self.outbound_peers.get(&peer).cloned() else {
             return false;
         };
@@ -1672,12 +1716,16 @@ impl RibManager {
     ) -> HashSet<Prefix> {
         use std::cmp::Ordering;
 
+        self.record_deferred_unicast(affected);
         // Some(true): install the challenger directly (case 5).
         // Some(false): provably unchanged, skip (case 4).
         // None: full rescan (cases 1-3, 6).
         let mut changed = HashSet::new();
         let mut needs_full = HashSet::new();
         for prefix in affected {
+            if self.selection_deferred(prefix_family(prefix)) {
+                continue;
+            }
             let verdict = 'fast: {
                 let Some(best) = self.loc_rib.get(prefix) else {
                     break 'fast None; // case 1
@@ -1744,8 +1792,10 @@ impl RibManager {
         &mut self,
         affected: &HashSet<Prefix>,
     ) -> HashSet<Prefix> {
+        self.record_deferred_unicast(affected);
         let needs_full: HashSet<Prefix> = affected
             .iter()
+            .filter(|prefix| !self.selection_deferred(prefix_family(prefix)))
             .filter(|prefix| {
                 let Some(best) = self.loc_rib.get(prefix) else {
                     return true; // no best: rescan (cheap; re-checks invariant)
@@ -1764,8 +1814,12 @@ impl RibManager {
     /// Returns the set of prefixes that actually changed.
     /// Also emits route events to the broadcast channel.
     pub(super) fn recompute_best(&mut self, affected: &HashSet<Prefix>) -> HashSet<Prefix> {
+        self.record_deferred_unicast(affected);
         let mut changed = HashSet::new();
         for prefix in affected {
+            if self.selection_deferred(prefix_family(prefix)) {
+                continue;
+            }
             let previous_best = self.loc_rib.get(prefix).map(|r| (r.peer, r.path_id));
             // Inner scope: `candidates` borrows the Adj-RIB-Ins and must be
             // dropped before the `&mut self` event publication below.
@@ -1925,6 +1979,18 @@ impl RibManager {
         best_changed: &HashSet<Prefix>,
         all_affected: &HashSet<Prefix>,
     ) {
+        self.record_deferred_unicast(best_changed);
+        self.record_deferred_unicast(all_affected);
+        let best_changed: HashSet<_> = best_changed
+            .iter()
+            .filter(|prefix| !self.selection_deferred(prefix_family(prefix)))
+            .copied()
+            .collect();
+        let all_affected: HashSet<_> = all_affected
+            .iter()
+            .filter(|prefix| !self.selection_deferred(prefix_family(prefix)))
+            .copied()
+            .collect();
         if best_changed.is_empty()
             && all_affected.is_empty()
             && self.dirty_peers.is_empty()
@@ -1944,7 +2010,7 @@ impl RibManager {
         // loop below emits the deltas per member via the source-flip
         // matrix; disqualified peers take the per-peer staging path
         // exactly as before.
-        let group_stage = self.stage_update_groups(best_changed, &mut export_memo);
+        let group_stage = self.stage_update_groups(&best_changed, &mut export_memo);
         let mut shared_unicast_probe_cache = SharedUnicastProbeCache::default();
         for peer in peers {
             let member_of = self.grouped_member_of(peer);
@@ -2002,12 +2068,13 @@ impl RibManager {
                 if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
                     all.extend(extras.unicast.iter().map(|(prefix, _)| *prefix));
                 }
+                all.retain(|prefix| !self.selection_deferred(prefix_family(prefix)));
                 Cow::Owned(all)
             } else if member_of.is_some() {
                 // Grouped peers have no ORR / Add-Path extras (both are
                 // grouping disqualifiers): the group deltas cover
                 // exactly the best-changed set.
-                Cow::Borrowed(best_changed)
+                Cow::Borrowed(&best_changed)
             } else {
                 // An RFC 9107 ORR peer selects from the per-target
                 // candidate set, not the Loc-RIB best — a candidate
@@ -2038,7 +2105,7 @@ impl RibManager {
                 // per-peer clone of it — this loop runs once per
                 // outbound peer per distribution pass.
                 if extras.is_empty() {
-                    Cow::Borrowed(best_changed)
+                    Cow::Borrowed(&best_changed)
                 } else {
                     let mut prefixes = best_changed.clone();
                     prefixes.extend(extras);
@@ -2058,6 +2125,7 @@ impl RibManager {
                             .map(crate::route::FlowSpecRoute::selection_key),
                     );
                 }
+                all.retain(|key| !self.selection_deferred((key.afi, Safi::FlowSpec)));
                 all
             } else {
                 HashSet::new()
@@ -2071,6 +2139,9 @@ impl RibManager {
                     .collect();
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(rib_out.iter_evpn().map(crate::route::EvpnRibRoute::key));
+                }
+                if self.selection_deferred((Afi::L2Vpn, Safi::Evpn)) {
+                    all.clear();
                 }
                 all
             } else {
@@ -2086,6 +2157,7 @@ impl RibManager {
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(rib_out.iter_bgpls().map(crate::route::BgpLsRibRoute::key));
                 }
+                all.retain(|key| !self.selection_deferred(key.family.to_afi_safi()));
                 all
             } else {
                 HashSet::new()
@@ -2128,6 +2200,13 @@ impl RibManager {
                 if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
                     all.extend(extras.vpn.iter().copied());
                 }
+                all.retain(|key| {
+                    let family = match key.prefix.family() {
+                        rustbgpd_wire::VpnAddressFamily::V4 => (Afi::Ipv4, Safi::MplsVpn),
+                        rustbgpd_wire::VpnAddressFamily::V6 => (Afi::Ipv6, Safi::MplsVpn),
+                    };
+                    !self.selection_deferred(family)
+                });
                 all
             } else {
                 HashSet::new()
@@ -2149,6 +2228,13 @@ impl RibManager {
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(rib_out.iter_labeled().map(|route| route.nlri.key()));
                 }
+                all.retain(|prefix| {
+                    let afi = match prefix {
+                        Prefix::V4(_) => Afi::Ipv4,
+                        Prefix::V6(_) => Afi::Ipv6,
+                    };
+                    !self.selection_deferred((afi, Safi::LabeledUnicast))
+                });
                 all
             } else {
                 HashSet::new()
@@ -2162,6 +2248,9 @@ impl RibManager {
                     .collect();
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(rib_out.iter_rtc().map(crate::route::RtcRibRoute::key));
+                }
+                if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
+                    all.clear();
                 }
                 all
             } else {

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -199,6 +199,11 @@ impl RibManager {
     ) {
         use crate::route::RtcRibRoute;
 
+        self.record_deferred_rtc(affected);
+        if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
+            return;
+        }
+
         let mut changed_keys: HashSet<crate::route::RtcRibRouteKey> = HashSet::new();
         for key in affected {
             let candidates: Vec<RtcRibRoute> = self

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -675,7 +675,12 @@ impl RibManager {
         &mut self,
         affected: &HashSet<VpnRibRouteKey>,
     ) {
-        let affected_nlri: HashSet<VpnRouteKey> = affected.iter().map(|key| key.nlri_key).collect();
+        self.record_deferred_vpn(affected);
+        let affected_nlri: HashSet<VpnRouteKey> = affected
+            .iter()
+            .filter(|key| !self.selection_deferred(key.afi_safi()))
+            .map(|key| key.nlri_key)
+            .collect();
 
         let mut changed_keys: HashSet<VpnRouteKey> = HashSet::new();
         for key in &affected_nlri {

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -5,6 +5,7 @@ mod graceful_restart;
 mod helpers;
 mod peer_lifecycle;
 mod route_refresh;
+mod selection_deferral;
 mod update_groups;
 
 #[cfg(test)]
@@ -35,6 +36,7 @@ use crate::update::{
 use helpers::{
     DIRTY_RESYNC_INTERVAL, LlgrPeerConfig, gauge_val, prefix_family, unicast_route_family,
 };
+pub use selection_deferral::{SelectionDeferralConfig, SelectionDeferralWaiterConfig};
 
 #[cfg(test)]
 struct PermissiveTestExactExport;
@@ -175,6 +177,9 @@ pub struct RibManager {
     /// avoids making every non-transport `PeerUp` producer construct a fake
     /// wire encoder while still fencing collision losers by session id.
     pending_peer_export_encoders: HashMap<(IpAddr, u64), Arc<dyn ExactExportEncoder>>,
+    /// Session-stamped peer GR capability context staged immediately before
+    /// `PeerUp`, used only by the process-start RFC 4724 selection gate.
+    pending_peer_gr_context: HashMap<(IpAddr, u64), PeerSelectionDeferralContext>,
     /// Exact encoder owned by the active outbound registration. Every
     /// precommit pass captures one immutable snapshot from this handle and
     /// attaches that same snapshot to the outbound envelope.
@@ -315,6 +320,15 @@ pub struct RibManager {
     /// keep the immediate `EoR`: a client that never sends ROUTE-REFRESH
     /// would otherwise never see `EoR` at all.
     gr_deferred_eor: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
+    /// Process-start RFC 4724 route-selection gates. `None` on cold starts.
+    selection_deferral: Option<selection_deferral::SelectionDeferral>,
+    /// Route identities touched while their family's Loc-RIB was frozen.
+    /// Includes withdrawals so restored rows absent from Adj-RIB-In are
+    /// still removed when the gate releases.
+    deferred_selection_keys: selection_deferral::DeferredSelectionKeys,
+    /// Route-refresh responses received while family selection is frozen.
+    /// Replayed after the released initial table and `EoR` are queued.
+    selection_deferred_refresh: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Current RPKI VRP table for origin validation. `None` = no RPKI data.
     vrp_table: Option<Arc<VrpTable>>,
     /// Current ASPA table for path verification. `None` = no ASPA data.
@@ -459,7 +473,14 @@ pub(super) struct LiveSessionRecord {
     add_path_send_max: u32,
     negotiated_orf_recv: Vec<(Afi, Safi)>,
     negotiated_llgr_families: Vec<(Afi, Safi)>,
+    gr_context: Option<PeerSelectionDeferralContext>,
     exact_export_encoder: Option<Arc<dyn ExactExportEncoder>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PeerSelectionDeferralContext {
+    peer_restart_state: bool,
+    peer_gr_families: Vec<(Afi, Safi)>,
 }
 
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
@@ -875,6 +896,7 @@ impl RibManager {
             live_sessions: HashMap::new(),
             pending_peer_export_context: HashMap::new(),
             pending_peer_export_encoders: HashMap::new(),
+            pending_peer_gr_context: HashMap::new(),
             peer_export_encoders: HashMap::new(),
             peer_unexportable: HashMap::new(),
             export_policy,
@@ -916,6 +938,9 @@ impl RibManager {
             peer_rt_membership: HashMap::new(),
             peer_orf_pending: HashMap::new(),
             gr_deferred_eor: HashMap::new(),
+            selection_deferral: None,
+            deferred_selection_keys: selection_deferral::DeferredSelectionKeys::default(),
+            selection_deferred_refresh: HashMap::new(),
             peer_asn: HashMap::new(),
             peer_group: HashMap::new(),
             peer_bgp_id: HashMap::new(),
@@ -990,6 +1015,21 @@ impl RibManager {
     pub fn with_bmp_tx(mut self, bmp_tx: mpsc::Sender<rustbgpd_bmp::BmpEvent>) -> Self {
         self.bmp_tx = Some(bmp_tx);
         self
+    }
+
+    /// Install the startup-frozen RFC 4724 restarting-speaker waiter roster.
+    /// Called before the actor starts; cold starts leave the gate absent.
+    #[must_use]
+    pub fn with_selection_deferral(mut self, config: SelectionDeferralConfig) -> Self {
+        self.selection_deferral = selection_deferral::SelectionDeferral::new(config, &self.metrics);
+        self
+    }
+
+    #[must_use]
+    pub(super) fn selection_deferred(&self, family: (Afi, Safi)) -> bool {
+        self.selection_deferral
+            .as_ref()
+            .is_some_and(|state| state.is_gated(family))
     }
 
     /// Emit an RFC 9069 Loc-RIB Route Monitoring event. `pdu = None`
@@ -1087,9 +1127,18 @@ impl RibManager {
 
     fn drain_ready_updates(&mut self) -> bool {
         let mut drained = false;
+        // Route batches are actor-deferred for fairness. During a timer race,
+        // however, preserve channel order: an EoR or timeout must not release
+        // selection before route payloads accepted ahead of it are applied.
+        while self.process_next_route_chunk() {
+            drained = true;
+        }
         while let Ok(update) = self.rx.try_recv() {
             drained = true;
             self.handle_update(update);
+            while self.process_next_route_chunk() {
+                drained = true;
+            }
         }
         drained
     }
@@ -1313,6 +1362,20 @@ impl RibManager {
                 self.pending_peer_export_encoders
                     .insert((peer, session_id), encoder);
             }
+            RibUpdate::SetPeerGracefulRestartContext {
+                peer,
+                session_id,
+                peer_restart_state,
+                peer_gr_families,
+            } => {
+                self.pending_peer_gr_context.insert(
+                    (peer, session_id),
+                    PeerSelectionDeferralContext {
+                        peer_restart_state,
+                        peer_gr_families,
+                    },
+                );
+            }
             RibUpdate::InjectRoute { route, reply } => self.handle_inject_route(route, reply),
             RibUpdate::WithdrawInjected {
                 prefix,
@@ -1454,7 +1517,16 @@ impl RibManager {
                 safi,
             } => {
                 if !self.stale_session_message(peer, session_id, "EndOfRib", "eor") {
+                    let selection_released =
+                        self.selection_deferral_end_of_rib(peer, session_id, (afi, safi));
                     self.handle_end_of_rib(peer, afi, safi);
+                    if selection_released {
+                        self.finalize_selection_deferral_all_eor((afi, safi));
+                        self.release_selection_families(
+                            &[(afi, safi)],
+                            "all current-session End-of-RIB markers received",
+                        );
+                    }
                 }
             }
             RibUpdate::RouteRefreshRequest {
@@ -3242,7 +3314,9 @@ impl RibManager {
             }
             self.sync_attr_intern_gauge();
         }
-        self.rebuild_rtc_membership_and_restage_vpn(peer);
+        if !self.selection_deferred(family) {
+            self.rebuild_rtc_membership_and_restage_vpn(peer);
+        }
     }
 
     /// Rebuild `peer`'s RT-Constrain membership from its Adj-RIB-In (all
@@ -3429,7 +3503,8 @@ impl RibManager {
         let topology = crate::orr::OrrTopology::build(
             self.ribs
                 .values()
-                .flat_map(crate::adj_rib_in::AdjRibIn::iter_bgpls),
+                .flat_map(crate::adj_rib_in::AdjRibIn::iter_bgpls)
+                .filter(|route| !self.selection_deferred(route.family.to_afi_safi())),
         );
         let input_diagnostics = topology.input_diagnostics();
         log_orr_input_transition(self.orr.topology.input_diagnostics(), input_diagnostics);
@@ -3610,6 +3685,11 @@ impl RibManager {
         let refresh_sleep = tokio::time::sleep(std::time::Duration::from_hours(24));
         tokio::pin!(refresh_sleep);
 
+        // RFC 4724 restarting-speaker selection-deferral timer. The roster
+        // and deadline are frozen before this actor starts.
+        let selection_sleep = tokio::time::sleep(std::time::Duration::from_hours(24));
+        tokio::pin!(selection_sleep);
+
         loop {
             // Sample ingest-channel depth once per iteration — a gauge
             // pegged at the channel capacity on scrape means producers
@@ -3648,8 +3728,19 @@ impl RibManager {
                 false
             };
 
-            let needs_timers =
-                resync_armed || has_gr_timers || has_llgr_timers || has_refresh_timers;
+            let has_selection_timer =
+                if let Some(deadline) = self.next_selection_deferral_deadline() {
+                    selection_sleep.as_mut().reset(deadline);
+                    true
+                } else {
+                    false
+                };
+
+            let needs_timers = resync_armed
+                || has_gr_timers
+                || has_llgr_timers
+                || has_refresh_timers
+                || has_selection_timer;
 
             if query_rx_open && self.query_rx.is_closed() {
                 query_rx_open = false;
@@ -3700,6 +3791,15 @@ impl RibManager {
                     continue;
                 }
                 self.expire_refresh_windows();
+                continue;
+            }
+            if has_selection_timer && selection_sleep.deadline() <= now {
+                // A queued current-session EoR wins the all-EoR release race
+                // over a simultaneously ready timer.
+                if self.drain_ready_updates() {
+                    continue;
+                }
+                self.expire_selection_deferral();
                 continue;
             }
 
@@ -3769,6 +3869,12 @@ impl RibManager {
                             continue;
                         }
                         self.expire_refresh_windows();
+                    }
+                    () = selection_sleep.as_mut(), if has_selection_timer => {
+                        if self.drain_ready_updates() {
+                            continue;
+                        }
+                        self.expire_selection_deferral();
                     }
                 }
             } else {

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -97,6 +97,9 @@ impl RibManager {
         }
         // The active session went down. Prune it; if another live session
         // remains the registration fails over to it.
+        if let Some(selection) = self.selection_deferral.as_mut() {
+            selection.session_down(peer, session_id, &self.metrics);
+        }
         let survivor_remains = {
             let sessions = self.live_sessions.entry(peer).or_default();
             sessions.retain(|s| s.session_id != session_id);
@@ -262,6 +265,8 @@ impl RibManager {
         self.pending_peer_export_context
             .retain(|(context_peer, _), _| *context_peer != peer);
         self.pending_peer_export_encoders
+            .retain(|(context_peer, _), _| *context_peer != peer);
+        self.pending_peer_gr_context
             .retain(|(context_peer, _), _| *context_peer != peer);
         self.clear_policy_filtered_routes_for_peer(peer);
         if self.gr_peers.remove(&peer).is_some() {
@@ -462,6 +467,7 @@ impl RibManager {
         self.gr_deferred_eor.remove(&peer);
         self.dirty_peers.remove(&peer);
         self.pending_eor.remove(&peer);
+        self.selection_deferred_refresh.remove(&peer);
         // Purge the peer's queued route batches. This upholds the
         // "peer rib must exist before chunk processing" expectation in
         // the distribution chunk handlers: `enqueue_routes_received`
@@ -527,6 +533,11 @@ impl RibManager {
         // held stale for a restarting peer stay put — deadline-bounded
         // and swept on End-of-RIB, exactly as on a plain GR reconnect.
         if self.outbound_peers.contains_key(&peer) {
+            if let Some(previous_session_id) = self.outbound_session_ids.get(&peer).copied()
+                && let Some(selection) = self.selection_deferral.as_mut()
+            {
+                selection.session_down(peer, previous_session_id, &self.metrics);
+            }
             warn!(
                 %peer,
                 session_id,
@@ -551,6 +562,7 @@ impl RibManager {
         let exact_export_encoder = self
             .pending_peer_export_encoders
             .remove(&(peer, session_id));
+        let gr_context = self.pending_peer_gr_context.remove(&(peer, session_id));
 
         let record = LiveSessionRecord {
             session_id,
@@ -568,6 +580,7 @@ impl RibManager {
             add_path_send_max,
             negotiated_orf_recv,
             negotiated_llgr_families,
+            gr_context,
             exact_export_encoder,
         };
         let sessions = self.live_sessions.entry(peer).or_default();
@@ -594,6 +607,10 @@ impl RibManager {
     /// initial table dump. Shared by `handle_peer_up` and the
     /// registration failover; the caller has already cleared any prior
     /// registration's state.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "active-session registration installs every negotiated outbound capability"
+    )]
     fn register_active_session(&mut self, peer: IpAddr) {
         let Some(record) = self
             .live_sessions
@@ -618,6 +635,7 @@ impl RibManager {
         let add_path_send_max = record.add_path_send_max;
         let negotiated_orf_recv = record.negotiated_orf_recv.clone();
         let negotiated_llgr_families = record.negotiated_llgr_families.clone();
+        let gr_context = record.gr_context.clone();
         let exact_export_encoder = record.exact_export_encoder.clone();
         #[cfg(test)]
         let exact_export_encoder =
@@ -698,6 +716,30 @@ impl RibManager {
             // inherit its predecessor's filter (not-negotiated ⇒ unfiltered).
             self.set_rt_membership(peer, None);
         }
+
+        // Classify only the startup-frozen waiter already present for this
+        // peer. This runs before outbound registration, so if exclusion of
+        // the final waiter releases a family, existing peers receive the
+        // converged table and this peer receives it once in its normal
+        // initial dump below.
+        let released = if let Some(gr_context) = gr_context {
+            let peer_gr_families: HashSet<_> =
+                gr_context.peer_gr_families.iter().copied().collect();
+            self.selection_deferral
+                .as_mut()
+                .map_or_else(Vec::new, |selection| {
+                    selection.classify_session(
+                        peer,
+                        session_id,
+                        gr_context.peer_restart_state,
+                        &peer_gr_families,
+                        &self.metrics,
+                    )
+                })
+        } else {
+            Vec::new()
+        };
+        self.release_selection_families(&released, "all current waiters excluded");
 
         debug!(%peer, "peer up — registering for outbound updates");
         let peer_label = peer.to_string();
@@ -853,9 +895,16 @@ impl RibManager {
         let export_pol = self
             .export_policy_for(peer)
             .map(rustbgpd_policy::PolicyChain::share);
-        let sendable = self.peer_sendable_families.get(&peer).cloned();
+        let negotiated_sendable = self.peer_sendable_families.get(&peer).cloned();
+        let sendable = negotiated_sendable.as_ref().map(|families| {
+            families
+                .iter()
+                .copied()
+                .filter(|family| !self.selection_deferred(*family))
+                .collect::<Vec<_>>()
+        });
         let llgr = self.peer_advertised_llgr_families.get(&peer).cloned();
-        let rtc_filter = self.rtc_vpn_filter(peer, sendable.as_ref());
+        let rtc_filter = self.rtc_vpn_filter(peer, negotiated_sendable.as_ref());
         // RFC 5291 §6 initial-advertisement gate: suppress route advertisement
         // for families still awaiting the peer's first ROUTE-REFRESH. For a
         // non-GR peer the EoR is still emitted (an honest "empty table so
@@ -909,7 +958,7 @@ impl RibManager {
         let mut vpn_group_replayed = false;
         if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {
             for route in group.table.iter() {
-                if route.peer == peer {
+                if route.peer == peer || self.selection_deferred(prefix_family(&route.prefix)) {
                     continue;
                 }
                 nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
@@ -924,6 +973,7 @@ impl RibManager {
                 vpn_group_replayed = true;
                 for route in group.table.iter_vpn() {
                     if route.peer == peer
+                        || self.selection_deferred(route.afi_safi())
                         || !super::update_groups::rt_passes(rtc_filter.as_ref(), route)
                     {
                         continue;
@@ -1344,11 +1394,7 @@ impl RibManager {
         }
 
         // Determine EoR families from this peer's sendable families
-        let mut eor_families = self
-            .peer_sendable_families
-            .get(&peer)
-            .cloned()
-            .unwrap_or_default();
+        let mut eor_families = sendable.clone().unwrap_or_default();
         // RFC 4724: a GR RESTARTER takes our EoR as "this peer's initial
         // update is complete", proceeds with route selection, and sweeps the
         // stale routes it retained from our previous session. For an

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -592,6 +592,14 @@ impl RibManager {
     )]
     pub(super) fn send_route_refresh_response(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
         let family = (afi, safi);
+        if self.selection_deferred(family) {
+            self.selection_deferred_refresh
+                .entry(peer)
+                .or_default()
+                .insert(family);
+            debug!(%peer, ?afi, ?safi, "route-refresh response deferred behind RFC 4724 selection gate");
+            return;
+        }
         // RFC 5291 §6: a ROUTE-REFRESH (plain or ORF-carrying) for this family
         // lifts the initial-advertisement gate, so this response is the first
         // advertisement of the family — filtered through any installed ORF.
@@ -1216,19 +1224,25 @@ impl RibManager {
         let Some(families) = self.pending_eor.remove(&peer) else {
             return;
         };
-        if families.is_empty() {
+        let (blocked, ready): (HashSet<_>, HashSet<_>) = families
+            .into_iter()
+            .partition(|family| self.selection_deferred(*family));
+        if !blocked.is_empty() {
+            self.pending_eor.entry(peer).or_default().extend(blocked);
+        }
+        if ready.is_empty() {
             return;
         }
         let Some(tx) = self.outbound_peers.get(&peer) else {
             return;
         };
         let eor = OutboundRouteUpdate {
-            end_of_rib: families.iter().copied().collect(),
+            end_of_rib: ready.iter().copied().collect(),
             ..OutboundRouteUpdate::default()
         };
         if tx.try_send(eor).is_err() {
             warn!(%peer, "outbound channel full — `EoR` still deferred");
-            self.pending_eor.insert(peer, families);
+            self.pending_eor.entry(peer).or_default().extend(ready);
             self.mark_outbound_dirty(peer);
         }
     }

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -222,8 +222,15 @@ impl SelectionDeferral {
         peer_gr_families: &HashSet<(Afi, Safi)>,
         metrics: &BgpMetrics,
     ) -> Vec<(Afi, Safi)> {
-        if session_id == 0 || self.ambiguous_peers.contains(&peer) {
+        if session_id == 0 {
             tracing::warn!(%peer, "selection-deferral waiter received unstamped PeerUp; keeping it blocked");
+            return Vec::new();
+        }
+        if self.ambiguous_peers.contains(&peer) {
+            tracing::warn!(
+                %peer,
+                "selection-deferral waiter address is ambiguous in the configured roster; keeping it blocked"
+            );
             return Vec::new();
         }
         let families: Vec<_> = self.active.keys().copied().collect();

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -1,0 +1,641 @@
+//! RFC 4724 restarting-speaker route-selection deferral.
+//!
+//! The startup roster is frozen before the RIB actor starts.  A configured
+//! peer remains a waiter until its OPEN proves that the current session is
+//! GR-capable for the family and does not carry Restart State, or proves that
+//! it must be excluded.  `EoR` completion is bound to that classified session.
+
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::time::Duration;
+
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{Afi, Safi};
+
+use super::RibManager;
+
+#[derive(Debug, Default)]
+pub(super) struct DeferredSelectionKeys {
+    unicast: HashSet<rustbgpd_wire::Prefix>,
+    flowspec: HashSet<crate::route::FlowSpecKey>,
+    evpn: HashSet<rustbgpd_wire::EvpnRouteKey>,
+    vpn: HashSet<crate::route::VpnRibRouteKey>,
+    labeled: HashSet<crate::route::LabeledRibRouteKey>,
+    bgpls: HashSet<crate::route::BgpLsRouteKey>,
+    rtc: HashSet<crate::route::RtcRibRouteKey>,
+}
+use super::helpers::{afi_safi_label, gauge_val};
+
+/// One peer in the startup-frozen RFC 4724 waiter roster.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectionDeferralWaiterConfig {
+    /// Static peer address.
+    pub peer: IpAddr,
+    /// Configured families for which this peer may become an `EoR` waiter.
+    pub families: Vec<(Afi, Safi)>,
+}
+
+/// Process-start configuration for restarting-speaker selection deferral.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectionDeferralConfig {
+    /// Upper bound shared by every per-family deferral gate.
+    pub timeout: Duration,
+    /// Complete static-peer roster, captured before any session starts.
+    pub waiters: Vec<SelectionDeferralWaiterConfig>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SelectionDeferralReleaseReason {
+    AllEndOfRib,
+    TimerExpired,
+}
+
+impl SelectionDeferralReleaseReason {
+    fn label(self) -> &'static str {
+        match self {
+            Self::AllEndOfRib => "all_eor",
+            Self::TimerExpired => "timer",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WaiterState {
+    AwaitingSession,
+    AwaitingEor { session_id: u64 },
+    Satisfied { session_id: u64 },
+    Excluded { session_id: u64 },
+}
+
+impl WaiterState {
+    fn snapshot(self) -> (&'static str, Option<u64>) {
+        match self {
+            Self::AwaitingSession => ("awaiting_session", None),
+            Self::AwaitingEor { session_id } => ("awaiting_eor", Some(session_id)),
+            Self::Satisfied { session_id } => ("satisfied", Some(session_id)),
+            Self::Excluded { session_id } => ("excluded", Some(session_id)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FamilyGate {
+    waiters: HashMap<IpAddr, WaiterState>,
+}
+
+#[derive(Debug)]
+struct ReleasedFamily {
+    reason: SelectionDeferralReleaseReason,
+    waiters: HashMap<IpAddr, WaiterState>,
+}
+
+/// Actor-owned selection-deferral state.  Released families are retained in
+/// `released` for process-lifetime operator diagnostics; only `active` gates
+/// participate in selection and outbound suppression.
+#[derive(Debug)]
+pub(super) struct SelectionDeferral {
+    deadline: tokio::time::Instant,
+    active: HashMap<(Afi, Safi), FamilyGate>,
+    released: HashMap<(Afi, Safi), ReleasedFamily>,
+    /// Address-only RIB identity cannot disambiguate scoped duplicate peers.
+    /// Keep such peers blocked until the timer rather than let one `EoR` satisfy
+    /// both configured sessions.
+    ambiguous_peers: HashSet<IpAddr>,
+}
+
+impl SelectionDeferral {
+    fn blocking_waiters(gate: &FamilyGate) -> usize {
+        gate.waiters
+            .values()
+            .filter(|state| {
+                matches!(
+                    state,
+                    WaiterState::AwaitingSession | WaiterState::AwaitingEor { .. }
+                )
+            })
+            .count()
+    }
+
+    fn complete(gate: &FamilyGate) -> bool {
+        Self::blocking_waiters(gate) == 0
+    }
+
+    pub(super) fn new(config: SelectionDeferralConfig, metrics: &BgpMetrics) -> Option<Self> {
+        let mut active: HashMap<(Afi, Safi), FamilyGate> = HashMap::new();
+        let mut seen = HashSet::new();
+        let mut ambiguous_peers = HashSet::new();
+        for waiter in config.waiters {
+            if !seen.insert(waiter.peer) {
+                ambiguous_peers.insert(waiter.peer);
+            }
+            for family in waiter.families {
+                active
+                    .entry(family)
+                    .or_insert_with(|| FamilyGate {
+                        waiters: HashMap::new(),
+                    })
+                    .waiters
+                    .insert(waiter.peer, WaiterState::AwaitingSession);
+            }
+        }
+        for peer in &ambiguous_peers {
+            tracing::warn!(%peer, "duplicate static peer address in selection-deferral roster; waiting for timer because scoped identity is ambiguous");
+        }
+        if active.is_empty() || config.timeout.is_zero() {
+            return None;
+        }
+        for (&(afi, safi), gate) in &active {
+            let label = afi_safi_label(afi, safi);
+            metrics.set_selection_deferral_active(label, true);
+            metrics.set_selection_deferral_waiters(label, gauge_val(Self::blocking_waiters(gate)));
+        }
+        Some(Self {
+            deadline: tokio::time::Instant::now() + config.timeout,
+            active,
+            released: HashMap::new(),
+            ambiguous_peers,
+        })
+    }
+
+    pub(super) fn is_gated(&self, family: (Afi, Safi)) -> bool {
+        self.active.contains_key(&family)
+    }
+
+    pub(super) fn deadline(&self) -> Option<tokio::time::Instant> {
+        (!self.active.is_empty()).then_some(self.deadline)
+    }
+
+    pub(super) fn peer_snapshot(
+        &self,
+        peer: IpAddr,
+    ) -> Vec<crate::update::SelectionDeferralPeerFamilyState> {
+        let now = tokio::time::Instant::now();
+        let remaining_millis =
+            u64::try_from(self.deadline.saturating_duration_since(now).as_millis())
+                .unwrap_or(u64::MAX);
+        let mut rows = Vec::with_capacity(self.active.len() + self.released.len());
+        for (&(afi, safi), gate) in &self.active {
+            let (waiter_state, waiter_session_id) = gate
+                .waiters
+                .get(&peer)
+                .copied()
+                .map_or(("not_in_roster", None), WaiterState::snapshot);
+            rows.push(crate::update::SelectionDeferralPeerFamilyState {
+                afi,
+                safi,
+                active: true,
+                waiter_state: waiter_state.to_string(),
+                waiter_session_id,
+                blocking_waiters: u64::try_from(Self::blocking_waiters(gate)).unwrap_or(u64::MAX),
+                remaining_millis,
+                release_reason: String::new(),
+            });
+        }
+        for (&(afi, safi), released) in &self.released {
+            let (waiter_state, waiter_session_id) = released
+                .waiters
+                .get(&peer)
+                .copied()
+                .map_or(("not_in_roster", None), WaiterState::snapshot);
+            rows.push(crate::update::SelectionDeferralPeerFamilyState {
+                afi,
+                safi,
+                active: false,
+                waiter_state: waiter_state.to_string(),
+                waiter_session_id,
+                blocking_waiters: 0,
+                remaining_millis: 0,
+                release_reason: released.reason.label().to_string(),
+            });
+        }
+        rows.sort_by_key(|row| (row.afi as u16, row.safi as u8));
+        rows
+    }
+
+    /// Bind a startup waiter to the currently active transport generation, or
+    /// remove it when OPEN proves that RFC 4724 says not to wait for it.
+    pub(super) fn classify_session(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        peer_restart_state: bool,
+        peer_gr_families: &HashSet<(Afi, Safi)>,
+        metrics: &BgpMetrics,
+    ) -> Vec<(Afi, Safi)> {
+        if session_id == 0 || self.ambiguous_peers.contains(&peer) {
+            tracing::warn!(%peer, "selection-deferral waiter received unstamped PeerUp; keeping it blocked");
+            return Vec::new();
+        }
+        let families: Vec<_> = self.active.keys().copied().collect();
+        let mut released = Vec::new();
+        for family in families {
+            let Some(gate) = self.active.get_mut(&family) else {
+                continue;
+            };
+            if !gate.waiters.contains_key(&peer) {
+                continue;
+            }
+            if peer_restart_state || !peer_gr_families.contains(&family) {
+                gate.waiters
+                    .insert(peer, WaiterState::Excluded { session_id });
+            } else {
+                gate.waiters
+                    .insert(peer, WaiterState::AwaitingEor { session_id });
+            }
+            metrics.set_selection_deferral_waiters(
+                afi_safi_label(family.0, family.1),
+                gauge_val(Self::blocking_waiters(gate)),
+            );
+            if Self::complete(gate) {
+                self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
+                released.push(family);
+            }
+        }
+        released
+    }
+
+    /// Revert a current-session waiter to the not-yet-established state.  A
+    /// flap cannot shrink the frozen cohort and accidentally release a family.
+    pub(super) fn session_down(&mut self, peer: IpAddr, session_id: u64, metrics: &BgpMetrics) {
+        for (&family, gate) in &mut self.active {
+            if matches!(
+                gate.waiters.get(&peer),
+                Some(
+                    WaiterState::AwaitingEor { session_id: current }
+                        | WaiterState::Satisfied { session_id: current }
+                        | WaiterState::Excluded { session_id: current }
+                ) if *current == session_id
+            ) {
+                gate.waiters.insert(peer, WaiterState::AwaitingSession);
+                metrics.set_selection_deferral_waiters(
+                    afi_safi_label(family.0, family.1),
+                    gauge_val(Self::blocking_waiters(gate)),
+                );
+            }
+        }
+    }
+
+    pub(super) fn end_of_rib(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+        metrics: &BgpMetrics,
+    ) -> bool {
+        if session_id == 0 {
+            return false;
+        }
+        let Some(gate) = self.active.get_mut(&family) else {
+            return false;
+        };
+        if gate.waiters.get(&peer) != Some(&WaiterState::AwaitingEor { session_id }) {
+            return false;
+        }
+        gate.waiters
+            .insert(peer, WaiterState::Satisfied { session_id });
+        metrics.set_selection_deferral_waiters(
+            afi_safi_label(family.0, family.1),
+            gauge_val(Self::blocking_waiters(gate)),
+        );
+        Self::complete(gate)
+    }
+
+    pub(super) fn finalize_all_eor(&mut self, family: (Afi, Safi), metrics: &BgpMetrics) {
+        if self.active.get(&family).is_some_and(Self::complete) {
+            self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
+        }
+    }
+
+    pub(super) fn expire(&mut self, metrics: &BgpMetrics) -> Vec<(Afi, Safi)> {
+        let families: Vec<_> = self.active.keys().copied().collect();
+        for &family in &families {
+            self.release(
+                family,
+                SelectionDeferralReleaseReason::TimerExpired,
+                metrics,
+            );
+        }
+        families
+    }
+
+    fn release(
+        &mut self,
+        family: (Afi, Safi),
+        reason: SelectionDeferralReleaseReason,
+        metrics: &BgpMetrics,
+    ) {
+        let Some(gate) = self.active.remove(&family) else {
+            return;
+        };
+        self.released.insert(
+            family,
+            ReleasedFamily {
+                reason,
+                waiters: gate.waiters,
+            },
+        );
+        let label = afi_safi_label(family.0, family.1);
+        metrics.set_selection_deferral_active(label, false);
+        metrics.set_selection_deferral_waiters(label, 0);
+        metrics.record_selection_deferral_release(label, reason.label());
+        if reason == SelectionDeferralReleaseReason::TimerExpired {
+            metrics.record_selection_deferral_timeout(label);
+        }
+    }
+}
+
+impl RibManager {
+    pub(super) fn record_deferred_unicast(&mut self, affected: &HashSet<rustbgpd_wire::Prefix>) {
+        let deferred: Vec<_> = affected
+            .iter()
+            .filter(|prefix| self.selection_deferred(super::helpers::prefix_family(prefix)))
+            .copied()
+            .collect();
+        self.deferred_selection_keys.unicast.extend(deferred);
+    }
+
+    pub(super) fn record_deferred_flowspec(
+        &mut self,
+        affected: &HashSet<crate::route::FlowSpecKey>,
+    ) {
+        let deferred: Vec<_> = affected
+            .iter()
+            .filter(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
+            .cloned()
+            .collect();
+        self.deferred_selection_keys.flowspec.extend(deferred);
+    }
+
+    pub(super) fn record_deferred_evpn(&mut self, affected: &HashSet<rustbgpd_wire::EvpnRouteKey>) {
+        if self.selection_deferred((Afi::L2Vpn, Safi::Evpn)) {
+            self.deferred_selection_keys
+                .evpn
+                .extend(affected.iter().copied());
+        }
+    }
+
+    pub(super) fn record_deferred_vpn(&mut self, affected: &HashSet<crate::route::VpnRibRouteKey>) {
+        let deferred: Vec<_> = affected
+            .iter()
+            .filter(|key| self.selection_deferred(key.afi_safi()))
+            .cloned()
+            .collect();
+        self.deferred_selection_keys.vpn.extend(deferred);
+    }
+
+    pub(super) fn record_deferred_labeled(
+        &mut self,
+        affected: &HashSet<crate::route::LabeledRibRouteKey>,
+    ) {
+        let deferred: Vec<_> = affected
+            .iter()
+            .filter(|key| self.selection_deferred(key.afi_safi()))
+            .copied()
+            .collect();
+        self.deferred_selection_keys.labeled.extend(deferred);
+    }
+
+    pub(super) fn record_deferred_bgpls(
+        &mut self,
+        affected: &HashSet<crate::route::BgpLsRouteKey>,
+    ) {
+        let deferred: Vec<_> = affected
+            .iter()
+            .filter(|key| self.selection_deferred(key.family.to_afi_safi()))
+            .cloned()
+            .collect();
+        self.deferred_selection_keys.bgpls.extend(deferred);
+    }
+
+    pub(super) fn record_deferred_rtc(&mut self, affected: &HashSet<crate::route::RtcRibRouteKey>) {
+        if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
+            self.deferred_selection_keys
+                .rtc
+                .extend(affected.iter().cloned());
+        }
+    }
+
+    /// Consume a current-session `EoR` in the startup gate. The caller invokes
+    /// the ordinary GR/LLGR `EoR` handler after this, then recomputes the released
+    /// family against the complete Adj-RIB-In cohort.
+    pub(super) fn selection_deferral_end_of_rib(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+    ) -> bool {
+        self.selection_deferral
+            .as_mut()
+            .is_some_and(|selection| selection.end_of_rib(peer, session_id, family, &self.metrics))
+    }
+
+    pub(super) fn finalize_selection_deferral_all_eor(&mut self, family: (Afi, Safi)) {
+        if let Some(selection) = self.selection_deferral.as_mut() {
+            selection.finalize_all_eor(family, &self.metrics);
+        }
+    }
+
+    pub(super) fn expire_selection_deferral(&mut self) {
+        let families = self
+            .selection_deferral
+            .as_mut()
+            .map_or_else(Vec::new, |selection| selection.expire(&self.metrics));
+        self.release_selection_families(&families, "Selection_Deferral_Timer expired");
+    }
+
+    pub(super) fn next_selection_deferral_deadline(&self) -> Option<tokio::time::Instant> {
+        self.selection_deferral
+            .as_ref()
+            .and_then(SelectionDeferral::deadline)
+    }
+
+    /// Run the delayed family selection exactly once after its gate opens.
+    /// All identity sets come from Adj-RIB-In, which continued accepting the
+    /// current sessions' updates while Loc-RIB selection was frozen.
+    pub(super) fn release_selection_families(
+        &mut self,
+        families: &[(Afi, Safi)],
+        reason: &'static str,
+    ) {
+        for &family in families {
+            tracing::info!(
+                afi = ?family.0,
+                safi = ?family.1,
+                reason,
+                "RFC 4724 route-selection deferral released"
+            );
+            self.recompute_released_selection_family(family);
+            // Existing sessions received no initial table and no EoR while
+            // gated. Queue the marker only after the released selection has
+            // been staged; dirty peers keep it pending until their full resync
+            // succeeds, preserving table-before-EoR ordering.
+            let peers: Vec<_> = self
+                .peer_sendable_families
+                .iter()
+                .filter_map(|(&peer, sendable)| sendable.contains(&family).then_some(peer))
+                .collect();
+            for peer in peers {
+                self.pending_eor.entry(peer).or_default().insert(family);
+                if !self.dirty_peers.contains(&peer) {
+                    self.flush_pending_eor(peer);
+                }
+            }
+            let refresh_peers: Vec<_> = self
+                .selection_deferred_refresh
+                .iter()
+                .filter_map(|(&peer, families)| families.contains(&family).then_some(peer))
+                .collect();
+            for peer in refresh_peers {
+                if let Some(families) = self.selection_deferred_refresh.get_mut(&peer) {
+                    families.remove(&family);
+                    if families.is_empty() {
+                        self.selection_deferred_refresh.remove(&peer);
+                    }
+                }
+                self.send_route_refresh_response(peer, family.0, family.1);
+            }
+        }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "release must sweep every typed RIB family from one atomic family gate"
+    )]
+    fn recompute_released_selection_family(&mut self, family: (Afi, Safi)) {
+        let mut prefixes: HashSet<_> = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter)
+            .filter(|route| super::helpers::prefix_family(&route.prefix) == family)
+            .map(|route| route.prefix)
+            .collect();
+        prefixes.extend(
+            self.deferred_selection_keys
+                .unicast
+                .iter()
+                .filter(|prefix| super::helpers::prefix_family(prefix) == family)
+                .copied(),
+        );
+        self.deferred_selection_keys
+            .unicast
+            .retain(|prefix| super::helpers::prefix_family(prefix) != family);
+        if !prefixes.is_empty() {
+            let changed = self.recompute_best(&prefixes);
+            self.distribute_changes(&changed, &prefixes);
+        }
+
+        let mut flowspec: HashSet<_> = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter_flowspec)
+            .filter(|route| (route.afi, Safi::FlowSpec) == family)
+            .map(crate::route::FlowSpecRoute::selection_key)
+            .collect();
+        flowspec.extend(
+            self.deferred_selection_keys
+                .flowspec
+                .iter()
+                .filter(|key| (key.afi, Safi::FlowSpec) == family)
+                .cloned(),
+        );
+        self.deferred_selection_keys
+            .flowspec
+            .retain(|key| (key.afi, Safi::FlowSpec) != family);
+        if !flowspec.is_empty() {
+            self.recompute_and_distribute_flowspec(&flowspec);
+        }
+
+        if family == (Afi::L2Vpn, Safi::Evpn) {
+            let mut evpn: HashSet<_> = self
+                .ribs
+                .values()
+                .flat_map(crate::adj_rib_in::AdjRibIn::iter_evpn)
+                .map(crate::route::EvpnRibRoute::key)
+                .collect();
+            evpn.extend(self.deferred_selection_keys.evpn.drain());
+            if !evpn.is_empty() {
+                self.recompute_and_distribute_evpn(&evpn);
+            }
+        }
+
+        let mut vpn: HashSet<_> = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter_vpn)
+            .filter(|route| route.afi_safi() == family)
+            .map(crate::route::VpnRibRoute::key)
+            .collect();
+        vpn.extend(
+            self.deferred_selection_keys
+                .vpn
+                .iter()
+                .filter(|key| key.afi_safi() == family)
+                .cloned(),
+        );
+        self.deferred_selection_keys
+            .vpn
+            .retain(|key| key.afi_safi() != family);
+        if !vpn.is_empty() {
+            self.recompute_vpn_keys(&vpn);
+        }
+
+        let mut labeled: HashSet<_> = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter_labeled)
+            .filter(|route| route.afi_safi() == family)
+            .map(crate::route::LabeledRibRoute::key)
+            .collect();
+        labeled.extend(
+            self.deferred_selection_keys
+                .labeled
+                .iter()
+                .filter(|key| key.afi_safi() == family)
+                .copied(),
+        );
+        self.deferred_selection_keys
+            .labeled
+            .retain(|key| key.afi_safi() != family);
+        if !labeled.is_empty() {
+            self.recompute_labeled_keys(&labeled);
+        }
+
+        let mut bgpls: HashSet<_> = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter_bgpls)
+            .filter(|route| route.family.to_afi_safi() == family)
+            .map(crate::route::BgpLsRibRoute::key)
+            .collect();
+        bgpls.extend(
+            self.deferred_selection_keys
+                .bgpls
+                .iter()
+                .filter(|key| key.family.to_afi_safi() == family)
+                .cloned(),
+        );
+        self.deferred_selection_keys
+            .bgpls
+            .retain(|key| key.family.to_afi_safi() != family);
+        if !bgpls.is_empty() {
+            self.recompute_bgpls_keys(&bgpls);
+        }
+
+        if family == crate::route::RtcRibRouteKey::afi_safi() {
+            let mut rtc: HashSet<_> = self
+                .ribs
+                .values()
+                .flat_map(crate::adj_rib_in::AdjRibIn::iter_rtc)
+                .map(crate::route::RtcRibRoute::key)
+                .collect();
+            rtc.extend(self.deferred_selection_keys.rtc.drain());
+            if !rtc.is_empty() {
+                self.recompute_rtc_keys(&rtc);
+            }
+            let rtc_peers: Vec<_> = self.peer_rt_membership.keys().copied().collect();
+            for peer in rtc_peers {
+                self.rebuild_rtc_membership_and_restage_vpn(peer);
+            }
+        }
+    }
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -944,6 +944,7 @@ mod policy;
 mod refresh;
 mod rpki;
 mod rtc;
+mod selection_deferral;
 mod unicast;
 mod update_groups;
 mod update_groups_fault_corpus;

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -11,6 +11,77 @@ fn counter_metric_value(metrics: &BgpMetrics, name: &str) -> f64 {
         .map_or(0.0, |metric| metric.get_counter().value())
 }
 
+/// A still-gated BGP-LS family must not influence already-released unicast
+/// ORR selection. The topology becomes visible only when the BGP-LS gate
+/// itself releases.
+#[tokio::test]
+async fn selection_deferral_hides_bgpls_topology_until_family_release() {
+    let feed = Ipv4Addr::new(10, 9, 9, 9);
+    let feed_peer = IpAddr::V4(feed);
+    let family = (Afi::BgpLs, Safi::BgpLs);
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_selection_deferral(SelectionDeferralConfig {
+            timeout: Duration::from_mins(1),
+            waiters: vec![SelectionDeferralWaiterConfig {
+                peer: feed_peer,
+                families: vec![family],
+            }],
+        });
+    let handle = tokio::spawn(manager.run());
+
+    feed_square_topology(&tx, feed).await;
+    let client = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let _client_rx = orr_client_peer_up(&tx, client, Some(vantage_at_node_a())).await;
+    let gated = query_orr_status(&tx).await;
+    assert_eq!(gated.topology_nodes, 0);
+    assert!(!gated.vantages[0].resolved);
+
+    tx.send(RibUpdate::SetPeerGracefulRestartContext {
+        peer: feed_peer,
+        session_id: 1,
+        peer_restart_state: false,
+        peer_gr_families: vec![family],
+    })
+    .await
+    .unwrap();
+    let (feed_tx, _feed_rx) = mpsc::channel(8);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 1,
+        peer: feed_peer,
+        peer_asn: 65000,
+        peer_router_id: feed,
+        outbound_tx: feed_tx,
+        export_policy: None,
+        sendable_families: vec![family],
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: Vec::new(),
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: feed_peer,
+        session_id: 1,
+        afi: family.0,
+        safi: family.1,
+    })
+    .await
+    .unwrap();
+
+    let released = query_orr_status(&tx).await;
+    assert_eq!(released.topology_nodes, 4);
+    assert!(released.vantages[0].resolved);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// `PeerUp` with an `orr_vantage` registers the vantage (visible through
 /// `QueryOrrStatus` and the topology gauges); tearing the peer down
 /// clears the registry and empties the cached state again.

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -1,0 +1,565 @@
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{Afi, Ipv4Prefix, Safi};
+use tokio::sync::{mpsc, oneshot};
+
+use super::{dummy_query_rx, make_route_with_lp, query_best_routes};
+use crate::{
+    PeerOutboundState, RibManager, RibUpdate, SelectionDeferralConfig,
+    SelectionDeferralWaiterConfig,
+};
+
+const FAMILY: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
+
+fn peer(octet: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(10, 0, 0, octet))
+}
+
+fn peer_up(
+    peer: IpAddr,
+    session_id: u64,
+    outbound_tx: mpsc::Sender<crate::OutboundRouteUpdate>,
+) -> RibUpdate {
+    RibUpdate::PeerUp {
+        peer,
+        session_id,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::new(10, 0, 0, 254),
+        outbound_tx,
+        export_policy: None,
+        sendable_families: vec![FAMILY],
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        per_client_best: false,
+        add_path_send_families: Vec::new(),
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    }
+}
+
+async fn stage_gr_context(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr, session_id: u64) {
+    stage_gr_context_with(tx, peer, session_id, false, vec![FAMILY]).await;
+}
+
+async fn stage_gr_context_with(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    session_id: u64,
+    peer_restart_state: bool,
+    peer_gr_families: Vec<(Afi, Safi)>,
+) {
+    tx.send(RibUpdate::SetPeerGracefulRestartContext {
+        peer,
+        session_id,
+        peer_restart_state,
+        peer_gr_families,
+    })
+    .await
+    .unwrap();
+}
+
+async fn query_state(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> PeerOutboundState {
+    let (reply, rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryPeerOutboundState { peer, reply })
+        .await
+        .unwrap();
+    rx.await.unwrap()
+}
+
+async fn advertised_count(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> usize {
+    let (reply, rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedCount { peer, reply })
+        .await
+        .unwrap();
+    rx.await.unwrap()
+}
+
+async fn assert_table_before_eor(rx: &mut mpsc::Receiver<crate::OutboundRouteUpdate>) {
+    let mut saw_table = false;
+    loop {
+        let update = rx.recv().await.unwrap();
+        if update.end_of_rib.contains(&FAMILY) {
+            assert!(saw_table, "EoR overtook the released initial table");
+            return;
+        }
+        saw_table |= !update.announce.is_empty();
+    }
+}
+
+fn config(timeout: Duration, peers: &[IpAddr]) -> SelectionDeferralConfig {
+    SelectionDeferralConfig {
+        timeout,
+        waiters: peers
+            .iter()
+            .copied()
+            .map(|peer| SelectionDeferralWaiterConfig {
+                peer,
+                families: vec![FAMILY],
+            })
+            .collect(),
+    }
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one adversarial scenario pins the complete replacement and release ordering"
+)]
+async fn frozen_roster_rearms_satisfied_peer_on_session_replacement() {
+    let a = peer(1);
+    let b = peer(2);
+    let observer = peer(3);
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[a, b]));
+    let handle = tokio::spawn(manager.run());
+
+    let (a1_tx, mut a1_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, a, 1).await;
+    tx.send(peer_up(a, 1, a1_tx)).await.unwrap();
+    let (b_tx, mut b_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, b, 2).await;
+    tx.send(peer_up(b, 2, b_tx)).await.unwrap();
+    let (observer_tx, mut observer_rx) = mpsc::channel(16);
+    tx.send(peer_up(observer, 7, observer_tx)).await.unwrap();
+
+    tokio::task::yield_now().await;
+    assert!(a1_rx.try_recv().is_err());
+    assert!(b_rx.try_recv().is_err());
+    assert!(observer_rx.try_recv().is_err());
+
+    let route = make_route_with_lp(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        Ipv4Addr::new(10, 0, 0, 2),
+        100,
+    );
+    tx.send(RibUpdate::RoutesReceived {
+        peer: b,
+        session_id: 2,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    assert!(query_best_routes(&tx).await.is_empty());
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: observer,
+        session_id: 7,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    tokio::task::yield_now().await;
+    assert!(
+        observer_rx.try_recv().is_err(),
+        "route refresh leaked a gated family"
+    );
+
+    tx.send(RibUpdate::EndOfRib {
+        peer: a,
+        session_id: 1,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+
+    let (a3_tx, _a3_rx) = mpsc::channel(16);
+    tx.send(peer_up(a, 3, a3_tx)).await.unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: b,
+        session_id: 2,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+
+    let state = query_state(&tx, a).await;
+    assert_eq!(state.selection_deferral.len(), 1);
+    assert!(state.selection_deferral[0].active);
+    assert_eq!(state.selection_deferral[0].waiter_state, "awaiting_session");
+    assert_eq!(state.selection_deferral[0].waiter_session_id, None);
+    assert_eq!(state.selection_deferral[0].blocking_waiters, 1);
+    assert!(query_best_routes(&tx).await.is_empty());
+
+    // Missing staged OPEN context fails closed. A later fully stamped
+    // replacement binds the immutable roster entry to its new session.
+    let (a4_tx, mut a4_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, a, 4).await;
+    tx.send(peer_up(a, 4, a4_tx)).await.unwrap();
+    let rebound = query_state(&tx, a).await;
+    assert_eq!(rebound.selection_deferral[0].waiter_state, "awaiting_eor");
+    assert_eq!(rebound.selection_deferral[0].waiter_session_id, Some(4));
+
+    tx.send(RibUpdate::EndOfRib {
+        peer: a,
+        session_id: 1,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    assert!(query_state(&tx, a).await.selection_deferral[0].active);
+
+    tx.send(RibUpdate::EndOfRib {
+        peer: a,
+        session_id: 4,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let released = query_state(&tx, a).await;
+    assert!(!released.selection_deferral[0].active);
+    assert_eq!(released.selection_deferral[0].release_reason, "all_eor");
+    assert_eq!(query_best_routes(&tx).await.len(), 1);
+    assert_eq!(advertised_count(&tx, a).await, 1);
+    assert_eq!(advertised_count(&tx, observer).await, 1);
+
+    assert_table_before_eor(&mut observer_rx).await;
+    assert_table_before_eor(&mut a4_rx).await;
+    assert_eq!(b_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+    let refresh = observer_rx.recv().await.unwrap();
+    assert_eq!(refresh.announce.len(), 1);
+    assert_eq!(
+        refresh.refresh_markers,
+        vec![
+            (FAMILY.0, FAMILY.1, rustbgpd_wire::RouteRefreshSubtype::BoRR,),
+            (FAMILY.0, FAMILY.1, rustbgpd_wire::RouteRefreshSubtype::EoRR,),
+        ]
+    );
+
+    drop(a1_rx);
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn restart_state_and_non_gr_sessions_are_excluded_without_waiting_for_eor() {
+    let a = peer(1);
+    let b = peer(2);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[a, b]));
+    let handle = tokio::spawn(manager.run());
+
+    let (a_tx, mut a_rx) = mpsc::channel(8);
+    stage_gr_context_with(&tx, a, 1, true, vec![FAMILY]).await;
+    tx.send(peer_up(a, 1, a_tx)).await.unwrap();
+    let a_state = query_state(&tx, a).await;
+    assert!(a_state.selection_deferral[0].active);
+    assert_eq!(a_state.selection_deferral[0].waiter_state, "excluded");
+    assert_eq!(a_state.selection_deferral[0].blocking_waiters, 1);
+    assert!(a_rx.try_recv().is_err());
+
+    let (b_tx, mut b_rx) = mpsc::channel(8);
+    stage_gr_context_with(&tx, b, 2, false, Vec::new()).await;
+    tx.send(peer_up(b, 2, b_tx)).await.unwrap();
+
+    let a_released = query_state(&tx, a).await;
+    let b_released = query_state(&tx, b).await;
+    assert!(!a_released.selection_deferral[0].active);
+    assert_eq!(a_released.selection_deferral[0].waiter_state, "excluded");
+    assert_eq!(b_released.selection_deferral[0].waiter_state, "excluded");
+    assert_eq!(a_released.selection_deferral[0].release_reason, "all_eor");
+    assert_eq!(a_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+    assert_eq!(b_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn duplicate_address_roster_fails_closed_until_timer() {
+    let a = peer(1);
+    let (tx, rx) = mpsc::channel(16);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_selection_deferral(config(Duration::from_secs(5), &[a, a]));
+    let handle = tokio::spawn(manager.run());
+
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, a, 1).await;
+    tx.send(peer_up(a, 1, outbound_tx)).await.unwrap();
+    let blocked = query_state(&tx, a).await;
+    assert!(blocked.selection_deferral[0].active);
+    assert_eq!(
+        blocked.selection_deferral[0].waiter_state,
+        "awaiting_session"
+    );
+    assert!(outbound_rx.try_recv().is_err());
+
+    tokio::time::advance(Duration::from_secs(5)).await;
+    tokio::task::yield_now().await;
+    let released = query_state(&tx, a).await;
+    assert!(!released.selection_deferral[0].active);
+    assert_eq!(released.selection_deferral[0].release_reason, "timer");
+    assert_eq!(outbound_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[test]
+fn withdrawn_restored_key_is_recomputed_before_release_eor() {
+    let source = peer(1);
+    let observer = peer(2);
+    let (_tx, rx) = mpsc::channel(32);
+    let mut manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    );
+
+    let (observer_tx, mut observer_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(observer, 7, observer_tx));
+    while observer_rx.try_recv().is_ok() {}
+
+    let route = make_route_with_lp(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        Ipv4Addr::new(10, 0, 0, 1),
+        100,
+    );
+    let prefix = route.prefix;
+    manager.enqueue_routes_received(
+        source,
+        vec![route],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    while manager.process_next_route_chunk() {}
+    assert!(manager.loc_rib.get(&prefix).is_some());
+    while observer_rx.try_recv().is_ok() {}
+
+    // Model a route restored before the planned-restart gate is installed.
+    // A withdrawal received while gated disappears from Adj-RIB-In, so the
+    // deferred identity ledger is the only release-time evidence that the
+    // stale Loc-RIB row must be removed.
+    manager = manager.with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    manager.enqueue_routes_received(
+        source,
+        Vec::new(),
+        vec![(prefix, 0)],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    while manager.process_next_route_chunk() {}
+    assert!(manager.loc_rib.get(&prefix).is_some());
+
+    let metrics = manager.metrics.clone();
+    let peer_gr_families = HashSet::from([FAMILY]);
+    let released = manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .classify_session(source, 8, false, &peer_gr_families, &metrics);
+    assert!(released.is_empty());
+    assert!(manager.selection_deferral_end_of_rib(source, 8, FAMILY));
+    manager.handle_end_of_rib(source, FAMILY.0, FAMILY.1);
+    manager.finalize_selection_deferral_all_eor(FAMILY);
+    manager.release_selection_families(&[FAMILY], "test all EoRs received");
+
+    assert!(manager.loc_rib.get(&prefix).is_none());
+    let mut saw_withdraw = false;
+    loop {
+        let update = observer_rx.try_recv().unwrap();
+        if update.end_of_rib.contains(&FAMILY) {
+            assert!(saw_withdraw, "EoR overtook the deferred withdrawal");
+            break;
+        }
+        saw_withdraw |= update.withdraw.iter().any(|(p, _)| *p == prefix);
+    }
+}
+
+#[test]
+fn peer_teardown_discards_unconsumed_gr_context() {
+    let a = peer(1);
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+        peer: a,
+        session_id: 9,
+        peer_restart_state: false,
+        peer_gr_families: vec![FAMILY],
+    });
+    assert!(manager.pending_peer_gr_context.contains_key(&(a, 9)));
+    manager.peer_down_teardown(a);
+    assert!(!manager.pending_peer_gr_context.contains_key(&(a, 9)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_route_is_applied_before_simultaneous_eor_and_timer_release() {
+    let source = peer(1);
+    let observer = peer(2);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_secs(5), &[source]));
+    let handle = tokio::spawn(manager.run());
+
+    let (source_tx, mut source_rx) = mpsc::channel(8);
+    let (observer_tx, mut observer_rx) = mpsc::channel(8);
+    tx.try_send(RibUpdate::SetPeerGracefulRestartContext {
+        peer: source,
+        session_id: 1,
+        peer_restart_state: false,
+        peer_gr_families: vec![FAMILY],
+    })
+    .unwrap();
+    tx.try_send(peer_up(source, 1, source_tx)).unwrap();
+    tx.try_send(peer_up(observer, 2, observer_tx)).unwrap();
+    tx.try_send(RibUpdate::RoutesReceived {
+        peer: source,
+        session_id: 1,
+        announced: vec![make_route_with_lp(
+            Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            Ipv4Addr::new(10, 0, 0, 1),
+            100,
+        )],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    })
+    .unwrap();
+    tx.try_send(RibUpdate::EndOfRib {
+        peer: source,
+        session_id: 1,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .unwrap();
+
+    // The actor first runs with the channel batch and timer both ready.
+    tokio::time::advance(Duration::from_secs(5)).await;
+    let state = query_state(&tx, source).await;
+    assert_eq!(state.selection_deferral[0].release_reason, "all_eor");
+    assert_eq!(query_best_routes(&tx).await.len(), 1);
+    assert_table_before_eor(&mut observer_rx).await;
+    assert_eq!(source_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn full_outbound_channel_keeps_eor_pending_until_dirty_resync() {
+    let source = peer(1);
+    let observer = peer(2);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    let handle = tokio::spawn(manager.run());
+
+    let (source_tx, mut source_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, source, 1).await;
+    tx.send(peer_up(source, 1, source_tx)).await.unwrap();
+    let (observer_tx, mut observer_rx) = mpsc::channel(1);
+    tx.send(peer_up(observer, 2, observer_tx)).await.unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: source,
+        session_id: 1,
+        announced: vec![make_route_with_lp(
+            Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24),
+            Ipv4Addr::new(10, 0, 0, 1),
+            100,
+        )],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: source,
+        session_id: 1,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+
+    let table = observer_rx.recv().await.unwrap();
+    assert_eq!(table.announce.len(), 1);
+    assert!(table.end_of_rib.is_empty());
+    assert_eq!(source_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    // The one-slot observer channel rejected the first EoR attempt. Once
+    // capacity is available, dirty resync must finish and only then flush it.
+    tokio::time::advance(Duration::from_secs(1)).await;
+    let resync = observer_rx.recv().await.unwrap();
+    assert_eq!(resync.announce.len(), 1);
+    assert_eq!(resync.end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn timer_releases_never_established_waiter_and_records_reason() {
+    let a = peer(1);
+    let metrics = BgpMetrics::new();
+    let (tx, rx) = mpsc::channel(16);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_secs(5), &[a]));
+    let handle = tokio::spawn(manager.run());
+
+    tokio::time::advance(Duration::from_secs(5)).await;
+    let state = query_state(&tx, a).await;
+    assert_eq!(state.selection_deferral[0].release_reason, "timer");
+    assert!(!state.selection_deferral[0].active);
+
+    let families = metrics.registry().gather();
+    let timeout = families
+        .iter()
+        .find(|family| family.name() == "bgp_selection_deferral_timeouts_total")
+        .unwrap();
+    assert!((timeout.get_metric()[0].get_counter().value() - 1.0).abs() < f64::EPSILON);
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2424,6 +2424,10 @@ impl RibManager {
         let _ = reply.send(PeerOutboundState {
             update_group,
             effective_distribution_mode,
+            selection_deferral: self
+                .selection_deferral
+                .as_ref()
+                .map_or_else(Vec::new, |selection| selection.peer_snapshot(peer)),
         });
     }
 }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1006,6 +1006,21 @@ pub struct PeerOutboundState {
     pub update_group: String,
     /// Effective live distribution mode.
     pub effective_distribution_mode: EffectiveDistributionMode,
+    /// Process-start RFC 4724 selection-deferral state, one row per family.
+    pub selection_deferral: Vec<SelectionDeferralPeerFamilyState>,
+}
+
+/// Neighbor-facing RFC 4724 selection-deferral state for one family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectionDeferralPeerFamilyState {
+    pub afi: Afi,
+    pub safi: Safi,
+    pub active: bool,
+    pub waiter_state: String,
+    pub waiter_session_id: Option<u64>,
+    pub blocking_waiters: u64,
+    pub remaining_millis: u64,
+    pub release_reason: String,
 }
 
 /// Messages sent from peer sessions to the RIB manager.
@@ -1220,6 +1235,19 @@ pub enum RibUpdate {
         session_id: u64,
         /// Session-owned replaceable encoder.
         encoder: Arc<dyn ExactExportEncoder>,
+    },
+    /// Stage the peer's negotiated GR context before `PeerUp` builds any
+    /// outbound state. The startup selection-deferral roster uses this to
+    /// exclude Restart-State/non-GR peers and stamp the remaining `EoR` waiter.
+    SetPeerGracefulRestartContext {
+        /// Peer whose OPEN was negotiated.
+        peer: IpAddr,
+        /// Transport generation that owns this immutable OPEN context.
+        session_id: u64,
+        /// Peer's RFC 4724 Restart State bit.
+        peer_restart_state: bool,
+        /// Negotiated families present in the peer's GR capability.
+        peer_gr_families: Vec<(Afi, Safi)>,
     },
     /// Inject a locally-originated route.
     InjectRoute {

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -171,6 +171,10 @@ pub struct BgpMetrics {
     gr_active_peers: IntGaugeVec,
     gr_stale_routes: IntGaugeVec,
     gr_timer_expired: IntCounterVec,
+    selection_deferral_active: IntGaugeVec,
+    selection_deferral_waiters: IntGaugeVec,
+    selection_deferral_releases: IntCounterVec,
+    selection_deferral_timeouts: IntCounterVec,
 
     // ── RPKI ───────────────────────────────────────────────────
     rpki_vrp_count: IntGaugeVec,
@@ -879,6 +883,42 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let selection_deferral_active = IntGaugeVec::new(
+            Opts::new(
+                "bgp_selection_deferral_active",
+                "Whether RFC 4724 restarting-speaker route selection is deferred for an address family.",
+            ),
+            &["afi_safi"],
+        )
+        .expect("valid metric definition");
+
+        let selection_deferral_waiters = IntGaugeVec::new(
+            Opts::new(
+                "bgp_selection_deferral_waiters",
+                "Startup-frozen peers whose current-session End-of-RIB is still required before selecting an address family.",
+            ),
+            &["afi_safi"],
+        )
+        .expect("valid metric definition");
+
+        let selection_deferral_releases = IntCounterVec::new(
+            Opts::new(
+                "bgp_selection_deferral_releases_total",
+                "RFC 4724 selection-deferral releases by address family and bounded reason.",
+            ),
+            &["afi_safi", "reason"],
+        )
+        .expect("valid metric definition");
+
+        let selection_deferral_timeouts = IntCounterVec::new(
+            Opts::new(
+                "bgp_selection_deferral_timeouts_total",
+                "RFC 4724 selection-deferral timer expirations by address family.",
+            ),
+            &["afi_safi"],
+        )
+        .expect("valid metric definition");
+
         let rpki_vrp_count = IntGaugeVec::new(
             Opts::new(
                 "bgp_rpki_vrp_count",
@@ -1569,6 +1609,18 @@ impl BgpMetrics {
             .register(Box::new(gr_timer_expired.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(selection_deferral_active.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(selection_deferral_waiters.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(selection_deferral_releases.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(selection_deferral_timeouts.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(rpki_vrp_count.clone()))
             .expect("metric not already registered");
         registry
@@ -1818,6 +1870,10 @@ impl BgpMetrics {
             gr_active_peers,
             gr_stale_routes,
             gr_timer_expired,
+            selection_deferral_active,
+            selection_deferral_waiters,
+            selection_deferral_releases,
+            selection_deferral_timeouts,
             rpki_vrp_count,
             aspa_records,
             validation_import_refreshes,
@@ -2679,6 +2735,34 @@ impl BgpMetrics {
     /// Record a GR timer expiration for a peer.
     pub fn record_gr_timer_expired(&self, peer: &str) {
         self.gr_timer_expired.with_label_values(&[peer]).inc();
+    }
+
+    /// Set whether restarting-speaker route selection is deferred for a family.
+    pub fn set_selection_deferral_active(&self, afi_safi: &str, active: bool) {
+        self.selection_deferral_active
+            .with_label_values(&[afi_safi])
+            .set(i64::from(active));
+    }
+
+    /// Set the number of startup-frozen peers still blocking a family.
+    pub fn set_selection_deferral_waiters(&self, afi_safi: &str, count: i64) {
+        self.selection_deferral_waiters
+            .with_label_values(&[afi_safi])
+            .set(count);
+    }
+
+    /// Record release of one family gate (`all_eor` or `timer`).
+    pub fn record_selection_deferral_release(&self, afi_safi: &str, reason: &str) {
+        self.selection_deferral_releases
+            .with_label_values(&[afi_safi, reason])
+            .inc();
+    }
+
+    /// Record expiry of one family `Selection_Deferral_Timer`.
+    pub fn record_selection_deferral_timeout(&self, afi_safi: &str) {
+        self.selection_deferral_timeouts
+            .with_label_values(&[afi_safi])
+            .inc();
     }
 
     /// Set RPKI VRP count by address family.

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -428,6 +428,12 @@ impl PeerSession {
                         .map(|(family, limit)| (*family, *limit))
                         .collect();
 
+                    let peer_restart_state = neg.peer_restart_state;
+                    let peer_gr_families = neg
+                        .peer_gr_families
+                        .iter()
+                        .map(|family| (family.afi, family.safi))
+                        .collect();
                     self.negotiated = Some(*neg);
                     self.publish_export_profile();
                     self.established_at = Some(Instant::now());
@@ -462,6 +468,20 @@ impl PeerSession {
                             peer: self.peer_ip,
                             session_id: self.session_identity.id,
                             encoder: self.export_encoder.clone(),
+                        })
+                        .await;
+
+                    // Stage immutable RFC 4724 OPEN context before `PeerUp`.
+                    // The restarting-speaker selection gate consumes only the
+                    // matching session, so a collision loser cannot satisfy or
+                    // reclassify the winner's frozen EoR waiter.
+                    let _ = self
+                        .rib_tx
+                        .send(RibUpdate::SetPeerGracefulRestartContext {
+                            peer: self.peer_ip,
+                            session_id: self.session_identity.id,
+                            peer_restart_state,
+                            peer_gr_families,
                         })
                         .await;
 

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -592,6 +592,10 @@ async fn recv_peer_up_after_export_context(rib_rx: &mut mpsc::Receiver<RibUpdate
         rib_rx.recv().await.unwrap(),
         RibUpdate::SetPeerExportEncoder { .. }
     ));
+    assert!(matches!(
+        rib_rx.recv().await.unwrap(),
+        RibUpdate::SetPeerGracefulRestartContext { .. }
+    ));
     rib_rx.recv().await.unwrap()
 }
 /// All-empty `OutboundRouteUpdate` for the rib-out BMP tap tests.

--- a/docs/API.md
+++ b/docs/API.md
@@ -279,6 +279,13 @@ peer has no active outbound registration; `UNSPECIFIED` remains the
 backward-compatible value returned by older servers. This field is independent
 of the diagnostic `update_group` label.
 
+`NeighborState.selection_deferral` is empty on a cold start. During a planned,
+marker-backed RFC 4724 restart it reports one row per frozen address-family
+gate: whether the gate is active, this peer's waiter state and stamped session,
+the process-wide blocking-waiter count, and remaining time. Released rows are
+retained for the daemon lifetime with reason `all_eor` or `timer`, so an
+operator can distinguish complete convergence from timer-driven release.
+
 `NeighborState.paths_limits` is sorted by numeric AFI then SAFI. Legacy field
 `effective_send_max` retains raw semantics (`UINT32_MAX` unlimited, zero
 inactive). Optional `effective_send_limit` is the normalized view: presence

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -968,10 +968,22 @@ remote_asn = 65003
 graceful_restart = false
 ```
 
-**Implementation note:** restarting-speaker mode is deliberately minimal and
-honest. The daemon may advertise `R=1` after a planned restart, but it does
-not claim forwarding-state preservation (`forwarding_preserved = false`) and
-does not persist route state across restarts.
+**Implementation note:** restarting-speaker mode is deliberately honest. The
+daemon may advertise `R=1` after a planned restart, but it does not claim
+forwarding-state preservation (`forwarding_preserved = false`) and does not
+yet persist route state across restarts. During that marker-backed startup it
+freezes the effective static GR peer/family roster and defers each family's
+route selection plus initial table/EoR until all eligible current sessions
+send EoR or the remaining marker window expires. `gr_restart_time` therefore
+bounds both the advertised restart window and, via the maximum effective value
+across static peers, the process-start selection deferral.
+
+`rbgp neighbor <address>` shows `Selection Deferral` rows while active and
+retains their `all_eor` or `timer` release reason afterward. Metrics are
+`bgp_selection_deferral_active`, `bgp_selection_deferral_waiters`,
+`bgp_selection_deferral_releases_total`, and
+`bgp_selection_deferral_timeouts_total` (all bounded by configured family and
+release-reason labels).
 See [ADR-0024](adr/0024-graceful-restart.md).
 
 ### Long-Lived Graceful Restart (RFC 9494)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -745,6 +745,15 @@ owned-state.
 | `bgp_gr_active_peers` | Peers currently in GR stale-route state |
 | `bgp_gr_stale_routes` | Routes currently marked stale |
 | `bgp_gr_timer_expired_total` | GR timers that expired (routes swept) |
+| `bgp_selection_deferral_active{afi_safi}` | Planned-restart family selection gate (1 = active) |
+| `bgp_selection_deferral_waiters{afi_safi}` | Frozen-roster peers still blocking selection for the family |
+| `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor` or `timer` |
+| `bgp_selection_deferral_timeouts_total{afi_safi}` | Family gates released by the selection-deferral timer |
+
+For active gates, `rbgp neighbor <address>` and
+`NeighborService.GetNeighborState` also show the peer's waiter state, stamped
+session, blocking-waiter count, and remaining time. A released row retains its
+reason for the daemon lifetime.
 
 ### BFD
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -410,10 +410,11 @@ may reject them, but this is not v1 scope.
 
 ## RFC 4724 — Graceful Restart Mechanism for BGP
 
-rustbgpd implements the **receiving speaker** role only. When a peer that
-previously advertised the Graceful Restart capability goes down, rustbgpd
-preserves that peer's routes as stale rather than immediately withdrawing
-them.
+rustbgpd implements the **receiving speaker** role and a planned-restart
+**restarting speaker** role. As a receiver, when a peer that previously
+advertised the Graceful Restart capability goes down, rustbgpd preserves that
+peer's routes as stale rather than immediately withdrawing them. The bounded
+restarting-speaker behavior is described in §4.1 and ADR-0040.
 
 ### §3 — Graceful Restart Capability
 
@@ -432,11 +433,16 @@ them.
 
 ### §4.1 — Procedures for the Restarting Speaker
 
-Minimal restarting-speaker mode implemented (ADR-0040). After a coordinated
+Restarting-speaker mode is implemented (ADR-0040). After a coordinated
 shutdown, a marker file is written to `runtime_state_dir`. On startup, if the
 marker is present and not expired, static peers from config are offered R=1 in
 OPEN. `forwarding_preserved` remains false because rustbgpd does not own or
-verify the FIB. Dynamic gRPC-added peers always get R=0.
+verify the FIB. Dynamic gRPC-added peers always get R=0. Before sessions start,
+the RIB freezes the resolved static GR peer/family roster. Per-family Loc-RIB
+selection and outbound initial table/EoR are held until current-session EoRs
+arrive from every eligible waiter or the marker-bounded selection timer
+expires. Peer Restart State and absent GR families exclude that peer/family;
+superseded-session EoRs are rejected.
 
 ### §4.2 — Procedures for the Receiving Speaker
 

--- a/docs/adr/0040-gr-restarting-speaker.md
+++ b/docs/adr/0040-gr-restarting-speaker.md
@@ -21,7 +21,7 @@ misleading today.
 
 ## Decision
 
-Implement a **minimal, honest restarting-speaker mode**:
+Implement an honest restarting-speaker mode:
 
 1. On coordinated daemon shutdown, rustbgpd writes a small restart marker
    file under `global.runtime_state_dir`.
@@ -34,6 +34,19 @@ Implement a **minimal, honest restarting-speaker mode**:
 4. Dynamic peers added later via gRPC do **not** participate in that window.
 5. Once the window expires, subsequent reconnects revert to normal
    `restart_state = false`.
+6. On a marker-backed startup, freeze the complete GR-enabled static-peer
+   roster before any session starts. Route selection is deferred separately
+   for every locally supported family until all roster peers are either:
+   - bound to a current session that sends that family's End-of-RIB;
+   - excluded because its OPEN omitted GR/the family or carried Restart State;
+   - or the marker-bounded `Selection_Deferral_Timer` expires.
+7. Adj-RIB-In continues ingesting while a family is gated, but Loc-RIB
+   selection, initial outbound table data, route-refresh responses, and EoR
+   remain withheld. On release, deferred route identities (withdrawals
+   included) are selected and advertised before EoR.
+8. Waiters are transport-generation stamped. A replacement or failed-over
+   session re-arms its frozen roster entry, and an EoR from a predecessor or
+   collision loser cannot release the gate.
 
 This mode helps peers retain our routes briefly during a planned restart,
 but makes **no claim** that rustbgpd preserved dataplane continuity.
@@ -50,3 +63,12 @@ but makes **no claim** that rustbgpd preserved dataplane continuity.
   daemon-owned runtime state.
 - This does **not** replace the helper-mode state machine in ADR-0024; it
   complements it.
+- The current `Selection_Deferral_Timer` upper bound is the remaining
+  coordinated-restart marker lifetime, derived from the maximum effective
+  `gr_restart_time` across resolved static peers. This reuses the existing
+  configurable planned-restart window rather than introducing a second
+  startup-only duration knob.
+- `rbgp neighbor <peer>` and its JSON output expose per-family active/released
+  state, the queried peer's stamped waiter state, blocking waiter count,
+  remaining time, and release reason. Prometheus exposes the same family gate
+  and waiter gauges plus bounded release-reason and timeout counters.

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -472,6 +472,20 @@ message NeighborState {
   // Effective live unicast distribution mode reported by the RIB. This is
   // UNKNOWN while the peer has no active outbound registration.
   EffectiveDistributionMode effective_distribution_mode = 30;
+  // Process-start RFC 4724 selection-deferral state. Empty on cold starts.
+  repeated SelectionDeferralFamilyState selection_deferral = 31;
+}
+
+message SelectionDeferralFamilyState {
+  uint32 afi = 1;
+  uint32 safi = 2;
+  bool active = 3;
+  string waiter_state = 4;
+  optional uint64 waiter_session_id = 5;
+  uint64 blocking_waiters = 6;
+  uint64 remaining_millis = 7;
+  // Empty while active; "all_eor" or "timer" after release.
+  string release_reason = 8;
 }
 
 enum EffectiveDistributionMode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,10 +456,11 @@ fn grpc_principal_roles(config: &Config) -> BTreeMap<String, rustbgpd_api::authz
 
 fn max_gr_restart_time_secs(config: &Config) -> Option<u64> {
     config
-        .neighbors
+        .resolved_neighbors()
+        .ok()?
         .iter()
-        .filter(|neighbor| neighbor.graceful_restart.unwrap_or(true))
-        .map(|neighbor| u64::from(neighbor.gr_restart_time.unwrap_or(120)))
+        .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
+        .map(|neighbor| u64::from(neighbor.transport_config.peer.gr_restart_time))
         .max()
 }
 
@@ -1483,6 +1484,14 @@ async fn run<T>(
         );
         process::exit(1);
     });
+    // Resolve the complete static-peer set before the RIB actor or any BGP
+    // session starts. RFC 4724 restarting-speaker deferral must freeze this
+    // roster up front; discovering peers incrementally after the first EoR
+    // can release selection prematurely in a multi-peer topology.
+    let peer_configs = config.resolved_neighbors().unwrap_or_else(|e| {
+        error!("invalid policy configuration: {e}");
+        process::exit(1);
+    });
 
     // ── ADR-0072: Durable event outbox (EventHistoryManager) ───────
     //
@@ -1670,6 +1679,26 @@ async fn run<T>(
         cluster_id,
         metrics.clone(),
     );
+    if let Some(deadline) = local_gr_restart_until {
+        let waiters = peer_configs
+            .iter()
+            .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
+            .map(|neighbor| rustbgpd_rib::SelectionDeferralWaiterConfig {
+                peer: neighbor.transport_config.remote_addr.ip(),
+                families: neighbor
+                    .transport_config
+                    .peer
+                    .effective_families()
+                    .into_iter()
+                    .filter(|family| rustbgpd_fsm::graceful_restart_preserves_family(*family))
+                    .collect(),
+            })
+            .collect();
+        rib_manager = rib_manager.with_selection_deferral(rustbgpd_rib::SelectionDeferralConfig {
+            timeout: deadline.saturating_duration_since(StdInstant::now()),
+            waiters,
+        });
+    }
     if let Some(tx) = bmp_loc_rib_tx {
         rib_manager = rib_manager.with_bmp_tx(tx);
     }
@@ -2820,10 +2849,6 @@ async fn run<T>(
         .await;
     });
 
-    let peer_configs = config.resolved_neighbors().unwrap_or_else(|e| {
-        error!("invalid policy configuration: {e}");
-        process::exit(1);
-    });
     // Spawn BGP inbound TCP listener. The current daemon opens one
     // listener socket from `Config::listen_addr()`; only install TCP-AO
     // MKTs whose peer family can match that socket. Outbound active-open

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,14 +454,30 @@ fn grpc_principal_roles(config: &Config) -> BTreeMap<String, rustbgpd_api::authz
         .collect()
 }
 
-fn max_gr_restart_time_secs(config: &Config) -> Option<u64> {
+fn raw_max_gr_restart_time_secs(config: &Config) -> Option<u64> {
     config
-        .resolved_neighbors()
-        .ok()?
+        .neighbors
         .iter()
-        .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
-        .map(|neighbor| u64::from(neighbor.transport_config.peer.gr_restart_time))
+        .filter(|neighbor| neighbor.graceful_restart.unwrap_or(true))
+        .map(|neighbor| u64::from(neighbor.gr_restart_time.unwrap_or(120)))
         .max()
+}
+
+fn max_gr_restart_time_secs(config: &Config) -> Option<u64> {
+    match config.resolved_neighbors() {
+        Ok(neighbors) => neighbors
+            .iter()
+            .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
+            .map(|neighbor| u64::from(neighbor.transport_config.peer.gr_restart_time))
+            .max(),
+        Err(error) => {
+            warn!(
+                %error,
+                "failed to resolve effective neighbors while computing the planned-restart window; falling back to raw neighbor GR settings"
+            );
+            raw_max_gr_restart_time_secs(config)
+        }
+    }
 }
 
 fn marker_expires_at(marker: &GrRestartMarker) -> Result<SystemTime, String> {
@@ -3786,5 +3802,15 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         };
 
         assert_eq!(max_gr_restart_time_secs(&config), Some(180));
+
+        let mut unresolved = config.clone();
+        unresolved.neighbors[0].address = "fe80::1".to_string();
+        unresolved.neighbors[0].interface = Some("rbgp-definitely-missing0".to_string());
+        assert!(unresolved.resolved_neighbors().is_err());
+        assert_eq!(
+            max_gr_restart_time_secs(&unresolved),
+            Some(180),
+            "resolution failure must retain the previous raw-config marker fallback"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- freeze a per-family restarting-speaker waiter roster only after a valid planned-restart marker is consumed
- bind eligible GR peers, End-of-RIB markers, and replacements to the current stamped session generation
- defer best-path selection and every outbound path while a family is gated, including dirty/force resync, route refresh, ORF, RTC, VPN, EVPN, FlowSpec, labeled-unicast, and BGP-LS/ORR topology
- retain a typed deferred-key ledger for announcements and withdrawals, then recompute current RIB truth exactly once at release
- apply queued route work before simultaneous EoR/timer release and guarantee table data precedes the release EoR under backpressure
- expose timer/release reason, waiter state, and deferred-family status through metrics, NeighborState, CLI, JSON, API docs, configuration docs, operations guidance, RFC notes, and ADR-0040

## Why

RFC 4724 restarting-speaker behavior cannot advertise restored or partially converged state immediately after startup. Selection must wait for the frozen eligible peer/family cohort to complete its current-session EoRs or for the deferral timer to expire. This is also the correctness prerequisite for future MRT warm-boot restoration.

## Correctness properties

- cold start is unchanged when no planned-restart marker is present
- the startup waiter roster cannot release early when configured peers have not established
- Restart-State peers and non-GR families are excluded from the waiter cohort
- stale EoRs from predecessor/collision-loser sessions cannot satisfy a current waiter
- a replacement session re-arms a previously satisfied address without duplicating the roster
- withdrawals received during deferral remove restored keys before the single release recomputation
- simultaneous queued routes, EoR, and timer expiry apply route truth first
- a full outbound channel keeps the release EoR pending until the dirty resync succeeds
- BGP-LS topology remains hidden from ORR while the family gate is active
- teardown discards unconsumed staged GR context

## Review state

#858 and #860 are merged. This branch was collapsed onto resulting `main` at `5c191dc4`, retargeted to `main`, and the two feature commits were replayed as `abecd7cf` and `4de1f1a5`.

Suggested review order:

1. `selection_deferral.rs` contract and dedicated tests
2. RIB lifecycle plus distribution/refresh gates
3. session-generation and EoR wiring
4. metrics/API/CLI/configuration and documentation

## Validation

- post-collapse selection-deferral/ORR suite: 9 passed
- transport GR teardown, planned-restart marker fallback, API state, and CLI JSON tests passed
- `cargo fmt --all -- --check` and three-dot diff check passed
- `cargo check --workspace --all-targets` passed
- exact-head push hooks: fmt, Clippy, workspace tests, and rustdoc passed
- independent review found and fixed two high-severity ordering/isolation issues before publication
- the initial Copilot pass produced two actionable findings; marker fallback and ambiguous-roster diagnostics are fixed in the current head

Docs: API, configuration, operations, RFC notes, and ADR-0040 updated.

Linear: LAN-367
