### PR TITLE
bench(perf): gate event-history producer offload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@ clab-*/
 # postmortem into the tree.
 tests/soak/runs/
 docs/artifacts/
+docs/perf/artifacts/
 target/criterion/
 *.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       - run: cargo check -p rustbgpd-rib --features bench-internals --benches
       # Transport has the same feature-gated `bench-internals` bench surface.
       - run: cargo check -p rustbgpd-transport --features bench-internals --benches
+      # API owns the feature-gated LAN-393 event-history producer bench.
+      - run: cargo check -p rustbgpd-api --features bench-internals --benches
       # Same class of gap for the root crate: `bench-internals` exposes
       # `pub mod config` (and its EVPN reload-diff dependencies) in the
       # lib, a surface the default `--all-targets` clippy never compiles.
@@ -61,6 +63,23 @@ jobs:
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py
+      - name: Check LAN-393 fail-closed measurement tooling
+        run: |
+          set -euo pipefail
+          python3 -m venv "$RUNNER_TEMP/lan393-venv"
+          "$RUNNER_TEMP/lan393-venv/bin/pip" install --disable-pip-version-check 'PyYAML==6.0.2'
+          bash docs/perf/test-lan393-host-fence.sh
+          "$RUNNER_TEMP/lan393-venv/bin/python" -m unittest -v \
+            docs/perf/test_validate_lan393_receipt.py \
+            docs/perf/test_validate_lan393_criterion.py \
+            docs/perf/test_validate_lan393_perf.py \
+            docs/perf/test_validate_lan393_full_comparison.py
+          shellcheck -x \
+            docs/perf/lan393-host-fence.sh \
+            docs/perf/run-lan393-criterion.sh \
+            docs/perf/run-lan393-full-daemon.sh \
+            docs/perf/bgperf-rustbgpd-ehm-wrapper.sh \
+            docs/perf/test-lan393-host-fence.sh
       - run: cargo test --workspace
       - run: cargo doc --workspace --lib --no-deps
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,7 @@ version = "0.51.0"
 dependencies = [
  "arc-swap",
  "bytes",
+ "criterion",
  "futures",
  "prometheus",
  "prost",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -11,6 +11,12 @@ categories.workspace = true
 description = "gRPC API server — tonic bindings for the rustbgpd services (Global, Neighbor, Policy, PeerGroup, Rib, Injection, Control, Evpn)"
 readme = "README.md"
 
+[features]
+# Exposes the RIB manager's benchmark-only event-publish driver to the
+# event-history producer benchmark. Normal API and daemon builds do not compile
+# that surface.
+bench-internals = ["rustbgpd-rib/bench-internals"]
+
 [dependencies]
 rustbgpd-wire.workspace = true
 rustbgpd-fsm.workspace = true
@@ -42,5 +48,11 @@ tonic-prost-build.workspace = true
 protoc-bin-vendored = "3"
 
 [dev-dependencies]
+criterion.workspace = true
 rcgen.workspace = true
 tempfile.workspace = true
+
+[[bench]]
+name = "event_history_producer"
+harness = false
+required-features = ["bench-internals"]

--- a/crates/api/benches/event_history_producer.rs
+++ b/crates/api/benches/event_history_producer.rs
@@ -1,0 +1,463 @@
+//! LAN-393 measurement gate for RIB-produced durable events.
+//!
+//! The `lan393_manager_self_time` group times only the synchronous
+//! `RibManager::publish_*` phase. It compares the default no-op sink with the
+//! real EHM sink. All no-op cases finish before EHM is started, and each EHM
+//! sample starts only after the preceding sample reaches EHM's committed
+//! high-water mark. Commit fences and health checks run in Criterion setup and
+//! are therefore outside the timed region.
+//!
+//! The `lan393_sqlite_end_to_end` group starts at the same manager publish
+//! helper and ends when every event is observed on EHM's post-commit broadcast.
+//! It therefore includes conversion, prost encoding, the bounded queue, SQLite
+//! commit, cursor allocation, and committed-event delivery.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use prometheus::Encoder;
+use rustbgpd_event_history::{
+    EhmState, EventHistoryConfig, EventHistoryHandle, EventHistoryManager, EventHistorySender,
+    SynchronousMode,
+};
+use rustbgpd_rib::{
+    EvpnRibRoute, EvpnRouteEvent, RibManager, RouteEvent, RouteEventType, RouteOrigin,
+};
+use rustbgpd_telemetry::BgpMetrics;
+use rustbgpd_wire::{
+    AsPath, AsPathSegment, EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute,
+    Ipv4Prefix, MacAddress, MplsLabel, Origin, PathAttribute, Prefix, RouteDistinguisher,
+};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+use tokio::sync::{broadcast, mpsc};
+
+const EVENTS_PER_SAMPLE: usize = 256;
+const EHM_QUEUE_CAPACITY: usize = 4_096;
+const QUEUE_FENCE_TIMEOUT: Duration = Duration::from_secs(10);
+const COMMIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+enum EventShape {
+    RouteAdded,
+    RoutePolicyFiltered,
+    EvpnBestChanged,
+}
+
+impl EventShape {
+    const ALL: [Self; 3] = [
+        Self::RouteAdded,
+        Self::RoutePolicyFiltered,
+        Self::EvpnBestChanged,
+    ];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::RouteAdded => "route_added",
+            Self::RoutePolicyFiltered => "route_policy_filtered",
+            Self::EvpnBestChanged => "evpn_best_changed",
+        }
+    }
+
+    fn batch(self) -> EventBatch {
+        match self {
+            Self::RouteAdded => EventBatch::Route(
+                (0..EVENTS_PER_SAMPLE)
+                    .map(|index| route_event(index, RouteEventType::Added))
+                    .collect(),
+            ),
+            Self::RoutePolicyFiltered => EventBatch::Route(
+                (0..EVENTS_PER_SAMPLE)
+                    .map(|index| route_event(index, RouteEventType::PolicyFiltered))
+                    .collect(),
+            ),
+            Self::EvpnBestChanged => EventBatch::Evpn(
+                (0..EVENTS_PER_SAMPLE)
+                    .map(evpn_best_changed_event)
+                    .collect(),
+            ),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum EventBatch {
+    Route(Vec<RouteEvent>),
+    Evpn(Vec<EvpnRouteEvent>),
+}
+
+impl EventBatch {
+    fn publish(self, manager: &mut RibManager) {
+        match self {
+            Self::Route(events) => manager.bench_publish_route_events(events),
+            Self::Evpn(events) => manager.bench_publish_evpn_events(events),
+        }
+    }
+}
+
+struct EhmHarness {
+    runtime: Runtime,
+    manager: Option<RibManager>,
+    history: Option<EventHistoryManager>,
+    handle: EventHistoryHandle,
+    sender: EventHistorySender,
+    metrics: BgpMetrics,
+    committed_rx: Option<broadcast::Receiver<rustbgpd_event_history::CommittedEvent>>,
+    last_cursor: u64,
+    _dir: TempDir,
+}
+
+impl EhmHarness {
+    fn new(subscribe_to_commits: bool) -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_name("lan393-ehm")
+            .enable_all()
+            .build()
+            .expect("LAN-393 benchmark runtime");
+        let dir = tempfile::tempdir().expect("LAN-393 benchmark tempdir");
+        let metrics = BgpMetrics::new();
+        let history = runtime
+            .block_on(EventHistoryManager::start(EventHistoryConfig {
+                path: dir.path().join("events.db"),
+                required: true,
+                queue_capacity: EHM_QUEUE_CAPACITY,
+                batch_size: EVENTS_PER_SAMPLE,
+                batch_interval: Duration::from_millis(50),
+                broadcast_capacity: EHM_QUEUE_CAPACITY,
+                max_events: 10_000_000,
+                max_bytes: 8_000_000_000,
+                synchronous: SynchronousMode::Full,
+                retention_interval: Duration::from_secs(3_600),
+                sidecar_flush_interval_batches: u64::MAX,
+                metrics: Some(metrics.clone()),
+            }))
+            .expect("start LAN-393 benchmark EHM");
+        let handle = history.handle();
+        let sender = handle.sender();
+        let committed_rx = subscribe_to_commits.then(|| handle.subscribe_live());
+        let sink =
+            rustbgpd_api::event_history_sinks::make_rib_event_sink(handle.clone(), metrics.clone());
+        let manager = manager_with_metrics(metrics.clone()).with_event_sink(sink);
+
+        Self {
+            runtime,
+            manager: Some(manager),
+            history: Some(history),
+            handle,
+            sender,
+            metrics,
+            committed_rx,
+            last_cursor: 0,
+            _dir: dir,
+        }
+    }
+
+    fn assert_healthy(&self) {
+        assert_healthy(self.handle.state(), &self.metrics);
+    }
+
+    fn shutdown(mut self) {
+        fence_queue(&self.sender);
+        self.assert_healthy();
+        assert_eq!(
+            self.handle.state().latest_event_id(),
+            self.last_cursor,
+            "EHM committed high-water mark changed before shutdown"
+        );
+        drop(self.manager.take());
+        let history = self.history.take().expect("EHM manager present");
+        self.runtime.block_on(history.shutdown());
+        self.assert_healthy();
+        assert_eq!(
+            self.handle.state().latest_event_id(),
+            self.last_cursor,
+            "EHM exposed committed high-water mark changed across shutdown"
+        );
+    }
+}
+
+fn manager() -> RibManager {
+    manager_with_metrics(BgpMetrics::new())
+}
+
+fn manager_with_metrics(metrics: BgpMetrics) -> RibManager {
+    let (_update_tx, update_rx) = mpsc::channel(16);
+    let (_query_tx, query_rx) = mpsc::channel(16);
+    RibManager::new(update_rx, query_rx, None, None, metrics)
+}
+
+fn route_event(index: usize, event_type: RouteEventType) -> RouteEvent {
+    let [high, low] = u16::try_from(index)
+        .expect("sample index fits u16")
+        .to_be_bytes();
+    let policy_filtered = event_type == RouteEventType::PolicyFiltered;
+    RouteEvent {
+        event_id: 0,
+        event_type,
+        prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 18, high, low), 32)),
+        peer: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+        previous_peer: None,
+        target_peer: policy_filtered.then_some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 254))),
+        timestamp: "1783915200".to_string(),
+        path_id: u32::try_from(index).expect("sample index fits u32"),
+        reason: if policy_filtered {
+            "policy_denied".to_string()
+        } else {
+            String::new()
+        },
+    }
+}
+
+fn evpn_route(peer: Ipv4Addr, index: usize) -> EvpnRibRoute {
+    let [high, low] = u16::try_from(index)
+        .expect("sample index fits u16")
+        .to_be_bytes();
+    EvpnRibRoute {
+        route: EvpnRoute::MacIp(EvpnMacIp {
+            rd: RouteDistinguisher::new([0, 0, 0xfd, 0xe8, 0, 0, high, low]),
+            esi: EthernetSegmentIdentifier::ZERO,
+            ethernet_tag: EthernetTagId(100),
+            mac: MacAddress::new([0x02, 0, 0, 0, high, low]),
+            ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, high, low))),
+            label1: MplsLabel::new(10_000 + u32::try_from(index).expect("sample index fits u32")),
+            label2: None,
+        }),
+        next_hop: IpAddr::V4(peer),
+        link_local_next_hop: None,
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![64_512, 64_513])],
+            }),
+            PathAttribute::NextHop(peer),
+            PathAttribute::LocalPref(100),
+        ]),
+        received_at: Instant::now(),
+        origin_type: RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+    }
+}
+
+fn evpn_best_changed_event(index: usize) -> EvpnRouteEvent {
+    let best = evpn_route(Ipv4Addr::new(192, 0, 2, 2), index);
+    let previous_best = evpn_route(Ipv4Addr::new(192, 0, 2, 1), index);
+    EvpnRouteEvent {
+        event_type: RouteEventType::BestChanged,
+        key: best.key(),
+        best: Some(best),
+        previous_best: Some(previous_best),
+        peer: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2))),
+        previous_peer: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+        timestamp: "1783915200".to_string(),
+    }
+}
+
+fn fence_queue(sender: &EventHistorySender) {
+    let deadline = Instant::now() + QUEUE_FENCE_TIMEOUT;
+    while sender.available() != sender.max_capacity() {
+        assert!(
+            Instant::now() < deadline,
+            "EHM producer queue did not drain within {QUEUE_FENCE_TIMEOUT:?}"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+fn fence_committed_through(
+    runtime: &Runtime,
+    committed_rx: &mut broadcast::Receiver<rustbgpd_event_history::CommittedEvent>,
+    state: &Arc<EhmState>,
+    last_cursor: &mut u64,
+    expected_last: u64,
+) {
+    assert!(
+        expected_last >= *last_cursor,
+        "committed high-water fence moved backwards"
+    );
+    runtime.block_on(async {
+        tokio::time::timeout(COMMIT_TIMEOUT, async {
+            while *last_cursor < expected_last {
+                let expected = last_cursor.checked_add(1).expect("cursor space");
+                let committed = committed_rx
+                    .recv()
+                    .await
+                    .expect("committed-event broadcast remains open");
+                assert_eq!(
+                    committed.event_id, expected,
+                    "EHM cursor order changed during benchmark"
+                );
+                *last_cursor = expected;
+            }
+        })
+        .await
+        .expect("EHM committed high-water fence timed out");
+    });
+    assert_eq!(
+        state.latest_event_id(),
+        expected_last,
+        "EHM state did not reach the expected committed high-water mark"
+    );
+}
+
+fn metrics_text(metrics: &BgpMetrics) -> String {
+    let encoder = prometheus::TextEncoder::new();
+    let families = metrics.registry().gather();
+    let mut out = Vec::new();
+    encoder
+        .encode(&families, &mut out)
+        .expect("encode benchmark metrics");
+    String::from_utf8(out).expect("Prometheus text is UTF-8")
+}
+
+fn assert_healthy(state: &Arc<EhmState>, metrics: &BgpMetrics) {
+    assert!(!state.degraded(), "EHM state degraded during benchmark");
+    assert!(
+        !metrics.event_outbox_degraded(),
+        "event-outbox degraded gauge moved during benchmark"
+    );
+    let text = metrics_text(metrics);
+    let drops: Vec<&str> = text
+        .lines()
+        .filter(|line| line.starts_with("bgp_event_outbox_dropped_total{"))
+        .collect();
+    assert!(
+        drops.is_empty(),
+        "event-outbox drop counter moved during benchmark: {drops:?}"
+    );
+}
+
+fn manager_self_time(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lan393_manager_self_time");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.throughput(Throughput::Elements(
+        u64::try_from(EVENTS_PER_SAMPLE).expect("sample size fits u64"),
+    ));
+
+    // Measure every no-op case before starting EHM so no SQLite or EHM actor
+    // work can contaminate the default-disabled samples.
+    let mut noop_manager = manager();
+    for shape in EventShape::ALL {
+        let batch = shape.batch();
+        group.bench_function(format!("{}/noop", shape.label()), |bencher| {
+            bencher.iter_batched(
+                || batch.clone(),
+                |events| events.publish(&mut noop_manager),
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    drop(noop_manager);
+
+    let mut ehm = EhmHarness::new(true);
+    for shape in EventShape::ALL {
+        let batch = shape.batch();
+        let sender = ehm.sender.clone();
+        let state = ehm.handle.state().clone();
+        let metrics = ehm.metrics.clone();
+        let runtime = &ehm.runtime;
+        let ehm_manager = ehm.manager.as_mut().expect("RIB manager present");
+        let committed_rx = ehm
+            .committed_rx
+            .as_mut()
+            .expect("manager harness subscribes before publishing");
+        let last_cursor = &mut ehm.last_cursor;
+        let mut expected_cursor = *last_cursor;
+        group.bench_function(format!("{}/ehm", shape.label()), |bencher| {
+            bencher.iter_batched(
+                || {
+                    fence_committed_through(
+                        runtime,
+                        committed_rx,
+                        &state,
+                        last_cursor,
+                        expected_cursor,
+                    );
+                    fence_queue(&sender);
+                    assert_healthy(&state, &metrics);
+                    expected_cursor = expected_cursor
+                        .checked_add(
+                            u64::try_from(EVENTS_PER_SAMPLE).expect("sample size fits u64"),
+                        )
+                        .expect("cursor space");
+                    batch.clone()
+                },
+                |events| events.publish(ehm_manager),
+                BatchSize::PerIteration,
+            );
+        });
+        fence_committed_through(runtime, committed_rx, &state, last_cursor, expected_cursor);
+        fence_queue(&ehm.sender);
+        ehm.assert_healthy();
+    }
+
+    group.finish();
+    ehm.shutdown();
+}
+
+fn sqlite_end_to_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lan393_sqlite_end_to_end");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    group.throughput(Throughput::Elements(
+        u64::try_from(EVENTS_PER_SAMPLE).expect("sample size fits u64"),
+    ));
+
+    let mut ehm = EhmHarness::new(true);
+    for shape in EventShape::ALL {
+        let batch = shape.batch();
+        let sender = ehm.sender.clone();
+        let state = ehm.handle.state().clone();
+        let metrics = ehm.metrics.clone();
+        let runtime = &ehm.runtime;
+        let ehm_manager = ehm.manager.as_mut().expect("RIB manager present");
+        let committed_rx = ehm
+            .committed_rx
+            .as_mut()
+            .expect("end-to-end harness subscribes before publishing");
+        let last_cursor = &mut ehm.last_cursor;
+
+        group.bench_function(format!("{}/full", shape.label()), |bencher| {
+            bencher.iter_batched(
+                || {
+                    fence_queue(&sender);
+                    assert_healthy(&state, &metrics);
+                    batch.clone()
+                },
+                |events| {
+                    events.publish(ehm_manager);
+                    let expected_last = last_cursor
+                        .checked_add(
+                            u64::try_from(EVENTS_PER_SAMPLE).expect("sample size fits u64"),
+                        )
+                        .expect("cursor space");
+                    fence_committed_through(
+                        runtime,
+                        committed_rx,
+                        &state,
+                        last_cursor,
+                        expected_last,
+                    );
+                    std::hint::black_box(expected_last);
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        fence_queue(&ehm.sender);
+        ehm.assert_healthy();
+    }
+
+    group.finish();
+    ehm.shutdown();
+}
+
+criterion_group!(benches, manager_self_time, sqlite_end_to_end);
+criterion_main!(benches);

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -1,15 +1,16 @@
-//! Bench-only fanout driver.
+//! Bench-only manager hot-path drivers.
 //!
-//! Exposed solely to the `fanout` distribution microbench behind the
-//! `bench-internals` feature (set via `required-features` on the bench target).
-//! The `pub fn bench_*` methods join the crate's public surface only when that
-//! feature is enabled; in a normal (default-feature) build the whole module is
-//! compiled out and nothing here is reachable.
+//! Exposed solely to workspace microbenchmarks behind the `bench-internals`
+//! feature (set via `required-features` on each bench target). The `pub fn
+//! bench_*` methods join the crate's public surface only when that feature is
+//! enabled; in a normal (default-feature) build the whole module is compiled
+//! out and nothing here is reachable.
 //!
-//! The driver registers N synthetic outbound peers, seeds the Loc-RIB, and runs
-//! the manager's `distribute_changes` directly, so the bench measures the
-//! per-peer export fanout cost (policy eval + Adj-RIB-Out staging + bounded
-//! channel send) without the async `run()` task loop in the way.
+//! The fanout driver registers synthetic outbound peers, seeds the Loc-RIB, and
+//! runs `distribute_changes` directly. The event-history driver calls the same
+//! private publish helpers as the manager actor so the API crate can compare
+//! the default no-op sink with its concrete EHM sink without widening the
+//! normal public API or duplicating manager-side ring/broadcast work.
 
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
@@ -21,6 +22,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::RibManager;
 use crate::adj_rib_in::AdjRibIn;
+use crate::event::{EvpnRouteEvent, RouteEvent};
 use crate::route::Route;
 use crate::update::{
     ExactExportEncoder, OutboundRouteUpdate, RoutePage, RouteQueryKey, RouteQueryScope,
@@ -156,5 +158,27 @@ impl RibManager {
         response
             .try_recv()
             .expect("route page handler replies synchronously")
+    }
+
+    /// Publish an owned batch through the production route-event helper.
+    ///
+    /// Input construction belongs in the benchmark setup closure. Consuming
+    /// the batch here keeps event cloning out of the timed manager phase while
+    /// retaining the real process-local ID, ring, sink, and legacy-broadcast
+    /// work performed by `RibManager::publish_route_event`.
+    pub fn bench_publish_route_events(&mut self, events: impl IntoIterator<Item = RouteEvent>) {
+        for event in events {
+            self.publish_route_event(event);
+        }
+    }
+
+    /// Publish an owned batch through the production EVPN-event helper.
+    ///
+    /// Like [`Self::bench_publish_route_events`], this method exists only under
+    /// `bench-internals` and deliberately adds no alternate production path.
+    pub fn bench_publish_evpn_events(&mut self, events: impl IntoIterator<Item = EvpnRouteEvent>) {
+        for event in events {
+            self.publish_evpn_route_event(event);
+        }
     }
 }

--- a/docs/perf/artifacts/event-history-producer-2026-07/README.md
+++ b/docs/perf/artifacts/event-history-producer-2026-07/README.md
@@ -1,0 +1,105 @@
+# LAN-393 machine-artifact manifest
+
+This directory is intentionally receipt-only. Generated measurements are not
+present until the host is clear and the exact commands in
+`docs/perf/event-history-producer-2026-07.md` have completed.
+
+Expected baseline files:
+
+- `environment.txt` — commit, dirty state, compiler, kernel, CPU topology, and
+  filesystem/mount details;
+- `rustbgpd-baseline-source.tar.gz`, `candidate-environment.txt`, and
+  `rustbgpd-candidate-source.tar.gz` — exact clean baseline/candidate identities
+  and reconstructable source trees. The candidate identity also proves the
+  recorded baseline is its ancestor;
+- `source-sha256.txt` — relative-path hashes for the baseline and, once it
+  exists, candidate rustbgpd source archives. The full-daemon bgperf2 hash is
+  kept in the separate phase-specific source manifest below;
+- `microbench-{baseline,candidate}-toolchain.txt` — byte-identical retained
+  `rustc -Vv`, `cargo -Vv`, and `protoc --version` identity. Candidate setup
+  fails before building if it differs from the baseline;
+- `microbench-{baseline,candidate}-host-preflight.tsv` — every load,
+  all-CPU-governor, and competing-process poll immediately preceding a
+  retained Criterion group while the shared host lock is held;
+- `microbench-{baseline,candidate}-perf-environment.txt` and
+  `microbench-{baseline,candidate}-perf-host-preflight.tsv` — exact clean phase
+  commit/source/toolchain/binary identity plus the fixed load/governor/process
+  fence immediately before the retained `perf stat` and `perf record` runs,
+  with the shared lock held across both;
+- `criterion/lan393_manager_self_time/**/{benchmark,estimates,sample}.json`;
+- `criterion/lan393_sqlite_end_to_end/**/{benchmark,estimates,sample}.json`;
+- `criterion-comparison/**/new/estimates.json` — candidate estimates;
+- `criterion-comparison/**/change/estimates.json` — candidate versus the
+  retained `origin-main` baseline;
+- `microbench-{baseline,candidate}-perf-bench-build.jsonl` — Cargo
+  compiler-artifact messages that identify the exact hashed benchmark
+  executable;
+- `microbench-{baseline,candidate}-perf-stat.csv` — machine-readable CPU
+  counters;
+- `microbench-{baseline,candidate}-perf.data` and
+  `microbench-{baseline,candidate}-perf-report.txt` — raw sampled profile and
+  inspectable symbol attribution;
+- `microbench-{baseline,candidate}-perf-completion.txt` and
+  `microbench-{baseline,candidate}-perf-SHA256SUMS` — the phase success sentinel
+  and aggregate relative-path binding for its identity, preflight, Cargo,
+  counter, profile, toolchain, and exact source-archive receipts.
+
+Expected full-daemon proceed-gate files:
+
+- `full-daemon-baseline-environment.txt` — the recorded/current rustbgpd
+  baseline, pinned bgperf2 commit, clean states, exact base images, and profiling
+  image content digest;
+- `bgperf2-source-fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9.tar.gz` — exact
+  source tree for the pinned profiling adapter;
+- `full-daemon-baseline-image-inspect.json` plus
+  `full-daemon-baseline-{identity-validation,builder-provenance,
+  runtime-provenance,binary-sha256,image-validation,running-image}.txt` —
+  build/run identity, compiler/Cargo/protoc/package provenance, exact OCI
+  revision/base labels, and proof that the running container used the validated
+  image digest;
+- `full-daemon-baseline-source-sha256.txt` — relative-path hashes for the exact
+  baseline rustbgpd archive and pinned bgperf2 archive (the candidate phase adds
+  its distinct rustbgpd archive). The selected rustbgpd archive is also the
+  Docker build context; the mutable checkout is never copied into the image;
+- `full-daemon-baseline-host-preflight.tsv` — the retained idle/load,
+  all-CPU-governor, and competing-process fence before the build and again
+  before bgperf starts, under the shared host lock;
+- `full-daemon-baseline-config.toml` plus
+  `full-daemon-baseline-{event-history-config,profile-ready,
+  processes-pre-attach}.txt` — the generated daemon config, explicit
+  EHM-enabled excerpt, and stopped pre-exec profiler barrier;
+- `full-daemon-baseline-scenario.yaml`, raw `bgperf.log` and time series,
+  normalized `bgperf-result.csv`, and `bgperf-validation.txt` — the generated
+  scenario plus fail-closed proof of exactly 2 BIRD peers x 100k prefixes and
+  `required=received=200000`;
+- `full-daemon-baseline-tester-logs/{10.10.0.3,10.10.0.4}.log` — copies from
+  this exact custom bgperf run. The validator requires the source directory's
+  complete `*.log` inventory to contain exactly those two regular, non-symlink
+  names, verifies the copies are byte-identical, and records their hashes. Any
+  case-sensitive `RMT` line other than a `NEXT_HOP` diagnostic fails the
+  receipt. The adapter's tester-error value remains in the raw log and is
+  recorded as ignored in validator output because it can describe stale
+  `/tmp/bgperf2` logs; the normalized CSV contains the run-scoped verdict. The
+  pinned BIRD adapter exposes no timeout detector, so its structural zero
+  timeout field is retained but is not claimed as evidence. The run receipt,
+  tester directories, and source/retained scenario paths reject symlink
+  components, and the scenario copy is byte-bound to the exact run;
+- `full-daemon-baseline-{metrics,docker-stats}.txt` and
+  `full-daemon-baseline-rustbgpd.log` — post-drain outbox integrity/health and
+  resource snapshot;
+- `full-daemon-baseline-ehm.perf.data`,
+  `full-daemon-baseline-ehm.perf-report.txt`, and
+  `full-daemon-baseline-ehm.perf-script.txt` — raw and inspectable daemon
+  profiles used for the 5% RIB-actor attribution gate.
+- `full-daemon-baseline-completion.txt` and
+  `full-daemon-baseline-SHA256SUMS` — the success sentinel written only after
+  all convergence, outbox, resource, and perf checks, plus an aggregate
+  relative-path manifest for every phase-prefixed file and exact source
+  archive. Both are required for a complete receipt.
+
+The later offload measurement uses the same manifest with
+`full-daemon-candidate-` prefixes. It is not a proceed-gate baseline and the
+driver rejects it unless its recorded commit differs from the baseline.
+
+Do not add hand-written result JSON here. Criterion and perf outputs are the
+source of truth; the Markdown receipt only summarizes them.

--- a/docs/perf/artifacts/event-history-producer-2026-07/README.md
+++ b/docs/perf/artifacts/event-history-producer-2026-07/README.md
@@ -44,6 +44,9 @@ Each of `baseline-enabled`, `baseline-disabled`, `candidate-enabled`, and
 - safe host fingerprint/toolchain, load/governor/process preflight, OCI image
   inspection, binary hashes, and builder/runtime package provenance;
 - exact generated scenario/config and explicit enabled/disabled EHM verdict;
+- normalized `barrier_reached=1` evidence for the stopped-wrapper attach point;
+  the raw PID-bearing barrier remains private under
+  `target/lan393-private-perf/`;
 - raw bgperf log/time series, normalized finite-value result CSV, two exact
   run-scoped BIRD logs, and validator output;
 - post-drain metrics, resource snapshot, daemon log, and cursor/drop/degraded

--- a/docs/perf/artifacts/event-history-producer-2026-07/README.md
+++ b/docs/perf/artifacts/event-history-producer-2026-07/README.md
@@ -1,105 +1,77 @@
 # LAN-393 machine-artifact manifest
 
-This directory is intentionally receipt-only. Generated measurements are not
-present until the host is clear and the exact commands in
-`docs/perf/event-history-producer-2026-07.md` have completed.
+This directory is receipt-only. Measurements are intentionally absent until
+the exact drivers in `docs/perf/event-history-producer-2026-07.md` complete on a
+quiet host.
 
-Expected baseline files:
+## Criterion phases
 
-- `environment.txt` — commit, dirty state, compiler, kernel, CPU topology, and
-  filesystem/mount details;
-- `rustbgpd-baseline-source.tar.gz`, `candidate-environment.txt`, and
-  `rustbgpd-candidate-source.tar.gz` — exact clean baseline/candidate identities
-  and reconstructable source trees. The candidate identity also proves the
-  recorded baseline is its ancestor;
-- `source-sha256.txt` — relative-path hashes for the baseline and, once it
-  exists, candidate rustbgpd source archives. The full-daemon bgperf2 hash is
-  kept in the separate phase-specific source manifest below;
-- `microbench-{baseline,candidate}-toolchain.txt` — byte-identical retained
-  `rustc -Vv`, `cargo -Vv`, and `protoc --version` identity. Candidate setup
-  fails before building if it differs from the baseline;
-- `microbench-{baseline,candidate}-host-preflight.tsv` — every load,
-  all-CPU-governor, and competing-process poll immediately preceding a
-  retained Criterion group while the shared host lock is held;
-- `microbench-{baseline,candidate}-perf-environment.txt` and
-  `microbench-{baseline,candidate}-perf-host-preflight.tsv` — exact clean phase
-  commit/source/toolchain/binary identity plus the fixed load/governor/process
-  fence immediately before the retained `perf stat` and `perf record` runs,
-  with the shared lock held across both;
-- `criterion/lan393_manager_self_time/**/{benchmark,estimates,sample}.json`;
-- `criterion/lan393_sqlite_end_to_end/**/{benchmark,estimates,sample}.json`;
-- `criterion-comparison/**/new/estimates.json` — candidate estimates;
-- `criterion-comparison/**/change/estimates.json` — candidate versus the
-  retained `origin-main` baseline;
-- `microbench-{baseline,candidate}-perf-bench-build.jsonl` — Cargo
-  compiler-artifact messages that identify the exact hashed benchmark
-  executable;
-- `microbench-{baseline,candidate}-perf-stat.csv` — machine-readable CPU
-  counters;
-- `microbench-{baseline,candidate}-perf.data` and
-  `microbench-{baseline,candidate}-perf-report.txt` — raw sampled profile and
-  inspectable symbol attribution;
-- `microbench-{baseline,candidate}-perf-completion.txt` and
-  `microbench-{baseline,candidate}-perf-SHA256SUMS` — the phase success sentinel
-  and aggregate relative-path binding for its identity, preflight, Cargo,
-  counter, profile, toolchain, and exact source-archive receipts.
+Each `baseline` or `candidate` phase produces:
 
-Expected full-daemon proceed-gate files:
+- `microbench-<phase>-environment.txt`: exact source/base identities, canonical
+  repository slug, detached-worktree/separate-target/shared-state proof,
+  Cargo-config and build-environment hashes, executable basename/hash, and
+  normalized lock/fence policy;
+- `microbench-<phase>-{host-fingerprint,toolchain}.txt` and
+  `microbench-<phase>-harness-SHA256SUMS`;
+- `microbench-<phase>-host-preflight.tsv`, whose process column contains only
+  executable names;
+- `microbench-<phase>-bench-build.json`, sanitized to the selected target,
+  enabled features, executable basename, and executable hash;
+- `microbench-<phase>-baseline-state-SHA256SUMS`, binding the exact named
+  Criterion baseline state consumed by candidate;
+- `criterion-<phase>/**/{benchmark,estimates,sample,tukey}.json` for the exact
+  nine-case matrix; candidate also retains `change/` JSON;
+- `microbench-<phase>-results.csv` and `microbench-<phase>-verdict.json`;
+- `rustbgpd-<phase>-source.tar.gz`; and
+- `microbench-<phase>-completion.txt` plus
+  `microbench-<phase>-SHA256SUMS`.
 
-- `full-daemon-baseline-environment.txt` — the recorded/current rustbgpd
-  baseline, pinned bgperf2 commit, clean states, exact base images, and profiling
-  image content digest;
-- `bgperf2-source-fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9.tar.gz` — exact
-  source tree for the pinned profiling adapter;
-- `full-daemon-baseline-image-inspect.json` plus
-  `full-daemon-baseline-{identity-validation,builder-provenance,
-  runtime-provenance,binary-sha256,image-validation,running-image}.txt` —
-  build/run identity, compiler/Cargo/protoc/package provenance, exact OCI
-  revision/base labels, and proof that the running container used the validated
-  image digest;
-- `full-daemon-baseline-source-sha256.txt` — relative-path hashes for the exact
-  baseline rustbgpd archive and pinned bgperf2 archive (the candidate phase adds
-  its distinct rustbgpd archive). The selected rustbgpd archive is also the
-  Docker build context; the mutable checkout is never copied into the image;
-- `full-daemon-baseline-host-preflight.tsv` — the retained idle/load,
-  all-CPU-governor, and competing-process fence before the build and again
-  before bgperf starts, under the shared host lock;
-- `full-daemon-baseline-config.toml` plus
-  `full-daemon-baseline-{event-history-config,profile-ready,
-  processes-pre-attach}.txt` — the generated daemon config, explicit
-  EHM-enabled excerpt, and stopped pre-exec profiler barrier;
-- `full-daemon-baseline-scenario.yaml`, raw `bgperf.log` and time series,
-  normalized `bgperf-result.csv`, and `bgperf-validation.txt` — the generated
-  scenario plus fail-closed proof of exactly 2 BIRD peers x 100k prefixes and
-  `required=received=200000`;
-- `full-daemon-baseline-tester-logs/{10.10.0.3,10.10.0.4}.log` — copies from
-  this exact custom bgperf run. The validator requires the source directory's
-  complete `*.log` inventory to contain exactly those two regular, non-symlink
-  names, verifies the copies are byte-identical, and records their hashes. Any
-  case-sensitive `RMT` line other than a `NEXT_HOP` diagnostic fails the
-  receipt. The adapter's tester-error value remains in the raw log and is
-  recorded as ignored in validator output because it can describe stale
-  `/tmp/bgperf2` logs; the normalized CSV contains the run-scoped verdict. The
-  pinned BIRD adapter exposes no timeout detector, so its structural zero
-  timeout field is retained but is not claimed as evidence. The run receipt,
-  tester directories, and source/retained scenario paths reject symlink
-  components, and the scenario copy is byte-bound to the exact run;
-- `full-daemon-baseline-{metrics,docker-stats}.txt` and
-  `full-daemon-baseline-rustbgpd.log` — post-drain outbox integrity/health and
-  resource snapshot;
-- `full-daemon-baseline-ehm.perf.data`,
-  `full-daemon-baseline-ehm.perf-report.txt`, and
-  `full-daemon-baseline-ehm.perf-script.txt` — raw and inspectable daemon
-  profiles used for the 5% RIB-actor attribution gate.
-- `full-daemon-baseline-completion.txt` and
-  `full-daemon-baseline-SHA256SUMS` — the success sentinel written only after
-  all convergence, outbox, resource, and perf checks, plus an aggregate
-  relative-path manifest for every phase-prefixed file and exact source
-  archive. Both are required for a complete receipt.
+A phase is complete only when `matrix_complete=1` is present and its manifest
+verifies from this directory:
 
-The later offload measurement uses the same manifest with
-`full-daemon-candidate-` prefixes. It is not a proceed-gate baseline and the
-driver rejects it unless its recorded commit differs from the baseline.
+```bash
+sha256sum --check microbench-baseline-SHA256SUMS
+sha256sum --check microbench-candidate-SHA256SUMS
+```
 
-Do not add hand-written result JSON here. Criterion and perf outputs are the
-source of truth; the Markdown receipt only summarizes them.
+## Full-daemon profiles
+
+Each of `baseline-enabled`, `baseline-disabled`, `candidate-enabled`, and
+`candidate-disabled` has a `full-daemon-<profile>-` prefix and retains:
+
+- exact source and pinned bgperf2 archive hashes;
+- safe host fingerprint/toolchain, load/governor/process preflight, OCI image
+  inspection, binary hashes, and builder/runtime package provenance;
+- exact generated scenario/config and explicit enabled/disabled EHM verdict;
+- raw bgperf log/time series, normalized finite-value result CSV, two exact
+  run-scoped BIRD logs, and validator output;
+- post-drain metrics, resource snapshot, daemon log, and cursor/drop/degraded
+  checks;
+- sanitized perf report/script, machine attribution JSON/validation, and the
+  private raw perf capture's SHA-256;
+- after each disabled profile, an overall baseline-proceed or
+  candidate-acceptance verdict combining Criterion, attribution, and disabled
+  CPU/RSS; and
+- completion sentinel plus aggregate phase `SHA256SUMS`.
+
+The baseline/candidate source archives and pinned bgperf2 archive are created
+once. Later profiles regenerate them only into temporary files and must prove
+byte identity, so no file already bound by an earlier manifest is replaced.
+
+Raw `perf.data` is intentionally not publication material. It remains under
+`target/lan393-private-perf/`; the public receipt binds its digest and retains
+the sanitized, classifiable derivatives.
+
+Verify a profile from this directory, for example:
+
+```bash
+sha256sum --check full-daemon-baseline-enabled-SHA256SUMS
+```
+
+## Privacy
+
+Do not add hand-written result JSON or unsanitized raw data. Public artifacts
+must not contain remote URLs/credentials, usernames, host paths, lock paths,
+PIDs, argv, environment dumps, raw Cargo JSON, raw perf script, or `perf.data`.
+The drivers run a final privacy scan before writing a checksummed completion.

--- a/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
+++ b/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Profiling-only bgperf2 entrypoint for the LAN-393 proceed gate.
+set -eu
+
+case "${1:-}" in
+    -* | "")
+        exec /usr/local/bin/rustbgpd.real "$@"
+        ;;
+esac
+
+config=$1
+if ! grep -q '^\[event_history\]$' "$config"; then
+    cat >>"$config" <<'EOF'
+
+[event_history]
+enabled = true
+required = true
+path = "/var/lib/rustbgpd/events.db"
+synchronous = "full"
+queue_capacity = 262144
+EOF
+fi
+
+# bgperf2 launches this entrypoint through `docker exec`, so the container init
+# PID is not the daemon PID. Stop this exec process at a host-visible barrier;
+# the receipt attaches perf to it and sends SIGCONT. The subsequent exec keeps
+# the same host PID while replacing this shell with the real daemon.
+printf '%s\n' "$$" >"$(dirname "$config")/lan393-profile-ready"
+kill -STOP "$$"
+exec /usr/local/bin/rustbgpd.real "$@"

--- a/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
+++ b/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
@@ -9,8 +9,14 @@ case "${1:-}" in
 esac
 
 config=$1
-if ! grep -q '^\[event_history\]$' "$config"; then
-    cat >>"$config" <<'EOF'
+mode=${LAN393_EVENT_HISTORY_MODE:-}
+case "$mode" in
+    enabled)
+        if grep -q '^\[event_history\]$' "$config"; then
+            printf '%s\n' 'event_history block unexpectedly supplied by bgperf2' >&2
+            exit 1
+        fi
+        cat >>"$config" <<'EOF'
 
 [event_history]
 enabled = true
@@ -19,7 +25,18 @@ path = "/var/lib/rustbgpd/events.db"
 synchronous = "full"
 queue_capacity = 262144
 EOF
-fi
+        ;;
+    disabled)
+        if grep -q '^\[event_history\]$' "$config"; then
+            printf '%s\n' 'disabled profile contains an event_history block' >&2
+            exit 1
+        fi
+        ;;
+    *)
+        printf 'LAN393_EVENT_HISTORY_MODE must be enabled or disabled, got %s\n' "$mode" >&2
+        exit 2
+        ;;
+esac
 
 # bgperf2 launches this entrypoint through `docker exec`, so the container init
 # PID is not the daemon PID. Stop this exec process at a host-visible barrier;

--- a/docs/perf/event-history-producer-2026-07.md
+++ b/docs/perf/event-history-producer-2026-07.md
@@ -132,9 +132,12 @@ makes no independent zero-timeout claim.
 Perf attaches before the stopped wrapper execs the daemon. Raw `perf.data`
 remains under `target/lan393-private-perf/` and is represented in the public
 receipt by its SHA-256. The retained report and script have host paths and
-PID/TID/timestamps sanitized. `validate-lan393-perf.py` classifies sanitized
-stacks and emits the exact RIB-manager denominator, EHM producer numerator,
-percentage, and 5% baseline proceed verdict.
+PID/TID/timestamps sanitized. The wrapper's raw PID-bearing readiness barrier
+also remains there; the public receipt retains only `barrier_reached=1` after
+matching it to the namespace identity of the stopped host process.
+`validate-lan393-perf.py` classifies sanitized stacks and emits the exact
+RIB-manager denominator, EHM producer numerator, percentage, and 5% baseline
+proceed verdict.
 
 ## Privacy and artifact contract
 

--- a/docs/perf/event-history-producer-2026-07.md
+++ b/docs/perf/event-history-producer-2026-07.md
@@ -1,642 +1,177 @@
 # LAN-393 event-history producer measurement gate
 
-Status: **harness implemented; measurements pending**. Do not begin the
-offload implementation until the baseline below is captured on an otherwise
-idle host and the proceed gate passes.
+Status: **harness implemented; measurements pending**. Do not implement the
+producer offload until the baseline proceed gate below is captured on an idle
+host and passes.
 
-This receipt separates the two costs that the existing bgperf2 comparison
-combines:
+The Criterion harness separates two costs:
 
-- `lan393_manager_self_time` times only the synchronous
-  `RibManager::publish_*` call. `noop` is the default-disabled sink; `ehm` is
-  the production EHM sink, including route/EVPN proto conversion, prost
-  encoding, index-string construction, and non-blocking queue enqueue. Every
-  noop case finishes before EHM is started. For enabled cases, committed-cursor
-  fences and health checks are Criterion setup and are not timed.
+- `lan393_manager_self_time` measures the synchronous `RibManager::publish_*`
+  phase. `noop` is the default-disabled sink. `ehm` is the production EHM sink,
+  including route/EVPN conversion, prost encoding, index construction, and the
+  bounded non-blocking enqueue.
 - `lan393_sqlite_end_to_end` starts at the same manager helper and stops after
-  all 256 events arrive on EHM's post-commit broadcast. It therefore includes
-  the manager phase, EHM queue, SQLite `synchronous=FULL` batch commit, durable
-  cursor allocation, and committed-event delivery.
+  all 256 events are durably committed and observed on EHM's post-commit
+  broadcast.
 
-Both modes cover route-added, route-policy-filtered, and realistic EVPN
-best-change events. Every timed iteration uses 256 owned events. Criterion uses
-`BatchSize::PerIteration`, and the 4096-entry EHM queue is fenced empty before
-every enabled iteration. The manager benchmark also waits for the previous
-iteration's last cursor to be committed before starting another sample; queue
-capacity alone is not treated as proof of a SQLite commit. Any
-queue-full/closed/database drop exposed by the outbox metrics, degraded-state
-transition, timeout, broadcast lag, or non-contiguous cursor fails the
-benchmark rather than producing a deceptively fast result. After shutdown, the
-benchmark re-reads the exposed degraded/drop/cursor signals. The production
-shutdown API is best-effort and returns no storage result, so this harness does
-not claim to prove that an otherwise-unreported final sidecar flush or WAL
-checkpoint succeeded.
+Every enabled iteration begins with an empty queue and a committed-cursor
+fence. Queue-full/closed/database drops, degraded state, timeouts, broadcast
+lag, or a non-contiguous cursor fail the benchmark. Noop cases run before EHM
+starts, so SQLite work cannot contaminate the disabled/default samples.
 
-## Reproduce
+## Exact Criterion driver
 
-Run from the repository root. Keep the target directory explicit so the exact
-Criterion JSON copied below cannot be confused with another worktree's build.
+Use the checked-in driver; do not reproduce its steps by hand.
 
 ```bash
-set -euo pipefail
+# After this harness commit is merged to current origin/main:
+docs/perf/run-lan393-criterion.sh baseline
 
-export CARGO_TARGET_DIR="$PWD/target/lan393"
-export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
-HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
-# shellcheck source=docs/perf/lan393-host-fence.sh
-source "$HOST_FENCE"
-lan393_acquire_host_lock
-BASELINE_REF=${BASELINE_REF:-origin/main}
-BASELINE_COMMIT=$(git rev-parse HEAD)
-BASELINE_REF_COMMIT=$(git rev-parse "$BASELINE_REF^{commit}")
-if [ "$BASELINE_COMMIT" != "$BASELINE_REF_COMMIT" ]; then
-  printf 'baseline HEAD %s does not match %s at %s\n' \
-    "$BASELINE_COMMIT" "$BASELINE_REF" "$BASELINE_REF_COMMIT" >&2
-  exit 1
-fi
-BASELINE_STATUS=$(git status --porcelain=v1 --untracked-files=all)
-if [ -n "$BASELINE_STATUS" ]; then
-  printf '%s\n' "refusing dirty baseline source tree:" >&2
-  printf '%s\n' "$BASELINE_STATUS" >&2
-  exit 1
-fi
-if [ -d "$ARTIFACT_DIR" ]; then
-  EXISTING_ARTIFACT=$(find "$ARTIFACT_DIR" -mindepth 1 \
-    ! -name README.md -print -quit)
-  if [ -n "$EXISTING_ARTIFACT" ]; then
-    printf 'refusing nonempty artifact directory: %s\n' \
-      "$EXISTING_ARTIFACT" >&2
-    exit 1
-  fi
-fi
-rm -rf "$ARTIFACT_DIR/criterion"
-mkdir -p "$ARTIFACT_DIR/criterion"
-HOST_PREFLIGHT="$ARTIFACT_DIR/microbench-baseline-host-preflight.tsv"
-lan393_init_host_preflight_log "$HOST_PREFLIGHT"
-BASELINE_TOOLCHAIN="$ARTIFACT_DIR/microbench-baseline-toolchain.txt"
-{
-  rustc -Vv
-  cargo -Vv
-  protoc --version
-} > "$BASELINE_TOOLCHAIN"
-BASELINE_TOOLCHAIN_SHA256=$(sha256sum "$BASELINE_TOOLCHAIN" | awk '{print $1}')
-
-{
-  printf 'baseline_commit=%s\n' "$BASELINE_COMMIT"
-  printf 'baseline_ref=%s\n' "$BASELINE_REF"
-  printf 'baseline_ref_commit=%s\n' "$BASELINE_REF_COMMIT"
-  printf 'baseline_remote=%s\n' "$(git remote get-url origin)"
-  printf 'baseline_status=%s\n' "$BASELINE_STATUS"
-  printf 'toolchain_receipt=%s\n' "$(basename "$BASELINE_TOOLCHAIN")"
-  printf 'toolchain_sha256=%s\n' "$BASELINE_TOOLCHAIN_SHA256"
-  uname -a
-  lscpu
-  findmnt -T "$PWD" -o TARGET,SOURCE,FSTYPE,OPTIONS
-  findmnt -T /tmp -o TARGET,SOURCE,FSTYPE,OPTIONS
-  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
-  printf 'host_lock_acquired=1\n'
-  printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
-  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
-  printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
-  printf 'required_governor=performance\n'
-} > "$ARTIFACT_DIR/environment.txt"
-
-git archive --format=tar.gz \
-  --output "$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz" \
-  "$BASELINE_COMMIT"
-( cd "$ARTIFACT_DIR" && \
-  sha256sum rustbgpd-baseline-source.tar.gz > source-sha256.txt )
-
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  --no-run
-
-lan393_wait_for_idle baseline-manager "$HOST_PREFLIGHT"
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  -- lan393_manager_self_time \
-  --save-baseline origin-main
-
-lan393_wait_for_idle baseline-sqlite "$HOST_PREFLIGHT"
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  -- lan393_sqlite_end_to_end \
-  --save-baseline origin-main
-
-cp -a \
-  "$CARGO_TARGET_DIR/criterion/lan393_manager_self_time" \
-  "$CARGO_TARGET_DIR/criterion/lan393_sqlite_end_to_end" \
-  "$ARTIFACT_DIR/criterion/"
+# Only after an offload candidate exists on a clean descendant commit:
+docs/perf/run-lan393-criterion.sh candidate
 ```
 
-Those commands are the pre-offload harness run, whose production behavior must
-still match current main. Preserve that target directory: the named
-`origin-main` samples under it are what Criterion compares against.
-The sourced host fence holds the same nonblocking
-`${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` used by the other
-retained rustbgpd performance drivers. After the locked warm build and before
-each Criterion group, it records every poll and requires one-minute load below
-the fixed 2.0 ceiling, no competing Cargo/rustc/rustbgpd benchmark/perf
-process, and
-`performance` on every available CPU governor. A timeout exits 75 instead of
-emitting a publishable-looking noisy sample.
-The baseline retains exact `rustc -Vv`, `cargo -Vv`, and `protoc --version`
-output. The candidate captures the same receipt and byte-compares it before
-building, so a compiler/toolchain change cannot masquerade as an offload gain.
+The driver fixes the baseline to `refs/remotes/origin/main`, requires the
+invoking checkout to be clean outside the receipt directory, and resolves both
+revisions to exact 40-character commits. It creates detached worktrees, uses a
+separate Cargo target for each revision, and shares only an explicit Criterion
+state directory. The baseline state is checksummed immediately after capture
+and reverified immediately before a candidate run. Candidate measurement stops
+if the baseline state, host fingerprint, toolchain, Cargo-home config, hashed
+build environment, or any measurement-harness file changed. The saved baseline
+bytes are reverified again after candidate measurement.
 
-On the candidate commit, use `--baseline origin-main` (not
-`--save-baseline lan393-offload`) so Criterion actually performs the
-before/after comparison:
+The warm build uses `--locked`, disables Cargo incremental compilation,
+rejects `RUSTFLAGS`, compiler wrappers, and Cargo profile/target rustflag
+overrides, selects exactly one benchmark executable from Cargo JSON, proves it
+is inside the phase target, and records its basename and SHA-256. Raw Cargo JSON
+and absolute executable paths are temporary and are never publication
+artifacts.
+
+Both phases acquire the shared non-blocking rustbgpd host lock before building.
+Before each retained Criterion group, the fixed host fence records every poll
+and requires:
+
+- one-minute load below 2.0;
+- `performance` on every available CPU governor; and
+- no concurrent Cargo, rustc, perf, rustbgpd, bgperf2, or known repository
+  benchmark process.
+
+The retained process field contains executable names only—never PID or argv.
+A timeout exits 75. The driver writes a completion sentinel and aggregate
+relative-path `SHA256SUMS` only after exact-matrix parsing, machine gating, and
+the privacy scan pass.
+
+## Machine gates
+
+`validate-lan393-criterion.py` requires exactly these nine cases and rejects
+missing, duplicate, extra, malformed, non-finite, non-positive, or non-95%-CI
+estimates:
+
+- manager route-added, route-policy-filtered, and EVPN-best-changed, each with
+  `noop` and `ehm`;
+- SQLite end-to-end for the same three shapes.
+
+The baseline manager proceed gate requires EHM to be at least 25% slower than
+noop, with non-overlapping mean confidence intervals, in at least two shapes.
+The separate enabled full-daemon profile must additionally attribute at least
+5% of RIB-manager samples to EHM producer conversion/encoding work.
+
+The candidate Criterion gate requires, for every shape:
+
+- EHM-enabled manager time at least 50% lower, with the candidate CI entirely
+  below baseline;
+- noop/default-disabled regression below 3%, with overlapping CIs; and
+- SQLite end-to-end regression below 5%, with overlapping CIs whenever the
+  point estimate regresses; a statistically separated improvement is allowed.
+
+The validator emits machine-readable `results.csv` and `verdict.json`. A
+no-proceed baseline or rejected candidate remains publishable evidence; the
+verdict says it failed and implementation stops.
+
+## Full-daemon profiles
+
+Run the four profiles in this order:
 
 ```bash
-set -euo pipefail
+docs/perf/run-lan393-full-daemon.sh baseline-enabled
+docs/perf/run-lan393-full-daemon.sh baseline-disabled
 
-export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$PWD/target/lan393"}
-export ARTIFACT_DIR=${ARTIFACT_DIR:-"$PWD/docs/perf/artifacts/event-history-producer-2026-07"}
-HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
-# shellcheck source=docs/perf/lan393-host-fence.sh
-source "$HOST_FENCE"
-lan393_acquire_host_lock
-CANDIDATE_COMMIT=$(git rev-parse HEAD)
-RECORDED_BASELINE_COMMIT=$(awk -F= \
-  '$1 == "baseline_commit" { print $2 }' \
-  "$ARTIFACT_DIR/environment.txt")
-test -n "$RECORDED_BASELINE_COMMIT"
-if [ "$CANDIDATE_COMMIT" = "$RECORDED_BASELINE_COMMIT" ]; then
-  printf '%s\n' "candidate commit matches recorded baseline" >&2
-  exit 1
-fi
-if ! git merge-base --is-ancestor \
-  "$RECORDED_BASELINE_COMMIT" "$CANDIDATE_COMMIT"; then
-  printf 'recorded baseline is not an ancestor of candidate: %s !<= %s\n' \
-    "$RECORDED_BASELINE_COMMIT" "$CANDIDATE_COMMIT" >&2
-  exit 1
-fi
-CANDIDATE_STATUS=$(git status --porcelain=v1 --untracked-files=all \
-  -- . \
-  ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
-CANDIDATE_ARTIFACT_STATUS=$(git status --porcelain=v1 --untracked-files=all \
-  -- docs/perf/artifacts/event-history-producer-2026-07)
-if [ -n "$CANDIDATE_STATUS" ]; then
-  printf '%s\n' "refusing dirty candidate source tree:" >&2
-  printf '%s\n' "$CANDIDATE_STATUS" >&2
-  exit 1
-fi
-HOST_PREFLIGHT="$ARTIFACT_DIR/microbench-candidate-host-preflight.tsv"
-lan393_init_host_preflight_log "$HOST_PREFLIGHT"
-BASELINE_TOOLCHAIN="$ARTIFACT_DIR/microbench-baseline-toolchain.txt"
-if [ ! -f "$BASELINE_TOOLCHAIN" ] || [ -L "$BASELINE_TOOLCHAIN" ]; then
-  printf 'missing regular baseline toolchain receipt: %s\n' \
-    "$BASELINE_TOOLCHAIN" >&2
-  exit 1
-fi
-CANDIDATE_TOOLCHAIN="$ARTIFACT_DIR/microbench-candidate-toolchain.txt"
-CANDIDATE_TOOLCHAIN_TMP=$(mktemp "$ARTIFACT_DIR/.candidate-toolchain.XXXXXX")
-{
-  rustc -Vv
-  cargo -Vv
-  protoc --version
-} > "$CANDIDATE_TOOLCHAIN_TMP"
-if ! cmp --silent "$BASELINE_TOOLCHAIN" "$CANDIDATE_TOOLCHAIN_TMP"; then
-  printf '%s\n' 'candidate toolchain differs from retained baseline' >&2
-  diff -u "$BASELINE_TOOLCHAIN" "$CANDIDATE_TOOLCHAIN_TMP" >&2 || true
-  rm -f "$CANDIDATE_TOOLCHAIN_TMP"
-  exit 1
-fi
-mv "$CANDIDATE_TOOLCHAIN_TMP" "$CANDIDATE_TOOLCHAIN"
-CANDIDATE_TOOLCHAIN_SHA256=$(sha256sum "$CANDIDATE_TOOLCHAIN" | awk '{print $1}')
-{
-  printf 'candidate_commit=%s\n' "$CANDIDATE_COMMIT"
-  printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
-  printf 'candidate_baseline_ancestor=true\n'
-  printf 'candidate_remote=%s\n' "$(git remote get-url origin)"
-  printf 'candidate_status=%s\n' "$CANDIDATE_STATUS"
-  printf 'preexisting_artifact_status=%s\n' "$CANDIDATE_ARTIFACT_STATUS"
-  printf 'toolchain_receipt=%s\n' "$(basename "$CANDIDATE_TOOLCHAIN")"
-  printf 'toolchain_sha256=%s\n' "$CANDIDATE_TOOLCHAIN_SHA256"
-  printf 'baseline_toolchain_match=1\n'
-  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
-  printf 'host_lock_acquired=1\n'
-  printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
-  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
-  printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
-  printf 'required_governor=performance\n'
-} > "$ARTIFACT_DIR/candidate-environment.txt"
-git archive --format=tar.gz \
-  --output "$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz" \
-  "$CANDIDATE_COMMIT"
-( cd "$ARTIFACT_DIR" && \
-  sha256sum rustbgpd-baseline-source.tar.gz \
-    rustbgpd-candidate-source.tar.gz > source-sha256.txt )
-
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  --no-run
-
-lan393_wait_for_idle candidate-manager "$HOST_PREFLIGHT"
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  -- lan393_manager_self_time \
-  --baseline origin-main
-
-lan393_wait_for_idle candidate-sqlite "$HOST_PREFLIGHT"
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  -- lan393_sqlite_end_to_end \
-  --baseline origin-main
-
-rm -rf "$ARTIFACT_DIR/criterion-comparison"
-mkdir -p "$ARTIFACT_DIR/criterion-comparison"
-cp -a \
-  "$CARGO_TARGET_DIR/criterion/lan393_manager_self_time" \
-  "$CARGO_TARGET_DIR/criterion/lan393_sqlite_end_to_end" \
-  "$ARTIFACT_DIR/criterion-comparison/"
-
-find "$ARTIFACT_DIR/criterion-comparison" \
-  -path '*/change/estimates.json' -print | sort
+# After the candidate Criterion run passes:
+docs/perf/run-lan393-full-daemon.sh candidate-enabled
+docs/perf/run-lan393-full-daemon.sh candidate-disabled
 ```
 
-The candidate estimates are retained in each case's `new/estimates.json`; the
-comparison against `origin-main` is in `change/estimates.json`. Copy those
-directories before any optional later `--save-baseline` run can replace
-Criterion's `new` sample. Candidate cleanliness excludes only the receipt
-directory itself, so the retained baseline artifacts can remain present while
-any source or harness change still fails closed.
+The enabled and disabled profiles use the same exact 2-peer x 100k-prefix
+bgperf2 workload. The wrapper appends an exact required, synchronous-FULL EHM
+block only in enabled mode and fails if bgperf2 supplied its own block. Disabled
+mode requires the block to be absent, preserving shipped default behavior.
 
-Capture CPU counters after the benchmark executable is warm-built. Set
-`PERF_PHASE=baseline` for the proceed-gate evidence or `candidate` for the
-later implementation comparison. The recipe binds every output to that
-phase's exact clean commit, source archive, and byte-identical toolchain before
-building. The manager command deliberately filters to one enabled case so the
-counter and profile receipts are not blended with the no-op baseline.
+The full-daemon driver builds only from the retained exact-commit archive. It
+pins bgperf2 at `fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9`, pins the Rust and
+Debian base-image digests, uses Cargo `--locked`, verifies OCI revision/mode
+labels and the running image ID, retains binary and package inventories, and
+requires every later profile's builder/runtime inventory and host tools to
+match `baseline-enabled` after excluding only the expected rustbgpd commit
+line. Exact source archives are established once and later profiles prove byte
+identity without overwriting them; enabled and disabled builds of the same
+source must also have identical binary checksums. The driver byte-matches the
+phase's safe host fingerprint to its Criterion receipt.
 
-```bash
-set -euo pipefail
+The validator rejects a failed or wrong workload, anything other than exactly
+200,000/200,000 routes, malformed/non-finite/negative CPU/RSS/timing fields,
+unexpected scenario keys, tester-log inventory drift, BIRD `RMT` diagnostics
+other than `NEXT_HOP`, outbox drops/degradation/cursor gaps, and nonzero drained
+queue depth. Enabled mode requires committed count and latest cursor to agree;
+disabled mode requires both to remain zero.
 
-export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$PWD/target/lan393"}
-export ARTIFACT_DIR=${ARTIFACT_DIR:-"$PWD/docs/perf/artifacts/event-history-producer-2026-07"}
-: "${PERF_PHASE:?set PERF_PHASE to baseline or candidate}"
-case "$PERF_PHASE" in
-  baseline)
-    IDENTITY_FILE="$ARTIFACT_DIR/environment.txt"
-    IDENTITY_KEY=baseline_commit
-    PERF_SOURCE_ARCHIVE="$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz"
-    ;;
-  candidate)
-    IDENTITY_FILE="$ARTIFACT_DIR/candidate-environment.txt"
-    IDENTITY_KEY=candidate_commit
-    PERF_SOURCE_ARCHIVE="$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz"
-    ;;
-  *)
-    printf 'PERF_PHASE must be baseline or candidate, got %s\n' \
-      "$PERF_PHASE" >&2
-    exit 2
-    ;;
-esac
+The pinned BIRD adapter has no timeout detector. Its compatibility field must
+be zero, but the receipt explicitly records timeout evidence as unsupported and
+makes no independent zero-timeout claim.
 
-read_receipt_value() {
-  awk -F= -v key="$2" \
-    '$1 == key { sub(/^[^=]*=/, ""); print; found = 1 }
-     END { if (!found) exit 1 }' "$1"
-}
+Perf attaches before the stopped wrapper execs the daemon. Raw `perf.data`
+remains under `target/lan393-private-perf/` and is represented in the public
+receipt by its SHA-256. The retained report and script have host paths and
+PID/TID/timestamps sanitized. `validate-lan393-perf.py` classifies sanitized
+stacks and emits the exact RIB-manager denominator, EHM producer numerator,
+percentage, and 5% baseline proceed verdict.
 
-test -f "$IDENTITY_FILE" && test ! -L "$IDENTITY_FILE"
-EXPECTED_COMMIT=$(read_receipt_value "$IDENTITY_FILE" "$IDENTITY_KEY")
-if [[ ! "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
-  printf 'invalid %s in %s: %s\n' \
-    "$IDENTITY_KEY" "$IDENTITY_FILE" "$EXPECTED_COMMIT" >&2
-  exit 1
-fi
-test "$(git rev-parse "$EXPECTED_COMMIT^{commit}")" = "$EXPECTED_COMMIT"
-test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
+## Privacy and artifact contract
 
-if [ "$PERF_PHASE" = candidate ]; then
-  RECORDED_BASELINE_COMMIT=$(read_receipt_value \
-    "$IDENTITY_FILE" recorded_baseline_commit)
-  test "$RECORDED_BASELINE_COMMIT" = \
-    "$(read_receipt_value "$ARTIFACT_DIR/environment.txt" baseline_commit)"
-  git merge-base --is-ancestor \
-    "$RECORDED_BASELINE_COMMIT" "$EXPECTED_COMMIT"
-fi
+Publication artifacts never contain:
 
-PERF_SOURCE_STATUS=$(git status --porcelain=v1 --untracked-files=all \
-  -- . \
-  ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
-if [ -n "$PERF_SOURCE_STATUS" ]; then
-  printf '%s\n' "refusing dirty $PERF_PHASE perf source tree:" >&2
-  printf '%s\n' "$PERF_SOURCE_STATUS" >&2
-  exit 1
-fi
-test -f "$PERF_SOURCE_ARCHIVE" && test ! -L "$PERF_SOURCE_ARCHIVE"
-ARCHIVE_CHECK=$(mktemp /tmp/lan393-perf-source.XXXXXX.tar.gz)
-git archive --format=tar.gz --output "$ARCHIVE_CHECK" "$EXPECTED_COMMIT"
-if ! cmp --silent "$ARCHIVE_CHECK" "$PERF_SOURCE_ARCHIVE"; then
-  rm -f "$ARCHIVE_CHECK"
-  printf 'retained %s source archive does not match %s\n' \
-    "$PERF_PHASE" "$EXPECTED_COMMIT" >&2
-  exit 1
-fi
-rm -f "$ARCHIVE_CHECK"
+- remote URLs or credentials;
+- usernames, home/worktree/target paths, or lock-file paths;
+- PIDs, raw process arguments, or an environment dump; or
+- unsanitized Cargo JSON, perf script, or `perf.data`.
 
-HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
-# shellcheck source=docs/perf/lan393-host-fence.sh
-source "$HOST_FENCE"
-lan393_acquire_host_lock
-PHASE_TOOLCHAIN="$ARTIFACT_DIR/microbench-$PERF_PHASE-toolchain.txt"
-test -f "$PHASE_TOOLCHAIN" && test ! -L "$PHASE_TOOLCHAIN"
-CURRENT_TOOLCHAIN=$(mktemp /tmp/lan393-perf-toolchain.XXXXXX)
-{
-  rustc -Vv
-  cargo -Vv
-  protoc --version
-} > "$CURRENT_TOOLCHAIN"
-if ! cmp --silent "$PHASE_TOOLCHAIN" "$CURRENT_TOOLCHAIN"; then
-  diff -u "$PHASE_TOOLCHAIN" "$CURRENT_TOOLCHAIN" >&2 || true
-  rm -f "$CURRENT_TOOLCHAIN"
-  printf '%s\n' "current toolchain differs from $PERF_PHASE receipt" >&2
-  exit 1
-fi
-rm -f "$CURRENT_TOOLCHAIN"
+They retain the canonical repository slug, exact commits, source archives,
+privacy-safe hardware fingerprint, tool/package hashes, normalized process
+names, commands encoded by the checked-in drivers, machine results/verdicts,
+completion sentinels, and phase manifests. The source archives are exact Git
+objects and are not treated as host metadata.
 
-PERF_PREFIX="$ARTIFACT_DIR/microbench-$PERF_PHASE-perf"
-PERF_ENVIRONMENT="$PERF_PREFIX-environment.txt"
-PERF_HOST_PREFLIGHT="$PERF_PREFIX-host-preflight.tsv"
-BENCH_BUILD="$PERF_PREFIX-bench-build.jsonl"
-PERF_STAT="$PERF_PREFIX-stat.csv"
-PERF_DATA="$PERF_PREFIX.data"
-PERF_REPORT="$PERF_PREFIX-report.txt"
-PERF_COMPLETION="$PERF_PREFIX-completion.txt"
-PERF_MANIFEST="$PERF_PREFIX-SHA256SUMS"
-for OUTPUT in \
-  "$PERF_ENVIRONMENT" "$PERF_HOST_PREFLIGHT" "$BENCH_BUILD" \
-  "$PERF_STAT" "$PERF_DATA" "$PERF_REPORT" "$PERF_COMPLETION" \
-  "$PERF_MANIFEST"; do
-  if [ -e "$OUTPUT" ]; then
-    printf 'refusing existing %s perf receipt: %s\n' \
-      "$PERF_PHASE" "$OUTPUT" >&2
-    exit 1
-  fi
-done
-lan393_init_host_preflight_log "$PERF_HOST_PREFLIGHT"
+See `docs/perf/artifacts/event-history-producer-2026-07/README.md` for the exact
+file inventory and offline checksum rules.
 
-cargo bench -p rustbgpd-api \
-  --features bench-internals \
-  --bench event_history_producer \
-  --locked \
-  --no-run \
-  --message-format=json \
-  > "$BENCH_BUILD"
+## Stop conditions
 
-BENCH_BIN=$(
-  python3 - "$BENCH_BUILD" <<'PY'
-import json
-import sys
+Stop or record a no-proceed/rejected verdict when:
 
-executables = set()
-with open(sys.argv[1], encoding="utf-8") as messages:
-    for line in messages:
-        message = json.loads(line)
-        target = message.get("target", {})
-        executable = message.get("executable")
-        if (
-            message.get("reason") == "compiler-artifact"
-            and target.get("name") == "event_history_producer"
-            and "bench" in target.get("kind", [])
-            and executable
-        ):
-            executables.add(executable)
+- exact source identity, ancestry, detached worktree, or saved Criterion state
+  cannot be proven;
+- source is dirty, the harness changed, or host/toolchain/Cargo/package inputs
+  differ;
+- the shared lock is busy, load/governor/process preflight times out, or any
+  matrix/profile is partial;
+- parsing, finite-value, privacy, completion, or checksum validation fails;
+- baseline manager or full-daemon attribution misses its proceed gate;
+- candidate manager/default/SQLite gates miss their acceptance bounds; or
+- the eventual offload cannot preserve order, producer timestamps, durable
+  payload bytes, cursor IDs, bounded non-blocking enqueue, queue-full/closed
+  counters, degraded state, shutdown drain, and legacy ring/broadcast behavior.
 
-if len(executables) != 1:
-    raise SystemExit(
-        f"expected exactly one event_history_producer bench executable, got {sorted(executables)!r}"
-    )
-print(executables.pop())
-PY
-)
-test -x "$BENCH_BIN"
+## Results
 
-{
-  printf 'profile_phase=%s\n' "$PERF_PHASE"
-  printf 'expected_commit=%s\n' "$EXPECTED_COMMIT"
-  printf 'source_head=%s\n' "$(git rev-parse HEAD)"
-  printf 'source_status=%s\n' "$PERF_SOURCE_STATUS"
-  printf 'identity_receipt=%s\n' "$(basename "$IDENTITY_FILE")"
-  printf 'source_archive=%s\n' "$(basename "$PERF_SOURCE_ARCHIVE")"
-  printf 'source_archive_sha256=%s\n' \
-    "$(sha256sum "$PERF_SOURCE_ARCHIVE" | awk '{print $1}')"
-  printf 'toolchain_receipt=%s\n' "$(basename "$PHASE_TOOLCHAIN")"
-  printf 'toolchain_sha256=%s\n' \
-    "$(sha256sum "$PHASE_TOOLCHAIN" | awk '{print $1}')"
-  printf 'bench_binary=%s\n' "$BENCH_BIN"
-  printf 'bench_binary_sha256=%s\n' \
-    "$(sha256sum "$BENCH_BIN" | awk '{print $1}')"
-  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
-  printf 'host_lock_acquired=1\n'
-  printf 'host_preflight=%s\n' "$(basename "$PERF_HOST_PREFLIGHT")"
-  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
-  printf 'required_governor=performance\n'
-} > "$PERF_ENVIRONMENT"
-
-lan393_wait_for_idle "$PERF_PHASE-perf-stat" "$PERF_HOST_PREFLIGHT"
-perf stat -x, \
-  -e task-clock,cycles,instructions,branches,branch-misses,cache-misses \
-  -o "$PERF_STAT" \
-  "$BENCH_BIN" --bench --exact \
-  'lan393_manager_self_time/route_added/ehm' --profile-time 30
-
-lan393_wait_for_idle "$PERF_PHASE-perf-record" "$PERF_HOST_PREFLIGHT"
-perf record --call-graph dwarf \
-  -o "$PERF_DATA" \
-  "$BENCH_BIN" --bench --exact \
-  'lan393_manager_self_time/route_added/ehm' --profile-time 30
-
-perf report --stdio \
-  -i "$PERF_DATA" \
-  > "$PERF_REPORT"
-
-test -s "$PERF_STAT"
-test -s "$PERF_DATA"
-test -s "$PERF_REPORT"
-{
-  printf 'profile_phase=%s\n' "$PERF_PHASE"
-  printf 'expected_commit=%s\n' "$EXPECTED_COMMIT"
-  printf 'run_utc_complete=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  printf 'phase_complete=1\n'
-} > "$PERF_COMPLETION"
-(
-  cd "$ARTIFACT_DIR"
-  sha256sum \
-    "$(basename "$PERF_ENVIRONMENT")" \
-    "$(basename "$PERF_HOST_PREFLIGHT")" \
-    "$(basename "$BENCH_BUILD")" \
-    "$(basename "$PERF_STAT")" \
-    "$(basename "$PERF_DATA")" \
-    "$(basename "$PERF_REPORT")" \
-    "$(basename "$PERF_COMPLETION")" \
-    "$(basename "$PHASE_TOOLCHAIN")" \
-    "$(basename "$PERF_SOURCE_ARCHIVE")" \
-    > "$(basename "$PERF_MANIFEST")"
-  sha256sum --check "$(basename "$PERF_MANIFEST")" >/dev/null
-)
-```
-
-The Cargo JSON selection is intentional: hashed bench filenames are not ordered
-by freshness, so sorting `target/release/deps` can silently profile a stale
-executable. A phase receipt is complete only when its `completion.txt` and
-relative-path `SHA256SUMS` both exist and the latter verifies.
-
-## Full-daemon proceed profile
-
-The proceed gate also requires a real daemon processing a full table with EHM
-enabled. The pinned bgperf2 adapter correctly treats event history as
-opt-in/default-off and omits the block when no mode is selected. For this
-profile, the profiling-only wrapper in
-`docs/perf/bgperf-rustbgpd-ehm-wrapper.sh` is the sole authority: both adapter
-environment controls are unset, and the wrapper appends an explicit
-`[event_history]` block to bgperf2's generated config. It stops its own process
-before `exec`-ing the daemon. The host attaches `perf`, then resumes that same
-PID so recording begins before the peers can converge. It does not change the
-rustbgpd binary.
-
-The checked-in driver has two deliberately separate modes:
-
-- `baseline` is the only mode that satisfies the proceed gate. It reads the
-  exact `baseline_commit` and `baseline_ref_commit` captured in
-  `environment.txt`, requires both to agree with the clean source `HEAD`, and
-  regenerates and hashes the archive from that commit before building.
-- `candidate` is only for evaluating a later offload implementation. It reads
-  `candidate_commit` from `candidate-environment.txt`, requires the clean
-  source `HEAD` to match, and fails if the candidate equals the recorded
-  baseline. Candidate artifacts have a separate filename prefix and cannot
-  overwrite the baseline profile.
-
-Both modes clone the fork into a disposable directory at the reviewed bgperf2
-commit. The custom profiling image reproduces the adapter's digest-pinned Rust
-1.95 and Debian bases, uses `cargo --locked`, and retains the image inspection,
-content digest, binary hashes, compiler/Cargo/protoc versions, complete builder
-and runtime package inventories, and OCI revision/base labels. Before profiling,
-the driver verifies those labels against the exact rustbgpd and bgperf2 commits;
-after bgperf starts, it also verifies that the running container uses that same
-image digest. Docker's build context is an extraction of the retained
-phase-specific rustbgpd commit archive, never the mutable checkout that invoked
-the driver, so the image bytes and revision label have the same source of truth.
-Both modes also hold the shared rustbgpd host lock from before the image build
-through receipt completion. A retained TSV records the idle/load,
-all-CPU-governor, and competing-process fence before the build and again after
-the build, immediately before bgperf starts. The driver writes its completion
-sentinel only after convergence, outbox-health, resource, and perf validation;
-the final phase-specific `SHA256SUMS` binds that sentinel, every other
-phase-prefixed file, and the exact rustbgpd/bgperf2 source archives.
-
-Run the current-main proceed profile from the clean recorded baseline checkout:
-
-```bash
-set -euo pipefail
-
-export RUSTBGPD_SOURCE="$PWD"
-export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
-docs/perf/run-lan393-full-daemon.sh baseline
-```
-
-Do not use `candidate` until the current-main gate has passed and an offload
-candidate has been implemented and measured with the preceding Criterion
-comparison:
-
-```bash
-set -euo pipefail
-
-export RUSTBGPD_SOURCE="$PWD"
-export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
-docs/perf/run-lan393-full-daemon.sh candidate
-```
-
-The driver does not trust bgperf2's exit status alone. It parses the retained
-scenario and final result, rejects any `FAILED` marker, and requires exactly
-two BIRD peers with 100,000 prefixes each, `required=received=200000`, no
-policy/filter input, and the expected rustbgpd scenario identity. It also
-copies the two BIRD logs from this exact phase's custom run directory and makes
-those copies authoritative for tester errors. The pinned adapter intends an
-error to mean a case-sensitive line containing `RMT`, except lines containing
-`NEXT_HOP`; its helper accidentally reads `/tmp/bgperf2/tester` regardless of
-`--dir` and `--bench-name`, so the driver applies that rule itself to the
-run-scoped copies and records their hashes. It inventories every source
-`*.log` entry, requires exactly the two scenario peer names as regular,
-non-symlink files, and verifies the retained copies remain byte-identical;
-the run receipt, tester directories, and source/retained scenario paths reject
-symlink components, and the two scenario copies must be byte-identical. Non-log
-BIRD configuration and control-socket entries remain permitted. The
-raw bgperf log retains the adapter's tester-error field for forensic context,
-while the validator records that ignored value separately and writes the
-authoritative run-scoped verdict to the normalized CSV. A stale default
-directory therefore cannot create either a false pass or a false failure.
-
-The pinned BIRD adapter does not implement timeout detection:
-`find_timeouts()` is the base-class constant zero. The normalized CSV must
-still carry zero in that compatibility field, but the receipt labels timeout
-evidence as unsupported and makes no independent "zero BIRD timeouts" claim.
-Remote-state diagnostics that BIRD labels `RMT` are covered by the authoritative
-error rule above; timeout diagnostics without that label are not independently
-classified. The normalized result, run-scoped tester logs, their hashes, and
-validator output are retained beside the raw bgperf log and time series.
-
-Use the inclusive call stacks rooted in RIB-manager processing as the proceed
-gate denominator. The numerator is samples in `EhmRibSink`, route/EVPN proto
-conversion, prost encoding, or allocation directly owned by those frames. The
-raw `perf.data` and `perf-script.txt` make that classification reviewable; do
-not use the isolated microbenchmark profile to satisfy the full-daemon gate.
-
-## Proceed gate
-
-Implement the offload only when both conditions are true on the current-main
-baseline:
-
-1. The EHM manager phase is at least 25% slower than noop in at least two of
-   the three event shapes, with non-overlapping Criterion confidence intervals.
-2. The enabled 2-peer, 100k-prefix full-table profile above (or an equally
-   retained churn profile) attributes at least 5% of RIB-actor samples to
-   `EhmRibSink`, route/EVPN proto conversion, prost encoding, or their
-   directly-owned allocation work.
-
-If either condition fails, LAN-393 is a no-proceed: SQLite or another stage is
-the material cost and an encoder queue would add complexity without moving the
-bound.
-
-The implementation is accepted only if the candidate then demonstrates:
-
-- at least 50% lower EHM-enabled manager producer time in this harness;
-- noop/default-disabled time within 3% of baseline and overlapping confidence
-  intervals;
-- no regression in SQLite end-to-end throughput beyond the run-to-run noise
-  recorded here;
-- zero outbox drops/degraded transitions and contiguous committed cursors;
-- full-daemon enabled/disabled CPU, RSS, queue-depth, drop, and cursor-integrity
-  receipts retained alongside these microbench artifacts.
-
-## Baseline results
-
-Pending host clearance. Fill this table from Criterion's `estimates.json`; do
-not transcribe terminal-only numbers without retaining the JSON.
-
-| Mode | Event shape | Estimate | 95% CI | Events/s | Verdict |
-|---|---|---:|---:|---:|---|
-| manager/noop | route added | pending | pending | pending | pending |
-| manager/ehm | route added | pending | pending | pending | pending |
-| manager/noop | policy filtered | pending | pending | pending | pending |
-| manager/ehm | policy filtered | pending | pending | pending | pending |
-| manager/noop | EVPN best changed | pending | pending | pending | pending |
-| manager/ehm | EVPN best changed | pending | pending | pending | pending |
-| SQLite end-to-end | route added | pending | pending | pending | pending |
-| SQLite end-to-end | policy filtered | pending | pending | pending | pending |
-| SQLite end-to-end | EVPN best changed | pending | pending | pending | pending |
+Pending host clearance. Summaries must be generated from the retained CSV/JSON
+and full-daemon normalized receipts; terminal-only transcription is not valid.

--- a/docs/perf/event-history-producer-2026-07.md
+++ b/docs/perf/event-history-producer-2026-07.md
@@ -1,0 +1,642 @@
+# LAN-393 event-history producer measurement gate
+
+Status: **harness implemented; measurements pending**. Do not begin the
+offload implementation until the baseline below is captured on an otherwise
+idle host and the proceed gate passes.
+
+This receipt separates the two costs that the existing bgperf2 comparison
+combines:
+
+- `lan393_manager_self_time` times only the synchronous
+  `RibManager::publish_*` call. `noop` is the default-disabled sink; `ehm` is
+  the production EHM sink, including route/EVPN proto conversion, prost
+  encoding, index-string construction, and non-blocking queue enqueue. Every
+  noop case finishes before EHM is started. For enabled cases, committed-cursor
+  fences and health checks are Criterion setup and are not timed.
+- `lan393_sqlite_end_to_end` starts at the same manager helper and stops after
+  all 256 events arrive on EHM's post-commit broadcast. It therefore includes
+  the manager phase, EHM queue, SQLite `synchronous=FULL` batch commit, durable
+  cursor allocation, and committed-event delivery.
+
+Both modes cover route-added, route-policy-filtered, and realistic EVPN
+best-change events. Every timed iteration uses 256 owned events. Criterion uses
+`BatchSize::PerIteration`, and the 4096-entry EHM queue is fenced empty before
+every enabled iteration. The manager benchmark also waits for the previous
+iteration's last cursor to be committed before starting another sample; queue
+capacity alone is not treated as proof of a SQLite commit. Any
+queue-full/closed/database drop exposed by the outbox metrics, degraded-state
+transition, timeout, broadcast lag, or non-contiguous cursor fails the
+benchmark rather than producing a deceptively fast result. After shutdown, the
+benchmark re-reads the exposed degraded/drop/cursor signals. The production
+shutdown API is best-effort and returns no storage result, so this harness does
+not claim to prove that an otherwise-unreported final sidecar flush or WAL
+checkpoint succeeded.
+
+## Reproduce
+
+Run from the repository root. Keep the target directory explicit so the exact
+Criterion JSON copied below cannot be confused with another worktree's build.
+
+```bash
+set -euo pipefail
+
+export CARGO_TARGET_DIR="$PWD/target/lan393"
+export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
+HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$HOST_FENCE"
+lan393_acquire_host_lock
+BASELINE_REF=${BASELINE_REF:-origin/main}
+BASELINE_COMMIT=$(git rev-parse HEAD)
+BASELINE_REF_COMMIT=$(git rev-parse "$BASELINE_REF^{commit}")
+if [ "$BASELINE_COMMIT" != "$BASELINE_REF_COMMIT" ]; then
+  printf 'baseline HEAD %s does not match %s at %s\n' \
+    "$BASELINE_COMMIT" "$BASELINE_REF" "$BASELINE_REF_COMMIT" >&2
+  exit 1
+fi
+BASELINE_STATUS=$(git status --porcelain=v1 --untracked-files=all)
+if [ -n "$BASELINE_STATUS" ]; then
+  printf '%s\n' "refusing dirty baseline source tree:" >&2
+  printf '%s\n' "$BASELINE_STATUS" >&2
+  exit 1
+fi
+if [ -d "$ARTIFACT_DIR" ]; then
+  EXISTING_ARTIFACT=$(find "$ARTIFACT_DIR" -mindepth 1 \
+    ! -name README.md -print -quit)
+  if [ -n "$EXISTING_ARTIFACT" ]; then
+    printf 'refusing nonempty artifact directory: %s\n' \
+      "$EXISTING_ARTIFACT" >&2
+    exit 1
+  fi
+fi
+rm -rf "$ARTIFACT_DIR/criterion"
+mkdir -p "$ARTIFACT_DIR/criterion"
+HOST_PREFLIGHT="$ARTIFACT_DIR/microbench-baseline-host-preflight.tsv"
+lan393_init_host_preflight_log "$HOST_PREFLIGHT"
+BASELINE_TOOLCHAIN="$ARTIFACT_DIR/microbench-baseline-toolchain.txt"
+{
+  rustc -Vv
+  cargo -Vv
+  protoc --version
+} > "$BASELINE_TOOLCHAIN"
+BASELINE_TOOLCHAIN_SHA256=$(sha256sum "$BASELINE_TOOLCHAIN" | awk '{print $1}')
+
+{
+  printf 'baseline_commit=%s\n' "$BASELINE_COMMIT"
+  printf 'baseline_ref=%s\n' "$BASELINE_REF"
+  printf 'baseline_ref_commit=%s\n' "$BASELINE_REF_COMMIT"
+  printf 'baseline_remote=%s\n' "$(git remote get-url origin)"
+  printf 'baseline_status=%s\n' "$BASELINE_STATUS"
+  printf 'toolchain_receipt=%s\n' "$(basename "$BASELINE_TOOLCHAIN")"
+  printf 'toolchain_sha256=%s\n' "$BASELINE_TOOLCHAIN_SHA256"
+  uname -a
+  lscpu
+  findmnt -T "$PWD" -o TARGET,SOURCE,FSTYPE,OPTIONS
+  findmnt -T /tmp -o TARGET,SOURCE,FSTYPE,OPTIONS
+  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
+  printf 'host_lock_acquired=1\n'
+  printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
+  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+  printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
+  printf 'required_governor=performance\n'
+} > "$ARTIFACT_DIR/environment.txt"
+
+git archive --format=tar.gz \
+  --output "$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz" \
+  "$BASELINE_COMMIT"
+( cd "$ARTIFACT_DIR" && \
+  sha256sum rustbgpd-baseline-source.tar.gz > source-sha256.txt )
+
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  --no-run
+
+lan393_wait_for_idle baseline-manager "$HOST_PREFLIGHT"
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  -- lan393_manager_self_time \
+  --save-baseline origin-main
+
+lan393_wait_for_idle baseline-sqlite "$HOST_PREFLIGHT"
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  -- lan393_sqlite_end_to_end \
+  --save-baseline origin-main
+
+cp -a \
+  "$CARGO_TARGET_DIR/criterion/lan393_manager_self_time" \
+  "$CARGO_TARGET_DIR/criterion/lan393_sqlite_end_to_end" \
+  "$ARTIFACT_DIR/criterion/"
+```
+
+Those commands are the pre-offload harness run, whose production behavior must
+still match current main. Preserve that target directory: the named
+`origin-main` samples under it are what Criterion compares against.
+The sourced host fence holds the same nonblocking
+`${RUSTBGPD_HOST_LOCK:-$HOME/.local/state/rustbgpd-host.lock}` used by the other
+retained rustbgpd performance drivers. After the locked warm build and before
+each Criterion group, it records every poll and requires one-minute load below
+the fixed 2.0 ceiling, no competing Cargo/rustc/rustbgpd benchmark/perf
+process, and
+`performance` on every available CPU governor. A timeout exits 75 instead of
+emitting a publishable-looking noisy sample.
+The baseline retains exact `rustc -Vv`, `cargo -Vv`, and `protoc --version`
+output. The candidate captures the same receipt and byte-compares it before
+building, so a compiler/toolchain change cannot masquerade as an offload gain.
+
+On the candidate commit, use `--baseline origin-main` (not
+`--save-baseline lan393-offload`) so Criterion actually performs the
+before/after comparison:
+
+```bash
+set -euo pipefail
+
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$PWD/target/lan393"}
+export ARTIFACT_DIR=${ARTIFACT_DIR:-"$PWD/docs/perf/artifacts/event-history-producer-2026-07"}
+HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$HOST_FENCE"
+lan393_acquire_host_lock
+CANDIDATE_COMMIT=$(git rev-parse HEAD)
+RECORDED_BASELINE_COMMIT=$(awk -F= \
+  '$1 == "baseline_commit" { print $2 }' \
+  "$ARTIFACT_DIR/environment.txt")
+test -n "$RECORDED_BASELINE_COMMIT"
+if [ "$CANDIDATE_COMMIT" = "$RECORDED_BASELINE_COMMIT" ]; then
+  printf '%s\n' "candidate commit matches recorded baseline" >&2
+  exit 1
+fi
+if ! git merge-base --is-ancestor \
+  "$RECORDED_BASELINE_COMMIT" "$CANDIDATE_COMMIT"; then
+  printf 'recorded baseline is not an ancestor of candidate: %s !<= %s\n' \
+    "$RECORDED_BASELINE_COMMIT" "$CANDIDATE_COMMIT" >&2
+  exit 1
+fi
+CANDIDATE_STATUS=$(git status --porcelain=v1 --untracked-files=all \
+  -- . \
+  ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
+CANDIDATE_ARTIFACT_STATUS=$(git status --porcelain=v1 --untracked-files=all \
+  -- docs/perf/artifacts/event-history-producer-2026-07)
+if [ -n "$CANDIDATE_STATUS" ]; then
+  printf '%s\n' "refusing dirty candidate source tree:" >&2
+  printf '%s\n' "$CANDIDATE_STATUS" >&2
+  exit 1
+fi
+HOST_PREFLIGHT="$ARTIFACT_DIR/microbench-candidate-host-preflight.tsv"
+lan393_init_host_preflight_log "$HOST_PREFLIGHT"
+BASELINE_TOOLCHAIN="$ARTIFACT_DIR/microbench-baseline-toolchain.txt"
+if [ ! -f "$BASELINE_TOOLCHAIN" ] || [ -L "$BASELINE_TOOLCHAIN" ]; then
+  printf 'missing regular baseline toolchain receipt: %s\n' \
+    "$BASELINE_TOOLCHAIN" >&2
+  exit 1
+fi
+CANDIDATE_TOOLCHAIN="$ARTIFACT_DIR/microbench-candidate-toolchain.txt"
+CANDIDATE_TOOLCHAIN_TMP=$(mktemp "$ARTIFACT_DIR/.candidate-toolchain.XXXXXX")
+{
+  rustc -Vv
+  cargo -Vv
+  protoc --version
+} > "$CANDIDATE_TOOLCHAIN_TMP"
+if ! cmp --silent "$BASELINE_TOOLCHAIN" "$CANDIDATE_TOOLCHAIN_TMP"; then
+  printf '%s\n' 'candidate toolchain differs from retained baseline' >&2
+  diff -u "$BASELINE_TOOLCHAIN" "$CANDIDATE_TOOLCHAIN_TMP" >&2 || true
+  rm -f "$CANDIDATE_TOOLCHAIN_TMP"
+  exit 1
+fi
+mv "$CANDIDATE_TOOLCHAIN_TMP" "$CANDIDATE_TOOLCHAIN"
+CANDIDATE_TOOLCHAIN_SHA256=$(sha256sum "$CANDIDATE_TOOLCHAIN" | awk '{print $1}')
+{
+  printf 'candidate_commit=%s\n' "$CANDIDATE_COMMIT"
+  printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
+  printf 'candidate_baseline_ancestor=true\n'
+  printf 'candidate_remote=%s\n' "$(git remote get-url origin)"
+  printf 'candidate_status=%s\n' "$CANDIDATE_STATUS"
+  printf 'preexisting_artifact_status=%s\n' "$CANDIDATE_ARTIFACT_STATUS"
+  printf 'toolchain_receipt=%s\n' "$(basename "$CANDIDATE_TOOLCHAIN")"
+  printf 'toolchain_sha256=%s\n' "$CANDIDATE_TOOLCHAIN_SHA256"
+  printf 'baseline_toolchain_match=1\n'
+  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
+  printf 'host_lock_acquired=1\n'
+  printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
+  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+  printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
+  printf 'required_governor=performance\n'
+} > "$ARTIFACT_DIR/candidate-environment.txt"
+git archive --format=tar.gz \
+  --output "$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz" \
+  "$CANDIDATE_COMMIT"
+( cd "$ARTIFACT_DIR" && \
+  sha256sum rustbgpd-baseline-source.tar.gz \
+    rustbgpd-candidate-source.tar.gz > source-sha256.txt )
+
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  --no-run
+
+lan393_wait_for_idle candidate-manager "$HOST_PREFLIGHT"
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  -- lan393_manager_self_time \
+  --baseline origin-main
+
+lan393_wait_for_idle candidate-sqlite "$HOST_PREFLIGHT"
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  -- lan393_sqlite_end_to_end \
+  --baseline origin-main
+
+rm -rf "$ARTIFACT_DIR/criterion-comparison"
+mkdir -p "$ARTIFACT_DIR/criterion-comparison"
+cp -a \
+  "$CARGO_TARGET_DIR/criterion/lan393_manager_self_time" \
+  "$CARGO_TARGET_DIR/criterion/lan393_sqlite_end_to_end" \
+  "$ARTIFACT_DIR/criterion-comparison/"
+
+find "$ARTIFACT_DIR/criterion-comparison" \
+  -path '*/change/estimates.json' -print | sort
+```
+
+The candidate estimates are retained in each case's `new/estimates.json`; the
+comparison against `origin-main` is in `change/estimates.json`. Copy those
+directories before any optional later `--save-baseline` run can replace
+Criterion's `new` sample. Candidate cleanliness excludes only the receipt
+directory itself, so the retained baseline artifacts can remain present while
+any source or harness change still fails closed.
+
+Capture CPU counters after the benchmark executable is warm-built. Set
+`PERF_PHASE=baseline` for the proceed-gate evidence or `candidate` for the
+later implementation comparison. The recipe binds every output to that
+phase's exact clean commit, source archive, and byte-identical toolchain before
+building. The manager command deliberately filters to one enabled case so the
+counter and profile receipts are not blended with the no-op baseline.
+
+```bash
+set -euo pipefail
+
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$PWD/target/lan393"}
+export ARTIFACT_DIR=${ARTIFACT_DIR:-"$PWD/docs/perf/artifacts/event-history-producer-2026-07"}
+: "${PERF_PHASE:?set PERF_PHASE to baseline or candidate}"
+case "$PERF_PHASE" in
+  baseline)
+    IDENTITY_FILE="$ARTIFACT_DIR/environment.txt"
+    IDENTITY_KEY=baseline_commit
+    PERF_SOURCE_ARCHIVE="$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz"
+    ;;
+  candidate)
+    IDENTITY_FILE="$ARTIFACT_DIR/candidate-environment.txt"
+    IDENTITY_KEY=candidate_commit
+    PERF_SOURCE_ARCHIVE="$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz"
+    ;;
+  *)
+    printf 'PERF_PHASE must be baseline or candidate, got %s\n' \
+      "$PERF_PHASE" >&2
+    exit 2
+    ;;
+esac
+
+read_receipt_value() {
+  awk -F= -v key="$2" \
+    '$1 == key { sub(/^[^=]*=/, ""); print; found = 1 }
+     END { if (!found) exit 1 }' "$1"
+}
+
+test -f "$IDENTITY_FILE" && test ! -L "$IDENTITY_FILE"
+EXPECTED_COMMIT=$(read_receipt_value "$IDENTITY_FILE" "$IDENTITY_KEY")
+if [[ ! "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'invalid %s in %s: %s\n' \
+    "$IDENTITY_KEY" "$IDENTITY_FILE" "$EXPECTED_COMMIT" >&2
+  exit 1
+fi
+test "$(git rev-parse "$EXPECTED_COMMIT^{commit}")" = "$EXPECTED_COMMIT"
+test "$(git rev-parse HEAD)" = "$EXPECTED_COMMIT"
+
+if [ "$PERF_PHASE" = candidate ]; then
+  RECORDED_BASELINE_COMMIT=$(read_receipt_value \
+    "$IDENTITY_FILE" recorded_baseline_commit)
+  test "$RECORDED_BASELINE_COMMIT" = \
+    "$(read_receipt_value "$ARTIFACT_DIR/environment.txt" baseline_commit)"
+  git merge-base --is-ancestor \
+    "$RECORDED_BASELINE_COMMIT" "$EXPECTED_COMMIT"
+fi
+
+PERF_SOURCE_STATUS=$(git status --porcelain=v1 --untracked-files=all \
+  -- . \
+  ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
+if [ -n "$PERF_SOURCE_STATUS" ]; then
+  printf '%s\n' "refusing dirty $PERF_PHASE perf source tree:" >&2
+  printf '%s\n' "$PERF_SOURCE_STATUS" >&2
+  exit 1
+fi
+test -f "$PERF_SOURCE_ARCHIVE" && test ! -L "$PERF_SOURCE_ARCHIVE"
+ARCHIVE_CHECK=$(mktemp /tmp/lan393-perf-source.XXXXXX.tar.gz)
+git archive --format=tar.gz --output "$ARCHIVE_CHECK" "$EXPECTED_COMMIT"
+if ! cmp --silent "$ARCHIVE_CHECK" "$PERF_SOURCE_ARCHIVE"; then
+  rm -f "$ARCHIVE_CHECK"
+  printf 'retained %s source archive does not match %s\n' \
+    "$PERF_PHASE" "$EXPECTED_COMMIT" >&2
+  exit 1
+fi
+rm -f "$ARCHIVE_CHECK"
+
+HOST_FENCE="$PWD/docs/perf/lan393-host-fence.sh"
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$HOST_FENCE"
+lan393_acquire_host_lock
+PHASE_TOOLCHAIN="$ARTIFACT_DIR/microbench-$PERF_PHASE-toolchain.txt"
+test -f "$PHASE_TOOLCHAIN" && test ! -L "$PHASE_TOOLCHAIN"
+CURRENT_TOOLCHAIN=$(mktemp /tmp/lan393-perf-toolchain.XXXXXX)
+{
+  rustc -Vv
+  cargo -Vv
+  protoc --version
+} > "$CURRENT_TOOLCHAIN"
+if ! cmp --silent "$PHASE_TOOLCHAIN" "$CURRENT_TOOLCHAIN"; then
+  diff -u "$PHASE_TOOLCHAIN" "$CURRENT_TOOLCHAIN" >&2 || true
+  rm -f "$CURRENT_TOOLCHAIN"
+  printf '%s\n' "current toolchain differs from $PERF_PHASE receipt" >&2
+  exit 1
+fi
+rm -f "$CURRENT_TOOLCHAIN"
+
+PERF_PREFIX="$ARTIFACT_DIR/microbench-$PERF_PHASE-perf"
+PERF_ENVIRONMENT="$PERF_PREFIX-environment.txt"
+PERF_HOST_PREFLIGHT="$PERF_PREFIX-host-preflight.tsv"
+BENCH_BUILD="$PERF_PREFIX-bench-build.jsonl"
+PERF_STAT="$PERF_PREFIX-stat.csv"
+PERF_DATA="$PERF_PREFIX.data"
+PERF_REPORT="$PERF_PREFIX-report.txt"
+PERF_COMPLETION="$PERF_PREFIX-completion.txt"
+PERF_MANIFEST="$PERF_PREFIX-SHA256SUMS"
+for OUTPUT in \
+  "$PERF_ENVIRONMENT" "$PERF_HOST_PREFLIGHT" "$BENCH_BUILD" \
+  "$PERF_STAT" "$PERF_DATA" "$PERF_REPORT" "$PERF_COMPLETION" \
+  "$PERF_MANIFEST"; do
+  if [ -e "$OUTPUT" ]; then
+    printf 'refusing existing %s perf receipt: %s\n' \
+      "$PERF_PHASE" "$OUTPUT" >&2
+    exit 1
+  fi
+done
+lan393_init_host_preflight_log "$PERF_HOST_PREFLIGHT"
+
+cargo bench -p rustbgpd-api \
+  --features bench-internals \
+  --bench event_history_producer \
+  --locked \
+  --no-run \
+  --message-format=json \
+  > "$BENCH_BUILD"
+
+BENCH_BIN=$(
+  python3 - "$BENCH_BUILD" <<'PY'
+import json
+import sys
+
+executables = set()
+with open(sys.argv[1], encoding="utf-8") as messages:
+    for line in messages:
+        message = json.loads(line)
+        target = message.get("target", {})
+        executable = message.get("executable")
+        if (
+            message.get("reason") == "compiler-artifact"
+            and target.get("name") == "event_history_producer"
+            and "bench" in target.get("kind", [])
+            and executable
+        ):
+            executables.add(executable)
+
+if len(executables) != 1:
+    raise SystemExit(
+        f"expected exactly one event_history_producer bench executable, got {sorted(executables)!r}"
+    )
+print(executables.pop())
+PY
+)
+test -x "$BENCH_BIN"
+
+{
+  printf 'profile_phase=%s\n' "$PERF_PHASE"
+  printf 'expected_commit=%s\n' "$EXPECTED_COMMIT"
+  printf 'source_head=%s\n' "$(git rev-parse HEAD)"
+  printf 'source_status=%s\n' "$PERF_SOURCE_STATUS"
+  printf 'identity_receipt=%s\n' "$(basename "$IDENTITY_FILE")"
+  printf 'source_archive=%s\n' "$(basename "$PERF_SOURCE_ARCHIVE")"
+  printf 'source_archive_sha256=%s\n' \
+    "$(sha256sum "$PERF_SOURCE_ARCHIVE" | awk '{print $1}')"
+  printf 'toolchain_receipt=%s\n' "$(basename "$PHASE_TOOLCHAIN")"
+  printf 'toolchain_sha256=%s\n' \
+    "$(sha256sum "$PHASE_TOOLCHAIN" | awk '{print $1}')"
+  printf 'bench_binary=%s\n' "$BENCH_BIN"
+  printf 'bench_binary_sha256=%s\n' \
+    "$(sha256sum "$BENCH_BIN" | awk '{print $1}')"
+  printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
+  printf 'host_lock_acquired=1\n'
+  printf 'host_preflight=%s\n' "$(basename "$PERF_HOST_PREFLIGHT")"
+  printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+  printf 'required_governor=performance\n'
+} > "$PERF_ENVIRONMENT"
+
+lan393_wait_for_idle "$PERF_PHASE-perf-stat" "$PERF_HOST_PREFLIGHT"
+perf stat -x, \
+  -e task-clock,cycles,instructions,branches,branch-misses,cache-misses \
+  -o "$PERF_STAT" \
+  "$BENCH_BIN" --bench --exact \
+  'lan393_manager_self_time/route_added/ehm' --profile-time 30
+
+lan393_wait_for_idle "$PERF_PHASE-perf-record" "$PERF_HOST_PREFLIGHT"
+perf record --call-graph dwarf \
+  -o "$PERF_DATA" \
+  "$BENCH_BIN" --bench --exact \
+  'lan393_manager_self_time/route_added/ehm' --profile-time 30
+
+perf report --stdio \
+  -i "$PERF_DATA" \
+  > "$PERF_REPORT"
+
+test -s "$PERF_STAT"
+test -s "$PERF_DATA"
+test -s "$PERF_REPORT"
+{
+  printf 'profile_phase=%s\n' "$PERF_PHASE"
+  printf 'expected_commit=%s\n' "$EXPECTED_COMMIT"
+  printf 'run_utc_complete=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'phase_complete=1\n'
+} > "$PERF_COMPLETION"
+(
+  cd "$ARTIFACT_DIR"
+  sha256sum \
+    "$(basename "$PERF_ENVIRONMENT")" \
+    "$(basename "$PERF_HOST_PREFLIGHT")" \
+    "$(basename "$BENCH_BUILD")" \
+    "$(basename "$PERF_STAT")" \
+    "$(basename "$PERF_DATA")" \
+    "$(basename "$PERF_REPORT")" \
+    "$(basename "$PERF_COMPLETION")" \
+    "$(basename "$PHASE_TOOLCHAIN")" \
+    "$(basename "$PERF_SOURCE_ARCHIVE")" \
+    > "$(basename "$PERF_MANIFEST")"
+  sha256sum --check "$(basename "$PERF_MANIFEST")" >/dev/null
+)
+```
+
+The Cargo JSON selection is intentional: hashed bench filenames are not ordered
+by freshness, so sorting `target/release/deps` can silently profile a stale
+executable. A phase receipt is complete only when its `completion.txt` and
+relative-path `SHA256SUMS` both exist and the latter verifies.
+
+## Full-daemon proceed profile
+
+The proceed gate also requires a real daemon processing a full table with EHM
+enabled. The pinned bgperf2 adapter correctly treats event history as
+opt-in/default-off and omits the block when no mode is selected. For this
+profile, the profiling-only wrapper in
+`docs/perf/bgperf-rustbgpd-ehm-wrapper.sh` is the sole authority: both adapter
+environment controls are unset, and the wrapper appends an explicit
+`[event_history]` block to bgperf2's generated config. It stops its own process
+before `exec`-ing the daemon. The host attaches `perf`, then resumes that same
+PID so recording begins before the peers can converge. It does not change the
+rustbgpd binary.
+
+The checked-in driver has two deliberately separate modes:
+
+- `baseline` is the only mode that satisfies the proceed gate. It reads the
+  exact `baseline_commit` and `baseline_ref_commit` captured in
+  `environment.txt`, requires both to agree with the clean source `HEAD`, and
+  regenerates and hashes the archive from that commit before building.
+- `candidate` is only for evaluating a later offload implementation. It reads
+  `candidate_commit` from `candidate-environment.txt`, requires the clean
+  source `HEAD` to match, and fails if the candidate equals the recorded
+  baseline. Candidate artifacts have a separate filename prefix and cannot
+  overwrite the baseline profile.
+
+Both modes clone the fork into a disposable directory at the reviewed bgperf2
+commit. The custom profiling image reproduces the adapter's digest-pinned Rust
+1.95 and Debian bases, uses `cargo --locked`, and retains the image inspection,
+content digest, binary hashes, compiler/Cargo/protoc versions, complete builder
+and runtime package inventories, and OCI revision/base labels. Before profiling,
+the driver verifies those labels against the exact rustbgpd and bgperf2 commits;
+after bgperf starts, it also verifies that the running container uses that same
+image digest. Docker's build context is an extraction of the retained
+phase-specific rustbgpd commit archive, never the mutable checkout that invoked
+the driver, so the image bytes and revision label have the same source of truth.
+Both modes also hold the shared rustbgpd host lock from before the image build
+through receipt completion. A retained TSV records the idle/load,
+all-CPU-governor, and competing-process fence before the build and again after
+the build, immediately before bgperf starts. The driver writes its completion
+sentinel only after convergence, outbox-health, resource, and perf validation;
+the final phase-specific `SHA256SUMS` binds that sentinel, every other
+phase-prefixed file, and the exact rustbgpd/bgperf2 source archives.
+
+Run the current-main proceed profile from the clean recorded baseline checkout:
+
+```bash
+set -euo pipefail
+
+export RUSTBGPD_SOURCE="$PWD"
+export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
+docs/perf/run-lan393-full-daemon.sh baseline
+```
+
+Do not use `candidate` until the current-main gate has passed and an offload
+candidate has been implemented and measured with the preceding Criterion
+comparison:
+
+```bash
+set -euo pipefail
+
+export RUSTBGPD_SOURCE="$PWD"
+export ARTIFACT_DIR="$PWD/docs/perf/artifacts/event-history-producer-2026-07"
+docs/perf/run-lan393-full-daemon.sh candidate
+```
+
+The driver does not trust bgperf2's exit status alone. It parses the retained
+scenario and final result, rejects any `FAILED` marker, and requires exactly
+two BIRD peers with 100,000 prefixes each, `required=received=200000`, no
+policy/filter input, and the expected rustbgpd scenario identity. It also
+copies the two BIRD logs from this exact phase's custom run directory and makes
+those copies authoritative for tester errors. The pinned adapter intends an
+error to mean a case-sensitive line containing `RMT`, except lines containing
+`NEXT_HOP`; its helper accidentally reads `/tmp/bgperf2/tester` regardless of
+`--dir` and `--bench-name`, so the driver applies that rule itself to the
+run-scoped copies and records their hashes. It inventories every source
+`*.log` entry, requires exactly the two scenario peer names as regular,
+non-symlink files, and verifies the retained copies remain byte-identical;
+the run receipt, tester directories, and source/retained scenario paths reject
+symlink components, and the two scenario copies must be byte-identical. Non-log
+BIRD configuration and control-socket entries remain permitted. The
+raw bgperf log retains the adapter's tester-error field for forensic context,
+while the validator records that ignored value separately and writes the
+authoritative run-scoped verdict to the normalized CSV. A stale default
+directory therefore cannot create either a false pass or a false failure.
+
+The pinned BIRD adapter does not implement timeout detection:
+`find_timeouts()` is the base-class constant zero. The normalized CSV must
+still carry zero in that compatibility field, but the receipt labels timeout
+evidence as unsupported and makes no independent "zero BIRD timeouts" claim.
+Remote-state diagnostics that BIRD labels `RMT` are covered by the authoritative
+error rule above; timeout diagnostics without that label are not independently
+classified. The normalized result, run-scoped tester logs, their hashes, and
+validator output are retained beside the raw bgperf log and time series.
+
+Use the inclusive call stacks rooted in RIB-manager processing as the proceed
+gate denominator. The numerator is samples in `EhmRibSink`, route/EVPN proto
+conversion, prost encoding, or allocation directly owned by those frames. The
+raw `perf.data` and `perf-script.txt` make that classification reviewable; do
+not use the isolated microbenchmark profile to satisfy the full-daemon gate.
+
+## Proceed gate
+
+Implement the offload only when both conditions are true on the current-main
+baseline:
+
+1. The EHM manager phase is at least 25% slower than noop in at least two of
+   the three event shapes, with non-overlapping Criterion confidence intervals.
+2. The enabled 2-peer, 100k-prefix full-table profile above (or an equally
+   retained churn profile) attributes at least 5% of RIB-actor samples to
+   `EhmRibSink`, route/EVPN proto conversion, prost encoding, or their
+   directly-owned allocation work.
+
+If either condition fails, LAN-393 is a no-proceed: SQLite or another stage is
+the material cost and an encoder queue would add complexity without moving the
+bound.
+
+The implementation is accepted only if the candidate then demonstrates:
+
+- at least 50% lower EHM-enabled manager producer time in this harness;
+- noop/default-disabled time within 3% of baseline and overlapping confidence
+  intervals;
+- no regression in SQLite end-to-end throughput beyond the run-to-run noise
+  recorded here;
+- zero outbox drops/degraded transitions and contiguous committed cursors;
+- full-daemon enabled/disabled CPU, RSS, queue-depth, drop, and cursor-integrity
+  receipts retained alongside these microbench artifacts.
+
+## Baseline results
+
+Pending host clearance. Fill this table from Criterion's `estimates.json`; do
+not transcribe terminal-only numbers without retaining the JSON.
+
+| Mode | Event shape | Estimate | 95% CI | Events/s | Verdict |
+|---|---|---:|---:|---:|---|
+| manager/noop | route added | pending | pending | pending | pending |
+| manager/ehm | route added | pending | pending | pending | pending |
+| manager/noop | policy filtered | pending | pending | pending | pending |
+| manager/ehm | policy filtered | pending | pending | pending | pending |
+| manager/noop | EVPN best changed | pending | pending | pending | pending |
+| manager/ehm | EVPN best changed | pending | pending | pending | pending |
+| SQLite end-to-end | route added | pending | pending | pending | pending |
+| SQLite end-to-end | policy filtered | pending | pending | pending | pending |
+| SQLite end-to-end | EVPN best changed | pending | pending | pending | pending |

--- a/docs/perf/lan393-host-fence.sh
+++ b/docs/perf/lan393-host-fence.sh
@@ -83,7 +83,10 @@ lan393_competing_process_snapshot() {
              $2 ~ /^validate($|-)/ || $2 ~ /^evpn-tester($|-)/ ||
              $2 ~ /^evpn-monitor($|-)/ || $2 ~ /^rustbgpd-evpn-/ ||
              $0 ~ /[[:space:]]bgperf2\.py[[:space:]]/) {
-                print
+                # Retain only the bounded executable name. PIDs and argv can
+                # contain usernames, checkout paths, tokens, or unrelated
+                # command-line data and are not required to prove the fence.
+                print $2
             }
         '
 }

--- a/docs/perf/lan393-host-fence.sh
+++ b/docs/perf/lan393-host-fence.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Shared host-isolation helpers for retained LAN-393 measurements.
+#
+# Source this file from a `set -euo pipefail` driver. The acquired descriptor
+# intentionally remains open in the caller until that shell exits.
+
+# Retained LAN-393 receipts use one fixed noise gate. An environment override
+# would make two otherwise identical receipts incomparable and could turn a
+# noisy run into a publishable-looking success.
+readonly LAN393_REQUIRED_LOAD_ONE_MAX=2.0
+
+lan393_acquire_host_lock() {
+    command -v flock >/dev/null 2>&1 || {
+        printf '%s\n' 'required command not found: flock' >&2
+        return 1
+    }
+
+    LAN393_HOST_LOCK_PATH=${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}
+    mkdir -p "$(dirname "$LAN393_HOST_LOCK_PATH")"
+    touch "$LAN393_HOST_LOCK_PATH"
+    # shellcheck disable=SC1083 # bash dynamic descriptor syntax is intentional.
+    exec {LAN393_HOST_LOCK_FD}>"$LAN393_HOST_LOCK_PATH"
+    if ! flock -n "$LAN393_HOST_LOCK_FD"; then
+        printf 'error: %s is held by another retained soak or benchmark\n' \
+            "$LAN393_HOST_LOCK_PATH" >&2
+        printf '%s\n' '       no LAN-393 build or measurement was started' >&2
+        return 75
+    fi
+    printf 'acquired host lock: %s\n' "$LAN393_HOST_LOCK_PATH"
+}
+
+lan393_init_host_preflight_log() {
+    local log=$1
+    [[ ! -e "$log" ]] || {
+        printf 'refusing existing LAN-393 preflight log: %s\n' "$log" >&2
+        return 1
+    }
+    printf 'phase\tattempt\tutc\tload_1m\tload_1m_max\tgovernor\trequired_governor\tcompeting_process_count\tcompeting_processes\tstatus\n' \
+        >"$log"
+}
+
+lan393_governor_snapshot() {
+    local -a paths
+    local path value first='' mixed=0
+    shopt -s nullglob
+    paths=(/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor)
+    shopt -u nullglob
+    ((${#paths[@]} > 0)) || {
+        printf '%s\n' unavailable
+        return
+    }
+    for path in "${paths[@]}"; do
+        [[ -r "$path" ]] || {
+            printf '%s\n' unavailable
+            return
+        }
+        value=$(tr -d '\n' <"$path")
+        if [[ -z "$first" ]]; then
+            first=$value
+        elif [[ "$value" != "$first" ]]; then
+            mixed=1
+        fi
+    done
+    if ((mixed)); then
+        printf '%s\n' mixed
+    else
+        printf '%s\n' "$first"
+    fi
+}
+
+lan393_competing_process_snapshot() {
+    ps -eo pid=,comm=,args= --no-headers \
+        | awk -v self="$$" '
+            $1 != self &&
+            ($2 == "cargo" || $2 == "rustc" || $2 == "perf" ||
+             $2 == "rustbgpd" ||
+             $2 ~ /^rrharness($|-)/ || $2 ~ /^reloadstall($|-)/ ||
+             $2 ~ /^route_paging($|-)/ || $2 ~ /^rib_nlri_build/ ||
+             $2 ~ /^nlri_build($|-)/ || $2 ~ /^event_history_/ ||
+             $2 ~ /^codec($|-)/ || $2 ~ /^fanout($|-)/ ||
+             $2 ~ /^inbound_attrs/ || $2 ~ /^rib_ops($|-)/ ||
+             $2 ~ /^policy_eval($|-)/ || $2 ~ /^explain_snapsho/ ||
+             $2 ~ /^validate($|-)/ || $2 ~ /^evpn-tester($|-)/ ||
+             $2 ~ /^evpn-monitor($|-)/ || $2 ~ /^rustbgpd-evpn-/ ||
+             $0 ~ /[[:space:]]bgperf2\.py[[:space:]]/) {
+                print
+            }
+        '
+}
+
+lan393_wait_for_idle() {
+    local phase=$1 log=$2
+    local load_one_max=$LAN393_REQUIRED_LOAD_ONE_MAX
+    local wait_seconds=${LAN393_PREFLIGHT_WAIT_SECONDS:-120}
+    local poll_seconds=${LAN393_PREFLIGHT_POLL_SECONDS:-1}
+    local required_governor=performance
+    local deadline=$((SECONDS + wait_seconds)) attempt=0
+    local utc load_one governor process_lines process_count process_summary status
+
+    [[ "$wait_seconds" =~ ^[1-9][0-9]*$ ]] || {
+        printf 'LAN393_PREFLIGHT_WAIT_SECONDS must be positive, got %s\n' \
+            "$wait_seconds" >&2
+        return 2
+    }
+    [[ "$poll_seconds" =~ ^[1-9][0-9]*$ ]] || {
+        printf 'LAN393_PREFLIGHT_POLL_SECONDS must be positive, got %s\n' \
+            "$poll_seconds" >&2
+        return 2
+    }
+    [[ -f "$log" ]] || {
+        printf 'LAN-393 preflight log is not initialized: %s\n' "$log" >&2
+        return 1
+    }
+
+    while true; do
+        ((attempt += 1))
+        utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        load_one=$(awk '{print $1}' /proc/loadavg)
+        governor=$(lan393_governor_snapshot)
+        process_lines=$(lan393_competing_process_snapshot)
+        if [[ -n "$process_lines" ]]; then
+            process_count=$(wc -l <<<"$process_lines")
+            process_summary=$(printf '%s' "$process_lines" | tr '\t\n' '  ' | tr -s ' ')
+        else
+            process_count=0
+            process_summary=none
+        fi
+
+        status=pass
+        if ! awk -v observed="$load_one" -v maximum="$load_one_max" \
+            'BEGIN { exit !(observed + 0 < maximum + 0) }'; then
+            status=wait-load
+        elif [[ "$governor" != "$required_governor" ]]; then
+            status=wait-governor
+        elif ((process_count != 0)); then
+            status=wait-processes
+        fi
+
+        if [[ "$status" != pass ]] && ((SECONDS >= deadline)); then
+            status=${status/wait-/timeout-}
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$phase" "$attempt" "$utc" "$load_one" "$load_one_max" \
+            "$governor" "$required_governor" "$process_count" \
+            "$process_summary" "$status" >>"$log"
+
+        if [[ "$status" == pass ]]; then
+            return
+        fi
+        if [[ "$status" == timeout-* ]]; then
+            printf 'LAN-393 idle preflight timed out after %ss: %s (load=%s governor=%s processes=%s)\n' \
+                "$wait_seconds" "$phase" "$load_one" "$governor" \
+                "$process_summary" >&2
+            return 75
+        fi
+        sleep "$poll_seconds"
+    done
+}

--- a/docs/perf/run-lan393-criterion.sh
+++ b/docs/perf/run-lan393-criterion.sh
@@ -81,7 +81,10 @@ write_host_fingerprint() {
     local output=$1 cpu_model physical_cores logical_cpus memory_bytes
     cpu_model=$(awk -F: '/model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
     logical_cpus=$(getconf _NPROCESSORS_ONLN)
-    physical_cores=$(lscpu -p=CORE,SOCKET | awk '!/^#/ { seen[$1 FS $2]=1 } END { print length(seen) }')
+    physical_cores=$(lscpu -p=CORE,SOCKET | awk '
+        !/^#/ { seen[$1 FS $2]=1 }
+        END { for (key in seen) count++; print count + 0 }
+    ')
     memory_bytes=$(awk '/MemTotal:/ { print $2 * 1024 }' /proc/meminfo)
     {
         printf 'schema=1\n'

--- a/docs/perf/run-lan393-criterion.sh
+++ b/docs/perf/run-lan393-criterion.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# Exact-ref, privacy-safe Criterion receipt driver for LAN-393.
+set -euo pipefail
+
+usage() {
+    printf 'usage: %s baseline|candidate\n' "$0" >&2
+    exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+PHASE=$1
+case "$PHASE" in baseline | candidate) ;; *) usage ;; esac
+
+ROOT=$(git rev-parse --show-toplevel)
+ARTIFACT_DIR=${ARTIFACT_DIR:-$ROOT/docs/perf/artifacts/event-history-producer-2026-07}
+STATE_DIR=${LAN393_STATE_DIR:-$ROOT/target/lan393-criterion-state}
+BASELINE_REF=refs/remotes/origin/main
+BASELINE_NAME=lan393-exact-baseline
+FENCE=$ROOT/docs/perf/lan393-host-fence.sh
+VALIDATOR_REL=docs/perf/validate-lan393-criterion.py
+PERF_VALIDATOR_REL=docs/perf/validate-lan393-perf.py
+FULL_COMPARISON_REL=docs/perf/validate-lan393-full-comparison.py
+RECEIPT_VALIDATOR_REL=docs/perf/validate-lan393-receipt.py
+BENCH_REL=crates/api/benches/event_history_producer.rs
+BENCH_SUPPORT_REL=crates/rib/src/manager/bench_support.rs
+DRIVER_REL=docs/perf/run-lan393-criterion.sh
+FULL_DRIVER_REL=docs/perf/run-lan393-full-daemon.sh
+FENCE_REL=docs/perf/lan393-host-fence.sh
+WRAPPER_REL=docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
+WORK_ROOT=''
+
+cleanup() {
+    if [[ -n "$WORK_ROOT" ]]; then
+        for directory in "$WORK_ROOT/base" "$WORK_ROOT/candidate"; do
+            if [[ -d "$directory" ]]; then
+                git -C "$ROOT" worktree remove --force "$directory" >/dev/null 2>&1 || true
+            fi
+        done
+        rm -rf -- "$WORK_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'LAN-393 Criterion error: %s\n' "$*" >&2
+    exit 1
+}
+
+read_value() {
+    local file=$1 key=$2
+    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; found=1 } END { if (!found) exit 1 }' "$file"
+}
+
+require_safe_build_environment() {
+    local name
+    for name in RUSTFLAGS CARGO_ENCODED_RUSTFLAGS RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER; do
+        [[ -z "${!name:-}" ]] || fail "$name must be unset for retained measurements"
+    done
+    while IFS='=' read -r name _; do
+        case "$name" in
+            CARGO_PROFILE_* | CARGO_TARGET_*_RUSTFLAGS)
+                fail "$name must be unset for retained measurements"
+                ;;
+        esac
+    done < <(env)
+    export CARGO_INCREMENTAL=0
+}
+
+repo_slug() {
+    local remote
+    remote=$(git -C "$ROOT" remote get-url origin)
+    case "$remote" in
+        git@github.com:lance0/rustbgpd.git | https://github.com/lance0/rustbgpd.git | https://github.com/lance0/rustbgpd)
+            printf '%s\n' lance0/rustbgpd
+            ;;
+        *) fail 'origin is not the canonical lance0/rustbgpd repository' ;;
+    esac
+}
+
+write_host_fingerprint() {
+    local output=$1 cpu_model physical_cores logical_cpus memory_bytes
+    cpu_model=$(awk -F: '/model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
+    logical_cpus=$(getconf _NPROCESSORS_ONLN)
+    physical_cores=$(lscpu -p=CORE,SOCKET | awk '!/^#/ { seen[$1 FS $2]=1 } END { print length(seen) }')
+    memory_bytes=$(awk '/MemTotal:/ { print $2 * 1024 }' /proc/meminfo)
+    {
+        printf 'schema=1\n'
+        printf 'kernel=%s\n' "$(uname -srm)"
+        printf 'architecture=%s\n' "$(uname -m)"
+        printf 'cpu_model=%s\n' "$cpu_model"
+        printf 'physical_cores=%s\n' "$physical_cores"
+        printf 'logical_cpus=%s\n' "$logical_cpus"
+        printf 'memory_bytes=%.0f\n' "$memory_bytes"
+        printf 'repo_fs=%s\n' "$(findmnt -n -T "$ROOT" -o FSTYPE)"
+        printf 'tmp_fs=%s\n' "$(findmnt -n -T /tmp -o FSTYPE)"
+    } >"$output"
+}
+
+write_toolchain() {
+    local output=$1
+    {
+        rustc -Vv
+        cargo -Vv
+        protoc --version
+        perf --version
+    } >"$output"
+}
+
+config_hash() {
+    local cargo_home=${CARGO_HOME:-$HOME/.cargo}
+    local legacy=$cargo_home/config modern=$cargo_home/config.toml
+    for config in "$legacy" "$modern"; do
+        if [[ -e "$config" || -L "$config" ]]; then
+            [[ -f "$config" && ! -L "$config" ]] || \
+                fail "Cargo home configuration is not a regular file: $(basename "$config")"
+        fi
+    done
+    if [[ -f "$legacy" && -f "$modern" ]]; then
+        fail 'both Cargo home config and config.toml exist; measurement input is ambiguous'
+    elif [[ -f "$legacy" ]]; then
+        sha256sum "$legacy" | awk '{print $1}'
+    elif [[ -f "$modern" ]]; then
+        sha256sum "$modern" | awk '{print $1}'
+    else
+        printf '%s\n' absent
+    fi
+}
+
+build_environment_hash() {
+    python3 <<'PY'
+import hashlib
+import json
+import os
+
+exact = {
+    "AR", "CC", "CFLAGS", "CPATH", "CXX", "CXXFLAGS", "LD", "LDFLAGS",
+    "LIBRARY_PATH", "PATH", "PROTOC", "RUSTUP_TOOLCHAIN", "SOURCE_DATE_EPOCH",
+}
+prefixes = ("CARGO_", "PKG_CONFIG_", "RUST")
+relevant = {
+    name: value
+    for name, value in os.environ.items()
+    if name in exact or name.startswith(prefixes)
+}
+payload = json.dumps(relevant, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+print(hashlib.sha256(payload.encode()).hexdigest())
+PY
+}
+
+harness_hashes() {
+    local source=$1 output=$2
+    (
+        cd "$source"
+        sha256sum "$BENCH_REL" "$BENCH_SUPPORT_REL" \
+            "$DRIVER_REL" "$FULL_DRIVER_REL" \
+            "$FENCE_REL" "$WRAPPER_REL" "$VALIDATOR_REL" \
+            "$PERF_VALIDATOR_REL" "$FULL_COMPARISON_REL" \
+            "$RECEIPT_VALIDATOR_REL"
+    ) >"$output"
+}
+
+sanitize_build_receipt() {
+    local raw=$1 output=$2 target_dir=$3 binary_file=$4
+    python3 - "$raw" "$output" "$target_dir" "$binary_file" <<'PY'
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+raw, output, target_root, binary_output = map(Path, sys.argv[1:])
+target_root = target_root.resolve()
+executables = set()
+receipt = []
+with raw.open(encoding="utf-8") as source:
+    for line in source:
+        message = json.loads(line)
+        if message.get("reason") != "compiler-artifact":
+            continue
+        target = message.get("target", {})
+        executable = message.get("executable")
+        if (
+            target.get("name") == "event_history_producer"
+            and "bench" in target.get("kind", [])
+            and executable
+        ):
+            path = Path(executable).resolve()
+            try:
+                path.relative_to(target_root)
+            except ValueError:
+                raise SystemExit("benchmark executable escaped its exact target directory")
+            executables.add(path)
+            receipt.append(
+                {
+                    "target_name": target.get("name"),
+                    "target_kind": target.get("kind"),
+                    "features": sorted(message.get("features", [])),
+                    "executable_basename": path.name,
+                    "executable_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                }
+            )
+if len(executables) != 1 or len(receipt) != 1:
+    raise SystemExit(f"expected one benchmark executable, got {sorted(map(str, executables))!r}")
+output.write_text(json.dumps(receipt[0], indent=2, sort_keys=True) + "\n", encoding="utf-8")
+binary_output.write_text(str(executables.pop()) + "\n", encoding="utf-8")
+PY
+}
+
+copy_criterion_json() {
+    local source=$1 destination=$2
+    rm -rf "$destination"
+    mkdir -p "$destination"
+    while IFS= read -r -d '' file; do
+        local relative=${file#"$source"/}
+        mkdir -p "$destination/$(dirname "$relative")"
+        cp -- "$file" "$destination/$relative"
+    done < <(
+        find "$source" -type f \
+            \( -path "*/$BASELINE_NAME/*.json" -o -path '*/new/*.json' -o -path '*/change/*.json' \) \
+            -print0
+    )
+}
+
+write_manifest() {
+    local phase=$1 source_archive=$2
+    local manifest=$ARTIFACT_DIR/microbench-$phase-SHA256SUMS
+    local temporary
+    temporary=$(mktemp "$ARTIFACT_DIR/.microbench-$phase-SHA256SUMS.XXXXXX")
+    (
+        cd "$ARTIFACT_DIR"
+        {
+            find . -type f \
+                \( -name "microbench-$phase-*" -o -path "./criterion-$phase/*" \) \
+                ! -name "microbench-$phase-SHA256SUMS" -print0
+            printf './%s\0' "$(basename "$source_archive")"
+        } | sort -zu | xargs -0 sha256sum
+    ) >"$temporary"
+    mv "$temporary" "$manifest"
+    (cd "$ARTIFACT_DIR" && sha256sum --check "$(basename "$manifest")" >/dev/null)
+}
+
+privacy_check() {
+    local phase=$1
+    python3 - "$ARTIFACT_DIR" "$phase" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+phase = sys.argv[2]
+private = re.compile(r"(?:/home/[^/\s]+|/Users/[^/\s]+|https?://[^/\s:@]+:[^/\s@]+@|git@)")
+for path in root.rglob("*"):
+    if not path.is_file() or path.is_symlink():
+        continue
+    if not (path.name.startswith(f"microbench-{phase}-") or f"criterion-{phase}" in path.parts):
+        continue
+    if path.suffix not in {".txt", ".tsv", ".json", ".csv", ".jsonl"} and "SHA256SUMS" not in path.name:
+        continue
+    text = path.read_text(encoding="utf-8", errors="strict")
+    match = private.search(text)
+    if match:
+        raise SystemExit(f"private host material in {path.name}: {match.group(0)!r}")
+PY
+}
+
+require_safe_build_environment
+[[ -x "$FENCE" ]] || fail "missing executable host fence: $FENCE"
+[[ -x "$ROOT/$VALIDATOR_REL" ]] || fail "missing executable Criterion validator"
+if [[ -L "$ARTIFACT_DIR" || -L "$STATE_DIR" ]]; then
+    fail 'artifact and state directories must not be symlinks'
+fi
+mkdir -p "$ARTIFACT_DIR" "$STATE_DIR/targets" "$STATE_DIR/criterion"
+if [[ "$PHASE" == baseline ]]; then
+    unexpected=$(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 ! -name README.md -print -quit)
+else
+    unexpected=$(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 \
+        \( -name 'microbench-candidate-*' -o -name 'criterion-candidate' \
+           -o -name 'rustbgpd-candidate-source.tar.gz' \) -print -quit)
+fi
+[[ -z "$unexpected" ]] || fail "refusing preexisting phase artifact: $unexpected"
+ROOT_STATUS=$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all -- . \
+    ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
+[[ -z "$ROOT_STATUS" ]] || fail 'invoking source checkout is dirty outside the receipt directory'
+REPO_SLUG=$(repo_slug)
+
+BASELINE_ENV=$ARTIFACT_DIR/microbench-baseline-environment.txt
+if [[ "$PHASE" == baseline ]]; then
+    BASELINE_COMMIT=$(git -C "$ROOT" rev-parse "$BASELINE_REF^{commit}")
+    [[ "$(git -C "$ROOT" rev-parse HEAD)" == "$BASELINE_COMMIT" ]] || \
+        fail "baseline must run from exact current $BASELINE_REF"
+    [[ ! -e "$BASELINE_ENV" ]] || fail "baseline receipt already exists: $BASELINE_ENV"
+    if find "$STATE_DIR/criterion" -mindepth 1 -print -quit | grep -q .; then
+        fail 'baseline requires an empty LAN-393 Criterion state directory'
+    fi
+    SOURCE_COMMIT=$BASELINE_COMMIT
+else
+    [[ -f "$BASELINE_ENV" && ! -L "$BASELINE_ENV" ]] || fail 'missing regular baseline environment receipt'
+    (cd "$ARTIFACT_DIR" && sha256sum --check microbench-baseline-SHA256SUMS >/dev/null) || \
+        fail 'baseline publication manifest no longer verifies'
+    BASELINE_COMMIT=$(read_value "$BASELINE_ENV" baseline_commit)
+    [[ "$BASELINE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail 'invalid recorded baseline commit'
+    SOURCE_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+    [[ "$SOURCE_COMMIT" != "$BASELINE_COMMIT" ]] || fail 'candidate equals recorded baseline'
+    git -C "$ROOT" merge-base --is-ancestor "$BASELINE_COMMIT" "$SOURCE_COMMIT" || \
+        fail 'recorded baseline is not an ancestor of candidate'
+    [[ ! -e "$ARTIFACT_DIR/microbench-candidate-environment.txt" ]] || \
+        fail 'candidate receipt already exists'
+fi
+
+WORK_ROOT=$(mktemp -d /tmp/lan393-criterion-worktrees.XXXXXX)
+git -C "$ROOT" worktree add --detach "$WORK_ROOT/base" "$BASELINE_COMMIT" >/dev/null
+if [[ "$PHASE" == candidate ]]; then
+    git -C "$ROOT" worktree add --detach "$WORK_ROOT/candidate" "$SOURCE_COMMIT" >/dev/null
+    SOURCE_DIR=$WORK_ROOT/candidate
+else
+    SOURCE_DIR=$WORK_ROOT/base
+fi
+[[ -z "$(git -C "$WORK_ROOT/base" status --porcelain=v1 --untracked-files=all)" ]]
+[[ -z "$(git -C "$SOURCE_DIR" status --porcelain=v1 --untracked-files=all)" ]]
+
+HOST_FINGERPRINT=$ARTIFACT_DIR/microbench-$PHASE-host-fingerprint.txt
+TOOLCHAIN=$ARTIFACT_DIR/microbench-$PHASE-toolchain.txt
+HARNESS_HASHES=$ARTIFACT_DIR/microbench-$PHASE-harness-SHA256SUMS
+write_host_fingerprint "$HOST_FINGERPRINT"
+write_toolchain "$TOOLCHAIN"
+harness_hashes "$SOURCE_DIR" "$HARNESS_HASHES"
+if [[ "$PHASE" == candidate ]]; then
+    cmp --silent "$ARTIFACT_DIR/microbench-baseline-host-fingerprint.txt" "$HOST_FINGERPRINT" || \
+        fail 'candidate host fingerprint differs from baseline'
+    cmp --silent "$ARTIFACT_DIR/microbench-baseline-toolchain.txt" "$TOOLCHAIN" || \
+        fail 'candidate toolchain differs from baseline'
+    cmp --silent "$ARTIFACT_DIR/microbench-baseline-harness-SHA256SUMS" "$HARNESS_HASHES" || \
+        fail 'measurement harness differs from baseline'
+fi
+CARGO_CONFIG_SHA256=$(config_hash)
+BUILD_ENVIRONMENT_SHA256=$(build_environment_hash)
+if [[ "$PHASE" == candidate ]]; then
+    [[ "$(read_value "$BASELINE_ENV" cargo_home_config_sha256)" == \
+        "$CARGO_CONFIG_SHA256" ]] || \
+        fail 'candidate Cargo home configuration differs from baseline'
+    [[ "$(read_value "$BASELINE_ENV" build_environment_sha256)" == \
+        "$BUILD_ENVIRONMENT_SHA256" ]] || \
+        fail 'candidate build environment differs from baseline'
+fi
+
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$FENCE"
+lan393_acquire_host_lock
+PREFLIGHT=$ARTIFACT_DIR/microbench-$PHASE-host-preflight.tsv
+lan393_init_host_preflight_log "$PREFLIGHT"
+
+TARGET_DIR=$STATE_DIR/targets/$PHASE-$SOURCE_COMMIT
+BUILD_RAW=$(mktemp /tmp/lan393-build.XXXXXX.jsonl)
+BUILD_RECEIPT=$ARTIFACT_DIR/microbench-$PHASE-bench-build.json
+BINARY_FILE=$(mktemp /tmp/lan393-binary.XXXXXX)
+(
+    cd "$SOURCE_DIR"
+    CARGO_TARGET_DIR=$TARGET_DIR cargo bench -p rustbgpd-api \
+        --features bench-internals --bench event_history_producer \
+        --locked --no-run --message-format=json >"$BUILD_RAW"
+)
+sanitize_build_receipt "$BUILD_RAW" "$BUILD_RECEIPT" "$TARGET_DIR" "$BINARY_FILE"
+rm -f "$BUILD_RAW"
+BENCH_BIN=$(<"$BINARY_FILE")
+rm -f "$BINARY_FILE"
+[[ -x "$BENCH_BIN" ]] || fail 'resolved benchmark executable is not executable'
+BENCH_SHA=$(sha256sum "$BENCH_BIN" | awk '{print $1}')
+
+STATE_MANIFEST=$STATE_DIR/baseline-state-SHA256SUMS
+if [[ "$PHASE" == candidate ]]; then
+    [[ -f "$STATE_MANIFEST" && ! -L "$STATE_MANIFEST" ]] || fail 'missing baseline Criterion state manifest'
+    [[ "$(sha256sum "$STATE_MANIFEST" | awk '{print $1}')" == \
+        "$(read_value "$BASELINE_ENV" live_baseline_state_manifest_sha256)" ]] || \
+        fail 'live baseline state manifest does not match the published baseline receipt'
+    (cd "$STATE_DIR" && sha256sum --check "$(basename "$STATE_MANIFEST")" >/dev/null) || \
+        fail 'baseline Criterion state changed before candidate run'
+fi
+
+for group in lan393_manager_self_time lan393_sqlite_end_to_end; do
+    lan393_wait_for_idle "$PHASE-$group" "$PREFLIGHT"
+    if [[ "$PHASE" == baseline ]]; then
+        CRITERION_HOME=$STATE_DIR/criterion "$BENCH_BIN" --bench "$group" \
+            --save-baseline "$BASELINE_NAME" --noplot
+    else
+        CRITERION_HOME=$STATE_DIR/criterion "$BENCH_BIN" --bench "$group" \
+            --baseline "$BASELINE_NAME" --noplot
+    fi
+done
+[[ "$(sha256sum "$BENCH_BIN" | awk '{print $1}')" == "$BENCH_SHA" ]] || \
+    fail 'benchmark executable changed during measurement'
+[[ "$(config_hash)" == "$CARGO_CONFIG_SHA256" ]] || \
+    fail 'Cargo home configuration changed during measurement'
+[[ "$(build_environment_hash)" == "$BUILD_ENVIRONMENT_SHA256" ]] || \
+    fail 'build environment changed during measurement'
+if [[ "$PHASE" == candidate ]]; then
+    (cd "$STATE_DIR" && sha256sum --check "$(basename "$STATE_MANIFEST")" >/dev/null) || \
+        fail 'candidate measurement changed the saved baseline state'
+fi
+
+if [[ "$PHASE" == baseline ]]; then
+    STATE_MANIFEST_TMP=$(mktemp "$STATE_DIR/.baseline-state.XXXXXX")
+    (
+        cd "$STATE_DIR"
+        find criterion -type f -path "*/$BASELINE_NAME/*.json" -print0 \
+            | sort -z | xargs -0 -r sha256sum
+    ) >"$STATE_MANIFEST_TMP"
+    [[ -s "$STATE_MANIFEST_TMP" ]] || fail 'Criterion emitted no named baseline state'
+    mv "$STATE_MANIFEST_TMP" "$STATE_MANIFEST"
+    (cd "$STATE_DIR" && sha256sum --check "$(basename "$STATE_MANIFEST")" >/dev/null)
+fi
+
+CRITERION_ARTIFACT=$ARTIFACT_DIR/criterion-$PHASE
+copy_criterion_json "$STATE_DIR/criterion" "$CRITERION_ARTIFACT"
+ARTIFACT_STATE_MANIFEST=$ARTIFACT_DIR/microbench-$PHASE-baseline-state-SHA256SUMS
+(
+    cd "$ARTIFACT_DIR"
+    find "criterion-$PHASE" -type f -path "*/$BASELINE_NAME/*.json" -print0 \
+        | sort -z | xargs -0 -r sha256sum
+) >"$ARTIFACT_STATE_MANIFEST"
+[[ -s "$ARTIFACT_STATE_MANIFEST" ]] || fail 'retained artifact omitted named baseline state'
+RESULTS=$ARTIFACT_DIR/microbench-$PHASE-results.csv
+VERDICT=$ARTIFACT_DIR/microbench-$PHASE-verdict.json
+python3 "$SOURCE_DIR/$VALIDATOR_REL" \
+    --phase "$PHASE" \
+    --criterion-dir "$CRITERION_ARTIFACT" \
+    --baseline-name "$BASELINE_NAME" \
+    --results "$RESULTS" \
+    --verdict "$VERDICT"
+
+SOURCE_ARCHIVE=$ARTIFACT_DIR/rustbgpd-$PHASE-source.tar.gz
+git -C "$ROOT" archive --format=tar.gz --output "$SOURCE_ARCHIVE" "$SOURCE_COMMIT"
+ENVIRONMENT=$ARTIFACT_DIR/microbench-$PHASE-environment.txt
+{
+    printf 'receipt_schema=2\n'
+    printf 'phase=%s\n' "$PHASE"
+    printf 'repository=%s\n' "$REPO_SLUG"
+    printf 'source_commit=%s\n' "$SOURCE_COMMIT"
+    printf 'baseline_commit=%s\n' "$BASELINE_COMMIT"
+    printf 'baseline_ref=%s\n' "$BASELINE_REF"
+    printf 'baseline_name=%s\n' "$BASELINE_NAME"
+    printf 'live_baseline_state_manifest_sha256=%s\n' "$(sha256sum "$STATE_MANIFEST" | awk '{print $1}')"
+    printf 'detached_worktree=1\n'
+    printf 'separate_target_dir=1\n'
+    printf 'shared_criterion_dir=1\n'
+    printf 'cargo_incremental=0\n'
+    printf 'cargo_home_config_sha256=%s\n' "$CARGO_CONFIG_SHA256"
+    printf 'build_environment_sha256=%s\n' "$BUILD_ENVIRONMENT_SHA256"
+    printf 'benchmark_binary_basename=%s\n' "$(basename "$BENCH_BIN")"
+    printf 'benchmark_binary_sha256=%s\n' "$BENCH_SHA"
+    printf 'host_lock_policy=rustbgpd-shared-user-lock\n'
+    printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+    printf 'required_governor=performance\n'
+} >"$ENVIRONMENT"
+if [[ "$PHASE" == candidate ]]; then
+    [[ "$(read_value "$ARTIFACT_DIR/microbench-baseline-environment.txt" live_baseline_state_manifest_sha256)" == \
+        "$(read_value "$ENVIRONMENT" live_baseline_state_manifest_sha256)" ]] || \
+        fail 'candidate consumed a different named baseline state'
+fi
+
+COMPLETION=$ARTIFACT_DIR/microbench-$PHASE-completion.txt
+privacy_check "$PHASE"
+{
+    printf 'phase=%s\n' "$PHASE"
+    printf 'source_commit=%s\n' "$SOURCE_COMMIT"
+    printf 'matrix_complete=1\n'
+    printf 'privacy_check=pass\n'
+    printf 'run_utc_complete=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$COMPLETION"
+privacy_check "$PHASE"
+write_manifest "$PHASE" "$SOURCE_ARCHIVE"
+printf 'LAN-393 %s Criterion receipt complete: %s\n' "$PHASE" "$VERDICT"

--- a/docs/perf/run-lan393-full-daemon.sh
+++ b/docs/perf/run-lan393-full-daemon.sh
@@ -3,37 +3,41 @@
 set -euo pipefail
 
 usage() {
-    printf 'usage: %s baseline|candidate\n' "$0" >&2
+    printf 'usage: %s baseline-enabled|baseline-disabled|candidate-enabled|candidate-disabled\n' "$0" >&2
     exit 2
 }
 
 [[ $# -eq 1 ]] || usage
-PHASE=$1
-case "$PHASE" in
-    baseline | candidate) ;;
+PROFILE=$1
+case "$PROFILE" in
+    baseline-enabled | baseline-disabled | candidate-enabled | candidate-disabled) ;;
     *) usage ;;
 esac
+SOURCE_PHASE=${PROFILE%%-*}
+EHM_MODE=${PROFILE##*-}
 
 RUSTBGPD_SOURCE=${RUSTBGPD_SOURCE:-$PWD}
 ARTIFACT_DIR=${ARTIFACT_DIR:-$RUSTBGPD_SOURCE/docs/perf/artifacts/event-history-producer-2026-07}
 BGPERF2_REMOTE=https://github.com/lance0/bgperf2.git
 BGPERF2_COMMIT=fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9
 BGPERF2_DIR=${BGPERF2_DIR:-/tmp/lan393-bgperf2-$BGPERF2_COMMIT}
-BGPERF_RUN_DIR=${BGPERF_RUN_DIR:-/tmp/lan393-bgperf-$PHASE}
-BENCH_NAME=lan393-$PHASE
-PROFILE_IMAGE=${PROFILE_IMAGE:-bgperf/rustbgpd:lan393-$PHASE-ehm-prof}
+BGPERF_RUN_DIR=${BGPERF_RUN_DIR:-/tmp/lan393-bgperf-$PROFILE}
+BENCH_NAME=lan393-$PROFILE
+PROFILE_IMAGE=${PROFILE_IMAGE:-bgperf/rustbgpd:lan393-$PROFILE-prof}
 TARGET_CONTAINER=${TARGET_CONTAINER:-bgperf_rustbgpd_target}
 VALIDATOR=$RUSTBGPD_SOURCE/docs/perf/validate-lan393-receipt.py
 WRAPPER=$RUSTBGPD_SOURCE/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
 HOST_FENCE=$RUSTBGPD_SOURCE/docs/perf/lan393-host-fence.sh
-PREFIX=$ARTIFACT_DIR/full-daemon-$PHASE
-BASELINE_ENV=$ARTIFACT_DIR/environment.txt
-CANDIDATE_ENV=$ARTIFACT_DIR/candidate-environment.txt
+PREFIX=$ARTIFACT_DIR/full-daemon-$PROFILE
+BASELINE_ENV=$ARTIFACT_DIR/microbench-baseline-environment.txt
+CANDIDATE_ENV=$ARTIFACT_DIR/microbench-candidate-environment.txt
 RUST_BUILDER_IMAGE='rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1'
 DEBIAN_RUNTIME_IMAGE='debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df'
 BUILD_CONTEXT=''
 BGPERF_PID=''
 TARGET_PID=''
+PRIVATE_PERF_DIR=${LAN393_PRIVATE_PERF_DIR:-$RUSTBGPD_SOURCE/target/lan393-private-perf}
+PRIVATE_PERF_DATA=$PRIVATE_PERF_DIR/full-daemon-$PROFILE.perf.data
 
 cleanup() {
     if [[ -n "$TARGET_PID" ]]; then
@@ -54,6 +58,72 @@ read_receipt_value() {
     awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; found = 1 } END { if (!found) exit 1 }' "$file"
 }
 
+write_host_fingerprint() {
+    local output=$1 cpu_model physical_cores logical_cpus memory_bytes
+    cpu_model=$(awk -F: '/model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
+    logical_cpus=$(getconf _NPROCESSORS_ONLN)
+    physical_cores=$(lscpu -p=CORE,SOCKET | awk '!/^#/ { seen[$1 FS $2]=1 } END { print length(seen) }')
+    memory_bytes=$(awk '/MemTotal:/ { print $2 * 1024 }' /proc/meminfo)
+    {
+        printf 'schema=1\n'
+        printf 'kernel=%s\n' "$(uname -srm)"
+        printf 'architecture=%s\n' "$(uname -m)"
+        printf 'cpu_model=%s\n' "$cpu_model"
+        printf 'physical_cores=%s\n' "$physical_cores"
+        printf 'logical_cpus=%s\n' "$logical_cpus"
+        printf 'memory_bytes=%.0f\n' "$memory_bytes"
+        printf 'repo_fs=%s\n' "$(findmnt -n -T "$RUSTBGPD_SOURCE" -o FSTYPE)"
+        printf 'tmp_fs=%s\n' "$(findmnt -n -T /tmp -o FSTYPE)"
+    } >"$output"
+}
+
+write_host_toolchain() {
+    local output=$1 package_hash
+    package_hash=$(python3 -m pip list --format=freeze 2>/dev/null | LC_ALL=C sort | sha256sum | awk '{print $1}')
+    {
+        python3 --version
+        docker --version
+        perf --version
+        printf 'python_packages_sha256=%s\n' "$package_hash"
+    } >"$output"
+}
+
+compare_provenance_without_source_commit() {
+    local reference=$1 candidate=$2 label=$3 left right
+    left=$(mktemp /tmp/lan393-provenance-reference.XXXXXX)
+    right=$(mktemp /tmp/lan393-provenance-candidate.XXXXXX)
+    sed '/^rustbgpd_commit=/d' "$reference" >"$left"
+    sed '/^rustbgpd_commit=/d' "$candidate" >"$right"
+    if ! cmp --silent "$left" "$right"; then
+        diff -u "$left" "$right" >&2 || true
+        rm -f "$left" "$right"
+        printf '%s provenance differs from baseline-enabled\n' "$label" >&2
+        exit 1
+    fi
+    rm -f "$left" "$right"
+}
+
+privacy_check() {
+    python3 - "$ARTIFACT_DIR" "$PROFILE" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+profile = sys.argv[2]
+private = re.compile(r"(?:/home/[^/\s]+|/Users/[^/\s]+|https?://[^/\s:@]+:[^/\s@]+@|git@)")
+for path in root.rglob(f"full-daemon-{profile}-*"):
+    if not path.is_file() or path.is_symlink():
+        continue
+    if path.suffix not in {".txt", ".tsv", ".json", ".csv", ".toml", ".log", ".yaml"} and "SHA256SUMS" not in path.name:
+        continue
+    text = path.read_text(encoding="utf-8", errors="strict")
+    match = private.search(text)
+    if match:
+        raise SystemExit(f"private host material in {path.name}: {match.group(0)!r}")
+PY
+}
+
 require_clean_source() {
     RUSTBGPD_STATUS=$(git -C "$RUSTBGPD_SOURCE" status \
         --porcelain=v1 --untracked-files=all \
@@ -69,15 +139,19 @@ require_clean_source() {
 require_new_phase_receipt() {
     local existing
     existing=$(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 \
-        -name "full-daemon-$PHASE-*" -print -quit 2>/dev/null || true)
+        -name "full-daemon-$PROFILE-*" -print -quit 2>/dev/null || true)
     if [[ -n "$existing" ]]; then
-        printf 'refusing existing %s receipt: %s\n' "$PHASE" "$existing" >&2
+        printf 'refusing existing %s receipt: %s\n' "$PROFILE" "$existing" >&2
         exit 1
     fi
 }
 
+[[ ! -L "$ARTIFACT_DIR" ]] || {
+    printf 'artifact directory must not be a symlink: %s\n' "$ARTIFACT_DIR" >&2
+    exit 1
+}
 mkdir -p "$ARTIFACT_DIR"
-[[ -f "$BASELINE_ENV" ]] || {
+[[ -f "$BASELINE_ENV" && ! -L "$BASELINE_ENV" ]] || {
     printf 'missing baseline identity: %s\n' "$BASELINE_ENV" >&2
     exit 1
 }
@@ -91,12 +165,7 @@ mkdir -p "$ARTIFACT_DIR"
 }
 
 RECORDED_BASELINE_COMMIT=$(read_receipt_value "$BASELINE_ENV" baseline_commit)
-RECORDED_BASELINE_REF_COMMIT=$(read_receipt_value "$BASELINE_ENV" baseline_ref_commit)
-[[ "$RECORDED_BASELINE_COMMIT" == "$RECORDED_BASELINE_REF_COMMIT" ]] || {
-    printf 'recorded baseline/ref mismatch: %s != %s\n' \
-        "$RECORDED_BASELINE_COMMIT" "$RECORDED_BASELINE_REF_COMMIT" >&2
-    exit 1
-}
+RECORDED_BASELINE_REF_COMMIT=$RECORDED_BASELINE_COMMIT
 [[ "$(git -C "$RUSTBGPD_SOURCE" rev-parse "$RECORDED_BASELINE_COMMIT^{commit}")" == \
     "$RECORDED_BASELINE_COMMIT" ]] || {
     printf 'recorded baseline is not an exact local commit: %s\n' \
@@ -105,7 +174,7 @@ RECORDED_BASELINE_REF_COMMIT=$(read_receipt_value "$BASELINE_ENV" baseline_ref_c
 }
 
 RUSTBGPD_COMMIT=$(git -C "$RUSTBGPD_SOURCE" rev-parse HEAD)
-case "$PHASE" in
+case "$SOURCE_PHASE" in
     baseline)
         [[ "$RUSTBGPD_COMMIT" == "$RECORDED_BASELINE_COMMIT" ]] || {
             printf 'baseline profile HEAD %s does not match recorded baseline %s\n' \
@@ -114,13 +183,12 @@ case "$PHASE" in
         }
         ;;
     candidate)
-        [[ -f "$CANDIDATE_ENV" ]] || {
+        [[ -f "$CANDIDATE_ENV" && ! -L "$CANDIDATE_ENV" ]] || {
             printf 'missing candidate identity: %s\n' "$CANDIDATE_ENV" >&2
             exit 1
         }
-        RECORDED_CANDIDATE_COMMIT=$(read_receipt_value "$CANDIDATE_ENV" candidate_commit)
-        CANDIDATE_BASELINE_COMMIT=$(read_receipt_value \
-            "$CANDIDATE_ENV" recorded_baseline_commit)
+        RECORDED_CANDIDATE_COMMIT=$(read_receipt_value "$CANDIDATE_ENV" source_commit)
+        CANDIDATE_BASELINE_COMMIT=$(read_receipt_value "$CANDIDATE_ENV" baseline_commit)
         [[ "$CANDIDATE_BASELINE_COMMIT" == "$RECORDED_BASELINE_COMMIT" ]] || {
             printf 'candidate receipt baseline %s does not match recorded baseline %s\n' \
                 "$CANDIDATE_BASELINE_COMMIT" "$RECORDED_BASELINE_COMMIT" >&2
@@ -145,6 +213,49 @@ case "$PHASE" in
         ;;
 esac
 
+if [[ "$SOURCE_PHASE" == candidate ]]; then
+    python3 - "$ARTIFACT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+requirements = (
+    (root / "microbench-candidate-verdict.json", "candidate_acceptance_pass"),
+    (root / "full-daemon-baseline-disabled-overall-verdict.json", "overall_proceed_pass"),
+)
+for path, key in requirements:
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"missing required prior verdict: {path.name}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get(key) is not True:
+        raise SystemExit(f"prior verdict did not pass: {path.name}:{key}")
+PY
+fi
+
+(
+    cd "$ARTIFACT_DIR"
+    sha256sum --check "microbench-$SOURCE_PHASE-SHA256SUMS" >/dev/null
+)
+if [[ "$PROFILE" != baseline-enabled ]]; then
+    (
+        cd "$ARTIFACT_DIR"
+        sha256sum --check full-daemon-baseline-enabled-SHA256SUMS >/dev/null
+    )
+fi
+if [[ "$SOURCE_PHASE" == candidate ]]; then
+    (
+        cd "$ARTIFACT_DIR"
+        sha256sum --check full-daemon-baseline-disabled-SHA256SUMS >/dev/null
+    )
+fi
+if [[ "$PROFILE" == candidate-disabled ]]; then
+    (
+        cd "$ARTIFACT_DIR"
+        sha256sum --check full-daemon-candidate-enabled-SHA256SUMS >/dev/null
+    )
+fi
+
 require_clean_source
 require_new_phase_receipt
 # shellcheck source=docs/perf/lan393-host-fence.sh
@@ -152,36 +263,68 @@ source "$HOST_FENCE"
 lan393_acquire_host_lock
 HOST_PREFLIGHT=$PREFIX-host-preflight.tsv
 lan393_init_host_preflight_log "$HOST_PREFLIGHT"
-lan393_wait_for_idle "$PHASE-before-build" "$HOST_PREFLIGHT"
+HOST_FINGERPRINT=$PREFIX-host-fingerprint.txt
+HOST_TOOLCHAIN=$PREFIX-host-toolchain.txt
+write_host_fingerprint "$HOST_FINGERPRINT"
+write_host_toolchain "$HOST_TOOLCHAIN"
+cmp --silent "$ARTIFACT_DIR/microbench-$SOURCE_PHASE-host-fingerprint.txt" "$HOST_FINGERPRINT" || {
+    printf '%s\n' 'full-daemon host differs from its microbenchmark phase' >&2
+    exit 1
+}
+if [[ "$PROFILE" != baseline-enabled ]]; then
+    cmp --silent "$ARTIFACT_DIR/full-daemon-baseline-enabled-host-toolchain.txt" "$HOST_TOOLCHAIN" || {
+        printf '%s\n' 'full-daemon host tools differ from baseline-enabled' >&2
+        exit 1
+    }
+fi
+lan393_wait_for_idle "$PROFILE-before-build" "$HOST_PREFLIGHT"
 rm -rf "$BGPERF_RUN_DIR"
 
-# Rebuild the baseline archive from the receipt's exact commit. Baseline runs
-# replace it; candidate runs prove the retained archive is byte-identical.
+# Criterion establishes each exact source archive. Every full-daemon profile
+# regenerates it into a temporary file and proves byte identity without
+# mutating prior manifests.
 BASELINE_ARCHIVE=$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz
+[[ ! -L "$BASELINE_ARCHIVE" ]] || {
+    printf 'baseline source archive must not be a symlink: %s\n' "$BASELINE_ARCHIVE" >&2
+    exit 1
+}
 BASELINE_ARCHIVE_TMP=$(mktemp "$ARTIFACT_DIR/.baseline-source.XXXXXX.tar.gz")
 git -C "$RUSTBGPD_SOURCE" archive --format=tar.gz \
     --output "$BASELINE_ARCHIVE_TMP" "$RECORDED_BASELINE_COMMIT"
-if [[ "$PHASE" == baseline ]]; then
-    mv "$BASELINE_ARCHIVE_TMP" "$BASELINE_ARCHIVE"
-else
-    [[ -f "$BASELINE_ARCHIVE" ]] || {
-        printf 'candidate profile requires retained baseline archive: %s\n' \
-            "$BASELINE_ARCHIVE" >&2
-        rm -f "$BASELINE_ARCHIVE_TMP"
-        exit 1
-    }
-    cmp --silent "$BASELINE_ARCHIVE_TMP" "$BASELINE_ARCHIVE" || {
-        printf '%s\n' 'retained baseline archive does not match recorded commit' >&2
-        rm -f "$BASELINE_ARCHIVE_TMP"
-        exit 1
-    }
+[[ -f "$BASELINE_ARCHIVE" ]] || {
+    printf 'profile requires retained microbenchmark baseline archive: %s\n' \
+        "$BASELINE_ARCHIVE" >&2
     rm -f "$BASELINE_ARCHIVE_TMP"
-fi
+    exit 1
+}
+cmp --silent "$BASELINE_ARCHIVE_TMP" "$BASELINE_ARCHIVE" || {
+    printf '%s\n' 'retained baseline archive does not match recorded commit' >&2
+    rm -f "$BASELINE_ARCHIVE_TMP"
+    exit 1
+}
+rm -f "$BASELINE_ARCHIVE_TMP"
 
-if [[ "$PHASE" == candidate ]]; then
+if [[ "$SOURCE_PHASE" == candidate ]]; then
     CANDIDATE_ARCHIVE=$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz
+    [[ ! -L "$CANDIDATE_ARCHIVE" ]] || {
+        printf 'candidate source archive must not be a symlink: %s\n' "$CANDIDATE_ARCHIVE" >&2
+        exit 1
+    }
+    CANDIDATE_ARCHIVE_TMP=$(mktemp "$ARTIFACT_DIR/.candidate-source.XXXXXX.tar.gz")
     git -C "$RUSTBGPD_SOURCE" archive --format=tar.gz \
-        --output "$CANDIDATE_ARCHIVE" "$RUSTBGPD_COMMIT"
+        --output "$CANDIDATE_ARCHIVE_TMP" "$RUSTBGPD_COMMIT"
+    [[ -f "$CANDIDATE_ARCHIVE" ]] || {
+        printf 'profile requires retained microbenchmark candidate archive: %s\n' \
+            "$CANDIDATE_ARCHIVE" >&2
+        rm -f "$CANDIDATE_ARCHIVE_TMP"
+        exit 1
+    }
+    cmp --silent "$CANDIDATE_ARCHIVE_TMP" "$CANDIDATE_ARCHIVE" || {
+        printf '%s\n' 'retained candidate archive does not match recorded commit' >&2
+        rm -f "$CANDIDATE_ARCHIVE_TMP"
+        exit 1
+    }
+    rm -f "$CANDIDATE_ARCHIVE_TMP"
     BUILD_ARCHIVE=$CANDIDATE_ARCHIVE
 else
     BUILD_ARCHIVE=$BASELINE_ARCHIVE
@@ -199,12 +342,12 @@ VALIDATOR=$BUILD_CONTEXT/docs/perf/validate-lan393-receipt.py
 
 IDENTITY_ARGS=(
     identity
-    --phase "$PHASE"
+    --phase "$SOURCE_PHASE"
     --source-head "$RUSTBGPD_COMMIT"
     --baseline-commit "$RECORDED_BASELINE_COMMIT"
     --baseline-ref-commit "$RECORDED_BASELINE_REF_COMMIT"
 )
-if [[ "$PHASE" == candidate ]]; then
+if [[ "$SOURCE_PHASE" == candidate ]]; then
     IDENTITY_ARGS+=(
         --candidate-commit "$RECORDED_CANDIDATE_COMMIT"
         --candidate-baseline-ancestor true
@@ -223,13 +366,29 @@ BGPERF2_STATUS=$(git -C "$BGPERF2_DIR" status --porcelain=v1 --untracked-files=a
     exit 1
 }
 BGPERF2_ARCHIVE=$ARTIFACT_DIR/bgperf2-source-$BGPERF2_COMMIT.tar.gz
+BGPERF2_ARCHIVE_TMP=$(mktemp "$ARTIFACT_DIR/.bgperf2-source.XXXXXX.tar.gz")
 git -C "$BGPERF2_DIR" archive --format=tar.gz \
-    --output "$BGPERF2_ARCHIVE" "$BGPERF2_COMMIT"
+    --output "$BGPERF2_ARCHIVE_TMP" "$BGPERF2_COMMIT"
+if [[ "$PROFILE" == baseline-enabled ]]; then
+    mv "$BGPERF2_ARCHIVE_TMP" "$BGPERF2_ARCHIVE"
+else
+    [[ -f "$BGPERF2_ARCHIVE" ]] || {
+        printf 'profile requires retained bgperf2 archive: %s\n' "$BGPERF2_ARCHIVE" >&2
+        rm -f "$BGPERF2_ARCHIVE_TMP"
+        exit 1
+    }
+    cmp --silent "$BGPERF2_ARCHIVE_TMP" "$BGPERF2_ARCHIVE" || {
+        printf '%s\n' 'retained bgperf2 archive does not match pinned commit' >&2
+        rm -f "$BGPERF2_ARCHIVE_TMP"
+        exit 1
+    }
+    rm -f "$BGPERF2_ARCHIVE_TMP"
+fi
 
 SOURCE_HASHES=$PREFIX-source-sha256.txt
 (
     cd "$ARTIFACT_DIR"
-    if [[ "$PHASE" == baseline ]]; then
+    if [[ "$SOURCE_PHASE" == baseline ]]; then
         sha256sum "$(basename "$BASELINE_ARCHIVE")" \
             "$(basename "$BGPERF2_ARCHIVE")"
     else
@@ -242,7 +401,8 @@ SOURCE_HASHES=$PREFIX-source-sha256.txt
 docker build --no-cache \
     --build-arg "RUSTBGPD_COMMIT=$RUSTBGPD_COMMIT" \
     --build-arg "BGPERF2_COMMIT=$BGPERF2_COMMIT" \
-    --build-arg "PROFILE_PHASE=$PHASE" \
+    --build-arg "PROFILE_PHASE=$SOURCE_PHASE" \
+    --build-arg "EVENT_HISTORY_MODE=$EHM_MODE" \
     --file - \
     --tag "$PROFILE_IMAGE" \
     "$BUILD_CONTEXT" <<DOCKERFILE
@@ -270,6 +430,7 @@ FROM $DEBIAN_RUNTIME_IMAGE
 ARG RUSTBGPD_COMMIT
 ARG BGPERF2_COMMIT
 ARG PROFILE_PHASE
+ARG EVENT_HISTORY_MODE
 LABEL org.opencontainers.image.revision="\$RUSTBGPD_COMMIT"
 LABEL org.rustbgpd.bgperf2.revision="\$BGPERF2_COMMIT"
 LABEL org.opencontainers.image.base.name="$DEBIAN_RUNTIME_IMAGE"
@@ -277,6 +438,8 @@ LABEL org.opencontainers.image.base.digest="${DEBIAN_RUNTIME_IMAGE##*sha256:}"
 LABEL org.rustbgpd.bgperf2.builder-base.digest="${RUST_BUILDER_IMAGE##*sha256:}"
 LABEL org.rustbgpd.bgperf2.rust-toolchain="1.95"
 LABEL org.rustbgpd.lan393.profile-phase="\$PROFILE_PHASE"
+LABEL org.rustbgpd.lan393.event-history-mode="\$EVENT_HISTORY_MODE"
+ENV LAN393_EVENT_HISTORY_MODE="\$EVENT_HISTORY_MODE"
 WORKDIR /root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
@@ -309,34 +472,50 @@ docker cp \
     "$PROVENANCE_CONTAINER:/usr/local/share/rustbgpd-runtime-provenance.txt" \
     "$RUNTIME_PROVENANCE"
 docker rm "$PROVENANCE_CONTAINER" >/dev/null
+if [[ "$PROFILE" != baseline-enabled ]]; then
+    compare_provenance_without_source_commit \
+        "$ARTIFACT_DIR/full-daemon-baseline-enabled-builder-provenance.txt" \
+        "$BUILDER_PROVENANCE" builder
+    compare_provenance_without_source_commit \
+        "$ARTIFACT_DIR/full-daemon-baseline-enabled-runtime-provenance.txt" \
+        "$RUNTIME_PROVENANCE" runtime
+fi
 docker run --rm --entrypoint sha256sum "$PROFILE_IMAGE" \
     /usr/local/bin/rustbgpd.real /usr/local/bin/rustbgpctl >"$BINARY_HASHES"
+if [[ "$EHM_MODE" == disabled ]]; then
+    cmp --silent \
+        "$ARTIFACT_DIR/full-daemon-$SOURCE_PHASE-enabled-binary-sha256.txt" \
+        "$BINARY_HASHES" || {
+        printf '%s\n' 'enabled/disabled images contain different rustbgpd binaries' >&2
+        exit 1
+    }
+fi
 python3 "$VALIDATOR" image \
     --inspect "$IMAGE_INSPECT" \
     --builder-provenance "$BUILDER_PROVENANCE" \
     --runtime-provenance "$RUNTIME_PROVENANCE" \
     --source-commit "$RUSTBGPD_COMMIT" \
     --bgperf2-commit "$BGPERF2_COMMIT" \
-    --phase "$PHASE" >"$IMAGE_VALIDATION"
+    --phase "$SOURCE_PHASE" \
+    --mode "$EHM_MODE" >"$IMAGE_VALIDATION"
 
 PROFILE_IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$PROFILE_IMAGE")
 {
-    printf 'profile_phase=%s\n' "$PHASE"
+    printf 'profile_phase=%s\n' "$SOURCE_PHASE"
+    printf 'event_history_mode=%s\n' "$EHM_MODE"
     printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
     printf 'rustbgpd_commit=%s\n' "$RUSTBGPD_COMMIT"
-    printf 'rustbgpd_remote=%s\n' \
-        "$(git -C "$RUSTBGPD_SOURCE" remote get-url origin)"
+    printf 'repository=lance0/rustbgpd\n'
     printf 'rustbgpd_status=%s\n' "$RUSTBGPD_STATUS"
     printf 'rustbgpd_build_context=exact_commit_archive\n'
     printf 'bgperf2_commit=%s\n' "$BGPERF2_COMMIT"
-    printf 'bgperf2_remote=%s\n' \
-        "$(git -C "$BGPERF2_DIR" remote get-url origin)"
+    printf 'bgperf2_repository=lance0/bgperf2\n'
     printf 'bgperf2_status=%s\n' "$BGPERF2_STATUS"
     printf 'builder_base=%s\n' "$RUST_BUILDER_IMAGE"
     printf 'runtime_base=%s\n' "$DEBIAN_RUNTIME_IMAGE"
     printf 'profile_image_tag=%s\n' "$PROFILE_IMAGE"
     printf 'profile_image_id=%s\n' "$PROFILE_IMAGE_ID"
-    printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
+    printf 'host_lock_policy=rustbgpd-shared-user-lock\n'
     printf 'host_lock_acquired=1\n'
     printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
     printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
@@ -344,7 +523,7 @@ PROFILE_IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$PROFILE_IMAGE")
     printf 'required_governor=performance\n'
 } >"$PREFIX-environment.txt"
 
-lan393_wait_for_idle "$PHASE-before-bgperf" "$HOST_PREFLIGHT"
+lan393_wait_for_idle "$PROFILE-before-bgperf" "$HOST_PREFLIGHT"
 (
     cd "$BGPERF2_DIR"
     env -u RUSTBGPD_EVENT_HISTORY \
@@ -371,6 +550,7 @@ for _ in $(seq 1 300); do
 done
 [[ -n "$TARGET_PID" ]]
 docker top "$TARGET_CONTAINER" -eo pid,stat,args \
+    | awk 'NR == 1 { print "state command"; next } { command=$3; sub(/^.*\//, "", command); print $2, command }' \
     >"$PREFIX-processes-pre-attach.txt"
 
 RUNNING_IMAGE_ID=$(docker inspect --format '{{.Image}}' "$TARGET_CONTAINER")
@@ -386,19 +566,35 @@ docker cp "$TARGET_CONTAINER:/root/config/config.toml" "$PREFIX-config.toml"
 docker cp \
     "$TARGET_CONTAINER:/root/config/lan393-profile-ready" \
     "$PREFIX-profile-ready.txt"
-grep -A6 '^\[event_history\]$' "$PREFIX-config.toml" \
-    >"$PREFIX-event-history-config.txt"
-grep -q '^enabled = true$' "$PREFIX-event-history-config.txt"
-grep -q '^required = true$' "$PREFIX-event-history-config.txt"
-grep -q '^synchronous = "full"$' "$PREFIX-event-history-config.txt"
+if [[ "$EHM_MODE" == enabled ]]; then
+    grep -A6 '^\[event_history\]$' "$PREFIX-config.toml" \
+        >"$PREFIX-event-history-config.txt"
+    grep -q '^enabled = true$' "$PREFIX-event-history-config.txt"
+    grep -q '^required = true$' "$PREFIX-event-history-config.txt"
+    grep -q '^path = "/var/lib/rustbgpd/events.db"$' "$PREFIX-event-history-config.txt"
+    grep -q '^synchronous = "full"$' "$PREFIX-event-history-config.txt"
+    grep -q '^queue_capacity = 262144$' "$PREFIX-event-history-config.txt"
+else
+    if grep -q '^\[event_history\]$' "$PREFIX-config.toml"; then
+        printf '%s\n' 'disabled profile unexpectedly contains event_history config' >&2
+        exit 1
+    fi
+    printf 'event_history_mode=disabled\nevent_history_block=absent\n' \
+        >"$PREFIX-event-history-config.txt"
+fi
 
+mkdir -p "$PRIVATE_PERF_DIR"
+[[ ! -e "$PRIVATE_PERF_DATA" ]] || {
+    printf 'refusing existing private perf capture: %s\n' "$PRIVATE_PERF_DATA" >&2
+    exit 1
+}
 sudo perf buildid-cache --add \
     "/proc/$TARGET_PID/root/usr/local/bin/rustbgpd.real"
 sudo perf record \
     --freq 997 \
     --call-graph dwarf \
     --pid "$TARGET_PID" \
-    --output "$PREFIX-ehm.perf.data" \
+    --output "$PRIVATE_PERF_DATA" \
     -- sleep 30 &
 PERF_PID=$!
 sleep 1
@@ -438,7 +634,8 @@ cmp --silent "$SOURCE_SCENARIO" "$PREFIX-scenario.yaml"
 python3 "$VALIDATOR" bgperf \
     --log "$PREFIX-bgperf.log" \
     --scenario "$PREFIX-scenario.yaml" \
-    --phase "$PHASE" \
+    --phase "$SOURCE_PHASE" \
+    --mode "$EHM_MODE" \
     --bench-name "$BENCH_NAME" \
     --run-receipt-dir "$RUN_RECEIPT_DIR" \
     --source-scenario "$SOURCE_SCENARIO" \
@@ -464,52 +661,81 @@ for _ in $(seq 1 100); do
     break
 done
 
-awk '
-  /^bgp_event_outbox_committed_total/ { committed += $NF }
+awk -v mode="$EHM_MODE" '
+  /^bgp_event_outbox_committed_total/ { committed += $NF; seen_committed = 1 }
   /^bgp_event_outbox_dropped_total/ && $NF != 0 { bad = 1 }
-  /^bgp_event_outbox_queue_depth/ && $NF != 0 { bad = 1 }
-  /^bgp_event_outbox_latest_event_id / { latest = $NF }
-  /^bgp_event_outbox_degraded / && $NF != 0 { bad = 1 }
-  /^bgp_event_outbox_cursor_gap_total / && $NF != 0 { bad = 1 }
+  /^bgp_event_outbox_queue_depth/ { seen_queue = 1; if ($NF != 0) bad = 1 }
+  /^bgp_event_outbox_latest_event_id / { latest = $NF; seen_latest = 1 }
+  /^bgp_event_outbox_degraded / { seen_degraded = 1; if ($NF != 0) bad = 1 }
+  /^bgp_event_outbox_cursor_gap_total / { seen_gap = 1; if ($NF != 0) bad = 1 }
   END {
-    if (committed == 0 || latest != committed || bad) exit 1
+    if (bad || !seen_latest || !seen_degraded || !seen_gap) exit 1
+    if (mode == "enabled" && (!seen_committed || !seen_queue || committed == 0 || latest != committed)) exit 1
+    if (mode == "disabled" && (committed != 0 || latest != 0)) exit 1
   }
 ' "$PREFIX-metrics.txt"
 
 docker cp "$TARGET_CONTAINER:/root/config/rustbgpd.log" "$PREFIX-rustbgpd.log"
 docker stats --no-stream "$TARGET_CONTAINER" >"$PREFIX-docker-stats.txt"
 sudo perf report --stdio --children \
-    --input "$PREFIX-ehm.perf.data" \
-    | tee "$PREFIX-ehm.perf-report.txt" >/dev/null
+    --input "$PRIVATE_PERF_DATA" \
+    | sed -E 's#/home/[^ /]+#<host-home>#g; s#/Users/[^ /]+#<host-home>#g' \
+    >"$PREFIX-perf-report.txt"
 sudo perf script \
-    --input "$PREFIX-ehm.perf.data" \
-    | tee "$PREFIX-ehm.perf-script.txt" >/dev/null
-sudo chown "$(id -u):$(id -g)" "$PREFIX-ehm.perf.data"
+    --input "$PRIVATE_PERF_DATA" \
+    | python3 -c 'import re,sys
+for line in sys.stdin:
+    line=re.sub(r"^([^\n]*?)\s+[0-9]+(?:/[0-9]+)?\s+\[[0-9]+\]\s+[0-9.]+:", r"\1 PID/TID [CPU] TIME:", line)
+    line=re.sub(r"/(?:home|Users)/[^ /)]+", "<host-home>", line)
+    sys.stdout.write(line)' \
+    >"$PREFIX-perf-script.txt"
+python3 "$BUILD_CONTEXT/docs/perf/validate-lan393-perf.py" \
+    --input "$PREFIX-perf-script.txt" \
+    --phase "$SOURCE_PHASE" \
+    --mode "$EHM_MODE" \
+    --output "$PREFIX-perf-attribution.json" \
+    >"$PREFIX-perf-validation.txt"
+sudo sha256sum "$PRIVATE_PERF_DATA" \
+    | awk '{ print $1 "  private-perf.data" }' \
+    >"$PREFIX-private-perf-sha256.txt"
+sudo chown "$(id -u):$(id -g)" "$PRIVATE_PERF_DATA"
 
 # The completion sentinel is written only after convergence validation,
 # outbox-health checks, resource capture, and both inspectable perf derivatives
 # succeed. The phase manifest then binds every phase-prefixed receipt plus the
 # exact source archives it names.
+privacy_check
 {
-    printf 'profile_phase=%s\n' "$PHASE"
+    printf 'profile_phase=%s\n' "$SOURCE_PHASE"
+    printf 'event_history_mode=%s\n' "$EHM_MODE"
     printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
     printf 'rustbgpd_commit=%s\n' "$RUSTBGPD_COMMIT"
     printf 'run_utc_complete=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'phase_complete=1\n'
 } >"$PREFIX-completion.txt"
 
+if [[ "$EHM_MODE" == disabled ]]; then
+    python3 "$BUILD_CONTEXT/docs/perf/validate-lan393-full-comparison.py" \
+        --artifact-dir "$ARTIFACT_DIR" \
+        --phase "$SOURCE_PHASE" \
+        --output "$PREFIX-overall-verdict.json" \
+        >"$PREFIX-overall-validation.txt"
+fi
+
+privacy_check
+
 MANIFEST=$PREFIX-SHA256SUMS
-MANIFEST_TMP=$(mktemp "$ARTIFACT_DIR/.full-daemon-$PHASE-SHA256SUMS.XXXXXX")
+MANIFEST_TMP=$(mktemp "$ARTIFACT_DIR/.full-daemon-$PROFILE-SHA256SUMS.XXXXXX")
 (
     cd "$ARTIFACT_DIR"
     {
         find . -type f \
-            \( -name "full-daemon-$PHASE-*" \
-               -o -path "./full-daemon-$PHASE-*/*" \) \
-            ! -name "full-daemon-$PHASE-SHA256SUMS" -print0
+            \( -name "full-daemon-$PROFILE-*" \
+               -o -path "./full-daemon-$PROFILE-*/*" \) \
+            ! -name "full-daemon-$PROFILE-SHA256SUMS" -print0
         printf './%s\0' "$(basename "$BASELINE_ARCHIVE")" \
             "$(basename "$BGPERF2_ARCHIVE")"
-        if [[ "$PHASE" == candidate ]]; then
+        if [[ "$SOURCE_PHASE" == candidate ]]; then
             printf './%s\0' "$(basename "$CANDIDATE_ARCHIVE")"
         fi
     } | sort -zu | xargs -0 sha256sum

--- a/docs/perf/run-lan393-full-daemon.sh
+++ b/docs/perf/run-lan393-full-daemon.sh
@@ -63,7 +63,10 @@ write_host_fingerprint() {
     local output=$1 cpu_model physical_cores logical_cpus memory_bytes
     cpu_model=$(awk -F: '/model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }' /proc/cpuinfo)
     logical_cpus=$(getconf _NPROCESSORS_ONLN)
-    physical_cores=$(lscpu -p=CORE,SOCKET | awk '!/^#/ { seen[$1 FS $2]=1 } END { print length(seen) }')
+    physical_cores=$(lscpu -p=CORE,SOCKET | awk '
+        !/^#/ { seen[$1 FS $2]=1 }
+        END { for (key in seen) count++; print count + 0 }
+    ')
     memory_bytes=$(awk '/MemTotal:/ { print $2 * 1024 }' /proc/meminfo)
     {
         printf 'schema=1\n'

--- a/docs/perf/run-lan393-full-daemon.sh
+++ b/docs/perf/run-lan393-full-daemon.sh
@@ -38,6 +38,7 @@ BGPERF_PID=''
 TARGET_PID=''
 PRIVATE_PERF_DIR=${LAN393_PRIVATE_PERF_DIR:-$RUSTBGPD_SOURCE/target/lan393-private-perf}
 PRIVATE_PERF_DATA=$PRIVATE_PERF_DIR/full-daemon-$PROFILE.perf.data
+PRIVATE_PROFILE_READY=$PRIVATE_PERF_DIR/full-daemon-$PROFILE.profile-ready
 
 cleanup() {
     if [[ -n "$TARGET_PID" ]]; then
@@ -549,6 +550,15 @@ for _ in $(seq 1 300); do
     sleep 0.1
 done
 [[ -n "$TARGET_PID" ]]
+TARGET_NAMESPACE_PID=$(awk '
+    $1 == "NSpid:" { print $NF; found = 1 }
+    END { if (!found) exit 1 }
+' "/proc/$TARGET_PID/status")
+[[ "$TARGET_NAMESPACE_PID" =~ ^[1-9][0-9]*$ ]] || {
+    printf 'stopped target has malformed namespace PID: %s\n' \
+        "$TARGET_NAMESPACE_PID" >&2
+    exit 1
+}
 docker top "$TARGET_CONTAINER" -eo pid,stat,args \
     | awk 'NR == 1 { print "state command"; next } { command=$3; sub(/^.*\//, "", command); print $2, command }' \
     >"$PREFIX-processes-pre-attach.txt"
@@ -563,9 +573,18 @@ printf 'running_container_image_id=%s\n' "$RUNNING_IMAGE_ID" \
     >"$PREFIX-running-image.txt"
 
 docker cp "$TARGET_CONTAINER:/root/config/config.toml" "$PREFIX-config.toml"
+mkdir -p "$PRIVATE_PERF_DIR"
+[[ ! -e "$PRIVATE_PROFILE_READY" && ! -L "$PRIVATE_PROFILE_READY" ]] || {
+    printf 'refusing existing private profile barrier: %s\n' "$PRIVATE_PROFILE_READY" >&2
+    exit 1
+}
 docker cp \
     "$TARGET_CONTAINER:/root/config/lan393-profile-ready" \
-    "$PREFIX-profile-ready.txt"
+    "$PRIVATE_PROFILE_READY"
+python3 "$VALIDATOR" barrier \
+    --raw "$PRIVATE_PROFILE_READY" \
+    --expected-pid "$TARGET_NAMESPACE_PID" \
+    --output "$PREFIX-profile-ready.txt"
 if [[ "$EHM_MODE" == enabled ]]; then
     grep -A6 '^\[event_history\]$' "$PREFIX-config.toml" \
         >"$PREFIX-event-history-config.txt"
@@ -583,7 +602,6 @@ else
         >"$PREFIX-event-history-config.txt"
 fi
 
-mkdir -p "$PRIVATE_PERF_DIR"
 [[ ! -e "$PRIVATE_PERF_DATA" ]] || {
     printf 'refusing existing private perf capture: %s\n' "$PRIVATE_PERF_DATA" >&2
     exit 1

--- a/docs/perf/run-lan393-full-daemon.sh
+++ b/docs/perf/run-lan393-full-daemon.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# Reproducible LAN-393 full-daemon baseline/candidate profile receipt.
+set -euo pipefail
+
+usage() {
+    printf 'usage: %s baseline|candidate\n' "$0" >&2
+    exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+PHASE=$1
+case "$PHASE" in
+    baseline | candidate) ;;
+    *) usage ;;
+esac
+
+RUSTBGPD_SOURCE=${RUSTBGPD_SOURCE:-$PWD}
+ARTIFACT_DIR=${ARTIFACT_DIR:-$RUSTBGPD_SOURCE/docs/perf/artifacts/event-history-producer-2026-07}
+BGPERF2_REMOTE=https://github.com/lance0/bgperf2.git
+BGPERF2_COMMIT=fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9
+BGPERF2_DIR=${BGPERF2_DIR:-/tmp/lan393-bgperf2-$BGPERF2_COMMIT}
+BGPERF_RUN_DIR=${BGPERF_RUN_DIR:-/tmp/lan393-bgperf-$PHASE}
+BENCH_NAME=lan393-$PHASE
+PROFILE_IMAGE=${PROFILE_IMAGE:-bgperf/rustbgpd:lan393-$PHASE-ehm-prof}
+TARGET_CONTAINER=${TARGET_CONTAINER:-bgperf_rustbgpd_target}
+VALIDATOR=$RUSTBGPD_SOURCE/docs/perf/validate-lan393-receipt.py
+WRAPPER=$RUSTBGPD_SOURCE/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
+HOST_FENCE=$RUSTBGPD_SOURCE/docs/perf/lan393-host-fence.sh
+PREFIX=$ARTIFACT_DIR/full-daemon-$PHASE
+BASELINE_ENV=$ARTIFACT_DIR/environment.txt
+CANDIDATE_ENV=$ARTIFACT_DIR/candidate-environment.txt
+RUST_BUILDER_IMAGE='rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1'
+DEBIAN_RUNTIME_IMAGE='debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df'
+BUILD_CONTEXT=''
+BGPERF_PID=''
+TARGET_PID=''
+
+cleanup() {
+    if [[ -n "$TARGET_PID" ]]; then
+        sudo kill -CONT "$TARGET_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$BGPERF_PID" ]]; then
+        kill "$BGPERF_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$BUILD_CONTEXT" ]]; then
+        rm -rf -- "$BUILD_CONTEXT"
+    fi
+}
+trap cleanup EXIT
+
+read_receipt_value() {
+    local file=$1
+    local key=$2
+    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; found = 1 } END { if (!found) exit 1 }' "$file"
+}
+
+require_clean_source() {
+    RUSTBGPD_STATUS=$(git -C "$RUSTBGPD_SOURCE" status \
+        --porcelain=v1 --untracked-files=all \
+        -- . \
+        ':(exclude)docs/perf/artifacts/event-history-producer-2026-07')
+    if [[ -n "$RUSTBGPD_STATUS" ]]; then
+        printf '%s\n' "refusing dirty rustbgpd source tree:" >&2
+        printf '%s\n' "$RUSTBGPD_STATUS" >&2
+        exit 1
+    fi
+}
+
+require_new_phase_receipt() {
+    local existing
+    existing=$(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 1 \
+        -name "full-daemon-$PHASE-*" -print -quit 2>/dev/null || true)
+    if [[ -n "$existing" ]]; then
+        printf 'refusing existing %s receipt: %s\n' "$PHASE" "$existing" >&2
+        exit 1
+    fi
+}
+
+mkdir -p "$ARTIFACT_DIR"
+[[ -f "$BASELINE_ENV" ]] || {
+    printf 'missing baseline identity: %s\n' "$BASELINE_ENV" >&2
+    exit 1
+}
+[[ -x "$VALIDATOR" ]] || {
+    printf 'validator is not executable: %s\n' "$VALIDATOR" >&2
+    exit 1
+}
+[[ -x "$WRAPPER" ]] || {
+    printf 'wrapper is not executable: %s\n' "$WRAPPER" >&2
+    exit 1
+}
+
+RECORDED_BASELINE_COMMIT=$(read_receipt_value "$BASELINE_ENV" baseline_commit)
+RECORDED_BASELINE_REF_COMMIT=$(read_receipt_value "$BASELINE_ENV" baseline_ref_commit)
+[[ "$RECORDED_BASELINE_COMMIT" == "$RECORDED_BASELINE_REF_COMMIT" ]] || {
+    printf 'recorded baseline/ref mismatch: %s != %s\n' \
+        "$RECORDED_BASELINE_COMMIT" "$RECORDED_BASELINE_REF_COMMIT" >&2
+    exit 1
+}
+[[ "$(git -C "$RUSTBGPD_SOURCE" rev-parse "$RECORDED_BASELINE_COMMIT^{commit}")" == \
+    "$RECORDED_BASELINE_COMMIT" ]] || {
+    printf 'recorded baseline is not an exact local commit: %s\n' \
+        "$RECORDED_BASELINE_COMMIT" >&2
+    exit 1
+}
+
+RUSTBGPD_COMMIT=$(git -C "$RUSTBGPD_SOURCE" rev-parse HEAD)
+case "$PHASE" in
+    baseline)
+        [[ "$RUSTBGPD_COMMIT" == "$RECORDED_BASELINE_COMMIT" ]] || {
+            printf 'baseline profile HEAD %s does not match recorded baseline %s\n' \
+                "$RUSTBGPD_COMMIT" "$RECORDED_BASELINE_COMMIT" >&2
+            exit 1
+        }
+        ;;
+    candidate)
+        [[ -f "$CANDIDATE_ENV" ]] || {
+            printf 'missing candidate identity: %s\n' "$CANDIDATE_ENV" >&2
+            exit 1
+        }
+        RECORDED_CANDIDATE_COMMIT=$(read_receipt_value "$CANDIDATE_ENV" candidate_commit)
+        CANDIDATE_BASELINE_COMMIT=$(read_receipt_value \
+            "$CANDIDATE_ENV" recorded_baseline_commit)
+        [[ "$CANDIDATE_BASELINE_COMMIT" == "$RECORDED_BASELINE_COMMIT" ]] || {
+            printf 'candidate receipt baseline %s does not match recorded baseline %s\n' \
+                "$CANDIDATE_BASELINE_COMMIT" "$RECORDED_BASELINE_COMMIT" >&2
+            exit 1
+        }
+        [[ "$RECORDED_CANDIDATE_COMMIT" != "$RECORDED_BASELINE_COMMIT" ]] || {
+            printf 'candidate commit matches recorded baseline: %s\n' \
+                "$RECORDED_CANDIDATE_COMMIT" >&2
+            exit 1
+        }
+        git -C "$RUSTBGPD_SOURCE" merge-base --is-ancestor \
+            "$RECORDED_BASELINE_COMMIT" "$RECORDED_CANDIDATE_COMMIT" || {
+            printf 'recorded baseline is not an ancestor of candidate: %s !<= %s\n' \
+                "$RECORDED_BASELINE_COMMIT" "$RECORDED_CANDIDATE_COMMIT" >&2
+            exit 1
+        }
+        [[ "$RUSTBGPD_COMMIT" == "$RECORDED_CANDIDATE_COMMIT" ]] || {
+            printf 'candidate profile HEAD %s does not match recorded candidate %s\n' \
+                "$RUSTBGPD_COMMIT" "$RECORDED_CANDIDATE_COMMIT" >&2
+            exit 1
+        }
+        ;;
+esac
+
+require_clean_source
+require_new_phase_receipt
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$HOST_FENCE"
+lan393_acquire_host_lock
+HOST_PREFLIGHT=$PREFIX-host-preflight.tsv
+lan393_init_host_preflight_log "$HOST_PREFLIGHT"
+lan393_wait_for_idle "$PHASE-before-build" "$HOST_PREFLIGHT"
+rm -rf "$BGPERF_RUN_DIR"
+
+# Rebuild the baseline archive from the receipt's exact commit. Baseline runs
+# replace it; candidate runs prove the retained archive is byte-identical.
+BASELINE_ARCHIVE=$ARTIFACT_DIR/rustbgpd-baseline-source.tar.gz
+BASELINE_ARCHIVE_TMP=$(mktemp "$ARTIFACT_DIR/.baseline-source.XXXXXX.tar.gz")
+git -C "$RUSTBGPD_SOURCE" archive --format=tar.gz \
+    --output "$BASELINE_ARCHIVE_TMP" "$RECORDED_BASELINE_COMMIT"
+if [[ "$PHASE" == baseline ]]; then
+    mv "$BASELINE_ARCHIVE_TMP" "$BASELINE_ARCHIVE"
+else
+    [[ -f "$BASELINE_ARCHIVE" ]] || {
+        printf 'candidate profile requires retained baseline archive: %s\n' \
+            "$BASELINE_ARCHIVE" >&2
+        rm -f "$BASELINE_ARCHIVE_TMP"
+        exit 1
+    }
+    cmp --silent "$BASELINE_ARCHIVE_TMP" "$BASELINE_ARCHIVE" || {
+        printf '%s\n' 'retained baseline archive does not match recorded commit' >&2
+        rm -f "$BASELINE_ARCHIVE_TMP"
+        exit 1
+    }
+    rm -f "$BASELINE_ARCHIVE_TMP"
+fi
+
+if [[ "$PHASE" == candidate ]]; then
+    CANDIDATE_ARCHIVE=$ARTIFACT_DIR/rustbgpd-candidate-source.tar.gz
+    git -C "$RUSTBGPD_SOURCE" archive --format=tar.gz \
+        --output "$CANDIDATE_ARCHIVE" "$RUSTBGPD_COMMIT"
+    BUILD_ARCHIVE=$CANDIDATE_ARCHIVE
+else
+    BUILD_ARCHIVE=$BASELINE_ARCHIVE
+fi
+
+# Docker and the receipt validator consume only the retained exact-commit
+# archive. The mutable checkout is identity input, never build input.
+BUILD_CONTEXT=$(mktemp -d /tmp/lan393-rustbgpd-build.XXXXXX)
+tar -xzf "$BUILD_ARCHIVE" -C "$BUILD_CONTEXT"
+VALIDATOR=$BUILD_CONTEXT/docs/perf/validate-lan393-receipt.py
+[[ -x "$VALIDATOR" ]] || {
+    printf 'archived validator is not executable: %s\n' "$VALIDATOR" >&2
+    exit 1
+}
+
+IDENTITY_ARGS=(
+    identity
+    --phase "$PHASE"
+    --source-head "$RUSTBGPD_COMMIT"
+    --baseline-commit "$RECORDED_BASELINE_COMMIT"
+    --baseline-ref-commit "$RECORDED_BASELINE_REF_COMMIT"
+)
+if [[ "$PHASE" == candidate ]]; then
+    IDENTITY_ARGS+=(
+        --candidate-commit "$RECORDED_CANDIDATE_COMMIT"
+        --candidate-baseline-ancestor true
+    )
+fi
+python3 "$VALIDATOR" "${IDENTITY_ARGS[@]}" >"$PREFIX-identity-validation.txt"
+
+rm -rf "$BGPERF2_DIR"
+git clone --no-checkout "$BGPERF2_REMOTE" "$BGPERF2_DIR"
+git -C "$BGPERF2_DIR" checkout --detach "$BGPERF2_COMMIT"
+[[ "$(git -C "$BGPERF2_DIR" rev-parse HEAD)" == "$BGPERF2_COMMIT" ]]
+BGPERF2_STATUS=$(git -C "$BGPERF2_DIR" status --porcelain=v1 --untracked-files=all)
+[[ -z "$BGPERF2_STATUS" ]] || {
+    printf '%s\n' "refusing dirty bgperf2 source tree:" >&2
+    printf '%s\n' "$BGPERF2_STATUS" >&2
+    exit 1
+}
+BGPERF2_ARCHIVE=$ARTIFACT_DIR/bgperf2-source-$BGPERF2_COMMIT.tar.gz
+git -C "$BGPERF2_DIR" archive --format=tar.gz \
+    --output "$BGPERF2_ARCHIVE" "$BGPERF2_COMMIT"
+
+SOURCE_HASHES=$PREFIX-source-sha256.txt
+(
+    cd "$ARTIFACT_DIR"
+    if [[ "$PHASE" == baseline ]]; then
+        sha256sum "$(basename "$BASELINE_ARCHIVE")" \
+            "$(basename "$BGPERF2_ARCHIVE")"
+    else
+        sha256sum "$(basename "$BASELINE_ARCHIVE")" \
+            "$(basename "$CANDIDATE_ARCHIVE")" \
+            "$(basename "$BGPERF2_ARCHIVE")"
+    fi
+) >"$SOURCE_HASHES"
+
+docker build --no-cache \
+    --build-arg "RUSTBGPD_COMMIT=$RUSTBGPD_COMMIT" \
+    --build-arg "BGPERF2_COMMIT=$BGPERF2_COMMIT" \
+    --build-arg "PROFILE_PHASE=$PHASE" \
+    --file - \
+    --tag "$PROFILE_IMAGE" \
+    "$BUILD_CONTEXT" <<DOCKERFILE
+FROM $RUST_BUILDER_IMAGE AS builder
+ARG RUSTBGPD_COMMIT
+ARG BGPERF2_COMMIT
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY . .
+RUN cargo build --workspace --profile release-prof --locked
+RUN mkdir -p /build-provenance \
+    && { \
+        echo "rustbgpd_commit=\$RUSTBGPD_COMMIT"; \
+        echo "bgperf2_commit=\$BGPERF2_COMMIT"; \
+        echo "builder_base=$RUST_BUILDER_IMAGE"; \
+        rustc --version --verbose; \
+        cargo --version --verbose; \
+        protoc --version; \
+        dpkg-query -W -f='\${Package}=\${Version}\\n' | sort; \
+    } >/build-provenance/builder.txt
+
+FROM $DEBIAN_RUNTIME_IMAGE
+ARG RUSTBGPD_COMMIT
+ARG BGPERF2_COMMIT
+ARG PROFILE_PHASE
+LABEL org.opencontainers.image.revision="\$RUSTBGPD_COMMIT"
+LABEL org.rustbgpd.bgperf2.revision="\$BGPERF2_COMMIT"
+LABEL org.opencontainers.image.base.name="$DEBIAN_RUNTIME_IMAGE"
+LABEL org.opencontainers.image.base.digest="${DEBIAN_RUNTIME_IMAGE##*sha256:}"
+LABEL org.rustbgpd.bgperf2.builder-base.digest="${RUST_BUILDER_IMAGE##*sha256:}"
+LABEL org.rustbgpd.bgperf2.rust-toolchain="1.95"
+LABEL org.rustbgpd.lan393.profile-phase="\$PROFILE_PHASE"
+WORKDIR /root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/release-prof/rustbgpd /usr/local/bin/rustbgpd.real
+COPY --from=builder /build/target/release-prof/rbgp /usr/local/bin/rustbgpctl
+COPY --from=builder /build-provenance/builder.txt /usr/local/share/rustbgpd-builder-provenance.txt
+COPY docs/perf/bgperf-rustbgpd-ehm-wrapper.sh /usr/local/bin/rustbgpd
+RUN chmod 0755 /usr/local/bin/rustbgpd \
+    && mkdir -p /var/lib/rustbgpd \
+    && { \
+        echo "rustbgpd_commit=\$RUSTBGPD_COMMIT"; \
+        echo "bgperf2_commit=\$BGPERF2_COMMIT"; \
+        echo "runtime_base=$DEBIAN_RUNTIME_IMAGE"; \
+        dpkg-query -W -f='\${Package}=\${Version}\\n' | sort; \
+    } >/usr/local/share/rustbgpd-runtime-provenance.txt
+DOCKERFILE
+
+IMAGE_INSPECT=$PREFIX-image-inspect.json
+BUILDER_PROVENANCE=$PREFIX-builder-provenance.txt
+RUNTIME_PROVENANCE=$PREFIX-runtime-provenance.txt
+BINARY_HASHES=$PREFIX-binary-sha256.txt
+IMAGE_VALIDATION=$PREFIX-image-validation.txt
+docker image inspect "$PROFILE_IMAGE" >"$IMAGE_INSPECT"
+PROVENANCE_CONTAINER=$(docker create "$PROFILE_IMAGE")
+docker cp \
+    "$PROVENANCE_CONTAINER:/usr/local/share/rustbgpd-builder-provenance.txt" \
+    "$BUILDER_PROVENANCE"
+docker cp \
+    "$PROVENANCE_CONTAINER:/usr/local/share/rustbgpd-runtime-provenance.txt" \
+    "$RUNTIME_PROVENANCE"
+docker rm "$PROVENANCE_CONTAINER" >/dev/null
+docker run --rm --entrypoint sha256sum "$PROFILE_IMAGE" \
+    /usr/local/bin/rustbgpd.real /usr/local/bin/rustbgpctl >"$BINARY_HASHES"
+python3 "$VALIDATOR" image \
+    --inspect "$IMAGE_INSPECT" \
+    --builder-provenance "$BUILDER_PROVENANCE" \
+    --runtime-provenance "$RUNTIME_PROVENANCE" \
+    --source-commit "$RUSTBGPD_COMMIT" \
+    --bgperf2-commit "$BGPERF2_COMMIT" \
+    --phase "$PHASE" >"$IMAGE_VALIDATION"
+
+PROFILE_IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$PROFILE_IMAGE")
+{
+    printf 'profile_phase=%s\n' "$PHASE"
+    printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
+    printf 'rustbgpd_commit=%s\n' "$RUSTBGPD_COMMIT"
+    printf 'rustbgpd_remote=%s\n' \
+        "$(git -C "$RUSTBGPD_SOURCE" remote get-url origin)"
+    printf 'rustbgpd_status=%s\n' "$RUSTBGPD_STATUS"
+    printf 'rustbgpd_build_context=exact_commit_archive\n'
+    printf 'bgperf2_commit=%s\n' "$BGPERF2_COMMIT"
+    printf 'bgperf2_remote=%s\n' \
+        "$(git -C "$BGPERF2_DIR" remote get-url origin)"
+    printf 'bgperf2_status=%s\n' "$BGPERF2_STATUS"
+    printf 'builder_base=%s\n' "$RUST_BUILDER_IMAGE"
+    printf 'runtime_base=%s\n' "$DEBIAN_RUNTIME_IMAGE"
+    printf 'profile_image_tag=%s\n' "$PROFILE_IMAGE"
+    printf 'profile_image_id=%s\n' "$PROFILE_IMAGE_ID"
+    printf 'host_lock=%s\n' "$LAN393_HOST_LOCK_PATH"
+    printf 'host_lock_acquired=1\n'
+    printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
+    printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+    printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
+    printf 'required_governor=performance\n'
+} >"$PREFIX-environment.txt"
+
+lan393_wait_for_idle "$PHASE-before-bgperf" "$HOST_PREFLIGHT"
+(
+    cd "$BGPERF2_DIR"
+    env -u RUSTBGPD_EVENT_HISTORY \
+        -u RUSTBGPD_EVENT_HISTORY_OFF \
+        python3 bgperf2.py \
+        --bench-name "$BENCH_NAME" \
+        --dir "$BGPERF_RUN_DIR" \
+        bench \
+        --target rustbgpd \
+        --image "$PROFILE_IMAGE" \
+        --tester-type bird \
+        --neighbor-num 2 \
+        --prefix-num 100000 \
+        --output "$PREFIX-bgperf-timeseries.csv"
+) >"$PREFIX-bgperf.log" 2>&1 &
+BGPERF_PID=$!
+
+for _ in $(seq 1 300); do
+    TARGET_PID=$(docker top "$TARGET_CONTAINER" -eo pid,stat,args 2>/dev/null \
+        | awk '$2 ~ /^T/ && /\/usr\/local\/bin\/rustbgpd \/root\/config\/config.toml/ { print $1 }' \
+        || true)
+    [[ -z "$TARGET_PID" ]] || break
+    sleep 0.1
+done
+[[ -n "$TARGET_PID" ]]
+docker top "$TARGET_CONTAINER" -eo pid,stat,args \
+    >"$PREFIX-processes-pre-attach.txt"
+
+RUNNING_IMAGE_ID=$(docker inspect --format '{{.Image}}' "$TARGET_CONTAINER")
+[[ "$RUNNING_IMAGE_ID" == "$PROFILE_IMAGE_ID" ]] || {
+    printf 'running container image %s does not match built image %s\n' \
+        "$RUNNING_IMAGE_ID" "$PROFILE_IMAGE_ID" >&2
+    exit 1
+}
+printf 'running_container_image_id=%s\n' "$RUNNING_IMAGE_ID" \
+    >"$PREFIX-running-image.txt"
+
+docker cp "$TARGET_CONTAINER:/root/config/config.toml" "$PREFIX-config.toml"
+docker cp \
+    "$TARGET_CONTAINER:/root/config/lan393-profile-ready" \
+    "$PREFIX-profile-ready.txt"
+grep -A6 '^\[event_history\]$' "$PREFIX-config.toml" \
+    >"$PREFIX-event-history-config.txt"
+grep -q '^enabled = true$' "$PREFIX-event-history-config.txt"
+grep -q '^required = true$' "$PREFIX-event-history-config.txt"
+grep -q '^synchronous = "full"$' "$PREFIX-event-history-config.txt"
+
+sudo perf buildid-cache --add \
+    "/proc/$TARGET_PID/root/usr/local/bin/rustbgpd.real"
+sudo perf record \
+    --freq 997 \
+    --call-graph dwarf \
+    --pid "$TARGET_PID" \
+    --output "$PREFIX-ehm.perf.data" \
+    -- sleep 30 &
+PERF_PID=$!
+sleep 1
+sudo kill -CONT "$TARGET_PID"
+TARGET_PID=''
+wait "$PERF_PID"
+
+# bgperf2 can encode a failed benchmark in its output and still exit zero.
+# Its pinned BIRD error helper also reads /tmp/bgperf2/tester regardless of
+# --dir/--bench-name, and its BIRD timeout helper is a constant zero. Retain and
+# validate the actual run-scoped tester logs instead of trusting those fields.
+# The validator inventories every source *.log entry (including symlinks and
+# special files) and byte-binds these copies to the two expected regular logs.
+wait "$BGPERF_PID"
+BGPERF_PID=''
+RUN_RECEIPT_DIR=$BGPERF_RUN_DIR/$BENCH_NAME
+TESTER_SOURCE_DIR=$RUN_RECEIPT_DIR/tester
+TESTER_LOG_DIR=$PREFIX-tester-logs
+[[ -d "$TESTER_SOURCE_DIR" ]]
+mkdir "$TESTER_LOG_DIR"
+for PEER in 10.10.0.3 10.10.0.4; do
+    SOURCE_LOG=$TESTER_SOURCE_DIR/$PEER.log
+    [[ -f "$SOURCE_LOG" && ! -L "$SOURCE_LOG" ]] || {
+        printf 'missing regular run-scoped BIRD log: %s\n' "$SOURCE_LOG" >&2
+        exit 1
+    }
+    cp -- "$SOURCE_LOG" "$TESTER_LOG_DIR/$PEER.log"
+    cmp --silent "$SOURCE_LOG" "$TESTER_LOG_DIR/$PEER.log"
+done
+SOURCE_SCENARIO=$RUN_RECEIPT_DIR/scenario.yaml
+[[ -f "$SOURCE_SCENARIO" && ! -L "$SOURCE_SCENARIO" ]] || {
+    printf 'missing regular run-scoped scenario: %s\n' "$SOURCE_SCENARIO" >&2
+    exit 1
+}
+cp -- "$SOURCE_SCENARIO" "$PREFIX-scenario.yaml"
+cmp --silent "$SOURCE_SCENARIO" "$PREFIX-scenario.yaml"
+python3 "$VALIDATOR" bgperf \
+    --log "$PREFIX-bgperf.log" \
+    --scenario "$PREFIX-scenario.yaml" \
+    --phase "$PHASE" \
+    --bench-name "$BENCH_NAME" \
+    --run-receipt-dir "$RUN_RECEIPT_DIR" \
+    --source-scenario "$SOURCE_SCENARIO" \
+    --source-tester-log-dir "$TESTER_SOURCE_DIR" \
+    --tester-log-dir "$TESTER_LOG_DIR" \
+    --result "$PREFIX-bgperf-result.csv" \
+    >"$PREFIX-bgperf-validation.txt"
+
+TARGET_IP=$(docker inspect \
+    --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+    "$TARGET_CONTAINER")
+for _ in $(seq 1 100); do
+    curl --fail --silent --show-error \
+        "http://$TARGET_IP:9179/metrics" >"$PREFIX-metrics.txt"
+    if ! awk '/^bgp_event_outbox_queue_depth/ && $NF != 0 { found = 1 } END { exit found }' \
+        "$PREFIX-metrics.txt"; then
+        sleep 0.1
+        continue
+    fi
+    sleep 1
+    curl --fail --silent --show-error \
+        "http://$TARGET_IP:9179/metrics" >"$PREFIX-metrics.txt"
+    break
+done
+
+awk '
+  /^bgp_event_outbox_committed_total/ { committed += $NF }
+  /^bgp_event_outbox_dropped_total/ && $NF != 0 { bad = 1 }
+  /^bgp_event_outbox_queue_depth/ && $NF != 0 { bad = 1 }
+  /^bgp_event_outbox_latest_event_id / { latest = $NF }
+  /^bgp_event_outbox_degraded / && $NF != 0 { bad = 1 }
+  /^bgp_event_outbox_cursor_gap_total / && $NF != 0 { bad = 1 }
+  END {
+    if (committed == 0 || latest != committed || bad) exit 1
+  }
+' "$PREFIX-metrics.txt"
+
+docker cp "$TARGET_CONTAINER:/root/config/rustbgpd.log" "$PREFIX-rustbgpd.log"
+docker stats --no-stream "$TARGET_CONTAINER" >"$PREFIX-docker-stats.txt"
+sudo perf report --stdio --children \
+    --input "$PREFIX-ehm.perf.data" \
+    | tee "$PREFIX-ehm.perf-report.txt" >/dev/null
+sudo perf script \
+    --input "$PREFIX-ehm.perf.data" \
+    | tee "$PREFIX-ehm.perf-script.txt" >/dev/null
+sudo chown "$(id -u):$(id -g)" "$PREFIX-ehm.perf.data"
+
+# The completion sentinel is written only after convergence validation,
+# outbox-health checks, resource capture, and both inspectable perf derivatives
+# succeed. The phase manifest then binds every phase-prefixed receipt plus the
+# exact source archives it names.
+{
+    printf 'profile_phase=%s\n' "$PHASE"
+    printf 'recorded_baseline_commit=%s\n' "$RECORDED_BASELINE_COMMIT"
+    printf 'rustbgpd_commit=%s\n' "$RUSTBGPD_COMMIT"
+    printf 'run_utc_complete=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'phase_complete=1\n'
+} >"$PREFIX-completion.txt"
+
+MANIFEST=$PREFIX-SHA256SUMS
+MANIFEST_TMP=$(mktemp "$ARTIFACT_DIR/.full-daemon-$PHASE-SHA256SUMS.XXXXXX")
+(
+    cd "$ARTIFACT_DIR"
+    {
+        find . -type f \
+            \( -name "full-daemon-$PHASE-*" \
+               -o -path "./full-daemon-$PHASE-*/*" \) \
+            ! -name "full-daemon-$PHASE-SHA256SUMS" -print0
+        printf './%s\0' "$(basename "$BASELINE_ARCHIVE")" \
+            "$(basename "$BGPERF2_ARCHIVE")"
+        if [[ "$PHASE" == candidate ]]; then
+            printf './%s\0' "$(basename "$CANDIDATE_ARCHIVE")"
+        fi
+    } | sort -zu | xargs -0 sha256sum
+) >"$MANIFEST_TMP"
+mv "$MANIFEST_TMP" "$MANIFEST"
+(
+    cd "$ARTIFACT_DIR"
+    sha256sum --check "$(basename "$MANIFEST")" >/dev/null
+)

--- a/docs/perf/test-lan393-host-fence.sh
+++ b/docs/perf/test-lan393-host-fence.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Adversarial probes for the retained LAN-393 host-isolation helpers.
+set -euo pipefail
+
+export LAN393_LOAD_ONE_MAX=999
+# shellcheck source=docs/perf/lan393-host-fence.sh
+source "$(dirname "$0")/lan393-host-fence.sh"
+
+[[ "$LAN393_REQUIRED_LOAD_ONE_MAX" == 2.0 ]]
+
+# Model the Linux TASK_COMM_LEN truncation used by `ps comm`, plus every
+# repository benchmark family that can continue running after Cargo exits.
+ps() {
+    printf '%s\n' \
+        '101 codec-91a /repo/target/release/deps/codec-91a --bench' \
+        '102 fanout-91a /repo/target/release/deps/fanout-91a --bench' \
+        '103 inbound_attrs-9 /repo/target/release/deps/inbound_attrs-91a --bench' \
+        '104 rib_ops-91a /repo/target/release/deps/rib_ops-91a --bench' \
+        '105 policy_eval-91a /repo/target/release/deps/policy_eval-91a --bench' \
+        '106 explain_snapsho /repo/target/release/deps/explain_snapshot-91a --bench' \
+        '107 validate-91a /repo/target/release/deps/validate-91a --bench' \
+        '108 event_history_ /repo/target/release/deps/event_history_producer-91a --bench' \
+        '109 rrharness /repo/bench/scale/rrharness/target/release/rrharness flood' \
+        '110 reloadstall /repo/bench/scale/reloadstall/target/release/reloadstall' \
+        '111 route_paging-9 /repo/target/release/deps/route_paging-91a --bench' \
+        '112 rib_nlri_build /repo/target/release/deps/rib_nlri_build-91a --bench' \
+        '113 evpn-tester /repo/bench/evpn-load/target/release/evpn-tester' \
+        '114 evpn-monitor /repo/bench/evpn-load/target/release/evpn-monitor' \
+        '115 python3 python3 bgperf2.py --bench-name another-run bench' \
+        '116 sleep sleep 30'
+}
+
+snapshot=$(lan393_competing_process_snapshot)
+[[ $(wc -l <<<"$snapshot") -eq 15 ]]
+[[ "$snapshot" != *'sleep 30'* ]]
+
+printf '%s\n' 'LAN-393 host-fence adversarial probes passed'

--- a/docs/perf/test-lan393-host-fence.sh
+++ b/docs/perf/test-lan393-host-fence.sh
@@ -33,5 +33,8 @@ ps() {
 snapshot=$(lan393_competing_process_snapshot)
 [[ $(wc -l <<<"$snapshot") -eq 15 ]]
 [[ "$snapshot" != *'sleep 30'* ]]
+[[ "$snapshot" != *'/repo/'* ]]
+[[ "$snapshot" != *'101 '* ]]
+[[ "$snapshot" == *'event_history_'* ]]
 
 printf '%s\n' 'LAN-393 host-fence adversarial probes passed'

--- a/docs/perf/test_validate_lan393_criterion.py
+++ b/docs/perf/test_validate_lan393_criterion.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Adversarial tests for the LAN-393 Criterion matrix validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate-lan393-criterion.py")
+SPEC = importlib.util.spec_from_file_location("lan393_criterion", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+criterion = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = criterion
+SPEC.loader.exec_module(criterion)
+
+
+def write_case(root: Path, full_id: str, run_name: str, point: float) -> None:
+    directory = root / full_id.replace("/", "_") / run_name
+    directory.mkdir(parents=True)
+    (directory / "benchmark.json").write_text(
+        json.dumps({"full_id": full_id}) + "\n", encoding="utf-8"
+    )
+    (directory / "estimates.json").write_text(
+        json.dumps(
+            {
+                "mean": {
+                    "confidence_interval": {
+                        "confidence_level": 0.95,
+                        "lower_bound": point * 0.99,
+                        "upper_bound": point * 1.01,
+                    },
+                    "point_estimate": point,
+                    "standard_error": point * 0.001,
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def populate(root: Path, run_name: str, *, candidate: bool = False) -> None:
+    for full_id in criterion.EXPECTED_IDS:
+        if "/noop" in full_id:
+            point = 100.0 if not candidate else 101.0
+        elif criterion.MANAGER_GROUP in full_id:
+            point = 150.0 if not candidate else 70.0
+        else:
+            point = 1_000.0 if not candidate else 1_010.0
+        write_case(root, full_id, run_name, point)
+
+
+class CriterionValidatorTests(unittest.TestCase):
+    def test_exact_matrix_and_both_gates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            base = criterion.inventory(root, "lan393-baseline")
+            self.assertTrue(criterion.gate_baseline(base)["manager_proceed_pass"])
+
+            populate(root, "new", candidate=True)
+            head = criterion.inventory(root, "new")
+            self.assertTrue(criterion.gate_candidate(base, head)["candidate_acceptance_pass"])
+
+    def test_missing_extra_duplicate_and_nonfinite_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            victim = next(root.glob("**/lan393-baseline/benchmark.json"))
+            victim.unlink()
+            with self.assertRaises(SystemExit):
+                criterion.inventory(root, "lan393-baseline")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            write_case(root, "unexpected/case", "lan393-baseline", 1.0)
+            with self.assertRaises(SystemExit):
+                criterion.inventory(root, "lan393-baseline")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            duplicate = root / "duplicate" / "lan393-baseline"
+            duplicate.mkdir(parents=True)
+            original = next(root.glob("**/lan393-baseline/benchmark.json"))
+            (duplicate / "benchmark.json").write_bytes(original.read_bytes())
+            (duplicate / "estimates.json").write_bytes(
+                original.with_name("estimates.json").read_bytes()
+            )
+            with self.assertRaises(SystemExit):
+                criterion.inventory(root, "lan393-baseline")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            estimates = next(root.glob("**/lan393-baseline/estimates.json"))
+            data = json.loads(estimates.read_text(encoding="utf-8"))
+            data["mean"]["point_estimate"] = float("nan")
+            estimates.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                criterion.inventory(root, "lan393-baseline")
+
+    def test_candidate_gate_rejects_regressions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root, "lan393-baseline")
+            populate(root, "new", candidate=True)
+            base = criterion.inventory(root, "lan393-baseline")
+            head = criterion.inventory(root, "new")
+            self.assertTrue(criterion.gate_candidate(base, head)["candidate_acceptance_pass"])
+
+            key = f"{criterion.MANAGER_GROUP}/route_added/noop"
+            regressed = dict(head)
+            regressed[key] = criterion.Estimate(point=110.0, lower=109.0, upper=111.0)
+            self.assertFalse(
+                criterion.gate_candidate(base, regressed)["candidate_acceptance_pass"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/perf/test_validate_lan393_full_comparison.py
+++ b/docs/perf/test_validate_lan393_full_comparison.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests for the LAN-393 combined full-daemon verdict."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate-lan393-full-comparison.py")
+SPEC = importlib.util.spec_from_file_location("lan393_full_comparison", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+comparison = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(comparison)
+
+
+HEADER = comparison.RESULT_HEADER
+
+
+def write_json(path: Path, value: dict[str, object]) -> None:
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+def write_result(path: Path, cpu: float, memory: float) -> None:
+    row = ["0"] * 25
+    row[12] = str(cpu)
+    row[13] = str(memory)
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.writer(output, lineterminator="\n")
+        writer.writerow(HEADER)
+        writer.writerow(row)
+
+
+def write_manifest(root: Path, name: str) -> None:
+    target = root / f"{name}.data"
+    target.write_text("bound\n", encoding="utf-8")
+    digest = hashlib.sha256(target.read_bytes()).hexdigest()
+    (root / name).write_text(f"{digest}  {target.name}\n", encoding="utf-8")
+
+
+def populate(root: Path) -> None:
+    write_json(root / "microbench-baseline-verdict.json", {"manager_proceed_pass": True})
+    write_json(root / "microbench-candidate-verdict.json", {"candidate_acceptance_pass": True})
+    for phase in ("baseline", "candidate"):
+        for mode in ("enabled", "disabled"):
+            (root / f"full-daemon-{phase}-{mode}-completion.txt").write_text(
+                "phase_complete=1\n", encoding="utf-8"
+            )
+            write_json(
+                root / f"full-daemon-{phase}-{mode}-perf-attribution.json",
+                {
+                    "baseline_proceed_pass": phase == "baseline" and mode == "enabled",
+                    "ehm_producer_samples": 0 if mode == "disabled" else 10,
+                },
+            )
+            write_result(
+                root / f"full-daemon-{phase}-{mode}-bgperf-result.csv",
+                100.0 if phase == "baseline" else 102.0,
+                1.0 if phase == "baseline" else 1.02,
+            )
+    for manifest in (
+        "microbench-baseline-SHA256SUMS",
+        "microbench-candidate-SHA256SUMS",
+        "full-daemon-baseline-enabled-SHA256SUMS",
+        "full-daemon-baseline-disabled-SHA256SUMS",
+        "full-daemon-candidate-enabled-SHA256SUMS",
+    ):
+        write_manifest(root, manifest)
+
+
+class FullComparisonTests(unittest.TestCase):
+    def test_baseline_and_candidate_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            self.assertTrue(comparison.baseline(root)["overall_proceed_pass"])
+            self.assertTrue(comparison.candidate(root)["candidate_acceptance_pass"])
+
+    def test_default_regression_and_partial_receipt_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            write_result(root / "full-daemon-candidate-disabled-bgperf-result.csv", 106.0, 1.0)
+            self.assertFalse(comparison.candidate(root)["candidate_acceptance_pass"])
+            (root / "full-daemon-baseline-enabled-completion.txt").unlink()
+            with self.assertRaises(SystemExit):
+                comparison.candidate(root)
+
+    def test_malformed_header_and_empty_manifest_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            rows = list(
+                csv.reader(
+                    (root / "full-daemon-candidate-disabled-bgperf-result.csv")
+                    .read_text(encoding="utf-8")
+                    .splitlines()
+                )
+            )
+            rows[0][12] = "wrong cpu field"
+            with (root / "full-daemon-candidate-disabled-bgperf-result.csv").open(
+                "w", encoding="utf-8", newline=""
+            ) as output:
+                csv.writer(output, lineterminator="\n").writerows(rows)
+            with self.assertRaises(SystemExit):
+                comparison.candidate(root)
+
+            (root / "microbench-baseline-SHA256SUMS").write_text("", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                comparison.baseline(root)
+
+    def test_boolean_sample_count_does_not_alias_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            write_json(
+                root / "full-daemon-baseline-disabled-perf-attribution.json",
+                {"ehm_producer_samples": False},
+            )
+            with self.assertRaises(SystemExit):
+                comparison.baseline(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/perf/test_validate_lan393_full_comparison.py
+++ b/docs/perf/test_validate_lan393_full_comparison.py
@@ -69,6 +69,7 @@ def populate(root: Path) -> None:
         "full-daemon-baseline-enabled-SHA256SUMS",
         "full-daemon-baseline-disabled-SHA256SUMS",
         "full-daemon-candidate-enabled-SHA256SUMS",
+        "full-daemon-candidate-disabled-SHA256SUMS",
     ):
         write_manifest(root, manifest)
 
@@ -124,6 +125,21 @@ class FullComparisonTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit):
                 comparison.baseline(root)
+
+    def test_disabled_receipt_manifests_are_mandatory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            (root / "full-daemon-baseline-disabled-SHA256SUMS").unlink()
+            with self.assertRaises(SystemExit):
+                comparison.baseline(root)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate(root)
+            (root / "full-daemon-candidate-disabled-SHA256SUMS").unlink()
+            with self.assertRaises(SystemExit):
+                comparison.candidate(root)
 
 
 if __name__ == "__main__":

--- a/docs/perf/test_validate_lan393_perf.py
+++ b/docs/perf/test_validate_lan393_perf.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Adversarial tests for the LAN-393 full-daemon perf classifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate-lan393-perf.py")
+SPEC = importlib.util.spec_from_file_location("lan393_perf", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+perf = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(perf)
+
+
+MANAGER = """rustbgpd PID/TID [CPU] TIME: cycles:
+        rustbgpd_rib::manager::RibManager::process_update
+        tokio::runtime::task
+"""
+PRODUCER = """rustbgpd PID/TID [CPU] TIME: cycles:
+        rustbgpd_api::event_history_sinks::EhmRibSink::publish_route_event
+        rustbgpd_rib::manager::RibManager::publish_route_event
+"""
+OTHER = """rustbgpd PID/TID [CPU] TIME: cycles:
+        tokio::runtime::park
+"""
+UNRELATED_PROTOST = """rustbgpd PID/TID [CPU] TIME: cycles:
+        prost::message::Message::encode_to_vec
+        rustbgpd_rib::manager::RibManager::process_update
+"""
+
+
+class PerfClassifierTests(unittest.TestCase):
+    def write(self, root: Path, text: str) -> Path:
+        path = root / "perf-script.txt"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_enabled_gate_and_disabled_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write(Path(directory), "\n".join([MANAGER] * 19 + [PRODUCER, OTHER]))
+            result = perf.classify(path, "baseline", "enabled")
+            self.assertTrue(result["baseline_proceed_pass"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write(
+                Path(directory), MANAGER + "\n" + UNRELATED_PROTOST + "\n" + OTHER
+            )
+            result = perf.classify(path, "baseline", "disabled")
+            self.assertEqual(result["ehm_producer_samples"], 0)
+
+    def test_missing_manager_unsanitized_path_and_disabled_producer_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(SystemExit):
+                perf.classify(self.write(Path(directory), OTHER), "baseline", "enabled")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(SystemExit):
+                perf.classify(
+                    self.write(Path(directory), MANAGER + "        /home/alice/private\n"),
+                    "baseline",
+                    "enabled",
+                )
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(SystemExit):
+                perf.classify(self.write(Path(directory), PRODUCER), "baseline", "disabled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/perf/test_validate_lan393_perf.py
+++ b/docs/perf/test_validate_lan393_perf.py
@@ -69,6 +69,23 @@ class PerfClassifierTests(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 perf.classify(self.write(Path(directory), PRODUCER), "baseline", "disabled")
 
+    def test_parent_symlink_and_invalid_utf8_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            real = root / "real"
+            real.mkdir()
+            path = self.write(real, MANAGER)
+            alias = root / "alias"
+            alias.symlink_to(real, target_is_directory=True)
+            with self.assertRaises(SystemExit):
+                perf.classify(alias / path.name, "baseline", "enabled")
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "perf-script.txt"
+            path.write_bytes(b"\xff\xfe")
+            with self.assertRaises(SystemExit):
+                perf.classify(path, "baseline", "enabled")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/perf/test_validate_lan393_receipt.py
+++ b/docs/perf/test_validate_lan393_receipt.py
@@ -191,6 +191,43 @@ class ReceiptValidatorTests(unittest.TestCase):
                 )
             )
 
+    def test_profile_barrier_retains_evidence_without_publishing_pid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            raw = root / "profile-ready.private"
+            output = root / "profile-ready.txt"
+            raw.write_text("48291\n", encoding="ascii")
+            receipt.validate_barrier(
+                argparse.Namespace(raw=raw, expected_pid="48291", output=output)
+            )
+            retained = output.read_text(encoding="ascii")
+            self.assertEqual(retained, "barrier_reached=1\n")
+            self.assertNotIn("48291", retained)
+
+    def test_profile_barrier_rejects_mismatch_and_malformed_input(self) -> None:
+        for raw_value, expected in (
+            ("48291\n", "48292"),
+            ("48291\nextra\n", "48291"),
+            ("48291", "48291"),
+            ("0\n", "0"),
+            ("not-a-pid\n", "48291"),
+        ):
+            with (
+                self.subTest(raw=raw_value, expected=expected),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = Path(directory)
+                raw = root / "profile-ready.private"
+                raw.write_text(raw_value, encoding="ascii")
+                with self.assertRaises(SystemExit):
+                    receipt.validate_barrier(
+                        argparse.Namespace(
+                            raw=raw,
+                            expected_pid=expected,
+                            output=root / "profile-ready.txt",
+                        )
+                    )
+
     def test_candidate_without_proven_ancestry_fails_closed(self) -> None:
         for ancestry in (None, "false"):
             with self.subTest(ancestry=ancestry), self.assertRaises(SystemExit):

--- a/docs/perf/test_validate_lan393_receipt.py
+++ b/docs/perf/test_validate_lan393_receipt.py
@@ -104,15 +104,16 @@ class ReceiptValidatorTests(unittest.TestCase):
         *,
         row: list[str] | None = None,
         phase: str = "baseline",
+        mode: str = "enabled",
     ) -> argparse.Namespace:
-        scenario = root / f"full-daemon-{phase}-scenario.yaml"
+        scenario = root / f"full-daemon-{phase}-{mode}-scenario.yaml"
         log = root / "bgperf.log"
         result = root / "result.csv"
-        run_receipt_dir = root / f"lan393-{phase}"
+        run_receipt_dir = root / f"lan393-{phase}-{mode}"
         source_tester_logs = run_receipt_dir / "tester"
         source_tester_logs.mkdir(parents=True)
         source_scenario = run_receipt_dir / "scenario.yaml"
-        tester_logs = root / f"full-daemon-{phase}-tester-logs"
+        tester_logs = root / f"full-daemon-{phase}-{mode}-tester-logs"
         tester_logs.mkdir()
         # The pinned helper intentionally excludes NEXT_HOP RMT diagnostics.
         (source_tester_logs / "10.10.0.3.log").write_text(
@@ -136,7 +137,8 @@ class ReceiptValidatorTests(unittest.TestCase):
             scenario=scenario,
             result=result,
             phase=phase,
-            bench_name=f"lan393-{phase}",
+            mode=mode,
+            bench_name=f"lan393-{phase}-{mode}",
             run_receipt_dir=run_receipt_dir,
             source_scenario=source_scenario,
             source_tester_log_dir=source_tester_logs,
@@ -234,6 +236,21 @@ class ReceiptValidatorTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit):
                 receipt.validate_bgperf(args)
+
+    def test_nonfinite_negative_and_inconsistent_metrics_fail_closed(self) -> None:
+        for index, value in ((11, "nan"), (12, "-1"), (13, "inf"), (14, "101")):
+            with self.subTest(index=index, value=value), tempfile.TemporaryDirectory() as directory:
+                row = successful_result()
+                row[index] = value
+                with self.assertRaises(SystemExit):
+                    receipt.validate_bgperf(self.bgperf_files(Path(directory), row=row))
+
+        with tempfile.TemporaryDirectory() as directory:
+            row = successful_result()
+            row[8] = "5"
+            row[10] = "9"
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(self.bgperf_files(Path(directory), row=row))
 
     def test_stale_default_logs_are_not_receipt_authority(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -367,14 +384,14 @@ class ReceiptValidatorTests(unittest.TestCase):
     def test_tester_logs_are_bound_to_phase_and_bench_name(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             args = self.bgperf_files(Path(directory))
-            args.bench_name = "lan393-candidate"
+            args.bench_name = "lan393-candidate-enabled"
             with self.assertRaises(SystemExit):
                 receipt.validate_bgperf(args)
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             args = self.bgperf_files(root)
-            wrong_dir = root / "full-daemon-candidate-tester-logs"
+            wrong_dir = root / "full-daemon-candidate-enabled-tester-logs"
             args.tester_log_dir.rename(wrong_dir)
             args.tester_log_dir = wrong_dir
             with self.assertRaises(SystemExit):
@@ -393,6 +410,7 @@ class ReceiptValidatorTests(unittest.TestCase):
             )[1],
             "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
             "org.rustbgpd.lan393.profile-phase": "baseline",
+            "org.rustbgpd.lan393.event-history-mode": "enabled",
         }
         inspect = root / "inspect.json"
         inspect.write_text(
@@ -433,6 +451,7 @@ class ReceiptValidatorTests(unittest.TestCase):
             source_commit=BASELINE,
             bgperf2_commit=BGPERF2,
             phase="baseline",
+            mode="enabled",
         )
 
     def test_image_labels_and_provenance_are_bound(self) -> None:

--- a/docs/perf/test_validate_lan393_receipt.py
+++ b/docs/perf/test_validate_lan393_receipt.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Adversarial probes for the LAN-393 receipt validators."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import importlib.util
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate-lan393-receipt.py")
+SPEC = importlib.util.spec_from_file_location("lan393_receipt", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+receipt = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(receipt)
+
+
+BASELINE = "1" * 40
+CANDIDATE = "2" * 40
+BGPERF2 = receipt.BGPERF2_COMMIT
+
+
+SCENARIO = """\
+<%
+# The real scenario has helper imports here.
+%>
+local_prefix: 10.10.0.0/16
+monitor:
+  as: 1001
+  check-points: [200000]
+  local-address: 10.10.0.2
+  router-id: 10.10.0.2
+policy: {}
+target:
+  as: 1000
+  local-address: 10.10.255.254
+  router-id: 10.10.255.254
+  single-table: false
+testers:
+- name: tester
+  type: bird
+  neighbors:
+    10.10.0.3:
+      as: 1003
+      check-points: 100000
+      count: 100000
+      filter: {in: []}
+      local-address: 10.10.0.3
+      paths: ${gen_paths(100000)}
+      router-id: 10.10.0.3
+    10.10.0.4:
+      as: 1004
+      check-points: 100000
+      count: 100000
+      filter: {in: []}
+      local-address: 10.10.0.4
+      paths: ${gen_paths(100000)}
+      router-id: 10.10.0.4
+"""
+
+
+def successful_result() -> list[str]:
+    return [
+        "rustbgpd",
+        "rustbgpd",
+        "rustbgpd 0.51.0",
+        "2",
+        "100000",
+        "200000",
+        "200000",
+        "1",
+        "10",
+        "1",
+        "9",
+        "12.34",
+        "100",
+        "1.0",
+        "50",
+        "8.0",
+        "",
+        "2026-07-13",
+        "8",
+        "16GB",
+        "0",
+        "0",
+        "",
+        "",
+        "",
+    ]
+
+
+class ReceiptValidatorTests(unittest.TestCase):
+    def bgperf_files(
+        self,
+        root: Path,
+        *,
+        row: list[str] | None = None,
+        phase: str = "baseline",
+    ) -> argparse.Namespace:
+        scenario = root / f"full-daemon-{phase}-scenario.yaml"
+        log = root / "bgperf.log"
+        result = root / "result.csv"
+        run_receipt_dir = root / f"lan393-{phase}"
+        source_tester_logs = run_receipt_dir / "tester"
+        source_tester_logs.mkdir(parents=True)
+        source_scenario = run_receipt_dir / "scenario.yaml"
+        tester_logs = root / f"full-daemon-{phase}-tester-logs"
+        tester_logs.mkdir()
+        # The pinned helper intentionally excludes NEXT_HOP RMT diagnostics.
+        (source_tester_logs / "10.10.0.3.log").write_text(
+            "RMT route ignored: NEXT_HOP is not directly reachable\n",
+            encoding="utf-8",
+        )
+        (source_tester_logs / "10.10.0.4.log").write_text(
+            "BIRD ready\n", encoding="utf-8"
+        )
+        for source in source_tester_logs.glob("*.log"):
+            shutil.copyfile(source, tester_logs / source.name)
+        source_scenario.write_text(SCENARIO, encoding="utf-8")
+        shutil.copyfile(source_scenario, scenario)
+        buffer = io.StringIO()
+        csv.writer(buffer, lineterminator="\n").writerow(
+            successful_result() if row is None else row
+        )
+        log.write_text("progress\n" + buffer.getvalue(), encoding="utf-8")
+        return argparse.Namespace(
+            log=log,
+            scenario=scenario,
+            result=result,
+            phase=phase,
+            bench_name=f"lan393-{phase}",
+            run_receipt_dir=run_receipt_dir,
+            source_scenario=source_scenario,
+            source_tester_log_dir=source_tester_logs,
+            tester_log_dir=tester_logs,
+        )
+
+    def test_identity_accepts_bound_baseline_and_distinct_candidate(self) -> None:
+        receipt.validate_identity(
+            argparse.Namespace(
+                phase="baseline",
+                source_head=BASELINE,
+                baseline_commit=BASELINE,
+                baseline_ref_commit=BASELINE,
+                candidate_commit=None,
+                candidate_baseline_ancestor=None,
+            )
+        )
+        receipt.validate_identity(
+            argparse.Namespace(
+                phase="candidate",
+                source_head=CANDIDATE,
+                baseline_commit=BASELINE,
+                baseline_ref_commit=BASELINE,
+                candidate_commit=CANDIDATE,
+                candidate_baseline_ancestor="true",
+            )
+        )
+
+    def test_wrong_head_and_equal_candidate_fail_closed(self) -> None:
+        with self.assertRaises(SystemExit):
+            receipt.validate_identity(
+                argparse.Namespace(
+                    phase="baseline",
+                    source_head=CANDIDATE,
+                    baseline_commit=BASELINE,
+                    baseline_ref_commit=BASELINE,
+                    candidate_commit=None,
+                    candidate_baseline_ancestor=None,
+                )
+            )
+        with self.assertRaises(SystemExit):
+            receipt.validate_identity(
+                argparse.Namespace(
+                    phase="candidate",
+                    source_head=BASELINE,
+                    baseline_commit=BASELINE,
+                    baseline_ref_commit=BASELINE,
+                    candidate_commit=BASELINE,
+                    candidate_baseline_ancestor="true",
+                )
+            )
+
+    def test_candidate_without_proven_ancestry_fails_closed(self) -> None:
+        for ancestry in (None, "false"):
+            with self.subTest(ancestry=ancestry), self.assertRaises(SystemExit):
+                receipt.validate_identity(
+                    argparse.Namespace(
+                        phase="candidate",
+                        source_head=CANDIDATE,
+                        baseline_commit=BASELINE,
+                        baseline_ref_commit=BASELINE,
+                        candidate_commit=CANDIDATE,
+                        candidate_baseline_ancestor=ancestry,
+                    )
+                )
+
+    def test_bgperf_success_is_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            args = self.bgperf_files(root)
+            receipt.validate_bgperf(args)
+            rows = list(
+                csv.reader(args.result.read_text(encoding="utf-8").splitlines())
+            )
+            self.assertEqual(rows[1][5:7], ["200000", "200000"])
+            self.assertEqual(rows[1][20:23], ["0", "0", ""])
+
+    def test_failed_output_and_wrong_workload_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            row = successful_result()
+            row[22] = "FAILED"
+            args = self.bgperf_files(root, row=row)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+            changed_scenario = SCENARIO.replace(
+                "check-points: [200000]", "check-points: [198000]"
+            )
+            args.source_scenario.write_text(changed_scenario, encoding="utf-8")
+            args.scenario.write_text(changed_scenario, encoding="utf-8")
+            args.log.write_text(
+                io.StringIO(",".join(successful_result()) + "\n").getvalue(),
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_stale_default_logs_are_not_receipt_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            row = successful_result()
+            # Model the pinned helper counting stale /tmp/bgperf2 logs. The
+            # compatibility field must be retained but cannot decide success.
+            row[20] = "7"
+            args = self.bgperf_files(root, row=row)
+            stale_default = root / "tmp" / "bgperf2" / "tester"
+            stale_default.mkdir(parents=True)
+            (stale_default / "10.10.0.3.log").write_text(
+                "RMT stale unrelated failure\n", encoding="utf-8"
+            )
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                receipt.validate_bgperf(args)
+            normalized = list(
+                csv.reader(args.result.read_text(encoding="utf-8").splitlines())
+            )
+            self.assertEqual(normalized[1][20], "0")
+            self.assertIn("adapter_tester_errors_ignored=7", output.getvalue())
+
+    def test_actual_run_scoped_bird_error_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            (args.source_tester_log_dir / "10.10.0.4.log").write_text(
+                "RMT Hold timer expired\n", encoding="utf-8"
+            )
+            (args.tester_log_dir / "10.10.0.4.log").write_text(
+                "RMT Hold timer expired\n", encoding="utf-8"
+            )
+
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_source_log_inventory_rejects_extra_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            (args.source_tester_log_dir / "unexpected.log").symlink_to(
+                args.source_tester_log_dir / "10.10.0.3.log"
+            )
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_run_scoped_directories_reject_symlink_components(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            real_tester = args.run_receipt_dir / "real-tester"
+            args.source_tester_log_dir.rename(real_tester)
+            args.source_tester_log_dir.symlink_to(real_tester, target_is_directory=True)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            args = self.bgperf_files(root)
+            real_run = root / "real-run"
+            args.run_receipt_dir.rename(real_run)
+            args.run_receipt_dir.symlink_to(real_run, target_is_directory=True)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_run_scoped_scenario_must_be_regular_and_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            args.scenario.unlink()
+            args.scenario.symlink_to(args.source_scenario)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            real_source_scenario = args.run_receipt_dir / "scenario-real.yaml"
+            args.source_scenario.rename(real_source_scenario)
+            args.source_scenario.symlink_to(real_source_scenario)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            args.scenario.write_text("target: stale\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_source_log_inventory_rejects_fifo_and_extra_regular_log(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            (args.source_tester_log_dir / "10.10.0.4.log").unlink()
+            os.mkfifo(args.source_tester_log_dir / "10.10.0.4.log")
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            (args.source_tester_log_dir / "unexpected.log").write_text(
+                "BIRD ready\n", encoding="utf-8"
+            )
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_source_and_retained_log_content_must_match(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            (args.source_tester_log_dir / "10.10.0.4.log").write_text(
+                "BIRD changed after copy\n", encoding="utf-8"
+            )
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_bird_timeout_field_is_explicitly_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            args = self.bgperf_files(root)
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                receipt.validate_bgperf(args)
+            self.assertIn(
+                "tester_timeout_evidence=unsupported_by_pinned_bird_adapter",
+                output.getvalue(),
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            row = successful_result()
+            row[21] = "1"
+            args = self.bgperf_files(Path(directory), row=row)
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def test_tester_logs_are_bound_to_phase_and_bench_name(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            args.bench_name = "lan393-candidate"
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            args = self.bgperf_files(root)
+            wrong_dir = root / "full-daemon-candidate-tester-logs"
+            args.tester_log_dir.rename(wrong_dir)
+            args.tester_log_dir = wrong_dir
+            with self.assertRaises(SystemExit):
+                receipt.validate_bgperf(args)
+
+    def image_files(self, root: Path, *, revision: str = BASELINE) -> argparse.Namespace:
+        labels = {
+            "org.opencontainers.image.revision": revision,
+            "org.rustbgpd.bgperf2.revision": BGPERF2,
+            "org.opencontainers.image.base.name": receipt.DEBIAN_RUNTIME_IMAGE,
+            "org.opencontainers.image.base.digest": receipt.DEBIAN_RUNTIME_IMAGE.split(
+                "sha256:", 1
+            )[1],
+            "org.rustbgpd.bgperf2.builder-base.digest": receipt.RUST_BUILDER_IMAGE.split(
+                "sha256:", 1
+            )[1],
+            "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
+            "org.rustbgpd.lan393.profile-phase": "baseline",
+        }
+        inspect = root / "inspect.json"
+        inspect.write_text(
+            json.dumps([{"Id": "sha256:" + "a" * 64, "Config": {"Labels": labels}}]),
+            encoding="utf-8",
+        )
+        builder = root / "builder.txt"
+        builder.write_text(
+            "\n".join(
+                [
+                    f"rustbgpd_commit={BASELINE}",
+                    f"bgperf2_commit={BGPERF2}",
+                    f"builder_base={receipt.RUST_BUILDER_IMAGE}",
+                    "rustc 1.95.0 (test)",
+                    "cargo 1.95.0 (test)",
+                    "libprotoc 3.21.12",
+                    "protobuf-compiler=3.21.12-3",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        runtime = root / "runtime.txt"
+        runtime.write_text(
+            "\n".join(
+                [
+                    f"rustbgpd_commit={BASELINE}",
+                    f"bgperf2_commit={BGPERF2}",
+                    f"runtime_base={receipt.DEBIAN_RUNTIME_IMAGE}",
+                    "iproute2=6.1.0-3",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return argparse.Namespace(
+            inspect=inspect,
+            builder_provenance=builder,
+            runtime_provenance=runtime,
+            source_commit=BASELINE,
+            bgperf2_commit=BGPERF2,
+            phase="baseline",
+        )
+
+    def test_image_labels_and_provenance_are_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            receipt.validate_image(self.image_files(Path(directory)))
+
+    def test_wrong_image_revision_label_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(SystemExit):
+                receipt.validate_image(
+                    self.image_files(Path(directory), revision=CANDIDATE)
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/perf/test_validate_lan393_receipt.py
+++ b/docs/perf/test_validate_lan393_receipt.py
@@ -502,6 +502,31 @@ class ReceiptValidatorTests(unittest.TestCase):
                     self.image_files(Path(directory), revision=CANDIDATE)
                 )
 
+    def test_malformed_image_json_fails_closed_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.image_files(Path(directory))
+            args.inspect.write_text("{not-json\n", encoding="utf-8")
+            with self.assertRaises(SystemExit) as raised:
+                receipt.validate_image(args)
+            self.assertIn("cannot parse Docker image inspection JSON", str(raised.exception))
+
+    def test_malformed_scenario_and_bgperf_encoding_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            malformed = "target: [unterminated\n"
+            args.scenario.write_text(malformed, encoding="utf-8")
+            args.source_scenario.write_text(malformed, encoding="utf-8")
+            with self.assertRaises(SystemExit) as raised:
+                receipt.validate_bgperf(args)
+            self.assertIn("cannot parse scenario YAML", str(raised.exception))
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.bgperf_files(Path(directory))
+            args.log.write_bytes(b"\xff\xfe")
+            with self.assertRaises(SystemExit) as raised:
+                receipt.validate_bgperf(args)
+            self.assertIn("cannot decode retained bgperf log", str(raised.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/perf/validate-lan393-criterion.py
+++ b/docs/perf/validate-lan393-criterion.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Validate and gate the exact LAN-393 Criterion result matrix."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SHAPES = ("route_added", "route_policy_filtered", "evpn_best_changed")
+MANAGER_GROUP = "lan393_manager_self_time"
+SQLITE_GROUP = "lan393_sqlite_end_to_end"
+EXPECTED_IDS = {
+    *(f"{MANAGER_GROUP}/{shape}/{mode}" for shape in SHAPES for mode in ("noop", "ehm")),
+    *(f"{SQLITE_GROUP}/{shape}/full" for shape in SHAPES),
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def regular_file(path: Path, label: str) -> None:
+    if path.is_symlink() or not path.is_file():
+        fail(f"{label} is not a regular file: {path}")
+
+
+def read_json(path: Path, label: str) -> dict[str, object]:
+    regular_file(path, label)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        fail(f"cannot read {label}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{label} must contain a JSON object")
+    return value
+
+
+def finite_positive(value: object, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        fail(f"{label} is not numeric: {value!r}")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        fail(f"{label} is not finite and positive: {value!r}")
+    return result
+
+
+@dataclass(frozen=True)
+class Estimate:
+    point: float
+    lower: float
+    upper: float
+
+
+def estimate(path: Path, label: str) -> Estimate:
+    root = read_json(path, label)
+    mean = root.get("mean")
+    if not isinstance(mean, dict):
+        fail(f"{label} has no mean estimate")
+    interval = mean.get("confidence_interval")
+    if not isinstance(interval, dict):
+        fail(f"{label} has no mean confidence interval")
+    confidence = finite_positive(interval.get("confidence_level"), f"{label} confidence")
+    if not math.isclose(confidence, 0.95, rel_tol=0, abs_tol=1e-12):
+        fail(f"{label} confidence is not 0.95: {confidence}")
+    result = Estimate(
+        point=finite_positive(mean.get("point_estimate"), f"{label} point"),
+        lower=finite_positive(interval.get("lower_bound"), f"{label} lower bound"),
+        upper=finite_positive(interval.get("upper_bound"), f"{label} upper bound"),
+    )
+    if not result.lower <= result.point <= result.upper:
+        fail(f"{label} point is outside its confidence interval")
+    return result
+
+
+def inventory(root: Path, run_name: str) -> dict[str, Estimate]:
+    if root.is_symlink() or not root.is_dir():
+        fail(f"Criterion directory is not a regular directory: {root}")
+    found: dict[str, Estimate] = {}
+    for benchmark_path in root.glob(f"**/{run_name}/benchmark.json"):
+        benchmark = read_json(benchmark_path, "Criterion benchmark identity")
+        full_id = benchmark.get("full_id")
+        if not isinstance(full_id, str) or not full_id:
+            fail(f"Criterion benchmark has no full_id: {benchmark_path}")
+        if full_id in found:
+            fail(f"duplicate Criterion benchmark identity: {full_id}")
+        found[full_id] = estimate(
+            benchmark_path.with_name("estimates.json"),
+            f"Criterion estimate {full_id}/{run_name}",
+        )
+    if set(found) != EXPECTED_IDS:
+        missing = sorted(EXPECTED_IDS - set(found))
+        extra = sorted(set(found) - EXPECTED_IDS)
+        fail(f"Criterion matrix mismatch: missing={missing!r} extra={extra!r}")
+    return found
+
+
+def intervals_overlap(left: Estimate, right: Estimate) -> bool:
+    return left.lower <= right.upper and right.lower <= left.upper
+
+
+def pct_delta(base: Estimate, head: Estimate) -> float:
+    return ((head.point / base.point) - 1.0) * 100.0
+
+
+def gate_baseline(base: dict[str, Estimate]) -> dict[str, object]:
+    rows: list[dict[str, object]] = []
+    passing = 0
+    for shape in SHAPES:
+        noop = base[f"{MANAGER_GROUP}/{shape}/noop"]
+        ehm = base[f"{MANAGER_GROUP}/{shape}/ehm"]
+        overhead = pct_delta(noop, ehm)
+        ci_separated = ehm.lower > noop.upper
+        passed = overhead >= 25.0 and ci_separated
+        passing += int(passed)
+        rows.append(
+            {
+                "shape": shape,
+                "ehm_overhead_pct": overhead,
+                "confidence_intervals_separated": ci_separated,
+                "pass": passed,
+            }
+        )
+    return {
+        "phase": "baseline",
+        "manager_proceed_pass": passing >= 2,
+        "manager_shapes_passing": passing,
+        "required_manager_shapes": 2,
+        "full_daemon_attribution_required_pct": 5.0,
+        "full_daemon_attribution_status": "separate_required_receipt",
+        "rows": rows,
+    }
+
+
+def gate_candidate(
+    base: dict[str, Estimate], head: dict[str, Estimate]
+) -> dict[str, object]:
+    rows: list[dict[str, object]] = []
+    all_pass = True
+    for shape in SHAPES:
+        base_ehm = base[f"{MANAGER_GROUP}/{shape}/ehm"]
+        head_ehm = head[f"{MANAGER_GROUP}/{shape}/ehm"]
+        reduction = -pct_delta(base_ehm, head_ehm)
+        ehm_pass = reduction >= 50.0 and head_ehm.upper < base_ehm.lower
+        rows.append(
+            {
+                "gate": "manager_ehm",
+                "shape": shape,
+                "reduction_pct": reduction,
+                "confidence_intervals_separated": head_ehm.upper < base_ehm.lower,
+                "pass": ehm_pass,
+            }
+        )
+        all_pass &= ehm_pass
+
+        base_noop = base[f"{MANAGER_GROUP}/{shape}/noop"]
+        head_noop = head[f"{MANAGER_GROUP}/{shape}/noop"]
+        noop_delta = pct_delta(base_noop, head_noop)
+        noop_pass = noop_delta < 3.0 and intervals_overlap(base_noop, head_noop)
+        rows.append(
+            {
+                "gate": "manager_noop",
+                "shape": shape,
+                "delta_pct": noop_delta,
+                "confidence_intervals_overlap": intervals_overlap(base_noop, head_noop),
+                "pass": noop_pass,
+            }
+        )
+        all_pass &= noop_pass
+
+        base_full = base[f"{SQLITE_GROUP}/{shape}/full"]
+        head_full = head[f"{SQLITE_GROUP}/{shape}/full"]
+        sqlite_delta = pct_delta(base_full, head_full)
+        sqlite_overlap = intervals_overlap(base_full, head_full)
+        sqlite_pass = sqlite_delta < 5.0 and (sqlite_delta <= 0.0 or sqlite_overlap)
+        rows.append(
+            {
+                "gate": "sqlite_end_to_end",
+                "shape": shape,
+                "delta_pct": sqlite_delta,
+                "confidence_intervals_overlap": sqlite_overlap,
+                "pass": sqlite_pass,
+            }
+        )
+        all_pass &= sqlite_pass
+    return {
+        "phase": "candidate",
+        "candidate_acceptance_pass": all_pass,
+        "rows": rows,
+    }
+
+
+def write_csv(
+    path: Path,
+    base: dict[str, Estimate],
+    head: dict[str, Estimate] | None,
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.writer(output, lineterminator="\n")
+        writer.writerow(("variant", "benchmark", "mean_ns", "ci95_lower_ns", "ci95_upper_ns"))
+        for variant, values in (("baseline", base), ("candidate", head)):
+            if values is None:
+                continue
+            for full_id in sorted(values):
+                value = values[full_id]
+                writer.writerow((variant, full_id, value.point, value.lower, value.upper))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    parser.add_argument("--criterion-dir", type=Path, required=True)
+    parser.add_argument("--baseline-name", required=True)
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--verdict", type=Path, required=True)
+    args = parser.parse_args()
+
+    base = inventory(args.criterion_dir, args.baseline_name)
+    head = inventory(args.criterion_dir, "new") if args.phase == "candidate" else None
+    verdict = gate_baseline(base) if head is None else gate_candidate(base, head)
+    write_csv(args.results, base, head)
+    args.verdict.write_text(
+        json.dumps(verdict, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"phase={args.phase}")
+    print(f"criterion_cases={len(base)}")
+    print(f"verdict={args.verdict.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/perf/validate-lan393-full-comparison.py
+++ b/docs/perf/validate-lan393-full-comparison.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Combine LAN-393 enabled/disabled daemon receipts into the final gate."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from pathlib import Path
+
+
+RESULT_HEADER = [
+    "name",
+    "target",
+    "version",
+    "peers",
+    "prefixes per peer",
+    "required",
+    "received",
+    "monitor (s)",
+    "elapsed (s)",
+    "prefix received (s)",
+    "testers (s)",
+    "total time",
+    "max cpu %",
+    "max mem (GB)",
+    "min idle%",
+    "min free mem (GB)",
+    "flags",
+    "date",
+    "cores",
+    "Mem (GB)",
+    "tester errors",
+    "tester timeouts",
+    "failed",
+    "MSG",
+    "filters",
+]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        fail(f"missing regular JSON receipt: {path.name}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        fail(f"cannot parse {path.name}: {error}")
+    if not isinstance(value, dict):
+        fail(f"JSON receipt is not an object: {path.name}")
+    return value
+
+
+def resource_row(path: Path) -> dict[str, float]:
+    if path.is_symlink() or not path.is_file():
+        fail(f"missing regular bgperf result: {path.name}")
+    rows = list(csv.reader(path.read_text(encoding="utf-8").splitlines()))
+    if len(rows) != 2 or rows[0] != RESULT_HEADER or len(rows[1]) != len(RESULT_HEADER):
+        fail(f"invalid normalized bgperf matrix: {path.name}")
+    values: dict[str, float] = {}
+    for name, index in (("max_cpu_pct", 12), ("max_mem_gb", 13)):
+        try:
+            value = float(rows[1][index])
+        except ValueError:
+            fail(f"invalid {name} in {path.name}")
+        if not math.isfinite(value) or value <= 0:
+            fail(f"non-finite/non-positive {name} in {path.name}")
+        values[name] = value
+    return values
+
+
+def completion(path: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        fail(f"missing profile completion: {path.name}")
+    text = path.read_text(encoding="utf-8")
+    if "phase_complete=1" not in text.splitlines():
+        fail(f"profile is incomplete: {path.name}")
+
+
+def verify_manifest(root: Path, name: str) -> None:
+    manifest = root / name
+    if manifest.is_symlink() or not manifest.is_file():
+        fail(f"missing regular checksum manifest: {name}")
+    seen: set[Path] = set()
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        if len(line) < 67 or line[64:66] != "  ":
+            fail(f"malformed checksum line in {name}")
+        expected = line[:64]
+        relative = Path(line[66:])
+        if any(part == ".." for part in relative.parts) or relative.is_absolute():
+            fail(f"unsafe checksum path in {name}: {relative}")
+        path = root / relative
+        if path in seen:
+            fail(f"duplicate checksum path in {name}: {relative}")
+        seen.add(path)
+        if path.is_symlink() or not path.is_file():
+            fail(f"checksum target is not regular in {name}: {relative}")
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != expected:
+            fail(f"checksum mismatch in {name}: {relative}")
+    if not seen:
+        fail(f"empty checksum manifest: {name}")
+
+
+def percent_delta(base: float, head: float) -> float:
+    return ((head / base) - 1.0) * 100.0
+
+
+def zero_producer_samples(receipt: dict[str, object], label: str) -> bool:
+    value = receipt.get("ehm_producer_samples")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        fail(f"invalid EHM producer sample count in {label}")
+    return value == 0
+
+
+def baseline(root: Path) -> dict[str, object]:
+    verify_manifest(root, "microbench-baseline-SHA256SUMS")
+    verify_manifest(root, "full-daemon-baseline-enabled-SHA256SUMS")
+    manager = read_json(root / "microbench-baseline-verdict.json")
+    enabled = read_json(root / "full-daemon-baseline-enabled-perf-attribution.json")
+    disabled = read_json(root / "full-daemon-baseline-disabled-perf-attribution.json")
+    for mode in ("enabled", "disabled"):
+        completion(root / f"full-daemon-baseline-{mode}-completion.txt")
+    manager_pass = manager.get("manager_proceed_pass") is True
+    attribution_pass = enabled.get("baseline_proceed_pass") is True
+    disabled_clean = zero_producer_samples(disabled, "baseline-disabled attribution")
+    return {
+        "phase": "baseline",
+        "manager_proceed_pass": manager_pass,
+        "full_daemon_attribution_pass": attribution_pass,
+        "disabled_default_producer_clean": disabled_clean,
+        "overall_proceed_pass": manager_pass and attribution_pass and disabled_clean,
+        "enabled_resources": resource_row(
+            root / "full-daemon-baseline-enabled-bgperf-result.csv"
+        ),
+        "disabled_resources": resource_row(
+            root / "full-daemon-baseline-disabled-bgperf-result.csv"
+        ),
+    }
+
+
+def candidate(root: Path) -> dict[str, object]:
+    for manifest in (
+        "microbench-baseline-SHA256SUMS",
+        "microbench-candidate-SHA256SUMS",
+        "full-daemon-baseline-enabled-SHA256SUMS",
+        "full-daemon-baseline-disabled-SHA256SUMS",
+        "full-daemon-candidate-enabled-SHA256SUMS",
+    ):
+        verify_manifest(root, manifest)
+    microbench = read_json(root / "microbench-candidate-verdict.json")
+    for phase in ("baseline", "candidate"):
+        for mode in ("enabled", "disabled"):
+            completion(root / f"full-daemon-{phase}-{mode}-completion.txt")
+    base_disabled = resource_row(root / "full-daemon-baseline-disabled-bgperf-result.csv")
+    head_disabled = resource_row(root / "full-daemon-candidate-disabled-bgperf-result.csv")
+    cpu_delta = percent_delta(base_disabled["max_cpu_pct"], head_disabled["max_cpu_pct"])
+    memory_delta = percent_delta(base_disabled["max_mem_gb"], head_disabled["max_mem_gb"])
+    disabled_resource_pass = cpu_delta < 5.0 and memory_delta < 5.0
+    disabled_attr = read_json(root / "full-daemon-candidate-disabled-perf-attribution.json")
+    disabled_clean = zero_producer_samples(disabled_attr, "candidate-disabled attribution")
+    criterion_pass = microbench.get("candidate_acceptance_pass") is True
+    return {
+        "phase": "candidate",
+        "criterion_acceptance_pass": criterion_pass,
+        "disabled_default_cpu_delta_pct": cpu_delta,
+        "disabled_default_memory_delta_pct": memory_delta,
+        "disabled_default_resource_pass": disabled_resource_pass,
+        "disabled_default_producer_clean": disabled_clean,
+        "candidate_acceptance_pass": criterion_pass
+        and disabled_resource_pass
+        and disabled_clean,
+        "baseline_enabled_resources": resource_row(
+            root / "full-daemon-baseline-enabled-bgperf-result.csv"
+        ),
+        "candidate_enabled_resources": resource_row(
+            root / "full-daemon-candidate-enabled-bgperf-result.csv"
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = baseline(args.artifact_dir) if args.phase == "baseline" else candidate(args.artifact_dir)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"phase={args.phase}")
+    print(f"verdict={args.output.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/perf/validate-lan393-full-comparison.py
+++ b/docs/perf/validate-lan393-full-comparison.py
@@ -121,6 +121,7 @@ def zero_producer_samples(receipt: dict[str, object], label: str) -> bool:
 def baseline(root: Path) -> dict[str, object]:
     verify_manifest(root, "microbench-baseline-SHA256SUMS")
     verify_manifest(root, "full-daemon-baseline-enabled-SHA256SUMS")
+    verify_manifest(root, "full-daemon-baseline-disabled-SHA256SUMS")
     manager = read_json(root / "microbench-baseline-verdict.json")
     enabled = read_json(root / "full-daemon-baseline-enabled-perf-attribution.json")
     disabled = read_json(root / "full-daemon-baseline-disabled-perf-attribution.json")
@@ -151,6 +152,7 @@ def candidate(root: Path) -> dict[str, object]:
         "full-daemon-baseline-enabled-SHA256SUMS",
         "full-daemon-baseline-disabled-SHA256SUMS",
         "full-daemon-candidate-enabled-SHA256SUMS",
+        "full-daemon-candidate-disabled-SHA256SUMS",
     ):
         verify_manifest(root, manifest)
     microbench = read_json(root / "microbench-candidate-verdict.json")

--- a/docs/perf/validate-lan393-perf.py
+++ b/docs/perf/validate-lan393-perf.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Classify sanitized LAN-393 full-daemon perf stacks and apply the proceed gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+MANAGER_MARKERS = (
+    "rustbgpd_rib::manager::",
+    "rustbgpd_rib::manager::RibManager",
+)
+PRODUCER_MARKERS = (
+    "EhmRibSink",
+    "route_event_to_bgp_event",
+    "evpn_event_to_bgp_event",
+)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def classify(path: Path, phase: str, mode: str) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        fail(f"perf script is not a regular file: {path}")
+    text = path.read_text(encoding="utf-8", errors="strict")
+    if "/home/" in text or "/Users/" in text:
+        fail("perf script contains an unsanitized host path")
+    blocks = [block for block in text.split("\n\n") if block.strip()]
+    total = manager = producer = 0
+    for block in blocks:
+        lines = block.splitlines()
+        if not any("PID/TID [CPU] TIME:" in line for line in lines[:2]):
+            continue
+        if len(lines) < 2:
+            fail("perf sample has no callchain")
+        total += 1
+        stack = "\n".join(lines[1:])
+        is_manager = any(marker in stack for marker in MANAGER_MARKERS)
+        is_producer = any(marker in stack for marker in PRODUCER_MARKERS)
+        manager += int(is_manager)
+        producer += int(is_manager and is_producer)
+    if total == 0:
+        fail("perf script contains no sanitized samples")
+    if manager == 0:
+        fail("perf script contains no RIB-manager samples")
+    percent = producer * 100.0 / manager
+    if not math.isfinite(percent):
+        fail("producer attribution is non-finite")
+    if mode == "disabled" and producer != 0:
+        fail("disabled/default profile contains EHM producer samples")
+    result = {
+        "phase": phase,
+        "event_history_mode": mode,
+        "total_samples": total,
+        "rib_manager_samples": manager,
+        "ehm_producer_samples": producer,
+        "ehm_producer_pct_of_rib_manager": percent,
+        "baseline_proceed_threshold_pct": 5.0,
+        "baseline_proceed_pass": mode == "enabled" and phase == "baseline" and percent >= 5.0,
+    }
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    parser.add_argument("--mode", choices=("enabled", "disabled"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = classify(args.input, args.phase, args.mode)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"rib_manager_samples={result['rib_manager_samples']}")
+    print(f"ehm_producer_samples={result['ehm_producer_samples']}")
+    print(f"ehm_producer_pct={result['ehm_producer_pct_of_rib_manager']:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/perf/validate-lan393-perf.py
+++ b/docs/perf/validate-lan393-perf.py
@@ -24,10 +24,26 @@ def fail(message: str) -> None:
     raise SystemExit(message)
 
 
+def require_no_symlink_components(path: Path) -> None:
+    """Reject a perf input whose leaf or any existing parent is a symlink."""
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            fail("perf script contains a symlink component")
+
+
 def classify(path: Path, phase: str, mode: str) -> dict[str, object]:
-    if path.is_symlink() or not path.is_file():
-        fail(f"perf script is not a regular file: {path}")
-    text = path.read_text(encoding="utf-8", errors="strict")
+    require_no_symlink_components(path)
+    if not path.is_file():
+        fail("perf script is not a regular file")
+    try:
+        text = path.read_text(encoding="utf-8", errors="strict")
+    except OSError as error:
+        fail(f"cannot read perf script: {error.strerror or error.__class__.__name__}")
+    except UnicodeError as error:
+        fail(f"cannot decode perf script: {error}")
     if "/home/" in text or "/Users/" in text:
         fail("perf script contains an unsanitized host path")
     blocks = [block for block in text.split("\n\n") if block.strip()]

--- a/docs/perf/validate-lan393-receipt.py
+++ b/docs/perf/validate-lan393-receipt.py
@@ -26,6 +26,7 @@ DEBIAN_RUNTIME_IMAGE = (
 )
 BGPERF2_COMMIT = "fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9"
 COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+PID_RE = re.compile(r"[1-9][0-9]*")
 
 
 def fail(message: str) -> None:
@@ -176,6 +177,28 @@ def validate_image(args: argparse.Namespace) -> None:
     print(f"event_history_mode={args.mode}")
     print(f"builder_provenance_sha256={sha256_file(args.builder_provenance)}")
     print(f"runtime_provenance_sha256={sha256_file(args.runtime_provenance)}")
+
+
+def validate_barrier(args: argparse.Namespace) -> None:
+    """Bind the stopped wrapper barrier without publishing its host PID."""
+    require_regular_file(args.raw, "private profile-ready barrier")
+    try:
+        raw = args.raw.read_text(encoding="ascii", errors="strict")
+    except (OSError, UnicodeError) as error:
+        fail(f"cannot read private profile-ready barrier: {error}")
+    if re.fullmatch(r"[1-9][0-9]*\n", raw) is None:
+        fail("private profile-ready barrier must contain exactly one positive PID")
+    observed_pid = raw.removesuffix("\n")
+    if PID_RE.fullmatch(args.expected_pid) is None:
+        fail(f"expected profile PID is malformed: {args.expected_pid!r}")
+    require_equal(observed_pid, args.expected_pid, "profile-ready barrier PID")
+
+    require_directory(args.output.parent, "barrier receipt directory")
+    require_no_symlink_components(args.output, "barrier receipt")
+    if args.output.exists():
+        fail(f"refusing existing barrier receipt: {args.output}")
+    args.output.write_text("barrier_reached=1\n", encoding="ascii")
+    print("barrier_reached=1")
 
 
 def load_scenario(path: Path) -> dict[str, object]:
@@ -536,6 +559,14 @@ def parser() -> argparse.ArgumentParser:
     image.add_argument("--phase", choices=("baseline", "candidate"), required=True)
     image.add_argument("--mode", choices=("enabled", "disabled"), required=True)
     image.set_defaults(func=validate_image)
+
+    barrier = commands.add_parser(
+        "barrier", help="validate the private wrapper barrier and normalize its receipt"
+    )
+    barrier.add_argument("--raw", type=Path, required=True)
+    barrier.add_argument("--expected-pid", required=True)
+    barrier.add_argument("--output", type=Path, required=True)
+    barrier.set_defaults(func=validate_barrier)
 
     bgperf = commands.add_parser("bgperf", help="validate scenario and final result")
     bgperf.add_argument("--log", type=Path, required=True)

--- a/docs/perf/validate-lan393-receipt.py
+++ b/docs/perf/validate-lan393-receipt.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Fail-closed validators for the LAN-393 full-daemon receipt."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+RUST_BUILDER_IMAGE = (
+    "rust:1.95-bookworm@sha256:"
+    "6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1"
+)
+DEBIAN_RUNTIME_IMAGE = (
+    "debian:bookworm-slim@sha256:"
+    "60eac759739651111db372c07be67863818726f754804b8707c90979bda511df"
+)
+BGPERF2_COMMIT = "fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9"
+COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require_equal(actual: object, expected: object, label: str) -> None:
+    if actual != expected:
+        fail(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_no_symlink_components(path: Path, label: str) -> None:
+    """Reject a path whose leaf or any existing parent is a symlink."""
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            fail(f"{label} contains a symlink component: {current}")
+
+
+def require_regular_file(path: Path, label: str) -> None:
+    require_no_symlink_components(path, label)
+    if not path.is_file():
+        fail(f"{label} is not a regular file: {path}")
+
+
+def require_directory(path: Path, label: str) -> None:
+    require_no_symlink_components(path, label)
+    if not path.is_dir():
+        fail(f"{label} is not a directory: {path}")
+
+
+def validate_identity(args: argparse.Namespace) -> None:
+    candidate_baseline_ancestor = getattr(args, "candidate_baseline_ancestor", None)
+    identities = {
+        "source HEAD": args.source_head,
+        "baseline commit": args.baseline_commit,
+        "baseline ref commit": args.baseline_ref_commit,
+    }
+    if args.candidate_commit is not None:
+        identities["candidate commit"] = args.candidate_commit
+    for label, commit in identities.items():
+        if COMMIT_RE.fullmatch(commit) is None:
+            fail(f"{label} is not an exact 40-character commit: {commit!r}")
+
+    require_equal(
+        args.baseline_ref_commit,
+        args.baseline_commit,
+        "recorded baseline/ref identity",
+    )
+    if args.phase == "baseline":
+        if args.candidate_commit is not None:
+            fail("baseline identity must not include a candidate commit")
+        if candidate_baseline_ancestor is not None:
+            fail("baseline identity must not include candidate ancestry")
+        require_equal(args.source_head, args.baseline_commit, "baseline source HEAD")
+    else:
+        if args.candidate_commit is None:
+            fail("candidate identity requires --candidate-commit")
+        if args.candidate_commit == args.baseline_commit:
+            fail("candidate commit matches recorded baseline")
+        require_equal(
+            candidate_baseline_ancestor,
+            "true",
+            "candidate baseline-ancestor validation",
+        )
+        require_equal(args.source_head, args.candidate_commit, "candidate source HEAD")
+
+    print(f"profile_phase={args.phase}")
+    print(f"source_head={args.source_head}")
+    print(f"baseline_commit={args.baseline_commit}")
+    if args.candidate_commit is not None:
+        print(f"candidate_commit={args.candidate_commit}")
+        print("candidate_baseline_ancestor=true")
+
+
+def validate_image(args: argparse.Namespace) -> None:
+    require_equal(args.bgperf2_commit, BGPERF2_COMMIT, "pinned bgperf2 commit")
+    inspect = json.loads(args.inspect.read_text(encoding="utf-8"))
+    if not isinstance(inspect, list) or len(inspect) != 1:
+        fail("Docker image inspection must contain exactly one image")
+    image = inspect[0]
+    image_id = image.get("Id", "")
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", image_id) is None:
+        fail(f"Docker image ID is not a content digest: {image_id!r}")
+
+    labels = image.get("Config", {}).get("Labels") or {}
+    expected_labels = {
+        "org.opencontainers.image.revision": args.source_commit,
+        "org.rustbgpd.bgperf2.revision": args.bgperf2_commit,
+        "org.opencontainers.image.base.name": DEBIAN_RUNTIME_IMAGE,
+        "org.opencontainers.image.base.digest": DEBIAN_RUNTIME_IMAGE.split("sha256:", 1)[1],
+        "org.rustbgpd.bgperf2.builder-base.digest": RUST_BUILDER_IMAGE.split(
+            "sha256:", 1
+        )[1],
+        "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
+        "org.rustbgpd.lan393.profile-phase": args.phase,
+    }
+    for name, expected in expected_labels.items():
+        require_equal(labels.get(name), expected, f"OCI label {name}")
+
+    builder = args.builder_provenance.read_text(encoding="utf-8")
+    runtime = args.runtime_provenance.read_text(encoding="utf-8")
+    required_builder_lines = (
+        f"rustbgpd_commit={args.source_commit}",
+        f"bgperf2_commit={args.bgperf2_commit}",
+        f"builder_base={RUST_BUILDER_IMAGE}",
+    )
+    required_runtime_lines = (
+        f"rustbgpd_commit={args.source_commit}",
+        f"bgperf2_commit={args.bgperf2_commit}",
+        f"runtime_base={DEBIAN_RUNTIME_IMAGE}",
+    )
+    for line in required_builder_lines:
+        if line not in builder.splitlines():
+            fail(f"builder provenance is missing {line!r}")
+    for line in required_runtime_lines:
+        if line not in runtime.splitlines():
+            fail(f"runtime provenance is missing {line!r}")
+
+    required_patterns = (
+        (builder, r"(?m)^rustc 1\.95(?:\.\d+)?(?: |$)", "rustc 1.95 provenance"),
+        (builder, r"(?m)^cargo 1\.95(?:\.\d+)?(?: |$)", "cargo 1.95 provenance"),
+        (builder, r"(?m)^libprotoc \S+", "protoc provenance"),
+        (builder, r"(?m)^protobuf-compiler=\S+", "builder package provenance"),
+        (runtime, r"(?m)^iproute2=\S+", "runtime package provenance"),
+    )
+    for content, pattern, label in required_patterns:
+        if re.search(pattern, content) is None:
+            fail(f"{label} is missing")
+
+    print(f"image_id={image_id}")
+    print(f"source_commit={args.source_commit}")
+    print(f"bgperf2_commit={args.bgperf2_commit}")
+    print(f"builder_provenance_sha256={sha256_file(args.builder_provenance)}")
+    print(f"runtime_provenance_sha256={sha256_file(args.runtime_provenance)}")
+
+
+def load_scenario(path: Path) -> dict[str, object]:
+    raw = path.read_text(encoding="utf-8")
+    # bgperf2 stores a Mako helper followed by ordinary YAML. The unexpanded
+    # ${gen_paths(...)} token is useful receipt identity and need not allocate
+    # 200k route strings merely to validate the scenario.
+    if raw.startswith("<%"):
+        end = raw.find("%>")
+        if end < 0:
+            fail("scenario has an unterminated Mako preamble")
+        raw = raw[end + 2 :]
+    scenario = yaml.safe_load(raw)
+    if not isinstance(scenario, dict):
+        fail("scenario must decode to a mapping")
+    return scenario
+
+
+def validate_scenario(path: Path) -> dict[str, object]:
+    scenario = load_scenario(path)
+    require_equal(scenario.get("local_prefix"), "10.10.0.0/16", "scenario local_prefix")
+    require_equal(scenario.get("policy"), {}, "scenario policy")
+
+    monitor = scenario.get("monitor")
+    if not isinstance(monitor, dict):
+        fail("scenario monitor must be a mapping")
+    expected_monitor = {
+        "as": 1001,
+        "check-points": [200_000],
+        "local-address": "10.10.0.2",
+        "router-id": "10.10.0.2",
+    }
+    require_equal(monitor, expected_monitor, "scenario monitor identity")
+
+    target = scenario.get("target")
+    if not isinstance(target, dict):
+        fail("scenario target must be a mapping")
+    expected_target = {
+        "as": 1000,
+        "local-address": "10.10.255.254",
+        "router-id": "10.10.255.254",
+        "single-table": False,
+    }
+    require_equal(target, expected_target, "scenario target identity")
+
+    testers = scenario.get("testers")
+    if not isinstance(testers, list) or len(testers) != 1:
+        fail("scenario must contain exactly one tester group")
+    tester = testers[0]
+    if not isinstance(tester, dict):
+        fail("scenario tester must be a mapping")
+    require_equal(tester.get("name"), "tester", "tester name")
+    require_equal(tester.get("type"), "bird", "tester type")
+    neighbors = tester.get("neighbors")
+    if not isinstance(neighbors, dict):
+        fail("tester neighbors must be a mapping")
+    require_equal(set(neighbors), {"10.10.0.3", "10.10.0.4"}, "tester peers")
+    for position, address in enumerate(sorted(neighbors), start=3):
+        neighbor = neighbors[address]
+        if not isinstance(neighbor, dict):
+            fail(f"neighbor {address} must be a mapping")
+        expected = {
+            "as": 1000 + position,
+            "check-points": 100_000,
+            "count": 100_000,
+            "filter": {"in": []},
+            "local-address": address,
+            "paths": "${gen_paths(100000)}",
+            "router-id": address,
+        }
+        require_equal(neighbor, expected, f"neighbor {address} identity")
+    return scenario
+
+
+def bird_log_inventory(
+    directory: Path,
+    expected_names: set[str],
+    *,
+    label: str,
+    allow_non_log_entries: bool,
+) -> dict[str, Path]:
+    """Return an exact, regular-file-only BIRD log inventory."""
+    require_directory(directory, label)
+    try:
+        entries = list(directory.iterdir())
+    except OSError as error:
+        fail(f"cannot read {label} directory: {error}")
+
+    log_entries = [entry for entry in entries if entry.name.endswith(".log")]
+    actual_names = {entry.name for entry in log_entries}
+    require_equal(actual_names, expected_names, f"{label} files")
+    if len(log_entries) != len(expected_names):
+        fail(f"{label} contains duplicate log names")
+    for entry in log_entries:
+        if entry.is_symlink():
+            fail(f"{label} contains a symlink: {entry.name}")
+        if not entry.is_file():
+            fail(f"{label} contains a non-regular log: {entry.name}")
+
+    if not allow_non_log_entries and len(entries) != len(expected_names):
+        fail(f"{label} contains non-log entries")
+    return {entry.name: entry for entry in log_entries}
+
+
+def validate_bird_tester_logs(
+    args: argparse.Namespace, scenario: dict[str, object]
+) -> None:
+    """Validate the retained logs from this exact bgperf BIRD run.
+
+    The pinned adapter's BIRD error helper intends to count case-sensitive
+    ``RMT`` diagnostics except ``NEXT_HOP`` diagnostics, but reads a hard-coded
+    directory unrelated to ``--dir``/``--bench-name``. Apply that exact rule to
+    the two run-scoped logs copied by the driver. The adapter implements no
+    BIRD timeout detector; its CSV timeout field is therefore compatibility
+    data, not timeout evidence.
+    """
+    expected_bench_name = f"lan393-{args.phase}"
+    require_equal(args.bench_name, expected_bench_name, "bgperf bench name")
+    require_equal(
+        args.run_receipt_dir.name,
+        args.bench_name,
+        "run receipt directory",
+    )
+    require_directory(args.run_receipt_dir, "run receipt directory")
+    require_equal(
+        args.source_tester_log_dir.absolute(),
+        (args.run_receipt_dir / "tester").absolute(),
+        "source tester-log directory",
+    )
+    require_equal(
+        args.source_scenario.absolute(),
+        (args.run_receipt_dir / "scenario.yaml").absolute(),
+        "source scenario path",
+    )
+    require_equal(
+        args.tester_log_dir.name,
+        f"full-daemon-{args.phase}-tester-logs",
+        "retained tester-log directory",
+    )
+    require_regular_file(args.source_scenario, "source run-scoped scenario")
+    require_regular_file(args.scenario, "retained run-scoped scenario")
+    require_equal(
+        sha256_file(args.scenario),
+        sha256_file(args.source_scenario),
+        "copied run-scoped scenario",
+    )
+
+    testers = scenario.get("testers")
+    if not isinstance(testers, list) or len(testers) != 1:
+        fail("scenario must contain exactly one tester group before log validation")
+    tester = testers[0]
+    if not isinstance(tester, dict) or tester.get("type") != "bird":
+        fail("run-scoped log validation supports exactly the pinned BIRD tester")
+    neighbors = tester.get("neighbors")
+    if not isinstance(neighbors, dict):
+        fail("scenario tester neighbors are unavailable for log validation")
+
+    expected_names = {f"{peer}.log" for peer in neighbors}
+    source_logs = bird_log_inventory(
+        args.source_tester_log_dir,
+        expected_names,
+        label="source run-scoped BIRD logs",
+        allow_non_log_entries=True,
+    )
+    retained_logs = bird_log_inventory(
+        args.tester_log_dir,
+        expected_names,
+        label="retained run-scoped BIRD logs",
+        allow_non_log_entries=False,
+    )
+
+    errors: list[str] = []
+    for name in sorted(expected_names):
+        source_path = source_logs[name]
+        path = retained_logs[name]
+        require_equal(
+            sha256_file(path),
+            sha256_file(source_path),
+            f"copied BIRD log {name}",
+        )
+        try:
+            content = path.read_text(encoding="utf-8", errors="strict")
+        except (OSError, UnicodeError) as error:
+            fail(f"cannot read retained BIRD log {path.name}: {error}")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            if "RMT" in line and "NEXT_HOP" not in line:
+                errors.append(f"{path.name}:{line_number}")
+        print(f"tester_log_sha256[{path.name}]={sha256_file(path)}")
+    if errors:
+        fail(
+            "run-scoped BIRD logs contain RMT diagnostics other than "
+            f"NEXT_HOP: {errors!r}"
+        )
+
+    print(f"profile_phase={args.phase}")
+    print(f"bgperf_bench_name={args.bench_name}")
+    print("bird_error_rule=case-sensitive RMT excluding NEXT_HOP")
+    print("bird_error_lines=0")
+    print("tester_timeout_evidence=unsupported_by_pinned_bird_adapter")
+
+
+RESULT_HEADER = [
+    "name",
+    "target",
+    "version",
+    "peers",
+    "prefixes per peer",
+    "required",
+    "received",
+    "monitor (s)",
+    "elapsed (s)",
+    "prefix received (s)",
+    "testers (s)",
+    "total time",
+    "max cpu %",
+    "max mem (GB)",
+    "min idle%",
+    "min free mem (GB)",
+    "flags",
+    "date",
+    "cores",
+    "Mem (GB)",
+    "tester errors",
+    "tester timeouts",
+    "failed",
+    "MSG",
+    "filters",
+]
+
+
+def validate_bgperf(args: argparse.Namespace) -> None:
+    require_regular_file(args.log, "retained bgperf log")
+    scenario = validate_scenario(args.scenario)
+    validate_bird_tester_logs(args, scenario)
+    log = args.log.read_text(encoding="utf-8", errors="strict")
+    if "FAILED" in log:
+        fail("bgperf log contains FAILED")
+
+    rows: list[list[str]] = []
+    for raw_line in log.splitlines():
+        # Progress redraws can leave carriage-return fragments in a captured
+        # log. The final machine row is still a single RFC 4180 CSV record.
+        line = raw_line.rsplit("\r", 1)[-1]
+        try:
+            row = next(csv.reader([line]))
+        except csv.Error:
+            continue
+        if len(row) == len(RESULT_HEADER) and row[1].strip() == "rustbgpd":
+            rows.append([field.strip() for field in row])
+    if len(rows) != 1:
+        fail(f"expected exactly one rustbgpd result row, found {len(rows)}")
+    row = rows[0]
+
+    expected = {
+        0: "rustbgpd",
+        1: "rustbgpd",
+        3: "2",
+        4: "100000",
+        5: "200000",
+        6: "200000",
+        21: "0",
+        22: "",
+        23: "",
+        24: "",
+    }
+    for index, value in expected.items():
+        require_equal(row[index], value, f"bgperf result field {RESULT_HEADER[index]}")
+    if not row[2]:
+        fail("bgperf result has no rustbgpd version identity")
+    try:
+        adapter_tester_errors = int(row[20])
+    except ValueError:
+        fail(f"bgperf adapter tester-error field is not an integer: {row[20]!r}")
+    if adapter_tester_errors < 0:
+        fail(f"bgperf adapter tester-error field is negative: {adapter_tester_errors}")
+    # The raw log retains the adapter's hard-coded-directory value. Replace it
+    # in the normalized receipt with the authoritative run-scoped verdict.
+    row[20] = "0"
+
+    args.result.parent.mkdir(parents=True, exist_ok=True)
+    with args.result.open("w", encoding="utf-8", newline="") as result:
+        writer = csv.writer(result, lineterminator="\n")
+        writer.writerow(RESULT_HEADER)
+        writer.writerow(row)
+    print(f"result_sha256={sha256_file(args.result)}")
+    print("peers=2")
+    print("prefixes_per_peer=100000")
+    print("required=200000")
+    print("received=200000")
+    print("tester_errors=0")
+    print("tester_error_authority=run_scoped_bird_logs")
+    print(f"adapter_tester_errors_ignored={adapter_tester_errors}")
+    print("tester_timeouts_field=0")
+    print("tester_timeout_evidence=unsupported_by_pinned_bird_adapter")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+
+    identity = commands.add_parser("identity", help="validate baseline/candidate commits")
+    identity.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    identity.add_argument("--source-head", required=True)
+    identity.add_argument("--baseline-commit", required=True)
+    identity.add_argument("--baseline-ref-commit", required=True)
+    identity.add_argument("--candidate-commit")
+    identity.add_argument("--candidate-baseline-ancestor", choices=("true", "false"))
+    identity.set_defaults(func=validate_identity)
+
+    image = commands.add_parser("image", help="validate image labels and provenance")
+    image.add_argument("--inspect", type=Path, required=True)
+    image.add_argument("--builder-provenance", type=Path, required=True)
+    image.add_argument("--runtime-provenance", type=Path, required=True)
+    image.add_argument("--source-commit", required=True)
+    image.add_argument("--bgperf2-commit", required=True)
+    image.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    image.set_defaults(func=validate_image)
+
+    bgperf = commands.add_parser("bgperf", help="validate scenario and final result")
+    bgperf.add_argument("--log", type=Path, required=True)
+    bgperf.add_argument("--scenario", type=Path, required=True)
+    bgperf.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    bgperf.add_argument("--bench-name", required=True)
+    bgperf.add_argument("--run-receipt-dir", type=Path, required=True)
+    bgperf.add_argument("--source-scenario", type=Path, required=True)
+    bgperf.add_argument("--source-tester-log-dir", type=Path, required=True)
+    bgperf.add_argument("--tester-log-dir", type=Path, required=True)
+    bgperf.add_argument("--result", type=Path, required=True)
+    bgperf.set_defaults(func=validate_bgperf)
+    return root
+
+
+def main() -> None:
+    args = parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/perf/validate-lan393-receipt.py
+++ b/docs/perf/validate-lan393-receipt.py
@@ -68,6 +68,16 @@ def require_directory(path: Path, label: str) -> None:
         fail(f"{label} is not a directory: {path}")
 
 
+def read_text(path: Path, label: str, *, encoding: str = "utf-8") -> str:
+    """Read retained text without leaking a traceback or a private path."""
+    try:
+        return path.read_text(encoding=encoding, errors="strict")
+    except OSError as error:
+        fail(f"cannot read {label}: {error.strerror or error.__class__.__name__}")
+    except UnicodeError as error:
+        fail(f"cannot decode {label}: {error}")
+
+
 def validate_identity(args: argparse.Namespace) -> None:
     candidate_baseline_ancestor = getattr(args, "candidate_baseline_ancestor", None)
     identities = {
@@ -117,7 +127,10 @@ def validate_image(args: argparse.Namespace) -> None:
     require_regular_file(args.builder_provenance, "builder provenance")
     require_regular_file(args.runtime_provenance, "runtime provenance")
     require_equal(args.bgperf2_commit, BGPERF2_COMMIT, "pinned bgperf2 commit")
-    inspect = json.loads(args.inspect.read_text(encoding="utf-8"))
+    try:
+        inspect = json.loads(read_text(args.inspect, "Docker image inspection"))
+    except json.JSONDecodeError as error:
+        fail(f"cannot parse Docker image inspection JSON: {error.msg}")
     if not isinstance(inspect, list) or len(inspect) != 1:
         fail("Docker image inspection must contain exactly one image")
     image = inspect[0]
@@ -141,8 +154,8 @@ def validate_image(args: argparse.Namespace) -> None:
     for name, expected in expected_labels.items():
         require_equal(labels.get(name), expected, f"OCI label {name}")
 
-    builder = args.builder_provenance.read_text(encoding="utf-8")
-    runtime = args.runtime_provenance.read_text(encoding="utf-8")
+    builder = read_text(args.builder_provenance, "builder provenance")
+    runtime = read_text(args.runtime_provenance, "runtime provenance")
     required_builder_lines = (
         f"rustbgpd_commit={args.source_commit}",
         f"bgperf2_commit={args.bgperf2_commit}",
@@ -202,7 +215,8 @@ def validate_barrier(args: argparse.Namespace) -> None:
 
 
 def load_scenario(path: Path) -> dict[str, object]:
-    raw = path.read_text(encoding="utf-8")
+    require_regular_file(path, "scenario")
+    raw = read_text(path, "scenario")
     # bgperf2 stores a Mako helper followed by ordinary YAML. The unexpanded
     # ${gen_paths(...)} token is useful receipt identity and need not allocate
     # 200k route strings merely to validate the scenario.
@@ -211,7 +225,11 @@ def load_scenario(path: Path) -> dict[str, object]:
         if end < 0:
             fail("scenario has an unterminated Mako preamble")
         raw = raw[end + 2 :]
-    scenario = yaml.safe_load(raw)
+    try:
+        scenario = yaml.safe_load(raw)
+    except yaml.YAMLError as error:
+        detail = getattr(error, "problem", None) or error.__class__.__name__
+        fail(f"cannot parse scenario YAML: {detail}")
     if not isinstance(scenario, dict):
         fail("scenario must decode to a mapping")
     return scenario
@@ -384,10 +402,7 @@ def validate_bird_tester_logs(
             sha256_file(source_path),
             f"copied BIRD log {name}",
         )
-        try:
-            content = path.read_text(encoding="utf-8", errors="strict")
-        except (OSError, UnicodeError) as error:
-            fail(f"cannot read retained BIRD log {path.name}: {error}")
+        content = read_text(path, f"tester log {path.name}")
         for line_number, line in enumerate(content.splitlines(), start=1):
             if "RMT" in line and "NEXT_HOP" not in line:
                 errors.append(f"{path.name}:{line_number}")
@@ -439,7 +454,7 @@ def validate_bgperf(args: argparse.Namespace) -> None:
     require_regular_file(args.log, "retained bgperf log")
     scenario = validate_scenario(args.scenario)
     validate_bird_tester_logs(args, scenario)
-    log = args.log.read_text(encoding="utf-8", errors="strict")
+    log = read_text(args.log, "retained bgperf log")
     if "FAILED" in log:
         fail("bgperf log contains FAILED")
 

--- a/docs/perf/validate-lan393-receipt.py
+++ b/docs/perf/validate-lan393-receipt.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import csv
+import datetime
 import hashlib
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -110,6 +112,9 @@ def validate_identity(args: argparse.Namespace) -> None:
 
 
 def validate_image(args: argparse.Namespace) -> None:
+    require_regular_file(args.inspect, "Docker image inspection")
+    require_regular_file(args.builder_provenance, "builder provenance")
+    require_regular_file(args.runtime_provenance, "runtime provenance")
     require_equal(args.bgperf2_commit, BGPERF2_COMMIT, "pinned bgperf2 commit")
     inspect = json.loads(args.inspect.read_text(encoding="utf-8"))
     if not isinstance(inspect, list) or len(inspect) != 1:
@@ -130,6 +135,7 @@ def validate_image(args: argparse.Namespace) -> None:
         )[1],
         "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
         "org.rustbgpd.lan393.profile-phase": args.phase,
+        "org.rustbgpd.lan393.event-history-mode": args.mode,
     }
     for name, expected in expected_labels.items():
         require_equal(labels.get(name), expected, f"OCI label {name}")
@@ -167,6 +173,7 @@ def validate_image(args: argparse.Namespace) -> None:
     print(f"image_id={image_id}")
     print(f"source_commit={args.source_commit}")
     print(f"bgperf2_commit={args.bgperf2_commit}")
+    print(f"event_history_mode={args.mode}")
     print(f"builder_provenance_sha256={sha256_file(args.builder_provenance)}")
     print(f"runtime_provenance_sha256={sha256_file(args.runtime_provenance)}")
 
@@ -189,6 +196,11 @@ def load_scenario(path: Path) -> dict[str, object]:
 
 def validate_scenario(path: Path) -> dict[str, object]:
     scenario = load_scenario(path)
+    require_equal(
+        set(scenario),
+        {"local_prefix", "monitor", "policy", "target", "testers"},
+        "scenario top-level keys",
+    )
     require_equal(scenario.get("local_prefix"), "10.10.0.0/16", "scenario local_prefix")
     require_equal(scenario.get("policy"), {}, "scenario policy")
 
@@ -285,7 +297,7 @@ def validate_bird_tester_logs(
     BIRD timeout detector; its CSV timeout field is therefore compatibility
     data, not timeout evidence.
     """
-    expected_bench_name = f"lan393-{args.phase}"
+    expected_bench_name = f"lan393-{args.phase}-{args.mode}"
     require_equal(args.bench_name, expected_bench_name, "bgperf bench name")
     require_equal(
         args.run_receipt_dir.name,
@@ -305,7 +317,7 @@ def validate_bird_tester_logs(
     )
     require_equal(
         args.tester_log_dir.name,
-        f"full-daemon-{args.phase}-tester-logs",
+        f"full-daemon-{args.phase}-{args.mode}-tester-logs",
         "retained tester-log directory",
     )
     require_regular_file(args.source_scenario, "source run-scoped scenario")
@@ -364,6 +376,7 @@ def validate_bird_tester_logs(
         )
 
     print(f"profile_phase={args.phase}")
+    print(f"event_history_mode={args.mode}")
     print(f"bgperf_bench_name={args.bench_name}")
     print("bird_error_rule=case-sensitive RMT excluding NEXT_HOP")
     print("bird_error_lines=0")
@@ -438,6 +451,41 @@ def validate_bgperf(args: argparse.Namespace) -> None:
         require_equal(row[index], value, f"bgperf result field {RESULT_HEADER[index]}")
     if not row[2]:
         fail("bgperf result has no rustbgpd version identity")
+
+    def finite_number(index: int, *, positive: bool = False) -> float:
+        label = RESULT_HEADER[index]
+        try:
+            value = float(row[index])
+        except ValueError:
+            fail(f"bgperf result field {label} is not numeric: {row[index]!r}")
+        if not math.isfinite(value) or value < 0 or (positive and value == 0):
+            fail(f"bgperf result field {label} is not finite and valid: {row[index]!r}")
+        return value
+
+    monitor_wait = finite_number(7)
+    elapsed = finite_number(8)
+    first_received = finite_number(9)
+    tester_window = finite_number(10)
+    total_time = finite_number(11, positive=True)
+    finite_number(12)
+    finite_number(13, positive=True)
+    min_idle = finite_number(14)
+    finite_number(15)
+    cores = finite_number(18, positive=True)
+    if not cores.is_integer():
+        fail(f"bgperf result field cores is not an integer: {row[18]!r}")
+    if min_idle > 100:
+        fail(f"bgperf result min idle exceeds 100%: {row[14]!r}")
+    if first_received > elapsed or tester_window > elapsed or elapsed > total_time:
+        fail("bgperf timing fields violate first/tester <= elapsed <= total")
+    if monitor_wait > total_time:
+        fail("bgperf monitor wait exceeds total time")
+    if re.fullmatch(r"[0-9]+(?:\.[0-9]+)?(?:B|KB|MB|GB|TB)", row[19]) is None:
+        fail(f"bgperf result memory identity is malformed: {row[19]!r}")
+    try:
+        datetime.date.fromisoformat(row[17])
+    except ValueError:
+        fail(f"bgperf result date is malformed: {row[17]!r}")
     try:
         adapter_tester_errors = int(row[20])
     except ValueError:
@@ -458,6 +506,7 @@ def validate_bgperf(args: argparse.Namespace) -> None:
     print("prefixes_per_peer=100000")
     print("required=200000")
     print("received=200000")
+    print(f"event_history_mode={args.mode}")
     print("tester_errors=0")
     print("tester_error_authority=run_scoped_bird_logs")
     print(f"adapter_tester_errors_ignored={adapter_tester_errors}")
@@ -485,12 +534,14 @@ def parser() -> argparse.ArgumentParser:
     image.add_argument("--source-commit", required=True)
     image.add_argument("--bgperf2-commit", required=True)
     image.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    image.add_argument("--mode", choices=("enabled", "disabled"), required=True)
     image.set_defaults(func=validate_image)
 
     bgperf = commands.add_parser("bgperf", help="validate scenario and final result")
     bgperf.add_argument("--log", type=Path, required=True)
     bgperf.add_argument("--scenario", type=Path, required=True)
     bgperf.add_argument("--phase", choices=("baseline", "candidate"), required=True)
+    bgperf.add_argument("--mode", choices=("enabled", "disabled"), required=True)
     bgperf.add_argument("--bench-name", required=True)
     bgperf.add_argument("--run-receipt-dir", type=Path, required=True)
     bgperf.add_argument("--source-scenario", type=Path, required=True)


### PR DESCRIPTION
## What changed

- Add a feature-gated Criterion benchmark for route-event producer cost using the real `RibManager` event publishers and production `EhmRibSink`.
- Measure durable event history disabled, enabled with a noop sink, and enabled with the production sink so manager-side conversion/encoding is isolated from unrelated work.
- Add a full-daemon bgperf2 comparison driver for enabled/disabled EHM runs with pinned workload/image inputs, event-volume and cursor-integrity gates, CPU/RSS/query-latency capture, and counterbalanced order.
- Add shared host-lock/preflight fencing and fail-closed validators for Criterion, daemon receipts, and the final comparison.
- Add CI coverage for the feature-gated API benchmark plus shell/Python/adversarial receipt tests.
- Keep raw process identity private; the public barrier proof is normalized to `barrier_reached=1` after strict PID/NSpid validation.

## Why

Durable event history currently performs route-event conversion and protobuf encoding synchronously on the single-threaded RIB actor before its non-blocking queue send. Existing end-to-end numbers combine that producer cost with SQLite consumer work, so they cannot justify moving work across an actor boundary safely.

LAN-393 is explicitly measurement-gated. This PR lands the reproducible harness and acceptance contract first. After it merges, the baseline must run from exact current `main`; only then should an implementation branch move producer work off-actor if the measured attribution clears the ticket's threshold.

## Correctness and evidence gates

- The Criterion bench uses production event publishers and the real EHM sink, with noop isolation and committed-cursor fences.
- Queue/drop/degraded accounting, event counts, cursor continuity, payload hashes, and query results are receipt gates rather than prose-only observations.
- Detached worktrees, separate targets, immutable baseline inputs, executable selection, host lock, CPU/load checks, and source archives fail closed.
- The daemon driver validates the stopped host process's namespace PID against a private raw barrier and publishes no PID.
- The tracked artifact directory is intentionally a pending-results contract; this PR does not claim a performance win or include a baseline generated from the feature branch.

## Validation

- RIB `bench-internals` benchmark check
- API `bench-internals` benchmark check and clippy with warnings denied
- 28 Python validator/adversarial tests
- host-fence adversarial test
- Bash syntax and ShellCheck across all five scripts
- formatting, diff checks, metadata lock, and full pre-push fmt/clippy/test/doc hooks
- independent full-diff and rebase review, including preservation of current route-paging and multi-source benchmark helpers

Linear: LAN-393
