### PR TITLE
test: fuzz warm-bundle manifest loading

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -48,13 +48,36 @@ jobs:
             [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
             cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=8192
           done
-      - name: Fuzz MRT snapshot reader (2 minutes per target)
+      - name: Fuzz EVPN parsers (2 minutes per target)
+        run: |
+          cd crates/evpn
+          # Keep target discovery fail-closed as new EVPN parsers are added.
+          targets=$(cargo +nightly fuzz list)
+          if [ -z "$targets" ]; then
+            echo "fuzz-target enumeration returned no targets" >&2
+            exit 1
+          fi
+          if ! grep -Fxq parse_rt <<<"$targets"; then
+            echo "required EVPN fuzz target parse_rt is missing" >&2
+            exit 1
+          fi
+          for t in $targets; do
+            mkdir -p "fuzz/corpus/$t"
+            seeds=""
+            [ -d "fuzz/seeds/$t" ] && seeds="fuzz/seeds/$t"
+            cargo +nightly fuzz run "$t" "fuzz/corpus/$t" $seeds -- -max_total_time=120 -max_len=1024
+          done
+      - name: Fuzz MRT snapshot and warm-bundle readers (2 minutes per target)
         run: |
           cd crates/mrt
           # Keep target discovery fail-closed as new MRT parsers are added.
           targets=$(cargo +nightly fuzz list)
           if [ -z "$targets" ]; then
             echo "fuzz-target enumeration returned no targets" >&2
+            exit 1
+          fi
+          if ! grep -Fxq warm_bundle_manifest <<<"$targets"; then
+            echo "required MRT fuzz target warm_bundle_manifest is missing" >&2
             exit 1
           fi
           for t in $targets; do
@@ -71,4 +94,5 @@ jobs:
           path: |
             crates/wire/fuzz/artifacts/
             crates/policy/fuzz/artifacts/
+            crates/evpn/fuzz/artifacts/
             crates/mrt/fuzz/artifacts/

--- a/crates/mrt/fuzz/Cargo.toml
+++ b/crates/mrt/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+tempfile = "3"
 
 [dependencies.rustbgpd-mrt]
 path = ".."
@@ -16,6 +17,12 @@ path = ".."
 [[bin]]
 name = "snapshot_reader_drain"
 path = "fuzz_targets/snapshot_reader_drain.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "warm_bundle_manifest"
+path = "fuzz_targets/warm_bundle_manifest.rs"
 test = false
 doc = false
 

--- a/crates/mrt/fuzz/fuzz_targets/warm_bundle_manifest.rs
+++ b/crates/mrt/fuzz/fuzz_targets/warm_bundle_manifest.rs
@@ -1,0 +1,70 @@
+#![no_main]
+
+use std::fs;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr};
+use std::os::unix::fs::PermissionsExt as _;
+
+use libfuzzer_sys::fuzz_target;
+use rustbgpd_mrt::warm_bundle::{
+    WARM_BUNDLE_MANIFEST_FILE, WARM_BUNDLE_POLICY_DIGEST_VERSION, WarmBundleDirectory,
+    WarmBundleError, WarmBundleExpectedV1, WarmBundleFamilyV1, WarmBundleFreshnessV1,
+    WarmBundlePolicyDigestV1, WarmBundleViewKindV1, WarmBundleViewV1, load_warm_bundle,
+};
+
+const SHA256: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const CREATED_AT_UTC_SECONDS: i64 = 1_800_000_000;
+const CANONICAL_MANIFEST: &[u8] = include_bytes!("../seeds/warm_bundle_manifest/canonical-v1.json");
+
+fn expected() -> WarmBundleExpectedV1 {
+    WarmBundleExpectedV1 {
+        checkpoint_generation: "fuzz-generation-1".to_string(),
+        local_asn: 64_500,
+        local_router_id: Ipv4Addr::new(10, 255, 0, 1),
+        config_sha256: SHA256.to_string(),
+        resolved_import_policy: WarmBundlePolicyDigestV1 {
+            version: WARM_BUNDLE_POLICY_DIGEST_VERSION,
+            sha256: SHA256.to_string(),
+        },
+        views: vec![WarmBundleViewV1 {
+            kind: WarmBundleViewKindV1::AdjRibInPostImportPolicy,
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            peer_asn: 64_501,
+            peer_router_id: Ipv4Addr::new(10, 0, 0, 1),
+            family: WarmBundleFamilyV1::Ipv4Unicast,
+            add_path_receive: false,
+        }],
+    }
+}
+
+fn freshness() -> WarmBundleFreshnessV1 {
+    WarmBundleFreshnessV1 {
+        now_utc_seconds: CREATED_AT_UTC_SECONDS + 10,
+        max_age_seconds: 60,
+        max_future_skew_seconds: 5,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let temp = tempfile::tempdir().expect("fuzz harness must create its private bundle directory");
+    fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o700))
+        .expect("fuzz harness must enforce owner-only bundle-directory permissions");
+    let manifest = temp.path().join(WARM_BUNDLE_MANIFEST_FILE);
+    fs::write(&manifest, data).expect("fuzz harness must write manifest input");
+    fs::set_permissions(&manifest, fs::Permissions::from_mode(0o600))
+        .expect("fuzz harness must enforce owner-only manifest permissions");
+    let directory = WarmBundleDirectory::open(temp.path())
+        .expect("fuzz harness private directory must pass the production owner/mode check");
+
+    let result = load_warm_bundle(&directory, &expected(), freshness());
+    if data == CANONICAL_MANIFEST {
+        assert!(
+            matches!(
+                &result,
+                Err(WarmBundleError::Io { source, .. })
+                    if source.kind() == io::ErrorKind::NotFound
+            ),
+            "canonical manifest must reach the absent snapshot lookup: {result:?}"
+        );
+    }
+});

--- a/crates/mrt/fuzz/seeds/warm_bundle_manifest/canonical-v1.json
+++ b/crates/mrt/fuzz/seeds/warm_bundle_manifest/canonical-v1.json
@@ -1,0 +1,32 @@
+{
+  "format_version": 1,
+  "identity": {
+    "checkpoint_generation": "fuzz-generation-1",
+    "created_at_utc_seconds": 1800000000,
+    "snapshot_revision": 1,
+    "local_asn": 64500,
+    "local_router_id": "10.255.0.1",
+    "peer_index_table_view": "fuzz-generation-1",
+    "config_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "resolved_import_policy": {
+      "version": 1,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    "views": [
+      {
+        "kind": "adj-rib-in-post-import-policy",
+        "peer": "192.0.2.1",
+        "peer_asn": 64501,
+        "peer_router_id": "10.0.0.1",
+        "family": "ipv4-unicast",
+        "add_path_receive": false
+      }
+    ]
+  },
+  "snapshot": {
+    "path": "snapshot-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.mrt",
+    "size_bytes": 0,
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "view_route_counts": [0]
+}

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -1,12 +1,15 @@
 # Fuzzing
 
-rustbgpd fuzzes every peer-fed decode surface with
+rustbgpd fuzzes untrusted decode surfaces with
 [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) (libFuzzer). There are
-two fuzz crates, one per fuzzed workspace crate:
+four fuzz crates, one per fuzzed workspace crate:
 
 - `crates/wire/fuzz` — the BGP wire codec (`rustbgpd-wire`)
 - `crates/policy/fuzz` — the `.rpol` policy-language frontend
   (`rustbgpd-policy`)
+- `crates/evpn/fuzz` — EVPN route-target parsing (`rustbgpd-evpn`)
+- `crates/mrt/fuzz` — the MRT snapshot and warm-bundle readers
+  (`rustbgpd-mrt`)
 
 BMP (`crates/bmp`) is encode-only — rustbgpd never decodes BMP from the
 network — so it has no fuzz surface.
@@ -28,6 +31,9 @@ network — so it has no fuzz surface.
 | `decode_rtc` | wire | RFC 4684 RT-Constrain NLRI (AFI 1/SAFI 132), default + 32..96-bit prefixes | lossless round-trip |
 | `parse_rd` | wire | Route Distinguisher `FromStr` | Display→FromStr lossless |
 | `rpol_compile` | policy | `.rpol` lexer, parser, typechecker, lowering, and the in-language `test`-block runner (eval engine on fuzzer-authored programs) | returns `Diagnostics`, never panics/aborts/hangs |
+| `parse_rt` | EVPN | Route Target `FromStr` over arbitrary UTF-8 | Display→FromStr lossless |
+| `snapshot_reader_drain` | MRT | arbitrary MRT framing plus arbitrary records after a valid empty peer-index table | reader construction and full iteration never panic |
+| `warm_bundle_manifest` | MRT | real owner-checked `manifest.json` load through JSON decoding, V1 structure, boot identity, freshness, and safe snapshot lookup/error handling | loader never panics |
 
 "Round-trip" targets assert the promise the interop labs pin for specific
 bytes (M73 BGP-LS byte fidelity, M74 VPN preserve-verbatim) over the whole
@@ -38,10 +44,13 @@ reachable input space: decode → encode → decode must reproduce the value.
 Requires nightly and cargo-fuzz (`cargo install cargo-fuzz`).
 
 ```sh
-cd crates/wire          # or crates/policy
+cd crates/wire
 cargo +nightly fuzz list
 cargo +nightly fuzz run decode_update fuzz/corpus/decode_update fuzz/seeds/decode_update -- -max_total_time=300 -max_len=4096
 ```
+
+Run the same `list`/`run` flow from `crates/policy`, `crates/evpn`, or
+`crates/mrt`, choosing a target and length bound for that crate.
 
 A crash writes a reproducer under `fuzz/artifacts/<target>/`; replay it with
 `cargo +nightly fuzz run <target> fuzz/artifacts/<target>/<file>`.
@@ -58,15 +67,15 @@ A crash writes a reproducer under `fuzz/artifacts/<target>/`; replay it with
 ## CI
 
 `.github/workflows/fuzz.yml` runs nightly (04:00 UTC) and on manual
-dispatch: every target in both fuzz crates for 120 seconds each, starting
+dispatch: every target in all four fuzz crates for 120 seconds each, starting
 from the tracked seeds. Crash artifacts upload on failure. Budget choice:
 all targets briefly rather than a rotating subset — every surface gets
-nightly coverage and the whole job stays under ~35 minutes.
+nightly coverage and the whole job stays bounded by per-target timers.
 
 ## OSS-Fuzz onboarding
 
 The standard OSS-Fuzz project files are staged in `fuzz/oss-fuzz/`
-(`project.yaml`, `Dockerfile`, `build.sh`). `build.sh` builds both fuzz
+(`project.yaml`, `Dockerfile`, `build.sh`). `build.sh` builds all four fuzz
 crates with `cargo fuzz build -O --debug-assertions` and ships each
 `fuzz/seeds/<target>/` directory as a `<target>_seed_corpus.zip`.
 

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -31,9 +31,9 @@ network — so it has no fuzz surface.
 | `decode_rtc` | wire | RFC 4684 RT-Constrain NLRI (AFI 1/SAFI 132), default + 32..96-bit prefixes | lossless round-trip |
 | `parse_rd` | wire | Route Distinguisher `FromStr` | Display→FromStr lossless |
 | `rpol_compile` | policy | `.rpol` lexer, parser, typechecker, lowering, and the in-language `test`-block runner (eval engine on fuzzer-authored programs) | returns `Diagnostics`, never panics/aborts/hangs |
-| `parse_rt` | EVPN | Route Target `FromStr` over arbitrary UTF-8 | Display→FromStr lossless |
-| `snapshot_reader_drain` | MRT | arbitrary MRT framing plus arbitrary records after a valid empty peer-index table | reader construction and full iteration never panic |
-| `warm_bundle_manifest` | MRT | real owner-checked `manifest.json` load through JSON decoding, V1 structure, boot identity, freshness, and safe snapshot lookup/error handling | loader never panics |
+| `parse_rt` | evpn | Route Target `FromStr` over arbitrary UTF-8 | Display→FromStr lossless |
+| `snapshot_reader_drain` | mrt | arbitrary MRT framing plus arbitrary records after a valid empty peer-index table | reader construction and full iteration never panic |
+| `warm_bundle_manifest` | mrt | real owner-checked `manifest.json` load through JSON decoding, V1 structure, boot identity, freshness, and safe snapshot lookup/error handling | loader never panics |
 
 "Round-trip" targets assert the promise the interop labs pin for specific
 bytes (M73 BGP-LS byte fidelity, M74 VPN preserve-verbatim) over the whole

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -176,7 +176,7 @@ artifacts under [`artifacts/soak/`](artifacts/soak/). Harnesses live in
 | [`ci.yml`](../.github/workflows/ci.yml) | every PR / push | fmt, clippy (warnings denied), workspace tests, rustdoc, kernel-primitive gate |
 | [`interop.yml`](../.github/workflows/interop.yml) | every PR / push | The PR-gated M-series table above, one containerlab job per milestone |
 | [`kernel-dataplane.yml`](../.github/workflows/kernel-dataplane.yml) | PR, push, nightly 07:00 UTC | Privileged EVPN/FIB/BFD/TCP-AO dataplane receipts + netns selectors |
-| [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC + PR smoke | libFuzzer wire-decode harnesses |
+| [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC | libFuzzer wire, policy, EVPN route-target, MRT snapshot, and warm-bundle manifest harnesses |
 | [`bench-nightly.yml`](../.github/workflows/bench-nightly.yml) | nightly 05:00 UTC | Benchmark tracking on the bench runner |
 | [`audit.yml`](../.github/workflows/audit.yml) | daily 06:00 UTC | `cargo audit` / dependency advisories |
 | [`privileged-interop.yml`](../.github/workflows/privileged-interop.yml) | manual dispatch | Direct-`cargo` privileged netns suites |

--- a/docs/RECEIPTS.md
+++ b/docs/RECEIPTS.md
@@ -176,7 +176,7 @@ artifacts under [`artifacts/soak/`](artifacts/soak/). Harnesses live in
 | [`ci.yml`](../.github/workflows/ci.yml) | every PR / push | fmt, clippy (warnings denied), workspace tests, rustdoc, kernel-primitive gate |
 | [`interop.yml`](../.github/workflows/interop.yml) | every PR / push | The PR-gated M-series table above, one containerlab job per milestone |
 | [`kernel-dataplane.yml`](../.github/workflows/kernel-dataplane.yml) | PR, push, nightly 07:00 UTC | Privileged EVPN/FIB/BFD/TCP-AO dataplane receipts + netns selectors |
-| [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC | libFuzzer wire, policy, EVPN route-target, MRT snapshot, and warm-bundle manifest harnesses |
+| [`fuzz.yml`](../.github/workflows/fuzz.yml) | nightly 04:00 UTC + manual dispatch | libFuzzer wire, policy, EVPN route-target, MRT snapshot, and warm-bundle manifest harnesses |
 | [`bench-nightly.yml`](../.github/workflows/bench-nightly.yml) | nightly 05:00 UTC | Benchmark tracking on the bench runner |
 | [`audit.yml`](../.github/workflows/audit.yml) | daily 06:00 UTC | `cargo audit` / dependency advisories |
 | [`privileged-interop.yml`](../.github/workflows/privileged-interop.yml) | manual dispatch | Direct-`cargo` privileged netns suites |

--- a/fuzz/oss-fuzz/build.sh
+++ b/fuzz/oss-fuzz/build.sh
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # rustbgpd carries one cargo-fuzz crate per fuzzed workspace crate.
-# Target names are globally unique across the two directories.
-FUZZ_DIRS="crates/wire crates/policy"
+# Target names are globally unique across the four directories.
+FUZZ_DIRS="crates/wire crates/policy crates/evpn crates/mrt"
 TARGET_DIR="fuzz/target/x86_64-unknown-linux-gnu/release"
 
 for dir in $FUZZ_DIRS; do


### PR DESCRIPTION
## What changed

- add a cargo-fuzz target that drives arbitrary `manifest.json` bytes through the real permission-checked `WarmBundleDirectory` and public `load_warm_bundle` path
- add a canonical V1 seed that must pass JSON, structure, identity, and freshness validation before reaching the expected missing-snapshot boundary
- make nightly fuzzing explicitly require the warm-manifest and EVPN route-target targets
- reconcile nightly artifacts, staged OSS-Fuzz discovery, and fuzz documentation with all four fuzz crates

## Why

Warm-bundle restore will make manifest loading a live untrusted-input boundary. Raw MRT record fuzzing already existed, but it never exercised manifest decoding or validation. The canonical seed prevents the harness from silently stopping before the production loader seam.

The inventory true-up also closes a pre-existing gap discovered during self-review: the EVPN `parse_rt` target existed but was absent from nightly fuzzing, crash-artifact collection, OSS-Fuzz staging, and the fuzzing guide.

## Load-bearing proof

- removing `warm_bundle_manifest` registration leaves the existing MRT target present but makes the nightly exact-target requirement fail
- removing or renaming `parse_rt` makes the EVPN nightly inventory fail
- making the production directory-open check reject the harness's safe `0700` directory makes the canonical smoke crash at setup instead of silently skipping the loader
- inserting a temporary panic immediately after production manifest validation makes the canonical seed crash, proving the real parser/validator is reached
- removing the canonical seed makes `include_bytes!` fail compilation

Every mutation above was restored and its focused command returned green afterward.

## Validation

- EVPN fuzz fmt, list, build, and 1,000-run bounded smoke
- MRT fuzz fmt, list, build, and canonical-seed smoke
- OSS-Fuzz shell syntax
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

No production source, public API, or warm-restore behavior changes in this PR.
