### PR TITLE
fix(policy): bound rollback RIB wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Policy rollback has one aggregate RIB wait budget.** Authoritative
+  self-heal and a subsequent cohort unwind now share one lazy absolute
+  five-second deadline instead of waiting up to five seconds per peer. Every
+  reverse-order RIB restore is registered before rollback Route Refresh or
+  later lifecycle work; timeout and caller cancellation retain the same pinned
+  late repairs while conservative pending flags preserve explicit retry intent.
+  The bound covers cumulative rollback RIB send/reply waiting, not sequential
+  session commands, Route Refresh acknowledgements, or late RIB repair.
+
 - **Mixed policy reloads batch their eligible export-only cohort.** Snapshot
   application now selects the first equivalent Established export-only cohort
   in configuration order, commits it through one shared RIB transition, then

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -136,11 +136,22 @@ leaves retry intent where the existing per-peer path can preserve it. A later
 persistence failure replays the successful transaction's returned prior token
 through the same transaction owner.
 
-The ordinary RIB replacement wait has a five-second timeout per peer. The
-current rollback loop has no aggregate deadline, so N congested RIB restores
-can consume N times five seconds. Bounding the aggregate rollback RIB wait is
-required follow-up; this ADR does not hide that cost by calling the
-cross-actor operation atomic.
+Rollback session and bookkeeping restoration remains newest first and may do
+O(peers) bounded session work. RIB compensation has one lazy absolute
+five-second deadline per top-level policy transaction, shared by authoritative
+self-heal and any later cohort unwind. Each partition first-polls every pinned
+RIB restore future newest first, without Tokio's cooperative budget, before it
+issues any rollback Route Refresh. This registers every bounded-channel waiter
+in FIFO order; refresh-generated route work and later peer lifecycle mutations
+cannot overtake a restore merely because the channel is full.
+
+PeerManager then awaits the registered aggregate while continuing to service
+readiness. Deadline expiry or caller cancellation detaches that same aggregate
+rather than reconstructing commands: already-registered repairs may finish in
+order after the caller returns, while conservative per-peer pending flags keep
+explicit retry intent. The five-second claim bounds cumulative rollback RIB
+send/reply waiting across all partitions. It does not bound sequential session
+commands, Route Refresh acknowledgements, or the RIB actor's late repair work.
 
 ### 5. Readiness and observability
 
@@ -231,8 +242,9 @@ wall-clock guarantee. See the
   profile growth.
 - **Authoritative remainder and compensating rollback:** keep as the complete
   fallback and mixed-fleet correctness path. It handles every shape the fast
-  path rejects. Its sequential, per-peer RIB waits need one aggregate rollback
-  deadline.
+  path rejects. Its session work remains sequential, but cumulative rollback
+  RIB send/reply waiting is bounded by one transaction-wide deadline; retaining
+  pinned late repairs and conservative retry flags is the cancellation cost.
 - **Final global retry opportunity:** keep until production poll data says
   otherwise. It promptly drains unrelated dirty/forced residue before the
   successful transaction reply, matching the authoritative replacement seam.
@@ -270,8 +282,8 @@ semantics for both newly created and already-maintained destinations.
   emission model belongs in a separately measured and reviewed transaction.
 - Do not introduce a fleet-wide two-phase commit protocol for session tasks
   and the RIB. The current single-owner plus compensating rollback is adequate
-  for the measured route-reflector/route-server workload once the rollback's
-  aggregate RIB wait is bounded.
+  for the measured route-reflector/route-server workload with the rollback's
+  aggregate RIB wait bounded.
 
 ## Consequences
 

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::net::IpAddr;
+use std::pin::Pin;
+use std::task::Poll;
 use std::time::Instant;
 
 use rustbgpd_api::peer_types::{
@@ -79,6 +82,51 @@ struct CapturedResolvedPolicy {
     /// two branches: the asymmetry is what keeps a compound (rollback-time)
     /// refresh failure from either leaving routes stale or arming a spurious retry.
     forward_completed: bool,
+}
+
+#[derive(Default)]
+struct PolicyRollbackRibBudget {
+    deadline: Option<tokio::time::Instant>,
+}
+
+impl PolicyRollbackRibBudget {
+    fn deadline(&mut self) -> tokio::time::Instant {
+        *self
+            .deadline
+            .get_or_insert_with(|| tokio::time::Instant::now() + super::RIB_REPLY_TIMEOUT)
+    }
+}
+
+struct PolicyRollbackPeerPlan {
+    peer_key: PeerKey,
+    export_restore: Option<(Option<PolicyChain>, bool)>,
+    refresh_failure: Option<RefreshFailureHandling>,
+    is_established: bool,
+    restore_prior_pending: Option<(bool, bool)>,
+}
+
+type PolicyRollbackRibOutcome = (usize, Result<(), RibCommandError>);
+type PolicyRollbackRibFuture =
+    Pin<Box<dyn Future<Output = PolicyRollbackRibOutcome> + Send + 'static>>;
+
+async fn first_poll_policy_rollback_rib(
+    future: &mut PolicyRollbackRibFuture,
+) -> Option<PolicyRollbackRibOutcome> {
+    std::future::poll_fn(|cx| {
+        let mut unconstrained = std::pin::pin!(tokio::task::unconstrained(future.as_mut()));
+        let poll = unconstrained.as_mut().poll(cx);
+        Poll::Ready(match poll {
+            Poll::Ready(outcome) => Some(outcome),
+            Poll::Pending => None,
+        })
+    })
+    .await
+}
+
+struct RegisteredPolicyRollbackRib {
+    deadline: tokio::time::Instant,
+    refreshable: Vec<bool>,
+    task: tokio::task::JoinHandle<Vec<PolicyRollbackRibOutcome>>,
 }
 
 fn metric_count(value: usize) -> u64 {
@@ -175,6 +223,7 @@ impl PeerManager {
             import_policy,
             export_policy,
             RefreshFailureHandling::Fatal,
+            None,
         )
         .await
     }
@@ -193,6 +242,7 @@ impl PeerManager {
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
     ) -> Result<Vec<ResolvedPeerPolicy>, String> {
+        let mut rollback_rib_budget = PolicyRollbackRibBudget::default();
         let total_targets = targets.len();
         let mut seen = BTreeSet::new();
         let has_duplicate = targets
@@ -200,7 +250,7 @@ impl PeerManager {
             .any(|target| !seen.insert(PeerKey::new(target.address, target.interface.clone())));
         if has_duplicate {
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets)
+                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
                 .await
                 .map(|captured| {
                     captured
@@ -214,7 +264,7 @@ impl PeerManager {
         let cohort_targets = cohort_mask.iter().filter(|&&selected| selected).count();
         if cohort_targets < 2 {
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets)
+                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
                 .await
                 .map(|captured| {
                     captured
@@ -236,11 +286,14 @@ impl PeerManager {
             cohort_targets, remainder_targets, "partitioned resolved policy snapshot"
         );
 
-        let Some(cohort_result) = self.try_apply_export_only_policy_cohort(&cohort).await else {
+        let Some(cohort_result) = self
+            .try_apply_export_only_policy_cohort(&cohort, &mut rollback_rib_budget)
+            .await
+        else {
             // Defensive invariant fallback: no mutation occurs before this
             // helper returns `None`, so preserve original authoritative order.
             return self
-                .apply_resolved_policy_snapshot_authoritatively(targets)
+                .apply_resolved_policy_snapshot_authoritatively(targets, &mut rollback_rib_budget)
                 .await
                 .map(|captured| {
                     captured
@@ -257,7 +310,7 @@ impl PeerManager {
             .filter_map(|(target, selected)| (!selected).then_some(target))
             .collect();
         match self
-            .apply_resolved_policy_snapshot_authoritatively(remainder)
+            .apply_resolved_policy_snapshot_authoritatively(remainder, &mut rollback_rib_budget)
             .await
         {
             Ok(mut remainder_captured) => {
@@ -274,16 +327,21 @@ impl PeerManager {
                     .map(|captured| captured.policy)
                     .collect())
             }
-            Err(remainder_error) => Err(match self.restore_resolved_policies(captured).await {
-                Ok(()) => format!(
-                    "failed to apply authoritative policy remainder: {remainder_error}; \
+            Err(remainder_error) => Err(
+                match self
+                    .restore_resolved_policies(captured, &mut rollback_rib_budget)
+                    .await
+                {
+                    Ok(()) => format!(
+                        "failed to apply authoritative policy remainder: {remainder_error}; \
                      committed cohort restored"
-                ),
-                Err(cohort_restore_error) => format!(
-                    "failed to apply authoritative policy remainder: {remainder_error}; \
+                    ),
+                    Err(cohort_restore_error) => format!(
+                        "failed to apply authoritative policy remainder: {remainder_error}; \
                      restoring committed cohort also failed: {cohort_restore_error}"
-                ),
-            }),
+                    ),
+                },
+            ),
         }
     }
 
@@ -382,6 +440,7 @@ impl PeerManager {
     async fn apply_resolved_policy_snapshot_authoritatively(
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
+        rollback_rib_budget: &mut PolicyRollbackRibBudget,
     ) -> Result<Vec<CapturedResolvedPolicy>, String> {
         // Captured priors, in application order, for peers actually mutated.
         let mut applied: Vec<CapturedResolvedPolicy> = Vec::new();
@@ -412,22 +471,28 @@ impl PeerManager {
                     target.import_policy.clone(),
                     target.export_policy.clone(),
                     RefreshFailureHandling::Fatal,
+                    None,
                 )
                 .await
             {
                 let restored = std::mem::take(&mut applied);
-                return Err(match self.restore_resolved_policies(restored).await {
-                    Ok(()) => format!(
-                        "failed to apply resolved policy to {}: {apply_error}; \
+                return Err(
+                    match self
+                        .restore_resolved_policies(restored, rollback_rib_budget)
+                        .await
+                    {
+                        Ok(()) => format!(
+                            "failed to apply resolved policy to {}: {apply_error}; \
                          already-applied peers restored",
-                        target.address
-                    ),
-                    Err(restore_error) => format!(
-                        "failed to apply resolved policy to {}: {apply_error}; \
+                            target.address
+                        ),
+                        Err(restore_error) => format!(
+                            "failed to apply resolved policy to {}: {apply_error}; \
                          restoring already-applied peers also failed: {restore_error}",
-                        target.address
-                    ),
-                });
+                            target.address
+                        ),
+                    },
+                );
             }
             applied[applied_idx].forward_completed = true;
         }
@@ -450,6 +515,7 @@ impl PeerManager {
     async fn try_apply_export_only_policy_cohort(
         &mut self,
         targets: &[&ResolvedPeerPolicy],
+        rollback_rib_budget: &mut PolicyRollbackRibBudget,
     ) -> Option<Result<Vec<CapturedResolvedPolicy>, String>> {
         if targets.len() < 2 {
             return None;
@@ -527,7 +593,9 @@ impl PeerManager {
                     .map_err(|restore_error| {
                         format!("{} session restore failed: {restore_error}", target.address)
                     });
-                let prior_restore = self.restore_resolved_policies(captured).await;
+                let prior_restore = self
+                    .restore_resolved_policies(captured, rollback_rib_budget)
+                    .await;
                 let restore_error = match (failing_restore, prior_restore) {
                     (Ok(()), Ok(())) => None,
                     (Err(error), Ok(())) | (Ok(()), Err(error)) => Some(error),
@@ -583,7 +651,9 @@ impl PeerManager {
             Err(error) => Err(error),
         };
         if let Err(error) = rib_result {
-            let rollback = self.restore_resolved_policies(captured).await;
+            let rollback = self
+                .restore_resolved_policies(captured, rollback_rib_budget)
+                .await;
             return Some(Err(match rollback {
                 Ok(()) => format!(
                     "failed to update export policy cohort: {error}; already-applied peers restored"
@@ -764,14 +834,176 @@ impl PeerManager {
         Ok(targets)
     }
 
+    async fn register_policy_rollback_rib(
+        &self,
+        plans: &[PolicyRollbackPeerPlan],
+        budget: &mut PolicyRollbackRibBudget,
+    ) -> Option<RegisteredPolicyRollbackRib> {
+        let mut futures = Vec::new();
+        for (index, plan) in plans.iter().enumerate() {
+            let Some((export_policy, _)) = &plan.export_restore else {
+                continue;
+            };
+            let rib_tx = self.rib_tx.clone();
+            let peer = plan.peer_key.address;
+            let export_policy = export_policy.clone();
+            let future: PolicyRollbackRibFuture = Box::pin(async move {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                let result = if rib_tx
+                    .send(RibUpdate::ReplacePeerExportPolicy {
+                        peer,
+                        export_policy,
+                        reply: reply_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    Err(RibCommandError::internal("RIB manager unavailable"))
+                } else {
+                    match reply_rx.await {
+                        Ok(result) => result,
+                        Err(_) => Err(RibCommandError::internal("RIB manager dropped reply")),
+                    }
+                };
+                (index, result)
+            });
+            futures.push((index, future));
+        }
+        if futures.is_empty() {
+            return None;
+        }
+
+        let deadline = budget.deadline();
+        let mut completed = Vec::new();
+        let mut pending = Vec::new();
+        let mut refreshable = vec![false; plans.len()];
+        for (index, mut future) in futures {
+            // Poll every reverse-order send once without Tokio's cooperative
+            // budget. A full bounded channel therefore registers every waiter
+            // in FIFO order before rollback can emit a Route Refresh, time out,
+            // or return control to a later PeerManager mutation.
+            let first_poll = first_poll_policy_rollback_rib(&mut future).await;
+            if let Some(outcome) = first_poll {
+                refreshable[index] = match &outcome.1 {
+                    Ok(()) => true,
+                    Err(RibCommandError::NotFound(_)) => plans[index]
+                        .export_restore
+                        .as_ref()
+                        .is_some_and(|(_, is_known_non_established)| *is_known_non_established),
+                    Err(_) => false,
+                };
+                completed.push(outcome);
+            } else {
+                // The send either reached the RIB and awaits its reply, or
+                // owns its FIFO place in a full channel. Keep the import
+                // rollback moving: this pinned future survives the caller
+                // deadline and remains ahead of refresh-generated RIB work.
+                refreshable[index] = true;
+                pending.push(future);
+            }
+        }
+
+        let task = tokio::spawn(async move {
+            completed.extend(futures::future::join_all(pending).await);
+            completed
+        });
+        Some(RegisteredPolicyRollbackRib {
+            deadline,
+            refreshable,
+            task,
+        })
+    }
+
+    async fn finish_policy_rollback_refresh(&mut self, plan: &PolicyRollbackPeerPlan) {
+        let Some(refresh_failure) = plan.refresh_failure else {
+            return;
+        };
+        let pending_after = if plan.is_established {
+            match self.soft_reset_in(plan.peer_key.clone(), Vec::new()).await {
+                Ok(()) => plan
+                    .restore_prior_pending
+                    .is_some_and(|(pending_refresh, _)| pending_refresh),
+                Err(error) => {
+                    warn!(
+                        peer = %plan.peer_key.address,
+                        %error,
+                        "route refresh failed during policy rollback; retained safe pending state"
+                    );
+                    match refresh_failure {
+                        RefreshFailureHandling::Fatal | RefreshFailureHandling::BestEffortRearm => {
+                            true
+                        }
+                        RefreshFailureHandling::BestEffortRestorePrior { pending_refresh } => {
+                            pending_refresh
+                        }
+                    }
+                }
+            }
+        } else {
+            match refresh_failure {
+                RefreshFailureHandling::Fatal | RefreshFailureHandling::BestEffortRearm => true,
+                RefreshFailureHandling::BestEffortRestorePrior { pending_refresh } => {
+                    pending_refresh
+                }
+            }
+        };
+        if let Some(managed) = self.peers.get_mut(&plan.peer_key) {
+            managed.pending_refresh = pending_after;
+        }
+    }
+
+    fn finish_policy_rollback_rib_success(&mut self, plan: &PolicyRollbackPeerPlan) {
+        let Some(managed) = self.peers.get_mut(&plan.peer_key) else {
+            return;
+        };
+        if let Some((pending_refresh, pending_export_apply)) = plan.restore_prior_pending {
+            managed.pending_refresh = pending_refresh;
+            managed.pending_export_apply = pending_export_apply;
+        } else {
+            managed.pending_export_apply = false;
+        }
+    }
+
+    fn retain_policy_rollback_rib_intent(&mut self, plan: &PolicyRollbackPeerPlan) {
+        if let Some(managed) = self.peers.get_mut(&plan.peer_key) {
+            managed.pending_export_apply = true;
+            if plan.refresh_failure.is_some() {
+                managed.pending_refresh = true;
+            }
+        }
+    }
+
+    async fn finish_policy_rollback_refreshes(
+        &mut self,
+        plans: &[PolicyRollbackPeerPlan],
+        registered: Option<&RegisteredPolicyRollbackRib>,
+    ) {
+        for (index, plan) in plans.iter().enumerate() {
+            let refreshable = plan.export_restore.is_none()
+                || registered.is_some_and(|registered| registered.refreshable[index]);
+            if refreshable {
+                self.finish_policy_rollback_refresh(plan).await;
+            }
+            if plan.export_restore.is_none() {
+                self.finish_policy_rollback_rib_success(plan);
+            }
+        }
+    }
+
     /// Re-apply captured prior chains (reverse of application order) to restore
-    /// live peers during a transaction rollback. Composes per-peer failures;
-    /// peers no longer live are skipped.
+    /// live peers during a transaction rollback. Session/bookkeeping restores
+    /// run first. Every required RIB send is then registered in reverse order
+    /// before any Route Refresh, and all RIB sends/replies share one lazy
+    /// absolute deadline across this top-level policy transaction. Timing out or
+    /// dropping the caller detaches the exact registered aggregate so FIFO repair
+    /// can continue while conservative pending flags retain retry intent.
     async fn restore_resolved_policies(
         &mut self,
         priors: Vec<CapturedResolvedPolicy>,
+        budget: &mut PolicyRollbackRibBudget,
     ) -> Result<(), String> {
         let mut errors: Vec<String> = Vec::new();
+        let mut plans = Vec::new();
         for prior in priors.into_iter().rev() {
             let address = prior.policy.address;
             let peer_key = PeerKey::new(address, prior.policy.interface.clone());
@@ -785,23 +1017,83 @@ impl PeerManager {
                     pending_refresh: prior.pending_refresh,
                 }
             };
-            if let Err(error) = self
+            let mut plan = None;
+            match self
                 .update_runtime_policies_for_peer_key(
-                    peer_key.clone(),
+                    peer_key,
                     prior.policy.import_policy,
                     prior.policy.export_policy,
                     refresh_failure,
+                    Some(&mut plan),
                 )
                 .await
             {
-                errors.push(format!("{address}: {error}"));
-            } else if !prior.forward_completed
-                && let Some(managed) = self.peers.get_mut(&peer_key)
-            {
-                managed.pending_refresh = prior.pending_refresh;
-                managed.pending_export_apply = prior.pending_export_apply;
+                Err(error) => errors.push(format!("{address}: {error}")),
+                Ok(()) => {
+                    if let Some(mut plan) = plan {
+                        if !prior.forward_completed {
+                            plan.restore_prior_pending =
+                                Some((prior.pending_refresh, prior.pending_export_apply));
+                        }
+                        plans.push(plan);
+                    }
+                }
             }
         }
+
+        let registered = self.register_policy_rollback_rib(&plans, budget).await;
+        self.finish_policy_rollback_refreshes(&plans, registered.as_ref())
+            .await;
+
+        if let Some(registered) = registered {
+            match tokio::time::timeout_at(
+                registered.deadline,
+                self.await_with_readiness(registered.task),
+            )
+            .await
+            {
+                Err(_) => {
+                    for plan in plans.iter().filter(|plan| plan.export_restore.is_some()) {
+                        self.retain_policy_rollback_rib_intent(plan);
+                    }
+                    errors.push(format!(
+                        "rollback RIB restores exceeded the shared {:?} deadline; late ordered repair continues",
+                        super::RIB_REPLY_TIMEOUT
+                    ));
+                }
+                Ok(Err(error)) => {
+                    for plan in plans.iter().filter(|plan| plan.export_restore.is_some()) {
+                        self.retain_policy_rollback_rib_intent(plan);
+                    }
+                    errors.push(format!("rollback RIB restore task failed: {error}"));
+                }
+                Ok(Ok(outcomes)) => {
+                    for (index, outcome) in outcomes {
+                        let plan = &plans[index];
+                        match outcome {
+                            Ok(()) => self.finish_policy_rollback_rib_success(plan),
+                            Err(error @ RibCommandError::NotFound(_))
+                                if plan.export_restore.as_ref().is_some_and(
+                                    |(_, is_known_non_established)| *is_known_non_established,
+                                ) =>
+                            {
+                                info!(
+                                    peer = %plan.peer_key.address,
+                                    %error,
+                                    "policy rollback found no RIB outbound registration; the restored session policy will be authoritative on PeerUp"
+                                );
+                                self.finish_policy_rollback_rib_success(plan);
+                            }
+                            Err(error) => {
+                                self.retain_policy_rollback_rib_intent(plan);
+                                errors.push(format!("{}: {error}", plan.peer_key.address));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         if errors.is_empty() {
             Ok(())
         } else {
@@ -1039,6 +1331,7 @@ impl PeerManager {
         import_policy: Option<PolicyChain>,
         export_policy: Option<PolicyChain>,
         refresh_failure: RefreshFailureHandling,
+        rollback_plan: Option<&mut Option<PolicyRollbackPeerPlan>>,
     ) -> Result<(), String> {
         use std::fmt::Write as _;
         let address = peer_key.address;
@@ -1257,6 +1550,29 @@ impl PeerManager {
         }
 
         let is_rollback = !matches!(refresh_failure, RefreshFailureHandling::Fatal);
+        if let Some(rollback_plan) = rollback_plan {
+            debug_assert!(
+                is_rollback,
+                "rollback planning requires best-effort handling"
+            );
+            if let Some(managed) = self.peers.get_mut(&peer_key) {
+                if needs_refresh {
+                    managed.pending_refresh = true;
+                }
+                if needs_export_apply {
+                    managed.pending_export_apply = true;
+                }
+            }
+            *rollback_plan = Some(PolicyRollbackPeerPlan {
+                peer_key,
+                export_restore: needs_export_apply
+                    .then_some((export_policy, is_known_non_established)),
+                refresh_failure: needs_refresh.then_some(refresh_failure),
+                is_established,
+                restore_prior_pending: None,
+            });
+            return Ok(());
+        }
         if needs_export_apply && (is_established || is_rollback) {
             // The RIB step sits between session-side hot-apply (already
             // succeeded if we reached here) and Route Refresh. If it
@@ -1684,6 +2000,7 @@ impl PeerManager {
                     import_policy,
                     export_policy,
                     RefreshFailureHandling::Fatal,
+                    None,
                 )
                 .await
             {
@@ -1766,6 +2083,7 @@ impl PeerManager {
                     import_policy,
                     export_policy,
                     RefreshFailureHandling::Fatal,
+                    None,
                 )
                 .await
             {
@@ -1922,5 +2240,83 @@ impl PeerManager {
         self.current_config = next_config;
         self.publish_policy_config_event(&event, priors.len());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod first_poll_tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum QueueItem {
+        Sentinel,
+        Rollback,
+        Marker,
+    }
+
+    #[tokio::test]
+    async fn rollback_first_poll_registers_after_cooperative_budget_is_exhausted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(QueueItem::Sentinel).await.unwrap();
+
+        let rollback_tx = tx.clone();
+        let mut rollback: PolicyRollbackRibFuture = Box::pin(async move {
+            let result = rollback_tx
+                .send(QueueItem::Rollback)
+                .await
+                .map_err(|_| RibCommandError::internal("test RIB channel unavailable"));
+            (0, result)
+        });
+        let marker_tx = tx.clone();
+        let mut marker = Box::pin(async move { marker_tx.send(QueueItem::Marker).await });
+
+        std::future::poll_fn(|cx| {
+            loop {
+                match tokio::task::coop::poll_proceed(cx) {
+                    Poll::Ready(permit) => permit.made_progress(),
+                    Poll::Pending => return Poll::Ready(()),
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            first_poll_policy_rollback_rib(&mut rollback)
+                .await
+                .is_none()
+        );
+        let marker_registered = std::future::poll_fn(|cx| {
+            let mut marker = std::pin::pin!(tokio::task::unconstrained(marker.as_mut()));
+            Poll::Ready(marker.as_mut().poll(cx).is_ready())
+        })
+        .await;
+        assert!(!marker_registered);
+
+        assert_eq!(
+            tokio::task::unconstrained(rx.recv()).await,
+            Some(QueueItem::Sentinel)
+        );
+        let readiness = std::future::poll_fn(|cx| {
+            let marker_ready = {
+                let mut marker = std::pin::pin!(tokio::task::unconstrained(marker.as_mut()));
+                marker.as_mut().poll(cx).is_ready()
+            };
+            let rollback_ready = {
+                let mut rollback = std::pin::pin!(tokio::task::unconstrained(rollback.as_mut()));
+                rollback.as_mut().poll(cx).is_ready()
+            };
+            Poll::Ready((marker_ready, rollback_ready))
+        })
+        .await;
+
+        // LOAD-BEARING: removing only the helper's `unconstrained` wrapper
+        // changes this tuple to `(true, false)`: Marker claims the freed slot
+        // because Rollback was never registered under the exhausted budget.
+        assert_eq!(readiness, (false, true));
+        assert_eq!(
+            tokio::task::unconstrained(rx.recv()).await,
+            Some(QueueItem::Rollback)
+        );
     }
 }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1181,6 +1181,89 @@ fn established_export_policy_test_session(
     PeerHandle::from_parts(session_tx, task)
 }
 
+fn rollback_ordering_policy_session(
+    addr: IpAddr,
+    rib_tx: mpsc::Sender<RibUpdate>,
+    fail_first_export: bool,
+    rollback_export_delay: Option<Duration>,
+) -> PeerHandle {
+    use rustbgpd_transport::{PeerCommand, PeerCommandError};
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let task = tokio::spawn(async move {
+        let mut export_attempts = 0;
+        let mut refresh_attempts = 0;
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::UpdateImportPolicy { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    export_attempts += 1;
+                    let result = if fail_first_export && export_attempts == 1 {
+                        Err(PeerCommandError::CommandFailed(
+                            "injected final session failure".to_string(),
+                        ))
+                    } else {
+                        if export_attempts > 1
+                            && let Some(delay) = rollback_export_delay
+                        {
+                            tokio::time::sleep(delay).await;
+                        }
+                        Ok(())
+                    };
+                    let _ = reply.send(result);
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(PeerSessionState {
+                        fsm_state: SessionState::Established,
+                        peer_ip: addr,
+                        peer_asn: Some(65002),
+                        prefix_count: 0,
+                        negotiated_hold_time: Some(90),
+                        four_octet_as: Some(true),
+                        remote_router_id: None,
+                        local_role: None,
+                        remote_role: None,
+                        role_negotiated: false,
+                        peer_paths_limits: Vec::new(),
+                        effective_add_path_send_limits: Vec::new(),
+                        updates_received: 0,
+                        updates_sent: 0,
+                        notifications_received: 0,
+                        notifications_sent: 0,
+                        messages_received: 0,
+                        messages_sent: 0,
+                        otc_routes_blocked: 0,
+                        import_policy_routes_permitted: 0,
+                        import_policy_routes_denied: 0,
+                        flap_count: 0,
+                        uptime_secs: 1,
+                        last_error: String::new(),
+                        tcp_ao_info: None,
+                        tcp_ao_protected: false,
+                    });
+                }
+                PeerCommand::SendRouteRefresh { reply, .. } => {
+                    refresh_attempts += 1;
+                    if refresh_attempts > 1 {
+                        let (marker_tx, marker_rx) = oneshot::channel();
+                        let _ = rib_tx
+                            .send(RibUpdate::QueryLocRibCount { reply: marker_tx })
+                            .await;
+                        let _ = marker_rx.await;
+                    }
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
 fn stalled_export_policy_test_session(
     addr: IpAddr,
 ) -> (
@@ -8022,6 +8105,428 @@ async fn export_only_snapshot_remainder_failure_restores_remainder_then_cohort()
     );
 }
 
+#[tokio::test(start_paused = true)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the cross-partition deadline proof must hold both rollback partitions at once"
+)]
+async fn policy_rollback_rib_wait_has_one_cross_partition_deadline() {
+    use rustbgpd_api::peer_types::{PeerManagerReadinessQuery, ResolvedPeerPolicy};
+
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 39, 2, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 39, 2, 2)),
+        IpAddr::V4(Ipv4Addr::new(10, 39, 2, 3)),
+        IpAddr::V4(Ipv4Addr::new(10, 39, 2, 4)),
+    ];
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let (readiness_tx, readiness_rx) = mpsc::channel(4);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_readiness_queries(readiness_rx);
+    for peer in peers {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&attempts), None),
+            false,
+        );
+    }
+
+    let cohort_policy = deny_policy_chain();
+    let remainder_policy = validation_policy_chain(ImportValidationDependency::Aspa);
+    let started = tokio::time::Instant::now();
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .into_iter()
+            .zip([
+                cohort_policy.clone(),
+                cohort_policy,
+                remainder_policy.clone(),
+                remainder_policy,
+            ])
+            .map(|(address, export_policy)| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: None,
+                export_policy: Some(export_policy),
+            })
+            .collect(),
+    );
+    let drive_rib = async {
+        let RibUpdate::ReplacePeerExportPolicies { reply, .. } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected cohort commit");
+        };
+        reply
+            .send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed))
+            .unwrap();
+
+        for (index, expected_peer) in peers[2..].iter().copied().enumerate() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected remainder forward command");
+            };
+            assert_eq!(peer, expected_peer);
+            if index == 0 {
+                reply.send(Ok(())).unwrap();
+            } else {
+                reply
+                    .send(Err(rustbgpd_rib::RibCommandError::internal(
+                        "force cross-partition rollback",
+                    )))
+                    .unwrap();
+            }
+        }
+
+        let mut late_replies = Vec::new();
+        for expected_peer in peers[2..].iter().rev() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected remainder rollback command");
+            };
+            assert_eq!(peer, *expected_peer);
+            late_replies.push(reply);
+        }
+
+        let (readiness_reply, readiness_response) = oneshot::channel();
+        readiness_tx
+            .send(PeerManagerReadinessQuery::ListPeers {
+                reply: readiness_reply,
+            })
+            .await
+            .unwrap();
+        // LOAD-BEARING: awaiting the registered aggregate without the
+        // read-only readiness lane makes this deadline expire.
+        assert_eq!(
+            tokio::time::timeout(
+                rustbgpd_api::health_probe::CORE_READINESS_DEADLINE,
+                readiness_response,
+            )
+            .await
+            .expect("readiness must remain live during rollback RIB congestion")
+            .unwrap()
+            .len(),
+            peers.len()
+        );
+
+        tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        for expected_peer in peers[..2].iter().rev() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected cohort rollback command");
+            };
+            assert_eq!(peer, *expected_peer);
+            late_replies.push(reply);
+        }
+        late_replies
+    };
+    let (result, late_replies) = tokio::join!(apply, drive_rib);
+
+    // LOAD-BEARING: constructing a fresh five-second timeout for the cohort
+    // unwind makes elapsed time ten seconds and this assertion goes red.
+    assert!(
+        tokio::time::Instant::now().duration_since(started)
+            < RIB_REPLY_TIMEOUT + Duration::from_secs(1),
+        "all rollback partitions must share the first rollback RIB deadline"
+    );
+    assert!(
+        result.as_ref().is_err_and(|error| {
+            error.contains("force cross-partition rollback")
+                && error.matches("shared 5s deadline").count() == 2
+        }),
+        "both timed-out partitions must report the shared deadline: {result:?}"
+    );
+    for reply in late_replies {
+        assert!(
+            reply.send(Ok(())).is_ok(),
+            "the exact timed-out RIB future must remain detached for late repair"
+        );
+    }
+    for peer in peers {
+        let peer_state = manager.peers.get(&key(peer)).unwrap();
+        assert!(peer_state.pending_export_apply);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn policy_rollback_rib_deadline_starts_after_session_restores() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    const PEER_COUNT: u8 = 13;
+    const ROLLBACK_EXPORT_DELAY: Duration = Duration::from_millis(450);
+
+    let peers = (1..=PEER_COUNT)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 39, 5, last)))
+        .collect::<Vec<_>>();
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx.clone(),
+        None,
+    );
+    for (index, peer) in peers.iter().copied().enumerate() {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            rollback_ordering_policy_session(
+                peer,
+                rib_tx.clone(),
+                index + 1 == peers.len(),
+                Some(ROLLBACK_EXPORT_DELAY),
+            ),
+            false,
+        );
+    }
+
+    let started = tokio::time::Instant::now();
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .copied()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: None,
+                export_policy: Some(deny_policy_chain()),
+            })
+            .collect(),
+    );
+    let drive_rib = async {
+        let mut replies = Vec::new();
+        for expected_peer in peers[..peers.len() - 1].iter().rev() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected rollback RIB restore");
+            };
+            assert_eq!(peer, *expected_peer);
+            replies.push(reply);
+        }
+        assert!(
+            tokio::time::Instant::now().duration_since(started) > RIB_REPLY_TIMEOUT,
+            "successful session restores must consume more than the RIB-only deadline"
+        );
+
+        tokio::time::advance(
+            RIB_REPLY_TIMEOUT
+                .checked_sub(Duration::from_millis(1))
+                .expect("RIB reply timeout exceeds one millisecond"),
+        )
+        .await;
+        tokio::task::yield_now().await;
+        for reply in replies {
+            reply.send(Ok(())).unwrap();
+        }
+    };
+    let (result, ()) = tokio::join!(apply, drive_rib);
+
+    // LOAD-BEARING: moving `budget.deadline()` to the start of
+    // `restore_resolved_policies` makes this red because the successful session
+    // restores consume that prematurely anchored RIB-only wait budget.
+    assert!(
+        result.as_ref().is_err_and(|error| {
+            error.contains("injected final session failure")
+                && error.contains("already-applied peers restored")
+        }),
+        "rollback RIB waiting must receive a fresh deadline after session restores: {result:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn timed_out_policy_rollback_rearms_import_and_export_retry_intent() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 39, 3, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 39, 3, 2)),
+    ];
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let (_command_tx, command_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for peer in peers {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            acking_policy_handle(peer, SessionState::Established),
+            false,
+        );
+    }
+    let next = deny_policy_chain();
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .copied()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: Some(next.clone()),
+                export_policy: Some(next.clone()),
+            })
+            .collect(),
+    );
+    let drive_rib = async {
+        for (index, expected_peer) in peers.iter().copied().enumerate() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected forward RIB command");
+            };
+            assert_eq!(peer, expected_peer);
+            if index == 0 {
+                reply.send(Ok(())).unwrap();
+            } else {
+                reply
+                    .send(Err(rustbgpd_rib::RibCommandError::internal(
+                        "force rollback timeout",
+                    )))
+                    .unwrap();
+            }
+        }
+        let mut held = Vec::new();
+        for expected_peer in peers.iter().rev() {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected rollback RIB command");
+            };
+            assert_eq!(peer, *expected_peer);
+            held.push(reply);
+        }
+        tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+        held
+    };
+    let (result, held) = tokio::join!(apply, drive_rib);
+    assert!(result.is_err());
+
+    for peer in peers {
+        let peer_state = manager.peers.get(&key(peer)).unwrap();
+        // LOAD-BEARING: clearing rollback refresh state before a timed-out RIB
+        // aggregate without rearming it makes pending_refresh false here.
+        assert!(peer_state.pending_refresh);
+        assert!(peer_state.pending_export_apply);
+    }
+    for reply in held {
+        assert!(reply.send(Ok(())).is_ok());
+    }
+}
+
+#[tokio::test]
+async fn policy_rollback_skips_refresh_when_rib_restore_cannot_register() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 39, 4, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 39, 4, 2)),
+    ];
+    let counters = [
+        Arc::new(FakePeerCounters::default()),
+        Arc::new(FakePeerCounters::default()),
+    ];
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let (_command_tx, command_rx) = mpsc::channel(8);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for (peer, counter) in peers.iter().copied().zip(&counters) {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            acking_counted_policy_handle(peer, Arc::clone(counter)),
+            false,
+        );
+    }
+
+    let next = deny_policy_chain();
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .copied()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: Some(next.clone()),
+                export_policy: Some(next.clone()),
+            })
+            .collect(),
+    );
+    let close_rib_before_rollback = async {
+        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected first forward RIB command");
+        };
+        assert_eq!(peer, peers[0]);
+        reply.send(Ok(())).unwrap();
+
+        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected second forward RIB command");
+        };
+        assert_eq!(peer, peers[1]);
+        reply
+            .send(Err(rustbgpd_rib::RibCommandError::internal(
+                "force rollback after one completed peer",
+            )))
+            .unwrap();
+        drop(rib_rx);
+    };
+    let (result, ()) = tokio::join!(apply, close_rib_before_rollback);
+
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|error| error.contains("force rollback after one completed peer")),
+        "the injected second-peer failure must drive rollback: {result:?}"
+    );
+    // LOAD-BEARING: removing the immediate-registration-failure refresh gate
+    // sends a second Route Refresh to peer 1 even though its RIB restore was
+    // never queued, making this exact count red. Peer 2 failed before its
+    // forward refresh, so it must remain at zero as well.
+    assert_eq!(counters[0].route_refresh.load(Ordering::SeqCst), 1);
+    assert_eq!(counters[1].route_refresh.load(Ordering::SeqCst), 0);
+    for peer in peers {
+        let peer_state = manager.peers.get(&key(peer)).unwrap();
+        assert!(peer_state.pending_refresh);
+        assert!(peer_state.pending_export_apply);
+    }
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -8126,6 +8631,9 @@ async fn export_only_snapshot_reasserts_prior_import_after_remainder_ack_loss() 
         }),
         "the ambiguous remainder failure must unwind both phases: {result:?}"
     );
+    // LOAD-BEARING: treating the ambiguous forward import command as complete
+    // suppresses its rollback reassertion; the live chain and install count
+    // below then remain on the changed policy and make this test red.
     assert_eq!(
         *live_import.lock().unwrap(),
         None,
@@ -8598,6 +9106,233 @@ async fn export_only_snapshot_handoff_timeout_restores_after_the_owned_forward_c
     }
 }
 
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the bounded-channel proof keeps registration, refresh, and later lifecycle ordering together"
+)]
+async fn policy_rollback_registers_every_rib_restore_before_refresh_and_lifecycle_work() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    const PEER_COUNT: u8 = 160;
+    let peers = (1..=PEER_COUNT)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 40, 0, last)))
+        .collect::<Vec<_>>();
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+    let lifecycle_tx = rib_tx.clone();
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx.clone(),
+        None,
+    );
+    for (index, peer) in peers.iter().copied().enumerate() {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            rollback_ordering_policy_session(peer, rib_tx.clone(), index + 1 == peers.len(), None),
+            false,
+        );
+    }
+
+    let next = deny_policy_chain();
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .copied()
+            .map(|address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: Some(next.clone()),
+                export_policy: Some(next.clone()),
+            })
+            .collect(),
+    );
+    let drive_rib = async {
+        for expected_peer in peers.iter().take(peers.len() - 1) {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected forward RIB restore");
+            };
+            assert_eq!(peer, *expected_peer);
+            reply.send(Ok(())).unwrap();
+        }
+
+        let mut lifecycle_task = None;
+        let mut restores = Vec::new();
+        let mut refresh_markers = 0;
+        let mut saw_delete = false;
+        let mut saw_recreate = false;
+        while restores.len() < peers.len()
+            || refresh_markers < peers.len() - 1
+            || !saw_delete
+            || !saw_recreate
+        {
+            match rib_rx.recv().await.unwrap() {
+                RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
+                    if restores.is_empty() {
+                        let later_tx = lifecycle_tx.clone();
+                        let recreated = peers[0];
+                        lifecycle_task = Some(tokio::spawn(async move {
+                            later_tx
+                                .send(RibUpdate::PeerDeleted { peer: recreated })
+                                .await
+                                .unwrap();
+                            let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+                            later_tx
+                                .send(RibUpdate::PeerUp {
+                                    peer: recreated,
+                                    session_id: 99,
+                                    peer_asn: 65002,
+                                    peer_router_id: Ipv4Addr::new(192, 0, 2, 1),
+                                    outbound_tx,
+                                    export_policy: None,
+                                    sendable_families: vec![(Afi::Ipv4, Safi::Unicast)],
+                                    is_ebgp: true,
+                                    route_reflector_client: false,
+                                    orr_vantage: None,
+                                    per_client_best: false,
+                                    add_path_send_families: Vec::new(),
+                                    add_path_send_max: 0,
+                                    negotiated_orf_recv: Vec::new(),
+                                    negotiated_llgr_families: Vec::new(),
+                                })
+                                .await
+                                .unwrap();
+                        }));
+                    }
+                    assert_eq!(peer, peers[peers.len() - 1 - restores.len()]);
+                    restores.push(peer);
+                    reply.send(Ok(())).unwrap();
+                }
+                RibUpdate::QueryLocRibCount { reply } => {
+                    // LOAD-BEARING: moving Route Refresh ahead of aggregate
+                    // registration lets this marker overtake a restore.
+                    assert_eq!(restores.len(), peers.len());
+                    refresh_markers += 1;
+                    reply.send(0).unwrap();
+                }
+                RibUpdate::PeerDeleted { peer } => {
+                    // LOAD-BEARING: removing reverse-order pre-registration
+                    // lets this later delete overtake an unregistered restore.
+                    assert_eq!(restores.len(), peers.len());
+                    assert_eq!(peer, peers[0]);
+                    saw_delete = true;
+                }
+                RibUpdate::PeerUp {
+                    peer, session_id, ..
+                } => {
+                    assert!(saw_delete);
+                    assert_eq!(restores.len(), peers.len());
+                    assert_eq!(peer, peers[0]);
+                    assert_eq!(session_id, 99);
+                    saw_recreate = true;
+                }
+                _ => panic!("unexpected RIB command in rollback ordering proof"),
+            }
+        }
+        lifecycle_task.unwrap().await.unwrap();
+    };
+    let (result, ()) = tokio::join!(apply, drive_rib);
+
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|error| error.contains("injected final session failure")),
+        "the forced final failure must drive a complete rollback: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn policy_rollback_registered_rib_futures_survive_caller_cancellation() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = (1..=8)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 41, 0, last)))
+        .collect::<Vec<_>>();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(1);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for (index, peer) in peers.iter().copied().enumerate() {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(
+                peer,
+                Arc::clone(&attempts),
+                (index + 1 == peers.len()).then_some(peers.len()),
+            ),
+            false,
+        );
+    }
+    let task_peers = peers.clone();
+    let apply_task = tokio::spawn(async move {
+        manager
+            .apply_resolved_policy_snapshot(
+                task_peers
+                    .iter()
+                    .copied()
+                    .map(|address| ResolvedPeerPolicy {
+                        address,
+                        interface: None,
+                        import_policy: None,
+                        export_policy: Some(deny_policy_chain()),
+                    })
+                    .collect(),
+            )
+            .await
+    });
+
+    let RibUpdate::ReplacePeerExportPolicy {
+        peer: first_restore,
+        reply,
+        ..
+    } = rib_rx.recv().await.unwrap()
+    else {
+        panic!("expected the first registered rollback restore");
+    };
+    assert_eq!(first_restore, peers[peers.len() - 2]);
+    apply_task.abort();
+    assert!(apply_task.await.unwrap_err().is_cancelled());
+    reply.send(Ok(())).unwrap();
+
+    let mut restored = vec![first_restore];
+    while restored.len() < peers.len() - 1 {
+        let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected detached rollback restore");
+        };
+        restored.push(peer);
+        reply.send(Ok(())).unwrap();
+    }
+    // LOAD-BEARING: awaiting rollback futures directly in the caller drops
+    // this suffix on cancellation, closing the channel before all peers arrive.
+    assert_eq!(
+        restored,
+        peers[..peers.len() - 1]
+            .iter()
+            .rev()
+            .copied()
+            .collect::<Vec<_>>()
+    );
+}
+
 #[tokio::test(start_paused = true)]
 #[expect(
     clippy::too_many_lines,
@@ -8962,6 +9697,8 @@ async fn export_only_snapshot_restores_newest_first_after_session_failure() {
         2,
         "the failing session must have its prior chain reasserted too"
     );
+    // LOAD-BEARING: planning RIB compensation for the session whose forward
+    // command failed increases this to two and makes the assertion red.
     assert_eq!(rib_single_restores.load(Ordering::SeqCst), 1);
     for peer in [first, second] {
         let peer_state = manager.peers.get(&key(peer)).unwrap();


### PR DESCRIPTION
## Summary

- give all rollback RIB sends and replies in one policy transaction one lazy absolute five-second wait budget, shared across authoritative and cohort unwind paths
- first-poll and retain the exact pinned sends so bounded-channel FIFO repair stays ahead of rollback refreshes, later lifecycle work, timeout return, and caller cancellation
- suppress rollback refresh when the RIB restore is immediately known to be unregistered, retain conservative retry intent on timeout or error, and document the precise bound and exclusions

The bound covers cumulative rollback RIB send and reply waiting. It intentionally does not claim to bound sequential session commands, Route Refresh acknowledgements, or late RIB actor repair.

## Load-bearing regression proof

- policy_rollback_rib_wait_has_one_cross_partition_deadline turns red if each partition receives a fresh timeout
- policy_rollback_rib_deadline_starts_after_session_restores turns red if the deadline is anchored before sequential session restoration
- timed_out_policy_rollback_rearms_import_and_export_retry_intent turns red if timeout clears either retry marker
- rollback_first_poll_registers_after_cooperative_budget_is_exhausted turns red if the first poll loses its Tokio unconstrained wrapper
- policy_rollback_skips_refresh_when_rib_restore_cannot_register turns red if immediate registration failure still emits rollback refresh
- policy_rollback_registers_every_rib_restore_before_refresh_and_lifecycle_work turns red if refresh or later lifecycle RIB work overtakes a restore
- policy_rollback_registered_rib_futures_survive_caller_cancellation turns red if caller abort cancels the registered suffix
- export_only_snapshot_reasserts_prior_import_after_remainder_ack_loss turns red if ambiguous import state is not reasserted before refresh
- export_only_snapshot_restores_newest_first_after_session_failure turns red if rollback compensates a peer whose forward session command never committed

Each mutation was injected against the focused assertion, observed red, restored, and rerun green.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- commit and push hooks
- independent exact-head correctness and false-green review