### PR TITLE
Enforce policy safety for RTC and BGP-LS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   resolver.
 
 - **RFC 1997 `NO_ADVERTISE` can no longer be bypassed or leaked by export
-  policy.** IPv4/IPv6 unicast, VPNv4/VPNv6, and labeled-unicast check both the
-  stored source route before export policy and the modified route after policy
-  across single-best plus Add-Path. Unicast also covers grouped/private, RFC
+  policy.** IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS
+  SAFI 71/72 check both the stored source route before export policy and the
+  modified route after policy across their supported export shapes. Unicast
+  also covers grouped/private, RFC
   7947 per-client-best, and RFC 9107 ORR; VPN covers grouped/private, and
   labeled-unicast covers RFC 9107 ORR. Policy cannot remove the community to
   make a scoped route exportable, and a policy-added community suppresses the
@@ -187,10 +188,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OTC, AS_PATH-loop, and route-reflector-loop rejects now retire the exact
   accepted `(prefix, path_id)` while first-seen rejects remain filter-only.
 
-- **Import-policy-denied unicast, VPN, and labeled-unicast replacements
+- **Import-policy-denied unicast, VPN, labeled-unicast, RTC, and BGP-LS replacements
   withdraw prior accepted paths.** Classic and MP-unicast updates retire the
   exact `(prefix, path_id)`; VPNv4/VPNv6 retire `(RD + prefix, path_id)`, and
-  labeled-unicast retires `(prefix, path_id)` previously accepted from that
+  labeled-unicast retires `(prefix, path_id)`, RTC retires `(NLRI, path_id)`,
+  and BGP-LS retires `(family, NLRI, path_id)` previously accepted from that
   peer. The removal reaches the RIB immediately. First-seen denials remain
   filter-only, explicit withdrawals are deduplicated, and Add-Path siblings
   stay intact.

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -55,6 +55,15 @@ impl RibManager {
                 continue;
             };
 
+            // RFC 1997: NO_ADVERTISE is a pre-policy export restriction.
+            // Policy cannot remove it to make the source route exportable.
+            if super::no_advertise_export_suppressed(best.communities()) {
+                if rib_out.get_bgpls(key).is_some() {
+                    bgpls_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
             // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
             // suppressed. See `llgr_stale_export_suppressed`.
             if super::llgr_stale_export_suppressed(
@@ -157,6 +166,15 @@ impl RibManager {
                 }
             }
             modified.path_id = 0;
+
+            // Export policy may scope an otherwise eligible route by adding
+            // NO_ADVERTISE. Stop it before the Adj-RIB-Out commit.
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                if rib_out.get_bgpls(key).is_some() {
+                    bgpls_withdraw.push(key.clone());
+                }
+                continue;
+            }
 
             if !force
                 && rib_out

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -624,8 +624,9 @@ fn llgr_stale_export_suppressed(
 /// means that a route "MUST NOT be advertised to any BGP peer", so the
 /// source route is ineligible before export policy can remove the community,
 /// and a modified route is ineligible when policy adds it. This predicate is
-/// deliberately target-independent: every supported unicast, VPN, and
-/// labeled-unicast selection shape applies both checks.
+/// deliberately target-independent: every supported unicast, VPN,
+/// labeled-unicast, RT-Constrain, and BGP-LS selection shape applies both
+/// checks.
 pub(super) fn no_advertise_export_suppressed(communities: &[u32]) -> bool {
     communities.contains(&rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
 }

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -76,6 +76,15 @@ impl RibManager {
                 continue;
             };
 
+            // RFC 1997: NO_ADVERTISE is a pre-policy export restriction.
+            // Policy cannot remove it to make the source route exportable.
+            if super::no_advertise_export_suppressed(best.communities()) {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
+
             // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
             // suppressed. See `llgr_stale_export_suppressed`.
             if super::llgr_stale_export_suppressed(
@@ -178,6 +187,15 @@ impl RibManager {
                 }
             }
             modified.path_id = 0;
+
+            // Export policy may scope an otherwise eligible route by adding
+            // NO_ADVERTISE. Stop it before the Adj-RIB-Out commit.
+            if super::no_advertise_export_suppressed(modified.communities()) {
+                if rib_out.get_rtc(key).is_some() {
+                    rtc_withdraw.push(key.clone());
+                }
+                continue;
+            }
 
             if !force
                 && rib_out

--- a/crates/rib/src/manager/tests/bgpls.rs
+++ b/crates/rib/src/manager/tests/bgpls.rs
@@ -1,5 +1,67 @@
 use super::*;
 
+fn with_bgpls_no_advertise(mut route: crate::route::BgpLsRibRoute) -> crate::route::BgpLsRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ]));
+    route
+}
+
+fn bgpls_no_advertise_policy(next_hop: IpAddr, add: bool) -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: Some(next_hop),
+            modifications: rustbgpd_policy::RouteModifications {
+                communities_add: add
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                communities_remove: (!add)
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+        }],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
+fn make_bgpls_policy_route(
+    family: crate::route::BgpLsFamily,
+    peer: Ipv4Addr,
+) -> crate::route::BgpLsRibRoute {
+    let mut route = make_bgpls_route(peer, 42, 100);
+    route.family = family;
+    if family == crate::route::BgpLsFamily::LinkStateVpn {
+        route.nlri = rustbgpd_wire::bgpls::decode_bgpls_vpn_nlri(&[
+            0xfd, 0xe8, 0, 11, // 8-byte RD + 3-byte opaque payload
+            0, 0, 0xfd, 0xe8, 0, 0, 0, 42, 0xaa, 0xbb, 0x2a,
+        ])
+        .expect("fixture BGP-LS VPN NLRI decodes")
+        .pop()
+        .expect("fixture contains one BGP-LS VPN NLRI");
+    }
+    route
+}
+
 #[tokio::test]
 async fn bgpls_routes_received_recompute_and_withdraw() {
     let (tx, rx) = mpsc::channel(64);
@@ -181,6 +243,134 @@ async fn bgpls_routes_received_reflects_and_withdraws_to_eligible_peer() {
 
     drop(tx);
     handle.await.unwrap();
+}
+
+/// Both BGP-LS SAFIs enforce RFC 1997 before and after export policy,
+/// withdraw the exact prior Adj-RIB-Out identity, and recover when the source
+/// or policy scope is removed.
+///
+/// Break-to-red: deleting the pre-policy guard lets the removal policy export
+/// the source-scoped route; deleting the post-policy guard retains the route
+/// when policy adds `NO_ADVERTISE`; deleting either existing-state withdrawal
+/// leaves the exact SAFI-specific key advertised; sticky suppression prevents
+/// the two recovery announcements.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn bgpls_no_advertise_withdraws_exact_prior_and_recovers_for_both_safis() {
+    #[allow(clippy::too_many_lines)]
+    async fn exercise(family: crate::route::BgpLsFamily) {
+        let (tx, rx) = mpsc::channel(64);
+        let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+        let handle = tokio::spawn(manager.run());
+        let source = Ipv4Addr::new(198, 51, 100, 11);
+        let source_ip = IpAddr::V4(source);
+        let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 31));
+        let (out_tx, mut out_rx) = mpsc::channel(16);
+        tx.send(RibUpdate::PeerUp {
+            per_client_best: false,
+            session_id: 0,
+            peer: target,
+            peer_asn: 65100,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx: out_tx,
+            export_policy: Some(bgpls_no_advertise_policy(source_ip, false)),
+            sendable_families: vec![family.to_afi_safi()],
+            is_ebgp: true,
+            route_reflector_client: false,
+            orr_vantage: None,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: Vec::new(),
+            negotiated_llgr_families: Vec::new(),
+        })
+        .await
+        .unwrap();
+        drain_eor(&mut out_rx).await;
+
+        let route = make_bgpls_policy_route(family, source);
+        let key = route.key();
+        tx.send(RibUpdate::BgpLsRoutesReceived {
+            session_id: 0,
+            peer: source_ip,
+            announced: vec![route.clone()],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_bgpls_routes(&tx).await;
+        let initial = out_rx
+            .try_recv()
+            .expect("plain BGP-LS route must be announced");
+        assert_eq!(initial.bgpls_announce.len(), 1);
+        assert_eq!(initial.bgpls_announce[0].key(), key);
+
+        tx.send(RibUpdate::BgpLsRoutesReceived {
+            session_id: 0,
+            peer: source_ip,
+            announced: vec![with_bgpls_no_advertise(route.clone())],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_bgpls_routes(&tx).await;
+        let source_scoped = out_rx
+            .try_recv()
+            .expect("source NO_ADVERTISE must withdraw the prior BGP-LS route");
+        assert!(source_scoped.bgpls_announce.is_empty());
+        assert_eq!(source_scoped.bgpls_withdraw, vec![key.clone()]);
+
+        tx.send(RibUpdate::BgpLsRoutesReceived {
+            session_id: 0,
+            peer: source_ip,
+            announced: vec![route],
+            withdrawn: vec![],
+        })
+        .await
+        .unwrap();
+        let _ = query_bgpls_routes(&tx).await;
+        let source_recovered = out_rx.try_recv().expect("plain BGP-LS route must recover");
+        assert_eq!(source_recovered.bgpls_announce.len(), 1);
+        assert!(source_recovered.bgpls_withdraw.is_empty());
+
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: target,
+            export_policy: Some(bgpls_no_advertise_policy(source_ip, true)),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+        let _ = query_bgpls_routes(&tx).await;
+        let policy_scoped = out_rx
+            .try_recv()
+            .expect("policy-added NO_ADVERTISE must withdraw BGP-LS");
+        assert!(policy_scoped.bgpls_announce.is_empty());
+        assert_eq!(policy_scoped.bgpls_withdraw, vec![key]);
+
+        let (reply, response) = oneshot::channel();
+        tx.send(RibUpdate::ReplacePeerExportPolicy {
+            peer: target,
+            export_policy: Some(bgpls_no_advertise_policy(source_ip, false)),
+            reply,
+        })
+        .await
+        .unwrap();
+        response.await.unwrap().unwrap();
+        let _ = query_bgpls_routes(&tx).await;
+        let policy_recovered = out_rx
+            .try_recv()
+            .expect("removing policy-added NO_ADVERTISE must re-announce BGP-LS");
+        assert_eq!(policy_recovered.bgpls_announce.len(), 1);
+        assert!(policy_recovered.bgpls_withdraw.is_empty());
+        assert!(out_rx.try_recv().is_err());
+
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    exercise(crate::route::BgpLsFamily::LinkState).await;
+    exercise(crate::route::BgpLsFamily::LinkStateVpn).await;
 }
 
 #[tokio::test]

--- a/crates/rib/src/manager/tests/bgpls.rs
+++ b/crates/rib/src/manager/tests/bgpls.rs
@@ -255,9 +255,15 @@ async fn bgpls_routes_received_reflects_and_withdraws_to_eligible_peer() {
 /// leaves the exact SAFI-specific key advertised; sticky suppression prevents
 /// the two recovery announcements.
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered state-machine regression covers both BGP-LS SAFIs"
+)]
 async fn bgpls_no_advertise_withdraws_exact_prior_and_recovers_for_both_safis() {
-    #[allow(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the per-SAFI sequence proves suppression, withdrawal, and recovery"
+    )]
     async fn exercise(family: crate::route::BgpLsFamily) {
         let (tx, rx) = mpsc::channel(64);
         let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());

--- a/crates/rib/src/manager/tests/rtc.rs
+++ b/crates/rib/src/manager/tests/rtc.rs
@@ -198,7 +198,10 @@ async fn rtc_route_reflects_between_ibgp_clients_with_originator_and_cluster_lis
 /// leaves the exact key advertised; making suppression sticky prevents the two
 /// recovery announcements.
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered state-machine regression proves suppression, withdrawal, and recovery"
+)]
 async fn rtc_no_advertise_withdraws_exact_prior_and_recovers() {
     let (tx, rx) = mpsc::channel(64);
     let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());

--- a/crates/rib/src/manager/tests/rtc.rs
+++ b/crates/rib/src/manager/tests/rtc.rs
@@ -1,5 +1,51 @@
 use super::*;
 
+fn with_rtc_no_advertise(mut route: crate::route::RtcRibRoute) -> crate::route::RtcRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(vec![
+        rustbgpd_wire::COMMUNITY_NO_ADVERTISE,
+    ]));
+    route
+}
+
+fn rtc_no_advertise_policy(next_hop: IpAddr, add: bool) -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: Some(next_hop),
+            modifications: rustbgpd_policy::RouteModifications {
+                communities_add: add
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                communities_remove: (!add)
+                    .then_some(rustbgpd_wire::COMMUNITY_NO_ADVERTISE)
+                    .into_iter()
+                    .collect(),
+                ..rustbgpd_policy::RouteModifications::default()
+            },
+        }],
+        // The locally originated default RTC NLRI has an unspecified next
+        // hop, so this narrow fixture never changes or suppresses it.
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
 /// Received RTC routes land in the typed Adj-RIB-In / Loc-RIB and are
 /// queryable through `QueryRtcRoutes`.
 #[tokio::test]
@@ -137,6 +183,128 @@ async fn rtc_route_reflects_between_ibgp_clients_with_originator_and_cluster_lis
         crate::route::RouteOrigin::Ibgp,
         "reflected route keeps iBGP origin so transport attaches ORIGINATOR_ID/CLUSTER_LIST"
     );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// RT-Constrain enforces RFC 1997 before and after export policy, withdraws
+/// the exact prior Adj-RIB-Out identity, and re-announces after either scope is
+/// removed without disturbing the locally originated default RTC NLRI.
+///
+/// Break-to-red: deleting the pre-policy guard lets the removal policy export
+/// the source-scoped route; deleting the post-policy guard retains the route
+/// when policy adds `NO_ADVERTISE`; deleting either existing-state withdrawal
+/// leaves the exact key advertised; making suppression sticky prevents the two
+/// recovery announcements.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn rtc_no_advertise_withdraws_exact_prior_and_recovers() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let source = Ipv4Addr::new(198, 51, 100, 10);
+    let source_ip = IpAddr::V4(source);
+    let target = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 30));
+    let (out_tx, mut out_rx) = mpsc::channel(16);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: Some(rtc_no_advertise_policy(source_ip, false)),
+        sendable_families: rtc_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_rtc_initial_dump(&mut out_rx).await;
+
+    let route = make_rtc_rib_route(source, 442, 100);
+    let key = route.key();
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![route.clone()],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_rtc_routes(&tx).await;
+    let initial = out_rx
+        .try_recv()
+        .expect("plain RTC route must be announced");
+    assert_eq!(initial.rtc_announce.len(), 1);
+    assert_eq!(initial.rtc_announce[0].key(), key);
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![with_rtc_no_advertise(route.clone())],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_rtc_routes(&tx).await;
+    let source_scoped = out_rx
+        .try_recv()
+        .expect("source NO_ADVERTISE must withdraw the prior RTC route");
+    assert!(source_scoped.rtc_announce.is_empty());
+    assert_eq!(source_scoped.rtc_withdraw, vec![key.clone()]);
+
+    tx.send(RibUpdate::RtcRoutesReceived {
+        session_id: 0,
+        peer: source_ip,
+        announced: vec![route],
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_rtc_routes(&tx).await;
+    let source_recovered = out_rx.try_recv().expect("plain RTC route must recover");
+    assert_eq!(source_recovered.rtc_announce.len(), 1);
+    assert!(source_recovered.rtc_withdraw.is_empty());
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(rtc_no_advertise_policy(source_ip, true)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_rtc_routes(&tx).await;
+    let policy_scoped = out_rx
+        .try_recv()
+        .expect("policy-added NO_ADVERTISE must withdraw the RTC route");
+    assert!(policy_scoped.rtc_announce.is_empty());
+    assert_eq!(policy_scoped.rtc_withdraw, vec![key]);
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicy {
+        peer: target,
+        export_policy: Some(rtc_no_advertise_policy(source_ip, false)),
+        reply,
+    })
+    .await
+    .unwrap();
+    response.await.unwrap().unwrap();
+    let _ = query_rtc_routes(&tx).await;
+    let policy_recovered = out_rx
+        .try_recv()
+        .expect("removing policy-added NO_ADVERTISE must re-announce RTC");
+    assert_eq!(policy_recovered.rtc_announce.len(), 1);
+    assert!(policy_recovered.rtc_withdraw.is_empty());
+    assert!(out_rx.try_recv().is_err(), "default RTC must not churn");
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1505,6 +1505,7 @@ impl PeerSession {
         let mut evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
         let mut bgpls_announced: Vec<BgpLsRibRoute> = Vec::new();
         let mut bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+        let mut denied_bgpls: Vec<BgpLsRouteKey> = Vec::new();
         let mut vpn_announced: Vec<VpnRibRoute> = Vec::new();
         let mut vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
         let mut denied_vpn: Vec<VpnRibRouteKey> = Vec::new();
@@ -1513,6 +1514,7 @@ impl PeerSession {
         let mut denied_labeled: Vec<LabeledRibRouteKey> = Vec::new();
         let mut rtc_announced: Vec<RtcRibRoute> = Vec::new();
         let mut rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
+        let mut denied_rtc: Vec<RtcRibRouteKey> = Vec::new();
         for attr in &parsed.attributes {
             match attr {
                 PathAttribute::MpReachNlri(mp) => {
@@ -1746,6 +1748,12 @@ impl PeerSession {
                                     is_llgr_stale: false,
                                     path_id: 0,
                                 });
+                            } else {
+                                denied_bgpls.push(BgpLsRouteKey {
+                                    family: bgpls_family,
+                                    nlri: nlri.key(),
+                                    path_id: 0,
+                                });
                             }
                         }
                         continue;
@@ -1946,6 +1954,11 @@ impl PeerSession {
                                         .map_or(Ipv4Addr::UNSPECIFIED, |n| n.peer_router_id),
                                     is_stale: false,
                                     is_llgr_stale: false,
+                                    path_id: 0,
+                                });
+                            } else {
+                                denied_rtc.push(RtcRibRouteKey {
+                                    nlri: *nlri,
                                     path_id: 0,
                                 });
                             }
@@ -2190,6 +2203,11 @@ impl PeerSession {
         for key in &bgpls_withdrawn {
             self.known_bgpls.remove(key);
         }
+        for key in denied_bgpls {
+            if self.known_bgpls.remove(&key) {
+                bgpls_withdrawn.push(key);
+            }
+        }
         for route in &bgpls_announced {
             self.known_bgpls.insert(route.key());
         }
@@ -2224,6 +2242,11 @@ impl PeerSession {
         }
         for key in &rtc_withdrawn {
             self.known_rtc.remove(key);
+        }
+        for key in denied_rtc {
+            if self.known_rtc.remove(&key) {
+                rtc_withdrawn.push(key);
+            }
         }
         for route in &rtc_announced {
             self.known_rtc.insert(route.key());

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -11,7 +11,7 @@ use rustbgpd_wire::{
     Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, Ipv6PrefixOffset, LlgrFamily, Message, MplsLabelEntry,
     NumericMatch, OrfAction, OrfEntries, OrfEntryGroup, OrfMatch, OrfPayload, OrfType, Origin,
     PathAttribute, RouteDistinguisher, VpnNlri, VpnPrefix, WhenToRefresh,
-    bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri},
+    bgpls::{BgpLsNlri, BgpLsNlriType, decode_bgpls_nlri, decode_bgpls_vpn_nlri},
 };
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -4470,6 +4470,377 @@ async fn denied_vpn_add_path_replacements_withdraw_exact_known_identity() {
 
     exercise(Afi::Ipv4).await;
     exercise(Afi::Ipv6).await;
+}
+
+/// Import-policy denial retires an accepted RTC identity exactly once,
+/// deduplicates an overlapping explicit withdrawal, keeps first-seen denials
+/// silent, and reconciles max-prefix plus Enhanced Refresh accounting.
+///
+/// Break-to-red: deleting denied-key collection leaves the accepted route and
+/// stale refresh identity live; appending without `known_rtc.remove` duplicates
+/// the overlap and emits a first-seen withdrawal; capturing refresh state
+/// without the synthetic withdrawal leaves the stale count unchanged.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn denied_rtc_replacements_reconcile_exact_refresh_identity() {
+    use rustbgpd_wire::{MpReachNlri, MpUnreachNlri, RtcNlri};
+
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let family = (Afi::Ipv4, Safi::RtConstrain);
+    let mut negotiated = negotiated_session(65002, false);
+    negotiated.negotiated_families = vec![family];
+    negotiated.peer_route_refresh = true;
+    negotiated.peer_enhanced_route_refresh = true;
+    install_test_negotiated_session(&mut session, negotiated);
+
+    let nlri =
+        |admin: u16| RtcNlri::new(65002, 0x0002_FDEA_0000_0000 | u64::from(admin), 96).unwrap();
+    let first = nlri(11);
+    let overlap = nlri(22);
+    let first_seen = nlri(33);
+    let key = |nlri| rustbgpd_rib::RtcRibRouteKey { nlri, path_id: 0 };
+    let base_attrs = || {
+        vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+        ]
+    };
+    let reach = |nlris: Vec<RtcNlri>| {
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: nlris,
+        })
+    };
+    let unreach = |nlris: Vec<RtcNlri>| {
+        PathAttribute::MpUnreachNlri(MpUnreachNlri {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            withdrawn: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_withdrawn: vec![],
+            bgpls_withdrawn: vec![],
+            labeled_withdrawn: vec![],
+            vpn_withdrawn: vec![],
+            rtc_withdrawn: nlris,
+        })
+    };
+    let update = |mut attributes: Vec<PathAttribute>, reach_attr, unreach_attr| {
+        attributes.push(reach_attr);
+        if let Some(unreach_attr) = unreach_attr {
+            attributes.push(unreach_attr);
+        }
+        UpdateMessage::build(&[], &[], &attributes, true, false, Ipv4UnicastMode::Body)
+    };
+
+    session
+        .process_update(update(base_attrs(), reach(vec![first, overlap]), None))
+        .await;
+    let RibUpdate::RtcRoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("accepted RTC routes reach the RIB")
+    else {
+        panic!("expected RtcRoutesReceived");
+    };
+    assert_eq!(announced.len(), 2);
+    assert!(withdrawn.is_empty());
+    assert_eq!(session.known_prefix_count(), 2);
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::RtConstrain,
+        RouteRefreshSubtype::BoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::BeginRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            ..
+        })
+    ));
+    assert_eq!(session.refresh_accounting_stale_count(family), Some(2));
+
+    session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }])));
+
+    session
+        .process_update(update(base_attrs(), reach(vec![first]), None))
+        .await;
+    let RibUpdate::RtcRoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx
+        .try_recv()
+        .expect("denied RTC replacement reaches the RIB")
+    else {
+        panic!("expected RtcRoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![key(first)]);
+    assert_eq!(session.known_prefix_count(), 1);
+    assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+    session
+        .process_update(update(
+            base_attrs(),
+            reach(vec![overlap]),
+            Some(unreach(vec![overlap])),
+        ))
+        .await;
+    let RibUpdate::RtcRoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().expect("overlap reaches the RIB once")
+    else {
+        panic!("expected RtcRoutesReceived");
+    };
+    assert!(announced.is_empty());
+    assert_eq!(withdrawn, vec![key(overlap)]);
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.refresh_accounting_stale_count(family), Some(0));
+
+    session
+        .process_update(update(base_attrs(), reach(vec![first_seen]), None))
+        .await;
+    assert!(
+        rib_rx.try_recv().is_err(),
+        "first-seen RTC denial is silent"
+    );
+    assert!(!session.known_rtc.contains(&key(first_seen)));
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(session.refresh_accounting_stale_count(family), Some(0));
+
+    buffer_route_refresh(
+        &mut session,
+        Afi::Ipv4,
+        Safi::RtConstrain,
+        RouteRefreshSubtype::EoRR,
+    );
+    session.process_read_buffer().await;
+    assert!(matches!(
+        rib_rx.try_recv(),
+        Ok(RibUpdate::EndRouteRefresh {
+            afi: Afi::Ipv4,
+            safi: Safi::RtConstrain,
+            ..
+        })
+    ));
+    assert_eq!(session.refresh_accounting_window_count(), 0);
+}
+
+/// Import-policy denial retires an accepted BGP-LS identity exactly once for
+/// SAFI 71 and 72, deduplicates an overlapping explicit withdrawal, keeps
+/// first-seen denials silent, and reconciles max-prefix plus Enhanced Refresh.
+///
+/// Break-to-red: deleting denied-key collection leaves the accepted topology
+/// object and stale refresh identity live; appending without
+/// `known_bgpls.remove` duplicates the overlap and emits first-seen state;
+/// omitting the synthetic withdrawal from refresh capture leaves stale count.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn denied_bgpls_replacements_reconcile_exact_refresh_identity_for_both_safis() {
+    use rustbgpd_rib::BgpLsFamily;
+    use rustbgpd_wire::{MpReachNlri, MpUnreachNlri};
+
+    fn nlri(safi: Safi, suffix: u8) -> BgpLsNlri {
+        match safi {
+            Safi::BgpLs => decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xbb, suffix]),
+            Safi::BgpLsVpn => decode_bgpls_vpn_nlri(&[
+                0xfd, 0xe8, 0, 11, // 8-byte RD + 3-byte opaque payload
+                0, 0, 0xfd, 0xea, 0, 0, 0, 44, 0xaa, 0xbb, suffix,
+            ]),
+            _ => unreachable!("fixture covers only BGP-LS SAFIs"),
+        }
+        .expect("fixture BGP-LS NLRI decodes")
+        .pop()
+        .expect("fixture contains one BGP-LS NLRI")
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn exercise(safi: Safi) {
+        let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+        let afi = Afi::BgpLs;
+        let family = (afi, safi);
+        let bgpls_family = BgpLsFamily::from_afi_safi(afi, safi).unwrap();
+        let mut negotiated = negotiated_session(65002, false);
+        negotiated.negotiated_families = vec![family];
+        negotiated.peer_route_refresh = true;
+        negotiated.peer_enhanced_route_refresh = true;
+        install_test_negotiated_session(&mut session, negotiated);
+
+        let first = nlri(safi, 11);
+        let overlap = nlri(safi, 22);
+        let first_seen = nlri(safi, 33);
+        let key = |nlri: &BgpLsNlri| rustbgpd_rib::BgpLsRouteKey {
+            family: bgpls_family,
+            nlri: nlri.key(),
+            path_id: 0,
+        };
+        let base_attrs = || {
+            vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![65002])],
+                }),
+            ]
+        };
+        let reach = |nlris: Vec<BgpLsNlri>| {
+            PathAttribute::MpReachNlri(MpReachNlri {
+                afi,
+                safi,
+                next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+                link_local_next_hop: None,
+                announced: vec![],
+                flowspec_announced: vec![],
+                evpn_announced: vec![],
+                bgpls_announced: nlris,
+                labeled_announced: vec![],
+                vpn_announced: vec![],
+                rtc_announced: vec![],
+            })
+        };
+        let unreach = |nlris: Vec<BgpLsNlri>| {
+            PathAttribute::MpUnreachNlri(MpUnreachNlri {
+                afi,
+                safi,
+                withdrawn: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_withdrawn: vec![],
+                bgpls_withdrawn: nlris,
+                labeled_withdrawn: vec![],
+                vpn_withdrawn: vec![],
+                rtc_withdrawn: vec![],
+            })
+        };
+        let update = |mut attributes: Vec<PathAttribute>, reach_attr, unreach_attr| {
+            attributes.push(reach_attr);
+            if let Some(unreach_attr) = unreach_attr {
+                attributes.push(unreach_attr);
+            }
+            UpdateMessage::build(&[], &[], &attributes, true, false, Ipv4UnicastMode::Body)
+        };
+
+        session
+            .process_update(update(
+                base_attrs(),
+                reach(vec![first.clone(), overlap.clone()]),
+                None,
+            ))
+            .await;
+        let RibUpdate::BgpLsRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("accepted BGP-LS routes reach RIB")
+        else {
+            panic!("expected BgpLsRoutesReceived");
+        };
+        assert_eq!(announced.len(), 2);
+        assert!(withdrawn.is_empty());
+        assert_eq!(session.known_prefix_count(), 2);
+
+        buffer_route_refresh(&mut session, afi, safi, RouteRefreshSubtype::BoRR);
+        session.process_read_buffer().await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::BeginRouteRefresh {
+                afi: Afi::BgpLs,
+                safi: marker_safi,
+                ..
+            }) if marker_safi == safi
+        ));
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(2));
+
+        session.install_import_policy(Some(PolicyChain::new(vec![Policy {
+            entries: vec![],
+            default_action: PolicyAction::Deny,
+        }])));
+
+        session
+            .process_update(update(base_attrs(), reach(vec![first.clone()]), None))
+            .await;
+        let RibUpdate::BgpLsRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("denied BGP-LS replacement reaches RIB")
+        else {
+            panic!("expected BgpLsRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(&first)]);
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        session
+            .process_update(update(
+                base_attrs(),
+                reach(vec![overlap.clone()]),
+                Some(unreach(vec![overlap.clone()])),
+            ))
+            .await;
+        let RibUpdate::BgpLsRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("BGP-LS overlap reaches RIB once")
+        else {
+            panic!("expected BgpLsRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(&overlap)]);
+        assert_eq!(session.known_prefix_count(), 0);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(0));
+
+        session
+            .process_update(update(base_attrs(), reach(vec![first_seen.clone()]), None))
+            .await;
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "first-seen BGP-LS denial is silent"
+        );
+        assert!(!session.known_bgpls.contains(&key(&first_seen)));
+        assert_eq!(session.known_prefix_count(), 0);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(0));
+
+        buffer_route_refresh(&mut session, afi, safi, RouteRefreshSubtype::EoRR);
+        session.process_read_buffer().await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::EndRouteRefresh {
+                afi: Afi::BgpLs,
+                safi: marker_safi,
+                ..
+            }) if marker_safi == safi
+        ));
+        assert_eq!(session.refresh_accounting_window_count(), 0);
+    }
+
+    exercise(Safi::BgpLs).await;
+    exercise(Safi::BgpLsVpn).await;
 }
 
 /// iBGP reflection of a VPN route on an RR adds `ORIGINATOR_ID` and

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -4481,7 +4481,10 @@ async fn denied_vpn_add_path_replacements_withdraw_exact_known_identity() {
 /// the overlap and emits a first-seen withdrawal; capturing refresh state
 /// without the synthetic withdrawal leaves the stale count unchanged.
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered refresh sequence proves replacement, deduplication, and accounting"
+)]
 async fn denied_rtc_replacements_reconcile_exact_refresh_identity() {
     use rustbgpd_wire::{MpReachNlri, MpUnreachNlri, RtcNlri};
 
@@ -4658,7 +4661,10 @@ async fn denied_rtc_replacements_reconcile_exact_refresh_identity() {
 /// `known_bgpls.remove` duplicates the overlap and emits first-seen state;
 /// omitting the synthetic withdrawal from refresh capture leaves stale count.
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one ordered refresh sequence covers both BGP-LS SAFIs"
+)]
 async fn denied_bgpls_replacements_reconcile_exact_refresh_identity_for_both_safis() {
     use rustbgpd_rib::BgpLsFamily;
     use rustbgpd_wire::{MpReachNlri, MpUnreachNlri};
@@ -4677,7 +4683,10 @@ async fn denied_bgpls_replacements_reconcile_exact_refresh_identity_for_both_saf
         .expect("fixture contains one BGP-LS NLRI")
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the per-SAFI sequence proves replacement, deduplication, and accounting"
+    )]
     async fn exercise(safi: Safi) {
         let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
         let afi = Afi::BgpLs;

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -34,32 +34,34 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ## RFC 1997 — NO_ADVERTISE export restriction
 
-- IPv4/IPv6 unicast, VPNv4/VPNv6, and labeled-unicast routes carrying
-  `NO_ADVERTISE` are ineligible before export policy, and the post-policy route
-  is checked again before Adj-RIB-Out commit. A permit policy cannot remove the
-  community to bypass the restriction; a policy that adds it suppresses the
-  modified route.
+- IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS SAFI 71/72
+  routes carrying `NO_ADVERTISE` are ineligible before export policy, and the
+  post-policy route is checked again before Adj-RIB-Out commit. A permit policy
+  cannot remove the community to bypass the restriction; a policy that adds it
+  suppresses the modified route.
 - The same predicate covers single-best plus Add-Path for unicast, VPN, and
   labeled routes; grouped/private and RFC 7947 per-client-best shapes apply to
   unicast, grouped/private applies to VPN, and RFC 9107 ORR applies to unicast
-  and labeled-unicast. Existing advertisements are withdrawn and logical
-  Adj-RIB-Out state is cleared.
+  and labeled-unicast. RTC and both BGP-LS SAFIs use their single-best export
+  paths. Existing advertisements are withdrawn and logical Adj-RIB-Out state is
+  cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
   candidates whose result carries `NO_ADVERTISE`. ORR first selects its
   per-vantage best and suppresses that winner without falling back to a
   different route, whether the community arrived on the source or from policy.
-- `NO_ADVERTISE` enforcement for other non-unicast families remains deferred.
+- `NO_ADVERTISE` enforcement for EVPN and FlowSpec remains deferred.
 
 ---
 
 ## Inbound import-policy replacement semantics
 
 - Import-policy denial of a replacement retires the exact previously accepted
-  VPN `(RD + prefix, path_id)` or labeled-unicast `(prefix, path_id)` identity.
-  First-seen denials remain filter-only, explicit overlapping withdrawals are
-  deduplicated, and Add-Path siblings remain intact. Other non-unicast families
-  retain their existing policy behavior.
+  VPN `(RD + prefix, path_id)`, labeled-unicast `(prefix, path_id)`, RTC
+  `(NLRI, path_id)`, or BGP-LS `(family, NLRI, path_id)` identity. First-seen
+  denials remain filter-only, explicit overlapping withdrawals are deduplicated,
+  and Add-Path siblings remain intact. EVPN and FlowSpec retain their existing
+  policy behavior.
 
 ---
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -18,7 +18,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 | Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
-| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, and labeled-unicast |
+| Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS |
 | Route reflection | RFC 4456, RFC 9107 (ORR, ADR-0095) | Per-client best paths via BGP-LS-sourced SPF |
 | Graceful restart | RFC 4724 (GR helper), RFC 9494 (LLGR) | Stale retention across all RR families; no forwarding-state preservation |
 | VPN / MPLS families (RR / controller-feed only, ADR-0077) | RFC 4364/4659 VPNv4/v6 (SAFI 128), RFC 4684 RT-Constrain (SAFI 132), RFC 8277 labeled-unicast (SAFI 4), RFC 9552 BGP-LS (SAFI 71/72) | RD/label/next-hop/RT preserved verbatim; no VRF import, no MPLS FIB, no local BGP-LS production |


### PR DESCRIPTION
## Summary

- enforce RFC 1997 NO_ADVERTISE before and after export policy for RT-Constrain and BGP-LS SAFI 71/72
- retire an exact previously accepted RTC or BGP-LS identity when an import-policy replacement is denied, while keeping first-seen denials silent and deduplicating explicit withdrawals
- reconcile max-prefix and Enhanced Route Refresh accounting, and document the shipped family coverage

This is the bounded Phase 3 slice of LAN-442. It does not close LAN-442: the separately reviewed safety-rejection slice and the held EVPN/FlowSpec remainder remain.

## Load-bearing regression proof

Each new regression was executed against a destructive production mutation and failed for the intended runtime assertion:

- removing the RTC pre-policy guard failed at the missing source-scoped withdrawal
- removing the RTC post-policy guard failed because the policy-scoped route remained announced
- removing the BGP-LS pre-policy guard failed at the missing source-scoped withdrawal
- removing the BGP-LS post-policy guard failed because the policy-scoped route remained announced
- removing denied-key collection for RTC or BGP-LS failed at the missing accepted-replacement withdrawal
- removing the known-identity presence gate produced duplicate overlap withdrawals
- excluding synthetic RTC or BGP-LS withdrawals from refresh capture left the stale count at 2 instead of 1

All mutations were restored, and all focused tests returned green.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`
