### PR TITLE
fix: bound restart deferral across clock steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lines, while the latest exercise targets `vMAJOR.MINOR.0` and the inventory
   separately pins the exact workspace patch version.
 
+- **Planned-restart deferral remains bounded across backward clock steps.**
+  Marker-backed startup now clamps the persisted marker's remaining lifetime to
+  the maximum effective `gr_restart_time`, so a wall-clock correction cannot
+  extend restarting-speaker signaling or route-selection deferral beyond the
+  configured window. Expired markers still produce an immediate cold start.
+
 - **Unexportable routes now fail before Adj-RIB-Out commit.** Every
   route-bearing envelope carries one immutable snapshot of the session's exact
   encoder and negotiated message ceiling. The RIB probes the final one-route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Marker-backed startup now clamps the persisted marker's remaining lifetime to
   the maximum effective `gr_restart_time`, so a wall-clock correction cannot
   extend restarting-speaker signaling or route-selection deferral beyond the
-  configured window. Expired markers still produce an immediate cold start.
+  configured window. Expired markers, or markers without a positive effective
+  restart window, produce an immediate cold start.
 
 - **Unexportable routes now fail before Adj-RIB-Out commit.** Every
   route-bearing envelope carries one immutable snapshot of the session's exact

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,6 +480,17 @@ fn max_gr_restart_time_secs(config: &Config) -> Option<u64> {
     }
 }
 
+fn gr_restart_marker_remaining_time(
+    expires_at: SystemTime,
+    now: SystemTime,
+    max_restart_time_secs: Option<u64>,
+) -> Result<Duration, std::time::SystemTimeError> {
+    let remaining = expires_at.duration_since(now)?;
+    Ok(max_restart_time_secs
+        .map(Duration::from_secs)
+        .map_or(remaining, |maximum| remaining.min(maximum)))
+}
+
 fn marker_expires_at(marker: &GrRestartMarker) -> Result<SystemTime, String> {
     if marker.version != GR_RESTART_MARKER_VERSION {
         return Err(format!(
@@ -1392,7 +1403,12 @@ async fn run<T>(
     let gr_restart_marker_path = config.gr_restart_marker_path();
     let local_gr_restart_until = match read_gr_restart_marker(&gr_restart_marker_path) {
         Ok(Some(expires_at)) => {
-            if let Ok(remaining) = expires_at.duration_since(SystemTime::now()) {
+            let max_restart_time_secs = max_gr_restart_time_secs(&config);
+            if let Ok(remaining) = gr_restart_marker_remaining_time(
+                expires_at,
+                SystemTime::now(),
+                max_restart_time_secs,
+            ) {
                 let deadline = StdInstant::now() + remaining;
                 info!(
                     marker = %gr_restart_marker_path.display(),
@@ -3605,6 +3621,38 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         let err = read_gr_restart_marker(&path).unwrap_err();
         assert!(err.contains("unsupported marker version"));
         remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn gr_restart_marker_remaining_time_clamps_backward_clock_step() {
+        let marker_written_at = UNIX_EPOCH + Duration::from_hours(2);
+        let expires_at = marker_written_at + Duration::from_mins(2);
+        let clock_after_backward_step = marker_written_at - Duration::from_hours(1);
+
+        assert_eq!(
+            gr_restart_marker_remaining_time(expires_at, clock_after_backward_step, Some(120))
+                .unwrap(),
+            Duration::from_mins(2)
+        );
+    }
+
+    #[test]
+    fn gr_restart_marker_remaining_time_preserves_normal_and_expired_cases() {
+        let now = UNIX_EPOCH + Duration::from_hours(2);
+
+        assert_eq!(
+            gr_restart_marker_remaining_time(now + Duration::from_secs(30), now, Some(120))
+                .unwrap(),
+            Duration::from_secs(30)
+        );
+        assert!(
+            gr_restart_marker_remaining_time(
+                now + Duration::from_mins(2),
+                now + Duration::from_hours(1),
+                Some(120),
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,11 +484,10 @@ fn gr_restart_marker_remaining_time(
     expires_at: SystemTime,
     now: SystemTime,
     max_restart_time_secs: Option<u64>,
-) -> Result<Duration, std::time::SystemTimeError> {
-    let remaining = expires_at.duration_since(now)?;
-    Ok(max_restart_time_secs
-        .map(Duration::from_secs)
-        .map_or(remaining, |maximum| remaining.min(maximum)))
+) -> Option<Duration> {
+    let maximum = max_restart_time_secs.filter(|maximum| *maximum > 0)?;
+    let remaining = expires_at.duration_since(now).ok()?;
+    Some(remaining.min(Duration::from_secs(maximum)))
 }
 
 fn marker_expires_at(marker: &GrRestartMarker) -> Result<SystemTime, String> {
@@ -1404,7 +1403,7 @@ async fn run<T>(
     let local_gr_restart_until = match read_gr_restart_marker(&gr_restart_marker_path) {
         Ok(Some(expires_at)) => {
             let max_restart_time_secs = max_gr_restart_time_secs(&config);
-            if let Ok(remaining) = gr_restart_marker_remaining_time(
+            if let Some(remaining) = gr_restart_marker_remaining_time(
                 expires_at,
                 SystemTime::now(),
                 max_restart_time_secs,
@@ -1419,13 +1418,13 @@ async fn run<T>(
             } else {
                 info!(
                     marker = %gr_restart_marker_path.display(),
-                    "ignoring expired GR restart marker"
+                    "ignoring expired or unusable GR restart marker"
                 );
                 if let Err(e) = remove_gr_restart_marker(&gr_restart_marker_path) {
                     warn!(
                         marker = %gr_restart_marker_path.display(),
                         error = %e,
-                        "failed to remove expired GR restart marker"
+                        "failed to remove expired or unusable GR restart marker"
                     );
                 }
                 None
@@ -3651,8 +3650,45 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                 now + Duration::from_hours(1),
                 Some(120),
             )
-            .is_err()
+            .is_none()
         );
+    }
+
+    #[test]
+    fn gr_restart_marker_remaining_time_rejects_missing_and_zero_maximum() {
+        let now = UNIX_EPOCH + Duration::from_hours(2);
+        let expires_at = now + Duration::from_mins(2);
+
+        assert_eq!(
+            gr_restart_marker_remaining_time(expires_at, now, None),
+            None
+        );
+        assert_eq!(
+            gr_restart_marker_remaining_time(expires_at, now, Some(0)),
+            None
+        );
+    }
+
+    #[test]
+    fn gr_restart_marker_remaining_time_rejects_or_clamps_valid_far_future_marker() {
+        let path = unique_temp_path("gr-restart-far-future");
+        let far_future_secs = i64::MAX.unsigned_abs();
+        std::fs::write(
+            &path,
+            format!("version = 1\nexpires_at_unix = {far_future_secs}\n"),
+        )
+        .unwrap();
+        let expires_at = read_gr_restart_marker(&path).unwrap().unwrap();
+
+        assert_eq!(
+            gr_restart_marker_remaining_time(expires_at, UNIX_EPOCH, None),
+            None
+        );
+        assert_eq!(
+            gr_restart_marker_remaining_time(expires_at, UNIX_EPOCH, Some(120)).unwrap(),
+            Duration::from_mins(2)
+        );
+        remove_gr_restart_marker(&path).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clamp persisted graceful-restart marker lifetime to the current effective restart maximum
- ignore and remove markers when no positive restart window is configured
- preserve normal and expired-marker behavior while preventing backward-clock and far-future deadlines from extending selection deferral

## Validation

- six focused restart-marker tests, including backward step, normal, expired, missing, zero, and far-future cases
- effective configured-maximum regression
- formatting and all-features Clippy
- full workspace test and rustdoc push hooks
- independent final review at exact pushed head