### PR TITLE
Enforce VPN policy suppression and replacement withdrawal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   resolver.
 
 - **RFC 1997 `NO_ADVERTISE` can no longer be bypassed or leaked by export
-  policy.** IPv4/IPv6 unicast checks both the stored source route before export
-  policy and the modified route after policy across grouped and private
-  single-best, Add-Path, RFC 7947 per-client-best, and RFC 9107 ORR. Policy
-  cannot remove the community to make a scoped route exportable, and a
-  policy-added community suppresses the resulting route before Adj-RIB-Out
-  commit. Scoped replacements withdraw existing state; candidate modes compact
-  surviving siblings, while ORR suppresses its selected winner without falling
-  back.
+  policy.** IPv4/IPv6 unicast and VPNv4/VPNv6 check both the stored source
+  route before export policy and the modified route after policy across grouped
+  and private single-best plus Add-Path; unicast also covers RFC 7947
+  per-client-best and RFC 9107 ORR. Policy cannot remove the community to make
+  a scoped route exportable, and a policy-added community suppresses the
+  resulting route before Adj-RIB-Out commit. Scoped replacements withdraw
+  existing state; candidate modes compact surviving siblings, while ORR
+  suppresses its selected winner without falling back.
   Terminal export explain reports suppression and, for a post-policy stop,
   shows the triggering modification; Add-Path best-path explain mirrors the
   compacted advertised ranks.
@@ -186,11 +186,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OTC, AS_PATH-loop, and route-reflector-loop rejects now retire the exact
   accepted `(prefix, path_id)` while first-seen rejects remain filter-only.
 
-- **Import-policy-denied unicast replacements withdraw prior accepted paths.**
-  Classic and MP-unicast updates denied on import now retire the exact
-  `(prefix, path_id)` previously accepted from that peer and send the removal
-  to the RIB immediately. First-seen denials remain filter-only, explicit
-  withdrawals are deduplicated, and Add-Path siblings stay intact.
+- **Import-policy-denied unicast and VPN replacements withdraw prior accepted
+  paths.** Classic and MP-unicast updates retire the exact `(prefix, path_id)`;
+  VPNv4/VPNv6 updates retire the exact `(RD + prefix, path_id)` previously
+  accepted from that peer and send the removal to the RIB immediately.
+  First-seen denials remain filter-only, explicit withdrawals are deduplicated,
+  and Add-Path siblings stay intact.
 
 - **Enhanced-refresh omissions no longer poison max-prefix accounting.**
   Inbound RFC 7313 windows now mirror exact typed route identities across every

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -613,8 +613,8 @@ fn llgr_stale_export_suppressed(
 /// means that a route "MUST NOT be advertised to any BGP peer", so the
 /// source route is ineligible before export policy can remove the community,
 /// and a modified route is ineligible when policy adds it. This predicate is
-/// deliberately target-independent: every unicast selection shape applies
-/// both checks.
+/// deliberately target-independent: every supported unicast and VPN selection
+/// shape applies both checks.
 pub(super) fn no_advertise_export_suppressed(communities: &[u32]) -> bool {
     communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
 }

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -228,6 +228,10 @@ impl RibManager {
                         continue;
                     }
 
+                    if super::no_advertise_export_suppressed(candidate.communities()) {
+                        continue;
+                    }
+
                     let aspath_str = if needs_as_path_string {
                         candidate
                             .as_path()
@@ -276,6 +280,9 @@ impl RibManager {
                         if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                             modified.next_hop = addr;
                         }
+                    }
+                    if super::no_advertise_export_suppressed(modified.communities()) {
+                        continue;
                     }
                     modified.path_id = next_rank;
 
@@ -517,6 +524,20 @@ impl RibManager {
                 || "iBGP split-horizon / RFC 4456 reflection rules permit this route".to_string(),
             );
 
+            if super::no_advertise_export_suppressed(best.communities()) {
+                target.gate(
+                    "no_advertise",
+                    "no_advertise_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "source route carries NO_ADVERTISE; RFC 1997 forbids advertising it"
+                            .to_string()
+                    },
+                );
+                withdraw_existing(vpn_withdraw, existing_path_ids);
+                continue;
+            }
+
             let aspath_str = if needs_as_path_string {
                 best.as_path()
                     .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
@@ -603,6 +624,19 @@ impl RibManager {
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
+            }
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                target.gate(
+                    "no_advertise",
+                    "no_advertise_policy_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "export policy produced NO_ADVERTISE; RFC 1997 forbids advertising it"
+                            .to_string()
+                    },
+                );
+                withdraw_existing(vpn_withdraw, existing_path_ids);
+                continue;
             }
             modified.path_id = 0;
 

--- a/crates/rib/src/manager/tests/vpn.rs
+++ b/crates/rib/src/manager/tests/vpn.rs
@@ -1,5 +1,63 @@
 use super::*;
 
+fn with_vpn_no_advertise(mut route: VpnRibRoute) -> VpnRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ]));
+    route
+}
+
+fn make_vpn_v6_rib_route(peer: Ipv4Addr, local_pref: u32) -> VpnRibRoute {
+    VpnRibRoute {
+        nlri: VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(300, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 2]),
+            prefix: VpnPrefix::v6("2001:db8:442::".parse().unwrap(), 64).unwrap(),
+        },
+        next_hop: IpAddr::V6("2001:db8::1".parse().unwrap()),
+        link_local_next_hop: None,
+        peer: IpAddr::V4(peer),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::LocalPref(local_pref),
+        ]),
+        received_at: Instant::now(),
+        origin_type: crate::route::RouteOrigin::Ibgp,
+        peer_router_id: peer,
+        is_stale: false,
+        is_llgr_stale: false,
+        path_id: 0,
+    }
+}
+
+fn drain_vpn_delta(
+    rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+) -> (Vec<VpnRibRoute>, Vec<crate::route::VpnRibRouteKey>) {
+    let mut announced = Vec::new();
+    let mut withdrawn = Vec::new();
+    while let Ok(update) = rx.try_recv() {
+        announced.extend(update.vpn_announce);
+        withdrawn.extend(update.vpn_withdraw);
+    }
+    (announced, withdrawn)
+}
+
+async fn query_vpn_group_label(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> String {
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::QueryPeerUpdateGroup { peer, reply })
+        .await
+        .unwrap();
+    response.await.unwrap()
+}
+
+async fn query_vpn_advertised(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Vec<(String, IpAddr)> {
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::TestQueryVpnAdvertised { peer, reply })
+        .await
+        .unwrap();
+    response.await.unwrap()
+}
+
 /// A peer entering GR with (IPv4, `MplsVpn`) in its capability keeps its VPN
 /// routes as stale. Staleness demotes the tiebreak rank, so a fresh route
 /// from another peer takes over; with every candidate stale the normal
@@ -353,6 +411,412 @@ async fn vpn_gr_consecutive_restart_deletes_stale_routes() {
     assert!(
         query_vpn_routes(&tx).await.is_empty(),
         "a route still stale at the next restart must be deleted, not re-marked"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Grouped and private VPN targets enforce RFC 1997 before and after export
+/// policy for both `VPNv4` and `VPNv6`, withdraw prior state, and recover when the
+/// restriction is removed.
+///
+/// Break-to-red: removing either single-best guard in `stage_vpn_routes`, or
+/// retaining the guard while deleting its `withdraw_existing`, makes the
+/// corresponding source/policy phase advertise or retain both exact keys.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario pins both VPN families across grouped/private source and policy transitions"
+)]
+async fn vpn_no_advertise_withdraws_grouped_and_private_single_best() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let grouped_a: IpAddr = "192.0.2.30".parse().unwrap();
+    let grouped_b: IpAddr = "192.0.2.31".parse().unwrap();
+    let private: IpAddr = "192.0.2.32".parse().unwrap();
+    let families = vec![(Afi::Ipv4, Safi::MplsVpn), (Afi::Ipv6, Safi::MplsVpn)];
+    let mut receivers = Vec::new();
+
+    for (peer, peer_context) in [(grouped_a, false), (grouped_b, false), (private, true)] {
+        let (out_tx, mut out_rx) = mpsc::channel(16);
+        tx.send(RibUpdate::PeerUp {
+            per_client_best: false,
+            session_id: 0,
+            peer,
+            peer_asn: 65100,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: Some(super::unicast::no_advertise_removal_chain(peer_context)),
+            sendable_families: families.clone(),
+            is_ebgp: true,
+            route_reflector_client: false,
+            orr_vantage: None,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+        receivers.push((peer, out_rx));
+    }
+
+    let group = query_vpn_group_label(&tx, grouped_a).await;
+    assert!(group.starts_with("group:"));
+    assert_eq!(query_vpn_group_label(&tx, grouped_b).await, group);
+    assert_eq!(
+        query_vpn_group_label(&tx, private).await,
+        "policy_peer_context"
+    );
+
+    let source = Ipv4Addr::new(198, 51, 100, 10);
+    let v4 = make_vpn_rib_route(source, 42, 200, 200);
+    let v6 = make_vpn_v6_rib_route(source, 200);
+    let expected_keys: HashSet<_> = [v4.key(), v6.key()].into_iter().collect();
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![v4.clone(), v6.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    for (_, out_rx) in &mut receivers {
+        let (announced, withdrawn) = drain_vpn_delta(out_rx);
+        assert_eq!(announced.len(), 2);
+        assert!(withdrawn.is_empty());
+    }
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![
+            with_vpn_no_advertise(v4.clone()),
+            with_vpn_no_advertise(v6.clone()),
+        ],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    for (peer, out_rx) in &mut receivers {
+        let (announced, withdrawn) = drain_vpn_delta(out_rx);
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn.len(), 2, "each VPN identity withdraws once");
+        assert_eq!(withdrawn.into_iter().collect::<HashSet<_>>(), expected_keys);
+        assert!(query_vpn_advertised(&tx, *peer).await.is_empty());
+    }
+    for route in [&v4, &v6] {
+        let grouped_explain = query_explain_advertised_vpn_route(
+            &tx,
+            grouped_a,
+            route.inner_prefix(),
+            route.nlri.route_distinguisher,
+        )
+        .await;
+        let private_explain = query_explain_advertised_vpn_route(
+            &tx,
+            private,
+            route.inner_prefix(),
+            route.nlri.route_distinguisher,
+        )
+        .await;
+        assert!(grouped_explain.update_group_id.is_some());
+        assert!(private_explain.update_group_id.is_none());
+        assert_eq!(
+            grouped_explain.decision,
+            crate::update::ExplainDecision::Deny
+        );
+        assert_eq!(private_explain.decision, grouped_explain.decision);
+        assert_eq!(
+            grouped_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code)),
+            Some(("no_advertise", "no_advertise_suppressed"))
+        );
+        assert_eq!(
+            private_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code)),
+            grouped_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code))
+        );
+        assert!(grouped_explain.modifications.communities_remove.is_empty());
+    }
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![v4.clone(), v6.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    for (_, out_rx) in &mut receivers {
+        let (announced, withdrawn) = drain_vpn_delta(out_rx);
+        assert_eq!(announced.len(), 2);
+        assert!(withdrawn.is_empty());
+    }
+
+    for (peer, _) in &receivers {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: *peer,
+            export_policy: Some(super::unicast::no_advertise_addition_chain(
+                *peer == private,
+            )),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+    }
+    let _ = query_vpn_routes(&tx).await;
+    for (peer, out_rx) in &mut receivers {
+        let (announced, withdrawn) = drain_vpn_delta(out_rx);
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn.len(), 2, "each VPN identity withdraws once");
+        assert_eq!(withdrawn.into_iter().collect::<HashSet<_>>(), expected_keys);
+        assert!(query_vpn_advertised(&tx, *peer).await.is_empty());
+    }
+    for route in [&v4, &v6] {
+        let grouped_explain = query_explain_advertised_vpn_route(
+            &tx,
+            grouped_a,
+            route.inner_prefix(),
+            route.nlri.route_distinguisher,
+        )
+        .await;
+        let private_explain = query_explain_advertised_vpn_route(
+            &tx,
+            private,
+            route.inner_prefix(),
+            route.nlri.route_distinguisher,
+        )
+        .await;
+        assert!(grouped_explain.update_group_id.is_some());
+        assert!(private_explain.update_group_id.is_none());
+        assert_eq!(
+            grouped_explain.decision,
+            crate::update::ExplainDecision::Deny
+        );
+        assert_eq!(private_explain.decision, grouped_explain.decision);
+        assert_eq!(
+            grouped_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code)),
+            Some(("no_advertise", "no_advertise_policy_suppressed"))
+        );
+        assert_eq!(
+            private_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code)),
+            grouped_explain
+                .gates
+                .last()
+                .map(|gate| (gate.gate, gate.code))
+        );
+        assert!(
+            grouped_explain
+                .modifications
+                .communities_add
+                .contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+        );
+    }
+
+    for (peer, _) in &receivers {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: *peer,
+            export_policy: Some(super::unicast::no_advertise_removal_chain(*peer == private)),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+    }
+    let _ = query_vpn_routes(&tx).await;
+    for (_, out_rx) in &mut receivers {
+        let (announced, withdrawn) = drain_vpn_delta(out_rx);
+        assert_eq!(announced.len(), 2);
+        assert!(withdrawn.is_empty());
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// VPN Add-Path removes source- and policy-scoped candidates before assigning
+/// outbound ranks, compacts survivors, and withdraws stale ranks.
+///
+/// Break-to-red: deleting either Add-Path guard, or moving it after the rank
+/// increment, leaves the scoped best/rank hole or retains a policy-scoped rank.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario proves source suppression, policy suppression, rank compaction, stale cleanup, and recovery"
+)]
+async fn vpn_add_path_no_advertise_compacts_and_withdraws_ranks() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let target: IpAddr = "192.0.2.40".parse().unwrap();
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        sendable_families: vpn_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vpn_sendable(),
+        add_path_send_max: 2,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+    assert_eq!(query_vpn_group_label(&tx, target).await, "add_path_send");
+
+    let best = make_vpn_rib_route(Ipv4Addr::new(198, 51, 100, 11), 43, 100, 200);
+    let second = make_vpn_rib_route(Ipv4Addr::new(198, 51, 100, 12), 43, 200, 100);
+    let nlri_key = best.nlri.key();
+    for route in [&best, &second] {
+        tx.send(RibUpdate::VpnRoutesReceived {
+            session_id: 0,
+            peer: route.peer,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    let _ = query_vpn_routes(&tx).await;
+    let initial = drain_final_vpn(&mut out_rx);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(
+        initial[&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1
+        }]
+            .peer,
+        best.peer
+    );
+    assert_eq!(
+        initial[&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2
+        }]
+            .peer,
+        second.peer
+    );
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: best.peer,
+        announced: vec![with_vpn_no_advertise(best.clone())],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    let (announced, withdrawn) = drain_vpn_delta(&mut out_rx);
+    assert_eq!(announced.len(), 1);
+    assert_eq!(announced[0].path_id, 1);
+    assert_eq!(announced[0].peer, second.peer);
+    assert_eq!(
+        withdrawn,
+        vec![crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2
+        }]
+    );
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_addition_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    let (announced, withdrawn) = drain_vpn_delta(&mut out_rx);
+    assert!(announced.is_empty());
+    assert_eq!(
+        withdrawn,
+        vec![crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1
+        }]
+    );
+    assert!(query_vpn_advertised(&tx, target).await.is_empty());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    let recovered = drain_final_vpn(&mut out_rx);
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(
+        recovered[&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1
+        }]
+            .peer,
+        second.peer
+    );
+
+    tx.send(RibUpdate::VpnRoutesReceived {
+        session_id: 0,
+        peer: best.peer,
+        announced: vec![best.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_vpn_routes(&tx).await;
+    let recovered = drain_final_vpn(&mut out_rx);
+    assert_eq!(recovered.len(), 2);
+    assert_eq!(
+        recovered[&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 1
+        }]
+            .peer,
+        best.peer
+    );
+    assert_eq!(
+        recovered[&crate::route::VpnRibRouteKey {
+            nlri_key,
+            path_id: 2
+        }]
+            .peer,
+        second.peer
     );
 
     drop(tx);

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1507,6 +1507,7 @@ impl PeerSession {
         let mut bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
         let mut vpn_announced: Vec<VpnRibRoute> = Vec::new();
         let mut vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+        let mut denied_vpn: Vec<VpnRibRouteKey> = Vec::new();
         let mut labeled_announced: Vec<LabeledRibRoute> = Vec::new();
         let mut labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
         let mut rtc_announced: Vec<RtcRibRoute> = Vec::new();
@@ -1807,6 +1808,11 @@ impl PeerSession {
                                         .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
                                     is_stale: false,
                                     is_llgr_stale: false,
+                                    path_id: entry.path_id,
+                                });
+                            } else {
+                                denied_vpn.push(VpnRibRouteKey {
+                                    nlri_key: entry.nlri.key(),
                                     path_id: entry.path_id,
                                 });
                             }
@@ -2183,6 +2189,11 @@ impl PeerSession {
         }
         for key in &vpn_withdrawn {
             self.known_vpn.remove(key);
+        }
+        for key in denied_vpn {
+            if self.known_vpn.remove(&key) {
+                vpn_withdrawn.push(key);
+            }
         }
         for route in &vpn_announced {
             // Keyed by (RD+prefix, path_id): under VPN Add-Path each received

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4080,6 +4080,182 @@ async fn process_update_threads_vpn_add_path_ids_into_rib_keys() {
         }]
     );
 }
+
+/// Import-policy denial retires an accepted VPN Add-Path identity exactly,
+/// deduplicates an overlapping explicit withdrawal, preserves siblings, and
+/// keeps first-seen denials silent for both `VPNv4` and `VPNv6`.
+///
+/// Break-to-red: deleting denied-key collection or its presence-gated
+/// `known_vpn.remove` leaves the denied path accepted; blindly appending the
+/// key duplicates the overlap and emits the first-seen path.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario pins exact VPN identity and accounting across both address families"
+)]
+async fn denied_vpn_add_path_replacements_withdraw_exact_known_identity() {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the shared dual-AFI fixture keeps all identity transitions in one stateful session"
+    )]
+    async fn exercise(afi: Afi) {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let family = (afi, Safi::MplsVpn);
+        let mut negotiated = negotiated_session(65002, true);
+        negotiated.negotiated_families = vec![family];
+        negotiated
+            .add_path_families
+            .insert(family, AddPathMode::Both);
+        install_test_negotiated_session(&mut session, negotiated);
+
+        let prefix = match afi {
+            Afi::Ipv4 => VpnPrefix::v4(Ipv4Addr::new(10, 44, 2, 0), 24).unwrap(),
+            Afi::Ipv6 => VpnPrefix::v6("2001:db8:442::".parse().unwrap(), 64).unwrap(),
+            _ => unreachable!("test covers IP VPN families"),
+        };
+        let nlri = VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xFD, 0xE8, 0, 0, 0, 44]),
+            prefix,
+        };
+        let next_hop = match afi {
+            Afi::Ipv4 => IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+            Afi::Ipv6 => IpAddr::V6("2001:db8::7".parse().unwrap()),
+            _ => unreachable!("test covers IP VPN families"),
+        };
+        let base_attrs = || {
+            vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                }),
+            ]
+        };
+        let reach = |path_ids: &[u32]| {
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi,
+                safi: Safi::MplsVpn,
+                next_hop,
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: vec![],
+                labeled_announced: vec![],
+                vpn_announced: path_ids
+                    .iter()
+                    .map(|path_id| rustbgpd_wire::VpnNlriEntry {
+                        path_id: *path_id,
+                        nlri: nlri.clone(),
+                    })
+                    .collect(),
+                rtc_announced: vec![],
+            })
+        };
+        let unreach = |path_id| {
+            PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                afi,
+                safi: Safi::MplsVpn,
+                withdrawn: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_withdrawn: vec![],
+                bgpls_withdrawn: vec![],
+                labeled_withdrawn: vec![],
+                vpn_withdrawn: vec![rustbgpd_wire::VpnNlriEntry {
+                    path_id,
+                    nlri: VpnNlri {
+                        labels: vec![],
+                        route_distinguisher: nlri.route_distinguisher,
+                        prefix: nlri.prefix,
+                    },
+                }],
+                rtc_withdrawn: vec![],
+            })
+        };
+        let update = |attributes: Vec<PathAttribute>| {
+            UpdateMessage::build(&[], &[], &attributes, true, true, Ipv4UnicastMode::Body)
+        };
+        let key = |path_id| rustbgpd_rib::VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id,
+        };
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[11, 22, 33]));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::VpnRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("accepted VPN paths reach the RIB")
+        else {
+            panic!("expected VpnRoutesReceived");
+        };
+        assert_eq!(announced.len(), 3);
+        assert!(withdrawn.is_empty());
+        assert_eq!(session.known_prefix_count(), 3);
+        for path_id in [11, 22, 33] {
+            assert!(session.known_vpn.contains(&key(path_id)));
+        }
+
+        session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+            entries: vec![],
+            default_action: PolicyAction::Deny,
+        }])));
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[11]));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::VpnRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("denied replacement reaches the RIB")
+        else {
+            panic!("expected VpnRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(11)]);
+        assert!(!session.known_vpn.contains(&key(11)));
+        assert!(session.known_vpn.contains(&key(22)));
+        assert!(session.known_vpn.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 2);
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[22]));
+        attributes.push(unreach(22));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::VpnRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("overlapping withdrawal reaches the RIB")
+        else {
+            panic!("expected VpnRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn.len(), 1, "overlap must not duplicate the key");
+        assert_eq!(withdrawn, vec![key(22)]);
+        assert!(!session.known_vpn.contains(&key(22)));
+        assert!(session.known_vpn.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 1);
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[44]));
+        session.process_update(update(attributes)).await;
+        assert!(rib_rx.try_recv().is_err(), "first-seen denial stays silent");
+        assert!(!session.known_vpn.contains(&key(44)));
+        assert_eq!(session.known_prefix_count(), 1);
+    }
+
+    exercise(Afi::Ipv4).await;
+    exercise(Afi::Ipv6).await;
+}
+
 /// iBGP reflection of a VPN route on an RR adds `ORIGINATOR_ID` and
 /// `CLUSTER_LIST`, keeps `LOCAL_PREF`, and never emits inline `NextHop`/MP attrs.
 #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -47,6 +47,12 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   candidates whose result carries `NO_ADVERTISE`. ORR first selects its
   per-vantage best and suppresses that winner without falling back to a
   different route, whether the community arrived on the source or from policy.
+- `NO_ADVERTISE` enforcement for other non-unicast families remains deferred.
+
+---
+
+## Inbound import-policy replacement semantics
+
 - Import-policy denial of a replacement retires the exact previously accepted
   VPN `(RD + prefix, path_id)` identity. First-seen denials remain filter-only,
   explicit overlapping withdrawals are deduplicated, and Add-Path siblings

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast and VPNv4/VPNv6 |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
 | VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |
@@ -34,20 +34,24 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ## RFC 1997 — NO_ADVERTISE export restriction
 
-- IPv4/IPv6 unicast routes carrying `NO_ADVERTISE` are ineligible before
-  export policy, and the post-policy route is checked again before Adj-RIB-Out
-  commit. A permit policy cannot remove the community to bypass the
-  restriction; a policy that adds it suppresses the modified route.
-- The same predicate covers grouped and private single-best, Add-Path,
-  RFC 7947 per-client-best, and RFC 9107 ORR. Existing advertisements are
-  withdrawn and logical Adj-RIB-Out state is cleared.
+- IPv4/IPv6 unicast and VPNv4/VPNv6 routes carrying `NO_ADVERTISE` are
+  ineligible before export policy, and the post-policy route is checked again
+  before Adj-RIB-Out commit. A permit policy cannot remove the community to
+  bypass the restriction; a policy that adds it suppresses the modified route.
+- The same predicate covers grouped and private single-best plus Add-Path for
+  unicast and VPN routes, and RFC 7947 per-client-best plus RFC 9107 ORR for
+  unicast. Existing advertisements are withdrawn and logical Adj-RIB-Out state
+  is cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
   candidates whose result carries `NO_ADVERTISE`. ORR first selects its
   per-vantage best and suppresses that winner without falling back to a
   different route, whether the community arrived on the source or from policy.
-- This enforcement is currently scoped to IPv4/IPv6 unicast. Other route
-  families retain their existing policy behavior.
+- Import-policy denial of a replacement retires the exact previously accepted
+  VPN `(RD + prefix, path_id)` identity. First-seen denials remain filter-only,
+  explicit overlapping withdrawals are deduplicated, and Add-Path siblings
+  remain intact. Other non-unicast families retain their existing policy
+  behavior.
 
 ---
 


### PR DESCRIPTION
## Summary

- enforce RFC 1997 NO_ADVERTISE before and after export policy for shared VPNv4/VPNv6 single-best and Add-Path paths
- withdraw stale Adj-RIB-Out identities and compact surviving Add-Path ranks
- retire exact previously accepted VPN identities when import policy denies an identical replacement
- document the Phase 1 conformance boundary; other LAN-442 families remain deferred

## Load-bearing proof

- removing either single-best source or post-policy guard makes the grouped/private VPNv4+VPNv6 test advertise or retain the blocked identities
- retaining those guards but removing withdrawal cleanup leaves stale advertised state
- removing either Add-Path guard makes a blocked candidate consume or retain a rank
- removing stale-rank cleanup leaves path ID 2 advertised after compaction
- removing denied-key collection leaves an accepted replacement installed
- removing the known-identity presence gate emits duplicate and first-seen withdrawals
- processing denied keys before explicit withdrawals duplicates an overlapping key

Each mutation was run against its focused test and failed at the guarded assertion before the clean implementation was restored.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- focused VPN single-best, Add-Path, and import-denial regressions
- git diff --check

Linear: LAN-442 (Phase 1; remaining non-unicast families stay open)