### PR TITLE
fix(mrt): harden warm-bundle shutdown and cleanup paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Shutdown GR marker publication and warm-bundle maintenance can no longer
+  wedge or wedge-loop.** GR restart marker publication, its generationless
+  fallback, and marker removal at coordinated shutdown now run on a detached
+  writer thread under a 5-second terminal deadline, so a hung filesystem
+  cannot stall daemon exit. Warm-bundle entry verification treats an entry
+  grown by a same-UID writer mid-read as a typed mismatch instead of
+  panicking in the shutdown thread. A cleanup pass over a bundle directory
+  holding more than 65,536 candidates now removes the first cap-worth in
+  deterministic name order before reporting the over-cap error, so the
+  directory shrinks on every pass instead of failing unchanged forever.
+
 - **The route-server starter now applies documented dual-stack ingress
   hygiene.** Its policy rejects both default routes and a dated 2025-10-09
   snapshot of active IANA special-purpose rows marked non-globally reachable,

--- a/crates/mrt/src/warm_bundle.rs
+++ b/crates/mrt/src/warm_bundle.rs
@@ -19,13 +19,13 @@
 //! recognizable crash-leaked temporary files. Cleanup failure is logged but
 //! never invalidates or rolls back the newly committed generation.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, Read as _, Seek as _, SeekFrom, Write as _};
 use std::net::{IpAddr, Ipv4Addr};
 use std::os::fd::OwnedFd;
-use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::ffi::OsStringExt as _;
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -362,8 +362,10 @@ impl WarmBundleDirectory {
     ///
     /// Returns an error without deleting anything when the manifest is
     /// corrupt, unsafe, oversized, or changes before deletion, or when the
-    /// directory scan or candidate bound fails. A durability-sync error can be
-    /// reported after canonical stale entries were already removed.
+    /// directory scan fails. When the directory holds more candidates than
+    /// the bounded inventory, the pass removes the first cap-worth in name
+    /// order and still reports the over-cap error. A durability-sync error
+    /// can be reported after canonical stale entries were already removed.
     pub fn scavenge_owned_entries(&self) -> Result<WarmBundleCleanupReport, WarmBundleError> {
         scavenge_owned_entries_inner(self, FaultPoint::None)
     }
@@ -418,10 +420,12 @@ pub enum WarmBundleError {
         /// Later rollback or cleanup error.
         recovery: Box<WarmBundleError>,
     },
-    /// A cleanup pass exceeded its bounded candidate inventory.
+    /// A cleanup pass exceeded its bounded candidate inventory. The pass
+    /// still processed the first `cap` candidates in name order, so the
+    /// directory shrinks across passes.
     #[error("warm bundle cleanup found more than {cap} canonical candidates")]
     CleanupCandidateLimitExceeded {
-        /// Maximum candidate count accepted before any deletion.
+        /// Maximum candidate count processed by one cleanup pass.
         cap: usize,
     },
     /// Directory/file ownership or permissions were unsafe.
@@ -793,7 +797,7 @@ fn cleanup_owned_candidates(
             current_snapshot, ..
         } => Some(current_snapshot.as_bytes()),
     };
-    let candidates = collect_cleanup_candidates(directory, current_snapshot, budget)?;
+    let (candidates, over_cap) = collect_cleanup_candidates(directory, current_snapshot, budget)?;
 
     if !candidates.is_empty() {
         #[cfg(test)]
@@ -877,6 +881,13 @@ fn cleanup_owned_candidates(
     if let Some(error) = pending_error {
         return Err(error);
     }
+    if over_cap {
+        // Surfaced only after this pass removed its bounded inventory, so
+        // the condition stays visible while every pass makes progress.
+        return Err(WarmBundleError::CleanupCandidateLimitExceeded {
+            cap: MAX_CLEANUP_CANDIDATES,
+        });
+    }
     Ok(WarmBundleCleanupReport {
         removed,
         failed,
@@ -901,7 +912,7 @@ fn collect_cleanup_candidates(
     directory: &WarmBundleDirectory,
     current_snapshot: Option<&[u8]>,
     budget: Option<&WarmSnapshotBudget>,
-) -> Result<Vec<OsString>, WarmBundleError> {
+) -> Result<(Vec<OsString>, bool), WarmBundleError> {
     let cloned = directory
         .file
         .try_clone()
@@ -909,7 +920,8 @@ fn collect_cleanup_candidates(
     let owned: OwnedFd = cloned.into();
     let mut entries =
         Dir::from_fd(owned).map_err(|source| nix_io(&directory.display_path, source))?;
-    let mut candidates = Vec::<OsString>::new();
+    let mut candidates = BinaryHeap::<OsString>::new();
+    let mut over_cap = false;
     for entry in entries.iter() {
         if let Some(budget) = budget {
             budget.check()?;
@@ -922,11 +934,6 @@ fn collect_cleanup_candidates(
         {
             continue;
         }
-        if candidates.len() == MAX_CLEANUP_CANDIDATES {
-            return Err(WarmBundleError::CleanupCandidateLimitExceeded {
-                cap: MAX_CLEANUP_CANDIDATES,
-            });
-        }
         candidates
             .try_reserve(1)
             .map_err(|_| WarmBundleError::AllocationFailed {
@@ -934,9 +941,15 @@ fn collect_cleanup_candidates(
                 requested: u64::try_from(candidates.len().saturating_add(1)).unwrap_or(u64::MAX),
             })?;
         candidates.push(OsString::from_vec(bytes.to_vec()));
+        if candidates.len() > MAX_CLEANUP_CANDIDATES {
+            // Keep only the first cap-worth of names: this pass still makes
+            // deletion progress, so an over-cap directory shrinks across
+            // passes instead of failing every future cleanup unchanged.
+            candidates.pop();
+            over_cap = true;
+        }
     }
-    candidates.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
-    Ok(candidates)
+    Ok((candidates.into_sorted_vec(), over_cap))
 }
 
 fn verify_cleanup_manifest_guard(
@@ -2012,7 +2025,7 @@ fn verify_existing_entry(
         let read = file
             .read(&mut chunk)
             .map_err(|source| io_error(&display, source))?;
-        if read == 0 || chunk[..read] != expected[offset..offset + read] {
+        if read == 0 || !chunk_matches_expected(expected, offset, &chunk[..read]) {
             return Err(io_error(
                 &display,
                 io::Error::new(
@@ -2024,6 +2037,18 @@ fn verify_existing_entry(
         offset += read;
     }
     Ok(())
+}
+
+/// Compare one streamed chunk against the expected bytes at `offset`.
+///
+/// A chunk that runs past the end of `expected` is a mismatch, not a bounds
+/// violation: a same-UID writer grew the entry after its length was checked,
+/// so the entry no longer matches the expected content by definition.
+fn chunk_matches_expected(expected: &[u8], offset: usize, chunk: &[u8]) -> bool {
+    offset
+        .checked_add(chunk.len())
+        .and_then(|end| expected.get(offset..end))
+        == Some(chunk)
 }
 
 fn rollback_atomic_destination(
@@ -3116,6 +3141,51 @@ mod tests {
         symlink(&target, temp.path().join(WARM_BUNDLE_MANIFEST_FILE)).unwrap();
         assert!(dir.scavenge_owned_entries().is_err());
         assert!(temp.path().join(&stale).is_file());
+    }
+
+    #[test]
+    fn over_cap_scavenge_shrinks_the_directory_across_passes() {
+        let temp = tempfile::tempdir().unwrap();
+        let dir = opened(&temp);
+        let extra = 3;
+        for index in 0..MAX_CLEANUP_CANDIDATES + extra {
+            fs::write(temp.path().join(format!("snapshot-{index:064x}.mrt")), b"").unwrap();
+        }
+
+        let error = dir.scavenge_owned_entries().unwrap_err();
+        assert!(matches!(
+            error,
+            WarmBundleError::CleanupCandidateLimitExceeded {
+                cap: MAX_CLEANUP_CANDIDATES,
+            }
+        ));
+        assert_eq!(fs::read_dir(temp.path()).unwrap().count(), extra);
+        for index in MAX_CLEANUP_CANDIDATES..MAX_CLEANUP_CANDIDATES + extra {
+            // The first cap-worth in name order was removed; only the
+            // largest names survive to the next pass.
+            assert!(
+                temp.path()
+                    .join(format!("snapshot-{index:064x}.mrt"))
+                    .is_file()
+            );
+        }
+
+        let report = dir.scavenge_owned_entries().unwrap();
+        assert_eq!(report.removed(), extra as u64);
+        assert_eq!(fs::read_dir(temp.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn chunk_compare_treats_a_grown_entry_as_a_mismatch() {
+        // A same-UID writer can grow an entry between the length check and a
+        // later read; an oversized chunk must compare as a mismatch instead
+        // of indexing past the expected bytes.
+        assert!(chunk_matches_expected(b"abcd", 0, b"abcd"));
+        assert!(chunk_matches_expected(b"abcd", 2, b"cd"));
+        assert!(!chunk_matches_expected(b"abcd", 2, b"cx"));
+        assert!(!chunk_matches_expected(b"abcd", 2, b"cde"));
+        assert!(!chunk_matches_expected(b"abcd", 4, b"e"));
+        assert!(!chunk_matches_expected(b"abcd", usize::MAX, b"e"));
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -161,6 +161,12 @@ orphan cleanup, and a corrupt, unsafe, oversized, or changed manifest deletes
 nothing. One undeletable stale entry is reported but does not suppress later
 entries in deterministic filename order.
 
+Turning `warm_cache_checkpoint_on_shutdown` back off does not remove the last
+committed bundle: nothing scavenges `<runtime_state_dir>/warm-bundle-v1` once
+the option is disabled. The bundle contains routing table contents (see the
+shutdown warm-checkpoint confidentiality note in SECURITY.md), so delete that
+directory manually if the cached routing data must not persist.
+
 Every concurrently running rustbgpd daemon must use a distinct
 `runtime_state_dir`. Sharing one runtime-state directory between live daemon
 processes is unsupported because the restart marker, warm checkpoint, FIB

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,11 @@ const WARM_BUNDLE_DIRECTORY: &str = "warm-bundle-v1";
 const MAX_GR_RESTART_MARKER_BYTES: u64 = 4096;
 const MAX_CHECKPOINT_GENERATION_BYTES: usize = 128;
 const WARM_CHECKPOINT_DEADLINE: Duration = Duration::from_secs(30);
+/// Terminal bound for shutdown GR restart marker publication and removal.
+/// The marker is tiny next to the 30-second warm-checkpoint budget, but its
+/// open/write/sync/rename sequence hits the same filesystem: a hung mount
+/// must not stall daemon exit.
+const GR_MARKER_IO_DEADLINE: Duration = Duration::from_secs(5);
 static MARKER_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static WARM_CHECKPOINT_REVISION: AtomicU64 = AtomicU64::new(0);
 
@@ -679,6 +684,33 @@ where
                 }
             }
         }
+    }
+}
+
+/// Run one small GR restart marker operation on a dedicated OS thread,
+/// bounded by `deadline`. Returns `None` when the deadline fires or the
+/// thread cannot start. Like the warm-checkpoint writer, this avoids Tokio's
+/// blocking pool: a timed-out `spawn_blocking` task cannot be cancelled and
+/// the runtime waits for it during shutdown, defeating the bound. A late
+/// worker is left detached and its result discarded.
+async fn bounded_gr_marker_io<T, F>(deadline: Duration, operation: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (reply, receiver) = oneshot::channel();
+    if std::thread::Builder::new()
+        .name("gr-marker-io".to_string())
+        .spawn(move || {
+            let _ = reply.send(operation());
+        })
+        .is_err()
+    {
+        return None;
+    }
+    match tokio::time::timeout(deadline, receiver).await {
+        Ok(Ok(value)) => Some(value),
+        Ok(Err(_)) | Err(_) => None,
     }
 }
 
@@ -4518,10 +4550,11 @@ async fn run<T>(
 
     if let Some(restart_time_secs) = restart_time_secs {
         let restart_duration = Duration::from_secs(restart_time_secs);
-        let publication = publish_gr_restart_marker_with_fallback(
-            checkpoint_generation.as_deref(),
-            |generation| {
-                gr_restart_marker_store.as_ref().map_or_else(
+        let store = gr_restart_marker_store.clone();
+        let generation = checkpoint_generation.clone();
+        let publication = bounded_gr_marker_io(GR_MARKER_IO_DEADLINE, move || {
+            publish_gr_restart_marker_with_fallback(generation.as_deref(), |generation| {
+                store.as_ref().map_or_else(
                     || {
                         Err(std::io::Error::other(
                             "pinned runtime-state marker storage is unavailable",
@@ -4530,65 +4563,84 @@ async fn run<T>(
                     },
                     |store| store.write_selected(restart_duration, generation),
                 )
-            },
-        );
-        if let Some(error) = publication.initial_error.as_ref() {
-            warn!(
-                marker = %gr_restart_marker_path.display(),
-                marker_visible = error.visible_outcome.is_some(),
-                %error,
-                "initial GR restart marker publication did not reach directory-synced durability"
-            );
-        }
-        if let Some(error) = publication.fallback_error.as_ref() {
-            warn!(
-                marker = %gr_restart_marker_path.display(),
-                marker_visible = error.visible_outcome.is_some(),
-                %error,
-                "generationless GR restart marker fallback did not reach directory-synced durability"
-            );
-        }
-        if let Some(visible) = publication.visible {
-            let outcome = visible.outcome;
-            if visible.durability == GrRestartMarkerDurability::VisibleDirectorySyncUncertain {
+            })
+        })
+        .await;
+        if let Some(publication) = publication {
+            if let Some(error) = publication.initial_error.as_ref() {
                 warn!(
                     marker = %gr_restart_marker_path.display(),
-                    marker_version = outcome.version,
+                    marker_visible = error.visible_outcome.is_some(),
+                    %error,
+                    "initial GR restart marker publication did not reach directory-synced durability"
+                );
+            }
+            if let Some(error) = publication.fallback_error.as_ref() {
+                warn!(
+                    marker = %gr_restart_marker_path.display(),
+                    marker_visible = error.visible_outcome.is_some(),
+                    %error,
+                    "generationless GR restart marker fallback did not reach directory-synced durability"
+                );
+            }
+            if let Some(visible) = publication.visible {
+                let outcome = visible.outcome;
+                if visible.durability == GrRestartMarkerDurability::VisibleDirectorySyncUncertain {
+                    warn!(
+                        marker = %gr_restart_marker_path.display(),
+                        marker_version = outcome.version,
+                        checkpoint_generation = outcome.checkpoint_generation.as_deref().unwrap_or("none"),
+                        publication_durability = visible.durability.as_str(),
+                        "GR restart marker is visible but parent-directory durability is unconfirmed"
+                    );
+                }
+                if let Some(reason) = outcome.degraded_reason.as_deref() {
+                    warn!(
+                        marker = %gr_restart_marker_path.display(),
+                        marker_version = outcome.version,
+                        %reason,
+                        "published GR restart marker with wall-clock fallback because boottime protection was unavailable"
+                    );
+                }
+                info!(
+                    marker = %gr_restart_marker_path.display(),
+                    restart_time_secs,
                     checkpoint_generation = outcome.checkpoint_generation.as_deref().unwrap_or("none"),
+                    marker_version = outcome.version,
                     publication_durability = visible.durability.as_str(),
-                    "GR restart marker is visible but parent-directory durability is unconfirmed"
+                    "finished GR restart marker publication for coordinated shutdown"
                 );
-            }
-            if let Some(reason) = outcome.degraded_reason.as_deref() {
+            } else {
                 warn!(
                     marker = %gr_restart_marker_path.display(),
-                    marker_version = outcome.version,
-                    %reason,
-                    "published GR restart marker with wall-clock fallback because boottime protection was unavailable"
+                    "neither publication attempt made a new GR restart marker visible — restarting-speaker mode is not guaranteed on the next start"
                 );
             }
-            info!(
-                marker = %gr_restart_marker_path.display(),
-                restart_time_secs,
-                checkpoint_generation = outcome.checkpoint_generation.as_deref().unwrap_or("none"),
-                marker_version = outcome.version,
-                publication_durability = visible.durability.as_str(),
-                "finished GR restart marker publication for coordinated shutdown"
-            );
         } else {
             warn!(
                 marker = %gr_restart_marker_path.display(),
-                "neither publication attempt made a new GR restart marker visible — restarting-speaker mode is not guaranteed on the next start"
+                deadline_secs = GR_MARKER_IO_DEADLINE.as_secs(),
+                "GR restart marker publication exceeded its terminal deadline; continuing shutdown — restarting-speaker mode is not guaranteed on the next start"
             );
         }
-    } else if let Some(store) = gr_restart_marker_store.as_ref()
-        && let Err(e) = store.remove()
-    {
-        warn!(
-            marker = %gr_restart_marker_path.display(),
-            error = %e,
-            "failed to clear GR restart marker"
-        );
+    } else if let Some(store) = gr_restart_marker_store.clone() {
+        match bounded_gr_marker_io(GR_MARKER_IO_DEADLINE, move || store.remove()).await {
+            Some(Ok(())) => {}
+            Some(Err(e)) => {
+                warn!(
+                    marker = %gr_restart_marker_path.display(),
+                    error = %e,
+                    "failed to clear GR restart marker"
+                );
+            }
+            None => {
+                warn!(
+                    marker = %gr_restart_marker_path.display(),
+                    deadline_secs = GR_MARKER_IO_DEADLINE.as_secs(),
+                    "clearing the GR restart marker exceeded its terminal deadline; continuing shutdown"
+                );
+            }
+        }
     }
     // ADR-0080: fence in-flight EVPN runtime applies out of the teardown.
     // Applies run on detached tasks (a dropped or aborted caller cannot
@@ -5884,6 +5936,24 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
         let marker = store.read().unwrap().unwrap();
         assert_eq!(marker.checkpoint_generation, None);
         store.remove().unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_marker_io_returns_completed_results() {
+        let result = bounded_gr_marker_io(GR_MARKER_IO_DEADLINE, || 7_u32).await;
+        assert_eq!(result, Some(7));
+    }
+
+    #[tokio::test]
+    async fn bounded_marker_io_detaches_a_stalled_operation() {
+        // The stall far exceeds any plausible scheduler delay of the timeout,
+        // and the detached thread dies with the test process.
+        let result = bounded_gr_marker_io(Duration::from_millis(20), || {
+            std::thread::sleep(Duration::from_mins(1));
+            7_u32
+        })
+        .await;
+        assert_eq!(result, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Four hardening fixes from a review of the warm-restart/checkpoint arc.

## 1. Grown-entry race in `verify_existing_entry` panicked instead of erroring

`crates/mrt/src/warm_bundle.rs`: the streamed compare loop indexed `expected[offset..offset + read]` after the fstat length check. A same-UID writer growing the entry between fstat and a read made the slice index panic in the shutdown thread. The compare now routes through `chunk_matches_expected`, which treats a chunk running past the end of `expected` as a content mismatch, returning the same typed `InvalidData` mismatch error as every other same-UID-race path in the module. Direct unit test covers the oversized-chunk and offset-overflow inputs.

## 2. Shutdown GR marker publication had no deadline

`src/main.rs`: the marker open/write/sync/rename/dir-sync sequence ran unbounded while the adjacent warm checkpoint is bounded at 30 s, so a hung filesystem stalled daemon exit indefinitely. Marker publication (primary and generationless fallback together) and marker removal now run through `bounded_gr_marker_io`: a dedicated detached OS thread plus a 5-second `tokio::time::timeout`, the same shape as the warm-checkpoint writer (Tokio's blocking pool is avoided for the same reason — a timed-out `spawn_blocking` task stalls runtime shutdown). On timeout, a warning is logged and shutdown continues. Marker semantics are unchanged. Unit tests cover the completed and stalled paths.

## 3. Over-cap warm-bundle cleanup failed forever without deleting anything

`crates/mrt/src/warm_bundle.rs`: `collect_cleanup_candidates` errored at the 65,536-candidate cap before any deletion, and cleanup errors are warn-only, so once tripped every future startup-scavenge and post-commit pass failed while the directory only grew. Collection now keeps the first cap-worth of names in deterministic name order (bounded max-heap, memory still capped), the pass deletes them, and the over-cap error is surfaced afterward so the condition stays visible while every pass makes progress. The cap constant is unchanged. Unit test proves a directory over the cap shrinks across passes.

## 4. Operator note for disabling `warm_cache_checkpoint_on_shutdown`

`docs/CONFIGURATION.md`: documents that turning the option off leaves the last committed bundle under `<runtime_state_dir>/warm-bundle-v1` unscavenged; it contains routing table contents (see SECURITY.md's warm-checkpoint confidentiality note) and must be removed manually if the cached routing data must not persist.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-mrt` — exit 0 (95 passed)
- `cargo test --workspace` — exit 0 (6074 passed, 0 failed)