### PR TITLE
perf(rib): flush policy-transition commits under a poll time budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Shared policy-transition commit polls now flush validated members under a
+  25 ms wall-clock budget instead of parking after a fixed 8 members. The
+  readiness lane keeps its mid-flush seam (bounded at the budget, well under
+  the 200 ms readiness deadline), while emission start no longer scales
+  linearly with update-group size — a fixed-count poll cost ~0.88 s of
+  staggered first emission at 700 members.
+
 - **RFC 1997 `NO_EXPORT`/`NO_EXPORT_SUBCONFED` are now honored at eBGP egress
   by default.** Routes received with either community are suppressed at
   export staging toward eBGP peers across unicast (incl. RFC 8950 next-hop

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1580,26 +1580,44 @@ impl RibManager {
                 // batches, so no mutation can invalidate the prepared state.
                 // Never fall back from here — an envelope may already be on
                 // a member's wire (see the phase-level invariant comment).
-                let batch = super::COMMIT_MEMBERS_PER_POLL.min(prepared.len());
-                for member in prepared.drain(..batch) {
-                    self.commit_clean_policy_transition_member(member.peer, source, destination);
-                    self.clear_policy_filtered_routes_for_peer(member.peer);
-                    self.apply_clean_policy_transition_counters(member.peer, &inventory);
-                    if let Some(permit) = member.permit {
-                        permit.send(OutboundRouteUpdate {
-                            exact_export_snapshot: member.snapshot,
-                            announce_source_exclusion: Some(member.peer),
-                            announce: Arc::clone(&inventory.announce),
-                            next_hop_override: Arc::clone(&inventory.next_hop_override),
-                            ..OutboundRouteUpdate::default()
-                        });
+                // Flush stride-sized batches until the poll's wall-clock
+                // budget elapses. A member commit is ~0.1 ms but ~10 ms of
+                // interleaved actor work separates polls, so parking on a
+                // fixed member count makes emission start scale with fleet
+                // size; the budget bounds the readiness-seam latency
+                // instead.
+                let poll_start = std::time::Instant::now();
+                let mut flushed = 0_usize;
+                loop {
+                    let batch = super::COMMIT_MEMBERS_PER_POLL.min(prepared.len());
+                    for member in prepared.drain(..batch) {
+                        self.commit_clean_policy_transition_member(
+                            member.peer,
+                            source,
+                            destination,
+                        );
+                        self.clear_policy_filtered_routes_for_peer(member.peer);
+                        self.apply_clean_policy_transition_counters(member.peer, &inventory);
+                        if let Some(permit) = member.permit {
+                            permit.send(OutboundRouteUpdate {
+                                exact_export_snapshot: member.snapshot,
+                                announce_source_exclusion: Some(member.peer),
+                                announce: Arc::clone(&inventory.announce),
+                                next_hop_override: Arc::clone(&inventory.next_hop_override),
+                                ..OutboundRouteUpdate::default()
+                            });
+                        }
+                        let advertised = self.grouped_advertised_count(member.peer).unwrap_or(0);
+                        self.metrics.set_adj_rib_out_prefixes(
+                            &member.peer.to_string(),
+                            "all",
+                            gauge_val(advertised),
+                        );
                     }
-                    let advertised = self.grouped_advertised_count(member.peer).unwrap_or(0);
-                    self.metrics.set_adj_rib_out_prefixes(
-                        &member.peer.to_string(),
-                        "all",
-                        gauge_val(advertised),
-                    );
+                    flushed += batch;
+                    if prepared.is_empty() || poll_start.elapsed() >= self.commit_flush_budget {
+                        break;
+                    }
                 }
                 if !prepared.is_empty() {
                     pending.phase = Some(CleanPolicyTransitionPhase::CommitMembers {
@@ -1608,7 +1626,7 @@ impl RibManager {
                         inventory,
                         prepared,
                         full_probe_count,
-                        cursor: cursor + batch,
+                        cursor: cursor + flushed,
                     });
                     return CleanPolicyTransitionAdvance::Continue(pending);
                 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -243,6 +243,14 @@ pub struct RibManager {
     cluster_id: Option<Ipv4Addr>,
     /// Peers that failed a `try_send()` and need a full export resync.
     dirty_peers: HashSet<IpAddr>,
+    /// Wall-clock budget one commit-kind transition poll may spend flushing
+    /// validated members before parking for the readiness seam. Committing a
+    /// member is cheap (~0.1 ms), but ~10 ms of interleaved actor work
+    /// elapses between polls, so a fixed per-poll member count makes
+    /// emission start scale linearly with fleet size (measured ~0.88 s of
+    /// stagger at 700 members). Tests override this to force deterministic
+    /// per-stride parking.
+    commit_flush_budget: std::time::Duration,
     /// Peers whose next `distribute_changes` pass must bypass the
     /// `AdjRibOut`-already-matches suppression for currently-
     /// advertised routes. Used by `RibUpdate::RefreshPeerOutbound`
@@ -756,10 +764,17 @@ pub(in crate::manager) fn policy_transition_slice_end(
 }
 /// Maximum members classified by one strict shared-policy actor poll.
 pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
-/// Maximum validated members committed and flushed by one strict
-/// shared-policy actor poll (matches `QUERY_BUDGET_PER_CHUNK` so readiness
-/// keeps its per-seam service ratio through the commit flush).
+/// Stride of validated members committed between wall-clock checks inside
+/// one commit-kind actor poll (matches `QUERY_BUDGET_PER_CHUNK`). The poll
+/// keeps flushing strides until [`COMMIT_FLUSH_POLL_BUDGET`] elapses, then
+/// parks so the readiness lane gets its seam.
 pub(in crate::manager) const COMMIT_MEMBERS_PER_POLL: usize = 8;
+/// Wall-clock budget for one commit-kind poll's member flush. Bounds the
+/// readiness-seam latency during a shared policy transition (well under the
+/// 200 ms readiness deadline) while decoupling emission start from fleet
+/// size — a fixed 8-member poll at ~10 ms of interleaved actor work per
+/// poll seam cost ~0.88 s of staggered emission at 700 members.
+const COMMIT_FLUSH_POLL_BUDGET: std::time::Duration = std::time::Duration::from_millis(25);
 /// Maximum dirty peers resynced by one resync-timer tick. Each dirty peer
 /// costs O(table) enumeration and staging, so an unbounded tick stalls the
 /// actor for the whole backlog; the same peers-keyed bound as the commit
@@ -1091,6 +1106,7 @@ impl RibManager {
             loc_rib: LocRib::new(),
             adj_ribs_out: HashMap::new(),
             outbound_peers: HashMap::new(),
+            commit_flush_budget: COMMIT_FLUSH_POLL_BUDGET,
             outbound_session_ids: HashMap::new(),
             live_sessions: HashMap::new(),
             pending_peer_export_context: HashMap::new(),

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -3398,6 +3398,9 @@ fn direct_clean_transition_manager(
 ) {
     let (_tx, rx) = mpsc::channel(1);
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // Zero flush budget parks the commit poll after every stride, making the
+    // per-poll batch boundaries deterministic for the seam assertions below.
+    manager.commit_flush_budget = std::time::Duration::ZERO;
     if let Some(readiness_rx) = readiness_rx {
         manager = manager.with_readiness_queries(readiness_rx);
     }
@@ -3617,6 +3620,46 @@ async fn commit_flush_batches_are_bounded_and_drain_monotonically() {
     for &peer in &peers {
         assert_eq!(manager.grouped_member_of(peer), Some(destination));
     }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+}
+
+/// With wall-clock budget available, one commit poll keeps flushing strides
+/// instead of parking after a fixed member count — emission start must not
+/// scale with fleet size when the actor has time in hand.
+#[tokio::test]
+async fn commit_flush_uses_full_poll_budget_before_parking() {
+    const MEMBER_COUNT: usize = 3 * super::super::COMMIT_MEMBERS_PER_POLL + 2;
+    const ROUTE_COUNT: usize = 2;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    // The helper zeroes the budget for deterministic seam tests; restore a
+    // generous one so the whole cohort fits a single poll.
+    manager.commit_flush_budget = std::time::Duration::from_mins(1);
+    let next_policy = community_chain(0xFDE8_2105);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    let mut commit_polls = 0_usize;
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_ne!(outcome, "fallback");
+        if kind == "commit" {
+            commit_polls += 1;
+            if outcome == "committed" {
+                break;
+            }
+        } else {
+            assert_eq!(outcome, "continue");
+        }
+    }
+    assert_eq!(commit_polls, 1, "budgeted poll drains the whole cohort");
+    let delivered = receivers
+        .iter_mut()
+        .filter_map(|receiver| receiver.try_recv().ok())
+        .count();
+    assert_eq!(delivered, MEMBER_COUNT);
     assert_eq!(
         response.try_recv().unwrap(),
         Ok(crate::update::ExportPolicyCohortOutcome::Committed)


### PR DESCRIPTION
## Problem

A commit-kind policy-transition actor poll parked after a fixed 8 members (`COMMIT_MEMBERS_PER_POLL`). Committing a member costs ~0.1 ms, but ~10 ms of interleaved actor work separates polls, so first-emission stagger grows linearly with update-group size. On the 700 × 400,400 reload campaign this contributed ~0.88 s of staggered emission start (88 polls × ~10 ms), pushing the observer stall past the 1 s receipt gate (LAN-458).

## Change

The commit poll keeps flushing 8-member strides until a 25 ms wall-clock budget (`COMMIT_FLUSH_POLL_BUDGET`) elapses, then parks. The readiness lane keeps its mid-flush seam — now bounded by the budget (well under the 200 ms readiness deadline) instead of recurring every 8 members. At 700 members this collapses ~88 seam polls to a handful. Emission ordering, the no-fallback-after-first-emission invariant, and the terminal-batch reply placement are unchanged.

## Tests

- Existing seam-contract tests (`readiness_answered_between_commit_flush_batches`, `commit_flush_batches_are_bounded_and_drain_monotonically`, `commit_flush_never_falls_back_after_first_emission`) stay deterministic: the test constructor pins the budget to zero so every stride parks, preserving the per-poll batch assertions.
- New: `commit_flush_uses_full_poll_budget_before_parking` — with budget in hand, one commit poll drains the whole 26-member cohort and the transition ends Committed.

Gates: clippy `-D warnings`, rib suite, bench-internals check, full workspace suite, cargo doc — all green. The 700-peer campaign re-runs as the LAN-350 acceptance gate once the companion encode work lands.