### PR TITLE
fix(rib): enforce NO_ADVERTISE before outbound commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **RFC 1997 `NO_ADVERTISE` can no longer be bypassed or leaked by export
+  policy.** IPv4/IPv6 unicast checks both the stored source route before export
+  policy and the modified route after policy across grouped and private
+  single-best, Add-Path, RFC 7947 per-client-best, and RFC 9107 ORR. Policy
+  cannot remove the community to make a scoped route exportable, and a
+  policy-added community suppresses the resulting route before Adj-RIB-Out
+  commit. Scoped replacements withdraw existing state; candidate modes compact
+  surviving siblings, while ORR suppresses its selected winner without falling
+  back.
+  Terminal export explain reports suppression and, for a post-policy stop,
+  shows the triggering modification; Add-Path best-path explain mirrors the
+  compacted advertised ranks.
+
 ### Added
 
 - **Planned-restart markers resist wall-clock steps across a daemon restart on Linux.**

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -609,6 +609,16 @@ fn llgr_stale_export_suppressed(
         && (is_llgr_stale || communities.contains(&rustbgpd_wire::COMMUNITY_LLGR_STALE))
 }
 
+/// RFC 1997 well-known-community export restriction. `NO_ADVERTISE`
+/// means that a route "MUST NOT be advertised to any BGP peer", so the
+/// source route is ineligible before export policy can remove the community,
+/// and a modified route is ineligible when policy adds it. This predicate is
+/// deliberately target-independent: every unicast selection shape applies
+/// both checks.
+pub(super) fn no_advertise_export_suppressed(communities: &[u32]) -> bool {
+    communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+}
+
 /// RFC 9234 §5 egress rule for IPv4/IPv6 unicast: a route that already
 /// carries OTC must not be propagated toward a Provider, Peer, or Route
 /// Server. The local role names our side of those relationships.

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -47,7 +47,7 @@ fn orr_candidates<'a>(
 /// Candidate paths for `prefix` visible to `target_peer` in the live
 /// multipath / per-client-best collector: [`orr_candidates`]'
 /// split-horizon and RFC 4456 reflection filter plus the per-candidate
-/// RFC 9494 §4.4 LLGR export gate. Shared by
+/// RFC 1997 `NO_ADVERTISE` and RFC 9494 §4.4 LLGR export gates. Shared by
 /// `distribute_multipath_prefix` and the per-client-best explain arm so
 /// explain walks exactly the candidate set live staging walks.
 #[expect(
@@ -77,6 +77,12 @@ fn multipath_candidates<'a>(
         cluster_id,
     )
     .filter(move |route| {
+        // RFC 1997: NO_ADVERTISE is selection ineligibility, not a
+        // post-policy attribute rewrite. A permit policy that removes
+        // the community must not make the route exportable.
+        if super::no_advertise_export_suppressed(route.communities()) {
+            return false;
+        }
         // RFC 9494 §4.4: each staged candidate is gated individually —
         // a stale candidate must not occupy an Add-Path rank (or the
         // filtered-best slot) toward a non-LLGR eBGP peer.
@@ -99,10 +105,11 @@ impl RibManager {
     /// the Loc-RIB best / their staging is multipath). Candidate
     /// collection is shared with live distribution (`orr_candidates` /
     /// `multipath_candidates`), and every gate reuses the same helper
-    /// the live bodies call (`llgr_stale_export_suppressed`,
-    /// `OrfFilterSet::permits`, `rr_suppression_reason`,
-    /// `routes_equal`), in the live bodies' evaluation order (family →
-    /// ORF → selection → LLGR → policy → Adj-RIB-Out diff).
+    /// the live bodies call (`no_advertise_export_suppressed`,
+    /// `llgr_stale_export_suppressed`, `OrfFilterSet::permits`,
+    /// `rr_suppression_reason`, `routes_equal`), in the live bodies'
+    /// evaluation order (family → ORF → selection → LLGR /
+    /// `NO_ADVERTISE` → policy → Adj-RIB-Out diff).
     ///
     /// `per_client_best` selects the RFC 7947 §2.3.2 arm: rank the live
     /// collector's candidate set with the Loc-RIB comparator and take
@@ -363,8 +370,8 @@ impl RibManager {
             ranked.sort_by(|a, b| crate::best_path::best_path_cmp(a, b));
             if ranked.is_empty() {
                 let message = "no candidate for this prefix survives split-horizon / \
-                               reflection / LLGR filtering for this per-client best-path \
-                               peer"
+                               reflection / NO_ADVERTISE / LLGR filtering for this per-client \
+                               best-path peer"
                     .to_string();
                 gate(
                     &mut explain.gates,
@@ -382,6 +389,8 @@ impl RibManager {
             let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
             let total = ranked.len();
             let mut winner = None;
+            let mut policy_memo = super::ExportMemo::default();
+            let mut first_no_advertise_suppression = None;
             for (index, &candidate) in ranked.iter().enumerate() {
                 // Per-candidate export-policy verdict — the same
                 // context the live per-candidate walk builds, evaluated
@@ -421,7 +430,32 @@ impl RibManager {
                     Some(chain) => {
                         let (result, evaluation) = chain.compiled().evaluate_with_attribution(&ctx);
                         if result.action == PolicyAction::Permit {
-                            true
+                            let (modified, _) = policy_memo.apply(candidate, &result.modifications);
+                            if super::no_advertise_export_suppressed(modified.communities()) {
+                                let label = super::policy_label_with_term(
+                                    export_pol,
+                                    &ctx,
+                                    evaluation.matched_policy.as_deref(),
+                                );
+                                if first_no_advertise_suppression.is_none() {
+                                    first_no_advertise_suppression =
+                                        Some((result.modifications.clone(), label.clone()));
+                                }
+                                explain.reasons.push(ExplainReason {
+                                    code: "per_client_candidate_no_advertise",
+                                    message: format!(
+                                        "candidate {rank} of {total} (from {peer}, next hop \
+                                         {next_hop}) suppressed after export policy {label:?} \
+                                         added NO_ADVERTISE",
+                                        rank = index + 1,
+                                        peer = candidate.peer,
+                                        next_hop = candidate.next_hop,
+                                    ),
+                                });
+                                false
+                            } else {
+                                true
+                            }
                         } else {
                             let label = super::policy_label_with_term(
                                 export_pol,
@@ -448,11 +482,40 @@ impl RibManager {
                     break;
                 }
             }
+            if winner.is_none()
+                && let Some((modifications, label)) = first_no_advertise_suppression
+            {
+                explain.decision = ExplainDecision::Deny;
+                explain.modifications = modifications;
+                gate(
+                    &mut explain.gates,
+                    "export_policy",
+                    "policy_permitted",
+                    Pass,
+                    format!("export policy {label:?} permitted a ranked candidate"),
+                );
+                let message = "no candidate is exportable; at least one export-policy Permit \
+                               result carried NO_ADVERTISE, which RFC 1997 forbids advertising \
+                               to any BGP peer"
+                    .to_string();
+                gate(
+                    &mut explain.gates,
+                    "no_advertise",
+                    "no_advertise_policy_suppressed",
+                    Stop,
+                    message.clone(),
+                );
+                explain.reasons.push(ExplainReason {
+                    code: "no_advertise_policy_suppressed",
+                    message,
+                });
+                return explain;
+            }
             let Some((rank, winner)) = winner else {
                 explain.decision = ExplainDecision::Deny;
                 let message = format!(
-                    "all {total} candidate(s) denied by export policy — per-client \
-                     best-path (RFC 7947 §2.3.2) advertises nothing"
+                    "all {total} candidate(s) denied by export policy — per-client best-path \
+                     (RFC 7947 §2.3.2) advertises nothing"
                 );
                 gate(
                     &mut explain.gates,
@@ -611,6 +674,27 @@ impl RibManager {
             "route is not suppressed by the RFC 9494 LLGR export restriction".to_string(),
         );
 
+        // RFC 1997 — a route carrying NO_ADVERTISE is ineligible before
+        // export policy, so a permit policy cannot remove the community
+        // and bypass the well-known-community restriction.
+        if super::no_advertise_export_suppressed(best.communities()) {
+            explain.decision = ExplainDecision::Deny;
+            let message = "route carries NO_ADVERTISE and RFC 1997 forbids advertisement to any \
+                           BGP peer"
+                .to_string();
+            gate(
+                &mut explain.gates,
+                "no_advertise",
+                "no_advertise_suppressed",
+                Stop,
+                message.clone(),
+            );
+            explain.reasons.push(ExplainReason {
+                code: "no_advertise_suppressed",
+                message,
+            });
+            return explain;
+        }
         let aspath_str = if export_pol.is_some_and(PolicyChain::requires_as_path_string) {
             best.as_path()
                 .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
@@ -695,9 +779,27 @@ impl RibManager {
         }
 
         explain.modifications = result.modifications.clone();
-        let mut otc_memo = super::ExportMemo::default();
-        let (otc_candidate, _) = otc_memo.apply(best, &result.modifications);
-        if super::otc_egress_blocked(&otc_candidate, target_local_role) {
+        let mut post_policy_memo = super::ExportMemo::default();
+        let (post_policy_candidate, _) = post_policy_memo.apply(best, &result.modifications);
+        if super::no_advertise_export_suppressed(post_policy_candidate.communities()) {
+            explain.decision = ExplainDecision::Deny;
+            let message = "export policy produced a route carrying NO_ADVERTISE; RFC 1997 \
+                           forbids advertisement to any BGP peer"
+                .to_string();
+            gate(
+                &mut explain.gates,
+                "no_advertise",
+                "no_advertise_policy_suppressed",
+                Stop,
+                message.clone(),
+            );
+            explain.reasons.push(ExplainReason {
+                code: "no_advertise_policy_suppressed",
+                message,
+            });
+            return explain;
+        }
+        if super::otc_egress_blocked(&post_policy_candidate, target_local_role) {
             explain.decision = ExplainDecision::Deny;
             let message = "route already carries Only-To-Customer and RFC 9234 forbids propagation toward this Provider, Peer, or Route Server".to_string();
             gate(
@@ -1168,6 +1270,9 @@ impl RibManager {
             // post-modification attribute Arc across every (route, peer)
             // with the same source attrs and equal modifications.
             let (mut modified, nh_action) = memo.apply(candidate, &result.modifications);
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                continue;
+            }
             modified.path_id = if stage_path_id_zero { 0 } else { next_rank };
 
             // Only announce if different from what's already in AdjRibOut.
@@ -1381,6 +1486,20 @@ impl RibManager {
             });
         }
 
+        // RFC 1997: NO_ADVERTISE is a pre-policy export restriction.
+        // The group and private single-best paths share this body, so
+        // both withdraw existing state before a policy can remove it.
+        if super::no_advertise_export_suppressed(best.communities()) {
+            target.gate("no_advertise", "no_advertise_suppressed", Stop, || {
+                "route carries NO_ADVERTISE and RFC 1997 forbids advertisement to any BGP \
+                     peer"
+                    .to_string()
+            });
+            for &path_id in &existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
         // Export policy check. Group staging passes no peer-context
         // fields: a chain that reads them disqualifies its peers from
         // grouping (`requires_peer_context`), so the verdict here is
@@ -1473,6 +1592,26 @@ impl RibManager {
         // source Arc as before.
         let (mut modified, nh_action) = memo.apply(best, &result.modifications);
         modified.path_id = 0;
+
+        // Export policy may add NO_ADVERTISE to an otherwise eligible
+        // route. Enforce the resulting RFC 1997 state before committing
+        // grouped or private Adj-RIB-Out state.
+        if super::no_advertise_export_suppressed(modified.communities()) {
+            target.gate(
+                "no_advertise",
+                "no_advertise_policy_suppressed",
+                Stop,
+                || {
+                    "export policy produced a route carrying NO_ADVERTISE; RFC 1997 forbids \
+                     advertisement to any BGP peer"
+                        .to_string()
+                },
+            );
+            for &path_id in &existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
 
         // RFC 9234 §5 egress enforcement belongs before the advertised-state
         // diff. Group staging and explain carry their group-uniform/local
@@ -1683,6 +1822,16 @@ impl RibManager {
             return;
         }
 
+        // RFC 1997: select the per-vantage winner first, then suppress
+        // that winner before policy. ORR does not fall back to its
+        // runner-up merely because the selected best is NO_ADVERTISE.
+        if super::no_advertise_export_suppressed(best.communities()) {
+            for &path_id in &existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
+
         // Export policy check — same tail as `distribute_single_best_prefix`.
         let aspath_str = export_pol
             .is_some_and(PolicyChain::requires_as_path_string)
@@ -1734,6 +1883,13 @@ impl RibManager {
         // independent of which candidate won.
         let (mut modified, nh_action) = memo.apply(best, &result.modifications);
         modified.path_id = 0;
+
+        if super::no_advertise_export_suppressed(modified.communities()) {
+            for &path_id in &existing_path_ids {
+                withdraw.push((*prefix, path_id));
+            }
+            return;
+        }
 
         // `force` semantics as in `distribute_single_best_prefix`.
         let changed = force

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2844,9 +2844,10 @@ impl RibManager {
         // each candidate can be tagged with its `advertised_path_id`.
         // The selection mirrors `distribute_multipath_prefix` exactly:
         // family check → split-horizon → iBGP/RR suppression → export
-        // policy → top-N by best-path. Mirroring the contract is
-        // deliberate — operators trust explain only if it produces
-        // the same selection that distribution would, modulo state
+        // eligibility (including source `NO_ADVERTISE`) → export policy →
+        // modified-route `NO_ADVERTISE` → top-N by best-path. Mirroring the
+        // contract is deliberate — operators trust explain only if it
+        // produces the same selection that distribution would, modulo state
         // changes between the two calls.
         let mut advertised: Vec<(IpAddr, u32, u32)> = Vec::new();
         let mut add_path_send_max: u32 = 0;
@@ -2925,6 +2926,7 @@ impl RibManager {
                 let needs_as_path_string =
                     export_pol.is_some_and(PolicyChain::requires_as_path_string);
                 let mut next_rank: u32 = 1;
+                let mut export_memo = distribution::ExportMemo::default();
                 for cand in &filtered {
                     if (next_rank as usize) > limit {
                         break;
@@ -2958,7 +2960,15 @@ impl RibManager {
                         local_pref: cand.local_pref_attr(),
                         med: cand.med_attr(),
                     };
-                    if evaluate_chain(export_pol, &ctx).action != PolicyAction::Permit {
+                    if distribution::no_advertise_export_suppressed(cand.communities()) {
+                        continue;
+                    }
+                    let result = evaluate_chain(export_pol, &ctx);
+                    if result.action != PolicyAction::Permit {
+                        continue;
+                    }
+                    let (modified, _) = export_memo.apply(cand, &result.modifications);
+                    if distribution::no_advertise_export_suppressed(modified.communities()) {
                         continue;
                     }
                     let outbound_rank = next_rank;

--- a/crates/rib/src/manager/tests/multipath_fib.rs
+++ b/crates/rib/src/manager/tests/multipath_fib.rs
@@ -122,6 +122,172 @@ async fn multipath_send_advertises_multiple_routes() {
     handle.await.unwrap();
 }
 
+/// `NO_ADVERTISE` removes one Add-Path candidate before ranking and
+/// export policy. The remaining sibling compacts to rank/path-id 1;
+/// the old rank 2 is withdrawn even when policy would remove the
+/// well-known community and permit the scoped route.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario proves live and explain rank parity before and after policy"
+)]
+#[tokio::test]
+async fn no_advertise_candidate_is_removed_before_add_path_rank_compaction() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source_a = Ipv4Addr::new(10, 0, 1, 1);
+    let source_b = Ipv4Addr::new(10, 0, 1, 2);
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 3));
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+
+    for (source, local_pref) in [(source_a, 200), (source_b, 100)] {
+        tx.send(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(source),
+            announced: vec![make_multipath_route(
+                prefix,
+                source,
+                vec![u32::from(source.octets()[3]) + 65000],
+                local_pref,
+            )],
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: ipv4_sendable(),
+        add_path_send_max: 2,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    let initial = out_rx.recv().await.unwrap();
+    assert_eq!(initial.announce.len(), 2);
+    assert_eq!(
+        initial
+            .announce
+            .iter()
+            .find(|route| route.path_id == 1)
+            .unwrap()
+            .peer,
+        IpAddr::V4(source_a)
+    );
+    drain_eor(&mut out_rx).await;
+
+    let scoped =
+        super::unicast::with_no_advertise(make_multipath_route(prefix, source_a, vec![65001], 200));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source_a),
+        announced: vec![scoped],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+
+    let update = out_rx
+        .try_recv()
+        .expect("rank compaction emitted after query synchronization");
+    assert_eq!(update.announce.len(), 1);
+    assert_eq!(update.announce[0].peer, IpAddr::V4(source_b));
+    assert_eq!(update.announce[0].path_id, 1);
+    assert_eq!(update.withdraw, vec![(Prefix::V4(prefix), 2)]);
+    assert!(
+        out_rx.try_recv().is_err(),
+        "one compact delta is sufficient"
+    );
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: target,
+        reply,
+    })
+    .await
+    .unwrap();
+    let advertised = response.await.unwrap();
+    assert_eq!(advertised.len(), 1);
+    assert_eq!(advertised[0].peer, IpAddr::V4(source_b));
+    assert_eq!(advertised[0].path_id, 1);
+
+    let explain = query_explain_best_path_for_peer(&tx, Prefix::V4(prefix), target)
+        .await
+        .expect("known Add-Path peer");
+    let sibling = explain
+        .candidates
+        .iter()
+        .find(|candidate| candidate.route.peer == IpAddr::V4(source_b))
+        .expect("runner-up is present in best-path explain");
+    assert_eq!(
+        sibling.advertised_path_id, 1,
+        "ExplainBestPath applies pre-policy NO_ADVERTISE before rank assignment"
+    );
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_addition_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.await.unwrap(), Ok(()));
+    let _ = query_best_routes(&tx).await;
+
+    let update = out_rx
+        .try_recv()
+        .expect("policy-added NO_ADVERTISE withdraws the remaining rank");
+    assert!(update.announce.is_empty());
+    assert_eq!(update.withdraw, vec![(Prefix::V4(prefix), 1)]);
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: target,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.unwrap().is_empty());
+
+    let explain = query_explain_best_path_for_peer(&tx, Prefix::V4(prefix), target)
+        .await
+        .expect("known Add-Path peer");
+    let sibling = explain
+        .candidates
+        .iter()
+        .find(|candidate| candidate.route.peer == IpAddr::V4(source_b))
+        .expect("runner-up is present in best-path explain");
+    assert_eq!(
+        sibling.advertised_path_id, 0,
+        "ExplainBestPath skips post-policy NO_ADVERTISE before rank assignment"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn multipath_send_respects_send_max() {
     let (tx, rx) = mpsc::channel(64);

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -1011,6 +1011,147 @@ async fn explain_advertised_route_reports_orr_vantage_and_costs() {
     handle.await.unwrap();
 }
 
+/// ORR selects the per-vantage winner before applying RFC 1997. If that
+/// winner becomes `NO_ADVERTISE`, it is withdrawn without falling back
+/// to the runner-up; export explain names the same pre-policy stop even
+/// when policy would remove the community and permit the route.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario proves ORR winner suppression before and after export policy"
+)]
+#[tokio::test]
+async fn no_advertise_orr_winner_is_withdrawn_without_runner_up_fallback() {
+    let (tx, handle) = orr_rr_manager().await;
+    let client_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 33));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: client_b,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: Some(vantage_at_node_b()),
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    announce_divergent_bests(&tx).await;
+    let initial = drain_final_unicast(&mut out_rx);
+    assert_eq!(
+        initial.get(&orr_prefix_key()).map(|route| route.next_hop),
+        Some(orr_nh_y()),
+        "vantage B initially selects the Y exit"
+    );
+
+    let scoped_winner =
+        super::unicast::with_no_advertise(ibgp_route(orr_prefix(), ORR_SRC_Y, orr_nh_y()));
+    announce_unicast(&tx, ORR_SRC_Y, vec![scoped_winner]).await;
+    let _ = query_best_routes(&tx).await;
+
+    let update = out_rx
+        .try_recv()
+        .expect("ORR withdrawal emitted after query synchronization");
+    assert!(
+        update.announce.is_empty(),
+        "ORR must not fall back to the X runner-up"
+    );
+    assert_eq!(update.withdraw, vec![orr_prefix_key()]);
+    assert!(out_rx.try_recv().is_err());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: client_b,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.unwrap().is_empty());
+
+    let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    assert_eq!(explain.orr_vantage, Some(vantage_at_node_b()));
+    assert_eq!(explain.orr_candidates.len(), 2);
+    assert!(explain.orr_candidates[0].selected);
+    assert_eq!(explain.orr_candidates[0].next_hop, orr_nh_y());
+    let stop = explain
+        .gates
+        .iter()
+        .find(|step| step.verdict == crate::update::ExportGateVerdict::Stop)
+        .unwrap();
+    assert_eq!(
+        (stop.gate, stop.code),
+        ("no_advertise", "no_advertise_suppressed")
+    );
+    assert!(
+        explain.modifications.communities_remove.is_empty(),
+        "explain must stop before applying the configured removal"
+    );
+
+    announce_unicast(
+        &tx,
+        ORR_SRC_Y,
+        vec![ibgp_route(orr_prefix(), ORR_SRC_Y, orr_nh_y())],
+    )
+    .await;
+    let _ = query_best_routes(&tx).await;
+    let update = out_rx
+        .try_recv()
+        .expect("plain ORR winner is restored before policy replacement");
+    assert_eq!(update.announce.len(), 1);
+    assert_eq!(update.announce[0].next_hop, orr_nh_y());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: client_b,
+        export_policy: Some(super::unicast::no_advertise_addition_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.await.unwrap(), Ok(()));
+    let _ = query_best_routes(&tx).await;
+    let update = out_rx
+        .try_recv()
+        .expect("policy-added NO_ADVERTISE withdraws the ORR winner");
+    assert!(update.announce.is_empty());
+    assert_eq!(update.withdraw, vec![orr_prefix_key()]);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: client_b,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.unwrap().is_empty());
+
+    let explain = query_explain_advertised_route(&tx, client_b, Prefix::V4(orr_prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    assert_eq!(
+        explain.gates.last().map(|step| (step.gate, step.code)),
+        Some(("no_advertise", "no_advertise_policy_suppressed"))
+    );
+    assert!(
+        explain
+            .modifications
+            .communities_add
+            .contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Regression: a peer with NO ORR vantage gets the pre-ORR explain
 /// shape in the same scenario — Loc-RIB best, no vantage, no candidate
 /// list, no ORR reason codes.

--- a/crates/rib/src/manager/tests/per_client_best.rs
+++ b/crates/rib/src/manager/tests/per_client_best.rs
@@ -212,6 +212,120 @@ async fn best_denied_single_best_hides_per_client_best_sends_runner_up() {
     handle.await.unwrap();
 }
 
+/// A per-client-best target treats `NO_ADVERTISE` as candidate
+/// ineligibility before policy. When the current winner becomes scoped,
+/// the next permitted candidate replaces it at path-id 0 without a
+/// withdraw/announce gap, even if policy would remove the community.
+#[tokio::test]
+async fn no_advertise_winner_is_replaced_by_per_client_runner_up_before_policy() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let initial_best = ebgp_route(prefix(), SOURCE_A, vec![65001], vec![]);
+    announce_from(&tx, SOURCE_A, vec![initial_best]).await;
+    announce_from(&tx, SOURCE_B, vec![runner_up_route()]).await;
+    sync(&tx).await;
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 40));
+    let mut out_rx = client_peer_up(
+        &tx,
+        target,
+        Some(super::unicast::no_advertise_removal_chain(false)),
+        true,
+    )
+    .await;
+    let initial = out_rx.recv().await.unwrap();
+    assert_eq!(initial.announce.len(), 1);
+    assert_eq!(initial.announce[0].peer, IpAddr::V4(SOURCE_A));
+    assert_eq!(initial.announce[0].path_id, 0);
+    drain_eor(&mut out_rx).await;
+
+    announce_from(
+        &tx,
+        SOURCE_A,
+        vec![ebgp_route(
+            prefix(),
+            SOURCE_A,
+            vec![65001],
+            vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE],
+        )],
+    )
+    .await;
+    sync(&tx).await;
+
+    let replacement = out_rx
+        .try_recv()
+        .expect("runner-up replacement emitted after query synchronization");
+    assert_eq!(replacement.announce.len(), 1);
+    assert_eq!(replacement.announce[0].peer, IpAddr::V4(SOURCE_B));
+    assert_eq!(replacement.announce[0].path_id, 0);
+    assert!(
+        replacement.withdraw.is_empty(),
+        "path-id 0 replacement is an implicit withdraw"
+    );
+    assert!(out_rx.try_recv().is_err());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: target,
+        reply,
+    })
+    .await
+    .unwrap();
+    let advertised = response.await.unwrap();
+    assert_eq!(advertised.len(), 1);
+    assert_eq!(advertised[0].peer, IpAddr::V4(SOURCE_B));
+    assert_eq!(advertised[0].path_id, 0);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_addition_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.await.unwrap(), Ok(()));
+    sync(&tx).await;
+
+    let update = out_rx
+        .try_recv()
+        .expect("policy-added NO_ADVERTISE withdraws the per-client winner");
+    assert!(update.announce.is_empty());
+    assert_eq!(update.withdraw, vec![(Prefix::V4(prefix()), 0)]);
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryAdvertisedRoutes {
+        peer: target,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(response.await.unwrap().is_empty());
+
+    let explain = query_explain_advertised_route(&tx, target, Prefix::V4(prefix())).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    assert_eq!(
+        explain.gates.last().map(|step| (step.gate, step.code)),
+        Some(("no_advertise", "no_advertise_policy_suppressed"))
+    );
+    assert!(
+        explain
+            .modifications
+            .communities_add
+            .contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+    );
+    assert!(
+        explain
+            .reasons
+            .iter()
+            .any(|reason| reason.code == "per_client_candidate_no_advertise")
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
 /// Split horizon inside the collector: the member sourcing the Loc-RIB
 /// best receives the runner-up (its own path is excluded from its
 /// candidate set), where single-best would have sent nothing.

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -1,4 +1,64 @@
 use super::*;
+use rustbgpd_policy::{
+    NeighborSetMatch, Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications,
+};
+
+fn no_advertise_chain(peer_context: bool, add: bool) -> PolicyChain {
+    let statement = PolicyStatement {
+        prefix: None,
+        ge: None,
+        le: None,
+        action: PolicyAction::Permit,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: peer_context.then_some(NeighborSetMatch {
+            addresses: vec![],
+            remote_asns: vec![65100],
+            peer_groups: vec![],
+        }),
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications {
+            communities_add: add
+                .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                .into_iter()
+                .collect(),
+            communities_remove: (!add)
+                .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                .into_iter()
+                .collect(),
+            ..RouteModifications::default()
+        },
+    };
+    PolicyChain::new(vec![Policy {
+        entries: vec![statement],
+        default_action: PolicyAction::Deny,
+    }])
+}
+
+pub(super) fn no_advertise_removal_chain(peer_context: bool) -> PolicyChain {
+    no_advertise_chain(peer_context, false)
+}
+
+pub(super) fn no_advertise_addition_chain(peer_context: bool) -> PolicyChain {
+    no_advertise_chain(peer_context, true)
+}
+
+pub(super) fn with_no_advertise(mut route: Route) -> Route {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ]));
+    route
+}
 
 fn with_otc(mut route: Route, asn: u32) -> Route {
     Arc::make_mut(&mut route.attributes).push(PathAttribute::OnlyToCustomer(asn));
@@ -18,6 +78,199 @@ fn drain_unicast_state(
         }
     }
     state
+}
+
+/// A grouped and a genuinely private single-best target must both apply
+/// RFC 1997 before a permit policy that removes `NO_ADVERTISE`. Replacing
+/// an advertised route with the scoped form withdraws it, clears logical
+/// advertised state, and explains the same pre-policy stop on both paths.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario proves grouped/private staging, policy order, withdrawal, state, and explain parity"
+)]
+async fn no_advertise_precedes_policy_for_grouped_and_private_single_best() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let grouped_a: IpAddr = "192.0.2.30".parse().unwrap();
+    let grouped_b: IpAddr = "192.0.2.31".parse().unwrap();
+    let private: IpAddr = "192.0.2.32".parse().unwrap();
+    let mut receivers = Vec::new();
+
+    for (peer, peer_context) in [(grouped_a, false), (grouped_b, false), (private, true)] {
+        let (out_tx, mut out_rx) = mpsc::channel(16);
+        tx.send(RibUpdate::PeerUp {
+            peer,
+            session_id: 0,
+            peer_asn: 65100,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: Some(no_advertise_removal_chain(peer_context)),
+            sendable_families: ipv4_sendable(),
+            is_ebgp: true,
+            route_reflector_client: false,
+            orr_vantage: None,
+            per_client_best: false,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: vec![],
+            negotiated_llgr_families: vec![],
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+        receivers.push((peer, out_rx));
+    }
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 115, 0), 24);
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10));
+    let plain = make_route(prefix, Ipv4Addr::new(198, 51, 100, 10));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![plain.clone()],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    for (_, out_rx) in &mut receivers {
+        let update = out_rx.try_recv().expect("plain route announced after sync");
+        assert_eq!(update.announce.len(), 1);
+        assert!(update.withdraw.is_empty());
+    }
+
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![with_no_advertise(plain.clone())],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    for (peer, out_rx) in &mut receivers {
+        let update = out_rx
+            .try_recv()
+            .expect("NO_ADVERTISE replacement withdrawn after sync");
+        assert!(
+            update.announce.is_empty(),
+            "{peer} must not receive the route"
+        );
+        assert_eq!(update.withdraw, vec![(Prefix::V4(prefix), 0)]);
+
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::QueryAdvertisedRoutes { peer: *peer, reply })
+            .await
+            .unwrap();
+        assert!(response.await.unwrap().is_empty());
+
+        let explain = query_explain_advertised_route(&tx, *peer, Prefix::V4(prefix)).await;
+        assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+        assert_eq!(
+            explain.update_group_id.is_some(),
+            *peer != private,
+            "group membership must distinguish shared from private staging"
+        );
+        let stop = explain
+            .gates
+            .iter()
+            .find(|step| step.verdict == crate::update::ExportGateVerdict::Stop)
+            .unwrap();
+        assert_eq!(
+            (stop.gate, stop.code),
+            ("no_advertise", "no_advertise_suppressed")
+        );
+        assert!(
+            explain.modifications.communities_remove.is_empty(),
+            "the pre-policy stop must occur before the configured removal"
+        );
+    }
+
+    // Restore a plain source route under the removal policy, then replace
+    // each target's policy with one that adds NO_ADVERTISE. The post-policy
+    // guard must withdraw the route on both staging shapes.
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![plain],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    for (_, out_rx) in &mut receivers {
+        let update = out_rx
+            .try_recv()
+            .expect("plain replacement announced after query synchronization");
+        assert_eq!(update.announce.len(), 1);
+    }
+
+    for (peer, _) in &receivers {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: *peer,
+            export_policy: Some(no_advertise_addition_chain(*peer == private)),
+            reply,
+        })
+        .await
+        .unwrap();
+        assert_eq!(response.await.unwrap(), Ok(()));
+    }
+    let _ = query_best_routes(&tx).await;
+
+    for (peer, out_rx) in &mut receivers {
+        let mut saw_withdraw = false;
+        while let Ok(update) = out_rx.try_recv() {
+            assert!(
+                update.announce.is_empty(),
+                "policy-added NO_ADVERTISE must not be announced to {peer}"
+            );
+            saw_withdraw |= update.withdraw.contains(&(Prefix::V4(prefix), 0));
+        }
+        assert!(saw_withdraw, "policy replacement must withdraw from {peer}");
+
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::QueryAdvertisedRoutes { peer: *peer, reply })
+            .await
+            .unwrap();
+        assert!(response.await.unwrap().is_empty());
+
+        let explain = query_explain_advertised_route(&tx, *peer, Prefix::V4(prefix)).await;
+        assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+        assert_eq!(
+            explain.update_group_id.is_some(),
+            *peer != private,
+            "replacement keeps grouped/private staging distinction"
+        );
+        assert_eq!(
+            explain.gates.last().map(|step| (step.gate, step.code)),
+            Some(("no_advertise", "no_advertise_policy_suppressed"))
+        );
+        assert!(
+            explain
+                .modifications
+                .communities_add
+                .contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE),
+            "explain shows the policy modification that triggered suppression"
+        );
+    }
+
+    drop(tx);
+    handle.await.unwrap();
 }
 
 #[tokio::test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -267,8 +267,11 @@ RFC 7999 deliberately requires an explicit operator directive before a router
 discards traffic for tagged prefixes. This knob is that directive for the
 control-plane scoping behavior rustbgpd can enforce today: it preserves the
 `BLACKHOLE` marker and adds `NO_ADVERTISE` at the chain tail so a blackhole
-request is not propagated to other peers unless the operator writes a more
-specific policy. Earlier operator denies still short-circuit normally.
+request is not propagated to other peers. RFC 1997 egress enforcement happens
+before export policy, so `set_community_remove = ["NO_ADVERTISE"]` cannot make
+the scoped route exportable. The post-policy result is checked as well, so a
+policy that adds `NO_ADVERTISE` suppresses the modified route instead of
+advertising it. Earlier operator denies still short-circuit normally.
 
 By default this does **not** install a kernel discard/null route. To turn
 local RTBH enforcement on, set both:

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
 | VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |
@@ -29,6 +29,25 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Liveness | RFC 5880/5881/5882 (BFD), RFC 9687 (Send Hold Timer) | Single-hop async BFD for static neighbors |
 | Maintenance | RFC 8326 (Graceful Shutdown), RFC 8203 (Admin Shutdown Communication) | Receiver gating + initiator toggle |
 | Monitoring | RFC 7854/8671/9069 (BMP trio), RFC 6396 (MRT TABLE_DUMP_V2), RFC 7951 (gNMI/OpenConfig JSON) | Pre-policy / post-policy / Loc-RIB BMP views |
+
+---
+
+## RFC 1997 — NO_ADVERTISE export restriction
+
+- IPv4/IPv6 unicast routes carrying `NO_ADVERTISE` are ineligible before
+  export policy, and the post-policy route is checked again before Adj-RIB-Out
+  commit. A permit policy cannot remove the community to bypass the
+  restriction; a policy that adds it suppresses the modified route.
+- The same predicate covers grouped and private single-best, Add-Path,
+  RFC 7947 per-client-best, and RFC 9107 ORR. Existing advertisements are
+  withdrawn and logical Adj-RIB-Out state is cleared.
+- Add-Path and per-client-best remove scoped candidates before ranking, so
+  surviving siblings compact normally. They also skip policy-modified
+  candidates whose result carries `NO_ADVERTISE`. ORR first selects its
+  per-vantage best and suppresses that winner without falling back to a
+  different route, whether the community arrived on the source or from policy.
+- This enforcement is currently scoped to IPv4/IPv6 unicast. Other route
+  families retain their existing policy behavior.
 
 ---
 

--- a/docs/adr/0060-rfc-7999-blackhole.md
+++ b/docs/adr/0060-rfc-7999-blackhole.md
@@ -51,10 +51,21 @@ allows explicit operator import policy to reject unsafe prefixes first
 and still lets the implicit rule add the scoping community to accepted
 routes.
 
-The rule is EBGP-only. iBGP propagation inside the local AS should carry
-the already-scoped route; reapplying the receiver rule at every iBGP hop
-would make local route-server and route-reflector behavior harder to
-reason about.
+RFC 1997 `NO_ADVERTISE` is enforced as pre-export-policy route
+ineligibility for IPv4/IPv6 unicast. Grouped and private single-best,
+Add-Path, per-client-best, and ORR therefore cannot be made to propagate
+the scoped route by an export policy that removes the community. The
+post-policy result is checked again before Adj-RIB-Out commit, so a policy
+that adds `NO_ADVERTISE` suppresses rather than leaks the modified route.
+A route that becomes scoped is withdrawn from any existing Adj-RIB-Out
+state; ORR suppresses its selected per-vantage winner rather than
+substituting a runner-up, while Add-Path and per-client-best filter
+individual candidates before ranking and after policy modification.
+
+Automatic insertion of the RFC 7999 receiver rule is EBGP-only; it is not
+reapplied on iBGP ingress. That boundary does not permit onward iBGP
+propagation: the independent RFC 1997 egress rule above suppresses an
+already-scoped unicast route toward every BGP peer.
 
 ### 4. SIGHUP hot-applies the policy-only knob
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -819,9 +819,10 @@ impl Config {
     /// RFC 7999 leaves honoring semantics to explicit operator policy. This
     /// built-in receiver rule does the safe control-plane half only: it keeps
     /// the `BLACKHOLE` marker present even if an earlier policy tried to
-    /// remove it, and adds `NO_ADVERTISE` so the request stays local unless an
-    /// operator deliberately writes a different policy. Kernel discard route
-    /// installation is a separate `install_blackhole_discard` opt-in.
+    /// remove it, and adds `NO_ADVERTISE` so the request stays local. RFC 1997
+    /// egress enforcement runs before export policy, so a policy cannot make
+    /// the scoped route exportable by removing `NO_ADVERTISE`. Kernel discard
+    /// route installation is a separate `install_blackhole_discard` opt-in.
     fn build_implicit_blackhole_policy() -> Policy {
         Policy {
             entries: vec![PolicyStatement {


### PR DESCRIPTION
## Summary

- enforce RFC 1997 `NO_ADVERTISE` before export policy can remove it and again after policy can add it
- cover grouped and private single-best, Add-Path, per-client-best, ORR, export explain, and Add-Path best-path rank reconstruction
- withdraw stale Adj-RIB-Out state while preserving each mode's existing selection semantics
- document the unicast scope and the distinction between EBGP-only BLACKHOLE receiver-rule insertion and all-peer egress enforcement

## Why

`honor_blackhole` scopes accepted BLACKHOLE routes with `NO_ADVERTISE`, but the outbound distribution paths did not enforce that well-known community. A route could therefore be propagated after an export policy removed the marker, while a policy-added marker could still be committed to Adj-RIB-Out.

RFC 1997 requires a route carrying `NO_ADVERTISE` not to be advertised to any BGP peer. The restriction is target-independent and belongs before outbound state commit.

## Behavior

- grouped/private single-best withdraw an existing route when the source or policy result carries `NO_ADVERTISE`
- Add-Path removes ineligible candidates before ranking and compacts surviving path IDs
- per-client-best replaces an ineligible winner with the next eligible candidate
- ORR suppresses its selected per-vantage winner without introducing a new runner-up fallback
- explain surfaces mirror the live source and post-policy checks

The change is deliberately limited to IPv4/IPv6 unicast. It does not add configuration, alter BLACKHOLE import policy, or change other address-family behavior.

## Load-bearing regression proof

Each scenario was run after literal removal of the production logic it guards and observed red, then restored and rerun green:

- `no_advertise_precedes_policy_for_grouped_and_private_single_best` fails if either the shared source pre-policy stop or post-policy stop is removed: the scoped replacement is announced/retained instead of withdrawn, or explain applies the removal policy
- `no_advertise_candidate_is_removed_before_add_path_rank_compaction` fails if source/post-policy candidate filtering or ExplainBestPath rank filtering is removed: the scoped path occupies an advertised rank or the remaining sibling does not compact to path ID 1
- `no_advertise_winner_is_replaced_by_per_client_runner_up_before_policy` fails if candidate ineligibility, post-policy suppression, or explain parity is removed: the scoped winner remains, the runner-up is not selected, or policy-added suppression is not reported
- `no_advertise_orr_winner_is_withdrawn_without_runner_up_fallback` fails if either ORR live guard or its dedicated explain guard is removed: the selected scoped winner remains advertised or explain diverges from the live withdrawal

## Validation

- `cargo test -p rustbgpd-rib no_advertise -- --nocapture`
- `cargo fmt --all -- --check`
- `python3 scripts/check-clippy-reasons.py`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps`
- `git diff --check`

Docs: `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/RFC_NOTES.md`, ADR-0060, and the config commentary now describe the enforced behavior and its boundary.

Linear: LAN-438
