### PR TITLE
perf(rib): drain dirty-peer resync under the poll time budget with fair rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Dirty-peer resync ticks now drain the backlog under the same 25 ms
+  wall-clock poll budget as policy-transition commit flushes, instead of a
+  fixed 8 peers per 10 ms re-arm, and select peers round-robin so a peer
+  whose sends keep failing cannot monopolize successive ticks while
+  drainable peers starve. Recovery throughput under outbound backpressure
+  no longer scales inversely with fleet size; each peer is attempted at
+  most once per tick, and failed peers keep waiting for the ordinary retry
+  interval.
+
 - Shared policy-transition commit polls now flush validated members under a
   25 ms wall-clock budget instead of parking after a fixed 8 members. The
   readiness lane keeps its mid-flush seam (bounded at the budget, well under

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1615,7 +1615,7 @@ impl RibManager {
                         );
                     }
                     flushed += batch;
-                    if prepared.is_empty() || poll_start.elapsed() >= self.commit_flush_budget {
+                    if prepared.is_empty() || poll_start.elapsed() >= self.flush_poll_budget {
                         break;
                     }
                 }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 #[cfg(test)]
 use crate::ERR_REFRESH_TIMEOUT;
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::hash::{BuildHasher, Hasher};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -242,15 +242,23 @@ pub struct RibManager {
     /// Local cluster ID for route reflection (RFC 4456). `None` = not an RR.
     cluster_id: Option<Ipv4Addr>,
     /// Peers that failed a `try_send()` and need a full export resync.
-    dirty_peers: HashSet<IpAddr>,
-    /// Wall-clock budget one commit-kind transition poll may spend flushing
-    /// validated members before parking for the readiness seam. Committing a
-    /// member is cheap (~0.1 ms), but ~10 ms of interleaved actor work
-    /// elapses between polls, so a fixed per-poll member count makes
-    /// emission start scale linearly with fleet size (measured ~0.88 s of
-    /// stagger at 700 members). Tests override this to force deterministic
-    /// per-stride parking.
-    commit_flush_budget: std::time::Duration,
+    /// Ordered (`BTreeSet`) so the resync tick can round-robin fairly via
+    /// [`Self::dirty_resync_cursor`] instead of re-drawing an arbitrary
+    /// subset each tick.
+    dirty_peers: BTreeSet<IpAddr>,
+    /// Ring position of the dirty-resync round-robin: the last peer
+    /// attempted. Selection resumes strictly after it (wrapping), so peers
+    /// whose sends keep failing cannot monopolize every tick while
+    /// drainable peers starve.
+    dirty_resync_cursor: Option<IpAddr>,
+    /// Wall-clock budget one actor poll may spend flushing paced work —
+    /// commit-kind transition polls and dirty-resync ticks — before parking
+    /// for the readiness seam. A unit of paced work is cheap-to-moderate,
+    /// but ~10 ms of interleaved actor work elapses between polls, so a
+    /// fixed per-poll item count makes throughput scale inversely with
+    /// fleet size (measured ~0.88 s of emission stagger at 700 members).
+    /// Tests override this to force deterministic per-stride parking.
+    flush_poll_budget: std::time::Duration,
     /// Peers whose next `distribute_changes` pass must bypass the
     /// `AdjRibOut`-already-matches suppression for currently-
     /// advertised routes. Used by `RibUpdate::RefreshPeerOutbound`
@@ -769,16 +777,17 @@ pub(in crate::manager) const POLICY_TRANSITION_MEMBER_SLICE: usize = 8;
 /// keeps flushing strides until [`COMMIT_FLUSH_POLL_BUDGET`] elapses, then
 /// parks so the readiness lane gets its seam.
 pub(in crate::manager) const COMMIT_MEMBERS_PER_POLL: usize = 8;
-/// Wall-clock budget for one commit-kind poll's member flush. Bounds the
-/// readiness-seam latency during a shared policy transition (well under the
-/// 200 ms readiness deadline) while decoupling emission start from fleet
-/// size — a fixed 8-member poll at ~10 ms of interleaved actor work per
+/// Wall-clock budget for one paced actor poll — a commit-kind member flush
+/// or a dirty-resync tick. Bounds the readiness-seam latency (well under
+/// the 200 ms readiness deadline) while decoupling paced throughput from
+/// fleet size — a fixed 8-item poll at ~10 ms of interleaved actor work per
 /// poll seam cost ~0.88 s of staggered emission at 700 members.
-const COMMIT_FLUSH_POLL_BUDGET: std::time::Duration = std::time::Duration::from_millis(25);
-/// Maximum dirty peers resynced by one resync-timer tick. Each dirty peer
-/// costs O(table) enumeration and staging, so an unbounded tick stalls the
-/// actor for the whole backlog; the same peers-keyed bound as the commit
-/// flush keeps the actor responsive while a withheld remainder re-arms the
+const FLUSH_POLL_BUDGET: std::time::Duration = std::time::Duration::from_millis(25);
+/// Stride of dirty peers handed to one `distribute_changes` pass between
+/// wall-clock checks inside a resync-timer tick. Each dirty peer costs
+/// O(table) enumeration and staging, so an unbounded pass stalls the actor
+/// for the whole backlog; the tick keeps taking strides until
+/// [`FLUSH_POLL_BUDGET`] elapses, then a withheld remainder re-arms the
 /// timer at [`DIRTY_RESYNC_BACKLOG_INTERVAL`].
 const RESYNC_PEERS_PER_TICK: usize = 8;
 /// Re-arm interval while a withheld dirty-resync backlog remains. Short by
@@ -1106,7 +1115,7 @@ impl RibManager {
             loc_rib: LocRib::new(),
             adj_ribs_out: HashMap::new(),
             outbound_peers: HashMap::new(),
-            commit_flush_budget: COMMIT_FLUSH_POLL_BUDGET,
+            flush_poll_budget: FLUSH_POLL_BUDGET,
             outbound_session_ids: HashMap::new(),
             live_sessions: HashMap::new(),
             pending_peer_export_context: HashMap::new(),
@@ -1125,7 +1134,8 @@ impl RibManager {
             peer_orr_vantage: HashMap::new(),
             orr: crate::orr::OrrState::default(),
             cluster_id,
-            dirty_peers: HashSet::new(),
+            dirty_peers: BTreeSet::new(),
+            dirty_resync_cursor: None,
             force_outbound_peers: HashSet::new(),
             pending_eor: HashMap::new(),
             pending_refresh: HashMap::new(),
@@ -1493,11 +1503,16 @@ impl RibManager {
         }
     }
 
-    /// One bounded resync-timer tick: hand at most [`RESYNC_PEERS_PER_TICK`]
-    /// dirty peers to `distribute_changes`, withholding the remainder so the
-    /// actor yields between slices. Returns whether a withheld backlog
-    /// remains (distinct from peers that stayed dirty because their send
-    /// failed — those wait for the ordinary retry interval).
+    /// One bounded resync-timer tick: hand [`RESYNC_PEERS_PER_TICK`]-sized
+    /// slices of dirty peers to `distribute_changes` until the poll's
+    /// wall-clock budget elapses, withholding the remainder so the actor
+    /// yields between polls. Selection round-robins from
+    /// [`Self::dirty_resync_cursor`] and never re-attempts a peer within
+    /// the same tick, so peers whose sends keep failing cannot spin the
+    /// budget loop or monopolize successive ticks. Returns whether a
+    /// withheld (not-yet-attempted) backlog remains — distinct from peers
+    /// that stayed dirty because their send failed; those wait for the
+    /// ordinary retry interval.
     ///
     /// Safe to run partially: per-peer resync is idempotent — Adj-RIB-Out
     /// state and the dirty flag are committed/cleared only after a
@@ -1518,23 +1533,55 @@ impl RibManager {
             debug!(%peer, "dropping dirty peer whose outbound channel closed");
             self.drop_gone_dirty_peer(peer);
         }
-        let withheld: Vec<IpAddr> = if self.dirty_peers.len() > RESYNC_PEERS_PER_TICK {
-            let selected: HashSet<IpAddr> = self
+        let poll_start = std::time::Instant::now();
+        let mut attempted: HashSet<IpAddr> = HashSet::new();
+        loop {
+            // Ring selection: up to RESYNC_PEERS_PER_TICK unattempted peers,
+            // starting strictly after the cursor and wrapping. Ring order is
+            // preserved so the cursor lands on the last peer actually
+            // attempted, not the numerically largest.
+            let ring: Vec<IpAddr> = {
+                let after = self
+                    .dirty_peers
+                    .iter()
+                    .filter(|peer| match self.dirty_resync_cursor {
+                        Some(cursor) => **peer > cursor,
+                        None => true,
+                    });
+                let wrapped = self.dirty_peers.iter().filter(|peer| {
+                    self.dirty_resync_cursor
+                        .is_some_and(|cursor| **peer <= cursor)
+                });
+                after
+                    .chain(wrapped)
+                    .filter(|peer| !attempted.contains(*peer))
+                    .take(RESYNC_PEERS_PER_TICK)
+                    .copied()
+                    .collect()
+            };
+            let Some(&last) = ring.last() else {
+                // Nothing unattempted remains: any peers still dirty failed
+                // their send this tick and wait for the ordinary retry.
+                return false;
+            };
+            self.dirty_resync_cursor = Some(last);
+            attempted.extend(ring.iter().copied());
+            let selected: BTreeSet<IpAddr> = ring.into_iter().collect();
+            let withheld: Vec<IpAddr> = self.dirty_peers.difference(&selected).copied().collect();
+            self.dirty_peers = selected;
+            self.distribute_changes(&HashSet::new(), &HashSet::new());
+            self.dirty_peers.extend(withheld);
+            let unattempted_remain = self
                 .dirty_peers
                 .iter()
-                .copied()
-                .take(RESYNC_PEERS_PER_TICK)
-                .collect();
-            let withheld = self.dirty_peers.difference(&selected).copied().collect();
-            self.dirty_peers = selected;
-            withheld
-        } else {
-            Vec::new()
-        };
-        self.distribute_changes(&HashSet::new(), &HashSet::new());
-        let backlog = !withheld.is_empty();
-        self.dirty_peers.extend(withheld);
-        backlog
+                .any(|peer| !attempted.contains(peer));
+            if !unattempted_remain {
+                return false;
+            }
+            if poll_start.elapsed() >= self.flush_poll_budget {
+                return true;
+            }
+        }
     }
 
     async fn receive_readiness_query(

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -3400,7 +3400,7 @@ fn direct_clean_transition_manager(
     let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
     // Zero flush budget parks the commit poll after every stride, making the
     // per-poll batch boundaries deterministic for the seam assertions below.
-    manager.commit_flush_budget = std::time::Duration::ZERO;
+    manager.flush_poll_budget = std::time::Duration::ZERO;
     if let Some(readiness_rx) = readiness_rx {
         manager = manager.with_readiness_queries(readiness_rx);
     }
@@ -3637,7 +3637,7 @@ async fn commit_flush_uses_full_poll_budget_before_parking() {
         direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
     // The helper zeroes the budget for deterministic seam tests; restore a
     // generous one so the whole cohort fits a single poll.
-    manager.commit_flush_budget = std::time::Duration::from_mins(1);
+    manager.flush_poll_budget = std::time::Duration::from_mins(1);
     let next_policy = community_chain(0xFDE8_2105);
     let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
 
@@ -3898,6 +3898,75 @@ async fn dirty_resync_tick_bounds_peers_and_preserves_backlog() {
     assert_eq!(
         second_tick_envelopes,
         PEER_COUNT - super::super::RESYNC_PEERS_PER_TICK
+    );
+}
+
+/// With wall-clock budget in hand, one resync tick keeps taking strides
+/// instead of parking after a fixed peer count — backlog recovery
+/// throughput must not scale inversely with fleet size when the actor has
+/// time available.
+#[tokio::test]
+async fn dirty_resync_tick_uses_full_poll_budget_before_parking() {
+    const PEER_COUNT: usize = 12;
+    const ROUTE_COUNT: usize = 1;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(PEER_COUNT, ROUTE_COUNT, None);
+    // The helper zeroes the budget for deterministic per-stride tests;
+    // restore a generous one so the whole backlog drains in a single tick.
+    manager.flush_poll_budget = std::time::Duration::from_mins(1);
+    for &peer in &peers {
+        manager.mark_outbound_dirty(peer);
+    }
+    assert_eq!(manager.dirty_peers.len(), PEER_COUNT);
+
+    let backlog = manager.resync_dirty_peers_bounded();
+    assert!(!backlog, "budgeted tick drains the whole backlog");
+    assert!(manager.dirty_peers.is_empty());
+    let envelopes = receivers
+        .iter_mut()
+        .filter_map(|receiver| receiver.try_recv().ok())
+        .count();
+    assert_eq!(envelopes, PEER_COUNT);
+}
+
+/// Failed sends must not spin the budget loop: peers whose channel is full
+/// stay dirty after their attempt, and the tick returns without backlog
+/// (they wait for the ordinary retry interval) instead of re-attempting
+/// them until the budget expires.
+#[tokio::test]
+async fn dirty_resync_tick_attempts_each_peer_at_most_once() {
+    const PEER_COUNT: usize = 12;
+    const ROUTE_COUNT: usize = 1;
+    let (mut manager, peers, mut receivers) =
+        direct_clean_transition_manager(PEER_COUNT, ROUTE_COUNT, None);
+    manager.flush_poll_budget = std::time::Duration::from_mins(1);
+    // Saturate every outbound channel (helper capacity 8) by repeatedly
+    // re-dirtying and resyncing without draining the receivers: each
+    // grouped dirty resync replays the group table as one envelope, so the
+    // channels fill and further sends fail, leaving the peers dirty.
+    for _ in 0..9 {
+        for &peer in &peers {
+            manager.mark_outbound_dirty(peer);
+        }
+        manager.resync_dirty_peers_bounded();
+    }
+    for &peer in &peers {
+        manager.mark_outbound_dirty(peer);
+    }
+    let _ = &mut receivers;
+    let started = std::time::Instant::now();
+    let backlog = manager.resync_dirty_peers_bounded();
+    assert!(
+        !backlog,
+        "attempted-but-failed peers are not withheld backlog"
+    );
+    assert!(
+        !manager.dirty_peers.is_empty(),
+        "peers with saturated channels stay dirty for the ordinary retry"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(30),
+        "the tick must terminate without spinning the budget loop"
     );
 }
 


### PR DESCRIPTION
## Problem

The dirty-peer resync tick handed a fixed 8 peers to `distribute_changes` per 10 ms re-arm, so backlog recovery throughput scaled inversely with fleet size. On the 700 × 400,400 reload campaign this is the dominant term in the completion regression (~155 s → ~273 s p50, LAN-458): the import-chain reload triggers a Route-Refresh re-ingestion flood, outbound channels saturate under 700 receivers, and the dirty-resync path fired 761 times — each tick doing at most 8 O(table) rebuilds before re-arming.

A second defect compounded it: the tick selected its 8 via arbitrary `HashSet` iteration, so peers whose sends kept failing could be re-drawn every tick — O(table) staging for zero forward progress — while drainable peers starved.

## Change

- The tick reuses the poll time budget introduced for commit flushes in #947 (field renamed `commit_flush_budget` → `flush_poll_budget`): it keeps taking 8-peer strides until 25 ms elapses, then parks for the readiness seam.
- `dirty_peers` becomes a `BTreeSet` and selection round-robins from a ring cursor, resuming strictly after the last attempted peer (wrapping).
- Each peer is attempted at most once per tick; the withheld-backlog return (10 ms re-arm) now means unattempted peers only, so attempted-but-failed peers keep waiting for the ordinary retry interval, exactly as documented before.
- The gone-channel prune from #946 is unchanged.

## Tests

- Existing per-stride contracts stay deterministic via the zero-budget test pin (`dirty_resync_tick_bounds_peers_and_preserves_backlog`, the #946 quiescence pair).
- New: `dirty_resync_tick_uses_full_poll_budget_before_parking` (budgeted tick drains a 12-peer backlog in one call) and `dirty_resync_tick_attempts_each_peer_at_most_once` (saturated channels: tick terminates without spinning the budget loop, failed peers stay dirty without backlog re-arm).

Gates: clippy `-D warnings`, rib suite, bench-internals check, full workspace, cargo doc — all green. Validated end-to-end by the LAN-350 700-peer acceptance campaign after the companion encode work lands.