### PR TITLE
fix(rib): harden session invariant boundaries

### DIFF
--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1072,6 +1072,17 @@ impl RibManager {
             return 0;
         }
         let family = prefix_family(prefix);
+        // The exact family map is subordinate to the negotiated Add-Path
+        // send set. Keep this check ahead of the map lookup so a malformed
+        // cross-crate payload can never enable Add-Path for an unnegotiated
+        // family in release builds.
+        if !self
+            .peer_add_path_send_families
+            .get(&peer)
+            .is_some_and(|families| families.contains(&family))
+        {
+            return 0;
+        }
         if let Some(limit) = self
             .peer_add_path_send_limits
             .get(&peer)
@@ -1079,15 +1090,7 @@ impl RibManager {
         {
             return *limit;
         }
-        if self
-            .peer_add_path_send_families
-            .get(&peer)
-            .is_some_and(|families| families.contains(&family))
-        {
-            send_max
-        } else {
-            0
-        }
+        send_max
     }
 
     /// Resolve the export policy for a peer: per-peer if set, else global.
@@ -1286,7 +1289,31 @@ impl RibManager {
                 // reconfiguration surface (a decrease requires a new session
                 // so excess advertised path IDs are withdrawn by teardown).
                 if self.outbound_session_ids.get(&peer).copied() == Some(session_id) {
-                    let new_limits: HashMap<_, _> = limits.into_iter().collect();
+                    let send_families = self
+                        .peer_add_path_send_families
+                        .get(&peer)
+                        .cloned()
+                        .unwrap_or_default();
+                    let mut rejected_families = Vec::new();
+                    let new_limits: HashMap<_, _> = limits
+                        .into_iter()
+                        .filter(|(family, _)| {
+                            let accepted = send_families.contains(family);
+                            if !accepted {
+                                rejected_families.push(*family);
+                            }
+                            accepted
+                        })
+                        .collect();
+                    if !rejected_families.is_empty() {
+                        rejected_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                        rejected_families.dedup();
+                        warn!(
+                            %peer,
+                            ?rejected_families,
+                            "ignoring Paths-Limit entries outside the negotiated Add-Path send families"
+                        );
+                    }
                     let scalar_limit = self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0);
                     let effective_limit_changed = self
                         .peer_add_path_send_families

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -492,6 +492,55 @@ fn paths_limit_updates_resync_only_for_effective_unicast_changes() {
     assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 8);
 }
 
+#[test]
+fn paths_limit_ignores_entries_outside_negotiated_send_families() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer: IpAddr = "192.0.2.2".parse().unwrap();
+    let (out_tx, mut out_rx) = mpsc::channel(8);
+    let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24));
+    let v6 = Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32));
+
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id: 7,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: dual_stack_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        add_path_send_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        add_path_send_max: 8,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    });
+    assert_one_dual_stack_eor(&mut out_rx);
+
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![((Afi::Ipv6, Safi::Unicast), 2)],
+    });
+
+    assert!(
+        manager
+            .peer_add_path_send_limits
+            .get(&peer)
+            .is_some_and(HashMap::is_empty),
+        "an unnegotiated family must not survive into the exact limit map"
+    );
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 8);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 0);
+    assert!(
+        matches!(out_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "rejecting an inert foreign-family limit must not replay the table"
+    );
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,

--- a/crates/rib/src/orr.rs
+++ b/crates/rib/src/orr.rs
@@ -255,6 +255,7 @@ pub struct OrrInputDiagnostics {
 impl OrrInputDiagnostics {
     fn record(&mut self, classification: InputClassification) {
         match classification {
+            InputClassification::IgnoredUnknown => {}
             InputClassification::IncludedDefault => {
                 self.included_default = self.included_default.saturating_add(1);
             }
@@ -318,6 +319,7 @@ impl OrrInputDiagnostics {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InputClassification {
+    IgnoredUnknown,
     IncludedDefault,
     ExcludedNonDefault,
     MalformedTopology,
@@ -338,6 +340,12 @@ fn classify_input(
     nlri: &BgpLsNlri,
     attributes: Result<Option<&[BgpLsTlv]>, ()>,
 ) -> InputClassification {
+    // Unknown NLRI are retained for reflection, but they are opaque to ORR.
+    // Classify that contract here so every caller gets the same uncounted
+    // result instead of relying on a separate guard before classification.
+    if matches!(nlri.nlri_type, BgpLsNlriType::Unknown(_)) {
+        return InputClassification::IgnoredUnknown;
+    }
     // Descriptor/topology framing takes precedence over Attribute 29. This
     // keeps one stable classification when both independent surfaces are bad.
     let descriptor_scope = descriptor_topology_scope(nlri);
@@ -375,7 +383,7 @@ fn classify_input(
                 descriptor_scope
             }
         }
-        BgpLsNlriType::Unknown(_) => return InputClassification::MalformedTopology,
+        BgpLsNlriType::Unknown(_) => unreachable!("unknown BGP-LS NLRI returned above"),
     };
     match scope {
         TopologyScope::NonDefault => InputClassification::ExcludedNonDefault,
@@ -494,10 +502,13 @@ impl OrrTopology {
         let mut seen: HashMap<&'a BgpLsNlri, usize> = HashMap::new();
         let mut input_diagnostics = OrrInputDiagnostics::default();
         for route in routes {
-            if matches!(route.nlri.nlri_type, BgpLsNlriType::Unknown(_)) {
-                continue;
-            }
-            let attribute_tlvs = attribute_tlvs(route);
+            // Unknown NLRI are opaque to ORR, including their attributes. Do
+            // not parse Attribute 29 merely to discard the classification.
+            let attribute_tlvs = if matches!(route.nlri.nlri_type, BgpLsNlriType::Unknown(_)) {
+                Ok(None)
+            } else {
+                attribute_tlvs(route)
+            };
             let classification_attributes = match &attribute_tlvs {
                 Ok(tlvs) => Ok(tlvs.as_deref()),
                 Err(()) => Err(()),
@@ -1400,6 +1411,26 @@ mod tests {
 
     fn raw_tlv(type_code: u16, value: &[u8]) -> BgpLsTlv {
         BgpLsTlv::new(type_code, Bytes::copy_from_slice(value))
+    }
+
+    #[test]
+    fn unknown_nlri_is_ignored_and_uncounted() {
+        let nlri = BgpLsNlri::try_new(
+            BgpLsNlriType::Unknown(65_000),
+            None,
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        )
+        .expect("opaque unknown NLRI is valid");
+        assert_eq!(
+            classify(nlri.clone(), vec![]),
+            InputClassification::IgnoredUnknown
+        );
+
+        let route = rib_route(PEER1, nlri, vec![]);
+        let topology = OrrTopology::build(std::iter::once(&route));
+        assert_eq!(topology.input_diagnostics(), OrrInputDiagnostics::default());
+        assert_eq!(topology.node_count(), 0);
+        assert_eq!(topology.link_count(), 0);
     }
 
     #[test]

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -1,6 +1,6 @@
 use super::export::{
-    ExportWithdrawal, PreparedAttrCache, PreparedUnicastCandidate, PreparedWithdrawal, ReachNlri,
-    SessionExportProfile, UnreachNlri, has_otc,
+    ExportProbeError, ExportWithdrawal, PreparedAttrCache, PreparedUnicastCandidate,
+    PreparedWithdrawal, ReachNlri, SessionExportProfile, UnreachNlri, has_otc,
 };
 use super::{
     Afi, BgpRole, EvpnRoute, FlowSpecRule, IpAddr, Ipv4Addr, Ipv4NlriEntry, Ipv4UnicastMode,
@@ -248,6 +248,7 @@ impl PeerSession {
         let mut v4_mp_wire = None;
         let mut v6_withdraw: Vec<NlriEntry> = Vec::new();
         let mut v6_wire = None;
+        let mut scoped_ipv4_without_extended_nexthop = 0usize;
         for &(ref prefix, path_id) in &update.withdraw {
             if !self.is_family_negotiated(prefix) {
                 continue;
@@ -268,6 +269,10 @@ impl PeerSession {
                     }
                 }
                 Ok(_) => unreachable!("unicast withdrawal must prepare as unicast"),
+                Err(ExportProbeError::Ipv4RequiresExtendedNextHop) => {
+                    scoped_ipv4_without_extended_nexthop =
+                        scoped_ipv4_without_extended_nexthop.saturating_add(1);
+                }
                 Err(error) => warn!(
                     peer = %self.peer_label,
                     %prefix,
@@ -275,6 +280,13 @@ impl PeerSession {
                     "not sending unicast withdrawal: exact export preparation failed"
                 ),
             }
+        }
+        if scoped_ipv4_without_extended_nexthop != 0 {
+            warn!(
+                peer = %self.peer_label,
+                dropped = scoped_ipv4_without_extended_nexthop,
+                "not sending IPv4 withdrawals to scoped link-local peer without negotiated Extended Next Hop"
+            );
         }
         if !v4_body_withdraw.is_empty() {
             let max_len = export.max_message_len();
@@ -490,6 +502,10 @@ impl PeerSession {
                     unreachable!("IPv6 must prepare as MP_REACH")
                 }
                 Err(error) => {
+                    debug_assert!(
+                        !matches!(&error, ExportProbeError::MissingIpv6NextHop),
+                        "RIB sent IPv6 route to eBGP peer with no valid IPv6 next-hop"
+                    );
                     warn!(
                         peer = %self.peer_label,
                         prefix = %route.prefix,
@@ -1813,9 +1829,11 @@ mod tests {
     use bytes::Bytes;
     use rustbgpd_fsm::PeerConfig;
     use rustbgpd_wire::{
-        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, MacAddress, MplsLabel, Origin,
-        RouteDistinguisher, notification::NotificationCode, notification::cease_subcode,
+        AsPath, AsPathSegment, EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, Ipv6Prefix,
+        MacAddress, MplsLabel, Origin, RouteDistinguisher, notification::NotificationCode,
+        notification::cease_subcode,
     };
+    use std::time::Instant;
     use tokio::io::AsyncReadExt;
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::mpsc;
@@ -1860,6 +1878,46 @@ mod tests {
         complete.extend_from_slice(&body);
         let mut bytes = Bytes::from(complete);
         rustbgpd_wire::decode_message(&mut bytes, rustbgpd_wire::MAX_MESSAGE_LEN).unwrap()
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "RIB sent IPv6 route to eBGP peer with no valid IPv6 next-hop")]
+    fn ipv6_ebgp_without_local_next_hop_trips_debug_contract() {
+        let mut session = make_test_session();
+        session.config.peer.families = vec![(Afi::Ipv6, Safi::Unicast)];
+        session.negotiated_families = vec![(Afi::Ipv6, Safi::Unicast)];
+        let snapshot = session
+            .export_encoder
+            .publish(SessionExportProfile::capture(&session).with_test_ebgp(true));
+        let route = Route {
+            prefix: Prefix::V6(Ipv6Prefix::new("2001:db8:1::".parse().unwrap(), 64)),
+            next_hop: IpAddr::V6("2001:db8::2".parse().unwrap()),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: IpAddr::V6("2001:db8::2".parse().unwrap()),
+            attributes: Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                }),
+            ]),
+            received_at: Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ebgp,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        };
+        session.send_route_update(OutboundRouteUpdate {
+            exact_export_snapshot: Some(snapshot),
+            announce: Arc::from([route]),
+            next_hop_override: Arc::from([None]),
+            ..OutboundRouteUpdate::default()
+        });
     }
 
     /// A single EVPN NLRI that cannot fit the negotiated message ceiling is

--- a/docs/API.md
+++ b/docs/API.md
@@ -283,7 +283,9 @@ surface. When multiple mechanisms apply, its primary-label precedence is
 `ADD_PATH` > `PER_CLIENT_BEST` > `ORR` > `SINGLE_BEST`. It is `UNKNOWN` when the
 peer has no active outbound registration; `UNSPECIFIED` remains the
 backward-compatible value returned by older servers. This field is independent
-of the diagnostic `update_group` label.
+of the diagnostic `update_group` label. A peer eligible for both per-client-best
+and ORR reports `PER_CLIENT_BEST` because it is the primary label; that value
+does not mean its configured ORR vantage is inactive.
 
 `NeighborState.selection_deferral` is empty on a cold start. During a planned,
 marker-backed RFC 4724 restart it reports one row per frozen address-family


### PR DESCRIPTION
## Summary

Harden three adjacent RIB/transport contract boundaries so malformed internal state fails closed in release builds, trips loudly in debug builds, and keeps operator-facing diagnostics stable.

## Changes

- ignore Paths-Limit entries outside negotiated Add-Path send families and prevent them from enabling foreign-family Add-Path or triggering replay
- classify unknown BGP-LS NLRI as opaque and uncounted for ORR through one authoritative classification path
- restore the debug invariant tripwire for impossible IPv6 eBGP announcements without a valid next hop
- aggregate scoped IPv4-without-Extended-NH withdrawal drops into one batch warning
- document per-client-best precedence when both PCB and ORR apply

## Testing

- [x] cargo test -p rustbgpd-rib --lib (788 passed, 1 ignored)
- [x] cargo test -p rustbgpd-transport --lib (271 passed, 1 ignored)
- [x] cargo clippy -p rustbgpd-rib -p rustbgpd-transport --all-targets -- -D warnings
- [x] cargo check --workspace --all-targets
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] Performance receipt intentionally not applicable; this is invariant and diagnostic hardening

## Docs / release notes

- [x] docs/API.md clarifies effective distribution-mode precedence
- [x] CHANGELOG and ROADMAP intentionally unchanged because no supported wire behavior or roadmap completion changes

## Related issues

- LAN-385
- LAN-387
- LAN-386