### PR TITLE
perf(rib): cooperative post-commit policy-transition flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   nothing-emitted contract, and 30-second stalled verdict are unchanged. The
   poll histogram gains a `commit` poll kind for re-measurement. (LAN-447)
 
+- **Dirty-peer resync is bounded per timer tick.** A resync-timer tick used
+  to hand every dirty peer to one synchronous `distribute_changes` pass at
+  O(table) each; it now processes at most eight dirty peers per tick and
+  re-arms the timer at a short 10 ms interval while a withheld backlog
+  remains. Partial passes are safe because per-peer resync is idempotent:
+  Adj-RIB-Out state and the dirty flag are committed only after a successful
+  send, and withheld peers are untouched. (LAN-447)
+
 - **`rustbgpd-wire` 0.14.1 → 0.15.0 (breaking, prepared for publish).** The
   exhaustive public `Capability` enum gains the experimental
   `PathsLimit(Vec<PathsLimitFamily>)` variant for the expired, archived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,18 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Grouped export-policy transitions commit in bounded member batches.** The
+  transition's former single finalization poll — one synchronous actor poll
+  containing the whole per-peer commit/flush loop — is now a `Validate` poll
+  (the last that can fall back) followed by `CommitMembers` polls that flush
+  at most eight members each, yielding to the dedicated readiness lane
+  between batches. At internet scale (1M routes / 500 peers / 300 changed)
+  the old loop blocked the actor 1.6–2.4 s and depooled `/readyz`; the stall
+  is peer-fleet-driven and volume-flat, so the bound is keyed on members, not
+  routes. The commit reply position, terminal retry pass, fallback-implies-
+  nothing-emitted contract, and 30-second stalled verdict are unchanged. The
+  poll histogram gains a `commit` poll kind for re-measurement. (LAN-447)
+
 - **`rustbgpd-wire` 0.14.1 → 0.15.0 (breaking, prepared for publish).** The
   exhaustive public `Capability` enum gains the experimental
   `PathsLimit(Vec<PathsLimitFamily>)` variant for the expired, archived

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -42,6 +42,7 @@ pub struct PolicyTransitionBenchReceipt {
     pub max_actor_poll: std::time::Duration,
     pub max_prefix_snapshot_poll: std::time::Duration,
     pub max_finalize_poll: std::time::Duration,
+    pub max_commit_poll: std::time::Duration,
     pub authoritative_peer_applies: usize,
     pub max_authoritative_peer_apply: std::time::Duration,
     pub max_uninterrupted_work: std::time::Duration,
@@ -274,6 +275,7 @@ impl RibManager {
                 "policy_transition_receipt peers={n_peers} fast={fast} plans={} \
                  full_exact_probes={} route_shell_materializations={} actor_polls={} \
                  max_actor_poll_ns={} max_prefix_snapshot_poll_ns={} max_finalize_poll_ns={} \
+                 max_commit_poll_ns={} \
                  authoritative_peer_applies={} max_authoritative_peer_apply_ns={} \
                  max_uninterrupted_work_ns={}",
                 receipt.plan_builds,
@@ -283,6 +285,7 @@ impl RibManager {
                 receipt.max_actor_poll.as_nanos(),
                 receipt.max_prefix_snapshot_poll.as_nanos(),
                 receipt.max_finalize_poll.as_nanos(),
+                receipt.max_commit_poll.as_nanos(),
                 receipt.authoritative_peer_applies,
                 receipt.max_authoritative_peer_apply.as_nanos(),
                 receipt.max_uninterrupted_work.as_nanos(),
@@ -324,6 +327,7 @@ impl RibManager {
             max_actor_poll: stats.max_actor_slice,
             max_prefix_snapshot_poll: stats.max_prefix_snapshot_poll,
             max_finalize_poll: stats.max_finalize_poll,
+            max_commit_poll: stats.max_commit_poll,
             authoritative_peer_applies: stats.authoritative_peer_applies,
             max_authoritative_peer_apply: stats.max_authoritative_peer_apply,
             max_uninterrupted_work: stats

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -247,7 +247,8 @@ struct PreparedCleanPolicyTransitionPeer {
 
 /// One actor-owned, pre-emission clean policy transition. The RIB run loop
 /// advances exactly one bounded phase step and yields before polling it again;
-/// ordinary mutation traffic remains queued until `Finalize` completes.
+/// ordinary mutation traffic remains queued until the terminal
+/// `CommitMembers` batch completes.
 pub(super) struct PendingCleanPolicyTransition {
     replacements: Vec<PeerExportPolicyReplacement>,
     reply: Option<
@@ -259,9 +260,9 @@ pub(super) struct PendingCleanPolicyTransition {
     created_destination: Option<usize>,
 }
 
-/// The deliberately narrow five-phase transition contract approved for the
-/// shared grouped-to-grouped path. No phase before `Finalize` emits or changes
-/// committed membership.
+/// The deliberately narrow six-phase transition contract approved for the
+/// shared grouped-to-grouped path. No phase before `CommitMembers` emits or
+/// changes committed membership.
 enum CleanPolicyTransitionPhase {
     Classify {
         cursor: usize,
@@ -292,12 +293,30 @@ enum CleanPolicyTransitionPhase {
         active_probe: Option<CleanPolicyTransitionProbe>,
         full_probe_count: usize,
     },
-    Finalize {
+    Validate {
         source: usize,
         destination: usize,
         inventory: super::update_groups::CleanPolicyTransitionInventory,
         prepared: Vec<PreparedCleanPolicyTransitionPeer>,
         full_probe_count: usize,
+    },
+    /// Commit the validated members in bounded batches of at most
+    /// [`super::COMMIT_MEMBERS_PER_POLL`] per poll, draining `prepared` so
+    /// parked state shrinks monotonically; `cursor` counts committed members.
+    ///
+    /// INVARIANT: `Validate` is the last phase that may return `Fallback`.
+    /// Once the first batch has emitted, later polls only `Continue` or
+    /// terminate `Committed` — per-batch revalidation is deliberately absent.
+    /// A transport receiver dropped mid-flush is benign: permits were
+    /// reserved in `ProbeAndPrepare`, sending on a closed channel is a
+    /// no-op, and the queued `PeerDown` cleans up after the fence lifts.
+    CommitMembers {
+        source: usize,
+        destination: usize,
+        inventory: super::update_groups::CleanPolicyTransitionInventory,
+        prepared: Vec<PreparedCleanPolicyTransitionPeer>,
+        full_probe_count: usize,
+        cursor: usize,
     },
 }
 
@@ -323,6 +342,7 @@ pub(super) enum CleanPolicyTransitionPollKind {
     Bounded,
     PrefixSnapshot,
     Finalize,
+    Commit,
 }
 
 impl CleanPolicyTransitionPollKind {
@@ -331,6 +351,7 @@ impl CleanPolicyTransitionPollKind {
             Self::Bounded => "bounded",
             Self::PrefixSnapshot => "prefix_snapshot",
             Self::Finalize => "finalize",
+            Self::Commit => "commit",
         }
     }
 }
@@ -390,10 +411,23 @@ impl PendingCleanPolicyTransition {
                 CleanPolicyTransitionPhase::StageDestination { prefixes: None, .. }
                 | CleanPolicyTransitionPhase::BuildInventory { keys: None, .. },
             ) => CleanPolicyTransitionPollKind::PrefixSnapshot,
-            Some(CleanPolicyTransitionPhase::Finalize { .. }) => {
+            Some(CleanPolicyTransitionPhase::Validate { .. }) => {
                 CleanPolicyTransitionPollKind::Finalize
             }
+            Some(CleanPolicyTransitionPhase::CommitMembers { .. }) => {
+                CleanPolicyTransitionPollKind::Commit
+            }
             _ => CleanPolicyTransitionPollKind::Bounded,
+        }
+    }
+
+    /// Members committed so far, while the commit phase is parked. Test-only
+    /// observation of mid-flush progress.
+    #[cfg(test)]
+    pub(super) fn commit_cursor(&self) -> Option<usize> {
+        match self.phase.as_ref() {
+            Some(CleanPolicyTransitionPhase::CommitMembers { cursor, .. }) => Some(*cursor),
+            _ => None,
         }
     }
 
@@ -1104,11 +1138,11 @@ impl RibManager {
     }
 
     /// Advance one bounded production step of the actor-owned transition.
-    /// Every return before `Finalize` is pre-emission and leaves committed
-    /// membership and installed policy state untouched.
+    /// Every return before `CommitMembers` is pre-emission and leaves
+    /// committed membership and installed policy state untouched.
     #[expect(
         clippy::too_many_lines,
-        reason = "the five explicit phases stay together so ownership and no-emission transitions remain auditable"
+        reason = "the six explicit phases stay together so ownership and no-emission transitions remain auditable"
     )]
     pub(super) fn advance_clean_policy_transition(
         &mut self,
@@ -1432,7 +1466,7 @@ impl RibManager {
                 }
 
                 if cursor == pending.replacements.len() && active_probe.is_none() {
-                    pending.phase = Some(CleanPolicyTransitionPhase::Finalize {
+                    pending.phase = Some(CleanPolicyTransitionPhase::Validate {
                         source,
                         destination,
                         inventory,
@@ -1453,7 +1487,7 @@ impl RibManager {
                 }
                 CleanPolicyTransitionAdvance::Continue(pending)
             }
-            CleanPolicyTransitionPhase::Finalize {
+            CleanPolicyTransitionPhase::Validate {
                 source,
                 destination,
                 inventory,
@@ -1489,9 +1523,31 @@ impl RibManager {
                 if !all_current {
                     return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
-
-                let materialized_routes = inventory.announce.len();
-                for member in prepared {
+                pending.phase = Some(CleanPolicyTransitionPhase::CommitMembers {
+                    source,
+                    destination,
+                    inventory,
+                    prepared,
+                    full_probe_count,
+                    cursor: 0,
+                });
+                CleanPolicyTransitionAdvance::Continue(pending)
+            }
+            CleanPolicyTransitionPhase::CommitMembers {
+                source,
+                destination,
+                inventory,
+                mut prepared,
+                full_probe_count,
+                cursor,
+            } => {
+                // Validation happened once, in `Validate`; the actor fence
+                // admits only the read-only readiness lane between these
+                // batches, so no mutation can invalidate the prepared state.
+                // Never fall back from here — an envelope may already be on
+                // a member's wire (see the phase-level invariant comment).
+                let batch = super::COMMIT_MEMBERS_PER_POLL.min(prepared.len());
+                for member in prepared.drain(..batch) {
                     self.commit_clean_policy_transition_member(member.peer, source, destination);
                     self.clear_policy_filtered_routes_for_peer(member.peer);
                     self.apply_clean_policy_transition_counters(member.peer, &inventory);
@@ -1511,6 +1567,23 @@ impl RibManager {
                         gauge_val(advertised),
                     );
                 }
+                if !prepared.is_empty() {
+                    pending.phase = Some(CleanPolicyTransitionPhase::CommitMembers {
+                        source,
+                        destination,
+                        inventory,
+                        prepared,
+                        full_probe_count,
+                        cursor: cursor + batch,
+                    });
+                    return CleanPolicyTransitionAdvance::Continue(pending);
+                }
+
+                // Terminal batch: the tail below runs exactly once, and the
+                // `Committed` reply stays after the global retry pass — the
+                // peer manager treats it as flush-complete before launching
+                // remainder per-peer applies and rollback restores.
+                let materialized_routes = inventory.announce.len();
                 self.finish_clean_policy_transition_commit();
                 // Match the authoritative single-peer replacement seam: a
                 // successful policy transaction also owns the global retry

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -669,6 +669,16 @@ pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
 /// shared-policy actor poll (matches `QUERY_BUDGET_PER_CHUNK` so readiness
 /// keeps its per-seam service ratio through the commit flush).
 pub(in crate::manager) const COMMIT_MEMBERS_PER_POLL: usize = 8;
+/// Maximum dirty peers resynced by one resync-timer tick. Each dirty peer
+/// costs O(table) enumeration and staging, so an unbounded tick stalls the
+/// actor for the whole backlog; the same peers-keyed bound as the commit
+/// flush keeps the actor responsive while a withheld remainder re-arms the
+/// timer at [`DIRTY_RESYNC_BACKLOG_INTERVAL`].
+const RESYNC_PEERS_PER_TICK: usize = 8;
+/// Re-arm interval while a withheld dirty-resync backlog remains. Short by
+/// design: the backlog is work the actor already owes, so the next slice
+/// should run as soon as queued updates and queries have had a turn.
+const DIRTY_RESYNC_BACKLOG_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 
@@ -1279,6 +1289,35 @@ impl RibManager {
             };
             self.handle_readiness_query(query, policy_transition_elapsed);
         }
+    }
+
+    /// One bounded resync-timer tick: hand at most [`RESYNC_PEERS_PER_TICK`]
+    /// dirty peers to `distribute_changes`, withholding the remainder so the
+    /// actor yields between slices. Returns whether a withheld backlog
+    /// remains (distinct from peers that stayed dirty because their send
+    /// failed — those wait for the ordinary retry interval).
+    ///
+    /// Safe to run partially: per-peer resync is idempotent — Adj-RIB-Out
+    /// state and the dirty flag are committed/cleared only after a
+    /// successful send, and withheld peers are not touched at all.
+    fn resync_dirty_peers_bounded(&mut self) -> bool {
+        let withheld: Vec<IpAddr> = if self.dirty_peers.len() > RESYNC_PEERS_PER_TICK {
+            let selected: HashSet<IpAddr> = self
+                .dirty_peers
+                .iter()
+                .copied()
+                .take(RESYNC_PEERS_PER_TICK)
+                .collect();
+            let withheld = self.dirty_peers.difference(&selected).copied().collect();
+            self.dirty_peers = selected;
+            withheld
+        } else {
+            Vec::new()
+        };
+        self.distribute_changes(&HashSet::new(), &HashSet::new());
+        let backlog = !withheld.is_empty();
+        self.dirty_peers.extend(withheld);
+        backlog
     }
 
     async fn receive_readiness_query(
@@ -4357,15 +4396,20 @@ impl RibManager {
                     count = self.dirty_peers.len(),
                     "resync timer fired for dirty peers"
                 );
-                self.distribute_changes(&HashSet::new(), &HashSet::new());
+                let backlog = self.resync_dirty_peers_bounded();
                 if self.dirty_peers.is_empty() {
                     self.metrics.record_rib_dirty_resync("cleared");
                     resync_armed = false;
                 } else {
                     self.metrics.record_rib_dirty_resync("still_dirty");
+                    let interval = if backlog {
+                        DIRTY_RESYNC_BACKLOG_INTERVAL
+                    } else {
+                        DIRTY_RESYNC_INTERVAL
+                    };
                     resync_sleep
                         .as_mut()
-                        .reset(tokio::time::Instant::now() + DIRTY_RESYNC_INTERVAL);
+                        .reset(tokio::time::Instant::now() + interval);
                 }
                 continue;
             }
@@ -4441,7 +4485,7 @@ impl RibManager {
                             count = self.dirty_peers.len(),
                             "resync timer fired for dirty peers"
                         );
-                        self.distribute_changes(&HashSet::new(), &HashSet::new());
+                        let backlog = self.resync_dirty_peers_bounded();
 
                         // Reset for next tick if still dirty, otherwise disarm.
                         if self.dirty_peers.is_empty() {
@@ -4449,8 +4493,13 @@ impl RibManager {
                             resync_armed = false;
                         } else {
                             self.metrics.record_rib_dirty_resync("still_dirty");
+                            let interval = if backlog {
+                                DIRTY_RESYNC_BACKLOG_INTERVAL
+                            } else {
+                                DIRTY_RESYNC_INTERVAL
+                            };
                             resync_sleep.as_mut().reset(
-                                tokio::time::Instant::now() + DIRTY_RESYNC_INTERVAL,
+                                tokio::time::Instant::now() + interval,
                             );
                         }
                     }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -54,6 +54,7 @@ struct PolicyTransitionStats {
     max_actor_slice: std::time::Duration,
     max_prefix_snapshot_poll: std::time::Duration,
     max_finalize_poll: std::time::Duration,
+    max_commit_poll: std::time::Duration,
     #[cfg(feature = "bench-internals")]
     authoritative_peer_applies: usize,
     #[cfg(feature = "bench-internals")]
@@ -664,6 +665,10 @@ pub(in crate::manager) fn policy_transition_slice_end(
 }
 /// Maximum members classified by one strict shared-policy actor poll.
 pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
+/// Maximum validated members committed and flushed by one strict
+/// shared-policy actor poll (matches `QUERY_BUDGET_PER_CHUNK` so readiness
+/// keeps its per-seam service ratio through the commit flush).
+pub(in crate::manager) const COMMIT_MEMBERS_PER_POLL: usize = 8;
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 
@@ -1311,6 +1316,10 @@ impl RibManager {
                 distribution::CleanPolicyTransitionPollKind::Finalize => {
                     self.policy_transition_stats.max_finalize_poll =
                         self.policy_transition_stats.max_finalize_poll.max(elapsed);
+                }
+                distribution::CleanPolicyTransitionPollKind::Commit => {
+                    self.policy_transition_stats.max_commit_poll =
+                        self.policy_transition_stats.max_commit_poll.max(elapsed);
                 }
                 distribution::CleanPolicyTransitionPollKind::Bounded => {}
             }

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -1308,8 +1308,10 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
         BTreeMap::from([
             (
                 "bounded".to_owned(),
-                u64::try_from(actor_polls - 3).unwrap()
+                u64::try_from(actor_polls - 4).unwrap()
             ),
+            // MEMBER_COUNT members fit one COMMIT_MEMBERS_PER_POLL batch.
+            ("commit".to_owned(), 1),
             ("finalize".to_owned(), 1),
             ("prefix_snapshot".to_owned(), 2),
         ])
@@ -3370,6 +3372,437 @@ async fn grouped_and_ungrouped_export_counters_match_after_dirty_resync() {
         post_grouped.export_policy_routes_denied,
         post_ungrouped.export_policy_routes_denied,
     );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Direct-drive fixture for mid-flush observation: `member_count` grouped
+/// RR-client members installed on one shared export policy, `route_count`
+/// Loc-RIB routes distributed and drained, no actor task. Tests step the
+/// parked transition through the same seam the run loop polls.
+fn direct_clean_transition_manager(
+    member_count: usize,
+    route_count: usize,
+    readiness_rx: Option<mpsc::Receiver<crate::update::RibReadinessQuery>>,
+) -> (
+    RibManager,
+    Vec<IpAddr>,
+    Vec<mpsc::Receiver<OutboundRouteUpdate>>,
+) {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    if let Some(readiness_rx) = readiness_rx {
+        manager = manager.with_readiness_queries(readiness_rx);
+    }
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_2101);
+    let mut peers = Vec::new();
+    let mut receivers = Vec::new();
+    for index in 0..member_count {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 42, 0, u8::try_from(index + 1).unwrap()));
+        peers.push(peer);
+        manager.handle_update(RibUpdate::SetPeerExportEncoder {
+            peer,
+            session_id: 0,
+            encoder: Arc::new(CohortExactEncoder {
+                owner: u64::try_from(index + 1).unwrap(),
+                profile: 42,
+                max_len: 65_535,
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&probes),
+                reuses: Arc::clone(&reuses),
+            }),
+        });
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(8);
+        manager.handle_update(RibUpdate::PeerUp {
+            peer,
+            session_id: 0,
+            peer_asn: 65_000,
+            peer_router_id: Ipv4Addr::UNSPECIFIED,
+            outbound_tx,
+            export_policy: Some(old_policy.clone()),
+            sendable_families: ipv4_sendable(),
+            is_ebgp: false,
+            route_reflector_client: true,
+            orr_vantage: None,
+            per_client_best: false,
+            add_path_send_families: vec![],
+            add_path_send_max: 0,
+            negotiated_orf_recv: vec![],
+            negotiated_llgr_families: vec![],
+        });
+        let eor = outbound_rx.try_recv().unwrap();
+        assert_eq!(eor.end_of_rib, ipv4_sendable());
+        receivers.push(outbound_rx);
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 42);
+    let announced = (0..route_count)
+        .map(|index| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(198, 51, u8::try_from(index).unwrap(), 0), 24),
+                source,
+            )
+        })
+        .collect();
+    manager.handle_update(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+    for receiver in &mut receivers {
+        while receiver.try_recv().is_ok() {}
+    }
+    (manager, peers, receivers)
+}
+
+/// One run-loop poll of the parked transition, returning the recorded poll
+/// kind and outcome exactly as the actor seam observes them.
+fn step_parked_transition(manager: &mut RibManager) -> (&'static str, &'static str) {
+    use crate::manager::distribution::CleanPolicyTransitionAdvance;
+    let pending = manager
+        .pending_clean_policy_transition
+        .take()
+        .expect("a parked transition to poll");
+    let kind = pending.poll_kind().as_str();
+    match manager.advance_clean_policy_transition(pending) {
+        CleanPolicyTransitionAdvance::Continue(next) => {
+            manager.pending_clean_policy_transition = Some(next);
+            (kind, "continue")
+        }
+        CleanPolicyTransitionAdvance::Committed(_) => (kind, "committed"),
+        CleanPolicyTransitionAdvance::Fallback(mut failed) => {
+            failed
+                .discard_uncommitted_transition(manager)
+                .expect("fallback cleanup succeeds");
+            (kind, "fallback")
+        }
+    }
+}
+
+fn start_clean_transition(
+    manager: &mut RibManager,
+    peers: &[IpAddr],
+    next_policy: &PolicyChain,
+) -> oneshot::Receiver<Result<crate::update::ExportPolicyCohortOutcome, String>> {
+    let (reply, response) = oneshot::channel();
+    manager.handle_update(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(next_policy.clone()),
+            })
+            .collect(),
+        reply,
+    });
+    assert!(manager.pending_clean_policy_transition.is_some());
+    response
+}
+
+/// LAN-447: the dedicated readiness lane must be answerable BETWEEN commit
+/// batches. With a monolithic finalize poll (no Validate/CommitMembers
+/// split) no mid-flush seam exists and this test fails: the first
+/// commit-kind poll would terminate the transition.
+#[tokio::test]
+async fn readiness_answered_between_commit_flush_batches() {
+    const MEMBER_COUNT: usize = 3 * super::super::COMMIT_MEMBERS_PER_POLL + 2;
+    const ROUTE_COUNT: usize = 2;
+    let (readiness_tx, readiness_rx) = mpsc::channel(8);
+    let (mut manager, peers, _receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, Some(readiness_rx));
+    let next_policy = community_chain(0xFDE8_2102);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    // Drive the poll seam until the FIRST commit poll completes.
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(outcome, "continue", "{kind} poll must park mid-transition");
+        if kind == "commit" {
+            break;
+        }
+    }
+    let pending = manager
+        .pending_clean_policy_transition
+        .as_ref()
+        .expect("transition still owned mid-flush");
+    let cursor = pending.commit_cursor().expect("commit phase parked");
+    assert_eq!(cursor, super::super::COMMIT_MEMBERS_PER_POLL);
+    assert!(cursor < MEMBER_COUNT);
+    let elapsed = pending.elapsed();
+
+    // The readiness lane is serviced at exactly this seam.
+    let (reply, mut probe) = oneshot::channel();
+    readiness_tx
+        .try_send(crate::update::RibReadinessQuery::LocRibCount { reply })
+        .unwrap();
+    manager.drain_readiness_queries(Some(elapsed));
+    assert_eq!(
+        probe
+            .try_recv()
+            .expect("readiness answered mid-flush")
+            .expect("healthy verdict while the flush is parked"),
+        ROUTE_COUNT
+    );
+    assert!(manager.pending_clean_policy_transition.is_some());
+
+    // The flush then completes without fallback.
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(kind, "commit");
+        if outcome == "committed" {
+            break;
+        }
+        assert_eq!(outcome, "continue");
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+}
+
+/// The commit phase drains members in bounded batches: ceil(M/8)-1 Continue
+/// polls, each flushing at most `COMMIT_MEMBERS_PER_POLL` members.
+#[tokio::test]
+async fn commit_flush_batches_are_bounded_and_drain_monotonically() {
+    const MEMBER_COUNT: usize = 3 * super::super::COMMIT_MEMBERS_PER_POLL + 2;
+    const ROUTE_COUNT: usize = 2;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    let next_policy = community_chain(0xFDE8_2103);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    let mut batch_sizes = Vec::new();
+    let mut commit_continues = 0_usize;
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_ne!(outcome, "fallback");
+        if kind == "commit" {
+            // Each member receives exactly one shared flush envelope, so the
+            // per-poll count of newly delivered envelopes IS the batch size.
+            let delivered = receivers
+                .iter_mut()
+                .filter_map(|receiver| receiver.try_recv().ok())
+                .count();
+            batch_sizes.push(delivered);
+            if outcome == "committed" {
+                break;
+            }
+            commit_continues += 1;
+        } else {
+            assert_eq!(outcome, "continue");
+        }
+    }
+    assert_eq!(batch_sizes, vec![8, 8, 8, 2]);
+    assert_eq!(
+        commit_continues,
+        MEMBER_COUNT.div_ceil(super::super::COMMIT_MEMBERS_PER_POLL) - 1
+    );
+    let destination = manager.grouped_member_of(peers[0]).expect("grouped");
+    for &peer in &peers {
+        assert_eq!(manager.grouped_member_of(peer), Some(destination));
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+}
+
+/// Once the first batch has emitted, a member's dropped transport receiver
+/// must not fall the transition back: the dead peer's envelope is silently
+/// dropped, every other member commits, and the cohort ends Committed.
+#[tokio::test]
+async fn commit_flush_never_falls_back_after_first_emission() {
+    const MEMBER_COUNT: usize = 10;
+    const ROUTE_COUNT: usize = 2;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    let next_policy = community_chain(0xFDE8_2104);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    // First commit batch flushes members 0..8 (replacement order).
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(outcome, "continue");
+        if kind == "commit" {
+            break;
+        }
+    }
+    for receiver in &mut receivers[..8] {
+        assert!(
+            receiver.try_recv().is_ok(),
+            "first batch flushed members 0..8"
+        );
+    }
+    // Drop a NOT-yet-committed member's transport receiver mid-flush.
+    drop(receivers.remove(9));
+
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(kind, "commit");
+        match outcome {
+            "committed" => break,
+            "continue" => {}
+            other => panic!("post-emission poll must never {other}"),
+        }
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    // The surviving ninth member got its envelope; the dead member's
+    // membership still committed with the cohort.
+    assert!(receivers[8].try_recv().is_ok());
+    let destination = manager.grouped_member_of(peers[0]).expect("grouped");
+    assert_eq!(manager.grouped_member_of(peers[9]), Some(destination));
+}
+
+/// Fence integrity across the batched flush: a primary route update and a
+/// second cohort enqueued behind an owned transition are processed only
+/// after its terminal commit, in order — every member observes
+/// flush-then-mutation-then-second-flush.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the fence regression preserves full cohort setup plus the three-message queue-order proof"
+)]
+async fn fence_holds_queued_work_until_commit_flush_terminal() {
+    const MEMBER_COUNT: usize = 3 * super::super::COMMIT_MEMBERS_PER_POLL + 2;
+    const ROUTE_COUNT: usize = 2;
+    let (tx, rx) = mpsc::channel(256);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_2105);
+    let mid_policy = community_chain(0xFDE8_2106);
+    let final_policy = community_chain(0xFDE8_2107);
+    let mut peers = Vec::new();
+    let mut receivers = Vec::new();
+    for index in 0..MEMBER_COUNT {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 43, 0, u8::try_from(index + 1).unwrap()));
+        peers.push(peer);
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(
+            peer_up_with_cohort_encoder(
+                &tx,
+                spec,
+                Arc::new(CohortExactEncoder {
+                    owner: u64::try_from(index + 1).unwrap(),
+                    profile: 43,
+                    max_len: 65_535,
+                    generation: AtomicUsize::new(0),
+                    advance_generation: false,
+                    probes: Arc::clone(&probes),
+                    reuses: Arc::clone(&reuses),
+                }),
+            )
+            .await,
+        );
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 43);
+    let announced = (0..ROUTE_COUNT)
+        .map(|index| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(198, 51, u8::try_from(index).unwrap(), 0), 24),
+                source,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), ROUTE_COUNT);
+    }
+
+    // Enqueue the cohort, then a primary update, then a second cohort —
+    // all queued behind the owned transition.
+    let (reply_mid, response_mid) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(mid_policy.clone()),
+            })
+            .collect(),
+        reply: reply_mid,
+    })
+    .await
+    .unwrap();
+    let later_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(later_prefix, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    let (reply_final, response_final) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(final_policy.clone()),
+            })
+            .collect(),
+        reply: reply_final,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        response_mid.await.unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    assert_eq!(
+        response_final.await.unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed),
+        "the second cohort must queue behind the fence, not race the flush"
+    );
+    for receiver in &mut receivers {
+        let flush = receiver.recv().await.unwrap();
+        assert_eq!(
+            flush.announce.len(),
+            ROUTE_COUNT,
+            "cohort flush precedes the queued primary update"
+        );
+        let primary = receiver.recv().await.unwrap();
+        assert_eq!(primary.announce.len(), 1);
+        assert_eq!(primary.announce[0].prefix, Prefix::V4(later_prefix));
+        let second_flush = receiver.recv().await.unwrap();
+        assert_eq!(
+            second_flush.announce.len(),
+            ROUTE_COUNT + 1,
+            "second cohort flushes the post-mutation table"
+        );
+    }
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -3807,3 +3807,46 @@ async fn fence_holds_queued_work_until_commit_flush_terminal() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// LAN-447 companion bound: one resync-timer tick hands at most
+/// `RESYNC_PEERS_PER_TICK` dirty peers to the O(table) resync pass; the
+/// withheld remainder survives untouched for the next tick.
+#[tokio::test]
+async fn dirty_resync_tick_bounds_peers_and_preserves_backlog() {
+    const PEER_COUNT: usize = 12;
+    const ROUTE_COUNT: usize = 1;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(PEER_COUNT, ROUTE_COUNT, None);
+    for &peer in &peers {
+        manager.mark_outbound_dirty(peer);
+    }
+    assert_eq!(manager.dirty_peers.len(), PEER_COUNT);
+
+    // First tick: exactly the bounded slice resyncs (each successful dirty
+    // resync of a grouped member replays the group table as one envelope);
+    // the withheld backlog is reported and survives untouched.
+    let backlog = manager.resync_dirty_peers_bounded();
+    assert!(backlog, "a withheld remainder must be reported as backlog");
+    assert_eq!(
+        manager.dirty_peers.len(),
+        PEER_COUNT - super::super::RESYNC_PEERS_PER_TICK
+    );
+    let first_tick_envelopes = receivers
+        .iter_mut()
+        .filter_map(|receiver| receiver.try_recv().ok())
+        .count();
+    assert_eq!(first_tick_envelopes, super::super::RESYNC_PEERS_PER_TICK);
+
+    // Second tick drains the remainder without over-reporting backlog.
+    let backlog = manager.resync_dirty_peers_bounded();
+    assert!(!backlog, "no withheld peers remain");
+    assert!(manager.dirty_peers.is_empty());
+    let second_tick_envelopes = receivers
+        .iter_mut()
+        .filter_map(|receiver| receiver.try_recv().ok())
+        .count();
+    assert_eq!(
+        second_tick_envelopes,
+        PEER_COUNT - super::super::RESYNC_PEERS_PER_TICK
+    );
+}

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -650,7 +650,7 @@ impl BgpMetrics {
         let rib_policy_transition_actor_poll_duration_seconds = HistogramVec::new(
             HistogramOpts::new(
                 "bgp_rib_policy_transition_actor_poll_duration_seconds",
-                "Wall-clock duration of each real export-policy transition actor poll, partitioned by bounded work, complete prefix snapshot, or finalization (including commit and retry work).",
+                "Wall-clock duration of each real export-policy transition actor poll, partitioned by bounded work, complete prefix snapshot, pre-commit validation (finalize), or a bounded member commit/flush batch (commit; the terminal batch includes the global retry tail).",
             )
             .buckets(vec![
                 0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.200, 0.500, 1.0, 2.5, 5.0, 10.0,

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -76,9 +76,9 @@ first optimized emission. PeerManager then performs ordinary authoritative
 RIB replacements for the entire selected policy cohort, one peer at a time,
 without hot-applying the session chain a second time.
 
-### 3. The five RIB phases
+### 3. The six RIB phases
 
-The actor-owned transition has exactly five phases:
+The actor-owned transition has exactly six phases:
 
 1. **Classify** examines at most eight members per poll, rejects duplicates or
    non-clean members, and proves that the complete cohort has one update-group
@@ -94,29 +94,39 @@ The actor-owned transition has exactly five phases:
    new wire profile, reuses a successful profile's largest encoded length when
    compatible, and reserves each member's outbound writer permit. It emits
    nothing.
-5. **Finalize** revalidates every session, sender, encoder owner/generation,
-   clean-state predicate, group pair, and reserved permit. In one synchronous
-   actor poll it changes memberships, replays counters, and sends the shared
-   `Arc` payload through the reserved permits. It then runs the global
-   `distribute_changes(empty, empty)` retry opportunity before replying, so
-   unrelated dirty or forced peers can drain promptly rather than waiting for
-   the retry timer.
+5. **Validate** revalidates every session, sender, encoder owner/generation,
+   clean-state predicate, group pair, and reserved permit in one actor poll.
+   It is the last phase that can fall back; it emits nothing.
+6. **CommitMembers** changes memberships, replays counters, and sends the
+   shared `Arc` payload through each member's reserved permit in bounded
+   batches of at most eight members per poll, draining committed members so
+   parked state shrinks monotonically. Once the first batch has emitted,
+   later polls only continue or terminate committed — per-batch revalidation
+   is deliberately absent because the actor fence admits only the read-only
+   readiness lane between batches, and a receiver dropped mid-flush is
+   benign (permits are pre-reserved, sending on a closed channel is a no-op,
+   and the queued `PeerDown` cleans up after the fence lifts). The terminal
+   batch then runs the global `distribute_changes(empty, empty)` retry
+   opportunity before replying, so unrelated dirty or forced peers can drain
+   promptly rather than waiting for the retry timer.
 
-No phase before `Finalize` changes committed membership, policy, counters, or
-wire state. On fallback, reserved permits are released and a destination
-created by this transition is removed only if it is still unowned. Failure to
-prove safe cleanup is an error rather than a per-peer handoff.
+No phase before `CommitMembers` changes committed membership, policy,
+counters, or wire state. On fallback, reserved permits are released and a
+destination created by this transition is removed only if it is still
+unowned. Failure to prove safe cleanup is an error rather than a per-peer
+handoff.
 
 The 1,024-route budget does not bound the two snapshot polls. The initial
 Loc-RIB prefix snapshot is O(Loc-RIB entries) in one actor poll; the later
 destination-key snapshot is O(destination entries) in one actor poll. They
 provide stable identity vectors for the chunked bodies, at the cost of two
 full-table allocations and two scheduler-visible, data-dependent polls.
-`Finalize` has an O(cohort members) commit body, but its global retry tail also
-enumerates outbound peers and can perform full Loc-RIB/Adj-RIB-Out work for
-unrelated dirty or forced peers. Its work shape can therefore reach
-O(outbound peers + table entries times dirty/forced peers) in one poll. These
-are explicit bounds of the current model, not claims of constant-time actor
+`CommitMembers` bounds the commit/flush body to eight members per poll, but
+the terminal batch's global retry tail still enumerates outbound peers and
+can perform full Loc-RIB/Adj-RIB-Out work for unrelated dirty or forced
+peers. The terminal poll's work shape can therefore reach
+O(outbound peers + table entries times dirty/forced peers). These are
+explicit bounds of the current model, not claims of constant-time actor
 latency.
 
 ### 4. Cross-partition apply and rollback order
@@ -164,10 +174,11 @@ running.
 
 Production exposes transition-in-progress and last-total-duration gauges,
 emits one slow warning after five seconds, and records every real actor poll in
-`bgp_rib_policy_transition_actor_poll_duration_seconds{poll_kind}`. The three
+`bgp_rib_policy_transition_actor_poll_duration_seconds{poll_kind}`. The four
 bounded label values separate chunked work (`bounded`), the two complete table
-snapshots (`prefix_snapshot`), and finalization including the atomic commit and
-global dirty/forced retry tail (`finalize`) so an operator can distinguish a
+snapshots (`prefix_snapshot`), the pre-commit validation poll (`finalize`),
+and the bounded member commit/flush batches (`commit`, whose terminal batch
+includes the global dirty/forced retry tail) so an operator can distinguish a
 long transaction from one long single-threaded poll.
 
 Readiness remains successful during legitimate bounded progress, but the
@@ -230,11 +241,11 @@ wall-clock guarantee. See the
   dominant shape without forcing content-stable or otherwise ineligible peers
   through the RIB batch. Multiple simultaneous policy cohorts would multiply
   state and rollback edges without current demand evidence.
-- **Actor fence, single RIB owner, and five phases:** keep. Together they buy
+- **Actor fence, single RIB owner, and six phases:** keep. Together they buy
   an auditable, observationally atomic RIB commit while bounded bodies provide
   scheduler opportunities. The cost is queued normal work; the two snapshot
-  polls, final member loop, and final global retry are not bounded by the route
-  chunk size.
+  polls and the terminal global retry are not bounded by the route chunk
+  size, though the member commit/flush loop now is (eight members per poll).
 - **Immutable inventory and wire-cohort probe sharing:** keep. They change
   staging and exact probing from routes-times-peers toward
   routes-times-compatible-profiles while retaining per-session generation and
@@ -248,8 +259,9 @@ wall-clock guarantee. See the
 - **Final global retry opportunity:** keep until production poll data says
   otherwise. It promptly drains unrelated dirty/forced residue before the
   successful transaction reply, matching the authoritative replacement seam.
-  Its cost is an unchunked global retry opportunity inside `Finalize`;
-  use the production poll histogram before optimizing or relocating it.
+  Its cost is an unchunked global retry opportunity inside the terminal
+  `CommitMembers` batch; use the production poll histogram before optimizing
+  or relocating it.
 - **Read-only readiness isolation:** keep. It avoids false depools during
   normal transactions, then fails closed at 30 seconds so a true soft wedge is
   automatically depooled. Its cost is a second narrow channel and one
@@ -296,8 +308,10 @@ semantics for both newly created and already-maintained destinations.
   readiness lanes remain responsive at actor seams, but an owned transition
   reports stalled from 30 seconds until terminal commit or cleaned-up fallback.
 - The current implementation deliberately retains two O(table) snapshot polls,
-  one data-dependent finalization poll with a global dirty/force retry tail, a
-  single-cohort partition, and a sequential authoritative remainder.
+  a terminal commit batch whose global dirty/force retry tail is data-
+  dependent, a single-cohort partition, and a sequential authoritative
+  remainder. The member commit/flush loop itself is bounded to eight members
+  per poll (LAN-447).
 - The measured completion win is retained together with its measured delivery-
   gap regression. Neither the ADR nor the microbenchmark receipts turn that
   regression into a success claim.

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1272,7 +1272,7 @@ impl PeerManager {
                     Ok(Ok(())) => {}
                     Ok(Err(error)) => failures.push(format!("{peer_key} (import): {error}")),
                     Err(_) => failures.push(format!(
-                        "{peer_key} (import): route refresh timed out after                          {PEER_POLICY_UPDATE_TIMEOUT:?}"
+                        "{peer_key} (import): route refresh timed out after {PEER_POLICY_UPDATE_TIMEOUT:?}"
                     )),
                 }
             }


### PR DESCRIPTION
## Problem (measured)

A policy reload at internet scale (1M routes / 500 peers / 300 changed) depools the node for 1.6–2.4 s: every `/readyz` probe in the reload window 503s. The transition's own state-machine polls stay under the 200 ms readiness deadline throughout — the stall is the **post-commit flush**, which ran as ONE actor poll containing the whole per-peer commit/flush loop. Per `docs/perf/reload-flush-envelope-2026-07.md`, the stall is **peer-fleet-driven and volume-flat**: a 5× swing in re-advertised route volume moves it by tens of ms, while it grows roughly linearly with changed-peer count and superlinearly with total fleet size. The fix therefore bounds *peers processed per poll*, not routes.

## Mechanism

**1. Bounded commit batches (`Validate` + `CommitMembers`).** The former `Finalize` phase is split:

- `Validate` runs the full revalidation pass (session, sender, encoder owner/generation, clean-state predicate, group pair, reserved permit) in one poll. It is the last phase that can fall back; it emits nothing.
- `CommitMembers` commits memberships, replays counters, and sends the shared `Arc` payload through each member's pre-reserved permit in batches of at most `COMMIT_MEMBERS_PER_POLL = 8` members per poll, draining committed members so parked state shrinks monotonically. The run loop services the dedicated readiness lane and yields between batches. The terminal batch runs the existing tail: commit finish, the global `distribute_changes(empty, empty)` retry pass, stats, and the `Committed` reply.

**2. Bounded dirty-peer resync per timer tick.** The resync timer handed ALL dirty peers to one synchronous `distribute_changes` at O(table) each. Each tick now processes at most `RESYNC_PEERS_PER_TICK = 8` dirty peers (remainder swapped out around the call) and re-arms at a short 10 ms interval while a withheld backlog remains. Partial passes are safe because per-peer resync is idempotent: staging does not mutate Adj-RIB-Out, adj-out state and the dirty flag commit only after a successful send, and withheld peers are untouched.

## Invariants preserved

- **Atomicity by construction.** The actor fence admits only the read-only readiness lane while a transition is pending; validate-once-then-commit-in-batches cannot observe interleaved mutation. The fence is unchanged.
- **No fallback after the first emission.** Once `CommitMembers` has sent any envelope, later polls only continue or terminate `Committed`. Per-batch revalidation is deliberately absent: permits are pre-reserved, sending on a dropped receiver is a no-op, and the queued `PeerDown` cleans up after the fence lifts. Documented in the phase comment and pinned by test.
- **Fallback ⇒ nothing emitted.** `Validate` is the sole remaining fallback point; all discard paths are intact.
- **Reply position.** The `Committed` reply stays in the terminal batch, after the tail's `distribute_changes` — the peer manager treats it as flush-complete before launching remainder per-peer applies and rollback restores.
- **Stalled coverage.** `in_progress` stays 1 and the ownership clock keeps aging through the flush, so the 30 s stalled verdict and slow-transition warning now cover the commit/flush as well.

## Observability for re-measurement

The existing `bgp_rib_policy_transition_actor_poll_duration_seconds{poll_kind}` histogram gains a `commit` poll kind (no schema change; `finalize` now labels the validation poll). The cfg-gated transition stats and bench receipt gain `max_commit_poll`. Any residual stall the new instrumentation attributes elsewhere (e.g. session encode) is out of scope here by design.

## Tests

- Readiness answered between commit batches mid-flush (fails without the split).
- Batch structure: `ceil(M/8)-1` Continue polls, ≤8 members flushed per poll, monotone drain.
- Dropped member receiver after the first batch: no fallback, cohort ends `Committed`.
- Fence integrity: a primary update and a second cohort queued mid-flush are processed only after terminal commit, in flush-then-mutation order.
- Resync bound: with >8 dirty peers, one tick resyncs exactly 8 and the withheld remainder survives to the next tick.
- Existing evidence pins updated where counts legitimately changed (poll-kind histogram map in the wire-cohort test).

Also collapses a corrupted whitespace run in the peer-manager route-refresh timeout message.