### PR TITLE
fix: reconcile queued TCP-AO children after rotation

### DIFF
--- a/.github/workflows/kernel-dataplane.yml
+++ b/.github/workflows/kernel-dataplane.yml
@@ -299,7 +299,7 @@ jobs:
           script: tests/interop/scripts/test-m51-bfd-frr.sh
 
   m43:
-    name: M43 — ADR-0062 TCP-AO two-key startup ring (BIRD 3.2.1)
+    name: M43 — TCP-AO queued-child and live successor rotation (BIRD 3.3.1)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -360,6 +360,22 @@ jobs:
           cargo test -p rustbgpd-transport --lib "$receipt" -- \
             --ignored --exact --nocapture
 
+      - name: Run queued-child TCP-AO successor reconciliation receipt
+        if: steps.tcp_ao.outputs.supported == 'true'
+        run: |
+          set -euo pipefail
+          receipt='listener::tests::queued_tcp_ao_child_reconciles_immediate_listener_successor'
+          test_count="$({
+            cargo test -p rustbgpd-transport --lib -- --list
+          } | awk -v target="${receipt}:" \
+            '$1 == target && $2 == "test" { count++ } END { print count + 0 }')"
+          if [ "$test_count" -ne 1 ]; then
+            echo "error: expected exactly one kernel receipt named $receipt; found $test_count" >&2
+            exit 1
+          fi
+          cargo test -p rustbgpd-transport --lib "$receipt" -- \
+            --ignored --exact --nocapture
+
       # Buildx GHA layer cache (LAN-252): the bird.nic.cz tarball fetch and
       # the full BIRD source build live in layers keyed on the Dockerfile
       # content (which pins BIRD_VERSION and the configure flags), so warm
@@ -367,14 +383,14 @@ jobs:
       # edits the Dockerfile and naturally invalidates. Buildx itself is set
       # up by setup-dataplane-host above. The dedicated scope keeps this
       # image's cache separate from rustbgpd:dev's.
-      - name: Build BIRD 3.2.1 TCP-AO image
+      - name: Build BIRD 3.3.1 TCP-AO image
         if: steps.tcp_ao.outputs.supported == 'true'
         uses: docker/build-push-action@v7
         with:
           context: tests/interop
           file: tests/interop/Dockerfile.bird3
           load: true
-          tags: bird:3.2.1-tcpao
+          tags: bird:3.3.1-tcpao
           cache-from: type=gha,scope=bird3-tcpao
           cache-to: type=gha,mode=max,scope=bird3-tcpao,ignore-error=true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lines, while the latest exercise targets `vMAJOR.MINOR.0` and the inventory
   separately pins the exact workspace patch version.
 
+- **TCP-AO passive accepts survive an add-only listener generation flip.**
+  Linux does not copy newly added listener MKTs into children that already
+  completed in the accept queue. rustbgpd now recognizes only the exact
+  immediately previous inventory, adds the missing successor suffix while it
+  still exclusively owns the child, verifies the exact current inventory, and
+  stamps the current generation. Partial inventories, generations outside the
+  applied/desired phase fence, and failed repairs remain fail-closed. The hosted
+  kernel receipt deterministically exercises the queued-child race, while M43
+  proves a live SIGHUP successor rotation against BIRD 3.3.1 without a session
+  flap.
+
 - **Planned-restart deferral remains bounded across backward clock steps.**
   Marker-backed startup now clamps the persisted marker's remaining lifetime to
   the maximum effective `gr_restart_time`, so a wall-clock correction cannot

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ fabric use.
   weighted multipath); broader routing-suite features remain future work.
 - **Validated** with a workspace test suite, fuzz targets, and an automated
   interop suite — primarily against FRR 10.3.1, plus GoBGP 3.37.0–4.6.0 and
-  StayRTR-backed RTR coverage, with BIRD 2.0.12 (M0) and BIRD 3.2.1 (TCP-AO
+  StayRTR-backed RTR coverage, with BIRD 2.0.12 (M0) and BIRD 3.3.1 (TCP-AO
   smoke). A foundation tier runs on every PR and the privileged Linux
   dataplane smokes run in hosted CI; longer soaks and platform-diversity
   scripts remain local. Full matrix: [`docs/INTEROP.md`](docs/INTEROP.md).
@@ -244,7 +244,7 @@ and more explicit internal architecture.
 |----------|---------|
 | Workspace tests | Unit, integration, and property tests (`cargo test --workspace`) |
 | Wire fuzzing | libFuzzer harnesses on message and attribute decoders, run nightly in CI |
-| Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 3.37.0–4.6.0 across labs and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.2.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
+| Interop suites | Automated interop suite (see `docs/INTEROP.md` for the full matrix), primarily against FRR 10.3.1 plus GoBGP 3.37.0–4.6.0 across labs and StayRTR-backed RTR coverage; BIRD 2.0.12 covers M0 and BIRD 3.3.1 covers the TCP-AO smoke. A foundation tier is gated on every PR, privileged Linux dataplane smokes run in hosted kernel-dataplane CI, and longer soaks / platform-diversity scripts remain local. |
 | Operational proof | Consolidated receipts for CI interop, hosted kernel dataplane, benchmarks, memory profiles, and archived 24 h soaks live in [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md). |
 | Protocol coverage | [Supported standards at a glance](docs/RFC_NOTES.md#supported-standards-at-a-glance) plus per-RFC conformance notes in [docs/RFC_NOTES.md](docs/RFC_NOTES.md); interop matrix in [docs/INTEROP.md](docs/INTEROP.md) and receipts in [docs/RECEIPTS.md](docs/RECEIPTS.md). |
 | Architecture decisions | ADRs documenting every protocol and design choice ([docs/adr/](docs/adr/)) |

--- a/crates/transport/src/listener.rs
+++ b/crates/transport/src/listener.rs
@@ -72,6 +72,10 @@ pub struct BgpListener {
     /// Latest generation installed in the listener kernel inventory. This may
     /// lead the globally committed generation while sessions are applying.
     tcp_ao_generation: TcpAoRotationGeneration,
+    /// Complete immediately previous listener generation retained only to
+    /// reconcile children that completed before the last successful add-only
+    /// listener flip. No older history is accepted.
+    previous_tcp_ao_generation: Option<TcpAoPreviousListenerGeneration>,
     tcp_ao_committed_generation: TcpAoRotationGeneration,
     rotation_rx: mpsc::Receiver<TcpAoListenerCommand>,
     rotation_tx: mpsc::Sender<TcpAoListenerCommand>,
@@ -80,6 +84,11 @@ pub struct BgpListener {
     /// may reconcile partial kernel additions, but may not redefine what the
     /// generation means.
     pending_tcp_ao_generation: Option<TcpAoListenerGeneration>,
+}
+
+struct TcpAoPreviousListenerGeneration {
+    generation: TcpAoRotationGeneration,
+    keys: TcpAoListenerKeyIndex,
 }
 
 /// One immutable desired listener inventory for the add-only rotation phase.
@@ -514,6 +523,7 @@ impl BgpListener {
             accept_tx,
             tcp_ao_keys: TcpAoListenerKeyIndex::new(options.tcp_ao_keys),
             tcp_ao_generation: TcpAoRotationGeneration::STARTUP,
+            previous_tcp_ao_generation: None,
             tcp_ao_committed_generation: TcpAoRotationGeneration::STARTUP,
             rotation_rx,
             rotation_tx,
@@ -683,13 +693,33 @@ impl BgpListener {
                 &desired_owners,
                 None,
             )
-            .map_err(crate::socket_opts::TcpAoAddOnlyApplyError::into_inner)?;
+            .map_err(|error| {
+                let mutation_started = error.mutation_started();
+                let error = error.into_inner();
+                if mutation_started {
+                    std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "{error}; listener mutation may be partial, so affected protected passive accepts may reject until this generation is retried or the daemon restarts"
+                        ),
+                    )
+                } else {
+                    error
+                }
+            })?;
             Ok::<(), std::io::Error>(())
         })();
 
         match apply {
             Ok(()) => {
-                self.tcp_ao_keys = TcpAoListenerKeyIndex::new(desired.keys.to_vec());
+                let previous_keys = std::mem::replace(
+                    &mut self.tcp_ao_keys,
+                    TcpAoListenerKeyIndex::new(desired.keys.to_vec()),
+                );
+                self.previous_tcp_ao_generation = Some(TcpAoPreviousListenerGeneration {
+                    generation: self.tcp_ao_generation,
+                    keys: previous_keys,
+                });
                 self.tcp_ao_generation = desired.generation;
                 status.applied = self.tcp_ao_committed_generation;
                 status.phase = TcpAoRotationPhase::AddOnly;
@@ -829,6 +859,11 @@ impl BgpListener {
         };
         let key = owner;
         let covering_owners = self.tcp_ao_keys.owned_union(peer_ip);
+        let previous_key_counts = accepted_previous_key_counts(
+            &covering_owners,
+            self.previous_tcp_ao_generation.as_ref(),
+            self.tcp_ao_generation,
+        );
         let receipt_owners = covering_owners
             .iter()
             .map(|owned| crate::socket_opts::TcpAoMktOwner {
@@ -841,13 +876,37 @@ impl BgpListener {
         // Compare the accepted child's inventory to the union of every
         // configured owner whose selector covers this peer. No secret-bearing
         // receipt survives this accept operation.
-        let receipt =
-            crate::socket_opts::capture_tcp_ao_owned_receipt(&self.listener, &receipt_owners)?;
-        let initial = crate::socket_opts::get_tcp_ao_info_for_receipt(stream, &receipt, peer_ip)?;
+        let receipt = crate::socket_opts::capture_tcp_ao_accepted_generation_receipt(
+            &self.listener,
+            &receipt_owners,
+            previous_key_counts.as_deref(),
+        )?;
+        let accepted =
+            crate::socket_opts::inspect_tcp_ao_accepted_generation(stream, &receipt, peer_ip)?;
+        let (initial, reconcile_previous) = match accepted {
+            crate::socket_opts::TcpAoAcceptedGeneration::Current(info) => (info, false),
+            crate::socket_opts::TcpAoAcceptedGeneration::Previous(info) => (info, true),
+        };
         // Validate the handshake-selected Current and initial RNext before
         // mutating either selection. Both must identify the resolved owner's
         // inherited MKT; a deprecated key remains valid when peer-selected.
         ensure_accepted_tcp_ao_info_valid(&initial, key, false)?;
+        if reconcile_previous {
+            let repaired = crate::socket_opts::reconcile_tcp_ao_accepted_previous(
+                stream,
+                &receipt,
+                &receipt_owners,
+                peer_ip,
+                &initial,
+            )
+            .map_err(crate::socket_opts::TcpAoAddOnlyApplyError::into_inner)?;
+            ensure_accepted_tcp_ao_info_valid(&repaired, key, false)?;
+            info!(
+                peer = %peer_ip,
+                generation = self.tcp_ao_generation.as_u64(),
+                "reconciled queued TCP-AO child to current listener generation"
+            );
+        }
 
         let selected_key = key.config.selected().ok_or_else(|| {
             std::io::Error::new(
@@ -856,7 +915,9 @@ impl BgpListener {
             )
         })?;
         crate::socket_opts::set_tcp_ao_rnext(stream, selected_key.recv_id)?;
-        let info = crate::socket_opts::get_tcp_ao_info_for_receipt(stream, &receipt, peer_ip)?;
+        let info = crate::socket_opts::get_tcp_ao_info_for_accepted_generation_receipt(
+            stream, &receipt, peer_ip,
+        )?;
         ensure_accepted_tcp_ao_info_valid(&info, key, true)?;
         info!(
             peer = %peer_ip,
@@ -875,6 +936,33 @@ impl BgpListener {
         );
         Ok(Some(info))
     }
+}
+
+fn accepted_previous_key_counts(
+    current: &[&TcpAoListenerKey],
+    previous: Option<&TcpAoPreviousListenerGeneration>,
+    current_generation: TcpAoRotationGeneration,
+) -> Option<Vec<usize>> {
+    let previous = previous?;
+    if previous.generation.next() != Some(current_generation) {
+        return None;
+    }
+    current
+        .iter()
+        .map(|owner| {
+            let identity = listener_owner_identity(owner);
+            let mut matches = previous
+                .keys
+                .keys
+                .iter()
+                .filter(|candidate| listener_owner_identity(candidate) == identity);
+            let prior = matches.next()?;
+            if matches.next().is_some() || !owner.config.0.starts_with(&prior.config.0) {
+                return None;
+            }
+            Some(prior.config.0.len())
+        })
+        .collect()
 }
 
 fn listener_owner_identity(key: &TcpAoListenerKey) -> (TcpAoListenerOwnerKind, IpAddr, u8) {
@@ -1233,6 +1321,50 @@ mod tests {
     }
 
     #[test]
+    fn accepted_child_fallback_requires_exact_adjacent_owner_prefix() {
+        let old = tcp_ao_owner();
+        let mut current = old.clone();
+        let mut successor = current.config.0[0].clone();
+        successor.key = "successor".to_string();
+        successor.send_id = 11;
+        successor.recv_id = 13;
+        successor.preferred = false;
+        current.config.0.push(successor);
+        let current_index = TcpAoListenerKeyIndex::new(vec![current]);
+        let current_union = current_index.owned_union(old.peer);
+        let previous = TcpAoPreviousListenerGeneration {
+            generation: TcpAoRotationGeneration::STARTUP,
+            keys: TcpAoListenerKeyIndex::new(vec![old.clone()]),
+        };
+        let generation_two = TcpAoRotationGeneration::new(2).unwrap();
+        assert_eq!(
+            accepted_previous_key_counts(&current_union, Some(&previous), generation_two),
+            Some(vec![1])
+        );
+
+        assert_eq!(
+            accepted_previous_key_counts(
+                &current_union,
+                Some(&previous),
+                TcpAoRotationGeneration::new(3).unwrap()
+            ),
+            None,
+            "an N-2 inventory must not be treated as the adjacent predecessor"
+        );
+
+        let mut redefined = old;
+        redefined.config.0[0].key = "redefined".to_string();
+        let redefined_previous = TcpAoPreviousListenerGeneration {
+            generation: TcpAoRotationGeneration::STARTUP,
+            keys: TcpAoListenerKeyIndex::new(vec![redefined]),
+        };
+        assert_eq!(
+            accepted_previous_key_counts(&current_union, Some(&redefined_previous), generation_two),
+            None
+        );
+    }
+
+    #[test]
     fn add_only_generation_rejects_preferred_successor_and_owner_replacement() {
         let old = tcp_ao_owner();
         let mut preferred = old.clone();
@@ -1413,6 +1545,10 @@ mod tests {
         let generation = TcpAoRotationGeneration::new(2).unwrap();
         let desired = TcpAoListenerGeneration::new(generation, Vec::new());
         listener.tcp_ao_generation = generation;
+        listener.previous_tcp_ao_generation = Some(TcpAoPreviousListenerGeneration {
+            generation: TcpAoRotationGeneration::STARTUP,
+            keys: TcpAoListenerKeyIndex::new(Vec::new()),
+        });
         listener.pending_tcp_ao_generation = Some(desired.clone());
         listener
             .rotation_status_tx
@@ -1441,6 +1577,14 @@ mod tests {
         assert_eq!(staged.desired, generation);
         assert_eq!(staged.applied, TcpAoRotationGeneration::STARTUP);
         assert_eq!(staged.phase, TcpAoRotationPhase::AddOnly);
+        assert_eq!(
+            listener
+                .previous_tcp_ao_generation
+                .as_ref()
+                .map(|previous| previous.generation),
+            Some(TcpAoRotationGeneration::STARTUP),
+            "same-generation retry must not replace the queued-child predecessor"
+        );
         let committed = listener
             .acknowledge_global_commit_generation_with(generation, |_socket, _desired| Ok(()))
             .unwrap();
@@ -1448,6 +1592,14 @@ mod tests {
         assert_eq!(committed.applied, generation);
         assert_eq!(committed.phase, TcpAoRotationPhase::Idle);
         assert!(listener.pending_tcp_ao_generation.is_none());
+        assert_eq!(
+            listener
+                .previous_tcp_ao_generation
+                .as_ref()
+                .map(|previous| previous.generation),
+            Some(TcpAoRotationGeneration::STARTUP),
+            "global commit must retain the predecessor for children still queued in the kernel"
+        );
     }
 
     #[tokio::test]
@@ -1931,6 +2083,148 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("4097"), "{err}");
         assert_eq!(*installed.borrow(), 0);
+    }
+
+    /// Deterministic Linux accept-queue receipt: complete the TCP-AO handshake
+    /// before the listener actor accepts the child, then flip the listener to
+    /// its add-only successor. Linux leaves the queued child at the previous
+    /// inventory, so accept must reconcile it forward without changing key
+    /// selection or dropping authenticated traffic.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    #[ignore = "requires a Linux kernel with CONFIG_TCP_AO=y"]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "kernel receipt keeps the queued handshake, listener flip, exact inventory, and traffic proof together"
+    )]
+    async fn queued_tcp_ao_child_reconciles_immediate_listener_successor() {
+        use std::time::Duration;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let peer_ip = Ipv4Addr::new(127, 0, 0, 2);
+        let current = TcpAoConfig {
+            key: "queued-child-current-secret".to_string(),
+            send_id: 21,
+            recv_id: 31,
+            algorithm: TcpAoAlgorithm::HmacSha256,
+            preferred: true,
+            deprecated: false,
+        };
+        let current_ring = TcpAoKeyring(vec![current.clone()]);
+        let owner = TcpAoListenerKey {
+            owner: TcpAoListenerOwnerKind::Static,
+            peer: peer_ip.into(),
+            prefix_len: 32,
+            config: current_ring.clone(),
+        };
+        let (accept_tx, mut accept_rx) = mpsc::channel(1);
+        let mut listener = BgpListener::bind_with_options(
+            "127.0.0.1:0".parse().unwrap(),
+            accept_tx,
+            ListenerSocketOptions {
+                tcp_ao_keys: vec![owner.clone()],
+            },
+        )
+        .await
+        .unwrap();
+        let destination = listener.local_addr().unwrap();
+
+        let client = tokio::task::spawn_blocking(move || -> std::io::Result<Socket> {
+            let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+            socket.bind(&SockAddr::from(SocketAddr::new(peer_ip.into(), 0)))?;
+            let client_key = TcpAoConfig {
+                send_id: current.recv_id,
+                recv_id: current.send_id,
+                ..current
+            };
+            crate::socket_opts::set_tcp_ao_config(
+                &socket,
+                destination.ip(),
+                32,
+                &client_key,
+                crate::socket_opts::TcpAoSocketRole::ActiveOpen,
+            )?;
+            socket.connect_timeout(&SockAddr::from(destination), Duration::from_secs(2))?;
+            Ok(socket)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        let mut desired_owner = owner;
+        desired_owner.config.0.push(TcpAoConfig {
+            key: "queued-child-successor-secret".to_string(),
+            send_id: 22,
+            recv_id: 32,
+            algorithm: TcpAoAlgorithm::HmacSha256,
+            preferred: false,
+            deprecated: false,
+        });
+        let generation = TcpAoRotationGeneration::new(2).unwrap();
+        listener
+            .apply_add_only_generation(&TcpAoListenerGeneration::new(
+                generation,
+                vec![desired_owner],
+            ))
+            .unwrap();
+        assert_eq!(listener.tcp_ao_generation, generation);
+        assert_eq!(
+            listener
+                .previous_tcp_ao_generation
+                .as_ref()
+                .map(|previous| previous.generation),
+            Some(TcpAoRotationGeneration::STARTUP)
+        );
+
+        let task = tokio::spawn(listener.run());
+        let mut accepted = tokio::time::timeout(Duration::from_secs(2), accept_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(accepted.tcp_ao_generation, Some(generation));
+        let info = accepted.tcp_ao_info.as_ref().unwrap();
+        assert_eq!(info.keys.len(), 2);
+        assert_eq!(info.current_key, 21);
+        assert_eq!(info.rnext_key, 31);
+        assert_eq!(info.pkt_bad, 0);
+        assert_eq!(info.pkt_key_not_found, 0);
+        assert_eq!(info.pkt_ao_required, 0);
+        assert!(
+            info.keys
+                .iter()
+                .any(|key| key.send_id == 22 && key.recv_id == 32)
+        );
+
+        let std_client: std::net::TcpStream = client.into();
+        std_client.set_nonblocking(true).unwrap();
+        let mut client = TcpStream::from_std(std_client).unwrap();
+        client
+            .write_all(b"previous-generation traffic")
+            .await
+            .unwrap();
+        let mut inbound = vec![0; b"previous-generation traffic".len()];
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            accepted.stream.read_exact(&mut inbound),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(inbound, b"previous-generation traffic");
+        accepted
+            .stream
+            .write_all(b"reconciled traffic")
+            .await
+            .unwrap();
+        let mut outbound = vec![0; b"reconciled traffic".len()];
+        tokio::time::timeout(Duration::from_secs(2), client.read_exact(&mut outbound))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(outbound, b"reconciled traffic");
+
+        drop((client, accepted));
+        task.abort();
     }
 
     /// Bounded privileged/kernel receipt for GitHub #158. Run on a Linux host

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -321,6 +321,32 @@ pub(crate) struct TcpAoMktReceipt {
     metadata: Vec<TcpAoMktMetadata>,
 }
 
+/// Short-lived proof used to classify an accepted child against the complete
+/// current listener inventory or its exact immediately previous inventory.
+/// The previous mask is meaningful only while the listener retains the
+/// adjacent generation that produced it.
+#[cfg(target_os = "linux")]
+pub(crate) struct TcpAoAcceptedGenerationReceipt {
+    current: TcpAoMktReceipt,
+    previous: Option<Vec<bool>>,
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) struct TcpAoAcceptedGenerationReceipt;
+
+/// Exact generation relation proved from one accepted-child inventory read.
+#[cfg(target_os = "linux")]
+pub(crate) enum TcpAoAcceptedGeneration {
+    Current(TcpAoInfoSnapshot),
+    Previous(TcpAoInfoSnapshot),
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) enum TcpAoAcceptedGeneration {
+    Current(TcpAoInfoSnapshot),
+    Previous(TcpAoInfoSnapshot),
+}
+
 #[cfg(not(target_os = "linux"))]
 pub(crate) struct TcpAoMktReceipt;
 
@@ -1488,13 +1514,53 @@ pub(crate) fn capture_tcp_ao_keyring_receipt(
     keyring_receipt_from_raw_inventory(&keys, peer, prefix_len, keyring, exact_inventory)
 }
 
+/// Capture the complete current covering-owner receipt and, when the listener
+/// can prove an adjacent predecessor, mark exactly the entries inherited by
+/// that predecessor. `previous_key_counts` is aligned to `owners`; listener
+/// code derives it with owner-kind-aware identity matching.
 #[cfg(target_os = "linux")]
-pub(crate) fn capture_tcp_ao_owned_receipt(
+pub(crate) fn capture_tcp_ao_accepted_generation_receipt(
     socket: &impl AsRawFd,
     owners: &[TcpAoMktOwner<'_>],
-) -> io::Result<TcpAoMktReceipt> {
+    previous_key_counts: Option<&[usize]>,
+) -> io::Result<TcpAoAcceptedGenerationReceipt> {
+    let previous = previous_key_counts
+        .map(|counts| {
+            if counts.len() != owners.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "TCP-AO previous listener inventory is not aligned to current owners",
+                ));
+            }
+            let expected = owners
+                .iter()
+                .map(|owner| owner.keyring.0.len())
+                .sum::<usize>();
+            let mut mask = Vec::with_capacity(expected);
+            for (owner, previous_count) in owners.iter().zip(counts) {
+                if *previous_count > owner.keyring.0.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "TCP-AO previous listener keyring is not a current-keyring prefix",
+                    ));
+                }
+                mask.extend((0..owner.keyring.0.len()).map(|index| index < *previous_count));
+            }
+            Ok(mask)
+        })
+        .transpose()?;
     let keys = get_tcp_ao_keys_with(|entries| query_tcp_ao_keys(socket, entries))?;
-    owned_receipt_from_raw_inventory(&keys, owners)
+    let current = owned_receipt_from_raw_inventory(&keys, owners)?;
+    if previous
+        .as_ref()
+        .is_some_and(|mask| mask.len() != current.cores.len())
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "TCP-AO previous listener inventory has an invalid receipt shape",
+        ));
+    }
+    Ok(TcpAoAcceptedGenerationReceipt { current, previous })
 }
 
 /// Capture a complete listener-generation receipt. Unlike accepted-child
@@ -1537,6 +1603,27 @@ fn annotate_tcp_ao_receipt(
     receipt: &TcpAoMktReceipt,
     connected_peer: IpAddr,
 ) -> io::Result<()> {
+    annotate_tcp_ao_receipt_subset(info, keys, receipt, connected_peer, None)
+}
+
+#[cfg(target_os = "linux")]
+fn annotate_tcp_ao_receipt_subset(
+    info: &mut TcpAoInfoSnapshot,
+    keys: &[TcpAoGetSockOpt],
+    receipt: &TcpAoMktReceipt,
+    connected_peer: IpAddr,
+    expected: Option<&[bool]>,
+) -> io::Result<()> {
+    if expected.is_some_and(|mask| mask.len() != receipt.cores.len()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "TCP-AO accepted-generation receipt has an invalid mask shape",
+        ));
+    }
+    let expected_entry = |index: usize| expected.is_none_or(|mask| mask[index]);
+    let expected_len = expected.map_or(receipt.cores.len(), |mask| {
+        mask.iter().filter(|included| **included).count()
+    });
     let mut states = keys
         .iter()
         .map(decode_tcp_ao_key_state)
@@ -1551,7 +1638,8 @@ fn annotate_tcp_ao_receipt(
                 .iter()
                 .enumerate()
                 .position(|(expected_index, expected)| {
-                    !expected_matched[expected_index]
+                    expected_entry(expected_index)
+                        && !expected_matched[expected_index]
                         && target_record_matches_receipt_entry(
                             &states[index],
                             connected_peer,
@@ -1567,9 +1655,12 @@ fn annotate_tcp_ao_receipt(
     // A connected socket must inherit exactly the complete expected-owned
     // keyring inventory. Missing, foreign, duplicated, or cryptographically
     // changed records all fail closed.
-    if matching.len() != receipt.cores.len()
-        || keys.len() != receipt.cores.len()
-        || expected_matched.iter().any(|matched| !matched)
+    if matching.len() != expected_len
+        || keys.len() != expected_len
+        || expected_matched
+            .iter()
+            .enumerate()
+            .any(|(index, matched)| expected_entry(index) && !matched)
     {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
@@ -1586,6 +1677,129 @@ fn annotate_tcp_ao_receipt(
     states.sort_by_key(|key| (key.peer, key.prefix_len, key.send_id, key.recv_id));
     info.keys = states;
     Ok(())
+}
+
+/// Read an accepted child once and classify only an exact current inventory or
+/// an exact adjacent-previous inventory. Arbitrary prefixes, partial successor
+/// applications, older generations, and foreign records all fail closed.
+#[cfg(target_os = "linux")]
+pub(crate) fn inspect_tcp_ao_accepted_generation(
+    socket: &impl AsRawFd,
+    receipt: &TcpAoAcceptedGenerationReceipt,
+    connected_peer: IpAddr,
+) -> io::Result<TcpAoAcceptedGeneration> {
+    let (info, keys) = get_tcp_ao_snapshot_with(
+        || get_tcp_ao_info_only(socket),
+        || get_tcp_ao_keys_with(|entries| query_tcp_ao_keys(socket, entries)),
+    )?;
+    if keys.len() == receipt.current.cores.len() {
+        let mut current = info;
+        annotate_tcp_ao_receipt(&mut current, &keys, &receipt.current, connected_peer)?;
+        return Ok(TcpAoAcceptedGeneration::Current(current));
+    }
+    if let Some(previous) = receipt.previous.as_deref()
+        && keys.len() == previous.iter().filter(|included| **included).count()
+    {
+        let mut previous_info = info;
+        annotate_tcp_ao_receipt_subset(
+            &mut previous_info,
+            &keys,
+            &receipt.current,
+            connected_peer,
+            Some(previous),
+        )?;
+        return Ok(TcpAoAcceptedGeneration::Previous(previous_info));
+    }
+    Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "TCP-AO accepted socket matches neither current nor immediate previous listener inventory",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn get_tcp_ao_info_for_accepted_generation_receipt(
+    socket: &impl AsRawFd,
+    receipt: &TcpAoAcceptedGenerationReceipt,
+    connected_peer: IpAddr,
+) -> io::Result<TcpAoInfoSnapshot> {
+    get_tcp_ao_info_for_receipt(socket, &receipt.current, connected_peer)
+}
+
+/// Add only the current-generation suffix missing from an exact
+/// adjacent-previous accepted child, then require one exact final inventory
+/// and unchanged Current/RNext selection. The child is still exclusively
+/// owned by the listener; callers must discard it on any error.
+#[cfg(target_os = "linux")]
+pub(crate) fn reconcile_tcp_ao_accepted_previous(
+    socket: &impl AsRawFd,
+    receipt: &TcpAoAcceptedGenerationReceipt,
+    owners: &[TcpAoMktOwner<'_>],
+    connected_peer: IpAddr,
+    initial: &TcpAoInfoSnapshot,
+) -> Result<TcpAoInfoSnapshot, TcpAoAddOnlyApplyError> {
+    let Some(previous) = receipt.previous.as_deref() else {
+        return Err(apply_error(
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TCP-AO accepted child has no adjacent previous-generation proof",
+            ),
+            false,
+        ));
+    };
+    let configs = owners
+        .iter()
+        .flat_map(|owner| {
+            owner
+                .keyring
+                .iter()
+                .map(move |config| (owner.peer, owner.prefix_len, config))
+        })
+        .collect::<Vec<_>>();
+    if configs.len() != receipt.current.cores.len() || previous.len() != configs.len() {
+        return Err(apply_error(
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TCP-AO accepted-child repair inventory differs from its listener receipt",
+            ),
+            false,
+        ));
+    }
+    let expected_selection = selection(initial);
+    let mut mutation_started = false;
+    for (index, (peer, prefix_len, config)) in configs.into_iter().enumerate() {
+        if previous[index] {
+            continue;
+        }
+        let metadata = &receipt.current.metadata[index];
+        if metadata.peer != peer
+            || metadata.prefix_len != prefix_len
+            || metadata.preferred != config.preferred
+            || metadata.deprecated != config.deprecated
+        {
+            return Err(apply_error(
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "TCP-AO accepted-child repair metadata differs from its listener receipt",
+                ),
+                mutation_started,
+            ));
+        }
+        mutation_started = true;
+        let key = tcp_ao_key_from_config(peer, prefix_len, config, TcpAoSocketRole::Listener);
+        set_tcp_ao_key(socket, &key).map_err(|error| apply_error(error, mutation_started))?;
+    }
+    let final_info = get_tcp_ao_info_for_receipt(socket, &receipt.current, connected_peer)
+        .map_err(|error| apply_error(error, mutation_started))?;
+    if selection(&final_info) != expected_selection {
+        return Err(apply_error(
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "TCP-AO accepted-child repair changed Current/RNext selection",
+            ),
+            mutation_started,
+        ));
+    }
+    Ok(final_info)
 }
 
 /// Reconcile a connected socket against a pre-connect/listener raw kernel MKT
@@ -1689,13 +1903,15 @@ pub(crate) fn capture_tcp_ao_keyring_receipt<T>(
 }
 
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn capture_tcp_ao_owned_receipt<T>(
+pub(crate) fn capture_tcp_ao_accepted_generation_receipt<T>(
     _socket: &T,
     owners: &[TcpAoMktOwner<'_>],
-) -> io::Result<TcpAoMktReceipt> {
+    previous_key_counts: Option<&[usize]>,
+) -> io::Result<TcpAoAcceptedGenerationReceipt> {
     for owner in owners {
         let _ = (owner.peer, owner.prefix_len, owner.keyring);
     }
+    let _ = previous_key_counts;
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "TCP-AO inspection is only supported on Linux",
@@ -1726,6 +1942,50 @@ pub(crate) fn get_tcp_ao_info_for_receipt<T>(
         io::ErrorKind::Unsupported,
         "TCP-AO inspection is only supported on Linux",
     ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn inspect_tcp_ao_accepted_generation<T>(
+    _socket: &T,
+    _receipt: &TcpAoAcceptedGenerationReceipt,
+    _connected_peer: std::net::IpAddr,
+) -> io::Result<TcpAoAcceptedGeneration> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP-AO inspection is only supported on Linux",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn get_tcp_ao_info_for_accepted_generation_receipt<T>(
+    _socket: &T,
+    _receipt: &TcpAoAcceptedGenerationReceipt,
+    _connected_peer: std::net::IpAddr,
+) -> io::Result<TcpAoInfoSnapshot> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "TCP-AO inspection is only supported on Linux",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn reconcile_tcp_ao_accepted_previous<T>(
+    _socket: &T,
+    _receipt: &TcpAoAcceptedGenerationReceipt,
+    owners: &[TcpAoMktOwner<'_>],
+    _connected_peer: std::net::IpAddr,
+    _initial: &TcpAoInfoSnapshot,
+) -> Result<TcpAoInfoSnapshot, TcpAoAddOnlyApplyError> {
+    for owner in owners {
+        let _ = (owner.peer, owner.prefix_len, owner.keyring);
+    }
+    Err(TcpAoAddOnlyApplyError {
+        error: io::Error::new(
+            io::ErrorKind::Unsupported,
+            "TCP-AO inspection is only supported on Linux",
+        ),
+        mutation_started: false,
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -2463,6 +2723,96 @@ mod tests {
                 .kind(),
             io::ErrorKind::PermissionDenied
         );
+    }
+
+    #[test]
+    fn accepted_generation_receipt_allows_only_exact_current_or_adjacent_previous() {
+        let owner = IpAddr::from([192, 0, 2, 0]);
+        let connected = IpAddr::from([192, 0, 2, 9]);
+        let configs = [("old", 7, 9), ("selected", 8, 10), ("successor", 11, 13)];
+        let ring = TcpAoKeyring(
+            configs
+                .iter()
+                .map(|(secret, send_id, recv_id)| TcpAoConfig {
+                    key: (*secret).into(),
+                    send_id: *send_id,
+                    recv_id: *recv_id,
+                    algorithm: TcpAoAlgorithm::HmacSha256,
+                    preferred: *send_id == 8,
+                    deprecated: *send_id == 7,
+                })
+                .collect(),
+        );
+        let listener = configs
+            .iter()
+            .map(|(secret, send_id, recv_id)| {
+                let mut raw = raw_dump_key(owner, "hmac(sha256)", secret.as_bytes());
+                raw.prefix = 24;
+                raw.sndid = *send_id;
+                raw.rcvid = *recv_id;
+                raw.flags = 0;
+                raw
+            })
+            .collect::<Vec<_>>();
+        let receipt =
+            keyring_receipt_from_raw_inventory(&listener, owner, 24, &ring, true).unwrap();
+        let info_raw = TcpAoInfoOpt {
+            flags: TCP_AO_INFO_SET_CURRENT | TCP_AO_INFO_SET_RNEXT,
+            reserved2: 0,
+            current_key: 8,
+            rnext: 10,
+            pkt_good: 1,
+            pkt_bad: 0,
+            pkt_key_not_found: 0,
+            pkt_ao_required: 0,
+            pkt_dropped_icmp: 0,
+        };
+        let child = |entries: &[usize]| {
+            entries
+                .iter()
+                .map(|index| {
+                    let (secret, send_id, recv_id) = configs[*index];
+                    let mut raw = raw_dump_key(connected, "hmac(sha256)", secret.as_bytes());
+                    raw.sndid = send_id;
+                    raw.rcvid = recv_id;
+                    raw.flags = 0;
+                    raw
+                })
+                .collect::<Vec<_>>()
+        };
+        let previous = [true, true, false];
+
+        let mut current_info = TcpAoInfoSnapshot::from_raw(&info_raw);
+        annotate_tcp_ao_receipt(&mut current_info, &child(&[0, 1, 2]), &receipt, connected)
+            .unwrap();
+        assert_eq!(current_info.keys.len(), 3);
+
+        let mut previous_info = TcpAoInfoSnapshot::from_raw(&info_raw);
+        annotate_tcp_ao_receipt_subset(
+            &mut previous_info,
+            &child(&[0, 1]),
+            &receipt,
+            connected,
+            Some(&previous),
+        )
+        .unwrap();
+        assert_eq!(previous_info.keys.len(), 2);
+
+        for invalid in [child(&[0]), child(&[0, 2]), child(&[0, 1, 2])] {
+            let mut info = TcpAoInfoSnapshot::from_raw(&info_raw);
+            assert_eq!(
+                annotate_tcp_ao_receipt_subset(
+                    &mut info,
+                    &invalid,
+                    &receipt,
+                    connected,
+                    Some(&previous),
+                )
+                .unwrap_err()
+                .kind(),
+                io::ErrorKind::PermissionDenied
+            );
+        }
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -283,8 +283,11 @@ For TCP-AO peers, `NeighborState.tcp_ao_desired_generation`,
 `tcp_ao_applied_generation`, `tcp_ao_rotation_phase`, and
 `tcp_ao_rotation_error` expose the secret-free add-only rollout state. A phase
 of `add_only_failed` retains the prior selectable keys and is retryable with
-another SIGHUP; newly accepted protected sockets are generation-fenced until
-the listener and all managed sessions converge.
+another SIGHUP. During `add_only`, protected accepts may carry either the
+globally applied generation or the exactly proved desired generation. During
+`add_only_failed`, only the applied generation may enter the peer manager;
+fully installed but uncommitted children remain fail-closed. A partial listener
+mutation may reject affected passive accepts until retry or restart.
 
 `NeighborState.effective_distribution_mode` reports the live RIB selection
 surface. When multiple mechanisms apply, its primary-label precedence is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -630,7 +630,12 @@ order, and every appended key has `preferred = false`. The daemon globally
 preflights capacity and every managed protected session, adds keys without
 changing Current/RNext, verifies the complete listener and connected-socket
 inventories, and generation-fences newly accepted protected sockets until all
-managed sessions converge. Changing selection, marking an existing key
+managed sessions converge. A child that completed in the kernel accept queue
+before the listener flip still has the exact immediately previous inventory;
+rustbgpd adds only that generation's missing suffix, requires an exact final
+current inventory, and then stamps the current generation. Arbitrary subsets,
+partial successor inventories, and children older than the immediate previous
+generation are rejected. Changing selection, marking an existing key
 deprecated, removing/editing/reordering a key, or changing a protected owner
 remains restart-required and is pinned to the live snapshot. Runtime deletion
 of a configured TCP-AO neighbor also remains rejected.
@@ -638,8 +643,10 @@ of a configured TCP-AO neighbor also remains rejected.
 If an add-only apply fails, the old selectable keys remain usable and the same
 desired generation is retryable with another SIGHUP. Some successor MKTs may
 already be present; retries accept them only when their kernel-normalized key
-material is identical. Protected inbound accepts can be rejected while a
-partially applied generation is fenced. Inspect per-neighbor
+material is identical. If listener mutation failed partway, affected protected
+passive accepts may reject until the same generation is retried or the daemon
+restarts; a fully installed but globally uncommitted generation also remains
+fenced. Established sessions retain their prior selectable keys. Inspect per-neighbor
 `tcp_ao_desired_generation`, `tcp_ao_applied_generation`,
 `tcp_ao_rotation_phase`, and `tcp_ao_rotation_error` in JSON, or the equivalent
 `TCP-AO Rotation` rows in human output.

--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -65,7 +65,7 @@ coverage that needs containerlab, kernel modules, or real netns route tables:
 set). Those jobs run on PRs, pushes to `main`, nightly schedule, and
 manual dispatch on GitHub-hosted `ubuntu-latest` runners.
 The current hosted runner advertises `CONFIG_TCP_AO=y`, so M43 runs the
-real BIRD 3.2.1 TCP-AO topology. The workflow still probes the selected
+real BIRD 3.3.1 TCP-AO topology. The workflow still probes the selected
 runner kernel first; a future runner without TCP-AO support reports a warning
 and skips only that topology.
 
@@ -156,7 +156,7 @@ the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
 | FRR (bgpd) ×2 | 10.3.1 | `tests/interop/m53-bgp-unnumbered-frr.clab.yml` | Tested (M53) | ADR-0069 BGP unnumbered / IPv6 link-local peering | rustbgpd (AS 65001) peers with two FRR interface neighbors over IPv6 link-local only: no IPv4 addresses are present on the fabric links. Both FRR peers advertise `198.51.100.53/32` using RFC 8950 Extended Next Hop over separate link-local sessions. The driver asserts rustbgpd's neighbor status carries both scoped identities, `ListReceivedRoutes` sees two paths, the Linux table 1000 route installs as ECMP via `fe80::2 dev eth1` and `fe80::3 dev eth2`, and `ListFibRoutes` reports two next-hops; then it withdraws frr2 and asserts the route collapses to the eth1 survivor, re-advertises and asserts two-way ECMP returns. It also injects `192.0.2.53/32` through rustbgpd and asserts both FRR peers receive it with a link-local next-hop, proving outbound unnumbered MP_REACH. **Hosted kernel-dataplane CI** via `.github/workflows/kernel-dataplane.yml`. |
 | FRR (bgpd) ×2 | 10.3.1 | `tests/interop/m53-bgp-unnumbered-spike.clab.yml` | Tested (M53 spike) | ADR-0069 BGP unnumbered target-behavior observation | FRR interface peers establish over IPv6 link-local only with no IPv4 addresses on the fabric link, exchange IPv4 unicast routes whose visible next-hop is `fe80::/10`, and expose RFC 8950 Extended Next Hop in neighbor state. The spike captures IPv4 MP_REACH with a 32-byte IPv6 next-hop and does not observe Link-Local Next Hop capability 77. This is retained as target-behavior evidence; the production rustbgpd↔FRR gate is M53 above. |
 | FRR (bgpd + bfdd) | 10.3.1 | `tests/interop/m51-bfd-frr.clab.yml` | Tested (M51) | ADR-0067 single-hop BFD + RFC 5882 BGP coupling | Single-peer EBGP topology with BFD enabled on both sides (FRR `bfdd`, fast profile: 300 ms × 3 ≈ 900 ms detection; BGP hold timer 90 s). rustbgpd (AS 65001) configures the neighbor with `bfd = { profile = "fast" }` (non-strict coupling); FRR (AS 65002) uses `neighbor … bfd profile fast`. The driver asserts BGP reaches Established **and** BFD reaches Up from both sides (`BfdService.GetBfdSessions` reports `BFD_SESSION_STATE_UP` and FRR `show bfd peers json` reports `status: up`), then kills FRR's `bfdd` (`killall -9 bfdd`, briefly re-killed so the down window is observable) and asserts rustbgpd's BFD goes Down and the RFC 5882 coupling tears the BGP session out of Established within a few detection windows — far faster than the 90 s hold timer, proving the coupling rather than a hold-timer expiry. `watchfrr` then restarts `bfdd`, and the driver asserts BFD + BGP both recover. **Hosted kernel-dataplane CI** via `.github/workflows/kernel-dataplane.yml`. |
-| BIRD | 3.2.1 | `tests/interop/m43-tcp-ao-bird.clab.yml` | Tested (M43) | ADR-0062 static-neighbor TCP-AO protected session | Single-peer EBGP topology. rustbgpd (AS 65001, 10.0.43.1) configures a two-key startup ring: deprecated SendID/RecvID `1/11` plus preferred `2/12`. BIRD 3.2.1 (AS 65043, 10.0.43.2) uses `authentication ao` with the directionally reversed IDs `11/1` and `12/2`, then advertises `203.0.113.43/32`. The driver asserts BIRD reaches Established, rustbgpd receives the route, neighbor state reports Current `2`, RNext `12`, and exactly the complete redacted two-key inventory, then restarts BIRD with a mismatched preferred-key secret and asserts the route withdraws and the session does not re-establish within the fail-closed window. **Hosted kernel-dataplane CI** includes M43; the current hosted runner advertises `CONFIG_TCP_AO=y` and runs the topology, while the workflow keeps a warning-only skip guard for future runner kernels without TCP-AO support. |
+| BIRD | 3.3.1 | `tests/interop/m43-tcp-ao-bird.clab.yml` | Tested (M43) | TCP-AO startup, queued-child reconciliation, and live successor rotation | Single-peer EBGP topology. rustbgpd (AS 65001, 10.0.43.1) starts with deprecated SendID/RecvID `1/11` plus preferred `2/12`; BIRD 3.3.1 (AS 65043, 10.0.43.2) uses directionally reversed IDs and preinstalls nonpreferred successor `13/3`. The driver proves the initial exact two-key inventory, SIGHUP-appends rustbgpd successor `3/13`, observes desired/applied generation 2 and the exact three-key inventory with Current `2` / RNext `12` unchanged, verifies BIRD's Established-since token and the advertised route do not flap, then restarts BIRD with a mismatched preferred-key secret and requires fail-closed withdrawal. The job also runs a deterministic kernel receipt where a child completes before the listener successor flip and is reconciled forward on accept. **Hosted kernel-dataplane CI** includes M43; the workflow keeps a warning-only skip guard for future runner kernels without TCP-AO support. |
 | grpcurl (mTLS client) | n/a | `tests/interop/m44-grpc-tier-authz.clab.yml` | Tested (M44) | ADR-0064 gRPC tier authorization over native mTLS | Single rustbgpd node, no BGP peer — exercises the gRPC authorization boundary, not a routing session. `tests/interop/scripts/gen-m44-certs.sh` builds a CA, a server cert (`DNS:rustbgpd.local`), and four client certs whose `rustbgpd://` URI SANs map to roles via `[security.grpc.roles]` (`observer`, `automation`, `operator`, plus an unmapped `intruder`). The daemon runs `enforcement = "tier"` (the v0.24.0 default) with an mTLS gRPC listener. The driver presents each client cert to `grpcurl` (verifying the server cert against `-servername rustbgpd.local`) and asserts the per-tier contract: observer can `ListReceivedRoutes` but not `AddNeighbor`; automation can `AddNeighbor` but not `TriggerMrtDump`; operator can `TriggerMrtDump`; the unmapped principal is denied any RPC; and `bgp_grpc_authz_decisions_total` records the `role_tier_denied` / `principal_unmapped` labels. **Hosted CI** in `.github/workflows/interop.yml` (no kernel features required). |
 | gnmic (mTLS client) | 0.46.0 | `tests/interop/m54-gnmi-openconfig.clab.yml` | Tested (M54) | ADR-0070 gNMI / OpenConfig telemetry + Set over native mTLS | Single rustbgpd node, no BGP peer — exercises the collector-facing and operator-facing gNMI surface through the real `gnmic` client. The daemon serves `gnmi.gNMI` only on an mTLS-configured TCP listener; the driver presents the operator client certificate generated by `tests/interop/scripts/gen-m54-certs.sh`, verifies `Capabilities` reports gNMI `0.10.0`, the OpenConfig BGP modules, and `JSON` / `JSON_IETF`, reads the supported OpenConfig BGP global and neighbor `state` paths with `Get`, proves static numbered-neighbor `Set` add/delete plus peer-group and dynamic-neighbor-prefix Set persistence, asserts an undefined dynamic-neighbor peer-group is rejected with `InvalidArgument`, proves commit-confirmed confirm/cancel, asserts read-tier `Set` is denied and unsupported leaves return `Unimplemented`, and proves `Subscribe STREAM/SAMPLE` emits repeated snapshots for `global/state/router-id`. **Hosted CI** in `.github/workflows/interop.yml` (no kernel features required). |
 | gnmic (mTLS client) + FRR (bgpd) | 0.46.0 / 10.3.1 | `tests/interop/m56-gnmi-onchange-frr.clab.yml` | Tested (M56) | ADR-0070 deferral resolved / ADR-0072 follow-up — gNMI `Subscribe ON_CHANGE` (session-state only) | Two-node topology (rustbgpd ↔ FRR) with `[event_history].enabled = true`. After the peering reaches Established, the driver first asserts that `STREAM ON_CHANGE` on an unsupported leaf (`state/peer-as`) is rejected with `Unimplemented`. It then runs a short subscribe with no flap to validate the initial-snapshot scope: the captured log must contain `ESTABLISHED` for the configured peer and the `sync_response` marker (sync_response detection is informational because gnmic versions render it inconsistently). A second subscribe opens in the background, the driver `clear bgp` on the FRR side to flap, and the driver asserts a non-ESTABLISHED state appears in the post-flap log (which can only come from the flap transition — the initial snapshot already showed ESTABLISHED). Finally, the driver opens a third subscription and asserts that reconnect yields a fresh initial snapshot (no replay of disconnected-window transitions — the v1 contract is that historical replay belongs to `SubscribeFromEvent`, not gNMI). Full re-ESTABLISHED inside the test window is informational because FRR reconverge time is timing-sensitive. Reuses the M54 mTLS PKI for the gNMI listener. **Hosted CI** in `.github/workflows/interop.yml` (no kernel features required). |
@@ -198,8 +198,8 @@ the protected BIRD TCP-AO smoke and M73 BGP-LS receipt).
 - containerlab installed
 - `rustbgpd:dev` Docker image built: `docker build --target dev -t rustbgpd:dev .`
 - `bird:2-bookworm` Docker image built: `docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop/`
-- `bird:3.2.1-tcpao` Docker image built for M43:
-  `docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/`
+- `bird:3.3.1-tcpao` Docker image built for M43:
+  `docker build -t bird:3.3.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/`
 
 ### FRR (M0)
 
@@ -251,11 +251,11 @@ containerlab destroy -t tests/interop/m0-bird.clab.yml
 
 ### BIRD TCP-AO (M43)
 
-M43 validates ADR-0062 static-neighbor TCP-AO against BIRD 3.2.1 on a
+M43 validates TCP-AO startup and live successor rotation against BIRD 3.3.1 on a
 Linux kernel with `CONFIG_TCP_AO=y`:
 
 ```sh
-docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/
+docker build -t bird:3.3.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop/
 docker build --target dev -t rustbgpd:dev .
 containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
 bash tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -264,11 +264,13 @@ containerlab destroy -t tests/interop/m43-tcp-ao-bird.clab.yml --cleanup
 
 The driver first proves that a two-key startup ring establishes with the
 preferred key, imports `203.0.113.43/32`, selects Current `2` / RNext `12`, and
-reports exactly two redacted MKT rows. It then restarts BIRD with the preferred
-key's secret mismatched and asserts the route withdraws and the session remains
-down. This covers restart-coordinated keyring selection and fail-closed
-inventory reconciliation. It does not yet exercise SIGHUP add-only successor
-installation or the still-deferred live selection/deletion phases.
+reports exactly two redacted MKT rows. BIRD already holds a third nonpreferred
+key. A rustbgpd SIGHUP appends its directionally matching successor, converges
+desired/applied generation 2, and reports exactly three rows without changing
+Current/RNext, BIRD's Established-since token, or the route. The job also runs a
+direct kernel receipt for the accepted-child/listener-flip race. Finally, it
+restarts BIRD with the preferred key's secret mismatched and requires
+fail-closed withdrawal. Live selection/deprecation/deletion remain deferred.
 
 ### Network Layouts
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -947,6 +947,11 @@ The same neighbor view reports TCP-AO rotation `desired`, `applied`, and
 inventory; `add_only` is an in-progress successor install; and
 `add_only_failed` includes a secret-free actionable error. A failed add-only
 generation does not select or delete keys and is safe to retry with SIGHUP.
+If listener mutation may have started, affected protected passive accepts can
+reject until the same generation is retried or the daemon restarts; established
+sessions keep their prior selectable keys. A child queued before a successful
+listener flip is repaired only when it exactly matches the immediately previous
+inventory. Partial inventories and older queued generations remain rejected.
 
 The optional per-key `vrf_ifindex` is Linux's VRF L3-master key selector, not
 an IPv6 link-local interface scope. rustbgpd currently installs VRF-unbound

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -92,7 +92,7 @@ proved with kernel evidence (routes, FDB rows, nexthop groups, netdev state).
 | M39b | Auto-derived Route Targets cross-vendor (RFC 8365 `AS:VNI`) | FRR 10.3.1 |
 | M40 | ADR-0059 EVPN aliasing dataplane ECMP via FDB nexthop groups | FRR EVPN-MH |
 | M42 | ADR-0061 opt-in general unicast Linux FIB runtime | FRR 10.3.1 |
-| M43 | ADR-0062 TCP-AO protected session (probed; skips only if the runner kernel lacks TCP-AO) | BIRD 3.2.1 |
+| M43 | TCP-AO queued-child receipt plus live SIGHUP successor/no-flap proof (probed; skips only if the runner kernel lacks TCP-AO) | BIRD 3.3.1 |
 | M46 | RFC 8584 Highest Random Weight DF election | rustbgpd ×2 |
 | M47 / M48 | ADR-0063 runtime EVPN tenant teardown (control plane / kernel L3 datapath) | FRR 10.3.1 |
 | M49 / M69 | RFC 9785 Highest-Preference DF election (rustbgpd↔rustbgpd and cross-vendor) | rustbgpd ×2 / FRR |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -191,9 +191,10 @@ active-open key-install failures fail the connection attempt and retry later
 without falling back to unauthenticated TCP.
 Runtime deletion of configured TCP-AO neighbors is rejected because listener
 MKTs are installed on the startup listener socket and are not deleted yet.
-Static-neighbor protected interop is validated by M43 against BIRD 3.2.1:
-matching keys establish and import a route, while a mismatched key withdraws
-the route and does not re-establish within the fail-closed window. The
+Static-neighbor protected interop is validated by M43 against BIRD 3.3.1:
+matching keys establish and import a route, a nonpreferred successor is added
+with SIGHUP without flapping the session, and a mismatched preferred key
+withdraws the route and does not re-establish within the fail-closed window. The
 hosted `kernel-dataplane` workflow includes M43, and the current hosted
 runner advertises `CONFIG_TCP_AO=y` and runs the topology. The workflow keeps a
 warning-only skip guard for future runner kernels without TCP-AO support.
@@ -209,6 +210,9 @@ connected socket without exposing key material. Ordered keyrings are
 supported. Static exact owners take precedence over dynamic longest-prefix
 matches; accepted sockets must expose the owned union of all covering protected
 selectors, while current and RNext selection must belong to the resolved owner.
+If a child completed before an add-only listener flip, only the exact
+immediately previous inventory may be reconciled forward; arbitrary subsets,
+partial successor inventories, and older generations remain fail-closed.
 Overlapping TCP-AO owners require directionally disjoint SendID and RecvID sets;
 TCP-AO/plaintext and TCP-AO/MD5 overlaps are rejected. Config validation and
 transport binding enforce the same 4,096-MKT inspection ceiling independently
@@ -348,7 +352,7 @@ the roadmap:
   plus add-only non-preferred successor installation on SIGHUP. Selection,
   deprecation, deletion, edits/reordering, and protected-owner CRUD require a
   restart.
-  Protected static-neighbor interop is covered by M43 against BIRD 3.2.1 on
+  Protected static-neighbor interop is covered by M43 against BIRD 3.3.1 on
   Linux with `CONFIG_TCP_AO=y`.
 - gRPC token and mTLS material behind unchanged paths rotate on SIGHUP as one
   all-listener generation. Alert on

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -108,7 +108,13 @@ slices have now shipped static-neighbor and startup-only dynamic-range support:
   configured keyring, including transient key-byte equality, matches the
   kernel inventory. Dropped-ICMP counters degrade health but do not by
   themselves reject an accepted authenticated socket.
-- Protected M43 interop against BIRD 3.2.1 runs in the GitHub-hosted
+- Linux does not copy keys newly added to a listener into already-established
+  children in its accept queue. Such a child is reconciled only when it exactly
+  matches the retained immediately previous generation; after adding the
+  successor suffix, the exact current inventory and unchanged Current/RNext
+  selection are required. Partial, arbitrary-subset, and older inventories are
+  rejected.
+- Protected M43 interop against BIRD 3.3.1 runs in the GitHub-hosted
   `kernel-dataplane` workflow on the current TCP-AO-capable runner. The
   workflow keeps a `CONFIG_TCP_AO` probe so future runner kernels without the
   feature skip M43 with a warning instead of failing unrelated dataplane gates.

--- a/docs/kernel-dataplane-runner.md
+++ b/docs/kernel-dataplane-runner.md
@@ -77,7 +77,7 @@ issue #187) so reviewers can distinguish real stability from flake masking.
 - M53: ADR-0069 BGP unnumbered / IPv6 link-local peering with scoped FIB ECMP
   against two FRR peers over unnumbered links.
 - M51: ADR-0067 single-hop BFD + RFC 5882 coupling against FRR `bfdd`.
-- M43: ADR-0062 static-neighbor TCP-AO protected session against BIRD 3.2.1
+- M43: TCP-AO queued-child reconciliation and live successor rotation against BIRD 3.3.1
   (conditional on the runner advertising `CONFIG_TCP_AO=y`).
 - M60: ADR-0079 EVPN adoption sweep kill-and-restart against FRR.
 - M61: ADR-0079 EVPN L3 adoption sweep kill-and-restart against FRR.

--- a/src/peer_manager/inbound.rs
+++ b/src/peer_manager/inbound.rs
@@ -17,11 +17,19 @@ fn tcp_ao_accept_generation_valid(
     accepted: Option<TcpAoRotationGeneration>,
     rotation: &rustbgpd_transport::TcpAoRotationStatus,
 ) -> bool {
-    if protected && rotation.phase == rustbgpd_transport::TcpAoRotationPhase::AddOnly {
-        return false;
+    match (protected, accepted) {
+        (false, None) => true,
+        (true, Some(generation)) => match rotation.phase {
+            rustbgpd_transport::TcpAoRotationPhase::AddOnly => {
+                generation == rotation.applied || generation == rotation.desired
+            }
+            rustbgpd_transport::TcpAoRotationPhase::Idle
+            | rustbgpd_transport::TcpAoRotationPhase::AddOnlyFailed => {
+                generation == rotation.applied
+            }
+        },
+        _ => false,
     }
-    matches!((protected, accepted), (false, None))
-        || matches!((protected, accepted), (true, Some(generation)) if generation == rotation.applied)
 }
 
 impl PeerManager {
@@ -135,21 +143,14 @@ impl PeerManager {
             tcp_ao_generation,
             &self.tcp_ao_rotation,
         ) {
-            if tcp_ao_info.is_some()
-                && self.tcp_ao_rotation.phase == rustbgpd_transport::TcpAoRotationPhase::AddOnly
-            {
+            if tcp_ao_info.is_some() {
                 warn!(
                     %peer_ip,
+                    accepted_generation = tcp_ao_generation.map(TcpAoRotationGeneration::as_u64),
                     desired_generation = self.tcp_ao_rotation.desired.as_u64(),
                     applied_generation = self.tcp_ao_rotation.applied.as_u64(),
-                    "rejecting protected inbound connection while TCP-AO generation preflight/apply is in progress"
-                );
-            } else if let Some(generation) = tcp_ao_generation {
-                warn!(
-                    %peer_ip,
-                    accepted_generation = generation.as_u64(),
-                    applied_generation = self.tcp_ao_generation.as_u64(),
-                    "rejecting protected inbound connection from a stale or partially applied TCP-AO generation"
+                    phase = ?self.tcp_ao_rotation.phase,
+                    "rejecting protected inbound connection outside the valid TCP-AO generation fence"
                 );
             } else {
                 warn!(%peer_ip, "rejecting inbound connection with inconsistent TCP-AO generation metadata");
@@ -649,7 +650,22 @@ mod generation_tests {
             phase: rustbgpd_transport::TcpAoRotationPhase::AddOnly,
             ..idle
         };
-        assert!(!tcp_ao_accept_generation_valid(true, Some(two), &applying));
+        assert!(tcp_ao_accept_generation_valid(true, Some(two), &applying));
+        assert!(!tcp_ao_accept_generation_valid(true, Some(one), &applying));
+
+        let applying = rustbgpd_transport::TcpAoRotationStatus {
+            desired: two,
+            applied: one,
+            phase: rustbgpd_transport::TcpAoRotationPhase::AddOnly,
+            last_error: None,
+        };
+        assert!(tcp_ao_accept_generation_valid(true, Some(one), &applying));
+        assert!(tcp_ao_accept_generation_valid(true, Some(two), &applying));
+        assert!(!tcp_ao_accept_generation_valid(
+            true,
+            TcpAoRotationGeneration::new(3),
+            &applying
+        ));
 
         let failed = rustbgpd_transport::TcpAoRotationStatus {
             desired: two,

--- a/tests/interop/Dockerfile.bird3
+++ b/tests/interop/Dockerfile.bird3
@@ -1,6 +1,6 @@
 FROM debian:trixie-slim
 
-ARG BIRD_VERSION=3.2.1
+ARG BIRD_VERSION=3.3.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bison \

--- a/tests/interop/configs/bird-m43-tcp-ao-bad.conf
+++ b/tests/interop/configs/bird-m43-tcp-ao-bad.conf
@@ -36,6 +36,12 @@ protocol bgp rustbgpd {
       algorithm hmac sha256;
       preferred;
     };
+    key {
+      send id 13;
+      recv id 3;
+      secret "interop-successor-secret-m43";
+      algorithm hmac sha256;
+    };
   };
 
   ipv4 {

--- a/tests/interop/configs/bird-m43-tcp-ao.conf
+++ b/tests/interop/configs/bird-m43-tcp-ao.conf
@@ -36,6 +36,12 @@ protocol bgp rustbgpd {
       algorithm hmac sha256;
       preferred;
     };
+    key {
+      send id 13;
+      recv id 3;
+      secret "interop-successor-secret-m43";
+      algorithm hmac sha256;
+    };
   };
 
   ipv4 {

--- a/tests/interop/configs/rustbgpd-m43-tcp-ao-successor.toml
+++ b/tests/interop/configs/rustbgpd-m43-tcp-ao-successor.toml
@@ -1,0 +1,25 @@
+[global]
+asn = 65001
+router_id = "10.0.43.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[global.telemetry.grpc_tcp]
+address = "0.0.0.0:50051"
+
+[[neighbors]]
+address = "10.0.43.2"
+remote_asn = 65043
+description = "bird3-tcp-ao"
+hold_time = 90
+tcp_ao = [
+  { key = "interop-old-secret-m43", send_id = 1, recv_id = 11, algorithm = "hmac(sha256)", deprecated = true },
+  { key = "interop-next-secret-m43", send_id = 2, recv_id = 12, algorithm = "hmac(sha256)", preferred = true },
+  { key = "interop-successor-secret-m43", send_id = 3, recv_id = 13, algorithm = "hmac(sha256)" },
+]
+
+[security.grpc]
+enforcement = "legacy"

--- a/tests/interop/m43-tcp-ao-bird.clab.yml
+++ b/tests/interop/m43-tcp-ao-bird.clab.yml
@@ -1,10 +1,10 @@
 # Containerlab topology: rustbgpd ↔ BIRD 3.x (M43 — TCP-AO)
 #
-# Validates an ordered two-key static-neighbor TCP-AO startup keyring against a
-# real BIRD 3.x peer on a Linux kernel with CONFIG_TCP_AO=y.
+# Validates an ordered TCP-AO startup keyring and no-flap add-only successor
+# rotation against a real BIRD 3.x peer on a Linux kernel with CONFIG_TCP_AO=y.
 #
 # Usage:
-#   docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
+#   docker build -t bird:3.3.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
 #   docker build --target dev -t rustbgpd:dev .
 #   containerlab deploy -t tests/interop/m43-tcp-ao-bird.clab.yml
 #   bash tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -20,6 +20,7 @@ topology:
       cmd: sleep infinity
       binds:
         - ./configs/rustbgpd-m43-tcp-ao.toml:/etc/rustbgpd/config.toml:ro
+        - ./configs/rustbgpd-m43-tcp-ao-successor.toml:/etc/rustbgpd/config-successor.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
         - ip addr add 10.0.43.1/24 dev eth1
@@ -29,7 +30,7 @@ topology:
 
     bird:
       kind: linux
-      image: bird:3.2.1-tcpao
+      image: bird:3.3.1-tcpao
       binds:
         - ./configs/bird-m43-tcp-ao.conf:/etc/bird/bird.conf:ro
         - ./configs/bird-m43-tcp-ao-bad.conf:/etc/bird/bird-bad.conf:ro

--- a/tests/interop/scripts/test-m43-tcp-ao-bird.sh
+++ b/tests/interop/scripts/test-m43-tcp-ao-bird.sh
@@ -4,12 +4,14 @@
 # Validates:
 #   1. BGP establishes with the preferred entry in a two-key startup ring.
 #   2. GET_KEYS exposes the complete redacted inventory and selected IDs.
-#   3. BIRD advertises a route over the protected session.
-#   4. A mismatch in the selected key fails closed and does not re-establish.
+#   3. SIGHUP appends a nonpreferred successor without changing selection or
+#      flapping the BIRD session.
+#   4. BIRD advertises a route throughout the protected live rotation.
+#   5. A mismatch in the selected key fails closed and does not re-establish.
 #
 # Prerequisites:
 #   - BIRD image built:
-#       docker build -t bird:3.2.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
+#       docker build -t bird:3.3.1-tcpao -f tests/interop/Dockerfile.bird3 tests/interop
 #   - rustbgpd image built:
 #       docker build --target dev -t rustbgpd:dev .
 #   - containerlab deployed:
@@ -41,6 +43,10 @@ grpc_neighbor_state() {
 
 bird_state() {
     docker exec "$BIRD" birdc show protocols rustbgpd 2>/dev/null || true
+}
+
+bird_since() {
+    bird_state | awk '$1 == "rustbgpd" { print $5; exit }'
 }
 
 dump_diagnostics() {
@@ -155,6 +161,71 @@ assert_two_key_inventory() {
     ok "Selected IDs are Current=2/RNext=12; GET_KEYS inventory is exact and redacted"
 }
 
+wait_successor_generation() {
+    log "Waiting for TCP-AO successor generation to converge..."
+    local state='{}'
+    for i in $(seq 1 30); do
+        state=$(grpc_neighbor_state || echo '{}')
+        if printf '%s' "$state" | grep -Eq \
+            'interop-(old|next|successor)-secret-m43|wrong-next-secret-m43'; then
+            fail "Neighbor state leaked TCP-AO secret material after rotation"
+            return 1
+        fi
+        if jq -e '
+            (.tcpAoDesiredGeneration | tonumber) == 2 and
+            (.tcpAoAppliedGeneration | tonumber) == 2 and
+            .tcpAoRotationPhase == "idle" and
+            (.tcpAoRotationError // "") == "" and
+            .authentication == "AUTHENTICATION_MODE_TCP_AO" and
+            .tcpAoHealth == "TCP_AO_HEALTH_HEALTHY" and
+            .tcpAo.currentKeyId == 2 and
+            .tcpAo.rnextKeyId == 12 and
+            ((.tcpAo.packetsBad // 0) | tonumber) == 0 and
+            ((.tcpAo.packetsKeyNotFound // 0) | tonumber) == 0 and
+            ((.tcpAo.packetsAoRequired // 0) | tonumber) == 0 and
+            (.tcpAo.keys | length) == 3 and
+            any(.tcpAo.keys[];
+              .sendId == 1 and .recvId == 11 and
+              .algorithm == "hmac(sha256)" and
+              .preferred != true and .deprecated == true and
+              .isCurrent != true and .isRnext != true) and
+            any(.tcpAo.keys[];
+              .sendId == 2 and .recvId == 12 and
+              .algorithm == "hmac(sha256)" and
+              .preferred == true and .deprecated != true and
+              .isCurrent == true and .isRnext == true) and
+            any(.tcpAo.keys[];
+              .sendId == 3 and .recvId == 13 and
+              .algorithm == "hmac(sha256)" and
+              .preferred != true and .deprecated != true and
+              .isCurrent != true and .isRnext != true)
+        ' >/dev/null <<<"$state"; then
+            ok "Generation 2 converged with the exact three-key inventory (attempt $i)"
+            return 0
+        fi
+        sleep 2
+    done
+    fail "TCP-AO successor generation did not converge within 60s"
+    printf '%s\n' "$state" >&2
+    dump_diagnostics
+    return 1
+}
+
+apply_successor_generation() {
+    log "Appending the nonpreferred TCP-AO successor with SIGHUP..."
+    docker exec "$RUSTBGPD" cp \
+        /etc/rustbgpd/config-successor.toml /tmp/m43-config.toml
+    if ! docker exec "$RUSTBGPD" sh -lc '
+        pid=$(pidof rustbgpd)
+        [ -n "$pid" ]
+        kill -HUP "$pid"
+    '; then
+        fail "could not deliver SIGHUP to rustbgpd"
+        return 1
+    fi
+    ok "SIGHUP delivered for the add-only successor generation"
+}
+
 wait_route_absent() {
     log "Waiting for $TEST_PREFIX/32 to be absent..."
     for i in $(seq 1 20); do
@@ -185,18 +256,42 @@ assert_bad_key_does_not_establish() {
 }
 
 main() {
-    log "M43 interop test: TCP-AO two-key startup ring with BIRD 3.x"
+    log "M43 interop test: TCP-AO live successor rotation with BIRD 3.3.1"
     log "Topology: $TOPO"
 
     resolve_grpc_addr
     start_bird "$GOOD_CONF"
-    # start_rustbgpd intentionally uses its default daemon wrapper here.
-    # shellcheck disable=SC2119
-    start_rustbgpd
+    docker exec "$RUSTBGPD" cp /etc/rustbgpd/config.toml /tmp/m43-config.toml
+    start_rustbgpd "exec /usr/local/bin/rustbgpd /tmp/m43-config.toml"
 
     wait_bird_established
     wait_route_present
     assert_two_key_inventory
+    local established_since
+    local initial_flaps
+    established_since=$(bird_since)
+    initial_flaps=$(grpc_neighbor_state | jq -r '((.flapCount // 0) | tonumber)')
+    if [ -z "$established_since" ]; then
+        fail "could not capture BIRD's Established-since token"
+        return 1
+    fi
+
+    apply_successor_generation
+    wait_successor_generation
+    wait_route_present
+    wait_bird_established
+    local rotated_since
+    local rotated_flaps
+    rotated_since=$(bird_since)
+    rotated_flaps=$(grpc_neighbor_state | jq -r '((.flapCount // 0) | tonumber)')
+    if [ "$rotated_since" = "$established_since" ] && \
+        [ "$rotated_flaps" -eq "$initial_flaps" ]; then
+        ok "Session did not flap across SIGHUP (BIRD since $rotated_since; flapCount $rotated_flaps)"
+    else
+        fail "Session flapped across SIGHUP (BIRD since $established_since -> $rotated_since; flapCount $initial_flaps -> $rotated_flaps)"
+        dump_diagnostics
+        return 1
+    fi
 
     log "Restarting BIRD with a mismatched preferred TCP-AO secret"
     start_bird "$BAD_CONF"


### PR DESCRIPTION
## Summary

- admit queued authenticated children only when their kernel inventory exactly matches the current TCP-AO generation or the one immediately preceding it
- repair an accepted previous-generation child by installing only the missing successor suffix while the socket remains exclusively listener-owned, then require a final exact current-generation receipt and stamp the current phase
- fail closed for arbitrary subsets, partial inventories, N-2 generations, selector drift, bad counters, failed repair, or peer-manager phases outside the applied/desired fence

## Operator impact

A child queued across an add-only key rotation can now reconcile without flapping the established BGP session, while ambiguous or unsafe kernel state still rejects before the peer manager accepts the socket. M43 pins BIRD 3.3.1 and exercises a live SIGHUP rotation with exact inventory, selector, counter, session-continuity, route-continuity, and bad-secret assertions.

## Verification

- `cargo test -p rustbgpd-transport --lib` (304 passed, 2 ignored)
- real-kernel queued-child and overlapping-owner TCP-AO receipts
- focused peer-manager applied/desired fence regression
- transport and daemon all-feature Clippy
- M43 Bash syntax and ShellCheck validation
- exact-head hosted kernel and BIRD interop gates are required before merge