### PR TITLE
fix(config): redact secret-bearing lines from parse diagnostics and snapshot token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   live policy-filtered observability (route events, transition-based) as an
   export-policy deny; previously only export explain covered it.
 
+- **Parse diagnostics no longer echo credential-bearing config lines.** When a
+  TOML error's snippet line — or the line immediately before it, for
+  unterminated-quote spans — mentions `md5_password` or TCP-AO key material,
+  the rendered diagnostic replaces the source line with a redaction placeholder
+  and collapses the caret run (whose width would reveal the secret's length),
+  while keeping the file/line/column pointer. This covers the SIGHUP reload
+  log, daemon stderr, and the `DiffRuntimeConfig`/`PlanConfigTransaction` gRPC
+  statuses in one place. The runtime snapshot token also drops its
+  config-rendering byte-length component (the rendering includes plaintext
+  secrets); tokens stay process-local equality tokens under the same keyed
+  digest. `Neighbor`, `PeerGroupConfig`, and `RuntimeConfigSnapshotReply` gain
+  manual `Debug` impls that redact `md5_password` and the runtime TOML, and
+  management-plane credential reads (bearer token, TLS private key) plus
+  retired `BearerAuthSecret` generations are zeroized on drop.
+
 - **Shutdown GR marker publication and warm-bundle maintenance can no longer
   wedge or wedge-loop.** GR restart marker publication, its generationless
   fallback, and marker removal at coordinated shutdown now run on a detached

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,6 +2854,7 @@ dependencies = [
  "tower",
  "tracing",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -43,6 +43,7 @@ bytes.workspace = true
 x509-parser.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
+zeroize.workspace = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true

--- a/crates/api/src/authz_runtime/context.rs
+++ b/crates/api/src/authz_runtime/context.rs
@@ -278,6 +278,18 @@ impl fmt::Debug for BearerAuthSecret {
     }
 }
 
+impl Drop for BearerAuthSecret {
+    fn drop(&mut self) {
+        // The shared header can only be scrubbed through the last live Arc;
+        // earlier clone drops are no-ops, so retired credential generations
+        // are zeroized when their final holder (e.g. a pinned RPC snapshot)
+        // goes away, not at rotation time.
+        if let Some(header) = Arc::get_mut(&mut self.expected_header) {
+            zeroize::Zeroize::zeroize(header);
+        }
+    }
+}
+
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     let max_len = a.len().max(b.len());
     let mut diff = a.len() ^ b.len();

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -9,6 +9,7 @@ use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
+use zeroize::Zeroizing;
 
 use crate::authz_runtime::BearerAuthSecret;
 
@@ -152,13 +153,15 @@ fn stage_listener(index: usize, source: &CredentialSource) -> Result<ListenerCre
         .token_file
         .as_ref()
         .map(|path| {
-            let token = fs::read_to_string(path).map_err(|e| {
+            // Zeroizing scrubs this transient read when it drops; the
+            // retained copy inside `BearerAuthSecret` scrubs on its own drop.
+            let raw = Zeroizing::new(fs::read_to_string(path).map_err(|e| {
                 format!(
                     "listener {index}: failed to read token file {}: {e}",
                     path.display()
                 )
-            })?;
-            let token = token.trim_end();
+            })?);
+            let token = raw.trim_end();
             if token.is_empty() {
                 return Err(format!(
                     "listener {index}: token file {} is empty",
@@ -176,13 +179,15 @@ fn stage_listener(index: usize, source: &CredentialSource) -> Result<ListenerCre
     Ok(ListenerCredentials { bearer, tls })
 }
 
-fn read_file(index: usize, label: &str, path: &Path) -> Result<Vec<u8>, String> {
-    let bytes = fs::read(path).map_err(|e| {
+/// Read a credential file into a buffer that is scrubbed on drop (the TLS
+/// private key in particular must not linger in freed heap after parsing).
+fn read_file(index: usize, label: &str, path: &Path) -> Result<Zeroizing<Vec<u8>>, String> {
+    let bytes = Zeroizing::new(fs::read(path).map_err(|e| {
         format!(
             "listener {index}: failed to read {label} file {}: {e}",
             path.display()
         )
-    })?;
+    })?);
     if bytes.is_empty() {
         return Err(format!(
             "listener {index}: {label} file {} is empty",

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -542,7 +542,7 @@ pub struct ResolvedPeerPolicy {
 /// Reply payload of [`PeerManagerCommand::RuntimeConfigSnapshot`]: the
 /// normalized runtime TOML plus the live compiled `.rpol` registry
 /// (which the TOML deliberately excludes — see the command docs).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RuntimeConfigSnapshotReply {
     /// Normalized TOML for the current runtime snapshot.
     pub toml: String,
@@ -550,6 +550,18 @@ pub struct RuntimeConfigSnapshotReply {
     pub rpol_files: Vec<String>,
     /// Live compiled `.rpol` policy registry.
     pub rpol: rustbgpd_policy::rpol::RpolPolicySet,
+}
+
+// Manual Debug: the runtime TOML carries live secret material
+// (`md5_password`, `tcp_ao` keys) and must never be rendered.
+impl std::fmt::Debug for RuntimeConfigSnapshotReply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeConfigSnapshotReply")
+            .field("toml", &"<redacted>")
+            .field("rpol_files", &self.rpol_files)
+            .field("rpol", &self.rpol)
+            .finish()
+    }
 }
 
 /// Current static-session negotiation identity captured for one coordinated
@@ -1961,4 +1973,20 @@ pub struct PolicyDatasetStatusRow {
     pub status: rustbgpd_policy::datasets::DatasetStatus,
     /// Bound snapshot file path (`[policy.datasets.<name>].path`).
     pub path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn runtime_config_snapshot_reply_debug_redacts_toml() {
+        let reply = super::RuntimeConfigSnapshotReply {
+            toml: "md5_password = \"hunter2-secret\"".to_string(),
+            rpol_files: vec!["/etc/rustbgpd/policy.rpol".to_string()],
+            rpol: rustbgpd_policy::rpol::RpolPolicySet::default(),
+        };
+        let rendered = format!("{reply:?}");
+        assert!(!rendered.contains("hunter2-secret"), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        assert!(rendered.contains("policy.rpol"), "{rendered}");
+    }
 }

--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -114,6 +114,20 @@ fn error_span_and_label(source: &str, error: &ConfigError) -> Option<(Range<usiz
     }
 }
 
+/// True when a source line may carry secret material and must not be echoed
+/// in a diagnostic. Keep in sync with the fields `Config::effective_redacted`
+/// masks: `md5_password` and TCP-AO `key` material (which renders either on a
+/// line mentioning `tcp_ao` or as a bare `key = "..."` line inside a
+/// `tcp_ao` table).
+fn line_mentions_secret(line: &str) -> bool {
+    line.contains("md5_password")
+        || line.contains("tcp_ao")
+        || line
+            .trim_start()
+            .strip_prefix("key")
+            .is_some_and(|rest| rest.trim_start().starts_with('='))
+}
+
 /// Render a source snippet with an underlined span, rustc-style.
 fn render_snippet(
     source: &str,
@@ -139,17 +153,41 @@ fn render_snippet(
     let line_num_width = line_num.to_string().len();
     let pad = " ".repeat(line_num_width);
 
+    // A parse error's span can land on the line after the secret it belongs
+    // to (an unterminated quote on `md5_password = "...` reports at the next
+    // line), so check the immediately preceding line too and redact
+    // conservatively.
+    let prev_text = if line_start == 0 {
+        ""
+    } else {
+        let prev_end = line_start - 1;
+        let prev_start = source[..prev_end].rfind('\n').map_or(0, |i| i + 1);
+        &source[prev_start..prev_end]
+    };
+    let redact = line_mentions_secret(line_text) || line_mentions_secret(prev_text);
+
     let mut out = String::new();
     let _ = writeln!(out, "error: {heading}");
     let _ = writeln!(out, "{pad} --> {path}:{line_num}:{col}");
     let _ = writeln!(out, "{pad} |");
-    let _ = writeln!(out, "{line_num} | {line_text}");
-    let _ = write!(
-        out,
-        "{pad} | {}{} {label}",
-        " ".repeat(col - 1),
-        "^".repeat(underline_len),
-    );
+    if redact {
+        // Never echo the source line; a caret run sized to the span would
+        // reveal the secret's length, so collapse the underline too. The
+        // line:column in the arrow line keeps the error actionable.
+        let _ = writeln!(
+            out,
+            "{line_num} | <line contains sensitive material, redacted>"
+        );
+        let _ = write!(out, "{pad} | ^ {label}");
+    } else {
+        let _ = writeln!(out, "{line_num} | {line_text}");
+        let _ = write!(
+            out,
+            "{pad} | {}{} {label}",
+            " ".repeat(col - 1),
+            "^".repeat(underline_len),
+        );
+    }
     out
 }
 
@@ -380,6 +418,62 @@ log_format = \"text\"
         assert!(output.contains("--> test.toml:3:"), "got: {output}");
         assert!(output.contains("hold_time = 2"), "got: {output}");
         assert!(output.contains("^ must be >= 3"), "got: {output}");
+    }
+
+    #[test]
+    fn parse_error_snippet_redacts_md5_password_line() {
+        // Unterminated quote: the secret sits on the reported line or the
+        // line before it; neither may be echoed.
+        let source = "\
+[global]
+asn = 65000
+router_id = \"1.2.3.4\"
+
+[[neighbors]]
+address = \"10.0.0.1\"
+remote_asn = 65001
+md5_password = \"hunter2-secret
+hold_time = 90
+";
+        let err: ConfigError = toml::from_str::<super::super::Config>(source)
+            .unwrap_err()
+            .into();
+        let rendered = render_diagnostic(source, "config.toml", &err).unwrap();
+        assert!(!rendered.contains("hunter2-secret"), "got: {rendered}");
+        assert!(rendered.contains("redacted"), "got: {rendered}");
+        assert!(
+            rendered.contains("config.toml:8:") || rendered.contains("config.toml:9:"),
+            "got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn parse_error_snippet_redacts_tcp_ao_key_line() {
+        let source = "\
+[global]
+asn = 65000
+router_id = \"1.2.3.4\"
+
+[[neighbors]]
+address = \"10.0.0.1\"
+remote_asn = 65001
+
+[neighbors.tcp_ao]
+key = \"s3cr3t-ao-key
+send_id = 1
+recv_id = 2
+algorithm = \"hmac(sha256)\"
+";
+        let err: ConfigError = toml::from_str::<super::super::Config>(source)
+            .unwrap_err()
+            .into();
+        let rendered = render_diagnostic(source, "config.toml", &err).unwrap();
+        assert!(!rendered.contains("s3cr3t-ao-key"), "got: {rendered}");
+        assert!(rendered.contains("redacted"), "got: {rendered}");
+        assert!(
+            rendered.contains("config.toml:10:") || rendered.contains("config.toml:11:"),
+            "got: {rendered}"
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2908,14 +2908,16 @@ impl RuntimeSnapshotKey {
         hasher.write_usize(context.len());
         hasher.write(context);
         let digest = hasher.finish();
+        // The token deliberately carries no length of the normalized
+        // rendering: that length varies with secret bytes (md5_password,
+        // tcp_ao keys), so encoding it would leak secret length to any
+        // token holder. Tokens are only equality-compared against tokens
+        // minted by this same in-process key, so the keyed digest alone is
+        // the change detector.
         if context.is_empty() {
-            Ok(format!("kv1:{digest:016x}:{}", normalized.len()))
+            Ok(format!("kv1:{digest:016x}"))
         } else {
-            Ok(format!(
-                "kv2:{digest:016x}:{}:{}",
-                normalized.len(),
-                context.len()
-            ))
+            Ok(format!("kv2:{digest:016x}:{}", context.len()))
         }
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -670,7 +670,7 @@ fn default_grpc_uds_mode() -> u32 {
     0o600
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Neighbor {
     /// Peer IP address (IPv4 or IPv6).
@@ -805,6 +805,54 @@ pub struct Neighbor {
     pub export_policy_chain: Vec<String>,
 }
 
+// Manual Debug: never render `md5_password` (mirrors `TcpAoConfig`; the
+// `tcp_ao` field redacts through `TcpAoConfig`'s own Debug).
+impl fmt::Debug for Neighbor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Neighbor")
+            .field("address", &self.address)
+            .field("interface", &self.interface)
+            .field("remote_asn", &self.remote_asn)
+            .field("description", &self.description)
+            .field("peer_group", &self.peer_group)
+            .field("hold_time", &self.hold_time)
+            .field("send_hold_time", &self.send_hold_time)
+            .field("max_prefixes", &self.max_prefixes)
+            .field("max_prefixes_ipv4", &self.max_prefixes_ipv4)
+            .field("max_prefixes_ipv6", &self.max_prefixes_ipv6)
+            .field(
+                "md5_password",
+                &self.md5_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field("tcp_ao", &self.tcp_ao)
+            .field("bfd", &self.bfd)
+            .field("ttl_security", &self.ttl_security)
+            .field("families", &self.families)
+            .field("graceful_restart", &self.graceful_restart)
+            .field("gr_restart_time", &self.gr_restart_time)
+            .field("gr_stale_routes_time", &self.gr_stale_routes_time)
+            .field("llgr_stale_time", &self.llgr_stale_time)
+            .field("local_ipv6_nexthop", &self.local_ipv6_nexthop)
+            .field("route_reflector_client", &self.route_reflector_client)
+            .field("orr_vantage", &self.orr_vantage)
+            .field("route_server_client", &self.route_server_client)
+            .field("per_client_best", &self.per_client_best)
+            .field("interpret_rfc1997", &self.interpret_rfc1997)
+            .field("role", &self.role)
+            .field("strict_role", &self.strict_role)
+            .field("prefix_orf_receive", &self.prefix_orf_receive)
+            .field("disable_ipv4_unicast", &self.disable_ipv4_unicast)
+            .field("remove_private_as", &self.remove_private_as)
+            .field("add_path", &self.add_path)
+            .field("log_level", &self.log_level)
+            .field("import_policy", &self.import_policy)
+            .field("export_policy", &self.export_policy)
+            .field("import_policy_chain", &self.import_policy_chain)
+            .field("export_policy_chain", &self.export_policy_chain)
+            .finish()
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TcpAoConfig {
@@ -925,7 +973,7 @@ impl Serialize for TcpAoKeyringConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PeerGroupConfig {
     /// Hold time inherited by neighbors in this group. See the
@@ -1012,6 +1060,47 @@ pub struct PeerGroupConfig {
     /// Named policy chain for export (mutually exclusive with `export_policy`).
     #[serde(default)]
     pub export_policy_chain: Vec<String>,
+}
+
+// Manual Debug: never render `md5_password` (mirrors `TcpAoConfig`).
+impl fmt::Debug for PeerGroupConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PeerGroupConfig")
+            .field("hold_time", &self.hold_time)
+            .field("send_hold_time", &self.send_hold_time)
+            .field("max_prefixes", &self.max_prefixes)
+            .field("max_prefixes_ipv4", &self.max_prefixes_ipv4)
+            .field("max_prefixes_ipv6", &self.max_prefixes_ipv6)
+            .field(
+                "md5_password",
+                &self.md5_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field("ttl_security", &self.ttl_security)
+            .field("bfd", &self.bfd)
+            .field("families", &self.families)
+            .field("graceful_restart", &self.graceful_restart)
+            .field("gr_restart_time", &self.gr_restart_time)
+            .field("gr_stale_routes_time", &self.gr_stale_routes_time)
+            .field("llgr_stale_time", &self.llgr_stale_time)
+            .field("local_ipv6_nexthop", &self.local_ipv6_nexthop)
+            .field("route_reflector_client", &self.route_reflector_client)
+            .field("orr_vantage", &self.orr_vantage)
+            .field("route_server_client", &self.route_server_client)
+            .field("per_client_best", &self.per_client_best)
+            .field("interpret_rfc1997", &self.interpret_rfc1997)
+            .field("role", &self.role)
+            .field("strict_role", &self.strict_role)
+            .field("prefix_orf_receive", &self.prefix_orf_receive)
+            .field("disable_ipv4_unicast", &self.disable_ipv4_unicast)
+            .field("remove_private_as", &self.remove_private_as)
+            .field("add_path", &self.add_path)
+            .field("log_level", &self.log_level)
+            .field("import_policy", &self.import_policy)
+            .field("export_policy", &self.export_policy)
+            .field("import_policy_chain", &self.import_policy_chain)
+            .field("export_policy_chain", &self.export_policy_chain)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -10640,6 +10640,41 @@ fn runtime_snapshot_token_changes_when_only_a_secret_rotates() {
 }
 
 #[test]
+fn runtime_snapshot_token_does_not_encode_config_length() {
+    // The normalized rendering includes plaintext secrets, so its byte
+    // length must not appear in the token: configs whose secrets differ
+    // only in length yield same-shape, digest-only tokens.
+    let mut short = parse(valid_toml()).unwrap();
+    short.neighbors[0].md5_password = Some("s".to_string());
+    let mut long = short.clone();
+    long.neighbors[0].md5_password = Some("s".repeat(64));
+
+    let key = RuntimeSnapshotKey::random();
+    let token_short = key.token(&short).unwrap();
+    let token_long = key.token(&long).unwrap();
+    assert_eq!(token_short.len(), "kv1:".len() + 16, "{token_short}");
+    assert_eq!(token_short.len(), token_long.len());
+    assert_ne!(token_short, token_long);
+}
+
+#[test]
+fn neighbor_and_peer_group_debug_redact_md5_password() {
+    let mut config = parse(valid_toml()).unwrap();
+    config.neighbors[0].md5_password = Some("hunter2-secret".to_string());
+    let rendered = format!("{:?}", config.neighbors[0]);
+    assert!(!rendered.contains("hunter2-secret"), "{rendered}");
+    assert!(rendered.contains("<redacted>"), "{rendered}");
+
+    let group = PeerGroupConfig {
+        md5_password: Some("hunter2-secret".to_string()),
+        ..PeerGroupConfig::default()
+    };
+    let rendered = format!("{group:?}");
+    assert!(!rendered.contains("hunter2-secret"), "{rendered}");
+    assert!(rendered.contains("<redacted>"), "{rendered}");
+}
+
+#[test]
 fn runtime_snapshot_token_differs_across_keys() {
     // The token is keyed: a caller who does not hold the per-process key cannot
     // reproduce the digest for a known config. That is what closes the


### PR DESCRIPTION
Four changes so that credential material (`md5_password`, TCP-AO keys, bearer tokens, TLS private keys) never appears in diagnostics, tokens, `Debug` output, or lingers in freed heap.

## Parse diagnostics no longer echo credential-bearing source lines

`render_snippet` printed the source line at an error span verbatim, so a TOML syntax error on or near an `md5_password = "..."` or `tcp_ao` key line reproduced the plaintext secret in the SIGHUP reload log, daemon stderr, and the `DiffRuntimeConfig`/`PlanConfigTransaction` gRPC statuses. The snippet renderer now redacts the echoed line when it — or the immediately preceding line, since an unterminated quote reports its span on the following line — mentions `md5_password`, `tcp_ao`, or a bare `key = ...` assignment (the TCP-AO key field). The redacted form keeps the `file:line:col` pointer and the label, and collapses the caret run to a single `^` so the underline width cannot reveal the secret's length:

```
error: failed to parse config
  --> config.toml:8:29
  |
8 | <line contains sensitive material, redacted>
  | ^ invalid basic string
```

Fixed once at the diagnostic layer, which every consumer (reload, startup stderr, gRPC candidate validation) routes through. The secret-key list mirrors the fields `Config::effective_redacted` masks.

## Snapshot token no longer encodes the config rendering's byte length

`RuntimeSnapshotKey::token_with_context` appended `normalized.len()` to the token, and the normalized rendering includes plaintext secrets — so the token exposed how secret lengths change across rotations. The length component is dropped rather than recomputed over a redacted rendering: tokens are process-local and only ever equality-compared against tokens minted by the same in-process key (plan/apply optimistic concurrency in `peer_manager/reconcile.rs`), so the keyed digest alone carries the change detection and nothing parses the token's shape. The `kv2` context-length component (a fixed-width live-snapshot digest, not config data) is unchanged.

## Redacted `Debug` for secret-carrying config and reply types

`Neighbor` and `PeerGroupConfig` derived `Debug` with plaintext `md5_password`; both now have manual impls that render `Some("<redacted>")`, mirroring the existing `TcpAoConfig` impl (the `tcp_ao` field already redacts through that impl). `RuntimeConfigSnapshotReply` derived `Debug` while carrying the full secret-bearing runtime TOML; its manual impl elides the `toml` field.

## Management-plane credential copies are zeroized

The bearer-token file read and the TLS credential file reads in `crates/api/src/credentials.rs` now use `Zeroizing` (zeroize is already a workspace dependency; added to `rustbgpd-api`), so the transient buffers — notably the TLS private key after rustls parses it — are scrubbed on drop. `BearerAuthSecret` gains a `Drop` impl that zeroizes its `"Bearer {token}"` header through `Arc::get_mut`; retired credential generations are scrubbed when their last holder (e.g. a pinned RPC snapshot) drops rather than at rotation time.

## Tests

- `config::diagnostic::tests::parse_error_snippet_redacts_md5_password_line`
- `config::diagnostic::tests::parse_error_snippet_redacts_tcp_ao_key_line`
- `config::tests::runtime_snapshot_token_does_not_encode_config_length`
- `config::tests::neighbor_and_peer_group_debug_redact_md5_password`
- `peer_types::tests::runtime_config_snapshot_reply_debug_redacts_toml`

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test -p rustbgpd-api` — exit 0 (444 passed)
- `cargo test --workspace` — exit 0