### PR TITLE
Fix selection-deferral teardown, failback gating, and release accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deterministic name order before reporting the over-cap error, so the
   directory shrinks on every pass instead of failing unchanged forever.
 
+- **Selection-deferral teardown, failback gating, and release accounting.**
+  Deleting a GR neighbor from configuration mid-deferral now removes its
+  waiters from the frozen roster, so the family releases when the remaining
+  waiters satisfy instead of freezing best-path selection until timer expiry.
+  Collision failback applies the same OPEN gating as ordinary classification:
+  a Restart-State, non-GR, or plain-refresh (no RFC 7313) survivor is excluded
+  instead of being parked in an unfulfillable `awaiting_refresh` that
+  convergence-holds the family for the whole window; the RFC 7313
+  `BoRR`/`EoRR` convergence proof is unchanged where negotiated. A family gate
+  that completes with zero completion markers consumed records the new
+  `all_excluded` release reason instead of claiming `all_eor`; simultaneous
+  identity-and-byte ledger exhaustion records `identities_and_logical_bytes`
+  instead of the identity cap always winning. A plain-refresh peer whose
+  deferred route-refresh response is delivered at release no longer receives a
+  second empty-UPDATE End-of-RIB after the genuine convergence EoR.
+
 - **The route-server starter now applies documented dual-stack ingress
   hygiene.** Its policy rejects both default routes and a dated 2025-10-09
   snapshot of active IANA special-purpose rows marked non-globally reachable,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -522,9 +522,17 @@ pub(super) struct LiveSessionRecord {
 }
 
 #[derive(Clone, Debug, Default)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "fields mirror the RibUpdate::SetPeerGracefulRestartContext wire names"
+)]
 struct PeerSelectionDeferralContext {
     peer_restart_state: bool,
     peer_gr_families: Vec<(Afi, Safi)>,
+    /// Peer negotiated enhanced route refresh (RFC 7313). Collision
+    /// failback only arms a `BoRR`/`EoRR` convergence wait when the
+    /// survivor can actually produce the pair.
+    peer_enhanced_refresh: bool,
 }
 
 const ROUTES_RECEIVED_CHUNK_SIZE: usize = 1024;
@@ -1604,12 +1612,14 @@ impl RibManager {
                 session_id,
                 peer_restart_state,
                 peer_gr_families,
+                peer_enhanced_refresh,
             } => {
                 self.pending_peer_gr_context.insert(
                     (peer, session_id),
                     PeerSelectionDeferralContext {
                         peer_restart_state,
                         peer_gr_families,
+                        peer_enhanced_refresh,
                     },
                 );
             }

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -408,6 +408,18 @@ impl RibManager {
     /// `handle_peer_down` does not apply.
     pub(super) fn handle_peer_deleted(&mut self, peer: IpAddr) {
         self.peer_down_teardown(peer);
+        // Deletion also removes the peer from the startup selection-deferral
+        // roster: no future session can satisfy its waiters, and leaving them
+        // in a blocking state would freeze the family until timer expiry even
+        // after every remaining waiter satisfies. Runs after the teardown so
+        // any resulting release recomputes against the cleared Adj-RIB-In.
+        let transitions = self
+            .selection_deferral
+            .as_mut()
+            .map_or_else(Vec::new, |selection| {
+                selection.peer_deleted(peer, &self.metrics)
+            });
+        self.apply_selection_deferral_transitions(transitions, "peer deleted from configuration");
         self.metrics.reap_peer_series(&peer.to_string());
     }
 
@@ -754,15 +766,30 @@ impl RibManager {
                 }
             }
             ActiveSessionRegistration::CollisionFailback => {
-                let waiting = self.selection_deferral.as_mut().and_then(|selection| {
-                    selection.await_collision_failback_refresh(peer, session_id, &self.metrics)
+                // Same fail-closed contract as the ordinary arm: without the
+                // staged OPEN context the survivor cannot be proven GR- and
+                // enhanced-refresh-capable for any family, so its waiters
+                // stay `AwaitingSession` (timer-bound).
+                let waiting = gr_context.as_ref().and_then(|gr_context| {
+                    let peer_gr_families: HashSet<_> =
+                        gr_context.peer_gr_families.iter().copied().collect();
+                    self.selection_deferral.as_mut().and_then(|selection| {
+                        selection.await_collision_failback_refresh(
+                            peer,
+                            session_id,
+                            gr_context.peer_restart_state,
+                            &peer_gr_families,
+                            gr_context.peer_enhanced_refresh,
+                            &self.metrics,
+                        )
+                    })
                 });
                 if let Some(transitions) = &waiting {
                     info!(
                         %peer,
                         session_id,
                         transition_count = transitions.len(),
-                        "exact collision-failback survivor is awaiting a post-failback enhanced ROUTE-REFRESH completion"
+                        "exact collision-failback survivor classified against the RFC 4724 roster (enhanced-refresh waiters hold convergence until EoRR)"
                     );
                 }
                 waiting.unwrap_or_default()

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -584,11 +584,27 @@ impl RibManager {
 
     /// Re-advertise the Loc-RIB for a given family to a peer, followed by `EoR`.
     /// Called when a peer sends ROUTE-REFRESH (RFC 2918).
+    pub(super) fn send_route_refresh_response(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
+        self.send_route_refresh_response_inner(peer, afi, safi, false);
+    }
+
+    /// `suppress_eor` is set by the selection-deferral release path, which
+    /// has already queued/flushed the genuine convergence `EoR` for this
+    /// peer and family: without it a plain-refresh (RFC 2918) peer would
+    /// receive a second empty-UPDATE `EoR` from this response. An RFC 7313
+    /// peer is unaffected either way — transport substitutes the response's
+    /// own `end_of_rib` entry with the `EoRR` demarcation marker.
     #[expect(
         clippy::too_many_lines,
         reason = "route-refresh replay keeps family staging, ORF gating, and EoR together"
     )]
-    pub(super) fn send_route_refresh_response(&mut self, peer: IpAddr, afi: Afi, safi: Safi) {
+    pub(super) fn send_route_refresh_response_inner(
+        &mut self,
+        peer: IpAddr,
+        afi: Afi,
+        safi: Safi,
+        suppress_eor: bool,
+    ) {
         let family = (afi, safi);
         if self.selection_convergence_held(family) {
             self.selection_deferred_refresh
@@ -1158,7 +1174,11 @@ impl RibManager {
                 nh_override_flags.into(),
                 announce.into(),
                 withdraw,
-                if deferred_eor { vec![] } else { vec![family] },
+                if deferred_eor || suppress_eor {
+                    vec![]
+                } else {
+                    vec![family]
+                },
                 vec![
                     (afi, safi, RouteRefreshSubtype::BoRR),
                     (afi, safi, RouteRefreshSubtype::EoRR),

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -45,6 +45,9 @@ impl Default for DeferredSelectionLimits {
 enum DeferredSelectionOverflowReason {
     Identities,
     LogicalBytes,
+    /// Both budgets were exhausted for the rejected identity; neither
+    /// reason alone would be truthful.
+    IdentitiesAndLogicalBytes,
 }
 
 impl DeferredSelectionOverflowReason {
@@ -52,6 +55,7 @@ impl DeferredSelectionOverflowReason {
         match self {
             Self::Identities => "identities",
             Self::LogicalBytes => "logical_bytes",
+            Self::IdentitiesAndLogicalBytes => "identities_and_logical_bytes",
         }
     }
 }
@@ -193,12 +197,11 @@ impl DeferredSelectionKeys {
             let remaining_key_bytes = limits
                 .retained_key_bytes
                 .saturating_sub(*retained_key_bytes);
-            let overflow_reason = if remaining == 0 {
-                Some(DeferredSelectionOverflowReason::Identities)
-            } else if charge > remaining_key_bytes {
-                Some(DeferredSelectionOverflowReason::LogicalBytes)
-            } else {
-                None
+            let overflow_reason = match (remaining == 0, charge > remaining_key_bytes) {
+                (true, true) => Some(DeferredSelectionOverflowReason::IdentitiesAndLogicalBytes),
+                (true, false) => Some(DeferredSelectionOverflowReason::Identities),
+                (false, true) => Some(DeferredSelectionOverflowReason::LogicalBytes),
+                (false, false) => None,
             };
             if let Some(reason) = overflow_reason {
                 if overflowed_families.insert(family) {
@@ -250,6 +253,10 @@ pub(super) enum SelectionDeferralReleaseReason {
     AllEndOfRib,
     CollisionRefreshComplete,
     TimerExpired,
+    /// The gate completed without any waiter delivering a completion signal:
+    /// every roster entry was excluded (or deleted from configuration), so
+    /// zero End-of-RIB or refresh markers were consumed.
+    AllExcluded,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -270,6 +277,7 @@ impl SelectionDeferralReleaseReason {
             Self::AllEndOfRib => "all_eor",
             Self::CollisionRefreshComplete => "collision_refresh",
             Self::TimerExpired => "timer",
+            Self::AllExcluded => "all_excluded",
         }
     }
 }
@@ -421,6 +429,19 @@ impl SelectionDeferral {
     ) -> Option<SelectionDeferralTransition> {
         let gate = self.active.get_mut(&family)?;
         let transition = if Self::complete(gate) {
+            // A gate can complete without any waiter having delivered a
+            // completion signal (every roster entry excluded or deleted).
+            // Recording the event reason there would claim End-of-RIB or
+            // refresh markers that were never received.
+            let release_reason = if gate
+                .waiters
+                .values()
+                .any(|state| matches!(state, WaiterState::Satisfied { .. }))
+            {
+                release_reason
+            } else {
+                SelectionDeferralReleaseReason::AllExcluded
+            };
             SelectionDeferralTransition::Release {
                 family,
                 already_staged: gate.selection_staged,
@@ -541,6 +562,12 @@ impl SelectionDeferral {
     /// completed. Only an unambiguous, stamped survivor whose current roster
     /// state was re-armed by the active session's teardown may take this path.
     ///
+    /// The refresh wait applies the same OPEN gating as `classify_session`:
+    /// a Restart-State or non-GR family is excluded, and a survivor that did
+    /// not negotiate enhanced route refresh (RFC 7313) is excluded too — it
+    /// will never produce the `BoRR`/`EoRR` pair, so `AwaitingRefresh` would
+    /// convergence-hold the family for the entire deferral window.
+    ///
     /// `Some` means at least one active family was classified; the contained
     /// transitions stage any family whose ordinary waiters are already done.
     /// `None` leaves every waiter unchanged.
@@ -548,6 +575,9 @@ impl SelectionDeferral {
         &mut self,
         peer: IpAddr,
         session_id: u64,
+        peer_restart_state: bool,
+        peer_gr_families: &HashSet<(Afi, Safi)>,
+        peer_enhanced_refresh: bool,
         metrics: &BgpMetrics,
     ) -> Option<Vec<SelectionDeferralTransition>> {
         if session_id == 0 {
@@ -576,13 +606,18 @@ impl SelectionDeferral {
             if gate.waiters.get(&peer) != Some(&WaiterState::AwaitingSession) {
                 continue;
             }
-            gate.waiters.insert(
-                peer,
+            let state = if peer_restart_state
+                || !peer_gr_families.contains(&family)
+                || !peer_enhanced_refresh
+            {
+                WaiterState::Excluded { session_id }
+            } else {
                 WaiterState::AwaitingRefresh {
                     session_id,
                     begin_received: false,
-                },
-            );
+                }
+            };
+            gate.waiters.insert(peer, state);
             classified = true;
             metrics.set_selection_deferral_waiters(
                 afi_safi_label(family.0, family.1),
@@ -620,6 +655,47 @@ impl SelectionDeferral {
                 );
             }
         }
+    }
+
+    /// Remove a deleted peer's waiters outright: configuration removed the
+    /// neighbor, so no future session can satisfy or re-arm them. Unlike
+    /// `session_down` (a flap must not shrink the frozen cohort), deletion
+    /// is authoritative — any family whose remaining waiters are already
+    /// done completes here instead of blocking until the timer. An
+    /// ambiguous roster address stays fail-closed: address-only identity
+    /// cannot tell which of the duplicate configured peers was deleted.
+    pub(super) fn peer_deleted(
+        &mut self,
+        peer: IpAddr,
+        metrics: &BgpMetrics,
+    ) -> Vec<SelectionDeferralTransition> {
+        if self.ambiguous_peers.contains(&peer) {
+            tracing::warn!(
+                %peer,
+                "deleted peer address is ambiguous in the selection-deferral roster; keeping its waiters blocked until the timer"
+            );
+            return Vec::new();
+        }
+        let families: Vec<_> = self.active.keys().copied().collect();
+        let mut transitions = Vec::new();
+        for family in families {
+            let Some(gate) = self.active.get_mut(&family) else {
+                continue;
+            };
+            if gate.waiters.remove(&peer).is_none() {
+                continue;
+            }
+            metrics.set_selection_deferral_waiters(
+                afi_safi_label(family.0, family.1),
+                gauge_val(Self::blocking_waiters(gate)),
+            );
+            if let Some(transition) =
+                self.evaluate_family(family, SelectionDeferralReleaseReason::AllEndOfRib)
+            {
+                transitions.push(transition);
+            }
+        }
+        transitions
     }
 
     pub(super) fn end_of_rib(
@@ -1159,7 +1235,21 @@ impl RibManager {
                 // convergence EoR before retrying this response.
                 self.pending_refresh.entry(peer).or_default().insert(family);
             } else {
-                self.send_route_refresh_response(peer, family.0, family.1);
+                // The convergence EoR loop above already queued/flushed the
+                // genuine EoR for every sendable peer, so the response must
+                // not carry its own `end_of_rib` entry — a plain-refresh
+                // (RFC 2918) peer would receive a duplicate empty-UPDATE
+                // EoR (RFC 7313 peers get the EoRR demarcation regardless).
+                let convergence_eor_queued = self
+                    .peer_sendable_families
+                    .get(&peer)
+                    .is_some_and(|sendable| sendable.contains(&family));
+                self.send_route_refresh_response_inner(
+                    peer,
+                    family.0,
+                    family.1,
+                    convergence_eor_queued,
+                );
             }
         }
     }
@@ -1497,6 +1587,40 @@ mod ledger_tests {
         );
         assert_eq!(overflowed, HashSet::from([unicast, flowspec]));
         assert_eq!(retained_bytes, 2);
+    }
+
+    #[test]
+    fn simultaneous_identity_and_byte_exhaustion_records_the_combined_reason() {
+        let unicast = (Afi::Ipv4, Safi::Unicast);
+        let mut identities = HashSet::new();
+        let mut overflowed = HashSet::new();
+        let mut bytes_by_family = HashMap::new();
+        let mut retained_bytes = 0;
+        let first = ChargedKey { id: 1, bytes: 1 };
+        let second = ChargedKey { id: 2, bytes: 1 };
+        let limits = DeferredSelectionLimits {
+            identities: 1,
+            retained_key_bytes: 1,
+        };
+
+        let newly_overflowed = DeferredSelectionKeys::extend_bounded(
+            &mut identities,
+            &mut overflowed,
+            &mut bytes_by_family,
+            &mut retained_bytes,
+            [(unicast, &first), (unicast, &second)],
+            0,
+            limits,
+        );
+        assert_eq!(identities, HashSet::from([first]));
+        assert_eq!(
+            newly_overflowed,
+            vec![(
+                unicast,
+                DeferredSelectionOverflowReason::IdentitiesAndLogicalBytes
+            )],
+            "with both budgets exhausted, neither single reason is truthful"
+        );
     }
 
     #[test]

--- a/crates/rib/src/manager/tests/orr.rs
+++ b/crates/rib/src/manager/tests/orr.rs
@@ -42,6 +42,7 @@ async fn selection_deferral_hides_bgpls_topology_until_family_release() {
         session_id: 1,
         peer_restart_state: false,
         peer_gr_families: vec![family],
+        peer_enhanced_refresh: true,
     })
     .await
     .unwrap();

--- a/crates/rib/src/manager/tests/selection_deferral.rs
+++ b/crates/rib/src/manager/tests/selection_deferral.rs
@@ -95,6 +95,25 @@ async fn stage_gr_context_with(
         session_id,
         peer_restart_state,
         peer_gr_families,
+        peer_enhanced_refresh: true,
+    })
+    .await
+    .unwrap();
+}
+
+/// Stage a GR-capable OPEN context whose session negotiated only plain
+/// RFC 2918 route refresh (no RFC 7313 enhanced route refresh).
+async fn stage_gr_context_plain_refresh(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    session_id: u64,
+) {
+    tx.send(RibUpdate::SetPeerGracefulRestartContext {
+        peer,
+        session_id,
+        peer_restart_state: false,
+        peer_gr_families: vec![FAMILY],
+        peer_enhanced_refresh: false,
     })
     .await
     .unwrap();
@@ -350,7 +369,12 @@ async fn restart_state_and_non_gr_sessions_are_excluded_without_waiting_for_eor(
     assert!(!a_released.selection_deferral[0].active);
     assert_eq!(a_released.selection_deferral[0].waiter_state, "excluded");
     assert_eq!(b_released.selection_deferral[0].waiter_state, "excluded");
-    assert_eq!(a_released.selection_deferral[0].release_reason, "all_eor");
+    // Zero End-of-RIB markers were consumed: the recorded reason must not
+    // claim `all_eor`.
+    assert_eq!(
+        a_released.selection_deferral[0].release_reason,
+        "all_excluded"
+    );
     assert_eq!(a_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
     assert_eq!(b_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
 
@@ -411,7 +435,14 @@ fn collision_failback_stages_then_waits_for_refresh_completion() {
     );
     selection.session_down(survivor, 11, &metrics);
     assert_eq!(
-        selection.await_collision_failback_refresh(survivor, 11, &metrics),
+        selection.await_collision_failback_refresh(
+            survivor,
+            11,
+            false,
+            &gr_families,
+            true,
+            &metrics
+        ),
         Some(Vec::new()),
         "the exact re-armed survivor must wait for a post-failback refresh"
     );
@@ -496,7 +527,14 @@ fn multiple_failback_survivors_release_only_after_every_waiter_converges() {
         );
         selection.session_down(peer, session_id, &metrics);
         assert_eq!(
-            selection.await_collision_failback_refresh(peer, session_id, &metrics),
+            selection.await_collision_failback_refresh(
+                peer,
+                session_id,
+                false,
+                &gr_families,
+                true,
+                &metrics
+            ),
             Some(Vec::new())
         );
         let waiting = selection.peer_snapshot(peer).remove(0);
@@ -581,7 +619,7 @@ fn staged_selection_rejects_eor_and_refresh_marker_commits() {
         );
         selection.session_down(source, 11, &metrics);
         selection
-            .await_collision_failback_refresh(source, 11, &metrics)
+            .await_collision_failback_refresh(source, 11, false, &gr_families, true, &metrics)
             .unwrap()
     };
     assert_eq!(
@@ -631,7 +669,7 @@ fn staged_selection_classifies_refresh_response_as_convergence_deferred() {
         );
         selection.session_down(source, 11, &metrics);
         selection
-            .await_collision_failback_refresh(source, 11, &metrics)
+            .await_collision_failback_refresh(source, 11, false, &gr_families, true, &metrics)
             .unwrap()
     };
     manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
@@ -672,7 +710,7 @@ fn dirty_resync_sends_ready_eor_and_retains_held_family() {
         );
         selection.session_down(source, 11, &metrics);
         selection
-            .await_collision_failback_refresh(source, 11, &metrics)
+            .await_collision_failback_refresh(source, 11, false, &gr_families, true, &metrics)
             .unwrap()
     };
     manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
@@ -761,6 +799,7 @@ fn dirty_observer_emits_convergence_eor_before_deferred_refresh() {
         session_id: 11,
         peer_restart_state: false,
         peer_gr_families: vec![FAMILY],
+        peer_enhanced_refresh: true,
     });
     manager.handle_update(peer_up(survivor, 11, survivor_tx));
     let (replacement_tx, _replacement_rx) = mpsc::channel(16);
@@ -769,6 +808,7 @@ fn dirty_observer_emits_convergence_eor_before_deferred_refresh() {
         session_id: 12,
         peer_restart_state: false,
         peer_gr_families: vec![FAMILY],
+        peer_enhanced_refresh: true,
     });
     manager.handle_update(peer_up(survivor, 12, replacement_tx));
 
@@ -901,7 +941,7 @@ fn no_diff_dirty_resync_keeps_refresh_behind_failed_convergence_eor() {
         );
         selection.session_down(survivor, 11, &metrics);
         selection
-            .await_collision_failback_refresh(survivor, 11, &metrics)
+            .await_collision_failback_refresh(survivor, 11, false, &gr_families, true, &metrics)
             .unwrap()
     };
     manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
@@ -1011,14 +1051,29 @@ fn unstamped_or_ambiguous_collision_failback_stays_timer_bound() {
         RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone()).with_selection_deferral(
             config(Duration::from_mins(1), &[unstamped, duplicate, duplicate]),
         );
+    let gr_families = HashSet::from([FAMILY]);
     let selection = manager.selection_deferral.as_mut().unwrap();
 
     assert_eq!(
-        selection.await_collision_failback_refresh(unstamped, 0, &metrics),
+        selection.await_collision_failback_refresh(
+            unstamped,
+            0,
+            false,
+            &gr_families,
+            true,
+            &metrics
+        ),
         None
     );
     assert_eq!(
-        selection.await_collision_failback_refresh(duplicate, 22, &metrics),
+        selection.await_collision_failback_refresh(
+            duplicate,
+            22,
+            false,
+            &gr_families,
+            true,
+            &metrics
+        ),
         None
     );
     for peer in [unstamped, duplicate] {
@@ -1473,6 +1528,7 @@ fn unavailable_survivor_channel_keeps_convergence_timer_bound() {
             session_id: 11,
             peer_restart_state: false,
             peer_gr_families: vec![FAMILY],
+            peer_enhanced_refresh: true,
         });
         manager.handle_update(peer_up(survivor, 11, survivor_tx.clone()));
         let (replacement_tx, _replacement_rx) = mpsc::channel(1);
@@ -1481,6 +1537,7 @@ fn unavailable_survivor_channel_keeps_convergence_timer_bound() {
             session_id: 12,
             peer_restart_state: false,
             peer_gr_families: vec![FAMILY],
+            peer_enhanced_refresh: true,
         });
         manager.handle_update(peer_up(survivor, 12, replacement_tx));
 
@@ -1612,7 +1669,7 @@ fn collision_failback_overflow_receipt(
         .selection_deferral
         .as_mut()
         .unwrap()
-        .await_collision_failback_refresh(source, 8, &metrics)
+        .await_collision_failback_refresh(source, 8, false, &peer_gr_families, true, &metrics)
         .unwrap();
     assert_eq!(
         transitions,
@@ -1869,6 +1926,7 @@ fn peer_teardown_discards_unconsumed_gr_context() {
         session_id: 9,
         peer_restart_state: false,
         peer_gr_families: vec![FAMILY],
+        peer_enhanced_refresh: true,
     });
     assert!(manager.pending_peer_gr_context.contains_key(&(a, 9)));
     manager.peer_down_teardown(a);
@@ -1897,6 +1955,7 @@ async fn queued_route_is_applied_before_simultaneous_eor_and_timer_release() {
         session_id: 1,
         peer_restart_state: false,
         peer_gr_families: vec![FAMILY],
+        peer_enhanced_refresh: true,
     })
     .unwrap();
     tx.try_send(peer_up(source, 1, source_tx)).unwrap();
@@ -2020,4 +2079,181 @@ async fn timer_releases_never_established_waiter_and_records_reason() {
 
     drop(tx);
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn deleted_peer_waiter_releases_family_when_remaining_waiters_satisfy() {
+    let a = peer(1);
+    let b = peer(2);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(
+        rx,
+        dummy_query_rx(),
+        None,
+        Some(Ipv4Addr::new(10, 0, 0, 254)),
+        BgpMetrics::new(),
+    )
+    .with_selection_deferral(config(Duration::from_mins(1), &[a, b]));
+    let handle = tokio::spawn(manager.run());
+
+    let (a_tx, mut a_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, a, 1).await;
+    tx.send(peer_up(a, 1, a_tx)).await.unwrap();
+    let (b_tx, _b_rx) = mpsc::channel(16);
+    stage_gr_context(&tx, b, 2).await;
+    tx.send(peer_up(b, 2, b_tx)).await.unwrap();
+
+    // Deleting b from configuration removes its waiter outright, but cannot
+    // release the family while a still owes its End-of-RIB.
+    tx.send(RibUpdate::PeerDeleted { peer: b }).await.unwrap();
+    let held = query_state(&tx, a).await;
+    assert!(held.selection_deferral[0].active);
+    assert_eq!(held.selection_deferral[0].waiter_state, "awaiting_eor");
+    assert_eq!(held.selection_deferral[0].blocking_waiters, 1);
+    assert_eq!(
+        query_state(&tx, b).await.selection_deferral[0].waiter_state,
+        "not_in_roster"
+    );
+
+    // The remaining waiter's EoR must release the family without waiting
+    // for the Selection_Deferral_Timer.
+    tx.send(RibUpdate::EndOfRib {
+        peer: a,
+        session_id: 1,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    })
+    .await
+    .unwrap();
+    let released = query_state(&tx, a).await;
+    assert!(
+        !released.selection_deferral[0].active,
+        "family stayed gated after every remaining waiter satisfied"
+    );
+    assert_eq!(released.selection_deferral[0].release_reason, "all_eor");
+    assert_eq!(a_rx.recv().await.unwrap().end_of_rib, vec![FAMILY]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn failback_survivor_without_enhanced_refresh_is_not_left_awaiting_refresh() {
+    let survivor = peer(1);
+    let (tx, rx) = mpsc::channel(32);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new())
+        .with_selection_deferral(config(Duration::from_mins(1), &[survivor]));
+    let handle = tokio::spawn(manager.run());
+
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
+    stage_gr_context_plain_refresh(&tx, survivor, 11).await;
+    tx.send(peer_up(survivor, 11, survivor_tx)).await.unwrap();
+    let (replacement_tx, _replacement_rx) = mpsc::channel(8);
+    stage_gr_context_plain_refresh(&tx, survivor, 12).await;
+    tx.send(peer_up(survivor, 12, replacement_tx))
+        .await
+        .unwrap();
+    tx.send(RibUpdate::PeerDown {
+        peer: survivor,
+        session_id: 12,
+    })
+    .await
+    .unwrap();
+
+    // A survivor that never negotiated RFC 7313 cannot produce the
+    // post-failback BoRR/EoRR pair: it must be excluded, not parked in an
+    // unfulfillable awaiting_refresh that holds the family all window.
+    let released = query_state(&tx, survivor).await;
+    assert_ne!(
+        released.selection_deferral[0].waiter_state,
+        "awaiting_refresh"
+    );
+    assert_eq!(released.selection_deferral[0].waiter_state, "excluded");
+    assert!(
+        !released.selection_deferral[0].active,
+        "plain-refresh survivor convergence-held the family"
+    );
+    assert_eq!(
+        released.selection_deferral[0].release_reason,
+        "all_excluded"
+    );
+    let mut saw_eor = false;
+    while let Ok(update) = survivor_rx.try_recv() {
+        saw_eor |= update.end_of_rib.contains(&FAMILY);
+    }
+    assert!(
+        saw_eor,
+        "release must deliver the family EoR to the survivor"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[test]
+fn release_sends_single_eor_to_refresh_deferred_peer() {
+    let source = peer(1);
+    let target = peer(2);
+    let metrics = BgpMetrics::new();
+    let (_tx, rx) = mpsc::channel(8);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone())
+        .with_selection_deferral(config(Duration::from_mins(1), &[source]));
+    let gr_families = HashSet::from([FAMILY]);
+    let transitions = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(
+            selection
+                .classify_session(source, 11, false, &gr_families, &metrics)
+                .is_empty()
+        );
+        selection.session_down(source, 11, &metrics);
+        selection
+            .await_collision_failback_refresh(source, 11, false, &gr_families, true, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions(transitions, "test collision failback stage");
+
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(target, 21, outbound_tx));
+    while outbound_rx.try_recv().is_ok() {}
+    manager.handle_update(RibUpdate::RouteRefreshRequest {
+        peer: target,
+        session_id: 21,
+        afi: FAMILY.0,
+        safi: FAMILY.1,
+    });
+    assert_eq!(
+        manager.selection_deferred_refresh.get(&target),
+        Some(&HashSet::from([FAMILY]))
+    );
+    assert!(outbound_rx.try_recv().is_err());
+
+    let release = {
+        let selection = manager.selection_deferral.as_mut().unwrap();
+        assert!(selection.begin_route_refresh(source, 11, FAMILY).is_none());
+        selection
+            .end_route_refresh(source, 11, FAMILY, &metrics)
+            .unwrap()
+    };
+    manager.apply_selection_deferral_transitions([release], "test refresh completion");
+
+    let mut eor_updates = 0;
+    let mut saw_refresh_markers = false;
+    while let Ok(update) = outbound_rx.try_recv() {
+        if update.end_of_rib.contains(&FAMILY) {
+            eor_updates += 1;
+        }
+        if !update.refresh_markers.is_empty() {
+            assert!(
+                update.end_of_rib.is_empty(),
+                "deferred refresh response duplicated the convergence EoR"
+            );
+            saw_refresh_markers = true;
+        }
+    }
+    assert_eq!(
+        eor_updates, 1,
+        "release must deliver exactly one genuine EoR to a refresh-deferred peer"
+    );
+    assert!(saw_refresh_markers);
 }

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1309,6 +1309,10 @@ pub enum RibUpdate {
         peer_restart_state: bool,
         /// Negotiated families present in the peer's GR capability.
         peer_gr_families: Vec<(Afi, Safi)>,
+        /// Peer negotiated enhanced route refresh (RFC 7313), so a
+        /// collision-failback convergence wait on `BoRR`/`EoRR` is
+        /// fulfillable.
+        peer_enhanced_refresh: bool,
     },
     /// Inject a locally-originated route.
     InjectRoute {

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -2813,7 +2813,8 @@ impl BgpMetrics {
             .set(count);
     }
 
-    /// Record release of one family gate (`all_eor` or `timer`).
+    /// Record release of one family gate (`all_eor`, `collision_refresh`,
+    /// `all_excluded`, or `timer`).
     pub fn record_selection_deferral_release(&self, afi_safi: &str, reason: &str) {
         self.selection_deferral_releases
             .with_label_values(&[afi_safi, reason])

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -434,6 +434,7 @@ impl PeerSession {
                         .iter()
                         .map(|family| (family.afi, family.safi))
                         .collect();
+                    let peer_enhanced_refresh = neg.peer_enhanced_route_refresh;
                     self.negotiated = Some(*neg);
                     self.publish_export_profile();
                     self.established_at = Some(Instant::now());
@@ -482,6 +483,7 @@ impl PeerSession {
                             session_id: self.session_identity.id,
                             peer_restart_state,
                             peer_gr_families,
+                            peer_enhanced_refresh,
                         })
                         .await;
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -302,8 +302,9 @@ does not mean its configured ORR vantage is inactive.
 marker-backed RFC 4724 restart it reports one row per frozen address-family
 gate: whether the gate is active, this peer's waiter state and stamped session,
 the process-wide blocking-waiter count, and remaining time. Released rows are
-retained for the daemon lifetime with reason `all_eor` or `timer`, so an
-operator can distinguish complete convergence from timer-driven release.
+retained for the daemon lifetime with reason `all_eor`, `all_excluded`, or
+`timer`, so an operator can distinguish complete convergence from timer-driven
+release.
 
 `NeighborState.paths_limits` is sorted by numeric AFI then SAFI. Legacy field
 `effective_send_max` retains raw semantics (`UINT32_MAX` unlimited, zero

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1101,17 +1101,20 @@ across static peers, the process-start selection deferral.
 During a same-address collision, ordinary replacement still re-arms the
 replacement session as an EoR waiter and stale predecessor EoR is rejected. If
 the replacement then loses and registration fails back to the exact nonzero,
-unambiguous survivor, only that survivor enters `awaiting_refresh`; other
-waiters continue to block. Once ordinary waiters finish, the current Loc-RIB is
-staged immediately, but family EoR and route-refresh responses remain held. A
-post-failback BoRR arms the waiter and only the matching peer EoRR releases it.
-An ordinary EoR, stray EoRR, or local refresh timeout cannot declare
-convergence. Without Enhanced Route Refresh, the original marker-bounded timer
-is the fallback.
+unambiguous survivor, only that survivor enters `awaiting_refresh` — and only
+when its session negotiated Enhanced Route Refresh for a GR family; a
+Restart-State, non-GR, or plain-refresh survivor is excluded instead, because
+it can never produce the BoRR/EoRR proof. Other waiters continue to block.
+Once ordinary waiters finish, the current Loc-RIB is staged immediately, but
+family EoR and route-refresh responses remain held. A post-failback BoRR arms
+the waiter and only the matching peer EoRR releases it. An ordinary EoR, stray
+EoRR, or local refresh timeout cannot declare convergence. The original
+marker-bounded timer remains the overall fallback.
 
 `rbgp neighbor <address>` shows `Selection Deferral` rows while active and
-retains their `all_eor`, `collision_refresh`, or `timer` release reason
-afterward. Metrics are
+retains their `all_eor`, `collision_refresh`, `all_excluded` (the gate
+completed with every waiter excluded or deleted — zero completion markers
+consumed), or `timer` release reason afterward. Metrics are
 `bgp_selection_deferral_active`, `bgp_selection_deferral_waiters`,
 `bgp_selection_deferral_releases_total`, and
 `bgp_selection_deferral_timeouts_total`. The process-wide deferred-identity

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -811,7 +811,7 @@ owned-state.
 | `bgp_gr_timer_expired_total` | GR timers that expired (routes swept) |
 | `bgp_selection_deferral_active{afi_safi}` | Planned-restart family convergence/release gate (1 = active); it remains active while collision failback waits for EoRR even after route selection is staged |
 | `bgp_selection_deferral_waiters{afi_safi}` | Frozen-roster peers still blocking family convergence/release, including an `awaiting_refresh` survivor after route selection is staged |
-| `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor`, `collision_refresh`, or `timer` |
+| `bgp_selection_deferral_releases_total{afi_safi,reason}` | Family gates released after `all_eor`, `collision_refresh`, `all_excluded`, or `timer` |
 | `bgp_selection_deferral_timeouts_total{afi_safi}` | Family gates released by the selection-deferral timer |
 | `bgp_selection_deferral_ledger_overflows_total{afi_safi}` | Gated families whose next identity would exceed the process-wide one-million-identity or 64 MiB logical retained-key-data ledger and therefore use a complete release sweep |
 


### PR DESCRIPTION
Five fixes in the GR restarting-speaker selection-deferral module, from an internal review.

## 1. Deleted-peer waiters are released
`handle_peer_deleted` never touched the deferral roster, so deleting a GR neighbor from configuration mid-deferral left its waiter in a selection-blocking state (`awaiting_session`/`awaiting_eor`) and froze best-path selection for the whole family until timer expiry — even after every remaining waiter satisfied. Deletion now removes that peer's waiters outright (`SelectionDeferral::peer_deleted`); the family completes when the remaining waiters satisfy. Ordinary session flaps keep the frozen-cohort behavior (`session_down` re-arms, never shrinks), and an ambiguous duplicate roster address stays fail-closed until the timer.

## 2. Collision-failback refresh-wait is gated on survivor capability
`await_collision_failback_refresh` armed `AwaitingRefresh` for every re-armed waiter unconditionally, but a plain RFC 2918 survivor never produces the post-failback BoRR/EoRR pair, so a non-RFC-7313 survivor convergence-held the family for the entire window. The failback arm now applies the same OPEN gating as the ordinary `classify_session` path: a Restart-State, non-GR-family, or non-enhanced-refresh survivor is excluded instead. The negotiated RFC 7313 bit is staged through `SetPeerGracefulRestartContext` (the transport session already knows it); a survivor without staged OPEN context fails closed (timer-bound), matching the ordinary path. The refresh-timeout invariant is unchanged: `RouteRefreshTimeout` still never feeds `selection_deferral_end_route_refresh`, and `synthetic_refresh_timeout_cannot_complete_collision_failback` passes unmodified.

## 3. Truthful release reason
A family gate that completed with zero completion markers consumed (every waiter excluded or deleted) recorded `all_eor`. It now records the new `all_excluded` reason, derived at completion from the final waiter states and wired through the `bgp_selection_deferral_releases_total{reason}` label, `rbgp neighbor` output, and docs.

## 4. No double EoR to plain-refresh refresh-deferred peers
At release, `complete_selection_family` flushes the queued convergence EoR and then the deferred route-refresh response carried `end_of_rib: [family]` again — a second empty-UPDATE EoR for plain-refresh peers. The release-path response now suppresses its own `end_of_rib` entry when the convergence EoR already covered the peer. RFC 7313 peers are wire-identical: their EoRR demarcation comes from the refresh markers either way.

## 5. Overflow-reason accuracy
`extend_bounded` reported `identities` whenever the identity cap was exhausted, even when the byte budget was exhausted for the same rejected identity. Simultaneous exhaustion now records `identities_and_logical_bytes`.

## Tests
- `deleted_peer_waiter_releases_family_when_remaining_waiters_satisfy` (fails without fix 1 by waiting on the timer)
- `failback_survivor_without_enhanced_refresh_is_not_left_awaiting_refresh` (fails without fix 2; also asserts the `all_excluded` reason)
- `release_sends_single_eor_to_refresh_deferred_peer` (fails without fix 4)
- `simultaneous_identity_and_byte_exhaustion_records_the_combined_reason` (fails without fix 5)
- `restart_state_and_non_gr_sessions_are_excluded_without_waiting_for_eor` updated to assert the truthful `all_excluded` reason (fix 3)

Each behavior test was verified to fail with its fix reverted.

## Gates
- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-rib` — exit 0 (853 passed)
- `cargo test --workspace` — exit 0