### PR TITLE
feat: publish bounded warm-shutdown checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Coordinated shutdown can publish a bounded warm checkpoint.** The
+  restart-required, default-off `warm_cache_checkpoint_on_shutdown` setting
+  captures eligible established static peers' pre-policy Adj-RIB-In views into
+  an owner-private, content-addressed MRT bundle under
+  `<runtime_state_dir>/warm-bundle-v1`. Publication is deadline-, allocation-,
+  and size-bounded, atomically binds exact live identity/config/policy inputs to
+  restart-marker v2, and falls back to the existing marker-v1 path on failure.
+  Startup does not restore, select, install, or advertise cached routes;
+  `forwarding_preserved` remains false.
+
 - **TCP-AO supports fail-closed add-only live rotation.** SIGHUP can append
   non-preferred successor MKTs to unchanged static-neighbor and direct
   dynamic-prefix owners. One immutable generation is globally preflighted,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
@@ -2816,6 +2817,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 clap_mangen = "0.2"
 serde_json = "1"
+sha2 = "0.10"
 owo-colors = { version = "4", features = ["supports-colors"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1"
@@ -151,6 +152,8 @@ prometheus.workspace = true
 thiserror.workspace = true
 bytes.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+uuid.workspace = true
 owo-colors.workspace = true
 axum.workspace = true
 socket2.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 rtnetlink = "0.21"
 netlink-packet-route = "0.30"
 libc.workspace = true
-nix.workspace = true
+nix = { workspace = true, features = ["fs", "user"] }
 futures = "0.3"
 
 [[bin]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ those.
 | BGP core (RFC 4271 FSM, 4-byte ASN, capabilities, collision detection) | Shipped | All 6 states, property-tested |
 | Address families: IPv4/IPv6 unicast (MP-BGP, RFC 4760) | Shipped | Dual-stack, FRR-interop validated |
 | Extensions: Add-Path (7911), Extended Messages (8654), Extended Nexthop (8950) | Partial | Extended Message send/receive directionality and per-type size-limit correction shipped |
-| Graceful Restart (4724) + LLGR (9494) + Notification GR (8538) | Partial | GR helper + minimal restarting speaker shipped; LLGR reconnect/consecutive-reset/per-AFI/SAFI timer corrections shipped; interop re-proof queued |
+| Graceful Restart (4724) + LLGR (9494) + Notification GR (8538) | Partial | GR helper + minimal restarting speaker shipped; optional bounded shutdown checkpoint publication shipped without boot restore/adoption; LLGR reconnect/consecutive-reset/per-AFI/SAFI timer corrections shipped; interop re-proof queued |
 | Route Refresh (2918) + Enhanced Route Refresh (7313) | Shipped | |
 | BGP Roles + Only-to-Customer (9234) | Shipped | Static eBGP, IPv4/IPv6 unicast (ADR-0071, M55) |
 | BGP unnumbered / IPv6 link-local peering | Shipped | Static interface-bound link-local (ADR-0069, M53) |

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -542,6 +542,29 @@ pub struct RuntimeConfigSnapshotReply {
     pub rpol: rustbgpd_policy::rpol::RpolPolicySet,
 }
 
+/// Current static-session negotiation identity captured for one coordinated
+/// warm checkpoint. This is daemon-internal plumbing, not a public API view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmCheckpointSession {
+    /// Unambiguous configured peer identity (V1 admits numbered peers only).
+    pub peer: PeerKey,
+    /// Peer-manager generation of the exact active transport session.
+    pub session_id: u64,
+    /// Remote ASN negotiated in the current OPEN exchange.
+    pub peer_asn: u32,
+    /// Remote BGP identifier negotiated in the current OPEN exchange.
+    pub peer_router_id: std::net::Ipv4Addr,
+    /// Address families negotiated on this exact session.
+    pub negotiated_families: Vec<(Afi, Safi)>,
+    /// GR families advertised by this exact session's peer OPEN.
+    pub peer_gr_families: Vec<(Afi, Safi)>,
+    /// Families for which Add-Path receive/both was negotiated.
+    pub add_path_receive_families: Vec<(Afi, Safi)>,
+    /// Canonical, redacted identity of the effective import policy captured
+    /// from the same peer-manager actor state as the session generation.
+    pub canonical_import_policy: Vec<u8>,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -573,6 +596,12 @@ pub enum PeerManagerCommand {
     ListPeers {
         /// Reply channel returning all peer snapshots.
         reply: oneshot::Sender<Vec<PeerInfo>>,
+    },
+    /// Capture all checkpoint-eligible static sessions under the peer-manager
+    /// actor. Any candidate query timeout rejects the entire reply.
+    QueryWarmCheckpointSessions {
+        /// Reply channel returning deterministic current-session identities.
+        reply: oneshot::Sender<Result<Vec<WarmCheckpointSession>, String>>,
     },
     /// Subscribe to live session lifecycle events.
     SubscribeSessionEvents {

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -565,6 +565,25 @@ pub struct WarmCheckpointSession {
     pub canonical_import_policy: Vec<u8>,
 }
 
+/// One peer-manager-actor-consistent checkpoint capture. The effective
+/// redacted config and resolved policies are sampled in the same blocked actor
+/// command, so a reload cannot pair routes with a different config identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmCheckpointCapture {
+    /// Authoritative local ASN from the live runtime config snapshot.
+    pub local_asn: u32,
+    /// Authoritative local router ID from the live runtime config snapshot.
+    pub local_router_id: std::net::Ipv4Addr,
+    /// Deterministic effective config with defaults materialized and secrets
+    /// redacted, captured from the live peer-manager config actor.
+    pub effective_config_toml: String,
+    /// Largest positive local GR restart retention among current resolved,
+    /// enabled static neighbors. `None` means no marker/cache is useful.
+    pub restart_time_secs: Option<u64>,
+    /// Current session generations plus their exact resolved import policies.
+    pub sessions: Vec<WarmCheckpointSession>,
+}
+
 pub enum PeerManagerCommand {
     /// Add a new peer with the given configuration.
     AddPeer {
@@ -599,9 +618,9 @@ pub enum PeerManagerCommand {
     },
     /// Capture all checkpoint-eligible static sessions under the peer-manager
     /// actor. Any candidate query timeout rejects the entire reply.
-    QueryWarmCheckpointSessions {
-        /// Reply channel returning deterministic current-session identities.
-        reply: oneshot::Sender<Result<Vec<WarmCheckpointSession>, String>>,
+    QueryWarmCheckpointCapture {
+        /// Reply channel returning one actor-consistent config/session capture.
+        reply: oneshot::Sender<Result<WarmCheckpointCapture, String>>,
     },
     /// Subscribe to live session lifecycle events.
     SubscribeSessionEvents {

--- a/crates/mrt/Cargo.toml
+++ b/crates/mrt/Cargo.toml
@@ -17,7 +17,7 @@ nix = { workspace = true, features = ["fs", "user"] }
 serde.workspace = true
 serde_json.workspace = true
 # Warm-checkpoint content digests; already present in the workspace graph.
-sha2 = "0.10"
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -6,7 +6,11 @@ use rustbgpd_wire::error::EncodeError as WireEncodeError;
 use rustbgpd_wire::{Afi, MpReachNlri, PathAttribute, Prefix, Safi, encode_evpn_nlri};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 use thiserror::Error;
+const MRT_HEADER_LEN: usize = 12;
 /// MRT message type for `TABLE_DUMP_V2`.
 pub(crate) const TABLE_DUMP_V2: u16 = 13;
 /// `TABLE_DUMP_V2` subtypes.
@@ -40,6 +44,90 @@ pub struct MrtAddPathReceiveProfile {
     /// Subsequent address family.
     pub safi: Safi,
 }
+
+/// Shared hard bound and cooperative cancellation contract for warm encoding.
+///
+/// The same cancellation token and monotonic deadline are used by the shutdown
+/// coordinator, MRT encoder, and durable bundle writer. The byte cap applies to
+/// the complete encoded snapshot and is checked before every output-buffer
+/// reservation, so a rejected checkpoint never materializes an oversized MRT
+/// byte vector.
+#[derive(Debug, Clone)]
+pub struct WarmSnapshotBudget {
+    deadline: Instant,
+    cancelled: Arc<AtomicBool>,
+    max_snapshot_bytes: usize,
+}
+
+impl WarmSnapshotBudget {
+    /// Create a bounded warm-snapshot work contract.
+    #[must_use]
+    pub fn new(deadline: Instant, cancelled: Arc<AtomicBool>, max_snapshot_bytes: usize) -> Self {
+        Self {
+            deadline,
+            cancelled,
+            max_snapshot_bytes,
+        }
+    }
+
+    /// Fail closed when the coordinator has gone away or its deadline elapsed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WarmSnapshotBudgetError::Cancelled`] or
+    /// [`WarmSnapshotBudgetError::DeadlineExceeded`] as appropriate.
+    pub fn check(&self) -> Result<(), WarmSnapshotBudgetError> {
+        if self.cancelled.load(Ordering::Acquire) {
+            return Err(WarmSnapshotBudgetError::Cancelled);
+        }
+        if Instant::now() >= self.deadline {
+            return Err(WarmSnapshotBudgetError::DeadlineExceeded);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_growth(
+        &self,
+        current: usize,
+        additional: usize,
+    ) -> Result<usize, WarmSnapshotBudgetError> {
+        self.check()?;
+        let attempted =
+            current
+                .checked_add(additional)
+                .ok_or(WarmSnapshotBudgetError::SizeLimitExceeded {
+                    attempted: usize::MAX,
+                    cap: self.max_snapshot_bytes,
+                })?;
+        if attempted > self.max_snapshot_bytes {
+            return Err(WarmSnapshotBudgetError::SizeLimitExceeded {
+                attempted,
+                cap: self.max_snapshot_bytes,
+            });
+        }
+        Ok(attempted)
+    }
+}
+
+/// Terminal warm-snapshot work-budget failure.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum WarmSnapshotBudgetError {
+    /// The async shutdown coordinator stopped waiting for this work.
+    #[error("warm checkpoint work was cancelled")]
+    Cancelled,
+    /// The shared monotonic shutdown deadline elapsed.
+    #[error("warm checkpoint work exceeded its terminal deadline")]
+    DeadlineExceeded,
+    /// Encoding would exceed the configured complete-snapshot cap.
+    #[error("warm checkpoint encoding would need {attempted} bytes, exceeding the {cap}-byte cap")]
+    SizeLimitExceeded {
+        /// Encoded length that the attempted append would produce.
+        attempted: usize,
+        /// Maximum complete encoded snapshot length.
+        cap: usize,
+    },
+}
+
 /// MRT encoding errors.
 #[derive(Debug, Error)]
 pub enum EncodeError {
@@ -82,28 +170,148 @@ pub enum EncodeError {
         /// Why the route cannot be restored exactly.
         reason: &'static str,
     },
+    /// Warm checkpoint cancellation, deadline, or complete-output cap fired.
+    #[error(transparent)]
+    WarmSnapshotBudget(#[from] WarmSnapshotBudgetError),
+    /// A checked output-buffer reservation failed.
+    #[error("failed to reserve {attempted} bytes for MRT encoding")]
+    AllocationFailed {
+        /// Encoded buffer length requested by the failed append.
+        attempted: usize,
+    },
 }
-/// Encode the 12-byte MRT common header.
+
+/// Checked append-only view over an MRT output vector.
+///
+/// Bounded buffers reserve geometrically, but never beyond the remaining hard
+/// cap. `try_reserve_exact` avoids `Vec`'s ordinary speculative over-allocation
+/// when the buffer is close to that cap.
+struct EncodeBuffer<'a> {
+    bytes: &'a mut Vec<u8>,
+    budget: Option<&'a WarmSnapshotBudget>,
+    accounted_prefix: usize,
+}
+
+impl<'a> EncodeBuffer<'a> {
+    fn new(bytes: &'a mut Vec<u8>, budget: Option<&'a WarmSnapshotBudget>) -> Self {
+        Self {
+            bytes,
+            budget,
+            accounted_prefix: 0,
+        }
+    }
+
+    fn child(
+        bytes: &'a mut Vec<u8>,
+        budget: Option<&'a WarmSnapshotBudget>,
+        accounted_prefix: usize,
+    ) -> Self {
+        Self {
+            bytes,
+            budget,
+            accounted_prefix,
+        }
+    }
+
+    fn check(&self) -> Result<(), EncodeError> {
+        self.budget.map_or(Ok(()), WarmSnapshotBudget::check)?;
+        Ok(())
+    }
+
+    fn reserve_for(&mut self, additional: usize) -> Result<usize, EncodeError> {
+        let local_attempted =
+            self.bytes
+                .len()
+                .checked_add(additional)
+                .ok_or(EncodeError::AllocationFailed {
+                    attempted: usize::MAX,
+                })?;
+        let attempted = if let Some(budget) = self.budget {
+            budget.check_growth(self.effective_len(), additional)?
+        } else {
+            local_attempted
+        };
+        if local_attempted <= self.bytes.capacity() {
+            return Ok(attempted);
+        }
+
+        let target_capacity = if let Some(budget) = self.budget {
+            let doubled = self.bytes.capacity().max(4096).saturating_mul(2);
+            local_attempted.max(doubled).min(
+                budget
+                    .max_snapshot_bytes
+                    .saturating_sub(self.accounted_prefix),
+            )
+        } else {
+            local_attempted
+        };
+        self.bytes
+            .try_reserve_exact(target_capacity.saturating_sub(self.bytes.len()))
+            .map_err(|_| EncodeError::AllocationFailed { attempted })?;
+        // Cancellation can race the allocation itself. Recheck before any
+        // bytes are committed; on failure the caller drops this bounded Vec.
+        self.check()?;
+        Ok(attempted)
+    }
+
+    fn extend_from_slice(&mut self, value: &[u8]) -> Result<(), EncodeError> {
+        self.reserve_for(value.len())?;
+        self.bytes.extend_from_slice(value);
+        Ok(())
+    }
+
+    fn push(&mut self, value: u8) -> Result<(), EncodeError> {
+        self.reserve_for(1)?;
+        self.bytes.push(value);
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn effective_len(&self) -> usize {
+        self.accounted_prefix.saturating_add(self.bytes.len())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.bytes.truncate(len);
+    }
+
+    fn finish_record(&mut self, start: usize) -> Result<(), EncodeError> {
+        let payload_len = self
+            .len()
+            .saturating_sub(start)
+            .saturating_sub(MRT_HEADER_LEN);
+        let length = u32::try_from(payload_len).map_err(|_| EncodeError::FieldTooLarge {
+            field: "MRT payload length",
+            value: payload_len,
+        })?;
+        self.bytes[start + 8..start + MRT_HEADER_LEN].copy_from_slice(&length.to_be_bytes());
+        Ok(())
+    }
+}
+
+/// Begin an MRT record with a placeholder payload length.
+fn begin_mrt_record(
+    buf: &mut EncodeBuffer<'_>,
+    timestamp: u32,
+    subtype: u16,
+) -> Result<usize, EncodeError> {
+    let start = buf.len();
+    buf.extend_from_slice(&timestamp.to_be_bytes())?;
+    buf.extend_from_slice(&TABLE_DUMP_V2.to_be_bytes())?;
+    buf.extend_from_slice(&subtype.to_be_bytes())?;
+    buf.extend_from_slice(&0u32.to_be_bytes())?;
+    Ok(start)
+}
+
+#[cfg(test)]
 fn encode_mrt_header(buf: &mut Vec<u8>, timestamp: u32, mrt_type: u16, subtype: u16, length: u32) {
     buf.extend_from_slice(&timestamp.to_be_bytes());
     buf.extend_from_slice(&mrt_type.to_be_bytes());
     buf.extend_from_slice(&subtype.to_be_bytes());
     buf.extend_from_slice(&length.to_be_bytes());
-}
-/// Encode a complete MRT record: header + payload.
-fn encode_mrt_record(
-    buf: &mut Vec<u8>,
-    timestamp: u32,
-    subtype: u16,
-    payload: &[u8],
-) -> Result<(), EncodeError> {
-    let length = u32::try_from(payload.len()).map_err(|_| EncodeError::FieldTooLarge {
-        field: "MRT payload length",
-        value: payload.len(),
-    })?;
-    encode_mrt_header(buf, timestamp, TABLE_DUMP_V2, subtype, length);
-    buf.extend_from_slice(payload);
-    Ok(())
 }
 /// Encode the `PEER_INDEX_TABLE` record (subtype 1).
 ///
@@ -120,42 +328,60 @@ pub fn encode_peer_index_table(
     view_name: &str,
     peers: &[MrtPeerEntry],
 ) -> Result<(), EncodeError> {
-    let mut payload = Vec::new();
-    // Collector BGP ID
-    payload.extend_from_slice(&collector_bgp_id.octets());
-    // View name
-    let name_bytes = view_name.as_bytes();
-    let view_name_len =
-        u16::try_from(name_bytes.len()).map_err(|_| EncodeError::FieldTooLarge {
-            field: "PEER_INDEX_TABLE.view_name length",
-            value: name_bytes.len(),
+    let mut output = EncodeBuffer::new(buf, None);
+    encode_peer_index_table_inner(&mut output, timestamp, collector_bgp_id, view_name, peers)
+}
+
+fn encode_peer_index_table_inner(
+    buf: &mut EncodeBuffer<'_>,
+    timestamp: u32,
+    collector_bgp_id: Ipv4Addr,
+    view_name: &str,
+    peers: &[MrtPeerEntry],
+) -> Result<(), EncodeError> {
+    let start = begin_mrt_record(buf, timestamp, PEER_INDEX_TABLE)?;
+    let result = (|| {
+        // Collector BGP ID
+        buf.extend_from_slice(&collector_bgp_id.octets())?;
+        // View name
+        let name_bytes = view_name.as_bytes();
+        let view_name_len =
+            u16::try_from(name_bytes.len()).map_err(|_| EncodeError::FieldTooLarge {
+                field: "PEER_INDEX_TABLE.view_name length",
+                value: name_bytes.len(),
+            })?;
+        buf.extend_from_slice(&view_name_len.to_be_bytes())?;
+        buf.extend_from_slice(name_bytes)?;
+        // Peer count
+        let peer_count = u16::try_from(peers.len()).map_err(|_| EncodeError::FieldTooLarge {
+            field: "PEER_INDEX_TABLE.peer_count",
+            value: peers.len(),
         })?;
-    payload.extend_from_slice(&view_name_len.to_be_bytes());
-    payload.extend_from_slice(name_bytes);
-    // Peer count
-    let peer_count = u16::try_from(peers.len()).map_err(|_| EncodeError::FieldTooLarge {
-        field: "PEER_INDEX_TABLE.peer_count",
-        value: peers.len(),
-    })?;
-    payload.extend_from_slice(&peer_count.to_be_bytes());
-    for peer in peers {
-        // Peer type: bit 0 = IPv6, bit 1 = AS4 (always set)
-        let peer_type: u8 = match peer.peer_addr {
-            IpAddr::V6(_) => 0b11, // IPv6 + AS4
-            IpAddr::V4(_) => 0b10, // AS4 only
-        };
-        payload.push(peer_type);
-        // Peer BGP ID
-        payload.extend_from_slice(&peer.peer_bgp_id.octets());
-        // Peer IP address
-        match peer.peer_addr {
-            IpAddr::V4(v4) => payload.extend_from_slice(&v4.octets()),
-            IpAddr::V6(v6) => payload.extend_from_slice(&v6.octets()),
+        buf.extend_from_slice(&peer_count.to_be_bytes())?;
+        for peer in peers {
+            buf.check()?;
+            // Peer type: bit 0 = IPv6, bit 1 = AS4 (always set)
+            let peer_type: u8 = match peer.peer_addr {
+                IpAddr::V6(_) => 0b11, // IPv6 + AS4
+                IpAddr::V4(_) => 0b10, // AS4 only
+            };
+            buf.push(peer_type)?;
+            // Peer BGP ID
+            buf.extend_from_slice(&peer.peer_bgp_id.octets())?;
+            // Peer IP address
+            match peer.peer_addr {
+                IpAddr::V4(v4) => buf.extend_from_slice(&v4.octets())?,
+                IpAddr::V6(v6) => buf.extend_from_slice(&v6.octets())?,
+            }
+            // Peer AS (always 4 bytes)
+            buf.extend_from_slice(&peer.peer_asn.to_be_bytes())?;
         }
-        // Peer AS (always 4 bytes)
-        payload.extend_from_slice(&peer.peer_asn.to_be_bytes());
+        buf.finish_record(start)
+    })();
+    if result.is_err() {
+        buf.truncate(start);
     }
-    encode_mrt_record(buf, timestamp, PEER_INDEX_TABLE, &payload)
+    result
 }
 /// Synthesize path attributes for MRT encoding from a `Route`.
 ///
@@ -268,47 +494,67 @@ pub fn synthesize_evpn_attributes(route: &EvpnRibRoute) -> Vec<PathAttribute> {
 /// Returns [`EncodeError::FieldTooLarge`] if the encoded attribute payload
 /// for the entry exceeds the 16-bit `attribute_length` field.
 fn encode_evpn_rib_generic(
-    buf: &mut Vec<u8>,
+    buf: &mut EncodeBuffer<'_>,
     timestamp: u32,
     seq_num: u32,
     route: &EvpnRibRoute,
     peer_index: u16,
     originated_time: u32,
 ) -> Result<(), EncodeError> {
-    let mut payload = Vec::new();
-    payload.extend_from_slice(&seq_num.to_be_bytes());
-    payload.extend_from_slice(&(Afi::L2Vpn as u16).to_be_bytes());
-    payload.push(Safi::Evpn as u8);
-    encode_evpn_nlri(std::slice::from_ref(&route.route), &mut payload);
-    payload.extend_from_slice(&1u16.to_be_bytes());
-    let entry = RibEntry {
-        peer_index,
-        originated_time,
-        path_id: 0,
-        attributes: synthesize_evpn_attributes(route),
-    };
-    encode_rib_entry(&mut payload, &entry, false)?;
-    encode_mrt_record(buf, timestamp, RIB_GENERIC, &payload)
+    let start = begin_mrt_record(buf, timestamp, RIB_GENERIC)?;
+    let result = (|| {
+        buf.extend_from_slice(&seq_num.to_be_bytes())?;
+        buf.extend_from_slice(&(Afi::L2Vpn as u16).to_be_bytes())?;
+        buf.push(Safi::Evpn as u8)?;
+        let mut nlri = Vec::new();
+        encode_evpn_nlri(std::slice::from_ref(&route.route), &mut nlri);
+        buf.extend_from_slice(&nlri)?;
+        buf.extend_from_slice(&1u16.to_be_bytes())?;
+        let entry = RibEntry {
+            peer_index,
+            originated_time,
+            path_id: 0,
+            attributes: synthesize_evpn_attributes(route),
+        };
+        encode_rib_entry(buf, &entry, false)?;
+        buf.finish_record(start)
+    })();
+    if result.is_err() {
+        buf.truncate(start);
+    }
+    result
 }
 /// Encode a single RIB entry (shared by all RIB_* subtypes).
 fn encode_rib_entry(
-    buf: &mut Vec<u8>,
+    buf: &mut EncodeBuffer<'_>,
     entry: &RibEntry,
     add_path: bool,
 ) -> Result<(), EncodeError> {
     if add_path {
-        buf.extend_from_slice(&entry.path_id.to_be_bytes());
+        buf.extend_from_slice(&entry.path_id.to_be_bytes())?;
     }
-    buf.extend_from_slice(&entry.peer_index.to_be_bytes());
-    buf.extend_from_slice(&entry.originated_time.to_be_bytes());
+    buf.extend_from_slice(&entry.peer_index.to_be_bytes())?;
+    buf.extend_from_slice(&entry.originated_time.to_be_bytes())?;
     let mut attr_buf = Vec::new();
-    encode_mrt_rib_attributes(&entry.attributes, &mut attr_buf)?;
+    {
+        let mut checked_attrs = EncodeBuffer::child(
+            &mut attr_buf,
+            buf.budget,
+            buf.effective_len().saturating_add(2),
+        );
+        encode_mrt_rib_attributes(&entry.attributes, &mut checked_attrs)?;
+    }
     let attr_len = u16::try_from(attr_buf.len()).map_err(|_| EncodeError::FieldTooLarge {
         field: "RIB entry attribute length",
         value: attr_buf.len(),
     })?;
-    buf.extend_from_slice(&attr_len.to_be_bytes());
-    buf.extend_from_slice(&attr_buf);
+    // Account for the two-byte length before appending the bounded attribute
+    // buffer. A single RIB entry remains protocol-bounded to u16 bytes.
+    if let Some(budget) = buf.budget {
+        budget.check_growth(buf.len(), 2usize.saturating_add(attr_buf.len()))?;
+    }
+    buf.extend_from_slice(&attr_len.to_be_bytes())?;
+    buf.extend_from_slice(&attr_buf)?;
     Ok(())
 }
 /// Encode path attributes for an MRT RIB entry per RFC 6396 §4.3.4.
@@ -320,17 +566,19 @@ fn encode_rib_entry(
 /// encode identically to a regular BGP UPDATE.
 fn encode_mrt_rib_attributes(
     attrs: &[PathAttribute],
-    buf: &mut Vec<u8>,
+    buf: &mut EncodeBuffer<'_>,
 ) -> Result<(), EncodeError> {
-    let others: Vec<PathAttribute> = attrs
-        .iter()
-        .filter(|a| !matches!(a, PathAttribute::MpReachNlri(_)))
-        .cloned()
-        .collect();
-    encode_path_attributes(&others, buf, true, false)?;
     for attr in attrs {
+        buf.check()?;
         if let PathAttribute::MpReachNlri(mp) = attr {
-            encode_mrt_mp_reach(mp.next_hop, mp.link_local_next_hop, buf);
+            encode_mrt_mp_reach(mp.next_hop, mp.link_local_next_hop, buf)?;
+        } else {
+            // The wire encoder is Vec-based. Encode one protocol-bounded
+            // attribute at a time, then perform the cap-aware append, rather
+            // than materializing a second complete attribute vector.
+            let mut encoded = Vec::new();
+            encode_path_attributes(std::slice::from_ref(attr), &mut encoded, true, false)?;
+            buf.extend_from_slice(&encoded)?;
         }
     }
     Ok(())
@@ -347,8 +595,8 @@ fn encode_mrt_rib_attributes(
 fn encode_mrt_mp_reach(
     next_hop: IpAddr,
     link_local: Option<std::net::Ipv6Addr>,
-    buf: &mut Vec<u8>,
-) {
+    buf: &mut EncodeBuffer<'_>,
+) -> Result<(), EncodeError> {
     let mut value: Vec<u8> = Vec::with_capacity(33);
     match (next_hop, link_local) {
         (IpAddr::V4(addr), _) => {
@@ -365,29 +613,31 @@ fn encode_mrt_mp_reach(
             value.extend_from_slice(&addr.octets());
         }
     }
-    buf.push(0x80);
-    buf.push(14);
+    buf.push(0x80)?;
+    buf.push(14)?;
     #[expect(
         clippy::cast_possible_truncation,
         reason = "value length is at most 33 bytes"
     )]
-    buf.push(value.len() as u8);
-    buf.extend_from_slice(&value);
+    buf.push(value.len() as u8)?;
+    buf.extend_from_slice(&value)?;
+    Ok(())
 }
 /// Encode a prefix into MRT format: length byte then ceil(len/8) prefix bytes.
-fn encode_prefix_bytes(buf: &mut Vec<u8>, prefix: &Prefix) {
+fn encode_prefix_bytes(buf: &mut EncodeBuffer<'_>, prefix: &Prefix) -> Result<(), EncodeError> {
     match prefix {
         Prefix::V4(v4) => {
-            buf.push(v4.len);
+            buf.push(v4.len)?;
             let byte_len = usize::from(v4.len).div_ceil(8);
-            buf.extend_from_slice(&v4.addr.octets()[..byte_len]);
+            buf.extend_from_slice(&v4.addr.octets()[..byte_len])?;
         }
         Prefix::V6(v6) => {
-            buf.push(v6.len);
+            buf.push(v6.len)?;
             let byte_len = usize::from(v6.len).div_ceil(8);
-            buf.extend_from_slice(&v6.addr.octets()[..byte_len]);
+            buf.extend_from_slice(&v6.addr.octets()[..byte_len])?;
         }
     }
+    Ok(())
 }
 /// Encode a `RIB_IPV4_UNICAST` or `RIB_IPV6_UNICAST` record.
 ///
@@ -405,11 +655,19 @@ pub fn encode_rib_entries(
     entries: &[RibEntry],
 ) -> Result<(), EncodeError> {
     let has_addpath = entries.iter().any(|e| e.path_id != 0);
-    encode_rib_entries_profile(buf, timestamp, seq_num, prefix, entries, has_addpath)
+    let mut output = EncodeBuffer::new(buf, None);
+    encode_rib_entries_profile(
+        &mut output,
+        timestamp,
+        seq_num,
+        prefix,
+        entries,
+        has_addpath,
+    )
 }
 
 fn encode_rib_entries_profile(
-    buf: &mut Vec<u8>,
+    buf: &mut EncodeBuffer<'_>,
     timestamp: u32,
     seq_num: u32,
     prefix: &Prefix,
@@ -422,18 +680,25 @@ fn encode_rib_entries_profile(
         (Prefix::V6(_), false) => RIB_IPV6_UNICAST,
         (Prefix::V6(_), true) => RIB_IPV6_UNICAST_ADDPATH,
     };
-    let mut payload = Vec::new();
-    payload.extend_from_slice(&seq_num.to_be_bytes());
-    encode_prefix_bytes(&mut payload, prefix);
-    let entry_count = u16::try_from(entries.len()).map_err(|_| EncodeError::FieldTooLarge {
-        field: "RIB entry count",
-        value: entries.len(),
-    })?;
-    payload.extend_from_slice(&entry_count.to_be_bytes());
-    for entry in entries {
-        encode_rib_entry(&mut payload, entry, has_addpath)?;
+    let start = begin_mrt_record(buf, timestamp, subtype)?;
+    let result = (|| {
+        buf.extend_from_slice(&seq_num.to_be_bytes())?;
+        encode_prefix_bytes(buf, prefix)?;
+        let entry_count = u16::try_from(entries.len()).map_err(|_| EncodeError::FieldTooLarge {
+            field: "RIB entry count",
+            value: entries.len(),
+        })?;
+        buf.extend_from_slice(&entry_count.to_be_bytes())?;
+        for entry in entries {
+            buf.check()?;
+            encode_rib_entry(buf, entry, has_addpath)?;
+        }
+        buf.finish_record(start)
+    })();
+    if result.is_err() {
+        buf.truncate(start);
     }
-    encode_mrt_record(buf, timestamp, subtype, &payload)
+    result
 }
 /// Encode a full MRT `TABLE_DUMP_V2` dump from a snapshot.
 ///
@@ -480,6 +745,7 @@ pub fn encode_snapshot_with_view(
         evpn_routes,
         timestamp,
         None,
+        None,
     )
 }
 
@@ -506,6 +772,73 @@ pub fn encode_warm_snapshot(
     timestamp: u32,
     add_path_receive: &[MrtAddPathReceiveProfile],
 ) -> Result<Vec<u8>, EncodeError> {
+    encode_warm_snapshot_inner(
+        collector_bgp_id,
+        view_name,
+        peers,
+        routes,
+        evpn_routes,
+        timestamp,
+        add_path_receive,
+        None,
+    )
+}
+
+/// Encode a warm snapshot under a hard complete-output cap and shared
+/// cancellation/deadline contract.
+///
+/// Unlike [`encode_warm_snapshot`], every reservation of the complete MRT
+/// output is checked before `Vec` growth. The encoder also checks the shared
+/// cancellation token throughout peer, route, prefix, and EVPN traversal.
+///
+/// # Errors
+///
+/// Returns the same profile errors as [`encode_warm_snapshot`], plus
+/// [`EncodeError::WarmSnapshotBudget`] when the cap, cancellation token, or
+/// deadline rejects the work.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "bounded warm encoding extends the established snapshot API with one shared work budget"
+)]
+pub fn encode_warm_snapshot_bounded(
+    collector_bgp_id: Ipv4Addr,
+    view_name: &str,
+    peers: &[MrtPeerEntry],
+    routes: &[Route],
+    evpn_routes: &[EvpnRibRoute],
+    timestamp: u32,
+    add_path_receive: &[MrtAddPathReceiveProfile],
+    budget: &WarmSnapshotBudget,
+) -> Result<Vec<u8>, EncodeError> {
+    encode_warm_snapshot_inner(
+        collector_bgp_id,
+        view_name,
+        peers,
+        routes,
+        evpn_routes,
+        timestamp,
+        add_path_receive,
+        Some(budget),
+    )
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "internal wrapper preserves the public snapshot fields plus the optional work budget"
+)]
+fn encode_warm_snapshot_inner(
+    collector_bgp_id: Ipv4Addr,
+    view_name: &str,
+    peers: &[MrtPeerEntry],
+    routes: &[Route],
+    evpn_routes: &[EvpnRibRoute],
+    timestamp: u32,
+    add_path_receive: &[MrtAddPathReceiveProfile],
+    budget: Option<&WarmSnapshotBudget>,
+) -> Result<Vec<u8>, EncodeError> {
+    if let Some(budget) = budget {
+        budget.check()?;
+    }
     if let Some(route) = routes.iter().find(|route| {
         route.next_hop_scope.is_some()
             || route.link_local_next_hop.is_some()
@@ -557,6 +890,7 @@ pub fn encode_warm_snapshot(
         evpn_routes,
         timestamp,
         Some(&unique),
+        budget,
     )
 }
 
@@ -568,6 +902,10 @@ fn is_ipv6_link_local(address: IpAddr) -> bool {
     clippy::too_many_lines,
     reason = "Single-pass encoder over peer index, unicast prefix groups, and EVPN RIB_GENERIC records — splitting hides the linear flow"
 )]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "snapshot identity, route families, Add-Path profile, and work budget are independent inputs"
+)]
 fn encode_snapshot_inner(
     collector_bgp_id: Ipv4Addr,
     view_name: &str,
@@ -576,12 +914,16 @@ fn encode_snapshot_inner(
     evpn_routes: &[EvpnRibRoute],
     timestamp: u32,
     add_path_receive: Option<&HashSet<MrtAddPathReceiveProfile>>,
+    budget: Option<&WarmSnapshotBudget>,
 ) -> Result<Vec<u8>, EncodeError> {
     let mut buf = Vec::new();
+    let mut output = EncodeBuffer::new(&mut buf, budget);
+    output.check()?;
     // 1. Build effective peer list from explicit peers + any route-origin peers.
     let mut effective_peers: Vec<MrtPeerEntry> = peers.to_vec();
     let mut seen_peers: HashSet<IpAddr> = effective_peers.iter().map(|p| p.peer_addr).collect();
     for route in routes {
+        output.check()?;
         if seen_peers.insert(route.peer) {
             effective_peers.push(MrtPeerEntry {
                 peer_addr: route.peer,
@@ -591,6 +933,7 @@ fn encode_snapshot_inner(
         }
     }
     for route in evpn_routes {
+        output.check()?;
         if seen_peers.insert(route.peer) {
             effective_peers.push(MrtPeerEntry {
                 peer_addr: route.peer,
@@ -613,9 +956,10 @@ fn encode_snapshot_inner(
             .then(a.peer_asn.cmp(&b.peer_asn))
             .then(a.peer_bgp_id.octets().cmp(&b.peer_bgp_id.octets()))
     });
+    output.check()?;
     // 2. `PEER_INDEX_TABLE`
-    encode_peer_index_table(
-        &mut buf,
+    encode_peer_index_table_inner(
+        &mut output,
         timestamp,
         collector_bgp_id,
         view_name,
@@ -634,9 +978,11 @@ fn encode_snapshot_inner(
                 })
         })
         .collect::<Result<_, _>>()?;
+    output.check()?;
     // 4. Group routes by prefix
     let mut by_prefix: HashMap<Prefix, Vec<&Route>> = HashMap::new();
     for route in routes {
+        output.check()?;
         by_prefix.entry(route.prefix).or_default().push(route);
     }
     // 5. Encode each prefix group
@@ -654,11 +1000,13 @@ fn encode_snapshot_inner(
         };
         a_bytes.cmp(&b_bytes)
     });
+    output.check()?;
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
     for prefix in &prefixes {
+        output.check()?;
         let mut prefix_routes = by_prefix[prefix].clone();
         prefix_routes.sort_by(|a, b| {
             let a_idx = peer_index.get(&a.peer).copied().unwrap_or(u16::MAX);
@@ -668,9 +1016,11 @@ fn encode_snapshot_inner(
                 .then(a.path_id.cmp(&b.path_id))
                 .then(prefix_family_sort_key(a.prefix).cmp(&prefix_family_sort_key(b.prefix)))
         });
+        output.check()?;
         let mut legacy_entries: Vec<RibEntry> = Vec::with_capacity(prefix_routes.len());
         let mut add_path_entries: Vec<RibEntry> = Vec::new();
         for route in prefix_routes {
+            output.check()?;
             let Some(&idx) = peer_index.get(&route.peer) else {
                 continue;
             };
@@ -709,7 +1059,7 @@ fn encode_snapshot_inner(
         if !legacy_entries.is_empty() {
             if add_path_receive.is_some() {
                 encode_rib_entries_profile(
-                    &mut buf,
+                    &mut output,
                     timestamp,
                     seq_num,
                     prefix,
@@ -717,13 +1067,20 @@ fn encode_snapshot_inner(
                     false,
                 )?;
             } else {
-                encode_rib_entries(&mut buf, timestamp, seq_num, prefix, &legacy_entries)?;
+                encode_rib_entries_profile(
+                    &mut output,
+                    timestamp,
+                    seq_num,
+                    prefix,
+                    &legacy_entries,
+                    legacy_entries.iter().any(|entry| entry.path_id != 0),
+                )?;
             }
             seq_num = seq_num.wrapping_add(1);
         }
         if !add_path_entries.is_empty() {
             encode_rib_entries_profile(
-                &mut buf,
+                &mut output,
                 timestamp,
                 seq_num,
                 prefix,
@@ -749,22 +1106,26 @@ fn encode_snapshot_inner(
             (route, nlri_bytes)
         })
         .collect();
+    output.check()?;
     sorted_evpn.sort_by(|(a, a_bytes), (b, b_bytes)| {
         let a_idx = peer_index.get(&a.peer).copied().unwrap_or(u16::MAX);
         let b_idx = peer_index.get(&b.peer).copied().unwrap_or(u16::MAX);
         a_idx.cmp(&b_idx).then_with(|| a_bytes.cmp(b_bytes))
     });
+    output.check()?;
     let sorted_evpn: Vec<&EvpnRibRoute> = sorted_evpn.into_iter().map(|(r, _)| r).collect();
     for route in sorted_evpn {
+        output.check()?;
         let Some(&idx) = peer_index.get(&route.peer) else {
             continue;
         };
         let age = route.received_at.elapsed().as_secs();
         let originated_u64 = now_secs.saturating_sub(age);
         let originated = u32::try_from(originated_u64).unwrap_or(u32::MAX);
-        encode_evpn_rib_generic(&mut buf, timestamp, seq_num, route, idx, originated)?;
+        encode_evpn_rib_generic(&mut output, timestamp, seq_num, route, idx, originated)?;
         seq_num = seq_num.wrapping_add(1);
     }
+    output.check()?;
     Ok(buf)
 }
 fn prefix_family_sort_key(prefix: Prefix) -> (u8, Vec<u8>, u8) {
@@ -782,7 +1143,8 @@ mod tests {
     };
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::sync::Arc;
-    use std::time::Instant;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
     fn make_peer(addr: IpAddr, asn: u32) -> MrtPeerEntry {
         let bgp_id = match addr {
             IpAddr::V4(v4) => v4,
@@ -818,6 +1180,87 @@ mod tests {
             aspa_state: rustbgpd_wire::AspaValidation::Unknown,
             aspa_context: rustbgpd_wire::AspaValidationContext::default(),
         }
+    }
+
+    #[test]
+    fn bounded_buffer_rejects_before_vec_growth_and_stops_after_cancellation() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::clone(&cancelled),
+            16,
+        );
+        let mut bytes = Vec::new();
+        let mut output = EncodeBuffer::new(&mut bytes, Some(&budget));
+        output.extend_from_slice(&[0; 16]).unwrap();
+        assert_eq!(output.len(), 16);
+        assert!(output.bytes.capacity() <= 16);
+
+        assert!(matches!(
+            output.push(1),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::SizeLimitExceeded {
+                    attempted: 17,
+                    cap: 16
+                }
+            ))
+        ));
+        assert_eq!(output.len(), 16, "cap failure must happen before growth");
+        assert!(output.bytes.capacity() <= 16);
+
+        output.truncate(8);
+        cancelled.store(true, Ordering::Release);
+        assert!(matches!(
+            output.push(1),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::Cancelled
+            ))
+        ));
+        assert_eq!(output.len(), 8, "cancellation must happen before growth");
+        assert!(output.bytes.capacity() <= 16);
+    }
+
+    #[test]
+    fn warm_snapshot_complete_output_cap_fails_closed() {
+        let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let prefix = Prefix::V4(Ipv4Prefix {
+            addr: Ipv4Addr::new(198, 51, 100, 0),
+            len: 24,
+        });
+        let peers = [make_peer(peer, 64_501)];
+        let routes = [make_route(prefix, peer, peer)];
+        let unbounded = encode_warm_snapshot(
+            Ipv4Addr::new(10, 0, 0, 1),
+            "generation-1",
+            &peers,
+            &routes,
+            &[],
+            1_700_000_000,
+            &[],
+        )
+        .unwrap();
+        let cap = unbounded.len() - 1;
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::new(AtomicBool::new(false)),
+            cap,
+        );
+
+        assert!(matches!(
+            encode_warm_snapshot_bounded(
+                Ipv4Addr::new(10, 0, 0, 1),
+                "generation-1",
+                &peers,
+                &routes,
+                &[],
+                1_700_000_000,
+                &[],
+                &budget,
+            ),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::SizeLimitExceeded { attempted, cap: actual_cap }
+            )) if attempted > actual_cap && actual_cap == cap
+        ));
     }
     #[test]
     fn mrt_header_encoding() {

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -4,6 +4,7 @@ use rustbgpd_rib::update::MrtPeerEntry;
 use rustbgpd_wire::attribute::encode_path_attributes;
 use rustbgpd_wire::error::EncodeError as WireEncodeError;
 use rustbgpd_wire::{Afi, MpReachNlri, PathAttribute, Prefix, Safi, encode_evpn_nlri};
+use std::cmp::Ordering as CmpOrdering;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -106,6 +107,10 @@ impl WarmSnapshotBudget {
             });
         }
         Ok(attempted)
+    }
+
+    fn check_temporary_allocation(&self, bytes: usize) -> Result<(), WarmSnapshotBudgetError> {
+        self.check_growth(0, bytes).map(drop)
     }
 }
 
@@ -290,6 +295,136 @@ impl<'a> EncodeBuffer<'a> {
         self.bytes[start + 8..start + MRT_HEADER_LEN].copy_from_slice(&length.to_be_bytes());
         Ok(())
     }
+
+    fn patch_u16(&mut self, offset: usize, value: u16) {
+        self.bytes[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+    }
+}
+
+const CANCELLABLE_SORT_RUN: usize = 256;
+
+fn collect_cancellable<T>(
+    values: impl ExactSizeIterator<Item = T>,
+    budget: Option<&WarmSnapshotBudget>,
+) -> Result<Vec<T>, EncodeError> {
+    let len = values.len();
+    let allocation_bytes =
+        len.checked_mul(std::mem::size_of::<T>())
+            .ok_or(EncodeError::AllocationFailed {
+                attempted: usize::MAX,
+            })?;
+    if let Some(budget) = budget {
+        budget.check_temporary_allocation(allocation_bytes)?;
+    }
+    let mut collected = Vec::new();
+    collected
+        .try_reserve_exact(len)
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: allocation_bytes,
+        })?;
+    if let Some(budget) = budget {
+        budget.check()?;
+    }
+    for value in values {
+        collected.push(value);
+        // Iterators used here yield borrowed keys in constant time. Checking
+        // after each yield also catches cancellation raised while a key is
+        // being materialized rather than waiting for the later sort.
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+    }
+    Ok(collected)
+}
+
+/// Bottom-up merge sort whose non-cancellable leaf work is capped to a
+/// small fixed run. Warm checkpoint inputs use reference/copy keys, so the one
+/// scratch allocation never duplicates route attributes or encoded records.
+fn sort_cancellable_by<T: Clone>(
+    values: &mut [T],
+    budget: Option<&WarmSnapshotBudget>,
+    compare: impl Fn(&T, &T) -> CmpOrdering + Copy,
+) -> Result<(), EncodeError> {
+    let Some(budget) = budget else {
+        values.sort_by(compare);
+        return Ok(());
+    };
+    if values.len() < 2 {
+        return budget.check().map_err(Into::into);
+    }
+
+    for run in values.chunks_mut(CANCELLABLE_SORT_RUN) {
+        budget.check()?;
+        run.sort_unstable_by(compare);
+        budget.check()?;
+    }
+
+    let scratch_bytes = values.len().checked_mul(std::mem::size_of::<T>()).ok_or(
+        EncodeError::AllocationFailed {
+            attempted: usize::MAX,
+        },
+    )?;
+    budget.check_temporary_allocation(scratch_bytes)?;
+    let mut scratch = Vec::<T>::new();
+    scratch
+        .try_reserve_exact(values.len())
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: scratch_bytes,
+        })?;
+    budget.check()?;
+
+    let mut width = CANCELLABLE_SORT_RUN;
+    while width < values.len() {
+        let step = width.saturating_mul(2);
+        let mut start = 0usize;
+        while start < values.len() {
+            budget.check()?;
+            let middle = start.saturating_add(width).min(values.len());
+            let end = start.saturating_add(step).min(values.len());
+            if middle == end {
+                start = end;
+                continue;
+            }
+            scratch.clear();
+            let mut left = start;
+            let mut right = middle;
+            let mut copied = 0usize;
+            while left < middle && right < end {
+                if copied.is_multiple_of(CANCELLABLE_SORT_RUN) {
+                    budget.check()?;
+                }
+                if compare(&values[left], &values[right]) == CmpOrdering::Greater {
+                    scratch.push(values[right].clone());
+                    right += 1;
+                } else {
+                    scratch.push(values[left].clone());
+                    left += 1;
+                }
+                copied += 1;
+            }
+            while left < middle {
+                if copied.is_multiple_of(CANCELLABLE_SORT_RUN) {
+                    budget.check()?;
+                }
+                scratch.push(values[left].clone());
+                left += 1;
+                copied += 1;
+            }
+            while right < end {
+                if copied.is_multiple_of(CANCELLABLE_SORT_RUN) {
+                    budget.check()?;
+                }
+                scratch.push(values[right].clone());
+                right += 1;
+                copied += 1;
+            }
+            values[start..end].clone_from_slice(&scratch);
+            start = end;
+        }
+        width = step;
+    }
+    budget.check()?;
+    Ok(())
 }
 
 /// Begin an MRT record with a placeholder payload length.
@@ -510,13 +645,7 @@ fn encode_evpn_rib_generic(
         encode_evpn_nlri(std::slice::from_ref(&route.route), &mut nlri);
         buf.extend_from_slice(&nlri)?;
         buf.extend_from_slice(&1u16.to_be_bytes())?;
-        let entry = RibEntry {
-            peer_index,
-            originated_time,
-            path_id: 0,
-            attributes: synthesize_evpn_attributes(route),
-        };
-        encode_rib_entry(buf, &entry, false)?;
+        encode_evpn_route_rib_entry(buf, route, peer_index, originated_time)?;
         buf.finish_record(start)
     })();
     if result.is_err() {
@@ -557,6 +686,86 @@ fn encode_rib_entry(
     buf.extend_from_slice(&attr_buf)?;
     Ok(())
 }
+
+fn encode_route_rib_entry(
+    buf: &mut EncodeBuffer<'_>,
+    route: &Route,
+    peer_index: u16,
+    originated_time: u32,
+    add_path: bool,
+) -> Result<(), EncodeError> {
+    if add_path {
+        buf.extend_from_slice(&route.path_id.to_be_bytes())?;
+    }
+    buf.extend_from_slice(&peer_index.to_be_bytes())?;
+    buf.extend_from_slice(&originated_time.to_be_bytes())?;
+    let attr_len_offset = buf.len();
+    buf.extend_from_slice(&0u16.to_be_bytes())?;
+    let attr_start = buf.len();
+    encode_route_mrt_attributes(route, buf)?;
+    let attr_len = buf.len().saturating_sub(attr_start);
+    let attr_len = u16::try_from(attr_len).map_err(|_| EncodeError::FieldTooLarge {
+        field: "RIB entry attribute length",
+        value: attr_len,
+    })?;
+    buf.patch_u16(attr_len_offset, attr_len);
+    Ok(())
+}
+
+fn encode_evpn_route_rib_entry(
+    buf: &mut EncodeBuffer<'_>,
+    route: &EvpnRibRoute,
+    peer_index: u16,
+    originated_time: u32,
+) -> Result<(), EncodeError> {
+    buf.extend_from_slice(&peer_index.to_be_bytes())?;
+    buf.extend_from_slice(&originated_time.to_be_bytes())?;
+    let attr_len_offset = buf.len();
+    buf.extend_from_slice(&0u16.to_be_bytes())?;
+    let attr_start = buf.len();
+    for attr in route.attributes.iter() {
+        encode_one_mrt_rib_attribute(attr, buf)?;
+    }
+    encode_mrt_mp_reach(route.next_hop, route.link_local_next_hop, buf)?;
+    let attr_len = buf.len().saturating_sub(attr_start);
+    let attr_len = u16::try_from(attr_len).map_err(|_| EncodeError::FieldTooLarge {
+        field: "RIB entry attribute length",
+        value: attr_len,
+    })?;
+    buf.patch_u16(attr_len_offset, attr_len);
+    Ok(())
+}
+
+fn encode_route_mrt_attributes(
+    route: &Route,
+    buf: &mut EncodeBuffer<'_>,
+) -> Result<(), EncodeError> {
+    let inject_ipv4_next_hop =
+        matches!(route.prefix, Prefix::V4(_)) && matches!(route.next_hop, IpAddr::V4(_));
+    let mut injected = false;
+    for attr in route.attributes.iter() {
+        if inject_ipv4_next_hop
+            && !injected
+            && !matches!(attr, PathAttribute::Origin(_) | PathAttribute::AsPath(_))
+        {
+            let IpAddr::V4(next_hop) = route.next_hop else {
+                unreachable!("IPv4 next-hop profile checked above")
+            };
+            encode_one_mrt_rib_attribute(&PathAttribute::NextHop(next_hop), buf)?;
+            injected = true;
+        }
+        encode_one_mrt_rib_attribute(attr, buf)?;
+    }
+    if inject_ipv4_next_hop && !injected {
+        let IpAddr::V4(next_hop) = route.next_hop else {
+            unreachable!("IPv4 next-hop profile checked above")
+        };
+        encode_one_mrt_rib_attribute(&PathAttribute::NextHop(next_hop), buf)?;
+    } else if !inject_ipv4_next_hop {
+        encode_mrt_mp_reach(route.next_hop, route.link_local_next_hop, buf)?;
+    }
+    Ok(())
+}
 /// Encode path attributes for an MRT RIB entry per RFC 6396 §4.3.4.
 ///
 /// `MP_REACH_NLRI` is rewritten to the MRT-reduced form: only NH-Len
@@ -570,18 +779,26 @@ fn encode_mrt_rib_attributes(
 ) -> Result<(), EncodeError> {
     for attr in attrs {
         buf.check()?;
-        if let PathAttribute::MpReachNlri(mp) = attr {
-            encode_mrt_mp_reach(mp.next_hop, mp.link_local_next_hop, buf)?;
-        } else {
-            // The wire encoder is Vec-based. Encode one protocol-bounded
-            // attribute at a time, then perform the cap-aware append, rather
-            // than materializing a second complete attribute vector.
-            let mut encoded = Vec::new();
-            encode_path_attributes(std::slice::from_ref(attr), &mut encoded, true, false)?;
-            buf.extend_from_slice(&encoded)?;
-        }
+        encode_one_mrt_rib_attribute(attr, buf)?;
     }
     Ok(())
+}
+
+fn encode_one_mrt_rib_attribute(
+    attr: &PathAttribute,
+    buf: &mut EncodeBuffer<'_>,
+) -> Result<(), EncodeError> {
+    buf.check()?;
+    if let PathAttribute::MpReachNlri(mp) = attr {
+        encode_mrt_mp_reach(mp.next_hop, mp.link_local_next_hop, buf)
+    } else {
+        // The wire encoder is Vec-based. One received BGP attribute is
+        // protocol-bounded to u16 bytes; append it immediately rather than
+        // retaining owned attributes for a complete prefix record.
+        let mut encoded = Vec::new();
+        encode_path_attributes(std::slice::from_ref(attr), &mut encoded, true, false)?;
+        buf.extend_from_slice(&encoded)
+    }
 }
 /// Append a single `MP_REACH_NLRI` attribute in MRT-reduced form.
 ///
@@ -693,6 +910,93 @@ fn encode_rib_entries_profile(
             buf.check()?;
             encode_rib_entry(buf, entry, has_addpath)?;
         }
+        buf.finish_record(start)
+    })();
+    if result.is_err() {
+        buf.truncate(start);
+    }
+    result
+}
+
+#[derive(Clone, Copy)]
+enum RouteEntrySelection {
+    All,
+    Legacy,
+    AddPath,
+}
+
+fn route_uses_add_path(
+    route: &Route,
+    profiles: Option<&HashSet<MrtAddPathReceiveProfile>>,
+) -> bool {
+    profiles.is_some_and(|profiles| {
+        let afi = match route.prefix {
+            Prefix::V4(_) => Afi::Ipv4,
+            Prefix::V6(_) => Afi::Ipv6,
+        };
+        profiles.contains(&MrtAddPathReceiveProfile {
+            peer: route.peer,
+            afi,
+            safi: Safi::Unicast,
+        })
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "borrowed route records need explicit MRT identity, selection, and timing inputs"
+)]
+fn encode_route_entries_profile(
+    buf: &mut EncodeBuffer<'_>,
+    timestamp: u32,
+    seq_num: u32,
+    prefix: &Prefix,
+    routes: &[&Route],
+    peer_index: &HashMap<IpAddr, u16>,
+    profiles: Option<&HashSet<MrtAddPathReceiveProfile>>,
+    selection: RouteEntrySelection,
+    entry_count: u16,
+    add_path: bool,
+    now_secs: u64,
+) -> Result<(), EncodeError> {
+    let subtype = match (prefix, add_path) {
+        (Prefix::V4(_), false) => RIB_IPV4_UNICAST,
+        (Prefix::V4(_), true) => RIB_IPV4_UNICAST_ADDPATH,
+        (Prefix::V6(_), false) => RIB_IPV6_UNICAST,
+        (Prefix::V6(_), true) => RIB_IPV6_UNICAST_ADDPATH,
+    };
+    let start = begin_mrt_record(buf, timestamp, subtype)?;
+    let result = (|| {
+        buf.extend_from_slice(&seq_num.to_be_bytes())?;
+        encode_prefix_bytes(buf, prefix)?;
+        buf.extend_from_slice(&entry_count.to_be_bytes())?;
+        let mut encoded_count = 0u16;
+        for route in routes {
+            buf.check()?;
+            let uses_add_path = route_uses_add_path(route, profiles);
+            let selected = match selection {
+                RouteEntrySelection::All => true,
+                RouteEntrySelection::Legacy => !uses_add_path,
+                RouteEntrySelection::AddPath => uses_add_path,
+            };
+            if !selected {
+                continue;
+            }
+            let peer_index = peer_index
+                .get(&route.peer)
+                .copied()
+                .expect("effective peer inventory includes every route origin");
+            let age = route.received_at.elapsed().as_secs();
+            let originated = u32::try_from(now_secs.saturating_sub(age)).unwrap_or(u32::MAX);
+            encode_route_rib_entry(buf, route, peer_index, originated, add_path)?;
+            encoded_count = encoded_count
+                .checked_add(1)
+                .ok_or(EncodeError::FieldTooLarge {
+                    field: "RIB entry count",
+                    value: usize::from(entry_count).saturating_add(1),
+                })?;
+        }
+        debug_assert_eq!(encoded_count, entry_count);
         buf.finish_record(start)
     })();
     if result.is_err() {
@@ -839,27 +1143,50 @@ fn encode_warm_snapshot_inner(
     if let Some(budget) = budget {
         budget.check()?;
     }
-    if let Some(route) = routes.iter().find(|route| {
-        route.next_hop_scope.is_some()
+    for route in routes {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        if route.next_hop_scope.is_some()
             || route.link_local_next_hop.is_some()
             || is_ipv6_link_local(route.next_hop)
-    }) {
-        return Err(EncodeError::UnsupportedWarmRouteProfile {
-            peer: route.peer,
-            reason: "scoped or link-local next-hop identity",
-        });
+        {
+            return Err(EncodeError::UnsupportedWarmRouteProfile {
+                peer: route.peer,
+                reason: "scoped or link-local next-hop identity",
+            });
+        }
     }
-    if let Some(route) = evpn_routes
-        .iter()
-        .find(|route| route.link_local_next_hop.is_some() || is_ipv6_link_local(route.next_hop))
-    {
-        return Err(EncodeError::UnsupportedWarmRouteProfile {
-            peer: route.peer,
-            reason: "link-local next-hop identity",
-        });
+    for route in evpn_routes {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        if route.link_local_next_hop.is_some() || is_ipv6_link_local(route.next_hop) {
+            return Err(EncodeError::UnsupportedWarmRouteProfile {
+                peer: route.peer,
+                reason: "link-local next-hop identity",
+            });
+        }
     }
-    let mut unique = HashSet::with_capacity(add_path_receive.len());
+    let profile_bytes = add_path_receive
+        .len()
+        .checked_mul(std::mem::size_of::<MrtAddPathReceiveProfile>())
+        .ok_or(EncodeError::AllocationFailed {
+            attempted: usize::MAX,
+        })?;
+    if let Some(budget) = budget {
+        budget.check_temporary_allocation(profile_bytes)?;
+    }
+    let mut unique = HashSet::new();
+    unique
+        .try_reserve(add_path_receive.len())
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: profile_bytes,
+        })?;
     for profile in add_path_receive {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
         if !unique.insert(*profile) {
             return Err(EncodeError::InvalidAddPathProfile {
                 peer: profile.peer,
@@ -868,19 +1195,17 @@ fn encode_warm_snapshot_inner(
                 reason: "duplicate profile",
             });
         }
-    }
-    if let Some(profile) = add_path_receive.iter().find(|profile| {
-        !matches!(
+        if !matches!(
             (profile.afi, profile.safi),
             (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast)
-        )
-    }) {
-        return Err(EncodeError::InvalidAddPathProfile {
-            peer: profile.peer,
-            afi: profile.afi,
-            safi: profile.safi,
-            reason: "only IPv4/IPv6 unicast Add-Path is supported by TABLE_DUMP_V2",
-        });
+        ) {
+            return Err(EncodeError::InvalidAddPathProfile {
+                peer: profile.peer,
+                afi: profile.afi,
+                safi: profile.safi,
+                reason: "only IPv4/IPv6 unicast Add-Path is supported by TABLE_DUMP_V2",
+            });
+        }
     }
     encode_snapshot_inner(
         collector_bgp_id,
@@ -920,11 +1245,61 @@ fn encode_snapshot_inner(
     let mut output = EncodeBuffer::new(&mut buf, budget);
     output.check()?;
     // 1. Build effective peer list from explicit peers + any route-origin peers.
-    let mut effective_peers: Vec<MrtPeerEntry> = peers.to_vec();
-    let mut seen_peers: HashSet<IpAddr> = effective_peers.iter().map(|p| p.peer_addr).collect();
+    if peers.len() > usize::from(u16::MAX) {
+        return Err(EncodeError::FieldTooLarge {
+            field: "PEER_INDEX_TABLE.peer_count",
+            value: peers.len(),
+        });
+    }
+    let peer_bytes = peers
+        .len()
+        .checked_mul(std::mem::size_of::<MrtPeerEntry>())
+        .ok_or(EncodeError::AllocationFailed {
+            attempted: usize::MAX,
+        })?;
+    if let Some(budget) = budget {
+        budget.check_temporary_allocation(peer_bytes)?;
+    }
+    let mut effective_peers = Vec::<MrtPeerEntry>::new();
+    effective_peers
+        .try_reserve_exact(peers.len())
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: peer_bytes,
+        })?;
+    effective_peers.extend_from_slice(peers);
+    let mut seen_peers = HashSet::<IpAddr>::new();
+    seen_peers
+        .try_reserve(peers.len())
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: peers.len().saturating_mul(std::mem::size_of::<IpAddr>()),
+        })?;
+    seen_peers.extend(effective_peers.iter().map(|peer| peer.peer_addr));
     for route in routes {
         output.check()?;
-        if seen_peers.insert(route.peer) {
+        if !seen_peers.contains(&route.peer) {
+            if effective_peers.len() == usize::from(u16::MAX) {
+                return Err(EncodeError::FieldTooLarge {
+                    field: "PEER_INDEX_TABLE.peer_count",
+                    value: effective_peers.len().saturating_add(1),
+                });
+            }
+            seen_peers
+                .try_reserve(1)
+                .map_err(|_| EncodeError::AllocationFailed {
+                    attempted: seen_peers
+                        .len()
+                        .saturating_add(1)
+                        .saturating_mul(std::mem::size_of::<IpAddr>()),
+                })?;
+            effective_peers
+                .try_reserve_exact(1)
+                .map_err(|_| EncodeError::AllocationFailed {
+                    attempted: effective_peers
+                        .len()
+                        .saturating_add(1)
+                        .saturating_mul(std::mem::size_of::<MrtPeerEntry>()),
+                })?;
+            seen_peers.insert(route.peer);
             effective_peers.push(MrtPeerEntry {
                 peer_addr: route.peer,
                 peer_bgp_id: Ipv4Addr::UNSPECIFIED,
@@ -934,7 +1309,30 @@ fn encode_snapshot_inner(
     }
     for route in evpn_routes {
         output.check()?;
-        if seen_peers.insert(route.peer) {
+        if !seen_peers.contains(&route.peer) {
+            if effective_peers.len() == usize::from(u16::MAX) {
+                return Err(EncodeError::FieldTooLarge {
+                    field: "PEER_INDEX_TABLE.peer_count",
+                    value: effective_peers.len().saturating_add(1),
+                });
+            }
+            seen_peers
+                .try_reserve(1)
+                .map_err(|_| EncodeError::AllocationFailed {
+                    attempted: seen_peers
+                        .len()
+                        .saturating_add(1)
+                        .saturating_mul(std::mem::size_of::<IpAddr>()),
+                })?;
+            effective_peers
+                .try_reserve_exact(1)
+                .map_err(|_| EncodeError::AllocationFailed {
+                    attempted: effective_peers
+                        .len()
+                        .saturating_add(1)
+                        .saturating_mul(std::mem::size_of::<MrtPeerEntry>()),
+                })?;
+            seen_peers.insert(route.peer);
             effective_peers.push(MrtPeerEntry {
                 peer_addr: route.peer,
                 peer_bgp_id: Ipv4Addr::UNSPECIFIED,
@@ -942,20 +1340,12 @@ fn encode_snapshot_inner(
             });
         }
     }
-    effective_peers.sort_by(|a, b| {
-        let a_key = match a.peer_addr {
-            IpAddr::V4(v4) => (0u8, v4.octets().to_vec()),
-            IpAddr::V6(v6) => (1u8, v6.octets().to_vec()),
-        };
-        let b_key = match b.peer_addr {
-            IpAddr::V4(v4) => (0u8, v4.octets().to_vec()),
-            IpAddr::V6(v6) => (1u8, v6.octets().to_vec()),
-        };
-        a_key
-            .cmp(&b_key)
+    sort_cancellable_by(&mut effective_peers, budget, |a, b| {
+        a.peer_addr
+            .cmp(&b.peer_addr)
             .then(a.peer_asn.cmp(&b.peer_asn))
             .then(a.peer_bgp_id.octets().cmp(&b.peer_bgp_id.octets()))
-    });
+    })?;
     output.check()?;
     // 2. `PEER_INDEX_TABLE`
     encode_peer_index_table_inner(
@@ -966,154 +1356,153 @@ fn encode_snapshot_inner(
         &effective_peers,
     )?;
     // 3. Build peer index lookup
-    let peer_index: HashMap<IpAddr, u16> = effective_peers
-        .iter()
-        .enumerate()
-        .map(|(i, p)| {
-            u16::try_from(i)
-                .map(|idx| (p.peer_addr, idx))
-                .map_err(|_| EncodeError::FieldTooLarge {
-                    field: "peer index",
-                    value: i,
-                })
-        })
-        .collect::<Result<_, _>>()?;
-    output.check()?;
-    // 4. Group routes by prefix
-    let mut by_prefix: HashMap<Prefix, Vec<&Route>> = HashMap::new();
-    for route in routes {
+    let mut peer_index = HashMap::<IpAddr, u16>::new();
+    peer_index
+        .try_reserve(effective_peers.len())
+        .map_err(|_| EncodeError::AllocationFailed {
+            attempted: effective_peers
+                .len()
+                .saturating_mul(std::mem::size_of::<(IpAddr, u16)>()),
+        })?;
+    for (index, peer) in effective_peers.iter().enumerate() {
         output.check()?;
-        by_prefix.entry(route.prefix).or_default().push(route);
+        let index = u16::try_from(index).map_err(|_| EncodeError::FieldTooLarge {
+            field: "peer index",
+            value: index,
+        })?;
+        peer_index.insert(peer.peer_addr, index);
     }
-    // 5. Encode each prefix group
-    let mut seq_num: u32 = 0;
-    // Sort prefixes for deterministic output
-    let mut prefixes: Vec<Prefix> = by_prefix.keys().copied().collect();
-    prefixes.sort_by(|a, b| {
-        let a_bytes = match a {
-            Prefix::V4(v4) => (0u8, v4.addr.octets().to_vec(), v4.len),
-            Prefix::V6(v6) => (1u8, v6.addr.octets().to_vec(), v6.len),
-        };
-        let b_bytes = match b {
-            Prefix::V4(v4) => (0u8, v4.addr.octets().to_vec(), v4.len),
-            Prefix::V6(v6) => (1u8, v6.addr.octets().to_vec(), v6.len),
-        };
-        a_bytes.cmp(&b_bytes)
-    });
     output.check()?;
+    // 4. Order borrowed routes once. No path attributes are cloned or retained
+    // per prefix; record entries are synthesized directly into the checked
+    // output after their profile counts have been preflighted.
+    let mut ordered_routes = collect_cancellable(routes.iter(), budget)?;
+    sort_cancellable_by(&mut ordered_routes, budget, |a, b| {
+        let a_index = peer_index.get(&a.peer).copied().unwrap_or(u16::MAX);
+        let b_index = peer_index.get(&b.peer).copied().unwrap_or(u16::MAX);
+        a.prefix
+            .cmp(&b.prefix)
+            .then(a_index.cmp(&b_index))
+            .then(a.path_id.cmp(&b.path_id))
+    })?;
+
+    // 5. Encode each contiguous prefix group.
+    let mut seq_num: u32 = 0;
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    for prefix in &prefixes {
+    let mut group_start = 0usize;
+    while group_start < ordered_routes.len() {
         output.check()?;
-        let mut prefix_routes = by_prefix[prefix].clone();
-        prefix_routes.sort_by(|a, b| {
-            let a_idx = peer_index.get(&a.peer).copied().unwrap_or(u16::MAX);
-            let b_idx = peer_index.get(&b.peer).copied().unwrap_or(u16::MAX);
-            a_idx
-                .cmp(&b_idx)
-                .then(a.path_id.cmp(&b.path_id))
-                .then(prefix_family_sort_key(a.prefix).cmp(&prefix_family_sort_key(b.prefix)))
-        });
-        output.check()?;
-        let mut legacy_entries: Vec<RibEntry> = Vec::with_capacity(prefix_routes.len());
-        let mut add_path_entries: Vec<RibEntry> = Vec::new();
+        let prefix = ordered_routes[group_start].prefix;
+        let mut group_end = group_start + 1;
+        while group_end < ordered_routes.len() && ordered_routes[group_end].prefix == prefix {
+            if (group_end - group_start).is_multiple_of(CANCELLABLE_SORT_RUN) {
+                output.check()?;
+            }
+            group_end += 1;
+        }
+        let prefix_routes = &ordered_routes[group_start..group_end];
+        if add_path_receive.is_none() {
+            let count =
+                u16::try_from(prefix_routes.len()).map_err(|_| EncodeError::FieldTooLarge {
+                    field: "RIB entry count",
+                    value: prefix_routes.len(),
+                })?;
+            let add_path = prefix_routes.iter().any(|route| route.path_id != 0);
+            encode_route_entries_profile(
+                &mut output,
+                timestamp,
+                seq_num,
+                &prefix,
+                prefix_routes,
+                &peer_index,
+                None,
+                RouteEntrySelection::All,
+                count,
+                add_path,
+                now_secs,
+            )?;
+            seq_num = seq_num.wrapping_add(1);
+            group_start = group_end;
+            continue;
+        }
+
+        let mut legacy_count = 0usize;
+        let mut add_path_count = 0usize;
         for route in prefix_routes {
             output.check()?;
-            let Some(&idx) = peer_index.get(&route.peer) else {
-                continue;
-            };
-            let age = route.received_at.elapsed().as_secs();
-            let originated_u64 = now_secs.saturating_sub(age);
-            let originated = u32::try_from(originated_u64).unwrap_or(u32::MAX);
-            let entry = RibEntry {
-                peer_index: idx,
-                originated_time: originated,
-                path_id: route.path_id,
-                attributes: synthesize_attributes(route),
-            };
-            let uses_add_path = add_path_receive.is_some_and(|profiles| {
-                let afi = match prefix {
-                    Prefix::V4(_) => Afi::Ipv4,
-                    Prefix::V6(_) => Afi::Ipv6,
-                };
-                profiles.contains(&MrtAddPathReceiveProfile {
-                    peer: route.peer,
-                    afi,
-                    safi: Safi::Unicast,
-                })
-            });
-            if add_path_receive.is_some() && !uses_add_path && route.path_id != 0 {
+            let uses_add_path = route_uses_add_path(route, add_path_receive);
+            if !uses_add_path && route.path_id != 0 {
                 return Err(EncodeError::AddPathProfileMismatch {
                     peer: route.peer,
                     path_id: route.path_id,
                 });
             }
             if uses_add_path {
-                add_path_entries.push(entry);
+                add_path_count = add_path_count.saturating_add(1);
             } else {
-                legacy_entries.push(entry);
+                legacy_count = legacy_count.saturating_add(1);
             }
         }
-        if !legacy_entries.is_empty() {
-            if add_path_receive.is_some() {
-                encode_rib_entries_profile(
-                    &mut output,
-                    timestamp,
-                    seq_num,
-                    prefix,
-                    &legacy_entries,
-                    false,
-                )?;
-            } else {
-                encode_rib_entries_profile(
-                    &mut output,
-                    timestamp,
-                    seq_num,
-                    prefix,
-                    &legacy_entries,
-                    legacy_entries.iter().any(|entry| entry.path_id != 0),
-                )?;
-            }
-            seq_num = seq_num.wrapping_add(1);
-        }
-        if !add_path_entries.is_empty() {
-            encode_rib_entries_profile(
+        if legacy_count != 0 {
+            let count = u16::try_from(legacy_count).map_err(|_| EncodeError::FieldTooLarge {
+                field: "RIB entry count",
+                value: legacy_count,
+            })?;
+            encode_route_entries_profile(
                 &mut output,
                 timestamp,
                 seq_num,
-                prefix,
-                &add_path_entries,
-                true,
+                &prefix,
+                prefix_routes,
+                &peer_index,
+                add_path_receive,
+                RouteEntrySelection::Legacy,
+                count,
+                false,
+                now_secs,
             )?;
             seq_num = seq_num.wrapping_add(1);
         }
+        if add_path_count != 0 {
+            let count = u16::try_from(add_path_count).map_err(|_| EncodeError::FieldTooLarge {
+                field: "RIB entry count",
+                value: add_path_count,
+            })?;
+            encode_route_entries_profile(
+                &mut output,
+                timestamp,
+                seq_num,
+                &prefix,
+                prefix_routes,
+                &peer_index,
+                add_path_receive,
+                RouteEntrySelection::AddPath,
+                count,
+                true,
+                now_secs,
+            )?;
+            seq_num = seq_num.wrapping_add(1);
+        }
+        group_start = group_end;
     }
     // 6. Encode EVPN routes as RIB_GENERIC records (RFC 6396 §4.3.5).
     // EVPN does not use Add-Path in this codebase, and EVPN keys are
     // already per-route (RD + ESI + ETag + MAC + IP), so each route maps
     // to a single-entry RIB_GENERIC record. Sort for deterministic output
     // by (peer_index, route).
-    // Sort by (peer_index, encoded EVPN NLRI bytes). EvpnRouteKey doesn't
-    // derive Ord, but the encoded NLRI is a canonical byte representation
-    // and gives a deterministic ordering.
-    let mut sorted_evpn: Vec<(&EvpnRibRoute, Vec<u8>)> = evpn_routes
-        .iter()
-        .map(|route| {
-            let mut nlri_bytes = Vec::new();
-            encode_evpn_nlri(std::slice::from_ref(&route.route), &mut nlri_bytes);
-            (route, nlri_bytes)
-        })
-        .collect();
-    output.check()?;
-    sorted_evpn.sort_by(|(a, a_bytes), (b, b_bytes)| {
+    // The typed identity key is allocation-free and totally ordered in wire
+    // route-type/field order. Do not retain one encoded NLRI Vec per route.
+    let mut sorted_evpn = collect_cancellable(evpn_routes.iter(), budget)?;
+    sort_cancellable_by(&mut sorted_evpn, budget, |a, b| {
         let a_idx = peer_index.get(&a.peer).copied().unwrap_or(u16::MAX);
         let b_idx = peer_index.get(&b.peer).copied().unwrap_or(u16::MAX);
-        a_idx.cmp(&b_idx).then_with(|| a_bytes.cmp(b_bytes))
-    });
-    output.check()?;
-    let sorted_evpn: Vec<&EvpnRibRoute> = sorted_evpn.into_iter().map(|(r, _)| r).collect();
+        a_idx
+            .cmp(&b_idx)
+            .then_with(|| a.route.key().cmp(&b.route.key()))
+    })?;
     for route in sorted_evpn {
         output.check()?;
         let Some(&idx) = peer_index.get(&route.peer) else {
@@ -1128,12 +1517,6 @@ fn encode_snapshot_inner(
     output.check()?;
     Ok(buf)
 }
-fn prefix_family_sort_key(prefix: Prefix) -> (u8, Vec<u8>, u8) {
-    match prefix {
-        Prefix::V4(v4) => (0u8, v4.addr.octets().to_vec(), v4.len),
-        Prefix::V6(v6) => (1u8, v6.addr.octets().to_vec(), v6.len),
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1143,7 +1526,7 @@ mod tests {
     };
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
     fn make_peer(addr: IpAddr, asn: u32) -> MrtPeerEntry {
         let bgp_id = match addr {
@@ -1261,6 +1644,116 @@ mod tests {
                 WarmSnapshotBudgetError::SizeLimitExceeded { attempted, cap: actual_cap }
             )) if attempted > actual_cap && actual_cap == cap
         ));
+    }
+
+    #[test]
+    fn cancellable_sort_stops_within_one_bounded_run() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::clone(&cancelled),
+            2 * 1024 * 1024,
+        );
+        let comparisons = AtomicUsize::new(0);
+        let mut values: Vec<_> = (0..100_000usize).rev().collect();
+        let result = sort_cancellable_by(&mut values, Some(&budget), |left, right| {
+            if comparisons.fetch_add(1, Ordering::Relaxed) == 1_000 {
+                cancelled.store(true, Ordering::Release);
+            }
+            left.cmp(right)
+        });
+
+        assert!(matches!(
+            result,
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::Cancelled
+            ))
+        ));
+        assert!(
+            comparisons.load(Ordering::Relaxed) < 2_000,
+            "cancellation must stop before another unbounded sort phase"
+        );
+    }
+
+    #[test]
+    fn cancellation_during_key_materialization_stops_before_sorting() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::clone(&cancelled),
+            2 * 1024 * 1024,
+        );
+        let materialized = AtomicUsize::new(0);
+        let values: Vec<_> = (0..100_000usize).collect();
+        let keys = values.iter().enumerate().map(|(index, value)| {
+            materialized.fetch_add(1, Ordering::Relaxed);
+            if index == 1_000 {
+                cancelled.store(true, Ordering::Release);
+            }
+            value
+        });
+
+        assert!(matches!(
+            collect_cancellable(keys, Some(&budget)),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::Cancelled
+            ))
+        ));
+        assert_eq!(materialized.load(Ordering::Relaxed), 1_001);
+    }
+
+    #[test]
+    fn large_same_prefix_attributes_hit_cap_without_owned_entry_staging() {
+        let peer = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let prefix = Prefix::V4(Ipv4Prefix {
+            addr: Ipv4Addr::new(198, 51, 100, 0),
+            len: 24,
+        });
+        let attributes = Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![rustbgpd_wire::AsPathSegment::AsSequence(vec![65001])],
+            }),
+            PathAttribute::Communities(vec![0x000a_000b; 2_048]),
+        ]);
+        let routes: Vec<_> = (1..=2_048u32)
+            .map(|path_id| {
+                let mut route = make_route(prefix, peer, peer);
+                route.path_id = path_id;
+                route.attributes = Arc::clone(&attributes);
+                route
+            })
+            .collect();
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::new(AtomicBool::new(false)),
+            128 * 1024,
+        );
+
+        assert!(matches!(
+            encode_warm_snapshot_bounded(
+                Ipv4Addr::new(10, 0, 0, 1),
+                "generation-large-prefix",
+                &[make_peer(peer, 64_501)],
+                &routes,
+                &[],
+                1_700_000_000,
+                &[MrtAddPathReceiveProfile {
+                    peer,
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                }],
+                &budget,
+            ),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::SizeLimitExceeded { cap: 131_072, .. }
+            ))
+        ));
+        assert_eq!(
+            Arc::strong_count(&attributes),
+            routes.len() + 1,
+            "borrowed encoding must retain the shared route attributes"
+        );
     }
     #[test]
     fn mrt_header_encoding() {
@@ -1708,6 +2201,45 @@ mod tests {
             &payload[7..7 + expected_nlri.len()],
             expected_nlri.as_slice()
         );
+    }
+
+    #[test]
+    fn large_evpn_inventory_hits_cap_without_owned_encoded_sort_keys() {
+        use rustbgpd_wire::{EvpnRoute, MacAddress};
+
+        let peer_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let mut routes = Vec::new();
+        routes.try_reserve_exact(4_096).unwrap();
+        for suffix in 0..4_096u16 {
+            let mut route = make_evpn_macip(peer_addr, peer_addr);
+            let EvpnRoute::MacIp(mac_ip) = &mut route.route else {
+                unreachable!("helper always returns MAC/IP routes")
+            };
+            let [high, low] = suffix.to_be_bytes();
+            mac_ip.mac = MacAddress([0x02, 0, 0, 0, high, low]);
+            routes.push(route);
+        }
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::new(AtomicBool::new(false)),
+            64 * 1024,
+        );
+
+        assert!(matches!(
+            encode_warm_snapshot_bounded(
+                Ipv4Addr::new(1, 2, 3, 4),
+                "generation-large-evpn",
+                &[make_peer(peer_addr, 65_002)],
+                &[],
+                &routes,
+                1_700_000_000,
+                &[],
+                &budget,
+            ),
+            Err(EncodeError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::SizeLimitExceeded { cap: 65_536, .. }
+            ))
+        ));
     }
     /// Walk a serialized BGP attribute block and return the value bytes
     /// of the first attribute matching `type_code`. Used by the

--- a/crates/mrt/src/codec.rs
+++ b/crates/mrt/src/codec.rs
@@ -680,7 +680,7 @@ fn encode_rib_entry(
     // Account for the two-byte length before appending the bounded attribute
     // buffer. A single RIB entry remains protocol-bounded to u16 bytes.
     if let Some(budget) = buf.budget {
-        budget.check_growth(buf.len(), 2usize.saturating_add(attr_buf.len()))?;
+        budget.check_growth(buf.effective_len(), 2usize.saturating_add(attr_buf.len()))?;
     }
     buf.extend_from_slice(&attr_len.to_be_bytes())?;
     buf.extend_from_slice(&attr_buf)?;

--- a/crates/mrt/src/lib.rs
+++ b/crates/mrt/src/lib.rs
@@ -29,4 +29,5 @@ pub use warm_bundle::{
     WarmBundleFreshnessV1, WarmBundleIdentityV1, WarmBundleManifestV1, WarmBundlePolicyDigestV1,
     WarmBundlePolicyInputV1, WarmBundleV1, WarmBundleViewKindV1, WarmBundleViewV1,
     load_warm_bundle, resolved_import_policy_digest_v1, write_warm_bundle,
+    write_warm_bundle_bounded,
 };

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 
+use crate::codec::{WarmSnapshotBudget, WarmSnapshotBudgetError};
 use crate::{ReadError, SnapshotNlri, SnapshotReader};
 
 /// On-disk format understood by this implementation.
@@ -353,6 +354,9 @@ pub enum WarmBundleError {
         /// Requested allocation size.
         requested: u64,
     },
+    /// The coordinated shutdown budget cancelled or expired.
+    #[error(transparent)]
+    WarmSnapshotBudget(#[from] WarmSnapshotBudgetError),
     /// JSON was torn, malformed, or not the exact V1 shape.
     #[error("warm bundle manifest is torn or corrupt: {0}")]
     CorruptManifest(#[source] serde_json::Error),
@@ -455,7 +459,34 @@ pub fn write_warm_bundle(
     identity: WarmBundleIdentityV1,
     snapshot: &[u8],
 ) -> Result<WarmBundleManifestV1, WarmBundleError> {
-    write_warm_bundle_inner(directory, identity, snapshot, FaultPoint::None)
+    write_warm_bundle_inner(directory, identity, snapshot, FaultPoint::None, None)
+}
+
+/// Atomically publish a V1 bundle while observing the shutdown work budget.
+///
+/// Semantic validation, hashing, chunked writes, fsync boundaries, and the
+/// final manifest commit all recheck the same cancellation token and monotonic
+/// deadline used by bounded MRT encoding. Cancellation before the manifest
+/// rename cannot select a partial or orphan artifact.
+///
+/// # Errors
+///
+/// Returns the same errors as [`write_warm_bundle`], plus
+/// [`WarmBundleError::WarmSnapshotBudget`] when shutdown cancellation or the
+/// terminal deadline fires.
+pub fn write_warm_bundle_bounded(
+    directory: &WarmBundleDirectory,
+    identity: WarmBundleIdentityV1,
+    snapshot: &[u8],
+    budget: &WarmSnapshotBudget,
+) -> Result<WarmBundleManifestV1, WarmBundleError> {
+    write_warm_bundle_inner(
+        directory,
+        identity,
+        snapshot,
+        FaultPoint::None,
+        Some(budget),
+    )
 }
 
 /// Load only an exact, fresh, byte- and semantically-valid bundle.
@@ -483,7 +514,7 @@ pub fn load_warm_bundle(
         serde_json::from_slice(&manifest_bytes).map_err(WarmBundleError::CorruptManifest)?;
     validate_manifest(&manifest, expected, freshness)?;
     let snapshot = read_verified_snapshot(directory, &manifest.snapshot)?;
-    let actual_counts = validate_snapshot_semantics(&snapshot, &manifest.identity)?;
+    let actual_counts = validate_snapshot_semantics(&snapshot, &manifest.identity, None)?;
     if actual_counts != manifest.view_route_counts {
         return Err(WarmBundleError::MrtIdentityMismatch {
             field: "per-view route counts",
@@ -497,7 +528,12 @@ fn write_warm_bundle_inner(
     identity: WarmBundleIdentityV1,
     snapshot: &[u8],
     fault: FaultPoint,
+    budget: Option<&WarmSnapshotBudget>,
 ) -> Result<WarmBundleManifestV1, WarmBundleError> {
+    if let Some(budget) = budget {
+        budget.check()?;
+        budget.check_growth(0, snapshot.len())?;
+    }
     validate_identity(&identity)?;
     let size_bytes = u64::try_from(snapshot.len()).unwrap_or(u64::MAX);
     if size_bytes > MAX_WARM_BUNDLE_SNAPSHOT_BYTES {
@@ -507,8 +543,8 @@ fn write_warm_bundle_inner(
             cap: MAX_WARM_BUNDLE_SNAPSHOT_BYTES,
         });
     }
-    let view_route_counts = validate_snapshot_semantics(snapshot, &identity)?;
-    let sha256 = sha256_hex(snapshot);
+    let view_route_counts = validate_snapshot_semantics(snapshot, &identity, budget)?;
+    let sha256 = sha256_hex_bounded(snapshot, budget)?;
     let manifest = WarmBundleManifestV1 {
         format_version: WARM_BUNDLE_FORMAT_VERSION,
         identity,
@@ -535,6 +571,7 @@ fn write_warm_bundle_inner(
         snapshot,
         AtomicRole::Artifact,
         fault,
+        budget,
     )?;
     write_atomic_at(
         directory,
@@ -542,6 +579,7 @@ fn write_warm_bundle_inner(
         &encoded,
         AtomicRole::Manifest,
         fault,
+        budget,
     )?;
     Ok(manifest)
 }
@@ -700,10 +738,18 @@ fn validate_view_route_counts(manifest: &WarmBundleManifestV1) -> Result<(), War
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass identity validation keeps every accepted MRT family under one fail-closed inventory"
+)]
 fn validate_snapshot_semantics(
     snapshot: &[u8],
     identity: &WarmBundleIdentityV1,
+    budget: Option<&WarmSnapshotBudget>,
 ) -> Result<Vec<u64>, WarmBundleError> {
+    if let Some(budget) = budget {
+        budget.check()?;
+    }
     let mut reader = SnapshotReader::new(snapshot).map_err(WarmBundleError::InvalidMrt)?;
     if reader.collector_bgp_id() != identity.local_router_id {
         return Err(WarmBundleError::MrtIdentityMismatch {
@@ -738,6 +784,9 @@ fn validate_snapshot_semantics(
         .map(|view| (view, 0))
         .collect();
     for decoded in &mut reader {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
         let entry = decoded.map_err(WarmBundleError::InvalidMrt)?;
         let family = match &entry.nlri {
             SnapshotNlri::Unicast(rustbgpd_wire::Prefix::V4(_)) => WarmBundleFamilyV1::Ipv4Unicast,
@@ -849,6 +898,22 @@ fn update_len_prefixed(digest: &mut Sha256, bytes: &[u8]) {
 
 fn sha256_hex(bytes: &[u8]) -> String {
     digest_hex(Sha256::digest(bytes))
+}
+
+fn sha256_hex_bounded(
+    bytes: &[u8],
+    budget: Option<&WarmSnapshotBudget>,
+) -> Result<String, WarmBundleError> {
+    let Some(budget) = budget else {
+        return Ok(sha256_hex(bytes));
+    };
+    let mut digest = Sha256::new();
+    for chunk in bytes.chunks(STREAM_BUFFER_BYTES) {
+        budget.check()?;
+        digest.update(chunk);
+    }
+    budget.check()?;
+    Ok(digest_hex(digest.finalize()))
 }
 
 fn digest_hex(digest: impl AsRef<[u8]>) -> String {
@@ -1142,19 +1207,48 @@ fn write_atomic_at(
     bytes: &[u8],
     role: AtomicRole,
     fault: FaultPoint,
+    budget: Option<&WarmSnapshotBudget>,
 ) -> Result<(), WarmBundleError> {
     let display = directory.display_path.join(name);
     let (temp_name, mut file) = create_temp(directory, name)?;
-    let result = (|| -> io::Result<()> {
-        fail_if(fault, stage(role, 0))?;
-        file.write_all(bytes)?;
-        fail_if(fault, stage(role, 1))?;
-        file.sync_all()?;
+    let result = (|| -> Result<(), WarmBundleError> {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        fail_if(fault, stage(role, 0)).map_err(|source| io_error(&display, source))?;
+        for chunk in bytes.chunks(STREAM_BUFFER_BYTES) {
+            if let Some(budget) = budget {
+                budget.check()?;
+            }
+            file.write_all(chunk)
+                .map_err(|source| io_error(&display, source))?;
+        }
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        fail_if(fault, stage(role, 1)).map_err(|source| io_error(&display, source))?;
+        file.sync_all()
+            .map_err(|source| io_error(&display, source))?;
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
         drop(file);
-        fail_if(fault, stage(role, 2))?;
-        renameat(&directory.file, temp_name.as_str(), &directory.file, name).map_err(errno_io)?;
-        fail_if(fault, stage(role, 3))?;
-        directory.file.sync_all()
+        fail_if(fault, stage(role, 2)).map_err(|source| io_error(&display, source))?;
+        renameat(&directory.file, temp_name.as_str(), &directory.file, name)
+            .map_err(errno_io)
+            .map_err(|source| io_error(&display, source))?;
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        fail_if(fault, stage(role, 3)).map_err(|source| io_error(&display, source))?;
+        directory
+            .file
+            .sync_all()
+            .map_err(|source| io_error(&display, source))?;
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        Ok(())
     })();
     if result.is_err() {
         let _ = unlinkat(
@@ -1163,7 +1257,7 @@ fn write_atomic_at(
             UnlinkatFlags::NoRemoveDir,
         );
     }
-    result.map_err(|source| io_error(&display, source))
+    result
 }
 
 fn create_temp(
@@ -1217,6 +1311,9 @@ mod tests {
     use std::fs::OpenOptions;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::os::unix::fs::{PermissionsExt as _, symlink};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::time::{Duration, Instant};
 
     const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const NOW: i64 = 1_800_000_000;
@@ -1283,6 +1380,57 @@ mod tests {
     fn opened(dir: &tempfile::TempDir) -> WarmBundleDirectory {
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
         WarmBundleDirectory::open(dir.path()).unwrap()
+    }
+
+    #[test]
+    fn cancelled_bounded_writer_publishes_no_artifact_or_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity();
+        let snapshot = valid_snapshot(&id);
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::new(AtomicBool::new(true)),
+            usize::try_from(MAX_WARM_BUNDLE_SNAPSHOT_BYTES).unwrap(),
+        );
+
+        assert!(matches!(
+            write_warm_bundle_bounded(&dir, id, &snapshot, &budget),
+            Err(WarmBundleError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::Cancelled
+            ))
+        ));
+        assert_eq!(
+            fs::read_dir(temp.path()).unwrap().count(),
+            0,
+            "cancelled writer must not publish an artifact, manifest, or temp file"
+        );
+    }
+
+    #[test]
+    fn oversized_bounded_writer_publishes_no_artifact_or_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity();
+        let snapshot = valid_snapshot(&id);
+        let cap = snapshot.len() - 1;
+        let budget = WarmSnapshotBudget::new(
+            Instant::now() + Duration::from_mins(1),
+            Arc::new(AtomicBool::new(false)),
+            cap,
+        );
+
+        assert!(matches!(
+            write_warm_bundle_bounded(&dir, id, &snapshot, &budget),
+            Err(WarmBundleError::WarmSnapshotBudget(
+                WarmSnapshotBudgetError::SizeLimitExceeded { attempted, cap: actual_cap }
+            )) if attempted == snapshot.len() && actual_cap == cap
+        ));
+        assert_eq!(
+            fs::read_dir(temp.path()).unwrap().count(),
+            0,
+            "oversized writer input must not publish an artifact, manifest, or temp file"
+        );
     }
 
     fn record(output: &mut Vec<u8>, subtype: u16, payload: &[u8]) {
@@ -1885,7 +2033,8 @@ mod tests {
             next.checkpoint_generation = "boot-42".to_string();
             next.snapshot_revision += 1;
             next.created_at_utc_seconds += 1;
-            let result = write_warm_bundle_inner(&dir, next.clone(), &valid_snapshot(&next), fault);
+            let result =
+                write_warm_bundle_inner(&dir, next.clone(), &valid_snapshot(&next), fault, None);
             assert!(result.is_err(), "{fault:?}");
             if fault == FaultPoint::ManifestDirSync {
                 assert!(load_warm_bundle(&dir, &expected(&next), freshness()).is_ok());

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -13,8 +13,9 @@
 //!
 //! Publication fsyncs and renames the content-addressed MRT artifact before it
 //! atomically replaces `manifest.json`, the commit point, then fsyncs the
-//! directory. A failure before the manifest rename leaves the previous commit
-//! authoritative. A failure after it can expose only the complete new commit.
+//! directory. Any reported failure rolls back destination entries to the exact
+//! state observed before publication; only a successful return exposes the new
+//! commit.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
@@ -24,7 +25,8 @@ use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use nix::fcntl::{OFlag, open, openat, renameat};
+use nix::errno::Errno;
+use nix::fcntl::{OFlag, RenameFlags, open, openat, renameat2};
 use nix::sys::stat::Mode;
 use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
 use serde::{Deserialize, Serialize};
@@ -555,17 +557,8 @@ fn write_warm_bundle_inner(
         },
         view_route_counts,
     };
-    let mut encoded = serde_json::to_vec(&manifest).map_err(WarmBundleError::CorruptManifest)?;
-    encoded.push(b'\n');
-    let manifest_size = u64::try_from(encoded.len()).unwrap_or(u64::MAX);
-    if manifest_size > MAX_WARM_BUNDLE_MANIFEST_BYTES {
-        return Err(WarmBundleError::FileTooLarge {
-            role: "manifest",
-            actual: manifest_size,
-            cap: MAX_WARM_BUNDLE_MANIFEST_BYTES,
-        });
-    }
-    write_atomic_at(
+    let encoded = encode_manifest_bounded(&manifest, MAX_WARM_BUNDLE_MANIFEST_BYTES)?;
+    let artifact_publication = write_atomic_at(
         directory,
         &manifest.snapshot.path,
         snapshot,
@@ -573,15 +566,106 @@ fn write_warm_bundle_inner(
         fault,
         budget,
     )?;
-    write_atomic_at(
+    if let Err(error) = write_atomic_at(
         directory,
         WARM_BUNDLE_MANIFEST_FILE,
         &encoded,
         AtomicRole::Manifest,
         fault,
         budget,
-    )?;
+    ) {
+        if artifact_publication == AtomicPublication::Created {
+            remove_committed_destination(directory, &manifest.snapshot.path)?;
+        }
+        return Err(error);
+    }
     Ok(manifest)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ManifestWriteFailure {
+    Limit { attempted: usize },
+    Allocation { attempted: usize },
+}
+
+struct BoundedManifestWriter {
+    bytes: Vec<u8>,
+    cap: usize,
+    failure: Option<ManifestWriteFailure>,
+}
+
+impl BoundedManifestWriter {
+    fn new(cap: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            cap,
+            failure: None,
+        }
+    }
+}
+
+impl io::Write for BoundedManifestWriter {
+    fn write(&mut self, input: &[u8]) -> io::Result<usize> {
+        let attempted = self.bytes.len().checked_add(input.len()).ok_or_else(|| {
+            self.failure = Some(ManifestWriteFailure::Limit {
+                attempted: usize::MAX,
+            });
+            io::Error::other("manifest size overflow")
+        })?;
+        if attempted > self.cap {
+            self.failure = Some(ManifestWriteFailure::Limit { attempted });
+            return Err(io::Error::other("manifest size limit exceeded"));
+        }
+        if attempted > self.bytes.capacity() {
+            let target = attempted
+                .max(self.bytes.capacity().max(4096).saturating_mul(2))
+                .min(self.cap);
+            if self
+                .bytes
+                .try_reserve_exact(target.saturating_sub(self.bytes.len()))
+                .is_err()
+            {
+                self.failure = Some(ManifestWriteFailure::Allocation { attempted });
+                return Err(io::Error::other("manifest allocation failed"));
+            }
+        }
+        self.bytes.extend_from_slice(input);
+        Ok(input.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn encode_manifest_bounded(
+    manifest: &WarmBundleManifestV1,
+    cap: u64,
+) -> Result<Vec<u8>, WarmBundleError> {
+    let cap = usize::try_from(cap).map_err(|_| WarmBundleError::AllocationFailed {
+        role: "manifest",
+        requested: cap,
+    })?;
+    let mut writer = BoundedManifestWriter::new(cap);
+    let result = serde_json::to_writer(&mut writer, manifest)
+        .and_then(|()| io::Write::write_all(&mut writer, b"\n").map_err(serde_json::Error::io));
+    if let Err(error) = result {
+        return match writer.failure {
+            Some(ManifestWriteFailure::Limit { attempted }) => Err(WarmBundleError::FileTooLarge {
+                role: "manifest",
+                actual: u64::try_from(attempted).unwrap_or(u64::MAX),
+                cap: u64::try_from(cap).unwrap_or(u64::MAX),
+            }),
+            Some(ManifestWriteFailure::Allocation { attempted }) => {
+                Err(WarmBundleError::AllocationFailed {
+                    role: "manifest",
+                    requested: u64::try_from(attempted).unwrap_or(u64::MAX),
+                })
+            }
+            None => Err(WarmBundleError::CorruptManifest(error)),
+        };
+    }
+    Ok(writer.bytes)
 }
 
 fn validate_manifest(
@@ -1168,16 +1252,42 @@ enum AtomicRole {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AtomicPublication {
+    Created,
+    Reused,
+    Replaced,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FaultPoint {
     None,
     ArtifactWrite,
     ArtifactFileSync,
     ArtifactRename,
+    #[cfg(test)]
+    ArtifactCancelAfterFileSync,
+    #[cfg(test)]
+    ArtifactCancelAfterRename,
+    #[cfg(test)]
+    ArtifactCancelAfterDirSync,
     ArtifactDirSync,
     ManifestWrite,
     ManifestFileSync,
     ManifestRename,
+    #[cfg(test)]
+    ManifestCancelAfterFileSync,
+    #[cfg(test)]
+    ManifestCancelAfterRename,
+    #[cfg(test)]
+    ManifestCancelAfterDirSync,
     ManifestDirSync,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AtomicBoundary {
+    FileSync,
+    Rename,
+    DirectorySync,
 }
 
 fn stage(role: AtomicRole, ordinal: u8) -> FaultPoint {
@@ -1201,6 +1311,63 @@ fn fail_if(selected: FaultPoint, current: FaultPoint) -> io::Result<()> {
     }
 }
 
+#[cfg(test)]
+fn cancel_at_boundary_if(
+    selected: FaultPoint,
+    role: AtomicRole,
+    boundary: AtomicBoundary,
+) -> Result<(), WarmBundleError> {
+    if matches!(
+        (selected, role, boundary),
+        (
+            FaultPoint::ArtifactCancelAfterFileSync,
+            AtomicRole::Artifact,
+            AtomicBoundary::FileSync
+        ) | (
+            FaultPoint::ArtifactCancelAfterRename,
+            AtomicRole::Artifact,
+            AtomicBoundary::Rename
+        ) | (
+            FaultPoint::ArtifactCancelAfterDirSync,
+            AtomicRole::Artifact,
+            AtomicBoundary::DirectorySync
+        ) | (
+            FaultPoint::ManifestCancelAfterFileSync,
+            AtomicRole::Manifest,
+            AtomicBoundary::FileSync
+        ) | (
+            FaultPoint::ManifestCancelAfterRename,
+            AtomicRole::Manifest,
+            AtomicBoundary::Rename
+        ) | (
+            FaultPoint::ManifestCancelAfterDirSync,
+            AtomicRole::Manifest,
+            AtomicBoundary::DirectorySync
+        )
+    ) {
+        Err(WarmSnapshotBudgetError::Cancelled.into())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(test))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "production and fault-injection builds share the transactional call site"
+)]
+fn cancel_at_boundary_if(
+    _selected: FaultPoint,
+    _role: AtomicRole,
+    _boundary: AtomicBoundary,
+) -> Result<(), WarmBundleError> {
+    Ok(())
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "atomic staging, publication, durability, and rollback form one transaction"
+)]
 fn write_atomic_at(
     directory: &WarmBundleDirectory,
     name: &str,
@@ -1208,10 +1375,11 @@ fn write_atomic_at(
     role: AtomicRole,
     fault: FaultPoint,
     budget: Option<&WarmSnapshotBudget>,
-) -> Result<(), WarmBundleError> {
+) -> Result<AtomicPublication, WarmBundleError> {
     let display = directory.display_path.join(name);
     let (temp_name, mut file) = create_temp(directory, name)?;
-    let result = (|| -> Result<(), WarmBundleError> {
+    let mut committed = None;
+    let result = (|| -> Result<AtomicPublication, WarmBundleError> {
         if let Some(budget) = budget {
             budget.check()?;
         }
@@ -1229,14 +1397,64 @@ fn write_atomic_at(
         fail_if(fault, stage(role, 1)).map_err(|source| io_error(&display, source))?;
         file.sync_all()
             .map_err(|source| io_error(&display, source))?;
+        cancel_at_boundary_if(fault, role, AtomicBoundary::FileSync)?;
         if let Some(budget) = budget {
             budget.check()?;
         }
         drop(file);
         fail_if(fault, stage(role, 2)).map_err(|source| io_error(&display, source))?;
-        renameat(&directory.file, temp_name.as_str(), &directory.file, name)
-            .map_err(errno_io)
-            .map_err(|source| io_error(&display, source))?;
+        let publication = match role {
+            AtomicRole::Artifact => match renameat2(
+                &directory.file,
+                temp_name.as_str(),
+                &directory.file,
+                name,
+                RenameFlags::RENAME_NOREPLACE,
+            ) {
+                Ok(()) => AtomicPublication::Created,
+                Err(Errno::EEXIST) => {
+                    verify_existing_entry(directory, name, bytes, budget)?;
+                    unlinkat(
+                        &directory.file,
+                        temp_name.as_str(),
+                        UnlinkatFlags::NoRemoveDir,
+                    )
+                    .map_err(errno_io)
+                    .map_err(|source| io_error(&display, source))?;
+                    directory
+                        .file
+                        .sync_all()
+                        .map_err(|source| io_error(&display, source))?;
+                    cancel_at_boundary_if(fault, role, AtomicBoundary::DirectorySync)?;
+                    return Ok(AtomicPublication::Reused);
+                }
+                Err(error) => return Err(io_error(&display, errno_io(error))),
+            },
+            AtomicRole::Manifest => match renameat2(
+                &directory.file,
+                temp_name.as_str(),
+                &directory.file,
+                name,
+                RenameFlags::RENAME_EXCHANGE,
+            ) {
+                Ok(()) => AtomicPublication::Replaced,
+                Err(Errno::ENOENT) => {
+                    renameat2(
+                        &directory.file,
+                        temp_name.as_str(),
+                        &directory.file,
+                        name,
+                        RenameFlags::RENAME_NOREPLACE,
+                    )
+                    .map_err(errno_io)
+                    .map_err(|source| io_error(&display, source))?;
+                    AtomicPublication::Created
+                }
+                Err(error) => return Err(io_error(&display, errno_io(error))),
+            },
+        };
+        committed = Some(publication);
+        cancel_at_boundary_if(fault, role, AtomicBoundary::Rename)?;
         if let Some(budget) = budget {
             budget.check()?;
         }
@@ -1245,19 +1463,144 @@ fn write_atomic_at(
             .file
             .sync_all()
             .map_err(|source| io_error(&display, source))?;
+        cancel_at_boundary_if(fault, role, AtomicBoundary::DirectorySync)?;
         if let Some(budget) = budget {
             budget.check()?;
         }
-        Ok(())
+        Ok(publication)
     })();
-    if result.is_err() {
+    let publication = match result {
+        Ok(publication) => publication,
+        Err(error) => {
+            if let Some(publication) = committed
+                && let Err(rollback_error) =
+                    rollback_atomic_destination(directory, name, &temp_name, publication)
+            {
+                return Err(rollback_error);
+            }
+            remove_temporary_entry(directory, &temp_name)?;
+            return Err(error);
+        }
+    };
+    if publication == AtomicPublication::Replaced {
+        // The exchange left the prior complete manifest at the temporary name.
+        // Its cleanup is not part of the new manifest's commit: after the new
+        // directory entry has been synced, failure to remove this hidden backup
+        // must not turn a successful durable commit into an error.
         let _ = unlinkat(
             &directory.file,
             temp_name.as_str(),
             UnlinkatFlags::NoRemoveDir,
         );
+        let _ = directory.file.sync_all();
     }
-    result
+    Ok(publication)
+}
+
+fn verify_existing_entry(
+    directory: &WarmBundleDirectory,
+    name: &str,
+    expected: &[u8],
+    budget: Option<&WarmSnapshotBudget>,
+) -> Result<(), WarmBundleError> {
+    let display = directory.display_path.join(name);
+    let mut file = open_entry(directory, name, "snapshot", OFlag::O_RDONLY, Mode::empty())?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| io_error(&display, source))?;
+    if metadata.len() != u64::try_from(expected.len()).unwrap_or(u64::MAX) {
+        return Err(io_error(
+            &display,
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "existing content-addressed artifact has the wrong length",
+            ),
+        ));
+    }
+    let mut offset = 0usize;
+    let mut chunk = [0u8; STREAM_BUFFER_BYTES];
+    while offset < expected.len() {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        let read = file
+            .read(&mut chunk)
+            .map_err(|source| io_error(&display, source))?;
+        if read == 0 || chunk[..read] != expected[offset..offset + read] {
+            return Err(io_error(
+                &display,
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "existing content-addressed artifact bytes differ",
+                ),
+            ));
+        }
+        offset += read;
+    }
+    Ok(())
+}
+
+fn rollback_atomic_destination(
+    directory: &WarmBundleDirectory,
+    name: &str,
+    temp_name: &str,
+    publication: AtomicPublication,
+) -> Result<(), WarmBundleError> {
+    let display = directory.display_path.join(name);
+    match publication {
+        AtomicPublication::Created => {
+            unlinkat(&directory.file, name, UnlinkatFlags::NoRemoveDir)
+                .map_err(errno_io)
+                .map_err(|source| io_error(&display, source))?;
+        }
+        AtomicPublication::Replaced => {
+            renameat2(
+                &directory.file,
+                temp_name,
+                &directory.file,
+                name,
+                RenameFlags::RENAME_EXCHANGE,
+            )
+            .map_err(errno_io)
+            .map_err(|source| io_error(&display, source))?;
+        }
+        AtomicPublication::Reused => return Ok(()),
+    }
+    directory
+        .file
+        .sync_all()
+        .map_err(|source| io_error(&display, source))?;
+    Ok(())
+}
+
+fn remove_committed_destination(
+    directory: &WarmBundleDirectory,
+    name: &str,
+) -> Result<(), WarmBundleError> {
+    let display = directory.display_path.join(name);
+    match unlinkat(&directory.file, name, UnlinkatFlags::NoRemoveDir) {
+        Ok(()) | Err(Errno::ENOENT) => {}
+        Err(error) => return Err(io_error(&display, errno_io(error))),
+    }
+    directory
+        .file
+        .sync_all()
+        .map_err(|source| io_error(&display, source))
+}
+
+fn remove_temporary_entry(
+    directory: &WarmBundleDirectory,
+    name: &str,
+) -> Result<(), WarmBundleError> {
+    let display = directory.display_path.join(name);
+    match unlinkat(&directory.file, name, UnlinkatFlags::NoRemoveDir) {
+        Ok(()) | Err(Errno::ENOENT) => {}
+        Err(error) => return Err(io_error(&display, errno_io(error))),
+    }
+    directory
+        .file
+        .sync_all()
+        .map_err(|source| io_error(&display, source))
 }
 
 fn create_temp(
@@ -1382,6 +1725,19 @@ mod tests {
         WarmBundleDirectory::open(dir.path()).unwrap()
     }
 
+    fn directory_image(dir: &tempfile::TempDir) -> BTreeMap<String, Vec<u8>> {
+        fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    fs::read(entry.path()).unwrap(),
+                )
+            })
+            .collect()
+    }
+
     #[test]
     fn cancelled_bounded_writer_publishes_no_artifact_or_manifest() {
         let temp = tempfile::tempdir().unwrap();
@@ -1431,6 +1787,42 @@ mod tests {
             0,
             "oversized writer input must not publish an artifact, manifest, or temp file"
         );
+    }
+
+    #[test]
+    fn manifest_serialization_stops_at_the_eight_mib_cap() {
+        let mut id = identity();
+        id.views = (0..=u16::MAX)
+            .map(|suffix| WarmBundleViewV1 {
+                kind: WarmBundleViewKindV1::AdjRibInPrePolicy,
+                peer: IpAddr::V6(Ipv6Addr::from(
+                    0x2001_0db8_0000_0000_0000_0000_0000_0000u128 + u128::from(suffix),
+                )),
+                peer_asn: 64_500,
+                peer_router_id: Ipv4Addr::new(10, 0, 0, 1),
+                family: WarmBundleFamilyV1::Ipv4Unicast,
+                add_path_receive: false,
+            })
+            .collect();
+        let manifest = WarmBundleManifestV1 {
+            format_version: WARM_BUNDLE_FORMAT_VERSION,
+            snapshot: WarmBundleArtifactV1 {
+                path: snapshot_name(SHA),
+                size_bytes: 0,
+                sha256: SHA.to_string(),
+            },
+            view_route_counts: vec![0; id.views.len()],
+            identity: id,
+        };
+
+        assert!(matches!(
+            encode_manifest_bounded(&manifest, MAX_WARM_BUNDLE_MANIFEST_BYTES),
+            Err(WarmBundleError::FileTooLarge {
+                role: "manifest",
+                actual,
+                cap: MAX_WARM_BUNDLE_MANIFEST_BYTES,
+            }) if actual > MAX_WARM_BUNDLE_MANIFEST_BYTES
+        ));
     }
 
     fn record(output: &mut Vec<u8>, subtype: u16, payload: &[u8]) {
@@ -2014,36 +2406,58 @@ mod tests {
     }
 
     #[test]
-    fn every_atomic_failure_has_an_old_or_complete_commit_point() {
+    fn every_atomic_failure_rolls_back_exact_destination_state() {
         for fault in [
             FaultPoint::ArtifactWrite,
             FaultPoint::ArtifactFileSync,
             FaultPoint::ArtifactRename,
+            FaultPoint::ArtifactCancelAfterFileSync,
+            FaultPoint::ArtifactCancelAfterRename,
+            FaultPoint::ArtifactCancelAfterDirSync,
             FaultPoint::ArtifactDirSync,
             FaultPoint::ManifestWrite,
             FaultPoint::ManifestFileSync,
             FaultPoint::ManifestRename,
+            FaultPoint::ManifestCancelAfterFileSync,
+            FaultPoint::ManifestCancelAfterRename,
+            FaultPoint::ManifestCancelAfterDirSync,
             FaultPoint::ManifestDirSync,
         ] {
             let temp = tempfile::tempdir().unwrap();
             let dir = opened(&temp);
             let old = identity();
             publish(&dir, &old);
+            let before = directory_image(&temp);
             let mut next = old.clone();
             next.checkpoint_generation = "boot-42".to_string();
+            next.peer_index_table_view = "boot-42".to_string();
             next.snapshot_revision += 1;
             next.created_at_utc_seconds += 1;
             let result =
                 write_warm_bundle_inner(&dir, next.clone(), &valid_snapshot(&next), fault, None);
             assert!(result.is_err(), "{fault:?}");
-            if fault == FaultPoint::ManifestDirSync {
-                assert!(load_warm_bundle(&dir, &expected(&next), freshness()).is_ok());
-            } else {
-                assert!(
-                    load_warm_bundle(&dir, &expected(&old), freshness()).is_ok(),
-                    "{fault:?}"
-                );
-            }
+            assert_eq!(directory_image(&temp), before, "{fault:?}");
+            assert!(
+                load_warm_bundle(&dir, &expected(&old), freshness()).is_ok(),
+                "{fault:?}"
+            );
+
+            let empty = tempfile::tempdir().unwrap();
+            let empty_dir = opened(&empty);
+            let first = identity();
+            let result = write_warm_bundle_inner(
+                &empty_dir,
+                first.clone(),
+                &valid_snapshot(&first),
+                fault,
+                None,
+            );
+            assert!(result.is_err(), "first publication at {fault:?}");
+            assert_eq!(
+                directory_image(&empty),
+                BTreeMap::new(),
+                "first publication at {fault:?}"
+            );
         }
     }
 

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -268,6 +268,43 @@ impl WarmBundleDirectory {
             display_path: path.to_path_buf(),
         })
     }
+
+    /// Open a single child directory relative to an already pinned parent.
+    ///
+    /// This is used by the daemon to keep the restart marker and bundle below
+    /// the same owner-verified runtime-state directory authority. `name` must
+    /// be exactly one ordinary path component; the child itself is opened with
+    /// `O_NOFOLLOW` and receives the same owner/mode validation as [`Self::open`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or descriptor-relative I/O error.
+    pub fn open_at(
+        parent: &File,
+        parent_display_path: &Path,
+        name: &str,
+    ) -> Result<Self, WarmBundleError> {
+        let component = Path::new(name);
+        if component.components().count() != 1
+            || component.file_name().and_then(|value| value.to_str()) != Some(name)
+            || matches!(name, "" | "." | "..")
+        {
+            return Err(WarmBundleError::InvalidSnapshotPath {
+                path: name.to_string(),
+            });
+        }
+        let display_path = parent_display_path.join(name);
+        let fd = openat(
+            parent,
+            name,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(|source| nix_io(&display_path, source))?;
+        let file = File::from(fd);
+        validate_owner_mode(&file, &display_path, "directory", true)?;
+        Ok(Self { file, display_path })
+    }
 }
 
 /// Warm-bundle storage or validation failure.

--- a/crates/policy/src/engine.rs
+++ b/crates/policy/src/engine.rs
@@ -1327,6 +1327,70 @@ impl PolicyChain {
         self.requires_rpki_validation() || self.requires_aspa_validation()
     }
 
+    /// Canonical, redacted V1 identity for durable warm-checkpoint matching.
+    ///
+    /// The byte framing contains only compiled policy semantics and canonical
+    /// set members. It deliberately omits derived hash indexes, hit counters,
+    /// source paths, and live dataset contents. Policies that depend on RPKI,
+    /// ASPA, or external datasets are not representable in V1 because their
+    /// verdicts cannot be reconstructed from the checkpoint alone.
+    ///
+    /// The framing is versioned and intentionally conservative: a compiler IR
+    /// shape change may force a cold boot after an upgrade, which is safer than
+    /// treating two potentially different policy programs as identical.
+    ///
+    /// # Errors
+    ///
+    /// Returns a static reason when the chain depends on external state.
+    pub fn warm_checkpoint_identity_v1(&self) -> Result<Vec<u8>, &'static str> {
+        use std::fmt::Write as _;
+
+        let compiled = self.compiled();
+        if compiled.requires_validation_state() {
+            return Err("import policy depends on RPKI or ASPA validation state");
+        }
+        if !compiled.datasets.is_empty() {
+            return Err("import policy depends on an external dataset");
+        }
+
+        let mut canonical = String::from("rustbgpd/policy-chain/warm-checkpoint/v1\n");
+        writeln!(canonical, "policies={:?}", compiled.policies)
+            .expect("writing canonical policy identity to String cannot fail");
+        for (index, set) in compiled.prefix_sets.iter().enumerate() {
+            writeln!(canonical, "prefix-set[{index}]={:?}", set.entries())
+                .expect("writing canonical policy identity to String cannot fail");
+        }
+        for (index, set) in compiled.community_sets.iter().enumerate() {
+            writeln!(canonical, "community-set[{index}]={:?}", set.criteria())
+                .expect("writing canonical policy identity to String cannot fail");
+        }
+        for (index, set) in compiled.asn_sets.iter().enumerate() {
+            writeln!(canonical, "asn-set[{index}]={:?}", set.asns())
+                .expect("writing canonical policy identity to String cannot fail");
+        }
+        for (index, regex) in compiled.as_path_regexes.iter().enumerate() {
+            writeln!(canonical, "as-path-regex[{index}]={:?}", regex.pattern())
+                .expect("writing canonical policy identity to String cannot fail");
+        }
+        writeln!(
+            canonical,
+            "prefix-set-names={:?}",
+            compiled.prefix_set_names
+        )
+        .expect("writing canonical policy identity to String cannot fail");
+        writeln!(
+            canonical,
+            "community-set-names={:?}",
+            compiled.community_set_names
+        )
+        .expect("writing canonical policy identity to String cannot fail");
+        writeln!(canonical, "asn-set-names={:?}", compiled.asn_set_names)
+            .expect("writing canonical policy identity to String cannot fail");
+        writeln!(canonical, "local-asn={:?}", compiled.local_asn)
+            .expect("writing canonical policy identity to String cannot fail");
+        Ok(canonical.into_bytes())
+    }
+
     /// Whether some compiled guard probes the named external dataset
     /// (LAN-305). Dataset-swap callers use this exactly like the
     /// RPKI/ASPA `requires_*` gates: a content swap refreshes only the

--- a/crates/policy/src/engine/tests/mod.rs
+++ b/crates/policy/src/engine/tests/mod.rs
@@ -19,6 +19,7 @@ mod prefix;
 mod rpki;
 mod short_circuit;
 mod statement_trace;
+mod warm_checkpoint;
 
 fn v4_prefix(addr: [u8; 4], len: u8) -> Prefix {
     Prefix::V4(Ipv4Prefix::new(

--- a/crates/policy/src/engine/tests/warm_checkpoint.rs
+++ b/crates/policy/src/engine/tests/warm_checkpoint.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[test]
+fn warm_checkpoint_identity_is_deterministic_and_semantic() {
+    let permit = PolicyChain::new(vec![Policy {
+        entries: vec![stmt(
+            Some(v4_prefix([203, 0, 113, 0], 24)),
+            PolicyAction::Permit,
+            vec![],
+        )],
+        default_action: PolicyAction::Deny,
+    }]);
+    let same = permit.clone();
+    let deny = PolicyChain::new(vec![Policy {
+        entries: vec![stmt(
+            Some(v4_prefix([203, 0, 113, 0], 24)),
+            PolicyAction::Deny,
+            vec![],
+        )],
+        default_action: PolicyAction::Deny,
+    }]);
+
+    assert_eq!(
+        permit.warm_checkpoint_identity_v1().unwrap(),
+        same.warm_checkpoint_identity_v1().unwrap()
+    );
+    assert_ne!(
+        permit.warm_checkpoint_identity_v1().unwrap(),
+        deny.warm_checkpoint_identity_v1().unwrap()
+    );
+}
+
+#[test]
+fn warm_checkpoint_identity_rejects_validation_dependent_policy() {
+    let mut validation_statement = stmt(None, PolicyAction::Permit, vec![]);
+    validation_statement.match_rpki_validation = Some(RpkiValidation::Valid);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![validation_statement],
+        default_action: PolicyAction::Deny,
+    }]);
+
+    let error = chain.warm_checkpoint_identity_v1().unwrap_err();
+    assert!(error.contains("RPKI or ASPA"), "{error}");
+}

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -72,6 +72,6 @@ pub use update::{
     RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
     SelectionDeferralPeerFamilyState, UpdateGroupClassification, UpdateGroupClassifierInput,
     UpdateGroupFamilyImpact, UpdateGroupFingerprint, UpdateGroupImpactPlan,
-    UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotView,
-    classify_update_group, route_query_key,
+    UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotBudget,
+    WarmMrtSnapshotView, classify_update_group, route_query_key,
 };

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -72,6 +72,6 @@ pub use update::{
     RibCommandError, RibUpdate, RoutePage, RouteQueryFilter, RouteQueryKey, RouteQueryScope,
     SelectionDeferralPeerFamilyState, UpdateGroupClassification, UpdateGroupClassifierInput,
     UpdateGroupFamilyImpact, UpdateGroupFingerprint, UpdateGroupImpactPlan,
-    UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, classify_update_group,
-    route_query_key,
+    UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotView,
+    classify_update_group, route_query_key,
 };

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -30,7 +30,8 @@ use crate::loc_rib::LocRib;
 use crate::update::{
     BestPathCandidate, ExactExportEncoder, ExactExportKey, ExplainAdvertisedRoute, ExplainBestPath,
     MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OutboundRouteUpdate, RibUpdate, RoutePage,
-    RouteQueryFilter, RouteQueryKey, RouteQueryScope, WarmMrtSnapshotView, route_query_key,
+    RouteQueryFilter, RouteQueryKey, RouteQueryScope, WarmMrtSnapshotBudget, WarmMrtSnapshotView,
+    route_query_key,
 };
 
 use helpers::{
@@ -1665,8 +1666,12 @@ impl RibManager {
             }
             RibUpdate::QueryOrrStatus { reply } => self.handle_query_orr_status(reply),
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
-            RibUpdate::QueryWarmMrtSnapshot { views, reply } => {
-                self.handle_query_warm_mrt_snapshot(&views, reply);
+            RibUpdate::QueryWarmMrtSnapshot {
+                views,
+                budget,
+                reply,
+            } => {
+                self.handle_query_warm_mrt_snapshot(&views, &budget, reply);
             }
             RibUpdate::QueryBmpLocRibDump { cursor, reply } => {
                 self.handle_query_bmp_loc_rib_dump(cursor, reply);
@@ -3686,9 +3691,10 @@ impl RibManager {
     fn handle_query_warm_mrt_snapshot(
         &mut self,
         views: &[WarmMrtSnapshotView],
+        budget: &WarmMrtSnapshotBudget,
         reply: tokio::sync::oneshot::Sender<Result<MrtSnapshotData, String>>,
     ) {
-        let result = self.build_warm_mrt_snapshot(views);
+        let result = self.build_warm_mrt_snapshot(views, budget);
         if reply.send(result).is_err() {
             warn!("warm MRT snapshot query caller dropped before receiving response");
         }
@@ -3710,7 +3716,9 @@ impl RibManager {
     fn build_warm_mrt_snapshot(
         &self,
         views: &[WarmMrtSnapshotView],
+        budget: &WarmMrtSnapshotBudget,
     ) -> Result<MrtSnapshotData, String> {
+        budget.check()?;
         if views.is_empty() {
             return Err("warm checkpoint has no eligible peer/family views".to_string());
         }
@@ -3726,6 +3734,7 @@ impl RibManager {
         let mut peer_identity = HashMap::<IpAddr, (u64, u32, Ipv4Addr)>::new();
         let mut families = HashMap::<IpAddr, HashSet<(Afi, Safi)>>::new();
         for view in views {
+            budget.check()?;
             if !matches!(
                 (view.afi, view.safi),
                 (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast) | (Afi::L2Vpn, Safi::Evpn)
@@ -3758,6 +3767,7 @@ impl RibManager {
         }
 
         for (&peer, &(session_id, peer_asn, peer_router_id)) in &peer_identity {
+            budget.check()?;
             if self.outbound_session_ids.get(&peer).copied() != Some(session_id) {
                 return Err(format!(
                     "peer {peer} changed active session during warm checkpoint"
@@ -3785,32 +3795,97 @@ impl RibManager {
             .collect();
         peers.sort_by_key(|peer| peer.peer_addr);
 
-        let routes = self
-            .ribs
-            .values()
-            .flat_map(crate::adj_rib_in::AdjRibIn::iter)
-            .filter(|route| {
-                let family = match route.prefix {
-                    Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
-                    Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
-                };
-                families
-                    .get(&route.peer)
-                    .is_some_and(|allowed| allowed.contains(&family))
+        let route_is_allowed = |route: &crate::route::Route| {
+            let family = match route.prefix {
+                Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
+                Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
+            };
+            families
+                .get(&route.peer)
+                .is_some_and(|allowed| allowed.contains(&family))
+        };
+        let evpn_is_allowed = |route: &crate::route::EvpnRibRoute| {
+            families
+                .get(&route.peer)
+                .is_some_and(|allowed| allowed.contains(&(Afi::L2Vpn, Safi::Evpn)))
+        };
+
+        // Count and bound every owned allocation before cloning even one
+        // route. Route attributes and interface names are Arc-backed; the
+        // only clone-side allocation outside the Vec buffers is the optional
+        // boxed next-hop scope, accounted explicitly below.
+        let mut route_count = 0usize;
+        let mut boxed_scope_count = 0usize;
+        let mut evpn_count = 0usize;
+        for rib in self.ribs.values() {
+            for route in rib.iter() {
+                budget.check()?;
+                if route_is_allowed(route) {
+                    route_count = route_count
+                        .checked_add(1)
+                        .ok_or_else(|| "warm checkpoint route count overflow".to_string())?;
+                    boxed_scope_count = boxed_scope_count
+                        .checked_add(usize::from(route.next_hop_scope.is_some()))
+                        .ok_or_else(|| "warm checkpoint route scope count overflow".to_string())?;
+                }
+            }
+            for route in rib.iter_evpn() {
+                budget.check()?;
+                if evpn_is_allowed(route) {
+                    evpn_count = evpn_count
+                        .checked_add(1)
+                        .ok_or_else(|| "warm checkpoint EVPN route count overflow".to_string())?;
+                }
+            }
+        }
+        let materialized_bytes = peers
+            .len()
+            .checked_mul(std::mem::size_of::<MrtPeerEntry>())
+            .and_then(|bytes| {
+                route_count
+                    .checked_mul(std::mem::size_of::<crate::route::Route>())
+                    .and_then(|routes| bytes.checked_add(routes))
             })
-            .cloned()
-            .collect();
-        let evpn_routes = self
-            .ribs
-            .values()
-            .flat_map(crate::adj_rib_in::AdjRibIn::iter_evpn)
-            .filter(|route| {
-                families
-                    .get(&route.peer)
-                    .is_some_and(|allowed| allowed.contains(&(Afi::L2Vpn, Safi::Evpn)))
+            .and_then(|bytes| {
+                boxed_scope_count
+                    .checked_mul(std::mem::size_of::<crate::route::NextHopScope>())
+                    .and_then(|scopes| bytes.checked_add(scopes))
             })
-            .cloned()
-            .collect();
+            .and_then(|bytes| {
+                evpn_count
+                    .checked_mul(std::mem::size_of::<crate::route::EvpnRibRoute>())
+                    .and_then(|routes| bytes.checked_add(routes))
+            })
+            .ok_or_else(|| "warm checkpoint materialized size overflow".to_string())?;
+        if materialized_bytes > budget.max_materialized_bytes {
+            return Err(format!(
+                "warm checkpoint needs {materialized_bytes} materialized bytes, exceeding the {}-byte cap",
+                budget.max_materialized_bytes
+            ));
+        }
+
+        let mut routes = Vec::new();
+        routes.try_reserve_exact(route_count).map_err(|_| {
+            format!("failed to reserve {route_count} warm checkpoint unicast routes")
+        })?;
+        let mut evpn_routes = Vec::new();
+        evpn_routes
+            .try_reserve_exact(evpn_count)
+            .map_err(|_| format!("failed to reserve {evpn_count} warm checkpoint EVPN routes"))?;
+        for rib in self.ribs.values() {
+            for route in rib.iter() {
+                budget.check()?;
+                if route_is_allowed(route) {
+                    routes.push(route.clone());
+                }
+            }
+            for route in rib.iter_evpn() {
+                budget.check()?;
+                if evpn_is_allowed(route) {
+                    evpn_routes.push(route.clone());
+                }
+            }
+        }
 
         Ok(MrtSnapshotData {
             peers,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -30,7 +30,7 @@ use crate::loc_rib::LocRib;
 use crate::update::{
     BestPathCandidate, ExactExportEncoder, ExactExportKey, ExplainAdvertisedRoute, ExplainBestPath,
     MrtPeerEntry, MrtSnapshotData, NeighborPolicyStats, OutboundRouteUpdate, RibUpdate, RoutePage,
-    RouteQueryFilter, RouteQueryKey, RouteQueryScope, route_query_key,
+    RouteQueryFilter, RouteQueryKey, RouteQueryScope, WarmMrtSnapshotView, route_query_key,
 };
 
 use helpers::{
@@ -1665,6 +1665,9 @@ impl RibManager {
             }
             RibUpdate::QueryOrrStatus { reply } => self.handle_query_orr_status(reply),
             RibUpdate::QueryMrtSnapshot { reply } => self.handle_query_mrt_snapshot(reply),
+            RibUpdate::QueryWarmMrtSnapshot { views, reply } => {
+                self.handle_query_warm_mrt_snapshot(&views, reply);
+            }
             RibUpdate::QueryBmpLocRibDump { cursor, reply } => {
                 self.handle_query_bmp_loc_rib_dump(cursor, reply);
             }
@@ -3678,6 +3681,137 @@ impl RibManager {
         if reply.send(snapshot).is_err() {
             warn!("MRT snapshot query caller dropped before receiving response");
         }
+    }
+
+    fn handle_query_warm_mrt_snapshot(
+        &mut self,
+        views: &[WarmMrtSnapshotView],
+        reply: tokio::sync::oneshot::Sender<Result<MrtSnapshotData, String>>,
+    ) {
+        let result = self.build_warm_mrt_snapshot(views);
+        if reply.send(result).is_err() {
+            warn!("warm MRT snapshot query caller dropped before receiving response");
+        }
+    }
+
+    /// Build a route snapshot and verify the exact active session inventory in
+    /// one RIB-actor turn. The supplied views came from the peer-manager actor;
+    /// session generation/ASN/router-ID checks close replacement races between
+    /// those two captures. Any mismatch rejects the complete checkpoint.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one actor turn validates the complete identity fence and captures every supported route view"
+    )]
+    fn build_warm_mrt_snapshot(
+        &self,
+        views: &[WarmMrtSnapshotView],
+    ) -> Result<MrtSnapshotData, String> {
+        if views.is_empty() {
+            return Err("warm checkpoint has no eligible peer/family views".to_string());
+        }
+        if views
+            .windows(2)
+            .any(|pair| pair[0].sort_key() >= pair[1].sort_key())
+        {
+            return Err(
+                "warm checkpoint views must be strictly sorted and duplicate-free".to_string(),
+            );
+        }
+
+        let mut peer_identity = HashMap::<IpAddr, (u64, u32, Ipv4Addr)>::new();
+        let mut families = HashMap::<IpAddr, HashSet<(Afi, Safi)>>::new();
+        for view in views {
+            if !matches!(
+                (view.afi, view.safi),
+                (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast) | (Afi::L2Vpn, Safi::Evpn)
+            ) {
+                return Err(format!(
+                    "warm checkpoint view for {} uses unsupported family {:?}/{:?}",
+                    view.peer, view.afi, view.safi
+                ));
+            }
+            let identity = (view.session_id, view.peer_asn, view.peer_router_id);
+            if peer_identity
+                .insert(view.peer, identity)
+                .is_some_and(|prior| prior != identity)
+            {
+                return Err(format!(
+                    "warm checkpoint views disagree on identity for peer {}",
+                    view.peer
+                ));
+            }
+            if !families
+                .entry(view.peer)
+                .or_default()
+                .insert((view.afi, view.safi))
+            {
+                return Err(format!(
+                    "warm checkpoint repeats family {:?}/{:?} for peer {}",
+                    view.afi, view.safi, view.peer
+                ));
+            }
+        }
+
+        for (&peer, &(session_id, peer_asn, peer_router_id)) in &peer_identity {
+            if self.outbound_session_ids.get(&peer).copied() != Some(session_id) {
+                return Err(format!(
+                    "peer {peer} changed active session during warm checkpoint"
+                ));
+            }
+            if self.peer_asn.get(&peer).copied() != Some(peer_asn) {
+                return Err(format!(
+                    "peer {peer} changed negotiated ASN during warm checkpoint"
+                ));
+            }
+            if self.peer_bgp_id.get(&peer).copied() != Some(peer_router_id) {
+                return Err(format!(
+                    "peer {peer} changed BGP identifier during warm checkpoint"
+                ));
+            }
+        }
+
+        let mut peers: Vec<_> = peer_identity
+            .iter()
+            .map(|(&peer_addr, &(_, peer_asn, peer_bgp_id))| MrtPeerEntry {
+                peer_addr,
+                peer_bgp_id,
+                peer_asn,
+            })
+            .collect();
+        peers.sort_by_key(|peer| peer.peer_addr);
+
+        let routes = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter)
+            .filter(|route| {
+                let family = match route.prefix {
+                    Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
+                    Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
+                };
+                families
+                    .get(&route.peer)
+                    .is_some_and(|allowed| allowed.contains(&family))
+            })
+            .cloned()
+            .collect();
+        let evpn_routes = self
+            .ribs
+            .values()
+            .flat_map(crate::adj_rib_in::AdjRibIn::iter_evpn)
+            .filter(|route| {
+                families
+                    .get(&route.peer)
+                    .is_some_and(|allowed| allowed.contains(&(Afi::L2Vpn, Safi::Evpn)))
+            })
+            .cloned()
+            .collect();
+
+        Ok(MrtSnapshotData {
+            peers,
+            routes,
+            evpn_routes,
+        })
     }
 
     /// Run the RIB manager event loop until the channel is closed.

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -3698,6 +3698,11 @@ impl RibManager {
     /// one RIB-actor turn. The supplied views came from the peer-manager actor;
     /// session generation/ASN/router-ID checks close replacement races between
     /// those two captures. Any mismatch rejects the complete checkpoint.
+    ///
+    /// This is an actor-ordered snapshot, not a global transport quiescence
+    /// barrier: UPDATEs the RIB actor processes before this query are included;
+    /// UPDATEs arriving later are not. On a later restore tranche, ordinary GR
+    /// stale-route reconciliation remains authoritative for that bounded edge.
     #[expect(
         clippy::too_many_lines,
         reason = "one actor turn validates the complete identity fence and captures every supported route view"

--- a/crates/rib/src/manager/tests/explain_mrt.rs
+++ b/crates/rib/src/manager/tests/explain_mrt.rs
@@ -119,6 +119,105 @@ async fn warm_mrt_snapshot_excludes_routes_for_family_outside_exact_view() {
 }
 
 #[tokio::test]
+async fn cancelled_warm_mrt_snapshot_fails_fast_without_wedging_actor() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(true));
+
+    let error = query_warm_mrt_snapshot_with_budget(
+        &tx,
+        Vec::new(),
+        crate::update::WarmMrtSnapshotBudget {
+            deadline: std::time::Instant::now() + Duration::from_secs(30),
+            cancelled,
+            max_materialized_bytes: 512 * 1024 * 1024,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.contains("cancelled"), "{error}");
+
+    // A following actor query must still complete; cancellation is scoped to
+    // the abandoned checkpoint and cannot wedge the single-threaded actor.
+    let snapshot = query_mrt_snapshot(&tx).await;
+    assert!(snapshot.routes.is_empty());
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn warm_mrt_snapshot_rejects_materialization_before_route_clone() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_router_id = Ipv4Addr::new(192, 0, 2, 1);
+    let (out_tx, _out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 42,
+        peer,
+        peer_asn: 65002,
+        peer_router_id,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 42,
+        peer,
+        announced: vec![make_route(
+            Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+            Ipv4Addr::new(10, 0, 0, 1),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let error = query_warm_mrt_snapshot_with_budget(
+        &tx,
+        vec![crate::update::WarmMrtSnapshotView {
+            peer,
+            session_id: 42,
+            peer_asn: 65002,
+            peer_router_id,
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            add_path_receive: false,
+        }],
+        crate::update::WarmMrtSnapshotBudget {
+            deadline: std::time::Instant::now() + Duration::from_secs(30),
+            cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_materialized_bytes: 0,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(error.contains("materialized bytes"), "{error}");
+
+    let snapshot = query_mrt_snapshot(&tx).await;
+    assert_eq!(snapshot.routes.len(), 1, "actor remained responsive");
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
 async fn mrt_snapshot_uses_adj_rib_in_routes_without_loc_rib_duplication() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());

--- a/crates/rib/src/manager/tests/explain_mrt.rs
+++ b/crates/rib/src/manager/tests/explain_mrt.rs
@@ -1,6 +1,124 @@
 use super::*;
 
 #[tokio::test]
+async fn warm_mrt_snapshot_rejects_session_generation_change_at_rib_fence() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_router_id = Ipv4Addr::new(192, 0, 2, 1);
+    let (out_tx, _out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 42,
+        peer,
+        peer_asn: 65002,
+        peer_router_id,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let error = query_warm_mrt_snapshot(
+        &tx,
+        vec![crate::update::WarmMrtSnapshotView {
+            peer,
+            session_id: 41,
+            peer_asn: 65002,
+            peer_router_id,
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            add_path_receive: false,
+        }],
+    )
+    .await
+    .unwrap_err();
+    assert!(error.contains("changed active session"), "{error}");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn warm_mrt_snapshot_excludes_routes_for_family_outside_exact_view() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let peer_router_id = Ipv4Addr::new(192, 0, 2, 1);
+    let (out_tx, _out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 42,
+        peer,
+        peer_asn: 65002,
+        peer_router_id,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let v4 = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let mut v6 = make_v6_route(
+        Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32),
+        "2001:db8::1".parse().unwrap(),
+    );
+    v6.peer = peer;
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 42,
+        peer,
+        announced: vec![make_route(v4, Ipv4Addr::new(10, 0, 0, 1)), v6],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let snapshot = query_warm_mrt_snapshot(
+        &tx,
+        vec![crate::update::WarmMrtSnapshotView {
+            peer,
+            session_id: 42,
+            peer_asn: 65002,
+            peer_router_id,
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            add_path_receive: false,
+        }],
+    )
+    .await
+    .unwrap();
+    assert_eq!(snapshot.routes.len(), 1);
+    assert_eq!(snapshot.routes[0].prefix, Prefix::V4(v4));
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
 async fn mrt_snapshot_uses_adj_rib_in_routes_without_loc_rib_duplication() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -392,9 +392,27 @@ async fn query_warm_mrt_snapshot(
     tx: &mpsc::Sender<RibUpdate>,
     views: Vec<crate::update::WarmMrtSnapshotView>,
 ) -> Result<crate::update::MrtSnapshotData, String> {
+    query_warm_mrt_snapshot_with_budget(
+        tx,
+        views,
+        crate::update::WarmMrtSnapshotBudget {
+            deadline: std::time::Instant::now() + Duration::from_secs(30),
+            cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_materialized_bytes: 512 * 1024 * 1024,
+        },
+    )
+    .await
+}
+
+async fn query_warm_mrt_snapshot_with_budget(
+    tx: &mpsc::Sender<RibUpdate>,
+    views: Vec<crate::update::WarmMrtSnapshotView>,
+    budget: crate::update::WarmMrtSnapshotBudget,
+) -> Result<crate::update::MrtSnapshotData, String> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryWarmMrtSnapshot {
         views,
+        budget,
         reply: reply_tx,
     })
     .await

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -388,6 +388,20 @@ async fn query_mrt_snapshot(tx: &mpsc::Sender<RibUpdate>) -> crate::update::MrtS
     reply_rx.await.unwrap()
 }
 
+async fn query_warm_mrt_snapshot(
+    tx: &mpsc::Sender<RibUpdate>,
+    views: Vec<crate::update::WarmMrtSnapshotView>,
+) -> Result<crate::update::MrtSnapshotData, String> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::QueryWarmMrtSnapshot {
+        views,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap()
+}
+
 async fn query_flowspec_routes(tx: &mpsc::Sender<RibUpdate>) -> Vec<FlowSpecRoute> {
     let (reply_tx, reply_rx) = oneshot::channel();
     tx.send(RibUpdate::QueryFlowSpecRoutes { reply: reply_tx })

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1683,6 +1683,15 @@ pub enum RibUpdate {
         /// Response channel.
         reply: oneshot::Sender<MrtSnapshotData>,
     },
+    /// Query one actor-consistent, session-fenced Adj-RIB-In snapshot for a
+    /// shutdown warm checkpoint. The caller supplies the exact PM/session
+    /// inventory; any mismatch rejects the complete snapshot.
+    QueryWarmMrtSnapshot {
+        /// Strictly sorted, duplicate-free eligible view inventory.
+        views: Vec<WarmMrtSnapshotView>,
+        /// Response channel. `Err` is a fail-closed checkpoint result.
+        reply: oneshot::Sender<Result<MrtSnapshotData, String>>,
+    },
     /// One bounded chunk of an RFC 9069 Loc-RIB table dump for a
     /// (re)connected BMP collector: synthesize at most one chunk of
     /// UPDATE PDUs (unicast + VPN bests, resumed from `cursor`) with
@@ -1729,4 +1738,39 @@ pub struct MrtSnapshotData {
     /// `RIB_GENERIC` records (AFI 25 / SAFI 70). Empty for non-EVPN
     /// deployments.
     pub evpn_routes: Vec<crate::route::EvpnRibRoute>,
+}
+
+/// One exact peer/family/session view requested for a warm MRT snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmMrtSnapshotView {
+    /// Configured numbered peer address.
+    pub peer: IpAddr,
+    /// Peer-manager generation of the active session.
+    pub session_id: u64,
+    /// Remote ASN negotiated by that session.
+    pub peer_asn: u32,
+    /// Remote BGP identifier negotiated by that session.
+    pub peer_router_id: Ipv4Addr,
+    /// Exact supported family.
+    pub afi: Afi,
+    /// Exact supported SAFI.
+    pub safi: Safi,
+    /// Whether Add-Path receive/both was negotiated for this view.
+    pub add_path_receive: bool,
+}
+
+impl WarmMrtSnapshotView {
+    /// Stable ordering key independent of enum declaration order.
+    #[must_use]
+    pub fn sort_key(&self) -> (IpAddr, u16, u8, u64, u32, Ipv4Addr, bool) {
+        (
+            self.peer,
+            self.afi as u16,
+            self.safi as u8,
+            self.session_id,
+            self.peer_asn,
+            self.peer_router_id,
+            self.add_path_receive,
+        )
+    }
 }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rpki::{AspaTable, VrpTable};
@@ -1689,6 +1691,11 @@ pub enum RibUpdate {
     QueryWarmMrtSnapshot {
         /// Strictly sorted, duplicate-free eligible view inventory.
         views: Vec<WarmMrtSnapshotView>,
+        /// Cooperative cancellation/deadline and pre-materialization limit.
+        /// The RIB actor checks this while counting and cloning routes so a
+        /// timed-out shutdown query cannot wedge the actor behind a full-table
+        /// synchronous snapshot.
+        budget: WarmMrtSnapshotBudget,
         /// Response channel. `Err` is a fail-closed checkpoint result.
         reply: oneshot::Sender<Result<MrtSnapshotData, String>>,
     },
@@ -1738,6 +1745,40 @@ pub struct MrtSnapshotData {
     /// `RIB_GENERIC` records (AFI 25 / SAFI 70). Empty for non-EVPN
     /// deployments.
     pub evpn_routes: Vec<crate::route::EvpnRibRoute>,
+}
+
+/// Bounded work contract for a shutdown warm snapshot.
+///
+/// `deadline` is checked inside the synchronous RIB actor loop. `cancelled`
+/// additionally lets a caller whose async wait was dropped stop an in-flight
+/// actor query from another runtime worker. `max_materialized_bytes` bounds the
+/// exact owned route-vector storage reserved before any route clone occurs.
+#[derive(Debug, Clone)]
+pub struct WarmMrtSnapshotBudget {
+    /// Monotonic terminal deadline shared with the shutdown coordinator.
+    pub deadline: Instant,
+    /// Set when the waiting coordinator is cancelled or times out.
+    pub cancelled: Arc<AtomicBool>,
+    /// Hard cap for owned snapshot vector storage.
+    pub max_materialized_bytes: usize,
+}
+
+impl WarmMrtSnapshotBudget {
+    /// Fail closed before or during synchronous actor work.
+    ///
+    /// # Errors
+    ///
+    /// Returns a bounded diagnostic when the caller cancelled the query or
+    /// the shared terminal deadline has elapsed.
+    pub fn check(&self) -> Result<(), String> {
+        if self.cancelled.load(Ordering::Acquire) {
+            return Err("warm checkpoint snapshot was cancelled".to_string());
+        }
+        if Instant::now() >= self.deadline {
+            return Err("warm checkpoint snapshot exceeded its terminal deadline".to_string());
+        }
+        Ok(())
+    }
 }
 
 /// One exact peer/family/session view requested for a warm MRT snapshot.

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -276,6 +276,13 @@ pub enum PeerCommand {
         /// Oneshot channel to receive the session state snapshot.
         reply: oneshot::Sender<PeerSessionState>,
     },
+    /// Query the negotiated identity needed by a coordinated warm checkpoint.
+    /// This is separate from operator state so checkpoint-only fields do not
+    /// silently become a public API contract.
+    QueryWarmCheckpointState {
+        /// Oneshot channel to receive one actor-consistent negotiation view.
+        reply: oneshot::Sender<WarmCheckpointSessionState>,
+    },
     /// Send a ROUTE-REFRESH message to the peer (RFC 2918).
     SendRouteRefresh {
         /// Address Family Identifier.
@@ -482,6 +489,28 @@ pub struct PeerSessionState {
     pub import_policy_routes_permitted: u64,
     /// Import policy evaluations that denied a route.
     pub import_policy_routes_denied: u64,
+}
+
+/// Actor-consistent negotiated session identity used only while publishing a
+/// shutdown warm checkpoint. No route or restore behavior lives here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmCheckpointSessionState {
+    /// Current FSM state; only `Established` is checkpoint-eligible.
+    pub fsm_state: SessionState,
+    /// Peer's ASN learned from the current OPEN exchange.
+    pub peer_asn: Option<u32>,
+    /// Peer's BGP identifier learned from the current OPEN exchange.
+    pub peer_router_id: Option<Ipv4Addr>,
+    /// Address families negotiated on the current session.
+    pub negotiated_families: Vec<(Afi, Safi)>,
+    /// GR families advertised by the current peer OPEN.
+    pub peer_gr_families: Vec<(Afi, Safi)>,
+    /// Whether the current peer OPEN advertised usable GR capability.
+    pub peer_gr_capable: bool,
+    /// Restart time advertised in the current peer GR capability.
+    pub peer_gr_restart_time: u16,
+    /// Families for which this session negotiated Add-Path receive/both.
+    pub add_path_receive_families: Vec<(Afi, Safi)>,
 }
 
 /// Handle for controlling a spawned peer session.
@@ -1238,6 +1267,28 @@ impl PeerHandle {
             let (reply_tx, reply_rx) = oneshot::channel();
             commands
                 .send(PeerCommand::QueryState { reply: reply_tx })
+                .await
+                .ok()?;
+            reply_rx.await.ok()
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    /// Bounded checkpoint-only query for current negotiated GR/Add-Path truth.
+    ///
+    /// Returns `None` on timeout, channel closure, or session exit. Callers
+    /// must reject the complete checkpoint rather than publishing a partial
+    /// peer inventory when any candidate cannot answer.
+    pub async fn query_warm_checkpoint_state_with(
+        commands: mpsc::Sender<PeerCommand>,
+        deadline: Duration,
+    ) -> Option<WarmCheckpointSessionState> {
+        tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::QueryWarmCheckpointState { reply: reply_tx })
                 .await
                 .ok()?;
             reply_rx.await.ok()

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -40,6 +40,7 @@ pub use handle::{
     ImportPolicyTermHits, PeerCommand, PeerCommandError, PeerHandle, PeerSessionState,
     PeerShutdownError, SessionIdentity, SessionLifecycleNotification, SessionNotification,
     SessionNotificationDirection, SessionNotificationEvent, SessionRole, StateQueryOutcome,
+    WarmCheckpointSessionState,
 };
 pub use listener::{
     AcceptedConnection, BgpListener, ListenerSocketOptions, TcpAoListenerGeneration,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -3,7 +3,7 @@ use super::{
     RibUpdate, RouteRefreshMessage, Safi, SessionNotificationDirection, SessionState,
     cease_subcode, debug, info, warn,
 };
-use crate::handle::PeerCommandError;
+use crate::handle::{PeerCommandError, WarmCheckpointSessionState};
 
 struct TcpAoSessionAddOnlyPlan {
     connected_peer: std::net::IpAddr,
@@ -486,6 +486,52 @@ impl PeerSession {
                     last_error: self.last_error.clone(),
                     tcp_ao_info: self.tcp_ao_info.clone().map(Box::new),
                     tcp_ao_protected: self.tcp_ao_protected,
+                };
+                let _ = reply.send(state);
+                ControlFlow::Continue(())
+            }
+            PeerCommand::QueryWarmCheckpointState { reply } => {
+                let neg = self.fsm.negotiated().or(self.negotiated.as_ref());
+                let mut negotiated_families = neg
+                    .map(|negotiated| negotiated.negotiated_families.clone())
+                    .unwrap_or_default();
+                negotiated_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                let mut peer_gr_families = neg
+                    .map(|negotiated| {
+                        negotiated
+                            .peer_gr_families
+                            .iter()
+                            .map(|family| (family.afi, family.safi))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                peer_gr_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                let mut add_path_receive_families = neg
+                    .map(|negotiated| {
+                        negotiated
+                            .add_path_families
+                            .iter()
+                            .filter_map(|(family, mode)| {
+                                matches!(
+                                    mode,
+                                    rustbgpd_wire::AddPathMode::Receive
+                                        | rustbgpd_wire::AddPathMode::Both
+                                )
+                                .then_some(*family)
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                add_path_receive_families.sort_by_key(|(afi, safi)| (*afi as u16, *safi as u8));
+                let state = WarmCheckpointSessionState {
+                    fsm_state: self.fsm.state(),
+                    peer_asn: neg.map(|negotiated| negotiated.peer_asn),
+                    peer_router_id: neg.map(|negotiated| negotiated.peer_router_id),
+                    negotiated_families,
+                    peer_gr_families,
+                    peer_gr_capable: neg.is_some_and(|negotiated| negotiated.peer_gr_capable),
+                    peer_gr_restart_time: neg.map_or(0, |negotiated| negotiated.peer_restart_time),
+                    add_path_receive_families,
                 };
                 let _ = reply.send(state);
                 ControlFlow::Continue(())

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -297,6 +297,61 @@ async fn query_state_sorts_both_paths_limit_vectors_by_numeric_family() {
     );
 }
 
+#[tokio::test]
+async fn warm_checkpoint_query_uses_current_gr_and_add_path_receive_direction() {
+    let mut session = make_test_session(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![
+        (Afi::Ipv6, Safi::Unicast),
+        (Afi::Ipv4, Safi::Unicast),
+        (Afi::L2Vpn, Safi::Evpn),
+    ];
+    negotiated.peer_gr_capable = true;
+    negotiated.peer_restart_time = 120;
+    negotiated.peer_gr_families = vec![rustbgpd_wire::GracefulRestartFamily {
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+        forwarding_preserved: true,
+    }];
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Receive);
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv6, Safi::Unicast), AddPathMode::Send);
+    negotiated
+        .add_path_families
+        .insert((Afi::L2Vpn, Safi::Evpn), AddPathMode::Both);
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let (reply, state) = oneshot::channel();
+    assert!(matches!(
+        session
+            .handle_command(PeerCommand::QueryWarmCheckpointState { reply })
+            .await,
+        ControlFlow::Continue(())
+    ));
+    let state = state.await.unwrap();
+
+    assert_eq!(state.peer_asn, Some(65002));
+    assert_eq!(state.peer_router_id, Some(Ipv4Addr::new(10, 0, 0, 2)));
+    assert!(state.peer_gr_capable);
+    assert_eq!(state.peer_gr_restart_time, 120);
+    assert_eq!(
+        state.negotiated_families,
+        vec![
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv6, Safi::Unicast),
+            (Afi::L2Vpn, Safi::Evpn),
+        ]
+    );
+    assert_eq!(state.peer_gr_families, vec![(Afi::Ipv4, Safi::Unicast)]);
+    assert_eq!(
+        state.add_path_receive_families,
+        vec![(Afi::Ipv4, Safi::Unicast), (Afi::L2Vpn, Safi::Evpn),]
+    );
+}
+
 fn make_bgpls_route(payload_tag: u8) -> rustbgpd_rib::BgpLsRibRoute {
     let nlri = decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, payload_tag])
         .expect("fixture BGP-LS NLRI decodes")

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -547,7 +547,7 @@ impl EvpnRoute {
 ///
 /// EAD per-ES and EAD per-EVI share a wire format but get distinct variants
 /// here so the RIB never accidentally collapses them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum EvpnRouteKey {
     /// Type 1 per-ES key.
     EadPerEs {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,7 +114,8 @@ Required. Defines the local BGP speaker identity.
 | `listen_port`       | u16    | yes      | --                   | TCP port to listen on (typically 179) |
 | `dynamic_neighbor_limit` | u32 | no     | `100`                | Maximum number of auto-accepted dynamic peers (1--5000) |
 | `worker_threads`    | usize  | no       | `min(cores, 8)`      | Tokio runtime worker threads. Unset caps to `min(CPU parallelism, 8)` to avoid over-provisioning the async runtime (one worker + stack reservation per core) on a high-core host for this I/O-bound daemon — reduces virtual-address reservation and scheduler footprint (RSS-neutral in benchmarks). `0` means unset. `RUSTBGPD_WORKER_THREADS` overrides. **Restart-required** (runtime built once at startup). |
-| `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker today) |
+| `runtime_state_dir` | string | no       | `"/var/lib/rustbgpd"` | Directory for daemon-owned runtime state (GR restart marker, optional warm checkpoint, FIB ownership receipt, and gRPC socket) |
+| `warm_cache_checkpoint_on_shutdown` | bool | no | `false`             | Publish a bounded daemon-private routing checkpoint during coordinated shutdown. **Restart-required.** Publication only; startup does not restore routes. |
 | `cluster_id`        | string | no       | --                    | Route reflector cluster ID (must be valid IPv4; enables RR mode) |
 | `honor_graceful_shutdown` | bool | no  | `false`              | Enable RFC 8326 §4 receiver behavior on EBGP imports — see below |
 | `honor_blackhole`   | bool   | no       | `false`              | Enable RFC 7999 receiver scoping on EBGP imports — see below |
@@ -129,6 +130,7 @@ asn = 65001
 router_id = "10.0.0.1"
 listen_port = 179
 runtime_state_dir = "/var/lib/rustbgpd"
+warm_cache_checkpoint_on_shutdown = false
 honor_graceful_shutdown = true
 honor_blackhole = true
 install_blackhole_discard = false
@@ -138,6 +140,21 @@ allow_blackhole_broad_prefixes = false
 `runtime_state_dir` must be writable by the rustbgpd process. In containers or
 non-root deployments, override the default to a mounted writable path (for
 example `/var/lib/rustbgpd` on a volume, or `/data/rustbgpd`).
+
+`warm_cache_checkpoint_on_shutdown` is an opt-in, restart-required publication
+step. During a coordinated shutdown, rustbgpd has up to 30 seconds to capture
+eligible established static peers' pre-policy Adj-RIB-In views and atomically
+publish a content-addressed MRT artifact plus `manifest.json` under
+`<runtime_state_dir>/warm-bundle-v1`. The bundle is capped at 512 MiB, binds
+the exact effective configuration, resolved import policies, live peer/family
+identity, and restart-marker generation, and is readable only through the
+daemon-private runtime-state directory. If capture or publication fails, the
+daemon falls back to the existing marker-v1 Graceful Restart behavior.
+
+This option does **not** make startup restore routes: no cached route is loaded,
+selected, installed, or advertised. A successful checkpoint only causes the GR
+restart marker to carry the matching generation (marker v2); the current boot
+path still rebuilds all routing state from peers.
 
 `dynamic_neighbor_limit` caps the number of active peers auto-created from
 `[[dynamic_neighbors]]` ranges. When omitted, rustbgpd allows up to 100 dynamic
@@ -1004,8 +1021,9 @@ Graceful Restart is enabled by default. rustbgpd implements:
   rustbgpd can temporarily advertise `restart_state = true` to static peers
   restored from config, using a marker file under `runtime_state_dir`.
   This helps peers retain our routes while we reconnect, but
-  `forwarding_preserved` remains false because rustbgpd does not persist
-  route/FIB ownership across restart or verify that forwarding state survived.
+  `forwarding_preserved` remains false because rustbgpd does not restore routing
+  state or verify that forwarding state survived. The optional shutdown warm
+  checkpoint is publication-only and does not change that claim.
   ADR-0061 FIB programming is opt-in and scoped; crash-left rows are preserved
   as foreign rather than adopted.
 
@@ -1029,8 +1047,9 @@ graceful_restart = false
 
 **Implementation note:** restarting-speaker mode is deliberately honest. The
 daemon may advertise `R=1` after a planned restart, but it does not claim
-forwarding-state preservation (`forwarding_preserved = false`) and does not
-yet persist route state across restarts. During that marker-backed startup it
+forwarding-state preservation (`forwarding_preserved = false`) and never
+restores route state from the optional shutdown checkpoint. During that
+marker-backed startup it
 freezes the effective static GR peer/family roster and defers each family's
 route selection plus initial table/EoR until all eligible current sessions
 send EoR or the remaining marker window expires. `gr_restart_time` therefore

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -302,14 +302,18 @@ chain, etc.).
 | Neighbor add/delete/modify via gRPC | Config file (atomic write) | Serialized with SIGHUP reload; the RPC waits for persistence acknowledgement and rolls runtime back if the write is rejected |
 | Dynamic-neighbor add/delete via gRPC | Config file (atomic write) | Serialized with SIGHUP reload; the RPC waits for persistence acknowledgement and rolls the matcher back if the write is rejected |
 | GR restart marker | `<runtime_state_dir>/gr-restart.toml` | On coordinated shutdown |
+| Optional shutdown warm checkpoint | `<runtime_state_dir>/warm-bundle-v1/` | On coordinated shutdown when `warm_cache_checkpoint_on_shutdown = true`; owner-private pre-policy Adj-RIB-In snapshot and manifest, never restored on boot |
 | General FIB owned-state | `<runtime_state_dir>/fib-owned.json` | After successful ADR-0061 FIB apply/drain |
 | MRT dump files | `[mrt] output_dir` | On periodic timer or `TriggerMrtDump` |
 | gRPC UDS socket | `<runtime_state_dir>/grpc.sock` | Daemon lifetime |
 
-**Not persisted:** routing state (Adj-RIB-In, Loc-RIB, Adj-RIB-Out), policy
-evaluation state, RPKI VRP tables, BMP client state. The ADR-0061 FIB file is
-only an ownership receipt for rows rustbgpd already installed; all route
-selection state is still rebuilt from peers after restart.
+**Not restored:** routing state, policy evaluation state, RPKI VRP tables, and
+BMP client state. The optional warm checkpoint persists only eligible
+pre-policy Adj-RIB-In views as a future-use artifact; the daemon does not load,
+select, install, or advertise any route from it. Loc-RIB and Adj-RIB-Out are
+never checkpointed. The ADR-0061 FIB file is only an ownership receipt for rows
+rustbgpd already installed; all route selection state is rebuilt from peers
+after restart.
 
 ---
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -444,6 +444,12 @@ arrive from every eligible waiter or the marker-bounded selection timer
 expires. Peer Restart State and absent GR families exclude that peer/family;
 superseded-session EoRs are rejected.
 
+When `warm_cache_checkpoint_on_shutdown = true`, a successful bounded
+checkpoint publication binds its generation into marker v2 (ADR-0104). A
+publication failure retains the marker-v1 path. This does not extend RFC 4724
+semantics: startup never restores or advertises cached routes, and
+`forwarding_preserved` remains false.
+
 ### §4.2 — Procedures for the Receiving Speaker
 
 **GR trigger:** On `SessionDown`, GR is entered when the peer previously
@@ -525,9 +531,10 @@ should not keep stale routes for days.
 
 ### Receiving Speaker Only
 
-Full restarting speaker mode with forwarding-state preservation requires
-FIB integration. Minimal honest mode (R=1 without forwarding claims) is
-implemented per ADR-0040.
+Full restarting speaker mode with forwarding-state preservation requires a
+verified restore/adoption design. Minimal honest mode (R=1 without forwarding
+claims) is implemented per ADR-0040; ADR-0104's publication-only checkpoint
+does not change that boundary.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -218,6 +218,22 @@ preflighted non-preferred successor generation without changing Current/RNext;
 selection, deprecation, deletion, protected-owner CRUD, and metrics exposure of
 per-socket inspection remain deferred.
 
+## Shutdown warm-checkpoint confidentiality
+
+The optional shutdown warm checkpoint contains pre-policy Adj-RIB-In routing
+data, peer identity, and digests of the effective configuration and resolved
+import policies. Treat `<runtime_state_dir>/warm-bundle-v1` as sensitive
+control-plane state: keep `runtime_state_dir` on local trusted storage, owned by
+the daemon account, and do not expose or back it up as a public MRT feed.
+
+Publication is descriptor-relative beneath an owner-verified directory that is
+not group/world-writable. Bundle files are owner-only, symlink traversal is
+rejected, content is size-bounded and hashed, and `manifest.json` is the atomic
+commit point. Startup does not load the checkpoint, so a stale or tampered
+bundle cannot currently inject, select, install, or advertise a route. The GR
+marker carries only an opaque generation and retains the existing marker-v1
+fallback if publication fails.
+
 ## Linux EVPN VTEP — `CAP_NET_ADMIN` requirement
 
 Running rustbgpd in **EVPN VTEP mode** on Linux (a non-empty

--- a/docs/adr/0040-gr-restarting-speaker.md
+++ b/docs/adr/0040-gr-restarting-speaker.md
@@ -10,10 +10,12 @@ can preserve a restarting peer's routes. That still leaves a production gap:
 when **rustbgpd itself** restarts, peers immediately withdraw its routes
 unless we advertise restarting-speaker state (`R=1`) in our next OPEN.
 
-The codebase does **not** own or verify the forwarding plane:
+The codebase does **not** own or verify the complete forwarding plane:
 
-1. There is no FIB integration.
-2. There is no persisted RIB snapshot across process restart.
+1. Opt-in unicast FIB integration exists, but it does not cover or prove the
+   complete forwarding plane across every advertised family.
+2. An optional shutdown checkpoint may persist eligible pre-policy
+   Adj-RIB-In views, but startup does not restore or adopt them (ADR-0104).
 3. There is no crash-safe journal.
 
 So a full RFC 4724 “forwarding state preserved” implementation would be
@@ -50,6 +52,10 @@ Implement an honest restarting-speaker mode:
 
 This mode helps peers retain our routes briefly during a planned restart,
 but makes **no claim** that rustbgpd preserved dataplane continuity.
+
+ADR-0104 extends coordinated shutdown with an optional generation-bound
+checkpoint publication. It deliberately does not change the startup behavior
+or the `forwarding_preserved = false` contract defined here.
 
 ## Consequences
 

--- a/docs/adr/0104-shutdown-warm-checkpoint-publication.md
+++ b/docs/adr/0104-shutdown-warm-checkpoint-publication.md
@@ -1,0 +1,61 @@
+# ADR-0104: Shutdown warm-checkpoint publication without boot restore
+
+**Status:** Accepted
+**Date:** 2026-07-13
+
+## Context
+
+ADR-0040's planned-restart marker lets rustbgpd honestly advertise Graceful
+Restart `R=1`, with `forwarding_preserved = false`, while routing state is
+relearned from peers. Future warm-start work needs a durable input that is
+bound to the exact live session, configuration, and policy identity at clean
+shutdown. Publishing that input is useful independently; adopting it on boot
+would require a separate fail-closed selection and reconciliation design.
+
+The artifact contains sensitive, potentially large pre-policy routing data.
+Publication must therefore be private, bounded, transactional, and unable to
+weaken the existing marker-v1 restart path.
+
+## Decision
+
+1. `global.warm_cache_checkpoint_on_shutdown` is default-off and
+   restart-required. When enabled, coordinated shutdown attempts one
+   checkpoint after closing the availability gate and fencing runtime config
+   and EVPN applies.
+2. One peer-manager capture binds the live local ASN/router ID, redacted
+   effective configuration, resolved import-policy identities, and current
+   static numbered sessions. The RIB supplies only eligible pre-policy
+   Adj-RIB-In views for negotiated Graceful Restart families. V1 supports IPv4
+   and IPv6 unicast, plus EVPN without Add-Path receive.
+3. Encoding, validation, hashing, and storage share a 30-second monotonic
+   deadline, cancellation token, and 512 MiB snapshot cap. The manifest is
+   capped at 8 MiB. Any ambiguity, timeout, unsupported view, or partial
+   failure rejects the complete checkpoint.
+4. The fixed `<runtime_state_dir>/warm-bundle-v1` directory is owner-verified
+   and descriptor-pinned. Filesystem operations reject symlinks and unsafe
+   ownership/modes. A content-addressed MRT artifact is durably committed
+   before atomic `manifest.json` replacement; failure restores the prior
+   committed directory image.
+5. A successful publication writes restart marker v2 with the exact checkpoint
+   generation. Failure writes the established marker-v1 form instead. Marker
+   and bundle operations remain independently fail-closed.
+6. This decision stops at publication and validation. The daemon has no boot
+   call site that loads the bundle. No cached route is inserted into Adj-RIB-In
+   or Loc-RIB, selected, installed, or advertised, and
+   `forwarding_preserved` remains false. Restore/adoption requires a separate
+   decision and implementation.
+
+## Consequences
+
+- Operators can opt into a durable, identity-bound shutdown artifact without
+  changing current restart convergence or forwarding claims.
+- The checkpoint contains pre-policy routing and topology data and must be
+  protected as sensitive daemon state.
+- Shutdown may spend up to 30 seconds attempting publication. Failure is
+  visible in logs but preserves the normal Graceful Restart marker fallback.
+- The V1 format intentionally excludes dynamic/scoped peers, ambiguous static
+  addresses, unsupported families, and EVPN Add-Path receive rather than
+  serializing an incomplete or ambiguous view.
+- Restore, adoption, route selection, and forwarding-state validation remain
+  deferred; the presence of a valid bundle is not evidence that any route will
+  be used after restart.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -112,6 +112,7 @@ consequences so future contributors understand *why*, not just *what*.
 | [0101](0101-route-server-profile.md) | IXP route-server profile — per-client best-path (RFC 7947 §2.3.2) | Accepted | 2026-07-03 |
 | [0102](0102-evpn-origination-acknowledgement.md) | EVPN origination acknowledgement-awareness (Type 1/2/4) | Accepted | 2026-07-09 |
 | [0103](0103-rpol-execution-model.md) | rpol execution model, purity contract, and evaluation budgets | Accepted | 2026-07-09 |
+| [0104](0104-shutdown-warm-checkpoint-publication.md) | Shutdown warm-checkpoint publication without boot restore | Accepted | 2026-07-13 |
 
 ## Template
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -611,12 +611,15 @@ Everything in `runtime_state_dir` (default `/var/lib/rustbgpd`):
 | File | Purpose | Survives restart |
 |---|---|---|
 | `gr-restart.toml` | Graceful Restart coordination marker. Written on clean shutdown, read on startup to set the R-bit in OPEN. | Yes |
+| `warm-bundle-v1/` | Optional owner-private shutdown checkpoint (`manifest.json` plus a content-addressed MRT artifact). Published only when `warm_cache_checkpoint_on_shutdown = true`; not restored on startup. | Yes |
 | `fib-owned.json` | FIB ownership receipt — which kernel routes the daemon installed (ADR-0061). Used to drain orphan installs on next start. | Yes |
 | `grpc.sock` | gRPC UDS endpoint (if `[global.telemetry.grpc_uds]` configured). | Recreated on start |
 
-Routing state — Adj-RIB-In, Loc-RIB, Adj-RIB-Out, policy evaluation —
-is **not persisted**. It rebuilds from peer routes after restart (with
-GR, the data path stays up while the rebuild happens).
+Routing state is **not restored**. The optional shutdown checkpoint contains
+only eligible pre-policy Adj-RIB-In views for future use; Loc-RIB,
+Adj-RIB-Out, and policy evaluation state are not checkpointed, and the current
+startup path loads none of it. Routing state rebuilds from peer routes after
+restart (with GR, the data path stays up while the rebuild happens).
 
 The config file itself is mutable across runs: neighbor add/delete
 operations via gRPC persist back to the config file (see

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -585,9 +585,11 @@ sudo install -m 0755 /tmp/rustbgpd-vX.Y.Z /usr/local/bin/rustbgpd
 sudo systemctl start rustbgpd
 ```
 
-GR is on by default; the peer side advertises `R=1` on the next OPEN.
-On a healthy GR-aware peer (FRR / BIRD / current GoBGP), the data path
-stays up across the restart window.
+GR is on by default; after a coordinated shutdown rustbgpd advertises `R=1`
+on the next OPEN. A GR-aware peer may retain eligible routes while sessions
+rebuild, but rustbgpd advertises `forwarding_preserved = false`: this is not a
+guarantee of forwarding continuity, and the peer may withdraw or replace routes
+until normal convergence.
 
 ### Schema migration
 
@@ -619,7 +621,9 @@ Routing state is **not restored**. The optional shutdown checkpoint contains
 only eligible pre-policy Adj-RIB-In views for future use; Loc-RIB,
 Adj-RIB-Out, and policy evaluation state are not checkpointed, and the current
 startup path loads none of it. Routing state rebuilds from peer routes after
-restart (with GR, the data path stays up while the rebuild happens).
+restart. GR and checkpoint state support bounded control-plane restart
+handling, but do not guarantee forwarding continuity; peers may withdraw or
+replace routes, and therefore forwarding, until normal convergence.
 
 The config file itself is mutable across runs: neighbor add/delete
 operations via gRPC persist back to the config file (see

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1018,6 +1018,11 @@
           "description": "Telemetry and control-plane listeners (Prometheus, gRPC,\nlooking glass) plus logging format.",
           "$ref": "#/$defs/TelemetryConfig"
         },
+        "warm_cache_checkpoint_on_shutdown": {
+          "description": "Publish one durable, daemon-private MRT warm-cache checkpoint during\ncoordinated shutdown. Off by default. This tranche only publishes the\ncheckpoint and a generation-bound restart marker; boot never loads or\nserves routes from the cache.\n\nThe checkpoint directory is fixed at\n`<runtime_state_dir>/warm-bundle-v1`. The setting is read at startup;\nchanging it requires a daemon restart.",
+          "type": "boolean",
+          "default": false
+        },
         "worker_threads": {
           "description": "Number of tokio runtime worker threads. Unset (the default) caps to\n`min(available CPU parallelism, 8)`: spawning one worker per core on a\nhigh-core-count host over-provisions the async runtime (each worker\nreserves a stack and a scheduler slot) for what is an I/O-bound daemon,\nnot a CPU-bound one. Capping reduces virtual-address reservation and\nscheduler footprint — same-host benchmarks showed it to be RSS-neutral,\nso this is runtime right-sizing, not a memory optimization. A value of `0` is\ntreated as unset. The `RUSTBGPD_WORKER_THREADS` environment variable\noverrides this field. **Restart-required:** the runtime is built once at\nstartup, so a change only takes effect on the next restart, not on SIGHUP.",
           "type": [

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -650,7 +650,7 @@ impl Config {
         self.runtime_state_dir().join("gr-restart.toml")
     }
 
-    /// Fixed daemon-private directory for LAN-337 warm checkpoint bundles.
+    /// Fixed daemon-private directory for shutdown warm-checkpoint bundles.
     ///
     /// Tranche 2 deliberately has no configurable path: one path rooted in
     /// `runtime_state_dir` keeps ownership, deployment, and marker binding
@@ -658,7 +658,7 @@ impl Config {
     #[must_use]
     #[allow(
         dead_code,
-        reason = "wired by the LAN-337 checkpoint coordinator slice"
+        reason = "wired by the shutdown warm-checkpoint coordinator"
     )]
     pub fn warm_bundle_dir(&self) -> PathBuf {
         self.runtime_state_dir().join("warm-bundle-v1")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -652,9 +652,9 @@ impl Config {
 
     /// Fixed daemon-private directory for shutdown warm-checkpoint bundles.
     ///
-    /// Tranche 2 deliberately has no configurable path: one path rooted in
-    /// `runtime_state_dir` keeps ownership, deployment, and marker binding
-    /// unambiguous. No boot-side restore exists yet.
+    /// Checkpoint publication deliberately has no configurable path: one path
+    /// rooted in `runtime_state_dir` keeps ownership, deployment, and marker
+    /// binding unambiguous. No boot-side restore exists yet.
     #[must_use]
     #[allow(
         dead_code,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -650,6 +650,20 @@ impl Config {
         self.runtime_state_dir().join("gr-restart.toml")
     }
 
+    /// Fixed daemon-private directory for LAN-337 warm checkpoint bundles.
+    ///
+    /// Tranche 2 deliberately has no configurable path: one path rooted in
+    /// `runtime_state_dir` keeps ownership, deployment, and marker binding
+    /// unambiguous. No boot-side restore exists yet.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "wired by the LAN-337 checkpoint coordinator slice"
+    )]
+    pub fn warm_bundle_dir(&self) -> PathBuf {
+        self.runtime_state_dir().join("warm-bundle-v1")
+    }
+
     #[must_use]
     pub fn default_grpc_uds_path(&self) -> PathBuf {
         self.runtime_state_dir().join("grpc.sock")

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -491,6 +491,16 @@ pub struct Global {
     /// `install_blackhole_discard = true`.
     #[serde(default)]
     pub allow_blackhole_broad_prefixes: bool,
+    /// Publish one durable, daemon-private MRT warm-cache checkpoint during
+    /// coordinated shutdown. Off by default. This tranche only publishes the
+    /// checkpoint and a generation-bound restart marker; boot never loads or
+    /// serves routes from the cache.
+    ///
+    /// The checkpoint directory is fixed at
+    /// `<runtime_state_dir>/warm-bundle-v1`. The setting is read at startup;
+    /// changing it requires a daemon restart.
+    #[serde(default)]
+    pub warm_cache_checkpoint_on_shutdown: bool,
     /// Directory for daemon-owned runtime state files.
     #[serde(default = "default_runtime_state_dir")]
     pub runtime_state_dir: String,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -427,6 +427,10 @@ fn runtime_state_dir_defaults_to_var_lib() {
         config.gr_restart_marker_path(),
         PathBuf::from("/var/lib/rustbgpd/gr-restart.toml")
     );
+    assert_eq!(
+        config.warm_bundle_dir(),
+        PathBuf::from("/var/lib/rustbgpd/warm-bundle-v1")
+    );
 }
 
 #[test]
@@ -443,6 +447,10 @@ fn runtime_state_dir_override_is_used() {
     assert_eq!(
         config.gr_restart_marker_path(),
         PathBuf::from("/tmp/rustbgpd-test/gr-restart.toml")
+    );
+    assert_eq!(
+        config.warm_bundle_dir(),
+        PathBuf::from("/tmp/rustbgpd-test/warm-bundle-v1")
     );
 }
 
@@ -5393,6 +5401,23 @@ hold_time = 90
     assert!(diff.has_any_changes());
     assert!(diff.global_changed);
     assert!(!diff.rpki_changed);
+}
+
+#[test]
+fn warm_cache_checkpoint_toggle_is_restart_required_and_defaults_off() {
+    let old = parse(valid_toml()).unwrap();
+    assert!(!old.global.warm_cache_checkpoint_on_shutdown);
+    let new_toml = valid_toml().replace(
+        "listen_port = 179\n",
+        "listen_port = 179\nwarm_cache_checkpoint_on_shutdown = true\n",
+    );
+    let new = parse(&new_toml).unwrap();
+    let diff = super::diff_config(&old, &new);
+
+    assert!(new.global.warm_cache_checkpoint_on_shutdown);
+    assert!(diff.global_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(!diff.has_reload_applied_changes());
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,8 +160,8 @@ struct GrRestartMarker {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ValidGrRestartMarker {
     expires_at: SystemTime,
-    /// Present only for durable marker v2. Tranche 2 records this binding but
-    /// deliberately has no boot-side cache load or route-serving behavior.
+    /// Present only for durable marker v2. Checkpoint publication records this
+    /// binding, but startup has no cache load or route-serving behavior.
     checkpoint_generation: Option<String>,
     /// SHA-256 of the exact bounded bytes read from the pinned marker entry.
     /// `None` only for values validated directly in unit tests before storage.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4641,16 +4641,15 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
 
     #[test]
     fn gr_restart_marker_remaining_time_rejects_or_clamps_valid_far_future_v2_marker() {
-        let path = unique_temp_path("gr-restart-far-future");
+        let (_dir, store) = marker_store();
         let far_future_secs = i64::MAX.unsigned_abs();
-        std::fs::write(
-            &path,
-            format!(
-                "version = 2\nexpires_at_unix = {far_future_secs}\ncheckpoint_generation = \"far-future-generation\"\n"
-            ),
-        )
-        .unwrap();
-        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        let expires_at = UNIX_EPOCH
+            .checked_add(Duration::from_secs(far_future_secs))
+            .unwrap();
+        store
+            .write_selected(expires_at, Some("far-future-generation"))
+            .unwrap();
+        let marker = store.read().unwrap().unwrap();
         assert_eq!(
             marker.checkpoint_generation.as_deref(),
             Some("far-future-generation")
@@ -4664,7 +4663,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             gr_restart_marker_remaining_time(marker.expires_at, UNIX_EPOCH, Some(120)).unwrap(),
             Duration::from_mins(2)
         );
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
 
+use rustbgpd_mrt::codec::WarmSnapshotBudget;
 use rustbgpd_mrt::{
     MAX_WARM_BUNDLE_SNAPSHOT_BYTES, WarmBundleDirectory, WarmBundleFamilyV1, WarmBundleIdentityV1,
     WarmBundlePolicyInputV1, WarmBundleViewKindV1, WarmBundleViewV1,
-    resolved_import_policy_digest_v1, write_warm_bundle,
+    resolved_import_policy_digest_v1, write_warm_bundle_bounded,
 };
 use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotBudget, WarmMrtSnapshotView};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
@@ -1064,6 +1065,23 @@ async fn publish_warm_checkpoint(
     directory: Arc<WarmBundleDirectory>,
     deadline: StdInstant,
 ) -> Result<String, String> {
+    publish_warm_checkpoint_bounded(
+        capture,
+        rib_query_tx,
+        directory,
+        deadline,
+        usize::try_from(MAX_WARM_BUNDLE_SNAPSHOT_BYTES).unwrap_or(usize::MAX),
+    )
+    .await
+}
+
+async fn publish_warm_checkpoint_bounded(
+    capture: WarmCheckpointCapture,
+    rib_query_tx: &mpsc::Sender<RibUpdate>,
+    directory: Arc<WarmBundleDirectory>,
+    deadline: StdInstant,
+    max_snapshot_bytes: usize,
+) -> Result<String, String> {
     let plan = build_warm_checkpoint_plan(&capture.sessions)?;
 
     let (rib_reply, rib_rx) = oneshot::channel();
@@ -1078,8 +1096,7 @@ async fn publish_warm_checkpoint(
             budget: WarmMrtSnapshotBudget {
                 deadline,
                 cancelled,
-                max_materialized_bytes: usize::try_from(MAX_WARM_BUNDLE_SNAPSHOT_BYTES)
-                    .unwrap_or(usize::MAX),
+                max_materialized_bytes: max_snapshot_bytes,
             },
             reply: rib_reply,
         })
@@ -1088,8 +1105,6 @@ async fn publish_warm_checkpoint(
     let snapshot = rib_rx
         .await
         .map_err(|_| "RIB actor dropped warm checkpoint query".to_string())??;
-    cancel_on_drop.armed = false;
-
     let now_seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|error| format!("system clock precedes Unix epoch: {error}"))?
@@ -1119,19 +1134,24 @@ async fn publish_warm_checkpoint(
     };
     let local_router_id = capture.local_router_id;
     let view_name = checkpoint_generation.clone();
+    let writer_budget = WarmSnapshotBudget::new(
+        deadline,
+        Arc::clone(&cancel_on_drop.cancelled),
+        max_snapshot_bytes,
+    );
     let (writer_reply, writer_rx) = oneshot::channel();
     // Do not use Tokio's blocking pool here. A timed-out spawn_blocking task
     // cannot be cancelled and the runtime waits for it during shutdown,
     // defeating the 30-second terminal bound. This dedicated OS thread is
-    // detached if the coordinator deadline fires; daemon teardown continues
-    // immediately and process exit terminates any remaining work. It may
-    // finish an orphan bundle generation in the meantime, but main publishes
-    // marker v2 only after this reply, so a late generation is never selected.
+    // detached if the coordinator deadline fires; dropping this future flips
+    // the shared cancellation token. Encoding, validation, hashing, and
+    // chunked writes observe that token and the same monotonic deadline, so a
+    // late worker stops bounded work and can never select marker v2.
     std::thread::Builder::new()
         .name("warm-checkpoint-writer".to_string())
         .spawn(move || {
             let result = (|| {
-                let encoded = rustbgpd_mrt::codec::encode_warm_snapshot(
+                let encoded = rustbgpd_mrt::codec::encode_warm_snapshot_bounded(
                     local_router_id,
                     &view_name,
                     &snapshot.peers,
@@ -1139,9 +1159,11 @@ async fn publish_warm_checkpoint(
                     &snapshot.evpn_routes,
                     mrt_timestamp,
                     &plan.add_path_receive,
+                    &writer_budget,
                 )
                 .map_err(|error| error.to_string())?;
-                write_warm_bundle(directory.as_ref(), identity, &encoded)
+                writer_budget.check().map_err(|error| error.to_string())?;
+                write_warm_bundle_bounded(directory.as_ref(), identity, &encoded, &writer_budget)
                     .map_err(|error| error.to_string())?;
                 Ok::<(), String>(())
             })();
@@ -1151,6 +1173,7 @@ async fn publish_warm_checkpoint(
     writer_rx
         .await
         .map_err(|_| "warm checkpoint writer exited without a result".to_string())??;
+    cancel_on_drop.armed = false;
     Ok(checkpoint_generation)
 }
 
@@ -4680,6 +4703,79 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         let marker = store.read().unwrap().unwrap();
         assert_eq!(marker.checkpoint_generation, None);
         store.remove().unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_checkpoint_publishes_no_bundle_or_v2_marker() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let pinned = Arc::new(PinnedRuntimeStateDirectory::prepare(temp.path()).unwrap());
+        let directory = Arc::new(pinned.prepare_warm_bundle().unwrap());
+        let marker_store = GrRestartMarkerStore::new(pinned);
+        let session = checkpoint_plan_session();
+        let capture = WarmCheckpointCapture {
+            local_asn: 65_001,
+            local_router_id: Ipv4Addr::new(192, 0, 2, 1),
+            effective_config_toml: "[global]\nasn = 65001\n".to_string(),
+            restart_time_secs: Some(120),
+            sessions: vec![session.clone()],
+        };
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let responder = tokio::spawn(async move {
+            let update = rib_rx.recv().await.expect("warm query sent");
+            let RibUpdate::QueryWarmMrtSnapshot { budget, reply, .. } = update else {
+                panic!("unexpected RIB query");
+            };
+            assert_eq!(budget.max_materialized_bytes, 32);
+            reply
+                .send(Ok(rustbgpd_rib::MrtSnapshotData {
+                    peers: vec![rustbgpd_rib::MrtPeerEntry {
+                        peer_addr: session.peer.address,
+                        peer_bgp_id: session.peer_router_id,
+                        peer_asn: session.peer_asn,
+                    }],
+                    routes: vec![],
+                    evpn_routes: vec![],
+                }))
+                .expect("coordinator still waiting");
+        });
+
+        let result = publish_warm_checkpoint_bounded(
+            capture,
+            &rib_tx,
+            Arc::clone(&directory),
+            StdInstant::now() + Duration::from_mins(1),
+            32,
+        )
+        .await;
+        responder.await.unwrap();
+        assert!(
+            result
+                .as_ref()
+                .is_err_and(|error| error.contains("32-byte cap"))
+        );
+        assert_eq!(
+            std::fs::read_dir(temp.path().join(WARM_BUNDLE_DIRECTORY))
+                .unwrap()
+                .count(),
+            0,
+            "oversized encoding must not publish an artifact, manifest, or temp file"
+        );
+
+        marker_store
+            .write_selected(
+                SystemTime::now() + Duration::from_mins(2),
+                result.ok().as_deref(),
+            )
+            .unwrap();
+        let marker = marker_store.read().unwrap().unwrap();
+        assert_eq!(
+            marker.checkpoint_generation, None,
+            "failed publication must retain marker-v1 fallback"
+        );
+        marker_store.remove().unwrap();
     }
 
     fn checkpoint_plan_session() -> WarmCheckpointSession {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,19 +48,23 @@ mod reload;
 mod test_support;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{Read as _, Write as _};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::os::unix::fs::DirBuilderExt as _;
-use std::path::Path;
+use std::os::unix::fs::MetadataExt as _;
+use std::path::{Path, PathBuf};
 use std::process;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
 
 use rustbgpd_mrt::{
-    WarmBundleDirectory, WarmBundleFamilyV1, WarmBundleIdentityV1, WarmBundlePolicyInputV1,
-    WarmBundleViewKindV1, WarmBundleViewV1, resolved_import_policy_digest_v1, write_warm_bundle,
+    MAX_WARM_BUNDLE_SNAPSHOT_BYTES, WarmBundleDirectory, WarmBundleFamilyV1, WarmBundleIdentityV1,
+    WarmBundlePolicyInputV1, WarmBundleViewKindV1, WarmBundleViewV1,
+    resolved_import_policy_digest_v1, write_warm_bundle,
 };
-use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotView};
+use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotBudget, WarmMrtSnapshotView};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
 use rustbgpd_transport::{
     BgpListener, ListenerSocketOptions, TcpAoAlgorithm, TcpAoConfig as TransportTcpAoConfig,
@@ -93,6 +97,9 @@ use rustbgpd_wire::{Afi, Safi};
 
 const GR_RESTART_MARKER_V1: u8 = 1;
 const GR_RESTART_MARKER_V2: u8 = 2;
+const GR_RESTART_MARKER_FILE: &str = "gr-restart.toml";
+const WARM_BUNDLE_DIRECTORY: &str = "warm-bundle-v1";
+const MAX_GR_RESTART_MARKER_BYTES: u64 = 4096;
 const MAX_CHECKPOINT_GENERATION_BYTES: usize = 128;
 const WARM_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(30);
 static MARKER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -155,6 +162,9 @@ struct ValidGrRestartMarker {
     /// Present only for durable marker v2. Tranche 2 records this binding but
     /// deliberately has no boot-side cache load or route-serving behavior.
     checkpoint_generation: Option<String>,
+    /// SHA-256 of the exact bounded bytes read from the pinned marker entry.
+    /// `None` only for values validated directly in unit tests before storage.
+    storage_sha256: Option<[u8; 32]>,
 }
 
 #[derive(Debug)]
@@ -163,6 +173,310 @@ struct WarmCheckpointPlan {
     rib_views: Vec<WarmMrtSnapshotView>,
     policy_inputs: Vec<WarmBundlePolicyInputV1>,
     add_path_receive: Vec<rustbgpd_mrt::codec::MrtAddPathReceiveProfile>,
+}
+
+/// Owner-verified runtime-state directory pinned for the daemon lifetime.
+/// Marker and bundle publication are both descriptor-relative beneath this
+/// authority, so replacing a pathname or planting a final symlink cannot
+/// redirect shutdown state.
+#[derive(Debug)]
+struct PinnedRuntimeStateDirectory {
+    file: File,
+    display_path: PathBuf,
+}
+
+impl PinnedRuntimeStateDirectory {
+    fn prepare(path: &Path) -> Result<Self, String> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+        use nix::unistd::geteuid;
+
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let mut builder = std::fs::DirBuilder::new();
+                builder.recursive(true).mode(0o700);
+                builder.create(path).map_err(|error| {
+                    format!(
+                        "failed to create runtime-state directory {}: {error}",
+                        path.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect runtime-state directory {}: {error}",
+                    path.display()
+                ));
+            }
+        }
+        let fd = open(
+            path,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(|error| {
+            format!(
+                "failed to pin runtime-state directory {}: {}",
+                path.display(),
+                std::io::Error::from_raw_os_error(error as i32)
+            )
+        })?;
+        let file = File::from(fd);
+        let metadata = file.metadata().map_err(|error| {
+            format!(
+                "failed to validate runtime-state directory {}: {error}",
+                path.display()
+            )
+        })?;
+        if !metadata.is_dir()
+            || metadata.uid() != geteuid().as_raw()
+            || metadata.mode() & 0o022 != 0
+        {
+            return Err(format!(
+                "runtime-state directory {} has unsafe type, owner, or mode (is_dir={}, uid={}, expected_uid={}, mode={:o})",
+                path.display(),
+                metadata.is_dir(),
+                metadata.uid(),
+                geteuid().as_raw(),
+                metadata.mode() & 0o7777
+            ));
+        }
+        Ok(Self {
+            file,
+            display_path: path.to_path_buf(),
+        })
+    }
+
+    fn prepare_warm_bundle(&self) -> Result<WarmBundleDirectory, String> {
+        use nix::errno::Errno;
+        use nix::sys::stat::{Mode, mkdirat};
+
+        match mkdirat(
+            &self.file,
+            WARM_BUNDLE_DIRECTORY,
+            Mode::from_bits_truncate(0o700),
+        ) {
+            Ok(()) | Err(Errno::EEXIST) => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to create warm checkpoint directory {}: {}",
+                    self.display_path.join(WARM_BUNDLE_DIRECTORY).display(),
+                    std::io::Error::from_raw_os_error(error as i32)
+                ));
+            }
+        }
+        WarmBundleDirectory::open_at(&self.file, &self.display_path, WARM_BUNDLE_DIRECTORY)
+            .map_err(|error| error.to_string())
+    }
+}
+
+/// Serialized descriptor-relative restart marker I/O. The shared lock closes
+/// the boot-expiry versus coordinated-shutdown publication race inside this
+/// process; exact identity comparison prevents an inherited timer from
+/// deleting a replacement marker.
+#[derive(Debug, Clone)]
+struct GrRestartMarkerStore {
+    directory: Arc<PinnedRuntimeStateDirectory>,
+    io_lock: Arc<Mutex<()>>,
+}
+
+impl GrRestartMarkerStore {
+    fn new(directory: Arc<PinnedRuntimeStateDirectory>) -> Self {
+        Self {
+            directory,
+            io_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    fn display_path(&self) -> PathBuf {
+        self.directory.display_path.join(GR_RESTART_MARKER_FILE)
+    }
+
+    fn read(&self) -> Result<Option<ValidGrRestartMarker>, String> {
+        let _guard = self
+            .io_lock
+            .lock()
+            .map_err(|_| "restart-marker I/O lock was poisoned".to_string())?;
+        self.read_locked()
+    }
+
+    fn read_locked(&self) -> Result<Option<ValidGrRestartMarker>, String> {
+        use nix::errno::Errno;
+        use nix::fcntl::{OFlag, openat};
+        use nix::sys::stat::Mode;
+        use nix::unistd::geteuid;
+
+        let fd = match openat(
+            &self.directory.file,
+            GR_RESTART_MARKER_FILE,
+            OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        ) {
+            Ok(fd) => fd,
+            Err(Errno::ENOENT) => return Ok(None),
+            Err(error) => return Err(error.to_string()),
+        };
+        let file = File::from(fd);
+        let metadata = file.metadata().map_err(|error| error.to_string())?;
+        if !metadata.is_file()
+            || metadata.uid() != geteuid().as_raw()
+            || metadata.mode() & 0o022 != 0
+        {
+            return Err("restart marker has unsafe type, owner, or mode".to_string());
+        }
+        if metadata.len() > MAX_GR_RESTART_MARKER_BYTES {
+            return Err(format!(
+                "restart marker exceeds the {MAX_GR_RESTART_MARKER_BYTES}-byte cap"
+            ));
+        }
+        let mut content = String::new();
+        file.take(MAX_GR_RESTART_MARKER_BYTES.saturating_add(1))
+            .read_to_string(&mut content)
+            .map_err(|error| error.to_string())?;
+        if u64::try_from(content.len()).unwrap_or(u64::MAX) > MAX_GR_RESTART_MARKER_BYTES {
+            return Err(format!(
+                "restart marker exceeds the {MAX_GR_RESTART_MARKER_BYTES}-byte cap"
+            ));
+        }
+        let marker: GrRestartMarker = toml::from_str(&content).map_err(|e| e.to_string())?;
+        let mut validated = validate_gr_restart_marker(marker)?;
+        validated.storage_sha256 = Some(Sha256::digest(content.as_bytes()).into());
+        Ok(Some(validated))
+    }
+
+    fn write_selected(
+        &self,
+        expires_at: SystemTime,
+        checkpoint_generation: Option<&str>,
+    ) -> std::io::Result<()> {
+        self.write_inner(expires_at, checkpoint_generation, MarkerFaultPoint::None)
+    }
+
+    fn write_inner(
+        &self,
+        expires_at: SystemTime,
+        checkpoint_generation: Option<&str>,
+        fault: MarkerFaultPoint,
+    ) -> std::io::Result<()> {
+        use nix::fcntl::{OFlag, openat, renameat};
+        use nix::sys::stat::Mode;
+        use nix::unistd::{UnlinkatFlags, unlinkat};
+
+        if checkpoint_generation.is_some_and(|generation| {
+            generation.is_empty()
+                || generation.len() > MAX_CHECKPOINT_GENERATION_BYTES
+                || generation.chars().any(char::is_control)
+        }) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid checkpoint generation",
+            ));
+        }
+        let expires_at_unix = expires_at
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| std::io::Error::other(e.to_string()))?
+            .as_secs();
+        let marker = GrRestartMarker {
+            version: if checkpoint_generation.is_some() {
+                GR_RESTART_MARKER_V2
+            } else {
+                GR_RESTART_MARKER_V1
+            },
+            expires_at_unix,
+            checkpoint_generation: checkpoint_generation.map(str::to_string),
+        };
+        let encoded =
+            toml::to_string(&marker).map_err(|error| std::io::Error::other(error.to_string()))?;
+        let sequence = MARKER_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let temp_name = format!(
+            ".{GR_RESTART_MARKER_FILE}.tmp.{}.{}",
+            std::process::id(),
+            sequence
+        );
+        let _guard = self
+            .io_lock
+            .lock()
+            .map_err(|_| std::io::Error::other("restart-marker I/O lock was poisoned"))?;
+        let result = (|| -> std::io::Result<()> {
+            marker_fail_if(fault, MarkerFaultPoint::Write)?;
+            let fd = openat(
+                &self.directory.file,
+                temp_name.as_str(),
+                OFlag::O_WRONLY
+                    | OFlag::O_CREAT
+                    | OFlag::O_EXCL
+                    | OFlag::O_CLOEXEC
+                    | OFlag::O_NOFOLLOW,
+                Mode::from_bits_truncate(0o600),
+            )
+            .map_err(|error| std::io::Error::from_raw_os_error(error as i32))?;
+            let mut temp = File::from(fd);
+            temp.write_all(encoded.as_bytes())?;
+            marker_fail_if(fault, MarkerFaultPoint::FileSync)?;
+            temp.sync_all()?;
+            drop(temp);
+            marker_fail_if(fault, MarkerFaultPoint::Rename)?;
+            renameat(
+                &self.directory.file,
+                temp_name.as_str(),
+                &self.directory.file,
+                GR_RESTART_MARKER_FILE,
+            )
+            .map_err(|error| std::io::Error::from_raw_os_error(error as i32))?;
+            marker_fail_if(fault, MarkerFaultPoint::DirectorySync)?;
+            self.directory.file.sync_all()
+        })();
+        if result.is_err() {
+            let _ = unlinkat(
+                &self.directory.file,
+                temp_name.as_str(),
+                UnlinkatFlags::NoRemoveDir,
+            );
+        }
+        result
+    }
+
+    fn remove(&self) -> std::io::Result<()> {
+        let _guard = self
+            .io_lock
+            .lock()
+            .map_err(|_| std::io::Error::other("restart-marker I/O lock was poisoned"))?;
+        self.remove_locked()
+    }
+
+    fn remove_if_matches(&self, expected: &ValidGrRestartMarker) -> std::io::Result<bool> {
+        let _guard = self
+            .io_lock
+            .lock()
+            .map_err(|_| std::io::Error::other("restart-marker I/O lock was poisoned"))?;
+        let current = self.read_locked().map_err(std::io::Error::other)?;
+        // Compare the exact file-byte identity, not just parsed semantics. A
+        // replacement marker can deliberately carry the same expiry and
+        // generation with different bytes; it belongs to a newer publisher
+        // and must survive this inherited timer.
+        if expected.storage_sha256.is_none()
+            || current.as_ref().and_then(|marker| marker.storage_sha256) != expected.storage_sha256
+        {
+            return Ok(false);
+        }
+        self.remove_locked()?;
+        Ok(true)
+    }
+
+    fn remove_locked(&self) -> std::io::Result<()> {
+        use nix::errno::Errno;
+        use nix::unistd::{UnlinkatFlags, unlinkat};
+
+        match unlinkat(
+            &self.directory.file,
+            GR_RESTART_MARKER_FILE,
+            UnlinkatFlags::NoRemoveDir,
+        ) {
+            Ok(()) | Err(Errno::ENOENT) => Ok(()),
+            Err(error) => Err(std::io::Error::from_raw_os_error(error as i32)),
+        }
+    }
 }
 
 struct BmpRuntime {
@@ -555,56 +869,8 @@ fn validate_gr_restart_marker(marker: GrRestartMarker) -> Result<ValidGrRestartM
     Ok(ValidGrRestartMarker {
         expires_at,
         checkpoint_generation: marker.checkpoint_generation,
+        storage_sha256: None,
     })
-}
-
-fn read_gr_restart_marker(path: &Path) -> Result<Option<ValidGrRestartMarker>, String> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(content) => content,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(e.to_string()),
-    };
-    let marker: GrRestartMarker = toml::from_str(&content).map_err(|e| e.to_string())?;
-    validate_gr_restart_marker(marker).map(Some)
-}
-
-fn write_gr_restart_marker(path: &Path, expires_at: SystemTime) -> std::io::Result<()> {
-    write_gr_restart_marker_inner(path, expires_at, None, MarkerFaultPoint::None)
-}
-
-/// Publish marker v2 only after the exact referenced warm bundle generation
-/// has committed. No boot-side restore consumes this reference in tranche 2.
-fn write_gr_restart_marker_v2(
-    path: &Path,
-    expires_at: SystemTime,
-    checkpoint_generation: &str,
-) -> std::io::Result<()> {
-    if checkpoint_generation.is_empty()
-        || checkpoint_generation.len() > MAX_CHECKPOINT_GENERATION_BYTES
-        || checkpoint_generation.chars().any(char::is_control)
-    {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "invalid checkpoint generation",
-        ));
-    }
-    write_gr_restart_marker_inner(
-        path,
-        expires_at,
-        Some(checkpoint_generation),
-        MarkerFaultPoint::None,
-    )
-}
-
-fn write_selected_gr_restart_marker(
-    path: &Path,
-    expires_at: SystemTime,
-    checkpoint_generation: Option<&str>,
-) -> std::io::Result<()> {
-    checkpoint_generation.map_or_else(
-        || write_gr_restart_marker(path, expires_at),
-        |generation| write_gr_restart_marker_v2(path, expires_at, generation),
-    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -614,73 +880,6 @@ enum MarkerFaultPoint {
     FileSync,
     Rename,
     DirectorySync,
-}
-
-fn write_gr_restart_marker_inner(
-    path: &Path,
-    expires_at: SystemTime,
-    checkpoint_generation: Option<&str>,
-    fault: MarkerFaultPoint,
-) -> std::io::Result<()> {
-    use std::io::Write as _;
-    use std::os::unix::fs::OpenOptionsExt as _;
-
-    let expires_at_unix = expires_at
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| std::io::Error::other(e.to_string()))?
-        .as_secs();
-    let marker = GrRestartMarker {
-        version: if checkpoint_generation.is_some() {
-            GR_RESTART_MARKER_V2
-        } else {
-            GR_RESTART_MARKER_V1
-        },
-        expires_at_unix,
-        checkpoint_generation: checkpoint_generation.map(str::to_string),
-    };
-    let parent = path.parent().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "restart marker path has no parent directory",
-        )
-    })?;
-    std::fs::create_dir_all(parent)?;
-    let encoded = toml::to_string(&marker).map_err(|e| std::io::Error::other(e.to_string()))?;
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "restart marker path has no UTF-8 file name",
-            )
-        })?;
-    let sequence = MARKER_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let temp_path = parent.join(format!(
-        ".{file_name}.tmp.{}.{}",
-        std::process::id(),
-        sequence
-    ));
-    let result = (|| -> std::io::Result<()> {
-        marker_fail_if(fault, MarkerFaultPoint::Write)?;
-        let mut temp = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&temp_path)?;
-        temp.write_all(encoded.as_bytes())?;
-        marker_fail_if(fault, MarkerFaultPoint::FileSync)?;
-        temp.sync_all()?;
-        drop(temp);
-        marker_fail_if(fault, MarkerFaultPoint::Rename)?;
-        std::fs::rename(&temp_path, path)?;
-        marker_fail_if(fault, MarkerFaultPoint::DirectorySync)?;
-        std::fs::File::open(parent)?.sync_all()
-    })();
-    if result.is_err() {
-        let _ = std::fs::remove_file(&temp_path);
-    }
-    result
 }
 
 fn marker_fail_if(selected: MarkerFaultPoint, current: MarkerFaultPoint) -> std::io::Result<()> {
@@ -761,37 +960,6 @@ fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, St
             }),
         })
         .collect()
-}
-
-fn remove_gr_restart_marker(path: &Path) -> std::io::Result<()> {
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
-    }
-}
-
-fn prepare_warm_bundle_directory(path: &Path) -> Result<WarmBundleDirectory, String> {
-    match std::fs::symlink_metadata(path) {
-        Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let mut builder = std::fs::DirBuilder::new();
-            builder.recursive(true).mode(0o700);
-            builder.create(path).map_err(|error| {
-                format!(
-                    "failed to create warm checkpoint directory {}: {error}",
-                    path.display()
-                )
-            })?;
-        }
-        Err(error) => {
-            return Err(format!(
-                "failed to inspect warm checkpoint directory {}: {error}",
-                path.display()
-            ));
-        }
-    }
-    WarmBundleDirectory::open(path).map_err(|error| error.to_string())
 }
 
 const fn warm_bundle_family_v1(afi: Afi, safi: Safi) -> Option<WarmBundleFamilyV1> {
@@ -894,13 +1062,25 @@ async fn publish_warm_checkpoint(
     capture: WarmCheckpointCapture,
     rib_query_tx: &mpsc::Sender<RibUpdate>,
     directory: Arc<WarmBundleDirectory>,
+    deadline: StdInstant,
 ) -> Result<String, String> {
     let plan = build_warm_checkpoint_plan(&capture.sessions)?;
 
     let (rib_reply, rib_rx) = oneshot::channel();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let mut cancel_on_drop = CancelWarmSnapshotOnDrop {
+        cancelled: Arc::clone(&cancelled),
+        armed: true,
+    };
     rib_query_tx
         .send(RibUpdate::QueryWarmMrtSnapshot {
             views: plan.rib_views,
+            budget: WarmMrtSnapshotBudget {
+                deadline,
+                cancelled,
+                max_materialized_bytes: usize::try_from(MAX_WARM_BUNDLE_SNAPSHOT_BYTES)
+                    .unwrap_or(usize::MAX),
+            },
             reply: rib_reply,
         })
         .await
@@ -908,6 +1088,7 @@ async fn publish_warm_checkpoint(
     let snapshot = rib_rx
         .await
         .map_err(|_| "RIB actor dropped warm checkpoint query".to_string())??;
+    cancel_on_drop.armed = false;
 
     let now_seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -971,6 +1152,19 @@ async fn publish_warm_checkpoint(
         .await
         .map_err(|_| "warm checkpoint writer exited without a result".to_string())??;
     Ok(checkpoint_generation)
+}
+
+struct CancelWarmSnapshotOnDrop {
+    cancelled: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl Drop for CancelWarmSnapshotOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancelled.store(true, Ordering::Release);
+        }
+    }
 }
 
 async fn query_warm_checkpoint_capture(
@@ -1775,13 +1969,33 @@ async fn run<T>(
 
     let start_time = tokio::time::Instant::now();
     let gr_restart_marker_path = config.gr_restart_marker_path();
-    // This knob and path are restart-required. Pin the verified directory at
-    // startup; later publication is descriptor-relative and cannot be
-    // redirected by replacing the pathname during shutdown.
+    let runtime_state_path = config.runtime_state_dir();
+    // Pin the shared authority before either marker or bundle access. Unsafe
+    // owner/mode or a final symlink disables both paths fail closed.
+    let runtime_state_directory = match PinnedRuntimeStateDirectory::prepare(&runtime_state_path) {
+        Ok(directory) => Some(Arc::new(directory)),
+        Err(error) => {
+            warn!(
+                path = %runtime_state_path.display(),
+                %error,
+                "runtime-state marker/checkpoint storage unavailable"
+            );
+            None
+        }
+    };
+    let gr_restart_marker_store = runtime_state_directory
+        .as_ref()
+        .map(|directory| GrRestartMarkerStore::new(Arc::clone(directory)));
+    // This knob and child name are restart-required. Open the bundle relative
+    // to the same verified descriptor as the marker.
     let warm_checkpoint_on_shutdown = config.global.warm_cache_checkpoint_on_shutdown;
     let warm_bundle_path = config.warm_bundle_dir();
     let warm_bundle_directory = if warm_checkpoint_on_shutdown {
-        match prepare_warm_bundle_directory(&warm_bundle_path) {
+        match runtime_state_directory
+            .as_ref()
+            .ok_or_else(|| "runtime-state directory is unavailable".to_string())
+            .and_then(|directory| directory.prepare_warm_bundle())
+        {
             Ok(directory) => {
                 info!(
                     path = %warm_bundle_path.display(),
@@ -1801,7 +2015,11 @@ async fn run<T>(
     } else {
         None
     };
-    let local_gr_restart_until = match read_gr_restart_marker(&gr_restart_marker_path) {
+    let mut inherited_gr_restart_marker = None;
+    let local_gr_restart_until = match gr_restart_marker_store
+        .as_ref()
+        .map_or(Ok(None), GrRestartMarkerStore::read)
+    {
         Ok(Some(marker)) => {
             let max_restart_time_secs = max_gr_restart_time_secs(&config);
             if let Some(remaining) = gr_restart_marker_remaining_time(
@@ -1816,13 +2034,16 @@ async fn run<T>(
                     checkpoint_generation = marker.checkpoint_generation.as_deref().unwrap_or("none"),
                     "detected GR restart marker — static peers will advertise R=1 until the restart window expires"
                 );
+                inherited_gr_restart_marker = Some(marker);
                 Some(deadline)
             } else {
                 info!(
                     marker = %gr_restart_marker_path.display(),
                     "ignoring expired or unusable GR restart marker"
                 );
-                if let Err(e) = remove_gr_restart_marker(&gr_restart_marker_path) {
+                if let Some(store) = gr_restart_marker_store.as_ref()
+                    && let Err(e) = store.remove()
+                {
                     warn!(
                         marker = %gr_restart_marker_path.display(),
                         error = %e,
@@ -1839,7 +2060,9 @@ async fn run<T>(
                 error = %e,
                 "ignoring invalid GR restart marker — starting without restarting-speaker mode"
             );
-            if let Err(remove_err) = remove_gr_restart_marker(&gr_restart_marker_path) {
+            if let Some(store) = gr_restart_marker_store.as_ref()
+                && let Err(remove_err) = store.remove()
+            {
                 warn!(
                     marker = %gr_restart_marker_path.display(),
                     error = %remove_err,
@@ -1850,17 +2073,30 @@ async fn run<T>(
         }
     };
 
-    if let Some(deadline) = local_gr_restart_until {
-        let marker_path = gr_restart_marker_path.clone();
+    if let (Some(deadline), Some(expected_marker)) =
+        (local_gr_restart_until, inherited_gr_restart_marker)
+    {
+        let marker_store = gr_restart_marker_store
+            .as_ref()
+            .expect("a read marker always has a pinned store")
+            .clone();
+        let marker_path = marker_store.display_path();
         let sleep_for = deadline.saturating_duration_since(StdInstant::now());
         tokio::spawn(async move {
             tokio::time::sleep(sleep_for).await;
-            if let Err(e) = remove_gr_restart_marker(&marker_path) {
-                warn!(
+            match marker_store.remove_if_matches(&expected_marker) {
+                Ok(true) => {}
+                Ok(false) => info!(
                     marker = %marker_path.display(),
-                    error = %e,
-                    "failed to remove expired GR restart marker"
-                );
+                    "retained replacement GR restart marker after inherited expiry"
+                ),
+                Err(e) => {
+                    warn!(
+                        marker = %marker_path.display(),
+                        error = %e,
+                        "failed to remove expired GR restart marker"
+                    );
+                }
             }
         });
     }
@@ -3653,7 +3889,12 @@ async fn run<T>(
                         if restart_time_secs.is_some() {
                             match tokio::time::timeout_at(
                                 deadline,
-                                publish_warm_checkpoint(capture, &rib_query_tx, directory),
+                                publish_warm_checkpoint(
+                                    capture,
+                                    &rib_query_tx,
+                                    directory,
+                                    deadline.into_std(),
+                                ),
                             )
                             .await
                             {
@@ -3696,10 +3937,13 @@ async fn run<T>(
 
     if let Some(restart_time_secs) = restart_time_secs {
         let expires_at = SystemTime::now() + Duration::from_secs(restart_time_secs);
-        let marker_result = write_selected_gr_restart_marker(
-            &gr_restart_marker_path,
-            expires_at,
-            checkpoint_generation.as_deref(),
+        let marker_result = gr_restart_marker_store.as_ref().map_or_else(
+            || {
+                Err(std::io::Error::other(
+                    "pinned runtime-state marker storage is unavailable",
+                ))
+            },
+            |store| store.write_selected(expires_at, checkpoint_generation.as_deref()),
         );
         if let Err(e) = marker_result {
             warn!(
@@ -3708,8 +3952,8 @@ async fn run<T>(
                 "failed to write GR restart marker"
             );
             if checkpoint_generation.is_some()
-                && let Err(fallback_error) =
-                    write_gr_restart_marker(&gr_restart_marker_path, expires_at)
+                && let Some(store) = gr_restart_marker_store.as_ref()
+                && let Err(fallback_error) = store.write_selected(expires_at, None)
             {
                 warn!(
                     marker = %gr_restart_marker_path.display(),
@@ -3726,7 +3970,9 @@ async fn run<T>(
                 "wrote GR restart marker for coordinated shutdown"
             );
         }
-    } else if let Err(e) = remove_gr_restart_marker(&gr_restart_marker_path) {
+    } else if let Some(store) = gr_restart_marker_store.as_ref()
+        && let Err(e) = store.remove()
+    {
         warn!(
             marker = %gr_restart_marker_path.display(),
             error = %e,
@@ -3923,6 +4169,15 @@ mod tests {
         std::env::temp_dir().join(format!("rustbgpd-{name}-{suffix}.toml"))
     }
 
+    fn marker_store() -> (tempfile::TempDir, GrRestartMarkerStore) {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let pinned = PinnedRuntimeStateDirectory::prepare(dir.path()).unwrap();
+        (dir, GrRestartMarkerStore::new(Arc::new(pinned)))
+    }
+
     fn load_config_from_toml(name: &str, toml: &str) -> Config {
         let path = unique_temp_path(name);
         std::fs::write(&path, toml).unwrap();
@@ -4106,26 +4361,28 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
 
     #[test]
     fn gr_restart_marker_round_trip() {
-        let path = unique_temp_path("gr-restart-marker");
+        let (_dir, store) = marker_store();
         let expires_at = SystemTime::now() + Duration::from_mins(2);
-        write_gr_restart_marker(&path, expires_at).unwrap();
-        let read_back = read_gr_restart_marker(&path).unwrap().unwrap();
+        store.write_selected(expires_at, None).unwrap();
+        let read_back = store.read().unwrap().unwrap();
         let diff = read_back
             .expires_at
             .duration_since(expires_at)
             .unwrap_or_else(|e| e.duration());
         assert!(diff < Duration::from_secs(1));
         assert_eq!(read_back.checkpoint_generation, None);
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]
     fn gr_restart_marker_v2_round_trip_binds_exact_generation() {
-        let path = unique_temp_path("gr-restart-marker-v2");
+        let (_dir, store) = marker_store();
         let expires_at = SystemTime::now() + Duration::from_mins(2);
-        write_gr_restart_marker_v2(&path, expires_at, "checkpoint-0007").unwrap();
+        store
+            .write_selected(expires_at, Some("checkpoint-0007"))
+            .unwrap();
 
-        let read_back = read_gr_restart_marker(&path).unwrap().unwrap();
+        let read_back = store.read().unwrap().unwrap();
         assert_eq!(
             read_back.checkpoint_generation.as_deref(),
             Some("checkpoint-0007")
@@ -4135,68 +4392,181 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             .duration_since(expires_at)
             .unwrap_or_else(|e| e.duration());
         assert!(diff < Duration::from_secs(1));
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]
     fn gr_restart_marker_invalid_shapes_are_rejected() {
-        let path = unique_temp_path("gr-restart-bad-version");
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (_dir, store) = marker_store();
+        let path = store.display_path();
         std::fs::write(&path, "version = 3\nexpires_at_unix = 1\n").unwrap();
-        let err = read_gr_restart_marker(&path).unwrap_err();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let err = store.read().unwrap_err();
         assert!(err.contains("unsupported marker version"));
         std::fs::write(&path, "version = 2\nexpires_at_unix = 1\n").unwrap();
-        let err = read_gr_restart_marker(&path).unwrap_err();
+        let err = store.read().unwrap_err();
         assert!(err.contains("missing checkpoint_generation"));
         std::fs::write(
             &path,
             "version = 1\nexpires_at_unix = 1\ncheckpoint_generation = \"unexpected\"\n",
         )
         .unwrap();
-        let err = read_gr_restart_marker(&path).unwrap_err();
+        let err = store.read().unwrap_err();
         assert!(err.contains("v1 must not reference"));
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]
     fn gr_restart_marker_precommit_failures_preserve_previous_generation() {
-        let path = unique_temp_path("gr-restart-marker-atomicity");
+        let (_dir, store) = marker_store();
         let expires_at = SystemTime::now() + Duration::from_mins(2);
-        write_gr_restart_marker_v2(&path, expires_at, "committed").unwrap();
+        store.write_selected(expires_at, Some("committed")).unwrap();
 
         for fault in [
             MarkerFaultPoint::Write,
             MarkerFaultPoint::FileSync,
             MarkerFaultPoint::Rename,
         ] {
-            let result =
-                write_gr_restart_marker_inner(&path, expires_at, Some("uncommitted"), fault);
+            let result = store.write_inner(expires_at, Some("uncommitted"), fault);
             assert!(result.is_err(), "fault {fault:?} must fail");
-            let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+            let marker = store.read().unwrap().unwrap();
             assert_eq!(
                 marker.checkpoint_generation.as_deref(),
                 Some("committed"),
                 "fault {fault:?} must preserve the prior committed marker"
             );
         }
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]
     fn gr_restart_marker_postrename_failure_exposes_only_complete_v2() {
-        let path = unique_temp_path("gr-restart-marker-postrename");
+        let (_dir, store) = marker_store();
         let expires_at = SystemTime::now() + Duration::from_mins(2);
-        write_gr_restart_marker_v2(&path, expires_at, "old").unwrap();
+        store.write_selected(expires_at, Some("old")).unwrap();
 
-        let result = write_gr_restart_marker_inner(
-            &path,
-            expires_at,
-            Some("new"),
-            MarkerFaultPoint::DirectorySync,
-        );
+        let result = store.write_inner(expires_at, Some("new"), MarkerFaultPoint::DirectorySync);
         assert!(result.is_err());
-        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        let marker = store.read().unwrap().unwrap();
         assert_eq!(marker.checkpoint_generation.as_deref(), Some("new"));
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
+    }
+
+    #[test]
+    fn inherited_marker_expiry_cannot_remove_replacement_generation() {
+        let (_dir, store) = marker_store();
+        let expires_at = SystemTime::now() + Duration::from_mins(2);
+        store.write_selected(expires_at, Some("old")).unwrap();
+        let inherited = store.read().unwrap().unwrap();
+
+        store.write_selected(expires_at, Some("new")).unwrap();
+        assert!(!store.remove_if_matches(&inherited).unwrap());
+        assert_eq!(
+            store
+                .read()
+                .unwrap()
+                .unwrap()
+                .checkpoint_generation
+                .as_deref(),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn inherited_marker_expiry_compares_exact_bytes_not_parsed_semantics() {
+        let (_dir, store) = marker_store();
+        let expires_at = UNIX_EPOCH + Duration::from_hours(500_000);
+        store.write_selected(expires_at, Some("same")).unwrap();
+        let inherited = store.read().unwrap().unwrap();
+
+        // Same parsed marker, different exact stored bytes and therefore a
+        // distinct publisher identity.
+        std::fs::write(
+            store.display_path(),
+            "# replacement\ncheckpoint_generation = \"same\"\nexpires_at_unix = 1800000000\nversion = 2\n",
+        )
+        .unwrap();
+        assert!(!store.remove_if_matches(&inherited).unwrap());
+        assert!(store.display_path().exists());
+        assert_eq!(
+            store
+                .read()
+                .unwrap()
+                .unwrap()
+                .checkpoint_generation
+                .as_deref(),
+            Some("same")
+        );
+    }
+
+    #[test]
+    fn pinned_marker_and_bundle_ignore_runtime_path_replacement() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let parent = tempfile::tempdir().unwrap();
+        let runtime = parent.path().join("runtime");
+        std::fs::create_dir(&runtime).unwrap();
+        std::fs::set_permissions(&runtime, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let pinned = Arc::new(PinnedRuntimeStateDirectory::prepare(&runtime).unwrap());
+        let store = GrRestartMarkerStore::new(Arc::clone(&pinned));
+
+        let original = parent.path().join("original");
+        std::fs::rename(&runtime, &original).unwrap();
+        let attacker = parent.path().join("attacker");
+        std::fs::create_dir(&attacker).unwrap();
+        symlink(&attacker, &runtime).unwrap();
+
+        store
+            .write_selected(SystemTime::now() + Duration::from_mins(2), Some("pinned"))
+            .unwrap();
+        pinned.prepare_warm_bundle().unwrap();
+        assert!(original.join(GR_RESTART_MARKER_FILE).is_file());
+        assert!(original.join(WARM_BUNDLE_DIRECTORY).is_dir());
+        assert!(!attacker.join(GR_RESTART_MARKER_FILE).exists());
+        assert!(!attacker.join(WARM_BUNDLE_DIRECTORY).exists());
+    }
+
+    #[test]
+    fn marker_storage_rejects_symlinks_and_unsafe_modes() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, "version = 1\nexpires_at_unix = 1\n").unwrap();
+        symlink(&target, dir.path().join(GR_RESTART_MARKER_FILE)).unwrap();
+        let store = GrRestartMarkerStore::new(Arc::new(
+            PinnedRuntimeStateDirectory::prepare(dir.path()).unwrap(),
+        ));
+        assert!(
+            store.read().is_err(),
+            "final marker symlink must be rejected"
+        );
+
+        std::fs::remove_file(dir.path().join(GR_RESTART_MARKER_FILE)).unwrap();
+        std::fs::write(
+            dir.path().join(GR_RESTART_MARKER_FILE),
+            "version = 1\nexpires_at_unix = 1\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(
+            dir.path().join(GR_RESTART_MARKER_FILE),
+            std::fs::Permissions::from_mode(0o666),
+        )
+        .unwrap();
+        assert!(
+            store
+                .read()
+                .unwrap_err()
+                .contains("unsafe type, owner, or mode")
+        );
+
+        let unsafe_dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(unsafe_dir.path(), std::fs::Permissions::from_mode(0o777))
+            .unwrap();
+        assert!(PinnedRuntimeStateDirectory::prepare(unsafe_dir.path()).is_err());
     }
 
     #[test]
@@ -4276,20 +4646,20 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
 
     #[test]
     fn authoritative_capture_restart_window_controls_v2_expiry() {
-        let path = unique_temp_path("gr-restart-authoritative-window");
+        let (_dir, store) = marker_store();
         // Represents a live runtime-config capture that advanced from a stale
         // startup value to 17 seconds. Production overwrites the fallback with
         // `capture.restart_time_secs` before selecting marker v2.
         let captured_restart_time_secs = 17;
         let before = SystemTime::now();
-        write_selected_gr_restart_marker(
-            &path,
-            before + Duration::from_secs(captured_restart_time_secs),
-            Some("captured-generation"),
-        )
-        .unwrap();
+        store
+            .write_selected(
+                before + Duration::from_secs(captured_restart_time_secs),
+                Some("captured-generation"),
+            )
+            .unwrap();
 
-        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        let marker = store.read().unwrap().unwrap();
         assert_eq!(
             marker.checkpoint_generation.as_deref(),
             Some("captured-generation")
@@ -4297,18 +4667,19 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         let retention = marker.expires_at.duration_since(before).unwrap();
         assert!(retention >= Duration::from_secs(16));
         assert!(retention <= Duration::from_secs(17));
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]
     fn failed_or_timed_out_writer_selects_v1_without_generation_reference() {
-        let path = unique_temp_path("gr-restart-writer-fallback");
-        write_selected_gr_restart_marker(&path, SystemTime::now() + Duration::from_mins(2), None)
+        let (_dir, store) = marker_store();
+        store
+            .write_selected(SystemTime::now() + Duration::from_mins(2), None)
             .unwrap();
 
-        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        let marker = store.read().unwrap().unwrap();
         assert_eq!(marker.checkpoint_generation, None);
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     fn checkpoint_plan_session() -> WarmCheckpointSession {
@@ -4341,16 +4712,17 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
 
     #[test]
     fn no_eligible_checkpoint_plan_retains_v1_fallback() {
-        let path = unique_temp_path("gr-restart-no-eligible-plan");
+        let (_dir, store) = marker_store();
         let mut session = checkpoint_plan_session();
         session.peer_gr_families.clear();
         assert!(build_warm_checkpoint_plan(&[session]).is_err());
 
-        write_selected_gr_restart_marker(&path, SystemTime::now() + Duration::from_mins(2), None)
+        store
+            .write_selected(SystemTime::now() + Duration::from_mins(2), None)
             .unwrap();
-        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        let marker = store.read().unwrap().unwrap();
         assert_eq!(marker.checkpoint_generation, None);
-        remove_gr_restart_marker(&path).unwrap();
+        store.remove().unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,19 +49,25 @@ mod test_support;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, SocketAddr};
+use std::os::unix::fs::DirBuilderExt as _;
 use std::path::Path;
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
 
-use rustbgpd_rib::{RibManager, RibUpdate};
+use rustbgpd_mrt::{
+    WarmBundleDirectory, WarmBundleFamilyV1, WarmBundleIdentityV1, WarmBundlePolicyInputV1,
+    WarmBundleViewKindV1, WarmBundleViewV1, resolved_import_policy_digest_v1, write_warm_bundle,
+};
+use rustbgpd_rib::{RibManager, RibUpdate, WarmMrtSnapshotView};
 use rustbgpd_telemetry::{BgpMetrics, init_logging};
 use rustbgpd_transport::{
     BgpListener, ListenerSocketOptions, TcpAoAlgorithm, TcpAoConfig as TransportTcpAoConfig,
     TcpAoKeyring, TcpAoListenerKey, TcpAoListenerOwnerKind,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -77,16 +83,20 @@ use crate::reload::{
 use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
+    WarmCheckpointCapture, WarmCheckpointSession,
 };
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
     ListenerEndpoint, ServeConfig,
 };
+use rustbgpd_wire::{Afi, Safi};
 
 const GR_RESTART_MARKER_V1: u8 = 1;
 const GR_RESTART_MARKER_V2: u8 = 2;
 const MAX_CHECKPOINT_GENERATION_BYTES: usize = 128;
+const WARM_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(30);
 static MARKER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static WARM_CHECKPOINT_REVISION: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ManagedNetdevMetricLabel {
@@ -145,6 +155,14 @@ struct ValidGrRestartMarker {
     /// Present only for durable marker v2. Tranche 2 records this binding but
     /// deliberately has no boot-side cache load or route-serving behavior.
     checkpoint_generation: Option<String>,
+}
+
+#[derive(Debug)]
+struct WarmCheckpointPlan {
+    views: Vec<WarmBundleViewV1>,
+    rib_views: Vec<WarmMrtSnapshotView>,
+    policy_inputs: Vec<WarmBundlePolicyInputV1>,
+    add_path_receive: Vec<rustbgpd_mrt::codec::MrtAddPathReceiveProfile>,
 }
 
 struct BmpRuntime {
@@ -475,6 +493,7 @@ fn raw_max_gr_restart_time_secs(config: &Config) -> Option<u64> {
         .iter()
         .filter(|neighbor| neighbor.graceful_restart.unwrap_or(true))
         .map(|neighbor| u64::from(neighbor.gr_restart_time.unwrap_or(120)))
+        .filter(|seconds| *seconds > 0)
         .max()
 }
 
@@ -484,6 +503,7 @@ fn max_gr_restart_time_secs(config: &Config) -> Option<u64> {
             .iter()
             .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
             .map(|neighbor| u64::from(neighbor.transport_config.peer.gr_restart_time))
+            .filter(|seconds| *seconds > 0)
             .max(),
         Err(error) => {
             warn!(
@@ -554,10 +574,6 @@ fn write_gr_restart_marker(path: &Path, expires_at: SystemTime) -> std::io::Resu
 
 /// Publish marker v2 only after the exact referenced warm bundle generation
 /// has committed. No boot-side restore consumes this reference in tranche 2.
-#[allow(
-    dead_code,
-    reason = "wired by the LAN-337 checkpoint coordinator slice"
-)]
 fn write_gr_restart_marker_v2(
     path: &Path,
     expires_at: SystemTime,
@@ -577,6 +593,17 @@ fn write_gr_restart_marker_v2(
         expires_at,
         Some(checkpoint_generation),
         MarkerFaultPoint::None,
+    )
+}
+
+fn write_selected_gr_restart_marker(
+    path: &Path,
+    expires_at: SystemTime,
+    checkpoint_generation: Option<&str>,
+) -> std::io::Result<()> {
+    checkpoint_generation.map_or_else(
+        || write_gr_restart_marker(path, expires_at),
+        |generation| write_gr_restart_marker_v2(path, expires_at, generation),
     )
 }
 
@@ -742,6 +769,220 @@ fn remove_gr_restart_marker(path: &Path) -> std::io::Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
     }
+}
+
+fn prepare_warm_bundle_directory(path: &Path) -> Result<WarmBundleDirectory, String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true).mode(0o700);
+            builder.create(path).map_err(|error| {
+                format!(
+                    "failed to create warm checkpoint directory {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect warm checkpoint directory {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    WarmBundleDirectory::open(path).map_err(|error| error.to_string())
+}
+
+const fn warm_bundle_family_v1(afi: Afi, safi: Safi) -> Option<WarmBundleFamilyV1> {
+    match (afi, safi) {
+        (Afi::Ipv4, Safi::Unicast) => Some(WarmBundleFamilyV1::Ipv4Unicast),
+        (Afi::Ipv6, Safi::Unicast) => Some(WarmBundleFamilyV1::Ipv6Unicast),
+        (Afi::L2Vpn, Safi::Evpn) => Some(WarmBundleFamilyV1::L2vpnEvpn),
+        _ => None,
+    }
+}
+
+fn build_warm_checkpoint_plan(
+    sessions: &[WarmCheckpointSession],
+) -> Result<WarmCheckpointPlan, String> {
+    let mut views = Vec::new();
+    let mut rib_views = Vec::new();
+    let mut policy_inputs = Vec::new();
+    let mut add_path_receive = Vec::new();
+
+    for session in sessions {
+        if session.peer.interface.is_some() {
+            return Err(format!(
+                "scoped peer {} reached the numbered-only warm checkpoint planner",
+                session.peer
+            ));
+        }
+        let peer = session.peer.address;
+        for &(afi, safi) in &session.peer_gr_families {
+            if !session.negotiated_families.contains(&(afi, safi)) {
+                continue;
+            }
+            let Some(family) = warm_bundle_family_v1(afi, safi) else {
+                continue;
+            };
+            let receives_add_path = session.add_path_receive_families.contains(&(afi, safi));
+            // TABLE_DUMP_V2 has Add-Path subtypes only for unicast. V1
+            // deliberately excludes an EVPN/Add-Path profile rather than
+            // serializing it under ambiguous RIB_GENERIC framing.
+            if family == WarmBundleFamilyV1::L2vpnEvpn && receives_add_path {
+                continue;
+            }
+            let view = WarmBundleViewV1 {
+                kind: WarmBundleViewKindV1::AdjRibInPrePolicy,
+                peer,
+                peer_asn: session.peer_asn,
+                peer_router_id: session.peer_router_id,
+                family,
+                add_path_receive: receives_add_path,
+            };
+            policy_inputs.push(WarmBundlePolicyInputV1 {
+                view: view.clone(),
+                canonical_policy: session.canonical_import_policy.clone(),
+            });
+            views.push(view);
+            rib_views.push(WarmMrtSnapshotView {
+                peer,
+                session_id: session.session_id,
+                peer_asn: session.peer_asn,
+                peer_router_id: session.peer_router_id,
+                afi,
+                safi,
+                add_path_receive: receives_add_path,
+            });
+            if receives_add_path {
+                add_path_receive.push(rustbgpd_mrt::codec::MrtAddPathReceiveProfile {
+                    peer,
+                    afi,
+                    safi,
+                });
+            }
+        }
+    }
+
+    views.sort();
+    if views.is_empty() {
+        return Err("warm checkpoint has no eligible peer/family views".to_string());
+    }
+    if views.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err("warm checkpoint views are not unique".to_string());
+    }
+    policy_inputs.sort_by(|left, right| left.view.cmp(&right.view));
+    rib_views.sort_by_key(WarmMrtSnapshotView::sort_key);
+    add_path_receive.sort_by_key(|profile| (profile.peer, profile.afi as u16, profile.safi as u8));
+
+    Ok(WarmCheckpointPlan {
+        views,
+        rib_views,
+        policy_inputs,
+        add_path_receive,
+    })
+}
+
+fn effective_config_sha256(effective_redacted_toml: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(effective_redacted_toml.as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+async fn publish_warm_checkpoint(
+    capture: WarmCheckpointCapture,
+    rib_query_tx: &mpsc::Sender<RibUpdate>,
+    directory: Arc<WarmBundleDirectory>,
+) -> Result<String, String> {
+    let plan = build_warm_checkpoint_plan(&capture.sessions)?;
+
+    let (rib_reply, rib_rx) = oneshot::channel();
+    rib_query_tx
+        .send(RibUpdate::QueryWarmMrtSnapshot {
+            views: plan.rib_views,
+            reply: rib_reply,
+        })
+        .await
+        .map_err(|_| "RIB actor exited before warm checkpoint query".to_string())?;
+    let snapshot = rib_rx
+        .await
+        .map_err(|_| "RIB actor dropped warm checkpoint query".to_string())??;
+
+    let now_seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("system clock precedes Unix epoch: {error}"))?
+        .as_secs();
+    let created_at_utc_seconds = i64::try_from(now_seconds)
+        .map_err(|_| "warm checkpoint timestamp exceeds i64".to_string())?;
+    let mrt_timestamp = u32::try_from(now_seconds)
+        .map_err(|_| "warm checkpoint timestamp exceeds MRT u32".to_string())?;
+    let snapshot_revision = WARM_CHECKPOINT_REVISION
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |revision| {
+            revision.checked_add(1)
+        })
+        .map(|prior| prior + 1)
+        .map_err(|_| "warm checkpoint revision exhausted".to_string())?;
+    let checkpoint_generation = uuid::Uuid::new_v4().simple().to_string();
+    let identity = WarmBundleIdentityV1 {
+        checkpoint_generation: checkpoint_generation.clone(),
+        created_at_utc_seconds,
+        snapshot_revision,
+        local_asn: capture.local_asn,
+        local_router_id: capture.local_router_id,
+        peer_index_table_view: checkpoint_generation.clone(),
+        config_sha256: effective_config_sha256(&capture.effective_config_toml),
+        resolved_import_policy: resolved_import_policy_digest_v1(&plan.policy_inputs)
+            .map_err(|error| error.to_string())?,
+        views: plan.views,
+    };
+    let local_router_id = capture.local_router_id;
+    let view_name = checkpoint_generation.clone();
+    let (writer_reply, writer_rx) = oneshot::channel();
+    // Do not use Tokio's blocking pool here. A timed-out spawn_blocking task
+    // cannot be cancelled and the runtime waits for it during shutdown,
+    // defeating the 30-second terminal bound. This dedicated OS thread is
+    // detached if the coordinator deadline fires; daemon teardown continues
+    // immediately and process exit terminates any remaining work. It may
+    // finish an orphan bundle generation in the meantime, but main publishes
+    // marker v2 only after this reply, so a late generation is never selected.
+    std::thread::Builder::new()
+        .name("warm-checkpoint-writer".to_string())
+        .spawn(move || {
+            let result = (|| {
+                let encoded = rustbgpd_mrt::codec::encode_warm_snapshot(
+                    local_router_id,
+                    &view_name,
+                    &snapshot.peers,
+                    &snapshot.routes,
+                    &snapshot.evpn_routes,
+                    mrt_timestamp,
+                    &plan.add_path_receive,
+                )
+                .map_err(|error| error.to_string())?;
+                write_warm_bundle(directory.as_ref(), identity, &encoded)
+                    .map_err(|error| error.to_string())?;
+                Ok::<(), String>(())
+            })();
+            let _ = writer_reply.send(result);
+        })
+        .map_err(|error| format!("failed to spawn warm checkpoint writer: {error}"))?;
+    writer_rx
+        .await
+        .map_err(|_| "warm checkpoint writer exited without a result".to_string())??;
+    Ok(checkpoint_generation)
+}
+
+async fn query_warm_checkpoint_capture(
+    peer_mgr_tx: &mpsc::Sender<PeerManagerCommand>,
+) -> Result<WarmCheckpointCapture, String> {
+    let (reply, rx) = oneshot::channel();
+    peer_mgr_tx
+        .send(PeerManagerCommand::QueryWarmCheckpointCapture { reply })
+        .await
+        .map_err(|_| "peer manager exited before warm checkpoint query".to_string())?;
+    rx.await
+        .map_err(|_| "peer manager dropped warm checkpoint query".to_string())?
 }
 
 fn tcp_ao_listener_key_for_neighbor(
@@ -1534,6 +1775,32 @@ async fn run<T>(
 
     let start_time = tokio::time::Instant::now();
     let gr_restart_marker_path = config.gr_restart_marker_path();
+    // This knob and path are restart-required. Pin the verified directory at
+    // startup; later publication is descriptor-relative and cannot be
+    // redirected by replacing the pathname during shutdown.
+    let warm_checkpoint_on_shutdown = config.global.warm_cache_checkpoint_on_shutdown;
+    let warm_bundle_path = config.warm_bundle_dir();
+    let warm_bundle_directory = if warm_checkpoint_on_shutdown {
+        match prepare_warm_bundle_directory(&warm_bundle_path) {
+            Ok(directory) => {
+                info!(
+                    path = %warm_bundle_path.display(),
+                    "prepared daemon-private warm checkpoint directory"
+                );
+                Some(Arc::new(directory))
+            }
+            Err(error) => {
+                warn!(
+                    path = %warm_bundle_path.display(),
+                    %error,
+                    "warm checkpoint publication unavailable; coordinated shutdown will retain marker-v1 GR fallback"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     let local_gr_restart_until = match read_gr_restart_marker(&gr_restart_marker_path) {
         Ok(Some(marker)) => {
             let max_restart_time_secs = max_gr_restart_time_secs(&config);
@@ -2646,7 +2913,7 @@ async fn run<T>(
 
     // Spawn gRPC API server (keep JoinHandle for supervision)
     let grpc_rib_tx = rib_tx.clone();
-    let grpc_rib_query_tx = rib_query_tx;
+    let grpc_rib_query_tx = rib_query_tx.clone();
     let grpc_peer_mgr_tx = peer_mgr_tx.clone();
     let evpn_duplicate_mac_clear = evpn_originator_handle.as_ref().map(|handle| {
         let control = handle.control();
@@ -3347,18 +3614,115 @@ async fn run<T>(
     // 1. Tell PeerManager to shut down (sends NOTIFICATIONs to all peers)
     daemon_gate.begin_shutdown();
     info!("initiating coordinated shutdown");
-    if let Some(restart_time_secs) = max_gr_restart_time_secs(&config) {
+    let mut restart_time_secs = max_gr_restart_time_secs(&config);
+    let mut checkpoint_generation = None;
+    let mut checkpoint_failure = None;
+    let mut _runtime_config_fence = None;
+    let mut evpn_apply_fence = None;
+
+    if warm_checkpoint_on_shutdown {
+        if let Some(directory) = warm_bundle_directory.clone() {
+            let deadline = tokio::time::Instant::now() + WARM_CHECKPOINT_DEADLINE;
+            match tokio::time::timeout_at(deadline, runtime_config_lock.lock()).await {
+                Ok(guard) => _runtime_config_fence = Some(guard),
+                Err(_) => {
+                    checkpoint_failure = Some(
+                        "timed out acquiring the authoritative runtime-config fence".to_string(),
+                    );
+                }
+            }
+            if checkpoint_failure.is_none() {
+                match tokio::time::timeout_at(deadline, evpn_runtime_apply_lock.lock()).await {
+                    Ok(guard) => evpn_apply_fence = Some(guard),
+                    Err(_) => {
+                        checkpoint_failure =
+                            Some("timed out waiting for the EVPN runtime-apply fence".to_string());
+                    }
+                }
+            }
+            if checkpoint_failure.is_none() {
+                match tokio::time::timeout_at(deadline, query_warm_checkpoint_capture(&peer_mgr_tx))
+                    .await
+                {
+                    Ok(Ok(capture)) => {
+                        // Marker expiry and bundle identity come from this same
+                        // actor-consistent capture. Main's Config can lag
+                        // accepted runtime CRUD and is only the marker-v1
+                        // compatibility fallback when capture itself fails.
+                        restart_time_secs = capture.restart_time_secs;
+                        if restart_time_secs.is_some() {
+                            match tokio::time::timeout_at(
+                                deadline,
+                                publish_warm_checkpoint(capture, &rib_query_tx, directory),
+                            )
+                            .await
+                            {
+                                Ok(Ok(generation)) => {
+                                    checkpoint_generation = Some(generation);
+                                }
+                                Ok(Err(error)) => checkpoint_failure = Some(error),
+                                Err(_) => {
+                                    checkpoint_failure = Some(format!(
+                                        "warm checkpoint exceeded its {}s terminal deadline",
+                                        WARM_CHECKPOINT_DEADLINE.as_secs()
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    Ok(Err(error)) => checkpoint_failure = Some(error),
+                    Err(_) => {
+                        checkpoint_failure = Some(format!(
+                            "warm checkpoint capture exceeded its {}s terminal deadline",
+                            WARM_CHECKPOINT_DEADLINE.as_secs()
+                        ));
+                    }
+                }
+            }
+        } else {
+            checkpoint_failure = Some(format!(
+                "warm checkpoint directory {} was unavailable at startup",
+                warm_bundle_path.display()
+            ));
+        }
+    }
+
+    if let Some(error) = checkpoint_failure.as_deref() {
+        warn!(
+            %error,
+            "warm checkpoint publication failed; retaining marker-v1 GR fallback"
+        );
+    }
+
+    if let Some(restart_time_secs) = restart_time_secs {
         let expires_at = SystemTime::now() + Duration::from_secs(restart_time_secs);
-        if let Err(e) = write_gr_restart_marker(&gr_restart_marker_path, expires_at) {
+        let marker_result = write_selected_gr_restart_marker(
+            &gr_restart_marker_path,
+            expires_at,
+            checkpoint_generation.as_deref(),
+        );
+        if let Err(e) = marker_result {
             warn!(
                 marker = %gr_restart_marker_path.display(),
                 error = %e,
-                "failed to write GR restart marker — restarting-speaker mode will be unavailable on the next start (check runtime_state_dir permissions)"
+                "failed to write GR restart marker"
             );
+            if checkpoint_generation.is_some()
+                && let Err(fallback_error) =
+                    write_gr_restart_marker(&gr_restart_marker_path, expires_at)
+            {
+                warn!(
+                    marker = %gr_restart_marker_path.display(),
+                    error = %fallback_error,
+                    "failed to publish marker-v1 after marker-v2 failure — restarting-speaker mode will be unavailable on the next start"
+                );
+            }
         } else {
             info!(
                 marker = %gr_restart_marker_path.display(),
                 restart_time_secs,
+                checkpoint_generation = checkpoint_generation.as_deref().unwrap_or("none"),
+                marker_version = if checkpoint_generation.is_some() { GR_RESTART_MARKER_V2 } else { GR_RESTART_MARKER_V1 },
                 "wrote GR restart marker for coordinated shutdown"
             );
         }
@@ -3376,15 +3740,20 @@ async fn run<T>(
     // and holding it for the rest of shutdown blocks a late apply from
     // re-originating routes after the withdraw-all sweep. Bounded so a
     // wedged converge cannot stall daemon exit.
-    let _evpn_apply_fence = tokio::time::timeout(
-        Duration::from_secs(10),
-        evpn_runtime_apply_lock.lock(),
-    )
-    .await
-    .inspect_err(|_| {
-        warn!("EVPN runtime apply still in flight after 10s; proceeding with shutdown teardown");
-    })
-    .ok();
+    if evpn_apply_fence.is_none() {
+        evpn_apply_fence = tokio::time::timeout(
+            Duration::from_secs(10),
+            evpn_runtime_apply_lock.lock(),
+        )
+        .await
+        .inspect_err(|_| {
+            warn!(
+                "EVPN runtime apply still in flight after 10s; proceeding with shutdown teardown"
+            );
+        })
+        .ok();
+    }
+    let _evpn_apply_fence_guard = evpn_apply_fence;
 
     // 1.9a-pre Stop the ADR-0085 link-drain coordinator before the
     // EVPN actors drain: a carrier edge arriving mid-teardown must
@@ -3878,25 +4247,118 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
     }
 
     #[test]
-    fn gr_restart_marker_remaining_time_rejects_or_clamps_valid_far_future_marker() {
+    fn gr_restart_marker_remaining_time_rejects_or_clamps_valid_far_future_v2_marker() {
         let path = unique_temp_path("gr-restart-far-future");
         let far_future_secs = i64::MAX.unsigned_abs();
         std::fs::write(
             &path,
-            format!("version = 1\nexpires_at_unix = {far_future_secs}\n"),
+            format!(
+                "version = 2\nexpires_at_unix = {far_future_secs}\ncheckpoint_generation = \"far-future-generation\"\n"
+            ),
         )
         .unwrap();
-        let expires_at = read_gr_restart_marker(&path).unwrap().unwrap();
+        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(
+            marker.checkpoint_generation.as_deref(),
+            Some("far-future-generation")
+        );
 
         assert_eq!(
-            gr_restart_marker_remaining_time(expires_at, UNIX_EPOCH, None),
+            gr_restart_marker_remaining_time(marker.expires_at, UNIX_EPOCH, None),
             None
         );
         assert_eq!(
-            gr_restart_marker_remaining_time(expires_at, UNIX_EPOCH, Some(120)).unwrap(),
+            gr_restart_marker_remaining_time(marker.expires_at, UNIX_EPOCH, Some(120)).unwrap(),
             Duration::from_mins(2)
         );
         remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn authoritative_capture_restart_window_controls_v2_expiry() {
+        let path = unique_temp_path("gr-restart-authoritative-window");
+        // Represents a live runtime-config capture that advanced from a stale
+        // startup value to 17 seconds. Production overwrites the fallback with
+        // `capture.restart_time_secs` before selecting marker v2.
+        let captured_restart_time_secs = 17;
+        let before = SystemTime::now();
+        write_selected_gr_restart_marker(
+            &path,
+            before + Duration::from_secs(captured_restart_time_secs),
+            Some("captured-generation"),
+        )
+        .unwrap();
+
+        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(
+            marker.checkpoint_generation.as_deref(),
+            Some("captured-generation")
+        );
+        let retention = marker.expires_at.duration_since(before).unwrap();
+        assert!(retention >= Duration::from_secs(16));
+        assert!(retention <= Duration::from_secs(17));
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn failed_or_timed_out_writer_selects_v1_without_generation_reference() {
+        let path = unique_temp_path("gr-restart-writer-fallback");
+        write_selected_gr_restart_marker(&path, SystemTime::now() + Duration::from_mins(2), None)
+            .unwrap();
+
+        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(marker.checkpoint_generation, None);
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    fn checkpoint_plan_session() -> WarmCheckpointSession {
+        WarmCheckpointSession {
+            peer: rustbgpd_api::peer_types::PeerKey::new("10.0.0.2".parse().unwrap(), None),
+            session_id: 41,
+            peer_asn: 65002,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            negotiated_families: vec![(Afi::Ipv4, Safi::Unicast)],
+            peer_gr_families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+            add_path_receive_families: vec![(Afi::Ipv4, Safi::Unicast)],
+            canonical_import_policy: b"canonical-policy-v1".to_vec(),
+        }
+    }
+
+    #[test]
+    fn warm_checkpoint_plan_intersects_gr_with_negotiated_family() {
+        let plan = build_warm_checkpoint_plan(&[checkpoint_plan_session()]).unwrap();
+        assert_eq!(plan.views.len(), 1);
+        assert_eq!(plan.views[0].family, WarmBundleFamilyV1::Ipv4Unicast);
+        assert!(plan.views[0].add_path_receive);
+        assert_eq!(plan.rib_views[0].session_id, 41);
+        assert_eq!(plan.policy_inputs[0].view, plan.views[0]);
+        assert_eq!(
+            plan.policy_inputs[0].canonical_policy,
+            b"canonical-policy-v1"
+        );
+        assert_eq!(plan.add_path_receive.len(), 1);
+    }
+
+    #[test]
+    fn no_eligible_checkpoint_plan_retains_v1_fallback() {
+        let path = unique_temp_path("gr-restart-no-eligible-plan");
+        let mut session = checkpoint_plan_session();
+        session.peer_gr_families.clear();
+        assert!(build_warm_checkpoint_plan(&[session]).is_err());
+
+        write_selected_gr_restart_marker(&path, SystemTime::now() + Duration::from_mins(2), None)
+            .unwrap();
+        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(marker.checkpoint_generation, None);
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn effective_config_digest_rejects_runtime_config_mismatch() {
+        let before = effective_config_sha256("asn = 65001\n");
+        let after = effective_config_sha256("asn = 65001\nhonor_blackhole = true\n");
+        assert_eq!(before.len(), 64);
+        assert_ne!(before, after);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
 
@@ -82,7 +83,10 @@ use rustbgpd_api::server::{
     ListenerEndpoint, ServeConfig,
 };
 
-const GR_RESTART_MARKER_VERSION: u8 = 1;
+const GR_RESTART_MARKER_V1: u8 = 1;
+const GR_RESTART_MARKER_V2: u8 = 2;
+const MAX_CHECKPOINT_GENERATION_BYTES: usize = 128;
+static MARKER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ManagedNetdevMetricLabel {
@@ -127,9 +131,20 @@ fn update_managed_netdev_metrics(
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct GrRestartMarker {
     version: u8,
     expires_at_unix: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    checkpoint_generation: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ValidGrRestartMarker {
+    expires_at: SystemTime,
+    /// Present only for durable marker v2. Tranche 2 records this binding but
+    /// deliberately has no boot-side cache load or route-serving behavior.
+    checkpoint_generation: Option<String>,
 }
 
 struct BmpRuntime {
@@ -490,36 +505,111 @@ fn gr_restart_marker_remaining_time(
     Some(remaining.min(Duration::from_secs(maximum)))
 }
 
-fn marker_expires_at(marker: &GrRestartMarker) -> Result<SystemTime, String> {
-    if marker.version != GR_RESTART_MARKER_VERSION {
-        return Err(format!(
-            "unsupported marker version {} (expected {})",
-            marker.version, GR_RESTART_MARKER_VERSION
-        ));
+fn validate_gr_restart_marker(marker: GrRestartMarker) -> Result<ValidGrRestartMarker, String> {
+    match marker.version {
+        GR_RESTART_MARKER_V1 if marker.checkpoint_generation.is_none() => {}
+        GR_RESTART_MARKER_V1 => {
+            return Err("restart marker v1 must not reference a checkpoint generation".to_string());
+        }
+        GR_RESTART_MARKER_V2 => {
+            let generation = marker
+                .checkpoint_generation
+                .as_deref()
+                .ok_or_else(|| "restart marker v2 is missing checkpoint_generation".to_string())?;
+            if generation.is_empty()
+                || generation.len() > MAX_CHECKPOINT_GENERATION_BYTES
+                || generation.chars().any(char::is_control)
+            {
+                return Err("restart marker v2 has an invalid checkpoint_generation".to_string());
+            }
+        }
+        version => {
+            return Err(format!(
+                "unsupported marker version {version} (expected {GR_RESTART_MARKER_V1} or {GR_RESTART_MARKER_V2})"
+            ));
+        }
     }
-    UNIX_EPOCH
+    let expires_at = UNIX_EPOCH
         .checked_add(Duration::from_secs(marker.expires_at_unix))
-        .ok_or_else(|| "marker expiry overflows system clock".to_string())
+        .ok_or_else(|| "marker expiry overflows system clock".to_string())?;
+    Ok(ValidGrRestartMarker {
+        expires_at,
+        checkpoint_generation: marker.checkpoint_generation,
+    })
 }
 
-fn read_gr_restart_marker(path: &Path) -> Result<Option<SystemTime>, String> {
+fn read_gr_restart_marker(path: &Path) -> Result<Option<ValidGrRestartMarker>, String> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(e.to_string()),
     };
     let marker: GrRestartMarker = toml::from_str(&content).map_err(|e| e.to_string())?;
-    marker_expires_at(&marker).map(Some)
+    validate_gr_restart_marker(marker).map(Some)
 }
 
 fn write_gr_restart_marker(path: &Path, expires_at: SystemTime) -> std::io::Result<()> {
+    write_gr_restart_marker_inner(path, expires_at, None, MarkerFaultPoint::None)
+}
+
+/// Publish marker v2 only after the exact referenced warm bundle generation
+/// has committed. No boot-side restore consumes this reference in tranche 2.
+#[allow(
+    dead_code,
+    reason = "wired by the LAN-337 checkpoint coordinator slice"
+)]
+fn write_gr_restart_marker_v2(
+    path: &Path,
+    expires_at: SystemTime,
+    checkpoint_generation: &str,
+) -> std::io::Result<()> {
+    if checkpoint_generation.is_empty()
+        || checkpoint_generation.len() > MAX_CHECKPOINT_GENERATION_BYTES
+        || checkpoint_generation.chars().any(char::is_control)
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid checkpoint generation",
+        ));
+    }
+    write_gr_restart_marker_inner(
+        path,
+        expires_at,
+        Some(checkpoint_generation),
+        MarkerFaultPoint::None,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerFaultPoint {
+    None,
+    Write,
+    FileSync,
+    Rename,
+    DirectorySync,
+}
+
+fn write_gr_restart_marker_inner(
+    path: &Path,
+    expires_at: SystemTime,
+    checkpoint_generation: Option<&str>,
+    fault: MarkerFaultPoint,
+) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
     let expires_at_unix = expires_at
         .duration_since(UNIX_EPOCH)
         .map_err(|e| std::io::Error::other(e.to_string()))?
         .as_secs();
     let marker = GrRestartMarker {
-        version: GR_RESTART_MARKER_VERSION,
+        version: if checkpoint_generation.is_some() {
+            GR_RESTART_MARKER_V2
+        } else {
+            GR_RESTART_MARKER_V1
+        },
         expires_at_unix,
+        checkpoint_generation: checkpoint_generation.map(str::to_string),
     };
     let parent = path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -529,7 +619,51 @@ fn write_gr_restart_marker(path: &Path, expires_at: SystemTime) -> std::io::Resu
     })?;
     std::fs::create_dir_all(parent)?;
     let encoded = toml::to_string(&marker).map_err(|e| std::io::Error::other(e.to_string()))?;
-    std::fs::write(path, encoded)
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "restart marker path has no UTF-8 file name",
+            )
+        })?;
+    let sequence = MARKER_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp_path = parent.join(format!(
+        ".{file_name}.tmp.{}.{}",
+        std::process::id(),
+        sequence
+    ));
+    let result = (|| -> std::io::Result<()> {
+        marker_fail_if(fault, MarkerFaultPoint::Write)?;
+        let mut temp = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp_path)?;
+        temp.write_all(encoded.as_bytes())?;
+        marker_fail_if(fault, MarkerFaultPoint::FileSync)?;
+        temp.sync_all()?;
+        drop(temp);
+        marker_fail_if(fault, MarkerFaultPoint::Rename)?;
+        std::fs::rename(&temp_path, path)?;
+        marker_fail_if(fault, MarkerFaultPoint::DirectorySync)?;
+        std::fs::File::open(parent)?.sync_all()
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn marker_fail_if(selected: MarkerFaultPoint, current: MarkerFaultPoint) -> std::io::Result<()> {
+    if selected == current {
+        Err(std::io::Error::other(format!(
+            "injected restart-marker failure at {current:?}"
+        )))
+    } else {
+        Ok(())
+    }
 }
 
 fn resolve_grpc_listeners(config: &Config) -> Result<Vec<GrpcListenerConfig>, String> {
@@ -1401,10 +1535,10 @@ async fn run<T>(
     let start_time = tokio::time::Instant::now();
     let gr_restart_marker_path = config.gr_restart_marker_path();
     let local_gr_restart_until = match read_gr_restart_marker(&gr_restart_marker_path) {
-        Ok(Some(expires_at)) => {
+        Ok(Some(marker)) => {
             let max_restart_time_secs = max_gr_restart_time_secs(&config);
             if let Some(remaining) = gr_restart_marker_remaining_time(
-                expires_at,
+                marker.expires_at,
                 SystemTime::now(),
                 max_restart_time_secs,
             ) {
@@ -1412,6 +1546,7 @@ async fn run<T>(
                 info!(
                     marker = %gr_restart_marker_path.display(),
                     restart_time_secs = remaining.as_secs(),
+                    checkpoint_generation = marker.checkpoint_generation.as_deref().unwrap_or("none"),
                     "detected GR restart marker — static peers will advertise R=1 until the restart window expires"
                 );
                 Some(deadline)
@@ -3607,6 +3742,27 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         write_gr_restart_marker(&path, expires_at).unwrap();
         let read_back = read_gr_restart_marker(&path).unwrap().unwrap();
         let diff = read_back
+            .expires_at
+            .duration_since(expires_at)
+            .unwrap_or_else(|e| e.duration());
+        assert!(diff < Duration::from_secs(1));
+        assert_eq!(read_back.checkpoint_generation, None);
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn gr_restart_marker_v2_round_trip_binds_exact_generation() {
+        let path = unique_temp_path("gr-restart-marker-v2");
+        let expires_at = SystemTime::now() + Duration::from_mins(2);
+        write_gr_restart_marker_v2(&path, expires_at, "checkpoint-0007").unwrap();
+
+        let read_back = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(
+            read_back.checkpoint_generation.as_deref(),
+            Some("checkpoint-0007")
+        );
+        let diff = read_back
+            .expires_at
             .duration_since(expires_at)
             .unwrap_or_else(|e| e.duration());
         assert!(diff < Duration::from_secs(1));
@@ -3614,11 +3770,63 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
     }
 
     #[test]
-    fn gr_restart_marker_invalid_version_rejected() {
+    fn gr_restart_marker_invalid_shapes_are_rejected() {
         let path = unique_temp_path("gr-restart-bad-version");
-        std::fs::write(&path, "version = 2\nexpires_at_unix = 1\n").unwrap();
+        std::fs::write(&path, "version = 3\nexpires_at_unix = 1\n").unwrap();
         let err = read_gr_restart_marker(&path).unwrap_err();
         assert!(err.contains("unsupported marker version"));
+        std::fs::write(&path, "version = 2\nexpires_at_unix = 1\n").unwrap();
+        let err = read_gr_restart_marker(&path).unwrap_err();
+        assert!(err.contains("missing checkpoint_generation"));
+        std::fs::write(
+            &path,
+            "version = 1\nexpires_at_unix = 1\ncheckpoint_generation = \"unexpected\"\n",
+        )
+        .unwrap();
+        let err = read_gr_restart_marker(&path).unwrap_err();
+        assert!(err.contains("v1 must not reference"));
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn gr_restart_marker_precommit_failures_preserve_previous_generation() {
+        let path = unique_temp_path("gr-restart-marker-atomicity");
+        let expires_at = SystemTime::now() + Duration::from_mins(2);
+        write_gr_restart_marker_v2(&path, expires_at, "committed").unwrap();
+
+        for fault in [
+            MarkerFaultPoint::Write,
+            MarkerFaultPoint::FileSync,
+            MarkerFaultPoint::Rename,
+        ] {
+            let result =
+                write_gr_restart_marker_inner(&path, expires_at, Some("uncommitted"), fault);
+            assert!(result.is_err(), "fault {fault:?} must fail");
+            let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+            assert_eq!(
+                marker.checkpoint_generation.as_deref(),
+                Some("committed"),
+                "fault {fault:?} must preserve the prior committed marker"
+            );
+        }
+        remove_gr_restart_marker(&path).unwrap();
+    }
+
+    #[test]
+    fn gr_restart_marker_postrename_failure_exposes_only_complete_v2() {
+        let path = unique_temp_path("gr-restart-marker-postrename");
+        let expires_at = SystemTime::now() + Duration::from_mins(2);
+        write_gr_restart_marker_v2(&path, expires_at, "old").unwrap();
+
+        let result = write_gr_restart_marker_inner(
+            &path,
+            expires_at,
+            Some("new"),
+            MarkerFaultPoint::DirectorySync,
+        );
+        assert!(result.is_err());
+        let marker = read_gr_restart_marker(&path).unwrap().unwrap();
+        assert_eq!(marker.checkpoint_generation.as_deref(), Some("new"));
         remove_gr_restart_marker(&path).unwrap();
     }
 
@@ -3774,6 +3982,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
                 link_bandwidth_weighted: false,
                 install_blackhole_discard: false,
                 allow_blackhole_broad_prefixes: false,
+                warm_cache_checkpoint_on_shutdown: false,
             },
             security: crate::config::SecurityConfig::default(),
             neighbors: vec![

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -657,9 +657,9 @@ impl PeerManager {
                             let infos = self.list_peers().await;
                             let _ = reply.send(infos);
                         }
-                        PeerManagerCommand::QueryWarmCheckpointSessions { reply } => {
-                            let sessions = self.query_warm_checkpoint_sessions().await;
-                            let _ = reply.send(sessions);
+                        PeerManagerCommand::QueryWarmCheckpointCapture { reply } => {
+                            let capture = self.query_warm_checkpoint_capture().await;
+                            let _ = reply.send(capture);
                         }
                         PeerManagerCommand::SubscribeSessionEvents { reply } => {
                             let _ = reply.send(self.session_events_tx.subscribe());

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -357,6 +357,7 @@ impl PeerManager {
                     link_bandwidth_weighted: false,
                     install_blackhole_discard: false,
                     allow_blackhole_broad_prefixes: false,
+                    warm_cache_checkpoint_on_shutdown: false,
                 },
                 // PeerManager::new constructs an in-memory baseline
                 // Config before the operator's TOML is applied. The

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -657,6 +657,10 @@ impl PeerManager {
                             let infos = self.list_peers().await;
                             let _ = reply.send(infos);
                         }
+                        PeerManagerCommand::QueryWarmCheckpointSessions { reply } => {
+                            let sessions = self.query_warm_checkpoint_sessions().await;
+                            let _ = reply.send(sessions);
+                        }
                         PeerManagerCommand::SubscribeSessionEvents { reply } => {
                             let _ = reply.send(self.session_events_tx.subscribe());
                         }

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use rustbgpd_api::peer_types::{PeerInfo, PeerKey};
+use rustbgpd_api::peer_types::{PeerInfo, PeerKey, WarmCheckpointSession};
 use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::{PeerHandle, PeerSessionState};
@@ -127,6 +127,99 @@ async fn collect_session_states(
 }
 
 impl PeerManager {
+    /// Capture negotiated truth for every V1 checkpoint candidate.
+    ///
+    /// Static, enabled, numbered, unambiguous peers are queried concurrently.
+    /// A timeout or collision candidate rejects the complete checkpoint rather
+    /// than publishing a partial identity inventory. Sessions that are not
+    /// currently Established with negotiated GR are simply ineligible: their
+    /// routes are excluded by the following RIB-actor query.
+    pub(super) async fn query_warm_checkpoint_sessions(
+        &self,
+    ) -> Result<Vec<WarmCheckpointSession>, String> {
+        let mut address_counts = HashMap::<IpAddr, usize>::new();
+        for (peer, managed) in &self.peers {
+            if !managed.is_dynamic {
+                *address_counts.entry(peer.address).or_default() += 1;
+            }
+        }
+
+        let mut tasks = Vec::new();
+        for (peer, managed) in &self.peers {
+            if managed.is_dynamic
+                || !managed.enabled
+                || peer.interface.is_some()
+                || address_counts.get(&peer.address).copied() != Some(1)
+                || !managed.transport_config.peer.graceful_restart
+            {
+                continue;
+            }
+            if managed.pending_inbound.is_some() {
+                return Err(format!(
+                    "peer {peer} has an unresolved collision candidate during checkpoint"
+                ));
+            }
+            let canonical_import_policy = match managed.import_policy.as_ref() {
+                Some(policy) => match policy.warm_checkpoint_identity_v1() {
+                    Ok(identity) => identity,
+                    Err(reason) => {
+                        warn!(peer = %peer, reason, "excluding peer from V1 warm checkpoint");
+                        continue;
+                    }
+                },
+                None => b"rustbgpd/policy-chain/warm-checkpoint/v1/implicit-permit\n".to_vec(),
+            };
+            let peer = peer.clone();
+            let session_id = managed.session_id;
+            let commands = managed.handle.commands_sender();
+            tasks.push(tokio::spawn(async move {
+                let state =
+                    PeerHandle::query_warm_checkpoint_state_with(commands, PEER_QUERY_TIMEOUT)
+                        .await;
+                (peer, session_id, canonical_import_policy, state)
+            }));
+        }
+
+        let mut sessions = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            let (peer, session_id, canonical_import_policy, state) = task
+                .await
+                .map_err(|error| format!("warm checkpoint session query task failed: {error}"))?;
+            let state = state.ok_or_else(|| {
+                format!("peer {peer} did not answer the bounded checkpoint query")
+            })?;
+            if state.fsm_state != SessionState::Established
+                || !state.peer_gr_capable
+                || state.peer_gr_restart_time == 0
+                || state.peer_gr_families.is_empty()
+            {
+                continue;
+            }
+            let peer_asn = state
+                .peer_asn
+                .filter(|asn| *asn != 0)
+                .ok_or_else(|| format!("Established peer {peer} has no negotiated remote ASN"))?;
+            let peer_router_id = state
+                .peer_router_id
+                .filter(|router_id| !router_id.is_unspecified())
+                .ok_or_else(|| {
+                    format!("Established peer {peer} has no negotiated BGP identifier")
+                })?;
+            sessions.push(WarmCheckpointSession {
+                peer,
+                session_id,
+                peer_asn,
+                peer_router_id,
+                negotiated_families: state.negotiated_families,
+                peer_gr_families: state.peer_gr_families,
+                add_path_receive_families: state.add_path_receive_families,
+                canonical_import_policy,
+            });
+        }
+        sessions.sort_by(|left, right| left.peer.cmp(&right.peer));
+        Ok(sessions)
+    }
+
     pub(super) async fn get_peer_info(&self, peer: &PeerKey) -> Option<PeerInfo> {
         let managed = self.peers.get(peer)?;
         let session_state = managed.handle.query_state_timeout(PEER_QUERY_TIMEOUT).await;

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -145,14 +145,27 @@ impl PeerManager {
         // manager remains inside this one command while those queries run, so
         // no reload/config transaction can advance `current_config` or the
         // resolved policies paired with the returned session generations.
-        let effective_config_toml = self.current_config.effective_redacted_toml()?;
-        let local_asn = self.current_config.global.asn;
-        let local_router_id = self
+        let desired_local_asn = self.current_config.global.asn;
+        let desired_local_router_id = self
             .current_config
             .global
             .router_id
             .parse::<Ipv4Addr>()
             .map_err(|error| format!("invalid live router ID during warm checkpoint: {error}"))?;
+        // ASN/router-ID changes are restart-required: `current_config` can
+        // legitimately contain the accepted desired values while the running
+        // listener and every live session still use these immutable fields.
+        // A checkpoint digest must never claim the desired identity describes
+        // the captured live routes. Fail closed until the restart applies it.
+        if desired_local_asn != self.local_asn || desired_local_router_id != self.router_id {
+            return Err(format!(
+                "restart-required local identity differs from the live daemon during warm checkpoint (desired ASN/router-ID {desired_local_asn}/{desired_local_router_id}, live {}/{})",
+                self.local_asn, self.router_id
+            ));
+        }
+        let effective_config_toml = self.current_config.effective_redacted_toml()?;
+        let local_asn = self.local_asn;
+        let local_router_id = self.router_id;
         let restart_time_secs = self
             .current_config
             .resolved_neighbors()

--- a/src/peer_manager/snapshot.rs
+++ b/src/peer_manager/snapshot.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use rustbgpd_api::peer_types::{PeerInfo, PeerKey, WarmCheckpointSession};
+use rustbgpd_api::peer_types::{PeerInfo, PeerKey, WarmCheckpointCapture, WarmCheckpointSession};
 use rustbgpd_bmp::{BmpEvent, BmpPeerInfo, BmpPeerType};
 use rustbgpd_fsm::SessionState;
 use rustbgpd_transport::{PeerHandle, PeerSessionState};
@@ -134,9 +134,36 @@ impl PeerManager {
     /// than publishing a partial identity inventory. Sessions that are not
     /// currently Established with negotiated GR are simply ineligible: their
     /// routes are excluded by the following RIB-actor query.
-    pub(super) async fn query_warm_checkpoint_sessions(
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one blocked peer-manager turn binds live config, policy, and every bounded session query"
+    )]
+    pub(super) async fn query_warm_checkpoint_capture(
         &self,
-    ) -> Result<Vec<WarmCheckpointSession>, String> {
+    ) -> Result<WarmCheckpointCapture, String> {
+        // Capture config identity before awaiting session actors. The peer
+        // manager remains inside this one command while those queries run, so
+        // no reload/config transaction can advance `current_config` or the
+        // resolved policies paired with the returned session generations.
+        let effective_config_toml = self.current_config.effective_redacted_toml()?;
+        let local_asn = self.current_config.global.asn;
+        let local_router_id = self
+            .current_config
+            .global
+            .router_id
+            .parse::<Ipv4Addr>()
+            .map_err(|error| format!("invalid live router ID during warm checkpoint: {error}"))?;
+        let restart_time_secs = self
+            .current_config
+            .resolved_neighbors()
+            .map_err(|error| {
+                format!("failed to resolve current neighbors for warm checkpoint: {error}")
+            })?
+            .iter()
+            .filter(|neighbor| neighbor.transport_config.peer.graceful_restart)
+            .map(|neighbor| u64::from(neighbor.transport_config.peer.gr_restart_time))
+            .filter(|seconds| *seconds > 0)
+            .max();
         let mut address_counts = HashMap::<IpAddr, usize>::new();
         for (peer, managed) in &self.peers {
             if !managed.is_dynamic {
@@ -217,7 +244,13 @@ impl PeerManager {
             });
         }
         sessions.sort_by(|left, right| left.peer.cmp(&right.peer));
-        Ok(sessions)
+        Ok(WarmCheckpointCapture {
+            local_asn,
+            local_router_id,
+            effective_config_toml,
+            restart_time_secs,
+            sessions,
+        })
     }
 
     pub(super) async fn get_peer_info(&self, peer: &PeerKey) -> Option<PeerInfo> {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -5,7 +5,7 @@ use rustbgpd_api::peer_types::{
     SessionLifecycleEventType,
 };
 use rustbgpd_fsm::SessionState;
-use rustbgpd_transport::{PeerSessionState, TcpAoRotationStatus};
+use rustbgpd_transport::{PeerSessionState, TcpAoRotationStatus, WarmCheckpointSessionState};
 use rustbgpd_wire::{
     Capability, Message, OpenMessage, decode_message, encode_message, peek_message_length,
 };
@@ -1250,6 +1250,132 @@ fn fake_peer_handle_with_route_refresh_reply(
         Ok(())
     });
     PeerHandle::from_parts(session_tx, task)
+}
+
+fn warm_checkpoint_peer_handle(response: Option<WarmCheckpointSessionState>) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(8);
+    let task = tokio::spawn(async move {
+        let mut held_replies = Vec::new();
+        while let Some(cmd) = session_rx.recv().await {
+            match cmd {
+                PeerCommand::QueryWarmCheckpointState { reply } => {
+                    if let Some(state) = response.clone() {
+                        let _ = reply.send(state);
+                    } else {
+                        held_replies.push(reply);
+                    }
+                }
+                PeerCommand::Shutdown | PeerCommand::Stop { .. } => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+fn eligible_warm_checkpoint_state() -> WarmCheckpointSessionState {
+    WarmCheckpointSessionState {
+        fsm_state: SessionState::Established,
+        peer_asn: Some(65002),
+        peer_router_id: Some(Ipv4Addr::new(10, 0, 0, 2)),
+        negotiated_families: vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+        peer_gr_families: vec![(Afi::Ipv4, Safi::Unicast)],
+        peer_gr_capable: true,
+        peer_gr_restart_time: 120,
+        add_path_receive_families: vec![(Afi::Ipv4, Safi::Unicast)],
+    }
+}
+
+#[tokio::test]
+async fn warm_checkpoint_session_query_returns_current_negotiated_identity() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "10.0.0.2".parse().unwrap();
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        warm_checkpoint_peer_handle(Some(eligible_warm_checkpoint_state())),
+        false,
+    );
+
+    let sessions = mgr.query_warm_checkpoint_sessions().await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    let session = &sessions[0];
+    assert_eq!(session.peer, key(addr));
+    assert_eq!(session.session_id, 1);
+    assert_eq!(session.peer_asn, 65002);
+    assert_eq!(session.peer_router_id, Ipv4Addr::new(10, 0, 0, 2));
+    assert_eq!(
+        session.add_path_receive_families,
+        vec![(Afi::Ipv4, Safi::Unicast)]
+    );
+    assert_eq!(
+        session.canonical_import_policy,
+        b"rustbgpd/policy-chain/warm-checkpoint/v1/implicit-permit\n"
+    );
+}
+
+#[tokio::test]
+async fn warm_checkpoint_session_query_rejects_pending_collision() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "10.0.0.2".parse().unwrap();
+    insert_test_managed_peer(
+        &mut mgr,
+        addr,
+        warm_checkpoint_peer_handle(Some(eligible_warm_checkpoint_state())),
+        false,
+    );
+    attach_test_pending_inbound(
+        &mut mgr,
+        addr,
+        warm_checkpoint_peer_handle(Some(eligible_warm_checkpoint_state())),
+        2,
+    );
+
+    let error = mgr.query_warm_checkpoint_sessions().await.unwrap_err();
+    assert!(error.contains("unresolved collision candidate"), "{error}");
+}
+
+#[tokio::test(start_paused = true)]
+async fn warm_checkpoint_session_query_timeout_rejects_complete_snapshot() {
+    let mut mgr = test_peer_manager();
+    let addr: IpAddr = "10.0.0.2".parse().unwrap();
+    insert_test_managed_peer(&mut mgr, addr, warm_checkpoint_peer_handle(None), false);
+
+    let error = mgr.query_warm_checkpoint_sessions().await.unwrap_err();
+    assert!(error.contains("bounded checkpoint query"), "{error}");
+}
+
+#[tokio::test]
+async fn warm_checkpoint_session_query_skips_unusable_gr_sessions() {
+    let mut mgr = test_peer_manager();
+    let no_family_addr: IpAddr = "10.0.0.2".parse().unwrap();
+    let zero_restart_addr: IpAddr = "10.0.0.3".parse().unwrap();
+    let mut no_family = eligible_warm_checkpoint_state();
+    no_family.peer_gr_families.clear();
+    let mut zero_restart = eligible_warm_checkpoint_state();
+    zero_restart.peer_gr_restart_time = 0;
+    insert_test_managed_peer(
+        &mut mgr,
+        no_family_addr,
+        warm_checkpoint_peer_handle(Some(no_family)),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut mgr,
+        zero_restart_addr,
+        warm_checkpoint_peer_handle(Some(zero_restart)),
+        false,
+    );
+
+    assert!(
+        mgr.query_warm_checkpoint_sessions()
+            .await
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1290,6 +1290,26 @@ fn eligible_warm_checkpoint_state() -> WarmCheckpointSessionState {
 }
 
 #[tokio::test]
+async fn warm_checkpoint_capture_uses_live_actor_config_identity() {
+    let mut mgr = test_peer_manager();
+    let startup = mgr.current_config.effective_redacted_toml().unwrap();
+    mgr.current_config.global.honor_blackhole = true;
+    let addr: IpAddr = "10.0.0.2".parse().unwrap();
+    let mut neighbor = config_neighbor(addr, 65002);
+    neighbor.gr_restart_time = Some(17);
+    mgr.current_config.neighbors.push(neighbor);
+
+    let capture = mgr.query_warm_checkpoint_capture().await.unwrap();
+    assert_ne!(capture.effective_config_toml, startup);
+    assert!(
+        capture
+            .effective_config_toml
+            .contains("honor_blackhole = true")
+    );
+    assert_eq!(capture.restart_time_secs, Some(17));
+}
+
+#[tokio::test]
 async fn warm_checkpoint_session_query_returns_current_negotiated_identity() {
     let mut mgr = test_peer_manager();
     let addr: IpAddr = "10.0.0.2".parse().unwrap();
@@ -1299,8 +1319,17 @@ async fn warm_checkpoint_session_query_returns_current_negotiated_identity() {
         warm_checkpoint_peer_handle(Some(eligible_warm_checkpoint_state())),
         false,
     );
+    let mut neighbor = config_neighbor(addr, 65002);
+    neighbor.graceful_restart = Some(true);
+    neighbor.gr_restart_time = Some(120);
+    mgr.current_config.neighbors.push(neighbor);
 
-    let sessions = mgr.query_warm_checkpoint_sessions().await.unwrap();
+    let capture = mgr.query_warm_checkpoint_capture().await.unwrap();
+    assert_eq!(capture.local_asn, 65001);
+    assert_eq!(capture.local_router_id, Ipv4Addr::new(10, 0, 0, 1));
+    assert!(capture.effective_config_toml.contains("asn = 65001"));
+    assert_eq!(capture.restart_time_secs, Some(120));
+    let sessions = capture.sessions;
     assert_eq!(sessions.len(), 1);
     let session = &sessions[0];
     assert_eq!(session.peer, key(addr));
@@ -1334,7 +1363,7 @@ async fn warm_checkpoint_session_query_rejects_pending_collision() {
         2,
     );
 
-    let error = mgr.query_warm_checkpoint_sessions().await.unwrap_err();
+    let error = mgr.query_warm_checkpoint_capture().await.unwrap_err();
     assert!(error.contains("unresolved collision candidate"), "{error}");
 }
 
@@ -1344,7 +1373,7 @@ async fn warm_checkpoint_session_query_timeout_rejects_complete_snapshot() {
     let addr: IpAddr = "10.0.0.2".parse().unwrap();
     insert_test_managed_peer(&mut mgr, addr, warm_checkpoint_peer_handle(None), false);
 
-    let error = mgr.query_warm_checkpoint_sessions().await.unwrap_err();
+    let error = mgr.query_warm_checkpoint_capture().await.unwrap_err();
     assert!(error.contains("bounded checkpoint query"), "{error}");
 }
 
@@ -1371,9 +1400,10 @@ async fn warm_checkpoint_session_query_skips_unusable_gr_sessions() {
     );
 
     assert!(
-        mgr.query_warm_checkpoint_sessions()
+        mgr.query_warm_checkpoint_capture()
             .await
             .unwrap()
+            .sessions
             .is_empty()
     );
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1310,6 +1310,26 @@ async fn warm_checkpoint_capture_uses_live_actor_config_identity() {
 }
 
 #[tokio::test]
+async fn warm_checkpoint_rejects_sighup_desired_live_global_identity_drift() {
+    let mut mgr = test_peer_manager();
+
+    // SIGHUP accepts restart-required global fields into the desired runtime
+    // snapshot, but the listener/session actors retain their boot identity.
+    mgr.current_config.global.asn = 65123;
+    let error = mgr.query_warm_checkpoint_capture().await.unwrap_err();
+    assert!(error.contains("restart-required local identity"), "{error}");
+    assert!(error.contains("65123/10.0.0.1"), "{error}");
+    assert!(error.contains("65001/10.0.0.1"), "{error}");
+
+    mgr.current_config.global.asn = 65001;
+    mgr.current_config.global.router_id = "192.0.2.99".to_string();
+    let error = mgr.query_warm_checkpoint_capture().await.unwrap_err();
+    assert!(error.contains("restart-required local identity"), "{error}");
+    assert!(error.contains("65001/192.0.2.99"), "{error}");
+    assert!(error.contains("65001/10.0.0.1"), "{error}");
+}
+
+#[tokio::test]
 async fn warm_checkpoint_session_query_returns_current_negotiated_identity() {
     let mut mgr = test_peer_manager();
     let addr: IpAddr = "10.0.0.2".parse().unwrap();

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -380,6 +380,7 @@ fn make_dynamic_manager_config() -> Config {
             link_bandwidth_weighted: false,
             install_blackhole_discard: false,
             allow_blackhole_broad_prefixes: false,
+            warm_cache_checkpoint_on_shutdown: false,
         },
         security: crate::config::SecurityConfig {
             grpc: crate::config::GrpcSecurityConfig {


### PR DESCRIPTION
## Summary

- publish a bounded, private warm-shutdown checkpoint bundle before planned restart
- bind graceful-restart marker v2 to the checkpoint identity while retaining marker-v1 cold compatibility
- snapshot session, Adj-RIB-In, Loc-RIB, policy, and transport state with deterministic encoding, validation, rollback, and cleanup
- expose the configuration/schema and document security, operations, deployment, RFC, and failure semantics
- keep restore/adoption explicitly out of scope: startup does not consume the checkpoint

## Safety boundaries

- fixed private bundle paths and bounded materialization
- fail-closed descriptor/marker validation and atomic publication
- no secret material and no forwarding-continuity guarantee
- failed publication preserves the prior authoritative state and does not change startup behavior

## Validation

- MRT 78, RIB 4, daemon warm 7, marker 17, transport 1, and policy 2 focused tests
- schema freshness and configuration knob tests
- current v1 gate, release-note selftest, formatting, and clippy-reason checks
- workspace all-target Clippy, full workspace tests, rustdoc, and pre-push hooks
- independent correctness, documentation, and exact-main integration reviews