### PR TITLE
Gate non-unicast safety replacements to accepted routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,9 +184,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Pre-policy safety rejections withdraw prior accepted unicast paths.**
-  OTC, AS_PATH-loop, and route-reflector-loop rejects now retire the exact
-  accepted `(prefix, path_id)` while first-seen rejects remain filter-only.
+- **Pre-policy safety rejections withdraw prior accepted paths.** OTC rejects
+  retire exact accepted unicast `(prefix, path_id)` identities. AS_PATH-loop
+  and route-reflector-loop rejects also retire exact VPN, labeled-unicast, RTC,
+  and BGP-LS identities while preserving distinct explicit withdrawals and
+  Add-Path siblings. First-seen and repeated rejects remain filter-only.
 
 - **Import-policy-denied unicast, VPN, labeled-unicast, RTC, and BGP-LS replacements
   withdraw prior accepted paths.** Classic and MP-unicast updates retire the

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -742,9 +742,13 @@ impl PeerSession {
             let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+            let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
             let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+            let mut loop_l3vpn_rejected: Vec<VpnRibRouteKey> = Vec::new();
             let mut loop_labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
+            let mut loop_labeled_rejected: Vec<LabeledRibRouteKey> = Vec::new();
             let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
+            let mut loop_rtc_rejected: Vec<RtcRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -792,44 +796,47 @@ impl PeerSession {
                         }
                     }
                 }
-                // VPN announcements in a loop-detected UPDATE are treated as
-                // withdrawals of any previously accepted version of the same
-                // RD+prefix, so a looped re-announcement can't strand a stale
-                // route in the Adj-RIB-In.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| {
+                        BgpLsRouteKey {
+                            family: bgpls_family,
+                            nlri: nlri.key(),
+                            path_id: 0,
+                        }
+                    }));
+                }
+                // A loop-rejected announcement replaces only an exact route
+                // that this session previously accepted.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::MplsVpn
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|entry| {
+                    loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| {
                         VpnRibRouteKey {
                             nlri_key: entry.nlri.key(),
                             path_id: entry.path_id,
                         }
                     }));
                 }
-                // Labeled announcements in a loop-detected UPDATE are
-                // likewise treated as withdrawals of any previously accepted
-                // version of the same prefix, so a looped re-announcement
-                // can't strand a stale route in the Adj-RIB-In.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::LabeledUnicast
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_labeled_withdrawn.extend(mp.labeled_announced.iter().map(|entry| {
+                    loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
                         LabeledRibRouteKey {
                             prefix: entry.nlri.key(),
                             path_id: entry.path_id,
                         }
                     }));
                 }
-                // RTC announcements in a loop-detected UPDATE are likewise
-                // treated as withdrawals of any previously accepted version
-                // of the same membership NLRI.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::RtConstrain
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_rtc_withdrawn.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
+                    loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
                         nlri: *nlri,
                         path_id: 0,
                     }));
@@ -867,14 +874,34 @@ impl PeerSession {
             for key in &loop_bgpls_withdrawn {
                 self.known_bgpls.remove(key);
             }
+            for key in loop_bgpls_rejected {
+                if self.known_bgpls.remove(&key) {
+                    loop_bgpls_withdrawn.push(key);
+                }
+            }
             for key in &loop_l3vpn_withdrawn {
                 self.known_vpn.remove(key);
+            }
+            for key in loop_l3vpn_rejected {
+                if self.known_vpn.remove(&key) {
+                    loop_l3vpn_withdrawn.push(key);
+                }
             }
             for key in &loop_labeled_withdrawn {
                 self.known_labeled.remove(key);
             }
+            for key in loop_labeled_rejected {
+                if self.known_labeled.remove(&key) {
+                    loop_labeled_withdrawn.push(key);
+                }
+            }
             for key in &loop_rtc_withdrawn {
                 self.known_rtc.remove(key);
+            }
+            for key in loop_rtc_rejected {
+                if self.known_rtc.remove(&key) {
+                    loop_rtc_withdrawn.push(key);
+                }
             }
             if !loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()
@@ -1025,9 +1052,13 @@ impl PeerSession {
             let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
             let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
             let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+            let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
             let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+            let mut loop_l3vpn_rejected: Vec<VpnRibRouteKey> = Vec::new();
             let mut loop_labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
+            let mut loop_labeled_rejected: Vec<LabeledRibRouteKey> = Vec::new();
             let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
+            let mut loop_rtc_rejected: Vec<RtcRibRouteKey> = Vec::new();
             for attr in &parsed.attributes {
                 if let PathAttribute::MpUnreachNlri(mp) = attr {
                     let family = (mp.afi, mp.safi);
@@ -1075,44 +1106,47 @@ impl PeerSession {
                         }
                     }
                 }
-                // VPN announcements in a loop-detected UPDATE are treated as
-                // withdrawals of any previously accepted version of the same
-                // RD+prefix, so a looped re-announcement can't strand a stale
-                // route in the Adj-RIB-In.
+                if let PathAttribute::MpReachNlri(mp) = attr
+                    && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
+                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
+                {
+                    loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| {
+                        BgpLsRouteKey {
+                            family: bgpls_family,
+                            nlri: nlri.key(),
+                            path_id: 0,
+                        }
+                    }));
+                }
+                // A loop-rejected announcement replaces only an exact route
+                // that this session previously accepted.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::MplsVpn
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_l3vpn_withdrawn.extend(mp.vpn_announced.iter().map(|entry| {
+                    loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| {
                         VpnRibRouteKey {
                             nlri_key: entry.nlri.key(),
                             path_id: entry.path_id,
                         }
                     }));
                 }
-                // Labeled announcements in a loop-detected UPDATE are
-                // likewise treated as withdrawals of any previously accepted
-                // version of the same prefix, so a looped re-announcement
-                // can't strand a stale route in the Adj-RIB-In.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::LabeledUnicast
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_labeled_withdrawn.extend(mp.labeled_announced.iter().map(|entry| {
+                    loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
                         LabeledRibRouteKey {
                             prefix: entry.nlri.key(),
                             path_id: entry.path_id,
                         }
                     }));
                 }
-                // RTC announcements in a loop-detected UPDATE are likewise
-                // treated as withdrawals of any previously accepted version
-                // of the same membership NLRI.
                 if let PathAttribute::MpReachNlri(mp) = attr
                     && mp.safi == Safi::RtConstrain
                     && self.negotiated_families.contains(&(mp.afi, mp.safi))
                 {
-                    loop_rtc_withdrawn.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
+                    loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
                         nlri: *nlri,
                         path_id: 0,
                     }));
@@ -1150,14 +1184,34 @@ impl PeerSession {
             for key in &loop_bgpls_withdrawn {
                 self.known_bgpls.remove(key);
             }
+            for key in loop_bgpls_rejected {
+                if self.known_bgpls.remove(&key) {
+                    loop_bgpls_withdrawn.push(key);
+                }
+            }
             for key in &loop_l3vpn_withdrawn {
                 self.known_vpn.remove(key);
+            }
+            for key in loop_l3vpn_rejected {
+                if self.known_vpn.remove(&key) {
+                    loop_l3vpn_withdrawn.push(key);
+                }
             }
             for key in &loop_labeled_withdrawn {
                 self.known_labeled.remove(key);
             }
+            for key in loop_labeled_rejected {
+                if self.known_labeled.remove(&key) {
+                    loop_labeled_withdrawn.push(key);
+                }
+            }
             for key in &loop_rtc_withdrawn {
                 self.known_rtc.remove(key);
+            }
+            for key in loop_rtc_rejected {
+                if self.known_rtc.remove(&key) {
+                    loop_rtc_withdrawn.push(key);
+                }
             }
             if !loop_withdrawn.is_empty()
                 || !loop_fs_withdrawn.is_empty()

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -10925,6 +10925,531 @@ async fn evpn_routes_counted_toward_max_prefix() {
         "teardown must clear max-prefix accounting"
     );
 }
+#[derive(Clone, Copy, Debug)]
+enum NonUnicastSafetyLoop {
+    AsPath,
+    Originator,
+}
+
+fn nonunicast_safety_session(
+    family: (Afi, Safi),
+    add_path: bool,
+    trigger: NonUnicastSafetyLoop,
+) -> (PeerSession, mpsc::Receiver<RibUpdate>) {
+    let remote_asn = match trigger {
+        NonUnicastSafetyLoop::AsPath => 65002,
+        NonUnicastSafetyLoop::Originator => 65001,
+    };
+    let (mut session, rib_rx) = make_test_session_with_rib(65001, remote_asn);
+    let mut negotiated = negotiated_session(remote_asn, false);
+    negotiated.negotiated_families = vec![family];
+    if add_path {
+        negotiated
+            .add_path_families
+            .insert(family, AddPathMode::Both);
+    }
+    negotiated.peer_route_refresh = true;
+    negotiated.peer_enhanced_route_refresh = true;
+    install_test_negotiated_session(&mut session, negotiated);
+    (session, rib_rx)
+}
+
+fn nonunicast_accepted_attrs() -> Vec<PathAttribute> {
+    vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+    ]
+}
+
+fn nonunicast_safety_attrs(
+    session: &PeerSession,
+    trigger: NonUnicastSafetyLoop,
+) -> Vec<PathAttribute> {
+    let mut attrs = vec![PathAttribute::Origin(Origin::Igp)];
+    match trigger {
+        NonUnicastSafetyLoop::AsPath => attrs.push(PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002, 65001])],
+        })),
+        NonUnicastSafetyLoop::Originator => {
+            attrs.push(PathAttribute::AsPath(AsPath { segments: vec![] }));
+            attrs.push(PathAttribute::OriginatorId(
+                session.config.peer.local_router_id,
+            ));
+        }
+    }
+    attrs
+}
+
+fn empty_nonunicast_reach(afi: Afi, safi: Safi, next_hop: IpAddr) -> rustbgpd_wire::MpReachNlri {
+    rustbgpd_wire::MpReachNlri {
+        afi,
+        safi,
+        next_hop,
+        link_local_next_hop: None,
+        announced: vec![],
+        flowspec_announced: vec![],
+        evpn_announced: vec![],
+        bgpls_announced: vec![],
+        labeled_announced: vec![],
+        vpn_announced: vec![],
+        rtc_announced: vec![],
+    }
+}
+
+fn empty_nonunicast_unreach(afi: Afi, safi: Safi) -> rustbgpd_wire::MpUnreachNlri {
+    rustbgpd_wire::MpUnreachNlri {
+        afi,
+        safi,
+        withdrawn: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_withdrawn: vec![],
+        bgpls_withdrawn: vec![],
+        labeled_withdrawn: vec![],
+        vpn_withdrawn: vec![],
+        rtc_withdrawn: vec![],
+    }
+}
+
+fn nonunicast_update(
+    mut attrs: Vec<PathAttribute>,
+    reach: rustbgpd_wire::MpReachNlri,
+    unreach: Option<rustbgpd_wire::MpUnreachNlri>,
+    add_path: bool,
+) -> UpdateMessage {
+    attrs.push(PathAttribute::MpReachNlri(reach));
+    if let Some(unreach) = unreach {
+        attrs.push(PathAttribute::MpUnreachNlri(unreach));
+    }
+    UpdateMessage::build(&[], &[], &attrs, true, add_path, Ipv4UnicastMode::Body)
+}
+
+/// Both pre-policy loop rejections retire only exact accepted VPN Add-Path
+/// identities. A distinct explicit withdrawal is preserved, while novel and
+/// repeated rejected announcements remain silent.
+///
+/// Break-to-red: blindly appending rejected keys emits the novel identity;
+/// gating the explicit withdrawal drops it; omitting the synthetic withdrawal
+/// leaves known/max-prefix/refresh state at two.
+#[tokio::test]
+async fn safety_loop_vpn_replacements_are_presence_gated_for_both_afis() {
+    async fn exercise(afi: Afi, trigger: NonUnicastSafetyLoop) {
+        let family = (afi, Safi::MplsVpn);
+        let (mut session, mut rib_rx) = nonunicast_safety_session(family, true, trigger);
+        let prefix = match afi {
+            Afi::Ipv4 => VpnPrefix::v4(Ipv4Addr::new(10, 44, 5, 0), 24).unwrap(),
+            Afi::Ipv6 => VpnPrefix::v6("2001:db8:445::".parse().unwrap(), 64).unwrap(),
+            _ => unreachable!("fixture covers VPNv4/v6"),
+        };
+        let nlri = VpnNlri {
+            labels: vec![MplsLabelEntry::try_new(4093, 0, true).unwrap()],
+            route_distinguisher: RouteDistinguisher([0, 0, 0xfd, 0xe8, 0, 0, 0, 45]),
+            prefix,
+        };
+        let key = |path_id| rustbgpd_rib::VpnRibRouteKey {
+            nlri_key: nlri.key(),
+            path_id,
+        };
+        let next_hop = match afi {
+            Afi::Ipv4 => IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)),
+            Afi::Ipv6 => IpAddr::V6("2001:db8::7".parse().unwrap()),
+            _ => unreachable!(),
+        };
+        let reach = |path_ids: &[u32]| {
+            let mut mp = empty_nonunicast_reach(afi, Safi::MplsVpn, next_hop);
+            mp.vpn_announced = path_ids
+                .iter()
+                .map(|path_id| rustbgpd_wire::VpnNlriEntry {
+                    path_id: *path_id,
+                    nlri: nlri.clone(),
+                })
+                .collect();
+            mp
+        };
+        let explicit = || {
+            let mut mp = empty_nonunicast_unreach(afi, Safi::MplsVpn);
+            mp.vpn_withdrawn = vec![rustbgpd_wire::VpnNlriEntry {
+                path_id: 22,
+                nlri: VpnNlri {
+                    labels: vec![],
+                    route_distinguisher: nlri.route_distinguisher,
+                    prefix: nlri.prefix,
+                },
+            }];
+            mp
+        };
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_accepted_attrs(),
+                reach(&[11, 33]),
+                None,
+                true,
+            ))
+            .await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::VpnRoutesReceived { ref announced, .. }) if announced.len() == 2
+        ));
+        session.begin_refresh_accounting(afi, Safi::MplsVpn);
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(&[11, 44]),
+                Some(explicit()),
+                true,
+            ))
+            .await;
+        let RibUpdate::VpnRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("VPN safety withdrawals reach RIB")
+        else {
+            panic!("expected VpnRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(22), key(11)]);
+        assert!(!session.known_vpn.contains(&key(44)));
+        assert!(session.known_vpn.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(&[11, 44]),
+                None,
+                true,
+            ))
+            .await;
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "repeated/novel rejects stay silent"
+        );
+    }
+
+    for trigger in [
+        NonUnicastSafetyLoop::AsPath,
+        NonUnicastSafetyLoop::Originator,
+    ] {
+        exercise(Afi::Ipv4, trigger).await;
+        exercise(Afi::Ipv6, trigger).await;
+    }
+}
+
+/// VPN-equivalent safety semantics apply to labeled-unicast without losing
+/// the Add-Path identity.
+///
+/// Break-to-red: removing the presence gate emits path 44; dropping the
+/// labeled rejected collection leaves path 11 known and refresh-stale.
+#[tokio::test]
+async fn safety_loop_labeled_replacements_are_presence_gated_for_both_afis() {
+    async fn exercise(afi: Afi, trigger: NonUnicastSafetyLoop) {
+        let family = (afi, Safi::LabeledUnicast);
+        let (mut session, mut rib_rx) = nonunicast_safety_session(family, true, trigger);
+        let prefix = match afi {
+            Afi::Ipv4 => Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 44, 6, 0), 24)),
+            Afi::Ipv6 => Prefix::V6(Ipv6Prefix::new("2001:db8:446::".parse().unwrap(), 64)),
+            _ => unreachable!("fixture covers labeled IPv4/IPv6"),
+        };
+        let nlri = rustbgpd_wire::LabeledNlri {
+            labels: vec![MplsLabelEntry::try_new(4092, 0, true).unwrap()],
+            prefix,
+        };
+        let key = |path_id| rustbgpd_rib::LabeledRibRouteKey { prefix, path_id };
+        let next_hop = match afi {
+            Afi::Ipv4 => IpAddr::V4(Ipv4Addr::new(192, 0, 2, 8)),
+            Afi::Ipv6 => IpAddr::V6("2001:db8::8".parse().unwrap()),
+            _ => unreachable!(),
+        };
+        let reach = |path_ids: &[u32]| {
+            let mut mp = empty_nonunicast_reach(afi, Safi::LabeledUnicast, next_hop);
+            mp.labeled_announced = path_ids
+                .iter()
+                .map(|path_id| rustbgpd_wire::LabeledNlriEntry {
+                    path_id: *path_id,
+                    nlri: nlri.clone(),
+                })
+                .collect();
+            mp
+        };
+        let explicit = || {
+            let mut mp = empty_nonunicast_unreach(afi, Safi::LabeledUnicast);
+            mp.labeled_withdrawn = vec![rustbgpd_wire::LabeledNlriEntry {
+                path_id: 22,
+                nlri: rustbgpd_wire::LabeledNlri {
+                    labels: vec![],
+                    prefix,
+                },
+            }];
+            mp
+        };
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_accepted_attrs(),
+                reach(&[11, 33]),
+                None,
+                true,
+            ))
+            .await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::LabeledRoutesReceived { ref announced, .. }) if announced.len() == 2
+        ));
+        session.begin_refresh_accounting(afi, Safi::LabeledUnicast);
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(&[11, 44]),
+                Some(explicit()),
+                true,
+            ))
+            .await;
+        let RibUpdate::LabeledRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("labeled safety withdrawals reach RIB")
+        else {
+            panic!("expected LabeledRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(22), key(11)]);
+        assert!(!session.known_labeled.contains(&key(44)));
+        assert!(session.known_labeled.contains(&key(33)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(&[11, 44]),
+                None,
+                true,
+            ))
+            .await;
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "repeated/novel rejects stay silent"
+        );
+    }
+
+    for trigger in [
+        NonUnicastSafetyLoop::AsPath,
+        NonUnicastSafetyLoop::Originator,
+    ] {
+        exercise(Afi::Ipv4, trigger).await;
+        exercise(Afi::Ipv6, trigger).await;
+    }
+}
+
+/// RTC loop rejection is presence-gated for both `AS_PATH` and RR-loop paths.
+///
+/// Break-to-red: deleting RTC rejected collection leaves the accepted NLRI
+/// live; blind append emits the novel NLRI; excluding the synthesized key from
+/// refresh capture leaves two stale identities.
+#[tokio::test]
+async fn safety_loop_rtc_replacements_are_presence_gated() {
+    use rustbgpd_wire::RtcNlri;
+
+    for trigger in [
+        NonUnicastSafetyLoop::AsPath,
+        NonUnicastSafetyLoop::Originator,
+    ] {
+        let family = (Afi::Ipv4, Safi::RtConstrain);
+        let (mut session, mut rib_rx) = nonunicast_safety_session(family, false, trigger);
+        let nlri =
+            |id: u16| RtcNlri::new(65002, 0x0002_FDEA_0000_0000 | u64::from(id), 96).unwrap();
+        let accepted = nlri(11);
+        let explicit = nlri(22);
+        let sibling = nlri(33);
+        let novel = nlri(44);
+        let key = |nlri| rustbgpd_rib::RtcRibRouteKey { nlri, path_id: 0 };
+        let reach = |nlris| {
+            let mut mp = empty_nonunicast_reach(
+                Afi::Ipv4,
+                Safi::RtConstrain,
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9)),
+            );
+            mp.rtc_announced = nlris;
+            mp
+        };
+        let unreach = |nlris| {
+            let mut mp = empty_nonunicast_unreach(Afi::Ipv4, Safi::RtConstrain);
+            mp.rtc_withdrawn = nlris;
+            mp
+        };
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_accepted_attrs(),
+                reach(vec![accepted, sibling]),
+                None,
+                false,
+            ))
+            .await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::RtcRoutesReceived { ref announced, .. }) if announced.len() == 2
+        ));
+        session.begin_refresh_accounting(Afi::Ipv4, Safi::RtConstrain);
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(vec![accepted, novel]),
+                Some(unreach(vec![explicit])),
+                false,
+            ))
+            .await;
+        let RibUpdate::RtcRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx.try_recv().expect("RTC safety withdrawals reach RIB")
+        else {
+            panic!("expected RtcRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(explicit), key(accepted)]);
+        assert!(!session.known_rtc.contains(&key(novel)));
+        assert!(session.known_rtc.contains(&key(sibling)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(vec![accepted, novel]),
+                None,
+                false,
+            ))
+            .await;
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "repeated/novel rejects stay silent"
+        );
+    }
+}
+
+/// Both BGP-LS SAFIs use their SAFI-derived identity under both safety-loop
+/// branches; explicit withdrawals remain independent of rejected `MP_REACH`.
+///
+/// Break-to-red: deleting either branch's BGP-LS collection leaves the exact
+/// accepted topology object known and refresh-stale; blind append emits the
+/// novel object.
+#[tokio::test]
+async fn safety_loop_bgpls_replacements_are_presence_gated_for_both_safis() {
+    use rustbgpd_rib::BgpLsFamily;
+
+    fn nlri(safi: Safi, suffix: u8) -> BgpLsNlri {
+        match safi {
+            Safi::BgpLs => decode_bgpls_nlri(&[0xfd, 0xe8, 0, 3, 0xaa, 0xcc, suffix]),
+            Safi::BgpLsVpn => decode_bgpls_vpn_nlri(&[
+                0xfd, 0xe8, 0, 11, 0, 0, 0xfd, 0xea, 0, 0, 0, 46, 0xaa, 0xcc, suffix,
+            ]),
+            _ => unreachable!("fixture covers BGP-LS SAFIs"),
+        }
+        .unwrap()
+        .pop()
+        .unwrap()
+    }
+
+    async fn exercise(safi: Safi, trigger: NonUnicastSafetyLoop) {
+        let afi = Afi::BgpLs;
+        let family = (afi, safi);
+        let typed_family = BgpLsFamily::from_afi_safi(afi, safi).unwrap();
+        let (mut session, mut rib_rx) = nonunicast_safety_session(family, false, trigger);
+        let accepted = nlri(safi, 11);
+        let explicit = nlri(safi, 22);
+        let sibling = nlri(safi, 33);
+        let novel = nlri(safi, 44);
+        let key = |nlri: &BgpLsNlri| rustbgpd_rib::BgpLsRouteKey {
+            family: typed_family,
+            nlri: nlri.key(),
+            path_id: 0,
+        };
+        let reach = |nlris| {
+            let mut mp =
+                empty_nonunicast_reach(afi, safi, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)));
+            mp.bgpls_announced = nlris;
+            mp
+        };
+        let unreach = |nlris| {
+            let mut mp = empty_nonunicast_unreach(afi, safi);
+            mp.bgpls_withdrawn = nlris;
+            mp
+        };
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_accepted_attrs(),
+                reach(vec![accepted.clone(), sibling.clone()]),
+                None,
+                false,
+            ))
+            .await;
+        assert!(matches!(
+            rib_rx.try_recv(),
+            Ok(RibUpdate::BgpLsRoutesReceived { ref announced, .. }) if announced.len() == 2
+        ));
+        session.begin_refresh_accounting(afi, safi);
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(vec![accepted.clone(), novel.clone()]),
+                Some(unreach(vec![explicit.clone()])),
+                false,
+            ))
+            .await;
+        let RibUpdate::BgpLsRoutesReceived {
+            announced,
+            withdrawn,
+            ..
+        } = rib_rx
+            .try_recv()
+            .expect("BGP-LS safety withdrawals reach RIB")
+        else {
+            panic!("expected BgpLsRoutesReceived");
+        };
+        assert!(announced.is_empty());
+        assert_eq!(withdrawn, vec![key(&explicit), key(&accepted)]);
+        assert!(!session.known_bgpls.contains(&key(&novel)));
+        assert!(session.known_bgpls.contains(&key(&sibling)));
+        assert_eq!(session.known_prefix_count(), 1);
+        assert_eq!(session.refresh_accounting_stale_count(family), Some(1));
+
+        session
+            .process_update(nonunicast_update(
+                nonunicast_safety_attrs(&session, trigger),
+                reach(vec![accepted, novel]),
+                None,
+                false,
+            ))
+            .await;
+        assert!(
+            rib_rx.try_recv().is_err(),
+            "repeated/novel rejects stay silent"
+        );
+    }
+
+    for trigger in [
+        NonUnicastSafetyLoop::AsPath,
+        NonUnicastSafetyLoop::Originator,
+    ] {
+        exercise(Safi::BgpLs, trigger).await;
+        exercise(Safi::BgpLsVpn, trigger).await;
+    }
+}
+
 /// A loop-detected UPDATE (RR cluster-list loop) must synthesize RTC
 /// withdrawals from both the `MP_UNREACH` withdrawals and the discarded
 /// `MP_REACH` announcements, so a looped re-announcement cannot strand a

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -54,7 +54,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ---
 
-## Inbound import-policy replacement semantics
+## Inbound filtered-replacement semantics
 
 - Import-policy denial of a replacement retires the exact previously accepted
   VPN `(RD + prefix, path_id)`, labeled-unicast `(prefix, path_id)`, RTC
@@ -62,6 +62,11 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   denials remain filter-only, explicit overlapping withdrawals are deduplicated,
   and Add-Path siblings remain intact. EVPN and FlowSpec retain their existing
   policy behavior.
+- `AS_PATH`-loop and route-reflector-loop rejection likewise retires an exact
+  previously accepted VPN, labeled-unicast, RTC, or BGP-LS replacement.
+  First-seen and repeated rejected announcements remain silent, distinct valid
+  `MP_UNREACH_NLRI` withdrawals still propagate, and exact Add-Path siblings
+  remain intact.
 
 ---
 


### PR DESCRIPTION
## Summary

Retire previously accepted VPN, labeled-unicast, RTC, and BGP-LS routes when a replacement is rejected by AS_PATH-loop or route-reflector-loop safety checks.

The fix is presence-gated: first-seen or repeated rejected routes remain silent, while a distinct explicit MP_UNREACH in the same update is still forwarded. VPN and labeled-unicast withdrawals preserve Path ID; RTC and BGP-LS use their typed route identities. This completes the v1 RR/controller-feed family slice of LAN-442; EVPN and FlowSpec remain held follow-ups.

## Changes

- collect rejected MP_REACH identities in both AS_PATH-loop and RR-loop paths
- synthesize withdrawals only for routes already present in Adj-RIB-In
- preserve independent explicit MP_UNREACH delivery, sibling routes, max-prefix counts, and ERR stale accounting
- document the supported-family behavior and release note

## Load-bearing regression proof

The four family tests exercise independent AS_PATH and ORIGINATOR_ID rejection paths. The following production reversions were applied and observed red before restoration:

- removing AS_PATH-loop VPN retirement makes the VPN test lose the accepted Path ID 11 withdrawal
- removing RR-loop labeled-unicast retirement makes the labeled test lose the accepted Path ID 11 withdrawal after its AS_PATH cases pass
- removing AS_PATH-loop RTC retirement makes the RTC test lose the accepted route-target withdrawal
- removing RR-loop BGP-LS retirement makes the BGP-LS test lose the accepted SAFI-qualified withdrawal after its AS_PATH cases pass
- blindly appending rejected VPN routes makes the novel Path ID 44 route withdraw, violating first-seen silence
- excluding the synthetic BGP-LS withdrawal from refresh accounting leaves two stale routes instead of one

Each mutation was restored byte-for-byte and every focused test was rerun green.

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] focused protocol tests cover both safety triggers across all supported families
- [x] performance receipt intentionally not applicable; this is a bounded rejection path

## Docs / release notes

- [x] CHANGELOG.md updated
- [x] ROADMAP.md intentionally not needed
- [x] docs/RFC_NOTES.md updated
- [x] no hot tracking document touched

## Related issues

Completes the v1-scoped portion of LAN-442.
