### PR TITLE
fix(outbound): refresh exports on hot-applied knobs; keep Paths-Limit across failback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deferred route-refresh response is delivered at release no longer receives a
   second empty-UPDATE End-of-RIB after the genuine convergence EoR.
 
+- **Hot-applied export-affecting knobs now re-probe suppressed routes.** A
+  SIGHUP reload that hot-applies `local_ipv6_nexthop` or `remove_private_as`
+  to a live session issues a forced outbound refresh (like the
+  graceful-shutdown toggle and live policy apply), so routes the exact-export
+  preflight suppressed under the old knobs go back on the wire immediately —
+  and already-advertised AS_PATHs re-encode — instead of waiting for
+  unrelated churn or a session bounce. Export-inert hot applies issue no
+  refresh.
+
+- **Per-family Paths-Limit caps survive a collision failback.** The RIB's
+  live-session record now carries the session's per-family Add-Path
+  Paths-Limit map and restores it when an outbound registration fails over
+  to a surviving session, instead of clamping every family to the scalar
+  send limit.
+
+- **Unicast exact-export encode failures after RIB commit now fail closed.**
+  The IPv6 no-next-hop and Extended-Next-Hop IPv4 preparation arms tear the
+  session down with Cease/Out-of-Resources like the oversize branches,
+  instead of silently dropping the route and leaving Adj-RIB-Out ahead of
+  the wire. Both arms are unreachable while producers run the exact-export
+  preflight; this aligns them with the fail-closed convention.
+
 - **The route-server starter now applies documented dual-stack ingress
   hygiene.** Its policy rejects both default routes and a dated 2025-10-09
   snapshot of active IANA special-purpose rows marked non-globally reachable,

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -515,6 +515,12 @@ pub(super) struct LiveSessionRecord {
     per_client_best: bool,
     add_path_send_families: Vec<(Afi, Safi)>,
     add_path_send_max: u32,
+    /// Per-family Paths-Limit caps (RFC-draft Paths-Limit), filtered to the
+    /// negotiated send families. Empty at `PeerUp`; the session emits its
+    /// `PeerAddPathLimits` exactly once, and the handler mirrors the accepted
+    /// map here so a collision failback replays it instead of clamping every
+    /// family back to the scalar `add_path_send_max`.
+    add_path_send_limits: HashMap<(Afi, Safi), u32>,
     negotiated_orf_recv: Vec<(Afi, Safi)>,
     negotiated_llgr_families: Vec<(Afi, Safi)>,
     gr_context: Option<PeerSelectionDeferralContext>,
@@ -1548,6 +1554,15 @@ impl RibManager {
                                 old != new
                             })
                         });
+                    // Mirror the accepted map into the live-session record —
+                    // the single registration truth an outbound failover
+                    // replays from. Without this, a collision failback would
+                    // permanently clamp every family to the scalar limit.
+                    if let Some(record) = self.live_sessions.get_mut(&peer).and_then(|sessions| {
+                        sessions.iter_mut().find(|s| s.session_id == session_id)
+                    }) {
+                        record.add_path_send_limits.clone_from(&new_limits);
+                    }
                     self.peer_add_path_send_limits.insert(peer, new_limits);
                     if effective_limit_changed {
                         self.send_initial_table(peer);

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -600,6 +600,9 @@ impl RibManager {
             per_client_best,
             add_path_send_families,
             add_path_send_max,
+            // Filled in by the `PeerAddPathLimits` handler; the session
+            // emits its per-family Paths-Limit map after this `PeerUp`.
+            add_path_send_limits: std::collections::HashMap::new(),
             negotiated_orf_recv,
             negotiated_llgr_families,
             gr_context,
@@ -656,6 +659,7 @@ impl RibManager {
         let per_client_best = record.per_client_best;
         let add_path_send_families = record.add_path_send_families.clone();
         let add_path_send_max = record.add_path_send_max;
+        let add_path_send_limits = record.add_path_send_limits.clone();
         let negotiated_orf_recv = record.negotiated_orf_recv.clone();
         let negotiated_llgr_families = record.negotiated_llgr_families.clone();
         let gr_context = record.gr_context.clone();
@@ -840,6 +844,16 @@ impl RibManager {
         self.peer_add_path_send_families
             .insert(peer, add_path_send_families);
         self.peer_add_path_send_max.insert(peer, add_path_send_max);
+        // Replay the session's per-family Paths-Limit map (collision
+        // failback: the session sent it exactly once, and the stale-session
+        // fence drops any re-send). Absent and empty are equivalent — every
+        // consumer falls back per family to the scalar limit — so an empty
+        // record map (limits never received, or explicitly empty) keeps the
+        // plain-PeerUp behavior of no stored entry.
+        if !add_path_send_limits.is_empty() {
+            self.peer_add_path_send_limits
+                .insert(peer, add_path_send_limits);
+        }
         // Per-registration like the vantage: a replacement session that
         // dropped the knob must not inherit it.
         if per_client_best {

--- a/crates/rib/src/manager/tests/unicast.rs
+++ b/crates/rib/src/manager/tests/unicast.rs
@@ -794,6 +794,74 @@ fn paths_limit_ignores_entries_outside_negotiated_send_families() {
     );
 }
 
+#[test]
+fn paths_limit_survives_collision_failback() {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let peer: IpAddr = "192.0.2.3".parse().unwrap();
+    let v4 = Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24));
+    let v6 = Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32));
+    let peer_up = |session_id, outbound_tx| RibUpdate::PeerUp {
+        peer,
+        session_id,
+        peer_asn: 65100,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: dual_stack_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        add_path_send_families: dual_stack_sendable(),
+        add_path_send_max: 8,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    };
+
+    // Survivor session comes up and sends its one per-family limit map.
+    let (survivor_tx, _survivor_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(7, survivor_tx));
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 7,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 2),
+            ((Afi::Ipv6, Safi::Unicast), 5),
+        ],
+    });
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 2);
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 5);
+
+    // RFC 4271 §6.8 collision window: the loser's PeerUp replaces the
+    // registration (clearing the stored limits), sends its own map, then
+    // goes down — the registration fails back to the survivor.
+    let (loser_tx, _loser_rx) = mpsc::channel(16);
+    manager.handle_update(peer_up(8, loser_tx));
+    manager.handle_update(RibUpdate::PeerAddPathLimits {
+        peer,
+        session_id: 8,
+        limits: vec![
+            ((Afi::Ipv4, Safi::Unicast), 1),
+            ((Afi::Ipv6, Safi::Unicast), 1),
+        ],
+    });
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v4), 1);
+    manager.handle_update(RibUpdate::PeerDown {
+        peer,
+        session_id: 8,
+    });
+
+    // The failback replay must restore the survivor's per-family caps, not
+    // clamp every family to the scalar minimum.
+    assert_eq!(
+        manager.add_path_send_max_for_prefix(peer, &v4),
+        2,
+        "collision failback lost the survivor's per-family Paths-Limit map"
+    );
+    assert_eq!(manager.add_path_send_max_for_prefix(peer, &v6), 5);
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -654,10 +654,15 @@ impl PeerSession {
             } => {
                 // LAN-341 hot-apply: these knobs are read from
                 // `self.config` on every evaluation (see the command's
-                // doc), so swapping them here is the whole apply — no
-                // FSM event, no TCP impact. A lowered `max_prefixes`
-                // trips on the next received UPDATE, matching the
-                // reload matrix's documented semantics.
+                // doc) — no FSM event, no TCP impact. A lowered
+                // `max_prefixes` trips on the next received UPDATE,
+                // matching the reload matrix's documented semantics.
+                // For the export-affecting knobs (`local_ipv6_nexthop`,
+                // `remove_private_as`) the swap alone is NOT the whole
+                // apply: the peer manager follows it with a
+                // `RibUpdate::RefreshPeerOutbound` so preflight-suppressed
+                // routes are re-probed and advertised AS_PATHs re-encoded
+                // under the new values.
                 self.config.max_prefixes = max_prefixes;
                 self.config.gr_stale_routes_time = gr_stale_routes_time;
                 self.config.local_ipv6_nexthop = local_ipv6_nexthop;

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -369,28 +369,37 @@ impl PeerSession {
                         nh_override,
                     )
                     .clone();
-                let prepared =
-                    match export.finish_unicast_candidate(route, nh_override, cached_attrs) {
-                        Ok(PreparedUnicastCandidate::Mp {
-                            next_hop,
-                            link_local_next_hop,
-                            attrs,
-                            entry,
-                            ..
-                        }) => (attrs, next_hop, link_local_next_hop, entry),
-                        Ok(PreparedUnicastCandidate::Ipv4Body { .. }) => {
-                            unreachable!("ENHE profile must prepare IPv4 as MP_REACH")
-                        }
-                        Err(error) => {
-                            warn!(
-                                peer = %self.peer_label,
-                                prefix = %route.prefix,
-                                %error,
-                                "cannot prepare IPv4 route with Extended Next Hop"
-                            );
-                            continue;
-                        }
-                    };
+                let prepared = match export.finish_unicast_candidate(
+                    route,
+                    nh_override,
+                    cached_attrs,
+                ) {
+                    Ok(PreparedUnicastCandidate::Mp {
+                        next_hop,
+                        link_local_next_hop,
+                        attrs,
+                        entry,
+                        ..
+                    }) => (attrs, next_hop, link_local_next_hop, entry),
+                    Ok(PreparedUnicastCandidate::Ipv4Body { .. }) => {
+                        unreachable!("ENHE profile must prepare IPv4 as MP_REACH")
+                    }
+                    Err(error) => {
+                        // Unreachable while every producer runs the
+                        // exact-export preflight on this same snapshot;
+                        // if it ever fires, a silent drop would leave
+                        // Adj-RIB-Out ahead of the wire, so fail closed
+                        // like the oversize branches.
+                        warn!(
+                            peer = %self.peer_label,
+                            prefix = %route.prefix,
+                            %error,
+                            "IPv4 Extended Next Hop route failed exact export preparation after RIB commit — sending Cease/Out-of-Resources and tearing down"
+                        );
+                        self.trigger_outbound_out_of_resources_teardown();
+                        return;
+                    }
+                };
                 let (attrs, next_hop, link_local_next_hop, entry) = prepared;
                 let key = AttrGroupKey {
                     attrs_ptr: Arc::as_ptr(&attrs) as usize,
@@ -514,13 +523,18 @@ impl PeerSession {
                         !matches!(&error, ExportProbeError::MissingIpv6NextHop),
                         "RIB sent IPv6 route to eBGP peer with no valid IPv6 next-hop"
                     );
+                    // Unreachable while every producer runs the exact-export
+                    // preflight on this same snapshot; if it ever fires, a
+                    // silent drop would leave Adj-RIB-Out ahead of the wire,
+                    // so fail closed like the oversize branches.
                     warn!(
                         peer = %self.peer_label,
                         prefix = %route.prefix,
                         %error,
-                        "dropping IPv6 route: exact export preparation failed"
+                        "IPv6 route failed exact export preparation after RIB commit — sending Cease/Out-of-Resources and tearing down"
                     );
-                    continue;
+                    self.trigger_outbound_out_of_resources_teardown();
+                    return;
                 }
             };
             let (attrs, nh, link_local_next_hop, nlri_entry) = prepared;
@@ -1136,10 +1150,13 @@ impl PeerSession {
                     // session still Established. Tear the session down instead
                     // (matching the BGP-LS/VPN chunkers): reconnect rebuilds
                     // Adj-RIB-Out from scratch, so the peer is visibly unhealthy
-                    // rather than falsely advertised. A route that is
-                    // intrinsically un-sendable will loop until withdrawn; the
-                    // durable fix is an exportability check before Adj-RIB-Out
-                    // commit.
+                    // rather than falsely advertised. An intrinsically
+                    // un-sendable route no longer flap-loops here: the RIB's
+                    // exact-export preflight probes encodability before the
+                    // Adj-RIB-Out commit and suppresses such routes as
+                    // peer-unexportable (re-probed on outbound refresh), so
+                    // this branch only fires if the wire encoding diverges
+                    // from that probe.
                     warn!(
                         peer = %self.peer_label,
                         size = encoded_len,

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -399,12 +399,16 @@ impl PeerManager {
     /// socket-scoped fields are copied from `config` into the stored
     /// transport config by the next rebuild path, which resolves from the
     /// config snapshot anyway).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear pass: change detection, policy seam, knob apply, export refresh, bookkeeping"
+    )]
     pub(super) async fn hot_update_peer(
         &mut self,
         config: PeerManagerNeighborConfig,
     ) -> Result<(), PeerLifecycleError> {
         let peer = PeerKey::new(config.address, config.interface.clone());
-        let (knobs_changed, policies_changed) = {
+        let (knobs_changed, export_knobs_changed, policies_changed) = {
             let managed = self
                 .peers
                 .get(&peer)
@@ -415,11 +419,18 @@ impl PeerManager {
                 )));
             }
             let tc = &managed.transport_config;
+            // The export-affecting subset: `local_ipv6_nexthop` decides the
+            // exact-export preflight's `MissingIpv6NextHop` suppression and
+            // `remove_private_as` changes the wire AS_PATH of routes already
+            // in Adj-RIB-Out, so a change to either must force an outbound
+            // re-probe below.
+            let export_knobs_changed = tc.local_ipv6_nexthop != config.local_ipv6_nexthop
+                || tc.remove_private_as != config.remove_private_as;
             (
                 tc.max_prefixes != config.max_prefixes
                     || tc.gr_stale_routes_time != config.gr_stale_routes_time
-                    || tc.local_ipv6_nexthop != config.local_ipv6_nexthop
-                    || tc.remove_private_as != config.remove_private_as,
+                    || export_knobs_changed,
+                export_knobs_changed,
                 managed.import_policy != config.import_policy
                     || managed.export_policy != config.export_policy,
             )
@@ -440,11 +451,11 @@ impl PeerManager {
             .map_err(PeerLifecycleError::Internal)?;
         }
 
-        let managed = self
-            .peers
-            .get_mut(&peer)
-            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
         if knobs_changed {
+            let managed = self
+                .peers
+                .get(&peer)
+                .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
             managed
                 .handle
                 .update_runtime_config_timeout(
@@ -462,8 +473,61 @@ impl PeerManager {
                 })?;
         }
 
+        // Force re-emission after an export-affecting knob swap — the same
+        // reason the gshut toggle and live-policy apply refresh: routes the
+        // exact-export preflight suppressed under the OLD knobs (e.g.
+        // `MissingIpv6NextHop`) are only re-probed, and already-advertised
+        // AS_PATHs only re-encoded, on an outbound event. Without this the
+        // remediation stays off the wire until unrelated churn or a session
+        // bounce. Runs BEFORE the bookkeeping below: a hard refresh failure
+        // returns Err while the stored transport config still holds the old
+        // values, so the next SIGHUP re-detects the diff and retries
+        // (idempotent — the session-side knob re-apply is a no-op).
+        if export_knobs_changed {
+            let addr = peer.address;
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.rib_tx
+                .send(RibUpdate::RefreshPeerOutbound {
+                    peer: addr,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|error| {
+                    PeerLifecycleError::Internal(format!(
+                        "failed to send RIB refresh after hot-applying export knobs to {peer}: {error}"
+                    ))
+                })?;
+            match tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply_rx).await {
+                Err(_) => {
+                    return Err(PeerLifecycleError::Internal(format!(
+                        "RIB did not reply to export-knob refresh for {peer} within {:?}",
+                        super::RIB_REPLY_TIMEOUT
+                    )));
+                }
+                Ok(Err(_)) => {
+                    return Err(PeerLifecycleError::Internal(format!(
+                        "RIB dropped reply for export-knob refresh for {peer}"
+                    )));
+                }
+                Ok(Ok(Err(error))) => {
+                    // "not registered for outbound updates" is expected for a
+                    // peer not yet Established — the next PeerUp emits from
+                    // the updated config.
+                    debug!(
+                        %addr, error = %error,
+                        "RIB declined export-knob refresh (peer likely not yet Established)"
+                    );
+                }
+                Ok(Ok(Ok(()))) => {}
+            }
+        }
+
         // Manager-side bookkeeping so `rbgp neighbor list` and any later
         // session rebuild see the new values.
+        let managed = self
+            .peers
+            .get_mut(&peer)
+            .ok_or_else(|| PeerLifecycleError::NotFound(peer.clone()))?;
         managed.description.clone_from(&config.description);
         managed.max_prefixes = config.max_prefixes;
         managed.transport_config.max_prefixes = config.max_prefixes;

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1979,6 +1979,96 @@ async fn hot_update_peer_applies_in_place_without_session_rebuild() {
 }
 
 #[tokio::test]
+async fn hot_update_peer_refreshes_outbound_for_export_affecting_knobs() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    // Mirror the gshut-toggle precedent: record every forced outbound
+    // refresh the RIB would receive, then reply so the apply completes.
+    let (seen_tx, mut seen_rx) = mpsc::channel(8);
+    tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::RefreshPeerOutbound { peer, reply } = update {
+                seen_tx.send(peer).await.unwrap();
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+
+    // `local_ipv6_nexthop` decides the exact-export preflight's
+    // `MissingIpv6NextHop` suppression: remediating it must re-probe
+    // the peer's suppressed routes without waiting for unrelated churn.
+    let mut updated = make_config(addr, 65002);
+    updated.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
+    mgr.hot_update_peer(updated).await.unwrap();
+    assert_eq!(
+        seen_rx
+            .try_recv()
+            .expect("hot-applying local_ipv6_nexthop must force an outbound refresh"),
+        addr
+    );
+
+    // `remove_private_as` changes already-advertised AS_PATHs.
+    let mut updated = make_config(addr, 65002);
+    updated.local_ipv6_nexthop = Some("2001:db8::1".parse().unwrap());
+    updated.remove_private_as = rustbgpd_transport::RemovePrivateAs::All;
+    mgr.hot_update_peer(updated).await.unwrap();
+    assert_eq!(
+        seen_rx
+            .try_recv()
+            .expect("hot-applying remove_private_as must force an outbound refresh"),
+        addr
+    );
+}
+
+#[tokio::test]
+async fn hot_update_peer_skips_outbound_refresh_when_export_knobs_unchanged() {
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    mgr.add_peer(make_config(addr, 65002), false).await.unwrap();
+
+    // Export-inert knob changes and a full no-op must not replay the
+    // peer's outbound table.
+    let mut updated = make_config(addr, 65002);
+    updated.description = "hot-updated".to_string();
+    updated.max_prefixes = Some(500);
+    updated.gr_stale_routes_time = 300;
+    mgr.hot_update_peer(updated.clone()).await.unwrap();
+    mgr.hot_update_peer(updated).await.unwrap();
+
+    while let Ok(update) = rib_rx.try_recv() {
+        assert!(
+            !matches!(update, RibUpdate::RefreshPeerOutbound { .. }),
+            "an export-inert hot apply must not force an outbound refresh"
+        );
+    }
+}
+
+#[tokio::test]
 async fn hot_update_peer_applies_policy_chains_in_place() {
     let (_tx, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);


### PR DESCRIPTION
## Summary

Four related outbound-correctness fixes traced end-to-end at c55eab42.

### Hot-applied export-affecting knobs never re-probed suppressed routes

`hot_update_peer` applied `local_ipv6_nexthop` / `remove_private_as` to the live session via `UpdateRuntimeConfig` but issued no outbound refresh. Routes suppressed by the exact-export preflight (e.g. `MissingIpv6NextHop` -> `peer_unexportable`) stayed silently off the wire after the operator remediated the knob via SIGHUP, until unrelated churn or a session bounce; a hot-applied `remove_private_as` change left already-advertised routes with stale AS_PATHs.

`hot_update_peer` now issues `RibUpdate::RefreshPeerOutbound` when an export-affecting knob actually changed, mirroring the gshut-toggle and live-policy-apply precedents. The refresh runs before the manager-side bookkeeping, so a hard refresh failure leaves the stored config on the old values and the next SIGHUP re-detects and retries. Export-inert hot applies (`max_prefixes`, `gr_stale_routes_time`, description) issue no refresh. The now-stale `UpdateRuntimeConfig` comment in the session command handler is corrected to match.

### Per-family Paths-Limit map lost on collision failback

`LiveSessionRecord` carried only the scalar `add_path_send_max`; a collision failback cleared `peer_add_path_send_limits` and replayed from the record, permanently clamping every family to the scalar limit (the session emits `PeerAddPathLimits` exactly once, and the session-id fence drops re-sends). The record now carries the accepted per-family map — mirrored there by the `PeerAddPathLimits` handler — and `register_active_session` restores it on failback, making the record the single registration truth.

### Fail-closed alignment on the unicast encode arms

The IPv6 no-next-hop and Extended-Next-Hop IPv4 preparation arms warned and silently dropped the route, desyncing Adj-RIB-Out from the wire — the class the oversize branches already eliminated via Cease/Out-of-Resources teardown. Both arms are unreachable while producers run the exact-export preflight on the same snapshot; they now tear down the same way (warn + `trigger_outbound_out_of_resources_teardown`), with the IPv6 arm's `debug_assert` preserved.

### Stale flap-loop comment

The `send_v4_chunked` comment claimed an intrinsically un-sendable route "will loop until withdrawn; the durable fix is an exportability check before Adj-RIB-Out commit" — that check has since landed (`peer_unexportable`, cleared on outbound-state teardown). Rewritten to describe current behavior.

## Tests

- `hot_update_peer_refreshes_outbound_for_export_affecting_knobs` — each export-affecting knob change forces exactly one outbound refresh
- `hot_update_peer_skips_outbound_refresh_when_export_knobs_unchanged` — export-inert changes and full no-ops issue none
- `paths_limit_survives_collision_failback` — divergent v4/v6 caps survive a collision failback instead of clamping to the scalar limit

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p rustbgpd-rib`, `cargo test -p rustbgpd-transport`, `cargo test --workspace` — all exit 0.