### PR TITLE
fix: release selection deferral on collision failback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   configured window. Expired markers, or markers without a positive effective
   restart window, produce an immediate cold start.
 
+- **Collision failback no longer strands startup route selection until the
+  timer.** When an active collision replacement drops, only the exact nonzero,
+  unambiguous surviving session is excluded from its re-armed frozen-roster
+  entries; ordinary replacement, real remaining waiters, and stale predecessor
+  EoR handling are unchanged. Complete family recomputation and ledger
+  reclamation still stage the table before EoR, while the survivor's inbound
+  ROUTE-REFRESH remains best-effort recovery assistance rather than a
+  completion signal.
+
 - **The v1 config compatibility gate now pins stable object shape.** Stable
   definition digests cover the complete required-field set and unknown-field
   policy in addition to selected property schemas, while continuing to allow

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -34,6 +34,12 @@ pub(super) enum SessionTeardownDisposition {
     TeardownActive,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum ActiveSessionRegistration {
+    PeerUp,
+    CollisionFailback,
+}
+
 impl RibManager {
     /// Session-down teardown, dispatched on session identity (see
     /// [`SessionTeardownDisposition`]): a stale teardown from a
@@ -191,16 +197,20 @@ impl RibManager {
     /// peer's natural re-advertisement (its next own route change) — that
     /// staleness window is logged by the session task.
     pub(super) fn fail_over_registration(&mut self, peer: IpAddr, down_id: u64, event: &str) {
-        let survivor_id = self
+        let Some(survivor_session_id) = self
             .live_sessions
             .get(&peer)
             .and_then(|sessions| sessions.last())
-            .map(|record| record.session_id);
+            .map(|record| record.session_id)
+        else {
+            debug_assert!(false, "registration failback without a live survivor");
+            return;
+        };
         warn!(
             %peer,
             event,
             down_session_id = down_id,
-            survivor_session_id = survivor_id,
+            survivor_session_id,
             "active session went down with another live session present — \
              failing the outbound registration over to the survivor"
         );
@@ -214,7 +224,7 @@ impl RibManager {
             self.clear_peer_adj_rib_in(peer);
         }
         self.clear_outbound_peer_state(peer);
-        self.register_active_session(peer);
+        self.register_active_session(peer, ActiveSessionRegistration::CollisionFailback);
         self.request_inbound_refresh(peer);
     }
 
@@ -599,19 +609,20 @@ impl RibManager {
             );
         }
 
-        self.register_active_session(peer);
+        self.register_active_session(peer, ActiveSessionRegistration::PeerUp);
     }
 
     /// Register the most recent live session (the last `live_sessions`
     /// entry) as the peer's active outbound registration and send it the
-    /// initial table dump. Shared by `handle_peer_up` and the
-    /// registration failover; the caller has already cleared any prior
-    /// registration's state.
+    /// initial table dump. Shared by `handle_peer_up` and collision failback;
+    /// the caller has already cleared any prior registration's state and the
+    /// registration origin controls only the startup selection-deferral
+    /// classification.
     #[expect(
         clippy::too_many_lines,
         reason = "active-session registration installs every negotiated outbound capability"
     )]
-    fn register_active_session(&mut self, peer: IpAddr) {
+    fn register_active_session(&mut self, peer: IpAddr, registration: ActiveSessionRegistration) {
         let Some(record) = self
             .live_sessions
             .get(&peer)
@@ -722,24 +733,42 @@ impl RibManager {
         // the final waiter releases a family, existing peers receive the
         // converged table and this peer receives it once in its normal
         // initial dump below.
-        let released = if let Some(gr_context) = gr_context {
-            let peer_gr_families: HashSet<_> =
-                gr_context.peer_gr_families.iter().copied().collect();
-            self.selection_deferral
-                .as_mut()
-                .map_or_else(Vec::new, |selection| {
-                    selection.classify_session(
-                        peer,
+        let released = match registration {
+            ActiveSessionRegistration::PeerUp => {
+                if let Some(gr_context) = gr_context {
+                    let peer_gr_families: HashSet<_> =
+                        gr_context.peer_gr_families.iter().copied().collect();
+                    self.selection_deferral
+                        .as_mut()
+                        .map_or_else(Vec::new, |selection| {
+                            selection.classify_session(
+                                peer,
+                                session_id,
+                                gr_context.peer_restart_state,
+                                &peer_gr_families,
+                                &self.metrics,
+                            )
+                        })
+                } else {
+                    Vec::new()
+                }
+            }
+            ActiveSessionRegistration::CollisionFailback => {
+                let excluded = self.selection_deferral.as_mut().and_then(|selection| {
+                    selection.exclude_collision_failback_survivor(peer, session_id, &self.metrics)
+                });
+                if let Some(released) = &excluded {
+                    info!(
+                        %peer,
                         session_id,
-                        gr_context.peer_restart_state,
-                        &peer_gr_families,
-                        &self.metrics,
-                    )
-                })
-        } else {
-            Vec::new()
+                        released_families = released.len(),
+                        "exact collision-failback survivor excluded from the startup selection roster; inbound ROUTE-REFRESH remains best-effort recovery assistance"
+                    );
+                }
+                excluded.unwrap_or_default()
+            }
         };
-        self.release_selection_families(&released, "all current waiters excluded");
+        self.release_selection_families(&released, "all current waiters satisfied or excluded");
 
         debug!(%peer, "peer up — registering for outbound updates");
         let peer_label = peer.to_string();

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -466,6 +466,63 @@ impl SelectionDeferral {
         released
     }
 
+    /// Exclude the exact session recovered by collision failback from the
+    /// startup-frozen roster. Its `EoR` may already have been discarded while
+    /// the session was superseded, and the best-effort ROUTE-REFRESH used to
+    /// rebuild its Adj-RIB-In has no completion signal. Only an unambiguous,
+    /// stamped survivor whose current roster state was re-armed by the active
+    /// session's teardown may take this path.
+    ///
+    /// `Some` means at least one active family was classified; the contained
+    /// families are those that became complete and must use the normal full
+    /// release path. `None` leaves every waiter unchanged.
+    pub(super) fn exclude_collision_failback_survivor(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        metrics: &BgpMetrics,
+    ) -> Option<Vec<(Afi, Safi)>> {
+        if session_id == 0 {
+            tracing::warn!(
+                %peer,
+                "selection-deferral collision-failback survivor is unstamped; keeping it blocked"
+            );
+            return None;
+        }
+        if self.ambiguous_peers.contains(&peer) {
+            tracing::warn!(
+                %peer,
+                session_id,
+                "selection-deferral collision-failback survivor address is ambiguous; keeping it blocked"
+            );
+            return None;
+        }
+
+        let families: Vec<_> = self.active.keys().copied().collect();
+        let mut classified = false;
+        let mut released = Vec::new();
+        for family in families {
+            let Some(gate) = self.active.get_mut(&family) else {
+                continue;
+            };
+            if gate.waiters.get(&peer) != Some(&WaiterState::AwaitingSession) {
+                continue;
+            }
+            gate.waiters
+                .insert(peer, WaiterState::Excluded { session_id });
+            classified = true;
+            metrics.set_selection_deferral_waiters(
+                afi_safi_label(family.0, family.1),
+                gauge_val(Self::blocking_waiters(gate)),
+            );
+            if Self::complete(gate) {
+                self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
+                released.push(family);
+            }
+        }
+        classified.then_some(released)
+    }
+
     /// Revert a current-session waiter to the not-yet-established state.  A
     /// flap cannot shrink the frozen cohort and accidentally release a family.
     pub(super) fn session_down(&mut self, peer: IpAddr, session_id: u64, metrics: &BgpMetrics) {
@@ -813,6 +870,19 @@ impl RibManager {
         family: (Afi, Safi),
     ) {
         self.recompute_released_selection_family(family);
+    }
+
+    #[cfg(test)]
+    pub(in crate::manager) fn deferred_selection_ledger_state_for_test(
+        &self,
+        family: (Afi, Safi),
+    ) -> (usize, bool) {
+        (
+            self.deferred_selection_keys.retained_key_bytes,
+            self.deferred_selection_keys
+                .overflowed_families
+                .contains(&family),
+        )
     }
 
     /// Consume a current-session `EoR` in the startup gate. The caller invokes

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -350,7 +350,248 @@ async fn duplicate_address_roster_fails_closed_until_timer() {
 }
 
 #[test]
-fn overflow_fallback_withdraws_restored_keys_before_release_eor() {
+fn collision_failback_excludes_only_the_rearmed_survivor() {
+    let survivor = peer(1);
+    let remaining = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[survivor, remaining]));
+    let gr_families = HashSet::from([FAMILY]);
+    let selection = manager.selection_deferral.as_mut().unwrap();
+
+    assert!(
+        selection
+            .classify_session(survivor, 11, false, &gr_families, &metrics)
+            .is_empty()
+    );
+    assert!(!selection.end_of_rib(survivor, 11, FAMILY, &metrics));
+    selection.session_down(survivor, 11, &metrics);
+    assert_eq!(
+        selection.exclude_collision_failback_survivor(survivor, 11, &metrics),
+        Some(Vec::new()),
+        "the exact re-armed survivor should stop blocking without releasing a real waiter"
+    );
+
+    let survivor_row = selection.peer_snapshot(survivor).remove(0);
+    assert!(survivor_row.active);
+    assert_eq!(survivor_row.waiter_state, "excluded");
+    assert_eq!(survivor_row.waiter_session_id, Some(11));
+    assert_eq!(survivor_row.blocking_waiters, 1);
+    assert!(
+        !selection.end_of_rib(survivor, 12, FAMILY, &metrics),
+        "an unrelated session must not satisfy the excluded survivor"
+    );
+
+    assert!(
+        selection
+            .classify_session(remaining, 21, false, &gr_families, &metrics)
+            .is_empty()
+    );
+    assert!(selection.end_of_rib(remaining, 21, FAMILY, &metrics));
+    selection.finalize_all_eor(FAMILY, &metrics);
+    let remaining_row = selection.peer_snapshot(remaining).remove(0);
+    assert!(!remaining_row.active);
+    assert_eq!(remaining_row.release_reason, "all_eor");
+}
+
+#[test]
+fn unstamped_or_ambiguous_collision_failback_stays_timer_bound() {
+    let unstamped = peer(1);
+    let duplicate = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager =
+        RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone()).with_selection_deferral(
+            config(Duration::from_mins(1), &[unstamped, duplicate, duplicate]),
+        );
+    let selection = manager.selection_deferral.as_mut().unwrap();
+
+    assert_eq!(
+        selection.exclude_collision_failback_survivor(unstamped, 0, &metrics),
+        None
+    );
+    assert_eq!(
+        selection.exclude_collision_failback_survivor(duplicate, 22, &metrics),
+        None
+    );
+    for peer in [unstamped, duplicate] {
+        let row = selection.peer_snapshot(peer).remove(0);
+        assert!(row.active);
+        assert_eq!(row.waiter_state, "awaiting_session");
+        assert_eq!(row.blocking_waiters, 2);
+    }
+}
+
+#[tokio::test]
+async fn exact_collision_failback_releases_table_before_eor_and_then_requests_refresh() {
+    let survivor = peer(1);
+    let remaining = peer(2);
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[survivor, remaining]));
+    let handle = tokio::spawn(manager.run());
+
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, survivor, 11).await;
+    tx.send(peer_up(survivor, 11, survivor_tx)).await.unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+
+    let (replacement_tx, _replacement_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, survivor, 12).await;
+    tx.send(peer_up(survivor, 12, replacement_tx))
+        .await
+        .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+
+    let (remaining_tx, _remaining_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, remaining, 21).await;
+    tx.send(peer_up(remaining, 21, remaining_tx)).await.unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: remaining,
+        session_id: 21,
+        announced: vec![make_route_with_lp(
+            Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            Ipv4Addr::new(10, 0, 0, 2),
+            100,
+        )],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndOfRib {
+        peer: remaining,
+        session_id: 21,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
+
+    tx.send(RibUpdate::PeerDown {
+        peer: survivor,
+        session_id: 12,
+    })
+    .await
+    .unwrap();
+
+    let state = query_state(&tx, survivor).await;
+    assert!(!state.selection_deferral[0].active);
+    assert_eq!(state.selection_deferral[0].waiter_state, "excluded");
+    assert_eq!(state.selection_deferral[0].waiter_session_id, Some(11));
+    assert_eq!(state.selection_deferral[0].release_reason, "all_eor");
+    assert_eq!(query_best_routes(&tx).await.len(), 1);
+
+    let mut saw_table = false;
+    let mut saw_eor = false;
+    loop {
+        let update = survivor_rx.recv().await.unwrap();
+        if !update.announce.is_empty() {
+            assert!(!saw_eor, "released table arrived after EoR");
+            saw_table = true;
+        }
+        if update.end_of_rib.contains(&FAMILY) {
+            assert!(saw_table, "EoR overtook the released table");
+            saw_eor = true;
+        }
+        if update.request_refresh_all_negotiated {
+            assert!(
+                saw_eor,
+                "best-effort refresh request overtook table and EoR"
+            );
+            break;
+        }
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[test]
+fn unavailable_survivor_channel_does_not_rearm_released_selection() {
+    for channel_closed in [false, true] {
+        let survivor = peer(1);
+        let metrics = BgpMetrics::new();
+        let (_tx, rx) = mpsc::channel(8);
+        let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics)
+            .with_selection_deferral(config(Duration::from_mins(1), &[survivor]));
+        let (survivor_tx, mut survivor_rx) = mpsc::channel(1);
+        manager.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+            peer: survivor,
+            session_id: 11,
+            peer_restart_state: false,
+            peer_gr_families: vec![FAMILY],
+        });
+        manager.handle_update(peer_up(survivor, 11, survivor_tx.clone()));
+        let (replacement_tx, _replacement_rx) = mpsc::channel(1);
+        manager.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+            peer: survivor,
+            session_id: 12,
+            peer_restart_state: false,
+            peer_gr_families: vec![FAMILY],
+        });
+        manager.handle_update(peer_up(survivor, 12, replacement_tx));
+
+        if channel_closed {
+            survivor_rx.close();
+        } else {
+            survivor_tx
+                .try_send(crate::OutboundRouteUpdate::default())
+                .unwrap();
+        }
+        manager.handle_update(RibUpdate::PeerDown {
+            peer: survivor,
+            session_id: 12,
+        });
+
+        let row = manager
+            .selection_deferral
+            .as_ref()
+            .unwrap()
+            .peer_snapshot(survivor)
+            .remove(0);
+        assert!(!row.active);
+        assert_eq!(row.waiter_state, "excluded");
+        assert_eq!(row.release_reason, "all_eor");
+        if !channel_closed {
+            let queued = survivor_rx.try_recv().unwrap();
+            assert!(!queued.request_refresh_all_negotiated);
+            assert!(survivor_rx.try_recv().is_err());
+        }
+    }
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one overflow fixture pins complete sweep, ordering, and byte reclamation"
+)]
+fn collision_failback_overflow_sweeps_and_reclaims_before_release_eor() {
     let source = peer(1);
     let observer = peer(2);
     let (_tx, rx) = mpsc::channel(32);
@@ -425,10 +666,19 @@ fn overflow_fallback_withdraws_restored_keys_before_release_eor() {
         .unwrap()
         .classify_session(source, 8, false, &peer_gr_families, &metrics);
     assert!(released.is_empty());
-    assert!(manager.selection_deferral_end_of_rib(source, 8, FAMILY));
-    manager.handle_end_of_rib(source, FAMILY.0, FAMILY.1);
-    manager.finalize_selection_deferral_all_eor(FAMILY);
-    manager.release_selection_families(&[FAMILY], "test all EoRs received");
+    manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .session_down(source, 8, &metrics);
+    let released = manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .exclude_collision_failback_survivor(source, 8, &metrics)
+        .unwrap();
+    assert_eq!(released, vec![FAMILY]);
+    manager.release_selection_families(&released, "test collision failback");
 
     assert!(manager.loc_rib.get(&prefix_a).is_none());
     assert!(manager.loc_rib.get(&prefix_b).is_none());
@@ -450,6 +700,11 @@ fn overflow_fallback_withdraws_restored_keys_before_release_eor() {
         &metrics,
         "bgp_selection_deferral_ledger_overflows_total",
         1.0,
+    );
+    assert_eq!(
+        manager.deferred_selection_ledger_state_for_test(FAMILY),
+        (0, false),
+        "complete failback release must reclaim the family byte charge and sticky overflow state"
     );
 }
 

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -604,8 +604,10 @@ impl BgpMetrics {
                  PeerDown/PeerGracefulRestart — the symmetric collision \
                  interleaving where the loser's PeerUp replaced the winner's \
                  registration before the loser went down. The survivor is \
-                 re-registered, re-sent the initial table, and asked for an \
-                 inbound ROUTE-REFRESH.",
+                 excluded from any re-armed startup selection wait only when \
+                 its stamped identity is exact and unambiguous, re-registered, \
+                 re-sent the initial table, and asked for a best-effort inbound \
+                 ROUTE-REFRESH.",
             ),
             &["peer"],
         )

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1083,6 +1083,13 @@ send EoR or the remaining marker window expires. `gr_restart_time` therefore
 bounds both the advertised restart window and, via the maximum effective value
 across static peers, the process-start selection deferral.
 
+During a same-address collision, ordinary replacement still re-arms the
+replacement session as an EoR waiter and stale predecessor EoR is rejected. If
+the replacement then loses and registration fails back to the exact nonzero,
+unambiguous survivor, only that survivor is excluded from its re-armed roster
+entry; other waiters continue to block. Its inbound ROUTE-REFRESH request is
+best-effort recovery assistance, not evidence that refresh completed.
+
 `rbgp neighbor <address>` shows `Selection Deferral` rows while active and
 retains their `all_eor` or `timer` release reason afterward. Metrics are
 `bgp_selection_deferral_active`, `bgp_selection_deferral_waiters`,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -483,7 +483,7 @@ authenticated sensitive-read surface.
 | `bgp_rib_outbound_registration_replaced_total{peer}` | `PeerUp` re-registrations that replaced a still-registered outbound sender for the same address — two sessions overlapped (collision window); the replacement resets the prior session's RIB state and keeps the superseded session live for failover; its `PeerDown` is matched by session identity |
 | `bgp_rib_stale_peer_down_ignored_total{peer}` | `PeerDown`/`PeerGracefulRestart` events discarded because their session id didn't match the registered session — a stale teardown from a superseded collision-loser session; the surviving session's state is untouched |
 | `bgp_rib_stale_session_message_ignored_total{peer,kind}` | Session-scoped RIB messages discarded by the same session-identity rule — a superseded session's queued message processed after the replacement's `PeerUp`. `kind` is `routes` (`RoutesReceived`), `eor` (End-of-RIB), `refresh` (route-refresh request / RFC 7313 BoRR/EoRR), `orf` (RFC 5291 ORF push), or `policy_context` (peer-group policy identity). The registered session's state is untouched |
-| `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The survivor is re-registered, re-sent the initial table, and asked for an inbound ROUTE-REFRESH |
+| `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The exact nonzero, unambiguous survivor is excluded from any re-armed startup selection wait, re-registered, re-sent the initial table, and asked for a best-effort inbound ROUTE-REFRESH |
 | `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
 | `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
 | `bgp_rib_policy_transition_in_progress` | Whether the RIB actor owns an atomic export-policy transition (`1` = in progress). General RIB queries and mutations remain fenced while the dedicated core-readiness lane stays live |
@@ -803,6 +803,15 @@ nested FlowSpec terms and BGP-LS payload bytes), not a promise about process
 RSS, allocator capacity, or hash-table overhead. An identity that lands exactly
 on either cap is retained; the family of the next identity that would exceed a
 cap enters overflow fallback.
+
+An ordinary same-address replacement remains an EoR waiter, and stale EoR from
+its predecessor is rejected. If collision resolution fails registration back
+to the exact nonzero, unambiguous survivor, only that survivor is excluded from
+its re-armed roster entries; other waiters remain blocking. The follow-up
+ROUTE-REFRESH request is best-effort Adj-RIB-In recovery assistance and is not
+treated as EoR or refresh completion. Full or closed survivor outbound channels
+can lose that request but cannot re-arm a family that selection already
+released.
 
 ### BFD
 

--- a/docs/adr/0040-gr-restarting-speaker.md
+++ b/docs/adr/0040-gr-restarting-speaker.md
@@ -50,9 +50,14 @@ Implement an honest restarting-speaker mode:
    selection, initial outbound table data, route-refresh responses, and EoR
    remain withheld. On release, deferred route identities (withdrawals
    included) are selected and advertised before EoR.
-8. Waiters are transport-generation stamped. A replacement or failed-over
-   session re-arms its frozen roster entry, and an EoR from a predecessor or
-   collision loser cannot release the gate.
+8. Waiters are transport-generation stamped. An ordinary replacement re-arms
+   its frozen roster entry, and an EoR from a predecessor or collision loser
+   cannot release the gate. If collision resolution instead fails the
+   registration back to the exact nonzero, unambiguous surviving session, that
+   survivor is excluded from its re-armed entries: its EoR may already have
+   been discarded while it was superseded, and the recovery ROUTE-REFRESH is
+   best-effort assistance rather than a completion signal. Every other real
+   waiter continues to gate the family.
 
 This mode helps peers retain our routes briefly during a planned restart,
 but makes **no claim** that rustbgpd preserved dataplane continuity.


### PR DESCRIPTION
## Summary

- distinguish ordinary peer registration from collision failback
- exclude only an exact, stamped, unambiguous survivor from re-armed startup selection waits
- preserve every other waiter and use the existing complete family release path
- keep inbound Route Refresh post-release and best-effort

## Correctness

Ordinary replacement still waits for the current-session End-of-RIB, and stale or foreign End-of-RIB remains rejected. Collision failback now uses the selected live-session identity by construction. Zero or ambiguous identities remain timer-bound. Complete recomputation, retained-key and overflow cleanup, table-before-EoR ordering, and full or closed outbound-channel behavior are covered by focused regressions.

## Validation

- 15 focused selection-deferral tests
- 826 RIB tests passed, 1 ignored
- 67 telemetry tests
- full workspace tests
- strict workspace all-target Clippy
- rustdoc with warnings denied
- formatting, diff, release-note selftest, and commit hooks
- independent exact-diff review with no findings