### PR TITLE
test: pin policy transition evidence contracts

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1173,7 +1173,11 @@ impl RibManager {
                 }
 
                 let snapshot = prefixes.as_ref().expect("initialized above");
-                let end = (cursor + super::POLICY_TRANSITION_ROUTE_SLICE).min(snapshot.len());
+                let end = super::policy_transition_slice_end(
+                    cursor,
+                    snapshot.len(),
+                    super::POLICY_TRANSITION_ROUTE_SLICE,
+                );
                 if cursor < end {
                     self.stage_policy_transition_group_chunk(
                         destination,
@@ -1226,7 +1230,11 @@ impl RibManager {
                     return CleanPolicyTransitionAdvance::Continue(pending);
                 }
                 let snapshot = keys.as_ref().expect("initialized above");
-                let end = (cursor + super::POLICY_TRANSITION_ROUTE_SLICE).min(snapshot.len());
+                let end = super::policy_transition_slice_end(
+                    cursor,
+                    snapshot.len(),
+                    super::POLICY_TRANSITION_ROUTE_SLICE,
+                );
                 if self
                     .extend_clean_policy_transition_inventory(
                         source,
@@ -1272,8 +1280,11 @@ impl RibManager {
                 mut full_probe_count,
             } => {
                 if let Some(mut probe) = active_probe.take() {
-                    let end = (probe.cursor + super::POLICY_TRANSITION_ROUTE_SLICE)
-                        .min(inventory.announce.len());
+                    let end = super::policy_transition_slice_end(
+                        probe.cursor,
+                        inventory.announce.len(),
+                        super::POLICY_TRANSITION_ROUTE_SLICE,
+                    );
                     let candidates = inventory.announce[probe.cursor..end]
                         .iter()
                         .zip(inventory.next_hop_override[probe.cursor..end].iter())

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -623,12 +623,23 @@ fn page_routes<'a>(
     }
 }
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
+/// Production route budget for one strict shared-policy actor poll.
+pub(in crate::manager) const POLICY_TRANSITION_PRODUCTION_ROUTE_SLICE: usize = 1_024;
 /// Maximum route identities processed by one strict shared-policy actor poll.
 #[cfg(not(test))]
-pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize = 1_024;
+pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize =
+    POLICY_TRANSITION_PRODUCTION_ROUTE_SLICE;
 /// Tiny deterministic unit used to prove multi-poll ordering in tests.
 #[cfg(test)]
 pub(in crate::manager) const POLICY_TRANSITION_ROUTE_SLICE: usize = 1;
+
+pub(in crate::manager) fn policy_transition_slice_end(
+    cursor: usize,
+    len: usize,
+    budget: usize,
+) -> usize {
+    (cursor + budget).min(len)
+}
 /// Maximum members classified by one strict shared-policy actor poll.
 pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -11,6 +11,27 @@ use rustbgpd_policy::{
 
 use super::*;
 
+#[test]
+fn policy_transition_production_slice_boundaries_are_exact() {
+    let budget = super::super::POLICY_TRANSITION_PRODUCTION_ROUTE_SLICE;
+    let slice_ends = |len| {
+        let mut cursor = 0;
+        let mut ends = Vec::new();
+        while cursor < len {
+            cursor = super::super::policy_transition_slice_end(cursor, len, budget);
+            ends.push(cursor);
+        }
+        ends
+    };
+
+    assert_eq!(budget, 1_024);
+    assert_eq!(slice_ends(0), Vec::<usize>::new());
+    assert_eq!(slice_ends(1_023), vec![1_023]);
+    assert_eq!(slice_ends(1_024), vec![1_024]);
+    assert_eq!(slice_ends(1_025), vec![1_024, 1_025]);
+    assert_eq!(slice_ends(2_049), vec![1_024, 2_048, 2_049]);
+}
+
 struct CohortExactEncoder {
     owner: u64,
     profile: u64,

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -608,8 +608,11 @@ pub trait ExactExportSnapshot: Any + Send + Sync {
     /// snapshots produce identical wire bytes for the same candidate after
     /// excluding only the target-owned message ceiling and identity fields.
     /// Probe failures are deliberately not representable here: callers may
-    /// reuse only encoded lengths from successful source probes. The returned
-    /// vector must preserve the input lengths' cardinality and order.
+    /// reuse only encoded lengths from successful source probes. For a
+    /// wire-equivalent source/target pair, acceptance must be monotone in the
+    /// encoded length: every value at or below the target's negotiated ceiling
+    /// succeeds, and every longer value fails. The returned vector must
+    /// preserve the input lengths' cardinality and order.
     fn reuse_successful_probes(
         &self,
         source: &dyn ExactExportSnapshot,

--- a/crates/transport/benches/fanout.rs
+++ b/crates/transport/benches/fanout.rs
@@ -33,6 +33,7 @@ use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_ma
 
 use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
 use rustbgpd_rib::RibManager;
+use rustbgpd_rib::manager::PolicyTransitionBenchReceipt;
 use rustbgpd_rib::route::{Route, RouteOrigin};
 use rustbgpd_rib::update::{OutboundRouteUpdate, RibUpdate};
 use rustbgpd_telemetry::BgpMetrics;
@@ -280,6 +281,51 @@ type PolicyRegroupState = (
     PolicyChain,
 );
 
+fn assert_shared_transition_receipt(
+    fast: bool,
+    receipt: &PolicyTransitionBenchReceipt,
+    routes: usize,
+    peers: usize,
+) {
+    assert_eq!(
+        fast,
+        peers > 1,
+        "only multi-peer fixtures are eligible for the clean shared transition"
+    );
+    if fast {
+        assert_eq!(receipt.plan_builds, 1, "one shared plan per transition");
+        assert_eq!(
+            receipt.full_exact_probes, routes,
+            "one full exact probe per route"
+        );
+        assert_eq!(
+            receipt.route_shell_materializations, routes,
+            "one route-shell materialization per route"
+        );
+        assert_eq!(
+            receipt.authoritative_peer_applies, 0,
+            "the clean shared transition must not use per-peer fallback"
+        );
+    } else {
+        assert_eq!(
+            receipt.plan_builds, 0,
+            "fallback must not build a shared plan"
+        );
+        assert_eq!(
+            receipt.full_exact_probes, 0,
+            "fallback must not run a shared exact probe"
+        );
+        assert_eq!(
+            receipt.route_shell_materializations, 0,
+            "fallback must not materialize shared route shells"
+        );
+        assert_eq!(
+            receipt.authoritative_peer_applies, 1,
+            "the one-peer fixture must use one authoritative apply"
+        );
+    }
+}
+
 fn build_policy_regroup(routes: usize, peers: usize) -> PolicyRegroupState {
     let (_tx, rx) = mpsc::channel::<RibUpdate>(16);
     let (_qtx, qrx) = mpsc::channel::<RibUpdate>(16);
@@ -361,7 +407,9 @@ fn bench_ixp_policy_regroup_resync(c: &mut Criterion) {
                         || build_ixp_policy_regroup(4_096, peers, distinct),
                         |(manager, _receivers, next)| {
                             let fast = manager.bench_replace_export_policy_cohort(peers, next);
-                            std::hint::black_box((fast, manager.bench_policy_transition_receipt()))
+                            let receipt = manager.bench_policy_transition_receipt();
+                            assert_shared_transition_receipt(fast, &receipt, 4_096, peers);
+                            std::hint::black_box((fast, receipt))
                         },
                         BatchSize::PerIteration,
                     );
@@ -386,7 +434,9 @@ fn bench_policy_regroup_resync(c: &mut Criterion) {
                         || build_policy_regroup(routes, peers),
                         |(manager, _receivers, next)| {
                             let fast = manager.bench_replace_export_policy_cohort(peers, next);
-                            std::hint::black_box((fast, manager.bench_policy_transition_receipt()))
+                            let receipt = manager.bench_policy_transition_receipt();
+                            assert_shared_transition_receipt(fast, &receipt, routes, peers);
+                            std::hint::black_box((fast, receipt))
                         },
                         BatchSize::PerIteration,
                     );
@@ -415,7 +465,9 @@ fn bench_policy_regroup_resync(c: &mut Criterion) {
                 || build_policy_regroup(routes, peers),
                 |(manager, _receivers, next)| {
                     let fast = manager.bench_replace_export_policy_cohort(peers, next);
-                    std::hint::black_box((fast, manager.bench_policy_transition_receipt()))
+                    let receipt = manager.bench_policy_transition_receipt();
+                    assert_shared_transition_receipt(fast, &receipt, routes, peers);
+                    std::hint::black_box((fast, receipt))
                 },
                 BatchSize::PerIteration,
             );

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -41,6 +41,9 @@ pub(crate) struct SessionExportProfile {
     remove_private_as: RemovePrivateAs,
     cluster_id: Option<Ipv4Addr>,
     configured_local_ipv6_nexthop: Option<Ipv6Addr>,
+    /// Current encoding rules consume the remote ASN only through this class.
+    /// Any future rule that depends on the ASN value must add the negotiated
+    /// remote ASN to this immutable profile before sharing wire results.
     is_ebgp: bool,
     four_octet_as: bool,
     extended_messages: bool,
@@ -90,7 +93,9 @@ impl SessionExportProfile {
     /// Snapshot identity, generation, and the negotiated message ceiling do
     /// not affect the bytes. Cloning and normalizing those fields before using
     /// the derived full-struct equality keeps newly-added wire inputs in this
-    /// proof by default instead of requiring a parallel allow-list.
+    /// proof by default instead of requiring a parallel allow-list. Remote ASN
+    /// identity is deliberately absent because current rules consume only the
+    /// stored eBGP/iBGP class; a value-dependent rule must restore it here.
     fn has_same_wire_encoding(&self, other: &Self) -> bool {
         let mut this = self.clone();
         let mut other = other.clone();
@@ -2224,21 +2229,6 @@ mod tests {
 
     #[test]
     fn distinct_ebgp_remote_asns_share_wire_results_but_ibgp_does_not() {
-        let mut source_config = config_with_auth_secret("not-retained");
-        source_config.route_server_client = true;
-        source_config.peer.remote_asn = 65_002;
-        let mut target_config = source_config.clone();
-        target_config.peer.remote_asn = 65_003;
-        let mut ibgp_config = source_config.clone();
-        ibgp_config.peer.remote_asn = ibgp_config.peer.local_asn;
-
-        let source = SessionExportProfile::initial(&source_config, None, false);
-        let target = SessionExportProfile::initial(&target_config, None, false);
-        let ibgp = SessionExportProfile::initial(&ibgp_config, None, false);
-        assert!(source.is_ebgp());
-        assert!(target.is_ebgp());
-        assert!(!ibgp.is_ebgp());
-
         let route = Route {
             prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
             next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
@@ -2274,33 +2264,73 @@ mod tests {
                     .into_message(),
             )
         };
-        let source_bytes = wire_bytes(&source);
 
-        assert_eq!(
-            source_bytes,
-            wire_bytes(&target),
-            "remote ASN identity does not change bytes within the eBGP class"
-        );
-        assert!(
-            target
-                .reuse_successful_probes(&source, &[source_bytes.len()])
-                .is_some(),
-            "distinct eBGP client ASNs reuse a successful exact result"
-        );
-        assert_ne!(
-            source_bytes,
-            wire_bytes(&ibgp),
-            "the eBGP/iBGP classification remains wire-relevant"
-        );
-        assert!(
-            ibgp.reuse_successful_probes(&source, &[source_bytes.len()])
-                .is_none(),
-            "eBGP results must not cross the iBGP boundary"
-        );
+        for route_server_client in [false, true] {
+            let mut source_config = config_with_auth_secret("not-retained");
+            source_config.route_server_client = route_server_client;
+            source_config.peer.remote_asn = 65_002;
+            let mut target_config = source_config.clone();
+            target_config.peer.remote_asn = 65_003;
+            let mut ibgp_config = source_config.clone();
+            ibgp_config.peer.remote_asn = ibgp_config.peer.local_asn;
+
+            let source = SessionExportProfile::initial(&source_config, None, false);
+            let target = SessionExportProfile::initial(&target_config, None, false);
+            let ibgp = SessionExportProfile::initial(&ibgp_config, None, false);
+            assert!(source.is_ebgp());
+            assert!(target.is_ebgp());
+            assert!(!ibgp.is_ebgp());
+
+            if !route_server_client {
+                let attrs = source.prepare_unicast_attributes(&route, source.local_ipv4(), None);
+                assert!(
+                    attrs.iter().any(|attr| matches!(
+                        attr,
+                        PathAttribute::AsPath(AsPath { segments })
+                            if matches!(
+                                segments.first(),
+                                Some(AsPathSegment::AsSequence(asns))
+                                    if asns.first() == Some(&source.local_asn)
+                            )
+                    )),
+                    "the ordinary eBGP fixture must exercise local-AS prepend"
+                );
+                assert!(
+                    attrs.iter().any(|attr| matches!(
+                        attr,
+                        PathAttribute::NextHop(next_hop) if *next_hop == source.local_ipv4()
+                    )),
+                    "the ordinary eBGP fixture must exercise next-hop-self rewriting"
+                );
+            }
+
+            let source_bytes = wire_bytes(&source);
+            assert_eq!(
+                source_bytes,
+                wire_bytes(&target),
+                "remote ASN identity does not change bytes within either eBGP profile"
+            );
+            assert!(
+                target
+                    .reuse_successful_probes(&source, &[source_bytes.len()])
+                    .is_some(),
+                "distinct eBGP remote ASNs reuse a successful exact result"
+            );
+            assert_ne!(
+                source_bytes,
+                wire_bytes(&ibgp),
+                "the eBGP/iBGP classification remains wire-relevant"
+            );
+            assert!(
+                ibgp.reuse_successful_probes(&source, &[source_bytes.len()])
+                    .is_none(),
+                "eBGP results must not cross the iBGP boundary"
+            );
+        }
     }
 
     #[test]
-    fn successful_extended_probe_reuse_reapplies_smaller_target_ceiling() {
+    fn successful_probe_reuse_is_monotone_at_target_ceiling() {
         let config = config_with_auth_secret("not-retained");
         let mut source = SessionExportProfile::initial(&config, None, false);
         source.extended_messages = true;
@@ -2310,22 +2340,29 @@ mod tests {
         target.extended_messages = false;
         target.owner_id = 29;
         target.generation = 17;
-        let encoded_len = usize::from(rustbgpd_wire::MAX_MESSAGE_LEN) + 1;
+        let max_len = usize::from(rustbgpd_wire::MAX_MESSAGE_LEN);
 
-        let error = target
-            .reuse_successful_probes(&source, &[encoded_len])
-            .expect("the message ceiling does not affect encoded bytes")
-            .pop()
-            .expect("one source length produces one target result")
-            .expect_err("the successful 64K probe must be rejected by a 4K target");
+        let results = target
+            .reuse_successful_probes(&source, &[max_len - 1, max_len, max_len + 1])
+            .expect("the message ceiling does not affect encoded bytes");
+        for (encoded_len, result) in [max_len - 1, max_len].into_iter().zip(&results[..2]) {
+            assert_eq!(
+                result,
+                &Ok(ExactExportResult {
+                    encoded_len,
+                    max_len,
+                    generation: 17,
+                }),
+                "every encoded length through the target ceiling is accepted"
+            );
+        }
+        let error = results[2]
+            .as_ref()
+            .expect_err("the first encoded length above the target ceiling is rejected");
 
         assert_eq!(error.code(), ExactExportErrorCode::MessageTooLong);
-        assert!(error.detail().contains(&encoded_len.to_string()));
-        assert!(
-            error
-                .detail()
-                .contains(&rustbgpd_wire::MAX_MESSAGE_LEN.to_string())
-        );
+        assert!(error.detail().contains(&(max_len + 1).to_string()));
+        assert!(error.detail().contains(&max_len.to_string()));
     }
 
     #[test]

--- a/docs/perf/artifacts/ixp-exact-export-cohorts-2026-07/README.md
+++ b/docs/perf/artifacts/ixp-exact-export-cohorts-2026-07/README.md
@@ -1,8 +1,9 @@
 # IXP exact-export cohort artifacts
 
-This directory retains the raw, normalized Criterion medians and deterministic
-production-state-machine counters for the IXP exact-export cohort campaign.
-All durations are nanoseconds. The measured fixture-only baseline is commit
+This directory retains normalized aggregate Criterion summaries and
+deterministic production-state-machine counters for the IXP exact-export cohort
+campaign. The CSVs do not contain raw samples. All durations are nanoseconds.
+The measured fixture-only baseline is commit
 `a47c618ebb7cdf9c99a48e6bd7ed753f42cac664`. The measured wire-equivalence
 optimization is commit `828e7a7f7be2a27d2556341320fe2dfc036d7e1a`.
 
@@ -19,7 +20,15 @@ eBGP route-server clients. The transition matrix used 4,096 routes and 64 or
 700 clients. `homogeneous_remote_asn` assigns AS 65001 to every client;
 `distinct_remote_asns` assigns consecutive ASNs beginning at 65001. Manager
 and transport fixtures agree on eBGP mode, route-server-client mode, local
-address, and capabilities.
+address, and capabilities. The fixtures are groupable plain single-best peers;
+per-client-best and Add-Path peers remain ungrouped and are outside this
+shared-cohort receipt.
+
+Criterion's `iter_batched_ref` setup closure registers peers, seeds the Loc-RIB,
+and drains initial output outside the timed routine. The first-advertise cells
+time only distribution, and the transition cells time only the production
+policy-transition routine. Counter CSV rows record the first measured
+production-state-machine invocation, not setup work.
 
 The two pinned worktrees compiled into separate clean target directories. This
 prevents Cargo from treating a binary produced by the other worktree as fresh.
@@ -29,25 +38,42 @@ binary was then compiled from its pinned commit and invoked with the matching
 Criterion baseline name. Criterion's paired change therefore compares the
 exact retained baseline samples without sharing build outputs across revisions.
 
+Bootstrap both PR-only source commits and isolated worktrees from a fresh
+clone before running the commands below:
+
+```console
+git clone https://github.com/lance0/rustbgpd.git rustbgpd-ixp-receipt
+cd rustbgpd-ixp-receipt
+git fetch origin refs/pull/885/head:refs/remotes/origin/pr-885
+
+BASE_WORKTREE=/tmp/rustbgpd-ixp-baseline
+HEAD_WORKTREE=/tmp/rustbgpd-ixp-optimized
+BASE_TARGET=/tmp/rustbgpd-ixp-baseline-target
+HEAD_TARGET=/tmp/rustbgpd-ixp-optimized-target
+
+git worktree add --detach "$BASE_WORKTREE" a47c618ebb7cdf9c99a48e6bd7ed753f42cac664
+git worktree add --detach "$HEAD_WORKTREE" 828e7a7f7be2a27d2556341320fe2dfc036d7e1a
+```
+
 Reproduce the first-advertise comparison from the two pinned worktrees:
 
 ```console
-# Run from the baseline worktree.
+(cd "$BASE_WORKTREE" &&
 taskset -c 7 env CARGO_TARGET_DIR="$BASE_TARGET" \
   cargo bench -p rustbgpd-transport --features bench-internals \
   --bench fanout -- 'ixp_exact_export_fanout' \
   --warm-up-time 1 --measurement-time 2 --sample-size 20 \
-  --save-baseline terminal-clean-raw-peer-asn --noplot
+  --save-baseline terminal-clean-raw-peer-asn --noplot)
 
 mkdir -p "$HEAD_TARGET/criterion"
 cp -a "$BASE_TARGET/criterion/." "$HEAD_TARGET/criterion/"
 
-# Run from the optimized worktree.
+(cd "$HEAD_WORKTREE" &&
 taskset -c 7 env CARGO_TARGET_DIR="$HEAD_TARGET" \
   cargo bench -p rustbgpd-transport --features bench-internals \
   --bench fanout -- 'ixp_exact_export_fanout' \
   --warm-up-time 1 --measurement-time 2 --sample-size 20 \
-  --baseline terminal-clean-raw-peer-asn --noplot
+  --baseline terminal-clean-raw-peer-asn --noplot)
 ```
 
 Reproduce one transition cell and its counter receipt. The baseline run used a
@@ -56,29 +82,30 @@ optimized run used the same name with `--baseline`. Set
 `RUSTBGPD_IXP_LARGE_RECEIPT=1` for 700 peers.
 
 ```console
-# Run from the baseline worktree.
+(cd "$BASE_WORKTREE" &&
 taskset -c 7 env CARGO_TARGET_DIR="$BASE_TARGET" \
   RUSTBGPD_POLICY_TRANSITION_RECEIPT=1 \
   cargo bench -p rustbgpd-transport --features bench-internals \
   --bench fanout -- \
   'ixp_policy_regroup_resync/shared_plan/distinct_remote_asns/4096/64' \
   --warm-up-time 1 --measurement-time 2 --sample-size 10 \
-  --save-baseline terminal-clean-distinct-64 --noplot
+  --save-baseline terminal-clean-distinct-64 --noplot)
 
 mkdir -p "$HEAD_TARGET/criterion"
 cp -a "$BASE_TARGET/criterion/." "$HEAD_TARGET/criterion/"
 
-# Run from the optimized worktree.
+(cd "$HEAD_WORKTREE" &&
 taskset -c 7 env CARGO_TARGET_DIR="$HEAD_TARGET" \
   RUSTBGPD_POLICY_TRANSITION_RECEIPT=1 \
   cargo bench -p rustbgpd-transport --features bench-internals \
   --bench fanout -- \
   'ixp_policy_regroup_resync/shared_plan/distinct_remote_asns/4096/64' \
   --warm-up-time 1 --measurement-time 2 --sample-size 10 \
-  --baseline terminal-clean-distinct-64 --noplot
+  --baseline terminal-clean-distinct-64 --noplot)
 ```
 
-Criterion's `median.point_estimate` and median confidence bounds are retained
-verbatim in the CSVs. The optimized CSV also retains Criterion's paired mean
-change estimate and confidence bounds. Counter receipts are the first measured
-production state-machine invocation emitted by the benchmark process.
+Criterion's aggregate `median.point_estimate` and median confidence bounds are
+retained verbatim in the CSV summaries. The optimized CSV also retains
+Criterion's paired mean change estimate and confidence bounds. Counter receipts
+are the first measured production state-machine invocation emitted by the
+benchmark process.

--- a/docs/perf/exact-export-fanout-2026-07.md
+++ b/docs/perf/exact-export-fanout-2026-07.md
@@ -380,9 +380,11 @@ advertise to eBGP route-server clients with the same local address,
 capabilities, route-server mode, and grouping inputs. One population assigns
 AS 65001 to every client; the other assigns a different remote ASN to each
 client. The transition matrix changes one export-policy community over 4,096
-routes. Every cell ran on the same pinned CPU and release binary settings; the
-raw medians, paired change confidence intervals, commands, and environment are
-retained in the campaign artifact directory.
+routes. These fixtures are groupable plain single-best peers; per-client-best
+and Add-Path peers remain ungrouped and receive no shared-cohort benefit. Every
+cell ran on the same pinned CPU and release binary settings; the aggregate
+Criterion estimates, paired change confidence intervals, commands, and
+environment are retained in the campaign artifact directory.
 
 ### Results
 
@@ -430,11 +432,12 @@ remove-private-AS mode, cluster and next-hop inputs, every negotiated family
 capability, local socket address, scoped-link-local mode, and GShut state.
 Target-owned message ceiling and generation checks still run for every member.
 
-A byte-level regression constructs two route-server profiles with different
-eBGP remote ASNs, proves their complete encoded UPDATEs are identical, and
-proves successful-length reuse. The same test changes the target to iBGP,
-observes different bytes, and requires reuse to fail. The eight-cohort bound is
-unchanged for profiles that differ on a real wire input.
+A byte-level regression constructs distinct-remote-ASN profiles in both
+route-server and ordinary eBGP modes, proves their complete encoded UPDATEs are
+identical, and proves successful-length reuse. The ordinary arm additionally
+asserts that local-AS prepend and next-hop rewriting ran. The same test changes
+the target to iBGP, observes different bytes, and requires reuse to fail. The
+eight-cohort bound is unchanged for profiles that differ on a real wire input.
 
 A separate live-capture canary configures dynamic `remote_asn = 0`, then proves
 that the negotiated ASN classifies an eBGP session as eBGP and a same-AS

--- a/docs/perf/policy-regroup-shared-plan-2026-07.md
+++ b/docs/perf/policy-regroup-shared-plan-2026-07.md
@@ -11,7 +11,9 @@ The optimized path is deliberately limited to clean grouped-to-grouped unicast
 members whose staging profile differs only by export-chain content. It builds
 one immutable old/new inventory, materializes changed route shells once, and
 reuses successful exact-export lengths only when each session snapshot proves
-wire compatibility. Dirty, force, ORF, Add-Path, RTC, VPN, mixed-family,
+wire compatibility. The path applies only to groupable plain single-best
+members; per-client-best and Add-Path peers remain ungrouped and do not receive
+this shared-cohort benefit. Dirty, force, ORF, RTC, VPN, mixed-family,
 generation-mismatched, saturated, or exact-rejecting cohorts fall back before
 the first optimized emission.
 
@@ -275,13 +277,17 @@ distinct-ASN clients, that produced 2,867,200 full probes, 3,599 actor polls,
 and a 510.332 ms median.
 
 The exact-export profile now stores the derived eBGP/iBGP class while retaining
-full equality for every actual wire input. The same distinct-ASN workload uses
-4,096 full probes and 803 polls and completes in 7.604 ms, a -98.51% Criterion
-mean change (-98.54%..-98.49%). The 64-client cell drops from 262,144 to 4,096
-full probes and from 49.206 ms to 3.464 ms. Optimized homogeneous and
-distinct-ASN receipts have identical plan/probe/shell/poll counts. Byte-level
-tests prove cross-ASN eBGP equality and preserve the eBGP/iBGP incompatibility
-boundary; per-member ceiling and generation checks remain mandatory.
+full equality for every actual wire input. The pass-local cache retains at most
+eight compatibility cohorts per update-group ID; profiles beyond that bound
+take the ordinary exact-probe path. The same distinct-ASN workload uses 4,096
+full probes and 803 polls and completes in 7.604 ms, a -98.51% Criterion mean
+change (-98.54%..-98.49%). The 64-client cell drops from 262,144 to 4,096 full
+probes and from 49.206 ms to 3.464 ms. Optimized homogeneous and distinct-ASN
+receipts have identical plan/probe/shell/poll counts. Byte-level tests prove
+cross-ASN equality for both route-server and ordinary eBGP transforms, including
+the ordinary local-AS prepend and next-hop rewrite, and preserve the eBGP/iBGP
+incompatibility boundary; per-member ceiling and generation checks remain
+mandatory.
 
 The homogeneous 700-client cell showed no detected change (-1.60% mean,
 -4.34%..+1.01%). The homogeneous 64-client cell also showed no detected change
@@ -291,7 +297,7 @@ The dynamic-neighbor capture canary additionally proves that configured
 `remote_asn = 0` defers classification to the negotiated ASN for both eBGP and
 same-AS iBGP sessions.
 
-Raw medians, confidence bounds, deterministic counters, environment, and
+Aggregate medians, confidence bounds, deterministic counters, environment, and
 reproduction commands are retained in
 [`artifacts/ixp-exact-export-cohorts-2026-07/`](artifacts/ixp-exact-export-cohorts-2026-07/).
 These results do not supersede the still-required loaded 700-peer campaign.


### PR DESCRIPTION
## Summary

- make policy-transition receipt benches fail when one-peer fallback or multi-peer shared-path counters drift
- prove remote-ASN wire equivalence across ordinary and route-server eBGP, and pin exact-export ceiling monotonicity plus production 1,024-route slice boundaries
- clarify the eight-cohort and single-best applicability limits, label retained CSVs as aggregate summaries, and make the pinned receipt reproducible from a fresh clone

This is an evidence-only tranche: it changes no production policy-transition behavior, adds no benchmark numbers, and leaves every historical CSV byte unchanged.

## Validation

- focused remote-ASN, 4,095/4,096/4,097 ceiling, and 1,023/1,024/1,025/2,049 slice tests
- reduced one-peer fallback, ordinary shared, and distinct-ASN IXP benchmark cells to exercise deterministic assertions only
- full rustbgpd-rib and rustbgpd-transport test suites
- workspace all-target Clippy with warnings denied
- Rust 1.95 workspace all-target check
- formatting and diff checks
- commit and pre-push hooks, including workspace tests and rustdoc

Independent exact-diff review approved SHA-256 dc8a73745b3da0620576b15d79ca676a821b151dc05a91cb540f5c3c0a9f4b0b with no findings.