### PR TITLE
fix: classify runtime config diff failures

### DIFF
--- a/crates/api/src/config_service.rs
+++ b/crates/api/src/config_service.rs
@@ -10,7 +10,7 @@ use crate::audit::{
     plan_config_transaction_summary, set_request_summary,
 };
 use crate::peer_types::{
-    PeerManagerCommand, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
+    PeerManagerCommand, RuntimeConfigDiff, RuntimeConfigDiffError, RuntimeConfigTransactionPlan,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use crate::proto;
@@ -151,6 +151,13 @@ fn plan_error_to_status(error: RuntimeConfigTransactionPlanError) -> Status {
     }
 }
 
+fn diff_error_to_status(error: RuntimeConfigDiffError) -> Status {
+    match error {
+        RuntimeConfigDiffError::InvalidCandidate(message) => Status::invalid_argument(message),
+        RuntimeConfigDiffError::Internal(message) => Status::internal(message),
+    }
+}
+
 #[tonic::async_trait]
 impl proto::config_service_server::ConfigService for ConfigService {
     async fn diff_runtime_config(
@@ -176,7 +183,7 @@ impl proto::config_service_server::ConfigService for ConfigService {
             .map_err(|_| Status::unavailable("peer manager dropped config diff reply"))?
         {
             Ok(diff) => Ok(Response::new(diff_to_proto(diff))),
-            Err(error) => Err(Status::invalid_argument(error)),
+            Err(error) => Err(diff_error_to_status(error)),
         }
     }
 
@@ -874,7 +881,9 @@ tcp_ao = { key = "ao-secret", algorithm = "hmac-sha-1-96" }
             let Some(PeerManagerCommand::DiffRuntimeConfig { reply, .. }) = rx.recv().await else {
                 panic!("expected DiffRuntimeConfig command");
             };
-            let _ = reply.send(Err("error: invalid candidate".to_string()));
+            let _ = reply.send(Err(RuntimeConfigDiffError::InvalidCandidate(
+                "error: invalid candidate".to_string(),
+            )));
         });
 
         let err = svc
@@ -885,5 +894,28 @@ tcp_ao = { key = "ao-secret", algorithm = "hmac-sha-1-96" }
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("invalid candidate"));
+    }
+
+    #[tokio::test]
+    async fn diff_runtime_config_maps_internal_render_error_to_internal() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let svc = ConfigService::new(tx);
+        tokio::spawn(async move {
+            let Some(PeerManagerCommand::DiffRuntimeConfig { reply, .. }) = rx.recv().await else {
+                panic!("expected DiffRuntimeConfig command");
+            };
+            let _ = reply.send(Err(RuntimeConfigDiffError::Internal(
+                "failed to serialize config diff".to_string(),
+            )));
+        });
+
+        let err = svc
+            .diff_runtime_config(Request::new(proto::DiffRuntimeConfigRequest {
+                candidate_toml: "[global]".to_string(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Internal);
+        assert!(err.message().contains("failed to serialize config diff"));
     }
 }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -370,6 +370,15 @@ pub struct RuntimeConfigDiff {
     pub diff_json: String,
 }
 
+/// Validate-only diff failure returned by the peer manager.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeConfigDiffError {
+    /// Candidate TOML/config failed validation.
+    InvalidCandidate(String),
+    /// Internal diff rendering or serialization failed.
+    Internal(String),
+}
+
 /// Validate-only classification for the config transaction model.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RuntimeConfigTransactionStatus {
@@ -658,7 +667,7 @@ pub enum PeerManagerCommand {
         /// Candidate TOML content supplied by the caller.
         candidate_toml: String,
         /// Reply channel returning redacted diff output only.
-        reply: oneshot::Sender<Result<RuntimeConfigDiff, String>>,
+        reply: oneshot::Sender<Result<RuntimeConfigDiff, RuntimeConfigDiffError>>,
     },
     /// Validate and classify a candidate config transaction without mutating
     /// daemon state.

--- a/src/peer_manager/reconcile.rs
+++ b/src/peer_manager/reconcile.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use rustbgpd_api::peer_types::{
     FibTableSnapshot, PeerKey, PeerManagerNeighborConfig, ReconcileFailure, ReconcileFailureKind,
-    ReconcileResult, RuntimeConfigDiff, RuntimeConfigTransactionPlan,
+    ReconcileResult, RuntimeConfigDiff, RuntimeConfigDiffError, RuntimeConfigTransactionPlan,
     RuntimeConfigTransactionPlanError, RuntimeConfigTransactionStatus,
 };
 use tracing::{info, warn};
@@ -122,11 +122,12 @@ impl PeerManager {
     pub(super) fn diff_runtime_config(
         &self,
         candidate_toml: &str,
-    ) -> Result<RuntimeConfigDiff, String> {
+    ) -> Result<RuntimeConfigDiff, RuntimeConfigDiffError> {
         let candidate =
-            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")?;
+            Config::load_toml_with_diagnostics(candidate_toml, "candidate runtime config")
+                .map_err(RuntimeConfigDiffError::InvalidCandidate)?;
         let diff = crate::config::diff_config(&self.current_config, &candidate);
-        runtime_config_diff_from_config_diff(&diff)
+        runtime_config_diff_from_config_diff(&diff).map_err(RuntimeConfigDiffError::Internal)
     }
 
     pub(super) async fn plan_config_transaction(


### PR DESCRIPTION
## Summary

- distinguish invalid runtime-config diff candidates from internal rendering failures
- return gRPC `INVALID_ARGUMENT` for operator input and `INTERNAL` for daemon-side serialization failures
- keep the change confined to the existing three-file diff path with focused regressions for both statuses

## Validation

- `cargo test -p rustbgpd-api diff_runtime_config`
- `cargo test -p rustbgpd peer_manager::tests::runtime_config_diff_compares_candidate_against_live_snapshot_and_redacts_secret -- --exact`
- `cargo clippy -p rustbgpd-api -p rustbgpd --all-targets -- -D warnings`
- pre-commit workspace Clippy
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: LAN-6