### PR TITLE
docs: correct RFC coverage, trust-boundary, and transition notes

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -283,7 +283,13 @@ request is not propagated to other peers. RFC 1997 egress enforcement happens
 before export policy, so `set_community_remove = ["NO_ADVERTISE"]` cannot make
 the scoped route exportable. The post-policy result is checked as well, so a
 policy that adds `NO_ADVERTISE` suppresses the modified route instead of
-advertising it. Earlier operator denies still short-circuit normally.
+advertising it. Earlier operator denies still short-circuit normally. There
+is no per-route escape hatch while the knob is enabled: chain evaluation
+accumulates permit modifications, so an earlier operator permit does not
+bypass the implicit tail rule, and the added `NO_ADVERTISE` cannot be removed
+at export. Deliberately propagating a blackhole request to selected peers
+requires leaving `honor_blackhole` off (its default) and scoping the
+community in operator policy instead.
 
 By default this does **not** install a kernel discard/null route. To turn
 local RTBH enforcement on, set both:

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -23,7 +23,12 @@ surfaces; it does not promote the rest of the project out of alpha.
   rustbgpd does not synthesize local BGP-LS objects. ORR computes only the
   RFC 9552 default topology: non-default MT-ID and malformed topology inputs
   are excluded fail-closed, while Flex-Algorithm data is ignored and no
-  selectable non-default/Flex SPF is implemented.
+  selectable non-default/Flex SPF is implemented. The BGP-LS trust boundary
+  is per-scope, not per-peer: ORR unions BGP-LS Adj-RIB-In across all peers
+  into one default topology, so any negotiated BGP-LS speaker can inject
+  well-formed default-topology nodes or links that shift another ORR client's
+  best-path selection. This is inherent to the RFC 9107 union model — the
+  MT/Flex isolation above scopes topology inputs, not speakers.
 - Confederations are not implemented.
 - Transparent route-server export preserves the accepted route's next hop but
   does not yet verify that the advertising client owns the wire next hop. See

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -32,13 +32,21 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 ---
 
-## RFC 1997 — NO_ADVERTISE export restriction
+## RFC 1997 — well-known community export coverage
 
 - IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS SAFI 71/72
   routes carrying `NO_ADVERTISE` are ineligible before export policy, and the
   post-policy route is checked again before Adj-RIB-Out commit. A permit policy
   cannot remove the community to bypass the restriction; a policy that adds it
   suppresses the modified route.
+- `NO_ADVERTISE` is currently the only RFC 1997 well-known community with
+  built-in egress enforcement. `NO_EXPORT` (0xFFFFFF01) and
+  `NO_EXPORT_SUBCONFED` (0xFFFFFF03) are matchable and settable in policy but
+  are not enforced at egress: routes carrying either community are accepted
+  and re-advertised to eBGP peers. Note that the RFC 9494 §4.6 intra-AS form
+  attaches `NO_EXPORT` (with `LOCAL_PREF` 0) to LLGR-stale routes advertised
+  to iBGP peers and relies on the receiving speaker to honor it — a downstream
+  rustbgpd does not yet provide that containment itself.
 - The same predicate covers single-best plus Add-Path for unicast, VPN, and
   labeled routes; grouped/private and RFC 7947 per-client-best shapes apply to
   unicast, grouped/private applies to VPN, and RFC 9107 ORR applies to unicast
@@ -47,9 +55,22 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   cleared.
 - Add-Path and per-client-best remove scoped candidates before ranking, so
   surviving siblings compact normally. They also skip policy-modified
-  candidates whose result carries `NO_ADVERTISE`. ORR first selects its
-  per-vantage best and suppresses that winner without falling back to a
-  different route, whether the community arrived on the source or from policy.
+  candidates whose result carries `NO_ADVERTISE`. ORR single-best first
+  selects its per-vantage best and suppresses that winner without falling back
+  to a different route, whether the community arrived on the source or from
+  policy. Ranked ORR is the asymmetric case: an Add-Path peer bound to a
+  vantage ranks with the ORR comparator over candidates already filtered for
+  `NO_ADVERTISE`, so the runner-up fills the vacated rank — the no-fallback
+  shape applies only to ORR single-best.
+- For RTC (SAFI 132), `NO_ADVERTISE` suppression has a wider blast radius than
+  for other families. An RT-membership NLRI suppressed by community policy is
+  withdrawn like any other route, and a receiver that filters VPN
+  advertisements by RT-Constrain membership then prunes every VPN route
+  carrying that Route Target; rustbgpd's own RFC 4684 outbound gate reacts the
+  same way toward a peer whose membership no longer covers an RT. The
+  mechanics are correct and fail-closed — the amplification is inherent to
+  SAFI 132, where one NLRI stands for the whole class of VPN routes carrying
+  that RT.
 - `NO_ADVERTISE` enforcement for EVPN and FlowSpec remains deferred.
 
 ---
@@ -669,6 +690,9 @@ Capability code 76 implements the tuple format from the expired
 `draft-abraitis-idr-addpath-paths-limit-04`. Each AFI/SAFI receiver preference
 is applied only to the matching negotiated Add-Path send direction. This is an
 experimental interoperability feature, not an adopted IETF standard.
+Enforcement is send-side only: rustbgpd caps what it sends at the peer's
+advertised limit but does not police received paths against its own
+advertised limit — the draft places that obligation on the sender.
 Neighbor output orders rows by numeric AFI/SAFI and carries an optional
 normalized limit whose presence distinguishes active unlimited from inactive,
 while retaining the legacy raw unlimited sentinel for rolling compatibility.

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -56,7 +56,10 @@ Everything not selected remains the authoritative remainder; the algorithm
 does not recursively find a second cohort. The local repeated-pair preflight is
 O(targets squared) in the worst case; after it finds a possible pair, the
 Established-state selection pass is linear in targets and issues at most one
-session query per locally eligible candidate.
+session query per locally eligible candidate. Those queries run sequentially
+and each is bounded by the 100 ms peer-query timeout, so a fleet of wedged
+sessions costs up to one timeout per candidate while the PeerManager actor
+services only its readiness lane.
 
 The policy cohort is not a wire-equivalence cohort. RibManager independently
 revalidates update-group source and destination, clean state, live session and
@@ -68,8 +71,11 @@ most eight wire cohorts per update group. A profile beyond that bound takes
 the ordinary exact-probe path rather than growing retained state.
 
 The fast RIB path accepts only clean, grouped-to-grouped, plain single-best
-unicast members moving across one source/destination group pair. Dirty or
-forced members, Add-Path, per-client-best, ORF, RTC, VPN or other private
+unicast members moving across one source/destination group pair. Clean
+requires zero policy-filtered routes in both the source and destination
+groups, so the fast path covers only permit-set-preserving (attribute-only)
+policy changes; a policy that filters even one route always falls back. Dirty
+or forced members, Add-Path, per-client-best, ORF, RTC, VPN or other private
 family state, selection gates, stale generations, closed or saturated writer
 channels, and exact-export rejection cause a fail-closed handoff before the
 first optimized emission. PeerManager then performs ordinary authoritative


### PR DESCRIPTION
Documentation-only corrections: RFC 1997 well-known community export coverage (NO_EXPORT/NO_EXPORT_SUBCONFED currently unenforced at egress, RTC suppression blast radius, Paths-Limit send-side scope, ORR single-best vs ranked asymmetry), the BGP-LS per-scope trust boundary in LIMITATIONS, the blackhole propagation escape-hatch note in CONFIGURATION, and two ADR-0105 clarifications (fast-path clean predicate, cohort-mask query bounds). Every statement verified against current code.