### PR TITLE
fix: bound coordinated peer shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Coordinated shutdown stays bounded at high peer counts.** Peer sessions now
+  drain with fixed cross-peer concurrency while preserving pending-before-primary
+  ordering and each session's existing timeout, abort, and reap guarantees. A
+  backpressured peer population can no longer multiply the per-session deadline
+  into a multi-minute daemon shutdown.
+
 - **The v1 stable-surface release gate now supports patch and major releases.**
   Upgrade exercises remain a contiguous, fail-closed chain of adjacent release
   lines, while the latest exercise targets `vMAJOR.MINOR.0` and the inventory

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -24,6 +24,14 @@ impl PeerManager {
         context: &'static str,
         handle: PeerHandle,
     ) -> PeerShutdownOutcome {
+        Self::shutdown_handle_bounded_owned(address, context, handle).await
+    }
+
+    pub(super) async fn shutdown_handle_bounded_owned(
+        address: std::net::IpAddr,
+        context: &'static str,
+        handle: PeerHandle,
+    ) -> PeerShutdownOutcome {
         match handle
             .shutdown_timeout(PEER_LIFECYCLE_COMMAND_TIMEOUT)
             .await

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -18,7 +18,8 @@ use rustbgpd_transport::{
 };
 use rustbgpd_wire::{Afi, Safi};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
-use tracing::{debug, info};
+use tokio::task::JoinSet;
+use tracing::{debug, error, info};
 
 use crate::config::Config;
 use crate::policy_admin::{
@@ -71,6 +72,13 @@ const PEER_POLICY_UPDATE_TIMEOUT: Duration = Duration::from_millis(500);
 /// draining it; actor paths must fail/log within this deadline instead of
 /// blocking every peer's RPC/reconcile work behind one stalled session.
 const PEER_LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Maximum number of independently owned peers drained at once during
+/// process shutdown. Each peer still drains a pending inbound candidate before
+/// its primary session, preserving the collision-owner ordering, while the
+/// fixed cross-peer cap prevents the daemon's shutdown time from growing as
+/// `peer_count * PEER_LIFECYCLE_COMMAND_TIMEOUT` under transport back-pressure.
+const PEER_SHUTDOWN_CONCURRENCY: usize = 64;
 
 /// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
 /// actor (export-policy swap, per-peer outbound refresh). Generous — the
@@ -1169,27 +1177,38 @@ impl PeerManager {
                         PeerManagerCommand::Shutdown => {
                             info!("peer manager shutting down {} peers", self.peers.len());
                             let drained: Vec<_> = self.peers.drain().collect();
+                            let mut shutdowns = JoinSet::new();
                             for (addr, mut managed) in drained {
-                                debug!(%addr, "shutting down peer");
-                                if let Some(pending) = managed.pending_inbound.take() {
-                                    let _ = self
-                                        .shutdown_handle_bounded(
+                                if shutdowns.len() == PEER_SHUTDOWN_CONCURRENCY
+                                    && let Some(Err(error)) = shutdowns.join_next().await
+                                {
+                                    error!(%error, "peer shutdown worker failed");
+                                }
+                                shutdowns.spawn(async move {
+                                    debug!(%addr, "shutting down peer");
+                                    if let Some(pending) = managed.pending_inbound.take() {
+                                        let _ = Self::shutdown_handle_bounded_owned(
                                             addr.address,
                                             "PeerManager shutdown pending inbound",
                                             pending.handle,
                                         )
                                         .await;
-                                }
-                                if self
-                                    .shutdown_handle_bounded(
+                                    }
+                                    if Self::shutdown_handle_bounded_owned(
                                         addr.address,
                                         "PeerManager shutdown primary",
                                         managed.handle,
                                     )
                                     .await
                                     .joined()
-                                {
-                                    debug!(%addr, "peer shut down");
+                                    {
+                                        debug!(%addr, "peer shut down");
+                                    }
+                                });
+                            }
+                            while let Some(result) = shutdowns.join_next().await {
+                                if let Err(error) = result {
+                                    error!(%error, "peer shutdown worker failed");
                                 }
                             }
                             return;

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1169,6 +1169,74 @@ struct FakePeerCounters {
     stop: AtomicU32,
 }
 
+struct TaskDropCounter(Arc<AtomicU32>);
+
+impl Drop for TaskDropCounter {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+async fn stalled_shutdown_peer_handle(dropped: Arc<AtomicU32>) -> PeerHandle {
+    let (commands, receiver) = mpsc::channel(1);
+    commands
+        .send(rustbgpd_transport::PeerCommand::Start)
+        .await
+        .expect("seed the deliberately full command channel");
+    let task = tokio::spawn(async move {
+        let _receiver = receiver;
+        let _drop_counter = TaskDropCounter(dropped);
+        std::future::pending::<Result<(), rustbgpd_transport::TransportError>>().await
+    });
+    PeerHandle::from_parts(commands, task)
+}
+
+#[tokio::test(start_paused = true)]
+async fn manager_shutdown_bounds_many_stalled_peers_by_concurrent_waves() {
+    let (tx, rx) = mpsc::channel(1);
+    let (rib_tx, _rib_rx) = mpsc::channel(1);
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    let peer_count = PEER_SHUTDOWN_CONCURRENCY + 1;
+    let dropped = Arc::new(AtomicU32::new(0));
+
+    for index in 0..peer_count {
+        let host = u8::try_from(index + 1).expect("test peer count fits one IPv4 /24");
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, host));
+        let primary = stalled_shutdown_peer_handle(dropped.clone()).await;
+        insert_test_managed_peer(&mut mgr, addr, primary, false);
+        let pending = stalled_shutdown_peer_handle(dropped.clone()).await;
+        mgr.peers.get_mut(&key(addr)).unwrap().pending_inbound = Some(PendingInbound {
+            handle: pending,
+            session_id: (index + peer_count + 1) as u64,
+        });
+    }
+
+    let started = tokio::time::Instant::now();
+    let manager = tokio::spawn(mgr.run());
+    tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    manager.await.unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= PEER_LIFECYCLE_COMMAND_TIMEOUT * 5,
+        "bounded cross-peer shutdown should take two pending+primary waves, took {elapsed:?}"
+    );
+    assert_eq!(
+        dropped.load(Ordering::SeqCst),
+        u32::try_from(peer_count * 2).expect("test handle count fits u32"),
+        "every timed-out pending and primary task must be aborted and reaped"
+    );
+}
+
 fn fake_peer_handle(
     peer_addr: IpAddr,
     state: SessionState,


### PR DESCRIPTION
## Why

A backpressured peer population could multiply the existing per-session shutdown deadline into a multi-minute daemon shutdown because peers were drained sequentially.

## What changed

- Drain independently owned peers with a fixed 64-worker concurrency cap.
- Preserve pending-inbound-before-primary ordering for each peer.
- Retain each handle’s existing 500 ms command/join budget, including timeout abort and task reap.
- Add a paused-clock regression that forces a second wave and proves every timed-out session task is reaped.

This adds no dependency, configuration knob, public API, or shutdown framework.

## Verification

- `cargo test -p rustbgpd --bin rustbgpd peer_manager::tests:: -- --test-threads=1` (153 passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- Full pre-push hooks: formatting, Clippy, tests, and docs

This fixes the diagnosed peer-manager shutdown bound. A fresh exact-source loaded policy-reload campaign remains required before claiming the full daemon meets its 30-second cleanup contract.