### PR TITLE
perf(rib,transport): encode update-group fanout wire streams once per group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Grouped policy-reload re-advertisement now encodes each update-group's
+  wire UPDATE stream once instead of once per member** (ADR-0109). The
+  clean export-policy transition hands every member envelope one
+  encode-once cell; the first consuming session task encodes the shared
+  inventory into per-source-peer, per-family chunks at the standard
+  4096-byte ceiling and every other member reuses the bytes after proving
+  its export profile wire-identical to the encoder's. Split horizon
+  composes from whole chunks (a member sends all chunks except its own
+  source's), members that negotiated fewer families skip those chunks, and
+  any anomaly — profile mismatch, preparation failure, OTC hit, oversize
+  single entry — falls back to the unchanged per-session encode. At
+  route-server scale this removes the N× duplicate encode that delayed
+  every observer's first post-reload UPDATE by the full-table encode time.
+
 - Dirty-peer resync ticks now drain the backlog under the same 25 ms
   wall-clock poll budget as policy-transition commit flushes, instead of a
   fixed 8 peers per 10 ms re-arm, and select peers round-robin so a peer

--- a/crates/rib/src/lib.rs
+++ b/crates/rib/src/lib.rs
@@ -76,8 +76,9 @@ pub use update::{
     NeighborPolicyStats, OrrExplainCandidate, OutboundRouteUpdate, PeerExportPolicyReplacement,
     PeerOutboundState, PlannedGroupability, RibCommandError, RibReadinessError, RibReadinessQuery,
     RibUpdate, RoutePage, RoutePageError, RoutePageVersion, RouteQueryFilter, RouteQueryKey,
-    RouteQueryScope, SelectionDeferralPeerFamilyState, UpdateGroupClassification,
-    UpdateGroupClassifierInput, UpdateGroupFamilyImpact, UpdateGroupFingerprint,
-    UpdateGroupImpactPlan, UpdateGroupImpactRollup, UpdateGroupPeerSnapshot, UpdateGroupSnapshot,
-    WarmMrtSnapshotBudget, WarmMrtSnapshotView, classify_update_group, route_query_key,
+    RouteQueryScope, SelectionDeferralPeerFamilyState, SharedGroupEncode,
+    UpdateGroupClassification, UpdateGroupClassifierInput, UpdateGroupFamilyImpact,
+    UpdateGroupFingerprint, UpdateGroupImpactPlan, UpdateGroupImpactRollup,
+    UpdateGroupPeerSnapshot, UpdateGroupSnapshot, WarmMrtSnapshotBudget, WarmMrtSnapshotView,
+    classify_update_group, route_query_key,
 };

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -317,6 +317,11 @@ enum CleanPolicyTransitionPhase {
         prepared: Vec<PreparedCleanPolicyTransitionPeer>,
         full_probe_count: usize,
         cursor: usize,
+        /// One encode-once cell for the whole fanout: every member envelope
+        /// across every batch carries this same cell so the first consuming
+        /// session task encodes the shared inventory and the rest reuse the
+        /// bytes (transport proves wire-equivalence before reusing).
+        shared_encode: Arc<crate::update::SharedGroupEncode>,
     },
 }
 
@@ -1564,6 +1569,7 @@ impl RibManager {
                     prepared,
                     full_probe_count,
                     cursor: 0,
+                    shared_encode: Arc::new(crate::update::SharedGroupEncode::default()),
                 });
                 CleanPolicyTransitionAdvance::Continue(pending)
             }
@@ -1574,6 +1580,7 @@ impl RibManager {
                 mut prepared,
                 full_probe_count,
                 cursor,
+                shared_encode,
             } => {
                 // Validation happened once, in `Validate`; the actor fence
                 // admits only the read-only readiness lane between these
@@ -1604,6 +1611,7 @@ impl RibManager {
                                 announce_source_exclusion: Some(member.peer),
                                 announce: Arc::clone(&inventory.announce),
                                 next_hop_override: Arc::clone(&inventory.next_hop_override),
+                                shared_group_encode: Some(Arc::clone(&shared_encode)),
                                 ..OutboundRouteUpdate::default()
                             });
                         }
@@ -1627,6 +1635,7 @@ impl RibManager {
                         prepared,
                         full_probe_count,
                         cursor: cursor + flushed,
+                        shared_encode,
                     });
                     return CleanPolicyTransitionAdvance::Continue(pending);
                 }
@@ -2338,6 +2347,7 @@ impl RibManager {
                 rtc_withdraw,
                 otc_blocked,
                 request_refresh_all_negotiated: false,
+                shared_group_encode: None,
             },
         );
         true

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -705,9 +705,13 @@ async fn run_clean_transition_equivalence(force_ungrouped: bool) -> Vec<Vec<Stri
     apply_authoritative_policy_handoff(&tx, &peers, Some(next_policy.clone()), outcome).await;
 
     let mut folded = Vec::new();
+    let mut shared_cells = Vec::new();
     for receiver in &mut receivers {
         let update = receiver.recv().await.unwrap();
         assert!(update.withdraw.is_empty());
+        if let Some(cell) = &update.shared_group_encode {
+            shared_cells.push(Arc::clone(cell));
+        }
         let mut routes = update
             .announce
             .iter()
@@ -722,6 +726,19 @@ async fn run_clean_transition_equivalence(force_ungrouped: bool) -> Vec<Vec<Stri
             .collect::<Vec<_>>();
         routes.sort_unstable();
         folded.push(routes);
+    }
+    // A grouped commit hands every member the SAME encode-once cell so the
+    // transport fanout encodes the shared inventory exactly once; the
+    // ungrouped per-peer path must never carry one.
+    if force_ungrouped {
+        assert!(shared_cells.is_empty());
+    } else {
+        assert_eq!(shared_cells.len(), receivers.len());
+        assert!(
+            shared_cells
+                .iter()
+                .all(|cell| Arc::ptr_eq(cell, &shared_cells[0]))
+        );
     }
     let (stats_reply, stats_response) = oneshot::channel();
     tx.send(RibUpdate::TestQueryPolicyTransitionStats { reply: stats_reply })

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -688,6 +688,22 @@ pub enum ExportPolicyCohortOutcome {
     RequiresAuthoritativePerPeerApply,
 }
 
+/// Once-per-update-group cell through which the first consuming session task
+/// publishes its encoded wire chunks so every other member of the group can
+/// reuse the bytes instead of re-encoding the same shared announce inventory.
+///
+/// The payload is transport-owned and deliberately opaque here (the same
+/// trust-boundary pattern as [`ExactExportSnapshot::as_any`]): the RIB only
+/// guarantees that every member envelope of one grouped fanout carries the
+/// same cell. Transport downcasts, proves wire-equivalence between its own
+/// export profile and the encoder's, and falls back to its ordinary
+/// per-session encode when the proof fails.
+#[derive(Default)]
+pub struct SharedGroupEncode {
+    /// First-consumer-initializes cell; losers await instead of re-encoding.
+    pub cell: tokio::sync::OnceCell<Arc<dyn Any + Send + Sync>>,
+}
+
 /// Routes to be sent outbound to a peer.
 #[derive(Default)]
 pub struct OutboundRouteUpdate {
@@ -764,6 +780,10 @@ pub struct OutboundRouteUpdate {
     /// skipped with a warning and inbound state recovers only on the
     /// peer's natural re-advertisement.
     pub request_refresh_all_negotiated: bool,
+    /// Encode-once cell shared by every member envelope of one grouped
+    /// fanout (set only by the clean group-transition seam alongside
+    /// `announce_source_exclusion`). `None` = ordinary per-session encode.
+    pub shared_group_encode: Option<Arc<SharedGroupEncode>>,
 }
 
 /// Aggregate route-policy evaluation counters for one neighbor.

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -96,7 +96,7 @@ impl SessionExportProfile {
     /// proof by default instead of requiring a parallel allow-list. Remote ASN
     /// identity is deliberately absent because current rules consume only the
     /// stored eBGP/iBGP class; a value-dependent rule must restore it here.
-    fn has_same_wire_encoding(&self, other: &Self) -> bool {
+    pub(super) fn has_same_wire_encoding(&self, other: &Self) -> bool {
         let mut this = self.clone();
         let mut other = other.clone();
         for profile in [&mut this, &mut other] {
@@ -221,6 +221,18 @@ impl SessionExportProfile {
 
     pub(super) fn is_ebgp(&self) -> bool {
         self.is_ebgp
+    }
+
+    /// Profile-level mirror of `PeerSession::otc_egress_blocks_unicast`
+    /// (RFC 9234 egress gate), evaluated from the captured `local_role` so
+    /// the update-group shared encoder applies the identical filter the
+    /// per-session path would.
+    pub(super) fn otc_blocks_unicast_egress(&self, route: &Route) -> bool {
+        has_otc(&route.attributes)
+            && matches!(
+                self.local_role,
+                Some(BgpRole::Customer | BgpRole::Peer | BgpRole::RouteServerClient)
+            )
     }
 
     pub(super) fn add_path_send(&self, family: (Afi, Safi)) -> bool {

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -152,17 +152,35 @@ impl PeerSession {
     pub(super) fn enqueue_bulk(&mut self, msg: &Message) -> Result<(), TransportError> {
         let max_len = self.outbound_max_message_len();
         let encoded = rustbgpd_wire::encode_message_with_limit(msg, max_len)?;
-        // Clone the sender so the caller's mutable borrow of self is
-        // free for the saturation handler if try_send returns Full.
-        let Some(tx) = self.writer_bulk_tx.clone() else {
+        if self.writer_bulk_tx.is_none() {
             debug!(
                 peer = %self.peer_label,
                 msg_type = %msg.message_type(),
                 "cannot send — not connected (bulk)"
             );
             return Ok(());
+        }
+        self.enqueue_bulk_encoded(Bytes::from(encoded), matches!(msg, Message::Update(_)))
+    }
+
+    /// Enqueue an already-encoded wire message on the writer's **bulk**
+    /// channel. Byte-level seam shared by [`Self::enqueue_bulk`] and the
+    /// update-group shared-encode path, so pre-encoded group chunks keep the
+    /// identical BMP rib-out tap and saturation-teardown semantics.
+    pub(super) fn enqueue_bulk_encoded(
+        &mut self,
+        encoded: Bytes,
+        is_update: bool,
+    ) -> Result<(), TransportError> {
+        // Clone the sender so the caller's mutable borrow of self is
+        // free for the saturation handler if try_send returns Full.
+        let Some(tx) = self.writer_bulk_tx.clone() else {
+            debug!(
+                peer = %self.peer_label,
+                "cannot send — not connected (bulk)"
+            );
+            return Ok(());
         };
-        let encoded = Bytes::from(encoded);
         // RFC 8671 post-policy Adj-RIB-Out tap: every outbound UPDATE
         // (announcements, withdraws, EoR markers — all families) funnels
         // through here as final wire bytes, so the BMP mirror is
@@ -179,9 +197,8 @@ impl PeerSession {
         //   latches `bmp_stream_diverged` and forces a PeerDown/PeerUp
         //   peer-state reset once the channel drains, so collectors
         //   never keep a silently incomplete rib-out view.
-        let bmp_rib_out_pdu =
-            (self.config.bmp_rib_out && self.bmp_tx.is_some() && matches!(msg, Message::Update(_)))
-                .then(|| encoded.clone());
+        let bmp_rib_out_pdu = (self.config.bmp_rib_out && self.bmp_tx.is_some() && is_update)
+            .then(|| encoded.clone());
         match tx.try_send(encoded) {
             Ok(()) => {
                 if let Some(update_pdu) = bmp_rib_out_pdu {

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod inbound;
 mod io;
 mod outbound;
 mod refresh_accounting;
+mod shared_group;
 mod writer;
 
 use std::collections::{HashMap, HashSet};
@@ -1530,7 +1531,7 @@ impl PeerSession {
                 // Outbound route updates from RIB manager
                 Some(update) = outbound_rx.recv(),
                     if self.fsm.state() == SessionState::Established => {
-                    self.send_route_update(update);
+                    self.handle_outbound_route_update(update).await;
                 }
             }
         }

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -1,0 +1,383 @@
+//! Encode-once fanout for update-group shared envelopes (LAN-455/LAN-458).
+//!
+//! A clean grouped export-policy transition releases the *same* announce
+//! inventory (`Arc`-shared) to every member of an update-group, differing
+//! per member only by `announce_source_exclusion`. Before this seam every
+//! session task re-encoded the full table itself, so N members paid N full
+//! encodes that fair-shared the cores and delayed everyone's first wire
+//! UPDATE by the total encode time divided by the core count.
+//!
+//! Here the first member to consume its envelope encodes the inventory once
+//! into per-`(source peer, family)` wire chunks at the standard 4096-byte
+//! ceiling and publishes them through the envelope's
+//! [`SharedGroupEncode`] cell; every other member awaits the cell, proves
+//! byte-equivalence with [`SessionExportProfile::has_same_wire_encoding`],
+//! and enqueues the shared bytes — skipping the chunks of its own source
+//! (split horizon) and of families it did not negotiate. Any anomaly
+//! (profile mismatch, preparation failure, OTC filter hit, single-entry
+//! oversize, scoped-link-local IPv4 drop) makes the payload unshareable and
+//! each member falls back to the ordinary per-session encode, which owns
+//! the established diagnostics and teardown semantics for every such case.
+//!
+//! Chunks never mix source peers even when global attribute interning gives
+//! two sources pointer-identical attribute sets: keeping the source in the
+//! group key is what lets a member's stream compose exactly as "all chunks
+//! minus its own source's". Chunking to the standard (non-extended) ceiling
+//! keeps one shared byte stream valid for every member because
+//! `has_same_wire_encoding` deliberately ignores the negotiated ceiling —
+//! a 4096-byte message is well-formed for an RFC 8654 extended peer too.
+
+use super::export::{PreparedAttrCache, PreparedUnicastCandidate, ReachNlri, SessionExportProfile};
+use super::{
+    Afi, IpAddr, Ipv4NlriEntry, Ipv4UnicastMode, Ipv6Addr, Message, NlriEntry, OutboundRouteUpdate,
+    PathAttribute, PeerSession, Route, Safi, UpdateMessage, debug,
+};
+use bytes::Bytes;
+use rustbgpd_rib::SharedGroupEncode;
+use rustc_hash::FxHashMap as HashMap;
+use std::any::Any;
+use std::sync::Arc;
+
+/// One pre-encoded wire UPDATE carrying routes from exactly one source peer
+/// and one unicast family.
+pub(super) struct SharedUnicastChunk {
+    pub(super) source: IpAddr,
+    pub(super) afi: Afi,
+    pub(super) bytes: Bytes,
+}
+
+/// Cell payload published by the first member to consume its envelope.
+pub(super) enum SharedUnicastEncode {
+    /// Chunks valid for every member whose export profile proves
+    /// [`SessionExportProfile::has_same_wire_encoding`] with `profile`.
+    Ready {
+        profile: SessionExportProfile,
+        chunks: Vec<SharedUnicastChunk>,
+    },
+    /// The encoding member hit an anomaly; every member (encoder included)
+    /// falls back to its ordinary per-session encode.
+    Unshareable,
+}
+
+/// Whether an envelope is shaped like a clean group-transition fanout:
+/// unicast announcements only, everything else empty. Anything richer keeps
+/// the ordinary path, which handles every payload kind.
+fn shared_encode_eligible(update: &OutboundRouteUpdate) -> bool {
+    update.shared_group_encode.is_some()
+        && !update.announce.is_empty()
+        && update.withdraw.is_empty()
+        && update.end_of_rib.is_empty()
+        && update.refresh_markers.is_empty()
+        && update.flowspec_announce.is_empty()
+        && update.flowspec_withdraw.is_empty()
+        && update.evpn_announce.is_empty()
+        && update.evpn_withdraw.is_empty()
+        && update.bgpls_announce.is_empty()
+        && update.bgpls_withdraw.is_empty()
+        && update.vpn_announce.is_empty()
+        && update.vpn_withdraw.is_empty()
+        && update.labeled_announce.is_empty()
+        && update.labeled_withdraw.is_empty()
+        && update.rtc_announce.is_empty()
+        && update.rtc_withdraw.is_empty()
+        && update.otc_blocked.is_empty()
+        && !update.request_refresh_all_negotiated
+}
+
+/// Size-halving chunker mirroring `send_v4_chunked` / `send_mp_chunked`,
+/// producing encoded bytes instead of enqueueing. `None` = unshareable
+/// (build failure or a single entry over the shared ceiling).
+fn encode_chunks<E>(
+    entries: &[E],
+    max_len: usize,
+    mut build: impl FnMut(&[E]) -> Result<UpdateMessage, rustbgpd_wire::EncodeError>,
+) -> Option<Vec<Bytes>> {
+    let mut out = Vec::new();
+    let mut chunk_size: usize = entries.len().min(max_len / 2).max(1);
+    let mut idx: usize = 0;
+    while idx < entries.len() {
+        let end = (idx + chunk_size).min(entries.len());
+        let msg = build(&entries[idx..end]).ok()?;
+        if msg.encoded_len() > max_len {
+            if chunk_size <= 1 {
+                return None;
+            }
+            chunk_size = (chunk_size / 2).max(1);
+            continue;
+        }
+        let encoded = rustbgpd_wire::encode_message_with_limit(
+            &Message::Update(msg),
+            rustbgpd_wire::MAX_MESSAGE_LEN,
+        )
+        .ok()?;
+        out.push(Bytes::from(encoded));
+        idx = end;
+    }
+    Some(out)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct SharedGroupKey {
+    source: IpAddr,
+    attrs_ptr: usize,
+    next_hop: Option<IpAddr>,
+    link_local_next_hop: Option<Ipv6Addr>,
+}
+
+enum SharedGroupBody {
+    V4Body {
+        attrs: Arc<Vec<PathAttribute>>,
+        entries: Vec<Ipv4NlriEntry>,
+    },
+    Mp {
+        afi: Afi,
+        next_hop: IpAddr,
+        link_local_next_hop: Option<Ipv6Addr>,
+        attrs: Arc<Vec<PathAttribute>>,
+        ipv4_mode: Ipv4UnicastMode,
+        entries: Vec<NlriEntry>,
+    },
+}
+
+struct SharedGroup {
+    source: IpAddr,
+    body: SharedGroupBody,
+}
+
+/// Encode the shared inventory once: prepare and group announcements
+/// exactly like the per-session path, with the source peer added to the
+/// group key, then chunk each group to the standard message ceiling.
+#[expect(
+    clippy::too_many_lines,
+    reason = "mirrors the per-session grouping branches in one auditable pass"
+)]
+pub(super) fn build_shared_unicast_encode(
+    export: &SessionExportProfile,
+    announce: &[Route],
+    next_hop_override: &[Option<rustbgpd_policy::NextHopAction>],
+) -> SharedUnicastEncode {
+    // Scoped link-local peers silently drop IPv4 with a per-member warning;
+    // keep that behavior on the per-session path.
+    if export.is_scoped_link_local_peer() {
+        return SharedUnicastEncode::Unshareable;
+    }
+    let max_len = usize::from(rustbgpd_wire::MAX_MESSAGE_LEN);
+    let local_ipv4 = export.local_ipv4();
+    let mut cache = PreparedAttrCache::default();
+    let mut index: HashMap<SharedGroupKey, usize> = HashMap::default();
+    let mut groups: Vec<SharedGroup> = Vec::new();
+    for (i, route) in announce.iter().enumerate() {
+        if export.otc_blocks_unicast_egress(route) {
+            // RIB staging removes OTC-blocked routes before this seam; if
+            // one slips through, the per-session path owns the per-member
+            // diagnostics.
+            return SharedUnicastEncode::Unshareable;
+        }
+        let nh_override = next_hop_override.get(i).and_then(Option::as_ref);
+        let attrs = export
+            .prepared_unicast_attributes_cached(&mut cache, route, local_ipv4, nh_override)
+            .clone();
+        // `finish_unicast_candidate` picks IPv4-body vs MP_REACH from the
+        // profile's Extended Next Hop state itself, so this match covers
+        // both per-session grouping branches without re-deriving the mode.
+        let (key, body_seed) = match export.finish_unicast_candidate(route, nh_override, attrs) {
+            Ok(PreparedUnicastCandidate::Ipv4Body { attrs, entry }) => (
+                SharedGroupKey {
+                    source: route.peer,
+                    attrs_ptr: Arc::as_ptr(&attrs) as usize,
+                    next_hop: None,
+                    link_local_next_hop: None,
+                },
+                SharedGroupBody::V4Body {
+                    attrs,
+                    entries: vec![entry],
+                },
+            ),
+            Ok(PreparedUnicastCandidate::Mp {
+                afi,
+                next_hop,
+                link_local_next_hop,
+                attrs,
+                entry,
+                ipv4_mode,
+            }) => (
+                SharedGroupKey {
+                    source: route.peer,
+                    attrs_ptr: Arc::as_ptr(&attrs) as usize,
+                    next_hop: Some(next_hop),
+                    link_local_next_hop,
+                },
+                SharedGroupBody::Mp {
+                    afi,
+                    next_hop,
+                    link_local_next_hop,
+                    attrs,
+                    ipv4_mode,
+                    entries: vec![entry],
+                },
+            ),
+            // The exact-export preflight probed every route on this same
+            // snapshot before commit; a failure here is the anomaly the
+            // per-session path turns into a teardown.
+            Err(_) => return SharedUnicastEncode::Unshareable,
+        };
+        if let Some(&at) = index.get(&key) {
+            match (&mut groups[at].body, body_seed) {
+                (
+                    SharedGroupBody::V4Body { entries, .. },
+                    SharedGroupBody::V4Body {
+                        entries: seed_entries,
+                        ..
+                    },
+                ) => entries.extend(seed_entries),
+                (
+                    SharedGroupBody::Mp { entries, .. },
+                    SharedGroupBody::Mp {
+                        entries: seed_entries,
+                        ..
+                    },
+                ) => entries.extend(seed_entries),
+                // A key collision across body kinds cannot happen (MP keys
+                // always carry a next hop, body keys never do), but sharing
+                // must stay provable rather than clever.
+                _ => return SharedUnicastEncode::Unshareable,
+            }
+        } else {
+            index.insert(key, groups.len());
+            groups.push(SharedGroup {
+                source: route.peer,
+                body: body_seed,
+            });
+        }
+    }
+    let mut chunks = Vec::new();
+    for group in &groups {
+        let (afi, encoded) = match &group.body {
+            SharedGroupBody::V4Body { attrs, entries } => (
+                Afi::Ipv4,
+                encode_chunks(entries, max_len, |chunk| {
+                    export.build_ipv4_body(chunk, &[], attrs)
+                }),
+            ),
+            SharedGroupBody::Mp {
+                afi,
+                next_hop,
+                link_local_next_hop,
+                attrs,
+                ipv4_mode,
+                entries,
+            } => (
+                *afi,
+                encode_chunks(entries, max_len, |chunk| {
+                    export.build_mp_reach(
+                        *afi,
+                        Safi::Unicast,
+                        *next_hop,
+                        *link_local_next_hop,
+                        attrs,
+                        ReachNlri::Unicast(chunk),
+                        *ipv4_mode,
+                    )
+                }),
+            ),
+        };
+        let Some(encoded) = encoded else {
+            return SharedUnicastEncode::Unshareable;
+        };
+        chunks.extend(encoded.into_iter().map(|bytes| SharedUnicastChunk {
+            source: group.source,
+            afi,
+            bytes,
+        }));
+    }
+    SharedUnicastEncode::Ready {
+        profile: export.clone(),
+        chunks,
+    }
+}
+
+impl PeerSession {
+    /// Entry point for envelopes from the RIB manager: try the update-group
+    /// encode-once path, fall back to the ordinary per-session encode.
+    pub(super) async fn handle_outbound_route_update(&mut self, update: OutboundRouteUpdate) {
+        if let Some(shared) = update.shared_group_encode.clone()
+            && shared_encode_eligible(&update)
+            && self.try_send_shared_group(&shared, &update).await
+        {
+            return;
+        }
+        self.send_route_update(update);
+    }
+
+    /// Returns `true` when this envelope was fully handled through the
+    /// shared bytes (including an enqueue failure, whose saturation/teardown
+    /// policy already ran — re-encoding locally would duplicate the stream).
+    /// `false` = fall back to the ordinary path, which re-runs the snapshot
+    /// trust checks and owns their teardown.
+    async fn try_send_shared_group(
+        &mut self,
+        shared: &SharedGroupEncode,
+        update: &OutboundRouteUpdate,
+    ) -> bool {
+        let Some(snapshot) = update.exact_export_snapshot.as_ref() else {
+            return false;
+        };
+        let Some(export) = snapshot.as_any().downcast_ref::<SessionExportProfile>() else {
+            return false;
+        };
+        if rustbgpd_rib::ExactExportSnapshot::owner_id(export)
+            != rustbgpd_rib::ExactExportEncoder::owner_id(self.export_encoder.as_ref())
+        {
+            return false;
+        }
+        let encoded = shared
+            .cell
+            .get_or_init(|| {
+                let value: Arc<dyn Any + Send + Sync> = Arc::new(build_shared_unicast_encode(
+                    export,
+                    &update.announce,
+                    &update.next_hop_override,
+                ));
+                std::future::ready(value)
+            })
+            .await;
+        let Some(encode) = encoded.downcast_ref::<SharedUnicastEncode>() else {
+            return false;
+        };
+        let SharedUnicastEncode::Ready { profile, chunks } = encode else {
+            return false;
+        };
+        if !export.has_same_wire_encoding(profile) {
+            return false;
+        }
+        let mut sent: u64 = 0;
+        for chunk in chunks {
+            if update.announce_source_exclusion == Some(chunk.source) {
+                continue;
+            }
+            if !self
+                .negotiated_families
+                .contains(&(chunk.afi, Safi::Unicast))
+            {
+                continue;
+            }
+            if self
+                .enqueue_bulk_encoded(chunk.bytes.clone(), true)
+                .is_err()
+            {
+                // Saturation teardown / writer-closed policy already ran
+                // inside; abort the batch like the ordinary chunked senders.
+                return true;
+            }
+            self.updates_sent += 1;
+            self.metrics.record_message_sent(&self.peer_label, "update");
+            sent += 1;
+        }
+        debug!(
+            peer = %self.peer_label,
+            updates = sent,
+            "sent update-group announcements from shared encode"
+        );
+        true
+    }
+}

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -992,6 +992,7 @@ fn empty_outbound_update() -> OutboundRouteUpdate {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     }
 }
 /// Expect the next BMP event to be a rib-out `RouteMonitoring` and
@@ -3035,6 +3036,7 @@ async fn send_route_update_batches_ipv4_routes_with_identical_attributes() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
@@ -3076,6 +3078,212 @@ async fn shared_transition_payload_excludes_only_the_target_source() {
     assert_eq!(parsed.announced.len(), 1);
     assert_eq!(parsed.announced[0].prefix, other_prefix);
 }
+
+/// Build a route-server-style route owned by `source` with a per-source
+/// `AS_PATH` so shared-encode grouping cannot merge sources through
+/// interned attribute pointers.
+fn make_sourced_route(source: Ipv4Addr, prefix: Ipv4Prefix, asn: u32) -> Route {
+    Route {
+        prefix: Prefix::V4(prefix),
+        peer: IpAddr::V4(source),
+        next_hop: IpAddr::V4(source),
+        attributes: Arc::new(vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![asn])],
+            }),
+            PathAttribute::NextHop(source),
+        ]),
+        ..make_route(100)
+    }
+}
+
+/// One update-group member session wired to a live loopback stream.
+async fn shared_group_member(local_asn: u32) -> (PeerSession, TcpStream) {
+    let (mut session, _rib_rx) = make_test_session_with_rib(local_asn, 65002);
+    let (client, server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    session.config.route_server_client = true;
+    (session, server)
+}
+
+fn shared_group_envelope(
+    session: &PeerSession,
+    shared: &Arc<rustbgpd_rib::SharedGroupEncode>,
+    excluded_source: Ipv4Addr,
+    announce: &[Route],
+) -> OutboundRouteUpdate {
+    let mut update = empty_outbound_update();
+    update.exact_export_snapshot = Some(session.publish_export_profile());
+    update.announce_source_exclusion = Some(IpAddr::V4(excluded_source));
+    update.announce = announce.to_vec().into();
+    update.next_hop_override = vec![None; announce.len()].into();
+    update.shared_group_encode = Some(Arc::clone(shared));
+    update
+}
+
+async fn read_announced_prefixes(stream: &mut TcpStream, expected_updates: usize) -> Vec<Prefix> {
+    let mut prefixes = Vec::new();
+    for _ in 0..expected_updates {
+        let Message::Update(message) = read_single_bgp_message(stream).await else {
+            panic!("expected UPDATE");
+        };
+        let parsed = message.parse(true, false, &[]).unwrap();
+        prefixes.extend(parsed.announced.iter().map(|nlri| Prefix::V4(nlri.prefix)));
+    }
+    prefixes.sort_unstable();
+    prefixes
+}
+
+/// The first member of a grouped fanout encodes the shared inventory once;
+/// the second reuses the published bytes. Each member's stream is the
+/// inventory minus its own source's chunks (split horizon composes from
+/// whole per-source chunks).
+#[tokio::test]
+async fn shared_group_encode_first_member_encodes_and_second_reuses() {
+    let source_a = Ipv4Addr::new(10, 30, 0, 1);
+    let source_b = Ipv4Addr::new(10, 30, 0, 2);
+    let source_c = Ipv4Addr::new(10, 30, 0, 3);
+    let prefix_a = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let prefix_b = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let prefix_c = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let announce = vec![
+        make_sourced_route(source_a, prefix_a, 64_601),
+        make_sourced_route(source_b, prefix_b, 64_602),
+        make_sourced_route(source_c, prefix_c, 64_603),
+    ];
+    let shared = Arc::new(rustbgpd_rib::SharedGroupEncode::default());
+
+    let (mut member_a, mut wire_a) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_a, &shared, source_a, &announce);
+    member_a.handle_outbound_route_update(update).await;
+    let published = shared.cell.get().expect("first member publishes the cell");
+    let super::shared_group::SharedUnicastEncode::Ready { chunks, .. } = published
+        .downcast_ref::<super::shared_group::SharedUnicastEncode>()
+        .expect("cell payload is the transport shared-encode type")
+    else {
+        panic!("uniform-profile inventory must be shareable");
+    };
+    assert_eq!(chunks.len(), 3, "one chunk per source at this size");
+    assert_eq!(
+        read_announced_prefixes(&mut wire_a, 2).await,
+        {
+            let mut expected = vec![Prefix::V4(prefix_b), Prefix::V4(prefix_c)];
+            expected.sort_unstable();
+            expected
+        },
+        "member A receives the table minus its own source"
+    );
+
+    let (mut member_b, mut wire_b) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_b, &shared, source_b, &announce);
+    member_b.handle_outbound_route_update(update).await;
+    assert!(
+        Arc::ptr_eq(shared.cell.get().unwrap(), published),
+        "second member reuses the published encode"
+    );
+    assert_eq!(
+        read_announced_prefixes(&mut wire_b, 2).await,
+        {
+            let mut expected = vec![Prefix::V4(prefix_a), Prefix::V4(prefix_c)];
+            expected.sort_unstable();
+            expected
+        },
+        "member B receives the table minus its own source"
+    );
+}
+
+/// A member whose export profile is not provably wire-identical to the
+/// encoder's must fall back to its ordinary per-session encode and still
+/// deliver a correct stream.
+#[tokio::test]
+async fn shared_group_encode_profile_mismatch_falls_back_to_local_encode() {
+    let source_a = Ipv4Addr::new(10, 31, 0, 1);
+    let source_b = Ipv4Addr::new(10, 31, 0, 2);
+    let prefix_a = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let prefix_b = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let announce = vec![
+        make_sourced_route(source_a, prefix_a, 64_601),
+        make_sourced_route(source_b, prefix_b, 64_602),
+    ];
+    let shared = Arc::new(rustbgpd_rib::SharedGroupEncode::default());
+
+    let (mut member_a, mut wire_a) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_a, &shared, source_a, &announce);
+    member_a.handle_outbound_route_update(update).await;
+    assert!(shared.cell.get().is_some());
+    assert_eq!(
+        read_announced_prefixes(&mut wire_a, 1).await,
+        vec![Prefix::V4(prefix_b)]
+    );
+
+    // Different local ASN = different wire bytes (AS_PATH prepend) — the
+    // equality proof must reject the published encode.
+    let (mut member_b, mut wire_b) = shared_group_member(64_999).await;
+    let update = shared_group_envelope(&member_b, &shared, source_b, &announce);
+    member_b.handle_outbound_route_update(update).await;
+    assert_eq!(
+        read_announced_prefixes(&mut wire_b, 1).await,
+        vec![Prefix::V4(prefix_a)],
+        "fallback member still delivers its correct per-session stream"
+    );
+}
+
+/// Shared chunks carry their family; a member that did not negotiate a
+/// family skips those chunks even though the encoder produced them.
+#[tokio::test]
+async fn shared_group_encode_skips_chunks_of_unnegotiated_families() {
+    let source_a = Ipv4Addr::new(10, 32, 0, 1);
+    let source_b = Ipv4Addr::new(10, 32, 0, 2);
+    let prefix_v4 = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let v6_route = Route {
+        prefix: Prefix::V6(Ipv6Prefix::new(
+            "2001:db8:2::".parse::<Ipv6Addr>().unwrap(),
+            48,
+        )),
+        next_hop: IpAddr::V6("2001:db8::b".parse::<Ipv6Addr>().unwrap()),
+        ..make_sourced_route(source_b, prefix_v4, 64_602)
+    };
+    let announce = vec![make_sourced_route(source_a, prefix_v4, 64_601), v6_route];
+    let shared = Arc::new(rustbgpd_rib::SharedGroupEncode::default());
+
+    // Encoder negotiated IPv4 only, and its own source is excluded — its
+    // wire stream must skip the IPv6 chunk it still encoded for the group.
+    let (mut member_a, mut wire_a) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_a, &shared, source_a, &announce);
+    member_a.handle_outbound_route_update(update).await;
+    let published = shared.cell.get().expect("cell published");
+    let super::shared_group::SharedUnicastEncode::Ready { chunks, .. } = published
+        .downcast_ref::<super::shared_group::SharedUnicastEncode>()
+        .unwrap()
+    else {
+        panic!("inventory must be shareable");
+    };
+    assert!(
+        chunks.iter().any(|chunk| chunk.afi == Afi::Ipv6),
+        "encoder produced the IPv6 chunk for dual-stack members"
+    );
+    // Member A negotiated only IPv4-unicast and excluded source A: nothing
+    // but the IPv6 chunk remains, and that chunk is skipped — so the next
+    // message on the wire would block forever. Prove the skip by sending a
+    // sentinel envelope through the ordinary path and reading it back.
+    let mut sentinel = empty_outbound_update();
+    sentinel.exact_export_snapshot = Some(member_a.publish_export_profile());
+    let sentinel_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 128), 25);
+    sentinel.announce = vec![make_sourced_route(source_b, sentinel_prefix, 64_602)].into();
+    sentinel.next_hop_override = vec![None].into();
+    member_a.handle_outbound_route_update(sentinel).await;
+    assert_eq!(
+        read_announced_prefixes(&mut wire_a, 1).await,
+        vec![Prefix::V4(sentinel_prefix)],
+        "no IPv6 UPDATE preceded the sentinel on an IPv4-only session"
+    );
+}
 #[tokio::test]
 async fn send_route_update_emits_bgpls_reach_and_unreach() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
@@ -3111,6 +3319,7 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected BGP-LS MP_REACH UPDATE");
@@ -3150,6 +3359,7 @@ async fn send_route_update_emits_bgpls_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected BGP-LS MP_UNREACH UPDATE");
@@ -3208,6 +3418,7 @@ async fn oversized_bgpls_output_tears_down_session() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     assert!(
         session.read_half.is_none(),
@@ -3324,6 +3535,7 @@ async fn send_route_update_emits_labeled_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected labeled MP_REACH UPDATE");
@@ -3373,6 +3585,7 @@ async fn send_route_update_emits_labeled_reach_and_unreach() {
         labeled_withdraw: vec![key],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected labeled MP_UNREACH UPDATE");
@@ -3462,6 +3675,7 @@ async fn send_route_update_reflects_labeled_v6_link_local_next_hop() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected labeled MP_REACH UPDATE");
@@ -3551,6 +3765,7 @@ async fn send_route_update_reflects_vpnv6_link_local_next_hop() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected VPN MP_REACH UPDATE");
@@ -3618,6 +3833,7 @@ async fn send_route_update_emits_labeled_add_path_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected labeled Add-Path MP_REACH UPDATE");
@@ -3642,26 +3858,8 @@ async fn send_route_update_emits_labeled_add_path_reach_and_unreach() {
     );
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
-        announce_source_exclusion: None,
-        otc_blocked: vec![],
-        announce: vec![].into(),
-        withdraw: vec![],
-        end_of_rib: vec![],
-        refresh_markers: vec![],
-        next_hop_override: vec![].into(),
-        flowspec_announce: vec![],
-        flowspec_withdraw: vec![],
-        evpn_announce: vec![],
-        evpn_withdraw: vec![],
-        bgpls_announce: vec![],
-        bgpls_withdraw: vec![],
-        vpn_announce: vec![],
-        labeled_announce: vec![],
-        rtc_announce: vec![],
-        vpn_withdraw: vec![],
         labeled_withdraw: vec![key],
-        rtc_withdraw: vec![],
-        request_refresh_all_negotiated: false,
+        ..empty_outbound_update()
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected labeled Add-Path MP_UNREACH UPDATE");
@@ -4073,6 +4271,7 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected VPN MP_REACH UPDATE");
@@ -4122,6 +4321,7 @@ async fn send_route_update_emits_vpn_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected VPN MP_UNREACH UPDATE");
@@ -4171,26 +4371,8 @@ async fn send_route_update_emits_vpn_add_path_reach_and_unreach() {
     let key = route.key();
     session.send_route_update(OutboundRouteUpdate {
         exact_export_snapshot: Some(session.publish_export_profile()),
-        announce_source_exclusion: None,
-        otc_blocked: vec![],
-        announce: vec![].into(),
-        withdraw: vec![],
-        end_of_rib: vec![],
-        refresh_markers: vec![],
-        next_hop_override: vec![].into(),
-        flowspec_announce: vec![],
-        flowspec_withdraw: vec![],
-        evpn_announce: vec![],
-        evpn_withdraw: vec![],
-        bgpls_announce: vec![],
-        bgpls_withdraw: vec![],
         vpn_announce: vec![route.clone()],
-        labeled_announce: vec![],
-        rtc_announce: vec![],
-        vpn_withdraw: vec![],
-        labeled_withdraw: vec![],
-        rtc_withdraw: vec![],
-        request_refresh_all_negotiated: false,
+        ..empty_outbound_update()
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected VPN Add-Path MP_REACH UPDATE");
@@ -4235,6 +4417,7 @@ async fn send_route_update_emits_vpn_add_path_reach_and_unreach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected VPN Add-Path MP_UNREACH UPDATE");
@@ -5058,6 +5241,7 @@ async fn send_route_update_emits_rtc_reach_and_unreach() {
         rtc_announce: vec![route.clone(), local_default],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     // Distinct next-hops (stored vs session-local) split into two UPDATEs.
     let mut seen_nlris = Vec::new();
@@ -5118,6 +5302,7 @@ async fn send_route_update_emits_rtc_reach_and_unreach() {
         rtc_announce: vec![],
         rtc_withdraw: vec![key],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected RTC MP_UNREACH UPDATE");
@@ -5209,6 +5394,7 @@ async fn send_route_update_emits_route_refresh_requests_for_all_negotiated_famil
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: true,
+        shared_group_encode: None,
     });
     let mut refreshed = Vec::new();
     for _ in 0..2 {
@@ -5337,6 +5523,7 @@ async fn send_route_update_skips_route_refresh_request_without_capability() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: true,
+        shared_group_encode: None,
     });
     // The first wire message must be the EoR UPDATE — no ROUTE-REFRESH
     // was emitted ahead of it.
@@ -5409,6 +5596,7 @@ async fn send_route_update_splits_ipv6_routes_by_next_hop() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(first) = read_single_bgp_message(&mut server).await else {
         panic!("expected first UPDATE");
@@ -6489,6 +6677,7 @@ async fn send_route_update_uses_ipv6_specific_next_hop_override() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     });
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
         panic!("expected UPDATE");
@@ -8028,6 +8217,7 @@ async fn route_server_client_extended_nexthop_preserves_ipv6_next_hop() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8080,6 +8270,7 @@ async fn unnumbered_ipv4_extended_nexthop_sends_link_local_mp_reach() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8138,6 +8329,7 @@ async fn unnumbered_ipv4_recomputes_link_local_companion_after_next_hop_self() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8196,6 +8388,7 @@ async fn extended_nexthop_clears_companion_when_primary_next_hop_is_rewritten() 
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8249,6 +8442,7 @@ async fn unnumbered_ipv4_without_extended_nexthop_does_not_fallback_to_body_nlri
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let mut header = [0_u8; 19];
@@ -8316,6 +8510,7 @@ async fn route_server_client_ipv6_preserves_next_hop() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8372,6 +8567,7 @@ async fn ipv6_next_hop_self_clears_stale_link_local_companion() {
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {
@@ -8430,6 +8626,7 @@ async fn scoped_peer_does_not_send_ipv6_unicast_with_link_local_primary_next_hop
         labeled_withdraw: vec![],
         rtc_withdraw: vec![],
         request_refresh_all_negotiated: false,
+        shared_group_encode: None,
     };
     session.send_route_update(update);
     let Message::Update(msg) = read_single_bgp_message(&mut server).await else {

--- a/docs/adr/0109-update-group-shared-encode.md
+++ b/docs/adr/0109-update-group-shared-encode.md
@@ -1,0 +1,89 @@
+# ADR-0109: Encode-once wire sharing for update-group fanout
+
+**Status:** Accepted
+**Date:** 2026-07-16
+
+## Context
+
+A clean grouped export-policy transition (ADR-0105) releases the same
+`Arc`-shared announce inventory to every member of an update-group; the
+envelopes differ per member only by `announce_source_exclusion` and the
+member's exact-export snapshot. Every member's session task then encoded its
+own full wire UPDATE stream from that shared inventory. At route-server
+scale the encodes are byte-identical work repeated N times: with 700
+members × 400,400 routes, the N full encodes fair-share the machine and
+every observer's first post-reload UPDATE arrives together after the total
+encode time divided by the core count — a measured flat ~1.03 s stall
+(p50≈p95), with a ~0.76 s floor attributable to encoding alone.
+
+Update-group membership already guarantees a shared export-policy outcome,
+and `SessionExportProfile::has_same_wire_encoding` already proves when two
+sessions' profiles produce identical bytes for the same route (it is the
+probe-reuse proof for the transition's exact-export preflight). Add-Path
+peers are disqualified from update-groups (ADR-0099), so per-member path-id
+divergence cannot arise on this seam.
+
+## Decision
+
+**Encode once per fanout, in the first consuming session task; share the
+encoded bytes through the envelope.** The `CommitMembers` phase creates one
+`SharedGroupEncode` cell (a `tokio::sync::OnceCell`) per transition and
+attaches it to every member envelope. The first member to consume its
+envelope encodes the whole inventory and publishes the result; concurrent
+members await the cell instead of re-encoding. Encoding in a session task —
+rather than in the RIB actor — keeps the actor's polls bounded and needs no
+new cross-crate encoding surface: the cell payload is opaque to the RIB
+(the same `as_any` trust-boundary pattern as the exact-export snapshot).
+
+**Sharing key: the wire-encoding profile.** A member reuses the published
+bytes only when its own envelope snapshot proves
+`has_same_wire_encoding` with the encoder's profile. That predicate is
+derived full-struct equality with only snapshot identity, generation, and
+the negotiated message ceiling normalized out, so newly added wire inputs
+stay inside the proof by default.
+
+**Exclusion mechanism: per-source chunks.** The shared encode groups routes
+exactly like the per-session path (prepared-attribute identity plus next
+hops) with the source peer added to the group key, then chunks each group
+to the message ceiling. A chunk therefore carries routes of exactly one
+source peer and one family, and a member's stream composes as "all chunks
+except its own source's, restricted to its negotiated families". Keeping
+the source in the key matters because global attribute interning can give
+two sources pointer-identical attribute sets; the per-session grouping is
+deliberately left unchanged (merging sources there produces fewer
+messages).
+
+**Ceiling: chunk to the standard 4096-byte maximum.** `has_same_wire_encoding`
+deliberately ignores the RFC 8654 extended-message capability because the
+ceiling does not change a route's bytes; a ≤4096-byte message is valid for
+extended peers too, so one shared byte stream serves members with mixed
+ceilings. A single entry that exceeds 4096 bytes makes the payload
+unshareable rather than reproducing the oversize-teardown policy here.
+
+**Fallback: the ordinary per-session encode, on any anomaly.** The encoder
+publishes an explicit *unshareable* marker on preparation failure, an OTC
+egress hit, a scoped-link-local IPv4 drop, or a single-entry oversize; a
+consuming member falls back when the payload is unshareable, when its
+profile fails the equality proof, when the envelope carries anything beyond
+unicast announcements, or when its snapshot fails the existing owner trust
+checks. The fallback is the unmodified existing path and owns all
+diagnostics and teardown semantics for those cases. Once a member has begun
+enqueueing shared chunks, an enqueue failure aborts the batch exactly like
+the per-session chunked senders (the saturation/teardown policy runs inside
+the byte-level enqueue seam, which the BMP rib-out tap also shares, keeping
+the mirror byte-exact).
+
+## Consequences
+
+- Reload re-advertisement encode cost drops from N× to 1× per update-group;
+  at 300 clients × 171,600 routes the observer max-gap p50 drops
+  correspondingly (measured in the PR introducing this ADR).
+- Members of one group can negotiate different family sets: chunks carry
+  their family and are filtered per member, preserving the per-session
+  path's negotiated-family semantics.
+- The ordinary incremental delta fanout (per-member materialized views) is
+  unchanged; extending sharing to it would require the same per-source
+  composition at the delta seam and is deliberately out of scope.
+- The shared bytes hold one encoded copy of the table for the life of the
+  fanout envelopes — bounded by the same inventory the envelopes already
+  share.


### PR DESCRIPTION
## Problem

At route-server scale, a policy reload's re-advertisement gives every observer a flat delay before its first wire UPDATE (measured ~1.03 s at 700 clients x 400,400 routes, p50~p95 within 2 ms). The clean grouped export-policy transition releases the same `Arc`-shared announce inventory to every update-group member, and each member's session task then synchronously encodes its own full wire UPDATE stream from that inventory — N byte-identical encodes fair-sharing the cores, so all first chunks complete together at roughly the total encode work divided by the core count.

## Design (ADR-0109)

Encode once per fanout, in the first consuming session task, and share the bytes through the envelope:

- `CommitMembers` creates one `SharedGroupEncode` cell (`tokio::sync::OnceCell`, payload opaque to the RIB via the existing `as_any` trust-boundary pattern) per transition and attaches it to every member envelope.
- The first member to consume its envelope encodes the inventory into per-`(source peer, family)` chunks at the standard 4096-byte ceiling and publishes them; every other member awaits the cell instead of re-encoding.
- **Sharing key:** a member reuses the bytes only after proving `has_same_wire_encoding` between its envelope snapshot and the encoder's profile — the same derived-equality byte-identity proof the transition's probe reuse already relies on. Chunking to the standard ceiling keeps one byte stream valid across mixed RFC 8654 ceilings because that predicate deliberately ignores `extended_messages`.
- **Exclusion:** chunks never mix source peers (the source is in the group key, guarding against interned attribute sets shared across sources), so `announce_source_exclusion` composes from whole chunks: a member sends all chunks except its own source's, restricted to its negotiated families.
- **Fallback:** any anomaly — profile mismatch, preparation failure, OTC egress hit, scoped-link-local IPv4 drop, single entry over 4096 bytes, richer envelope payload, failed snapshot trust checks — publishes an unshareable marker or skips sharing, and the member runs the unchanged per-session encode path, which owns all diagnostics and teardown semantics.
- The byte-level bulk enqueue seam is shared with the ordinary path, so the RFC 8671 BMP rib-out tap stays byte-exact and writer-saturation teardown semantics are identical.

## Measurement

Macro: `bench/scale/reloadstall`, 300 route-server clients x 171,600 routes, mixed export-only mode (all 300 changed), 2 reloads, release builds, same host/config, stock 8 worker threads. Pre = main (with the pre-existing bench-support build fix), post = this branch.

| all-observer metric (reload 1 / 2) | pre | post | delta |
|---|---|---|---|
| maxgap p50 (ms) | 543.3 / 543.0 | 408.9 / 417.3 | -24% |
| maxgap p95 (ms) | 721.5 / 704.8 | 555.8 / 578.8 | -20% |
| maxgap max (ms) | 757.9 / 740.8 | 606.7 / 603.6 | -19% |
| first_update p50 (ms, reload 2) | 543.0 | 0.66 | first UPDATE now immediate |
| completion p50 (s) | 0.56 / 0.55 | 0.62 / 0.54 | flat |
| sessions up / parse errors | 300/300, 0 | 300/300, 0 | — |

A debug-instrumented reload confirmed engagement: exactly 300 "sent update-group announcements from shared encode" lines — every member reused the shared bytes. The remaining ~410 ms flat component is the transition's serial pre-commit phases in the RIB actor (probe pass), a separate seam; the duplicate-encode term grows with fleet x table size, so larger shapes recover more.

Note for reproduction: the harness's historical mode (import+export change) never engages the grouped cohort (`export_only_policy_cohort_mask` selects no one because import chains changed) — mixed export-only mode is required, matching the receipt in `docs/perf/reload-stall-2026-07.md`.

Micro: criterion A/B (`rib_ops`, `--features bench-internals`, baseline on detached pre commit, same target dir): `bulk_initial_load/10000` -1.3% (p=0.21, no change), `bulk_initial_load/100000` -3.0%, `route_churn/10k_base_1k_churn` -2.7%. No touched-path regression.

## Invariants preserved

- LAN-360 oversized-group chunking: shared chunks are exact-length-checked against the 4096 ceiling with the same halving strategy; a single oversize entry falls back to the per-session path (whose teardown semantics are unchanged). Existing chunking tests untouched and green.
- Per-family max-prefix (#941), NO_EXPORT egress (#943), ORF, route refresh: enforcement points are upstream of this seam (RIB staging / envelope payloads other than plain unicast announcements bypass sharing entirely).
- RFC 9234 OTC egress: the shared encoder applies the same profile-derived filter; any hit makes the payload unshareable so per-member diagnostics stay on the existing path.
- Add-Path: disqualified from update-groups (ADR-0099); additionally covered by the profile equality proof (`add_path_send_families` is a compared field).
- Overload/backpressure: shed/dirty-resync semantics unchanged — sharing changes where bytes come from, not the channels, permits, or saturation policy.
- BMP rib-out mirror stays byte-exact (same enqueue seam, same Bytes).

## Tests

- Transport: encode-once + per-source exclusion oracle, profile-mismatch fallback correctness, unnegotiated-family chunk skip (`crates/transport/src/session/tests.rs`).
- RIB: grouped commits must hand every member the same cell; the ungrouped path must never carry one (`crates/rib/src/manager/tests/update_groups.rs`).

Gates (exit codes): clippy -D warnings 0; `cargo test -p rustbgpd-rib` 0; `-p rustbgpd-transport` 0; `--workspace` 0; `cargo check -p rustbgpd-rib --features bench-internals --benches` 0; `cargo doc --workspace --no-deps` 0.
