### PR TITLE
Keep grouped policy transitions responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,10 +294,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in bounded slices, and service live readiness through dedicated read-only
   PeerManager and RIB query lanes. Ordinary mutations remain ordered behind
   the transaction, while membership and reserved writer sends still commit as
-  one synchronous section. A pinned 65,536-route/64-peer receipt records a
-  1.676 ms maximum actor slice, down from 83.2-93.2 ms, and the paused-clock
-  regression completes eight in-flight readiness probes with zero 200 ms
-  timeouts.
+  one synchronous section. Pinned 65,536-route/64-peer and
+  4,096-route/700-peer receipts record 4.523 ms as the largest production
+  actor poll and 3.224 ms for the 700-member atomic finalization, both below
+  the 50 ms engineering budget. Paused-clock regressions complete in-flight
+  readiness probes with zero 200 ms timeouts, including while one session
+  policy command is independently stalled.
 
 - **Clean update-group exact precommit avoids unused per-peer bookkeeping.**
   Ordinary grouped members whose exact probes all succeed no longer rebuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `rbgp policy stats` exposes the staged evaluations and continues to advance
   as later routes arrive.
 
+- **Large uniform export-policy transitions stay observable while they
+  converge.** Clean grouped-to-grouped unicast cohorts reuse one immutable
+  transition inventory and exact-probe plan, process expensive preflight work
+  in bounded slices, and service live readiness through dedicated read-only
+  PeerManager and RIB query lanes. Ordinary mutations remain ordered behind
+  the transaction, while membership and reserved writer sends still commit as
+  one synchronous section. A pinned 65,536-route/64-peer receipt records a
+  1.676 ms maximum actor slice, down from 83.2-93.2 ms, and the paused-clock
+  regression completes eight in-flight readiness probes with zero 200 ms
+  timeouts.
+
 - **Clean update-group exact precommit avoids unused per-peer bookkeeping.**
   Ordinary grouped members whose exact probes all succeed no longer rebuild
   candidate keys or walk and allocate the group's prior advertised set; that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,20 +283,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Changed-policy update groups share transition work without hiding live
   export-policy counters.** Eligible grouped-to-grouped unicast reloads build
   and exact-probe one destination inventory per wire cohort, then reuse its
-  immutable payload across members. The first installed member now shares the
-  exact policy-chain instance used to stage that inventory, so
-  `rbgp policy stats` exposes the staged evaluations and continues to advance
-  as later routes arrive.
+  immutable payload across members. Every grouped membership path—optimized
+  commit, authoritative fallback/recompute, and rollback—now installs the
+  exact destination-group policy-chain counter instance for every member, so
+  `rbgp policy stats` exposes the same staged evaluations for the whole group
+  and continues to advance as later routes arrive.
 
 - **Large uniform export-policy transitions stay observable while they
   converge.** Clean grouped-to-grouped unicast cohorts reuse one immutable
-  transition inventory and exact-probe plan, process expensive preflight work
-  in bounded slices, and service live readiness through dedicated read-only
-  PeerManager and RIB query lanes. Ordinary mutations remain ordered behind
-  the transaction, while membership and reserved writer sends still commit as
-  one synchronous section. Pinned 65,536-route/64-peer and
-  4,096-route/700-peer receipts record 4.523 ms as the largest production
-  actor poll and 3.224 ms for the 700-member atomic finalization, both below
+  transition inventory and exact-probe plan. Their post-snapshot staging,
+  inventory, and probe bodies process at most 1,024 route identities per poll;
+  the preceding Loc-RIB prefix snapshot and destination-key inventory snapshot
+  remain two explicit, measured O(table) actor polls with no extrapolated hard
+  bound. Live readiness uses dedicated read-only PeerManager and RIB query
+  lanes. Ordinary mutations remain ordered behind the transaction, while
+  membership and reserved writer sends still commit as one synchronous
+  section. A successfully enqueued cohort RIB reply remains transaction-owned
+  past the ordinary five-second per-peer timeout, preventing a forward/rollback
+  race while readiness continues to be served. Pinned 65,536-route/64-peer and
+  4,096-route/700-peer receipts record 4.927 ms as the largest production
+  actor poll and 2.001 ms for the 700-member atomic finalization, both below
   the 50 ms engineering budget. Paused-clock regressions complete in-flight
   readiness probes with zero 200 ms timeouts, including while one session
   policy command is independently stalled.

--- a/crates/api/src/control_service.rs
+++ b/crates/api/src/control_service.rs
@@ -6,7 +6,7 @@ use tonic::{Request, Response, Status};
 use tracing::info;
 
 use crate::health_probe::CoreReadinessProbe;
-use crate::peer_types::PeerManagerCommand;
+use crate::peer_types::{PeerManagerCommand, PeerManagerReadinessQuery};
 use crate::proto;
 use crate::server::{AccessMode, read_only_rejection};
 use rustbgpd_rib::RibUpdate;
@@ -25,6 +25,7 @@ pub struct ControlService {
     start_time: tokio::time::Instant,
     metrics: BgpMetrics,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_readiness_tx: Option<mpsc::Sender<PeerManagerReadinessQuery>>,
     rib_tx: mpsc::Sender<RibUpdate>,
     shutdown_tx: watch::Sender<bool>,
     mrt_trigger_tx: Option<MrtTriggerTx>,
@@ -49,10 +50,22 @@ impl ControlService {
             start_time,
             metrics,
             peer_mgr_tx,
+            peer_mgr_readiness_tx: None,
             rib_tx,
             shutdown_tx,
             mrt_trigger_tx,
         }
+    }
+
+    /// Route health snapshots through the peer manager's read-only readiness
+    /// lane while retaining the ordinary sender for shutdown.
+    #[must_use]
+    pub fn with_peer_manager_readiness(
+        mut self,
+        peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
+    ) -> Self {
+        self.peer_mgr_readiness_tx = Some(peer_mgr_readiness_tx);
+        self
     }
 }
 
@@ -64,7 +77,11 @@ impl proto::control_service_server::ControlService for ControlService {
     ) -> Result<Response<proto::HealthResponse>, Status> {
         let uptime = self.start_time.elapsed().as_secs();
 
-        let snapshot = CoreReadinessProbe::new(self.peer_mgr_tx.clone(), self.rib_tx.clone())
+        let mut probe = CoreReadinessProbe::new(self.peer_mgr_tx.clone(), self.rib_tx.clone());
+        if let Some(readiness_tx) = &self.peer_mgr_readiness_tx {
+            probe = probe.with_peer_manager_readiness(readiness_tx.clone());
+        }
+        let snapshot = probe
             .snapshot()
             .await
             .map_err(|error| Status::internal(error.to_string()))?;

--- a/crates/api/src/health_probe.rs
+++ b/crates/api/src/health_probe.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 
-use crate::peer_types::{PeerInfo, PeerManagerCommand};
+use crate::peer_types::{PeerInfo, PeerManagerCommand, PeerManagerReadinessQuery};
 use rustbgpd_rib::RibUpdate;
 
 /// Total deadline for the core actor readiness probe.
@@ -82,6 +82,7 @@ pub struct CoreHealthSnapshot {
 #[derive(Clone)]
 pub struct CoreReadinessProbe {
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_readiness_tx: Option<mpsc::Sender<PeerManagerReadinessQuery>>,
     rib_tx: mpsc::Sender<RibUpdate>,
     gate: Option<DaemonGate>,
 }
@@ -95,9 +96,23 @@ impl CoreReadinessProbe {
     ) -> Self {
         Self {
             peer_mgr_tx,
+            peer_mgr_readiness_tx: None,
             rib_tx,
             gate: None,
         }
+    }
+
+    /// Route the peer-manager half of the probe through its dedicated
+    /// read-only lane. Production callers install this sender so readiness can
+    /// be serviced between bounded policy-transaction steps; tests and small
+    /// embedders may continue using the ordinary command lane.
+    #[must_use]
+    pub fn with_peer_manager_readiness(
+        mut self,
+        peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
+    ) -> Self {
+        self.peer_mgr_readiness_tx = Some(peer_mgr_readiness_tx);
+        self
     }
 
     /// Attach the process-wide [`DaemonGate`]: a recorded fault (bind
@@ -149,10 +164,17 @@ impl CoreReadinessProbe {
     ) -> Result<Vec<PeerInfo>, CoreReadinessError> {
         timeout_until(deadline, CoreReadinessError::PeerManagerTimedOut, async {
             let (reply_tx, reply_rx) = oneshot::channel();
-            self.peer_mgr_tx
-                .send(PeerManagerCommand::ListPeers { reply: reply_tx })
-                .await
-                .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            if let Some(readiness_tx) = &self.peer_mgr_readiness_tx {
+                readiness_tx
+                    .send(PeerManagerReadinessQuery::ListPeers { reply: reply_tx })
+                    .await
+                    .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            } else {
+                self.peer_mgr_tx
+                    .send(PeerManagerCommand::ListPeers { reply: reply_tx })
+                    .await
+                    .map_err(|_| CoreReadinessError::PeerManagerUnavailable)?;
+            }
             reply_rx
                 .await
                 .map_err(|_| CoreReadinessError::PeerManagerDroppedReply)
@@ -332,6 +354,28 @@ mod tests {
 
         assert!(snapshot.peers.is_empty());
         assert_eq!(snapshot.total_routes, 17);
+    }
+
+    #[tokio::test]
+    async fn snapshot_uses_dedicated_peer_manager_readiness_lane_when_installed() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (readiness_tx, mut readiness_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let probe =
+            CoreReadinessProbe::new(peer_tx, rib_tx).with_peer_manager_readiness(readiness_tx);
+
+        let (result, ()) = tokio::join!(probe.snapshot(), async {
+            let PeerManagerReadinessQuery::ListPeers { reply } =
+                readiness_rx.recv().await.expect("readiness query");
+            reply.send(Vec::new()).unwrap();
+            reply_to_rib(&mut rib_rx, 9).await;
+        });
+
+        assert_eq!(result.unwrap().total_routes, 9);
+        assert!(
+            peer_rx.try_recv().is_err(),
+            "ordinary peer-manager command lane must remain untouched"
+        );
     }
 
     #[tokio::test]

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -1283,6 +1283,18 @@ pub enum PeerManagerCommand {
     },
 }
 
+/// Read-only peer-manager queries admitted between bounded policy-transaction
+/// steps. This separate lane is intentionally narrow: mutation commands remain
+/// ordered on [`PeerManagerCommand`] and cannot observe or alter a partially
+/// applied transaction.
+pub enum PeerManagerReadinessQuery {
+    /// Return a live snapshot of all configured peers.
+    ListPeers {
+        /// Reply channel returning all peer snapshots.
+        reply: oneshot::Sender<Vec<PeerInfo>>,
+    },
+}
+
 /// Information about a configured dynamic neighbor range.
 #[derive(Debug, Clone)]
 pub struct DynamicNeighborInfo {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -40,7 +40,9 @@ use crate::gnmi_service::GnmiService;
 use crate::injection_service::InjectionService;
 use crate::neighbor_service::NeighborService;
 use crate::peer_group_service::PeerGroupService;
-use crate::peer_types::{CatalogMutationError, ConfigEvent, PeerManagerCommand};
+use crate::peer_types::{
+    CatalogMutationError, ConfigEvent, PeerManagerCommand, PeerManagerReadinessQuery,
+};
 use crate::policy_service::PolicyService;
 use crate::proto::bfd_service_server::BfdServiceServer;
 use crate::proto::config_service_server::ConfigServiceServer;
@@ -445,6 +447,8 @@ pub struct ServeConfig {
     pub metrics: BgpMetrics,
     /// Daemon start time for uptime calculation.
     pub start_time: tokio::time::Instant,
+    /// Dedicated read-only peer-manager lane used only by core readiness.
+    pub peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
     /// Optional MRT dump trigger channel (None if MRT not configured).
     pub mrt_trigger_tx: Option<MrtTriggerTx>,
     /// Live count provider for locally-originated Type 2 MAC routes
@@ -872,6 +876,7 @@ async fn run_listener(
     let listen_port = config.listen_port;
     let metrics = config.metrics;
     let start_time = config.start_time;
+    let peer_mgr_readiness_tx = config.peer_mgr_readiness_tx;
     let mrt_trigger_tx = config.mrt_trigger_tx;
     let evpn_originated_local_mac_count = config.evpn_originated_local_mac_count;
     let evpn_instance_status_snapshot = config.evpn_instance_status_snapshot;
@@ -927,6 +932,7 @@ async fn run_listener(
                 rib_tx,
                 rib_query_tx,
                 peer_mgr_tx,
+                peer_mgr_readiness_tx,
                 asn,
                 router_id,
                 listen_port,
@@ -983,6 +989,7 @@ async fn run_listener(
                 rib_tx,
                 rib_query_tx,
                 peer_mgr_tx,
+                peer_mgr_readiness_tx,
                 asn,
                 router_id,
                 listen_port,
@@ -1045,6 +1052,7 @@ async fn run_tcp_listener(
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
     asn: u32,
     router_id: String,
     listen_port: u32,
@@ -1259,7 +1267,8 @@ async fn run_tcp_listener(
             rib_query_tx,
             rpc_shutdown_tx,
             mrt_trigger_tx,
-        ),
+        )
+        .with_peer_manager_readiness(peer_mgr_readiness_tx),
         interceptor.clone(),
     ));
     if tls_enabled {
@@ -1297,6 +1306,7 @@ async fn run_uds_listener(
     rib_tx: mpsc::Sender<RibUpdate>,
     rib_query_tx: mpsc::Sender<RibUpdate>,
     peer_mgr_tx: mpsc::Sender<PeerManagerCommand>,
+    peer_mgr_readiness_tx: mpsc::Sender<PeerManagerReadinessQuery>,
     asn: u32,
     router_id: String,
     listen_port: u32,
@@ -1471,7 +1481,8 @@ async fn run_uds_listener(
             rib_query_tx,
             rpc_shutdown_tx,
             mrt_trigger_tx,
-        ),
+        )
+        .with_peer_manager_readiness(peer_mgr_readiness_tx),
         interceptor.clone(),
     ));
     routes.add_service(GNmiServer::with_interceptor(

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -32,6 +32,18 @@ use crate::update::{
 
 static POLICY_TRANSITION_RECEIPT_PRINTED: AtomicBool = AtomicBool::new(false);
 
+/// Instrumentation from the production clean-transition state machine.
+#[derive(Clone, Copy, Debug)]
+pub struct PolicyTransitionBenchReceipt {
+    pub plan_builds: usize,
+    pub full_exact_probes: usize,
+    pub route_shell_materializations: usize,
+    pub actor_polls: usize,
+    pub max_actor_poll: std::time::Duration,
+    pub max_prefix_snapshot_poll: std::time::Duration,
+    pub max_finalize_poll: std::time::Duration,
+}
+
 impl RibManager {
     /// Synthetic peer address used by [`Self::bench_register_peers`].
     ///
@@ -175,12 +187,18 @@ impl RibManager {
         if std::env::var_os("RUSTBGPD_POLICY_TRANSITION_RECEIPT").is_some()
             && !POLICY_TRANSITION_RECEIPT_PRINTED.swap(true, Ordering::Relaxed)
         {
-            let (plans, probes, materialized, max_slice) = self.bench_policy_transition_receipt();
+            let receipt = self.bench_policy_transition_receipt();
             eprintln!(
-                "policy_transition_receipt peers={n_peers} fast={fast} plans={plans} \
-                 full_exact_probes={probes} route_shell_materializations={materialized} \
-                 max_actor_slice_ns={}",
-                max_slice.as_nanos()
+                "policy_transition_receipt peers={n_peers} fast={fast} plans={} \
+                 full_exact_probes={} route_shell_materializations={} actor_polls={} \
+                 max_actor_poll_ns={} max_prefix_snapshot_poll_ns={} max_finalize_poll_ns={}",
+                receipt.plan_builds,
+                receipt.full_exact_probes,
+                receipt.route_shell_materializations,
+                receipt.actor_polls,
+                receipt.max_actor_poll.as_nanos(),
+                receipt.max_prefix_snapshot_poll.as_nanos(),
+                receipt.max_finalize_poll.as_nanos(),
             );
         }
         fast
@@ -206,17 +224,20 @@ impl RibManager {
         }
     }
 
-    /// `(plan builds, full probes, route-shell materializations, max actor
-    /// slice)` from the most recent shared transition.
+    /// Production state-machine instrumentation from the most recent shared
+    /// transition.
     #[must_use]
-    pub fn bench_policy_transition_receipt(&self) -> (usize, usize, usize, std::time::Duration) {
+    pub fn bench_policy_transition_receipt(&self) -> PolicyTransitionBenchReceipt {
         let stats = self.policy_transition_stats;
-        (
-            stats.plan_builds,
-            stats.full_exact_probes,
-            stats.route_shell_materializations,
-            stats.max_actor_slice,
-        )
+        PolicyTransitionBenchReceipt {
+            plan_builds: stats.plan_builds,
+            full_exact_probes: stats.full_exact_probes,
+            route_shell_materializations: stats.route_shell_materializations,
+            actor_polls: stats.actor_polls,
+            max_actor_poll: stats.max_actor_slice,
+            max_prefix_snapshot_poll: stats.max_prefix_snapshot_poll,
+            max_finalize_poll: stats.max_finalize_poll,
+        }
     }
 
     /// Drive the production paged-query handler synchronously and return its

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -124,6 +124,29 @@ impl SharedUnicastProbeCache {
             })
     }
 
+    /// Prove one strict all-success transition cohort against only its largest
+    /// source message. The snapshot contract still proves wire equivalence;
+    /// admitting the largest encoded length proves every shorter route fits
+    /// the target ceiling without allocating `routes * peers` result vectors.
+    fn reuse_grouped_exact_export_maximum(
+        &self,
+        group_id: usize,
+        announce: &Arc<[crate::route::Route]>,
+        next_hop_override: &Arc<[Option<rustbgpd_policy::NextHopAction>]>,
+        target: &dyn crate::update::ExactExportSnapshot,
+    ) -> Option<Result<crate::update::ExactExportResult, crate::update::ExactExportError>> {
+        self.groups
+            .get(&group_id)?
+            .iter()
+            .filter(|entry| Self::entry_matches_payload(entry, announce, next_hop_override))
+            .find_map(|entry| {
+                let maximum = entry.encoded_lengths.iter().copied().max().unwrap_or(0);
+                let mut results =
+                    target.reuse_successful_probes(entry.source_snapshot.as_ref(), &[maximum])?;
+                (results.len() == 1).then(|| results.pop().expect("one result validated above"))
+            })
+    }
+
     fn store(
         &mut self,
         group_id: usize,
@@ -887,11 +910,12 @@ impl RibManager {
     }
 
     fn prepare_clean_policy_transition_members(
-        &self,
+        &mut self,
         destination: usize,
         replacements: &[PeerExportPolicyReplacement],
         inventory: &super::update_groups::CleanPolicyTransitionInventory,
     ) -> Option<(Vec<PreparedCleanPolicyTransitionPeer>, usize)> {
+        let mut slice_started = std::time::Instant::now();
         let candidates = inventory
             .announce
             .iter()
@@ -903,6 +927,7 @@ impl RibManager {
                 },
             )
             .collect::<Vec<_>>();
+        self.finish_policy_transition_slice(&mut slice_started);
         let mut probe_cache = SharedUnicastProbeCache::default();
         let mut prepared = Vec::with_capacity(replacements.len());
         let mut full_probe_count = 0usize;
@@ -930,18 +955,25 @@ impl RibManager {
                 if snapshot.owner_id() != encoder.owner_id() {
                     return None;
                 }
-                let results = if let Some(results) = probe_cache.reuse_grouped_exact_export_ceiling(
+                let results = if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
                     destination,
                     &inventory.announce,
                     &inventory.next_hop_override,
                     snapshot.as_ref(),
                 ) {
-                    (results.len() == candidates.len()).then_some(results)?
+                    self.finish_policy_transition_slice(&mut slice_started);
+                    maximum.ok()?;
+                    Vec::new()
                 } else {
-                    let (results, cardinality_correct) =
-                        probe_exact_export_announcements(peer, snapshot.as_ref(), &candidates);
-                    if !cardinality_correct || results.iter().any(Result::is_err) {
-                        return None;
+                    let mut results = Vec::with_capacity(candidates.len());
+                    for chunk in candidates.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
+                        let (chunk_results, cardinality_correct) =
+                            probe_exact_export_announcements(peer, snapshot.as_ref(), chunk);
+                        if !cardinality_correct || chunk_results.iter().any(Result::is_err) {
+                            return None;
+                        }
+                        results.extend(chunk_results);
+                        self.finish_policy_transition_slice(&mut slice_started);
                     }
                     full_probe_count = full_probe_count.saturating_add(results.len());
                     let encoded_lengths = results
@@ -978,25 +1010,25 @@ impl RibManager {
                 snapshot,
                 permit,
             });
+            self.finish_policy_transition_slice(&mut slice_started);
         }
 
         // Revalidate owner/generation and active-session identity after the
         // potentially expensive shared preflight, still before any mutation.
-        prepared
-            .iter()
-            .all(|member| {
-                self.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
-                    && member.snapshot.as_ref().is_none_or(|snapshot| {
-                        self.peer_export_encoders
-                            .get(&member.peer)
-                            .is_some_and(|encoder| {
-                                let current = encoder.snapshot();
-                                current.owner_id() == snapshot.owner_id()
-                                    && current.generation() == snapshot.generation()
-                            })
-                    })
-            })
-            .then_some((prepared, full_probe_count))
+        let all_current = prepared.iter().all(|member| {
+            self.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
+                && member.snapshot.as_ref().is_none_or(|snapshot| {
+                    self.peer_export_encoders
+                        .get(&member.peer)
+                        .is_some_and(|encoder| {
+                            let current = encoder.snapshot();
+                            current.owner_id() == snapshot.owner_id()
+                                && current.generation() == snapshot.generation()
+                        })
+                })
+        });
+        self.finish_policy_transition_slice(&mut slice_started);
+        all_current.then_some((prepared, full_probe_count))
     }
 
     /// Attempt the strict clean grouped-to-grouped unicast transition.
@@ -1010,8 +1042,7 @@ impl RibManager {
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
     ) -> bool {
-        #[cfg(any(test, feature = "bench-internals"))]
-        let actor_slice_started = std::time::Instant::now();
+        let mut actor_slice_started = std::time::Instant::now();
         if replacements.len() < 2 {
             return false;
         }
@@ -1033,10 +1064,17 @@ impl RibManager {
                 return false;
             }
             transition = Some(pair);
+            if seen
+                .len()
+                .is_multiple_of(super::POLICY_TRANSITION_MEMBER_SLICE)
+            {
+                self.finish_policy_transition_slice(&mut actor_slice_started);
+            }
         }
         let Some((source, destination)) = transition else {
             return false;
         };
+        self.finish_policy_transition_slice(&mut actor_slice_started);
 
         // Keep the staged destination on a failed fast-path preflight: the
         // authoritative per-peer fallback immediately consumes the same
@@ -1056,6 +1094,7 @@ impl RibManager {
         else {
             return false;
         };
+        actor_slice_started = std::time::Instant::now();
 
         let materialized_routes = inventory.announce.len();
         for member in prepared {
@@ -1083,6 +1122,12 @@ impl RibManager {
                 gauge_val(advertised),
             );
         }
+        // Membership mutation and reserved-permit sends are one synchronous,
+        // infallible commit section. Priority queries are deliberately not
+        // drained inside it: they observe either the old membership or the
+        // complete committed cohort, never a half-applied transaction.
+        self.finish_clean_policy_transition_commit();
+        self.finish_policy_transition_slice(&mut actor_slice_started);
         debug!(
             source_group = source,
             destination_group = destination,
@@ -1103,10 +1148,6 @@ impl RibManager {
                 .policy_transition_stats
                 .route_shell_materializations
                 .saturating_add(materialized_routes);
-            self.policy_transition_stats.max_actor_slice = self
-                .policy_transition_stats
-                .max_actor_slice
-                .max(actor_slice_started.elapsed());
         }
         true
     }

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1307,14 +1307,7 @@ impl RibManager {
                         };
                         Some(permit)
                     };
-                    let export_policy = if cursor == 0 {
-                        self.group_ribs
-                            .get(&destination)
-                            .and_then(|group| group.export_chain.as_ref())
-                            .map(rustbgpd_policy::PolicyChain::share)
-                    } else {
-                        replacement.export_policy.clone()
-                    };
+                    let export_policy = replacement.export_policy.clone();
                     if inventory.announce.is_empty() {
                         prepared.push(PreparedCleanPolicyTransitionPeer {
                             peer,
@@ -1427,12 +1420,7 @@ impl RibManager {
 
                 let materialized_routes = inventory.announce.len();
                 for member in prepared {
-                    self.commit_clean_policy_transition_member(
-                        member.peer,
-                        source,
-                        destination,
-                        member.export_policy,
-                    );
+                    self.commit_clean_policy_transition_member(member.peer, source, destination);
                     self.clear_policy_filtered_routes_for_peer(member.peer);
                     self.apply_clean_policy_transition_counters(member.peer, &inventory);
                     if let Some(permit) = member.permit {

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -230,7 +230,138 @@ struct PreparedCleanPolicyTransitionPeer {
     session_id: u64,
     export_policy: Option<PolicyChain>,
     snapshot: Option<Arc<dyn crate::update::ExactExportSnapshot>>,
+    sender: tokio::sync::mpsc::Sender<OutboundRouteUpdate>,
     permit: Option<tokio::sync::mpsc::OwnedPermit<OutboundRouteUpdate>>,
+}
+
+/// One actor-owned, pre-emission clean policy transition. The RIB run loop
+/// advances exactly one bounded phase step and yields before polling it again;
+/// ordinary mutation traffic remains queued until `Finalize` completes.
+pub(super) struct PendingCleanPolicyTransition {
+    replacements: Vec<PeerExportPolicyReplacement>,
+    reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    phase: Option<CleanPolicyTransitionPhase>,
+    created_destination: Option<usize>,
+    destination_staged: bool,
+}
+
+/// The deliberately narrow five-phase transition contract approved for the
+/// shared grouped-to-grouped path. No phase before `Finalize` emits or changes
+/// committed membership.
+enum CleanPolicyTransitionPhase {
+    Classify {
+        cursor: usize,
+        seen: HashSet<IpAddr>,
+        transition: Option<(usize, usize)>,
+    },
+    StageDestination {
+        source: usize,
+        destination: usize,
+        prefixes: Option<Vec<Prefix>>,
+        cursor: usize,
+        memo: ExportMemo,
+    },
+    BuildInventory {
+        source: usize,
+        destination: usize,
+        keys: Option<Vec<(Prefix, u32)>>,
+        cursor: usize,
+        inventory: super::update_groups::CleanPolicyTransitionInventoryBuilder,
+    },
+    ProbeAndPrepare {
+        source: usize,
+        destination: usize,
+        inventory: super::update_groups::CleanPolicyTransitionInventory,
+        cursor: usize,
+        probe_cache: SharedUnicastProbeCache,
+        prepared: Vec<PreparedCleanPolicyTransitionPeer>,
+        active_probe: Option<CleanPolicyTransitionProbe>,
+        full_probe_count: usize,
+    },
+    Finalize {
+        source: usize,
+        destination: usize,
+        inventory: super::update_groups::CleanPolicyTransitionInventory,
+        prepared: Vec<PreparedCleanPolicyTransitionPeer>,
+        full_probe_count: usize,
+    },
+}
+
+struct CleanPolicyTransitionProbe {
+    peer: IpAddr,
+    session_id: u64,
+    export_policy: Option<PolicyChain>,
+    snapshot: Arc<dyn crate::update::ExactExportSnapshot>,
+    sender: tokio::sync::mpsc::Sender<OutboundRouteUpdate>,
+    permit: Option<tokio::sync::mpsc::OwnedPermit<OutboundRouteUpdate>>,
+    cursor: usize,
+    encoded_lengths: Vec<usize>,
+}
+
+pub(super) enum CleanPolicyTransitionAdvance {
+    Continue(PendingCleanPolicyTransition),
+    Committed(PendingCleanPolicyTransition),
+    Fallback(PendingCleanPolicyTransition),
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum CleanPolicyTransitionPollKind {
+    Bounded,
+    PrefixSnapshot,
+    Finalize,
+}
+
+impl PendingCleanPolicyTransition {
+    pub(super) fn new(
+        replacements: Vec<PeerExportPolicyReplacement>,
+        reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
+    ) -> Self {
+        Self {
+            replacements,
+            reply,
+            phase: Some(CleanPolicyTransitionPhase::Classify {
+                cursor: 0,
+                seen: HashSet::new(),
+                transition: None,
+            }),
+            created_destination: None,
+            destination_staged: false,
+        }
+    }
+
+    pub(super) fn take_reply(
+        &mut self,
+    ) -> Option<tokio::sync::oneshot::Sender<Result<(), String>>> {
+        self.reply.take()
+    }
+
+    pub(super) fn take_replacements(&mut self) -> Vec<PeerExportPolicyReplacement> {
+        // Drop any prepared writer permits before authoritative fallback tries
+        // to reserve/send through those same bounded channels.
+        self.phase = None;
+        std::mem::take(&mut self.replacements)
+    }
+
+    pub(super) fn poll_kind(&self) -> CleanPolicyTransitionPollKind {
+        match self.phase.as_ref() {
+            Some(
+                CleanPolicyTransitionPhase::StageDestination { prefixes: None, .. }
+                | CleanPolicyTransitionPhase::BuildInventory { keys: None, .. },
+            ) => CleanPolicyTransitionPollKind::PrefixSnapshot,
+            Some(CleanPolicyTransitionPhase::Finalize { .. }) => {
+                CleanPolicyTransitionPollKind::Finalize
+            }
+            _ => CleanPolicyTransitionPollKind::Bounded,
+        }
+    }
+
+    pub(super) fn cleanup_incomplete_destination(&self, manager: &mut RibManager) {
+        if !self.destination_staged
+            && let Some(destination) = self.created_destination
+        {
+            manager.discard_incomplete_policy_transition_group(destination);
+        }
+    }
 }
 
 #[inline(never)]
@@ -909,247 +1040,472 @@ impl RibManager {
             && !self.peer_orf_filters.contains_key(&peer)
     }
 
-    fn prepare_clean_policy_transition_members(
+    /// Advance one bounded production step of the actor-owned transition.
+    /// Every return before `Finalize` is pre-emission and leaves committed
+    /// membership and installed policy state untouched.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the five explicit phases stay together so ownership and no-emission transitions remain auditable"
+    )]
+    pub(super) fn advance_clean_policy_transition(
         &mut self,
-        destination: usize,
-        replacements: &[PeerExportPolicyReplacement],
-        inventory: &super::update_groups::CleanPolicyTransitionInventory,
-    ) -> Option<(Vec<PreparedCleanPolicyTransitionPeer>, usize)> {
-        let mut slice_started = std::time::Instant::now();
-        let candidates = inventory
-            .announce
-            .iter()
-            .zip(inventory.next_hop_override.iter())
-            .map(
-                |(route, next_hop_override)| crate::update::ExactExportCandidate::Unicast {
-                    route,
-                    next_hop_override: next_hop_override.as_ref(),
-                },
-            )
-            .collect::<Vec<_>>();
-        self.finish_policy_transition_slice(&mut slice_started);
-        let mut probe_cache = SharedUnicastProbeCache::default();
-        let mut prepared = Vec::with_capacity(replacements.len());
-        let mut full_probe_count = 0usize;
-        let destination_export_policy = self.group_ribs.get(&destination)?.export_chain.as_ref();
-
-        for (index, replacement) in replacements.iter().enumerate() {
-            let peer = replacement.peer;
-            let session_id = self.outbound_session_ids.get(&peer).copied()?;
-            let permit = if inventory.announce.is_empty() {
-                None
-            } else {
-                Some(
-                    self.outbound_peers
-                        .get(&peer)?
-                        .clone()
-                        .try_reserve_owned()
-                        .ok()?,
-                )
-            };
-            let snapshot = if candidates.is_empty() {
-                None
-            } else {
-                let encoder = self.peer_export_encoders.get(&peer)?;
-                let snapshot = encoder.snapshot();
-                if snapshot.owner_id() != encoder.owner_id() {
-                    return None;
+        mut pending: PendingCleanPolicyTransition,
+    ) -> CleanPolicyTransitionAdvance {
+        let phase = pending
+            .phase
+            .take()
+            .expect("pending clean transition always owns one phase");
+        match phase {
+            CleanPolicyTransitionPhase::Classify {
+                mut cursor,
+                mut seen,
+                mut transition,
+            } => {
+                if pending.replacements.len() < 2 {
+                    return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
-                let results = if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
-                    destination,
-                    &inventory.announce,
-                    &inventory.next_hop_override,
-                    snapshot.as_ref(),
-                ) {
-                    self.finish_policy_transition_slice(&mut slice_started);
-                    maximum.ok()?;
-                    Vec::new()
+                let end = (cursor + super::POLICY_TRANSITION_MEMBER_SLICE)
+                    .min(pending.replacements.len());
+                for replacement in &pending.replacements[cursor..end] {
+                    if !seen.insert(replacement.peer)
+                        || !self.clean_policy_transition_peer_ready(replacement.peer)
+                    {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    }
+                    let Some(pair) = self.clean_policy_transition_destination(
+                        replacement.peer,
+                        replacement.export_policy.as_ref(),
+                    ) else {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    };
+                    if transition.is_some_and(|expected| expected != pair) {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    }
+                    transition = Some(pair);
+                }
+                cursor = end;
+                if cursor < pending.replacements.len() {
+                    pending.phase = Some(CleanPolicyTransitionPhase::Classify {
+                        cursor,
+                        seen,
+                        transition,
+                    });
                 } else {
-                    let mut results = Vec::with_capacity(candidates.len());
-                    for chunk in candidates.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
-                        let (chunk_results, cardinality_correct) =
-                            probe_exact_export_announcements(peer, snapshot.as_ref(), chunk);
-                        if !cardinality_correct || chunk_results.iter().any(Result::is_err) {
-                            return None;
+                    let Some((source, destination)) = transition else {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    };
+                    pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
+                        source,
+                        destination,
+                        prefixes: None,
+                        cursor: 0,
+                        memo: ExportMemo::default(),
+                    });
+                }
+                CleanPolicyTransitionAdvance::Continue(pending)
+            }
+            CleanPolicyTransitionPhase::StageDestination {
+                source,
+                destination,
+                mut prefixes,
+                mut cursor,
+                mut memo,
+            } => {
+                if prefixes.is_none() {
+                    match self.begin_policy_transition_group(
+                        destination,
+                        pending.replacements[0].peer,
+                        pending.replacements[0].export_policy.as_ref(),
+                    ) {
+                        super::update_groups::PolicyTransitionGroupStart::Maintained => {
+                            pending.destination_staged = true;
+                            pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
+                                source,
+                                destination,
+                                keys: None,
+                                cursor: 0,
+                                inventory: super::update_groups::CleanPolicyTransitionInventoryBuilder::default(),
+                            });
                         }
-                        results.extend(chunk_results);
-                        self.finish_policy_transition_slice(&mut slice_started);
+                        super::update_groups::PolicyTransitionGroupStart::Created(snapshot) => {
+                            pending.created_destination = Some(destination);
+                            prefixes = Some(snapshot);
+                            pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
+                                source,
+                                destination,
+                                prefixes,
+                                cursor,
+                                memo,
+                            });
+                        }
+                    }
+                    return CleanPolicyTransitionAdvance::Continue(pending);
+                }
+
+                let snapshot = prefixes.as_ref().expect("initialized above");
+                let end = (cursor + super::POLICY_TRANSITION_ROUTE_SLICE).min(snapshot.len());
+                if cursor < end {
+                    self.stage_policy_transition_group_chunk(
+                        destination,
+                        &snapshot[cursor..end],
+                        &mut memo,
+                    );
+                    cursor = end;
+                }
+                if cursor < snapshot.len() {
+                    pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
+                        source,
+                        destination,
+                        prefixes,
+                        cursor,
+                        memo,
+                    });
+                } else {
+                    pending.destination_staged = true;
+                    pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
+                        source,
+                        destination,
+                        keys: None,
+                        cursor: 0,
+                        inventory:
+                            super::update_groups::CleanPolicyTransitionInventoryBuilder::default(),
+                    });
+                }
+                CleanPolicyTransitionAdvance::Continue(pending)
+            }
+            CleanPolicyTransitionPhase::BuildInventory {
+                source,
+                destination,
+                mut keys,
+                mut cursor,
+                mut inventory,
+            } => {
+                if keys.is_none() {
+                    let Some(snapshot) =
+                        self.begin_clean_policy_transition_inventory(source, destination)
+                    else {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    };
+                    keys = Some(snapshot);
+                    pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
+                        source,
+                        destination,
+                        keys,
+                        cursor,
+                        inventory,
+                    });
+                    return CleanPolicyTransitionAdvance::Continue(pending);
+                }
+                let snapshot = keys.as_ref().expect("initialized above");
+                let end = (cursor + super::POLICY_TRANSITION_ROUTE_SLICE).min(snapshot.len());
+                if self
+                    .extend_clean_policy_transition_inventory(
+                        source,
+                        destination,
+                        &snapshot[cursor..end],
+                        &mut inventory,
+                    )
+                    .is_none()
+                {
+                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                }
+                cursor = end;
+                if cursor < snapshot.len() {
+                    pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
+                        source,
+                        destination,
+                        keys,
+                        cursor,
+                        inventory,
+                    });
+                } else {
+                    pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare {
+                        source,
+                        destination,
+                        inventory: inventory.finish(),
+                        cursor: 0,
+                        probe_cache: SharedUnicastProbeCache::default(),
+                        prepared: Vec::with_capacity(pending.replacements.len()),
+                        active_probe: None,
+                        full_probe_count: 0,
+                    });
+                }
+                CleanPolicyTransitionAdvance::Continue(pending)
+            }
+            CleanPolicyTransitionPhase::ProbeAndPrepare {
+                source,
+                destination,
+                inventory,
+                mut cursor,
+                mut probe_cache,
+                mut prepared,
+                mut active_probe,
+                mut full_probe_count,
+            } => {
+                if let Some(mut probe) = active_probe.take() {
+                    let end = (probe.cursor + super::POLICY_TRANSITION_ROUTE_SLICE)
+                        .min(inventory.announce.len());
+                    let candidates = inventory.announce[probe.cursor..end]
+                        .iter()
+                        .zip(inventory.next_hop_override[probe.cursor..end].iter())
+                        .map(|(route, next_hop_override)| {
+                            crate::update::ExactExportCandidate::Unicast {
+                                route,
+                                next_hop_override: next_hop_override.as_ref(),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    let (results, cardinality_correct) = probe_exact_export_announcements(
+                        probe.peer,
+                        probe.snapshot.as_ref(),
+                        &candidates,
+                    );
+                    if !cardinality_correct || results.iter().any(Result::is_err) {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
                     }
                     full_probe_count = full_probe_count.saturating_add(results.len());
-                    let encoded_lengths = results
-                        .iter()
-                        .filter_map(|result| result.as_ref().ok().map(|result| result.encoded_len))
-                        .collect();
-                    probe_cache.store(
-                        destination,
-                        Arc::clone(&inventory.announce),
-                        Arc::clone(&inventory.next_hop_override),
-                        Arc::clone(&snapshot),
-                        encoded_lengths,
+                    probe.encoded_lengths.extend(
+                        results
+                            .into_iter()
+                            .filter_map(|result| result.ok().map(|accepted| accepted.encoded_len)),
                     );
-                    results
-                };
-                if results.iter().any(Result::is_err) {
-                    return None;
+                    probe.cursor = end;
+                    if probe.cursor < inventory.announce.len() {
+                        active_probe = Some(probe);
+                    } else {
+                        probe_cache.store(
+                            destination,
+                            Arc::clone(&inventory.announce),
+                            Arc::clone(&inventory.next_hop_override),
+                            Arc::clone(&probe.snapshot),
+                            probe.encoded_lengths,
+                        );
+                        prepared.push(PreparedCleanPolicyTransitionPeer {
+                            peer: probe.peer,
+                            session_id: probe.session_id,
+                            export_policy: probe.export_policy,
+                            snapshot: Some(probe.snapshot),
+                            sender: probe.sender,
+                            permit: probe.permit,
+                        });
+                        cursor += 1;
+                    }
+                } else if cursor < pending.replacements.len() {
+                    let replacement = &pending.replacements[cursor];
+                    let peer = replacement.peer;
+                    let Some(session_id) = self.outbound_session_ids.get(&peer).copied() else {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    };
+                    let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    };
+                    let permit = if inventory.announce.is_empty() {
+                        None
+                    } else {
+                        let Ok(permit) = sender.clone().try_reserve_owned() else {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        };
+                        Some(permit)
+                    };
+                    let export_policy = if cursor == 0 {
+                        self.group_ribs
+                            .get(&destination)
+                            .and_then(|group| group.export_chain.as_ref())
+                            .map(rustbgpd_policy::PolicyChain::share)
+                    } else {
+                        replacement.export_policy.clone()
+                    };
+                    if inventory.announce.is_empty() {
+                        prepared.push(PreparedCleanPolicyTransitionPeer {
+                            peer,
+                            session_id,
+                            export_policy,
+                            snapshot: None,
+                            sender,
+                            permit,
+                        });
+                        cursor += 1;
+                    } else {
+                        let Some(encoder) = self.peer_export_encoders.get(&peer) else {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        };
+                        let snapshot = encoder.snapshot();
+                        if snapshot.owner_id() != encoder.owner_id() {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        }
+                        if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
+                            destination,
+                            &inventory.announce,
+                            &inventory.next_hop_override,
+                            snapshot.as_ref(),
+                        ) {
+                            if maximum.is_err() {
+                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                            }
+                            prepared.push(PreparedCleanPolicyTransitionPeer {
+                                peer,
+                                session_id,
+                                export_policy,
+                                snapshot: Some(snapshot),
+                                sender,
+                                permit,
+                            });
+                            cursor += 1;
+                        } else {
+                            active_probe = Some(CleanPolicyTransitionProbe {
+                                peer,
+                                session_id,
+                                export_policy,
+                                snapshot,
+                                sender,
+                                permit,
+                                cursor: 0,
+                                encoded_lengths: Vec::with_capacity(inventory.announce.len()),
+                            });
+                        }
+                    }
                 }
-                Some(snapshot)
-            };
-            prepared.push(PreparedCleanPolicyTransitionPeer {
-                peer,
-                session_id,
-                // Install the first member through a handle onto the exact
-                // chain instance that staged the destination group. Its
-                // operator-visible term-hit counters then keep tracking group
-                // evaluations even when the destination group pre-existed.
-                // Later members retain the established fresh-clone semantics.
-                export_policy: if index == 0 {
-                    destination_export_policy.map(rustbgpd_policy::PolicyChain::share)
-                } else {
-                    replacement.export_policy.clone()
-                },
-                snapshot,
-                permit,
-            });
-            self.finish_policy_transition_slice(&mut slice_started);
-        }
 
-        // Revalidate owner/generation and active-session identity after the
-        // potentially expensive shared preflight, still before any mutation.
-        let all_current = prepared.iter().all(|member| {
-            self.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
-                && member.snapshot.as_ref().is_none_or(|snapshot| {
-                    self.peer_export_encoders
-                        .get(&member.peer)
-                        .is_some_and(|encoder| {
-                            let current = encoder.snapshot();
-                            current.owner_id() == snapshot.owner_id()
-                                && current.generation() == snapshot.generation()
+                if cursor == pending.replacements.len() && active_probe.is_none() {
+                    pending.phase = Some(CleanPolicyTransitionPhase::Finalize {
+                        source,
+                        destination,
+                        inventory,
+                        prepared,
+                        full_probe_count,
+                    });
+                } else {
+                    pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare {
+                        source,
+                        destination,
+                        inventory,
+                        cursor,
+                        probe_cache,
+                        prepared,
+                        active_probe,
+                        full_probe_count,
+                    });
+                }
+                CleanPolicyTransitionAdvance::Continue(pending)
+            }
+            CleanPolicyTransitionPhase::Finalize {
+                source,
+                destination,
+                inventory,
+                prepared,
+                full_probe_count,
+            } => {
+                let all_current = prepared.iter().all(|member| {
+                    self.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
+                        && self.outbound_peers.get(&member.peer).is_some_and(|sender| {
+                            sender.same_channel(&member.sender) && !sender.is_closed()
                         })
-                })
-        });
-        self.finish_policy_transition_slice(&mut slice_started);
-        all_current.then_some((prepared, full_probe_count))
+                        && self
+                            .live_sessions
+                            .get(&member.peer)
+                            .and_then(|sessions| sessions.last())
+                            .is_some_and(|session| session.session_id == member.session_id)
+                        && self.clean_policy_transition_peer_ready(member.peer)
+                        && self.clean_policy_transition_destination(
+                            member.peer,
+                            member.export_policy.as_ref(),
+                        ) == Some((source, destination))
+                        && member.snapshot.as_ref().is_none_or(|snapshot| {
+                            self.peer_export_encoders
+                                .get(&member.peer)
+                                .is_some_and(|encoder| {
+                                    let current = encoder.snapshot();
+                                    current.owner_id() == snapshot.owner_id()
+                                        && current.generation() == snapshot.generation()
+                                })
+                        })
+                        && (inventory.announce.is_empty() == member.permit.is_none())
+                });
+                if !all_current {
+                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                }
+
+                let materialized_routes = inventory.announce.len();
+                for member in prepared {
+                    self.commit_clean_policy_transition_member(
+                        member.peer,
+                        source,
+                        destination,
+                        member.export_policy,
+                    );
+                    self.clear_policy_filtered_routes_for_peer(member.peer);
+                    self.apply_clean_policy_transition_counters(member.peer, &inventory);
+                    if let Some(permit) = member.permit {
+                        permit.send(OutboundRouteUpdate {
+                            exact_export_snapshot: member.snapshot,
+                            announce_source_exclusion: Some(member.peer),
+                            announce: Arc::clone(&inventory.announce),
+                            next_hop_override: Arc::clone(&inventory.next_hop_override),
+                            ..OutboundRouteUpdate::default()
+                        });
+                    }
+                    let advertised = self.grouped_advertised_count(member.peer).unwrap_or(0);
+                    self.metrics.set_adj_rib_out_prefixes(
+                        &member.peer.to_string(),
+                        "all",
+                        gauge_val(advertised),
+                    );
+                }
+                self.finish_clean_policy_transition_commit();
+                debug!(
+                    source_group = source,
+                    destination_group = destination,
+                    members = pending.replacements.len(),
+                    materialized_routes,
+                    full_probe_count,
+                    "applied shared clean export-policy transition"
+                );
+                #[cfg(any(test, feature = "bench-internals"))]
+                {
+                    self.policy_transition_stats.plan_builds =
+                        self.policy_transition_stats.plan_builds.saturating_add(1);
+                    self.policy_transition_stats.full_exact_probes = self
+                        .policy_transition_stats
+                        .full_exact_probes
+                        .saturating_add(full_probe_count);
+                    self.policy_transition_stats.route_shell_materializations = self
+                        .policy_transition_stats
+                        .route_shell_materializations
+                        .saturating_add(materialized_routes);
+                }
+                CleanPolicyTransitionAdvance::Committed(pending)
+            }
+        }
     }
 
-    /// Attempt the strict clean grouped-to-grouped unicast transition.
-    ///
-    /// The destination table and immutable diff are built once. Every writer
-    /// slot, session identity, immutable exact snapshot, probe result, and
-    /// source-exclusion assumption is validated before the first membership
-    /// change. Returning `false` is therefore a wholesale, pre-emission
-    /// fallback to the proven per-peer regroup path.
+    /// Synchronous driver used only by the benchmark seam. Production owns
+    /// the same state in the actor loop and yields after every advance call.
+    #[cfg(feature = "bench-internals")]
     pub(in crate::manager) fn try_clean_group_policy_transition(
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
     ) -> bool {
-        let mut actor_slice_started = std::time::Instant::now();
-        if replacements.len() < 2 {
-            return false;
-        }
-        let mut seen = HashSet::with_capacity(replacements.len());
-        let mut transition = None;
-        for replacement in replacements {
-            if !seen.insert(replacement.peer)
-                || !self.clean_policy_transition_peer_ready(replacement.peer)
-            {
-                return false;
-            }
-            let Some(pair) = self.clean_policy_transition_destination(
-                replacement.peer,
-                replacement.export_policy.as_ref(),
-            ) else {
-                return false;
-            };
-            if transition.is_some_and(|expected| expected != pair) {
-                return false;
-            }
-            transition = Some(pair);
-            if seen
-                .len()
-                .is_multiple_of(super::POLICY_TRANSITION_MEMBER_SLICE)
-            {
-                self.finish_policy_transition_slice(&mut actor_slice_started);
+        let mut pending = PendingCleanPolicyTransition::new(replacements.to_vec(), None);
+        loop {
+            let kind = pending.poll_kind();
+            let started = std::time::Instant::now();
+            match self.advance_clean_policy_transition(pending) {
+                CleanPolicyTransitionAdvance::Continue(next) => {
+                    self.record_policy_transition_poll(kind, started.elapsed());
+                    pending = next;
+                }
+                CleanPolicyTransitionAdvance::Committed(done) => {
+                    self.record_policy_transition_poll(kind, started.elapsed());
+                    drop(done);
+                    return true;
+                }
+                CleanPolicyTransitionAdvance::Fallback(failed) => {
+                    self.record_policy_transition_poll(kind, started.elapsed());
+                    failed.cleanup_incomplete_destination(self);
+                    return false;
+                }
             }
         }
-        let Some((source, destination)) = transition else {
-            return false;
-        };
-        self.finish_policy_transition_slice(&mut actor_slice_started);
-
-        // Keep the staged destination on a failed fast-path preflight: the
-        // authoritative per-peer fallback immediately consumes the same
-        // group. Rebuilding it would double policy evaluations and detach the
-        // fallback's counters from the chain instance staged here.
-        self.ensure_policy_transition_group(
-            destination,
-            replacements[0].peer,
-            replacements[0].export_policy.as_ref(),
-        );
-        let Some(inventory) = self.clean_policy_transition_inventory(source, destination) else {
-            return false;
-        };
-
-        let Some((prepared, full_probe_count)) =
-            self.prepare_clean_policy_transition_members(destination, replacements, &inventory)
-        else {
-            return false;
-        };
-        actor_slice_started = std::time::Instant::now();
-
-        let materialized_routes = inventory.announce.len();
-        for member in prepared {
-            self.commit_clean_policy_transition_member(
-                member.peer,
-                source,
-                destination,
-                member.export_policy,
-            );
-            self.clear_policy_filtered_routes_for_peer(member.peer);
-            self.apply_clean_policy_transition_counters(member.peer, &inventory);
-            if let Some(permit) = member.permit {
-                permit.send(OutboundRouteUpdate {
-                    exact_export_snapshot: member.snapshot,
-                    announce_source_exclusion: Some(member.peer),
-                    announce: Arc::clone(&inventory.announce),
-                    next_hop_override: Arc::clone(&inventory.next_hop_override),
-                    ..OutboundRouteUpdate::default()
-                });
-            }
-            let advertised = self.grouped_advertised_count(member.peer).unwrap_or(0);
-            self.metrics.set_adj_rib_out_prefixes(
-                &member.peer.to_string(),
-                "all",
-                gauge_val(advertised),
-            );
-        }
-        // Membership mutation and reserved-permit sends are one synchronous,
-        // infallible commit section. Priority queries are deliberately not
-        // drained inside it: they observe either the old membership or the
-        // complete committed cohort, never a half-applied transaction.
-        self.finish_clean_policy_transition_commit();
-        self.finish_policy_transition_slice(&mut actor_slice_started);
-        debug!(
-            source_group = source,
-            destination_group = destination,
-            members = replacements.len(),
-            materialized_routes,
-            full_probe_count,
-            "applied shared clean export-policy transition"
-        );
-        #[cfg(any(test, feature = "bench-internals"))]
-        {
-            self.policy_transition_stats.plan_builds =
-                self.policy_transition_stats.plan_builds.saturating_add(1);
-            self.policy_transition_stats.full_exact_probes = self
-                .policy_transition_stats
-                .full_exact_probes
-                .saturating_add(full_probe_count);
-            self.policy_transition_stats.route_shell_materializations = self
-                .policy_transition_stats
-                .route_shell_materializations
-                .saturating_add(materialized_routes);
-        }
-        true
     }
 
     #[expect(
@@ -1839,17 +2195,12 @@ impl RibManager {
             )));
             return;
         }
-        if self.try_clean_group_policy_transition(&replacements) {
-            let _ = reply.send(Ok(()));
-            return;
-        }
-        let result = replacements.into_iter().try_for_each(|replacement| {
-            self.replace_peer_export_policy_synchronously(
-                replacement.peer,
-                replacement.export_policy,
-            )
-        });
-        let _ = reply.send(result);
+        assert!(
+            self.pending_clean_policy_transition.is_none(),
+            "normal RIB mutations must remain fenced behind a pending policy transition"
+        );
+        self.pending_clean_policy_transition =
+            Some(PendingCleanPolicyTransition::new(replacements, Some(reply)));
     }
 
     /// Force re-emission of all currently-advertised routes to a peer

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1473,6 +1473,9 @@ impl RibManager {
                         .route_shell_materializations
                         .saturating_add(materialized_routes);
                 }
+                if let Some(reply) = pending.take_reply() {
+                    let _ = reply.send(Ok(()));
+                }
                 CleanPolicyTransitionAdvance::Committed(pending)
             }
         }
@@ -1485,7 +1488,8 @@ impl RibManager {
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
     ) -> bool {
-        let mut pending = PendingCleanPolicyTransition::new(replacements.to_vec(), None);
+        let (reply, _response) = tokio::sync::oneshot::channel();
+        let mut pending = PendingCleanPolicyTransition::new(replacements.to_vec(), Some(reply));
         loop {
             let kind = pending.poll_kind();
             let started = std::time::Instant::now();

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -600,6 +600,11 @@ fn page_routes<'a>(
     }
 }
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
+/// Maximum route identities processed before the strict shared policy
+/// transition services the existing priority-query lane.
+pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize = 1_024;
+/// Maximum member commits between shared transition query drains.
+pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 
@@ -1141,6 +1146,25 @@ impl RibManager {
             };
             self.handle_update(query);
         }
+    }
+
+    /// Close one explicit policy-transition actor slice, record benchmark/test
+    /// evidence, then service only the existing priority-query lane. Normal RIB
+    /// mutations remain queued on `rx`, so no route or policy mutation can
+    /// interleave with the all-or-nothing preflight/commit transaction.
+    pub(in crate::manager) fn finish_policy_transition_slice(
+        &mut self,
+        started: &mut std::time::Instant,
+    ) {
+        #[cfg(any(test, feature = "bench-internals"))]
+        {
+            self.policy_transition_stats.max_actor_slice = self
+                .policy_transition_stats
+                .max_actor_slice
+                .max(started.elapsed());
+        }
+        self.drain_queries(QUERY_BUDGET_PER_CHUNK);
+        *started = std::time::Instant::now();
     }
 
     fn drain_ready_updates(&mut self) -> bool {

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1229,7 +1229,10 @@ impl RibManager {
     /// Record one real state-machine poll. Production yields immediately after
     /// each call; the benchmark driver invokes the same advance seam
     /// synchronously and records identical phase boundaries.
-    #[allow(clippy::unused_self)]
+    #[allow(
+        clippy::unused_self,
+        reason = "the shared production seam records state only in test and benchmark builds"
+    )]
     pub(in crate::manager) fn record_policy_transition_poll(
         &mut self,
         kind: distribution::CleanPolicyTransitionPollKind,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1270,6 +1270,12 @@ impl RibManager {
         while let Ok(update) = self.rx.try_recv() {
             drained = true;
             self.handle_update(update);
+            if self.pending_clean_policy_transition.is_some() {
+                // The accepted cohort command now owns FIFO. Leave every
+                // later primary update queued until its atomic finalize or
+                // authoritative fallback completes.
+                break;
+            }
             while self.process_next_route_chunk() {
                 drained = true;
             }
@@ -4097,11 +4103,9 @@ impl RibManager {
                         self.record_policy_transition_poll(kind, started.elapsed());
                         self.pending_clean_policy_transition = Some(next);
                     }
-                    distribution::CleanPolicyTransitionAdvance::Committed(mut done) => {
+                    distribution::CleanPolicyTransitionAdvance::Committed(done) => {
                         self.record_policy_transition_poll(kind, started.elapsed());
-                        if let Some(reply) = done.take_reply() {
-                            let _ = reply.send(Ok(()));
-                        }
+                        drop(done);
                     }
                     distribution::CleanPolicyTransitionAdvance::Fallback(mut failed) => {
                         self.record_policy_transition_poll(kind, started.elapsed());

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "bench-internals")]
 mod bench_support;
+#[cfg(feature = "bench-internals")]
+pub use bench_support::PolicyTransitionBenchReceipt;
 mod distribution;
 mod graceful_restart;
 mod helpers;
@@ -45,7 +47,10 @@ struct PolicyTransitionStats {
     plan_builds: usize,
     full_exact_probes: usize,
     route_shell_materializations: usize,
+    actor_polls: usize,
     max_actor_slice: std::time::Duration,
+    max_prefix_snapshot_poll: std::time::Duration,
+    max_finalize_poll: std::time::Duration,
 }
 
 #[cfg(test)]
@@ -392,6 +397,11 @@ pub struct RibManager {
     query_rx: mpsc::Receiver<RibUpdate>,
     /// Large route batches that are being processed in chunks.
     pending_route_batches: VecDeque<PendingRoutesReceived>,
+    /// One explicit shared policy transition advanced by the actor itself.
+    /// While present, only bounded read-only priority queries may interleave;
+    /// primary mutations and timers remain ordered behind the final commit or
+    /// authoritative fallback.
+    pending_clean_policy_transition: Option<distribution::PendingCleanPolicyTransition>,
     /// Withdrawn NLRI identities accumulated across the currently-draining
     /// batch. Retired only after distribution so the exact overlay can
     /// suppress any rejected-only wire withdrawal first.
@@ -600,10 +610,13 @@ fn page_routes<'a>(
     }
 }
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
-/// Maximum route identities processed before the strict shared policy
-/// transition services the existing priority-query lane.
+/// Maximum route identities processed by one strict shared-policy actor poll.
+#[cfg(not(test))]
 pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize = 1_024;
-/// Maximum member commits between shared transition query drains.
+/// Tiny deterministic unit used to prove multi-poll ordering in tests.
+#[cfg(test)]
+pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize = 1;
+/// Maximum members classified by one strict shared-policy actor poll.
 pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
@@ -986,6 +999,7 @@ impl RibManager {
             rx,
             query_rx,
             pending_route_batches: VecDeque::new(),
+            pending_clean_policy_transition: None,
             pending_exact_export_withdrawals: HashSet::new(),
             pending_distribute_changed: HashSet::new(),
             pending_distribute_affected: HashSet::new(),
@@ -1148,23 +1162,101 @@ impl RibManager {
         }
     }
 
-    /// Close one explicit policy-transition actor slice, record benchmark/test
-    /// evidence, then service only the existing priority-query lane. Normal RIB
-    /// mutations remain queued on `rx`, so no route or policy mutation can
-    /// interleave with the all-or-nothing preflight/commit transaction.
-    pub(in crate::manager) fn finish_policy_transition_slice(
+    fn is_read_only_priority_query(update: &RibUpdate) -> bool {
+        let production_query = matches!(
+            update,
+            RibUpdate::QueryReceivedRoutes { .. }
+                | RibUpdate::QueryRoutesPage { .. }
+                | RibUpdate::QueryBestRoutes { .. }
+                | RibUpdate::QueryFibInstallCandidates { .. }
+                | RibUpdate::QueryPeerGroups { .. }
+                | RibUpdate::QueryAdvertisedRoutes { .. }
+                | RibUpdate::ExplainBestPath { .. }
+                | RibUpdate::ExplainAdvertisedRoute { .. }
+                | RibUpdate::SubscribeRouteEvents { .. }
+                | RibUpdate::QueryRouteEventHistory { .. }
+                | RibUpdate::SubscribeEvpnRouteEvents { .. }
+                | RibUpdate::QueryEvpnRouteEventHistory { .. }
+                | RibUpdate::QueryLocRibCount { .. }
+                | RibUpdate::QueryAdjRibOutCounts { .. }
+                | RibUpdate::QueryAdvertisedCount { .. }
+                | RibUpdate::QueryNeighborPolicyStats { .. }
+                | RibUpdate::QueryPeerUpdateGroup { .. }
+                | RibUpdate::QueryPeerOutboundState { .. }
+                | RibUpdate::QueryUpdateGroupSnapshot { .. }
+                | RibUpdate::QueryExportPolicyTermHits { .. }
+                | RibUpdate::QueryFlowSpecRoutes { .. }
+                | RibUpdate::QueryEvpnRoutes { .. }
+                | RibUpdate::QueryBgpLsRoutes { .. }
+                | RibUpdate::QueryVpnRoutes { .. }
+                | RibUpdate::QueryLabeledRoutes { .. }
+                | RibUpdate::QueryRtcRoutes { .. }
+                | RibUpdate::QueryOrrTopology { .. }
+                | RibUpdate::QueryOrrStatus { .. }
+                | RibUpdate::QueryMrtSnapshot { .. }
+                | RibUpdate::QueryWarmMrtSnapshot { .. }
+                | RibUpdate::QueryBmpLocRibDump { .. }
+                | RibUpdate::QueryBmpLocRibStats { .. }
+        );
+        #[cfg(test)]
+        let test_query = matches!(
+            update,
+            RibUpdate::TestQueryVpnAdvertised { .. }
+                | RibUpdate::TestQueryOutboundHealth { .. }
+                | RibUpdate::TestQueryPolicyTransitionStats { .. }
+        );
+        #[cfg(not(test))]
+        let test_query = false;
+        production_query || test_query
+    }
+
+    /// Service only the explicitly enumerated read side while a policy
+    /// transaction owns the actor. A mutation on the query sender is an
+    /// internal wiring violation and fails closed rather than bypassing FIFO.
+    fn drain_policy_transition_queries(&mut self, limit: usize) {
+        for _ in 0..limit {
+            let Ok(query) = self.query_rx.try_recv() else {
+                break;
+            };
+            assert!(
+                Self::is_read_only_priority_query(&query),
+                "mutation routed onto RIB priority-query lane"
+            );
+            self.handle_update(query);
+        }
+    }
+
+    /// Record one real state-machine poll. Production yields immediately after
+    /// each call; the benchmark driver invokes the same advance seam
+    /// synchronously and records identical phase boundaries.
+    #[allow(clippy::unused_self)]
+    pub(in crate::manager) fn record_policy_transition_poll(
         &mut self,
-        started: &mut std::time::Instant,
+        kind: distribution::CleanPolicyTransitionPollKind,
+        elapsed: std::time::Duration,
     ) {
         #[cfg(any(test, feature = "bench-internals"))]
         {
-            self.policy_transition_stats.max_actor_slice = self
-                .policy_transition_stats
-                .max_actor_slice
-                .max(started.elapsed());
+            self.policy_transition_stats.actor_polls =
+                self.policy_transition_stats.actor_polls.saturating_add(1);
+            self.policy_transition_stats.max_actor_slice =
+                self.policy_transition_stats.max_actor_slice.max(elapsed);
+            match kind {
+                distribution::CleanPolicyTransitionPollKind::PrefixSnapshot => {
+                    self.policy_transition_stats.max_prefix_snapshot_poll = self
+                        .policy_transition_stats
+                        .max_prefix_snapshot_poll
+                        .max(elapsed);
+                }
+                distribution::CleanPolicyTransitionPollKind::Finalize => {
+                    self.policy_transition_stats.max_finalize_poll =
+                        self.policy_transition_stats.max_finalize_poll.max(elapsed);
+                }
+                distribution::CleanPolicyTransitionPollKind::Bounded => {}
+            }
         }
-        self.drain_queries(QUERY_BUDGET_PER_CHUNK);
-        *started = std::time::Instant::now();
+        #[cfg(not(any(test, feature = "bench-internals")))]
+        let _ = (kind, elapsed);
     }
 
     fn drain_ready_updates(&mut self) -> bool {
@@ -1573,6 +1665,7 @@ impl RibManager {
                     stats.full_exact_probes,
                     stats.route_shell_materializations,
                     stats.max_actor_slice.as_nanos(),
+                    stats.actor_polls,
                 ));
             }
             RibUpdate::QueryExportPolicyTermHits { peer, reply } => {
@@ -3990,6 +4083,45 @@ impl RibManager {
             // (sessions, local originators) are parked on backpressure.
             self.metrics
                 .set_rib_ingest_channel_depth(i64::try_from(self.rx.len()).unwrap_or(i64::MAX));
+
+            if let Some(pending) = self.pending_clean_policy_transition.take() {
+                // Queries admitted here are explicitly read-only and observe
+                // the old committed membership until the single atomic
+                // `Finalize` poll. Primary updates, route chunks, timers, and
+                // resync work are deliberately not polled in this branch.
+                self.drain_policy_transition_queries(QUERY_BUDGET_PER_CHUNK);
+                let kind = pending.poll_kind();
+                let started = std::time::Instant::now();
+                match self.advance_clean_policy_transition(pending) {
+                    distribution::CleanPolicyTransitionAdvance::Continue(next) => {
+                        self.record_policy_transition_poll(kind, started.elapsed());
+                        self.pending_clean_policy_transition = Some(next);
+                    }
+                    distribution::CleanPolicyTransitionAdvance::Committed(mut done) => {
+                        self.record_policy_transition_poll(kind, started.elapsed());
+                        if let Some(reply) = done.take_reply() {
+                            let _ = reply.send(Ok(()));
+                        }
+                    }
+                    distribution::CleanPolicyTransitionAdvance::Fallback(mut failed) => {
+                        self.record_policy_transition_poll(kind, started.elapsed());
+                        failed.cleanup_incomplete_destination(&mut self);
+                        let replacements = failed.take_replacements();
+                        let result = replacements.into_iter().try_for_each(|replacement| {
+                            self.replace_peer_export_policy_synchronously(
+                                replacement.peer,
+                                replacement.export_policy,
+                            )
+                        });
+                        if let Some(reply) = failed.take_reply() {
+                            let _ = reply.send(result);
+                        }
+                    }
+                }
+                self.drain_policy_transition_queries(QUERY_BUDGET_PER_CHUNK);
+                tokio::task::yield_now().await;
+                continue;
+            }
 
             // Arm the resync timer when dirty_peers transitions empty → non-empty.
             if !self.dirty_peers.is_empty() && !resync_armed {

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -50,7 +50,10 @@ impl crate::update::ExactExportSnapshot for CohortExactSnapshot {
                     matches!(attribute, PathAttribute::Communities(values) if values.contains(&0xFDE8_0002))
                 }) =>
             {
-                256
+                match route.prefix {
+                    Prefix::V4(prefix) if prefix.addr.octets()[2].is_multiple_of(2) => 256,
+                    _ => 192,
+                }
             }
             _ => 64,
         };
@@ -78,7 +81,8 @@ impl crate::update::ExactExportSnapshot for CohortExactSnapshot {
         if source.profile != self.profile {
             return None;
         }
-        self.reuses.fetch_add(1, Ordering::Relaxed);
+        self.reuses
+            .fetch_add(encoded_lengths.len(), Ordering::Relaxed);
         Some(
             encoded_lengths
                 .iter()
@@ -953,7 +957,11 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
         ROUTE_COUNT,
         "full exact probes scale with routes times compatible wire profiles"
     );
-    assert_eq!(reuses.load(Ordering::Relaxed), MEMBER_COUNT - 1);
+    assert_eq!(
+        reuses.load(Ordering::Relaxed),
+        MEMBER_COUNT - 1,
+        "each compatible member must recheck only the cohort maximum length"
+    );
 
     let (stats_reply, stats_response) = oneshot::channel();
     tx.send(RibUpdate::TestQueryPolicyTransitionStats { reply: stats_reply })

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -294,6 +294,24 @@ async fn query_update_group(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Strin
     reply_rx.await.unwrap()
 }
 
+async fn query_first_export_term_hits(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> (u64, u64) {
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryExportPolicyTermHits {
+        peer: Some(peer),
+        reply,
+    })
+    .await
+    .unwrap();
+    let hits = response.await.unwrap();
+    assert_eq!(hits.len(), 1, "peer must report its installed chain");
+    assert_eq!(
+        hits[0].terms.len(),
+        1,
+        "fixture policy must expose one term"
+    );
+    (hits[0].evals, hits[0].terms[0].hits)
+}
+
 async fn query_peer_outbound_state(
     tx: &mpsc::Sender<RibUpdate>,
     peer: IpAddr,
@@ -833,24 +851,6 @@ async fn content_identical_policy_replace_is_key_stable() {
     reason = "the scaling regression keeps every cohort counter assertion in one fixture"
 )]
 async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
-    async fn query_first_term_hits(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> (u64, u64) {
-        let (reply, response) = oneshot::channel();
-        tx.send(RibUpdate::QueryExportPolicyTermHits {
-            peer: Some(peer),
-            reply,
-        })
-        .await
-        .unwrap();
-        let hits = response.await.unwrap();
-        assert_eq!(hits.len(), 1, "peer must report its installed chain");
-        assert_eq!(
-            hits[0].terms.len(),
-            1,
-            "fixture policy must expose one term"
-        );
-        (hits[0].evals, hits[0].terms[0].hits)
-    }
-
     const MEMBER_COUNT: usize = 8;
     const ROUTE_COUNT: usize = 32;
 
@@ -931,13 +931,14 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
     .await
     .unwrap();
     assert_eq!(response.await.unwrap(), Ok(()));
-    let first_peer = peers[0];
-    let transition_hits = query_first_term_hits(&tx, first_peer).await;
-    assert_eq!(
-        transition_hits,
-        (ROUTE_COUNT as u64, ROUTE_COUNT as u64),
-        "the first installed member must expose the destination group's staged evaluations"
-    );
+    let transition_hits = (ROUTE_COUNT as u64, ROUTE_COUNT as u64);
+    for &peer in &peers {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            transition_hits,
+            "every installed member must expose the destination group's staged evaluations"
+        );
+    }
 
     let mut updates = Vec::new();
     for receiver in &mut receivers {
@@ -977,7 +978,7 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
         actor_polls >= ROUTE_COUNT,
         "the test-only one-route budget must require multiple real actor polls"
     );
-    for peer in peers {
+    for &peer in &peers {
         assert_eq!(query_update_group(&tx, peer).await, "group:1");
     }
 
@@ -999,11 +1000,147 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
         assert_eq!(update.announce.len(), 1);
         assert_eq!(update.announce[0].prefix, Prefix::V4(later_prefix));
     }
-    assert_eq!(
-        query_first_term_hits(&tx, first_peer).await,
-        (transition_hits.0 + 1, transition_hits.1 + 1),
-        "later group evaluations must keep advancing the installed member's counters"
-    );
+    for peer in peers {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (transition_hits.0 + 1, transition_hits.1 + 1),
+            "later group evaluations must advance every installed member's shared counters"
+        );
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the existing-destination regression checks every grouped counter handle before and after later staging"
+)]
+async fn clean_policy_transition_existing_destination_shares_every_members_counters() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let moving = [
+        IpAddr::V4(Ipv4Addr::new(10, 27, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 27, 0, 2)),
+    ];
+    let destination_member = IpAddr::V4(Ipv4Addr::new(10, 27, 0, 3));
+    let mut moving_receivers = Vec::new();
+    for (index, peer) in moving.iter().copied().enumerate() {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        moving_receivers.push(
+            peer_up_with_cohort_encoder(
+                &tx,
+                spec,
+                Arc::new(CohortExactEncoder {
+                    owner: u64::try_from(index + 1).unwrap(),
+                    profile: 31,
+                    max_len: 4_096,
+                    generation: AtomicUsize::new(0),
+                    advance_generation: false,
+                    probes: Arc::clone(&probes),
+                    reuses: Arc::clone(&reuses),
+                }),
+            )
+            .await,
+        );
+    }
+    let mut destination_spec = PeerUpSpec::ibgp(destination_member);
+    destination_spec.route_reflector_client = true;
+    destination_spec.export_policy = Some(next_policy.clone());
+    let mut destination_receiver = peer_up_with_cohort_encoder(
+        &tx,
+        destination_spec,
+        Arc::new(CohortExactEncoder {
+            owner: 3,
+            profile: 31,
+            max_len: 4_096,
+            generation: AtomicUsize::new(0),
+            advance_generation: false,
+            probes: Arc::clone(&probes),
+            reuses: Arc::clone(&reuses),
+        }),
+    )
+    .await;
+
+    let source = Ipv4Addr::new(192, 0, 2, 17);
+    let first_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 53, 0, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(first_prefix, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut moving_receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+    assert_eq!(destination_receiver.recv().await.unwrap().announce.len(), 1);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: moving
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(next_policy.clone()),
+            })
+            .collect(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.await.unwrap(), Ok(()));
+    for receiver in &mut moving_receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+    assert!(destination_receiver.try_recv().is_err());
+
+    for peer in moving.into_iter().chain([destination_member]) {
+        assert_eq!(query_update_group(&tx, peer).await, "group:1");
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (1, 1),
+            "every member must expose the maintained destination group's counter instance"
+        );
+    }
+
+    let later_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 53, 1, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(later_prefix, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut moving_receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+    assert_eq!(destination_receiver.recv().await.unwrap().announce.len(), 1);
+    for peer in moving.into_iter().chain([destination_member]) {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (2, 2),
+            "later staging must advance every member's shared counter view"
+        );
+    }
 
     drop(tx);
     handle.await.unwrap();
@@ -1265,6 +1402,10 @@ async fn clean_policy_transition_matches_force_ungrouped_member_views() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the fallback regression covers canonical counters through later staging and a complete prior-policy rollback"
+)]
 async fn clean_policy_transition_falls_back_wholesale_on_member_ceiling_rejection() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
@@ -1352,6 +1493,103 @@ async fn clean_policy_transition_falls_back_wholesale_on_member_ceiling_rejectio
         reuses.load(Ordering::Relaxed) >= 1,
         "the rejecting target must reapply its own ceiling to a proven wire-cohort length"
     );
+
+    for &peer in &peers {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (1, 1),
+            "authoritative fallback must install the destination group's actual counter instance for every grouped member"
+        );
+    }
+
+    let later_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 1, 113, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        announced: vec![crate::test_support::make_route(
+            later_prefix,
+            Ipv4Addr::new(192, 0, 2, 10),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    assert_eq!(receivers[0].recv().await.unwrap().announce.len(), 1);
+    for &peer in &peers {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (2, 2),
+            "later evaluations must remain visible through every fallback member"
+        );
+    }
+
+    // Model the peer-manager rollback after a failed outer transaction by
+    // reinstalling the captured prior chain as one cohort. The prior group was
+    // removed when its last member left, so this also proves a freshly rebuilt
+    // rollback destination canonicalizes every member, not just its creator.
+    let (rollback_reply, rollback_response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(old_policy.clone()),
+            })
+            .collect(),
+        reply: rollback_reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(rollback_response.await.unwrap(), Ok(()));
+    for receiver in &mut receivers {
+        let mut rollback_updates = 0;
+        while receiver.try_recv().is_ok() {
+            rollback_updates += 1;
+        }
+        assert!(
+            rollback_updates > 0,
+            "rollback must reconcile every member's prior wire view"
+        );
+    }
+    for &peer in &peers {
+        assert_eq!(query_update_group(&tx, peer).await, "group:0");
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (2, 2),
+            "rollback must expose the rebuilt prior group's counter instance for every member"
+        );
+    }
+
+    let post_rollback_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 2, 113, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        announced: vec![crate::test_support::make_route(
+            post_rollback_prefix,
+            Ipv4Addr::new(192, 0, 2, 10),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+    for peer in peers {
+        assert_eq!(
+            query_first_export_term_hits(&tx, peer).await,
+            (3, 3),
+            "post-rollback evaluations must keep every prior member's counters live"
+        );
+    }
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -967,11 +967,16 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
     tx.send(RibUpdate::TestQueryPolicyTransitionStats { reply: stats_reply })
         .await
         .unwrap();
-    let (plans, full_probes, materialized, max_slice_ns) = stats_response.await.unwrap();
+    let (plans, full_probes, materialized, max_slice_ns, actor_polls) =
+        stats_response.await.unwrap();
     assert_eq!(plans, 1);
     assert_eq!(full_probes, ROUTE_COUNT);
     assert_eq!(materialized, ROUTE_COUNT);
     assert!(max_slice_ns > 0);
+    assert!(
+        actor_polls >= ROUTE_COUNT,
+        "the test-only one-route budget must require multiple real actor polls"
+    );
     for peer in peers {
         assert_eq!(query_update_group(&tx, peer).await, "group:1");
     }
@@ -1001,6 +1006,253 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
     );
 
     drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the scheduler regression pins query visibility, no-emission, and mutation FIFO in one transaction"
+)]
+async fn clean_policy_transition_yields_to_queries_and_fences_mutations() {
+    const ROUTE_COUNT: usize = 32;
+    let (tx, rx) = mpsc::channel(128);
+    let (query_tx, query_rx) = mpsc::channel(128);
+    let manager = RibManager::new(rx, query_rx, None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_1001);
+    let next_policy = community_chain(0xFDE8_1002);
+    let later_policy = community_chain(0xFDE8_1003);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 25, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 25, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for (index, peer) in peers.iter().copied().enumerate() {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(
+            peer_up_with_cohort_encoder(
+                &tx,
+                spec,
+                Arc::new(CohortExactEncoder {
+                    owner: u64::try_from(index + 1).unwrap(),
+                    profile: 23,
+                    max_len: 4_096,
+                    generation: AtomicUsize::new(0),
+                    advance_generation: false,
+                    probes: Arc::clone(&probes),
+                    reuses: Arc::clone(&reuses),
+                }),
+            )
+            .await,
+        );
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 14);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: (0..ROUTE_COUNT)
+            .map(|index| {
+                crate::test_support::make_route(
+                    Ipv4Prefix::new(Ipv4Addr::new(198, 52, u8::try_from(index).unwrap(), 0), 24),
+                    source,
+                )
+            })
+            .collect(),
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), ROUTE_COUNT);
+    }
+
+    let replacements = peers
+        .iter()
+        .map(|&peer| crate::update::PeerExportPolicyReplacement {
+            peer,
+            export_policy: Some(next_policy.clone()),
+        })
+        .collect::<Vec<_>>();
+    let (reply, mut response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: replacements.clone(),
+        reply,
+    })
+    .await
+    .unwrap();
+
+    // Establish a scheduler-visible barrier: once a read-only priority query
+    // reports a completed actor poll, the next query is necessarily created
+    // after transition work has begun on this single-thread runtime.
+    loop {
+        let (reply, stats) = oneshot::channel();
+        query_tx
+            .send(RibUpdate::TestQueryPolicyTransitionStats { reply })
+            .await
+            .unwrap();
+        if stats.await.unwrap().4 > 0 {
+            break;
+        }
+    }
+    assert!(matches!(
+        response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+
+    tx.send(RibUpdate::PeerDown {
+        peer: peers[0],
+        session_id: 0,
+    })
+    .await
+    .unwrap();
+    let (second_reply, mut second_response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(later_policy.clone()),
+            })
+            .collect(),
+        reply: second_reply,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(query_update_group(&query_tx, peers[0]).await, "group:0");
+    let (count_reply, count_response) = oneshot::channel();
+    query_tx
+        .send(RibUpdate::QueryLocRibCount { reply: count_reply })
+        .await
+        .unwrap();
+    assert_eq!(count_response.await.unwrap(), ROUTE_COUNT);
+    assert!(
+        receivers
+            .iter_mut()
+            .all(|receiver| receiver.try_recv().is_err())
+    );
+    assert!(matches!(
+        second_response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+
+    assert_eq!(response.await.unwrap(), Ok(()));
+    assert!(
+        second_response.await.unwrap().is_err(),
+        "PeerDown queued first must unregister the peer before the second replacement"
+    );
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), ROUTE_COUNT);
+    }
+    assert_eq!(query_update_group(&query_tx, peers[0]).await, "");
+    assert_eq!(query_update_group(&query_tx, peers[1]).await, "group:1");
+
+    drop(tx);
+    drop(query_tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn clean_policy_transition_finishes_after_reply_and_channels_close() {
+    let (tx, rx) = mpsc::channel(32);
+    let (query_tx, query_rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, query_rx, None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_2001);
+    let next_policy = community_chain(0xFDE8_2002);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 26, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 26, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for (index, peer) in peers.iter().copied().enumerate() {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(
+            peer_up_with_cohort_encoder(
+                &tx,
+                spec,
+                Arc::new(CohortExactEncoder {
+                    owner: u64::try_from(index + 1).unwrap(),
+                    profile: 29,
+                    max_len: 4_096,
+                    generation: AtomicUsize::new(0),
+                    advance_generation: false,
+                    probes: Arc::clone(&probes),
+                    reuses: Arc::clone(&reuses),
+                }),
+            )
+            .await,
+        );
+    }
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 117, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 15)),
+        announced: vec![crate::test_support::make_route(
+            prefix,
+            Ipv4Addr::new(192, 0, 2, 15),
+        )],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+
+    let (reply, dropped_response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(next_policy.clone()),
+            })
+            .collect(),
+        reply,
+    })
+    .await
+    .unwrap();
+    drop(dropped_response);
+    let (dropped_query_reply, dropped_query_response) = oneshot::channel();
+    query_tx
+        .send(RibUpdate::QueryLocRibCount {
+            reply: dropped_query_reply,
+        })
+        .await
+        .unwrap();
+    drop(dropped_query_response);
+    drop(tx);
+    drop(query_tx);
+
+    for receiver in &mut receivers {
+        let update = receiver.recv().await.unwrap();
+        assert_eq!(update.announce.len(), 1);
+        assert!(update.announce[0].attributes.iter().any(|attribute| {
+            matches!(attribute, PathAttribute::Communities(values) if values.contains(&0xFDE8_2002))
+        }));
+    }
     handle.await.unwrap();
 }
 

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -750,6 +750,22 @@ impl Oracle {
         reply_rx.await.unwrap().iter().map(|row| row.evals).sum()
     }
 
+    /// Export-policy evaluations visible through one installed peer handle.
+    /// Grouped peers intentionally alias the same group counter instance, so
+    /// summing every per-peer row would multiply one real evaluation by the
+    /// number of members and cannot measure a zero-evaluation delta.
+    async fn export_policy_evals_for(&mut self, peer: Ipv4Addr) -> u64 {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(RibUpdate::QueryExportPolicyTermHits {
+                peer: Some(IpAddr::V4(peer)),
+                reply: reply_tx,
+            })
+            .await
+            .unwrap();
+        reply_rx.await.unwrap().iter().map(|row| row.evals).sum()
+    }
+
     /// Drain every receiver into the collected streams (no await — only
     /// messages already sent).
     fn drain_collected(&mut self) {
@@ -2543,7 +2559,10 @@ async fn rtc_membership_flip_at_scale_emits_delta_only_zero_evals() {
     o.quiesce().await;
     o.drain_collected();
     let msgs_before = o.collected.get(&IpAddr::V4(C)).map_or(0, Vec::len);
-    let evals_before = o.export_policy_evals().await;
+    // B and C share one group counter instance. Observe one representative
+    // member: summing both operator-visible aliases would double-count the
+    // same real group evaluation after each RTC reflection.
+    let evals_before = o.export_policy_evals_for(C).await;
     assert!(evals_before > 0, "the flood must have evaluated the chain");
 
     let per_rt = |n: u64| (0..N).filter(|k| u64::from(*k) % RT_POOL == n).count();
@@ -2567,7 +2586,7 @@ async fn rtc_membership_flip_at_scale_emits_delta_only_zero_evals() {
     // (one RTC staging eval) — identical on the per-peer path, and not
     // a VPN restage.
     assert_eq!(
-        o.export_policy_evals().await,
+        o.export_policy_evals_for(C).await,
         evals_before + 1,
         "membership widen must add only the SAFI-132 reflection eval, zero VPN evals"
     );
@@ -2584,7 +2603,7 @@ async fn rtc_membership_flip_at_scale_emits_delta_only_zero_evals() {
     // A SAFI-132 withdraw stages no eval (withdraw-if-present precedes
     // the policy check), so the narrow is exactly zero evals.
     assert_eq!(
-        o.export_policy_evals().await,
+        o.export_policy_evals_for(C).await,
         evals_before + 1,
         "membership narrow must run ZERO export-policy evaluations"
     );

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -235,6 +235,33 @@ pub(in crate::manager) struct CleanPolicyTransitionInventory {
     pub(in crate::manager) permit_by_source: HashMap<IpAddr, HashMap<Option<String>, u64>>,
 }
 
+/// Pre-emission inventory accumulated by the actor-owned clean transition.
+/// The builder is private to that transaction and never represents committed
+/// peer-visible state.
+#[derive(Default)]
+pub(in crate::manager) struct CleanPolicyTransitionInventoryBuilder {
+    announce: Vec<Route>,
+    next_hop_override: Vec<Option<NextHopAction>>,
+    permit_totals: HashMap<Option<String>, u64>,
+    permit_by_source: HashMap<IpAddr, HashMap<Option<String>, u64>>,
+}
+
+impl CleanPolicyTransitionInventoryBuilder {
+    pub(in crate::manager) fn finish(self) -> CleanPolicyTransitionInventory {
+        CleanPolicyTransitionInventory {
+            announce: self.announce.into(),
+            next_hop_override: self.next_hop_override.into(),
+            permit_totals: self.permit_totals,
+            permit_by_source: self.permit_by_source,
+        }
+    }
+}
+
+pub(in crate::manager) enum PolicyTransitionGroupStart {
+    Maintained,
+    Created(Vec<Prefix>),
+}
+
 /// Result of one shared staging pass over a group: the deltas (already
 /// committed to the group table), the accumulated export-policy
 /// verdicts for per-member counter replay, and the pre-built SHARED
@@ -995,14 +1022,14 @@ impl GroupRibOut {
 }
 
 impl RibManager {
-    /// Build the narrow immutable transition inventory. Any withdrawal,
-    /// source flip, denial residue, dirty state, or VPN participation rejects
-    /// the optimization before a member is moved or an envelope is emitted.
-    pub(in crate::manager) fn clean_policy_transition_inventory(
-        &mut self,
+    /// Snapshot route identities for the strict clean transition inventory.
+    /// Dirty state or private-family participation rejects the optimization
+    /// before a member is moved or an envelope is emitted.
+    pub(in crate::manager) fn begin_clean_policy_transition_inventory(
+        &self,
         source: usize,
         destination: usize,
-    ) -> Option<CleanPolicyTransitionInventory> {
+    ) -> Option<Vec<(Prefix, u32)>> {
         let clean = |group: &GroupRibOut| {
             group.dirty_members.is_empty()
                 && group.tombstones.is_empty()
@@ -1012,61 +1039,53 @@ impl RibManager {
                 && group.vpn_policy_denied.is_empty()
                 && group.otc_blocked.is_empty()
         };
-        let mut slice_started = std::time::Instant::now();
-        let keys = {
-            let old = self.group_ribs.get(&source)?;
-            let new = self.group_ribs.get(&destination)?;
-            if !clean(old) || !clean(new) || old.table.len() != new.table.len() {
-                return None;
-            }
+        let old = self.group_ribs.get(&source)?;
+        let new = self.group_ribs.get(&destination)?;
+        if !clean(old) || !clean(new) || old.table.len() != new.table.len() {
+            return None;
+        }
+        Some(
             new.table
                 .iter()
                 .map(|route| (route.prefix, route.path_id))
-                .collect::<Vec<_>>()
-        };
-        self.finish_policy_transition_slice(&mut slice_started);
+                .collect(),
+        )
+    }
 
-        let mut announce = Vec::new();
-        let mut next_hop_override = Vec::new();
-        let mut permit_totals: HashMap<Option<String>, u64> = HashMap::new();
-        let mut permit_by_source: HashMap<IpAddr, HashMap<Option<String>, u64>> = HashMap::new();
-        for chunk in keys.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
-            {
-                let old = self.group_ribs.get(&source)?;
-                let new = self.group_ribs.get(&destination)?;
-                for &(prefix, path_id) in chunk {
-                    let route = new.table.get(&prefix, path_id)?;
-                    let key = (prefix, path_id);
-                    let prior = old.table.get(&prefix, path_id)?;
-                    // A policy edit cannot safely reuse one member-source
-                    // exclusion if it changes the selected source identity.
-                    if prior.peer != route.peer {
-                        return None;
-                    }
-                    let next_hop = new.nh_override(key);
-                    if !routes_equal(prior, route) || old.nh_override(key) != next_hop {
-                        announce.push(route.clone());
-                        next_hop_override.push(next_hop);
-                    }
-
-                    let label = new.staged_labels.get(&key).cloned().unwrap_or(None);
-                    *permit_totals.entry(label.clone()).or_default() += 1;
-                    *permit_by_source
-                        .entry(route.peer)
-                        .or_default()
-                        .entry(label)
-                        .or_default() += 1;
-                }
+    /// Accumulate one bounded key chunk. A withdrawal, source flip, or table
+    /// drift rejects the complete optimized plan before emission.
+    pub(in crate::manager) fn extend_clean_policy_transition_inventory(
+        &self,
+        source: usize,
+        destination: usize,
+        keys: &[(Prefix, u32)],
+        inventory: &mut CleanPolicyTransitionInventoryBuilder,
+    ) -> Option<()> {
+        let old = self.group_ribs.get(&source)?;
+        let new = self.group_ribs.get(&destination)?;
+        for &(prefix, path_id) in keys {
+            let route = new.table.get(&prefix, path_id)?;
+            let key = (prefix, path_id);
+            let prior = old.table.get(&prefix, path_id)?;
+            if prior.peer != route.peer {
+                return None;
             }
-            self.finish_policy_transition_slice(&mut slice_started);
-        }
+            let next_hop = new.nh_override(key);
+            if !routes_equal(prior, route) || old.nh_override(key) != next_hop {
+                inventory.announce.push(route.clone());
+                inventory.next_hop_override.push(next_hop);
+            }
 
-        Some(CleanPolicyTransitionInventory {
-            announce: announce.into(),
-            next_hop_override: next_hop_override.into(),
-            permit_totals,
-            permit_by_source,
-        })
+            let label = new.staged_labels.get(&key).cloned().unwrap_or(None);
+            *inventory.permit_totals.entry(label.clone()).or_default() += 1;
+            *inventory
+                .permit_by_source
+                .entry(route.peer)
+                .or_default()
+                .entry(label)
+                .or_default() += 1;
+        }
+        Some(())
     }
 
     /// Apply the inventory's pre-aggregated permit counts to one member after
@@ -2382,17 +2401,17 @@ impl RibManager {
         .then_some((source, destination))
     }
 
-    /// Ensure a prospective destination group table exists without adding a
-    /// member. This lets the batch path compare immutable old/new inventories
-    /// before its first membership mutation or emission.
-    pub(in crate::manager) fn ensure_policy_transition_group(
+    /// Create an unowned prospective destination group and return its prefix
+    /// staging snapshot. An existing destination is already maintained and
+    /// therefore needs no staging (`None`).
+    pub(in crate::manager) fn begin_policy_transition_group(
         &mut self,
         gid: usize,
         peer: IpAddr,
         export_policy: Option<&PolicyChain>,
-    ) {
+    ) -> PolicyTransitionGroupStart {
         if self.group_ribs.contains_key(&gid) {
-            return;
+            return PolicyTransitionGroupStart::Maintained;
         }
         let group = GroupRibOut::new(
             export_policy.map(PolicyChain::share),
@@ -2410,19 +2429,36 @@ impl RibManager {
             self.loc_rib.len(),
         );
         self.group_ribs.insert(gid, group);
-        let prefixes = self
-            .loc_rib
-            .iter()
-            .map(|route| route.prefix)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let mut memo = super::distribution::ExportMemo::default();
-        let mut slice_started = std::time::Instant::now();
-        for chunk in prefixes.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
-            let chunk = chunk.iter().copied().collect::<HashSet<_>>();
-            let _ = self.stage_group_prefixes(gid, &chunk, &mut memo);
-            self.finish_policy_transition_slice(&mut slice_started);
+        PolicyTransitionGroupStart::Created(
+            self.loc_rib
+                .iter()
+                .map(|route| route.prefix)
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    /// Stage one bounded prefix chunk into an unowned destination group.
+    pub(in crate::manager) fn stage_policy_transition_group_chunk(
+        &mut self,
+        gid: usize,
+        prefixes: &[Prefix],
+        memo: &mut super::distribution::ExportMemo,
+    ) {
+        let prefixes = prefixes.iter().copied().collect::<HashSet<_>>();
+        let _ = self.stage_group_prefixes(gid, &prefixes, memo);
+    }
+
+    /// Remove a partially staged, still-unowned destination before the
+    /// authoritative fallback rebuilds it from the complete Loc-RIB.
+    pub(in crate::manager) fn discard_incomplete_policy_transition_group(&mut self, gid: usize) {
+        if self
+            .group_ribs
+            .get(&gid)
+            .is_some_and(|group| group.members.is_empty())
+        {
+            self.group_ribs.remove(&gid);
         }
     }
 

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -999,12 +999,10 @@ impl RibManager {
     /// source flip, denial residue, dirty state, or VPN participation rejects
     /// the optimization before a member is moved or an envelope is emitted.
     pub(in crate::manager) fn clean_policy_transition_inventory(
-        &self,
+        &mut self,
         source: usize,
         destination: usize,
     ) -> Option<CleanPolicyTransitionInventory> {
-        let old = self.group_ribs.get(&source)?;
-        let new = self.group_ribs.get(&destination)?;
         let clean = |group: &GroupRibOut| {
             group.dirty_members.is_empty()
                 && group.tombstones.is_empty()
@@ -1014,36 +1012,53 @@ impl RibManager {
                 && group.vpn_policy_denied.is_empty()
                 && group.otc_blocked.is_empty()
         };
-        if !clean(old) || !clean(new) || old.table.len() != new.table.len() {
-            return None;
-        }
+        let mut slice_started = std::time::Instant::now();
+        let keys = {
+            let old = self.group_ribs.get(&source)?;
+            let new = self.group_ribs.get(&destination)?;
+            if !clean(old) || !clean(new) || old.table.len() != new.table.len() {
+                return None;
+            }
+            new.table
+                .iter()
+                .map(|route| (route.prefix, route.path_id))
+                .collect::<Vec<_>>()
+        };
+        self.finish_policy_transition_slice(&mut slice_started);
 
         let mut announce = Vec::new();
         let mut next_hop_override = Vec::new();
         let mut permit_totals: HashMap<Option<String>, u64> = HashMap::new();
         let mut permit_by_source: HashMap<IpAddr, HashMap<Option<String>, u64>> = HashMap::new();
-        for route in new.table.iter() {
-            let key = (route.prefix, route.path_id);
-            let prior = old.table.get(&route.prefix, route.path_id)?;
-            // A policy edit cannot safely reuse one member-source exclusion
-            // if it changes the selected source identity. Keep that matrix on
-            // the authoritative regroup path.
-            if prior.peer != route.peer {
-                return None;
-            }
-            let next_hop = new.nh_override(key);
-            if !routes_equal(prior, route) || old.nh_override(key) != next_hop {
-                announce.push(route.clone());
-                next_hop_override.push(next_hop);
-            }
+        for chunk in keys.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
+            {
+                let old = self.group_ribs.get(&source)?;
+                let new = self.group_ribs.get(&destination)?;
+                for &(prefix, path_id) in chunk {
+                    let route = new.table.get(&prefix, path_id)?;
+                    let key = (prefix, path_id);
+                    let prior = old.table.get(&prefix, path_id)?;
+                    // A policy edit cannot safely reuse one member-source
+                    // exclusion if it changes the selected source identity.
+                    if prior.peer != route.peer {
+                        return None;
+                    }
+                    let next_hop = new.nh_override(key);
+                    if !routes_equal(prior, route) || old.nh_override(key) != next_hop {
+                        announce.push(route.clone());
+                        next_hop_override.push(next_hop);
+                    }
 
-            let label = new.staged_labels.get(&key).cloned().unwrap_or(None);
-            *permit_totals.entry(label.clone()).or_default() += 1;
-            *permit_by_source
-                .entry(route.peer)
-                .or_default()
-                .entry(label)
-                .or_default() += 1;
+                    let label = new.staged_labels.get(&key).cloned().unwrap_or(None);
+                    *permit_totals.entry(label.clone()).or_default() += 1;
+                    *permit_by_source
+                        .entry(route.peer)
+                        .or_default()
+                        .entry(label)
+                        .or_default() += 1;
+                }
+            }
+            self.finish_policy_transition_slice(&mut slice_started);
         }
 
         Some(CleanPolicyTransitionInventory {
@@ -2245,6 +2260,11 @@ impl RibManager {
     }
 
     fn leave_group(&mut self, gid: usize, peer: IpAddr) {
+        self.leave_group_without_gauge_refresh(gid, peer);
+        self.refresh_group_residue_gauge();
+    }
+
+    fn leave_group_without_gauge_refresh(&mut self, gid: usize, peer: IpAddr) {
         let Some(group) = self.group_ribs.get_mut(&gid) else {
             return;
         };
@@ -2258,7 +2278,6 @@ impl RibManager {
         if group.members.is_empty() {
             self.group_ribs.remove(&gid);
         }
-        self.refresh_group_residue_gauge();
     }
 
     /// Drop a departing peer's membership and group state (the
@@ -2391,9 +2410,20 @@ impl RibManager {
             self.loc_rib.len(),
         );
         self.group_ribs.insert(gid, group);
-        let prefixes: HashSet<Prefix> = self.loc_rib.iter().map(|route| route.prefix).collect();
+        let prefixes = self
+            .loc_rib
+            .iter()
+            .map(|route| route.prefix)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
         let mut memo = super::distribution::ExportMemo::default();
-        let _ = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+        let mut slice_started = std::time::Instant::now();
+        for chunk in prefixes.chunks(super::POLICY_TRANSITION_ROUTE_SLICE) {
+            let chunk = chunk.iter().copied().collect::<HashSet<_>>();
+            let _ = self.stage_group_prefixes(gid, &chunk, &mut memo);
+            self.finish_policy_transition_slice(&mut slice_started);
+        }
     }
 
     /// Commit a preflighted clean transition after every writer slot and exact
@@ -2408,7 +2438,7 @@ impl RibManager {
         export_policy: Option<PolicyChain>,
     ) {
         self.peer_export_policies.insert(peer, export_policy);
-        self.leave_group(source, peer);
+        self.leave_group_without_gauge_refresh(source, peer);
         self.update_groups
             .members
             .insert(peer, GroupMembership::Grouped(destination));
@@ -2418,6 +2448,12 @@ impl RibManager {
             group.recompute_vpn_member_counts(peer, filter.as_ref());
         }
         self.metrics.record_update_group_regroup();
+    }
+
+    /// Publish cohort-wide gauges once after the synchronous membership commit.
+    /// Refreshing them per member is both unobservable (queries cannot
+    /// interleave in the commit section) and quadratic for large cohorts.
+    pub(in crate::manager) fn finish_clean_policy_transition_commit(&mut self) {
         self.refresh_update_group_gauges();
         self.refresh_group_residue_gauge();
     }

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2269,6 +2269,25 @@ impl RibManager {
                 }
             }
         }
+        self.install_group_member(gid, peer);
+    }
+
+    /// Install one peer into an already-created group and make the peer's
+    /// operator-visible policy handle share the group's actual counter
+    /// instance. Every grouped membership path uses this seam: ordinary
+    /// recompute/fallback, rollback to a prior group, and the optimized clean
+    /// transition commit. Ungrouped peers never pass through it and retain
+    /// their independently installed chain.
+    fn install_group_member(&mut self, gid: usize, peer: IpAddr) {
+        let export_chain = self
+            .group_ribs
+            .get(&gid)
+            .expect("group must exist before installing a member")
+            .export_chain
+            .as_ref()
+            .map(PolicyChain::share);
+        self.peer_export_policies.insert(peer, export_chain);
+
         // The joining member's advertised-count seed (RTC groups only):
         // the O(table) walk rides the join replay's existing cost.
         let filter = self.member_rt_filter(peer);
@@ -2471,18 +2490,12 @@ impl RibManager {
         peer: IpAddr,
         source: usize,
         destination: usize,
-        export_policy: Option<PolicyChain>,
     ) {
-        self.peer_export_policies.insert(peer, export_policy);
         self.leave_group_without_gauge_refresh(source, peer);
         self.update_groups
             .members
             .insert(peer, GroupMembership::Grouped(destination));
-        let filter = self.member_rt_filter(peer);
-        if let Some(group) = self.group_ribs.get_mut(&destination) {
-            group.members.insert(peer);
-            group.recompute_vpn_member_counts(peer, filter.as_ref());
-        }
+        self.install_group_member(destination, peer);
         self.metrics.record_update_group_regroup();
     }
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1544,8 +1544,8 @@ pub enum RibUpdate {
     #[cfg(test)]
     TestQueryPolicyTransitionStats {
         /// Plan builds, full probes, route-shell materializations, max actor
-        /// slice in nanoseconds.
-        reply: oneshot::Sender<(usize, usize, usize, u128)>,
+        /// poll in nanoseconds, and actual state-machine poll count.
+        reply: oneshot::Sender<(usize, usize, usize, u128, usize)>,
     },
     /// Query: snapshot the live per-term guard-hit counters of the
     /// installed export chains (ADR-0096 Decision 3.3). Counters

--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -290,6 +290,20 @@ fn bench_policy_regroup_resync(c: &mut Criterion) {
             );
         }
     }
+    if std::env::var_os("RUSTBGPD_POLICY_TRANSITION_LARGE_RECEIPT").is_some() {
+        let routes = 4_096usize;
+        let peers = 700usize;
+        group.bench_function("shared_plan/4096/700", |bench| {
+            bench.iter_batched_ref(
+                || build_policy_regroup(routes, peers),
+                |(manager, _receivers, next)| {
+                    let fast = manager.bench_replace_export_policy_cohort(peers, next);
+                    std::hint::black_box((fast, manager.bench_policy_transition_receipt()))
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
     group.finish();
 }
 

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -1468,7 +1468,22 @@ impl PeerHandle {
         policy: Option<PolicyChain>,
         deadline: Duration,
     ) -> Result<(), PeerCommandError> {
-        let commands = self.commands.clone();
+        Self::update_export_policy_with(self.commands.clone(), policy, deadline).await
+    }
+
+    /// Owned-sender variant of [`Self::update_export_policy_timeout`]. This
+    /// lets an actor select the bounded session step against its own dedicated
+    /// read-only query lane without borrowing the managed peer entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is unreachable, replies with one, or
+    /// does not acknowledge inside `deadline`.
+    pub async fn update_export_policy_with(
+        commands: mpsc::Sender<PeerCommand>,
+        policy: Option<PolicyChain>,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
         match tokio::time::timeout(deadline, async move {
             let (reply_tx, reply_rx) = oneshot::channel();
             commands

--- a/docs/perf/policy-regroup-shared-plan-2026-07.md
+++ b/docs/perf/policy-regroup-shared-plan-2026-07.md
@@ -2,10 +2,10 @@
 
 ## Scope
 
-This receipt measures the strict clean update-group policy-transition path. It
-does not claim loaded reload acceptance: the 700-peer campaign remains rejected
-until the separate PeerManager readiness lane and the measured actor-slice
-residual are addressed.
+This receipt measures the strict clean update-group policy-transition path and
+its bounded-readiness follow-up. It does not claim loaded reload acceptance:
+the prior 700-peer campaign remains rejected until a fresh integrated run
+supersedes it.
 
 The optimized path is deliberately limited to clean grouped-to-grouped unicast
 members whose staging profile differs only by export-chain content. It builds
@@ -97,40 +97,40 @@ route-shell materializations scale with routes times compatible wire profiles,
 not routes times peers. At 65,536 routes and 64 compatible peers that is 65,536
 probes/materializations instead of the per-peer reference shape's 4,194,304.
 
-## Residual and next gate
+## Original scheduling residual
 
-The initial and rebased maximum synchronous RIB actor-slice samples were 83.2
-ms and 93.2 ms. This sample-level variance does not change the conclusion:
-both exceed the 50 ms engineering budget. The next tranche must slice only
-this explicit shared-plan builder/emitter and drain the existing priority-query
-lane between slices; it must not generalize chunking to every
-`distribute_changes` shape.
+The original and rebased PR-1 maximum synchronous RIB actor samples were 83.2
+ms and 93.2 ms. Both exceeded the 50 ms engineering budget. The follow-up below
+closes that specific scheduler-visible gap without generalizing chunking to
+other `distribute_changes` shapes.
 
 These results are microbenchmark evidence only. They do not accept or replace
-the loaded reload campaign, which remains blocked on that responsiveness work
-and the PeerManager readiness-query lane.
+the loaded reload campaign.
 
 ## Bounded responsiveness follow-up
 
-The follow-up source `106df0cd` is a true stack on the shared-plan head
-`2c5ad2bd`. It keeps the strict PR-1 eligibility and fallback rules, but bounds
-only the expensive shared-plan preflight: destination staging, immutable diff
-construction, and exact probing process at most 1,024 route identities before
-servicing up to eight requests from the existing RIB priority-query lane.
-Successful exact-probe reuse now checks only the cohort's largest encoded
-message for each compatible member. The snapshot contract still proves wire
+The follow-up measurement source is `29781f6d`, based on merged shared-plan
+main `d6d07a76`. It keeps the strict PR-1 eligibility and fallback rules. One
+actor-owned pending transition has exactly five phases: `Classify`,
+`StageDestination`, `BuildInventory`, `ProbeAndPrepare`, and `Finalize`. The
+RIB advances one production step, services only the explicitly enumerated
+read-only priority lane, then calls `tokio::task::yield_now`. It does not poll
+normal mutations, route batches, resync, GR/LLGR, refresh, selection, or other
+timers while the transaction is pending. Route-scaled steps process at most
+1,024 identities and classification processes at most eight members per poll.
+
+Successful exact-probe reuse checks only the cohort's largest encoded message
+for each compatible member. The snapshot contract still proves wire
 equivalence, and admitting the maximum proves every shorter message fits;
 incompatible wire profiles still perform their own chunked full probe.
 
-The final membership move and reserved-permit sends remain one synchronous,
-infallible section. Priority queries cannot observe half-applied membership.
-Every writer permit and exact snapshot is acquired before that section, then
-owner, generation, and active-session identity are revalidated. A preflight
-failure discards the local inventory and takes the authoritative whole-cohort
-fallback before emission. Dropping the caller does not cancel an applied
-prefix of the transaction: PeerManager continues to a complete RIB commit or
-the existing newest-first rollback before returning to its normal mutation
-lane.
+The final poll revalidates every active session, registration channel, encoder
+owner/generation, source/destination classification, and reserved writer permit
+before changing membership. Membership, counter replay, and all
+reserved-permit sends then remain one synchronous section, so a priority query
+observes either the old cohort or the complete new cohort. An incomplete
+unowned destination is discarded before authoritative fallback. Dropping the
+caller or closing the input channels does not cancel the owned transition.
 
 PeerManager also has a dedicated, type-narrow `ListPeers` readiness channel.
 The production `/readyz` path uses that channel plus the RIB priority-query
@@ -162,14 +162,31 @@ cargo test -p rustbgpd-rib \
   clean_policy_transition_builds_and_probes_once_per_wire_cohort -- --nocapture
 ```
 
-### Actor-slice receipt
+A current-thread scheduler regression creates a priority query only after the
+first transition poll has completed. It proves that the query sees old
+committed membership, no optimized envelope has been emitted, and queued
+`PeerDown` plus a second replacement remain FIFO behind finalization:
+
+```console
+cargo test -p rustbgpd-rib \
+  clean_policy_transition_yields_to_queries_and_fences_mutations -- --nocapture
+```
+
+Paused-time coverage also holds a session policy command for 250 ms, then
+proves a live peer snapshot completes inside the unchanged 200 ms core
+deadline with the independently stalled session marked stale. A separate
+failure test interleaves readiness before a rejected RIB commit and preserves
+newest-first rollback and prior policy state.
+
+### Actor-poll receipts
 
 - Toolchain: `rustc 1.97.0 (2d8144b78 2026-07-07)`.
 - CPU: AMD Ryzen Threadripper 7970X 32-Cores.
 - Profile: Criterion release benchmark, 1 second warm-up, 3 second target
   measurement, 10 samples, no plot.
-- Workload: the same 65,536-route, 64-peer, real-encoder shared policy-regroup
-  case described above.
+- Workloads: the same 65,536-route/64-peer real-encoder transition, plus a
+  4,096-route/700-peer run that isolates the largest required atomic member
+  finalization.
 
 ```console
 RUSTBGPD_POLICY_TRANSITION_RECEIPT=1 \
@@ -178,19 +195,47 @@ cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- \
   --warm-up-time 1 --measurement-time 3 --sample-size 10 --noplot
 ```
 
-The recorded result was 79.289 ms (77.908-80.799 ms) total transition time,
-with this counter receipt:
+The 65,536-route/64-peer result was 81.399 ms (80.573-82.337 ms) total
+transition time, with this production state-machine receipt:
 
 ```text
 fast=true
 plans=1
 full_exact_probes=65536
 route_shell_materializations=65536
-max_actor_slice_ns=1675871
+actor_polls=267
+max_actor_poll_ns=4522858
+max_prefix_snapshot_poll_ns=4522858
+max_finalize_poll_ns=2365980
 ```
 
-The 1.676 ms maximum recorded slice is below the 50 ms engineering budget and
-replaces the PR-1 samples of 83.2-93.2 ms. Total time remains microbenchmark
-evidence, not a loaded-reload acceptance claim. The exclusive 700-peer campaign
-must run from a fresh integrated SHA before the rejected campaign can be
-superseded.
+The 700-member finalization gate ran with:
+
+```console
+RUSTBGPD_POLICY_TRANSITION_RECEIPT=1 \
+RUSTBGPD_POLICY_TRANSITION_LARGE_RECEIPT=1 \
+cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- \
+  'policy_regroup_resync/shared_plan/4096/700' \
+  --warm-up-time 1 --measurement-time 3 --sample-size 10 --noplot
+```
+
+It completed in 8.152 ms (7.835-8.380 ms) total:
+
+```text
+fast=true
+plans=1
+full_exact_probes=4096
+route_shell_materializations=4096
+actor_polls=803
+max_actor_poll_ns=3223607
+max_prefix_snapshot_poll_ns=363616
+max_finalize_poll_ns=3223607
+```
+
+The largest recorded production poll was 4.523 ms and the 700-member atomic
+finalization was 3.224 ms, both below the 50 ms engineering budget. The old
+1.676 ms pseudo-slice result is intentionally withdrawn: it measured internal
+`try_recv` checkpoints without proving a Tokio scheduling opportunity. Total
+times and individual poll samples remain microbenchmark evidence, not a loaded
+reload acceptance claim. The exclusive 700-peer campaign must run from a fresh
+integrated SHA before the rejected campaign can be superseded.

--- a/docs/perf/policy-regroup-shared-plan-2026-07.md
+++ b/docs/perf/policy-regroup-shared-plan-2026-07.md
@@ -109,15 +109,22 @@ the loaded reload campaign.
 
 ## Bounded responsiveness follow-up
 
-The follow-up measurement source is `29781f6d`, based on merged shared-plan
+The follow-up measurement source is `114072d7`, based on merged shared-plan
 main `d6d07a76`. It keeps the strict PR-1 eligibility and fallback rules. One
 actor-owned pending transition has exactly five phases: `Classify`,
 `StageDestination`, `BuildInventory`, `ProbeAndPrepare`, and `Finalize`. The
 RIB advances one production step, services only the explicitly enumerated
 read-only priority lane, then calls `tokio::task::yield_now`. It does not poll
 normal mutations, route batches, resync, GR/LLGR, refresh, selection, or other
-timers while the transaction is pending. Route-scaled steps process at most
-1,024 identities and classification processes at most eight members per poll.
+timers while the transaction is pending. Classification processes at most
+eight members per poll. Two deliberately explicit O(table) snapshot polls
+precede the chunked bodies: `StageDestination` first snapshots all Loc-RIB
+prefix identities, and `BuildInventory` later snapshots all destination-table
+route keys. Both are measured production actor polls; the
+`max_prefix_snapshot_poll_ns` receipt reports the slower sample. The 1,024
+identity cap applies only to the staging, inventory-build, and exact-probe
+chunk bodies after their snapshot exists. These samples do not establish or
+extrapolate a hard bound for either full-table snapshot poll.
 
 Successful exact-probe reuse checks only the cohort's largest encoded message
 for each compatible member. The snapshot contract still proves wire
@@ -136,8 +143,12 @@ PeerManager also has a dedicated, type-narrow `ListPeers` readiness channel.
 The production `/readyz` path uses that channel plus the RIB priority-query
 channel while retaining the same absolute 200 ms deadline. Session-policy and
 RIB-reply waits select the transaction result first, then service one live
-readiness snapshot at a time. Ordinary add/delete/reconfigure/config/policy
-commands remain on the normal receiver and cannot bypass a transaction.
+readiness snapshot at a time. Once a cohort command is successfully enqueued,
+PeerManager owns its reply to terminal success, explicit failure, or sender
+closure; it does not start rollback on the ordinary five-second per-peer RIB
+timeout while the forward commit can still complete. Ordinary per-peer
+timeouts are unchanged. Add/delete/reconfigure/config/policy commands remain
+on the normal receiver and cannot bypass a transaction.
 
 ### Deterministic readiness gate
 
@@ -146,7 +157,9 @@ in-flight RIB commit, queues an ordinary runtime mutation, and issues eight
 live `ListPeers` snapshots through the dedicated channel. All eight complete
 inside the unchanged 200 ms timeout (zero timeouts), each returns all 16 live
 peers, the mutation remains unanswered, and the transaction reply remains
-unanswered until the held RIB commit is released:
+unanswered until the held RIB commit is released. The same test advances past
+the former five-second cohort timeout and proves that no rollback begins or
+races the still-owned forward commit while readiness remains live:
 
 ```console
 cargo test -p rustbgpd --bin rustbgpd \
@@ -195,7 +208,7 @@ cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- \
   --warm-up-time 1 --measurement-time 3 --sample-size 10 --noplot
 ```
 
-The 65,536-route/64-peer result was 81.399 ms (80.573-82.337 ms) total
+The 65,536-route/64-peer result was 82.791 ms (81.704-83.994 ms) total
 transition time, with this production state-machine receipt:
 
 ```text
@@ -204,9 +217,9 @@ plans=1
 full_exact_probes=65536
 route_shell_materializations=65536
 actor_polls=267
-max_actor_poll_ns=4522858
-max_prefix_snapshot_poll_ns=4522858
-max_finalize_poll_ns=2365980
+max_actor_poll_ns=4927435
+max_prefix_snapshot_poll_ns=4927435
+max_finalize_poll_ns=2075407
 ```
 
 The 700-member finalization gate ran with:
@@ -219,7 +232,7 @@ cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- \
   --warm-up-time 1 --measurement-time 3 --sample-size 10 --noplot
 ```
 
-It completed in 8.152 ms (7.835-8.380 ms) total:
+It completed in 7.970 ms (7.832-8.120 ms) total:
 
 ```text
 fast=true
@@ -227,15 +240,16 @@ plans=1
 full_exact_probes=4096
 route_shell_materializations=4096
 actor_polls=803
-max_actor_poll_ns=3223607
-max_prefix_snapshot_poll_ns=363616
-max_finalize_poll_ns=3223607
+max_actor_poll_ns=2001396
+max_prefix_snapshot_poll_ns=376183
+max_finalize_poll_ns=2001396
 ```
 
-The largest recorded production poll was 4.523 ms and the 700-member atomic
-finalization was 3.224 ms, both below the 50 ms engineering budget. The old
+The largest recorded production poll was 4.927 ms and the 700-member atomic
+finalization was 2.001 ms, both below the 50 ms engineering budget. The old
 1.676 ms pseudo-slice result is intentionally withdrawn: it measured internal
 `try_recv` checkpoints without proving a Tokio scheduling opportunity. Total
-times and individual poll samples remain microbenchmark evidence, not a loaded
-reload acceptance claim. The exclusive 700-peer campaign must run from a fresh
-integrated SHA before the rejected campaign can be superseded.
+times and individual poll samples—including the two O(table) prefix/inventory
+snapshot polls—remain microbenchmark evidence, not an extrapolated bound or a
+loaded-reload acceptance claim. The exclusive 700-peer campaign must run from
+a fresh integrated SHA before the rejected campaign can be superseded.

--- a/docs/perf/policy-regroup-shared-plan-2026-07.md
+++ b/docs/perf/policy-regroup-shared-plan-2026-07.md
@@ -109,3 +109,88 @@ lane between slices; it must not generalize chunking to every
 These results are microbenchmark evidence only. They do not accept or replace
 the loaded reload campaign, which remains blocked on that responsiveness work
 and the PeerManager readiness-query lane.
+
+## Bounded responsiveness follow-up
+
+The follow-up source `106df0cd` is a true stack on the shared-plan head
+`2c5ad2bd`. It keeps the strict PR-1 eligibility and fallback rules, but bounds
+only the expensive shared-plan preflight: destination staging, immutable diff
+construction, and exact probing process at most 1,024 route identities before
+servicing up to eight requests from the existing RIB priority-query lane.
+Successful exact-probe reuse now checks only the cohort's largest encoded
+message for each compatible member. The snapshot contract still proves wire
+equivalence, and admitting the maximum proves every shorter message fits;
+incompatible wire profiles still perform their own chunked full probe.
+
+The final membership move and reserved-permit sends remain one synchronous,
+infallible section. Priority queries cannot observe half-applied membership.
+Every writer permit and exact snapshot is acquired before that section, then
+owner, generation, and active-session identity are revalidated. A preflight
+failure discards the local inventory and takes the authoritative whole-cohort
+fallback before emission. Dropping the caller does not cancel an applied
+prefix of the transaction: PeerManager continues to a complete RIB commit or
+the existing newest-first rollback before returning to its normal mutation
+lane.
+
+PeerManager also has a dedicated, type-narrow `ListPeers` readiness channel.
+The production `/readyz` path uses that channel plus the RIB priority-query
+channel while retaining the same absolute 200 ms deadline. Session-policy and
+RIB-reply waits select the transaction result first, then service one live
+readiness snapshot at a time. Ordinary add/delete/reconfigure/config/policy
+commands remain on the normal receiver and cannot bypass a transaction.
+
+### Deterministic readiness gate
+
+The paused-clock regression holds a uniform 16-peer export-only cohort at its
+in-flight RIB commit, queues an ordinary runtime mutation, and issues eight
+live `ListPeers` snapshots through the dedicated channel. All eight complete
+inside the unchanged 200 ms timeout (zero timeouts), each returns all 16 live
+peers, the mutation remains unanswered, and the transaction reply remains
+unanswered until the held RIB commit is released:
+
+```console
+cargo test -p rustbgpd --bin rustbgpd \
+  export_only_snapshot_services_readiness_without_admitting_mutations -- --nocapture
+```
+
+The exact-cohort regression additionally varies synthetic encoded lengths and
+asserts that every compatible target rechecks one value (the cohort maximum),
+not one value per route:
+
+```console
+cargo test -p rustbgpd-rib \
+  clean_policy_transition_builds_and_probes_once_per_wire_cohort -- --nocapture
+```
+
+### Actor-slice receipt
+
+- Toolchain: `rustc 1.97.0 (2d8144b78 2026-07-07)`.
+- CPU: AMD Ryzen Threadripper 7970X 32-Cores.
+- Profile: Criterion release benchmark, 1 second warm-up, 3 second target
+  measurement, 10 samples, no plot.
+- Workload: the same 65,536-route, 64-peer, real-encoder shared policy-regroup
+  case described above.
+
+```console
+RUSTBGPD_POLICY_TRANSITION_RECEIPT=1 \
+cargo bench -p rustbgpd-transport --features bench-internals --bench fanout -- \
+  'policy_regroup_resync/shared_plan/65536/64' \
+  --warm-up-time 1 --measurement-time 3 --sample-size 10 --noplot
+```
+
+The recorded result was 79.289 ms (77.908-80.799 ms) total transition time,
+with this counter receipt:
+
+```text
+fast=true
+plans=1
+full_exact_probes=65536
+route_shell_materializations=65536
+max_actor_slice_ns=1675871
+```
+
+The 1.676 ms maximum recorded slice is below the 50 ms engineering budget and
+replaces the PR-1 samples of 83.2-93.2 ms. Total time remains microbenchmark
+evidence, not a loaded-reload acceptance claim. The exclusive 700-peer campaign
+must run from a fresh integrated SHA before the rejected campaign can be
+superseded.

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ use crate::reload::{
 use rustbgpd_api::health_probe::DaemonGate;
 use rustbgpd_api::peer_types::{
     ImportValidationDependency, PeerManagerCommand, PeerManagerNeighborConfig,
-    WarmCheckpointCapture, WarmCheckpointSession,
+    PeerManagerReadinessQuery, WarmCheckpointCapture, WarmCheckpointSession,
 };
 use rustbgpd_api::server::{
     AccessMode as GrpcServerAccessMode, ConfigMutationGateFn, ListenerConfig as GrpcListenerConfig,
@@ -2415,6 +2415,8 @@ async fn run<T>(
         tokio::sync::watch::channel(rustbgpd_rpki::ValidationSnapshot::default());
 
     let (peer_mgr_tx, peer_mgr_rx) = mpsc::channel::<PeerManagerCommand>(64);
+    let (peer_mgr_readiness_tx, peer_mgr_readiness_rx) =
+        mpsc::channel::<PeerManagerReadinessQuery>(64);
     let (peer_mgr_internal_tx, peer_mgr_internal_rx) = mpsc::unbounded_channel();
 
     // Spawn RPKI subsystem (VRP manager + per-cache RTR clients)
@@ -2545,6 +2547,7 @@ async fn run<T>(
         Some(validation_watch_rx),
         config.clone(),
     )
+    .with_readiness_queries(peer_mgr_readiness_rx)
     .with_event_history(event_history_handle.clone())
     .with_transport_event_sink(event_history_handle.clone().map(|handle| {
         rustbgpd_api::event_history_sinks::make_transport_event_sink(handle, metrics.clone())
@@ -3341,6 +3344,7 @@ async fn run<T>(
         listen_port: u32::from(config.global.listen_port),
         metrics: metrics.clone(),
         start_time,
+        peer_mgr_readiness_tx: peer_mgr_readiness_tx.clone(),
         mrt_trigger_tx,
         evpn_originated_local_mac_count: {
             let counts = evpn_originated_local_mac_counts.clone();
@@ -3693,8 +3697,9 @@ async fn run<T>(
         let metrics_clone = metrics.clone();
         let readiness_probe = rustbgpd_api::health_probe::CoreReadinessProbe::new(
             peer_mgr_tx.clone(),
-            rib_tx.clone(),
+            rib_query_tx.clone(),
         )
+        .with_peer_manager_readiness(peer_mgr_readiness_tx.clone())
         .with_gate(daemon_gate.clone());
         tokio::spawn(async move {
             metrics_server::serve_metrics(prometheus_addr, metrics_clone, readiness_probe).await;

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use rustbgpd_api::peer_types::{
     ConfigEvent, DynamicNeighborInfo, POLICY_EVENT_HISTORY_CAPACITY, PeerKey, PeerManagerCommand,
-    PeerManagerNeighborConfig, PolicyDatasetStatusRow, PolicyEvent, SESSION_EVENT_HISTORY_CAPACITY,
-    SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
+    PeerManagerNeighborConfig, PeerManagerReadinessQuery, PolicyDatasetStatusRow, PolicyEvent,
+    SESSION_EVENT_HISTORY_CAPACITY, SessionEvent, SessionLifecycleEvent, StageConfigSnapshotError,
 };
 use rustbgpd_bmp::BmpEvent;
 use rustbgpd_fsm::PeerConfig;
@@ -79,6 +80,11 @@ const PEER_LIFECYCLE_COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 /// fixed cross-peer cap prevents the daemon's shutdown time from growing as
 /// `peer_count * PEER_LIFECYCLE_COMMAND_TIMEOUT` under transport back-pressure.
 const PEER_SHUTDOWN_CONCURRENCY: usize = 64;
+
+/// Readiness requests serviced after each bounded policy-transaction step.
+/// A small fixed budget prevents probe traffic from starving forward policy
+/// progress while still keeping the unchanged 200 ms end-to-end deadline.
+const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 8;
 
 /// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
 /// actor (export-policy swap, per-peer outbound refresh). Generous — the
@@ -227,6 +233,10 @@ pub struct PeerManager {
     /// link-local peers can share the same address on different interfaces.
     session_index: HashMap<u64, PeerKey>,
     rx: mpsc::Receiver<PeerManagerCommand>,
+    /// Dedicated read-only lane drained only at safe actor seams. Mutation
+    /// commands remain on `rx` and therefore stay ordered behind a policy
+    /// transaction until it either commits or rolls back.
+    readiness_rx: Option<mpsc::Receiver<PeerManagerReadinessQuery>>,
     internal_rx: mpsc::UnboundedReceiver<InternalCommand>,
     local_asn: u32,
     router_id: Ipv4Addr,
@@ -403,6 +413,80 @@ impl PeerManager {
         )
     }
 
+    /// Install the dedicated read-only readiness-query receiver.
+    #[must_use]
+    pub fn with_readiness_queries(
+        mut self,
+        readiness_rx: mpsc::Receiver<PeerManagerReadinessQuery>,
+    ) -> Self {
+        self.readiness_rx = Some(readiness_rx);
+        self
+    }
+
+    /// Service a bounded number of live readiness snapshots at a transaction
+    /// seam. `try_recv` is deliberate: when no probe is waiting this does not
+    /// introduce an async suspension point or let ordinary commands bypass the
+    /// transaction.
+    async fn drain_readiness_queries(&mut self) {
+        for _ in 0..READINESS_QUERY_BUDGET_PER_POLICY_STEP {
+            let query = match self.readiness_rx.as_mut() {
+                Some(rx) => match rx.try_recv() {
+                    Ok(query) => query,
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        self.readiness_rx = None;
+                        break;
+                    }
+                },
+                None => break,
+            };
+            self.handle_readiness_query(query).await;
+        }
+    }
+
+    async fn handle_readiness_query(&self, query: PeerManagerReadinessQuery) {
+        match query {
+            PeerManagerReadinessQuery::ListPeers { reply } => {
+                let infos = self.list_peers().await;
+                let _ = reply.send(infos);
+            }
+        }
+    }
+
+    /// Drive one owned transaction step while servicing at most one read-only
+    /// readiness query at a time. The transaction future is biased first, so a
+    /// probe flood cannot delay a completed apply/rollback step.
+    async fn await_with_readiness<F>(&mut self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        tokio::pin!(future);
+        loop {
+            let Some(readiness_rx) = self.readiness_rx.as_mut() else {
+                return future.await;
+            };
+            tokio::select! {
+                biased;
+                result = &mut future => return result,
+                query = readiness_rx.recv() => {
+                    match query {
+                        Some(query) => self.handle_readiness_query(query).await,
+                        None => self.readiness_rx = None,
+                    }
+                }
+            }
+        }
+    }
+
+    async fn receive_readiness_query(
+        readiness_rx: &mut Option<mpsc::Receiver<PeerManagerReadinessQuery>>,
+    ) -> Option<PeerManagerReadinessQuery> {
+        match readiness_rx {
+            Some(rx) => rx.recv().await,
+            None => std::future::pending().await,
+        }
+    }
+
     #[expect(clippy::too_many_arguments)]
     pub fn new_with_config(
         rx: mpsc::Receiver<PeerManagerCommand>,
@@ -426,6 +510,7 @@ impl PeerManager {
             peers: HashMap::new(),
             session_index: HashMap::new(),
             rx,
+            readiness_rx: None,
             internal_rx,
             local_asn,
             router_id,
@@ -643,6 +728,12 @@ impl PeerManager {
 
         loop {
             tokio::select! {
+                query = Self::receive_readiness_query(&mut self.readiness_rx) => {
+                    match query {
+                        Some(query) => self.handle_readiness_query(query).await,
+                        None => self.readiness_rx = None,
+                    }
+                }
                 cmd = self.rx.recv() => {
                     let Some(cmd) = cmd else {
                         debug!("peer manager channel closed");

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -84,7 +84,7 @@ const PEER_SHUTDOWN_CONCURRENCY: usize = 64;
 /// Readiness requests serviced after each bounded policy-transaction step.
 /// A small fixed budget prevents probe traffic from starving forward policy
 /// progress while still keeping the unchanged 200 ms end-to-end deadline.
-const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 8;
+const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 1;
 
 /// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
 /// actor (export-policy swap, per-peer outbound refresh). Generous — the

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -447,6 +447,9 @@ impl PeerManager {
     async fn handle_readiness_query(&self, query: PeerManagerReadinessQuery) {
         match query {
             PeerManagerReadinessQuery::ListPeers { reply } => {
+                if reply.is_closed() {
+                    return;
+                }
                 let infos = self.list_peers().await;
                 let _ = reply.send(infos);
             }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -439,16 +439,9 @@ impl PeerManager {
         &mut self,
         reply_rx: oneshot::Receiver<Result<(), String>>,
     ) -> Result<(), String> {
-        match self
-            .await_with_readiness(tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx))
-            .await
-        {
-            Err(_) => Err(format!(
-                "RIB manager did not reply within {:?} while updating export policy cohort",
-                super::RIB_REPLY_TIMEOUT
-            )),
-            Ok(Err(_)) => Err("RIB manager dropped cohort reply".to_string()),
-            Ok(Ok(result)) => result,
+        match self.await_with_readiness(reply_rx).await {
+            Err(_) => Err("RIB manager dropped cohort reply".to_string()),
+            Ok(result) => result,
         }
     }
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -287,18 +287,23 @@ impl PeerManager {
         // Establishment is part of the fast-path preflight. The ordinary path
         // remains authoritative for reconnecting or query-stalled sessions.
         for peer_key in &peer_keys {
-            let managed = self
+            let commands = self
                 .peers
                 .get(peer_key)
-                .expect("cohort peer existed during local preflight");
-            let established = managed
+                .expect("cohort peer existed during local preflight")
                 .handle
-                .query_state_timeout(PEER_QUERY_TIMEOUT)
+                .commands_sender();
+            let established = self
+                .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_with(
+                    commands,
+                    PEER_QUERY_TIMEOUT,
+                ))
                 .await
                 .is_some_and(|state| state.fsm_state == SessionState::Established);
             if !established {
                 return None;
             }
+            self.drain_readiness_queries().await;
         }
 
         let mut captured = Vec::with_capacity(targets.len());
@@ -320,29 +325,37 @@ impl PeerManager {
                     forward_completed: false,
                 }
             };
-            let apply_result = self
+            let commands = self
                 .peers
                 .get(peer_key)
                 .expect("cohort peer existed before export hot-apply")
                 .handle
-                .update_export_policy_timeout(
+                .commands_sender();
+            let apply_result = self
+                .await_with_readiness(rustbgpd_transport::PeerHandle::update_export_policy_with(
+                    commands,
                     target.export_policy.clone(),
                     PEER_POLICY_UPDATE_TIMEOUT,
-                )
+                ))
                 .await;
             if let Err(error) = apply_result {
                 // A failed session command is not proof that the session kept
                 // its prior chain (the reply may fail after a partial local
                 // apply). Reassert the failing peer's prior chain first, then
                 // unwind the already-acknowledged peers newest-first.
-                let failing_restore = self
+                let restore_commands = self
                     .peers
                     .get(peer_key)
                     .expect("cohort peer existed while restoring failed export hot-apply")
                     .handle
-                    .update_export_policy_timeout(
-                        prior.policy.export_policy.clone(),
-                        PEER_POLICY_UPDATE_TIMEOUT,
+                    .commands_sender();
+                let failing_restore = self
+                    .await_with_readiness(
+                        rustbgpd_transport::PeerHandle::update_export_policy_with(
+                            restore_commands,
+                            prior.policy.export_policy.clone(),
+                            PEER_POLICY_UPDATE_TIMEOUT,
+                        ),
                     )
                     .await
                     .map_err(|restore_error| {
@@ -373,6 +386,7 @@ impl PeerManager {
                 .export_policy
                 .clone_from(&target.export_policy);
             captured.push(prior);
+            self.drain_readiness_queries().await;
         }
 
         let replacements = targets
@@ -392,14 +406,7 @@ impl PeerManager {
             .await;
         let rib_result = match send_result {
             Err(_) => Err("RIB manager unavailable".to_string()),
-            Ok(()) => match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
-                Err(_) => Err(format!(
-                    "RIB manager did not reply within {:?} while updating export policy cohort",
-                    super::RIB_REPLY_TIMEOUT
-                )),
-                Ok(Err(_)) => Err("RIB manager dropped cohort reply".to_string()),
-                Ok(Ok(result)) => result,
-            },
+            Ok(()) => self.await_export_policy_cohort_rib_reply(reply_rx).await,
         };
         if let Err(error) = rib_result {
             let rollback = self.restore_resolved_policies(captured).await;
@@ -420,6 +427,29 @@ impl PeerManager {
             .into_iter()
             .map(|captured| captured.policy)
             .collect()))
+    }
+
+    /// Await the cohort RIB reply while admitting only the dedicated
+    /// read-only readiness lane. The ordinary command receiver stays owned by
+    /// the run loop and is not polled, so mutations remain strictly behind the
+    /// transaction. Dropping the transaction caller does not cancel a
+    /// partially applied policy: this actor still drives commit or rollback to
+    /// completion before returning to the normal lane.
+    async fn await_export_policy_cohort_rib_reply(
+        &mut self,
+        reply_rx: oneshot::Receiver<Result<(), String>>,
+    ) -> Result<(), String> {
+        match self
+            .await_with_readiness(tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx))
+            .await
+        {
+            Err(_) => Err(format!(
+                "RIB manager did not reply within {:?} while updating export policy cohort",
+                super::RIB_REPLY_TIMEOUT
+            )),
+            Ok(Err(_)) => Err("RIB manager dropped cohort reply".to_string()),
+            Ok(Ok(result)) => result,
+        }
     }
 
     /// Apply a live-impact transaction that may include static neighbors and

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -6976,6 +6976,111 @@ async fn export_only_snapshot_uses_one_batched_rib_commit_and_preserves_priors()
     rib_task.await.unwrap();
 }
 
+#[tokio::test(start_paused = true)]
+async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
+    use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
+
+    let peers = (1..=16)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 33, 0, last)))
+        .collect::<Vec<_>>();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (command_tx, command_rx) = mpsc::channel(16);
+    let (readiness_tx, readiness_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    for peer in peers.iter().copied() {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&attempts), None),
+            false,
+        );
+    }
+    let manager_task = tokio::spawn(manager.run());
+
+    let (apply_reply, mut apply_response) = oneshot::channel();
+    command_tx
+        .send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+            targets: peers
+                .iter()
+                .copied()
+                .map(|address| ResolvedPeerPolicy {
+                    address,
+                    interface: None,
+                    import_policy: None,
+                    export_policy: Some(deny_policy_chain()),
+                })
+                .collect(),
+            reply: apply_reply,
+        })
+        .await
+        .unwrap();
+    let RibUpdate::ReplacePeerExportPolicies {
+        reply: rib_reply, ..
+    } = rib_rx.recv().await.unwrap()
+    else {
+        panic!("expected cohort RIB command");
+    };
+
+    let (mutation_reply, mut mutation_response) = oneshot::channel();
+    command_tx
+        .send(PeerManagerCommand::SyncExplainConfig {
+            enabled: false,
+            cache_size: 17,
+            reply: mutation_reply,
+        })
+        .await
+        .unwrap();
+
+    for _ in 0..8 {
+        let (readiness_reply, readiness_response) = oneshot::channel();
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers {
+                reply: readiness_reply,
+            })
+            .await
+            .unwrap();
+        let infos = tokio::time::timeout(
+            rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
+            readiness_response,
+        )
+        .await
+        .expect("live readiness must stay inside the unchanged 200ms deadline")
+        .unwrap();
+        assert_eq!(infos.len(), peers.len());
+    }
+    assert!(
+        matches!(
+            mutation_response.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ),
+        "ordinary mutation lane must stay blocked behind the policy transaction"
+    );
+    assert!(
+        matches!(
+            apply_response.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ),
+        "readiness must not fabricate cohort completion"
+    );
+
+    rib_reply.send(Ok(())).unwrap();
+    apply_response.await.unwrap().unwrap();
+    mutation_response.await.unwrap();
+    command_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    manager_task.await.unwrap();
+}
+
 #[tokio::test]
 async fn export_only_snapshot_restores_newest_first_after_session_failure() {
     use rustbgpd_api::peer_types::ResolvedPeerPolicy;

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -7159,6 +7159,48 @@ async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
         "readiness must not fabricate cohort completion"
     );
 
+    // The successfully enqueued RIB transaction owns its reply. Advancing
+    // beyond the ordinary per-peer five-second deadline must not start a
+    // competing rollback while the forward RIB commit can still complete.
+    tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_secs(1)).await;
+    for _ in 0..3 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        peers.len(),
+        "no session rollback may race an owned forward RIB transaction"
+    );
+    assert!(
+        matches!(rib_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "the prior timeout would enqueue a per-peer rollback while the forward reply remained owned"
+    );
+    assert!(matches!(
+        mutation_response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        apply_response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+
+    let (late_readiness_reply, late_readiness_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::ListPeers {
+            reply: late_readiness_reply,
+        })
+        .await
+        .unwrap();
+    let late_infos = tokio::time::timeout(
+        rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
+        late_readiness_response,
+    )
+    .await
+    .expect("readiness must remain live beyond the former five-second cohort timeout")
+    .unwrap();
+    assert_eq!(late_infos.len(), peers.len());
+    assert_eq!(attempts.load(Ordering::SeqCst), peers.len());
+
     rib_reply.send(Ok(())).unwrap();
     apply_response.await.unwrap().unwrap();
     mutation_response.await.unwrap();
@@ -7386,7 +7428,7 @@ async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
                         let _ = batch_seen.send(());
                     }
                     task_release.notified().await;
-                    let _ = reply.send(Err("injected cohort commit failure".to_string()));
+                    drop(reply);
                 }
                 RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
                     restore_order.push(peer);
@@ -7446,8 +7488,9 @@ async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
     assert!(
         result
             .as_ref()
-            .is_err_and(|error| error.contains("already-applied peers restored")),
-        "RIB cohort failure must restore every session and RIB policy: {result:?}"
+            .is_err_and(|error| error.contains("RIB manager dropped cohort reply")
+                && error.contains("already-applied peers restored")),
+        "a dropped owned RIB reply must restore every session and RIB policy: {result:?}"
     );
     assert_eq!(attempts.load(Ordering::SeqCst), 4);
     for peer in [first, second] {

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1181,6 +1181,69 @@ fn established_export_policy_test_session(
     PeerHandle::from_parts(session_tx, task)
 }
 
+fn stalled_export_policy_test_session(
+    addr: IpAddr,
+) -> (PeerHandle, oneshot::Receiver<()>, Arc<tokio::sync::Notify>) {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let (entered_tx, entered_rx) = oneshot::channel();
+    let release = Arc::new(tokio::sync::Notify::new());
+    let task_release = Arc::clone(&release);
+    let task = tokio::spawn(async move {
+        let mut entered_tx = Some(entered_tx);
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    if let Some(entered) = entered_tx.take() {
+                        let _ = entered.send(());
+                    }
+                    task_release.notified().await;
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: SessionState::Established,
+                        peer_ip: addr,
+                        peer_asn: Some(65002),
+                        prefix_count: 0,
+                        negotiated_hold_time: Some(90),
+                        four_octet_as: Some(true),
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        peer_paths_limits: Vec::new(),
+                        effective_add_path_send_limits: Vec::new(),
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        messages_received: 0,
+                        messages_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 1,
+                        last_error: String::new(),
+                        tcp_ao_info: None,
+                        tcp_ao_protected: false,
+                    });
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    (
+        PeerHandle::from_parts(session_tx, task),
+        entered_rx,
+        release,
+    )
+}
+
 fn insert_test_scoped_managed_peer(
     mgr: &mut PeerManager,
     addr: IpAddr,
@@ -6977,6 +7040,10 @@ async fn export_only_snapshot_uses_one_batched_rib_commit_and_preserves_priors()
 }
 
 #[tokio::test(start_paused = true)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the readiness regression keeps direct-lane and complete core-probe assertions in one held transaction"
+)]
 async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
     use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
 
@@ -7059,6 +7126,24 @@ async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
         .unwrap();
         assert_eq!(infos.len(), peers.len());
     }
+    let (health_rib_tx, mut health_rib_rx) = mpsc::channel(1);
+    let probe =
+        rustbgpd_api::health_probe::CoreReadinessProbe::new(command_tx.clone(), health_rib_tx)
+            .with_peer_manager_readiness(readiness_tx.clone());
+    let (health, ()) = tokio::join!(probe.snapshot(), async {
+        let RibUpdate::QueryLocRibCount { reply } =
+            health_rib_rx.recv().await.expect("core RIB query")
+        else {
+            panic!("core readiness must use the read-only RIB count query");
+        };
+        reply.send(17).unwrap();
+    });
+    assert_eq!(
+        health
+            .expect("complete core readiness must beat its unchanged deadline")
+            .total_routes,
+        17
+    );
     assert!(
         matches!(
             mutation_response.try_recv(),
@@ -7077,6 +7162,103 @@ async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
     rib_reply.send(Ok(())).unwrap();
     apply_response.await.unwrap().unwrap();
     mutation_response.await.unwrap();
+    command_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
+    manager_task.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_only_snapshot_services_readiness_during_stalled_session_apply() {
+    use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
+
+    let stalled = IpAddr::V4(Ipv4Addr::new(10, 34, 0, 1));
+    let responsive = IpAddr::V4(Ipv4Addr::new(10, 34, 0, 2));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (command_tx, command_rx) = mpsc::channel(16);
+    let (readiness_tx, readiness_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    let (stalled_handle, entered, release) = stalled_export_policy_test_session(stalled);
+    insert_test_managed_peer(&mut manager, stalled, stalled_handle, false);
+    insert_test_managed_peer(
+        &mut manager,
+        responsive,
+        established_export_policy_test_session(responsive, attempts, None),
+        false,
+    );
+    let manager_task = tokio::spawn(manager.run());
+
+    let (apply_reply, mut apply_response) = oneshot::channel();
+    command_tx
+        .send(PeerManagerCommand::ApplyResolvedPolicySnapshot {
+            targets: [stalled, responsive]
+                .into_iter()
+                .map(|address| ResolvedPeerPolicy {
+                    address,
+                    interface: None,
+                    import_policy: None,
+                    export_policy: Some(deny_policy_chain()),
+                })
+                .collect(),
+            reply: apply_reply,
+        })
+        .await
+        .unwrap();
+    entered.await.unwrap();
+    tokio::time::advance(std::time::Duration::from_millis(250)).await;
+    tokio::task::yield_now().await;
+    assert!(matches!(
+        apply_response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+
+    let (readiness_reply, readiness_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::ListPeers {
+            reply: readiness_reply,
+        })
+        .await
+        .unwrap();
+    let infos = tokio::time::timeout(
+        rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
+        readiness_response,
+    )
+    .await
+    .expect("readiness must beat the unchanged 200ms deadline")
+    .unwrap();
+    assert_eq!(infos.len(), 2);
+    assert!(
+        infos
+            .iter()
+            .find(|info| info.address == stalled)
+            .is_some_and(|info| info.stale),
+        "the independently stalled session must be reported as stale, not fabricated healthy"
+    );
+    assert!(
+        infos
+            .iter()
+            .find(|info| info.address == responsive)
+            .is_some_and(|info| !info.stale)
+    );
+
+    release.notify_one();
+    let RibUpdate::ReplacePeerExportPolicies {
+        reply: rib_reply, ..
+    } = rib_rx.recv().await.unwrap()
+    else {
+        panic!("expected cohort RIB command after the stalled session resumes");
+    };
+    rib_reply.send(Ok(())).unwrap();
+    apply_response.await.unwrap().unwrap();
     command_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     manager_task.await.unwrap();
 }
@@ -7173,17 +7355,25 @@ async fn export_only_snapshot_restores_newest_first_after_session_failure() {
 
 #[tokio::test]
 async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
-    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+    use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
 
     let first = IpAddr::V4(Ipv4Addr::new(10, 32, 0, 1));
     let second = IpAddr::V4(Ipv4Addr::new(10, 32, 0, 2));
     let attempts = Arc::new(AtomicUsize::new(0));
     let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (batch_seen_tx, batch_seen_rx) = oneshot::channel();
+    let release_batch = Arc::new(tokio::sync::Notify::new());
+    let task_release = Arc::clone(&release_batch);
     let rib_task = tokio::spawn(async move {
         let mut restore_order = Vec::new();
+        let mut batch_seen_tx = Some(batch_seen_tx);
         while let Some(update) = rib_rx.recv().await {
             match update {
                 RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    if let Some(batch_seen) = batch_seen_tx.take() {
+                        let _ = batch_seen.send(());
+                    }
+                    task_release.notified().await;
                     let _ = reply.send(Err("injected cohort commit failure".to_string()));
                 }
                 RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
@@ -7197,6 +7387,7 @@ async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
     });
 
     let (_command_tx, command_rx) = mpsc::channel(16);
+    let (readiness_tx, readiness_rx) = mpsc::channel(4);
     let mut manager = PeerManager::new(
         command_rx,
         65001,
@@ -7206,7 +7397,8 @@ async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
         BgpMetrics::new(),
         rib_tx,
         None,
-    );
+    )
+    .with_readiness_queries(readiness_rx);
     for peer in [first, second] {
         insert_test_managed_peer(
             &mut manager,
@@ -7216,19 +7408,29 @@ async fn export_only_snapshot_restores_newest_first_after_rib_batch_failure() {
         );
     }
     let next = deny_policy_chain();
-    let result = manager
-        .apply_resolved_policy_snapshot(
-            [first, second]
-                .into_iter()
-                .map(|address| ResolvedPeerPolicy {
-                    address,
-                    interface: None,
-                    import_policy: None,
-                    export_policy: Some(next.clone()),
-                })
-                .collect(),
-        )
-        .await;
+    let apply = manager.apply_resolved_policy_snapshot(
+        [first, second]
+            .into_iter()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: None,
+                export_policy: Some(next.clone()),
+            })
+            .collect(),
+    );
+    let readiness = async {
+        batch_seen_rx.await.unwrap();
+        let (reply, response) = oneshot::channel();
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers { reply })
+            .await
+            .unwrap();
+        let infos = response.await.unwrap();
+        assert_eq!(infos.len(), 2);
+        release_batch.notify_one();
+    };
+    let (result, ()) = tokio::join!(apply, readiness);
     assert!(
         result
             .as_ref()

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1183,13 +1183,20 @@ fn established_export_policy_test_session(
 
 fn stalled_export_policy_test_session(
     addr: IpAddr,
-) -> (PeerHandle, oneshot::Receiver<()>, Arc<tokio::sync::Notify>) {
+) -> (
+    PeerHandle,
+    oneshot::Receiver<()>,
+    Arc<tokio::sync::Notify>,
+    Arc<AtomicUsize>,
+) {
     use rustbgpd_transport::PeerCommand;
 
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
     let (entered_tx, entered_rx) = oneshot::channel();
     let release = Arc::new(tokio::sync::Notify::new());
     let task_release = Arc::clone(&release);
+    let state_queries = Arc::new(AtomicUsize::new(0));
+    let task_state_queries = Arc::clone(&state_queries);
     let task = tokio::spawn(async move {
         let mut entered_tx = Some(entered_tx);
         while let Some(command) = session_rx.recv().await {
@@ -1202,6 +1209,7 @@ fn stalled_export_policy_test_session(
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::QueryState { reply } => {
+                    task_state_queries.fetch_add(1, Ordering::SeqCst);
                     let _ = reply.send(PeerSessionState {
                         fsm_state: SessionState::Established,
                         peer_ip: addr,
@@ -1241,7 +1249,19 @@ fn stalled_export_policy_test_session(
         PeerHandle::from_parts(session_tx, task),
         entered_rx,
         release,
+        state_queries,
     )
+}
+
+async fn assert_session_state_query_count(counter: &AtomicUsize, expected: usize) {
+    for _ in 0..3 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        expected,
+        "expired readiness requests must not query every session"
+    );
 }
 
 fn insert_test_scoped_managed_peer(
@@ -7209,6 +7229,10 @@ async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
 }
 
 #[tokio::test(start_paused = true)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the readiness regression keeps cancellation and live probing in one held transaction"
+)]
 async fn export_only_snapshot_services_readiness_during_stalled_session_apply() {
     use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
 
@@ -7229,7 +7253,8 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
         None,
     )
     .with_readiness_queries(readiness_rx);
-    let (stalled_handle, entered, release) = stalled_export_policy_test_session(stalled);
+    let (stalled_handle, entered, release, state_queries) =
+        stalled_export_policy_test_session(stalled);
     insert_test_managed_peer(&mut manager, stalled, stalled_handle, false);
     insert_test_managed_peer(
         &mut manager,
@@ -7256,6 +7281,7 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
         .await
         .unwrap();
     entered.await.unwrap();
+    state_queries.store(0, Ordering::SeqCst);
     tokio::time::advance(std::time::Duration::from_millis(250)).await;
     tokio::task::yield_now().await;
     assert!(matches!(
@@ -7264,6 +7290,7 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
     ));
 
     let (cancelled_reply, cancelled_response) = oneshot::channel();
+    drop(cancelled_response);
     readiness_tx
         .send(PeerManagerReadinessQuery::ListPeers {
             reply: cancelled_reply,
@@ -7271,7 +7298,6 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
         .await
         .unwrap();
     tokio::task::yield_now().await;
-    drop(cancelled_response);
     tokio::time::advance(std::time::Duration::from_millis(100)).await;
     tokio::task::yield_now().await;
 
@@ -7313,6 +7339,7 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
     };
     rib_reply.send(Ok(())).unwrap();
     apply_response.await.unwrap().unwrap();
+    assert_session_state_query_count(&state_queries, 1).await;
     command_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
     manager_task.await.unwrap();
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -7221,6 +7221,18 @@ async fn export_only_snapshot_services_readiness_during_stalled_session_apply() 
         Err(oneshot::error::TryRecvError::Empty)
     ));
 
+    let (cancelled_reply, cancelled_response) = oneshot::channel();
+    readiness_tx
+        .send(PeerManagerReadinessQuery::ListPeers {
+            reply: cancelled_reply,
+        })
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    drop(cancelled_response);
+    tokio::time::advance(std::time::Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+
     let (readiness_reply, readiness_response) = oneshot::channel();
     readiness_tx
         .send(PeerManagerReadinessQuery::ListPeers {

--- a/tests/evpn_instances_binary.rs
+++ b/tests/evpn_instances_binary.rs
@@ -89,7 +89,26 @@ fn wait_for_cli_json(grpc_addr: &str, daemon: &mut Daemon) -> Output {
     while Instant::now() < deadline {
         let output = rbgp(grpc_addr, &["--json", "evpn", "instances"]);
         if output.status.success() {
-            return output;
+            // The gRPC listener can become available before the first
+            // asynchronous dataplane report reaches the watch-backed EVPN
+            // status snapshot. Only that documented cold-start `unknown`
+            // state is retryable; malformed output, missing rows, and any
+            // other terminal state return immediately to the assertions
+            // below so real contract regressions are not hidden.
+            let cold_start_unknown = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+                .ok()
+                .and_then(|value| {
+                    value.as_array().and_then(|rows| {
+                        rows.iter().find(|row| row["vni"] == 200).map(|row| {
+                            row["readiness"] == "unknown"
+                                && optional_json_string(row, "not_ready_reason").is_empty()
+                        })
+                    })
+                })
+                .unwrap_or(false);
+            if !cold_start_unknown {
+                return output;
+            }
         }
         last = Some(output);
         daemon.assert_still_running();


### PR DESCRIPTION
## What changed

- move clean grouped export-policy replacement through an actor-owned five-phase transition that yields between production steps
- admit only explicit old-view readiness queries while ordinary mutations and timers remain fenced behind the transition
- revalidate group ownership, generations, sessions, senders, and permits before one atomic membership/counter/send finalize
- preserve the destination group's live policy-counter handle for every member across optimized, fallback, recompute, and rollback paths
- keep an accepted cohort replacement transaction owned until its RIB reply resolves or drops, while continuing to service readiness
- document and benchmark both bounded post-snapshot work and the two remaining O(table) snapshot polls

## Why

A large grouped policy replacement previously occupied the single RIB actor synchronously. Health and readiness probes could time out even though the daemon was making progress. Splitting the computation without preserving the transaction boundary would risk exposing a partial policy generation, stale membership, or rollback racing a still-running forward transition.

This keeps the committed route view stable until finalization, makes readiness observable during the work, and retains the existing all-or-nothing emission boundary.

## Measured result

Exact production source: `114072d7`.

- 65,536 routes x 64 peers: 82.791 ms total; 4.927 ms maximum actor poll
- 4,096 routes x 700 peers: 7.970 ms total; 2.001 ms maximum/finalize poll

The 1,024-item cap applies to post-snapshot chunk bodies. Loc-RIB prefix collection and destination-table key collection remain measured O(table) polls, so this PR does not claim a universal hard poll bound. A fresh integrated loaded 700-peer campaign remains required before claiming loaded-reload acceptance.

## Validation

- full workspace all-feature tests
- workspace all-target Clippy with warnings denied
- workspace all-feature rustdoc
- nine focused clean-transition tests
- 100k-route alias-aware RTC oracle
- readiness beyond the former five-second timeout and dropped-reply rollback tests
- API readiness-lane and EVPN binary readiness tests
- mutation proofs for frozen later-member counters and premature rollback
- exact Criterion receipts and clean full-diff terminal review
