### PR TITLE
Pin TCP-AO secret and UAPI boundaries

### DIFF
--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -980,7 +980,7 @@ mod tests {
         assert_eq!(value["effective_send_active"], true);
     }
     use serde_json::Value;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn next_step_footer_golden_and_suppressed_under_json() {
@@ -1253,6 +1253,49 @@ mod tests {
         assert_eq!(value["tcp_ao_applied_generation"], 1);
         assert_eq!(value["tcp_ao_rotation_phase"], "add_only");
         assert_eq!(value["tcp_ao"]["keys"][0]["algorithm"], "hmac(sha256)");
+        // Load-bearing: additive fields at either redacted TCP-AO boundary
+        // must be reviewed rather than silently expanding secret exposure.
+        let tcp_ao = value["tcp_ao"]
+            .as_object()
+            .expect("TCP-AO state is an object");
+        assert_eq!(
+            tcp_ao.keys().map(String::as_str).collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "accept_icmps",
+                "ao_required",
+                "current_key_id",
+                "keys",
+                "packets_ao_required",
+                "packets_bad",
+                "packets_dropped_icmp",
+                "packets_good",
+                "packets_key_not_found",
+                "rnext_key_id",
+            ])
+        );
+        let first_key = tcp_ao["keys"][0]
+            .as_object()
+            .expect("TCP-AO key state is an object");
+        assert_eq!(
+            first_key
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "algorithm",
+                "deprecated",
+                "is_current",
+                "is_rnext",
+                "packets_bad",
+                "packets_good",
+                "peer_address",
+                "prefix_length",
+                "preferred",
+                "recv_id",
+                "send_id",
+                "vrf_ifindex",
+            ])
+        );
         assert!(value.to_string().find("secret").is_none());
         assert_eq!(value["otc_routes_blocked"], 3);
         assert_eq!(value["import_policy_routes_permitted"], 8);

--- a/crates/transport/src/socket_opts.rs
+++ b/crates/transport/src/socket_opts.rs
@@ -2203,16 +2203,23 @@ fn write_sockaddr(storage: &mut libc::sockaddr_storage, peer: IpAddr, scope_id: 
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
+#[allow(
+    unsafe_code,
+    reason = "decode the address prefix shared with Linux sockaddr_in and sockaddr_in6"
+)]
 fn read_sockaddr(storage: &libc::sockaddr_storage) -> io::Result<IpAddr> {
     match libc::c_int::from(storage.ss_family) {
         libc::AF_INET => {
+            // SAFETY: AF_INET selects sockaddr_in, whose ABI-compatible prefix
+            // is stored in this kernel-filled sockaddr_storage.
             let sin = unsafe { &*(std::ptr::from_ref(storage).cast::<libc::sockaddr_in>()) };
             Ok(IpAddr::V4(std::net::Ipv4Addr::from(u32::from_be(
                 sin.sin_addr.s_addr,
             ))))
         }
         libc::AF_INET6 => {
+            // SAFETY: AF_INET6 selects sockaddr_in6, whose ABI-compatible
+            // prefix is stored in this kernel-filled sockaddr_storage.
             let sin6 = unsafe { &*(std::ptr::from_ref(storage).cast::<libc::sockaddr_in6>()) };
             Ok(IpAddr::V6(std::net::Ipv6Addr::from(sin6.sin6_addr.s6_addr)))
         }
@@ -2317,6 +2324,29 @@ pub fn set_gtsm(_socket: &Socket, _remote: SocketAddr) -> io::Result<()> {
 mod tests {
     use super::*;
     use std::mem;
+
+    // Stable, dependency-free negative trait assertion. If `$ty` implements
+    // `$trait`, both marker implementations apply and inference fails E0283.
+    macro_rules! assert_not_impl {
+        ($ty:ty: $trait:path) => {
+            const _: fn() = || {
+                struct IfImpl;
+                trait Ambiguous<A> {
+                    fn check() {}
+                }
+                impl<T: ?Sized> Ambiguous<()> for T {}
+                impl<T: ?Sized + $trait> Ambiguous<IfImpl> for T {}
+                let _ = <$ty as Ambiguous<_>>::check;
+            };
+        };
+    }
+
+    assert_not_impl!(TcpAoAdd: std::fmt::Debug);
+    assert_not_impl!(TcpAoAdd: Clone);
+    assert_not_impl!(TcpAoGetSockOpt: std::fmt::Debug);
+    assert_not_impl!(TcpAoGetSockOpt: Clone);
+    assert_not_impl!(TcpAoMktCore: std::fmt::Debug);
+    assert_not_impl!(TcpAoMktCore: Clone);
 
     fn base_key() -> TcpAoKey<'static> {
         TcpAoKey {
@@ -2567,11 +2597,14 @@ mod tests {
         assert!(raw.key.iter().all(|byte| *byte == 0));
         assert_eq!(raw.keylen, 0);
 
+        assert!(std::mem::needs_drop::<TcpAoAdd>());
+        assert!(std::mem::needs_drop::<TcpAoGetSockOpt>());
         assert!(std::mem::needs_drop::<TcpAoMktCore>());
         let raw = raw_dump_key(IpAddr::from([192, 0, 2, 1]), "hmac(sha256)", b"secret");
         let core = mkt_core(&raw).unwrap();
         let heap_address = core.key.as_ptr();
         let moved = core;
+        let _: &Zeroizing<Vec<u8>> = &moved.key;
         assert_eq!(
             moved.key.as_ptr(),
             heap_address,
@@ -3053,6 +3086,7 @@ mod tests {
         assert_eq!(add.sndid, 7);
         assert_eq!(add.rcvid, 9);
         assert_eq!(add.maclen, 12);
+        assert_eq!(add.keyflags, 0);
         assert_eq!(add.keylen, 16);
         assert_eq!(add.flags, TCP_AO_ADD_SET_CURRENT | TCP_AO_ADD_SET_RNEXT);
         assert_eq!(&add.key[..16], b"0123456789abcdef");

--- a/docs/adr/0062-tcp-ao-foundation.md
+++ b/docs/adr/0062-tcp-ao-foundation.md
@@ -148,3 +148,27 @@ CRUD, plus peer-group inheritance. API/CLI neighbor state exposes redacted live
 inspection results (KeyIDs, validity flags, per-key inventory, and counters)
 and secret-free desired/applied generation, phase, and failure details for
 static and direct dynamic-prefix protected sessions.
+
+## Linux UAPI secrecy and normalization boundary
+
+The Linux v6.17 [`tcp_ao_add`
+UAPI](https://github.com/torvalds/linux/blob/v6.17/include/uapi/linux/tcp.h#L378-L402)
+defines `keyflags` separately from its selection flags. rustbgpd supplies zero:
+`TCP_AO_KEYF_IFINDEX` and `TCP_AO_KEYF_EXCLUDE_OPT` are both clear, so an MKT is
+not VRF-bound and [TCP options remain covered by
+authentication](https://github.com/torvalds/linux/blob/v6.17/net/ipv4/tcp_ao.c#L600-L602).
+Linux
+[`TCP_AO_GET_KEYS`](https://github.com/torvalds/linux/blob/v6.17/net/ipv4/tcp_ao.c#L2259-L2286)
+zeroes each output record and reconstructs an IPv6 family, port, and address,
+but not `sin6_scope_id`. IPv6 scope therefore remains socket/config authority,
+not an AO MKT selector.
+
+The raw add and GET_KEYS records contain key bytes and algorithm/key-length
+metadata, deliberately implement neither `Debug` nor `Clone`, and scrub those
+fields on drop. Reconciliation copies key bytes only into a
+`Zeroizing<Vec<u8>>` normalized core. The sole raw-address decoding boundary
+reads the `sockaddr_in` or `sockaddr_in6` prefix selected by the kernel-supplied
+family; no raw secret-bearing record crosses into CLI/API state. These rules
+track the [GET_KEYS record](https://github.com/torvalds/linux/blob/v6.17/include/uapi/linux/tcp.h#L438-L465)
+and Linux's [full-header hashing when options are
+included](https://github.com/torvalds/linux/blob/v6.17/net/ipv4/tcp_ao.c#L526-L551).


### PR DESCRIPTION
## Summary

- exact-pin only the redacted `tcp_ao` and first-key JSON boundaries so newly serialized secret-bearing fields fail review
- prove raw TCP-AO add/GET_KEYS/core records remain non-`Debug`, non-`Clone`, Drop-bearing, and `Zeroizing`-owned without unsafe post-Drop inspection
- pin `keyflags=0`, document IFINDEX/EXCLUDE_OPT and IPv6 scope normalization against Linux v6.17, and make the sockaddr safety boundary explicit

## Load-bearing proof

Eighteen independent mutations were run and restored byte-for-byte:

- 2 secret-like JSON field additions failed the exact outer/nested keysets
- 6 individual `Debug`/`Clone` derives failed the ambiguity oracle with E0283
- 2 individual raw Drop removals failed `needs_drop`
- 6 individual algorithm/key/key-length scrub removals failed exact value assertions
- replacing `Zeroizing<Vec<u8>>` with `Vec<u8>` failed the ownership type pin
- setting `TCP_AO_KEYF_EXCLUDE_OPT` failed the exact zero-keyflags assertion

## Validation

- focused CLI JSON test: 1/1
- transport `tcp_ao_` selector: 37 passed, 2 kernel-only ignored
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`

Docs: updated ADR-0062 with the pinned Linux v6.17 secrecy and normalization boundary.

Linear: LAN-388
