### PR TITLE
fix: bound selection deferral ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   policy in addition to selected property schemas, while continuing to allow
   unselected optional sibling fields and descriptive-prose changes.
 
+- **Planned-restart selection deferral now has a bounded identity ledger.**
+  At most one million affected route identities are retained across all gated
+  families. If a family exceeds that process-wide bound, release performs a
+  complete Adj-RIB-In plus Loc-RIB sweep so withdrawals received before EoR
+  cannot leave stale selected or advertised routes. A one-shot warning and
+  `bgp_selection_deferral_ledger_overflows_total{afi_safi}` expose the fallback.
+
 - **Unexportable routes now fail before Adj-RIB-Out commit.** Every
   route-bearing envelope carries one immutable snapshot of the session's exact
   encoder and negotiated message ceiling. The RIB probes the final one-route

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -6,6 +6,7 @@
 //! it must be excluded.  `EoR` completion is bound to that classified session.
 
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::net::IpAddr;
 use std::time::Duration;
 
@@ -13,6 +14,12 @@ use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{Afi, Safi};
 
 use super::RibManager;
+
+/// Process-wide ceiling across every typed identity retained while route
+/// selection is frozen.  One million matches the documented per-neighbor
+/// prefix ceiling without multiplying the safety bound by family or route
+/// kind.  Overflow falls back to a complete family Loc-RIB sweep at release.
+const MAX_DEFERRED_SELECTION_IDENTITIES: usize = 1_000_000;
 
 #[derive(Debug, Default)]
 pub(super) struct DeferredSelectionKeys {
@@ -23,6 +30,54 @@ pub(super) struct DeferredSelectionKeys {
     labeled: HashSet<crate::route::LabeledRibRouteKey>,
     bgpls: HashSet<crate::route::BgpLsRouteKey>,
     rtc: HashSet<crate::route::RtcRibRouteKey>,
+    /// Families for which at least one distinct identity could not be retained.
+    /// Release enumerates that family's Loc-RIB keys as the fail-safe source
+    /// for withdrawals already absent from Adj-RIB-In.
+    overflowed_families: HashSet<(Afi, Safi)>,
+}
+
+impl DeferredSelectionKeys {
+    fn len(&self) -> usize {
+        self.unicast.len()
+            + self.flowspec.len()
+            + self.evpn.len()
+            + self.vpn.len()
+            + self.labeled.len()
+            + self.bgpls.len()
+            + self.rtc.len()
+    }
+
+    /// Insert distinct typed identities until the process-wide ledger limit is
+    /// reached.  Returns each family that entered overflow fallback during
+    /// this call; an already-overflowed family stops retaining further keys.
+    fn extend_bounded<T>(
+        set: &mut HashSet<T>,
+        overflowed_families: &mut HashSet<(Afi, Safi)>,
+        identities: impl IntoIterator<Item = ((Afi, Safi), T)>,
+        current_len: usize,
+        limit: usize,
+    ) -> Vec<(Afi, Safi)>
+    where
+        T: Eq + Hash,
+    {
+        let mut remaining = limit.saturating_sub(current_len);
+        let mut newly_overflowed = Vec::new();
+        for (family, identity) in identities {
+            if overflowed_families.contains(&family) || set.contains(&identity) {
+                continue;
+            }
+            if remaining == 0 {
+                if overflowed_families.insert(family) {
+                    newly_overflowed.push(family);
+                }
+                continue;
+            }
+            if set.insert(identity) {
+                remaining -= 1;
+            }
+        }
+        newly_overflowed
+    }
 }
 use super::helpers::{afi_safi_label, gauge_val};
 
@@ -159,6 +214,10 @@ impl SelectionDeferral {
 
     pub(super) fn is_gated(&self, family: (Afi, Safi)) -> bool {
         self.active.contains_key(&family)
+    }
+
+    fn has_active_gates(&self) -> bool {
+        !self.active.is_empty()
     }
 
     pub(super) fn deadline(&self) -> Option<tokio::time::Instant> {
@@ -352,74 +411,207 @@ impl SelectionDeferral {
 }
 
 impl RibManager {
+    fn deferred_selection_recording_active(&self) -> bool {
+        self.selection_deferral
+            .as_ref()
+            .is_some_and(SelectionDeferral::has_active_gates)
+    }
+
+    fn record_selection_ledger_overflows(&self, families: Vec<(Afi, Safi)>) {
+        for (afi, safi) in families {
+            tracing::warn!(
+                ?afi,
+                ?safi,
+                cap = MAX_DEFERRED_SELECTION_IDENTITIES,
+                "selection-deferral identity ledger reached its bound; release will sweep the complete Adj-RIB-In and Loc-RIB family"
+            );
+            self.metrics
+                .record_selection_deferral_ledger_overflow(afi_safi_label(afi, safi));
+        }
+    }
+
     pub(super) fn record_deferred_unicast(&mut self, affected: &HashSet<rustbgpd_wire::Prefix>) {
+        self.record_deferred_unicast_bounded(affected, MAX_DEFERRED_SELECTION_IDENTITIES);
+    }
+
+    fn record_deferred_unicast_bounded(
+        &mut self,
+        affected: &HashSet<rustbgpd_wire::Prefix>,
+        limit: usize,
+    ) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         let deferred: Vec<_> = affected
             .iter()
             .filter(|prefix| self.selection_deferred(super::helpers::prefix_family(prefix)))
-            .copied()
+            .map(|prefix| (super::helpers::prefix_family(prefix), *prefix))
             .collect();
-        self.deferred_selection_keys.unicast.extend(deferred);
+        let current_len = self.deferred_selection_keys.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut self.deferred_selection_keys.unicast,
+            &mut self.deferred_selection_keys.overflowed_families,
+            deferred,
+            current_len,
+            limit,
+        );
+        self.record_selection_ledger_overflows(newly_overflowed);
     }
 
     pub(super) fn record_deferred_flowspec(
         &mut self,
         affected: &HashSet<crate::route::FlowSpecKey>,
     ) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         let deferred: Vec<_> = affected
             .iter()
             .filter(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
-            .cloned()
+            .map(|key| ((key.afi, Safi::FlowSpec), key.clone()))
             .collect();
-        self.deferred_selection_keys.flowspec.extend(deferred);
+        let current_len = self.deferred_selection_keys.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut self.deferred_selection_keys.flowspec,
+            &mut self.deferred_selection_keys.overflowed_families,
+            deferred,
+            current_len,
+            MAX_DEFERRED_SELECTION_IDENTITIES,
+        );
+        self.record_selection_ledger_overflows(newly_overflowed);
     }
 
     pub(super) fn record_deferred_evpn(&mut self, affected: &HashSet<rustbgpd_wire::EvpnRouteKey>) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         if self.selection_deferred((Afi::L2Vpn, Safi::Evpn)) {
-            self.deferred_selection_keys
-                .evpn
-                .extend(affected.iter().copied());
+            let deferred = affected
+                .iter()
+                .copied()
+                .map(|key| ((Afi::L2Vpn, Safi::Evpn), key));
+            let current_len = self.deferred_selection_keys.len();
+            let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+                &mut self.deferred_selection_keys.evpn,
+                &mut self.deferred_selection_keys.overflowed_families,
+                deferred,
+                current_len,
+                MAX_DEFERRED_SELECTION_IDENTITIES,
+            );
+            self.record_selection_ledger_overflows(newly_overflowed);
         }
     }
 
     pub(super) fn record_deferred_vpn(&mut self, affected: &HashSet<crate::route::VpnRibRouteKey>) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         let deferred: Vec<_> = affected
             .iter()
             .filter(|key| self.selection_deferred(key.afi_safi()))
-            .cloned()
+            .map(|key| (key.afi_safi(), key.clone()))
             .collect();
-        self.deferred_selection_keys.vpn.extend(deferred);
+        let current_len = self.deferred_selection_keys.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut self.deferred_selection_keys.vpn,
+            &mut self.deferred_selection_keys.overflowed_families,
+            deferred,
+            current_len,
+            MAX_DEFERRED_SELECTION_IDENTITIES,
+        );
+        self.record_selection_ledger_overflows(newly_overflowed);
     }
 
     pub(super) fn record_deferred_labeled(
         &mut self,
         affected: &HashSet<crate::route::LabeledRibRouteKey>,
     ) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         let deferred: Vec<_> = affected
             .iter()
             .filter(|key| self.selection_deferred(key.afi_safi()))
-            .copied()
+            .map(|key| (key.afi_safi(), *key))
             .collect();
-        self.deferred_selection_keys.labeled.extend(deferred);
+        let current_len = self.deferred_selection_keys.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut self.deferred_selection_keys.labeled,
+            &mut self.deferred_selection_keys.overflowed_families,
+            deferred,
+            current_len,
+            MAX_DEFERRED_SELECTION_IDENTITIES,
+        );
+        self.record_selection_ledger_overflows(newly_overflowed);
     }
 
     pub(super) fn record_deferred_bgpls(
         &mut self,
         affected: &HashSet<crate::route::BgpLsRouteKey>,
     ) {
+        if !self.deferred_selection_recording_active() {
+            return;
+        }
         let deferred: Vec<_> = affected
             .iter()
             .filter(|key| self.selection_deferred(key.family.to_afi_safi()))
-            .cloned()
+            .map(|key| (key.family.to_afi_safi(), key.clone()))
             .collect();
-        self.deferred_selection_keys.bgpls.extend(deferred);
+        let current_len = self.deferred_selection_keys.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut self.deferred_selection_keys.bgpls,
+            &mut self.deferred_selection_keys.overflowed_families,
+            deferred,
+            current_len,
+            MAX_DEFERRED_SELECTION_IDENTITIES,
+        );
+        self.record_selection_ledger_overflows(newly_overflowed);
     }
 
     pub(super) fn record_deferred_rtc(&mut self, affected: &HashSet<crate::route::RtcRibRouteKey>) {
-        if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
-            self.deferred_selection_keys
-                .rtc
-                .extend(affected.iter().cloned());
+        if !self.deferred_selection_recording_active() {
+            return;
         }
+        if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
+            let family = crate::route::RtcRibRouteKey::afi_safi();
+            let deferred = affected.iter().cloned().map(|key| (family, key));
+            let current_len = self.deferred_selection_keys.len();
+            let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+                &mut self.deferred_selection_keys.rtc,
+                &mut self.deferred_selection_keys.overflowed_families,
+                deferred,
+                current_len,
+                MAX_DEFERRED_SELECTION_IDENTITIES,
+            );
+            self.record_selection_ledger_overflows(newly_overflowed);
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::manager) fn record_deferred_unicast_with_test_limit(
+        &mut self,
+        affected: &HashSet<rustbgpd_wire::Prefix>,
+        limit: usize,
+    ) {
+        self.record_deferred_unicast_bounded(affected, limit);
+    }
+
+    #[cfg(test)]
+    pub(in crate::manager) fn mark_deferred_selection_overflow_for_test(
+        &mut self,
+        family: (Afi, Safi),
+    ) {
+        self.deferred_selection_keys
+            .overflowed_families
+            .insert(family);
+    }
+
+    #[cfg(test)]
+    pub(in crate::manager) fn recompute_released_selection_family_for_test(
+        &mut self,
+        family: (Afi, Safi),
+    ) {
+        self.recompute_released_selection_family(family);
     }
 
     /// Consume a current-session `EoR` in the startup gate. The caller invokes
@@ -509,6 +701,10 @@ impl RibManager {
         reason = "release must sweep every typed RIB family from one atomic family gate"
     )]
     fn recompute_released_selection_family(&mut self, family: (Afi, Safi)) {
+        let overflowed = self
+            .deferred_selection_keys
+            .overflowed_families
+            .remove(&family);
         let mut prefixes: HashSet<_> = self
             .ribs
             .values()
@@ -516,6 +712,14 @@ impl RibManager {
             .filter(|route| super::helpers::prefix_family(&route.prefix) == family)
             .map(|route| route.prefix)
             .collect();
+        if overflowed && family.1 == Safi::Unicast {
+            prefixes.extend(
+                self.loc_rib
+                    .iter()
+                    .filter(|route| super::helpers::prefix_family(&route.prefix) == family)
+                    .map(|route| route.prefix),
+            );
+        }
         prefixes.extend(
             self.deferred_selection_keys
                 .unicast
@@ -538,6 +742,14 @@ impl RibManager {
             .filter(|route| (route.afi, Safi::FlowSpec) == family)
             .map(crate::route::FlowSpecRoute::selection_key)
             .collect();
+        if overflowed && family.1 == Safi::FlowSpec {
+            flowspec.extend(
+                self.loc_rib
+                    .iter_flowspec()
+                    .filter(|route| (route.afi, Safi::FlowSpec) == family)
+                    .map(crate::route::FlowSpecRoute::selection_key),
+            );
+        }
         flowspec.extend(
             self.deferred_selection_keys
                 .flowspec
@@ -559,6 +771,13 @@ impl RibManager {
                 .flat_map(crate::adj_rib_in::AdjRibIn::iter_evpn)
                 .map(crate::route::EvpnRibRoute::key)
                 .collect();
+            if overflowed {
+                evpn.extend(
+                    self.loc_rib
+                        .iter_evpn()
+                        .map(crate::route::EvpnRibRoute::key),
+                );
+            }
             evpn.extend(self.deferred_selection_keys.evpn.drain());
             if !evpn.is_empty() {
                 self.recompute_and_distribute_evpn(&evpn);
@@ -572,6 +791,14 @@ impl RibManager {
             .filter(|route| route.afi_safi() == family)
             .map(crate::route::VpnRibRoute::key)
             .collect();
+        if overflowed && family.1 == Safi::MplsVpn {
+            vpn.extend(
+                self.loc_rib
+                    .iter_vpn()
+                    .filter(|route| route.afi_safi() == family)
+                    .map(crate::route::VpnRibRoute::key),
+            );
+        }
         vpn.extend(
             self.deferred_selection_keys
                 .vpn
@@ -593,6 +820,14 @@ impl RibManager {
             .filter(|route| route.afi_safi() == family)
             .map(crate::route::LabeledRibRoute::key)
             .collect();
+        if overflowed && family.1 == Safi::LabeledUnicast {
+            labeled.extend(
+                self.loc_rib
+                    .iter_labeled()
+                    .filter(|route| route.afi_safi() == family)
+                    .map(crate::route::LabeledRibRoute::key),
+            );
+        }
         labeled.extend(
             self.deferred_selection_keys
                 .labeled
@@ -614,6 +849,14 @@ impl RibManager {
             .filter(|route| route.family.to_afi_safi() == family)
             .map(crate::route::BgpLsRibRoute::key)
             .collect();
+        if overflowed && matches!(family.1, Safi::BgpLs | Safi::BgpLsVpn) {
+            bgpls.extend(
+                self.loc_rib
+                    .iter_bgpls()
+                    .filter(|route| route.family.to_afi_safi() == family)
+                    .map(crate::route::BgpLsRibRoute::key),
+            );
+        }
         bgpls.extend(
             self.deferred_selection_keys
                 .bgpls
@@ -635,6 +878,9 @@ impl RibManager {
                 .flat_map(crate::adj_rib_in::AdjRibIn::iter_rtc)
                 .map(crate::route::RtcRibRoute::key)
                 .collect();
+            if overflowed {
+                rtc.extend(self.loc_rib.iter_rtc().map(crate::route::RtcRibRoute::key));
+            }
             rtc.extend(self.deferred_selection_keys.rtc.drain());
             if !rtc.is_empty() {
                 self.recompute_rtc_keys(&rtc);
@@ -644,5 +890,41 @@ impl RibManager {
                 self.rebuild_rtc_membership_and_restage_vpn(peer);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ledger_tests {
+    use super::*;
+
+    #[test]
+    fn bounded_identity_tracking_marks_each_dropped_family_once() {
+        let unicast = (Afi::Ipv4, Safi::Unicast);
+        let flowspec = (Afi::Ipv4, Safi::FlowSpec);
+        let mut identities = HashSet::new();
+        let mut overflowed = HashSet::new();
+
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut identities,
+            &mut overflowed,
+            [(unicast, 1_u8), (unicast, 1), (unicast, 2), (unicast, 3)],
+            0,
+            2,
+        );
+        assert_eq!(identities, HashSet::from([1, 2]));
+        assert_eq!(newly_overflowed, vec![unicast]);
+        assert_eq!(overflowed, HashSet::from([unicast]));
+
+        let current_len = identities.len();
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut identities,
+            &mut overflowed,
+            [(unicast, 4_u8), (flowspec, 5), (flowspec, 6)],
+            current_len,
+            2,
+        );
+        assert_eq!(identities, HashSet::from([1, 2]));
+        assert_eq!(newly_overflowed, vec![flowspec]);
+        assert_eq!(overflowed, HashSet::from([unicast, flowspec]));
     }
 }

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -6,13 +6,39 @@ use rustbgpd_telemetry::BgpMetrics;
 use rustbgpd_wire::{Afi, Ipv4Prefix, Safi};
 use tokio::sync::{mpsc, oneshot};
 
-use super::{dummy_query_rx, make_route_with_lp, query_best_routes};
+use super::{
+    dummy_query_rx, make_bgpls_route, make_evpn_imet, make_flowspec_route, make_labeled_rib_route,
+    make_route_with_lp, make_rtc_rib_route, make_vpn_rib_route, query_best_routes,
+};
 use crate::{
     PeerOutboundState, RibManager, RibUpdate, SelectionDeferralConfig,
     SelectionDeferralWaiterConfig,
 };
 
 const FAMILY: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
+
+fn counter_value(metrics: &BgpMetrics, name: &str) -> f64 {
+    metrics
+        .registry()
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .map_or(0.0, |family| {
+            family
+                .get_metric()
+                .iter()
+                .map(|metric| metric.get_counter().value())
+                .sum()
+        })
+}
+
+fn assert_counter_value(metrics: &BgpMetrics, name: &str, expected: f64) {
+    let actual = counter_value(metrics, name);
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "expected {name}={expected}, got {actual}"
+    );
+}
 
 fn peer(octet: u8) -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(10, 0, 0, octet))
@@ -324,31 +350,38 @@ async fn duplicate_address_roster_fails_closed_until_timer() {
 }
 
 #[test]
-fn withdrawn_restored_key_is_recomputed_before_release_eor() {
+fn overflow_fallback_withdraws_restored_keys_before_release_eor() {
     let source = peer(1);
     let observer = peer(2);
     let (_tx, rx) = mpsc::channel(32);
+    let metrics = BgpMetrics::new();
     let mut manager = RibManager::new(
         rx,
         dummy_query_rx(),
         None,
         Some(Ipv4Addr::new(10, 0, 0, 254)),
-        BgpMetrics::new(),
+        metrics.clone(),
     );
 
     let (observer_tx, mut observer_rx) = mpsc::channel(16);
     manager.handle_update(peer_up(observer, 7, observer_tx));
     while observer_rx.try_recv().is_ok() {}
 
-    let route = make_route_with_lp(
+    let route_a = make_route_with_lp(
         Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
         Ipv4Addr::new(10, 0, 0, 1),
         100,
     );
-    let prefix = route.prefix;
+    let route_b = make_route_with_lp(
+        Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+        Ipv4Addr::new(10, 0, 0, 1),
+        100,
+    );
+    let prefix_a = route_a.prefix;
+    let prefix_b = route_b.prefix;
     manager.enqueue_routes_received(
         source,
-        vec![route],
+        vec![route_a, route_b],
         Vec::new(),
         Vec::new(),
         Vec::new(),
@@ -356,27 +389,34 @@ fn withdrawn_restored_key_is_recomputed_before_release_eor() {
         Vec::new(),
     );
     while manager.process_next_route_chunk() {}
-    assert!(manager.loc_rib.get(&prefix).is_some());
+    assert!(manager.loc_rib.get(&prefix_a).is_some());
+    assert!(manager.loc_rib.get(&prefix_b).is_some());
     while observer_rx.try_recv().is_ok() {}
 
     // Model a route restored before the planned-restart gate is installed.
-    // A withdrawal received while gated disappears from Adj-RIB-In, so the
-    // deferred identity ledger is the only release-time evidence that the
-    // stale Loc-RIB row must be removed.
+    // Only one identity fits in this test ledger. The second marks the family
+    // overflowed, after which later identities for that family are not retained.
+    // Release must use the frozen Loc-RIB as the fail-safe identity source.
     manager = manager.with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    manager.record_deferred_unicast_with_test_limit(&HashSet::from([prefix_a, prefix_b]), 1);
+    assert_counter_value(
+        &metrics,
+        "bgp_selection_deferral_ledger_overflows_total",
+        1.0,
+    );
     manager.enqueue_routes_received(
         source,
         Vec::new(),
-        vec![(prefix, 0)],
+        vec![(prefix_a, 0), (prefix_b, 0)],
         Vec::new(),
         Vec::new(),
         Vec::new(),
         Vec::new(),
     );
     while manager.process_next_route_chunk() {}
-    assert!(manager.loc_rib.get(&prefix).is_some());
+    assert!(manager.loc_rib.get(&prefix_a).is_some());
+    assert!(manager.loc_rib.get(&prefix_b).is_some());
 
-    let metrics = manager.metrics.clone();
     let peer_gr_families = HashSet::from([FAMILY]);
     let released = manager
         .selection_deferral
@@ -389,16 +429,131 @@ fn withdrawn_restored_key_is_recomputed_before_release_eor() {
     manager.finalize_selection_deferral_all_eor(FAMILY);
     manager.release_selection_families(&[FAMILY], "test all EoRs received");
 
-    assert!(manager.loc_rib.get(&prefix).is_none());
-    let mut saw_withdraw = false;
+    assert!(manager.loc_rib.get(&prefix_a).is_none());
+    assert!(manager.loc_rib.get(&prefix_b).is_none());
+    assert_eq!(manager.adj_ribs_out.get(&observer).unwrap().len(), 0);
+    let mut withdrawn = HashSet::new();
     loop {
         let update = observer_rx.try_recv().unwrap();
         if update.end_of_rib.contains(&FAMILY) {
-            assert!(saw_withdraw, "EoR overtook the deferred withdrawal");
+            assert_eq!(
+                withdrawn,
+                HashSet::from([prefix_a, prefix_b]),
+                "EoR overtook one or more deferred withdrawals"
+            );
             break;
         }
-        saw_withdraw |= update.withdraw.iter().any(|(p, _)| *p == prefix);
+        withdrawn.extend(update.withdraw.iter().map(|(prefix, _)| *prefix));
     }
+    assert_counter_value(
+        &metrics,
+        "bgp_selection_deferral_ledger_overflows_total",
+        1.0,
+    );
+}
+
+#[test]
+fn overflow_fallback_sweeps_every_typed_loc_rib_store() {
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let route_peer = Ipv4Addr::new(10, 0, 0, 1);
+
+    let unicast = make_route_with_lp(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        route_peer,
+        100,
+    );
+    let unicast_key = unicast.prefix;
+    assert!(
+        manager
+            .loc_rib
+            .recompute(unicast_key, std::iter::once(&unicast))
+    );
+
+    let flowspec = make_flowspec_route(route_peer);
+    let flowspec_key = flowspec.selection_key();
+    assert!(
+        manager
+            .loc_rib
+            .recompute_flowspec(flowspec_key.clone(), std::iter::once(&flowspec))
+    );
+
+    let evpn = make_evpn_imet(route_peer, 101);
+    let evpn_key = evpn.key();
+    assert!(
+        manager
+            .loc_rib
+            .recompute_evpn(evpn_key, std::iter::once(&evpn))
+    );
+
+    let vpn = make_vpn_rib_route(route_peer, 31, 100, 100);
+    let vpn_key = vpn.nlri.key();
+    manager.loc_rib.insert_vpn(vpn);
+
+    let labeled = make_labeled_rib_route(route_peer, 32, 100, 100);
+    let labeled_key = labeled.nlri.key();
+    manager.loc_rib.insert_labeled(labeled);
+
+    let bgpls = make_bgpls_route(route_peer, 33, 100);
+    let bgpls_key = bgpls.key();
+    let bgpls_family = bgpls.family.to_afi_safi();
+    manager.loc_rib.insert_bgpls(bgpls);
+
+    let rtc = make_rtc_rib_route(route_peer, 34, 100);
+    let rtc_key = rtc.key();
+    manager.loc_rib.insert_rtc(rtc);
+
+    let families = [
+        FAMILY,
+        (Afi::Ipv4, Safi::FlowSpec),
+        (Afi::L2Vpn, Safi::Evpn),
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::LabeledUnicast),
+        bgpls_family,
+        crate::route::RtcRibRouteKey::afi_safi(),
+    ];
+    for family in families {
+        manager.mark_deferred_selection_overflow_for_test(family);
+        manager.recompute_released_selection_family_for_test(family);
+    }
+
+    assert!(manager.loc_rib.get(&unicast_key).is_none());
+    assert!(manager.loc_rib.get_flowspec(&flowspec_key).is_none());
+    assert!(manager.loc_rib.get_evpn(&evpn_key).is_none());
+    assert!(manager.loc_rib.get_vpn(&vpn_key).is_none());
+    assert!(manager.loc_rib.get_labeled(&labeled_key).is_none());
+    assert!(manager.loc_rib.get_bgpls(&bgpls_key).is_none());
+    assert!(manager.loc_rib.get_rtc(&rtc_key).is_none());
+}
+
+#[test]
+fn inactive_selection_gate_skips_identity_tracking_before_and_after_release() {
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let prefix = rustbgpd_wire::Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    let affected = HashSet::from([prefix]);
+
+    manager.record_deferred_unicast_with_test_limit(&affected, 0);
+    assert_counter_value(
+        &metrics,
+        "bgp_selection_deferral_ledger_overflows_total",
+        0.0,
+    );
+
+    manager = manager.with_selection_deferral(config(Duration::from_secs(1), &[peer(1)]));
+    let released = manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .expire(&metrics);
+    assert_eq!(released, vec![FAMILY]);
+    manager.record_deferred_unicast_with_test_limit(&affected, 0);
+    assert_counter_value(
+        &metrics,
+        "bgp_selection_deferral_ledger_overflows_total",
+        0.0,
+    );
 }
 
 #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -175,6 +175,7 @@ pub struct BgpMetrics {
     selection_deferral_waiters: IntGaugeVec,
     selection_deferral_releases: IntCounterVec,
     selection_deferral_timeouts: IntCounterVec,
+    selection_deferral_ledger_overflows: IntCounterVec,
 
     // ── RPKI ───────────────────────────────────────────────────
     rpki_vrp_count: IntGaugeVec,
@@ -919,6 +920,15 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let selection_deferral_ledger_overflows = IntCounterVec::new(
+            Opts::new(
+                "bgp_selection_deferral_ledger_overflows_total",
+                "RFC 4724 selection-deferral families that exceeded the bounded identity ledger and required a complete release sweep.",
+            ),
+            &["afi_safi"],
+        )
+        .expect("valid metric definition");
+
         let rpki_vrp_count = IntGaugeVec::new(
             Opts::new(
                 "bgp_rpki_vrp_count",
@@ -1621,6 +1631,9 @@ impl BgpMetrics {
             .register(Box::new(selection_deferral_timeouts.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(selection_deferral_ledger_overflows.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(rpki_vrp_count.clone()))
             .expect("metric not already registered");
         registry
@@ -1874,6 +1887,7 @@ impl BgpMetrics {
             selection_deferral_waiters,
             selection_deferral_releases,
             selection_deferral_timeouts,
+            selection_deferral_ledger_overflows,
             rpki_vrp_count,
             aspa_records,
             validation_import_refreshes,
@@ -2761,6 +2775,13 @@ impl BgpMetrics {
     /// Record expiry of one family `Selection_Deferral_Timer`.
     pub fn record_selection_deferral_timeout(&self, afi_safi: &str) {
         self.selection_deferral_timeouts
+            .with_label_values(&[afi_safi])
+            .inc();
+    }
+
+    /// Record a family entering bounded-ledger release fallback.
+    pub fn record_selection_deferral_ledger_overflow(&self, afi_safi: &str) {
+        self.selection_deferral_ledger_overflows
             .with_label_values(&[afi_safi])
             .inc();
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1041,8 +1041,12 @@ across static peers, the process-start selection deferral.
 retains their `all_eor` or `timer` release reason afterward. Metrics are
 `bgp_selection_deferral_active`, `bgp_selection_deferral_waiters`,
 `bgp_selection_deferral_releases_total`, and
-`bgp_selection_deferral_timeouts_total` (all bounded by configured family and
-release-reason labels).
+`bgp_selection_deferral_timeouts_total`. The process-wide deferred-identity
+ledger is capped at one million keys; if it fills,
+`bgp_selection_deferral_ledger_overflows_total` increments once for each
+affected family and release sweeps the complete Adj-RIB-In plus Loc-RIB family
+so an already-withdrawn identity cannot remain stale. All labels are bounded by
+configured family and release reason.
 See [ADR-0024](adr/0024-graceful-restart.md).
 
 ### Long-Lived Graceful Restart (RFC 9494)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -749,11 +749,14 @@ owned-state.
 | `bgp_selection_deferral_waiters{afi_safi}` | Frozen-roster peers still blocking selection for the family |
 | `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor` or `timer` |
 | `bgp_selection_deferral_timeouts_total{afi_safi}` | Family gates released by the selection-deferral timer |
+| `bgp_selection_deferral_ledger_overflows_total{afi_safi}` | Gated families that exceeded the one-million-identity process ledger and used a complete release sweep |
 
 For active gates, `rbgp neighbor <address>` and
 `NeighborService.GetNeighborState` also show the peer's waiter state, stamped
 session, blocking-waiter count, and remaining time. A released row retains its
-reason for the daemon lifetime.
+reason for the daemon lifetime. A ledger-overflow warning is emitted once per
+family; release then enumerates the complete Adj-RIB-In and Loc-RIB family so
+withdrawals that already left Adj-RIB-In are still removed before EoR.
 
 ### BFD
 


### PR DESCRIPTION
## Summary

- bound the deferred-selection identity ledger to one million unique routes across all seven typed stores
- mark overflow per AFI/SAFI and recover with a complete Adj-RIB-In plus Loc-RIB family sweep at release
- avoid retaining identities when no selection-deferral gate is active
- expose one transition warning and counter, and document the fallback behavior

## Why

Selection deferral previously retained every affected identity until EoR or timeout, so a large or adversarial update stream could grow the ledger without a process-wide bound. Dropping excess identities alone would be unsafe: a route withdrawn before EoR may already be absent from Adj-RIB-In, allowing stale selected and advertised state to survive release.

The overflow sentinel keeps memory bounded while the full-family Loc-RIB fallback preserves the withdrawal/recompute contract.

## Development impact

This remains an internal invariant with a fixed safety bound. It adds no configuration, schema, API, protobuf, or distribution framework surface.

## Verification

- focused selection-deferral regressions, including all typed Loc-RIB stores and withdrawal-before-EoR ordering
- RIB library tests: 796 passed, 1 ignored
- telemetry tests: 66 passed
- workspace formatting, all-target Clippy, library tests, and rustdoc
- v1 stable-surface and release-note gates
- independent functional, integration, and maintainability reviews
- exact rebased production patch hash preserved across the current-main integration
