### PR TITLE
Pin exact-export precommit integrity

### DIFF
--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1918,6 +1918,15 @@ impl RibManager {
                     .is_some_and(|precommit| precommit.lazy_group_prior.is_some())
                 && probe_results.iter().all(Result::is_ok)
                 && !self.peer_unexportable.contains_key(&peer);
+            #[cfg(test)]
+            let fast_path = {
+                let enabled = fast_path && !self.test_force_exact_export_slow_path;
+                if enabled {
+                    self.test_exact_export_fast_path_hits =
+                        self.test_exact_export_fast_path_hits.saturating_add(1);
+                }
+                enabled
+            };
 
             if !fast_path {
                 // Keys and prior advertised state are fallback-only. A clean

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -472,6 +472,10 @@ pub struct RibManager {
     /// grouped run.
     #[cfg(test)]
     test_force_ungrouped: bool,
+    #[cfg(test)]
+    test_force_exact_export_slow_path: bool,
+    #[cfg(test)]
+    test_exact_export_fast_path_hits: u64,
     /// Test/benchmark-only evidence for the explicit clean policy transition.
     #[cfg(any(test, feature = "bench-internals"))]
     policy_transition_stats: PolicyTransitionStats,
@@ -1009,6 +1013,10 @@ impl RibManager {
             pending_extra_withdraws: HashMap::new(),
             #[cfg(test)]
             test_force_ungrouped: false,
+            #[cfg(test)]
+            test_force_exact_export_slow_path: false,
+            #[cfg(test)]
+            test_exact_export_fast_path_hits: 0,
             #[cfg(any(test, feature = "bench-internals"))]
             policy_transition_stats: PolicyTransitionStats::default(),
             vrp_table: None,

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -315,6 +315,232 @@ async fn query_update_group(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> Strin
     reply_rx.await.unwrap()
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct ExactUpdateSemantic {
+    snapshot: Option<(u64, u64)>,
+    payload: String,
+}
+fn exact_update_semantic(update: &OutboundRouteUpdate) -> ExactUpdateSemantic {
+    let snapshot = update
+        .exact_export_snapshot
+        .as_ref()
+        .map(|snapshot| (snapshot.owner_id(), snapshot.generation()));
+    ExactUpdateSemantic {
+        snapshot,
+        payload: format!(
+            "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{}",
+            update.announce_source_exclusion,
+            update.announce,
+            update.withdraw,
+            update.end_of_rib,
+            update.refresh_markers,
+            update.next_hop_override,
+            update.flowspec_announce,
+            update.flowspec_withdraw,
+            update.evpn_announce,
+            update.evpn_withdraw,
+            update.bgpls_announce,
+            update.bgpls_withdraw,
+            update.vpn_announce,
+            update.vpn_withdraw,
+            update.labeled_announce,
+            update.labeled_withdraw,
+            update.rtc_announce,
+            update.rtc_withdraw,
+            update.otc_blocked,
+            update.request_refresh_all_negotiated,
+        ),
+    }
+}
+#[derive(Debug, PartialEq, Eq)]
+struct ExactPrecommitState {
+    updates: [ExactUpdateSemantic; 2],
+    overlays: [HashSet<ExactExportKey>; 2],
+    advertised: [Vec<String>; 2],
+    groups: [Option<usize>; 2],
+}
+
+fn register_direct_exact_peer(
+    manager: &mut RibManager,
+    peer: IpAddr,
+    encoder: Arc<dyn crate::update::ExactExportEncoder>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
+    manager.handle_update(RibUpdate::SetPeerExportEncoder {
+        peer,
+        session_id: 0,
+        encoder,
+    });
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(8);
+    manager.handle_update(RibUpdate::PeerUp {
+        peer,
+        session_id: 0,
+        peer_asn: 65_000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    });
+    let eor = outbound_rx.try_recv().unwrap();
+    assert_eq!(eor.end_of_rib, ipv4_sendable());
+    outbound_rx
+}
+
+fn drive_exact_precommit_step(
+    manager: &mut RibManager,
+    peers: [IpAddr; 2],
+    receivers: &mut [mpsc::Receiver<OutboundRouteUpdate>; 2],
+    source: IpAddr,
+    route: Route,
+) -> (ExactPrecommitState, u64) {
+    let hits_before = manager.test_exact_export_fast_path_hits;
+    manager.handle_update(RibUpdate::RoutesReceived {
+        peer: source,
+        session_id: 0,
+        announced: vec![route],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+    let updates = receivers
+        .each_mut()
+        .map(|receiver| exact_update_semantic(&receiver.try_recv().unwrap()));
+    let rejected = &manager.peer_unexportable;
+    let overlays = peers.map(|peer| rejected.get(&peer).cloned().unwrap_or_default());
+    let advertised = peers.map(|peer| {
+        manager
+            .grouped_advertised_routes(peer)
+            .expect("both targets remain grouped")
+            .iter()
+            .map(|route| format!("{route:?}"))
+            .collect()
+    });
+    let groups = peers.map(|peer| manager.grouped_member_of(peer));
+    let state = ExactPrecommitState {
+        updates,
+        overlays,
+        advertised,
+        groups,
+    };
+    (
+        state,
+        manager.test_exact_export_fast_path_hits - hits_before,
+    )
+}
+
+fn run_exact_precommit_differential(
+    force_slow: bool,
+    routes: &[Route; 3],
+) -> Vec<(ExactPrecommitState, u64)> {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.test_force_exact_export_slow_path = force_slow;
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 90, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 90, 0, 2)),
+    ];
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let mut receivers = peers.map(|peer| {
+        let limited = peer == peers[1];
+        register_direct_exact_peer(
+            &mut manager,
+            peer,
+            Arc::new(CohortExactEncoder {
+                owner: if limited { 2 } else { 1 },
+                profile: 90,
+                max_len: if limited { 128 } else { 4_096 },
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&probes),
+                reuses: Arc::clone(&reuses),
+            }),
+        )
+    });
+    let source = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 90));
+    routes
+        .iter()
+        .cloned()
+        .map(|route| drive_exact_precommit_step(&mut manager, peers, &mut receivers, source, route))
+        .collect()
+}
+
+fn assert_plain_unicast_update(
+    actual: &ExactUpdateSemantic,
+    owner: u64,
+    announce: Vec<Route>,
+    withdraw: Vec<(Prefix, u32)>,
+) {
+    let expected = exact_update_semantic(&OutboundRouteUpdate {
+        next_hop_override: vec![None; announce.len()].into(),
+        announce: announce.into(),
+        withdraw,
+        ..OutboundRouteUpdate::default()
+    });
+    assert_eq!(actual.snapshot, Some((owner, 1)));
+    assert_eq!(actual.payload, expected.payload);
+}
+
+/// Load-bearing breaks: disable fast => [0,0,0]; drop success => oversize leak; retain overlay => route absent.
+#[test]
+fn real_caller_grouped_exact_precommit_fast_and_slow_paths_are_equivalent() {
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let source = Ipv4Addr::new(192, 0, 2, 90);
+    let small = crate::test_support::make_route(prefix, source);
+    let mut oversized = small.clone();
+    Arc::make_mut(&mut oversized.attributes).push(PathAttribute::Communities(vec![0xFDE8_0002]));
+    let routes = [small.clone(), oversized, small];
+    let normal = run_exact_precommit_differential(false, &routes);
+    let forced_slow = run_exact_precommit_differential(true, &routes);
+    let key = ExactExportKey::Unicast(Prefix::V4(prefix), 0);
+
+    let hit_deltas =
+        |steps: &[(ExactPrecommitState, u64)]| steps.iter().map(|step| step.1).collect::<Vec<_>>();
+    assert_eq!(hit_deltas(&normal), [2, 1, 1]);
+    assert_eq!(hit_deltas(&forced_slow), [0, 0, 0]);
+    for (normal, slow) in normal.iter().zip(&forced_slow) {
+        assert_eq!(normal.0, slow.0, "fast/slow semantic states must match");
+        assert_eq!(normal.0.groups, [Some(0), Some(0)]);
+    }
+    assert_eq!(normal[0].0.overlays, [HashSet::new(), HashSet::new()]);
+    assert_eq!(normal[1].0.overlays, [HashSet::new(), HashSet::from([key])]);
+    assert_eq!(normal[2].0.overlays, [HashSet::new(), HashSet::new()]);
+    let advertised = routes.each_ref().map(|route| vec![format!("{route:?}")]);
+    assert_eq!(
+        normal[0].0.advertised,
+        [advertised[0].clone(), advertised[0].clone()]
+    );
+    assert_eq!(
+        normal[1].0.advertised,
+        [vec![format!("{:?}", routes[1])], vec![]]
+    );
+    assert_eq!(
+        normal[2].0.advertised,
+        [advertised[2].clone(), advertised[2].clone()]
+    );
+    assert_plain_unicast_update(&normal[0].0.updates[0], 1, vec![routes[0].clone()], vec![]);
+    assert_plain_unicast_update(&normal[0].0.updates[1], 2, vec![routes[0].clone()], vec![]);
+    assert_plain_unicast_update(&normal[1].0.updates[0], 1, vec![routes[1].clone()], vec![]);
+    assert_plain_unicast_update(
+        &normal[1].0.updates[1],
+        2,
+        vec![],
+        vec![(Prefix::V4(prefix), 0)],
+    );
+    assert_plain_unicast_update(&normal[2].0.updates[0], 1, vec![routes[2].clone()], vec![]);
+    assert_plain_unicast_update(&normal[2].0.updates[1], 2, vec![routes[2].clone()], vec![]);
+}
+
 async fn query_first_export_term_hits(tx: &mpsc::Sender<RibUpdate>, peer: IpAddr) -> (u64, u64) {
     let (reply, response) = oneshot::channel();
     tx.send(RibUpdate::QueryExportPolicyTermHits {

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -810,9 +810,7 @@ impl SessionExportProfile {
         }
     }
 
-    /// Return the prepared attributes for one unicast route, memoized by every
-    /// route/profile input that changes attribute construction. Both live
-    /// envelope encoding and exact precommit probes use this implementation.
+    /// Memoize route-varying inputs in one immutable profile; fixed fields are omitted, so never reuse across peers/generations; live and probe paths share this.
     pub(super) fn prepared_unicast_attributes_cached<'a>(
         &self,
         cache: &'a mut PreparedAttrCache,
@@ -820,8 +818,10 @@ impl SessionExportProfile {
         local_ipv4: Ipv4Addr,
         next_hop_override: Option<&rustbgpd_policy::NextHopAction>,
     ) -> &'a PreparedUnicastAttributes {
+        #[cfg(debug_assertions)]
+        cache.bind(self.owner_id, self.generation);
         let key = self.prepared_attr_cache_key(route, local_ipv4, next_hop_override);
-        cache.entry(key).or_insert_with(|| {
+        cache.entries.entry(key).or_insert_with(|| {
             self.prepare_unicast_attribute_bundle(route, local_ipv4, next_hop_override)
         })
     }
@@ -1424,7 +1424,29 @@ pub(super) struct PreparedAttrCacheKey {
     next_hop_override: NextHopOverrideKey,
 }
 
-pub(super) type PreparedAttrCache = FxHashMap<PreparedAttrCacheKey, PreparedUnicastAttributes>;
+#[derive(Default)]
+pub(super) struct PreparedAttrCache {
+    entries: FxHashMap<PreparedAttrCacheKey, PreparedUnicastAttributes>,
+    #[cfg(debug_assertions)]
+    snapshot: Option<(u64, u64)>,
+}
+
+impl PreparedAttrCache {
+    #[cfg(debug_assertions)]
+    fn bind(&mut self, owner_id: u64, generation: u64) {
+        match self.snapshot {
+            Some(snapshot) => {
+                debug_assert_eq!(snapshot, (owner_id, generation), "cache snapshot mismatch");
+            }
+            None => self.snapshot = Some((owner_id, generation)),
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
 
 pub(super) struct PreparedMpCandidate<T> {
     pub(super) afi: Afi,
@@ -2428,12 +2450,33 @@ mod tests {
         }
     }
 
+    #[cfg(debug_assertions)]
+    fn prepared_attr_cache_test_route() -> Route {
+        Route {
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+            next_hop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            link_local_next_hop: None,
+            next_hop_scope: None,
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            attributes: Arc::new(vec![PathAttribute::Origin(rustbgpd_wire::Origin::Igp)]),
+            received_at: std::time::Instant::now(),
+            origin_type: rustbgpd_rib::RouteOrigin::Ibgp,
+            peer_router_id: Ipv4Addr::new(192, 0, 2, 2),
+            is_stale: false,
+            is_llgr_stale: false,
+            path_id: 0,
+            validation_state: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa_state: rustbgpd_wire::AspaValidation::Unknown,
+            aspa_context: rustbgpd_wire::AspaValidationContext::default(),
+        }
+    }
+
     #[test]
     #[allow(
         clippy::too_many_lines,
         reason = "one cache-key matrix keeps scalar equivalence and every memo dimension together"
     )]
-    fn batched_exact_probe_matches_scalar_and_memoizes_only_complete_attr_keys() {
+    fn same_snapshot_batch_memoizes_only_complete_attr_keys() {
         let config = config_with_auth_secret("not-retained");
         let profile = SessionExportProfile::initial(&config, None, false);
         let shared_attributes = Arc::new(vec![
@@ -2550,6 +2593,34 @@ mod tests {
                 "specific next-hop address is part of the cache key"
             );
         }
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "cache snapshot mismatch")]
+    fn prepared_attr_cache_rejects_a_different_snapshot_owner() {
+        let config = config_with_auth_secret("not-retained");
+        let profile = SessionExportProfile::initial(&config, None, false);
+        let route = prepared_attr_cache_test_route();
+        let mut cache = PreparedAttrCache::default();
+        profile.prepared_unicast_attributes_cached(&mut cache, &route, profile.local_ipv4(), None);
+        let mut other = profile.clone();
+        other.owner_id = profile.owner_id + 1;
+        other.prepared_unicast_attributes_cached(&mut cache, &route, other.local_ipv4(), None);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "cache snapshot mismatch")]
+    fn prepared_attr_cache_rejects_a_different_snapshot_generation() {
+        let config = config_with_auth_secret("not-retained");
+        let profile = SessionExportProfile::initial(&config, None, false);
+        let route = prepared_attr_cache_test_route();
+        let mut cache = PreparedAttrCache::default();
+        profile.prepared_unicast_attributes_cached(&mut cache, &route, profile.local_ipv4(), None);
+        let mut other = profile.clone();
+        other.generation = profile.generation + 1;
+        other.prepared_unicast_attributes_cached(&mut cache, &route, other.local_ipv4(), None);
     }
 
     fn encoded(message: UpdateMessage) -> Vec<u8> {


### PR DESCRIPTION
## Summary

- exercise the real grouped exact-precommit caller through initial export, peer-specific oversize rejection, and recovery
- prove natural fast bookkeeping is semantically equivalent to a forced slow path across complete outbound envelopes, rejection overlays, logical Adj-RIB-Out, and group membership
- require exact fast-path hit deltas so deleting or widening the optimization makes the regression red
- bind the prepared-attribute cache to one immutable profile owner/generation in debug builds and correct its ownership contract

## Load-bearing proof

- disabling the production fast predicate changes `[2,1,1]` to `[0,0,0]`
- deleting the all-probes-success guard changes `[2,1,1]` to `[2,2,2]`
- deleting successful rejection-overlay removal leaves recovery stale
- weakening the cache fence to generation-only makes the owner mismatch test fail
- weakening the cache fence to owner-only makes the generation mismatch test fail

All five mutations were restored before the final green run.

## Validation

- focused real-caller RIB differential: 1/1
- same-snapshot cache memoization: 1/1
- cache owner/generation mismatch tests: 2/2
- `cargo check -p rustbgpd-transport --release`
- `cargo clippy -p rustbgpd-transport --release --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

Release all-target transport Clippy still reports two pre-existing debug-test import warnings in untouched `outbound.rs`; the identical command fails identically on clean main. The changed release library is warning-free.

Linear: LAN-402, LAN-390

Docs: not needed because this is test/debug-only integrity hardening with no runtime, API, CLI, config, metric, or operator-visible behavior change.