### PR TITLE
Enforce labeled-unicast policy suppression and withdrawal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,17 +33,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   resolver.
 
 - **RFC 1997 `NO_ADVERTISE` can no longer be bypassed or leaked by export
-  policy.** IPv4/IPv6 unicast and VPNv4/VPNv6 check both the stored source
-  route before export policy and the modified route after policy across grouped
-  and private single-best plus Add-Path; unicast also covers RFC 7947
-  per-client-best and RFC 9107 ORR. Policy cannot remove the community to make
-  a scoped route exportable, and a policy-added community suppresses the
+  policy.** IPv4/IPv6 unicast, VPNv4/VPNv6, and labeled-unicast check both the
+  stored source route before export policy and the modified route after policy
+  across single-best plus Add-Path. Unicast also covers grouped/private, RFC
+  7947 per-client-best, and RFC 9107 ORR; VPN covers grouped/private, and
+  labeled-unicast covers RFC 9107 ORR. Policy cannot remove the community to
+  make a scoped route exportable, and a policy-added community suppresses the
   resulting route before Adj-RIB-Out commit. Scoped replacements withdraw
   existing state; candidate modes compact surviving siblings, while ORR
   suppresses its selected winner without falling back.
-  Terminal export explain reports suppression and, for a post-policy stop,
-  shows the triggering modification; Add-Path best-path explain mirrors the
-  compacted advertised ranks.
+  For unicast and VPN, terminal export explain reports suppression and, for a
+  post-policy stop, shows the triggering modification; unicast Add-Path
+  best-path explain mirrors the compacted advertised ranks.
 
 ### Added
 
@@ -186,12 +187,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OTC, AS_PATH-loop, and route-reflector-loop rejects now retire the exact
   accepted `(prefix, path_id)` while first-seen rejects remain filter-only.
 
-- **Import-policy-denied unicast and VPN replacements withdraw prior accepted
-  paths.** Classic and MP-unicast updates retire the exact `(prefix, path_id)`;
-  VPNv4/VPNv6 updates retire the exact `(RD + prefix, path_id)` previously
-  accepted from that peer and send the removal to the RIB immediately.
-  First-seen denials remain filter-only, explicit withdrawals are deduplicated,
-  and Add-Path siblings stay intact.
+- **Import-policy-denied unicast, VPN, and labeled-unicast replacements
+  withdraw prior accepted paths.** Classic and MP-unicast updates retire the
+  exact `(prefix, path_id)`; VPNv4/VPNv6 retire `(RD + prefix, path_id)`, and
+  labeled-unicast retires `(prefix, path_id)` previously accepted from that
+  peer. The removal reaches the RIB immediately. First-seen denials remain
+  filter-only, explicit withdrawals are deduplicated, and Add-Path siblings
+  stay intact.
 
 - **Enhanced-refresh omissions no longer poison max-prefix accounting.**
   Inbound RFC 7313 windows now mirror exact typed route identities across every

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -189,6 +189,10 @@ impl RibManager {
                         continue;
                     }
 
+                    if super::no_advertise_export_suppressed(candidate.communities()) {
+                        continue;
+                    }
+
                     let aspath_str = if needs_as_path_string {
                         candidate
                             .as_path()
@@ -242,6 +246,9 @@ impl RibManager {
                         if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                             modified.next_hop = addr;
                         }
+                    }
+                    if super::no_advertise_export_suppressed(modified.communities()) {
+                        continue;
                     }
                     modified.path_id = next_rank;
 
@@ -345,6 +352,11 @@ impl RibManager {
                 continue;
             }
 
+            if super::no_advertise_export_suppressed(best.communities()) {
+                withdraw_existing(labeled_withdraw, existing_path_ids);
+                continue;
+            }
+
             let aspath_str = if needs_as_path_string {
                 best.as_path()
                     .map_or_else(String::new, rustbgpd_wire::AsPath::to_aspath_string)
@@ -391,6 +403,10 @@ impl RibManager {
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
+            }
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                withdraw_existing(labeled_withdraw, existing_path_ids);
+                continue;
             }
             modified.path_id = 0;
 

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -613,8 +613,8 @@ fn llgr_stale_export_suppressed(
 /// means that a route "MUST NOT be advertised to any BGP peer", so the
 /// source route is ineligible before export policy can remove the community,
 /// and a modified route is ineligible when policy adds it. This predicate is
-/// deliberately target-independent: every supported unicast and VPN selection
-/// shape applies both checks.
+/// deliberately target-independent: every supported unicast, VPN, and
+/// labeled-unicast selection shape applies both checks.
 pub(super) fn no_advertise_export_suppressed(communities: &[u32]) -> bool {
     communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
 }

--- a/crates/rib/src/manager/tests/labeled.rs
+++ b/crates/rib/src/manager/tests/labeled.rs
@@ -1,6 +1,437 @@
 use super::*;
 
+fn with_labeled_no_advertise(
+    mut route: crate::route::LabeledRibRoute,
+) -> crate::route::LabeledRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ]));
+    route
+}
+
+fn labeled_route_at(
+    peer: Ipv4Addr,
+    prefix: Prefix,
+    next_hop: IpAddr,
+    local_pref: u32,
+) -> crate::route::LabeledRibRoute {
+    let mut route = make_labeled_rib_route(peer, 42, 4093, local_pref);
+    route.nlri.prefix = prefix;
+    route.next_hop = next_hop;
+    route
+}
+
+fn add_no_advertise_for_next_hop(next_hop: IpAddr) -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: Some(next_hop),
+            modifications: rustbgpd_policy::RouteModifications {
+                communities_add: vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE],
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+        }],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
+fn drain_labeled_delta(
+    rx: &mut mpsc::Receiver<OutboundRouteUpdate>,
+    state: &mut HashMap<crate::route::LabeledRibRouteKey, crate::route::LabeledRibRoute>,
+) -> (
+    Vec<crate::route::LabeledRibRoute>,
+    Vec<crate::route::LabeledRibRouteKey>,
+) {
+    let mut announced = Vec::new();
+    let mut withdrawn = Vec::new();
+    while let Ok(update) = rx.try_recv() {
+        for route in update.labeled_announce {
+            state.insert(route.key(), route.clone());
+            announced.push(route);
+        }
+        for key in update.labeled_withdraw {
+            state.remove(&key);
+            withdrawn.push(key);
+        }
+    }
+    (announced, withdrawn)
+}
+
 // --- Receive / reflect / withdraw (the SAFI 4 mirror of tests/vpn.rs) ---
+
+/// A resolved ORR client selects the vantage-closest labeled winner while a
+/// plain client keeps the Loc-RIB winner. Source- and policy-produced
+/// `NO_ADVERTISE` withdraw that selected winner without falling back, for both
+/// labeled IPv4 and IPv6, and clearing the restriction restores it.
+///
+/// Break-to-red: deleting either single-best guard advertises the scoped Y
+/// winner; moving the source guard into ORR candidate filtering announces X;
+/// deleting `withdraw_existing` loses the exact path-0 withdrawals and leaves
+/// the state non-empty or prevents the identical winner from recovering.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one stateful scenario pins dual-AFI plain/ORR winner suppression, zero fallback, exact withdrawal, and recovery"
+)]
+async fn labeled_no_advertise_suppresses_resolved_orr_winner_without_plain_churn() {
+    use crate::orr::fixtures::{A, B, X, Y};
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 255, 0, 1)),
+        BgpMetrics::new(),
+    );
+    let handle = tokio::spawn(manager.run());
+    let feed = Ipv4Addr::new(10, 9, 9, 9);
+    feed_square_topology(&tx, feed).await;
+
+    let next_hop_x = IpAddr::V4(Ipv4Addr::new(10, 0, X, A));
+    let next_hop_y = IpAddr::V4(Ipv4Addr::new(10, 0, Y, A));
+    let vantage_b = IpAddr::V4(Ipv4Addr::new(10, 0, B, X));
+    let source_x = Ipv4Addr::new(192, 0, 2, 1);
+    let source_y = Ipv4Addr::new(192, 0, 2, 2);
+    let families = vec![
+        (Afi::Ipv4, Safi::LabeledUnicast),
+        (Afi::Ipv6, Safi::LabeledUnicast),
+    ];
+    let plain = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 30));
+    let orr = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 31));
+    let mut receivers = Vec::new();
+    for (peer, vantage) in [(plain, None), (orr, Some(vantage_b))] {
+        let (out_tx, mut out_rx) = mpsc::channel(32);
+        tx.send(RibUpdate::PeerUp {
+            per_client_best: false,
+            session_id: 0,
+            peer,
+            peer_asn: 65000,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+            sendable_families: families.clone(),
+            is_ebgp: false,
+            route_reflector_client: true,
+            orr_vantage: vantage,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+        receivers.push((peer, out_rx, HashMap::new()));
+    }
+    let status = query_orr_status(&tx).await;
+    assert!(
+        status
+            .vantages
+            .iter()
+            .any(|entry| entry.vantage == vantage_b && entry.resolved),
+        "the ORR differential requires a resolved vantage"
+    );
+
+    let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24));
+    let v6 = Prefix::V6(Ipv6Prefix::new("2001:db8:442::".parse().unwrap(), 64));
+    let routes_x = vec![
+        labeled_route_at(source_x, v4, next_hop_x, 100),
+        labeled_route_at(source_x, v6, next_hop_x, 100),
+    ];
+    let routes_y = vec![
+        labeled_route_at(source_y, v4, next_hop_y, 100),
+        labeled_route_at(source_y, v6, next_hop_y, 100),
+    ];
+    let expected_keys: HashSet<_> = routes_x
+        .iter()
+        .map(crate::route::LabeledRibRoute::key)
+        .collect();
+    for (peer, routes) in [(source_x, routes_x.clone()), (source_y, routes_y.clone())] {
+        tx.send(RibUpdate::LabeledRoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(peer),
+            announced: routes,
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    let _ = query_labeled_routes(&tx).await;
+    for (peer, out_rx, state) in &mut receivers {
+        let (announced, withdrawn) = drain_labeled_delta(out_rx, state);
+        assert!(!announced.is_empty(), "baseline must stage real output");
+        assert!(withdrawn.is_empty());
+        assert_eq!(state.keys().copied().collect::<HashSet<_>>(), expected_keys);
+        let expected_source = if *peer == plain { source_x } else { source_y };
+        assert!(
+            state
+                .values()
+                .all(|route| route.peer == IpAddr::V4(expected_source))
+        );
+    }
+
+    tx.send(RibUpdate::LabeledRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source_y),
+        announced: routes_y
+            .iter()
+            .cloned()
+            .map(with_labeled_no_advertise)
+            .collect(),
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (_, plain_rx, plain_state) = &mut receivers[0];
+    let (announced, withdrawn) = drain_labeled_delta(plain_rx, plain_state);
+    assert!(announced.is_empty() && withdrawn.is_empty());
+    assert_eq!(plain_state.len(), 2);
+    let (_, orr_rx, orr_state) = &mut receivers[1];
+    let (announced, withdrawn) = drain_labeled_delta(orr_rx, orr_state);
+    assert!(announced.is_empty(), "ORR must not fall back to X");
+    assert_eq!(withdrawn.len(), 2);
+    assert_eq!(withdrawn.into_iter().collect::<HashSet<_>>(), expected_keys);
+    assert!(
+        orr_state.is_empty(),
+        "withdrawals clear the stateful oracle"
+    );
+
+    tx.send(RibUpdate::LabeledRoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source_y),
+        announced: routes_y.clone(),
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (announced, withdrawn) = drain_labeled_delta(orr_rx, orr_state);
+    assert_eq!(announced.len(), 2);
+    assert!(withdrawn.is_empty());
+    assert!(
+        orr_state
+            .values()
+            .all(|route| route.peer == IpAddr::V4(source_y))
+    );
+
+    for (peer, _, _) in &receivers {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: *peer,
+            export_policy: Some(add_no_advertise_for_next_hop(next_hop_y)),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+    }
+    let _ = query_labeled_routes(&tx).await;
+    let (_, plain_rx, plain_state) = &mut receivers[0];
+    let (announced, withdrawn) = drain_labeled_delta(plain_rx, plain_state);
+    assert!(announced.is_empty() && withdrawn.is_empty());
+    assert!(
+        plain_state
+            .values()
+            .all(|route| route.peer == IpAddr::V4(source_x))
+    );
+    let (_, orr_rx, orr_state) = &mut receivers[1];
+    let (announced, withdrawn) = drain_labeled_delta(orr_rx, orr_state);
+    assert!(
+        announced.is_empty(),
+        "policy-scoped ORR winner has no fallback"
+    );
+    assert_eq!(withdrawn.len(), 2);
+    assert_eq!(withdrawn.into_iter().collect::<HashSet<_>>(), expected_keys);
+    assert!(orr_state.is_empty());
+
+    for (peer, _, _) in &receivers {
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: *peer,
+            export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+    }
+    let _ = query_labeled_routes(&tx).await;
+    let (_, plain_rx, plain_state) = &mut receivers[0];
+    let (announced, withdrawn) = drain_labeled_delta(plain_rx, plain_state);
+    assert!(announced.is_empty() && withdrawn.is_empty());
+    let (_, orr_rx, orr_state) = &mut receivers[1];
+    let (announced, withdrawn) = drain_labeled_delta(orr_rx, orr_state);
+    assert_eq!(announced.len(), 2);
+    assert!(withdrawn.is_empty());
+    assert_eq!(
+        orr_state.keys().copied().collect::<HashSet<_>>(),
+        expected_keys
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Labeled Add-Path removes scoped candidates before assigning outbound ranks,
+/// compacts surviving ranks, withdraws stale ranks, and restores the full set.
+///
+/// Break-to-red: deleting either Add-Path guard, moving it after the rank
+/// increment, or deleting stale-rank cleanup changes the raw rank-1 announce,
+/// loses the exact rank-2/rank-1 withdrawal, or prevents full recovery.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one stateful scenario proves source and policy suppression, compact ranks, exact stale cleanup, and recovery"
+)]
+async fn labeled_add_path_no_advertise_compacts_and_withdraws_ranks() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let target = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 40));
+    let (out_tx, mut out_rx) = mpsc::channel(32);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        sendable_families: labeled_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: labeled_sendable(),
+        add_path_send_max: 2,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let best = make_labeled_rib_route(Ipv4Addr::new(192, 0, 2, 11), 43, 100, 200);
+    let second = make_labeled_rib_route(Ipv4Addr::new(192, 0, 2, 12), 43, 200, 100);
+    let prefix = best.nlri.key();
+    for route in [&best, &second] {
+        tx.send(RibUpdate::LabeledRoutesReceived {
+            session_id: 0,
+            peer: route.peer,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+    }
+    let _ = query_labeled_routes(&tx).await;
+    let mut state = HashMap::new();
+    let (announced, withdrawn) = drain_labeled_delta(&mut out_rx, &mut state);
+    assert!(!announced.is_empty(), "baseline must begin non-empty");
+    assert!(withdrawn.is_empty());
+    assert_eq!(state.len(), 2);
+    assert_eq!(
+        state[&crate::route::LabeledRibRouteKey { prefix, path_id: 1 }].peer,
+        best.peer
+    );
+    assert_eq!(
+        state[&crate::route::LabeledRibRouteKey { prefix, path_id: 2 }].peer,
+        second.peer
+    );
+
+    tx.send(RibUpdate::LabeledRoutesReceived {
+        session_id: 0,
+        peer: best.peer,
+        announced: vec![with_labeled_no_advertise(best.clone())],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (announced, withdrawn) = drain_labeled_delta(&mut out_rx, &mut state);
+    assert_eq!(announced.len(), 1);
+    assert_eq!((announced[0].path_id, announced[0].peer), (1, second.peer));
+    assert_eq!(
+        withdrawn,
+        vec![crate::route::LabeledRibRouteKey { prefix, path_id: 2 }]
+    );
+    assert_eq!(state.len(), 1);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_addition_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (announced, withdrawn) = drain_labeled_delta(&mut out_rx, &mut state);
+    assert!(announced.is_empty());
+    assert_eq!(
+        withdrawn,
+        vec![crate::route::LabeledRibRouteKey { prefix, path_id: 1 }]
+    );
+    assert!(state.is_empty());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(super::unicast::no_advertise_removal_chain(false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (announced, withdrawn) = drain_labeled_delta(&mut out_rx, &mut state);
+    assert_eq!(announced.len(), 1);
+    assert_eq!((announced[0].path_id, announced[0].peer), (1, second.peer));
+    assert!(withdrawn.is_empty());
+
+    tx.send(RibUpdate::LabeledRoutesReceived {
+        session_id: 0,
+        peer: best.peer,
+        announced: vec![best.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_labeled_routes(&tx).await;
+    let (announced, withdrawn) = drain_labeled_delta(&mut out_rx, &mut state);
+    assert_eq!(announced.len(), 2);
+    assert!(withdrawn.is_empty());
+    assert_eq!(state.len(), 2);
+    assert_eq!(
+        state[&crate::route::LabeledRibRouteKey { prefix, path_id: 1 }].peer,
+        best.peer
+    );
+    assert_eq!(
+        state[&crate::route::LabeledRibRouteKey { prefix, path_id: 2 }].peer,
+        second.peer
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
 
 /// A received labeled route must be reflected to an eligible (eBGP-export)
 /// peer, and a withdrawal must be staged with the prefix + path-id key.

--- a/crates/rib/src/manager/tests/labeled.rs
+++ b/crates/rib/src/manager/tests/labeled.rs
@@ -3,9 +3,19 @@ use super::*;
 fn with_labeled_no_advertise(
     mut route: crate::route::LabeledRibRoute,
 ) -> crate::route::LabeledRibRoute {
-    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
-        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
-    ]));
+    let attributes = Arc::make_mut(&mut route.attributes);
+    if let Some(PathAttribute::Communities(communities)) = attributes
+        .iter_mut()
+        .find(|attribute| matches!(attribute, PathAttribute::Communities(_)))
+    {
+        if !communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE) {
+            communities.push(rustbgpd_wire::COMMUNITY_NO_ADVERTISE);
+        }
+    } else {
+        attributes.push(PathAttribute::Communities(vec![
+            rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+        ]));
+    }
     route
 }
 

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1510,6 +1510,7 @@ impl PeerSession {
         let mut denied_vpn: Vec<VpnRibRouteKey> = Vec::new();
         let mut labeled_announced: Vec<LabeledRibRoute> = Vec::new();
         let mut labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
+        let mut denied_labeled: Vec<LabeledRibRouteKey> = Vec::new();
         let mut rtc_announced: Vec<RtcRibRoute> = Vec::new();
         let mut rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
         for attr in &parsed.attributes {
@@ -1881,6 +1882,11 @@ impl PeerSession {
                                     is_llgr_stale: false,
                                     path_id: entry.path_id,
                                 });
+                            } else {
+                                denied_labeled.push(LabeledRibRouteKey {
+                                    prefix: entry.nlri.key(),
+                                    path_id: entry.path_id,
+                                });
                             }
                         }
                         continue;
@@ -2204,6 +2210,11 @@ impl PeerSession {
         }
         for key in &labeled_withdrawn {
             self.known_labeled.remove(key);
+        }
+        for key in denied_labeled {
+            if self.known_labeled.remove(&key) {
+                labeled_withdrawn.push(key);
+            }
         }
         for route in &labeled_announced {
             // Keyed by (prefix, path_id): under labeled Add-Path each

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -3725,6 +3725,222 @@ async fn process_update_threads_labeled_add_path_ids_into_rib_keys() {
         }]
     );
 }
+
+/// Import-policy denial retires an exact accepted labeled Add-Path identity,
+/// deduplicates an overlapping explicit withdrawal, preserves siblings, keeps
+/// first-seen denials silent, and reconciles Enhanced Refresh accounting for
+/// both labeled IPv4 and IPv6.
+///
+/// Break-to-red: deleting denied-key collection/presence-gated removal leaves
+/// known/max-prefix/refresh state stale; appending without the membership gate
+/// duplicates the overlap and emits the first-seen denial; applying refresh
+/// capture before the synthetic withdrawal leaves the stale count unchanged.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one dual-AFI stateful scenario pins exact denial, overlap, accounting, and Enhanced Refresh transitions"
+)]
+async fn denied_labeled_add_path_replacements_reconcile_exact_refresh_identity() {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the shared per-AFI fixture keeps every identity transition inside one refresh window"
+    )]
+    async fn exercise(afi: Afi) {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let family = (afi, Safi::LabeledUnicast);
+        let mut negotiated = negotiated_session(65002, true);
+        negotiated.negotiated_families = vec![family];
+        negotiated
+            .add_path_families
+            .insert(family, AddPathMode::Both);
+        negotiated.peer_route_refresh = true;
+        negotiated.peer_enhanced_route_refresh = true;
+        install_test_negotiated_session(&mut session, negotiated);
+
+        let prefix = match afi {
+            Afi::Ipv4 => Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 44, 3, 0), 24)),
+            Afi::Ipv6 => Prefix::V6(Ipv6Prefix::new("2001:db8:443::".parse().unwrap(), 64)),
+            _ => unreachable!("test covers IP labeled-unicast families"),
+        };
+        let nlri = rustbgpd_wire::LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+            prefix,
+        };
+        let next_hop = match afi {
+            Afi::Ipv4 => IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+            Afi::Ipv6 => IpAddr::V6("2001:db8::7".parse().unwrap()),
+            _ => unreachable!("test covers IP labeled-unicast families"),
+        };
+        let base_attrs = || {
+            vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                }),
+            ]
+        };
+        let reach = |path_ids: &[u32]| {
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi,
+                safi: Safi::LabeledUnicast,
+                next_hop,
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: vec![],
+                vpn_announced: vec![],
+                labeled_announced: path_ids
+                    .iter()
+                    .map(|path_id| rustbgpd_wire::LabeledNlriEntry {
+                        path_id: *path_id,
+                        nlri: nlri.clone(),
+                    })
+                    .collect(),
+                rtc_announced: vec![],
+            })
+        };
+        let unreach = |path_id| {
+            PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                afi,
+                safi: Safi::LabeledUnicast,
+                withdrawn: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_withdrawn: vec![],
+                bgpls_withdrawn: vec![],
+                vpn_withdrawn: vec![],
+                labeled_withdrawn: vec![rustbgpd_wire::LabeledNlriEntry {
+                    path_id,
+                    nlri: rustbgpd_wire::LabeledNlri {
+                        labels: vec![],
+                        prefix,
+                    },
+                }],
+                rtc_withdrawn: vec![],
+            })
+        };
+        let update = |attributes: Vec<PathAttribute>| {
+            UpdateMessage::build(&[], &[], &attributes, true, true, Ipv4UnicastMode::Body)
+        };
+        let key = |path_id| rustbgpd_rib::LabeledRibRouteKey { prefix, path_id };
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[11, 22, 33]));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::LabeledRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("accepted labeled paths reach the RIB")
+        else {
+            panic!("expected LabeledRoutesReceived");
+        };
+        assert_eq!(announced.len(), 3);
+        assert!(withdrawn.is_empty());
+        assert_eq!(session.known_prefix_count(), 3);
+        for path_id in [11, 22, 33] {
+            assert!(session.known_labeled.contains(&key(path_id)));
+        }
+
+        buffer_route_refresh(
+            &mut session,
+            afi,
+            Safi::LabeledUnicast,
+            RouteRefreshSubtype::BoRR,
+        );
+        session.process_read_buffer().await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::BeginRouteRefresh {
+                afi: marker_afi,
+                safi: Safi::LabeledUnicast,
+                ..
+            }) if marker_afi == afi
+        ));
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(3));
+
+        session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+            entries: vec![],
+            default_action: PolicyAction::Deny,
+        }])));
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[11]));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::LabeledRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("denied labeled replacement reaches the RIB")
+        else {
+            panic!("expected LabeledRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(11)]);
+        assert!(!session.known_labeled.contains(&key(11)));
+        assert!(session.known_labeled.contains(&key(22)));
+        assert!(session.known_labeled.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 2);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(2));
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[22]));
+        attributes.push(unreach(22));
+        session.process_update(update(attributes)).await;
+        let RibUpdate::LabeledRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("overlap reaches the RIB once")
+        else {
+            panic!("expected LabeledRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn.len(), 1, "overlap must not duplicate the key");
+        assert_eq!(withdrawn, vec![key(22)]);
+        assert!(!session.known_labeled.contains(&key(22)));
+        assert!(session.known_labeled.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        let mut attributes = base_attrs();
+        attributes.push(reach(&[44]));
+        session.process_update(update(attributes)).await;
+        assert!(rib_rx.try_recv().is_err(), "first-seen denial stays silent");
+        assert!(!session.known_labeled.contains(&key(44)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+        assert_eq!(session.import_policy_routes_permitted, 3);
+        assert_eq!(session.import_policy_routes_denied, 3);
+
+        buffer_route_refresh(
+            &mut session,
+            afi,
+            Safi::LabeledUnicast,
+            RouteRefreshSubtype::EoRR,
+        );
+        session.process_read_buffer().await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::EndRouteRefresh {
+                afi: marker_afi,
+                safi: Safi::LabeledUnicast,
+                ..
+            }) if marker_afi == afi
+        ));
+        assert_eq!(session.refresh_accounting_window_count(), 0);
+        assert!(!session.known_labeled.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 0);
+    }
+
+    exercise(Afi::Ipv4).await;
+    exercise(Afi::Ipv6).await;
+}
+
 /// iBGP reflection of a labeled route on an RR adds `ORIGINATOR_ID` and
 /// `CLUSTER_LIST`, keeps `LOCAL_PREF`, and never emits inline `NextHop`/MP attrs.
 #[test]

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast and VPNv4/VPNv6 |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, and labeled-unicast |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
 | VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |
@@ -34,14 +34,16 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ## RFC 1997 — NO_ADVERTISE export restriction
 
-- IPv4/IPv6 unicast and VPNv4/VPNv6 routes carrying `NO_ADVERTISE` are
-  ineligible before export policy, and the post-policy route is checked again
-  before Adj-RIB-Out commit. A permit policy cannot remove the community to
-  bypass the restriction; a policy that adds it suppresses the modified route.
-- The same predicate covers grouped and private single-best plus Add-Path for
-  unicast and VPN routes, and RFC 7947 per-client-best plus RFC 9107 ORR for
-  unicast. Existing advertisements are withdrawn and logical Adj-RIB-Out state
-  is cleared.
+- IPv4/IPv6 unicast, VPNv4/VPNv6, and labeled-unicast routes carrying
+  `NO_ADVERTISE` are ineligible before export policy, and the post-policy route
+  is checked again before Adj-RIB-Out commit. A permit policy cannot remove the
+  community to bypass the restriction; a policy that adds it suppresses the
+  modified route.
+- The same predicate covers single-best plus Add-Path for unicast, VPN, and
+  labeled routes; grouped/private and RFC 7947 per-client-best shapes apply to
+  unicast, grouped/private applies to VPN, and RFC 9107 ORR applies to unicast
+  and labeled-unicast. Existing advertisements are withdrawn and logical
+  Adj-RIB-Out state is cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
   candidates whose result carries `NO_ADVERTISE`. ORR first selects its
@@ -54,10 +56,10 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 ## Inbound import-policy replacement semantics
 
 - Import-policy denial of a replacement retires the exact previously accepted
-  VPN `(RD + prefix, path_id)` identity. First-seen denials remain filter-only,
-  explicit overlapping withdrawals are deduplicated, and Add-Path siblings
-  remain intact. Other non-unicast families retain their existing policy
-  behavior.
+  VPN `(RD + prefix, path_id)` or labeled-unicast `(prefix, path_id)` identity.
+  First-seen denials remain filter-only, explicit overlapping withdrawals are
+  deduplicated, and Add-Path siblings remain intact. Other non-unicast families
+  retain their existing policy behavior.
 
 ---
 


### PR DESCRIPTION
## Summary

- enforce RFC 1997 `NO_ADVERTISE` before and after export policy for IPv4/IPv6 labeled-unicast
- preserve single-best and ORR winner selection without fallback while withdrawing prior advertised identities
- compact Add-Path ranks and retire stale path IDs when suppression changes the eligible set
- retire the exact `(prefix, received path_id)` identity when import policy denies a previously accepted labeled route
- document the labeled-unicast contract and release-facing behavior

## Correctness contract

The change keeps existing AS_PATH and RR-loop safety, ORR winner selection, Adj-RIB-Out ownership, max-prefix accounting, and Enhanced Route Refresh accounting intact. Source suppression is evaluated after the real single-best/ORR winner is chosen, so `NO_ADVERTISE` never causes fallback to a different candidate. Import reconciliation removes explicit withdrawals first, then presence-gates denied identities, then inserts permitted replacements.

## Load-bearing regression proof

Each new scenario was run green, then made red under the named destructive break, and restored green:

- resolved dual-AFI ORR/plain scenario: removing source or post-policy suppression, removing exact withdrawal cleanup, or pre-filtering `NO_ADVERTISE` before ORR selection turns the test red
- non-empty Add-Path scenario: removing source or post-policy suppression, advancing rank for a suppressed source, or deleting stale-rank cleanup turns the test red
- dual-AFI import/refresh scenario: removing denied-key collection, making denied withdrawal unconditional, reordering denial before explicit withdrawal, or bypassing refresh accounting turns the test red

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- focused labeled RIB and transport regressions
- independent exact-diff review

Linear: LAN-442 (Phase 2; remaining families stay open)