### PR TITLE
docs: record shipped stabilization milestones and refresh parity notes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ those.
 | EVPN-VXLAN: multi-homing (ESI, Type-1/4, DF election, BUM suppression, aliasing ECMP) | Partial (alpha) | Production-default enforcement with opt-out |
 | EVPN-VXLAN: symmetric IRB (Type-5 / L3VNI, 9136 §4.4.2) | Partial (alpha) | Receive-side GW-IP overlay-index recursion shipped; native GW-IP + ESI overlay-index origination shipped; single-active ESI overlay-index receive v1 shipped; all-active ESI overlay-index Type 5 writer shipped with same-host netns proof and M72 real-peer proof (ADR-0087/0090, FRR consume-side M68 for GW-IP, GoBGP receive-side M71 for single-active ESI recursion, GoBGP ×2 receive-side M72 for all-active ESI recursion) |
 | FIB / dataplane: unicast Linux FIB install, ECMP, weighted multipath, BLACKHOLE discard | Shipped | Opt-in `[[fib_tables]]` (ADR-0061/0066/0068) |
-| Security: TCP MD5, GTSM, static TCP-AO, native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop (M43); ADR-0064 authz |
+| Security: TCP MD5, GTSM, TCP-AO keyrings + live successor rotation (selection/deletion restart-required), native gRPC mTLS + tier authz | Shipped | TCP-AO BIRD-interop incl. live rotation (M43); ADR-0064 authz |
 | RPKI origin validation (6811 + 8210) | Partial | VRP table and policy match shipped; RTR epoch/reconnect-retention/identity/transaction-bound corrections shipped; M84 multi-cache RTR/ASPA epoch conformance lab shipped |
 | ASPA verification | Partial | Role-aware verification and policy match shipped; RTR v2 replacement/withdrawal semantics shipped; M84 RTR/ASPA epoch conformance lab shipped |
 | Policy: prefix lists, named chains, actions, community/AS_PATH/validation match | Shipped | GoBGP-style chain evaluation |
@@ -225,9 +225,18 @@ new AFI/SAFI and EVPN dataplane expansion.
 - **Make changed-policy reload the primary performance program.** The corrected
   700-client × 400,400-route mixed run is now measured: shared cohort work cuts
   median completion p50 116.185x and median completion maximum 149.261x, while
-  full-fleet delivery gaps regress 2.070x / 2.899x. Chunk member resync next so
-  queries and churn interleave, then gate repeated heterogeneous reloads on
-  completion time, control-query latency, session continuity, and folded
+  full-fleet delivery gaps regress 2.070x / 2.899x. The shared-cohort speedup
+  applies to permit-set-preserving (attribute-only) reloads — a policy that
+  filters even one route takes the authoritative fallback path. Member resync
+  and the post-commit flush are now chunked (#935: commit/flush at most eight
+  members per actor poll, dirty resync at most eight peers per tick); post-fix
+  the reload `/readyz` peak at the 500-client × 1M shape fell from 1.6–2.4 s
+  to ~360 ms
+  ([the reload-flush envelope receipt](docs/perf/reload-flush-envelope-2026-07.md)).
+  Remaining: rerun the corrected uniform-fleet receipt (unblocked by the flush
+  fix and the harness completion-detection fix), bound the transport-side
+  encode wake storm, then gate repeated heterogeneous reloads on completion
+  time, control-query latency, session continuity, and folded
   advertised-state equivalence. The withdrawn historical `< 1 s` claim remains
   superseded by the corrected raw receipt, not revived.
 - **Expose groupability before apply.** Config transaction planning now projects
@@ -252,9 +261,11 @@ new AFI/SAFI and EVPN dataplane expansion.
   shadow or canary run with explained differences, exact sanitized inputs, and
   an operator-readable rollback record.
 - **Tighten lifecycle security without reopening scope.** Preserve the shipped
-  unprivileged base service and opt-in dataplane capability profile; finish
-  typed API-error migration and decide the v1 posture for received eBGP-only
-  attributes. Management-plane bearer and mTLS bytes behind unchanged paths now
+  unprivileged base service and opt-in dataplane capability profile. The typed
+  API-error migration is complete (#898 closed the last API-visible stringly
+  seam), and the v1 posture for received eBGP-only attributes is decided:
+  eBGP-received LOCAL_PREF is ignored on ingress (#836). Management-plane
+  bearer and mTLS bytes behind unchanged paths now
   rotate atomically on SIGHUP; listener, path, auth-mode, principal, role, and
   access changes remain restart-required. Privilege separation remains a
   larger architectural choice, not a release-checkbox claim.
@@ -263,19 +274,20 @@ new AFI/SAFI and EVPN dataplane expansion.
   proposed opt-in strict-peer pilot. Bind its identity to the live session
   generation; same-AS alternate next hops and explicit authorization remain
   later modes behind a generation-consistent fleet inventory.
-- **Quantify the single-owner RIB actor ceiling before committing to sharding.**
-  The exact-export precommit and the grouped policy transition moved more
-  synchronous work onto the single `RibManager` actor — two un-chunked O(table)
-  snapshot polls plus an O(outbound-peers + table × dirty/forced-peers) finalize
-  tail, recorded as explicit bounds in ADR-0105.
-  `bgp_rib_policy_transition_actor_poll_duration_seconds` now instruments it, but
-  no run has exercised it at internet-table scale. Measure the worst-case actor
-  poll under a ~1M-route reload/churn to settle whether a single poll can exceed
-  the readiness deadline and to produce the named-workload number that gates
-  ADR-0100 parallel-RibManager (LAN-433). Sharding stays measurement-gated; the
-  cheaper alternative — chunking the two snapshot polls — is the first candidate
-  if a poll breaches readiness but the end-to-end evidence still does not justify
-  sharding.
+- **Single-owner RIB actor ceiling: measured at 1M; sharding stays unjustified.**
+  The named-workload number that gates ADR-0100 parallel-RibManager exists
+  ([the 1M actor-ceiling receipt](docs/perf/actor-ceiling-1m-2026-07.md),
+  LAN-433): at 500 route-server clients × 1M routes × 300 changed peers, the
+  worst policy-transition actor poll was 0.1–0.2 s — under the 200 ms readiness
+  deadline. The depool observed there was driven by the un-chunked post-commit
+  flush, fixed by cooperative `CommitMembers` batching (#935, at most eight
+  members per poll); post-fix every commit poll stays within the readiness
+  deadline and the reload `/readyz` peak fell from 1.6–2.4 s to ~360 ms at 1M
+  (post-fix section of
+  [the reload-flush envelope receipt](docs/perf/reload-flush-envelope-2026-07.md)).
+  The residual peak is the transport-side encode wake storm, tracked
+  separately. ADR-0100 sharding remains unjustified by this evidence at this
+  scale; the trigger stays open for evidence beyond it.
 - **Prove recently hardened transition paths against independent stacks before
   broadening support claims.** Live TCP-AO rotation (M43) and GR helper /
   graceful shutdown (M11/M35) have real-peer labs, but graceful-restart

--- a/docs/adr/0100-parallel-rib-manager.md
+++ b/docs/adr/0100-parallel-rib-manager.md
@@ -6,6 +6,14 @@
 **Repo:** rustbgpd, main ≥ `21a5ffaa`. Design only; nothing implemented.
 **Inputs:** `docs/perf/scale-receipt-2026-07.md` (measured), scratchpad `cpu-flamegraph-2026-07-03.md` (measured), ADR-0098/0099 (invariants), code read at HEAD.
 
+**Update (2026-07):** the gating question was answered at 1M-route /
+500-peer scale by [the actor-ceiling receipt](../perf/actor-ceiling-1m-2026-07.md):
+the worst policy-transition actor poll was 0.1–0.2 s, under the 200 ms
+readiness deadline. The depool observed in that run was the un-chunked
+post-commit flush, fixed by cooperative commit batching (#935), not a
+sharding candidate. This ADR is not rejected — the trigger stays open for
+evidence beyond that scale.
+
 ## 0. The measured starting point (facts, not estimates)
 
 - 1000 RR clients × 100k routes cold convergence: **1.80 s staged / 1.82 s wire** (`docs/perf/scale-receipt-2026-07.md`, commit `b26ff11c`). Wire trails staged by ≤ 25 ms at every point → **the single-threaded manager task is the wall-clock gate**; the 1000 session tasks (prepare+encode 42%, writer 37% of RR CPU) already parallelize across cores and keep pace.

--- a/docs/gobgp-parity.md
+++ b/docs/gobgp-parity.md
@@ -14,6 +14,13 @@ Extended Messages support was added in v4.7.0. Verified 2026-07-12. These are
 upstream capability claims, not rustbgpd interoperability receipts; receipts
 are identified explicitly where they exist.
 
+One trajectory caveat: GoBGP merged outbound UPDATE coalescing and
+table-scale improvements in early 2026
+([osrg/gobgp#3332](https://github.com/osrg/gobgp/pull/3332),
+[osrg/gobgp#3333](https://github.com/osrg/gobgp/pull/3333)), so scale and
+performance comparisons against GoBGP should be re-validated against current
+releases rather than carried forward from older measurements.
+
 ## Address Families
 
 | Feature | GoBGP | rustbgpd | Notes |
@@ -49,6 +56,7 @@ are identified explicitly where they exist.
 | Enhanced Route Refresh (RFC 7313) | Yes | Yes | `BoRR` / `EoRR` demarcation; inbound replacement semantics on `SoftResetIn` |
 | Prefix ORF (RFC 5291/5292) | No | Receive | GoBGP defines no ORF capability (code 3 absent from `bgp.go`). rustbgpd receive side for Address-Prefix ORF is shipped (route-server export filtering); send-side ORF remains deferred |
 | Add-Path (RFC 7911) | Yes | Yes | Dual-stack receive + multi-path send (route server mode) |
+| Add-Path Paths-Limit (capability 76, expired `draft-abraitis-idr-addpath-paths-limit-04`) | No | Experimental | rustbgpd advertises a per-family receiver preference and honors received code-76 tuples as outbound Add-Path send caps; real-FRR interop receipt (M89); explicitly experimental, outside the v1 contract. GoBGP does not implement it (open feature request osrg/gobgp#2786 since March 2024) |
 | Route Reflector (RFC 4456) | Yes | Yes | |
 | Confederation (RFC 5065) | Yes | No | |
 | Extended Messages (RFC 8654) | Yes | Yes | GoBGP upstream support was added in v4.7.0; no rustbgpd/GoBGP interop receipt is claimed here |


### PR DESCRIPTION
Docs true-up against merged code and receipts. Eight items were checked; six edits landed, two were already present at HEAD.

1. **ROADMAP — single-owner RIB actor ceiling**: the measurement is done. Rewritten to record the 1M receipt (`docs/perf/actor-ceiling-1m-2026-07.md`): 500 clients x 1M routes x 300 changed, worst transition poll 0.1-0.2 s, under the 200 ms readiness deadline; the depool driver was the un-chunked post-commit flush, fixed by cooperative CommitMembers batching (#935); post-fix `/readyz` peak ~360 ms at 1M; residual is the transport-side encode wake storm; ADR-0100 sharding stays unjustified at this scale.

2. **ROADMAP — changed-policy reload program**: "chunk member resync next" is shipped (#935: commit/flush <=8 members per poll, dirty resync <=8 peers per tick) with the post-fix numbers; remaining program is the corrected uniform-fleet receipt rerun and the encode wake-storm bound. Added the bounding sentence that the shared-cohort speedup covers permit-set-preserving (attribute-only) reloads only. The withdrawn `< 1 s` sentence is kept.

3. **ROADMAP — lifecycle security**: typed API-error migration recorded complete (#898) and the v1 eBGP-only-attribute posture recorded decided (eBGP LOCAL_PREF ignored on ingress, #836). SIGHUP-rotation and restart-required sentences unchanged.

4. **ROADMAP status table**: "static TCP-AO" replaced with "TCP-AO keyrings + live successor rotation (selection/deletion restart-required)" per #863/#870/#882 and the M43 receipt (which covers live rotation).

5. **ADR-0100**: added a measurement-gate update — the gating question was answered at 1M/500-peer scale by the actor-ceiling receipt; the observed depool was the commit flush, fixed by chunking (#935); the ADR is not rejected and its trigger stays open beyond that scale.

6. **ADR-0105**: skipped — both the fast-path zero-policy-filtered bound and the 100 ms sequential peer-query note are already present (added in #938).

7. **CHANGELOG [Unreleased]**: skipped — the `/readyz` hard-deadline Fixed entry (#937) and the fenced-continuation route-paging Added entry (#939) both landed with their PRs.

8. **docs/gobgp-parity.md**: added an Add-Path Paths-Limit row (rustbgpd: experimental capability 76, real-FRR receipt M89; GoBGP: not implemented, open feature request osrg/gobgp#2786 since March 2024) and a one-line trajectory caveat noting GoBGP's early-2026 update-coalescing and table-scale improvements (osrg/gobgp#3332/#3333), so scale comparisons should be re-validated against current releases.

Upstream citations verified against GitHub: osrg/gobgp#2786 open since 2024-03-20; #3332 merged 2026-03-17; #3333 landed on master via maintainer rebase-squash-merge in April 2026.

Gates: `cargo fmt --all -- --check` clean; diff scanned for host identifiers and absolute paths (none).