### PR TITLE
fix(rib): drop closed-channel peers from dirty resync so shutdown quiesces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Closed outbound channels no longer re-mark peers dirty for resync, so
+  shutdown quiesces instead of livelocking.** The outbound send path treated
+  a closed per-peer channel (session gone) the same as a full one (peer
+  slow): both re-marked the peer dirty, and the bounded dirty-resync tick
+  retried the dead channel forever — at scale each tick's export pass
+  outlasted the 10 ms backlog re-arm, so the RIB actor never returned to its
+  event loop to observe shutdown, spinning at full CPU after SIGTERM until
+  killed externally. `mark_outbound_dirty` — the single dirty-insertion
+  seam — now drops a peer's dirty state when its channel is closed or
+  deregistered, and the resync tick prunes closed-channel peers before
+  selecting its slice, so a dead backlog quiesces in one tick and the timer
+  disarms. Full session teardown remains with the `PeerDown` path. (LAN-459)
+
 - **`/readyz` now treats the 200 ms core-readiness deadline as a hard bound
   on the HTTP response.** A runtime stall (such as the post-commit outbound
   flush) could hold the probe past the deadline and then complete it, and the

--- a/crates/rib/src/manager/bench_support.rs
+++ b/crates/rib/src/manager/bench_support.rs
@@ -169,6 +169,7 @@ impl RibManager {
                 is_rr_client,
                 None,       // no ORR vantage
                 false,      // no per-client best (RS mode)
+                true,       // interpret RFC 1997 (production default)
                 Vec::new(), // no Add-Path send
                 0,
                 Vec::new(), // no negotiated receive-side ORF

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -1487,6 +1487,21 @@ impl RibManager {
     /// state and the dirty flag are committed/cleared only after a
     /// successful send, and withheld peers are not touched at all.
     fn resync_dirty_peers_bounded(&mut self) -> bool {
+        // Peers whose outbound channel is gone can never resync: drop them
+        // before selecting the slice, so a backlog of dead sessions (e.g.
+        // after shutdown tore the TCP sessions down) quiesces in one cheap
+        // tick — instead of burning an O(table) export pass per dead peer
+        // and re-arming forever, starving the shutdown observation.
+        let gone: Vec<IpAddr> = self
+            .dirty_peers
+            .iter()
+            .copied()
+            .filter(|&peer| self.outbound_channel_gone(peer))
+            .collect();
+        for peer in gone {
+            debug!(%peer, "dropping dirty peer whose outbound channel closed");
+            self.drop_gone_dirty_peer(peer);
+        }
         let withheld: Vec<IpAddr> = if self.dirty_peers.len() > RESYNC_PEERS_PER_TICK {
             let selected: HashSet<IpAddr> = self
                 .dirty_peers

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -3857,3 +3857,74 @@ async fn dirty_resync_tick_bounds_peers_and_preserves_backlog() {
         PEER_COUNT - super::super::RESYNC_PEERS_PER_TICK
     );
 }
+
+/// LAN-459 regression: a dirty backlog whose outbound channels are all
+/// closed (sessions torn down, e.g. at shutdown) must quiesce in one
+/// tick — the tick drops the dead peers instead of re-marking them, so
+/// the resync timer disarms (`dirty_peers` empty) and the actor can
+/// observe shutdown instead of re-arming forever.
+#[tokio::test]
+async fn dirty_resync_tick_drops_closed_channel_peers_and_quiesces() {
+    const PEER_COUNT: usize = 12;
+    const ROUTE_COUNT: usize = 1;
+    let (mut manager, peers, receivers) =
+        direct_clean_transition_manager(PEER_COUNT, ROUTE_COUNT, None);
+    for &peer in &peers {
+        manager.mark_outbound_dirty(peer);
+    }
+    assert_eq!(manager.dirty_peers.len(), PEER_COUNT);
+
+    // Tear down every session: the outbound receivers drop, closing the
+    // channels while the peers are still marked dirty.
+    drop(receivers);
+
+    let backlog = manager.resync_dirty_peers_bounded();
+    assert!(
+        !backlog,
+        "closed-channel peers must not be withheld as backlog"
+    );
+    assert!(
+        manager.dirty_peers.is_empty(),
+        "one tick must drop every closed-channel dirty peer so the resync timer disarms"
+    );
+    for &peer in &peers {
+        if let Some(gid) = manager.grouped_member_of(peer) {
+            assert!(
+                !manager.group_ribs[&gid].dirty_members.contains(&peer),
+                "group dirty flag must drop with the peer's dirty state"
+            );
+        }
+    }
+}
+
+/// LAN-459 regression: the send-failure retry path routes through
+/// `mark_outbound_dirty`; once a peer's channel is closed, that path
+/// must drop the peer's dirty state instead of re-inserting it — the
+/// livelock was closed channels re-marking themselves dirty on every
+/// resync attempt.
+#[tokio::test]
+async fn mark_outbound_dirty_drops_peer_with_closed_channel() {
+    const PEER_COUNT: usize = 2;
+    const ROUTE_COUNT: usize = 1;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(PEER_COUNT, ROUTE_COUNT, None);
+    let (live, dead) = (peers[0], peers[1]);
+
+    // Both channels open: both marks stick.
+    manager.mark_outbound_dirty(live);
+    manager.mark_outbound_dirty(dead);
+    assert_eq!(manager.dirty_peers.len(), PEER_COUNT);
+
+    // Close one session, then re-mark it (as the retry path would after a
+    // failed send): the mark must remove the peer, not keep it dirty.
+    drop(receivers.pop().unwrap());
+    manager.mark_outbound_dirty(dead);
+    assert!(
+        !manager.dirty_peers.contains(&dead),
+        "re-marking a closed-channel peer must drop it from the dirty set"
+    );
+    assert!(
+        manager.dirty_peers.contains(&live),
+        "an open-channel dirty peer is untouched"
+    );
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -35,7 +35,7 @@ use std::net::IpAddr;
 use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation};
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use rustc_hash::FxHashMap;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::helpers::{LOCAL_PEER, routes_equal, vpn_routes_equal};
 use super::{PolicyFilteredRouteKey, RibManager, RtcMembership};
@@ -1134,11 +1134,43 @@ impl RibManager {
         }
     }
 
+    /// Whether `peer`'s outbound channel can never accept another update:
+    /// the peer is deregistered, or its session receiver has been dropped
+    /// (the session is gone). A full-but-open channel is NOT gone — it
+    /// drains and the ordinary dirty resync retries it.
+    pub(in crate::manager) fn outbound_channel_gone(&self, peer: IpAddr) -> bool {
+        self.outbound_peers
+            .get(&peer)
+            .is_none_or(tokio::sync::mpsc::Sender::is_closed)
+    }
+
+    /// Drop a peer's dirty-resync state because its outbound channel is
+    /// gone: the resync timer must not re-arm against a channel that can
+    /// never accept — a backlog of dead sessions (e.g. after shutdown tore
+    /// the TCP sessions down) would otherwise livelock the actor loop and
+    /// block process exit. Session teardown proper stays with the
+    /// `PeerDown` path; this only stops the retry.
+    pub(in crate::manager) fn drop_gone_dirty_peer(&mut self, peer: IpAddr) {
+        self.dirty_peers.remove(&peer);
+        if let Some(gid) = self.grouped_member_of(peer)
+            && let Some(group) = self.group_ribs.get_mut(&gid)
+        {
+            group.dirty_members.remove(&peer);
+        }
+    }
+
     /// Mark a peer's outbound channel dirty for the resync timer, and —
     /// for a grouped member — flag it in its group so tombstone
     /// maintenance starts. Every `dirty_peers` insertion site routes
-    /// through here.
+    /// through here — including the send-failure retry path, so this is
+    /// where a closed channel (peer gone) is distinguished from a full
+    /// one (peer slow): only the latter may re-arm the resync timer.
     pub(in crate::manager) fn mark_outbound_dirty(&mut self, peer: IpAddr) {
+        if self.outbound_channel_gone(peer) {
+            debug!(%peer, "outbound channel closed — dropping dirty state instead of re-marking");
+            self.drop_gone_dirty_peer(peer);
+            return;
+        }
         self.dirty_peers.insert(peer);
         if let Some(gid) = self.grouped_member_of(peer)
             && let Some(group) = self.group_ribs.get_mut(&gid)


### PR DESCRIPTION
## Bug

After SIGTERM on a 700-peer run, the daemon never exited: it spun at ~150% CPU emitting over 1,100 repetitions of `outbound channel full or closed — marking dirty for resync` until killed externally (LAN-459).

## Mechanism

- The outbound send path (`try_reserve` on the per-peer channel) collapses `Closed` and `Full` into the same failure, and the failure path re-marks the peer dirty for resync.
- At shutdown the TCP sessions drop their receivers, closing every outbound channel while the peers are still dirty — with no per-peer `PeerDown` reaching the RIB actor to clear the dirty set.
- The bounded resync tick then retries: each selected peer runs its full O(table) export pass before hitting the dead channel, so at scale one tick outlasts the 10 ms backlog re-arm. The actor's inline timer-fire path re-fires immediately in a loop and never returns to the `select!` where channel/shutdown closure is observed — a livelock that blocks process exit.

## Fix

- `mark_outbound_dirty` — the documented single insertion seam for `dirty_peers`, including the send-failure retry path — now distinguishes a closed or deregistered channel (peer gone) from a full one (peer slow): a gone peer's dirty state is dropped instead of re-marked, so only a live channel can re-arm the resync timer.
- `resync_dirty_peers_bounded` prunes closed-channel peers before selecting its slice, so a backlog of dead sessions quiesces in one cheap tick (no per-peer export pass) and the timer disarms, letting the actor observe shutdown.
- Full session teardown remains owned by the `PeerDown` path; this change only stops the retry.
- Pacing constants and emission ordering are untouched.

Also restores the `bench-internals` build: the RFC 1997 egress change added an `interpret_rfc1997` argument to `handle_peer_up` that the bench peer-registration harness had not picked up.

## Tests

- `dirty_resync_tick_drops_closed_channel_peers_and_quiesces`: a dirty backlog whose channels are all closed must empty in a single tick with no backlog reported and no group dirty flags left behind.
- `mark_outbound_dirty_drops_peer_with_closed_channel`: re-marking after the channel closes (the retry path) removes the peer from the dirty set; open-channel peers are unaffected.
- Both tests fail on the pre-fix code.

Gates: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p rustbgpd-rib`, `cargo test --workspace`, `cargo check -p rustbgpd-rib --features bench-internals --benches`, `cargo doc --workspace --no-deps` (warnings denied) — all exit 0.