### PR TITLE
fix: reconcile max-prefix accounting after enhanced refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Enhanced-refresh omissions no longer poison max-prefix accounting.**
+  Inbound RFC 7313 windows now mirror exact typed route identities across every
+  counted family, retire replayed or withdrawn identities only after ordered
+  RIB acceptance, and reconcile omitted routes at `EoRR` or the shared timeout.
+  Timeout closure is ordered ahead of later buffered UPDATEs, remains safe under
+  RIB backpressure or shutdown, and runs for quiet peers; Graceful Restart peers
+  cannot open a family refresh window before that family's initial End-of-RIB.
+
 - **Coordinated shutdown stays bounded at high peer counts.** Peer sessions now
   drain with fixed cross-peer concurrency while preserving pending-before-primary
   ordering and each session's existing timeout, abort, and reap guarantees. A

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -8,6 +8,11 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 
+/// How long an inbound Enhanced Route Refresh window may remain open before
+/// unreplayed state is reconciled. Shared by the RIB stale-route owner and the
+/// transport max-prefix mirror so both use the same bounded lifecycle.
+pub const ERR_REFRESH_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
+
 /// Per-peer inbound RIB storage.
 pub mod adj_rib_in;
 /// Per-peer outbound RIB storage.

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -16,10 +16,6 @@ pub(super) const LOCAL_PEER: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 /// How long to wait before retrying distribution to dirty peers.
 pub(super) const DIRTY_RESYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// How long to wait for an inbound enhanced route refresh window to complete
-/// before sweeping unreplaced state.
-pub(super) const ERR_REFRESH_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
-
 /// Per-peer LLGR configuration stored when `PeerGracefulRestart` is received.
 ///
 /// The entry stays alive through the LLGR stale phase — `handle_peer_up`

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -13,6 +13,9 @@ mod update_groups;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+use crate::ERR_REFRESH_TIMEOUT;
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -120,7 +123,7 @@ fn permissive_test_exact_export_encoder() -> Arc<dyn ExactExportEncoder> {
 type UnicastPrefixPeers = rustc_hash::FxHashMap<Prefix, smallvec::SmallVec<[IpAddr; 1]>>;
 
 #[cfg(test)]
-use helpers::{ERR_REFRESH_TIMEOUT, LOCAL_PEER, validate_route_rpki};
+use helpers::{LOCAL_PEER, validate_route_rpki};
 
 /// A peer's RT-Constrain membership (RFC 4684): the Route Targets the peer
 /// declared interest in via SAFI-132 NLRI. Rebuilt whole from the peer's OWN

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -4,8 +4,9 @@ use std::net::IpAddr;
 use rustbgpd_wire::{Afi, EvpnRouteKey, Prefix, RouteRefreshSubtype, Safi};
 use tracing::{debug, info, warn};
 
-use super::helpers::{ERR_REFRESH_TIMEOUT, afi_safi_label, gauge_val, prefix_family};
+use super::helpers::{afi_safi_label, gauge_val, prefix_family};
 use super::{PolicyFilteredRouteKey, RibManager};
+use crate::ERR_REFRESH_TIMEOUT;
 use crate::adj_rib_out::AdjRibOut;
 use crate::route::{BgpLsFamily, FlowSpecKey, FlowSpecRoute, FlowSpecRouteKey};
 use crate::update::OutboundRouteUpdate;
@@ -476,23 +477,20 @@ impl RibManager {
             (peer, afi, safi),
             tokio::time::Instant::now() + ERR_REFRESH_TIMEOUT,
         );
-        // RFC 7313 §4 refresh-stale snapshot, joint with GR/LLGR retention
-        // (LAN-187). A route can be inside a refresh window AND GR/LLGR-stale
-        // at once: the peer re-established under GR (or during the LLGR
-        // phase), its End-of-RIB is still pending, and a refresh window
-        // opened. The four combinations at EoRR:
+        // RFC 7313 §4 refresh-stale snapshot, kept distinct from GR/LLGR
+        // retention. Transport rejects a GR-capable peer's BoRR until
+        // this family has received End-of-RIB, so a conforming current session
+        // cannot open a refresh window while its initial GR replay is pending.
+        // The GR/LLGR exclusions below remain defensive for retained state from
+        // an older session or direct RIB test/control senders. At EoRR:
         //   1. snapshotted, not GR/LLGR-stale, not re-advertised → purged
         //      (RFC 7313 §4: not re-advertised between BoRR and EoRR).
         //   2. re-advertised inside the window → kept; the insert removed
         //      the snapshot key and cleared any GR/LLGR staleness
         //      (implicit-replace, RFC 4724 §4.1).
-        //   3. GR/LLGR-stale at BoRR, not re-advertised → NOT snapshotted
-        //      below, so EoRR does not purge it: a restarting peer's replay
-        //      is not authoritative while it is still converging. RFC 4724
-        //      §4.1 retains stale paths until End-of-RIB or the restart
-        //      timer, and RFC 9494 §4.2 retains LLGR-stale paths until the
-        //      LLGR timer — those owners sweep the route later.
-        //   4. GR/LLGR-stale acquired DURING the window: unreachable — GR
+        //   3. defensive GR/LLGR-stale state at BoRR is not snapshotted, so its
+        //      RFC 4724/RFC 9494 lifecycle remains authoritative.
+        //   4. GR/LLGR-stale acquired DURING the window is unreachable — GR
         //      entry is session-down, which drops every refresh window for
         //      the peer (`clear_peer_refresh_state`).
         let mut stale_count = 0usize;

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -503,6 +503,8 @@ impl PeerSession {
             // IPv4 EoR: empty UPDATE (no NLRI, no withdrawn, no attributes)
             if parsed.attributes.is_empty() {
                 info!(peer = %self.peer_label, family = "ipv4_unicast", "received End-of-RIB");
+                self.received_eor_families
+                    .insert((Afi::Ipv4, Safi::Unicast));
                 let _ = self
                     .rib_tx
                     .send(RibUpdate::EndOfRib {
@@ -532,6 +534,7 @@ impl PeerSession {
                     safi = ?mp.safi,
                     "received End-of-RIB"
                 );
+                self.received_eor_families.insert((mp.afi, mp.safi));
                 let _ = self
                     .rib_tx
                     .send(RibUpdate::EndOfRib {
@@ -814,10 +817,19 @@ impl PeerSession {
             for key in &loop_rtc_withdrawn {
                 self.known_rtc.remove(key);
             }
-            if (!loop_withdrawn.is_empty()
+            if !loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty())
-                && self
+                || !loop_evpn_withdrawn.is_empty()
+            {
+                let refresh_delta = self.capture_routes_refresh_delta(
+                    &[],
+                    &loop_withdrawn,
+                    &[],
+                    &loop_fs_withdrawn,
+                    &[],
+                    &loop_evpn_withdrawn,
+                );
+                if self
                     .deliver_routes_to_rib(RibUpdate::RoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -830,11 +842,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_bgpls_withdrawn.is_empty()
-                && self
+            if !loop_bgpls_withdrawn.is_empty() {
+                let refresh_delta = self.capture_bgpls_refresh_delta(&[], &loop_bgpls_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -843,11 +860,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_l3vpn_withdrawn.is_empty()
-                && self
+            if !loop_l3vpn_withdrawn.is_empty() {
+                let refresh_delta = self.capture_vpn_refresh_delta(&[], &loop_l3vpn_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -856,11 +878,17 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_labeled_withdrawn.is_empty()
-                && self
+            if !loop_labeled_withdrawn.is_empty() {
+                let refresh_delta =
+                    self.capture_labeled_refresh_delta(&[], &loop_labeled_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -869,11 +897,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_rtc_withdrawn.is_empty()
-                && self
+            if !loop_rtc_withdrawn.is_empty() {
+                let refresh_delta = self.capture_rtc_refresh_delta(&[], &loop_rtc_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -882,8 +915,12 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
@@ -1042,10 +1079,19 @@ impl PeerSession {
             for key in &loop_rtc_withdrawn {
                 self.known_rtc.remove(key);
             }
-            if (!loop_withdrawn.is_empty()
+            if !loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty())
-                && self
+                || !loop_evpn_withdrawn.is_empty()
+            {
+                let refresh_delta = self.capture_routes_refresh_delta(
+                    &[],
+                    &loop_withdrawn,
+                    &[],
+                    &loop_fs_withdrawn,
+                    &[],
+                    &loop_evpn_withdrawn,
+                );
+                if self
                     .deliver_routes_to_rib(RibUpdate::RoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -1058,11 +1104,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_bgpls_withdrawn.is_empty()
-                && self
+            if !loop_bgpls_withdrawn.is_empty() {
+                let refresh_delta = self.capture_bgpls_refresh_delta(&[], &loop_bgpls_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -1071,11 +1122,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_l3vpn_withdrawn.is_empty()
-                && self
+            if !loop_l3vpn_withdrawn.is_empty() {
+                let refresh_delta = self.capture_vpn_refresh_delta(&[], &loop_l3vpn_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -1084,11 +1140,17 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_labeled_withdrawn.is_empty()
-                && self
+            if !loop_labeled_withdrawn.is_empty() {
+                let refresh_delta =
+                    self.capture_labeled_refresh_delta(&[], &loop_labeled_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -1097,11 +1159,16 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
-            if !loop_rtc_withdrawn.is_empty()
-                && self
+            if !loop_rtc_withdrawn.is_empty() {
+                let refresh_delta = self.capture_rtc_refresh_delta(&[], &loop_rtc_withdrawn);
+                if self
                     .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
                         peer: self.peer_ip,
                         session_id: self.session_identity.id,
@@ -1110,8 +1177,12 @@ impl PeerSession {
                     })
                     .await
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+                if let Some(delta) = refresh_delta {
+                    self.apply_refresh_accounting_delta(delta);
+                }
             }
             self.drive_fsm(Event::UpdateReceived).await;
             return;
@@ -2046,13 +2117,22 @@ impl PeerSession {
             self.drive_fsm(Event::UpdateValidationError(notif)).await;
             return;
         }
-        if (!announced.is_empty()
+        if !announced.is_empty()
             || !withdrawn.is_empty()
             || !flowspec_announced.is_empty()
             || !flowspec_withdrawn.is_empty()
             || !evpn_announced.is_empty()
-            || !evpn_withdrawn.is_empty())
-            && self
+            || !evpn_withdrawn.is_empty()
+        {
+            let refresh_delta = self.capture_routes_refresh_delta(
+                &announced,
+                &withdrawn,
+                &flowspec_announced,
+                &flowspec_withdrawn,
+                &evpn_announced,
+                &evpn_withdrawn,
+            );
+            if self
                 .deliver_routes_to_rib(RibUpdate::RoutesReceived {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
@@ -2065,11 +2145,17 @@ impl PeerSession {
                 })
                 .await
                 .is_err()
-        {
-            return;
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
         }
-        if (!bgpls_announced.is_empty() || !bgpls_withdrawn.is_empty())
-            && self
+        if !bgpls_announced.is_empty() || !bgpls_withdrawn.is_empty() {
+            let refresh_delta =
+                self.capture_bgpls_refresh_delta(&bgpls_announced, &bgpls_withdrawn);
+            if self
                 .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
@@ -2078,11 +2164,16 @@ impl PeerSession {
                 })
                 .await
                 .is_err()
-        {
-            return;
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
         }
-        if (!vpn_announced.is_empty() || !vpn_withdrawn.is_empty())
-            && self
+        if !vpn_announced.is_empty() || !vpn_withdrawn.is_empty() {
+            let refresh_delta = self.capture_vpn_refresh_delta(&vpn_announced, &vpn_withdrawn);
+            if self
                 .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
@@ -2091,11 +2182,17 @@ impl PeerSession {
                 })
                 .await
                 .is_err()
-        {
-            return;
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
         }
-        if (!labeled_announced.is_empty() || !labeled_withdrawn.is_empty())
-            && self
+        if !labeled_announced.is_empty() || !labeled_withdrawn.is_empty() {
+            let refresh_delta =
+                self.capture_labeled_refresh_delta(&labeled_announced, &labeled_withdrawn);
+            if self
                 .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
@@ -2104,11 +2201,16 @@ impl PeerSession {
                 })
                 .await
                 .is_err()
-        {
-            return;
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
         }
-        if (!rtc_announced.is_empty() || !rtc_withdrawn.is_empty())
-            && self
+        if !rtc_announced.is_empty() || !rtc_withdrawn.is_empty() {
+            let refresh_delta = self.capture_rtc_refresh_delta(&rtc_announced, &rtc_withdrawn);
+            if self
                 .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
@@ -2117,8 +2219,12 @@ impl PeerSession {
                 })
                 .await
                 .is_err()
-        {
-            return;
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
         }
         // 5. Tell FSM about the update (restarts hold timer)
         self.drive_fsm(Event::UpdateReceived).await;

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -364,6 +364,13 @@ impl PeerSession {
     )]
     pub(super) async fn process_read_buffer(&mut self) {
         loop {
+            // Reconcile a due refresh window before *each* buffered PDU, not
+            // merely once per socket read. One read can contain several UPDATEs
+            // and the first may park on RIB backpressure until after the shared
+            // deadline; the next one must see the corrected max-prefix count.
+            if self.expire_refresh_accounting_windows().await.is_err() {
+                return;
+            }
             match self.read_buf.try_decode() {
                 Ok(Some((msg, raw_pdu))) => {
                     let event = match msg {
@@ -538,6 +545,22 @@ impl PeerSession {
                                             ?afi, ?safi,
                                             "ignoring BoRR from peer without Enhanced Route Refresh"
                                         );
+                                    } else if self.negotiated.as_ref().is_some_and(|n| {
+                                        n.peer_capabilities.iter().any(|capability| {
+                                            matches!(
+                                                capability,
+                                                rustbgpd_wire::Capability::GracefulRestart { .. }
+                                            )
+                                        })
+                                    }) && !self
+                                        .received_eor_families
+                                        .contains(&(afi, safi))
+                                    {
+                                        warn!(
+                                            peer = %self.peer_label,
+                                            ?afi, ?safi,
+                                            "ignoring BoRR before End-of-RIB from Graceful Restart peer"
+                                        );
                                     } else if self
                                         .rib_tx
                                         .send(RibUpdate::BeginRouteRefresh {
@@ -554,6 +577,11 @@ impl PeerSession {
                                             "RIB manager unavailable — BeginRouteRefresh dropped"
                                         );
                                     } else {
+                                        // The channel acceptance orders the RIB's
+                                        // snapshot ahead of all later UPDATEs from
+                                        // this session. Only now mirror that window
+                                        // in transport-owned max-prefix state.
+                                        self.begin_refresh_accounting(afi, safi);
                                         info!(
                                             peer = %self.peer_label,
                                             ?afi, ?safi,
@@ -588,6 +616,10 @@ impl PeerSession {
                                             "RIB manager unavailable — EndRouteRefresh dropped"
                                         );
                                     } else {
+                                        // Consume before sweeping so a re-entrant
+                                        // observation can never see an active
+                                        // window whose stale identities are gone.
+                                        self.end_refresh_accounting(afi, safi);
                                         info!(
                                             peer = %self.peer_label,
                                             ?afi, ?safi,

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -5,6 +5,7 @@ pub mod import_decision_cache;
 pub(crate) mod inbound;
 mod io;
 mod outbound;
+mod refresh_accounting;
 mod writer;
 
 use std::collections::{HashMap, HashSet};
@@ -137,6 +138,10 @@ pub(crate) struct PeerSession {
     /// `SessionEstablished` and reused by inbound UPDATE decode instead of
     /// rebuilding from `NegotiatedSession::add_path_families` per UPDATE.
     add_path_receive_families: Vec<(Afi, Safi)>,
+    /// Families whose End-of-RIB marker has been received on this session.
+    /// RFC 7313 requires a GR-capable peer's `BoRR` to be ignored until the
+    /// corresponding initial GR replay has completed.
+    received_eor_families: HashSet<(Afi, Safi)>,
     /// Suppresses automatic restart when the FSM transitions to Idle.
     /// Set when the operator sends `ManualStop` or `Shutdown`.
     stop_requested: bool,
@@ -252,6 +257,12 @@ pub(crate) struct PeerSession {
     /// Accepted RT-Constrain routes from this peer (RFC 4684 keys). Counted
     /// toward max-prefix enforcement for the same reason.
     known_rtc: HashSet<RtcRibRouteKey>,
+    /// Ephemeral RFC 7313 stale-identity snapshots used to keep transport-owned
+    /// max-prefix accounting aligned with the RIB's refresh sweep.
+    refresh_accounting: refresh_accounting::RefreshMaxPrefixAccounting,
+    /// Earliest active refresh-accounting deadline. Kept separate from the
+    /// snapshot owner so the run loop can borrow it independently in `select!`.
+    refresh_accounting_timer: Option<Pin<Box<Sleep>>>,
     /// Session counters
     updates_received: u64,
     updates_sent: u64,
@@ -444,8 +455,9 @@ impl PeerSession {
 
     /// Total accepted route count across all negotiated families: unicast
     /// (unique prefixes, ignoring Add-Path multiplicity), `FlowSpec` rules,
-    /// EVPN keys, and BGP-LS objects. Used by max-prefix enforcement so a peer can't slip
-    /// past the cap by flooding non-unicast NLRI.
+    /// EVPN keys, BGP-LS objects, VPN routes, labeled-unicast routes, and
+    /// RT-Constrain membership. Used by max-prefix enforcement so a peer cannot
+    /// slip past the cap by flooding non-unicast NLRI.
     pub(super) fn known_prefix_count(&self) -> usize {
         self.known_prefix_refcounts.len()
             + self.known_flowspec.len()
@@ -499,6 +511,8 @@ impl PeerSession {
         self.known_vpn.clear();
         self.known_labeled.clear();
         self.known_rtc.clear();
+        self.received_eor_families.clear();
+        self.clear_refresh_accounting();
     }
 
     fn link_local_next_hop_scope_from_config(config: &TransportConfig) -> Option<NextHopScope> {
@@ -636,6 +650,7 @@ impl PeerSession {
             negotiated: None,
             negotiated_families: Vec::new(),
             add_path_receive_families: Vec::new(),
+            received_eor_families: HashSet::new(),
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,
@@ -665,6 +680,8 @@ impl PeerSession {
             known_vpn: HashSet::new(),
             known_labeled: HashSet::new(),
             known_rtc: HashSet::new(),
+            refresh_accounting: refresh_accounting::RefreshMaxPrefixAccounting::default(),
+            refresh_accounting_timer: None,
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,
@@ -694,6 +711,7 @@ impl PeerSession {
 
     #[expect(
         clippy::too_many_arguments,
+        clippy::too_many_lines,
         reason = "inbound constructor carries the same dependency boundary plus accepted stream"
     )]
     pub(crate) fn new_inbound_with_identity_and_lifecycle(
@@ -763,6 +781,7 @@ impl PeerSession {
             negotiated: None,
             negotiated_families: Vec::new(),
             add_path_receive_families: Vec::new(),
+            received_eor_families: HashSet::new(),
             stop_requested: false,
             reconnect_timer: None,
             connect_task: None,
@@ -792,6 +811,8 @@ impl PeerSession {
             known_vpn: HashSet::new(),
             known_labeled: HashSet::new(),
             known_rtc: HashSet::new(),
+            refresh_accounting: refresh_accounting::RefreshMaxPrefixAccounting::default(),
+            refresh_accounting_timer: None,
             updates_received: 0,
             updates_sent: 0,
             notifications_received: 0,
@@ -1187,6 +1208,7 @@ impl PeerSession {
                 outbound_rx,
                 writer_join,
                 bmp_repair_timer,
+                refresh_accounting_timer,
                 ..
             } = self;
 
@@ -1252,6 +1274,15 @@ impl PeerSession {
                 () = poll_timer(bmp_repair_timer) => {
                     self.bmp_repair_timer = None;
                     self.retry_bmp_stream_repair();
+                }
+
+                // RFC 7313 refresh-accounting timeout. The RIB owns its own
+                // matching stale-route timer; this session-local arm keeps the
+                // transport's max-prefix mirror exact even when the peer goes
+                // quiet after omitting routes from a refresh replay.
+                () = poll_timer(refresh_accounting_timer) => {
+                    self.refresh_accounting_timer = None;
+                    let _ = self.expire_refresh_accounting_windows().await;
                 }
 
                 // In-flight outbound TCP connect completion

--- a/crates/transport/src/session/refresh_accounting.rs
+++ b/crates/transport/src/session/refresh_accounting.rs
@@ -1,0 +1,486 @@
+use std::collections::{HashMap, HashSet};
+use std::pin::Pin;
+
+use rustbgpd_rib::{
+    BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, EvpnRibRoute, FlowSpecKey, FlowSpecRoute,
+    LabeledRibRoute, LabeledRibRouteKey, Route, RtcRibRoute, RtcRibRouteKey, VpnRibRoute,
+    VpnRibRouteKey,
+};
+use rustbgpd_wire::{Afi, EvpnRouteKey, Prefix, Safi};
+use tokio::time::{Instant, Sleep};
+
+use super::PeerSession;
+
+type Family = (Afi, Safi);
+
+/// Transport-owned RFC 7313 windows. These exist only while an inbound
+/// enhanced refresh is active; the ordinary no-refresh UPDATE path pays one
+/// `is_empty` branch and retains no per-route generation state.
+#[derive(Default)]
+pub(super) struct RefreshMaxPrefixAccounting {
+    windows: HashMap<Family, RefreshMaxPrefixWindow>,
+}
+
+struct RefreshMaxPrefixWindow {
+    deadline: Instant,
+    stale: RefreshStaleIdentities,
+}
+
+enum RefreshStaleIdentities {
+    Unicast(HashSet<(Prefix, u32)>),
+    FlowSpec(HashSet<FlowSpecKey>),
+    Evpn(HashSet<EvpnRouteKey>),
+    BgpLs(HashSet<BgpLsRouteKey>),
+    Vpn(HashSet<VpnRibRouteKey>),
+    Labeled(HashSet<LabeledRibRouteKey>),
+    Rtc(HashSet<RtcRibRouteKey>),
+    Uncounted,
+}
+
+/// Identities whose corresponding RIB update was accepted by the actor
+/// channel. Applying the delta after the send is what prevents an import-policy
+/// denial or failed RIB enqueue from falsely marking a stale route as replayed.
+#[derive(Default)]
+pub(super) struct RefreshAccountingDelta {
+    unicast: Vec<(Prefix, u32)>,
+    flowspec: Vec<FlowSpecKey>,
+    evpn: Vec<EvpnRouteKey>,
+    bgpls: Vec<BgpLsRouteKey>,
+    vpn: Vec<VpnRibRouteKey>,
+    labeled: Vec<LabeledRibRouteKey>,
+    rtc: Vec<RtcRibRouteKey>,
+}
+
+impl PeerSession {
+    /// Open or replace the exact family window after `BeginRouteRefresh` has
+    /// been accepted by the RIB channel. A duplicate `BoRR` deliberately takes a
+    /// fresh snapshot and deadline.
+    pub(super) fn begin_refresh_accounting(&mut self, afi: Afi, safi: Safi) {
+        let family = (afi, safi);
+        let stale = match family {
+            (Afi::Ipv4 | Afi::Ipv6, Safi::Unicast) => RefreshStaleIdentities::Unicast(
+                self.known_paths
+                    .iter()
+                    .copied()
+                    .filter(|(prefix, _)| unicast_family(*prefix) == family)
+                    .collect(),
+            ),
+            (_, Safi::FlowSpec) => RefreshStaleIdentities::FlowSpec(
+                self.known_flowspec
+                    .iter()
+                    .filter(|key| key.afi == afi)
+                    .cloned()
+                    .collect(),
+            ),
+            (Afi::L2Vpn, Safi::Evpn) => RefreshStaleIdentities::Evpn(self.known_evpn.clone()),
+            _ if BgpLsFamily::from_afi_safi(afi, safi).is_some() => RefreshStaleIdentities::BgpLs(
+                self.known_bgpls
+                    .iter()
+                    .filter(|key| key.family.to_afi_safi() == family)
+                    .cloned()
+                    .collect(),
+            ),
+            (_, Safi::MplsVpn) => RefreshStaleIdentities::Vpn(
+                self.known_vpn
+                    .iter()
+                    .filter(|key| key.afi_safi() == family)
+                    .cloned()
+                    .collect(),
+            ),
+            (_, Safi::LabeledUnicast) => RefreshStaleIdentities::Labeled(
+                self.known_labeled
+                    .iter()
+                    .filter(|key| key.afi_safi() == family)
+                    .copied()
+                    .collect(),
+            ),
+            (Afi::Ipv4, Safi::RtConstrain) => RefreshStaleIdentities::Rtc(self.known_rtc.clone()),
+            _ => RefreshStaleIdentities::Uncounted,
+        };
+        self.refresh_accounting.windows.insert(
+            family,
+            RefreshMaxPrefixWindow {
+                deadline: Instant::now() + rustbgpd_rib::ERR_REFRESH_TIMEOUT,
+                stale,
+            },
+        );
+        self.arm_refresh_accounting_timer();
+    }
+
+    /// Consume an explicit `EoRR` window before sweeping its remaining stale
+    /// identities from the live max-prefix authority. A stray `EoRR` is a no-op.
+    pub(super) fn end_refresh_accounting(&mut self, afi: Afi, safi: Safi) {
+        let Some(window) = self.refresh_accounting.windows.remove(&(afi, safi)) else {
+            return;
+        };
+        self.arm_refresh_accounting_timer();
+        self.sweep_refresh_accounting(window.stale);
+    }
+
+    /// Reconcile every due family. Called before each buffered PDU decode and
+    /// from the independent quiet-session run-loop timer.
+    ///
+    /// The timeout is first enqueued to the RIB as an ordinary `EoRR` so it is
+    /// ordered ahead of the next UPDATE from this session. Only after that send
+    /// succeeds may transport consume/sweep the matching local window. The
+    /// RIB's own timer remains an idempotent safety net.
+    pub(super) async fn expire_refresh_accounting_windows(&mut self) -> Result<(), ()> {
+        if self.refresh_accounting.windows.is_empty() {
+            self.refresh_accounting_timer = None;
+            return Ok(());
+        }
+
+        loop {
+            // Recompute after every awaited send: another family can become due
+            // while the RIB channel is applying backpressure.
+            let now = Instant::now();
+            let next_due = self
+                .refresh_accounting
+                .windows
+                .iter()
+                .filter(|&(_, window)| window.deadline <= now)
+                .min_by_key(|&(&(afi, safi), window)| (window.deadline, afi as u16, safi as u8))
+                .map(|(&family, _)| family);
+            let Some((afi, safi)) = next_due else {
+                self.arm_refresh_accounting_timer();
+                return Ok(());
+            };
+
+            if self
+                .rib_tx
+                .send(rustbgpd_rib::RibUpdate::EndRouteRefresh {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    afi,
+                    safi,
+                })
+                .await
+                .is_err()
+            {
+                // Preserve this and every later window. Re-arming an already
+                // elapsed deadline would spin the run loop while the RIB is
+                // gone; a later inbound decode may retry, and shutdown can win.
+                self.refresh_accounting_timer = None;
+                tracing::warn!(
+                    peer = %self.peer_label,
+                    ?afi,
+                    ?safi,
+                    "RIB manager unavailable — timed-out refresh accounting remains unswept"
+                );
+                return Err(());
+            }
+
+            tracing::warn!(
+                peer = %self.peer_label,
+                ?afi,
+                ?safi,
+                timeout_secs = rustbgpd_rib::ERR_REFRESH_TIMEOUT.as_secs(),
+                "enhanced route refresh timed out — reconciling max-prefix accounting"
+            );
+            self.end_refresh_accounting(afi, safi);
+        }
+    }
+
+    pub(super) fn clear_refresh_accounting(&mut self) {
+        self.refresh_accounting.windows.clear();
+        self.refresh_accounting_timer = None;
+    }
+
+    fn arm_refresh_accounting_timer(&mut self) {
+        self.refresh_accounting_timer = self
+            .refresh_accounting
+            .windows
+            .values()
+            .map(|window| window.deadline)
+            .min()
+            .map(|deadline| Box::pin(tokio::time::sleep_until(deadline)) as Pin<Box<Sleep>>);
+    }
+
+    fn sweep_refresh_accounting(&mut self, stale: RefreshStaleIdentities) {
+        match stale {
+            RefreshStaleIdentities::Unicast(keys) => {
+                for (prefix, path_id) in keys {
+                    self.forget_known_path(prefix, path_id);
+                }
+            }
+            RefreshStaleIdentities::FlowSpec(keys) => {
+                for key in keys {
+                    self.known_flowspec.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::Evpn(keys) => {
+                for key in keys {
+                    self.known_evpn.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::BgpLs(keys) => {
+                for key in keys {
+                    self.known_bgpls.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::Vpn(keys) => {
+                for key in keys {
+                    self.known_vpn.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::Labeled(keys) => {
+                for key in keys {
+                    self.known_labeled.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::Rtc(keys) => {
+                for key in keys {
+                    self.known_rtc.remove(&key);
+                }
+            }
+            RefreshStaleIdentities::Uncounted => {}
+        }
+    }
+
+    pub(super) fn capture_routes_refresh_delta(
+        &self,
+        announced: &[Route],
+        withdrawn: &[(Prefix, u32)],
+        flowspec_announced: &[FlowSpecRoute],
+        flowspec_withdrawn: &[FlowSpecKey],
+        evpn_announced: &[EvpnRibRoute],
+        evpn_withdrawn: &[EvpnRouteKey],
+    ) -> Option<RefreshAccountingDelta> {
+        if self.refresh_accounting.windows.is_empty() {
+            return None;
+        }
+        let mut delta = RefreshAccountingDelta::default();
+        delta.unicast.extend(
+            announced
+                .iter()
+                .map(|route| (route.prefix, route.path_id))
+                .chain(withdrawn.iter().copied())
+                .filter(|(prefix, _)| {
+                    self.refresh_accounting
+                        .windows
+                        .contains_key(&unicast_family(*prefix))
+                }),
+        );
+        delta.flowspec.extend(
+            flowspec_announced
+                .iter()
+                .map(FlowSpecRoute::selection_key)
+                .chain(flowspec_withdrawn.iter().cloned())
+                .filter(|key| {
+                    self.refresh_accounting
+                        .windows
+                        .contains_key(&(key.afi, Safi::FlowSpec))
+                }),
+        );
+        if self
+            .refresh_accounting
+            .windows
+            .contains_key(&(Afi::L2Vpn, Safi::Evpn))
+        {
+            delta
+                .evpn
+                .extend(evpn_announced.iter().map(EvpnRibRoute::key));
+            delta.evpn.extend(evpn_withdrawn.iter().copied());
+        }
+        Some(delta)
+    }
+
+    pub(super) fn capture_bgpls_refresh_delta(
+        &self,
+        announced: &[BgpLsRibRoute],
+        withdrawn: &[BgpLsRouteKey],
+    ) -> Option<RefreshAccountingDelta> {
+        if self.refresh_accounting.windows.is_empty() {
+            return None;
+        }
+        let mut delta = RefreshAccountingDelta::default();
+        delta.bgpls.extend(
+            announced
+                .iter()
+                .map(BgpLsRibRoute::key)
+                .chain(withdrawn.iter().cloned())
+                .filter(|key| {
+                    self.refresh_accounting
+                        .windows
+                        .contains_key(&key.family.to_afi_safi())
+                }),
+        );
+        Some(delta)
+    }
+
+    pub(super) fn capture_vpn_refresh_delta(
+        &self,
+        announced: &[VpnRibRoute],
+        withdrawn: &[VpnRibRouteKey],
+    ) -> Option<RefreshAccountingDelta> {
+        if self.refresh_accounting.windows.is_empty() {
+            return None;
+        }
+        let mut delta = RefreshAccountingDelta::default();
+        delta.vpn.extend(
+            announced
+                .iter()
+                .map(VpnRibRoute::key)
+                .chain(withdrawn.iter().cloned())
+                .filter(|key| {
+                    self.refresh_accounting
+                        .windows
+                        .contains_key(&key.afi_safi())
+                }),
+        );
+        Some(delta)
+    }
+
+    pub(super) fn capture_labeled_refresh_delta(
+        &self,
+        announced: &[LabeledRibRoute],
+        withdrawn: &[LabeledRibRouteKey],
+    ) -> Option<RefreshAccountingDelta> {
+        if self.refresh_accounting.windows.is_empty() {
+            return None;
+        }
+        let mut delta = RefreshAccountingDelta::default();
+        delta.labeled.extend(
+            announced
+                .iter()
+                .map(LabeledRibRoute::key)
+                .chain(withdrawn.iter().copied())
+                .filter(|key| {
+                    self.refresh_accounting
+                        .windows
+                        .contains_key(&key.afi_safi())
+                }),
+        );
+        Some(delta)
+    }
+
+    pub(super) fn capture_rtc_refresh_delta(
+        &self,
+        announced: &[RtcRibRoute],
+        withdrawn: &[RtcRibRouteKey],
+    ) -> Option<RefreshAccountingDelta> {
+        if self.refresh_accounting.windows.is_empty() {
+            return None;
+        }
+        let family = RtcRibRouteKey::afi_safi();
+        let mut delta = RefreshAccountingDelta::default();
+        if self.refresh_accounting.windows.contains_key(&family) {
+            delta.rtc.extend(announced.iter().map(RtcRibRoute::key));
+            delta.rtc.extend(withdrawn.iter().cloned());
+        }
+        Some(delta)
+    }
+
+    pub(super) fn apply_refresh_accounting_delta(&mut self, delta: RefreshAccountingDelta) {
+        for (prefix, path_id) in delta.unicast {
+            if let Some(RefreshMaxPrefixWindow {
+                stale: RefreshStaleIdentities::Unicast(stale),
+                ..
+            }) = self
+                .refresh_accounting
+                .windows
+                .get_mut(&unicast_family(prefix))
+            {
+                stale.remove(&(prefix, path_id));
+            }
+        }
+        for key in delta.flowspec {
+            if let Some(RefreshMaxPrefixWindow {
+                stale: RefreshStaleIdentities::FlowSpec(stale),
+                ..
+            }) = self
+                .refresh_accounting
+                .windows
+                .get_mut(&(key.afi, Safi::FlowSpec))
+            {
+                stale.remove(&key);
+            }
+        }
+        if let Some(RefreshMaxPrefixWindow {
+            stale: RefreshStaleIdentities::Evpn(stale),
+            ..
+        }) = self
+            .refresh_accounting
+            .windows
+            .get_mut(&(Afi::L2Vpn, Safi::Evpn))
+        {
+            for key in delta.evpn {
+                stale.remove(&key);
+            }
+        }
+        for key in delta.bgpls {
+            if let Some(RefreshMaxPrefixWindow {
+                stale: RefreshStaleIdentities::BgpLs(stale),
+                ..
+            }) = self
+                .refresh_accounting
+                .windows
+                .get_mut(&key.family.to_afi_safi())
+            {
+                stale.remove(&key);
+            }
+        }
+        for key in delta.vpn {
+            if let Some(RefreshMaxPrefixWindow {
+                stale: RefreshStaleIdentities::Vpn(stale),
+                ..
+            }) = self.refresh_accounting.windows.get_mut(&key.afi_safi())
+            {
+                stale.remove(&key);
+            }
+        }
+        for key in delta.labeled {
+            if let Some(RefreshMaxPrefixWindow {
+                stale: RefreshStaleIdentities::Labeled(stale),
+                ..
+            }) = self.refresh_accounting.windows.get_mut(&key.afi_safi())
+            {
+                stale.remove(&key);
+            }
+        }
+        let rtc_family = RtcRibRouteKey::afi_safi();
+        if let Some(RefreshMaxPrefixWindow {
+            stale: RefreshStaleIdentities::Rtc(stale),
+            ..
+        }) = self.refresh_accounting.windows.get_mut(&rtc_family)
+        {
+            for key in delta.rtc {
+                stale.remove(&key);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn refresh_accounting_window_count(&self) -> usize {
+        self.refresh_accounting.windows.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn refresh_accounting_has_window(&self, family: Family) -> bool {
+        self.refresh_accounting.windows.contains_key(&family)
+    }
+
+    #[cfg(test)]
+    pub(super) fn refresh_accounting_stale_count(&self, family: Family) -> Option<usize> {
+        self.refresh_accounting
+            .windows
+            .get(&family)
+            .map(|window| match &window.stale {
+                RefreshStaleIdentities::Unicast(keys) => keys.len(),
+                RefreshStaleIdentities::FlowSpec(keys) => keys.len(),
+                RefreshStaleIdentities::Evpn(keys) => keys.len(),
+                RefreshStaleIdentities::BgpLs(keys) => keys.len(),
+                RefreshStaleIdentities::Vpn(keys) => keys.len(),
+                RefreshStaleIdentities::Labeled(keys) => keys.len(),
+                RefreshStaleIdentities::Rtc(keys) => keys.len(),
+                RefreshStaleIdentities::Uncounted => 0,
+            })
+    }
+}
+
+const fn unicast_family(prefix: Prefix) -> Family {
+    match prefix {
+        Prefix::V4(_) => (Afi::Ipv4, Safi::Unicast),
+        Prefix::V6(_) => (Afi::Ipv6, Safi::Unicast),
+    }
+}

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -169,18 +169,32 @@ fn make_test_session_with_rib(
     local_asn: u32,
     remote_asn: u32,
 ) -> (PeerSession, mpsc::Receiver<RibUpdate>) {
+    let (session, _cmd_tx, rib_rx) = make_test_session_with_channels(local_asn, remote_asn, 64);
+    (session, rib_rx)
+}
+
+fn make_test_session_with_channels(
+    local_asn: u32,
+    remote_asn: u32,
+    rib_capacity: usize,
+) -> (
+    PeerSession,
+    mpsc::Sender<PeerCommand>,
+    mpsc::Receiver<RibUpdate>,
+) {
     let mut peer_config = PeerConfig::new(local_asn, remote_asn, Ipv4Addr::new(10, 0, 0, 1));
     peer_config.connect_retry_secs = 30;
     peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
     peer_config.gr_restart_time = 120;
     let config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
     let metrics = BgpMetrics::new();
-    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
-    let (rib_tx, rib_rx) = mpsc::channel(64);
+    let (cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, rib_rx) = mpsc::channel(rib_capacity);
     (
         PeerSession::new(
             config, metrics, cmd_rx, rib_tx, None, None, None, None, None, false,
         ),
+        cmd_tx,
         rib_rx,
     )
 }
@@ -249,6 +263,69 @@ fn install_test_negotiated_session(session: &mut PeerSession, negotiated: Negoti
         })
         .collect();
     session.negotiated = Some(negotiated);
+}
+
+fn install_enhanced_refresh_session(
+    session: &mut PeerSession,
+    families: Vec<(Afi, Safi)>,
+    graceful_restart: bool,
+) {
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = families;
+    negotiated.peer_route_refresh = true;
+    negotiated.peer_enhanced_route_refresh = true;
+    if graceful_restart {
+        negotiated
+            .peer_capabilities
+            .push(Capability::GracefulRestart {
+                restart_state: false,
+                notification: false,
+                restart_time: 120,
+                families: vec![],
+            });
+    }
+    install_test_negotiated_session(session, negotiated);
+}
+
+fn buffer_route_refresh(
+    session: &mut PeerSession,
+    afi: Afi,
+    safi: Safi,
+    subtype: RouteRefreshSubtype,
+) {
+    let encoded = rustbgpd_wire::encode_message(&Message::RouteRefresh(
+        RouteRefreshMessage::new_with_subtype(afi, safi, subtype),
+    ))
+    .unwrap();
+    session.read_buf.buf.extend_from_slice(&encoded);
+}
+
+fn ipv4_announce(prefix: Ipv4Prefix, path_id: u32, add_path: bool) -> UpdateMessage {
+    UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id, prefix }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        ],
+        true,
+        add_path,
+        Ipv4UnicastMode::Body,
+    )
+}
+
+fn ipv4_withdraw(prefix: Ipv4Prefix, path_id: u32, add_path: bool) -> UpdateMessage {
+    UpdateMessage::build(
+        &[],
+        &[Ipv4NlriEntry { path_id, prefix }],
+        &[],
+        true,
+        add_path,
+        Ipv4UnicastMode::Body,
+    )
 }
 
 #[tokio::test]
@@ -1942,6 +2019,651 @@ fn known_prefix_refcount_tracks_add_path_withdrawals() {
         "the last path withdrawal removes the unique prefix"
     );
 }
+
+#[tokio::test]
+async fn enhanced_refresh_markers_follow_gr_end_of_rib_gate_per_family() {
+    let families = vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)];
+
+    let (mut plain, mut plain_rib) = make_test_session_with_rib(65001, 65002);
+    install_enhanced_refresh_session(&mut plain, families.clone(), false);
+    buffer_route_refresh(
+        &mut plain,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    plain.process_read_buffer().await;
+    assert!(matches!(
+        plain_rib.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert!(
+        plain.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)),
+        "a non-GR peer may begin ERR before any End-of-RIB"
+    );
+
+    let (mut gr, mut gr_rib) = make_test_session_with_rib(65001, 65002);
+    install_enhanced_refresh_session(&mut gr, families, true);
+    buffer_route_refresh(&mut gr, Afi::Ipv4, Safi::Unicast, RouteRefreshSubtype::BoRR);
+    gr.process_read_buffer().await;
+    assert!(gr_rib.try_recv().is_err());
+    assert_eq!(gr.refresh_accounting_window_count(), 0);
+
+    // An empty UPDATE completes only IPv4 unicast GR replay.
+    gr.process_update(UpdateMessage::build(
+        &[],
+        &[],
+        &[],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    ))
+    .await;
+    assert!(matches!(
+        gr_rib.try_recv(),
+        Ok(RibUpdate::EndOfRib {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    buffer_route_refresh(&mut gr, Afi::Ipv4, Safi::Unicast, RouteRefreshSubtype::BoRR);
+    buffer_route_refresh(&mut gr, Afi::Ipv6, Safi::Unicast, RouteRefreshSubtype::BoRR);
+    gr.process_read_buffer().await;
+    assert!(matches!(
+        gr_rib.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert!(gr_rib.try_recv().is_err(), "IPv6 BoRR must remain gated");
+    assert!(gr.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert!(!gr.refresh_accounting_has_window((Afi::Ipv6, Safi::Unicast)));
+}
+
+#[tokio::test]
+async fn enhanced_refresh_sweeps_every_counted_family_with_typed_identity() {
+    let mut session = make_test_session(65001, 65002);
+    let unicast = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(unicast, 7);
+    let flowspec = rustbgpd_rib::FlowSpecKey {
+        afi: Afi::Ipv4,
+        rule: FlowSpecRule {
+            components: vec![FlowSpecComponent::DestinationPrefix(FlowSpecPrefix::V4(
+                Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            ))],
+        },
+    };
+    session.known_flowspec.insert(flowspec);
+    let evpn = rustbgpd_wire::EvpnRouteKey::Imet {
+        rd: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 1]),
+        ethernet_tag: rustbgpd_wire::EthernetTagId(100),
+        originator_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+    };
+    session.known_evpn.insert(evpn);
+    session.known_bgpls.insert(make_bgpls_route(1).key());
+    session.known_vpn.insert(make_vpn_rib_route(100).key());
+    session
+        .known_labeled
+        .insert(make_labeled_rib_route(200).key());
+    session.known_rtc.insert(make_rtc_rib_route(300).key());
+    let families = [
+        (Afi::Ipv4, Safi::Unicast),
+        (Afi::Ipv4, Safi::FlowSpec),
+        (Afi::L2Vpn, Safi::Evpn),
+        (Afi::BgpLs, Safi::BgpLs),
+        (Afi::Ipv4, Safi::MplsVpn),
+        (Afi::Ipv4, Safi::LabeledUnicast),
+        (Afi::Ipv4, Safi::RtConstrain),
+    ];
+    assert_eq!(session.known_prefix_count(), families.len());
+    for family in families {
+        session.begin_refresh_accounting(family.0, family.1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+        assert_eq!(
+            session.known_prefix_count(),
+            families.len(),
+            "BoRR snapshots must not change live max-prefix accounting"
+        );
+    }
+    for family in families {
+        session.end_refresh_accounting(family.0, family.1);
+    }
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+}
+
+#[tokio::test]
+async fn duplicate_borr_resnapshots_routes_replayed_in_the_prior_window() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session.remember_known_path(Prefix::V4(prefix), 0);
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    session
+        .process_update(ipv4_announce(prefix, 0, false))
+        .await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RoutesReceived { .. })
+    ));
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::Ipv4, Safi::Unicast)),
+        Some(0)
+    );
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::Ipv4, Safi::Unicast)),
+        Some(1),
+        "duplicate BoRR must snapshot the route that the first replay made current"
+    );
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh { .. })
+    ));
+    assert_eq!(session.known_prefix_count(), 0);
+}
+
+#[tokio::test]
+async fn eorr_reconciles_omitted_prefix_before_later_max_prefix_check() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+    session.config.max_prefixes = Some(2);
+    let replayed = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let omitted = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    session.remember_known_path(Prefix::V4(replayed), 0);
+    session.remember_known_path(Prefix::V4(omitted), 0);
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    session
+        .process_update(ipv4_announce(replayed, 0, false))
+        .await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RoutesReceived { .. })
+    ));
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh { .. })
+    ));
+    assert_eq!(session.known_prefix_count(), 1);
+
+    let later = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    session.process_update(ipv4_announce(later, 0, false)).await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RoutesReceived { .. })
+    ));
+    assert_eq!(session.known_prefix_count(), 2);
+}
+
+#[tokio::test]
+async fn add_path_partial_replay_sweeps_only_omitted_identity_and_keeps_prefix_count() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated
+        .add_path_families
+        .insert((Afi::Ipv4, Safi::Unicast), AddPathMode::Both);
+    install_test_negotiated_session(&mut session, negotiated);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session.remember_known_path(Prefix::V4(prefix), 1);
+    session.remember_known_path(Prefix::V4(prefix), 2);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    session.process_update(ipv4_announce(prefix, 1, true)).await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RoutesReceived { .. })
+    ));
+    session.end_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    assert!(session.known_paths.contains(&(Prefix::V4(prefix), 1)));
+    assert!(!session.known_paths.contains(&(Prefix::V4(prefix), 2)));
+    assert_eq!(session.known_prefix_count(), 1);
+}
+
+#[tokio::test]
+async fn import_policy_denial_does_not_mark_refresh_stale_identity_replayed() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    install_test_negotiated_session(&mut session, negotiated_session(65002, false));
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }])));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session.remember_known_path(Prefix::V4(prefix), 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    session
+        .process_update(ipv4_announce(prefix, 0, false))
+        .await;
+    assert!(rib_rx.try_recv().is_err());
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::Ipv4, Safi::Unicast)),
+        Some(1)
+    );
+    session.end_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    assert_eq!(session.known_prefix_count(), 0);
+}
+
+#[tokio::test]
+async fn ordinary_withdrawal_retires_refresh_stale_identity() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    install_test_negotiated_session(&mut session, negotiated_session(65002, false));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session.remember_known_path(Prefix::V4(prefix), 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+
+    session
+        .process_update(ipv4_withdraw(prefix, 0, false))
+        .await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::RoutesReceived { .. })
+    ));
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::Ipv4, Safi::Unicast)),
+        Some(0)
+    );
+    session.end_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    assert_eq!(session.known_prefix_count(), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn closed_rib_timeout_preserves_refresh_window_and_live_count() {
+    let mut session = make_test_session(65001, 65002);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(prefix, 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+
+    tokio::time::advance(rustbgpd_rib::ERR_REFRESH_TIMEOUT).await;
+    assert_eq!(session.expire_refresh_accounting_windows().await, Err(()));
+    assert!(session.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert_eq!(session.known_prefix_count(), 1);
+    assert!(
+        session.refresh_accounting_timer.is_none(),
+        "a closed RIB must not spin a past-due timer"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn staggered_refresh_timeouts_sweep_only_due_family_and_rearm() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    let v6 = Prefix::V6(Ipv6Prefix::new(Ipv6Addr::LOCALHOST, 128));
+    session.remember_known_path(v4, 0);
+    session.remember_known_path(v6, 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    tokio::time::advance(Duration::from_secs(1)).await;
+    session.begin_refresh_accounting(Afi::Ipv6, Safi::Unicast);
+
+    tokio::time::advance(
+        rustbgpd_rib::ERR_REFRESH_TIMEOUT
+            .checked_sub(Duration::from_secs(1))
+            .unwrap(),
+    )
+    .await;
+    session.expire_refresh_accounting_windows().await.unwrap();
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert!(!session.known_paths.contains(&(v4, 0)));
+    assert!(session.known_paths.contains(&(v6, 0)));
+    assert!(!session.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert!(session.refresh_accounting_has_window((Afi::Ipv6, Safi::Unicast)));
+    assert!(session.refresh_accounting_timer.is_some());
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    session.expire_refresh_accounting_windows().await.unwrap();
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn quiet_run_loop_expires_refresh_accounting() {
+    let (mut session, cmd_tx, mut rib_rx) = make_test_session_with_channels(65001, 65002, 8);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(prefix, 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    let task = tokio::spawn(async move {
+        session.run().await.unwrap();
+    });
+
+    tokio::time::advance(rustbgpd_rib::ERR_REFRESH_TIMEOUT).await;
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    let (reply, state) = oneshot::channel();
+    cmd_tx
+        .send(PeerCommand::QueryState { reply })
+        .await
+        .unwrap();
+    assert_eq!(state.await.unwrap().prefix_count, 0);
+    cmd_tx.send(PeerCommand::Shutdown).await.unwrap();
+    task.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn timeout_eorr_precedes_next_buffered_update_after_rib_backpressure() {
+    let (mut session, _cmd_tx, mut rib_rx) = make_test_session_with_channels(65001, 65002, 1);
+    install_test_negotiated_session(&mut session, negotiated_session(65002, false));
+    let stale = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let first = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let second = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    session.remember_known_path(Prefix::V4(stale), 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    session
+        .rib_tx
+        .try_send(RibUpdate::BeginRouteRefresh {
+            peer: session.peer_ip,
+            session_id: session.session_identity.id,
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+        })
+        .unwrap();
+    for update in [
+        ipv4_announce(first, 0, false),
+        ipv4_announce(second, 0, false),
+    ] {
+        let encoded = rustbgpd_wire::encode_message(&Message::Update(update)).unwrap();
+        session.read_buf.buf.extend_from_slice(&encoded);
+    }
+    let task = tokio::spawn(async move {
+        session.process_read_buffer().await;
+        session
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !task.is_finished(),
+        "the first UPDATE must park on the full RIB channel"
+    );
+
+    tokio::time::advance(rustbgpd_rib::ERR_REFRESH_TIMEOUT).await;
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::RoutesReceived { ref announced, .. })
+            if announced.iter().any(|route| route.prefix == Prefix::V4(first))
+    ));
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::RoutesReceived { ref announced, .. })
+            if announced.iter().any(|route| route.prefix == Prefix::V4(second))
+    ));
+    let session = task.await.unwrap();
+    assert!(!session.known_paths.contains(&(Prefix::V4(stale), 0)));
+    assert_eq!(session.known_prefix_count(), 2);
+}
+
+#[tokio::test]
+async fn full_rib_channel_delays_marker_accounting_mutation_until_acceptance() {
+    let (mut session, _cmd_tx, mut rib_rx) = make_test_session_with_channels(65001, 65002, 1);
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(prefix, 0);
+    session
+        .rib_tx
+        .try_send(RibUpdate::BeginRouteRefresh {
+            peer: session.peer_ip,
+            session_id: session.session_identity.id,
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+        })
+        .unwrap();
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    {
+        let process = session.process_read_buffer();
+        tokio::pin!(process);
+        tokio::select! {
+            () = tokio::task::yield_now() => {}
+            () = &mut process => panic!("BoRR unexpectedly crossed a full RIB channel"),
+        }
+    }
+    assert_eq!(
+        session.refresh_accounting_window_count(),
+        0,
+        "BoRR must not open local accounting before RIB acceptance"
+    );
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(session.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::BeginRouteRefresh { .. })
+    ));
+
+    session
+        .rib_tx
+        .try_send(RibUpdate::BeginRouteRefresh {
+            peer: session.peer_ip,
+            session_id: session.session_identity.id,
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+        })
+        .unwrap();
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    {
+        let process = session.process_read_buffer();
+        tokio::pin!(process);
+        tokio::select! {
+            () = tokio::task::yield_now() => {}
+            () = &mut process => panic!("EoRR unexpectedly crossed a full RIB channel"),
+        }
+    }
+    assert!(session.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert_eq!(
+        session.known_prefix_count(),
+        1,
+        "EoRR must not sweep local accounting before RIB acceptance"
+    );
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::BeginRouteRefresh { .. })
+    ));
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert!(matches!(
+        rib_rx.recv().await,
+        Some(RibUpdate::EndRouteRefresh { .. })
+    ));
+}
+
+#[tokio::test]
+async fn refresh_stale_routes_remain_conservatively_counted_until_boundary() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    while rib_rx.try_recv().is_ok() {}
+    session.config.max_prefixes = Some(1);
+    let stale = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session.remember_known_path(Prefix::V4(stale), 0);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    let new = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    session.process_update(ipv4_announce(new, 0, false)).await;
+    let post_overflow: Vec<_> = std::iter::from_fn(|| rib_rx.try_recv().ok()).collect();
+    assert!(
+        post_overflow
+            .iter()
+            .all(|update| !matches!(update, RibUpdate::RoutesReceived { .. })),
+        "a new route at the exact cap must not receive transient ERR headroom"
+    );
+    assert!(
+        post_overflow
+            .iter()
+            .any(|update| matches!(update, RibUpdate::PeerDown { .. })),
+        "the overflow must deregister the established peer"
+    );
+    assert!(
+        session.read_half.is_none(),
+        "the stale route must still count, so the new prefix drives Cease teardown"
+    );
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+}
+
+#[tokio::test]
+async fn failed_refresh_marker_sends_never_mutate_local_accounting_window() {
+    let mut session = make_test_session(65001, 65002);
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(prefix, 0);
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(session.refresh_accounting_has_window((Afi::Ipv4, Safi::Unicast)));
+    assert_eq!(session.known_prefix_count(), 1);
+}
+
+#[tokio::test]
+async fn stray_eorr_is_a_local_noop_after_ordered_rib_acceptance() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    install_enhanced_refresh_session(&mut session, vec![(Afi::Ipv4, Safi::Unicast)], false);
+    while rib_rx.try_recv().is_ok() {}
+    let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24));
+    session.remember_known_path(prefix, 0);
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::Unicast,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            ..
+        })
+    ));
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+    assert_eq!(session.known_prefix_count(), 1);
+    assert!(session.read_half.is_some());
+}
 /// Regression: `Action::SessionDown` must clear `known_flowspec` and
 /// `known_evpn` alongside unicast path accounting. Reconnects previously inherited
 /// stale accounting, which could trip false max-prefix violations on the
@@ -1949,7 +2671,18 @@ fn known_prefix_refcount_tracks_add_path_withdrawals() {
 #[tokio::test]
 async fn session_down_clears_all_known_sets() {
     let mut session = make_test_session(65001, 65002);
-    session.negotiated = Some(negotiated_session(65002, false));
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.peer_gr_capable = true;
+    negotiated
+        .peer_capabilities
+        .push(Capability::GracefulRestart {
+            restart_state: false,
+            notification: false,
+            restart_time: 120,
+            families: vec![],
+        });
+    session.negotiated = Some(negotiated);
+    session.config.peer.graceful_restart = true;
     session.established_at = Some(Instant::now());
     let prefix = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, 0), 24));
     session.remember_known_path(prefix, 1);
@@ -1969,6 +2702,10 @@ async fn session_down_clears_all_known_sets() {
         originator_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
     };
     session.known_evpn.insert(evpn_key);
+    session
+        .received_eor_families
+        .insert((Afi::Ipv4, Safi::Unicast));
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::Unicast);
     assert!(session.known_prefix_count() >= 3);
     session.execute_actions(vec![Action::SessionDown]).await;
     assert!(session.known_paths.is_empty(), "known_paths must clear");
@@ -1981,6 +2718,9 @@ async fn session_down_clears_all_known_sets() {
         "known_flowspec must clear"
     );
     assert!(session.known_evpn.is_empty(), "known_evpn must clear");
+    assert!(session.received_eor_families.is_empty());
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+    assert!(session.refresh_accounting_timer.is_none());
     assert_eq!(session.known_prefix_count(), 0);
 }
 #[test]
@@ -8775,6 +9515,8 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         label2: None,
     });
     let expected_key = withdrawn_route.key();
+    session.known_evpn.insert(expected_key);
+    session.begin_refresh_accounting(Afi::L2Vpn, Safi::Evpn);
     // Craft the UPDATE: loop-triggering CLUSTER_LIST + MP_UNREACH with
     // the EVPN withdrawal. Also include an MP_REACH with a bogus announce
     // so the loop-detect branch has something to discard.
@@ -8834,6 +9576,13 @@ async fn rr_loop_detected_update_still_applies_evpn_withdrawals() {
         }
         _ => panic!("expected RoutesReceived from the loop-detect path"),
     }
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::L2Vpn, Safi::Evpn)),
+        Some(0),
+        "RR-loop withdrawal must retire the exact stale identity"
+    );
+    session.end_refresh_accounting(Afi::L2Vpn, Safi::Evpn);
+    assert!(session.known_evpn.is_empty());
 }
 /// Regression: max-prefix enforcement must count EVPN keys (and `FlowSpec`
 /// rules) alongside unicast prefixes. Prior to the fix, `known_prefix_count`
@@ -8942,6 +9691,17 @@ async fn rr_loop_detected_update_synthesizes_rtc_withdrawals() {
     session.negotiated = Some(negotiated);
     let announced_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_0064, 96).unwrap();
     let withdrawn_nlri = RtcNlri::new(65001, 0x0002_FDE9_0000_00C8, 96).unwrap();
+    session.known_rtc.extend([
+        rustbgpd_rib::RtcRibRouteKey {
+            nlri: announced_nlri,
+            path_id: 0,
+        },
+        rustbgpd_rib::RtcRibRouteKey {
+            nlri: withdrawn_nlri,
+            path_id: 0,
+        },
+    ]);
+    session.begin_refresh_accounting(Afi::Ipv4, Safi::RtConstrain);
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
         PathAttribute::AsPath(AsPath { segments: vec![] }),
@@ -8999,6 +9759,13 @@ async fn rr_loop_detected_update_synthesizes_rtc_withdrawals() {
         }
         _ => panic!("expected RtcRoutesReceived from the loop-detect path"),
     }
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::Ipv4, Safi::RtConstrain)),
+        Some(0),
+        "synthesized RR-loop RTC withdrawals must retire both stale identities"
+    );
+    session.end_refresh_accounting(Afi::Ipv4, Safi::RtConstrain);
+    assert!(session.known_rtc.is_empty());
 }
 /// Max-prefix enforcement must count RTC membership NLRI alongside the
 /// other families.
@@ -9099,6 +9866,8 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         label2: None,
     });
     let expected_key = withdrawn_route.key();
+    session.known_evpn.insert(expected_key);
+    session.begin_refresh_accounting(Afi::L2Vpn, Safi::Evpn);
     // AS_PATH that contains our local ASN (65001) → loop trigger.
     let attrs = vec![
         PathAttribute::Origin(Origin::Igp),
@@ -9154,6 +9923,13 @@ async fn as_path_loop_update_still_applies_evpn_withdrawals() {
         }
         _ => panic!("expected RoutesReceived from the AS_PATH-loop path"),
     }
+    assert_eq!(
+        session.refresh_accounting_stale_count((Afi::L2Vpn, Safi::Evpn)),
+        Some(0),
+        "AS-loop withdrawal must retire the exact stale identity"
+    );
+    session.end_refresh_accounting(Afi::L2Vpn, Safi::Evpn);
+    assert!(session.known_evpn.is_empty());
 }
 /// ADR-0051: when the writer's bulk channel saturates, the session must
 /// emit a `Cease` / `Out of Resources` (RFC 4486 §4 subcode 8)

--- a/docs/adr/0038-enhanced-route-refresh.md
+++ b/docs/adr/0038-enhanced-route-refresh.md
@@ -51,12 +51,28 @@ When a peer sends:
 When we trigger `SoftResetIn` and the peer supports RFC 7313:
 
 1. Inbound `BoRR` marks current routes from that peer/family as
-   refresh-stale in external RIB manager state
+   refresh-stale in external RIB manager state and snapshots the transport's
+   matching typed route identities for max-prefix accounting
 2. Refreshed announcements/withdrawals clear the exact stale entries they
-   replace
-3. Inbound `EoRR` sweeps any remaining unreplaced routes for that family
+   replace in both views, after their ordered RIB update is accepted
+3. Inbound `EoRR` sweeps any remaining unreplaced routes for that family from
+   both the RIB and the transport's live max-prefix count
 
-This applies to both unicast families and `FlowSpec`.
+The transport mirror covers every family that contributes to the neighbor's
+max-prefix limit: IPv4/IPv6 unicast (including exact Add-Path identity),
+`FlowSpec`, EVPN, BGP-LS, VPN, labeled-unicast, and RT-Constrain. Stale routes
+remain counted during the refresh window. This intentionally provides no
+transient headroom: a peer already at its configured limit can still exceed it
+by announcing a new prefix before `EoRR` reconciles an omitted old prefix.
+
+Marker mutation is ordered behind acceptance by the peer's RIB sender. A full
+RIB channel applies backpressure without opening or closing the local window;
+a closed channel preserves the existing accounting state rather than sweeping
+only one side.
+
+For a peer that advertised Graceful Restart, rustbgpd ignores a `BoRR` for a
+family until that exact family has completed its initial End-of-RIB. This keeps
+RFC 7313 replacement state from overlapping the initial RFC 4724 replay.
 
 Graceful Restart stale state remains separate; ERR uses its own tracking and
 does not overload GR `is_stale`.
@@ -68,9 +84,18 @@ Each active inbound ERR window has a fixed 5-minute timeout.
 If a peer sends `BoRR` but never sends `EoRR`, rustbgpd treats the timeout as
 an implicit end-of-refresh sweep for that `(peer, afi, safi)`:
 
-1. remaining unreplaced refresh-stale entries are withdrawn
-2. the refresh window is closed
-3. a warning is logged
+1. transport enqueues an ordinary `EndRouteRefresh` on the same ordered peer
+   sender used by inbound UPDATEs
+2. after that enqueue succeeds, remaining unreplaced refresh-stale entries are
+   withdrawn from the RIB and transport max-prefix mirror
+3. the refresh window is closed and a warning is logged
+
+The transport checks expiry before every buffered PDU decode and also owns an
+independent timer for quiet peers. If the RIB channel is full, expiry waits so
+the implicit end marker cannot be overtaken by the next UPDATE. If the channel
+is closed, the session preserves the window and live count and stops processing
+the buffered batch; it does not perform an unpaired local sweep. Families with
+different refresh deadlines expire independently.
 
 This bounds resource use and prevents stale refresh state from persisting
 indefinitely due to buggy peers or dropped inbound markers.


### PR DESCRIPTION
## Summary

- mirror inbound Enhanced Route Refresh windows in transport max-prefix accounting for every counted route family
- retire replayed and withdrawn stale identities only after ordered RIB acceptance, then reconcile omissions at EoRR or the shared timeout
- order timeout closure ahead of later buffered UPDATEs, preserve accounting under RIB backpressure or shutdown, and handle quiet sessions
- keep Graceful Restart replay and refresh replacement from overlapping by requiring the family's initial End-of-RIB
- document the conservative no-headroom behavior and failure boundaries

## Verification

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- cargo test -p rustbgpd-transport refresh --no-fail-fast
- cargo test -p rustbgpd-rib refresh --no-fail-fast
- cargo test --workspace --all-features --locked --no-fail-fast
- independent exact-head review, including the policy-transition readiness isolation regressions
