### PR TITLE
Document the marker-v3 platform boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,15 +59,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   withdrawal. Mutation proofs make the independent BIRD stale-route check and
   rejection evidence fail when their production guards are removed. (LAN-434)
 
-- **Planned-restart markers resist wall-clock steps across a daemon restart on Linux.**
-  Marker v3 records a complete boot/time-namespace identity and checked
-  `CLOCK_BOOTTIME` deadline alongside its bounded wall fallback. Startup uses
-  boottime only when the live clock domain matches exactly; legacy markers,
-  mismatches, and sampling failures retain the bounded wall path. Publication
-  degrades atomically to complete v1/v2 markers when the domain cannot be
-  sampled or represented, and logs the actual visible version, checkpoint
-  binding, and directory-sync durability state. Runtime expiry remains
-  process-local monotonic time after startup.
+- **Planned-restart marker v3 resists discontinuous wall-clock steps in a
+  matched Linux clock domain.** On Linux 5.6+ with `CONFIG_TIME_NS`, this
+  requires a readable valid boot ID, inspectable time-namespace device/inode,
+  readable valid time-namespace offsets, and a sampleable and representable
+  `CLOCK_BOOTTIME` deadline. Startup uses boottime only when that complete
+  domain matches exactly, protecting against discontinuous `CLOCK_REALTIME`
+  steps between shutdown and startup. Legacy markers, mismatches, and sampling
+  failures use the wall deadline, bounded by the current configured maximum;
+  a forward wall-clock step can shorten or expire that fallback. Publication
+  degrades atomically to complete v1/v2 markers when necessary and logs the
+  actual visible version, checkpoint binding, and directory-sync durability
+  state. Runtime expiry remains process-local monotonic time after startup.
 
 - **Coordinated shutdown can publish a bounded warm checkpoint.** The
   restart-required, default-off `warm_cache_checkpoint_on_shutdown` setting

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -168,13 +168,19 @@ ownership receipt, and Unix socket are all single-writer state.
 
 This option does **not** make startup restore routes: no cached route is loaded,
 selected, installed, or advertised. A successful checkpoint only causes the GR
-restart marker to carry the matching generation. On Linux this is normally
-marker v3, whose complete boot/time-namespace identity and `CLOCK_BOOTTIME`
-deadline protect the shutdown-to-startup interval from wall-clock steps. If
-that clock domain cannot be sampled or represented, generation-bound marker v2
-retains the bounded wall-clock behavior. Checkpoint failure similarly selects
-a generationless v3 or wall-only v1 marker. The current boot path still
-rebuilds all routing state from peers.
+restart marker to carry the matching generation. Marker v3 protection requires
+Linux 5.6+ with `CONFIG_TIME_NS`, a readable valid
+`/proc/sys/kernel/random/boot_id`, inspectable `/proc/self/ns/time`
+device/inode, readable valid `/proc/self/timens_offsets`, and a sampleable and
+representable `CLOCK_BOOTTIME` deadline. When the complete live domain matches
+exactly at startup, that deadline is insulated from discontinuous
+`CLOCK_REALTIME` steps between shutdown and startup. Otherwise startup uses the
+marker's generation-bound wall deadline, capped by the current configured
+restart maximum; a forward wall-clock step can shorten or expire that fallback.
+If publication cannot form a complete v3 marker, it emits generation-bound v2.
+Checkpoint failure similarly selects a generationless v3 when available or
+wall-only v1 marker. The current boot path still rebuilds all routing state from
+peers.
 
 `dynamic_neighbor_limit` caps the number of active peers auto-created from
 `[[dynamic_neighbors]]` ranges. When omitted, rustbgpd allows up to 100 dynamic

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -310,13 +310,24 @@ chain, etc.).
 The GR marker format is versioned. V1 is generationless and wall-clock-only;
 v2 adds a required checkpoint generation; v3 adds a complete Linux boot and
 time-namespace identity plus an absolute `CLOCK_BOOTTIME` deadline, with an
-optional checkpoint generation. Startup trusts the v3 boottime deadline only
-when the live boot ID, current time-namespace device/inode, and both offset
-components match exactly. Otherwise it uses the marker's wall deadline,
-bounded by the current maximum configured restart time. Publication logs a
-warning when clock-domain sampling, checked arithmetic, or TOML's signed
-integer range forces a complete v1/v2 fallback; partial v3 markers are never
-published.
+optional checkpoint generation. Full v3 protection requires Linux 5.6+ built
+with `CONFIG_TIME_NS`, a readable valid
+`/proc/sys/kernel/random/boot_id`, inspectable `/proc/self/ns/time`
+device/inode, readable valid `/proc/self/timens_offsets`, and a sampleable
+`CLOCK_BOOTTIME` value, with the overall marker identity and deadline fitting
+their serialized representations. A missing or access-restricted procfs input
+cannot establish clock-domain continuity; it selects the fallback rather than
+proving that no time namespace exists.
+
+Startup trusts the v3 boottime deadline only when the live boot ID, current
+time-namespace device/inode, and both boottime-offset components match exactly.
+Only that exact-domain path protects the shutdown-to-startup interval from
+discontinuous `CLOCK_REALTIME` steps. Otherwise the daemon uses the marker's
+wall deadline, bounded by the current maximum configured restart time. A
+forward wall-clock step can therefore shorten or expire that wall fallback,
+including the v1/v2 publication fallback. Publication logs a warning when
+clock-domain sampling, checked arithmetic, or TOML's signed integer range
+forces a complete v1/v2 fallback; partial v3 markers are never published.
 
 Each concurrently running daemon requires its own `runtime_state_dir`.
 Sharing the directory across live daemon processes is unsupported: its restart
@@ -353,10 +364,17 @@ rustbgpd still advertises `forwarding_preserved = false`; use a drained
 route-server pair or another traffic-shift procedure when forwarding
 continuity matters.
 
-Marker v3 makes the shutdown-to-startup deadline resistant to wall-clock steps
-and includes suspend time before the new process resolves it. The daemon then
-uses its normal process-local monotonic timer for the remaining live window; it
-does not claim suspend-inclusive timing after startup.
+In a matching domain, marker v3 makes the shutdown-to-startup deadline
+resistant to discontinuous `CLOCK_REALTIME` steps and includes suspend time
+before the new process resolves it. The daemon then uses its normal
+process-local monotonic timer for the remaining live window; it does not claim
+suspend-inclusive timing after startup.
+
+Rolling back to a binary that predates marker v3 is a cold-start compatibility
+event: that binary rejects the v3 marker and starts without restarting-speaker
+mode. This does not guarantee a traffic blackhole; impact depends on peer and
+topology behavior. Operators requiring continuity should still use the drained
+route-server-pair procedure below.
 
 For zero-downtime upgrades in a route-server pair, drain traffic to the
 standby, upgrade, then swap.


### PR DESCRIPTION
## Summary

Document the exact Linux and procfs prerequisites for marker-v3 wall-step protection, the bounded wall fallback that remains when those inputs are unavailable, and the cold-start behavior of rolling back to a pre-v3 binary.

This is a docs-only truth-up. Runtime behavior and the marker format are unchanged.

## Changes

- qualify marker-v3 protection with Linux 5.6+, `CONFIG_TIME_NS`, the complete procfs clock-domain tuple, and representable `CLOCK_BOOTTIME`
- distinguish startup resolution of an existing v3 marker through its bounded wall deadline from publication-time downgrade to v1/v2
- state that a forward wall-clock step can shorten or expire the wall fallback
- document pre-v3 rollback as a cold-start compatibility event rather than a guaranteed blackhole
- preserve the existing no-restore and `forwarding_preserved = false` operator contract

## Correctness sources

- Linux `namespaces(7)` for `/proc/pid/ns/time` availability and device/inode identity
- Linux `time_namespaces(7)` for `CONFIG_TIME_NS`, `timens_offsets`, and BOOTTIME virtualization
- Linux `clock_gettime(2)` for BOOTTIME suspend behavior and discontinuous REALTIME steps
- Linux kernel sysctl documentation for `boot_id` generation and stability
- current `src/main.rs` for the sampled tuple, exact matching, representation checks, fallback path, and legacy-marker rejection

## Load-bearing proof

N/A: this PR changes documentation only and adds or modifies no test or gate.

## Testing

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Scope

- [x] exactly `CHANGELOG.md`, `docs/CONFIGURATION.md`, and `docs/OPERATIONS.md`
- [x] no Rust, tests, metrics, workflows, marker-format, or release-version changes
- [x] no soak or release cut

## Related issues

Closes LAN-420.
