### PR TITLE
Pin synthesized v1 effective defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   benchmark was rerun and no measured value or performance claim changed.
   (LAN-405)
 
+- **The v1 stable-surface gate now covers all inventoried contextual defaults.**
+  The dynamic-neighbor cap and address-/inheritance-dependent family set join
+  the existing resolver checks; the gate distinguishes their schema omission
+  representations from runtime values and pins `PeerManager` to the shared cap
+  resolver.
+
 - **RFC 1997 `NO_ADVERTISE` can no longer be bypassed or leaked by export
   policy.** IPv4/IPv6 unicast checks both the stored source route before export
   policy and the modified route after policy across grouped and private

--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -42,17 +42,19 @@ streaming mode. Each stable config definition's digest covers the selected
 property schemas, its complete (order-independent) required-field set, and its
 unknown-field policy. Unselected optional sibling properties and descriptive
 prose remain outside that digest, so additive optional siblings stay possible.
-The eight description-only contextual defaults scoped by this contract update
+The ten contextual defaults scoped by this contract update
 are pinned separately under `config.effective_defaults`. Their named resolver
 test loads real TOML and checks omission, peer-group inheritance, derived
-values, direct overrides, and conditional route-reflector behavior. This is a
-deliberately scoped guard, not an exhaustive catalog of every config omission
-behavior. These eight values remain description-only in the JSON Schema: a
-static JSON Schema `default` is reserved for context-free omission semantics and
-must not misrepresent an inherited, computed, or conditional result. The Python
-release checker pins this inventory and its linkage to a live, non-ignored Rust
-test; the focused Cargo test executes that test and is the gate that detects
-runtime resolver changes.
+values, direct overrides, address-dependent family synthesis, and conditional
+route-reflector behavior. This is a deliberately scoped guard, not an exhaustive
+catalog of every config omission behavior. Eight values remain description-only
+in the JSON Schema. `Global.dynamic_neighbor_limit = null` and
+`Neighbor.families = []` are pinned separately as serialization/schema
+representations of omission; they are not the runtime defaults of 100 and the
+address- and inheritance-dependent family set. The Python release checker pins
+the exact inventory, those two representation values, the daemon's shared
+dynamic-neighbor-limit accessor, and linkage to a live, non-ignored Rust test;
+the focused Cargo test executes that test and detects runtime resolver changes.
 Nested protobuf evolution follows the compatibility rules below. The
 message-graph digest is a review tripwire, not an implicit promotion:
 experimental fields such as Paths-Limit are explicitly excluded in the

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -97,7 +97,9 @@
     "effective_defaults": {
       "paths": [
         "Global.cluster_id",
+        "Global.dynamic_neighbor_limit",
         "Neighbor.disable_ipv4_unicast",
+        "Neighbor.families",
         "Neighbor.gr_restart_time",
         "Neighbor.gr_stale_routes_time",
         "Neighbor.graceful_restart",
@@ -105,6 +107,10 @@
         "Neighbor.llgr_stale_time",
         "Neighbor.send_hold_time"
       ],
+      "schema_representation_defaults": {
+        "Global.dynamic_neighbor_limit": null,
+        "Neighbor.families": []
+      },
       "validation_source": "src/config/tests.rs",
       "validation_test": "v1_stable_effective_defaults_match_runtime_resolution"
     },

--- a/scripts/check-v1-stable-surface.py
+++ b/scripts/check-v1-stable-surface.py
@@ -33,7 +33,9 @@ JSON_TYPES = {"array", "boolean", "null", "number", "object", "string"}
 V1_UPGRADE_HISTORY_ORIGIN = (0, 50, 0)
 EXPECTED_EFFECTIVE_DEFAULT_PATHS = (
     "Global.cluster_id",
+    "Global.dynamic_neighbor_limit",
     "Neighbor.disable_ipv4_unicast",
+    "Neighbor.families",
     "Neighbor.gr_restart_time",
     "Neighbor.gr_stale_routes_time",
     "Neighbor.graceful_restart",
@@ -41,10 +43,30 @@ EXPECTED_EFFECTIVE_DEFAULT_PATHS = (
     "Neighbor.llgr_stale_time",
     "Neighbor.send_hold_time",
 )
+EXPECTED_EFFECTIVE_DEFAULT_ASSERTION_PATHS = tuple(
+    path for path in EXPECTED_EFFECTIVE_DEFAULT_PATHS if path != "Neighbor.families"
+)
+EXPECTED_SCHEMA_REPRESENTATION_DEFAULTS = {
+    "Global.dynamic_neighbor_limit": None,
+    "Neighbor.families": [],
+}
+EXPECTED_EFFECTIVE_FAMILY_CASES = (
+    '"bare_ipv4",bare.transport_config.peer.families,&[(Afi::Ipv4,Safi::Unicast)]',
+    '"bare_ipv6",bare_ipv6.transport_config.peer.families,'
+    '&[(Afi::Ipv4,Safi::Unicast),(Afi::Ipv6,Safi::Unicast)]',
+    '"group_overrides_address_default",inherited.transport_config.peer.families,'
+    '&[(Afi::Ipv6,Safi::Unicast)]',
+    '"neighbor_overrides_group",overridden.transport_config.peer.families,'
+    '&[(Afi::Ipv4,Safi::Unicast)]',
+)
 EFFECTIVE_DEFAULT_ASSERTION_MACRO = "assert_v1_effective_default"
 EFFECTIVE_DEFAULT_ASSERTION_RE = re.compile(
     rf'\b{EFFECTIVE_DEFAULT_ASSERTION_MACRO}!\(\s*"([^"\\]+)"\s*,\s*'
     r"([a-z][a-z0-9_]*)\s*,\s*(None|true|false|\d+|\(\d+\s*,\s*\d+\))\s*\);"
+)
+EFFECTIVE_FAMILY_ASSERTION_MACRO = "assert_v1_family_case"
+EFFECTIVE_FAMILY_ASSERTION_RE = re.compile(
+    rf"\b{EFFECTIVE_FAMILY_ASSERTION_MACRO}!\((.*?)\);", re.DOTALL
 )
 
 
@@ -161,22 +183,78 @@ def check_effective_default_assertion_block(test_region: str, test: str) -> None
             "assertion macro"
         )
     assertions = EFFECTIVE_DEFAULT_ASSERTION_RE.findall(test_region)
-    if [path for path, _, _ in assertions] != list(EXPECTED_EFFECTIVE_DEFAULT_PATHS):
+    if [path for path, _, _ in assertions] != list(
+        EXPECTED_EFFECTIVE_DEFAULT_ASSERTION_PATHS
+    ):
         fail(
             f"effective-default validation test {test!r} must assert exactly the "
-            "eight scoped full paths in sorted order"
+            "nine scalar scoped full paths in sorted order"
         )
     for path, actual, _ in assertions:
         field = path.partition(".")[2]
+        runtime_field = (
+            "effective_dynamic_neighbor_limit"
+            if path == "Global.dynamic_neighbor_limit"
+            else field
+        )
         extraction = (
             rf"\blet\s+{re.escape(actual)}\s*=\s*"
-            rf"[^;\n]*\b{re.escape(field)}\b[^;\n]*;"
+            rf"[^;]*\b{re.escape(runtime_field)}\b[^;]*;"
         )
         if actual != field or not re.search(extraction, test_region):
             fail(
                 f"effective-default validation test {test!r} assertion for {path!r} "
                 "is not bound to that runtime field"
             )
+
+    if not re.search(
+        rf"""
+        macro_rules!\s+{EFFECTIVE_FAMILY_ASSERTION_MACRO}\s*\{{\s*
+        \(\s*\$case:literal\s*,\s*\$actual:expr\s*,\s*\$expected:expr\s*\)\s*=>\s*\{{\s*
+        assert_eq!\(\s*\$actual\.as_slice\(\)\s*,\s*\$expected\s*,.*?\);\s*
+        \}}\s*;\s*
+        \}}
+        """,
+        test_region,
+        flags=re.DOTALL | re.VERBOSE,
+    ):
+        fail(
+            f"effective-default validation test {test!r} has no typed "
+            "runtime-vs-expected family assertion macro"
+        )
+    family_cases = tuple(
+        re.sub(r"\s+", "", invocation)
+        for invocation in EFFECTIVE_FAMILY_ASSERTION_RE.findall(test_region)
+    )
+    if family_cases != EXPECTED_EFFECTIVE_FAMILY_CASES:
+        fail(
+            f"effective-default validation test {test!r} must assert exactly the "
+            "four typed family-resolution cases"
+        )
+
+
+def check_dynamic_neighbor_limit_linkage(
+    config_source: str, peer_manager_source: str
+) -> None:
+    if not re.search(
+        r"pub\(crate\)\s+fn\s+effective_dynamic_neighbor_limit\s*\(\s*&self\s*\)"
+        r"\s*->\s*u32\s*\{\s*self\.global\s*\.dynamic_neighbor_limit\s*"
+        r"\.unwrap_or\(DEFAULT_DYNAMIC_NEIGHBOR_LIMIT\)\s*\}",
+        config_source,
+        flags=re.DOTALL,
+    ):
+        fail(
+            "Config::effective_dynamic_neighbor_limit must resolve the shared "
+            "DEFAULT_DYNAMIC_NEIGHBOR_LIMIT"
+        )
+    if not re.search(
+        r"dynamic_neighbor_limit:\s*current_config"
+        r"\.effective_dynamic_neighbor_limit\(\)",
+        peer_manager_source,
+    ):
+        fail(
+            "PeerManager must consume Config::effective_dynamic_neighbor_limit"
+        )
 
 
 def check_effective_defaults(
@@ -185,11 +263,16 @@ def check_effective_defaults(
     effective = inventory["config"].get("effective_defaults")
     if not isinstance(effective, dict):
         fail("config.effective_defaults must be an object")
-    required_keys = {"paths", "validation_source", "validation_test"}
+    required_keys = {
+        "paths",
+        "schema_representation_defaults",
+        "validation_source",
+        "validation_test",
+    }
     if set(effective) != required_keys:
         fail(
-            "config.effective_defaults must contain exactly paths, validation_source, "
-            "and validation_test"
+            "config.effective_defaults must contain exactly paths, "
+            "schema_representation_defaults, validation_source, and validation_test"
         )
 
     paths = effective["paths"]
@@ -199,13 +282,25 @@ def check_effective_defaults(
         fail("config.effective_defaults.paths must be a non-empty string list")
     require_sorted_unique(paths, "config.effective_defaults.paths")
     if paths != list(EXPECTED_EFFECTIVE_DEFAULT_PATHS):
-        fail("config.effective_defaults.paths must match the exact eight-path scoped set")
+        fail("config.effective_defaults.paths must match the exact ten-path scoped set")
+    schema_defaults = effective["schema_representation_defaults"]
+    if schema_defaults != EXPECTED_SCHEMA_REPRESENTATION_DEFAULTS:
+        fail(
+            "config.effective_defaults.schema_representation_defaults must match "
+            "the exact two-path representation map"
+        )
     for path in paths:
         definition, separator, field = path.partition(".")
         if not separator or "." in field or path not in stable_paths:
             fail(f"effective default path {path!r} is not a stable config field")
         property_schema = schema_definition(schema, definition)["properties"][field]
-        if "default" in property_schema:
+        if path in schema_defaults:
+            if property_schema.get("default", object()) != schema_defaults[path]:
+                fail(
+                    f"schema representation default for {path!r} drifted from the "
+                    "pinned non-effective value"
+                )
+        elif "default" in property_schema:
             fail(
                 f"contextual effective default {path!r} must not claim a static JSON Schema default"
             )
@@ -234,7 +329,7 @@ def check_effective_defaults(
         lambda: check_effective_default_assertion_block(
             EFFECTIVE_DEFAULT_ASSERTION_RE.sub("", test_region), test
         ),
-        "must assert exactly the eight scoped full paths",
+        "must assert exactly the nine scalar scoped full paths",
         "missing effective-default runtime assertion block",
     )
     for broken_macro, label in (
@@ -260,11 +355,41 @@ def check_effective_defaults(
             "no runtime-vs-expected assertion macro",
             label,
         )
+    expect_checker_failure(
+        lambda: check_effective_default_assertion_block(
+            EFFECTIVE_FAMILY_ASSERTION_RE.sub("", test_region), test
+        ),
+        "must assert exactly the four typed family-resolution cases",
+        "missing effective-family runtime rows",
+    )
+    expect_checker_failure(
+        lambda: check_effective_default_assertion_block(
+            test_region.replace("$actual.as_slice()", "$expected", 1), test
+        ),
+        "no typed runtime-vs-expected family assertion macro",
+        "vacuous effective-family macro",
+    )
     for linkage in ("parse_strict(", "resolve_neighbor("):
         if linkage not in test_region:
             fail(
                 f"effective-default validation test {test!r} does not exercise {linkage[:-1]}"
             )
+
+    config_source = (ROOT / "src/config/mod.rs").read_text()
+    peer_manager_source = (ROOT / "src/peer_manager/mod.rs").read_text()
+    check_dynamic_neighbor_limit_linkage(config_source, peer_manager_source)
+    expect_checker_failure(
+        lambda: check_dynamic_neighbor_limit_linkage(
+            config_source,
+            peer_manager_source.replace(
+                "current_config.effective_dynamic_neighbor_limit()",
+                "current_config.global.dynamic_neighbor_limit.unwrap_or(100)",
+                1,
+            ),
+        ),
+        "PeerManager must consume Config::effective_dynamic_neighbor_limit",
+        "bypassed dynamic-neighbor-limit accessor",
+    )
 
 
 def check_config(inventory: dict, schema: dict) -> None:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,7 +32,9 @@ pub use schema::*;
 pub(crate) use validation::{effective_prefix, effective_prefix_str};
 
 use self::parse::{ChainDirection, parse_families, parse_policy, resolve_chain};
-use self::schema::{BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_HOLD_TIME};
+use self::schema::{
+    BGP_PORT, DEFAULT_CONNECT_RETRY_SECS, DEFAULT_DYNAMIC_NEIGHBOR_LIMIT, DEFAULT_HOLD_TIME,
+};
 
 #[cfg(test)]
 use self::parse::parse_named_policy;
@@ -713,6 +715,14 @@ impl Config {
             return Some(router_id);
         }
         None
+    }
+
+    /// Resolve the process-wide cap for accepted dynamic neighbors.
+    #[must_use]
+    pub(crate) fn effective_dynamic_neighbor_limit(&self) -> u32 {
+        self.global
+            .dynamic_neighbor_limit
+            .unwrap_or(DEFAULT_DYNAMIC_NEIGHBOR_LIMIT)
     }
 
     /// Emit the startup warning for the pre-ADR-0064 legacy gRPC

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -13,6 +13,8 @@ use rustbgpd_wire::BgpRole;
 /// exactly one place (completes the LAN-211 dedup; `PeerConfig::default()`
 /// and the gRPC send-hold-time validation use the same constant).
 pub(super) const DEFAULT_HOLD_TIME: u16 = rustbgpd_fsm::DEFAULT_HOLD_TIME;
+/// Runtime cap used when `global.dynamic_neighbor_limit` is omitted.
+pub(super) const DEFAULT_DYNAMIC_NEIGHBOR_LIMIT: u32 = 100;
 pub(super) const DEFAULT_CONNECT_RETRY_SECS: u32 = 5;
 pub(super) const BGP_PORT: u16 = 179;
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -210,6 +210,10 @@ gr_restart_time = 240
 gr_stale_routes_time = 720
 llgr_stale_time = 60
 disable_ipv4_unicast = false
+
+[[neighbors]]
+address = "2001:db8::5"
+remote_asn = 65005
 "#;
 
 const V1_CLUSTER_ID_DEFAULTS_TOML: &str = r#"
@@ -233,6 +237,10 @@ remote_asn = 65001
 peer_group = "rr"
 "#;
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "the v1 inventory checker requires all contextual-default proofs in one named test"
+)]
 #[test]
 fn v1_stable_effective_defaults_match_runtime_resolution() {
     macro_rules! assert_v1_effective_default {
@@ -244,9 +252,26 @@ fn v1_stable_effective_defaults_match_runtime_resolution() {
             );
         };
     }
+    macro_rules! assert_v1_family_case {
+        ($case:literal, $actual:expr, $expected:expr) => {
+            assert_eq!(
+                $actual.as_slice(),
+                $expected,
+                "runtime effective family default drifted for {}",
+                $case
+            );
+        };
+    }
 
     let config =
         parse_strict(V1_EFFECTIVE_DEFAULTS_TOML).expect("contextual-default fixture must load");
+    let explicit_dynamic_limit_toml = V1_EFFECTIVE_DEFAULTS_TOML.replacen(
+        "listen_port = 179",
+        "listen_port = 179\ndynamic_neighbor_limit = 500",
+        1,
+    );
+    let explicit_dynamic_limit = parse_strict(&explicit_dynamic_limit_toml)
+        .expect("explicit dynamic-neighbor limit fixture must load");
     let bare = config
         .resolve_neighbor(&config.neighbors[0])
         .expect("bare neighbor must resolve");
@@ -256,9 +281,17 @@ fn v1_stable_effective_defaults_match_runtime_resolution() {
     let overridden = config
         .resolve_neighbor(&config.neighbors[2])
         .expect("direct-override neighbor must resolve");
+    let bare_ipv6 = config
+        .resolve_neighbor(&config.neighbors[3])
+        .expect("bare IPv6 neighbor must resolve");
     let bare_peer = &bare.transport_config.peer;
     let bare_transport = &bare.transport_config;
     let cluster_id = config.cluster_id();
+    let explicit_dynamic_neighbor_limit = explicit_dynamic_limit.effective_dynamic_neighbor_limit();
+    let dynamic_neighbor_limit = (
+        config.effective_dynamic_neighbor_limit(),
+        explicit_dynamic_neighbor_limit,
+    );
     let disable_ipv4_unicast = bare_peer.disable_ipv4_unicast;
     let gr_restart_time = bare_peer.gr_restart_time;
     let gr_stale_routes_time = bare_transport.gr_stale_routes_time;
@@ -270,6 +303,11 @@ fn v1_stable_effective_defaults_match_runtime_resolution() {
     // Mutation-red: each full path is bound to its actual production-resolved
     // value and an explicit expected value; deleting or weakening any row is red.
     assert_v1_effective_default!("Global.cluster_id", cluster_id, None);
+    assert_v1_effective_default!(
+        "Global.dynamic_neighbor_limit",
+        dynamic_neighbor_limit,
+        (100, 500)
+    );
     assert_v1_effective_default!("Neighbor.disable_ipv4_unicast", disable_ipv4_unicast, false);
     assert_v1_effective_default!("Neighbor.gr_restart_time", gr_restart_time, 120);
     assert_v1_effective_default!("Neighbor.gr_stale_routes_time", gr_stale_routes_time, 360);
@@ -277,6 +315,30 @@ fn v1_stable_effective_defaults_match_runtime_resolution() {
     assert_v1_effective_default!("Neighbor.hold_time", hold_time, 90);
     assert_v1_effective_default!("Neighbor.llgr_stale_time", llgr_stale_time, (0, 0));
     assert_v1_effective_default!("Neighbor.send_hold_time", send_hold_time, 480);
+
+    // Mutation-red: changing the address-derived default, removing peer-group
+    // inheritance, or making the group outrank a neighbor override changes one
+    // of these typed rows.
+    assert_v1_family_case!(
+        "bare_ipv4",
+        bare.transport_config.peer.families,
+        &[(Afi::Ipv4, Safi::Unicast)]
+    );
+    assert_v1_family_case!(
+        "bare_ipv6",
+        bare_ipv6.transport_config.peer.families,
+        &[(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)]
+    );
+    assert_v1_family_case!(
+        "group_overrides_address_default",
+        inherited.transport_config.peer.families,
+        &[(Afi::Ipv6, Safi::Unicast)]
+    );
+    assert_v1_family_case!(
+        "neighbor_overrides_group",
+        overridden.transport_config.peer.families,
+        &[(Afi::Ipv4, Safi::Unicast)]
+    );
 
     let effective = |resolved: &ResolvedNeighbor| {
         let transport = &resolved.transport_config;

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -536,7 +536,7 @@ impl PeerManager {
             config_snapshot_staged: false,
             dynamic_ranges: Self::parse_dynamic_ranges(&current_config),
             dynamic_peer_count: 0,
-            dynamic_neighbor_limit: current_config.global.dynamic_neighbor_limit.unwrap_or(100),
+            dynamic_neighbor_limit: current_config.effective_dynamic_neighbor_limit(),
             dead_lettered_pending: HashMap::new(),
             dead_lettered_pending_order: VecDeque::new(),
             next_session_id: 1,


### PR DESCRIPTION
## Summary

- centralize the omitted dynamic-neighbor cap in `Config::effective_dynamic_neighbor_limit` and make `PeerManager` consume it
- extend the v1 stable-surface inventory from eight to ten contextual defaults, while distinguishing schema omission representations (`null` and `[]`) from runtime effective values
- exercise the real TOML parser and neighbor resolver for bare IPv4, bare IPv6, peer-group inheritance, and neighbor-over-group precedence
- document the strengthened v1 contract and release impact

## Root cause

The existing v1 gate covered contextual defaults only when they were already represented by scalar assertions. `Global.dynamic_neighbor_limit` synthesized `100` inline in `PeerManager`, and `Neighbor.families` synthesized its value from address family plus inheritance precedence. Neither runtime behavior was part of the stable-surface digest, so a breaking effective-default change could pass the release gate.

## Load-bearing proof

Each changed protection was forced red before restoration:

- changing the cap fallback from 100 to 101 fails the focused Rust contract test
- making the accessor ignore an explicit value fails the `(100, 500)` cap assertion
- bypassing the accessor in `PeerManager` fails the Python source-linkage gate
- removing the IPv4 seed, IPv6 augmentation, peer-group fallback, or neighbor precedence each fails its typed family row
- changing either raw schema sentinel, removing either inventory path, deleting scalar/family rows, or making the family macro vacuous fails the Python checker or one of its self-mutations

## Verification

- `python3 scripts/check-v1-stable-surface.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

LAN-432
