### PR TITLE
Harden update-group integrity gates

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -78,6 +78,17 @@ pub(in crate::manager) struct LazyCleanGroupPrior<'a> {
     pub(in crate::manager) deltas: &'a [super::update_groups::GroupDelta],
 }
 
+pub(in crate::manager) fn resolve_lazy_clean_group_prior<'a>(
+    eligible: bool,
+    peer: IpAddr,
+    group_id: Option<usize>,
+    staged_deltas: impl FnOnce(usize) -> Option<&'a [super::update_groups::GroupDelta]>,
+) -> Option<LazyCleanGroupPrior<'a>> {
+    let group_id = eligible.then_some(group_id).flatten()?;
+    let deltas = staged_deltas(group_id)?;
+    Some(LazyCleanGroupPrior { peer, deltas })
+}
+
 /// One-pass state shared by ordinary clean members of an update group.
 pub(in crate::manager) struct SharedUnicastPrecommit<'a> {
     pub(in crate::manager) group_id: usize,
@@ -3800,11 +3811,25 @@ impl RibManager {
                 // regroup, overlay, VPN-bearing, or mixed-family envelope
                 // retains the existing eager prior and authoritative slow
                 // path.
-                let defer_clean_group_prior = !resync
+                let lazy_group_prior_eligible = !resync
                     && shared_unicast_cache_group.is_some()
                     && !has_non_unicast_route_payload
                     && !self.pending_regroup_baseline.contains_key(&peer)
                     && !self.peer_unexportable.contains_key(&peer);
+                // Resolve the optional borrowed stage before deciding whether
+                // eager prior construction may be suppressed. Missing group
+                // identity or staging must take the authoritative slow path.
+                let lazy_group_prior = resolve_lazy_clean_group_prior(
+                    lazy_group_prior_eligible,
+                    peer,
+                    shared_unicast_cache_group,
+                    |group_id| {
+                        group_stage
+                            .get(&group_id)
+                            .map(|stage| stage.deltas.as_slice())
+                    },
+                );
+                let defer_clean_group_prior = lazy_group_prior.is_some();
                 let group_prior = if let Some(gid) = member_of {
                     let mut prior = HashSet::new();
                     if is_dirty {
@@ -3869,17 +3894,6 @@ impl RibManager {
                 } else {
                     HashSet::new()
                 };
-                let lazy_group_prior = defer_clean_group_prior.then(|| {
-                    let gid = shared_unicast_cache_group
-                        .expect("deferred clean prior requires a shared update group");
-                    LazyCleanGroupPrior {
-                        peer,
-                        deltas: &group_stage
-                            .get(&gid)
-                            .expect("shared update-group payload requires staged deltas")
-                            .deltas,
-                    }
-                });
                 if self.try_send_and_commit_outbound_update_with_group_prior(
                     peer,
                     nh_override_flags,

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, RwLock};
 
@@ -396,6 +396,75 @@ fn commit_shared_unicast_with_precommit(
             lazy_group_prior,
         }),
     )
+}
+
+#[test]
+fn lazy_clean_group_prior_falls_back_when_identity_or_stage_is_missing() {
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 40));
+    let staged: HashMap<usize, Vec<crate::manager::update_groups::GroupDelta>> = HashMap::new();
+
+    // Restoring either former `expect` makes one of these missing-input
+    // cases panic instead of selecting the eager exact-reconciliation path.
+    assert!(
+        crate::manager::distribution::resolve_lazy_clean_group_prior(
+            true,
+            target,
+            None,
+            |group_id| staged.get(&group_id).map(Vec::as_slice),
+        )
+        .is_none()
+    );
+    assert!(
+        crate::manager::distribution::resolve_lazy_clean_group_prior(
+            true,
+            target,
+            Some(7),
+            |group_id| staged.get(&group_id).map(Vec::as_slice),
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn lazy_clean_group_prior_defers_only_for_a_resolved_eligible_stage() {
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 41));
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 41));
+    let route = make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 116, 0), 24),
+        Ipv4Addr::new(198, 51, 100, 41),
+    );
+    let staged = HashMap::from([(
+        7,
+        vec![crate::manager::update_groups::GroupDelta {
+            prefix: route.prefix,
+            path_id: route.path_id,
+            new: Some((route.clone(), None)),
+            old_source: Some(source),
+            policy_label: None,
+        }],
+    )]);
+
+    // Always selecting the eager path makes the eligible assertion fail;
+    // ignoring eligibility makes the second assertion fail.
+    let resolved = crate::manager::distribution::resolve_lazy_clean_group_prior(
+        true,
+        target,
+        Some(7),
+        |group_id| staged.get(&group_id).map(Vec::as_slice),
+    )
+    .expect("an eligible existing stage must be deferred");
+    assert_eq!(resolved.peer, target);
+    assert_eq!(resolved.deltas.len(), 1);
+    assert_eq!(resolved.deltas[0].prefix, route.prefix);
+    assert!(
+        crate::manager::distribution::resolve_lazy_clean_group_prior(
+            false,
+            target,
+            Some(7),
+            |group_id| staged.get(&group_id).map(Vec::as_slice),
+        )
+        .is_none()
+    );
 }
 
 #[test]

--- a/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
+++ b/crates/rib/src/manager/tests/update_groups_fault_corpus.rs
@@ -4,7 +4,7 @@
 //! identities, not operation ordering. The ignored extension sweeps those same
 //! schedules under hard parameter/operation caps on a weekly hosted runner.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
@@ -98,13 +98,13 @@ enum ComparisonMode {
     SemanticFold,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FamilySet {
     Unicast,
     VpnRtc,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum PolicySpec {
     Permit,
     DenyOne(Ipv4Prefix),
@@ -112,7 +112,7 @@ enum PolicySpec {
     PeerContext,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MembershipExpectation {
     SharedGroup,
     PeerContextFallback,
@@ -120,7 +120,7 @@ enum MembershipExpectation {
     OrfFallback,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum Op {
     PeerUp {
         peer: Ipv4Addr,
@@ -182,6 +182,12 @@ enum Op {
         peer: Ipv4Addr,
         expectation: MembershipExpectation,
     },
+    AssertAnnouncedPaths {
+        peer: Ipv4Addr,
+        prefix: Ipv4Prefix,
+        expected: usize,
+    },
+    AssertLocRibAbsent(Ipv4Prefix),
     RtcDefaultAnnounce {
         peer: Ipv4Addr,
         generation: u64,
@@ -229,12 +235,19 @@ fn sentinel() -> Ipv4Prefix {
     Ipv4Prefix::new(Ipv4Addr::new(10, 255, 255, 0), 24)
 }
 
-fn seed_octet(seed: u64, byte: usize) -> u8 {
-    seed.to_le_bytes()[byte] | 1
+fn seed_octet(seed: u64, lane: usize) -> u8 {
+    // SplitMix64's stable finalizer makes every fixture lane depend on the
+    // whole seed; consecutive extended-corpus seeds therefore do not leave
+    // the high-byte lanes unchanged.
+    let lane = u64::try_from(lane).expect("fixture lanes fit in u64");
+    let mut mixed = seed ^ lane.wrapping_add(1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    (mixed ^ (mixed >> 31)).to_le_bytes()[0] | 1
 }
 
-fn distinct_seed_octet(seed: u64, byte: usize, other: u8) -> u8 {
-    let candidate = seed_octet(seed, byte);
+fn distinct_seed_octet(seed: u64, lane: usize, other: u8) -> u8 {
+    let candidate = seed_octet(seed, lane);
     if candidate == other {
         candidate.wrapping_add(2)
     } else {
@@ -242,8 +255,8 @@ fn distinct_seed_octet(seed: u64, byte: usize, other: u8) -> u8 {
     }
 }
 
-fn distinct_seed_octet_from(seed: u64, byte: usize, others: &[u8]) -> u8 {
-    let mut candidate = seed_octet(seed, byte);
+fn distinct_seed_octet_from(seed: u64, lane: usize, others: &[u8]) -> u8 {
+    let mut candidate = seed_octet(seed, lane);
     while others.contains(&candidate) {
         candidate = candidate.wrapping_add(2);
     }
@@ -410,6 +423,14 @@ async fn assert_membership(
     }
 }
 
+fn announced_paths(messages: &[NormMsg], prefix: Ipv4Prefix) -> HashSet<(u32, IpAddr)> {
+    messages
+        .iter()
+        .flat_map(|message| &message.announce)
+        .filter_map(|route| (route.0 == Prefix::V4(prefix)).then_some((route.1, route.3)))
+        .collect()
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "the exhaustive fault-script interpreter keeps every operation's behavior in one auditable match"
@@ -572,6 +593,28 @@ async fn apply(oracle: &mut Oracle, op: &Op, force_ungrouped: bool) {
         }
         Op::AssertMembership { peer, expectation } => {
             assert_membership(oracle, *peer, *expectation, force_ungrouped).await;
+        }
+        Op::AssertAnnouncedPaths {
+            peer,
+            prefix,
+            expected,
+        } => {
+            let messages = oracle.drain_peer_available(*peer).await;
+            let paths = announced_paths(&messages, *prefix);
+            assert_eq!(
+                paths.len(),
+                *expected,
+                "unexpected newly announced Add-Path identities for {prefix}: {paths:?}"
+            );
+        }
+        Op::AssertLocRibAbsent(prefix) => {
+            let routes = oracle.best_routes().await;
+            assert!(
+                routes
+                    .iter()
+                    .all(|route| route.prefix != Prefix::V4(*prefix)),
+                "stale-session replacement route reached the Loc-RIB: {prefix}"
+            );
         }
         Op::RtcDefaultAnnounce { peer, generation } => {
             oracle
@@ -996,6 +1039,14 @@ fn add_path_membership_schedule(seed: u64) -> Schedule {
                 peer: RIGHT,
                 expectation: MembershipExpectation::AddPathFallback,
             },
+            // Removing initial Add-Path fanout or rank compaction makes these
+            // operation-boundary counts fail instead of merely comparing two
+            // equally incomplete terminal folds.
+            Op::AssertAnnouncedPaths {
+                peer: RIGHT,
+                prefix,
+                expected: 2,
+            },
             // The predecessor generation cannot narrow the active session's
             // cap or trigger its replay.
             Op::AddPathLimit {
@@ -1003,10 +1054,20 @@ fn add_path_membership_schedule(seed: u64) -> Schedule {
                 generation: 2,
                 limit: 1,
             },
+            Op::AssertAnnouncedPaths {
+                peer: RIGHT,
+                prefix,
+                expected: 0,
+            },
             Op::AddPathLimit {
                 peer: RIGHT,
                 generation: 3,
                 limit: 1,
+            },
+            Op::AssertAnnouncedPaths {
+                peer: RIGHT,
+                prefix,
+                expected: 1,
             },
             Op::Withdraw {
                 peer: SOURCE,
@@ -1191,6 +1252,9 @@ fn replacement_during_resync_schedule(seed: u64) -> Schedule {
                 prefix: stale,
                 local_pref: 250,
             },
+            // Removing the received-route generation fence exposes this
+            // superseded session's higher-preference route in the Loc-RIB.
+            Op::AssertLocRibAbsent(stale),
             Op::AdvanceRetry,
             Op::AssertMembership {
                 peer: RIGHT,
@@ -1305,8 +1369,6 @@ fn completion_gate_rejects_equal_but_incomplete_streams() {
     let empty: Streams = [(IpAddr::V4(LEFT), vec![]), (IpAddr::V4(RIGHT), vec![])]
         .into_iter()
         .collect();
-    assert_eq!(semantic_effects(&empty), semantic_effects(&empty));
-    assert_eq!(fold(&empty), fold(&empty));
     assert!(
         validate_terminal_stream(&empty).is_err(),
         "equal empty streams must not pass the differential oracle"
@@ -1319,8 +1381,6 @@ fn completion_gate_rejects_equal_but_incomplete_streams() {
     ]
     .into_iter()
     .collect();
-    assert_eq!(semantic_effects(&truncated), semantic_effects(&truncated));
-    assert_eq!(fold(&truncated), fold(&truncated));
     assert!(
         validate_terminal_stream(&truncated).is_err(),
         "equal nonempty streams truncated before convergence must not pass"
@@ -1343,6 +1403,30 @@ fn completion_gate_rejects_equal_but_incomplete_streams() {
         validate_terminal_stream(&complete).is_err(),
         "a sentinel from a superseded connection cannot complete the current session"
     );
+}
+
+#[test]
+fn extended_seed_sweep_varies_every_schedule_operation_fixture() {
+    let baseline = schedules(DEFAULT_SEED_START);
+    let mut varied = [false; 6];
+    for offset in 1..DEFAULT_SEED_COUNT {
+        let seed = DEFAULT_SEED_START
+            + u64::try_from(offset).expect("extended seed count is capped at 64");
+        let candidate = schedules(seed);
+        for (index, (baseline, candidate)) in baseline.iter().zip(candidate.iter()).enumerate() {
+            varied[index] |= baseline.ops != candidate.ops;
+        }
+    }
+
+    // Reverting the mixer to raw little-endian seed bytes leaves four of
+    // these six actual operation fixtures unchanged across the default sweep.
+    for (schedule, varied) in baseline.iter().zip(varied) {
+        assert!(
+            varied,
+            "extended seeds did not vary operations for {}",
+            schedule.name
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/rib/src/manager/tests/update_groups_oracle.rs
+++ b/crates/rib/src/manager/tests/update_groups_oracle.rs
@@ -889,17 +889,24 @@ impl Oracle {
         reply_rx.await.unwrap().unwrap();
     }
 
-    /// Round-trip a query on the primary channel: the run loop only
-    /// handles it after every prior update (and its route chunks) has
-    /// been fully processed, so all resulting outbound sends have
-    /// happened by the time the reply arrives.
-    pub(super) async fn quiesce(&mut self) {
+    /// Return the current Loc-RIB best routes after a FIFO round trip on
+    /// the primary channel. The reply is also an ordering barrier for all
+    /// prior updates and their resulting outbound sends.
+    pub(super) async fn best_routes(&mut self) -> Vec<Route> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
             .send(RibUpdate::QueryBestRoutes { reply: reply_tx })
             .await
             .unwrap();
-        let _ = reply_rx.await.unwrap();
+        reply_rx.await.unwrap()
+    }
+
+    /// Round-trip a query on the primary channel: the run loop only
+    /// handles it after every prior update (and its route chunks) has
+    /// been fully processed, so all resulting outbound sends have
+    /// happened by the time the reply arrives.
+    pub(super) async fn quiesce(&mut self) {
+        let _ = self.best_routes().await;
     }
 
     /// Drain one pending message from a peer's channel (channel-fill
@@ -918,6 +925,24 @@ impl Oracle {
             .or_default()
             .push(normalize(&update));
         update
+    }
+
+    /// After a FIFO barrier, drain only one peer's currently available
+    /// messages. Each update is normalized once and retained in the full
+    /// collected history as well as returned to the operation-level oracle.
+    pub(super) async fn drain_peer_available(&mut self, peer: Ipv4Addr) -> Vec<NormMsg> {
+        self.quiesce().await;
+        let peer = IpAddr::V4(peer);
+        let rx = self.outs.get_mut(&peer).expect("peer registered");
+        let mut drained = Vec::new();
+        while let Ok(update) = rx.try_recv() {
+            drained.push(normalize(&update));
+        }
+        self.collected
+            .entry(peer)
+            .or_default()
+            .extend(drained.iter().cloned());
+        drained
     }
 
     /// Drain every currently available message without waiting for a send.


### PR DESCRIPTION
## Summary

- make lazy clean-group prior selection total over eligibility, group identity, and staged deltas
- resolve that selector before suppressing eager prior construction, so missing state falls back to exact reconciliation instead of panicking or losing an owed withdrawal
- make the permanent update-group fault corpus directly observe Add-Path generation fencing, stale-route rejection, and all six extended-seed fixtures
- remove tautological stream comparisons while preserving the terminal-sentinel completion gate

## Root cause

The clean grouped fast-path caller used two `expect` calls even though the eager path it replaced tolerated missing staging. Simply making the lookup optional after computing the defer flag would still suppress eager prior construction, so the selector now resolves first and its `Option` controls both lazy deferral and the authoritative fallback.

The fault corpus exercised stale Add-Path limits and stale replacement routes, but grouped-vs-ungrouped equality could not observe shared pre-grouping session fences. It now uses peer-local, FIFO-barriered output windows and a Loc-RIB query to assert the affected state directly. Extended seeds now mix the full replayable seed into every fixture lane.

This addresses LAN-402 finding 1 only. The remaining fast/slow bookkeeping differential stays tracked separately on LAN-402. This resolves LAN-404.

## Load-bearing proof

Each mutation was run against the focused test and then restored:

- requiring a group ID panics the missing-ID selector case
- requiring staged deltas panics the missing-stage selector case
- forcing the selector to return `None` fails the present-stage fast-path case
- accepting a stale Paths-Limit emits one path where zero is required
- disabling the current Paths-Limit handler emits zero paths where one is required
- accepting stale `RoutesReceived` puts the unique stale prefix into Loc-RIB
- restoring low-byte-only seed selection leaves four schedules invariant
- bypassing terminal-sentinel validation lets the empty stream through and fails the completion test

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- focused selector and fault-corpus suites
- explicit 24-seed ignored fault corpus
- independent exact-diff review

Documentation is unchanged because this is an internal safety fallback and test-integrity hardening; there is no operator-visible contract change.
