### PR TITLE
fix: harden TCP-MD5 secret lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,11 +179,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   proves a live SIGHUP successor rotation against BIRD 3.3.1 without a session
   flap.
 
-- **Transport-owned BGP authentication secrets are zeroized on drop.** TCP-AO
-  MKT secrets and TCP-MD5 passwords use an immutable redacting runtime wrapper,
-  so each transport clone scrubs its own allocation when replaced or dropped.
-  TOML parser, configuration snapshot, API, and kernel copies retain their
-  separate lifetimes. The queued-child kernel receipt now exercises a dynamic
+- **Runtime-owned BGP authentication secrets are zeroized on drop.** TCP-AO
+  MKT secrets and TCP-MD5 passwords use an immutable redacting wrapper across
+  the internal API, peer manager, and transport runtime, so each clone scrubs
+  its own allocation when replaced or dropped. The Linux `tcp_md5sig`
+  temporary also scrubs its key buffer and length after every socket-option
+  attempt. TOML parser, configuration snapshot, protobuf, compiler-created,
+  and kernel copies retain their separate lifetimes. The queued-child kernel
+  receipt now exercises a dynamic
   `127.0.0.0/24` owner and proves its successor is installed on the accepted
   child without changing Current/RNext or authenticated traffic.
 

--- a/crates/api/src/peer_group_service.rs
+++ b/crates/api/src/peer_group_service.rs
@@ -121,7 +121,7 @@ fn proto_definition_to_input(
         hold_time,
         send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
-        md5_password: definition.md5_password,
+        md5_password: definition.md5_password.map(Into::into),
         ttl_security: definition.ttl_security,
         families,
         graceful_restart: definition.graceful_restart,
@@ -743,11 +743,21 @@ mod tests {
     #[tokio::test]
     async fn read_peer_group_responses_redact_md5_password() {
         let definition = proto_definition_to_input(sample_definition()).unwrap();
-        assert_eq!(definition.md5_password.as_deref(), Some("secret"));
+        assert_eq!(
+            definition
+                .md5_password
+                .as_ref()
+                .map(std::convert::AsRef::as_ref),
+            Some("secret")
+        );
 
         let output = input_definition_to_proto(&definition);
         assert_eq!(output.md5_password, None);
         assert_eq!(output.has_md5_password, Some(true));
+
+        let debug = format!("{definition:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("secret"));
 
         let (peer_tx, mut peer_rx) = mpsc::channel(4);
         let svc = PeerGroupService::new(AccessMode::ReadOnly, peer_tx, None, None);
@@ -840,7 +850,13 @@ mod tests {
                 ack,
             }) => {
                 assert_eq!(name, "rs-clients");
-                assert_eq!(definition.md5_password.as_deref(), Some("secret"));
+                assert_eq!(
+                    definition
+                        .md5_password
+                        .as_ref()
+                        .map(std::convert::AsRef::as_ref),
+                    Some("secret")
+                );
                 assert_eq!(definition.families, vec!["ipv6_unicast"]);
                 ack.expect("persisted mutation must carry an ack")
                     .send(Ok(()))
@@ -882,7 +898,13 @@ mod tests {
                     PeerManagerCommand::SetPeerGroup {
                         definition, reply, ..
                     } => {
-                        assert_eq!(definition.md5_password.as_deref(), Some("super-secret"));
+                        assert_eq!(
+                            definition
+                                .md5_password
+                                .as_ref()
+                                .map(std::convert::AsRef::as_ref),
+                            Some("super-secret")
+                        );
                         let _ = reply.send(Ok(()));
                     }
                     _ => panic!("unexpected peer-manager command"),
@@ -1121,9 +1143,18 @@ mod tests {
 
         let sets = set_definitions.lock().await;
         assert_eq!(sets.len(), 2, "mutation then rollback");
-        assert_eq!(sets[0].md5_password.as_deref(), Some("new-secret"));
         assert_eq!(
-            sets[1].md5_password.as_deref(),
+            sets[0]
+                .md5_password
+                .as_ref()
+                .map(std::convert::AsRef::as_ref),
+            Some("new-secret")
+        );
+        assert_eq!(
+            sets[1]
+                .md5_password
+                .as_ref()
+                .map(std::convert::AsRef::as_ref),
             Some("old-secret"),
             "rollback must restore the prior definition with its stored secret"
         );

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -8,6 +8,7 @@ use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_transport::{
     ImportExplainReply, ImportPolicyTermHits, RemovePrivateAs, TcpAoInfoSnapshot, TcpAoKeyring,
+    TransportAuthSecret,
 };
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use tokio::net::TcpStream;
@@ -1463,7 +1464,7 @@ pub struct PeerGroupDefinition {
     /// Override max prefixes.
     pub max_prefixes: Option<u32>,
     /// Optional TCP MD5 password.
-    pub md5_password: Option<String>,
+    pub md5_password: Option<TransportAuthSecret>,
     /// Optional TTL-security override.
     pub ttl_security: Option<bool>,
     /// Address families override.
@@ -1547,7 +1548,7 @@ pub struct PeerManagerNeighborConfig {
     /// Maximum prefixes accepted before Cease/1 (None = unlimited).
     pub max_prefixes: Option<u32>,
     /// Optional TCP MD5 password.
-    pub md5_password: Option<String>,
+    pub md5_password: Option<TransportAuthSecret>,
     /// Optional ordered TCP-AO keyring for static-neighbor runtime sockets.
     pub tcp_ao: Option<TcpAoKeyring>,
     /// Whether GTSM / TTL security is enabled.

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -21,6 +21,46 @@ use socket2::Socket;
 #[cfg(target_os = "linux")]
 use zeroize::{Zeroize, Zeroizing};
 
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG_MAXKEYLEN: usize = 80;
+
+/// Linux `tcp_md5sig`. The key buffer is populated only for the duration of
+/// one `setsockopt` call and is scrubbed, together with its length, on drop.
+#[cfg(target_os = "linux")]
+#[repr(C)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the Linux tcp_md5sig ABI"
+)]
+struct TcpMd5Sig {
+    tcpm_addr: libc::sockaddr_storage,
+    tcpm_flags: u8,
+    tcpm_prefixlen: u8,
+    tcpm_keylen: u16,
+    tcpm_ifindex: libc::c_int,
+    tcpm_key: [u8; TCP_MD5SIG_MAXKEYLEN],
+}
+
+#[cfg(target_os = "linux")]
+impl TcpMd5Sig {
+    fn zeroed() -> Self {
+        // SAFETY: this is a C UAPI record made entirely of integer/byte fields.
+        unsafe { std::mem::zeroed() }
+    }
+
+    fn scrub(&mut self) {
+        self.tcpm_key.zeroize();
+        self.tcpm_keylen.zeroize();
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for TcpMd5Sig {
+    fn drop(&mut self) {
+        self.scrub();
+    }
+}
+
 /// Set TCP MD5 signature on a socket for a specific peer.
 ///
 /// This implements RFC 2385 by calling `setsockopt(TCP_MD5SIG)` on Linux.
@@ -36,22 +76,8 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
 
     const TCP_MD5SIG: libc::c_int = 14;
 
-    #[allow(
-        clippy::struct_field_names,
-        reason = "field names mirror the Linux tcp_md5sig ABI"
-    )]
-    #[repr(C)]
-    struct TcpMd5Sig {
-        tcpm_addr: libc::sockaddr_storage,
-        tcpm_flags: u8,
-        tcpm_prefixlen: u8,
-        tcpm_keylen: u16,
-        tcpm_ifindex: libc::c_int,
-        tcpm_key: [u8; 80],
-    }
-
     let peer_sa: socket2::SockAddr = peer.into();
-    let mut sig: TcpMd5Sig = unsafe { mem::zeroed() };
+    let mut sig = TcpMd5Sig::zeroed();
 
     // Copy the sockaddr into the struct
     let sa_bytes = peer_sa.as_ptr().cast::<u8>();
@@ -62,7 +88,7 @@ pub fn set_tcp_md5sig(socket: &Socket, peer: SocketAddr, password: &str) -> io::
     }
 
     let key_bytes = password.as_bytes();
-    if key_bytes.len() > 80 {
+    if key_bytes.len() > TCP_MD5SIG_MAXKEYLEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "MD5 password exceeds 80 bytes",
@@ -2305,6 +2331,27 @@ mod tests {
             set_current: true,
             set_rnext: true,
         }
+    }
+
+    #[test]
+    fn tcp_md5sig_uapi_layout_and_secret_scrub_match_linux_header() {
+        assert_eq!(mem::size_of::<TcpMd5Sig>(), 216);
+        assert_eq!(mem::align_of::<TcpMd5Sig>(), 8);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_addr), 0);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_flags), 128);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_prefixlen), 129);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_keylen), 130);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_ifindex), 132);
+        assert_eq!(mem::offset_of!(TcpMd5Sig, tcpm_key), 136);
+
+        let mut sig = TcpMd5Sig::zeroed();
+        sig.tcpm_keylen = 15;
+        sig.tcpm_key[..15].copy_from_slice(b"secret-sentinel");
+        sig.scrub();
+
+        assert_eq!(sig.tcpm_keylen, 0);
+        assert!(sig.tcpm_key.iter().all(|byte| *byte == 0));
+        assert!(mem::needs_drop::<TcpMd5Sig>());
     }
 
     #[test]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -984,11 +984,13 @@ lengths, hashes, and fingerprints are never returned. `TCP_AO_GET_KEYS` does
 copy raw key bytes into a private temporary buffer; rustbgpd compares accepted
 sockets against the complete configured keyring without logging the bytes and
 zeroizes every temporary on success, error, retry, and unwind.
-Longer-lived TCP-AO keys and TCP-MD5 passwords owned by the transport runtime
-are also redacted and each clone zeroizes its allocation when replaced or
-dropped. Parsed TOML, configuration snapshots, API messages, kernel MKTs, and
-other non-transport copies retain their own lifetimes and are not covered by
-that guarantee.
+Longer-lived TCP-AO keys and TCP-MD5 passwords owned by the internal API,
+peer-manager, and transport runtime are also redacted and each clone zeroizes
+its allocation when replaced or dropped. The temporary Linux `tcp_md5sig`
+record scrubs its key buffer and length after `setsockopt`. Parsed TOML,
+configuration snapshots, protobuf messages, compiler-created copies, and
+kernel-owned keys retain their own lifetimes and are not covered by that
+guarantee.
 
 The same neighbor view reports TCP-AO rotation `desired`, `applied`, and
 `phase` values. `idle` means the peer has acknowledged the desired immutable

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -175,6 +175,13 @@ access controls as Prometheus.
 Per-neighbor TCP MD5 authentication (RFC 2385) and GTSM / TTL security
 (RFC 5082) are supported on Linux via `md5_password` and `ttl_security`.
 These protect BGP transport sessions, not the gRPC management surface.
+After MD5 material crosses the protobuf or parsed-configuration boundary,
+internal API, peer-manager, and transport owners use a redacting wrapper whose
+independent clones zeroize their own allocation on drop. The temporary Linux
+`tcp_md5sig` record also scrubs its 80-byte key buffer and key length after
+every `setsockopt` attempt, including errors and unwinding. This narrows
+runtime retention; it does not erase separately owned parser/config/protobuf
+strings, compiler-created copies, or the key copied into the kernel.
 
 ## TCP-AO
 

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -115,9 +115,12 @@ slices have now shipped static-neighbor and startup-only dynamic-range support:
   selection are required. Partial, arbitrary-subset, and older inventories are
   rejected. A hosted real-kernel receipt proves this path for a dynamic
   `127.0.0.0/24` owner, retaining its logical owner metadata on the child.
-- TCP-AO keys and TCP-MD5 passwords owned by the transport runtime use an
-  immutable redacting wrapper whose independent clones zeroize on drop. This
-  deliberately excludes parser/config/API copies and kernel-owned MKTs.
+- TCP-AO keys and TCP-MD5 passwords owned by the internal API, peer manager,
+  and transport runtime use an immutable redacting wrapper whose independent
+  clones zeroize on drop. The short-lived Linux `tcp_md5sig` UAPI record also
+  scrubs its key buffer and length after every socket-option attempt. This
+  deliberately excludes parser/config/protobuf strings, compiler-created
+  copies, and kernel-owned keys.
 - Protected M43 interop against BIRD 3.3.1 runs in the GitHub-hosted
   `kernel-dataplane` workflow on the current TCP-AO-capable runner. The
   workflow keeps a `CONFIG_TCP_AO` probe so future runner kernels without the

--- a/src/main.rs
+++ b/src/main.rs
@@ -4204,10 +4204,7 @@ async fn run<T>(
                     hold_time: Some(transport_config.peer.hold_time),
                     send_hold_time: Some(transport_config.peer.send_hold_time),
                     max_prefixes: transport_config.max_prefixes,
-                    md5_password: transport_config
-                        .md5_password
-                        .as_ref()
-                        .map(|secret| secret.as_ref().to_owned()),
+                    md5_password: transport_config.md5_password.clone(),
                     tcp_ao: transport_config.tcp_ao.clone(),
                     ttl_security: transport_config.ttl_security,
                     families: transport_config.peer.families.clone(),

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -69,10 +69,7 @@ impl PeerManager {
             hold_time: managed.hold_time,
             send_hold_time: Some(tc.peer.send_hold_time),
             max_prefixes: managed.max_prefixes,
-            md5_password: tc
-                .md5_password
-                .as_ref()
-                .map(|secret| secret.as_ref().to_owned()),
+            md5_password: tc.md5_password.clone(),
             tcp_ao: tc.tcp_ao.clone(),
             ttl_security: tc.ttl_security,
             families: tc.peer.families.clone(),

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -643,7 +643,7 @@ impl PeerManager {
         transport.peer_scope_id = scope_id;
         transport.max_prefixes = config.max_prefixes;
         transport.peer_group.clone_from(&config.peer_group);
-        transport.md5_password = config.md5_password.clone().map(Into::into);
+        transport.md5_password.clone_from(&config.md5_password);
         transport.tcp_ao.clone_from(&config.tcp_ao);
         transport.ttl_security = config.ttl_security;
         transport.local_ipv6_nexthop = config.local_ipv6_nexthop;

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1816,10 +1816,7 @@ impl PeerManager {
             hold_time: Some(tc.peer.hold_time),
             send_hold_time: Some(tc.peer.send_hold_time),
             max_prefixes: tc.max_prefixes,
-            md5_password: tc
-                .md5_password
-                .as_ref()
-                .map(|secret| secret.as_ref().to_owned()),
+            md5_password: tc.md5_password.clone(),
             tcp_ao: tc.tcp_ao.clone(),
             ttl_security: tc.ttl_security,
             families: tc.peer.families.clone(),

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4433,7 +4433,7 @@ fn build_transport_config_reflects_every_transport_field() {
         hold_time: Some(240),
         send_hold_time: Some(600),
         max_prefixes: Some(1000),
-        md5_password: Some("hunter2".to_string()),
+        md5_password: Some("hunter2".into()),
         tcp_ao: Some(
             rustbgpd_transport::TcpAoConfig {
                 key: "ao-secret".into(),
@@ -4524,7 +4524,7 @@ fn build_transport_config_reflects_every_transport_field() {
     assert_eq!(t.max_prefixes, *max_prefixes, "max_prefixes");
     assert_eq!(
         t.md5_password.as_ref().map(std::convert::AsRef::as_ref),
-        md5_password.as_deref(),
+        md5_password.as_ref().map(std::convert::AsRef::as_ref),
         "md5_password"
     );
     assert_eq!(t.tcp_ao, *tcp_ao, "tcp_ao");

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -178,7 +178,10 @@ pub(crate) fn api_peer_group_to_config(definition: PeerGroupDefinition) -> PeerG
         hold_time: definition.hold_time,
         send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
-        md5_password: definition.md5_password,
+        md5_password: definition
+            .md5_password
+            .as_ref()
+            .map(|secret| secret.as_ref().to_owned()),
         ttl_security: definition.ttl_security,
         bfd: None,
         families: definition.families,
@@ -218,7 +221,7 @@ pub(crate) fn config_peer_group_to_api(definition: &PeerGroupConfig) -> PeerGrou
         hold_time: definition.hold_time,
         send_hold_time: definition.send_hold_time,
         max_prefixes: definition.max_prefixes,
-        md5_password: definition.md5_password.clone(),
+        md5_password: definition.md5_password.as_deref().map(Into::into),
         ttl_security: definition.ttl_security,
         families: definition.families.clone(),
         graceful_restart: definition.graceful_restart,
@@ -399,7 +402,10 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                     hold_time: cfg.hold_time,
                     send_hold_time: cfg.send_hold_time,
                     max_prefixes: cfg.max_prefixes,
-                    md5_password: cfg.md5_password.clone(),
+                    md5_password: cfg
+                        .md5_password
+                        .as_ref()
+                        .map(|secret| secret.as_ref().to_owned()),
                     tcp_ao: cfg.tcp_ao.as_ref().map(transport_tcp_ao_to_config),
                     bfd: None,
                     ttl_security: Some(cfg.ttl_security),

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -47,10 +47,7 @@ pub(crate) fn build_peer_mgr_config(
         hold_time: Some(tc.peer.hold_time),
         send_hold_time: Some(tc.peer.send_hold_time),
         max_prefixes: tc.max_prefixes,
-        md5_password: tc
-            .md5_password
-            .as_ref()
-            .map(|secret| secret.as_ref().to_owned()),
+        md5_password: tc.md5_password.clone(),
         tcp_ao: tc.tcp_ao.clone(),
         ttl_security: tc.ttl_security,
         families: tc.peer.families.clone(),


### PR DESCRIPTION
## Summary

- scrub the Linux `tcp_md5sig` key buffer and key length through RAII after every socket-option attempt
- retain the redacting, independently zeroizing authentication wrapper across internal API, peer-manager, and transport runtime ownership
- document the remaining parser, protobuf, configuration, compiler-copy, and kernel boundaries without changing external schemas

## Compatibility

- no protobuf, config-schema, v1 API, dependency, or socket behavior change
- plaintext allocation remains explicit only at existing parser/protobuf/config persistence boundaries

## Validation

- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- workspace rustdoc with warnings denied
- bench-internals/all-features checks, v1 stable-surface gate, release-notes selftest, and clippy-reason checks
- independent exact-diff review and focused Linux UAPI/scrub, redaction, API, and peer-manager tests

Linear: https://linear.app/lance0/issue/LAN-423