### PR TITLE
docs: refresh security truth and CLI completions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -253,9 +253,11 @@ new AFI/SAFI and EVPN dataplane expansion.
   an operator-readable rollback record.
 - **Tighten lifecycle security without reopening scope.** Preserve the shipped
   unprivileged base service and opt-in dataplane capability profile; finish
-  typed API-error migration and decide the v1 posture for live management-plane
-  credential rotation and received eBGP-only attributes. Privilege separation
-  remains a larger architectural choice, not a release-checkbox claim.
+  typed API-error migration and decide the v1 posture for received eBGP-only
+  attributes. Management-plane bearer and mTLS bytes behind unchanged paths now
+  rotate atomically on SIGHUP; listener, path, auth-mode, principal, role, and
+  access changes remain restart-required. Privilege separation remains a
+  larger architectural choice, not a release-checkbox claim.
 - **Pilot route-server next-hop ownership after its identity prerequisite.**
   ADR-0107 documents the current transparent-but-unchecked pipeline and a
   proposed opt-in strict-peer pilot. Bind its identity to the live session
@@ -1258,9 +1260,10 @@ gobmp/pmacct already terminate it into Kafka), and BGPsec.
   live neighbor API/CLI inspection are shipped. Ordered startup keyrings allow
   a restart-coordinated rollover: every key is installed, with a preferred or
   declaration-order-selected non-deprecated key used for startup transmission.
-  Live key rotation without a daemon restart (LAN-16 / #159), runtime
-  protected-range CRUD, and per-socket metrics remain demand-shaped rather
-  than core-feature blockers.
+  SIGHUP can also append non-preferred successors while owner sets and existing
+  key entries, order, and selection remain unchanged. Selection, deprecation,
+  removal, and edits/reordering (LAN-16 / #159), protected-owner CRUD, and
+  per-socket metrics remain demand-shaped rather than core-feature blockers.
 - **Dataplane-aware readiness.** The shipped `/readyz` (and the bounded
   `GetHealth`) probe scopes readiness to the **control-plane core** — PeerManager
   + RIB responsiveness within a 200 ms deadline — and deliberately excludes the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,15 +59,29 @@ input from the network. It runs under continuous fuzzing in CI.
 
 - **TCP MD5 (RFC 2385):** Supported. Linux only.
 - **GTSM (RFC 5082):** Supported. Configurable per peer.
-- **TCP-AO (RFC 5925):** Supported for static neighbors and direct dynamic-prefix listener keys on Linux (ADR-0062), including ordered startup keyrings, fail-closed accepted-socket owned-union validation, and live API/CLI health. Static-exact selection precedes dynamic longest-prefix-match; overlapping protected owners require directionally disjoint KeyIDs, AO/plaintext or AO/MD5 overlaps are rejected, and listener inventories are capped at 4,096 MKTs per address family. Keyring edits require a daemon restart; live rotation remains tracked in LAN-16 / #159.
+- **TCP-AO (RFC 5925):** Supported for static neighbors and direct
+  dynamic-prefix listener keys on Linux (ADR-0062), including ordered startup
+  keyrings, fail-closed accepted-socket owned-union validation, and live
+  API/CLI health. SIGHUP can append non-preferred successor keys to unchanged
+  owners. Selection, deprecation, deletion, editing/reordering, and protected-
+  owner changes remain restart-required. Static-exact selection precedes
+  dynamic longest-prefix-match; overlapping protected owners require
+  directionally disjoint KeyIDs, AO/plaintext or AO/MD5 overlaps are rejected,
+  and listener inventories are capped at 4,096 MKTs per address family.
 - **gRPC:** Unix domain socket by default (local-only). TCP listeners
   are opt-in via config. Per-listener bearer-token authentication is
   available via `token_file`. Native mTLS terminates in-process on TCP
   listeners via tonic + rustls/ring — configure `tls_cert_file`,
   `tls_key_file`, and `tls_client_ca_file` together on
   `[global.telemetry.grpc_tcp]` (partial config is rejected at config
-  load). An mTLS proxy front-end (see `examples/envoy-mtls/`) remains a
-  valid alternative for multi-host fan-out. Per-RPC authorization tiers
+  load). SIGHUP re-reads credential bytes from unchanged startup-captured
+  paths and publishes one atomic generation across all listeners before later
+  config reconciliation. New RPCs, including on existing HTTP/2 connections,
+  use the new bearer token; new TLS accepts use the new mTLS material, while
+  existing streams and TLS connections survive. Listener, path, auth-mode,
+  principal, role, and access changes remain restart-required. An mTLS proxy
+  front-end (see `examples/envoy-mtls/`) remains a valid alternative for
+  multi-host fan-out. Per-RPC authorization tiers
   (ADR-0064, enforced by default since v0.24.0) classify each method on
   top of the listener split; see [docs/SECURITY.md](docs/SECURITY.md) and
   [docs/grpc-method-inventory.md](docs/grpc-method-inventory.md).

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2912,6 +2912,25 @@ mod tests {
     }
 
     #[test]
+    fn checked_in_completions_match_current_cli() {
+        let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for (shell, relative_path) in [
+            (Shell::Bash, "examples/completions/rbgp.bash"),
+            (Shell::Zsh, "examples/completions/_rbgp"),
+            (Shell::Fish, "examples/completions/rbgp.fish"),
+        ] {
+            let mut generated = Vec::new();
+            generate_completions(shell, BINARY_NAME, &mut generated);
+            let checked_in = std::fs::read(repository.join(relative_path))
+                .unwrap_or_else(|error| panic!("failed to read {relative_path}: {error}"));
+            assert!(
+                generated == checked_in,
+                "{relative_path} is stale; regenerate it with `rbgp completions {shell}`"
+            );
+        }
+    }
+
+    #[test]
     fn test_man_page_is_roff_and_covers_nested_subcommands() {
         let mut output = Vec::new();
         generate_man(BINARY_NAME, &mut output).unwrap();

--- a/docs/API.md
+++ b/docs/API.md
@@ -55,10 +55,10 @@ unverified clients at the TLS layer before any gRPC handler runs.
 
 PEM material is pre-flight-validated at config load and `--check`
 time, so a successful `--check` rules out cert-rotation surprises
-at startup. Adding, removing, or rotating the TLS files is
-**restart-required** — SIGHUP reload pins the runtime listener
-config back to the live values and surfaces the drift in
-`rustbgpd --diff` until the daemon is restarted.
+at startup. Valid credential bytes behind unchanged TLS paths rotate on SIGHUP.
+Adding or removing TLS, changing a configured TLS path, or changing TLS/auth
+mode remains **restart-required**; runtime config pins that drift to the live
+values until the daemon is restarted.
 
 Native gNMI is available on the local UDS listener and on TCP listeners only
 when mTLS is configured. Plaintext or bearer-token-only TCP listeners serve the

--- a/docs/adr/0047-grpc-security-hardening.md
+++ b/docs/adr/0047-grpc-security-hardening.md
@@ -3,6 +3,15 @@
 - **Status:** Accepted
 - **Date:** 2026-03-06
 
+> **Current status (2026-07-15):** Native mTLS subsequently shipped. SIGHUP now
+> publishes bearer-token and mTLS credential bytes atomically across all
+> listeners from unchanged startup-captured paths before later config
+> reconciliation. New bearer-authenticated RPCs use the new token, including on
+> existing HTTP/2 connections; new TLS accepts use the new mTLS generation,
+> while existing streams and TLS connections survive. Listener, path,
+> auth-mode, principal, role, and access changes remain restart-required. The
+> decision record below preserves the original scope and tradeoffs.
+
 ## Context
 
 The gRPC management API exposes privileged operations: peer lifecycle, route

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -249,6 +249,7 @@ _arguments "${_arguments_options[@]}" : \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
 '--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
@@ -392,6 +393,7 @@ _arguments "${_arguments_options[@]}" : \
 '*--families=[Address families (comma-separated)]:FAMILIES:_default' \
 '--role=[Local BGP Role for RFC 9234 route-leak protection]:ROLE:_default' \
 '--add-path-send-max=[Max paths per prefix for Add-Path send]:ADD_PATH_SEND_MAX:_default' \
+'--paths-limit-receive-max=[Experimental Paths-Limit preference for Add-Path receive families]:PATHS_LIMIT_RECEIVE_MAX:_default' \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -5923,7 +5923,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__neighbor__subcmd__add)
-            opts="-s -j -h --asn --remote-asn --description --hold-time --send-hold-time --max-prefixes --families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --addr --token-file --json --no-color --help"
+            opts="-s -j -h --asn --remote-asn --description --hold-time --send-hold-time --max-prefixes --families --route-server-client --per-client-best --role --strict-role --add-path-receive --add-path-send --add-path-send-max --paths-limit-receive-max --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5962,6 +5962,10 @@ _rbgp() {
                     return 0
                     ;;
                 --add-path-send-max)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --paths-limit-receive-max)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -148,6 +148,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subc
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l add-path-send-max -d 'Max paths per prefix for Add-Path send' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l paths-limit-receive-max -d 'Experimental Paths-Limit preference for Add-Path receive families' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand neighbor; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'
@@ -206,6 +207,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l families -d 'Address families (comma-separated)' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l role -d 'Local BGP Role for RFC 9234 route-leak protection' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l add-path-send-max -d 'Max paths per prefix for Add-Path send' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l paths-limit-receive-max -d 'Experimental Paths-Limit preference for Add-Path receive families' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand summary; and __fish_seen_subcommand_from add" -l route-server-client -d 'Enable transparent route-server client mode (eBGP only)'


### PR DESCRIPTION
## Summary

- document the shipped TCP-AO add-only successor and management credential rotation boundaries accurately
- preserve ADR-0047 as historical context with a dated current-status note
- regenerate checked-in Bash, Zsh, and Fish completions for `--paths-limit-receive-max`
- add an exact-byte freshness test for all three checked-in completion examples

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `git diff --check`

## Load-bearing proof

Renaming only the production Clap long flag to `paths-limit-receive-max-broken` made `checked_in_completions_match_current_cli` fail with an exact-content stale-artifact assertion. Restoring the production flag returned the focused test to green.

No runtime, config, protobuf, dependency, version, release workflow, or changelog behavior changes.