### PR TITLE
fix: hold collision failback EoR until survivor convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,14 +197,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   configured window. Expired markers, or markers without a positive effective
   restart window, produce an immediate cold start.
 
-- **Collision failback no longer strands startup route selection until the
-  timer.** When an active collision replacement drops, only the exact nonzero,
-  unambiguous surviving session is excluded from its re-armed frozen-roster
-  entries; ordinary replacement, real remaining waiters, and stale predecessor
-  EoR handling are unchanged. Complete family recomputation and ledger
-  reclamation still stage the table before EoR, while the survivor's inbound
-  ROUTE-REFRESH remains best-effort recovery assistance rather than a
-  completion signal.
+- **Collision failback no longer declares planned-restart convergence before
+  the survivor's routes are re-learned.** When an active collision replacement
+  drops, the exact nonzero, unambiguous survivor enters an `awaiting_refresh`
+  state. The current Loc-RIB is still staged as soon as ordinary waiters finish,
+  but downstream EoR and route-refresh responses remain held until a
+  post-failback BoRR/EoRR cycle completes. Ordinary EoR, stray EoRR, and the
+  local refresh timeout cannot release the hold; the original marker-bounded
+  selection timer remains the fallback when Enhanced Route Refresh is absent
+  or incomplete.
 
 - **The v1 config compatibility gate now pins stable object shape.** Stable
   definition digests cover the complete required-field set and unknown-field

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1633,10 +1633,10 @@ impl RibManager {
                 .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
             || end_of_rib
                 .iter()
-                .any(|family| self.selection_deferred(*family))
+                .any(|family| self.selection_convergence_held(*family))
             || refresh_markers
                 .iter()
-                .any(|(afi, safi, _)| self.selection_deferred((*afi, *safi)))
+                .any(|(afi, safi, _)| self.selection_convergence_held((*afi, *safi)))
             || flowspec_announce
                 .iter()
                 .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
@@ -3739,8 +3739,10 @@ impl RibManager {
                 || self.pending_otc_blocked.contains_key(&peer)
             {
                 // If a prior initial dump / route-refresh EoR was deferred,
-                // piggyback it on the successful dirty resync update so it
-                // can't be starved behind the resync message on a small queue.
+                // piggyback only convergence-ready families on the successful
+                // dirty resync update so they cannot be starved behind the
+                // resync message on a small queue. Collision-failback holds
+                // stay pending until peer EoRR or the original timer.
                 // EoR piggyback only attaches to *dirty* resyncs (the
                 // dump-deferral pattern). A force-only resync is a
                 // GShut-style outbound-attribute refresh and never
@@ -3748,7 +3750,13 @@ impl RibManager {
                 let pending_eor = if is_dirty {
                     self.pending_eor
                         .get(&peer)
-                        .map(|families| families.iter().copied().collect())
+                        .map(|families| {
+                            families
+                                .iter()
+                                .copied()
+                                .filter(|family| !self.selection_convergence_held(*family))
+                                .collect()
+                        })
                         .unwrap_or_default()
                 } else {
                     vec![]
@@ -3898,7 +3906,14 @@ impl RibManager {
                             if pending_eor.is_empty() {
                                 self.flush_pending_eor(peer);
                             } else {
-                                self.pending_eor.remove(&peer);
+                                let empty =
+                                    self.pending_eor.get_mut(&peer).is_some_and(|families| {
+                                        families.retain(|family| !pending_eor.contains(family));
+                                        families.is_empty()
+                                    });
+                                if empty {
+                                    self.pending_eor.remove(&peer);
+                                }
                             }
                             self.retry_pending_refresh(peer);
                         }
@@ -3952,7 +3967,9 @@ impl RibManager {
                         self.dirty_peers.remove(&peer);
                         self.clear_grouped_member_synced(peer);
                         self.flush_pending_eor(peer);
-                        self.retry_pending_refresh(peer);
+                        if !self.dirty_peers.contains(&peer) {
+                            self.retry_pending_refresh(peer);
+                        }
                     }
                     if is_force {
                         self.force_outbound_peers.remove(&peer);

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -348,8 +348,8 @@ pub struct RibManager {
     /// Includes withdrawals so restored rows absent from Adj-RIB-In are
     /// still removed when the gate releases.
     deferred_selection_keys: selection_deferral::DeferredSelectionKeys,
-    /// Route-refresh responses received while family selection is frozen.
-    /// Replayed after the released initial table and `EoR` are queued.
+    /// Route-refresh responses received while family convergence and `EoR`
+    /// remain held. Replayed after the convergence `EoR` is queued.
     selection_deferred_refresh: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Current RPKI VRP table for origin validation. `None` = no RPKI data.
     vrp_table: Option<Arc<VrpTable>>,
@@ -1098,6 +1098,13 @@ impl RibManager {
     pub(super) fn selection_deferred(&self, family: (Afi, Safi)) -> bool {
         self.selection_deferral
             .as_ref()
+            .is_some_and(|state| state.selection_deferred(family))
+    }
+
+    #[must_use]
+    pub(super) fn selection_convergence_held(&self, family: (Afi, Safi)) -> bool {
+        self.selection_deferral
+            .as_ref()
             .is_some_and(|state| state.is_gated(family))
     }
 
@@ -1753,13 +1760,12 @@ impl RibManager {
                 safi,
             } => {
                 if !self.stale_session_message(peer, session_id, "EndOfRib", "eor") {
-                    let selection_released =
+                    let selection_transition =
                         self.selection_deferral_end_of_rib(peer, session_id, (afi, safi));
                     self.handle_end_of_rib(peer, afi, safi);
-                    if selection_released {
-                        self.finalize_selection_deferral_all_eor((afi, safi));
-                        self.release_selection_families(
-                            &[(afi, safi)],
+                    if let Some(transition) = selection_transition {
+                        self.apply_selection_deferral_transitions(
+                            [transition],
                             "all current-session End-of-RIB markers received",
                         );
                     }
@@ -1783,6 +1789,14 @@ impl RibManager {
             } => {
                 if !self.stale_session_message(peer, session_id, "BeginRouteRefresh", "refresh") {
                     self.handle_begin_route_refresh(peer, afi, safi);
+                    if let Some(transition) =
+                        self.selection_deferral_begin_route_refresh(peer, session_id, (afi, safi))
+                    {
+                        self.apply_selection_deferral_transitions(
+                            [transition],
+                            "collision-failback refresh began",
+                        );
+                    }
                 }
             }
             RibUpdate::EndRouteRefresh {
@@ -1793,6 +1807,24 @@ impl RibManager {
             } => {
                 if !self.stale_session_message(peer, session_id, "EndRouteRefresh", "refresh") {
                     self.handle_end_route_refresh(peer, afi, safi);
+                    if let Some(transition) =
+                        self.selection_deferral_end_route_refresh(peer, session_id, (afi, safi))
+                    {
+                        self.apply_selection_deferral_transitions(
+                            [transition],
+                            "collision-failback survivor refresh completed",
+                        );
+                    }
+                }
+            }
+            RibUpdate::RouteRefreshTimeout {
+                peer,
+                session_id,
+                afi,
+                safi,
+            } => {
+                if !self.stale_session_message(peer, session_id, "RouteRefreshTimeout", "refresh") {
+                    self.finish_route_refresh(peer, afi, safi, true);
                 }
             }
             RibUpdate::PeerGracefulRestart {

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -729,11 +729,11 @@ impl RibManager {
         }
 
         // Classify only the startup-frozen waiter already present for this
-        // peer. This runs before outbound registration, so if exclusion of
-        // the final waiter releases a family, existing peers receive the
-        // converged table and this peer receives it once in its normal
-        // initial dump below.
-        let released = match registration {
+        // peer. This runs before outbound registration, so a completed normal
+        // gate releases existing peers first, while collision failback can
+        // stage the current table for this peer's normal initial dump below
+        // without emitting the held convergence marker.
+        let transitions = match registration {
             ActiveSessionRegistration::PeerUp => {
                 if let Some(gr_context) = gr_context {
                     let peer_gr_families: HashSet<_> =
@@ -754,21 +754,24 @@ impl RibManager {
                 }
             }
             ActiveSessionRegistration::CollisionFailback => {
-                let excluded = self.selection_deferral.as_mut().and_then(|selection| {
-                    selection.exclude_collision_failback_survivor(peer, session_id, &self.metrics)
+                let waiting = self.selection_deferral.as_mut().and_then(|selection| {
+                    selection.await_collision_failback_refresh(peer, session_id, &self.metrics)
                 });
-                if let Some(released) = &excluded {
+                if let Some(transitions) = &waiting {
                     info!(
                         %peer,
                         session_id,
-                        released_families = released.len(),
-                        "exact collision-failback survivor excluded from the startup selection roster; inbound ROUTE-REFRESH remains best-effort recovery assistance"
+                        transition_count = transitions.len(),
+                        "exact collision-failback survivor is awaiting a post-failback enhanced ROUTE-REFRESH completion"
                     );
                 }
-                excluded.unwrap_or_default()
+                waiting.unwrap_or_default()
             }
         };
-        self.release_selection_families(&released, "all current waiters satisfied or excluded");
+        self.apply_selection_deferral_transitions(
+            transitions,
+            "all ordinary selection waiters satisfied or excluded",
+        );
 
         debug!(%peer, "peer up — registering for outbound updates");
         let peer_label = peer.to_string();
@@ -1447,6 +1450,23 @@ impl RibManager {
                 eor_families.retain(|family| !deferred.contains(family));
                 self.gr_deferred_eor.insert(peer, deferred);
             }
+        }
+
+        // Collision failback may stage the current Loc-RIB before the
+        // survivor has replayed its Adj-RIB-In. Send those staged routes, but
+        // keep the family EoR queued until an associated peer EoRR (or the
+        // original Selection_Deferral_Timer) proves convergence.
+        let convergence_held: HashSet<_> = eor_families
+            .iter()
+            .copied()
+            .filter(|family| self.selection_convergence_held(*family))
+            .collect();
+        if !convergence_held.is_empty() {
+            eor_families.retain(|family| !convergence_held.contains(family));
+            self.pending_eor
+                .entry(peer)
+                .or_default()
+                .extend(convergence_held);
         }
 
         let has_outbound_diff = !announce.is_empty()

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -590,12 +590,12 @@ impl RibManager {
     )]
     pub(super) fn send_route_refresh_response(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
         let family = (afi, safi);
-        if self.selection_deferred(family) {
+        if self.selection_convergence_held(family) {
             self.selection_deferred_refresh
                 .entry(peer)
                 .or_default()
                 .insert(family);
-            debug!(%peer, ?afi, ?safi, "route-refresh response deferred behind RFC 4724 selection gate");
+            debug!(%peer, ?afi, ?safi, "route-refresh response deferred behind RFC 4724 convergence gate");
             return;
         }
         // RFC 5291 §6: a ROUTE-REFRESH (plain or ORF-carrying) for this family
@@ -1224,7 +1224,7 @@ impl RibManager {
         };
         let (blocked, ready): (HashSet<_>, HashSet<_>) = families
             .into_iter()
-            .partition(|family| self.selection_deferred(*family));
+            .partition(|family| self.selection_convergence_held(*family));
         if !blocked.is_empty() {
             self.pending_eor.entry(peer).or_default().extend(blocked);
         }

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -248,13 +248,27 @@ pub struct SelectionDeferralConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum SelectionDeferralReleaseReason {
     AllEndOfRib,
+    CollisionRefreshComplete,
     TimerExpired,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SelectionDeferralTransition {
+    Stage {
+        family: (Afi, Safi),
+    },
+    Release {
+        family: (Afi, Safi),
+        already_staged: bool,
+        release_reason: SelectionDeferralReleaseReason,
+    },
 }
 
 impl SelectionDeferralReleaseReason {
     fn label(self) -> &'static str {
         match self {
             Self::AllEndOfRib => "all_eor",
+            Self::CollisionRefreshComplete => "collision_refresh",
             Self::TimerExpired => "timer",
         }
     }
@@ -263,9 +277,19 @@ impl SelectionDeferralReleaseReason {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WaiterState {
     AwaitingSession,
-    AwaitingEor { session_id: u64 },
-    Satisfied { session_id: u64 },
-    Excluded { session_id: u64 },
+    AwaitingEor {
+        session_id: u64,
+    },
+    AwaitingRefresh {
+        session_id: u64,
+        begin_received: bool,
+    },
+    Satisfied {
+        session_id: u64,
+    },
+    Excluded {
+        session_id: u64,
+    },
 }
 
 impl WaiterState {
@@ -273,6 +297,7 @@ impl WaiterState {
         match self {
             Self::AwaitingSession => ("awaiting_session", None),
             Self::AwaitingEor { session_id } => ("awaiting_eor", Some(session_id)),
+            Self::AwaitingRefresh { session_id, .. } => ("awaiting_refresh", Some(session_id)),
             Self::Satisfied { session_id } => ("satisfied", Some(session_id)),
             Self::Excluded { session_id } => ("excluded", Some(session_id)),
         }
@@ -282,6 +307,7 @@ impl WaiterState {
 #[derive(Debug)]
 struct FamilyGate {
     waiters: HashMap<IpAddr, WaiterState>,
+    selection_staged: bool,
 }
 
 #[derive(Debug)]
@@ -290,9 +316,10 @@ struct ReleasedFamily {
     waiters: HashMap<IpAddr, WaiterState>,
 }
 
-/// Actor-owned selection-deferral state.  Released families are retained in
-/// `released` for process-lifetime operator diagnostics; only `active` gates
-/// participate in selection and outbound suppression.
+/// Actor-owned selection-deferral state. Released families are retained in
+/// `released` for process-lifetime operator diagnostics. Every `active` gate
+/// suppresses convergence markers; an active gate whose selection is not yet
+/// staged also suppresses route selection and route payloads.
 #[derive(Debug)]
 pub(super) struct SelectionDeferral {
     deadline: tokio::time::Instant,
@@ -311,7 +338,9 @@ impl SelectionDeferral {
             .filter(|state| {
                 matches!(
                     state,
-                    WaiterState::AwaitingSession | WaiterState::AwaitingEor { .. }
+                    WaiterState::AwaitingSession
+                        | WaiterState::AwaitingEor { .. }
+                        | WaiterState::AwaitingRefresh { .. }
                 )
             })
             .count()
@@ -319,6 +348,18 @@ impl SelectionDeferral {
 
     fn complete(gate: &FamilyGate) -> bool {
         Self::blocking_waiters(gate) == 0
+    }
+
+    fn selection_blocking_waiters(gate: &FamilyGate) -> usize {
+        gate.waiters
+            .values()
+            .filter(|state| {
+                matches!(
+                    state,
+                    WaiterState::AwaitingSession | WaiterState::AwaitingEor { .. }
+                )
+            })
+            .count()
     }
 
     pub(super) fn new(config: SelectionDeferralConfig, metrics: &BgpMetrics) -> Option<Self> {
@@ -334,6 +375,7 @@ impl SelectionDeferral {
                     .entry(family)
                     .or_insert_with(|| FamilyGate {
                         waiters: HashMap::new(),
+                        selection_staged: false,
                     })
                     .waiters
                     .insert(waiter.peer, WaiterState::AwaitingSession);
@@ -362,8 +404,35 @@ impl SelectionDeferral {
         self.active.contains_key(&family)
     }
 
-    fn has_active_gates(&self) -> bool {
-        !self.active.is_empty()
+    pub(super) fn selection_deferred(&self, family: (Afi, Safi)) -> bool {
+        self.active
+            .get(&family)
+            .is_some_and(|gate| !gate.selection_staged)
+    }
+
+    fn has_deferred_selection(&self) -> bool {
+        self.active.values().any(|gate| !gate.selection_staged)
+    }
+
+    fn evaluate_family(
+        &mut self,
+        family: (Afi, Safi),
+        release_reason: SelectionDeferralReleaseReason,
+    ) -> Option<SelectionDeferralTransition> {
+        let gate = self.active.get_mut(&family)?;
+        let transition = if Self::complete(gate) {
+            SelectionDeferralTransition::Release {
+                family,
+                already_staged: gate.selection_staged,
+                release_reason,
+            }
+        } else if !gate.selection_staged && Self::selection_blocking_waiters(gate) == 0 {
+            gate.selection_staged = true;
+            SelectionDeferralTransition::Stage { family }
+        } else {
+            return None;
+        };
+        Some(transition)
     }
 
     pub(super) fn deadline(&self) -> Option<tokio::time::Instant> {
@@ -426,7 +495,7 @@ impl SelectionDeferral {
         peer_restart_state: bool,
         peer_gr_families: &HashSet<(Afi, Safi)>,
         metrics: &BgpMetrics,
-    ) -> Vec<(Afi, Safi)> {
+    ) -> Vec<SelectionDeferralTransition> {
         if session_id == 0 {
             tracing::warn!(%peer, "selection-deferral waiter received unstamped PeerUp; keeping it blocked");
             return Vec::new();
@@ -439,7 +508,7 @@ impl SelectionDeferral {
             return Vec::new();
         }
         let families: Vec<_> = self.active.keys().copied().collect();
-        let mut released = Vec::new();
+        let mut transitions = Vec::new();
         for family in families {
             let Some(gate) = self.active.get_mut(&family) else {
                 continue;
@@ -458,30 +527,29 @@ impl SelectionDeferral {
                 afi_safi_label(family.0, family.1),
                 gauge_val(Self::blocking_waiters(gate)),
             );
-            if Self::complete(gate) {
-                self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
-                released.push(family);
+            if let Some(transition) =
+                self.evaluate_family(family, SelectionDeferralReleaseReason::AllEndOfRib)
+            {
+                transitions.push(transition);
             }
         }
-        released
+        transitions
     }
 
-    /// Exclude the exact session recovered by collision failback from the
-    /// startup-frozen roster. Its `EoR` may already have been discarded while
-    /// the session was superseded, and the best-effort ROUTE-REFRESH used to
-    /// rebuild its Adj-RIB-In has no completion signal. Only an unambiguous,
-    /// stamped survivor whose current roster state was re-armed by the active
-    /// session's teardown may take this path.
+    /// Hold the exact session recovered by collision failback until a
+    /// post-failback `BoRR`/`EoRR` pair proves that its Adj-RIB-In replay
+    /// completed. Only an unambiguous, stamped survivor whose current roster
+    /// state was re-armed by the active session's teardown may take this path.
     ///
     /// `Some` means at least one active family was classified; the contained
-    /// families are those that became complete and must use the normal full
-    /// release path. `None` leaves every waiter unchanged.
-    pub(super) fn exclude_collision_failback_survivor(
+    /// transitions stage any family whose ordinary waiters are already done.
+    /// `None` leaves every waiter unchanged.
+    pub(super) fn await_collision_failback_refresh(
         &mut self,
         peer: IpAddr,
         session_id: u64,
         metrics: &BgpMetrics,
-    ) -> Option<Vec<(Afi, Safi)>> {
+    ) -> Option<Vec<SelectionDeferralTransition>> {
         if session_id == 0 {
             tracing::warn!(
                 %peer,
@@ -500,7 +568,7 @@ impl SelectionDeferral {
 
         let families: Vec<_> = self.active.keys().copied().collect();
         let mut classified = false;
-        let mut released = Vec::new();
+        let mut transitions = Vec::new();
         for family in families {
             let Some(gate) = self.active.get_mut(&family) else {
                 continue;
@@ -508,19 +576,25 @@ impl SelectionDeferral {
             if gate.waiters.get(&peer) != Some(&WaiterState::AwaitingSession) {
                 continue;
             }
-            gate.waiters
-                .insert(peer, WaiterState::Excluded { session_id });
+            gate.waiters.insert(
+                peer,
+                WaiterState::AwaitingRefresh {
+                    session_id,
+                    begin_received: false,
+                },
+            );
             classified = true;
             metrics.set_selection_deferral_waiters(
                 afi_safi_label(family.0, family.1),
                 gauge_val(Self::blocking_waiters(gate)),
             );
-            if Self::complete(gate) {
-                self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
-                released.push(family);
+            if let Some(transition) =
+                self.evaluate_family(family, SelectionDeferralReleaseReason::AllEndOfRib)
+            {
+                transitions.push(transition);
             }
         }
-        classified.then_some(released)
+        classified.then_some(transitions)
     }
 
     /// Revert a current-session waiter to the not-yet-established state.  A
@@ -531,6 +605,10 @@ impl SelectionDeferral {
                 gate.waiters.get(&peer),
                 Some(
                     WaiterState::AwaitingEor { session_id: current }
+                        | WaiterState::AwaitingRefresh {
+                            session_id: current,
+                            ..
+                        }
                         | WaiterState::Satisfied { session_id: current }
                         | WaiterState::Excluded { session_id: current }
                 ) if *current == session_id
@@ -550,15 +628,13 @@ impl SelectionDeferral {
         session_id: u64,
         family: (Afi, Safi),
         metrics: &BgpMetrics,
-    ) -> bool {
+    ) -> Option<SelectionDeferralTransition> {
         if session_id == 0 {
-            return false;
+            return None;
         }
-        let Some(gate) = self.active.get_mut(&family) else {
-            return false;
-        };
+        let gate = self.active.get_mut(&family)?;
         if gate.waiters.get(&peer) != Some(&WaiterState::AwaitingEor { session_id }) {
-            return false;
+            return None;
         }
         gate.waiters
             .insert(peer, WaiterState::Satisfied { session_id });
@@ -566,13 +642,60 @@ impl SelectionDeferral {
             afi_safi_label(family.0, family.1),
             gauge_val(Self::blocking_waiters(gate)),
         );
-        Self::complete(gate)
+        self.evaluate_family(family, SelectionDeferralReleaseReason::AllEndOfRib)
     }
 
-    pub(super) fn finalize_all_eor(&mut self, family: (Afi, Safi), metrics: &BgpMetrics) {
-        if self.active.get(&family).is_some_and(Self::complete) {
-            self.release(family, SelectionDeferralReleaseReason::AllEndOfRib, metrics);
+    pub(super) fn begin_route_refresh(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+    ) -> Option<SelectionDeferralTransition> {
+        let gate = self.active.get_mut(&family)?;
+        if gate.waiters.get(&peer)
+            != Some(&WaiterState::AwaitingRefresh {
+                session_id,
+                begin_received: false,
+            })
+        {
+            return None;
         }
+        gate.waiters.insert(
+            peer,
+            WaiterState::AwaitingRefresh {
+                session_id,
+                begin_received: true,
+            },
+        );
+        self.evaluate_family(family, SelectionDeferralReleaseReason::AllEndOfRib)
+    }
+
+    pub(super) fn end_route_refresh(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+        metrics: &BgpMetrics,
+    ) -> Option<SelectionDeferralTransition> {
+        let gate = self.active.get_mut(&family)?;
+        if gate.waiters.get(&peer)
+            != Some(&WaiterState::AwaitingRefresh {
+                session_id,
+                begin_received: true,
+            })
+        {
+            return None;
+        }
+        gate.waiters
+            .insert(peer, WaiterState::Satisfied { session_id });
+        metrics.set_selection_deferral_waiters(
+            afi_safi_label(family.0, family.1),
+            gauge_val(Self::blocking_waiters(gate)),
+        );
+        self.evaluate_family(
+            family,
+            SelectionDeferralReleaseReason::CollisionRefreshComplete,
+        )
     }
 
     pub(super) fn expire(&mut self, metrics: &BgpMetrics) -> Vec<(Afi, Safi)> {
@@ -617,7 +740,7 @@ impl RibManager {
     fn deferred_selection_recording_active(&self) -> bool {
         self.selection_deferral
             .as_ref()
-            .is_some_and(SelectionDeferral::has_active_gates)
+            .is_some_and(SelectionDeferral::has_deferred_selection)
     }
 
     fn record_selection_ledger_overflows(
@@ -650,13 +773,15 @@ impl RibManager {
         let Some(selection) = self
             .selection_deferral
             .as_ref()
-            .filter(|selection| selection.has_active_gates())
+            .filter(|selection| selection.has_deferred_selection())
         else {
             return;
         };
         let deferred = affected.iter().filter_map(|prefix| {
             let family = super::helpers::prefix_family(prefix);
-            selection.is_gated(family).then_some((family, prefix))
+            selection
+                .selection_deferred(family)
+                .then_some((family, prefix))
         });
         let current_len = self.deferred_selection_keys.len();
         let newly_overflowed = DeferredSelectionKeys::extend_bounded(
@@ -678,13 +803,15 @@ impl RibManager {
         let Some(selection) = self
             .selection_deferral
             .as_ref()
-            .filter(|selection| selection.has_active_gates())
+            .filter(|selection| selection.has_deferred_selection())
         else {
             return;
         };
         let deferred = affected.iter().filter_map(|key| {
             let family = (key.afi, Safi::FlowSpec);
-            selection.is_gated(family).then_some((family, key))
+            selection
+                .selection_deferred(family)
+                .then_some((family, key))
         });
         let current_len = self.deferred_selection_keys.len();
         let limits = self.deferred_selection_keys.limits;
@@ -725,13 +852,15 @@ impl RibManager {
         let Some(selection) = self
             .selection_deferral
             .as_ref()
-            .filter(|selection| selection.has_active_gates())
+            .filter(|selection| selection.has_deferred_selection())
         else {
             return;
         };
         let deferred = affected.iter().filter_map(|key| {
             let family = key.afi_safi();
-            selection.is_gated(family).then_some((family, key))
+            selection
+                .selection_deferred(family)
+                .then_some((family, key))
         });
         let current_len = self.deferred_selection_keys.len();
         let limits = self.deferred_selection_keys.limits;
@@ -754,13 +883,15 @@ impl RibManager {
         let Some(selection) = self
             .selection_deferral
             .as_ref()
-            .filter(|selection| selection.has_active_gates())
+            .filter(|selection| selection.has_deferred_selection())
         else {
             return;
         };
         let deferred = affected.iter().filter_map(|key| {
             let family = key.afi_safi();
-            selection.is_gated(family).then_some((family, key))
+            selection
+                .selection_deferred(family)
+                .then_some((family, key))
         });
         let current_len = self.deferred_selection_keys.len();
         let limits = self.deferred_selection_keys.limits;
@@ -783,13 +914,15 @@ impl RibManager {
         let Some(selection) = self
             .selection_deferral
             .as_ref()
-            .filter(|selection| selection.has_active_gates())
+            .filter(|selection| selection.has_deferred_selection())
         else {
             return;
         };
         let deferred = affected.iter().filter_map(|key| {
             let family = key.family.to_afi_safi();
-            selection.is_gated(family).then_some((family, key))
+            selection
+                .selection_deferred(family)
+                .then_some((family, key))
         });
         let current_len = self.deferred_selection_keys.len();
         let limits = self.deferred_selection_keys.limits;
@@ -893,16 +1026,32 @@ impl RibManager {
         peer: IpAddr,
         session_id: u64,
         family: (Afi, Safi),
-    ) -> bool {
+    ) -> Option<SelectionDeferralTransition> {
         self.selection_deferral
             .as_mut()
-            .is_some_and(|selection| selection.end_of_rib(peer, session_id, family, &self.metrics))
+            .and_then(|selection| selection.end_of_rib(peer, session_id, family, &self.metrics))
     }
 
-    pub(super) fn finalize_selection_deferral_all_eor(&mut self, family: (Afi, Safi)) {
-        if let Some(selection) = self.selection_deferral.as_mut() {
-            selection.finalize_all_eor(family, &self.metrics);
-        }
+    pub(super) fn selection_deferral_begin_route_refresh(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+    ) -> Option<SelectionDeferralTransition> {
+        self.selection_deferral
+            .as_mut()
+            .and_then(|selection| selection.begin_route_refresh(peer, session_id, family))
+    }
+
+    pub(super) fn selection_deferral_end_route_refresh(
+        &mut self,
+        peer: IpAddr,
+        session_id: u64,
+        family: (Afi, Safi),
+    ) -> Option<SelectionDeferralTransition> {
+        self.selection_deferral.as_mut().and_then(|selection| {
+            selection.end_route_refresh(peer, session_id, family, &self.metrics)
+        })
     }
 
     pub(super) fn expire_selection_deferral(&mut self) {
@@ -919,49 +1068,97 @@ impl RibManager {
             .and_then(SelectionDeferral::deadline)
     }
 
-    /// Run the delayed family selection exactly once after its gate opens.
-    /// All identity sets come from Adj-RIB-In, which continued accepting the
-    /// current sessions' updates while Loc-RIB selection was frozen.
+    /// Complete a family release. Ordinary release runs the delayed selection;
+    /// a timer fallback may recompute a family that collision failback staged
+    /// earlier. All identity sets come from Adj-RIB-In, which continued
+    /// accepting current-session updates while Loc-RIB selection was frozen.
     pub(super) fn release_selection_families(
         &mut self,
         families: &[(Afi, Safi)],
         reason: &'static str,
     ) {
         for &family in families {
-            tracing::info!(
-                afi = ?family.0,
-                safi = ?family.1,
-                reason,
-                "RFC 4724 route-selection deferral released"
-            );
-            self.recompute_released_selection_family(family);
-            // Existing sessions received no initial table and no EoR while
-            // gated. Queue the marker only after the released selection has
-            // been staged; dirty peers keep it pending until their full resync
-            // succeeds, preserving table-before-EoR ordering.
-            let peers: Vec<_> = self
-                .peer_sendable_families
-                .iter()
-                .filter_map(|(&peer, sendable)| sendable.contains(&family).then_some(peer))
-                .collect();
-            for peer in peers {
-                self.pending_eor.entry(peer).or_default().insert(family);
-                if !self.dirty_peers.contains(&peer) {
-                    self.flush_pending_eor(peer);
+            self.complete_selection_family(family, false, reason);
+        }
+    }
+
+    pub(super) fn apply_selection_deferral_transitions(
+        &mut self,
+        transitions: impl IntoIterator<Item = SelectionDeferralTransition>,
+        reason: &'static str,
+    ) {
+        for transition in transitions {
+            match transition {
+                SelectionDeferralTransition::Stage { family } => {
+                    tracing::info!(
+                        afi = ?family.0,
+                        safi = ?family.1,
+                        reason,
+                        "RFC 4724 route selection staged while collision-failback convergence remains held"
+                    );
+                    self.recompute_released_selection_family(family);
+                }
+                SelectionDeferralTransition::Release {
+                    family,
+                    already_staged,
+                    release_reason,
+                } => {
+                    if let Some(selection) = self.selection_deferral.as_mut() {
+                        selection.release(family, release_reason, &self.metrics);
+                    }
+                    self.complete_selection_family(family, already_staged, reason);
                 }
             }
-            let refresh_peers: Vec<_> = self
-                .selection_deferred_refresh
-                .iter()
-                .filter_map(|(&peer, families)| families.contains(&family).then_some(peer))
-                .collect();
-            for peer in refresh_peers {
-                if let Some(families) = self.selection_deferred_refresh.get_mut(&peer) {
-                    families.remove(&family);
-                    if families.is_empty() {
-                        self.selection_deferred_refresh.remove(&peer);
-                    }
+        }
+    }
+
+    fn complete_selection_family(
+        &mut self,
+        family: (Afi, Safi),
+        already_staged: bool,
+        reason: &'static str,
+    ) {
+        tracing::info!(
+            afi = ?family.0,
+            safi = ?family.1,
+            reason,
+            "RFC 4724 route-selection deferral released"
+        );
+        if !already_staged {
+            self.recompute_released_selection_family(family);
+        }
+        // Existing sessions received no initial table and no EoR while
+        // gated. Queue the marker only after the released selection has
+        // been staged; dirty peers keep it pending until their full resync
+        // succeeds, preserving table-before-EoR ordering.
+        let peers: Vec<_> = self
+            .peer_sendable_families
+            .iter()
+            .filter_map(|(&peer, sendable)| sendable.contains(&family).then_some(peer))
+            .collect();
+        for peer in peers {
+            self.pending_eor.entry(peer).or_default().insert(family);
+            if !self.dirty_peers.contains(&peer) {
+                self.flush_pending_eor(peer);
+            }
+        }
+        let refresh_peers: Vec<_> = self
+            .selection_deferred_refresh
+            .iter()
+            .filter_map(|(&peer, families)| families.contains(&family).then_some(peer))
+            .collect();
+        for peer in refresh_peers {
+            if let Some(families) = self.selection_deferred_refresh.get_mut(&peer) {
+                families.remove(&family);
+                if families.is_empty() {
+                    self.selection_deferred_refresh.remove(&peer);
                 }
+            }
+            if self.dirty_peers.contains(&peer) {
+                // The dirty-resync success path flushes or piggybacks the
+                // convergence EoR before retrying this response.
+                self.pending_refresh.entry(peer).or_default().insert(family);
+            } else {
                 self.send_route_refresh_response(peer, family.0, family.1);
             }
         }

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -3,19 +3,21 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use rustbgpd_telemetry::BgpMetrics;
-use rustbgpd_wire::{Afi, Ipv4Prefix, Safi};
+use rustbgpd_wire::{Afi, Ipv4Prefix, RouteRefreshSubtype, Safi};
 use tokio::sync::{mpsc, oneshot};
 
 use super::{
     dummy_query_rx, make_bgpls_route, make_evpn_imet, make_flowspec_route, make_labeled_rib_route,
     make_route_with_lp, make_rtc_rib_route, make_vpn_rib_route, query_best_routes,
 };
+use crate::manager::selection_deferral::SelectionDeferralTransition;
 use crate::{
     PeerOutboundState, RibManager, RibUpdate, SelectionDeferralConfig,
     SelectionDeferralWaiterConfig,
 };
 
 const FAMILY: (Afi, Safi) = (Afi::Ipv4, Safi::Unicast);
+const READY_FAMILY: (Afi, Safi) = (Afi::Ipv6, Safi::Unicast);
 
 fn counter_value(metrics: &BgpMetrics, name: &str) -> f64 {
     metrics
@@ -49,6 +51,15 @@ fn peer_up(
     session_id: u64,
     outbound_tx: mpsc::Sender<crate::OutboundRouteUpdate>,
 ) -> RibUpdate {
+    peer_up_with_families(peer, session_id, outbound_tx, vec![FAMILY])
+}
+
+fn peer_up_with_families(
+    peer: IpAddr,
+    session_id: u64,
+    outbound_tx: mpsc::Sender<crate::OutboundRouteUpdate>,
+    sendable_families: Vec<(Afi, Safi)>,
+) -> RibUpdate {
     RibUpdate::PeerUp {
         peer,
         session_id,
@@ -56,7 +67,7 @@ fn peer_up(
         peer_router_id: Ipv4Addr::new(10, 0, 0, 254),
         outbound_tx,
         export_policy: None,
-        sendable_families: vec![FAMILY],
+        sendable_families,
         is_ebgp: false,
         route_reflector_client: true,
         orr_vantage: None,
@@ -129,6 +140,34 @@ fn config(timeout: Duration, peers: &[IpAddr]) -> SelectionDeferralConfig {
             })
             .collect(),
     }
+}
+
+fn commit_control_markers(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    end_of_rib: Vec<(Afi, Safi)>,
+    refresh_markers: Vec<(Afi, Safi, RouteRefreshSubtype)>,
+) -> bool {
+    manager.try_send_and_commit_outbound_update(
+        peer,
+        Vec::new().into(),
+        Vec::new().into(),
+        Vec::new(),
+        end_of_rib,
+        refresh_markers,
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    )
 }
 
 #[tokio::test]
@@ -350,7 +389,7 @@ async fn duplicate_address_roster_fails_closed_until_timer() {
 }
 
 #[test]
-fn collision_failback_excludes_only_the_rearmed_survivor() {
+fn collision_failback_stages_then_waits_for_refresh_completion() {
     let survivor = peer(1);
     let remaining = peer(2);
     let metrics = BgpMetrics::new();
@@ -365,22 +404,28 @@ fn collision_failback_excludes_only_the_rearmed_survivor() {
             .classify_session(survivor, 11, false, &gr_families, &metrics)
             .is_empty()
     );
-    assert!(!selection.end_of_rib(survivor, 11, FAMILY, &metrics));
+    assert!(
+        selection
+            .end_of_rib(survivor, 11, FAMILY, &metrics)
+            .is_none()
+    );
     selection.session_down(survivor, 11, &metrics);
     assert_eq!(
-        selection.exclude_collision_failback_survivor(survivor, 11, &metrics),
+        selection.await_collision_failback_refresh(survivor, 11, &metrics),
         Some(Vec::new()),
-        "the exact re-armed survivor should stop blocking without releasing a real waiter"
+        "the exact re-armed survivor must wait for a post-failback refresh"
     );
 
     let survivor_row = selection.peer_snapshot(survivor).remove(0);
     assert!(survivor_row.active);
-    assert_eq!(survivor_row.waiter_state, "excluded");
+    assert_eq!(survivor_row.waiter_state, "awaiting_refresh");
     assert_eq!(survivor_row.waiter_session_id, Some(11));
-    assert_eq!(survivor_row.blocking_waiters, 1);
+    assert_eq!(survivor_row.blocking_waiters, 2);
     assert!(
-        !selection.end_of_rib(survivor, 12, FAMILY, &metrics),
-        "an unrelated session must not satisfy the excluded survivor"
+        selection
+            .end_of_rib(survivor, 12, FAMILY, &metrics)
+            .is_none(),
+        "an unrelated session must not satisfy the refresh waiter"
     );
 
     assert!(
@@ -388,11 +433,572 @@ fn collision_failback_excludes_only_the_rearmed_survivor() {
             .classify_session(remaining, 21, false, &gr_families, &metrics)
             .is_empty()
     );
-    assert!(selection.end_of_rib(remaining, 21, FAMILY, &metrics));
-    selection.finalize_all_eor(FAMILY, &metrics);
-    let remaining_row = selection.peer_snapshot(remaining).remove(0);
-    assert!(!remaining_row.active);
-    assert_eq!(remaining_row.release_reason, "all_eor");
+    assert_eq!(
+        selection.end_of_rib(remaining, 21, FAMILY, &metrics),
+        Some(SelectionDeferralTransition::Stage { family: FAMILY })
+    );
+    let staged = selection.peer_snapshot(survivor).remove(0);
+    assert!(staged.active);
+    assert_eq!(staged.waiter_state, "awaiting_refresh");
+    assert_eq!(staged.blocking_waiters, 1);
+    assert!(
+        selection
+            .begin_route_refresh(survivor, 11, FAMILY)
+            .is_none()
+    );
+    let release = selection
+        .end_route_refresh(survivor, 11, FAMILY, &metrics)
+        .unwrap();
+    assert!(matches!(
+        release,
+        SelectionDeferralTransition::Release {
+            family: FAMILY,
+            already_staged: true,
+            ..
+        }
+    ));
+    manager.apply_selection_deferral_transitions([release], "test refresh completion");
+    let released = manager
+        .selection_deferral
+        .as_ref()
+        .unwrap()
+        .peer_snapshot(survivor)
+        .remove(0);
+    assert!(!released.active);
+    assert_eq!(released.release_reason, "collision_refresh");
+}
+
+#[test]
+fn multiple_failback_survivors_release_only_after_every_waiter_converges() {
+    let first_survivor = peer(1);
+    let second_survivor = peer(2);
+    let ordinary = peer(3);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(
+            Duration::from_mins(1),
+            &[first_survivor, second_survivor, ordinary],
+        ));
+    let gr_families = HashSet::from([FAMILY]);
+    let selection = manager.selection_deferral.as_mut().unwrap();
+
+    for (peer, session_id) in [(first_survivor, 11), (second_survivor, 21)] {
+        assert!(
+            selection
+                .classify_session(peer, session_id, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        assert!(
+            selection
+                .end_of_rib(peer, session_id, FAMILY, &metrics)
+                .is_none()
+        );
+        selection.session_down(peer, session_id, &metrics);
+        assert_eq!(
+            selection.await_collision_failback_refresh(peer, session_id, &metrics),
+            Some(Vec::new())
+        );
+        let waiting = selection.peer_snapshot(peer).remove(0);
+        assert!(waiting.active);
+        assert_eq!(waiting.waiter_state, "awaiting_refresh");
+    }
+    assert!(
+        selection
+            .classify_session(ordinary, 31, false, &gr_families, &metrics)
+            .is_empty()
+    );
+
+    assert!(
+        selection
+            .begin_route_refresh(first_survivor, 11, FAMILY)
+            .is_none()
+    );
+    assert!(
+        selection
+            .end_route_refresh(first_survivor, 11, FAMILY, &metrics)
+            .is_none(),
+        "one survivor EoRR cannot release while another survivor and an ordinary waiter remain"
+    );
+    assert!(selection.peer_snapshot(ordinary)[0].active);
+
+    assert!(
+        selection
+            .begin_route_refresh(second_survivor, 21, FAMILY)
+            .is_none()
+    );
+    assert!(
+        selection
+            .end_route_refresh(second_survivor, 21, FAMILY, &metrics)
+            .is_none(),
+        "every survivor can finish refresh while the ordinary waiter still blocks selection"
+    );
+    let waiting = selection.peer_snapshot(ordinary).remove(0);
+    assert!(waiting.active);
+    assert_eq!(waiting.waiter_state, "awaiting_eor");
+    assert_eq!(waiting.blocking_waiters, 1);
+
+    let release = selection
+        .end_of_rib(ordinary, 31, FAMILY, &metrics)
+        .unwrap();
+    assert!(
+        matches!(
+            release,
+            SelectionDeferralTransition::Release {
+                family: FAMILY,
+                already_staged: false,
+                ..
+            }
+        ),
+        "the last ordinary EoR must perform the one full release recompute"
+    );
+    manager.apply_selection_deferral_transitions([release], "test ordinary completion");
+    let released = manager
+        .selection_deferral
+        .as_ref()
+        .unwrap()
+        .peer_snapshot(ordinary)
+        .remove(0);
+    assert!(!released.active);
+    assert_eq!(released.release_reason, "all_eor");
+}
+
+#[test]
+fn staged_selection_rejects_eor_and_refresh_marker_commits() {
+    let source = peer(1);
+    let target = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    let gr_families = HashSet::from([FAMILY]);
+    let transitions = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(
+            selection
+                .classify_session(source, 11, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        selection.session_down(source, 11, &metrics);
+        selection
+            .await_collision_failback_refresh(source, 11, &metrics)
+            .unwrap()
+    };
+    assert_eq!(
+        transitions,
+        vec![SelectionDeferralTransition::Stage { family: FAMILY }]
+    );
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
+    assert!(manager.selection_convergence_held(FAMILY));
+    assert!(!manager.selection_deferred(FAMILY));
+
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(4);
+    manager.outbound_peers.insert(target, outbound_tx);
+    assert!(
+        !commit_control_markers(&mut manager, target, vec![FAMILY], Vec::new()),
+        "staged selection must still reject a family EoR commit"
+    );
+    assert!(
+        !commit_control_markers(
+            &mut manager,
+            target,
+            Vec::new(),
+            vec![
+                (FAMILY.0, FAMILY.1, RouteRefreshSubtype::BoRR),
+                (FAMILY.0, FAMILY.1, RouteRefreshSubtype::EoRR),
+            ],
+        ),
+        "staged selection must still reject route-refresh marker commits"
+    );
+    assert!(outbound_rx.try_recv().is_err());
+}
+
+#[test]
+fn staged_selection_classifies_refresh_response_as_convergence_deferred() {
+    let source = peer(1);
+    let target = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    let gr_families = HashSet::from([FAMILY]);
+    let transitions = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(
+            selection
+                .classify_session(source, 11, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        selection.session_down(source, 11, &metrics);
+        selection
+            .await_collision_failback_refresh(source, 11, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(4);
+    manager.outbound_peers.insert(target, outbound_tx);
+
+    manager.send_route_refresh_response(target, FAMILY.0, FAMILY.1);
+
+    assert_eq!(
+        manager.selection_deferred_refresh.get(&target),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert!(!manager.pending_refresh.contains_key(&target));
+    assert!(outbound_rx.try_recv().is_err());
+}
+
+#[test]
+fn dirty_resync_sends_ready_eor_and_retains_held_family() {
+    let source = peer(1);
+    let target = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        metrics.clone(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    let gr_families = HashSet::from([FAMILY]);
+    let transitions = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(
+            selection
+                .classify_session(source, 11, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        selection.session_down(source, 11, &metrics);
+        selection
+            .await_collision_failback_refresh(source, 11, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
+
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up_with_families(
+        target,
+        21,
+        outbound_tx,
+        vec![FAMILY, READY_FAMILY],
+    ));
+    let initial_ready_eor = outbound_rx.try_recv().unwrap();
+    assert_eq!(initial_ready_eor.end_of_rib, vec![READY_FAMILY]);
+
+    let route = make_route_with_lp(
+        Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+        Ipv4Addr::new(10, 0, 0, 1),
+        100,
+    );
+    manager.enqueue_routes_received(
+        source,
+        vec![route],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    while manager.process_next_route_chunk() {}
+    assert!(!outbound_rx.try_recv().unwrap().announce.is_empty());
+
+    manager
+        .pending_eor
+        .entry(target)
+        .or_default()
+        .insert(READY_FAMILY);
+    manager.mark_outbound_dirty(target);
+    manager.distribute_changes(&HashSet::new(), &HashSet::new());
+
+    let resync = outbound_rx.try_recv().unwrap();
+    assert!(
+        !resync.announce.is_empty(),
+        "dirty resync omitted route payload"
+    );
+    assert_eq!(resync.end_of_rib, vec![READY_FAMILY]);
+    assert_eq!(
+        manager.pending_eor.get(&target),
+        Some(&HashSet::from([FAMILY])),
+        "successful mixed-family resync must retain only the convergence-held EoR"
+    );
+
+    let release = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(selection.begin_route_refresh(source, 11, FAMILY).is_none());
+        selection
+            .end_route_refresh(source, 11, FAMILY, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions([release], "test refresh completion");
+    assert_eq!(outbound_rx.try_recv().unwrap().end_of_rib, vec![FAMILY]);
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one production-shaped transcript pins dirty resync, EoR, and refresh ordering"
+)]
+fn dirty_observer_emits_convergence_eor_before_deferred_refresh() {
+    let survivor = peer(1);
+    let route_source = peer(2);
+    let observer = peer(3);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let (_tx, rx) = mpsc::channel(32);
+    let mut manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[survivor]));
+
+    let (survivor_tx, _survivor_rx) = mpsc::channel(16);
+    manager.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+        peer: survivor,
+        session_id: 11,
+        peer_restart_state: false,
+        peer_gr_families: vec![FAMILY],
+    });
+    manager.handle_update(peer_up(survivor, 11, survivor_tx));
+    let (replacement_tx, _replacement_rx) = mpsc::channel(16);
+    manager.handle_update(RibUpdate::SetPeerGracefulRestartContext {
+        peer: survivor,
+        session_id: 12,
+        peer_restart_state: false,
+        peer_gr_families: vec![FAMILY],
+    });
+    manager.handle_update(peer_up(survivor, 12, replacement_tx));
+
+    let (source_tx, _source_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(route_source, 21, source_tx));
+    let (observer_tx, mut observer_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(observer, 31, observer_tx));
+    manager.enqueue_routes_received(
+        route_source,
+        vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    while manager.process_next_route_chunk() {}
+    assert!(
+        manager
+            .loc_rib
+            .get(&rustbgpd_wire::Prefix::V4(prefix))
+            .is_none()
+    );
+    assert!(observer_rx.try_recv().is_err());
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer: survivor,
+        session_id: 12,
+    });
+    let staged = observer_rx.try_recv().unwrap();
+    assert!(
+        staged
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(prefix))
+    );
+    assert!(!staged.end_of_rib.contains(&FAMILY));
+    while observer_rx.try_recv().is_ok() {}
+
+    manager.handle_update(RibUpdate::RouteRefreshRequest {
+        peer: observer,
+        session_id: 31,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    });
+    assert_eq!(
+        manager.selection_deferred_refresh.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert!(observer_rx.try_recv().is_err());
+
+    manager.handle_update(RibUpdate::BeginRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    });
+    // Preserve the production EoRR ordering while injecting the dirty state
+    // at the release boundary: the ordinary refresh finisher runs first, then
+    // the selection transition consumes the peer EoRR.
+    manager.handle_end_route_refresh(survivor, FAMILY.0, FAMILY.1);
+    manager.mark_outbound_dirty(observer);
+    let release = manager
+        .selection_deferral_end_route_refresh(survivor, 11, FAMILY)
+        .unwrap();
+    manager.apply_selection_deferral_transitions([release], "test survivor EoRR completion");
+    assert!(!manager.selection_convergence_held(FAMILY));
+    assert!(manager.dirty_peers.contains(&observer));
+    assert!(
+        observer_rx.try_recv().is_err(),
+        "dirty observer emitted deferred BoRR/routes/EoRR before convergence resync/EoR"
+    );
+    assert_eq!(
+        manager.pending_eor.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert_eq!(
+        manager.pending_refresh.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+
+    manager.distribute_changes(&HashSet::new(), &HashSet::new());
+
+    let convergence = observer_rx.try_recv().unwrap();
+    assert_eq!(convergence.end_of_rib, vec![FAMILY]);
+    assert!(convergence.refresh_markers.is_empty());
+    assert!(
+        convergence
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(prefix))
+    );
+
+    let refresh = observer_rx.try_recv().unwrap();
+    assert_eq!(
+        refresh.refresh_markers,
+        vec![
+            (FAMILY.0, FAMILY.1, RouteRefreshSubtype::BoRR),
+            (FAMILY.0, FAMILY.1, RouteRefreshSubtype::EoRR),
+        ]
+    );
+    assert!(
+        refresh
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(prefix))
+    );
+    assert!(observer_rx.try_recv().is_err());
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one transcript pins the full-channel no-diff retry ordering"
+)]
+fn no_diff_dirty_resync_keeps_refresh_behind_failed_convergence_eor() {
+    let survivor = peer(1);
+    let observer = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(16);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[survivor]));
+    let gr_families = HashSet::from([FAMILY]);
+    let transitions = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(
+            selection
+                .classify_session(survivor, 11, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        selection.session_down(survivor, 11, &metrics);
+        selection
+            .await_collision_failback_refresh(survivor, 11, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
+
+    let (observer_tx, mut observer_rx) = mpsc::channel(2);
+    let fill_tx = observer_tx.clone();
+    manager.handle_update(peer_up(observer, 21, observer_tx));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    manager.enqueue_routes_received(
+        observer,
+        vec![make_route_with_lp(prefix, Ipv4Addr::new(10, 0, 0, 2), 100)],
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    while manager.process_next_route_chunk() {}
+    assert!(
+        manager
+            .loc_rib
+            .get(&rustbgpd_wire::Prefix::V4(prefix))
+            .is_some()
+    );
+    assert!(observer_rx.try_recv().is_err());
+    manager.handle_update(RibUpdate::RouteRefreshRequest {
+        peer: observer,
+        session_id: 21,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    });
+    assert_eq!(
+        manager.selection_deferred_refresh.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+
+    assert!(
+        manager
+            .selection_deferral_begin_route_refresh(survivor, 11, FAMILY)
+            .is_none()
+    );
+    manager.mark_outbound_dirty(observer);
+    let release = manager
+        .selection_deferral_end_route_refresh(survivor, 11, FAMILY)
+        .unwrap();
+    manager.apply_selection_deferral_transitions([release], "test survivor EoRR completion");
+    assert_eq!(
+        manager.pending_eor.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert_eq!(
+        manager.pending_refresh.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert!(observer_rx.try_recv().is_err());
+
+    fill_tx
+        .try_send(crate::OutboundRouteUpdate::default())
+        .unwrap();
+    fill_tx
+        .try_send(crate::OutboundRouteUpdate::default())
+        .unwrap();
+    assert_eq!(fill_tx.capacity(), 0);
+    manager.distribute_changes(&HashSet::new(), &HashSet::new());
+
+    assert_counter_value(&metrics, "bgp_outbound_route_drops_total", 0.0);
+    assert!(
+        manager.dirty_peers.contains(&observer),
+        "pending_eor={:?} pending_refresh={:?} channel_capacity={}",
+        manager.pending_eor.get(&observer),
+        manager.pending_refresh.get(&observer),
+        fill_tx.capacity()
+    );
+    assert_eq!(
+        manager.pending_eor.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert_eq!(
+        manager.pending_refresh.get(&observer),
+        Some(&HashSet::from([FAMILY]))
+    );
+    let _ = observer_rx.try_recv().unwrap();
+    let _ = observer_rx.try_recv().unwrap();
+    manager.distribute_changes(&HashSet::new(), &HashSet::new());
+
+    let convergence = observer_rx.try_recv().unwrap();
+    assert_eq!(convergence.end_of_rib, vec![FAMILY]);
+    assert!(convergence.refresh_markers.is_empty());
+    let refresh = observer_rx.try_recv().unwrap();
+    assert_eq!(
+        refresh.refresh_markers,
+        vec![
+            (FAMILY.0, FAMILY.1, RouteRefreshSubtype::BoRR),
+            (FAMILY.0, FAMILY.1, RouteRefreshSubtype::EoRR),
+        ]
+    );
+    assert!(observer_rx.try_recv().is_err());
 }
 
 #[test]
@@ -408,11 +1014,11 @@ fn unstamped_or_ambiguous_collision_failback_stays_timer_bound() {
     let selection = manager.selection_deferral.as_mut().unwrap();
 
     assert_eq!(
-        selection.exclude_collision_failback_survivor(unstamped, 0, &metrics),
+        selection.await_collision_failback_refresh(unstamped, 0, &metrics),
         None
     );
     assert_eq!(
-        selection.exclude_collision_failback_survivor(duplicate, 22, &metrics),
+        selection.await_collision_failback_refresh(duplicate, 22, &metrics),
         None
     );
     for peer in [unstamped, duplicate] {
@@ -423,10 +1029,17 @@ fn unstamped_or_ambiguous_collision_failback_stays_timer_bound() {
     }
 }
 
-#[tokio::test]
-async fn exact_collision_failback_releases_table_before_eor_and_then_requests_refresh() {
+#[tokio::test(start_paused = true)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one protocol transcript pins collision failback staging and convergence ordering"
+)]
+async fn collision_failback_withholds_eor_until_survivor_refresh_converges() {
     let survivor = peer(1);
     let remaining = peer(2);
+    let observer = peer(3);
+    let survivor_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let remaining_prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(
         rx,
@@ -441,6 +1054,22 @@ async fn exact_collision_failback_releases_table_before_eor_and_then_requests_re
     let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
     stage_gr_context(&tx, survivor, 11).await;
     tx.send(peer_up(survivor, 11, survivor_tx)).await.unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: survivor,
+        session_id: 11,
+        announced: vec![make_route_with_lp(
+            survivor_prefix,
+            Ipv4Addr::new(10, 0, 0, 1),
+            100,
+        )],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    })
+    .await
+    .unwrap();
     tx.send(RibUpdate::EndOfRib {
         peer: survivor,
         session_id: 11,
@@ -471,7 +1100,7 @@ async fn exact_collision_failback_releases_table_before_eor_and_then_requests_re
         peer: remaining,
         session_id: 21,
         announced: vec![make_route_with_lp(
-            Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24),
+            remaining_prefix,
             Ipv4Addr::new(10, 0, 0, 2),
             100,
         )],
@@ -491,6 +1120,9 @@ async fn exact_collision_failback_releases_table_before_eor_and_then_requests_re
     })
     .await
     .unwrap();
+
+    let (observer_tx, mut observer_rx) = mpsc::channel(16);
+    tx.send(peer_up(observer, 31, observer_tx)).await.unwrap();
     assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
 
     tx.send(RibUpdate::PeerDown {
@@ -501,39 +1133,334 @@ async fn exact_collision_failback_releases_table_before_eor_and_then_requests_re
     .unwrap();
 
     let state = query_state(&tx, survivor).await;
-    assert!(!state.selection_deferral[0].active);
-    assert_eq!(state.selection_deferral[0].waiter_state, "excluded");
+    assert!(
+        state.selection_deferral[0].active,
+        "collision failback declared convergence before the survivor replayed its routes"
+    );
+    assert_eq!(state.selection_deferral[0].waiter_state, "awaiting_refresh");
     assert_eq!(state.selection_deferral[0].waiter_session_id, Some(11));
-    assert_eq!(state.selection_deferral[0].release_reason, "all_eor");
+    assert!(state.selection_deferral[0].release_reason.is_empty());
     assert_eq!(query_best_routes(&tx).await.len(), 1);
 
-    let mut saw_table = false;
-    let mut saw_eor = false;
-    loop {
-        let update = survivor_rx.recv().await.unwrap();
-        if !update.announce.is_empty() {
-            assert!(!saw_eor, "released table arrived after EoR");
-            saw_table = true;
-        }
-        if update.end_of_rib.contains(&FAMILY) {
-            assert!(saw_table, "EoR overtook the released table");
-            saw_eor = true;
-        }
-        if update.request_refresh_all_negotiated {
+    let mut survivor_saw_remaining = false;
+    let mut survivor_saw_refresh_request = false;
+    while let Ok(update) = survivor_rx.try_recv() {
+        assert!(!update.end_of_rib.contains(&FAMILY));
+        survivor_saw_remaining |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(remaining_prefix));
+        survivor_saw_refresh_request |= update.request_refresh_all_negotiated;
+    }
+    assert!(
+        survivor_saw_remaining,
+        "fast stage omitted the remaining route"
+    );
+    assert!(
+        survivor_saw_refresh_request,
+        "failback omitted the inbound refresh request"
+    );
+    let mut observer_saw_remaining = false;
+    while let Ok(update) = observer_rx.try_recv() {
+        assert!(!update.end_of_rib.contains(&FAMILY));
+        observer_saw_remaining |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(remaining_prefix));
+    }
+    assert!(observer_saw_remaining, "observer missed the fast stage");
+
+    // Re-register the observer after staging. Its initial table is allowed,
+    // but its EoR must stay pending. Force one full-channel failure so the
+    // dirty-resync path calls `flush_pending_eor` while convergence is held.
+    let (observer_retry_tx, mut observer_retry_rx) = mpsc::channel(2);
+    let observer_fill_tx = observer_retry_tx.clone();
+    tx.send(peer_up(observer, 32, observer_retry_tx))
+        .await
+        .unwrap();
+    let _ = query_state(&tx, observer).await;
+    observer_fill_tx
+        .try_send(crate::OutboundRouteUpdate::default())
+        .unwrap();
+    let (reply, result) = oneshot::channel();
+    tx.send(RibUpdate::RefreshPeerOutbound {
+        peer: observer,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(result.await.unwrap(), Ok(()));
+    let mut retry_saw_remaining = false;
+    while let Ok(update) = observer_retry_rx.try_recv() {
+        assert!(!update.end_of_rib.contains(&FAMILY));
+        retry_saw_remaining |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(remaining_prefix));
+    }
+    assert!(
+        retry_saw_remaining,
+        "observer retry missed the staged table"
+    );
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    let _ = query_state(&tx, observer).await;
+    let mut resync_saw_remaining = false;
+    while let Ok(update) = observer_retry_rx.try_recv() {
+        assert!(
+            !update.end_of_rib.contains(&FAMILY),
+            "dirty resync flushed EoR before collision-failback convergence"
+        );
+        resync_saw_remaining |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(remaining_prefix));
+    }
+    assert!(resync_saw_remaining, "observer dirty resync did not run");
+    observer_rx = observer_retry_rx;
+
+    tx.send(RibUpdate::RouteRefreshRequest {
+        peer: observer,
+        session_id: 32,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let _ = query_state(&tx, observer).await;
+    assert!(
+        observer_rx.try_recv().is_err(),
+        "route-refresh response escaped before collision-failback convergence"
+    );
+
+    // A late ordinary EoR from the survivor cannot prove that the requested
+    // replay completed, and an EoRR without a post-failback BoRR is stray.
+    tx.send(RibUpdate::EndOfRib {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::EndRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RoutesReceived {
+        peer: survivor,
+        session_id: 11,
+        announced: vec![make_route_with_lp(
+            survivor_prefix,
+            Ipv4Addr::new(10, 0, 0, 1),
+            100,
+        )],
+        withdrawn: Vec::new(),
+        flowspec_announced: Vec::new(),
+        flowspec_withdrawn: Vec::new(),
+        evpn_announced: Vec::new(),
+        evpn_withdrawn: Vec::new(),
+    })
+    .await
+    .unwrap();
+    let best_before_eorr = query_best_routes(&tx).await;
+    assert_eq!(best_before_eorr.len(), 2);
+    assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
+    assert!(survivor_rx.try_recv().is_err());
+    let mut observer_saw_survivor = false;
+    while let Ok(update) = observer_rx.try_recv() {
+        assert!(!update.end_of_rib.contains(&FAMILY));
+        assert!(update.refresh_markers.is_empty());
+        observer_saw_survivor |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(survivor_prefix));
+    }
+    assert!(observer_saw_survivor, "observer missed the survivor replay");
+
+    tx.send(RibUpdate::EndRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let released = query_state(&tx, survivor).await;
+    assert!(!released.selection_deferral[0].active);
+    assert_eq!(
+        released.selection_deferral[0].release_reason,
+        "collision_refresh"
+    );
+    assert_eq!(query_best_routes(&tx).await.len(), 2);
+    assert_eq!(survivor_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    let mut observer_saw_convergence_eor = false;
+    let mut observer_saw_deferred_refresh = false;
+    while !observer_saw_convergence_eor || !observer_saw_deferred_refresh {
+        let update = observer_rx.recv().await.unwrap();
+        if update.end_of_rib.contains(&FAMILY) && update.refresh_markers.is_empty() {
             assert!(
-                saw_eor,
-                "best-effort refresh request overtook table and EoR"
+                observer_saw_survivor,
+                "convergence EoR overtook the survivor's replayed route"
             );
-            break;
+            observer_saw_convergence_eor = true;
         }
+        if !update.refresh_markers.is_empty() {
+            assert!(
+                observer_saw_convergence_eor,
+                "deferred route-refresh response overtook convergence EoR"
+            );
+            observer_saw_deferred_refresh = true;
+        }
+        observer_saw_survivor |= update
+            .announce
+            .iter()
+            .any(|route| route.prefix == rustbgpd_wire::Prefix::V4(survivor_prefix));
     }
 
     drop(tx);
     handle.await.unwrap();
 }
 
+#[tokio::test(start_paused = true)]
+async fn collision_failback_keeps_the_original_selection_deadline() {
+    let survivor = peer(1);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_selection_deferral(config(Duration::from_secs(5), &[survivor]));
+    let handle = tokio::spawn(manager.run());
+
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, survivor, 11).await;
+    tx.send(peer_up(survivor, 11, survivor_tx)).await.unwrap();
+    let (replacement_tx, _replacement_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, survivor, 12).await;
+    tx.send(peer_up(survivor, 12, replacement_tx))
+        .await
+        .unwrap();
+    assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    tx.send(RibUpdate::PeerDown {
+        peer: survivor,
+        session_id: 12,
+    })
+    .await
+    .unwrap();
+    let staged = query_state(&tx, survivor).await;
+    assert!(staged.selection_deferral[0].active);
+    assert_eq!(
+        staged.selection_deferral[0].waiter_state,
+        "awaiting_refresh"
+    );
+    assert!(staged.selection_deferral[0].remaining_millis <= 1_000);
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    let released = query_state(&tx, survivor).await;
+    assert!(!released.selection_deferral[0].active);
+    assert_eq!(released.selection_deferral[0].release_reason, "timer");
+    let mut saw_eor = false;
+    while let Ok(update) = survivor_rx.try_recv() {
+        saw_eor |= update.end_of_rib.contains(&FAMILY);
+    }
+    assert!(
+        saw_eor,
+        "the original timer must remain a bounded EoR fallback"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn synthetic_refresh_timeout_cannot_complete_collision_failback() {
+    let survivor = peer(1);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_selection_deferral(config(Duration::from_mins(1), &[survivor]));
+    let handle = tokio::spawn(manager.run());
+
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, survivor, 11).await;
+    tx.send(peer_up(survivor, 11, survivor_tx)).await.unwrap();
+    let (replacement_tx, _replacement_rx) = mpsc::channel(8);
+    stage_gr_context(&tx, survivor, 12).await;
+    tx.send(peer_up(survivor, 12, replacement_tx))
+        .await
+        .unwrap();
+    tx.send(RibUpdate::PeerDown {
+        peer: survivor,
+        session_id: 12,
+    })
+    .await
+    .unwrap();
+    assert!(query_state(&tx, survivor).await.selection_deferral[0].active);
+    while let Ok(update) = survivor_rx.try_recv() {
+        assert!(!update.end_of_rib.contains(&FAMILY));
+    }
+
+    tx.send(RibUpdate::BeginRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    tx.send(RibUpdate::RouteRefreshTimeout {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let held = query_state(&tx, survivor).await;
+    assert!(held.selection_deferral[0].active);
+    assert_eq!(held.selection_deferral[0].waiter_state, "awaiting_refresh");
+    assert!(survivor_rx.try_recv().is_err());
+
+    // The independent post-failback BoRR receipt survives the local sweep, so
+    // a later real peer EoRR can still prove convergence.
+    tx.send(RibUpdate::EndRouteRefresh {
+        peer: survivor,
+        session_id: 11,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let released = query_state(&tx, survivor).await;
+    assert!(!released.selection_deferral[0].active);
+    assert_eq!(
+        released.selection_deferral[0].release_reason,
+        "collision_refresh"
+    );
+    assert_eq!(survivor_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[test]
-fn unavailable_survivor_channel_does_not_rearm_released_selection() {
+fn unavailable_survivor_channel_keeps_convergence_timer_bound() {
     for channel_closed in [false, true] {
         let survivor = peer(1);
         let metrics = BgpMetrics::new();
@@ -575,9 +1502,9 @@ fn unavailable_survivor_channel_does_not_rearm_released_selection() {
             .unwrap()
             .peer_snapshot(survivor)
             .remove(0);
-        assert!(!row.active);
-        assert_eq!(row.waiter_state, "excluded");
-        assert_eq!(row.release_reason, "all_eor");
+        assert!(row.active);
+        assert_eq!(row.waiter_state, "awaiting_refresh");
+        assert!(row.release_reason.is_empty());
         if !channel_closed {
             let queued = survivor_rx.try_recv().unwrap();
             assert!(!queued.request_refresh_all_negotiated);
@@ -671,30 +1598,51 @@ fn collision_failback_overflow_sweeps_and_reclaims_before_release_eor() {
         .as_mut()
         .unwrap()
         .session_down(source, 8, &metrics);
-    let released = manager
+    let transitions = manager
         .selection_deferral
         .as_mut()
         .unwrap()
-        .exclude_collision_failback_survivor(source, 8, &metrics)
+        .await_collision_failback_refresh(source, 8, &metrics)
         .unwrap();
-    assert_eq!(released, vec![FAMILY]);
-    manager.release_selection_families(&released, "test collision failback");
+    assert_eq!(
+        transitions,
+        vec![SelectionDeferralTransition::Stage { family: FAMILY }]
+    );
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
 
     assert!(manager.loc_rib.get(&prefix_a).is_none());
     assert!(manager.loc_rib.get(&prefix_b).is_none());
     assert_eq!(manager.adj_ribs_out.get(&observer).unwrap().len(), 0);
     let mut withdrawn = HashSet::new();
+    while let Ok(update) = observer_rx.try_recv() {
+        assert!(
+            !update.end_of_rib.contains(&FAMILY),
+            "staging must not declare convergence"
+        );
+        withdrawn.extend(update.withdraw.iter().map(|(prefix, _)| *prefix));
+    }
+    assert_eq!(withdrawn, HashSet::from([prefix_a, prefix_b]));
+
+    assert!(
+        manager
+            .selection_deferral
+            .as_mut()
+            .unwrap()
+            .begin_route_refresh(source, 8, FAMILY)
+            .is_none()
+    );
+    let completed = manager
+        .selection_deferral
+        .as_mut()
+        .unwrap()
+        .end_route_refresh(source, 8, FAMILY, &metrics)
+        .into_iter();
+    manager.apply_selection_deferral_transitions(completed, "test refresh completion");
     loop {
         let update = observer_rx.try_recv().unwrap();
         if update.end_of_rib.contains(&FAMILY) {
-            assert_eq!(
-                withdrawn,
-                HashSet::from([prefix_a, prefix_b]),
-                "EoR overtook one or more deferred withdrawals"
-            );
             break;
         }
-        withdrawn.extend(update.withdraw.iter().map(|(prefix, _)| *prefix));
     }
     assert_counter_value(
         &metrics,

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1669,6 +1669,19 @@ pub enum RibUpdate {
         /// Subsequent address family identifier.
         safi: Safi,
     },
+    /// Local enhanced-route-refresh accounting expired for this family.
+    /// This synthetic event sweeps the RIB refresh window but cannot stand in
+    /// for an RFC 7313 `EoRR` received from the peer.
+    RouteRefreshTimeout {
+        /// Peer whose refresh accounting window expired.
+        peer: IpAddr,
+        /// Transport session identity owning the accounting window.
+        session_id: u64,
+        /// Address family identifier.
+        afi: Afi,
+        /// Subsequent address family identifier.
+        safi: Safi,
+    },
     /// RPKI cache update — new VRP table for origin validation.
     RpkiCacheUpdate {
         /// The new VRP table snapshot.

--- a/crates/transport/src/session/refresh_accounting.rs
+++ b/crates/transport/src/session/refresh_accounting.rs
@@ -120,10 +120,11 @@ impl PeerSession {
     /// Reconcile every due family. Called before each buffered PDU decode and
     /// from the independent quiet-session run-loop timer.
     ///
-    /// The timeout is first enqueued to the RIB as an ordinary `EoRR` so it is
-    /// ordered ahead of the next UPDATE from this session. Only after that send
-    /// succeeds may transport consume/sweep the matching local window. The
-    /// RIB's own timer remains an idempotent safety net.
+    /// The timeout is first enqueued to the RIB as a distinct local boundary so
+    /// it is ordered ahead of the next UPDATE from this session without being
+    /// mistaken for a peer `EoRR`. Only after that send succeeds may transport
+    /// consume/sweep the matching local window. The RIB's own timer remains an
+    /// idempotent safety net.
     pub(super) async fn expire_refresh_accounting_windows(&mut self) -> Result<(), ()> {
         if self.refresh_accounting.windows.is_empty() {
             self.refresh_accounting_timer = None;
@@ -148,7 +149,7 @@ impl PeerSession {
 
             if self
                 .rib_tx
-                .send(rustbgpd_rib::RibUpdate::EndRouteRefresh {
+                .send(rustbgpd_rib::RibUpdate::RouteRefreshTimeout {
                     peer: self.peer_ip,
                     session_id: self.session_identity.id,
                     afi,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -2356,7 +2356,7 @@ async fn staggered_refresh_timeouts_sweep_only_due_family_and_rearm() {
     session.expire_refresh_accounting_windows().await.unwrap();
     assert!(matches!(
         rib_rx.try_recv(),
-        Ok(RibUpdate::EndRouteRefresh {
+        Ok(RibUpdate::RouteRefreshTimeout {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
             ..
@@ -2372,7 +2372,7 @@ async fn staggered_refresh_timeouts_sweep_only_due_family_and_rearm() {
     session.expire_refresh_accounting_windows().await.unwrap();
     assert!(matches!(
         rib_rx.try_recv(),
-        Ok(RibUpdate::EndRouteRefresh {
+        Ok(RibUpdate::RouteRefreshTimeout {
             afi: Afi::Ipv6,
             safi: Safi::Unicast,
             ..
@@ -2395,7 +2395,7 @@ async fn quiet_run_loop_expires_refresh_accounting() {
     tokio::time::advance(rustbgpd_rib::ERR_REFRESH_TIMEOUT).await;
     assert!(matches!(
         rib_rx.recv().await,
-        Some(RibUpdate::EndRouteRefresh {
+        Some(RibUpdate::RouteRefreshTimeout {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
             ..
@@ -2412,7 +2412,7 @@ async fn quiet_run_loop_expires_refresh_accounting() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn timeout_eorr_precedes_next_buffered_update_after_rib_backpressure() {
+async fn refresh_timeout_precedes_next_buffered_update_after_rib_backpressure() {
     let (mut session, _cmd_tx, mut rib_rx) = make_test_session_with_channels(65001, 65002, 1);
     install_test_negotiated_session(&mut session, negotiated_session(65002, false));
     let stale = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
@@ -2458,7 +2458,7 @@ async fn timeout_eorr_precedes_next_buffered_update_after_rib_backpressure() {
     ));
     assert!(matches!(
         rib_rx.recv().await,
-        Some(RibUpdate::EndRouteRefresh {
+        Some(RibUpdate::RouteRefreshTimeout {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
             ..

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1086,12 +1086,17 @@ across static peers, the process-start selection deferral.
 During a same-address collision, ordinary replacement still re-arms the
 replacement session as an EoR waiter and stale predecessor EoR is rejected. If
 the replacement then loses and registration fails back to the exact nonzero,
-unambiguous survivor, only that survivor is excluded from its re-armed roster
-entry; other waiters continue to block. Its inbound ROUTE-REFRESH request is
-best-effort recovery assistance, not evidence that refresh completed.
+unambiguous survivor, only that survivor enters `awaiting_refresh`; other
+waiters continue to block. Once ordinary waiters finish, the current Loc-RIB is
+staged immediately, but family EoR and route-refresh responses remain held. A
+post-failback BoRR arms the waiter and only the matching peer EoRR releases it.
+An ordinary EoR, stray EoRR, or local refresh timeout cannot declare
+convergence. Without Enhanced Route Refresh, the original marker-bounded timer
+is the fallback.
 
 `rbgp neighbor <address>` shows `Selection Deferral` rows while active and
-retains their `all_eor` or `timer` release reason afterward. Metrics are
+retains their `all_eor`, `collision_refresh`, or `timer` release reason
+afterward. Metrics are
 `bgp_selection_deferral_active`, `bgp_selection_deferral_waiters`,
 `bgp_selection_deferral_releases_total`, and
 `bgp_selection_deferral_timeouts_total`. The process-wide deferred-identity

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -483,7 +483,7 @@ authenticated sensitive-read surface.
 | `bgp_rib_outbound_registration_replaced_total{peer}` | `PeerUp` re-registrations that replaced a still-registered outbound sender for the same address — two sessions overlapped (collision window); the replacement resets the prior session's RIB state and keeps the superseded session live for failover; its `PeerDown` is matched by session identity |
 | `bgp_rib_stale_peer_down_ignored_total{peer}` | `PeerDown`/`PeerGracefulRestart` events discarded because their session id didn't match the registered session — a stale teardown from a superseded collision-loser session; the surviving session's state is untouched |
 | `bgp_rib_stale_session_message_ignored_total{peer,kind}` | Session-scoped RIB messages discarded by the same session-identity rule — a superseded session's queued message processed after the replacement's `PeerUp`. `kind` is `routes` (`RoutesReceived`), `eor` (End-of-RIB), `refresh` (route-refresh request / RFC 7313 BoRR/EoRR), `orf` (RFC 5291 ORF push), or `policy_context` (peer-group policy identity). The registered session's state is untouched |
-| `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The exact nonzero, unambiguous survivor is excluded from any re-armed startup selection wait, re-registered, re-sent the initial table, and asked for a best-effort inbound ROUTE-REFRESH |
+| `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The exact nonzero, unambiguous survivor enters `awaiting_refresh`, is re-registered, receives the staged initial table without EoR, and is asked for an inbound ROUTE-REFRESH; matching post-failback BoRR/EoRR completes convergence |
 | `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
 | `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
 | `bgp_rib_policy_transition_in_progress` | Whether the RIB actor owns an atomic export-policy transition (`1` = in progress). General RIB queries and mutations remain fenced while the dedicated core-readiness lane stays live |
@@ -786,9 +786,9 @@ owned-state.
 | `bgp_gr_active_peers` | Peers currently in GR stale-route state |
 | `bgp_gr_stale_routes` | Routes currently marked stale |
 | `bgp_gr_timer_expired_total` | GR timers that expired (routes swept) |
-| `bgp_selection_deferral_active{afi_safi}` | Planned-restart family selection gate (1 = active) |
-| `bgp_selection_deferral_waiters{afi_safi}` | Frozen-roster peers still blocking selection for the family |
-| `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor` or `timer` |
+| `bgp_selection_deferral_active{afi_safi}` | Planned-restart family convergence/release gate (1 = active); it remains active while collision failback waits for EoRR even after route selection is staged |
+| `bgp_selection_deferral_waiters{afi_safi}` | Frozen-roster peers still blocking family convergence/release, including an `awaiting_refresh` survivor after route selection is staged |
+| `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor`, `collision_refresh`, or `timer` |
 | `bgp_selection_deferral_timeouts_total{afi_safi}` | Family gates released by the selection-deferral timer |
 | `bgp_selection_deferral_ledger_overflows_total{afi_safi}` | Gated families whose next identity would exceed the process-wide one-million-identity or 64 MiB logical retained-key-data ledger and therefore use a complete release sweep |
 
@@ -806,12 +806,13 @@ cap enters overflow fallback.
 
 An ordinary same-address replacement remains an EoR waiter, and stale EoR from
 its predecessor is rejected. If collision resolution fails registration back
-to the exact nonzero, unambiguous survivor, only that survivor is excluded from
-its re-armed roster entries; other waiters remain blocking. The follow-up
-ROUTE-REFRESH request is best-effort Adj-RIB-In recovery assistance and is not
-treated as EoR or refresh completion. Full or closed survivor outbound channels
-can lose that request but cannot re-arm a family that selection already
-released.
+to the exact nonzero, unambiguous survivor, only that survivor enters
+`awaiting_refresh`; other waiters remain blocking. The current Loc-RIB is staged
+as soon as ordinary waiters finish, but downstream EoR and route-refresh
+responses stay held until a post-failback BoRR is followed by the matching peer
+EoRR. Ordinary EoR, stray EoRR, and the local refresh timeout do not satisfy the
+waiter. Full or closed survivor outbound channels can lose the request, so the
+original selection-deferral deadline remains the bounded fallback.
 
 ### BFD
 

--- a/docs/adr/0038-enhanced-route-refresh.md
+++ b/docs/adr/0038-enhanced-route-refresh.md
@@ -84,8 +84,8 @@ Each active inbound ERR window has a fixed 5-minute timeout.
 If a peer sends `BoRR` but never sends `EoRR`, rustbgpd treats the timeout as
 an implicit end-of-refresh sweep for that `(peer, afi, safi)`:
 
-1. transport enqueues an ordinary `EndRouteRefresh` on the same ordered peer
-   sender used by inbound UPDATEs
+1. transport enqueues a distinct `RouteRefreshTimeout` on the same ordered
+   peer sender used by inbound UPDATEs
 2. after that enqueue succeeds, remaining unreplaced refresh-stale entries are
    withdrawn from the RIB and transport max-prefix mirror
 3. the refresh window is closed and a warning is logged
@@ -96,6 +96,12 @@ the implicit end marker cannot be overtaken by the next UPDATE. If the channel
 is closed, the session preserves the window and live count and stops processing
 the buffered batch; it does not perform an unpaired local sweep. Families with
 different refresh deadlines expire independently.
+
+The timeout is deliberately not a peer `EoRR`. In particular, it cannot
+release a planned-restart collision-failback convergence hold. The independent
+post-failback BoRR receipt remains armed after the local stale-route sweep, so
+a later real peer EoRR can still complete that hold; otherwise the original
+`Selection_Deferral_Timer` remains the bounded fallback.
 
 This bounds resource use and prevents stale refresh state from persisting
 indefinitely due to buggy peers or dropped inbound markers.

--- a/docs/adr/0040-gr-restarting-speaker.md
+++ b/docs/adr/0040-gr-restarting-speaker.md
@@ -42,22 +42,33 @@ Implement an honest restarting-speaker mode:
    `restart_state = false`.
 6. On a marker-backed startup, freeze the complete GR-enabled static-peer
    roster before any session starts. Route selection is deferred separately
-   for every locally supported family until all roster peers are either:
+   for every locally supported family while a roster peer is still awaiting a
+   session or its initial End-of-RIB. A family remains under a convergence/EoR
+   hold until all roster peers are either:
    - bound to a current session that sends that family's End-of-RIB;
    - excluded because its OPEN omitted GR/the family or carried Restart State;
+   - a collision-failback survivor whose post-failback enhanced refresh reaches
+     its associated EoRR;
    - or the marker-bounded `Selection_Deferral_Timer` expires.
-7. Adj-RIB-In continues ingesting while a family is gated, but Loc-RIB
-   selection, initial outbound table data, route-refresh responses, and EoR
-   remain withheld. On release, deferred route identities (withdrawals
-   included) are selected and advertised before EoR.
+7. Adj-RIB-In continues ingesting while route selection is deferred. If only
+   an `awaiting_refresh` collision survivor remains, rustbgpd stages the current
+   Loc-RIB and permits route payloads, while route-refresh responses and EoR
+   remain held. Ordinary release selects deferred route identities
+   (withdrawals included) before EoR; the timer fallback recomputes an already
+   staged collision-failback family before releasing its EoR.
 8. Waiters are transport-generation stamped. An ordinary replacement re-arms
    its frozen roster entry, and an EoR from a predecessor or collision loser
    cannot release the gate. If collision resolution instead fails the
    registration back to the exact nonzero, unambiguous surviving session, that
-   survivor is excluded from its re-armed entries: its EoR may already have
-   been discarded while it was superseded, and the recovery ROUTE-REFRESH is
-   best-effort assistance rather than a completion signal. Every other real
-   waiter continues to gate the family.
+   survivor enters `awaiting_refresh`: its EoR may already have been discarded
+   while it was superseded, so an ordinary EoR cannot release it. Once the
+   ordinary waiters finish, rustbgpd stages the complete current Loc-RIB but
+   withholds downstream EoR and route-refresh responses. A post-failback BoRR
+   arms the survivor waiter; only the matching peer EoRR declares convergence
+   and releases the held markers. A local refresh timeout sweeps refresh-stale
+   routes but is not peer completion. Peers without Enhanced Route Refresh use
+   the original `Selection_Deferral_Timer` as the bounded fallback. Every other
+   real waiter continues to gate the family.
 
 This mode helps peers retain our routes briefly during a planned restart,
 but makes **no claim** that rustbgpd preserved dataplane continuity.


### PR DESCRIPTION
## Summary

- keep a collision-failback survivor in an exact-session `awaiting_refresh` state instead of declaring the startup family converged
- stage the current Loc-RIB once ordinary startup waiters finish, while withholding downstream EoR and deferred route-refresh responses until the survivor's post-failback BoRR/EoRR completes
- preserve the original selection-deferral deadline as the bounded fallback and distinguish a local refresh timeout from a peer EoRR
- preserve table-before-EoR-before-refresh ordering through dirty resyncs, including no-diff and saturated-channel retries
- update GR/enhanced-refresh operator documentation and diagnostics for the staged-selection/convergence-held split

This follows the marker interaction required by RFC 7313 section 4: when Graceful Restart and Enhanced Route Refresh are both active, the initial EoR precedes BoRR. Stale-session fencing and the existing timer-bound termination path remain intact.

## Load-bearing regression proof

- the real-prefix collision transcript failed on the exact pre-change `main` because convergence was declared before the survivor replayed its routes
- reverting the collision waiter transition to the prior exclusion behavior makes the replacement regression fail
- reverting the dirty-release deferral makes the real dirty-observer transcript fail because BoRR/routes/EoRR overtake convergence EoR
- reverting the no-diff retry guard makes the saturated-channel transcript fail because refresh retry is attempted after EoR enqueue failure
- focused mutations also proved the stage/marker split, synthetic-timeout provenance, mixed-family pending-EoR retention, and original-deadline fallback red under their guarded production breaks

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

Linear: LAN-428
