### PR TITLE
fix(api): bound /readyz response at the core-readiness deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`/readyz` now treats the 200 ms core-readiness deadline as a hard bound
+  on the HTTP response.** A runtime stall (such as the post-commit outbound
+  flush) could hold the probe past the deadline and then complete it, and the
+  queued actor reply was polled before the expired probe timer — so the probe
+  answered a late 200 that silently violated the readiness contract. The
+  `/readyz` handler now wraps the probe in the deadline and rejects a late
+  success, answering `503 not ready: readiness probe deadline exceeded`
+  instead. The fast-503 daemon-gate path is unchanged. (LAN-448)
+
 - **Shutdown GR marker publication and warm-bundle maintenance can no longer
   wedge or wedge-loop.** GR restart marker publication, its generationless
   fallback, and marker removal at coordinated shutdown now run on a detached

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use prometheus::{Encoder, TextEncoder};
-use rustbgpd_api::health_probe::CoreReadinessProbe;
+use rustbgpd_api::health_probe::{CORE_READINESS_DEADLINE, CoreReadinessProbe};
 use rustbgpd_telemetry::BgpMetrics;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -115,13 +115,31 @@ async fn handle_connection(
             }
         },
         "/livez" => text_response("200 OK", "ok\n"),
-        "/readyz" => match readiness_probe.check().await {
-            Ok(()) => text_response("200 OK", "ready\n"),
-            Err(error) => {
-                warn!(%error, "readiness probe failed");
-                text_response("503 Service Unavailable", &format!("not ready: {error}\n"))
+        "/readyz" => {
+            // Hard bound on the response, not just the probe's internal
+            // waits: a runtime stall can hold the probe past the deadline
+            // and then complete it — on unpark the queued reply is polled
+            // before the expired timer, so without the elapsed guard a
+            // late success would be certified as a (contract-violating)
+            // late 200.
+            let started = std::time::Instant::now();
+            match tokio::time::timeout(CORE_READINESS_DEADLINE, readiness_probe.check()).await {
+                Ok(Ok(())) if started.elapsed() <= CORE_READINESS_DEADLINE => {
+                    text_response("200 OK", "ready\n")
+                }
+                Ok(Err(error)) => {
+                    warn!(%error, "readiness probe failed");
+                    text_response("503 Service Unavailable", &format!("not ready: {error}\n"))
+                }
+                Ok(Ok(())) | Err(_) => {
+                    warn!("readiness probe deadline exceeded");
+                    text_response(
+                        "503 Service Unavailable",
+                        "not ready: readiness probe deadline exceeded\n",
+                    )
+                }
             }
-        },
+        }
         _ => text_response("404 Not Found", "Not Found\n"),
     };
 
@@ -281,6 +299,105 @@ mod tests {
         let response = request(addr, "/readyz").await;
         assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
         assert!(response.ends_with("not ready: RIB manager probe timed out (200ms deadline)\n"));
+    }
+
+    #[tokio::test]
+    async fn get_readyz_returns_503_within_deadline_when_rib_reply_stalls() {
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let addr = start_server(CoreReadinessProbe::new(peer_tx, rib_tx)).await;
+
+        tokio::spawn(async move {
+            if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+                let _ = reply.send(Vec::new());
+            }
+        });
+        tokio::spawn(async move {
+            if let Some(RibUpdate::QueryLocRibCount { reply }) = rib_rx.recv().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                let _ = reply.send(0);
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let response = request(addr, "/readyz").await;
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a stalled RIB actor must not delay the /readyz response past the deadline"
+        );
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+    }
+
+    #[tokio::test]
+    async fn get_readyz_rejects_late_success_when_runtime_stall_outlives_deadline() {
+        // R1 from docs/perf/actor-ceiling-1m-2026-07.md: a wedged runtime
+        // holds the probe past the deadline, and on unpark the queued
+        // actor reply is polled before the expired probe timer, so the
+        // probe completes successfully. Without the response-side elapsed
+        // guard this is certified as a late 200.
+        let (peer_tx, mut peer_rx) = mpsc::channel(1);
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (wedge_tx, mut wedge_rx) = mpsc::channel::<Duration>(1);
+        let (engaged_tx, engaged_rx) = tokio::sync::oneshot::channel();
+        let (addr_tx, addr_rx) = tokio::sync::oneshot::channel();
+
+        // The server runs on its own single-threaded runtime so the test
+        // can wedge exactly the worker that owns the probe timers.
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async move {
+                let metrics = BgpMetrics::new();
+                let probe = CoreReadinessProbe::new(peer_tx, rib_tx);
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                addr_tx.send(listener.local_addr().unwrap()).unwrap();
+                tokio::spawn(async move {
+                    if let Some(stall) = wedge_rx.recv().await {
+                        let _ = engaged_tx.send(());
+                        // No await between the signal and the sleep, so the
+                        // worker is wedged before the reply can be polled.
+                        std::thread::sleep(stall);
+                    }
+                });
+                let (stream, _) = listener.accept().await.unwrap();
+                let _ = handle_connection(stream, &metrics, &probe).await;
+            });
+        });
+
+        let addr = addr_rx.await.unwrap();
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"GET /readyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        // Answer the peer half, then hold the RIB reply until the wedge is
+        // in place so it is already queued when the runtime unparks well
+        // past the deadline.
+        if let Some(PeerManagerCommand::ListPeers { reply }) = peer_rx.recv().await {
+            let _ = reply.send(Vec::new());
+        }
+        let Some(RibUpdate::QueryLocRibCount { reply }) = rib_rx.recv().await else {
+            panic!("expected QueryLocRibCount");
+        };
+        wedge_tx.send(Duration::from_millis(600)).await.unwrap();
+        engaged_rx.await.unwrap();
+        let _ = reply.send(0);
+
+        let response = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut buf = Vec::new();
+            stream.read_to_end(&mut buf).await.unwrap();
+            String::from_utf8_lossy(&buf).into_owned()
+        })
+        .await
+        .expect("response within 5s");
+        assert!(
+            response.starts_with("HTTP/1.1 503 Service Unavailable"),
+            "late probe success must not be certified as ready: {response}"
+        );
+        assert!(response.ends_with("not ready: readiness probe deadline exceeded\n"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Four changes so that credential material (`md5_password`, TCP-AO keys, bearer tokens, TLS private keys) never appears in diagnostics, tokens, `Debug` output, or lingers in freed heap.

## Parse diagnostics no longer echo credential-bearing source lines

`render_snippet` printed the source line at an error span verbatim, so a TOML syntax error on or near an `md5_password = "..."` or `tcp_ao` key line reproduced the plaintext secret in the SIGHUP reload log, daemon stderr, and the `DiffRuntimeConfig`/`PlanConfigTransaction` gRPC statuses. The snippet renderer now redacts the echoed line when it — or the immediately preceding line, since an unterminated quote reports its span on the following line — mentions `md5_password`, `tcp_ao`, or a bare `key = ...` assignment (the TCP-AO key field). The redacted form keeps the `file:line:col` pointer and the label, and collapses the caret run to a single `^` so the underline width cannot reveal the secret's length:

```
error: failed to parse config
  --> config.toml:8:29
  |
8 | <line contains sensitive material, redacted>
  | ^ invalid basic string
```

Fixed once at the diagnostic layer, which every consumer (reload, startup stderr, gRPC candidate validation) routes through. The secret-key list mirrors the fields `Config::effective_redacted` masks.

## Snapshot token no longer encodes the config rendering's byte length

`RuntimeSnapshotKey::token_with_context` appended `normalized.len()` to the token, and the normalized rendering includes plaintext secrets — so the token exposed how secret lengths change across rotations. The length component is dropped rather than recomputed over a redacted rendering: tokens are process-local and only ever equality-compared against tokens minted by the same in-process key (plan/apply optimistic concurrency in `peer_manager/reconcile.rs`), so the keyed digest alone carries the change detection and nothing parses the token's shape. The `kv2` context-length component (a fixed-width live-snapshot digest, not config data) is unchanged.

## Redacted `Debug` for secret-carrying config and reply types

`Neighbor` and `PeerGroupConfig` derived `Debug` with plaintext `md5_password`; both now have manual impls that render `Some("<redacted>")`, mirroring the existing `TcpAoConfig` impl (the `tcp_ao` field already redacts through that impl). `RuntimeConfigSnapshotReply` derived `Debug` while carrying the full secret-bearing runtime TOML; its manual impl elides the `toml` field.

## Management-plane credential copies are zeroized

The bearer-token file read and the TLS credential file reads in `crates/api/src/credentials.rs` now use `Zeroizing` (zeroize is already a workspace dependency; added to `rustbgpd-api`), so the transient buffers — notably the TLS private key after rustls parses it — are scrubbed on drop. `BearerAuthSecret` gains a `Drop` impl that zeroizes its `"Bearer {token}"` header through `Arc::get_mut`; retired credential generations are scrubbed when their last holder (e.g. a pinned RPC snapshot) drops rather than at rotation time.

## Tests

- `config::diagnostic::tests::parse_error_snippet_redacts_md5_password_line`
- `config::diagnostic::tests::parse_error_snippet_redacts_tcp_ao_key_line`
- `config::tests::runtime_snapshot_token_does_not_encode_config_length`
- `config::tests::neighbor_and_peer_group_debug_redact_md5_password`
- `peer_types::tests::runtime_config_snapshot_reply_debug_redacts_toml`

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-api` — exit 0 (433 passed)
- `cargo test --workspace` — exit 0
