### PR TITLE
fix: bound warm checkpoint bundle retention

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -48,6 +48,21 @@ jobs:
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
             cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=8192
           done
+      - name: Fuzz MRT snapshot reader (2 minutes per target)
+        run: |
+          cd crates/mrt
+          # Keep target discovery fail-closed as new MRT parsers are added.
+          targets=$(cargo +nightly fuzz list)
+          if [ -z "$targets" ]; then
+            echo "fuzz-target enumeration returned no targets" >&2
+            exit 1
+          fi
+          for t in $targets; do
+            mkdir -p "fuzz/corpus/$t"
+            seeds=""
+            [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
+            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=65536
+          done
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v7
@@ -56,3 +71,4 @@ jobs:
           path: |
             crates/wire/fuzz/artifacts/
             crates/policy/fuzz/artifacts/
+            crates/mrt/fuzz/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ crates/policy/fuzz/corpus/
 crates/policy/fuzz/target/
 crates/policy/fuzz/Cargo.lock
 crates/policy/fuzz/artifacts/
+crates/mrt/fuzz/corpus/
+crates/mrt/fuzz/target/
+crates/mrt/fuzz/Cargo.lock
+crates/mrt/fuzz/artifacts/
 
 # Profiling artifacts
 dhat-heap*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   backpressured peer population can no longer multiply the per-session deadline
   into a multi-minute daemon shutdown.
 
+- **Shutdown warm checkpoints retain one committed snapshot.** Only after the
+  new `manifest.json` rename and directory fsync establish the commit point,
+  publication removes superseded content-addressed snapshots and recognizable
+  crash-leaked temporary files through the pinned bundle directory. Cleanup
+  failure is warned but cannot roll back or delete the manifest's current
+  snapshot.
+
 - **The v1 stable-surface release gate now supports patch and major releases.**
   Upgrade exercises remain a contiguous, fail-closed chain of adjacent release
   lines, while the latest exercise targets `vMAJOR.MINOR.0` and the inventory

--- a/crates/mrt/Cargo.toml
+++ b/crates/mrt/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bytes.workspace = true
-nix = { workspace = true, features = ["fs", "user"] }
+nix = { workspace = true, features = ["dir", "fs", "user"] }
 serde.workspace = true
 serde_json.workspace = true
 # Warm-checkpoint content digests; already present in the workspace graph.

--- a/crates/mrt/fuzz/Cargo.toml
+++ b/crates/mrt/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rustbgpd-mrt-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.rustbgpd-mrt]
+path = ".."
+
+[[bin]]
+name = "snapshot_reader_drain"
+path = "fuzz_targets/snapshot_reader_drain.rs"
+test = false
+doc = false
+
+[workspace]

--- a/crates/mrt/fuzz/fuzz_targets/snapshot_reader_drain.rs
+++ b/crates/mrt/fuzz/fuzz_targets/snapshot_reader_drain.rs
@@ -1,0 +1,31 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_mrt::SnapshotReader;
+
+// A valid empty PEER_INDEX_TABLE lets every arbitrary suffix reach the
+// iterator as well as fuzzing construction directly from the original input.
+const EMPTY_PEER_INDEX_TABLE: &[u8] = &[
+    0, 0, 0, 0, // timestamp
+    0, 13, // TABLE_DUMP_V2
+    0, 1, // PEER_INDEX_TABLE
+    0, 0, 0, 8, // payload length
+    0, 0, 0, 0, // collector BGP ID
+    0, 0, // empty view name
+    0, 0, // zero peers
+];
+
+fn drain(bytes: &[u8]) {
+    if let Ok(mut reader) = SnapshotReader::new(bytes) {
+        while reader.next().is_some() {}
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    drain(data);
+
+    let mut after_peer_table = Vec::with_capacity(EMPTY_PEER_INDEX_TABLE.len() + data.len());
+    after_peer_table.extend_from_slice(EMPTY_PEER_INDEX_TABLE);
+    after_peer_table.extend_from_slice(data);
+    drain(&after_peer_table);
+});

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -13,18 +13,22 @@
 //!
 //! Publication fsyncs and renames the content-addressed MRT artifact before it
 //! atomically replaces `manifest.json`, the commit point, then fsyncs the
-//! directory. Any reported failure rolls back destination entries to the exact
-//! state observed before publication; only a successful return exposes the new
-//! commit.
+//! directory. Any reported publication failure rolls back destination entries
+//! to the exact state observed before publication. After that commit succeeds,
+//! a best-effort descriptor-relative sweep removes superseded snapshots and
+//! recognizable crash-leaked temporary files. Cleanup failure is logged but
+//! never invalidates or rolls back the newly committed generation.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{self, Read as _, Seek as _, SeekFrom, Write as _};
 use std::net::{IpAddr, Ipv4Addr};
+use std::os::fd::OwnedFd;
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use nix::dir::Dir;
 use nix::errno::Errno;
 use nix::fcntl::{OFlag, RenameFlags, open, openat, renameat2};
 use nix::sys::stat::Mode;
@@ -32,6 +36,7 @@ use nix::unistd::{UnlinkatFlags, geteuid, unlinkat};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
+use tracing::{debug, warn};
 
 use crate::codec::{WarmSnapshotBudget, WarmSnapshotBudgetError};
 use crate::{ReadError, SnapshotNlri, SnapshotReader};
@@ -579,7 +584,133 @@ fn write_warm_bundle_inner(
         }
         return Err(error);
     }
+    match cleanup_committed_bundle(directory, &manifest.snapshot.path, &encoded, fault, budget) {
+        Ok(removed) if removed > 0 => {
+            debug!(
+                removed,
+                current_snapshot = %manifest.snapshot.path,
+                "removed superseded warm-bundle entries after commit"
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            warn!(
+                error = %error,
+                current_snapshot = %manifest.snapshot.path,
+                "warm bundle remains committed but post-commit cleanup is incomplete"
+            );
+        }
+    }
     Ok(manifest)
+}
+
+/// Remove only names created by this module, after the manifest commit is
+/// durable. Unknown entries are deliberately left alone. The current
+/// manifest's exact content-addressed snapshot is never a cleanup candidate.
+#[cfg_attr(not(test), allow(unused_variables))]
+fn cleanup_committed_bundle(
+    directory: &WarmBundleDirectory,
+    current_snapshot: &str,
+    committed_manifest: &[u8],
+    fault: FaultPoint,
+    budget: Option<&WarmSnapshotBudget>,
+) -> Result<u64, WarmBundleError> {
+    #[cfg(test)]
+    fail_if(fault, FaultPoint::CleanupScan)
+        .map_err(|source| io_error(&directory.display_path, source))?;
+    verify_existing_entry(
+        directory,
+        WARM_BUNDLE_MANIFEST_FILE,
+        "manifest",
+        committed_manifest,
+        budget,
+    )?;
+
+    let cloned = directory
+        .file
+        .try_clone()
+        .map_err(|source| io_error(&directory.display_path, source))?;
+    let owned: OwnedFd = cloned.into();
+    let mut entries =
+        Dir::from_fd(owned).map_err(|source| nix_io(&directory.display_path, source))?;
+    let mut removed = 0_u64;
+    for entry in entries.iter() {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        let entry = entry.map_err(|source| nix_io(&directory.display_path, source))?;
+        let name = entry.file_name();
+        let bytes = name.to_bytes();
+        if bytes == current_snapshot.as_bytes()
+            || (!is_content_addressed_snapshot(bytes) && !is_atomic_temp_name(bytes))
+        {
+            continue;
+        }
+        let display = directory
+            .display_path
+            .join(String::from_utf8_lossy(bytes).into_owned());
+
+        #[cfg(test)]
+        fail_if(fault, FaultPoint::CleanupUnlink).map_err(|source| io_error(&display, source))?;
+        match unlinkat(&directory.file, name, UnlinkatFlags::NoRemoveDir) {
+            Ok(()) => {
+                removed = removed.saturating_add(1);
+            }
+            Err(Errno::ENOENT) => {}
+            Err(source) => {
+                return Err(io_error(&display, errno_io(source)));
+            }
+        }
+    }
+    if removed > 0 {
+        if let Some(budget) = budget {
+            budget.check()?;
+        }
+        #[cfg(test)]
+        fail_if(fault, FaultPoint::CleanupDirSync)
+            .map_err(|source| io_error(&directory.display_path, source))?;
+        directory
+            .file
+            .sync_all()
+            .map_err(|source| io_error(&directory.display_path, source))?;
+    }
+    Ok(removed)
+}
+
+fn is_content_addressed_snapshot(name: &[u8]) -> bool {
+    const PREFIX: &[u8] = b"snapshot-";
+    const SUFFIX: &[u8] = b".mrt";
+    name.len() == PREFIX.len() + 64 + SUFFIX.len()
+        && name.starts_with(PREFIX)
+        && name.ends_with(SUFFIX)
+        && name[PREFIX.len()..PREFIX.len() + 64]
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn is_atomic_temp_name(name: &[u8]) -> bool {
+    let Some(rest) = name.strip_prefix(b".") else {
+        return false;
+    };
+    let Some(marker) = rest.windows(5).position(|window| window == b".tmp.") else {
+        return false;
+    };
+    let base = &rest[..marker];
+    if base != WARM_BUNDLE_MANIFEST_FILE.as_bytes() && !is_content_addressed_snapshot(base) {
+        return false;
+    }
+    let mut identifiers = rest[marker + 5..].split(|byte| *byte == b'.');
+    let Some(pid) = identifiers.next() else {
+        return false;
+    };
+    let Some(sequence) = identifiers.next() else {
+        return false;
+    };
+    identifiers.next().is_none()
+        && !pid.is_empty()
+        && pid.iter().all(u8::is_ascii_digit)
+        && !sequence.is_empty()
+        && sequence.iter().all(u8::is_ascii_digit)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1261,8 +1392,11 @@ enum AtomicPublication {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FaultPoint {
     None,
+    #[cfg(test)]
     ArtifactWrite,
+    #[cfg(test)]
     ArtifactFileSync,
+    #[cfg(test)]
     ArtifactRename,
     #[cfg(test)]
     ArtifactCancelAfterFileSync,
@@ -1270,9 +1404,13 @@ enum FaultPoint {
     ArtifactCancelAfterRename,
     #[cfg(test)]
     ArtifactCancelAfterDirSync,
+    #[cfg(test)]
     ArtifactDirSync,
+    #[cfg(test)]
     ManifestWrite,
+    #[cfg(test)]
     ManifestFileSync,
+    #[cfg(test)]
     ManifestRename,
     #[cfg(test)]
     ManifestCancelAfterFileSync,
@@ -1280,9 +1418,17 @@ enum FaultPoint {
     ManifestCancelAfterRename,
     #[cfg(test)]
     ManifestCancelAfterDirSync,
+    #[cfg(test)]
     ManifestDirSync,
+    #[cfg(test)]
+    CleanupScan,
+    #[cfg(test)]
+    CleanupUnlink,
+    #[cfg(test)]
+    CleanupDirSync,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AtomicBoundary {
     FileSync,
@@ -1290,6 +1436,7 @@ enum AtomicBoundary {
     DirectorySync,
 }
 
+#[cfg(test)]
 fn stage(role: AtomicRole, ordinal: u8) -> FaultPoint {
     match (role, ordinal) {
         (AtomicRole::Artifact, 0) => FaultPoint::ArtifactWrite,
@@ -1303,6 +1450,7 @@ fn stage(role: AtomicRole, ordinal: u8) -> FaultPoint {
     }
 }
 
+#[cfg(test)]
 fn fail_if(selected: FaultPoint, current: FaultPoint) -> io::Result<()> {
     if selected == current {
         Err(io::Error::other(format!("injected failure at {current:?}")))
@@ -1351,23 +1499,11 @@ fn cancel_at_boundary_if(
     }
 }
 
-#[cfg(not(test))]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "production and fault-injection builds share the transactional call site"
-)]
-fn cancel_at_boundary_if(
-    _selected: FaultPoint,
-    _role: AtomicRole,
-    _boundary: AtomicBoundary,
-) -> Result<(), WarmBundleError> {
-    Ok(())
-}
-
 #[expect(
     clippy::too_many_lines,
     reason = "atomic staging, publication, durability, and rollback form one transaction"
 )]
+#[cfg_attr(not(test), allow(unused_variables))]
 fn write_atomic_at(
     directory: &WarmBundleDirectory,
     name: &str,
@@ -1383,6 +1519,7 @@ fn write_atomic_at(
         if let Some(budget) = budget {
             budget.check()?;
         }
+        #[cfg(test)]
         fail_if(fault, stage(role, 0)).map_err(|source| io_error(&display, source))?;
         for chunk in bytes.chunks(STREAM_BUFFER_BYTES) {
             if let Some(budget) = budget {
@@ -1394,14 +1531,17 @@ fn write_atomic_at(
         if let Some(budget) = budget {
             budget.check()?;
         }
+        #[cfg(test)]
         fail_if(fault, stage(role, 1)).map_err(|source| io_error(&display, source))?;
         file.sync_all()
             .map_err(|source| io_error(&display, source))?;
+        #[cfg(test)]
         cancel_at_boundary_if(fault, role, AtomicBoundary::FileSync)?;
         if let Some(budget) = budget {
             budget.check()?;
         }
         drop(file);
+        #[cfg(test)]
         fail_if(fault, stage(role, 2)).map_err(|source| io_error(&display, source))?;
         let publication = match role {
             AtomicRole::Artifact => match renameat2(
@@ -1413,7 +1553,13 @@ fn write_atomic_at(
             ) {
                 Ok(()) => AtomicPublication::Created,
                 Err(Errno::EEXIST) => {
-                    verify_existing_entry(directory, name, bytes, budget)?;
+                    verify_existing_entry(
+                        directory,
+                        name,
+                        "content-addressed snapshot",
+                        bytes,
+                        budget,
+                    )?;
                     unlinkat(
                         &directory.file,
                         temp_name.as_str(),
@@ -1425,6 +1571,7 @@ fn write_atomic_at(
                         .file
                         .sync_all()
                         .map_err(|source| io_error(&display, source))?;
+                    #[cfg(test)]
                     cancel_at_boundary_if(fault, role, AtomicBoundary::DirectorySync)?;
                     return Ok(AtomicPublication::Reused);
                 }
@@ -1454,15 +1601,18 @@ fn write_atomic_at(
             },
         };
         committed = Some(publication);
+        #[cfg(test)]
         cancel_at_boundary_if(fault, role, AtomicBoundary::Rename)?;
         if let Some(budget) = budget {
             budget.check()?;
         }
+        #[cfg(test)]
         fail_if(fault, stage(role, 3)).map_err(|source| io_error(&display, source))?;
         directory
             .file
             .sync_all()
             .map_err(|source| io_error(&display, source))?;
+        #[cfg(test)]
         cancel_at_boundary_if(fault, role, AtomicBoundary::DirectorySync)?;
         if let Some(budget) = budget {
             budget.check()?;
@@ -1500,11 +1650,12 @@ fn write_atomic_at(
 fn verify_existing_entry(
     directory: &WarmBundleDirectory,
     name: &str,
+    role: &'static str,
     expected: &[u8],
     budget: Option<&WarmSnapshotBudget>,
 ) -> Result<(), WarmBundleError> {
     let display = directory.display_path.join(name);
-    let mut file = open_entry(directory, name, "snapshot", OFlag::O_RDONLY, Mode::empty())?;
+    let mut file = open_entry(directory, name, role, OFlag::O_RDONLY, Mode::empty())?;
     let metadata = file
         .metadata()
         .map_err(|source| io_error(&display, source))?;
@@ -1513,7 +1664,7 @@ fn verify_existing_entry(
             &display,
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                "existing content-addressed artifact has the wrong length",
+                format!("existing {role} has the wrong length"),
             ),
         ));
     }
@@ -1531,7 +1682,7 @@ fn verify_existing_entry(
                 &display,
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "existing content-addressed artifact bytes differ",
+                    format!("existing {role} bytes differ"),
                 ),
             ));
         }
@@ -2459,6 +2610,145 @@ mod tests {
                 "first publication at {fault:?}"
             );
         }
+    }
+
+    #[test]
+    fn successful_commit_prunes_only_superseded_snapshots_and_crash_temps() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let old = identity();
+        let old_manifest = write_warm_bundle(&dir, old.clone(), &valid_snapshot(&old)).unwrap();
+        let leaked_manifest = ".manifest.json.tmp.123.7";
+        let leaked_snapshot = format!(".{}.tmp.123.8", old_manifest.snapshot.path);
+        fs::write(temp.path().join(leaked_manifest), b"torn manifest").unwrap();
+        fs::write(temp.path().join(&leaked_snapshot), b"torn snapshot").unwrap();
+        let unknown_snapshot = format!("{}.backup", old_manifest.snapshot.path);
+        fs::write(temp.path().join(&unknown_snapshot), b"operator-owned").unwrap();
+        let malformed_temp = ".manifest.json.tmp.not-a-pid.9";
+        fs::write(temp.path().join(malformed_temp), b"operator-owned").unwrap();
+
+        let mut next = old;
+        next.checkpoint_generation = "boot-42".to_string();
+        next.peer_index_table_view = "warm-generation-42".to_string();
+        next.snapshot_revision += 1;
+        next.created_at_utc_seconds += 1;
+        let next_snapshot = valid_snapshot(&next);
+        let current_temp = format!(".{}.tmp.123.9", snapshot_name(&sha256_hex(&next_snapshot)));
+        fs::write(temp.path().join(&current_temp), b"torn current snapshot").unwrap();
+        let current = write_warm_bundle(&dir, next.clone(), &next_snapshot).unwrap();
+
+        assert!(!temp.path().join(old_manifest.snapshot.path).exists());
+        assert!(!temp.path().join(leaked_manifest).exists());
+        assert!(!temp.path().join(leaked_snapshot).exists());
+        assert!(!temp.path().join(current_temp).exists());
+        assert!(temp.path().join(unknown_snapshot).is_file());
+        assert!(temp.path().join(malformed_temp).is_file());
+        assert!(temp.path().join(&current.snapshot.path).is_file());
+        assert!(temp.path().join(WARM_BUNDLE_MANIFEST_FILE).is_file());
+        assert!(load_warm_bundle(&dir, &expected(&next), freshness()).is_ok());
+    }
+
+    #[test]
+    fn cleanup_refuses_a_changed_manifest_before_unlinking_any_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let id = identity();
+        let current = write_warm_bundle(&dir, id.clone(), &valid_snapshot(&id)).unwrap();
+        let stale = snapshot_name(SHA);
+        assert_ne!(stale, current.snapshot.path);
+        fs::write(temp.path().join(&stale), b"stale").unwrap();
+        let mut expected_manifest = fs::read(temp.path().join(WARM_BUNDLE_MANIFEST_FILE)).unwrap();
+        expected_manifest[0] ^= 1;
+
+        assert!(
+            cleanup_committed_bundle(
+                &dir,
+                &current.snapshot.path,
+                &expected_manifest,
+                FaultPoint::None,
+                None,
+            )
+            .is_err()
+        );
+        assert!(temp.path().join(&stale).is_file());
+        assert!(temp.path().join(&current.snapshot.path).is_file());
+        assert!(load_warm_bundle(&dir, &expected(&id), freshness()).is_ok());
+    }
+
+    #[test]
+    fn postcommit_cleanup_faults_never_roll_back_the_current_generation() {
+        for fault in [
+            FaultPoint::CleanupScan,
+            FaultPoint::CleanupUnlink,
+            FaultPoint::CleanupDirSync,
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let dir = opened(&temp);
+            let old = identity();
+            publish(&dir, &old);
+            let mut next = old;
+            next.checkpoint_generation = "boot-42".to_string();
+            next.peer_index_table_view = "warm-generation-42".to_string();
+            next.snapshot_revision += 1;
+            next.created_at_utc_seconds += 1;
+
+            let manifest =
+                write_warm_bundle_inner(&dir, next.clone(), &valid_snapshot(&next), fault, None)
+                    .unwrap();
+
+            assert!(
+                temp.path().join(&manifest.snapshot.path).is_file(),
+                "{fault:?}"
+            );
+            assert!(
+                load_warm_bundle(&dir, &expected(&next), freshness()).is_ok(),
+                "{fault:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn adversarial_cleanup_entry_cannot_invalidate_the_committed_generation() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let old = identity();
+        publish(&dir, &old);
+        let obstructing_temp = temp.path().join(".manifest.json.tmp.321.9");
+        fs::create_dir(&obstructing_temp).unwrap();
+        let unknown = temp.path().join("snapshot-not-a-digest.mrt");
+        fs::write(&unknown, b"operator-owned").unwrap();
+
+        let mut next = old;
+        next.checkpoint_generation = "boot-42".to_string();
+        next.peer_index_table_view = "warm-generation-42".to_string();
+        next.snapshot_revision += 1;
+        next.created_at_utc_seconds += 1;
+        let manifest = write_warm_bundle(&dir, next.clone(), &valid_snapshot(&next)).unwrap();
+
+        assert!(obstructing_temp.is_dir());
+        assert!(unknown.is_file());
+        assert!(temp.path().join(&manifest.snapshot.path).is_file());
+        assert!(load_warm_bundle(&dir, &expected(&next), freshness()).is_ok());
+    }
+
+    #[test]
+    fn cleanup_name_matching_is_narrow_and_canonical() {
+        assert!(is_content_addressed_snapshot(
+            format!("snapshot-{SHA}.mrt").as_bytes()
+        ));
+        assert!(!is_content_addressed_snapshot(
+            format!("snapshot-{}.mrt", SHA.to_ascii_uppercase()).as_bytes()
+        ));
+        assert!(!is_content_addressed_snapshot(
+            format!("snapshot-{SHA}.mrt.backup").as_bytes()
+        ));
+        assert!(is_atomic_temp_name(b".manifest.json.tmp.12.34"));
+        assert!(is_atomic_temp_name(
+            format!(".snapshot-{SHA}.mrt.tmp.12.34").as_bytes()
+        ));
+        assert!(!is_atomic_temp_name(b".manifest.json.tmp.nope.34"));
+        assert!(!is_atomic_temp_name(b".manifest.json.tmp.12.34.extra"));
+        assert!(!is_atomic_temp_name(b".notes.tmp.12.34"));
     }
 
     #[test]

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -607,12 +607,11 @@ fn write_warm_bundle_inner(
 /// Remove only names created by this module, after the manifest commit is
 /// durable. Unknown entries are deliberately left alone. The current
 /// manifest's exact content-addressed snapshot is never a cleanup candidate.
-#[cfg_attr(not(test), allow(unused_variables))]
 fn cleanup_committed_bundle(
     directory: &WarmBundleDirectory,
     current_snapshot: &str,
     committed_manifest: &[u8],
-    fault: FaultPoint,
+    #[cfg_attr(not(test), allow(unused_variables))] fault: FaultPoint,
     budget: Option<&WarmSnapshotBudget>,
 ) -> Result<u64, WarmBundleError> {
     #[cfg(test)]
@@ -1503,13 +1502,12 @@ fn cancel_at_boundary_if(
     clippy::too_many_lines,
     reason = "atomic staging, publication, durability, and rollback form one transaction"
 )]
-#[cfg_attr(not(test), allow(unused_variables))]
 fn write_atomic_at(
     directory: &WarmBundleDirectory,
     name: &str,
     bytes: &[u8],
     role: AtomicRole,
-    fault: FaultPoint,
+    #[cfg_attr(not(test), allow(unused_variables))] fault: FaultPoint,
     budget: Option<&WarmSnapshotBudget>,
 ) -> Result<AtomicPublication, WarmBundleError> {
     let display = directory.display_path.join(name);

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -150,6 +150,11 @@ the exact effective configuration, resolved import policies, live peer/family
 identity, and restart-marker generation, and is readable only through the
 daemon-private runtime-state directory. If capture or publication fails, the
 daemon falls back to the existing marker-v1 Graceful Restart behavior.
+After a new manifest is durably committed, rustbgpd removes superseded
+content-addressed snapshots and recognizable interrupted-write temporary
+files from that pinned private directory. Cleanup failure is logged but does
+not invalidate the current manifest or its snapshot; unknown files are left
+untouched.
 
 This option does **not** make startup restore routes: no cached route is loaded,
 selected, installed, or advertised. A successful checkpoint only causes the GR

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -229,7 +229,11 @@ the daemon account, and do not expose or back it up as a public MRT feed.
 Publication is descriptor-relative beneath an owner-verified directory that is
 not group/world-writable. Bundle files are owner-only, symlink traversal is
 rejected, content is size-bounded and hashed, and `manifest.json` is the atomic
-commit point. Startup does not load the checkpoint, so a stale or tampered
+commit point. A descriptor-relative post-commit sweep removes only canonical
+superseded snapshot names and recognizable atomic temporary names; it preserves
+the manifest's exact current snapshot and ignores unknown entries. Cleanup
+failure is logged without invalidating the committed generation. Startup does
+not load the checkpoint, so a stale or tampered
 bundle cannot currently inject, select, install, or advertise a route. The GR
 marker carries only an opaque generation and retains the existing marker-v1
 fallback if publication fails.

--- a/docs/adr/0104-shutdown-warm-checkpoint-publication.md
+++ b/docs/adr/0104-shutdown-warm-checkpoint-publication.md
@@ -34,8 +34,13 @@ weaken the existing marker-v1 restart path.
 4. The fixed `<runtime_state_dir>/warm-bundle-v1` directory is owner-verified
    and descriptor-pinned. Filesystem operations reject symlinks and unsafe
    ownership/modes. A content-addressed MRT artifact is durably committed
-   before atomic `manifest.json` replacement; failure restores the prior
-   committed directory image.
+   before atomic `manifest.json` replacement; any failure through the manifest
+   rename and parent-directory fsync restores the prior committed directory
+   image. Only after that commit point, a descriptor-relative sweep removes
+   superseded `snapshot-<sha256>.mrt` files and recognizable atomic temporary
+   files. It never selects `manifest.json` or the exact snapshot named by the
+   current manifest. Cleanup failure is warned and leaves the new generation
+   committed; no background collector or directory-size policy is introduced.
 5. A successful publication writes restart marker v2 with the exact checkpoint
    generation. Failure writes the established marker-v1 form instead. Marker
    and bundle operations remain independently fail-closed.
@@ -53,6 +58,10 @@ weaken the existing marker-v1 restart path.
   protected as sensitive daemon state.
 - Shutdown may spend up to 30 seconds attempting publication. Failure is
   visible in logs but preserves the normal Graceful Restart marker fallback.
+- A successful checkpoint normally leaves one manifest and its one current
+  snapshot. Unknown files are not garbage-collected. A post-commit cleanup
+  warning means the new checkpoint remains committed but stale private bundle
+  entries may need operator inspection or removal.
 - The V1 format intentionally excludes dynamic/scoped peers, ambiguous static
   addresses, unsupported families, and EVPN Add-Path receive rather than
   serializing an incomplete or ambiguous view.


### PR DESCRIPTION
## Summary

- prune superseded warm-checkpoint snapshots and crash temporaries only after the new manifest is renamed and its parent directory is fsynced
- verify the committed manifest exactly before descriptor-relative, no-follow cleanup and preserve the selected snapshot on every failure path
- add fault-order regressions plus a full-drain SnapshotReader fuzz target in the existing nightly fuzz workflow

## Stack

- Depends on #877 and is based on its exact current head.
- This PR contains only the two LAN-403 cleanup and fuzz commits.
- Merge #877 first, then retarget this PR to main without changing its patch.

## Verification

- 25 warm-bundle tests and all 83 MRT tests
- MRT all-target Clippy with warnings denied
- nightly fuzz target build and two 2,000-run smokes
- full pre-push formatting, workspace Clippy, library tests, and rustdoc
- independent final review clean at exact head 26d11f4b0c11fff308ab48b21071d261e06b4ace

## Scope

No restore path, config/API/schema/proto change, background GC task, or operator knob. The daemon remains the single serialized checkpoint publisher.