### PR TITLE
test(config): pin contextual v1 defaults

### DIFF
--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -42,6 +42,17 @@ streaming mode. Each stable config definition's digest covers the selected
 property schemas, its complete (order-independent) required-field set, and its
 unknown-field policy. Unselected optional sibling properties and descriptive
 prose remain outside that digest, so additive optional siblings stay possible.
+The eight description-only contextual defaults scoped by this contract update
+are pinned separately under `config.effective_defaults`. Their named resolver
+test loads real TOML and checks omission, peer-group inheritance, derived
+values, direct overrides, and conditional route-reflector behavior. This is a
+deliberately scoped guard, not an exhaustive catalog of every config omission
+behavior. These eight values remain description-only in the JSON Schema: a
+static JSON Schema `default` is reserved for context-free omission semantics and
+must not misrepresent an inherited, computed, or conditional result. The Python
+release checker pins this inventory and its linkage to a live, non-ignored Rust
+test; the focused Cargo test executes that test and is the gate that detects
+runtime resolver changes.
 Nested protobuf evolution follows the compatibility rules below. The
 message-graph digest is a review tripwire, not an implicit promotion:
 experimental fields such as Paths-Limit are explicitly excluded in the
@@ -143,6 +154,7 @@ Run:
 python3 scripts/check-v1-stable-surface.py
 cargo test -p rustbgpctl v1_stable_cli_command_inventory_matches_clap_tree
 cargo test -p rustbgpd v1_stable_v0_50_route_server_fixture_parses
+cargo test -p rustbgpd v1_stable_effective_defaults_match_runtime_resolution
 ```
 
 Updating a digest is not a mechanical fix. Review the compatibility policy,

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -94,6 +94,20 @@
       {"definition": "GrpcMaxTierConfig", "schema_sha256": "244b9b776ca119f3c7af0e3fcfafac568318e3d830a9086e5de9646b923b83c8"},
       {"definition": "GrpcRoleConfig", "schema_sha256": "46719dcd128578a3754ea0bfcce98b7cbfb1c361aa941edacaf7fc4d2ac528a5"}
     ],
+    "effective_defaults": {
+      "paths": [
+        "Global.cluster_id",
+        "Neighbor.disable_ipv4_unicast",
+        "Neighbor.gr_restart_time",
+        "Neighbor.gr_stale_routes_time",
+        "Neighbor.graceful_restart",
+        "Neighbor.hold_time",
+        "Neighbor.llgr_stale_time",
+        "Neighbor.send_hold_time"
+      ],
+      "validation_source": "src/config/tests.rs",
+      "validation_test": "v1_stable_effective_defaults_match_runtime_resolution"
+    },
     "explicitly_unstable_roots": [
       {"path": "AddPathConfig.receive_max", "classification": "experimental"},
       {"path": "Config.apply_bum_enforcement", "classification": "alpha"},

--- a/scripts/check-v1-stable-surface.py
+++ b/scripts/check-v1-stable-surface.py
@@ -31,6 +31,21 @@ GRPC_INVENTORY_PATH = ROOT / "docs/grpc-method-inventory.json"
 WORKSPACE_MANIFEST_PATH = ROOT / "Cargo.toml"
 JSON_TYPES = {"array", "boolean", "null", "number", "object", "string"}
 V1_UPGRADE_HISTORY_ORIGIN = (0, 50, 0)
+EXPECTED_EFFECTIVE_DEFAULT_PATHS = (
+    "Global.cluster_id",
+    "Neighbor.disable_ipv4_unicast",
+    "Neighbor.gr_restart_time",
+    "Neighbor.gr_stale_routes_time",
+    "Neighbor.graceful_restart",
+    "Neighbor.hold_time",
+    "Neighbor.llgr_stale_time",
+    "Neighbor.send_hold_time",
+)
+EFFECTIVE_DEFAULT_ASSERTION_MACRO = "assert_v1_effective_default"
+EFFECTIVE_DEFAULT_ASSERTION_RE = re.compile(
+    rf'\b{EFFECTIVE_DEFAULT_ASSERTION_MACRO}!\(\s*"([^"\\]+)"\s*,\s*'
+    r"([a-z][a-z0-9_]*)\s*,\s*(None|true|false|\d+|\(\d+\s*,\s*\d+\))\s*\);"
+)
 
 
 def fail(message: str) -> None:
@@ -129,6 +144,129 @@ def check_stable_config_object_shape_regressions() -> None:
         fail("internal config-shape regression treated required ordering as semantic")
 
 
+def check_effective_default_assertion_block(test_region: str, test: str) -> None:
+    if not re.search(
+        rf"""
+        macro_rules!\s+{EFFECTIVE_DEFAULT_ASSERTION_MACRO}\s*\{{\s*
+        \(\s*\$path:literal\s*,\s*\$actual:expr\s*,\s*\$expected:expr\s*\)\s*=>\s*\{{\s*
+        assert_eq!\(\s*\$actual\s*,\s*\$expected\s*,.*?\);\s*
+        \}}\s*;\s*
+        \}}
+        """,
+        test_region,
+        flags=re.DOTALL | re.VERBOSE,
+    ):
+        fail(
+            f"effective-default validation test {test!r} has no runtime-vs-expected "
+            "assertion macro"
+        )
+    assertions = EFFECTIVE_DEFAULT_ASSERTION_RE.findall(test_region)
+    if [path for path, _, _ in assertions] != list(EXPECTED_EFFECTIVE_DEFAULT_PATHS):
+        fail(
+            f"effective-default validation test {test!r} must assert exactly the "
+            "eight scoped full paths in sorted order"
+        )
+    for path, actual, _ in assertions:
+        field = path.partition(".")[2]
+        extraction = (
+            rf"\blet\s+{re.escape(actual)}\s*=\s*"
+            rf"[^;\n]*\b{re.escape(field)}\b[^;\n]*;"
+        )
+        if actual != field or not re.search(extraction, test_region):
+            fail(
+                f"effective-default validation test {test!r} assertion for {path!r} "
+                "is not bound to that runtime field"
+            )
+
+
+def check_effective_defaults(
+    inventory: dict, schema: dict, stable_paths: set[str]
+) -> None:
+    effective = inventory["config"].get("effective_defaults")
+    if not isinstance(effective, dict):
+        fail("config.effective_defaults must be an object")
+    required_keys = {"paths", "validation_source", "validation_test"}
+    if set(effective) != required_keys:
+        fail(
+            "config.effective_defaults must contain exactly paths, validation_source, "
+            "and validation_test"
+        )
+
+    paths = effective["paths"]
+    if not isinstance(paths, list) or not paths or not all(
+        isinstance(path, str) and path for path in paths
+    ):
+        fail("config.effective_defaults.paths must be a non-empty string list")
+    require_sorted_unique(paths, "config.effective_defaults.paths")
+    if paths != list(EXPECTED_EFFECTIVE_DEFAULT_PATHS):
+        fail("config.effective_defaults.paths must match the exact eight-path scoped set")
+    for path in paths:
+        definition, separator, field = path.partition(".")
+        if not separator or "." in field or path not in stable_paths:
+            fail(f"effective default path {path!r} is not a stable config field")
+        property_schema = schema_definition(schema, definition)["properties"][field]
+        if "default" in property_schema:
+            fail(
+                f"contextual effective default {path!r} must not claim a static JSON Schema default"
+            )
+        description = property_schema.get("description")
+        if not isinstance(description, str) or not description.strip():
+            fail(f"contextual effective default {path!r} has no schema description")
+
+    source_name = effective["validation_source"]
+    test = effective["validation_test"]
+    if not isinstance(source_name, str) or not source_name:
+        fail("config.effective_defaults.validation_source must be a source path")
+    if not isinstance(test, str) or not test:
+        fail("config.effective_defaults.validation_test must be a test name")
+    source_path = ROOT / safe_relative_path(
+        source_name, "effective-default validation source"
+    )
+    try:
+        source = source_path.read_text()
+    except OSError as error:
+        fail(f"cannot read effective-default validation source {source_name}: {error}")
+    test_region = named_rust_test_region(source, test)
+    if test_region is None:
+        fail(f"effective-default validation test {test!r} is not a live named test")
+    check_effective_default_assertion_block(test_region, test)
+    expect_checker_failure(
+        lambda: check_effective_default_assertion_block(
+            EFFECTIVE_DEFAULT_ASSERTION_RE.sub("", test_region), test
+        ),
+        "must assert exactly the eight scoped full paths",
+        "missing effective-default runtime assertion block",
+    )
+    for broken_macro, label in (
+        (
+            test_region.replace("$actual, $expected", "$expected, $expected"),
+            "vacuous macro",
+        ),
+        (
+            re.sub(
+                r"assert_eq!\(\s*\$actual\s*,\s*\$expected\s*,.*?\);",
+                "",
+                test_region,
+                count=1,
+                flags=re.DOTALL,
+            ),
+            "no-op macro",
+        ),
+    ):
+        expect_checker_failure(
+            lambda broken_macro=broken_macro: check_effective_default_assertion_block(
+                broken_macro, test
+            ),
+            "no runtime-vs-expected assertion macro",
+            label,
+        )
+    for linkage in ("parse_strict(", "resolve_neighbor("):
+        if linkage not in test_region:
+            fail(
+                f"effective-default validation test {test!r} does not exercise {linkage[:-1]}"
+            )
+
+
 def check_config(inventory: dict, schema: dict) -> None:
     stable_entries = inventory["config"]["stable_fields"]
     definitions: set[str] = set()
@@ -202,6 +340,7 @@ def check_config(inventory: dict, schema: dict) -> None:
     missing = sorted(config_properties - classified_roots)
     if missing:
         fail(f"top-level config roots are unclassified: {', '.join(missing)}")
+    check_effective_defaults(inventory, schema, stable_paths)
 
 
 RPC_RE = re.compile(
@@ -688,10 +827,20 @@ def named_rust_test_region(source: str, name: str) -> str | None:
         r"((?:\s*#\[[^\]]*\])+\s*)$", source[: match.start()], flags=re.DOTALL
     )
     attributes = attributes_match.group(1) if attributes_match else ""
-    if not re.search(r"#\[(?:tokio::)?test(?:\([^\]]*\))?\]", attributes):
+    attribute_bodies = [body.strip() for body in re.findall(r"#\[(.*?)\]", attributes, re.DOTALL)]
+    if not any(
+        re.fullmatch(r"(?:tokio::)?test(?:\s*\(.*\))?", body, flags=re.DOTALL)
+        for body in attribute_bodies
+    ):
         return None
-    if re.search(r"#\[ignore(?:\([^\]]*\))?\]", attributes):
-        fail(f"JSON/upgrade contract test {name!r} must not be ignored")
+    for body in attribute_bodies:
+        is_cfg_attr = re.match(r"cfg_attr\b", body) is not None
+        if re.match(r"ignore\b", body) or (is_cfg_attr and re.search(r"\bignore\b", body)):
+            fail(f"inventory-linked contract test {name!r} must not be ignored")
+        if re.match(r"should_panic\b", body) or (
+            is_cfg_attr and re.search(r"\bshould_panic\b", body)
+        ):
+            fail(f"inventory-linked contract test {name!r} must not use should_panic")
     body_start = source.find("{", match.end())
     if body_start < 0:
         return None
@@ -931,6 +1080,40 @@ def check_cli_checker_selftests(inventory: dict) -> None:
     )
 
 
+def check_named_rust_test_region_selftests() -> None:
+    cases = [
+        ('#[test]\n#[ignore = "reason"]', "must not be ignored", "ignore with reason"),
+        (
+            "#[test]\n#[cfg_attr(test, ignore)]",
+            "must not be ignored",
+            "cfg_attr ignore",
+        ),
+        (
+            '#[test]\n#[cfg_attr(not(test), ignore = "reason")]',
+            "must not be ignored",
+            "conditional ignore with reason",
+        ),
+        ("#[test]\n#[should_panic]", "must not use should_panic", "should_panic"),
+        (
+            '#[test]\n#[should_panic(expected = "boom")]',
+            "must not use should_panic",
+            "should_panic with expected message",
+        ),
+        (
+            "#[test]\n#[cfg_attr(test, should_panic)]",
+            "must not use should_panic",
+            "cfg_attr should_panic",
+        ),
+    ]
+    for attributes, expected, label in cases:
+        source = f"{attributes}\nfn contract_probe() {{}}"
+        expect_checker_failure(
+            lambda source=source: named_rust_test_region(source, "contract_probe"),
+            expected,
+            label,
+        )
+
+
 def check_policy(inventory: dict) -> None:
     roles = inventory["roles"]
     role_ids = [role["id"] for role in roles]
@@ -960,6 +1143,7 @@ def check_policy(inventory: dict) -> None:
 def main() -> None:
     check_release_line_selftests()
     check_stable_config_object_shape_regressions()
+    check_named_rust_test_region_selftests()
     inventory = load_json(INVENTORY_PATH)
     if inventory.get("schema_version") != 1 or inventory.get("contract") != "rustbgpd-rs-rr-v1":
         fail("unexpected inventory schema or contract id")

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -158,6 +158,177 @@ fn v1_stable_v0_50_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.50.0 route-server config no longer validates: {err}"));
 }
 
+const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[peer_groups.context]
+families = ["ipv6_unicast"]
+hold_time = 300
+graceful_restart = false
+gr_restart_time = 0
+gr_stale_routes_time = 900
+llgr_stale_time = 1800
+disable_ipv4_unicast = true
+
+[peer_groups.override]
+families = ["ipv6_unicast"]
+hold_time = 300
+send_hold_time = 800
+graceful_restart = false
+gr_restart_time = 0
+gr_stale_routes_time = 900
+llgr_stale_time = 1800
+disable_ipv4_unicast = true
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65002
+
+[[neighbors]]
+address = "2001:db8::2"
+remote_asn = 65003
+peer_group = "context"
+
+[[neighbors]]
+address = "10.0.0.4"
+remote_asn = 65004
+peer_group = "override"
+families = ["ipv4_unicast"]
+hold_time = 45
+send_hold_time = 1000
+graceful_restart = true
+gr_restart_time = 240
+gr_stale_routes_time = 720
+llgr_stale_time = 60
+disable_ipv4_unicast = false
+"#;
+
+const V1_CLUSTER_ID_DEFAULTS_TOML: &str = r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+log_format = "json"
+
+[security.grpc]
+enforcement = "legacy"
+
+[peer_groups.rr]
+route_reflector_client = true
+
+[[neighbors]]
+address = "10.0.0.2"
+remote_asn = 65001
+peer_group = "rr"
+"#;
+
+#[test]
+fn v1_stable_effective_defaults_match_runtime_resolution() {
+    macro_rules! assert_v1_effective_default {
+        ($path:literal, $actual:expr, $expected:expr) => {
+            assert_eq!(
+                $actual, $expected,
+                "runtime effective default drifted for {}",
+                $path
+            );
+        };
+    }
+
+    let config =
+        parse_strict(V1_EFFECTIVE_DEFAULTS_TOML).expect("contextual-default fixture must load");
+    let bare = config
+        .resolve_neighbor(&config.neighbors[0])
+        .expect("bare neighbor must resolve");
+    let inherited = config
+        .resolve_neighbor(&config.neighbors[1])
+        .expect("peer-group neighbor must resolve");
+    let overridden = config
+        .resolve_neighbor(&config.neighbors[2])
+        .expect("direct-override neighbor must resolve");
+    let bare_peer = &bare.transport_config.peer;
+    let bare_transport = &bare.transport_config;
+    let cluster_id = config.cluster_id();
+    let disable_ipv4_unicast = bare_peer.disable_ipv4_unicast;
+    let gr_restart_time = bare_peer.gr_restart_time;
+    let gr_stale_routes_time = bare_transport.gr_stale_routes_time;
+    let graceful_restart = bare_peer.graceful_restart;
+    let hold_time = bare_peer.hold_time;
+    let llgr_stale_time = (bare_peer.llgr_stale_time, bare_transport.llgr_stale_time);
+    let send_hold_time = bare_peer.send_hold_time;
+
+    // Mutation-red: each full path is bound to its actual production-resolved
+    // value and an explicit expected value; deleting or weakening any row is red.
+    assert_v1_effective_default!("Global.cluster_id", cluster_id, None);
+    assert_v1_effective_default!("Neighbor.disable_ipv4_unicast", disable_ipv4_unicast, false);
+    assert_v1_effective_default!("Neighbor.gr_restart_time", gr_restart_time, 120);
+    assert_v1_effective_default!("Neighbor.gr_stale_routes_time", gr_stale_routes_time, 360);
+    assert_v1_effective_default!("Neighbor.graceful_restart", graceful_restart, true);
+    assert_v1_effective_default!("Neighbor.hold_time", hold_time, 90);
+    assert_v1_effective_default!("Neighbor.llgr_stale_time", llgr_stale_time, (0, 0));
+    assert_v1_effective_default!("Neighbor.send_hold_time", send_hold_time, 480);
+
+    let effective = |resolved: &ResolvedNeighbor| {
+        let transport = &resolved.transport_config;
+        (
+            transport.peer.hold_time,
+            transport.peer.send_hold_time,
+            transport.peer.graceful_restart,
+            transport.peer.gr_restart_time,
+            transport.gr_stale_routes_time,
+            (transport.peer.llgr_stale_time, transport.llgr_stale_time),
+            transport.peer.disable_ipv4_unicast,
+        )
+    };
+
+    // Mutation-red: removing peer-group fallback for any inventoried Neighbor
+    // field, or replacing derived send-hold max(480, 2 * 300) with 480, fails.
+    assert_eq!(
+        effective(&inherited),
+        (300, 600, false, 0, 900, (1800, 1800), true)
+    );
+    // Mutation-red: making peer-group values outrank any direct Neighbor
+    // override changes this tuple (and disable_ipv4_unicast may fail validation).
+    assert_eq!(
+        effective(&overridden),
+        (45, 1000, true, 240, 720, (60, 60), false)
+    );
+
+    let rr =
+        parse_strict(V1_CLUSTER_ID_DEFAULTS_TOML).expect("inherited RR-client fixture must load");
+    let explicit_rr_toml = V1_CLUSTER_ID_DEFAULTS_TOML.replace(
+        "listen_port = 179",
+        "listen_port = 179\ncluster_id = \"10.0.0.9\"",
+    );
+    let explicit_rr =
+        parse_strict(&explicit_rr_toml).expect("explicit cluster-id fixture must load");
+
+    // Mutation-red: unconditional router-id fallback, ignoring inherited RR
+    // status, or ignoring an explicit cluster_id changes this three-case tuple.
+    assert_eq!(
+        (
+            config.cluster_id(),
+            rr.cluster_id(),
+            explicit_rr.cluster_id()
+        ),
+        (
+            None,
+            Some(Ipv4Addr::new(10, 0, 0, 1)),
+            Some(Ipv4Addr::new(10, 0, 0, 9))
+        )
+    );
+}
+
 fn collect_example_toml_files(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in fs::read_dir(dir).unwrap_or_else(|err| {
         panic!("failed to read example directory {}: {err}", dir.display());


### PR DESCRIPTION
## Summary

Pins the eight contextual config defaults currently scoped by the v1 contract to their real runtime resolver behavior.

These values are inherited, derived, or conditional, so publishing static JSON Schema `default` annotations would misstate omission semantics. Instead, the stable-surface inventory links them to a real TOML parse/resolution test and the release checker verifies that the test remains live and load-bearing.

## Changes

- add an exact eight-field effective-default inventory to the v1 stable surface
- exercise omission, peer-group inheritance, direct override, derived send-hold, GR/LLGR, and conditional cluster-ID resolution
- reject missing, ignored, expected-panic, constantized, or vacuous contract assertions
- document why contextual defaults remain description-only in JSON Schema

## Load-bearing proof

The focused gates were mutation-tested and go red when:

- the scoped path set loses a field or gains an unrelated field
- the hold-time fallback changes from 90 to 91
- the transport-side LLGR fallback changes independently from 0 to 1
- an assertion row or its runtime extraction is deleted/constantized
- the assertion macro compares expected-to-expected or becomes a no-op
- the linked test is ignored, conditionally ignored, or marked expected-panic

## Testing

- [x] `python3 scripts/check-v1-stable-surface.py`
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] Relevant interop test intentionally not applicable (contract/test-only change)
- [x] Performance receipt intentionally not applicable

## Docs / release notes

- [x] CHANGELOG.md intentionally not needed (no runtime behavior change)
- [x] ROADMAP.md intentionally not needed
- [x] v1 stable-contract documentation updated
- [x] Hot tracking docs not touched

## Related issues

Completes the contextual effective-default integrity tranche tracked in the private backlog.
