### PR TITLE
Prepare wire 0.15.0 and FSM 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           cd dist
           sha256sum rustbgpd-${SUFFIX}.tar.gz > checksums-${SUFFIX}.txt
 
-      - name: Assert tarball contains licenses, man pages, and completions
+      - name: Assert tarball has nonempty licenses, man pages, and completions
         run: |
           set -euo pipefail
           SUFFIX=${{ matrix.suffix }}
@@ -154,6 +154,10 @@ jobs:
                    share/completions/rbgp.fish; do
             if ! grep -qxF "$f" <<<"$entries"; then
               echo "::error::${f} missing from dist/rustbgpd-${SUFFIX}.tar.gz"
+              exit 1
+            fi
+            if [ "$(tar -xOzf "dist/rustbgpd-${SUFFIX}.tar.gz" "$f" | wc -c)" -eq 0 ]; then
+              echo "::error::${f} is empty in dist/rustbgpd-${SUFFIX}.tar.gz"
               exit 1
             fi
           done
@@ -183,8 +187,7 @@ jobs:
         # the release body shows the curated notes instead of the
         # auto-generated commit list. Strips the heading line because
         # the GitHub release page already shows the version. If no
-        # matching section exists, write a stub so the action still
-        # has a body to publish (and surface the gap at release time).
+        # matching section exists, fail closed before creating a release.
         #
         # CHANGELOG.md is hard-wrapped (~72-80 cols) for review quality and
         # clean diffs, but GitHub renders release bodies with comment-style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **`rustbgpd-wire` 0.14.1 → 0.15.0 (breaking, prepared for publish).** The
+  exhaustive public `Capability` enum gains the experimental
+  `PathsLimit(Vec<PathsLimitFamily>)` variant for the expired, archived
+  draft-04 wire format using IANA-assigned capability code 76. Downstream
+  exhaustive matches must add an arm. `EvpnRouteKey` also gains the additive
+  `Ord` / `PartialOrd` implementations for deterministic keyed collections.
+
+- **`rustbgpd-fsm` 0.2.0 → 0.3.0 (breaking, prepared for publish).** The FSM's
+  public API now negotiates experimental family-local Paths-Limit state and
+  exports `graceful_restart_preserves_family`. Its new fields are additive
+  behind `#[non_exhaustive]`, but the public surface exposes wire types and now
+  depends on incompatible `rustbgpd-wire ^0.15.0`, requiring the 0.x breaking
+  bump. Wire must be published before the FSM package can be fully verified or
+  published against crates.io.
+
 - **Policy rollback has one aggregate RIB wait budget.** Authoritative
   self-heal and a subsequent cohort unwind now share one lazy absolute
   five-second deadline instead of waiting up to five seconds per peer. Every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "proptest",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ categories = ["network-programming"]
 
 [workspace.dependencies]
 # Internal crates
-rustbgpd-wire = { path = "crates/wire", version = "0.14" }
+rustbgpd-wire = { path = "crates/wire", version = "0.15.0" }
 rustbgpd-bfd = { path = "crates/bfd", version = "0.51.0" }
-rustbgpd-fsm = { path = "crates/fsm", version = "0.2" }
+rustbgpd-fsm = { path = "crates/fsm", version = "0.3.0" }
 rustbgpd-transport = { path = "crates/transport", version = "0.51.0" }
 rustbgpd-rib = { path = "crates/rib", version = "0.51.0" }
 rustbgpd-policy = { path = "crates/policy", version = "0.51.0" }

--- a/bench/scale/reloadstall/Cargo.lock
+++ b/bench/scale/reloadstall/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "thiserror",

--- a/bench/scale/rrharness/Cargo.lock
+++ b/bench/scale/rrharness/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-fsm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "rustbgpd-wire",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "rustbgpd-wire"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "thiserror 2.0.18",

--- a/crates/fsm/Cargo.toml
+++ b/crates/fsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-fsm"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -15,8 +15,14 @@ transitions.
 
 All six RFC 4271 states are implemented: Idle, Connect, Active,
 OpenSent, OpenConfirm, Established. Capability negotiation (4-octet AS,
-multi-protocol, Add-Path, graceful restart, extended messages) is
-handled during OPEN exchange.
+multi-protocol, Add-Path, experimental Paths-Limit, graceful restart,
+extended messages) is handled during OPEN exchange. Paths-Limit is applied
+only to matching negotiated Add-Path send families; negotiated state exposes
+the peer-advertised and effective family-local limits.
+
+`rustbgpd-fsm 0.3.0` moves with `rustbgpd-wire 0.15.0`: the FSM's public API
+exposes wire types, so the incompatible wire dependency requires the paired
+0.x breaking bump.
 
 ## Key types
 
@@ -24,7 +30,14 @@ handled during OPEN exchange.
 - **`SessionState`** — `Idle`, `Connect`, `Active`, `OpenSent`, `OpenConfirm`, `Established`
 - **`Event`** — `ManualStart`, `TcpConnectionConfirmed`, `BgpOpen`, `KeepAliveTimerExpires`, etc.
 - **`Action`** — `SendOpen`, `SendKeepalive`, `SendNotification`, `StartTimer`, `StopTimer`, etc.
-- **`NegotiatedSession`** — post-OPEN capabilities: families, Add-Path modes, GR state, extended message support
+- **`NegotiatedSession`** — post-OPEN capabilities: families, Add-Path modes,
+  `peer_paths_limits` / `effective_add_path_send_limits`, GR state, extended
+  message support
+- **`PeerConfig::paths_limit_receive_max`** — the preferred per-family receive
+  limit, defaulting to `0` (disabled); `paths_limit_capabilities()` advertises
+  it only when Add-Path receive is enabled
+- **`graceful_restart_preserves_family`** — rustbgpd's implementation-support
+  allowlist for families whose FSM/RIB lifecycle can retain GR/LLGR-stale routes
 
 ## License
 

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustbgpd-wire"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -61,7 +61,15 @@ analyzers, test harnesses, MRT readers, etc.
 | 9494 | Long-lived graceful restart capability |
 | 9552 | BGP-LS and BGP-LS-VPN NLRI/TLV codec with opaque preservation of unknown NLRI types and TLVs. The daemon consumes it for the ADR-0077 receive/API tranche. Typed topology read accessors now live in the crate (the `bgpls_topo` module); outbound reflection and topology production remain outside the wire crate |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
+| draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 | draft-ietf-idr-link-bandwidth | Link Bandwidth Extended Community (non-transitive two-octet-AS-specific, type 0x40 subtype 0x04): decode + construct of the advertising AS and the IEEE-754 bytes/second bandwidth used to weight unequal-cost multipath |
+
+### 0.15.0 compatibility note
+
+`Capability` is exhaustive, so adding `Capability::PathsLimit` makes 0.15.0 a
+breaking release for downstream exhaustive matches. Code 76 now decodes to
+typed `PathsLimitFamily` entries and is available as
+`constants::capability_code::PATHS_LIMIT`.
 
 ## Usage
 
@@ -127,10 +135,14 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
 - **`RpkiValidation` / `AspaValidation` / `AspaValidationContext`** — shared
   routing-domain validation state and ASPA session context used by rustbgpd's
   RIB, policy, transport, and RPKI crates
-- **`Capability`** — OPEN capabilities: multi-protocol, 4-octet AS, Add-Path, graceful restart, Outbound Route Filtering, etc.
+- **`Capability`** — OPEN capabilities: multi-protocol, 4-octet AS, Add-Path,
+  experimental Paths-Limit (`Capability::PathsLimit` / `PathsLimitFamily`,
+  code 76), graceful restart, Outbound Route Filtering, etc.
 - **ORF types** (`orf` module, RFC 5291/5292) — `OrfCapEntry` (capability blocks), `OrfPayload` / `OrfEntryGroup` / `OrfEntries` (the Route Refresh ORF section), and `AddressPrefixOrf` (one Address-Prefix entry: action, match, sequence, min/max length, prefix). `RouteRefreshMessage::orf` carries the decoded section; a malformed IPv4/IPv6 unicast Address-Prefix group decodes to `OrfEntries::Malformed` (RFC 5291 §5.2 reset) rather than failing the message, while non-unicast / future-family Address-Prefix groups are preserved as raw bytes until those family encodings are implemented. Adding `orf` to `RouteRefreshMessage` made that struct `Clone` rather than `Copy` (0.11.0)
 - **`FlowSpecRule`** / **`FlowSpecComponent`** — FlowSpec NLRI with all 13 match types
-- **`EvpnRoute`** / **`EvpnRouteKey`** — typed EVPN routes (Types 1–5) with full payloads (RFC 7432, RFC 9136)
+- **`EvpnRoute`** / **`EvpnRouteKey`** — typed EVPN routes (Types 1–5) with
+  full payloads (RFC 7432, RFC 9136); `EvpnRouteKey` implements `Ord` for
+  deterministic keyed collections
 - **`vpn` module** — VPNv4/VPNv6 labeled NLRI substrate, including label-stack
   validation, Route Distinguisher, and IPv4/IPv6 prefix payloads
 - **`bgpls` module** — BGP-LS/BGP-LS-VPN NLRI and TLV codec, preserving

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -16,8 +16,8 @@ reference for the publish-and-adoption plan (see the companion strategy memo).
 
 | Crate                    | Published? | Depends on (internal)              | Deps (external)            | Stability target | Role for embedders |
 |--------------------------|-----------|-----------------------------------|----------------------------|------------------|--------------------|
-| `rustbgpd-wire`          | **Yes** (crates.io, latest 0.13.0) | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
-| `rustbgpd-fsm`           | **Yes** (crates.io, latest 0.1.0) | `rustbgpd-wire`            | `thiserror`, `bytes`      | Pure FSM API     | Pure RFC 4271 FSM; no I/O. |
+| `rustbgpd-wire`          | **Yes** (crates.io `0.14.1`; repository prepared as `0.15.0`, not yet published) | none (internal)            | `bytes`, `thiserror`      | **Stable codec** | The one to link. Pure encode/decode. |
+| `rustbgpd-fsm`           | **Yes** (crates.io `0.2.0`; repository prepared as `0.3.0`, not yet published) | `rustbgpd-wire`            | `thiserror`, `bytes`      | Pure FSM API     | Pure RFC 4271 FSM; no I/O. |
 | `rustbgpd-rpki`          | No (`publish = false`) | `rustbgpd-wire`            | `tokio`, `tracing`, `smallvec` | Publish next     | VRP table + RTR client. |
 | `rustbgpd-rib`           | No           | wire, policy, telemetry, rpki     | `prefix-trie`, `ipnet`, ... | Later            | Adj/Loc-RIB; heavier. |
 | `rustbgpd-policy`        | No           | wire                              | —                          | Later            | Import/export policy. |
@@ -29,9 +29,11 @@ reference for the publish-and-adoption plan (see the companion strategy memo).
 | `rustbgpd-evpn-linux`    | No           | (internal)                        | `rtnetlink`, `nix`         | Never (Linux-specific) | Kernel dataplane. |
 | `rustbgpd` (daemon bin)  | No (`publish = false`) | all                            | —                          | N/A              | The daemon. Not a library. |
 
-**Publish order and why:** `wire` and `fsm` are published; `rpki` is the next
-natural candidate. The dependency DAG drives the order: `fsm` depends only on
-`wire`; `rpki` depends only on `wire`; `rib` depends on
+**Publish order and why:** `wire` and `fsm` are published; the repository has
+prepared their next versions, but the versions shown in the dependency
+examples below remain the versions available from crates.io. `rpki` is the
+next natural candidate. The dependency DAG drives the order: `fsm` depends
+only on `wire`; `rpki` depends only on `wire`; `rib` depends on
 `wire + policy + telemetry + rpki`. Publishing in this order means each
 published crate has only *already-published* (or external) dependencies, which
 is a hard crates.io requirement. `fsm` shipped before `rpki` because it is the
@@ -57,7 +59,8 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
   `peek_message_length(&Bytes) -> Option<usize>` (transport framing).
 - **`Message`** enum: `Open`, `Update`, `Keepalive`, `Notification`, `RouteRefresh`.
 - **`OpenMessage`** — capabilities negotiation; `Capability` enum (MP-BGP,
-  4-octet AS, Add-Path, GR/LLGR, ORF, BGP Roles, Extended Messages, ...).
+  4-octet AS, Add-Path, experimental Paths-Limit via `PathsLimitFamily`,
+  GR/LLGR, ORF, BGP Roles, Extended Messages, ...).
 - **`UpdateMessage`** — raw wire framing + `parse()` → `ParsedUpdate`
   (decoded NLRI + `Vec<PathAttribute>`).
 - **`PathAttribute`** — 14 typed variants + `Unknown` pass-through (`AsPath`,
@@ -65,7 +68,8 @@ Public surface (re-exported at crate root — `crates/wire/src/lib.rs`):
   `OnlyToCustomer`, ...).
 - **`Prefix`** (`V4(Ipv4Prefix)` / `V6(Ipv6Prefix)`), `NlriEntry`, Add-Path IDs.
 - **`Afi` / `Safi`** — IANA address-family identifiers.
-- **EVPN** (`EvpnRoute`/`EvpnRouteKey`, Types 1–5), **FlowSpec** (`FlowSpecRule`),
+- **EVPN** (`EvpnRoute`/`EvpnRouteKey`, Types 1–5; route keys implement `Ord`),
+  **FlowSpec** (`FlowSpecRule`),
   **VPNv4/v6** (`vpn` module), **BGP-LS** (`bgpls` module), **ORF** (`orf` module),
   **PMSI Tunnel**, **Route Distinguisher**.
 - **Well-known community constants** (`COMMUNITY_NO_EXPORT`, `COMMUNITY_BLACKHOLE`,
@@ -100,20 +104,18 @@ policy (`docs/RELEASE_CHECKLIST.md` §"Wire crate semver"):
 - **Minor**: new message types, attributes, helper methods, additive API changes.
 - **Major**: breaking API changes, changed method signatures, enum shape changes.
 
-**The 0.13.0 breaking change and `#[non_exhaustive]`:** Adding `Afi::BgpLs` and
-`Safi::BgpLs` / `Safi::BgpLsVpn` variants to the `Afi`/`Safi` enums is a breaking
-change because those enums are **not** `#[non_exhaustive]` (verified:
-`crates/wire/src/capability.rs:8-66`). The 0.12.0 → 0.13.0 bump correctly went to
-a major (0.x major = minor-number bump). The README and CHANGELOG call out that
-exhaustive downstream matches must add arms.
+**The prepared 0.15.0 change:** `Capability` is exhaustive, so adding
+`Capability::PathsLimit` is breaking for downstream exhaustive matches even
+though the new `PathsLimitFamily` codec is otherwise additive. The repository
+therefore prepares `0.15.0`, not a `0.14.x` patch. It also adds the additive
+`Ord` implementation on `EvpnRouteKey`. The published crates.io release remains
+`0.14.1` until the separate publish step completes.
 
-**Forward fix (first patch after publish):** Add `#[non_exhaustive]` to `Afi`
-and `Safi` (and any other IANA-registry-backed enum that can grow, e.g.
-`PmsiTunnelType` already uses an `Other(u8)` catch-all; `NotificationCode` is a
-candidate). Adding `#[non_exhaustive]` to an *existing* exhaustive enum is
-itself a breaking change, so this must land in the *next* major bump (0.14.0 or
-1.0.0), *not* a patch. Once marked, future IANA additions become minor bumps.
-See §5 of the strategy memo.
+The same rule applies to adding `#[non_exhaustive]` to an existing exhaustive
+enum: forcing downstream matches to add a wildcard arm is itself breaking.
+Future forward-compatibility work on `Afi`, `Safi`, `Capability`, and other
+wire enums therefore belongs in a later breaking release, not this packaging
+change.
 
 ---
 
@@ -127,7 +129,7 @@ This is the "MRT reader / monitor / analyzer" consumer. Links only
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.13"
+rustbgpd-wire = "0.14.1"
 bytes = "1"
 ```
 
@@ -187,8 +189,8 @@ intentional split (ADR-0002: inherent methods, no I/O in the FSM).
 ```toml
 # Cargo.toml
 [dependencies]
-rustbgpd-wire = "0.13"
-rustbgpd-fsm = "0.1"
+rustbgpd-wire = "0.14.1"
+rustbgpd-fsm = "0.2.0"
 bytes = "1"
 tokio = { version = "1", features = ["net", "io-util", "time", "rt"] }
 ```
@@ -199,24 +201,8 @@ use rustbgpd_wire::{Afi, Safi, encode_message, Message};
 use rustbgpd_fsm::{PeerConfig, Session, Event, Action, SessionState};
 
 // 1. Configure the peer (4-byte AS, IPv4 unicast, hold 90s).
-let cfg = PeerConfig {
-    local_asn: 65000,
-    remote_asn: 65001,
-    local_router_id: Ipv4Addr::new(10, 0, 0, 1),
-    hold_time: 90,
-    connect_retry_secs: 120,
-    families: vec![(Afi::Ipv4, Safi::Unicast)],
-    graceful_restart: false,
-    gr_restart_time: 0,
-    llgr_stale_time: 0,
-    add_path_receive: false,
-    add_path_send: false,
-    add_path_send_max: 0,
-    local_role: None,
-    strict_role: false,
-    prefix_orf_receive: false,
-    disable_ipv4_unicast: false,
-};
+let mut cfg = PeerConfig::new(65000, 65001, Ipv4Addr::new(10, 0, 0, 1));
+cfg.families = vec![(Afi::Ipv4, Safi::Unicast)];
 
 // 2. Create the FSM. Starts in Idle.
 let mut sm = Session::new(cfg);
@@ -272,12 +258,18 @@ once that crate is published.
 **Status: `wire` → `fsm` are published; `rpki` is next; `rib`, `bmp`, `mrt`,
 and `policy` are later.**
 
-1. **`rustbgpd-wire` (published as 0.13.0).** Already on crates.io; the 0.13.0
-   breaking bump carried BGP-LS Afi/Safi plus fallible `try_build`. This is the
-   foundation — nothing else can publish before it because every internal crate
-   depends on it.
+1. **`rustbgpd-wire` (published as `0.14.1`; `0.15.0` prepared).** The prepared
+   breaking bump adds the exhaustive `Capability::PathsLimit` variant and its
+   `PathsLimitFamily` entry type (experimental capability code 76), plus an
+   additive `Ord` implementation for `EvpnRouteKey`. This is the foundation —
+   dependent crate versions cannot publish before their wire dependency exists
+   on crates.io.
 
-2. **`rustbgpd-fsm` (published as decoupled `0.1.0`).** Why it was second:
+2. **`rustbgpd-fsm` (published as `0.2.0`; `0.3.0` prepared).** Its own new
+   fields are additive behind `#[non_exhaustive]`, but its public API exposes
+   wire types and the dependency moves from `^0.14` to incompatible `^0.15`.
+   The prepared FSM release therefore also needs a breaking 0.x bump. Why the
+   FSM was the second published crate:
    - It depends *only* on `rustbgpd-wire` + `thiserror` + `bytes`. Zero
      daemon-tier coupling.
    - It is the smallest, purest building block a second consumer needs. A test
@@ -331,16 +323,17 @@ GoBGP's library moat is not its codec; it is that the *whole daemon* is a Go
 library (`github.com/osrg/gobgp`), so Cilium imports the package and gets a
 session runtime + RIB + policy + gRPC server in-process. rustbgpd's
 complementary moat is the opposite and narrower: a *pure, memory-safe,
-zero-dep codec* that any Rust project can link without dragging in a runtime.
+runtime-free codec with no internal-crate dependencies* that any Rust project
+can link without dragging in the daemon stack.
 
 To be the de facto Rust BGP codec, the concrete gaps:
 
-1. **Make the enums forward-compatible.** Mark `Afi`, `Safi`, `Event`, `Action`,
-   `PathAttribute`, `Capability`, `Message`, `NotificationCode` and any
-   IANA-registry-backed enum `#[non_exhaustive]` in the next major bump. Today,
-   every new AFI/SAFI is a breaking change — that is a tax on adopters and on
-   us. (Verified: none are `#[non_exhaustive]` today.) This is the single
-   highest-leverage stability fix.
+1. **Finish the wire-enum forward-compatibility audit.** `Event` and `Action`
+   are already `#[non_exhaustive]`; wire enums such as `Afi`, `Safi`,
+   `PathAttribute`, `Capability`, `Message`, and `NotificationCode` still need
+   an intentional breaking-release plan. Every new variant on an exhaustive
+   enum is a breaking change — the exact reason Paths-Limit requires wire
+   `0.15.0`.
 2. **Ship an in-tree embedder as proof.** Add `examples/peer-loop/`: a ~150-line
    binary that links `wire + fsm`, opens one TCP session to a configured peer,
    drives the FSM, and prints every received UPDATE. This is the "it works"
@@ -368,28 +361,20 @@ To be the de facto Rust BGP codec, the concrete gaps:
 
 ---
 
-## 7. File-level checklist (execution)
+## 7. Published-crate release boundary
 
-- [ ] `crates/wire/Cargo.toml` — bump to `0.13.0` is staged; verify
-      `description`, `readme`, `keywords`, `categories` are present (they are).
-- [ ] `crates/wire/src/capability.rs` — add `#[non_exhaustive]` to `Afi` (line 9)
-      and `Safi` (line 37) in the *next* major bump (0.14.0 / 1.0.0), not 0.13.x.
-- [ ] `crates/wire/src/lib.rs` — add `#[non_exhaustive]` audit to the enums
-      listed in §6.1 above; add `tokio_util::codec` impl behind a feature.
-- [x] `crates/fsm/Cargo.toml` — published as independent `0.1.0` with
-      `description`, `readme`, `keywords`, and `categories`.
-- [x] `crates/fsm/src/config.rs` — `PeerConfig` is `#[non_exhaustive]` and has
-      constructor/default paths for external users.
-- [x] `crates/fsm/src/{event.rs,action.rs}` — `Event`, `Action`, and
-      `NegotiatedSession` are `#[non_exhaustive]`; `SessionState` remains the
-      exact RFC 4271 state enum.
-- [ ] `crates/rpki/Cargo.toml` — remove `publish = false`; decouple version.
-- [ ] `docs/RELEASE_CHECKLIST.md` — add a "library crate publish" sub-section
-      that runs `cargo semver-checks` and verifies docs.rs renders.
-- [ ] `examples/peer-loop/` — new example binary linking `wire + fsm`
-      (the embedding proof).
-- [ ] `.github/workflows/ci.yml` — gate `cargo semver-checks` on
-      `crates/wire/**` and `crates/fsm/**` path changes.
+- [x] Repository manifests prepare `rustbgpd-wire 0.15.0` and
+      `rustbgpd-fsm 0.3.0`; both retain their package metadata and README.
+- [x] The workspace dependency floors match the prepared versions.
+- [ ] Publish `rustbgpd-wire 0.15.0`, then verify it is registry-visible.
+- [ ] Only after that wire publish, run the fully verified package/dry-run gate
+      for `rustbgpd-fsm 0.3.0` and publish it. Cargo normalizes the FSM's path
+      dependency to `rustbgpd-wire = "^0.15.0"`, so a full FSM package verify
+      cannot resolve before wire is present in the registry.
+- [ ] Keep the dependency examples in §3 pinned to the versions actually
+      available from crates.io until the corresponding publish succeeds.
+- [ ] Treat the remaining wire-enum `#[non_exhaustive]` audit and any new
+      published crate as separate, demand-gated work.
 
 ---
 


### PR DESCRIPTION
## What changed

- prepare `rustbgpd-wire` 0.15.0 and `rustbgpd-fsm` 0.3.0 with matching workspace dependency floors and lockfile entries, including the two standalone scale-harness lockfiles
- document the complete package-visible Paths-Limit, EVPN key ordering, FSM negotiation, and GR-family predicate surface
- update the embedder guide to distinguish repository-prepared versions from the currently published crates.io versions
- fix the external `PeerConfig` example and stale publish/checklist wording
- require nonempty licenses, manpages, and completions in release archives, and correct the stale release-note extraction comment

## Why

`Capability` is exhaustive, so adding `PathsLimit` requires a breaking pre-1.0 wire bump. The FSM publicly exposes wire types, so moving its dependency from `^0.14` to incompatible `^0.15` requires the paired FSM bump. Preparing both together avoids an internally inconsistent release boundary while leaving publication as a separate, explicitly authorized step.

## Packaging status

- crates.io remains at wire 0.14.1 and FSM 0.2.0; this PR does not publish either crate
- wire: 32-file package, locked package verification, and locked publish dry run pass
- FSM: 15-file locked package listing and metadata requirement `^0.15.0` pass
- verified FSM packaging/dry run is intentionally deferred until wire 0.15.0 is actually registry-visible

## Load-bearing proofs

- reverting only the wire README while retaining the version bump makes the existing freshness gate fail; restoring it returns green
- a synthetic archive with a present-but-empty completion makes the exact archive assertion fail; restoring nonempty content returns green
- retaining the old standalone scale-harness lockfiles makes their committed `--locked` tests fail before compilation; refreshing only the path-package versions makes both harness suites pass

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --manifest-path bench/scale/rrharness/Cargo.toml --locked`
- `cargo test --manifest-path bench/scale/reloadstall/Cargo.toml --locked`
- `python3 scripts/reflow-release-notes.py --selftest`
- `git diff --check`

Tracks LAN-366.

No daemon version, tag, release, or crate publication is included.
