### PR TITLE
Stage the v0.51 stable-surface fixture

### DIFF
--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -148,6 +148,11 @@ of adjacent minor release lines from the canonical `v0.50.0` history origin,
 with an explicit transition into a new major. Future stable-surface migrations
 add a new consecutive-release fixture rather than overwriting this receipt.
 
+The v0.51.0 route-server example is also staged byte-for-byte under
+`tests/fixtures/v1-stable/v0.51.0/` and exercised by the current parser. This
+is only a current-parser proof: it is not yet an accepted v0.51.0-to-v0.52.0
+upgrade exercise and does not extend the inventory's accepted release chain.
+
 ## Release gate
 
 Run:
@@ -156,6 +161,7 @@ Run:
 python3 scripts/check-v1-stable-surface.py
 cargo test -p rustbgpctl v1_stable_cli_command_inventory_matches_clap_tree
 cargo test -p rustbgpd v1_stable_v0_50_route_server_fixture_parses
+cargo test -p rustbgpd v1_stable_v0_51_route_server_fixture_parses
 cargo test -p rustbgpd v1_stable_effective_defaults_match_runtime_resolution
 ```
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -503,6 +503,27 @@ fn v1_stable_v0_50_route_server_fixture_parses() {
         .unwrap_or_else(|err| panic!("v0.50.0 route-server config no longer validates: {err}"));
 }
 
+#[test]
+fn v1_stable_v0_51_route_server_fixture_parses() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/v1-stable/v0.51.0/route-server");
+    let config_path = fixture.join("config.toml");
+    let source = fs::read_to_string(&config_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read immutable v0.51.0 route-server fixture {}: {err}",
+            config_path.display()
+        );
+    });
+    let mut config: Config = toml::from_str(&source)
+        .unwrap_or_else(|err| panic!("v0.51.0 route-server config no longer parses: {err}"));
+    config
+        .load_rpol_files(Some(&fixture))
+        .unwrap_or_else(|err| panic!("v0.51.0 route-server rpol no longer loads: {err}"));
+    config
+        .validate()
+        .unwrap_or_else(|err| panic!("v0.51.0 route-server config no longer validates: {err}"));
+}
+
 const V1_EFFECTIVE_DEFAULTS_TOML: &str = r#"
 [global]
 asn = 65001

--- a/tests/fixtures/v1-stable/v0.51.0/route-server/config.toml
+++ b/tests/fixtures/v1-stable/v0.51.0/route-server/config.toml
@@ -1,0 +1,146 @@
+# IXP route server configuration
+#
+# rustbgpd as an IX route server with two members. Every member gets:
+# - transparent route-server mode (preserve original NEXT_HOP, no AS prepend)
+# - local BGP role "route_server" (RFC 9234: OTC attached on egress,
+#   role capability negotiated when the member also sets its role)
+# - dual-stack (IPv4 + IPv6 unicast)
+# - RPKI origin validation (drop invalid, prefer valid) and import
+#   hygiene (reject AS_SET, reject ASPA-invalid — see hygiene.rpol)
+#
+# Path-hiding mitigation (RFC 7947 §2.3.2), both flavors:
+# - member-alpha negotiates Add-Path send: it sees all candidate paths
+#   and runs its own selection (the preferred mitigation);
+# - member-beta cannot do Add-Path, so it opts into per_client_best:
+#   when its export policy denies the best path, the route server
+#   advertises the best *permitted* candidate instead of hiding the
+#   prefix (the BIRD-`secondary` equivalent).
+#
+# Add more [[neighbors]] blocks for additional IXP members, or manage
+# them dynamically via gRPC at runtime.
+
+[global]
+asn = 65500
+router_id = "198.51.100.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "127.0.0.1:9179"
+log_format = "json"
+
+# For remote management, prefer an mTLS proxy (see examples/envoy-mtls/).
+# Uncomment below only for trusted management networks:
+# [global.telemetry.grpc_tcp]
+# address = "127.0.0.1:50051"
+
+[global.telemetry.grpc_uds]
+path = "/var/lib/rustbgpd/grpc.sock"
+# Audit principal for this local socket (UDS access is gated by file perms);
+# mapped to a role in [security.grpc.roles] below.
+principal = "operator"
+
+[security.grpc]
+# Per-principal gRPC authorization (ADR-0064; default since v0.24.0).
+# Roles: observer (sensitive_read) | automation (mutating) | operator (operator_only)
+enforcement = "tier"
+
+[security.grpc.roles]
+operator = "operator"
+
+# --- RPKI origin validation ---
+
+[rpki]
+[[rpki.cache_servers]]
+address = "127.0.0.1:3323"       # Routinator, rpki-client, etc.
+
+# --- Named policy definitions ---
+
+[policy.definitions.reject-rpki-invalid]
+[[policy.definitions.reject-rpki-invalid.statements]]
+match_rpki_validation = "invalid"
+action = "deny"
+
+[policy.definitions.reject-bogon-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-bogon-prefixes.statements]]
+prefix = "0.0.0.0/0"
+action = "deny"
+[[policy.definitions.reject-bogon-prefixes.statements]]
+prefix = "10.0.0.0/8"
+le = 32
+action = "deny"
+[[policy.definitions.reject-bogon-prefixes.statements]]
+prefix = "172.16.0.0/12"
+le = 32
+action = "deny"
+[[policy.definitions.reject-bogon-prefixes.statements]]
+prefix = "192.168.0.0/16"
+le = 32
+action = "deny"
+
+[policy.definitions.reject-long-prefixes]
+default_action = "permit"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "0.0.0.0/0"
+ge = 25
+le = 32
+action = "deny"
+[[policy.definitions.reject-long-prefixes.statements]]
+prefix = "::/0"
+ge = 49
+le = 128
+action = "deny"
+
+[policy.definitions.prefer-rpki-valid]
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "valid"
+action = "permit"
+set_local_pref = 200
+[[policy.definitions.prefer-rpki-valid.statements]]
+match_rpki_validation = "not_found"
+action = "permit"
+set_local_pref = 100
+
+[policy]
+# ixp-hygiene (reject AS_SET, reject ASPA-invalid) lives in hygiene.rpol;
+# rpol and TOML policies share one namespace and compose in one chain.
+rpol_files = ["hygiene.rpol"]
+import_chain = [
+    "reject-rpki-invalid",
+    "ixp-hygiene",
+    "reject-bogon-prefixes",
+    "reject-long-prefixes",
+    "prefer-rpki-valid",
+]
+
+# --- IXP member peers ---
+
+# Add-Path-capable member: sees all candidate paths (preferred
+# path-hiding mitigation) and stays update-group-shareable.
+[[neighbors]]
+address = "198.51.100.2"
+remote_asn = 64501
+description = "member-alpha"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+role = "route_server"
+max_prefixes = 50000
+
+[neighbors.add_path]
+send = true
+send_max = 8
+
+# Member without Add-Path: per_client_best advertises the best
+# export-policy-permitted candidate when the overall best is denied
+# (RFC 7947 §2.3.2 per-client best-path). Requires route_server_client.
+[[neighbors]]
+address = "198.51.100.3"
+remote_asn = 64502
+description = "member-beta"
+hold_time = 90
+families = ["ipv4_unicast", "ipv6_unicast"]
+route_server_client = true
+per_client_best = true
+role = "route_server"
+max_prefixes = 50000

--- a/tests/fixtures/v1-stable/v0.51.0/route-server/hygiene.rpol
+++ b/tests/fixtures/v1-stable/v0.51.0/route-server/hygiene.rpol
@@ -1,0 +1,56 @@
+# IXP import hygiene (rpol policy language, ADR-0096).
+#
+# Referenced from config.toml via `[policy] rpol_files` and the import
+# chain; edits hot-apply via SIGHUP. Run the in-language tests below
+# with `rbgp policy check hygiene.rpol`.
+
+policy ixp-hygiene {
+    # Reject routes carrying an AS_SET (deprecated by RFC 9774; common
+    # IXP hygiene, arouteserver rejects them too). AS_PATHs render
+    # AS_SETs in braces — "65001 {65002 65003}" — so a literal `{`
+    # (escaped for the regex) matches any AS_SET segment.
+    term reject-as-set { if route.as-path matches "\\{" { reject } }
+    # Reject ASPA-invalid AS paths (draft-ietf-sidrops-aspa-verification).
+    # Inert (state = unknown) until ASPA objects are loaded from the
+    # RPKI cache; activates automatically once they are.
+    term reject-aspa-invalid { if route.aspa == invalid { reject } }
+    # Tag the RPKI origin-validation outcome as an RFC 8097 extended
+    # community (non-transitive opaque, type 0x43) so route-server
+    # clients can act on it without running their own validator.
+    # OV_INVALID never reaches clients here — the TOML import chain
+    # drops rpki-invalid routes — but tagging is harmless and keeps
+    # the terms uniform if that drop is ever relaxed.
+    term tag-ov-valid { if route.rpki == valid { add ext-community OV_VALID } }
+    term tag-ov-not-found { if route.rpki == not-found { add ext-community OV_NOT_FOUND } }
+    term tag-ov-invalid { if route.rpki == invalid { add ext-community OV_INVALID } }
+}
+
+test as-set-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501 {64502 64503}" }
+    expect ixp-hygiene == reject
+}
+
+test aspa-invalid-is-rejected {
+    route { prefix 203.0.113.0/24; as-path "64501"; aspa invalid }
+    expect ixp-hygiene == reject
+}
+
+test clean-route-falls-through {
+    route { prefix 203.0.113.0/24; as-path "64501 64510" }
+    expect ixp-hygiene == accept
+}
+
+test rpki-valid-is-tagged-ov-valid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki valid }
+    expect ixp-hygiene == accept with ext-community OV_VALID
+}
+
+test rpki-not-found-is-tagged-ov-not-found {
+    route { prefix 203.0.113.0/24; as-path "64501" }
+    expect ixp-hygiene == accept with ext-community OV_NOT_FOUND
+}
+
+test rpki-invalid-is-tagged-ov-invalid {
+    route { prefix 203.0.113.0/24; as-path "64501"; rpki invalid }
+    expect ixp-hygiene == accept with ext-community OV_INVALID
+}


### PR DESCRIPTION
## Summary

- archive the exact route-server config and policy bytes from tag `v0.51.0`
- prove the current strict parser, policy loader, and validator accept that immutable source fixture
- document this as staged compatibility evidence only, not an accepted v0.51-to-v0.52 upgrade exercise

## Load-bearing proof

Temporarily renaming the production `Global.router_id` serde key to `router_identifier` made the exact fixture test fail strict TOML decoding on the unknown `router_id` field. Restoring the production key returned the same test 1/1 green. The production mutation is absent from this diff.

## Provenance

- tag `v0.51.0` peels to `8711571252daa499a604208b891a6589057d36fc`
- config SHA-256: `fe68f301616b52385ea6460ba6642eb63fae099e3d1de6fdc1d15af9e81de044`
- policy SHA-256: `c1aea02c9c11810971ade843876d673f75045a9ce094f144f1833206215a4d96`
- both staged files compare byte-for-byte with `examples/route-server/` at that tag

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- focused immutable-fixture test
- v1 stable-surface inventory checker
- exact tag-byte comparison and hash verification

## Scope boundary

No stable-surface checker, workflow, manifest, version, or runtime behavior changes. The actual v0.51-to-v0.52 inventory extension remains an atomic release-cut step.

Tracks LAN-446.