### PR TITLE
docs: scrub public benchmark receipt hostname

### DIFF
--- a/docs/perf/rib-route-paging-2026-07.md
+++ b/docs/perf/rib-route-paging-2026-07.md
@@ -91,7 +91,7 @@ leaving the repeated table scan for a measured continuation tranche.
 
 | Field | Value |
 |---|---|
-| Host | `lancebox`; cooperating rustbgpd soak/bench work excluded by the shared host lock |
+| Host | `<BENCH_HOST>`; cooperating rustbgpd soak/bench work excluded by the shared host lock |
 | Kernel | Linux `6.17.0-35-generic` x86_64 |
 | CPU | AMD Ryzen Threadripper 7970X 32-Cores, 64 logical CPUs, one NUMA node |
 | Pinned core | `5` |


### PR DESCRIPTION
## Summary

- replace a committed developer hostname in the route-paging performance receipt with a neutral benchmark-host token
- preserve the recorded measurement and artifact semantics

## Validation

- tracked-tree and compressed-artifact privacy scans
- route-paging receipt checksum and driver validation
- Markdown links and `git diff --check`
- commit and push hooks