### PR TITLE
fix(api,transport): harden secret equality, credential reload, and gNMI on-change test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `TransportAuthSecret` equality is now constant-time. The derived
+  `PartialEq` compared secret bytes with an early-out; the manual
+  implementation compares in time dependent only on the longer input's
+  length and does not short-circuit on a length mismatch. Current callers
+  only diff config against config, so this hardens a footgun rather than
+  fixing an exploitable path.
+
+- `CredentialStore::reload` now serializes its sequence increment and
+  generation publish behind a reload lock, so concurrent reloads can no
+  longer mint duplicate generation sequences or publish out of order.
+  Today's only caller (SIGHUP) already serialized reloads; the store no
+  longer relies on that.
+
+- The gNMI `subscribe_on_change_streams_session_transitions` test no
+  longer flakes on a 2-second delivery timeout: the event-history test
+  fixture commits with `SYNCHRONOUS=NORMAL` instead of `FULL` (the
+  subscription tests exercise plumbing, not outbox durability, and the
+  per-commit fsyncs were the latency source), and the bounded wait is now
+  a hang guard rather than a latency assertion.
+
 - **Closed outbound channels no longer re-mark peers dirty for resync, so
   shutdown quiesces instead of livelocking.** The outbound send path treated
   a closed per-peer channel (session gone) the same as a full one (peer

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arc_swap::ArcSwap;
 use tokio_rustls::rustls::pki_types::pem::PemObject;
@@ -81,6 +81,10 @@ impl CredentialGeneration {
 pub struct CredentialStore {
     sources: Arc<[CredentialSource]>,
     active: Arc<ArcSwap<CredentialGeneration>>,
+    /// Serializes [`Self::reload`]'s read-increment-publish so
+    /// concurrent reloads can never mint duplicate sequences or
+    /// publish out of order. Readers stay lock-free via `active`.
+    reload_lock: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for CredentialStore {
@@ -112,6 +116,7 @@ impl CredentialStore {
         Ok(Self {
             sources,
             active: Arc::new(ArcSwap::from(generation)),
+            reload_lock: Arc::new(Mutex::new(())),
         })
     }
 
@@ -122,10 +127,18 @@ impl CredentialStore {
 
     /// Stage all configured files, then atomically publish one generation.
     ///
+    /// Reloads are serialized: concurrent callers each publish a distinct,
+    /// strictly increasing sequence (the SIGHUP path happens to serialize
+    /// reloads already, but the store does not rely on that).
+    ///
     /// # Errors
     /// Returns a redacted error when any listener fails staging. The active
     /// generation is left unchanged.
     pub fn reload(&self) -> Result<u64, String> {
+        let _guard = self
+            .reload_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sequence = self.load().sequence.saturating_add(1);
         let candidate = Arc::new(stage_generation(&self.sources, sequence)?);
         self.active.store(candidate);
@@ -483,6 +496,43 @@ mod tests {
         barrier.wait();
         store.reload().unwrap();
         reader.join().unwrap();
+    }
+
+    #[test]
+    fn concurrent_reloads_publish_unique_increasing_sequences() {
+        const THREADS: usize = 8;
+        const RELOADS: usize = 25;
+        let token = token_file("tok");
+        let store = CredentialStore::stage(vec![CredentialSource {
+            token_file: Some(token.path().to_path_buf()),
+            tls: None,
+        }])
+        .unwrap();
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    (0..RELOADS)
+                        .map(|_| store.reload().unwrap())
+                        .collect::<Vec<u64>>()
+                })
+            })
+            .collect();
+        let mut sequences: Vec<u64> = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().unwrap())
+            .collect();
+        sequences.sort_unstable();
+        // Serialized reloads mint every sequence exactly once: the initial
+        // generation is 1, so the published set is exactly 2..=total+1.
+        let total = u64::try_from(THREADS * RELOADS).unwrap();
+        let expected: Vec<u64> = (2..=total + 1).collect();
+        assert_eq!(sequences, expected);
+        assert_eq!(store.load().sequence(), total + 1);
     }
 
     #[tokio::test]

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -3356,7 +3356,11 @@ mod tests {
             path: dir.path().join("events.db"),
             max_events: 100,
             max_bytes: 1_000_000,
-            synchronous: SynchronousMode::Full,
+            // NORMAL, not FULL: this fixture exercises gNMI subscription
+            // plumbing, not outbox durability. FULL puts two fsyncs on the
+            // temp filesystem inside every commit the tests' bounded waits
+            // cover, which is where the old 2s-timeout flake came from.
+            synchronous: SynchronousMode::Normal,
             required: false,
             queue_capacity: 64,
             batch_size: 1,
@@ -3511,11 +3515,13 @@ mod tests {
         manager.handle().sender().try_send(envelope).unwrap();
 
         // The ON_CHANGE task forwards the transition with the new
-        // OpenConfig short-form state name. Bounded wait so the test
-        // doesn't hang on a regression.
-        let response = tokio::time::timeout(Duration::from_secs(2), stream.message())
+        // OpenConfig short-form state name. Delivery is race-free (the
+        // broadcast attach happens-before the sync_response drained
+        // above) but rides a real SQLite commit + broadcast hop, so the
+        // bound is a generous hang guard, not a latency assertion.
+        let response = tokio::time::timeout(Duration::from_secs(30), stream.message())
             .await
-            .expect("ON_CHANGE Update did not arrive within 2s")
+            .expect("ON_CHANGE Update did not arrive (hang guard)")
             .unwrap()
             .unwrap();
         let Some(gnmi::subscribe_response::Response::Update(notif)) = response.response else {

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -13,8 +13,31 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 /// The wrapper deliberately exposes only borrowed plaintext access. Its inner
 /// wrapper allocation is zeroized when that runtime copy is dropped; schema,
 /// parser, API, and kernel copies have separate lifetimes.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct TransportAuthSecret(Zeroizing<String>);
+
+/// Constant-time equality. Comparison cost depends only on the longer
+/// input's length — no early return on the first mismatching byte and no
+/// length-based short-circuit — so config-diff paths can't be turned into
+/// a byte-by-byte timing oracle if one side is ever attacker-influenced.
+impl PartialEq for TransportAuthSecret {
+    fn eq(&self, other: &Self) -> bool {
+        constant_time_eq(self.0.as_bytes(), other.0.as_bytes())
+    }
+}
+
+impl Eq for TransportAuthSecret {}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let max_len = a.len().max(b.len());
+    let mut diff = a.len() ^ b.len();
+    for idx in 0..max_len {
+        let lhs = a.get(idx).copied().unwrap_or(0);
+        let rhs = b.get(idx).copied().unwrap_or(0);
+        diff |= usize::from(lhs ^ rhs);
+    }
+    diff == 0
+}
 
 impl From<String> for TransportAuthSecret {
     fn from(secret: String) -> Self {
@@ -437,6 +460,17 @@ mod tests {
         secret.zeroize();
         assert!(secret.as_ref().is_empty());
         assert_eq!(retained_clone.as_ref(), "transport-secret-sentinel");
+    }
+
+    #[test]
+    fn transport_auth_secret_eq_matches_value_semantics() {
+        let a = TransportAuthSecret::from("secret");
+        assert_eq!(a, TransportAuthSecret::from("secret"));
+        assert_ne!(a, TransportAuthSecret::from("secreT"));
+        // Length differences (prefix and empty) must also compare unequal.
+        assert_ne!(a, TransportAuthSecret::from("secret-longer"));
+        assert_ne!(a, TransportAuthSecret::from(""));
+        assert_eq!(TransportAuthSecret::from(""), TransportAuthSecret::from(""));
     }
 
     #[test]


### PR DESCRIPTION
Closes three small items deferred from earlier PRs.

## TransportAuthSecret constant-time equality (crates/transport)

The derived `PartialEq` compared secret bytes with an early-out. The manual implementation compares in time dependent only on the longer input's length — no early return on the first mismatching byte, no length short-circuit (length mismatch is folded into the accumulator). All current callers diff config against config, so this closes a footgun rather than an exploitable path. Debug output remains `<redacted>`; no secret bytes, lengths, or hashes appear in any log path. Covered by a value-semantics equality test including differing-length and empty inputs.

## CredentialStore::reload serialization (crates/api)

`reload` performed an unsynchronized read-increment-publish against the `ArcSwap`: two concurrent reloads could both read sequence N and both publish N+1, losing an update and minting duplicate sequences. Reloads are now serialized behind a reload lock (readers stay lock-free via the `ArcSwap`). Today's only caller (SIGHUP) already serialized reloads; the store no longer relies on that. Covered by an 8-thread × 25-reload test asserting every published sequence is distinct and the final generation equals initial + total reloads.

## gNMI subscribe_on_change_streams_session_transitions flake (crates/api)

The delivery path is race-free — `run_on_change` attaches the broadcast receiver before emitting the snapshot and `sync_response`, the test drains the sync before injecting, and the actor broadcasts only after commit — so the event cannot be lost, only delayed. The flake was the fixed 2s timeout racing real durable-commit latency: the fixture configured `SYNCHRONOUS=FULL`, putting per-commit fsyncs on the temp filesystem inside the bounded wait. The fixture now uses `SYNCHRONOUS=NORMAL` (these tests exercise subscription plumbing, not outbox durability), and the bounded wait is sized as a hang guard rather than a latency assertion.

The flake did not reproduce at HEAD on this machine before the fix: 20/20 solo runs, 5/5 full-module runs, and 160/160 runs at 16-way parallelism pinned to 2 CPUs all passed. The latency-race diagnosis is from code analysis of the ordering seams plus the fixture's fsync configuration. Post-fix: 20/20 solo runs green.

## Gates (exit codes)

- `cargo clippy --workspace --all-targets -- -D warnings`: 0
- `cargo test -p rustbgpd-api`: 0
- `cargo test -p rustbgpd-transport`: 0
- `cargo test --workspace`: 0
- `cargo doc --workspace --no-deps`: 0