### PR TITLE
chore(perf): use behavior-based event-history harness names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - run: cargo check -p rustbgpd-rib --features bench-internals --benches
       # Transport has the same feature-gated `bench-internals` bench surface.
       - run: cargo check -p rustbgpd-transport --features bench-internals --benches
-      # API owns the feature-gated LAN-393 event-history producer bench.
+      # API owns the feature-gated event-history producer bench.
       - run: cargo check -p rustbgpd-api --features bench-internals --benches
       # Same class of gap for the root crate: `bench-internals` exposes
       # `pub mod config` (and its EVPN reload-diff dependencies) in the
@@ -63,23 +63,25 @@ jobs:
           python3 bench/scale/rebaseline/test_classifiers.py
           python3 bench/scale/rebaseline/test_parse_rrharness.py
           python3 bench/scale/rebaseline/test_validate_lan395_criterion.py
-      - name: Check LAN-393 fail-closed measurement tooling
+      - name: Check event-history producer fail-closed measurement tooling
         run: |
           set -euo pipefail
-          python3 -m venv "$RUNNER_TEMP/lan393-venv"
-          "$RUNNER_TEMP/lan393-venv/bin/pip" install --disable-pip-version-check 'PyYAML==6.0.2'
-          bash docs/perf/test-lan393-host-fence.sh
-          "$RUNNER_TEMP/lan393-venv/bin/python" -m unittest -v \
-            docs/perf/test_validate_lan393_receipt.py \
-            docs/perf/test_validate_lan393_criterion.py \
-            docs/perf/test_validate_lan393_perf.py \
-            docs/perf/test_validate_lan393_full_comparison.py
+          python3 -m venv "$RUNNER_TEMP/event-history-venv"
+          "$RUNNER_TEMP/event-history-venv/bin/pip" install --disable-pip-version-check 'PyYAML==6.0.2'
+          bash docs/perf/test-event-history-host-fence.sh
+          bash docs/perf/test-event-history-naming.sh
+          "$RUNNER_TEMP/event-history-venv/bin/python" -m unittest -v \
+            docs/perf/test_validate_event_history_receipt.py \
+            docs/perf/test_validate_event_history_criterion.py \
+            docs/perf/test_validate_event_history_perf.py \
+            docs/perf/test_validate_event_history_full_comparison.py
           shellcheck -x \
-            docs/perf/lan393-host-fence.sh \
-            docs/perf/run-lan393-criterion.sh \
-            docs/perf/run-lan393-full-daemon.sh \
+            docs/perf/event-history-host-fence.sh \
+            docs/perf/run-event-history-criterion.sh \
+            docs/perf/run-event-history-full-daemon.sh \
             docs/perf/bgperf-rustbgpd-ehm-wrapper.sh \
-            docs/perf/test-lan393-host-fence.sh
+            docs/perf/test-event-history-host-fence.sh \
+            docs/perf/test-event-history-naming.sh
       - run: cargo test --workspace
       - run: cargo doc --workspace --lib --no-deps
         env:

--- a/crates/api/benches/event_history_producer.rs
+++ b/crates/api/benches/event_history_producer.rs
@@ -1,13 +1,13 @@
-//! LAN-393 measurement gate for RIB-produced durable events.
+//! Event-history producer measurement gate for RIB-produced durable events.
 //!
-//! The `lan393_manager_self_time` group times only the synchronous
+//! The `event_history_manager_self_time` group times only the synchronous
 //! `RibManager::publish_*` phase. It compares the default no-op sink with the
 //! real EHM sink. All no-op cases finish before EHM is started, and each EHM
 //! sample starts only after the preceding sample reaches EHM's committed
 //! high-water mark. Commit fences and health checks run in Criterion setup and
 //! are therefore outside the timed region.
 //!
-//! The `lan393_sqlite_end_to_end` group starts at the same manager publish
+//! The `event_history_sqlite_end_to_end` group starts at the same manager publish
 //! helper and ends when every event is observed on EHM's post-commit broadcast.
 //! It therefore includes conversion, prost encoding, the bounded queue, SQLite
 //! commit, cursor allocation, and committed-event delivery.
@@ -113,11 +113,11 @@ impl EhmHarness {
     fn new(subscribe_to_commits: bool) -> Self {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
-            .thread_name("lan393-ehm")
+            .thread_name("event-history-ehm")
             .enable_all()
             .build()
-            .expect("LAN-393 benchmark runtime");
-        let dir = tempfile::tempdir().expect("LAN-393 benchmark tempdir");
+            .expect("event-history producer benchmark runtime");
+        let dir = tempfile::tempdir().expect("event-history producer benchmark tempdir");
         let metrics = BgpMetrics::new();
         let history = runtime
             .block_on(EventHistoryManager::start(EventHistoryConfig {
@@ -134,7 +134,7 @@ impl EhmHarness {
                 sidecar_flush_interval_batches: u64::MAX,
                 metrics: Some(metrics.clone()),
             }))
-            .expect("start LAN-393 benchmark EHM");
+            .expect("start event-history producer benchmark EHM");
         let handle = history.handle();
         let sender = handle.sender();
         let committed_rx = subscribe_to_commits.then(|| handle.subscribe_live());
@@ -333,7 +333,7 @@ fn assert_healthy(state: &Arc<EhmState>, metrics: &BgpMetrics) {
 }
 
 fn manager_self_time(c: &mut Criterion) {
-    let mut group = c.benchmark_group("lan393_manager_self_time");
+    let mut group = c.benchmark_group("event_history_manager_self_time");
     group.sample_size(10);
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(3));
@@ -403,7 +403,7 @@ fn manager_self_time(c: &mut Criterion) {
 }
 
 fn sqlite_end_to_end(c: &mut Criterion) {
-    let mut group = c.benchmark_group("lan393_sqlite_end_to_end");
+    let mut group = c.benchmark_group("event_history_sqlite_end_to_end");
     group.sample_size(10);
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(3));

--- a/docs/perf/artifacts/event-history-producer-2026-07/README.md
+++ b/docs/perf/artifacts/event-history-producer-2026-07/README.md
@@ -1,4 +1,4 @@
-# LAN-393 machine-artifact manifest
+# Event-history producer machine-artifact manifest
 
 This directory is receipt-only. Measurements are intentionally absent until
 the exact drivers in `docs/perf/event-history-producer-2026-07.md` complete on a
@@ -46,7 +46,7 @@ Each of `baseline-enabled`, `baseline-disabled`, `candidate-enabled`, and
 - exact generated scenario/config and explicit enabled/disabled EHM verdict;
 - normalized `barrier_reached=1` evidence for the stopped-wrapper attach point;
   the raw PID-bearing barrier remains private under
-  `target/lan393-private-perf/`;
+  `target/event-history-private-perf/`;
 - raw bgperf log/time series, normalized finite-value result CSV, two exact
   run-scoped BIRD logs, and validator output;
 - post-drain metrics, resource snapshot, daemon log, and cursor/drop/degraded
@@ -63,7 +63,7 @@ once. Later profiles regenerate them only into temporary files and must prove
 byte identity, so no file already bound by an earlier manifest is replaced.
 
 Raw `perf.data` is intentionally not publication material. It remains under
-`target/lan393-private-perf/`; the public receipt binds its digest and retains
+`target/event-history-private-perf/`; the public receipt binds its digest and retains
 the sanitized, classifiable derivatives.
 
 Verify a profile from this directory, for example:

--- a/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
+++ b/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Profiling-only bgperf2 entrypoint for the LAN-393 proceed gate.
+# Profiling-only bgperf2 entrypoint for the event-history producer proceed gate.
 set -eu
 
 case "${1:-}" in
@@ -9,7 +9,7 @@ case "${1:-}" in
 esac
 
 config=$1
-mode=${LAN393_EVENT_HISTORY_MODE:-}
+mode=${EVENT_HISTORY_PERF_MODE:-}
 case "$mode" in
     enabled)
         if grep -q '^\[event_history\]$' "$config"; then
@@ -33,7 +33,7 @@ EOF
         fi
         ;;
     *)
-        printf 'LAN393_EVENT_HISTORY_MODE must be enabled or disabled, got %s\n' "$mode" >&2
+        printf 'EVENT_HISTORY_PERF_MODE must be enabled or disabled, got %s\n' "$mode" >&2
         exit 2
         ;;
 esac
@@ -42,6 +42,6 @@ esac
 # PID is not the daemon PID. Stop this exec process at a host-visible barrier;
 # the receipt attaches perf to it and sends SIGCONT. The subsequent exec keeps
 # the same host PID while replacing this shell with the real daemon.
-printf '%s\n' "$$" >"$(dirname "$config")/lan393-profile-ready"
+printf '%s\n' "$$" >"$(dirname "$config")/event-history-profile-ready"
 kill -STOP "$$"
 exec /usr/local/bin/rustbgpd.real "$@"

--- a/docs/perf/event-history-host-fence.sh
+++ b/docs/perf/event-history-host-fence.sh
@@ -1,45 +1,45 @@
 #!/usr/bin/env bash
-# Shared host-isolation helpers for retained LAN-393 measurements.
+# Shared host-isolation helpers for retained event-history producer measurements.
 #
 # Source this file from a `set -euo pipefail` driver. The acquired descriptor
 # intentionally remains open in the caller until that shell exits.
 
-# Retained LAN-393 receipts use one fixed noise gate. An environment override
+# Retained event-history producer receipts use one fixed noise gate. An environment override
 # would make two otherwise identical receipts incomparable and could turn a
 # noisy run into a publishable-looking success.
-readonly LAN393_REQUIRED_LOAD_ONE_MAX=2.0
+readonly EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX=2.0
 
-lan393_acquire_host_lock() {
+event_history_acquire_host_lock() {
     command -v flock >/dev/null 2>&1 || {
         printf '%s\n' 'required command not found: flock' >&2
         return 1
     }
 
-    LAN393_HOST_LOCK_PATH=${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}
-    mkdir -p "$(dirname "$LAN393_HOST_LOCK_PATH")"
-    touch "$LAN393_HOST_LOCK_PATH"
+    EVENT_HISTORY_PERF_HOST_LOCK_PATH=${RUSTBGPD_HOST_LOCK:-${HOME}/.local/state/rustbgpd-host.lock}
+    mkdir -p "$(dirname "$EVENT_HISTORY_PERF_HOST_LOCK_PATH")"
+    touch "$EVENT_HISTORY_PERF_HOST_LOCK_PATH"
     # shellcheck disable=SC1083 # bash dynamic descriptor syntax is intentional.
-    exec {LAN393_HOST_LOCK_FD}>"$LAN393_HOST_LOCK_PATH"
-    if ! flock -n "$LAN393_HOST_LOCK_FD"; then
+    exec {EVENT_HISTORY_PERF_HOST_LOCK_FD}>"$EVENT_HISTORY_PERF_HOST_LOCK_PATH"
+    if ! flock -n "$EVENT_HISTORY_PERF_HOST_LOCK_FD"; then
         printf 'error: %s is held by another retained soak or benchmark\n' \
-            "$LAN393_HOST_LOCK_PATH" >&2
-        printf '%s\n' '       no LAN-393 build or measurement was started' >&2
+            "$EVENT_HISTORY_PERF_HOST_LOCK_PATH" >&2
+        printf '%s\n' '       no event-history producer build or measurement was started' >&2
         return 75
     fi
-    printf 'acquired host lock: %s\n' "$LAN393_HOST_LOCK_PATH"
+    printf 'acquired host lock: %s\n' "$EVENT_HISTORY_PERF_HOST_LOCK_PATH"
 }
 
-lan393_init_host_preflight_log() {
+event_history_init_host_preflight_log() {
     local log=$1
     [[ ! -e "$log" ]] || {
-        printf 'refusing existing LAN-393 preflight log: %s\n' "$log" >&2
+        printf 'refusing existing event-history producer preflight log: %s\n' "$log" >&2
         return 1
     }
     printf 'phase\tattempt\tutc\tload_1m\tload_1m_max\tgovernor\trequired_governor\tcompeting_process_count\tcompeting_processes\tstatus\n' \
         >"$log"
 }
 
-lan393_governor_snapshot() {
+event_history_governor_snapshot() {
     local -a paths
     local path value first='' mixed=0
     shopt -s nullglob
@@ -68,7 +68,7 @@ lan393_governor_snapshot() {
     fi
 }
 
-lan393_competing_process_snapshot() {
+event_history_competing_process_snapshot() {
     ps -eo pid=,comm=,args= --no-headers \
         | awk -v self="$$" '
             $1 != self &&
@@ -91,27 +91,27 @@ lan393_competing_process_snapshot() {
         '
 }
 
-lan393_wait_for_idle() {
+event_history_wait_for_idle() {
     local phase=$1 log=$2
-    local load_one_max=$LAN393_REQUIRED_LOAD_ONE_MAX
-    local wait_seconds=${LAN393_PREFLIGHT_WAIT_SECONDS:-120}
-    local poll_seconds=${LAN393_PREFLIGHT_POLL_SECONDS:-1}
+    local load_one_max=$EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX
+    local wait_seconds=${EVENT_HISTORY_PERF_PREFLIGHT_WAIT_SECONDS:-120}
+    local poll_seconds=${EVENT_HISTORY_PERF_PREFLIGHT_POLL_SECONDS:-1}
     local required_governor=performance
     local deadline=$((SECONDS + wait_seconds)) attempt=0
     local utc load_one governor process_lines process_count process_summary status
 
     [[ "$wait_seconds" =~ ^[1-9][0-9]*$ ]] || {
-        printf 'LAN393_PREFLIGHT_WAIT_SECONDS must be positive, got %s\n' \
+        printf 'EVENT_HISTORY_PERF_PREFLIGHT_WAIT_SECONDS must be positive, got %s\n' \
             "$wait_seconds" >&2
         return 2
     }
     [[ "$poll_seconds" =~ ^[1-9][0-9]*$ ]] || {
-        printf 'LAN393_PREFLIGHT_POLL_SECONDS must be positive, got %s\n' \
+        printf 'EVENT_HISTORY_PERF_PREFLIGHT_POLL_SECONDS must be positive, got %s\n' \
             "$poll_seconds" >&2
         return 2
     }
     [[ -f "$log" ]] || {
-        printf 'LAN-393 preflight log is not initialized: %s\n' "$log" >&2
+        printf 'event-history producer preflight log is not initialized: %s\n' "$log" >&2
         return 1
     }
 
@@ -119,8 +119,8 @@ lan393_wait_for_idle() {
         ((attempt += 1))
         utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
         load_one=$(awk '{print $1}' /proc/loadavg)
-        governor=$(lan393_governor_snapshot)
-        process_lines=$(lan393_competing_process_snapshot)
+        governor=$(event_history_governor_snapshot)
+        process_lines=$(event_history_competing_process_snapshot)
         if [[ -n "$process_lines" ]]; then
             process_count=$(wc -l <<<"$process_lines")
             process_summary=$(printf '%s' "$process_lines" | tr '\t\n' '  ' | tr -s ' ')
@@ -151,7 +151,7 @@ lan393_wait_for_idle() {
             return
         fi
         if [[ "$status" == timeout-* ]]; then
-            printf 'LAN-393 idle preflight timed out after %ss: %s (load=%s governor=%s processes=%s)\n' \
+            printf 'event-history producer idle preflight timed out after %ss: %s (load=%s governor=%s processes=%s)\n' \
                 "$wait_seconds" "$phase" "$load_one" "$governor" \
                 "$process_summary" >&2
             return 75

--- a/docs/perf/event-history-producer-2026-07.md
+++ b/docs/perf/event-history-producer-2026-07.md
@@ -1,4 +1,4 @@
-# LAN-393 event-history producer measurement gate
+# Event-history producer measurement gate
 
 Status: **harness implemented; measurements pending**. Do not implement the
 producer offload until the baseline proceed gate below is captured on an idle
@@ -6,11 +6,11 @@ host and passes.
 
 The Criterion harness separates two costs:
 
-- `lan393_manager_self_time` measures the synchronous `RibManager::publish_*`
+- `event_history_manager_self_time` measures the synchronous `RibManager::publish_*`
   phase. `noop` is the default-disabled sink. `ehm` is the production EHM sink,
   including route/EVPN conversion, prost encoding, index construction, and the
   bounded non-blocking enqueue.
-- `lan393_sqlite_end_to_end` starts at the same manager helper and stops after
+- `event_history_sqlite_end_to_end` starts at the same manager helper and stops after
   all 256 events are durably committed and observed on EHM's post-commit
   broadcast.
 
@@ -25,10 +25,10 @@ Use the checked-in driver; do not reproduce its steps by hand.
 
 ```bash
 # After this harness commit is merged to current origin/main:
-docs/perf/run-lan393-criterion.sh baseline
+docs/perf/run-event-history-criterion.sh baseline
 
 # Only after an offload candidate exists on a clean descendant commit:
-docs/perf/run-lan393-criterion.sh candidate
+docs/perf/run-event-history-criterion.sh candidate
 ```
 
 The driver fixes the baseline to `refs/remotes/origin/main`, requires the
@@ -64,7 +64,7 @@ the privacy scan pass.
 
 ## Machine gates
 
-`validate-lan393-criterion.py` requires exactly these nine cases and rejects
+`validate-event-history-criterion.py` requires exactly these nine cases and rejects
 missing, duplicate, extra, malformed, non-finite, non-positive, or non-95%-CI
 estimates:
 
@@ -94,12 +94,12 @@ verdict says it failed and implementation stops.
 Run the four profiles in this order:
 
 ```bash
-docs/perf/run-lan393-full-daemon.sh baseline-enabled
-docs/perf/run-lan393-full-daemon.sh baseline-disabled
+docs/perf/run-event-history-full-daemon.sh baseline-enabled
+docs/perf/run-event-history-full-daemon.sh baseline-disabled
 
 # After the candidate Criterion run passes:
-docs/perf/run-lan393-full-daemon.sh candidate-enabled
-docs/perf/run-lan393-full-daemon.sh candidate-disabled
+docs/perf/run-event-history-full-daemon.sh candidate-enabled
+docs/perf/run-event-history-full-daemon.sh candidate-disabled
 ```
 
 The enabled and disabled profiles use the same exact 2-peer x 100k-prefix
@@ -130,12 +130,12 @@ be zero, but the receipt explicitly records timeout evidence as unsupported and
 makes no independent zero-timeout claim.
 
 Perf attaches before the stopped wrapper execs the daemon. Raw `perf.data`
-remains under `target/lan393-private-perf/` and is represented in the public
+remains under `target/event-history-private-perf/` and is represented in the public
 receipt by its SHA-256. The retained report and script have host paths and
 PID/TID/timestamps sanitized. The wrapper's raw PID-bearing readiness barrier
 also remains there; the public receipt retains only `barrier_reached=1` after
 matching it to the namespace identity of the stopped host process.
-`validate-lan393-perf.py` classifies sanitized stacks and emits the exact
+`validate-event-history-perf.py` classifies sanitized stacks and emits the exact
 RIB-manager denominator, EHM producer numerator, percentage, and 5% baseline
 proceed verdict.
 

--- a/docs/perf/run-event-history-criterion.sh
+++ b/docs/perf/run-event-history-criterion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Exact-ref, privacy-safe Criterion receipt driver for LAN-393.
+# Exact-ref, privacy-safe Criterion receipt driver for event-history producer.
 set -euo pipefail
 
 usage() {
@@ -13,19 +13,19 @@ case "$PHASE" in baseline | candidate) ;; *) usage ;; esac
 
 ROOT=$(git rev-parse --show-toplevel)
 ARTIFACT_DIR=${ARTIFACT_DIR:-$ROOT/docs/perf/artifacts/event-history-producer-2026-07}
-STATE_DIR=${LAN393_STATE_DIR:-$ROOT/target/lan393-criterion-state}
+STATE_DIR=${EVENT_HISTORY_PERF_STATE_DIR:-$ROOT/target/event-history-criterion-state}
 BASELINE_REF=refs/remotes/origin/main
-BASELINE_NAME=lan393-exact-baseline
-FENCE=$ROOT/docs/perf/lan393-host-fence.sh
-VALIDATOR_REL=docs/perf/validate-lan393-criterion.py
-PERF_VALIDATOR_REL=docs/perf/validate-lan393-perf.py
-FULL_COMPARISON_REL=docs/perf/validate-lan393-full-comparison.py
-RECEIPT_VALIDATOR_REL=docs/perf/validate-lan393-receipt.py
+BASELINE_NAME=event-history-exact-baseline
+FENCE=$ROOT/docs/perf/event-history-host-fence.sh
+VALIDATOR_REL=docs/perf/validate-event-history-criterion.py
+PERF_VALIDATOR_REL=docs/perf/validate-event-history-perf.py
+FULL_COMPARISON_REL=docs/perf/validate-event-history-full-comparison.py
+RECEIPT_VALIDATOR_REL=docs/perf/validate-event-history-receipt.py
 BENCH_REL=crates/api/benches/event_history_producer.rs
 BENCH_SUPPORT_REL=crates/rib/src/manager/bench_support.rs
-DRIVER_REL=docs/perf/run-lan393-criterion.sh
-FULL_DRIVER_REL=docs/perf/run-lan393-full-daemon.sh
-FENCE_REL=docs/perf/lan393-host-fence.sh
+DRIVER_REL=docs/perf/run-event-history-criterion.sh
+FULL_DRIVER_REL=docs/perf/run-event-history-full-daemon.sh
+FENCE_REL=docs/perf/event-history-host-fence.sh
 WRAPPER_REL=docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
 WORK_ROOT=''
 
@@ -42,7 +42,7 @@ cleanup() {
 trap cleanup EXIT
 
 fail() {
-    printf 'LAN-393 Criterion error: %s\n' "$*" >&2
+    printf 'event-history producer Criterion error: %s\n' "$*" >&2
     exit 1
 }
 
@@ -293,7 +293,7 @@ if [[ "$PHASE" == baseline ]]; then
         fail "baseline must run from exact current $BASELINE_REF"
     [[ ! -e "$BASELINE_ENV" ]] || fail "baseline receipt already exists: $BASELINE_ENV"
     if find "$STATE_DIR/criterion" -mindepth 1 -print -quit | grep -q .; then
-        fail 'baseline requires an empty LAN-393 Criterion state directory'
+        fail 'baseline requires an empty event-history producer Criterion state directory'
     fi
     SOURCE_COMMIT=$BASELINE_COMMIT
 else
@@ -310,7 +310,7 @@ else
         fail 'candidate receipt already exists'
 fi
 
-WORK_ROOT=$(mktemp -d /tmp/lan393-criterion-worktrees.XXXXXX)
+WORK_ROOT=$(mktemp -d /tmp/event-history-criterion-worktrees.XXXXXX)
 git -C "$ROOT" worktree add --detach "$WORK_ROOT/base" "$BASELINE_COMMIT" >/dev/null
 if [[ "$PHASE" == candidate ]]; then
     git -C "$ROOT" worktree add --detach "$WORK_ROOT/candidate" "$SOURCE_COMMIT" >/dev/null
@@ -346,16 +346,16 @@ if [[ "$PHASE" == candidate ]]; then
         fail 'candidate build environment differs from baseline'
 fi
 
-# shellcheck source=docs/perf/lan393-host-fence.sh
+# shellcheck source=docs/perf/event-history-host-fence.sh
 source "$FENCE"
-lan393_acquire_host_lock
+event_history_acquire_host_lock
 PREFLIGHT=$ARTIFACT_DIR/microbench-$PHASE-host-preflight.tsv
-lan393_init_host_preflight_log "$PREFLIGHT"
+event_history_init_host_preflight_log "$PREFLIGHT"
 
 TARGET_DIR=$STATE_DIR/targets/$PHASE-$SOURCE_COMMIT
-BUILD_RAW=$(mktemp /tmp/lan393-build.XXXXXX.jsonl)
+BUILD_RAW=$(mktemp /tmp/event-history-build.XXXXXX.jsonl)
 BUILD_RECEIPT=$ARTIFACT_DIR/microbench-$PHASE-bench-build.json
-BINARY_FILE=$(mktemp /tmp/lan393-binary.XXXXXX)
+BINARY_FILE=$(mktemp /tmp/event-history-binary.XXXXXX)
 (
     cd "$SOURCE_DIR"
     CARGO_TARGET_DIR=$TARGET_DIR cargo bench -p rustbgpd-api \
@@ -379,8 +379,8 @@ if [[ "$PHASE" == candidate ]]; then
         fail 'baseline Criterion state changed before candidate run'
 fi
 
-for group in lan393_manager_self_time lan393_sqlite_end_to_end; do
-    lan393_wait_for_idle "$PHASE-$group" "$PREFLIGHT"
+for group in event_history_manager_self_time event_history_sqlite_end_to_end; do
+    event_history_wait_for_idle "$PHASE-$group" "$PREFLIGHT"
     if [[ "$PHASE" == baseline ]]; then
         CRITERION_HOME=$STATE_DIR/criterion "$BENCH_BIN" --bench "$group" \
             --save-baseline "$BASELINE_NAME" --noplot
@@ -451,7 +451,7 @@ ENVIRONMENT=$ARTIFACT_DIR/microbench-$PHASE-environment.txt
     printf 'benchmark_binary_basename=%s\n' "$(basename "$BENCH_BIN")"
     printf 'benchmark_binary_sha256=%s\n' "$BENCH_SHA"
     printf 'host_lock_policy=rustbgpd-shared-user-lock\n'
-    printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
+    printf 'load_one_max=%s\n' "$EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX"
     printf 'required_governor=performance\n'
 } >"$ENVIRONMENT"
 if [[ "$PHASE" == candidate ]]; then
@@ -471,4 +471,4 @@ privacy_check "$PHASE"
 } >"$COMPLETION"
 privacy_check "$PHASE"
 write_manifest "$PHASE" "$SOURCE_ARCHIVE"
-printf 'LAN-393 %s Criterion receipt complete: %s\n' "$PHASE" "$VERDICT"
+printf 'event-history producer %s Criterion receipt complete: %s\n' "$PHASE" "$VERDICT"

--- a/docs/perf/run-event-history-full-daemon.sh
+++ b/docs/perf/run-event-history-full-daemon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Reproducible LAN-393 full-daemon baseline/candidate profile receipt.
+# Reproducible event-history producer full-daemon baseline/candidate profile receipt.
 set -euo pipefail
 
 usage() {
@@ -20,14 +20,14 @@ RUSTBGPD_SOURCE=${RUSTBGPD_SOURCE:-$PWD}
 ARTIFACT_DIR=${ARTIFACT_DIR:-$RUSTBGPD_SOURCE/docs/perf/artifacts/event-history-producer-2026-07}
 BGPERF2_REMOTE=https://github.com/lance0/bgperf2.git
 BGPERF2_COMMIT=fe4fdab9f7efb56e2e98ad6e6bcffeda047761a9
-BGPERF2_DIR=${BGPERF2_DIR:-/tmp/lan393-bgperf2-$BGPERF2_COMMIT}
-BGPERF_RUN_DIR=${BGPERF_RUN_DIR:-/tmp/lan393-bgperf-$PROFILE}
-BENCH_NAME=lan393-$PROFILE
-PROFILE_IMAGE=${PROFILE_IMAGE:-bgperf/rustbgpd:lan393-$PROFILE-prof}
+BGPERF2_DIR=${BGPERF2_DIR:-/tmp/event-history-bgperf2-$BGPERF2_COMMIT}
+BGPERF_RUN_DIR=${BGPERF_RUN_DIR:-/tmp/event-history-bgperf-$PROFILE}
+BENCH_NAME=event-history-$PROFILE
+PROFILE_IMAGE=${PROFILE_IMAGE:-bgperf/rustbgpd:event-history-$PROFILE-prof}
 TARGET_CONTAINER=${TARGET_CONTAINER:-bgperf_rustbgpd_target}
-VALIDATOR=$RUSTBGPD_SOURCE/docs/perf/validate-lan393-receipt.py
+VALIDATOR=$RUSTBGPD_SOURCE/docs/perf/validate-event-history-receipt.py
 WRAPPER=$RUSTBGPD_SOURCE/docs/perf/bgperf-rustbgpd-ehm-wrapper.sh
-HOST_FENCE=$RUSTBGPD_SOURCE/docs/perf/lan393-host-fence.sh
+HOST_FENCE=$RUSTBGPD_SOURCE/docs/perf/event-history-host-fence.sh
 PREFIX=$ARTIFACT_DIR/full-daemon-$PROFILE
 BASELINE_ENV=$ARTIFACT_DIR/microbench-baseline-environment.txt
 CANDIDATE_ENV=$ARTIFACT_DIR/microbench-candidate-environment.txt
@@ -36,7 +36,7 @@ DEBIAN_RUNTIME_IMAGE='debian:bookworm-slim@sha256:60eac759739651111db372c07be678
 BUILD_CONTEXT=''
 BGPERF_PID=''
 TARGET_PID=''
-PRIVATE_PERF_DIR=${LAN393_PRIVATE_PERF_DIR:-$RUSTBGPD_SOURCE/target/lan393-private-perf}
+PRIVATE_PERF_DIR=${EVENT_HISTORY_PERF_PRIVATE_DIR:-$RUSTBGPD_SOURCE/target/event-history-private-perf}
 PRIVATE_PERF_DATA=$PRIVATE_PERF_DIR/full-daemon-$PROFILE.perf.data
 PRIVATE_PROFILE_READY=$PRIVATE_PERF_DIR/full-daemon-$PROFILE.profile-ready
 
@@ -94,8 +94,8 @@ write_host_toolchain() {
 
 compare_provenance_without_source_commit() {
     local reference=$1 candidate=$2 label=$3 left right
-    left=$(mktemp /tmp/lan393-provenance-reference.XXXXXX)
-    right=$(mktemp /tmp/lan393-provenance-candidate.XXXXXX)
+    left=$(mktemp /tmp/event-history-provenance-reference.XXXXXX)
+    right=$(mktemp /tmp/event-history-provenance-candidate.XXXXXX)
     sed '/^rustbgpd_commit=/d' "$reference" >"$left"
     sed '/^rustbgpd_commit=/d' "$candidate" >"$right"
     if ! cmp --silent "$left" "$right"; then
@@ -262,11 +262,11 @@ fi
 
 require_clean_source
 require_new_phase_receipt
-# shellcheck source=docs/perf/lan393-host-fence.sh
+# shellcheck source=docs/perf/event-history-host-fence.sh
 source "$HOST_FENCE"
-lan393_acquire_host_lock
+event_history_acquire_host_lock
 HOST_PREFLIGHT=$PREFIX-host-preflight.tsv
-lan393_init_host_preflight_log "$HOST_PREFLIGHT"
+event_history_init_host_preflight_log "$HOST_PREFLIGHT"
 HOST_FINGERPRINT=$PREFIX-host-fingerprint.txt
 HOST_TOOLCHAIN=$PREFIX-host-toolchain.txt
 write_host_fingerprint "$HOST_FINGERPRINT"
@@ -281,7 +281,7 @@ if [[ "$PROFILE" != baseline-enabled ]]; then
         exit 1
     }
 fi
-lan393_wait_for_idle "$PROFILE-before-build" "$HOST_PREFLIGHT"
+event_history_wait_for_idle "$PROFILE-before-build" "$HOST_PREFLIGHT"
 rm -rf "$BGPERF_RUN_DIR"
 
 # Criterion establishes each exact source archive. Every full-daemon profile
@@ -336,9 +336,9 @@ fi
 
 # Docker and the receipt validator consume only the retained exact-commit
 # archive. The mutable checkout is identity input, never build input.
-BUILD_CONTEXT=$(mktemp -d /tmp/lan393-rustbgpd-build.XXXXXX)
+BUILD_CONTEXT=$(mktemp -d /tmp/event-history-rustbgpd-build.XXXXXX)
 tar -xzf "$BUILD_ARCHIVE" -C "$BUILD_CONTEXT"
-VALIDATOR=$BUILD_CONTEXT/docs/perf/validate-lan393-receipt.py
+VALIDATOR=$BUILD_CONTEXT/docs/perf/validate-event-history-receipt.py
 [[ -x "$VALIDATOR" ]] || {
     printf 'archived validator is not executable: %s\n' "$VALIDATOR" >&2
     exit 1
@@ -441,9 +441,9 @@ LABEL org.opencontainers.image.base.name="$DEBIAN_RUNTIME_IMAGE"
 LABEL org.opencontainers.image.base.digest="${DEBIAN_RUNTIME_IMAGE##*sha256:}"
 LABEL org.rustbgpd.bgperf2.builder-base.digest="${RUST_BUILDER_IMAGE##*sha256:}"
 LABEL org.rustbgpd.bgperf2.rust-toolchain="1.95"
-LABEL org.rustbgpd.lan393.profile-phase="\$PROFILE_PHASE"
-LABEL org.rustbgpd.lan393.event-history-mode="\$EVENT_HISTORY_MODE"
-ENV LAN393_EVENT_HISTORY_MODE="\$EVENT_HISTORY_MODE"
+LABEL org.rustbgpd.event-history.profile-phase="\$PROFILE_PHASE"
+LABEL org.rustbgpd.event-history.mode="\$EVENT_HISTORY_MODE"
+ENV EVENT_HISTORY_PERF_MODE="\$EVENT_HISTORY_MODE"
 WORKDIR /root
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
@@ -522,12 +522,12 @@ PROFILE_IMAGE_ID=$(docker image inspect --format '{{.Id}}' "$PROFILE_IMAGE")
     printf 'host_lock_policy=rustbgpd-shared-user-lock\n'
     printf 'host_lock_acquired=1\n'
     printf 'host_preflight=%s\n' "$(basename "$HOST_PREFLIGHT")"
-    printf 'load_one_max=%s\n' "$LAN393_REQUIRED_LOAD_ONE_MAX"
-    printf 'preflight_wait_seconds=%s\n' "${LAN393_PREFLIGHT_WAIT_SECONDS:-120}"
+    printf 'load_one_max=%s\n' "$EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX"
+    printf 'preflight_wait_seconds=%s\n' "${EVENT_HISTORY_PERF_PREFLIGHT_WAIT_SECONDS:-120}"
     printf 'required_governor=performance\n'
 } >"$PREFIX-environment.txt"
 
-lan393_wait_for_idle "$PROFILE-before-bgperf" "$HOST_PREFLIGHT"
+event_history_wait_for_idle "$PROFILE-before-bgperf" "$HOST_PREFLIGHT"
 (
     cd "$BGPERF2_DIR"
     env -u RUSTBGPD_EVENT_HISTORY \
@@ -582,7 +582,7 @@ mkdir -p "$PRIVATE_PERF_DIR"
     exit 1
 }
 docker cp \
-    "$TARGET_CONTAINER:/root/config/lan393-profile-ready" \
+    "$TARGET_CONTAINER:/root/config/event-history-profile-ready" \
     "$PRIVATE_PROFILE_READY"
 python3 "$VALIDATOR" barrier \
     --raw "$PRIVATE_PROFILE_READY" \
@@ -710,7 +710,7 @@ for line in sys.stdin:
     line=re.sub(r"/(?:home|Users)/[^ /)]+", "<host-home>", line)
     sys.stdout.write(line)' \
     >"$PREFIX-perf-script.txt"
-python3 "$BUILD_CONTEXT/docs/perf/validate-lan393-perf.py" \
+python3 "$BUILD_CONTEXT/docs/perf/validate-event-history-perf.py" \
     --input "$PREFIX-perf-script.txt" \
     --phase "$SOURCE_PHASE" \
     --mode "$EHM_MODE" \
@@ -736,7 +736,7 @@ privacy_check
 } >"$PREFIX-completion.txt"
 
 if [[ "$EHM_MODE" == disabled ]]; then
-    python3 "$BUILD_CONTEXT/docs/perf/validate-lan393-full-comparison.py" \
+    python3 "$BUILD_CONTEXT/docs/perf/validate-event-history-full-comparison.py" \
         --artifact-dir "$ARTIFACT_DIR" \
         --phase "$SOURCE_PHASE" \
         --output "$PREFIX-overall-verdict.json" \

--- a/docs/perf/test-event-history-host-fence.sh
+++ b/docs/perf/test-event-history-host-fence.sh
@@ -2,7 +2,8 @@
 # Adversarial probes for the retained event-history producer host-isolation helpers.
 set -euo pipefail
 
-export EVENT_HISTORY_PERF_LOAD_ONE_MAX=999
+# Prove the inherited environment cannot relax the fixed receipt noise gate.
+export EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX=999
 # shellcheck source=docs/perf/event-history-host-fence.sh
 source "$(dirname "$0")/event-history-host-fence.sh"
 

--- a/docs/perf/test-event-history-host-fence.sh
+++ b/docs/perf/test-event-history-host-fence.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Adversarial probes for the retained LAN-393 host-isolation helpers.
+# Adversarial probes for the retained event-history producer host-isolation helpers.
 set -euo pipefail
 
-export LAN393_LOAD_ONE_MAX=999
-# shellcheck source=docs/perf/lan393-host-fence.sh
-source "$(dirname "$0")/lan393-host-fence.sh"
+export EVENT_HISTORY_PERF_LOAD_ONE_MAX=999
+# shellcheck source=docs/perf/event-history-host-fence.sh
+source "$(dirname "$0")/event-history-host-fence.sh"
 
-[[ "$LAN393_REQUIRED_LOAD_ONE_MAX" == 2.0 ]]
+[[ "$EVENT_HISTORY_PERF_REQUIRED_LOAD_ONE_MAX" == 2.0 ]]
 
 # Model the Linux TASK_COMM_LEN truncation used by `ps comm`, plus every
 # repository benchmark family that can continue running after Cargo exits.
@@ -30,11 +30,11 @@ ps() {
         '116 sleep sleep 30'
 }
 
-snapshot=$(lan393_competing_process_snapshot)
+snapshot=$(event_history_competing_process_snapshot)
 [[ $(wc -l <<<"$snapshot") -eq 15 ]]
 [[ "$snapshot" != *'sleep 30'* ]]
 [[ "$snapshot" != *'/repo/'* ]]
 [[ "$snapshot" != *'101 '* ]]
 [[ "$snapshot" == *'event_history_'* ]]
 
-printf '%s\n' 'LAN-393 host-fence adversarial probes passed'
+printf '%s\n' 'event-history producer host-fence adversarial probes passed'

--- a/docs/perf/test-event-history-naming.sh
+++ b/docs/perf/test-event-history-naming.sh
@@ -3,6 +3,13 @@
 # private issue tracker that operators and contributors cannot inspect.
 set -euo pipefail
 
+for required_command in git grep rg; do
+    command -v "$required_command" >/dev/null 2>&1 || {
+        printf 'required command not found: %s\n' "$required_command" >&2
+        exit 1
+    }
+done
+
 ROOT=$(git rev-parse --show-toplevel)
 mapfile -t files < <(
     git -C "$ROOT" ls-files -- \

--- a/docs/perf/test-event-history-naming.sh
+++ b/docs/perf/test-event-history-naming.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Keep the event-history performance surface named after its behavior, not a
+# private issue tracker that operators and contributors cannot inspect.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+mapfile -t files < <(
+    git -C "$ROOT" ls-files -- \
+        'crates/api/benches/event_history_producer.rs' \
+        'docs/perf/*event-history*' \
+        'docs/perf/bgperf-rustbgpd-ehm-wrapper.sh' \
+        'docs/perf/artifacts/event-history-producer-2026-07/**'
+)
+
+((${#files[@]} > 0)) || {
+    printf '%s\n' 'event-history naming guard found no tracked files' >&2
+    exit 1
+}
+
+if bad_paths=$(printf '%s\n' "${files[@]}" | grep -Ei 'lan-?[0-9]{3}'); then
+    printf '%s\n' 'private-ticket namespace found in event-history paths:' >&2
+    printf '%s\n' "$bad_paths" >&2
+    exit 1
+fi
+
+absolute_files=()
+for file in "${files[@]}"; do
+    absolute_files+=("$ROOT/$file")
+done
+if matches=$(rg -n -i 'lan-?[0-9]{3}' "${absolute_files[@]}"); then
+    printf '%s\n' 'private-ticket namespace found in event-history content:' >&2
+    printf '%s\n' "$matches" >&2
+    exit 1
+fi
+
+printf '%s\n' 'event-history naming guard passed'

--- a/docs/perf/test_validate_event_history_criterion.py
+++ b/docs/perf/test_validate_event_history_criterion.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adversarial tests for the LAN-393 Criterion matrix validator."""
+"""Adversarial tests for the event-history producer Criterion matrix validator."""
 
 from __future__ import annotations
 
@@ -11,8 +11,8 @@ import unittest
 from pathlib import Path
 
 
-MODULE_PATH = Path(__file__).with_name("validate-lan393-criterion.py")
-SPEC = importlib.util.spec_from_file_location("lan393_criterion", MODULE_PATH)
+MODULE_PATH = Path(__file__).with_name("validate-event-history-criterion.py")
+SPEC = importlib.util.spec_from_file_location("event_history_criterion", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 criterion = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = criterion
@@ -59,8 +59,8 @@ class CriterionValidatorTests(unittest.TestCase):
     def test_exact_matrix_and_both_gates(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
-            base = criterion.inventory(root, "lan393-baseline")
+            populate(root, "event-history-baseline")
+            base = criterion.inventory(root, "event-history-baseline")
             self.assertTrue(criterion.gate_baseline(base)["manager_proceed_pass"])
 
             populate(root, "new", candidate=True)
@@ -70,48 +70,48 @@ class CriterionValidatorTests(unittest.TestCase):
     def test_missing_extra_duplicate_and_nonfinite_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
-            victim = next(root.glob("**/lan393-baseline/benchmark.json"))
+            populate(root, "event-history-baseline")
+            victim = next(root.glob("**/event-history-baseline/benchmark.json"))
             victim.unlink()
             with self.assertRaises(SystemExit):
-                criterion.inventory(root, "lan393-baseline")
+                criterion.inventory(root, "event-history-baseline")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
-            write_case(root, "unexpected/case", "lan393-baseline", 1.0)
+            populate(root, "event-history-baseline")
+            write_case(root, "unexpected/case", "event-history-baseline", 1.0)
             with self.assertRaises(SystemExit):
-                criterion.inventory(root, "lan393-baseline")
+                criterion.inventory(root, "event-history-baseline")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
-            duplicate = root / "duplicate" / "lan393-baseline"
+            populate(root, "event-history-baseline")
+            duplicate = root / "duplicate" / "event-history-baseline"
             duplicate.mkdir(parents=True)
-            original = next(root.glob("**/lan393-baseline/benchmark.json"))
+            original = next(root.glob("**/event-history-baseline/benchmark.json"))
             (duplicate / "benchmark.json").write_bytes(original.read_bytes())
             (duplicate / "estimates.json").write_bytes(
                 original.with_name("estimates.json").read_bytes()
             )
             with self.assertRaises(SystemExit):
-                criterion.inventory(root, "lan393-baseline")
+                criterion.inventory(root, "event-history-baseline")
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
-            estimates = next(root.glob("**/lan393-baseline/estimates.json"))
+            populate(root, "event-history-baseline")
+            estimates = next(root.glob("**/event-history-baseline/estimates.json"))
             data = json.loads(estimates.read_text(encoding="utf-8"))
             data["mean"]["point_estimate"] = float("nan")
             estimates.write_text(json.dumps(data), encoding="utf-8")
             with self.assertRaises(SystemExit):
-                criterion.inventory(root, "lan393-baseline")
+                criterion.inventory(root, "event-history-baseline")
 
     def test_candidate_gate_rejects_regressions(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            populate(root, "lan393-baseline")
+            populate(root, "event-history-baseline")
             populate(root, "new", candidate=True)
-            base = criterion.inventory(root, "lan393-baseline")
+            base = criterion.inventory(root, "event-history-baseline")
             head = criterion.inventory(root, "new")
             self.assertTrue(criterion.gate_candidate(base, head)["candidate_acceptance_pass"])
 

--- a/docs/perf/test_validate_event_history_full_comparison.py
+++ b/docs/perf/test_validate_event_history_full_comparison.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the LAN-393 combined full-daemon verdict."""
+"""Tests for the event-history producer combined full-daemon verdict."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ import unittest
 from pathlib import Path
 
 
-MODULE_PATH = Path(__file__).with_name("validate-lan393-full-comparison.py")
-SPEC = importlib.util.spec_from_file_location("lan393_full_comparison", MODULE_PATH)
+MODULE_PATH = Path(__file__).with_name("validate-event-history-full-comparison.py")
+SPEC = importlib.util.spec_from_file_location("event_history_full_comparison", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 comparison = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(comparison)

--- a/docs/perf/test_validate_event_history_perf.py
+++ b/docs/perf/test_validate_event_history_perf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adversarial tests for the LAN-393 full-daemon perf classifier."""
+"""Adversarial tests for the event-history producer full-daemon perf classifier."""
 
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ import unittest
 from pathlib import Path
 
 
-MODULE_PATH = Path(__file__).with_name("validate-lan393-perf.py")
-SPEC = importlib.util.spec_from_file_location("lan393_perf", MODULE_PATH)
+MODULE_PATH = Path(__file__).with_name("validate-event-history-perf.py")
+SPEC = importlib.util.spec_from_file_location("event_history_perf", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 perf = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(perf)

--- a/docs/perf/test_validate_event_history_receipt.py
+++ b/docs/perf/test_validate_event_history_receipt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adversarial probes for the LAN-393 receipt validators."""
+"""Adversarial probes for the event-history producer receipt validators."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ import unittest
 from pathlib import Path
 
 
-MODULE_PATH = Path(__file__).with_name("validate-lan393-receipt.py")
-SPEC = importlib.util.spec_from_file_location("lan393_receipt", MODULE_PATH)
+MODULE_PATH = Path(__file__).with_name("validate-event-history-receipt.py")
+SPEC = importlib.util.spec_from_file_location("event_history_receipt", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 receipt = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(receipt)
@@ -109,7 +109,7 @@ class ReceiptValidatorTests(unittest.TestCase):
         scenario = root / f"full-daemon-{phase}-{mode}-scenario.yaml"
         log = root / "bgperf.log"
         result = root / "result.csv"
-        run_receipt_dir = root / f"lan393-{phase}-{mode}"
+        run_receipt_dir = root / f"event-history-{phase}-{mode}"
         source_tester_logs = run_receipt_dir / "tester"
         source_tester_logs.mkdir(parents=True)
         source_scenario = run_receipt_dir / "scenario.yaml"
@@ -138,7 +138,7 @@ class ReceiptValidatorTests(unittest.TestCase):
             result=result,
             phase=phase,
             mode=mode,
-            bench_name=f"lan393-{phase}-{mode}",
+            bench_name=f"event-history-{phase}-{mode}",
             run_receipt_dir=run_receipt_dir,
             source_scenario=source_scenario,
             source_tester_log_dir=source_tester_logs,
@@ -421,7 +421,7 @@ class ReceiptValidatorTests(unittest.TestCase):
     def test_tester_logs_are_bound_to_phase_and_bench_name(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             args = self.bgperf_files(Path(directory))
-            args.bench_name = "lan393-candidate-enabled"
+            args.bench_name = "event-history-candidate-enabled"
             with self.assertRaises(SystemExit):
                 receipt.validate_bgperf(args)
 
@@ -446,8 +446,8 @@ class ReceiptValidatorTests(unittest.TestCase):
                 "sha256:", 1
             )[1],
             "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
-            "org.rustbgpd.lan393.profile-phase": "baseline",
-            "org.rustbgpd.lan393.event-history-mode": "enabled",
+            "org.rustbgpd.event-history.profile-phase": "baseline",
+            "org.rustbgpd.event-history.mode": "enabled",
         }
         inspect = root / "inspect.json"
         inspect.write_text(

--- a/docs/perf/validate-event-history-criterion.py
+++ b/docs/perf/validate-event-history-criterion.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate and gate the exact LAN-393 Criterion result matrix."""
+"""Validate and gate the exact event-history producer Criterion result matrix."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ from pathlib import Path
 
 
 SHAPES = ("route_added", "route_policy_filtered", "evpn_best_changed")
-MANAGER_GROUP = "lan393_manager_self_time"
-SQLITE_GROUP = "lan393_sqlite_end_to_end"
+MANAGER_GROUP = "event_history_manager_self_time"
+SQLITE_GROUP = "event_history_sqlite_end_to_end"
 EXPECTED_IDS = {
     *(f"{MANAGER_GROUP}/{shape}/{mode}" for shape in SHAPES for mode in ("noop", "ehm")),
     *(f"{SQLITE_GROUP}/{shape}/full" for shape in SHAPES),

--- a/docs/perf/validate-event-history-full-comparison.py
+++ b/docs/perf/validate-event-history-full-comparison.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Combine LAN-393 enabled/disabled daemon receipts into the final gate."""
+"""Combine event-history producer enabled/disabled daemon receipts into the final gate."""
 
 from __future__ import annotations
 

--- a/docs/perf/validate-event-history-perf.py
+++ b/docs/perf/validate-event-history-perf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classify sanitized LAN-393 full-daemon perf stacks and apply the proceed gate."""
+"""Classify sanitized event-history producer full-daemon perf stacks and apply the proceed gate."""
 
 from __future__ import annotations
 

--- a/docs/perf/validate-event-history-receipt.py
+++ b/docs/perf/validate-event-history-receipt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed validators for the LAN-393 full-daemon receipt."""
+"""Fail-closed validators for the event-history producer full-daemon receipt."""
 
 from __future__ import annotations
 
@@ -148,8 +148,8 @@ def validate_image(args: argparse.Namespace) -> None:
             "sha256:", 1
         )[1],
         "org.rustbgpd.bgperf2.rust-toolchain": "1.95",
-        "org.rustbgpd.lan393.profile-phase": args.phase,
-        "org.rustbgpd.lan393.event-history-mode": args.mode,
+        "org.rustbgpd.event-history.profile-phase": args.phase,
+        "org.rustbgpd.event-history.mode": args.mode,
     }
     for name, expected in expected_labels.items():
         require_equal(labels.get(name), expected, f"OCI label {name}")
@@ -338,7 +338,7 @@ def validate_bird_tester_logs(
     BIRD timeout detector; its CSV timeout field is therefore compatibility
     data, not timeout evidence.
     """
-    expected_bench_name = f"lan393-{args.phase}-{args.mode}"
+    expected_bench_name = f"event-history-{args.phase}-{args.mode}"
     require_equal(args.bench_name, expected_bench_name, "bgperf bench name")
     require_equal(
         args.run_receipt_dir.name,


### PR DESCRIPTION
## Summary

- rename the event-history performance harness around its observable behavior instead of a private issue number
- update filenames, functions, environment variables, Criterion groups, OCI labels, paths, validators, tests, CI, and operator documentation consistently
- add a CI naming guard that rejects ticket-number-derived namespaces in the event-history performance surface

## Verification

- 32 Python validator tests
- event-history host-fence and naming adversarial probes
- Bash syntax and ShellCheck
- cargo check -p rustbgpd-api --features bench-internals --benches
- workspace fmt, Clippy, tests, and rustdoc through commit/push hooks