### PR TITLE
Wire labeled-unicast export staging into the explain gate ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Labeled-unicast export explain.** `rbgp rib advertised <peer> --prefix
+  <cidr> --explain --labeled` (gRPC `ExplainAdvertisedRoute` with
+  `labeled = true`) dry-runs the live labeled-unicast (SAFI 4, RFC 8277)
+  staging body with an explain-only target and reports the full export
+  gate ladder — family, best-route selection, RFC 9494 LLGR restriction,
+  split horizon, RFC 4456 reflection, RFC 1997 NO_ADVERTISE/NO_EXPORT,
+  export policy, and the advertised-state diff — matching the unicast and
+  VPN explains. Labeled export suppressions previously produced no reason
+  line.
+
 - **`interpret_rfc1997` per-neighbor / per-peer-group knob.** Controls the
   RFC 1997 `NO_EXPORT` egress enforcement above. Default is derived:
   `true` unless `route_server_client = true` (route servers stay
@@ -255,6 +265,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   subscription tests exercise plumbing, not outbox durability, and the
   per-commit fsyncs were the latency source), and the bounded wait is now
   a hang guard rather than a latency assertion.
+
+- **Single-best exports suppressed by policy-added NO_ADVERTISE now record
+  a policy-filtered entry.** When an export policy permitted a route but
+  added NO_ADVERTISE, the single-best and ORR single-best unicast staging
+  tails withheld the route without the policy-filtered entry the multipath
+  body records — the route disappeared from the peer with no
+  filtered-routes view entry or `policy_filtered` route event. Both tails
+  now record the suppression exactly like the policy-deny arm.
 
 - **Closed outbound channels no longer re-mark peers dirty for resync, so
   shutdown quiesces instead of livelocking.** The outbound send path treated

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -247,6 +247,7 @@ impl RibService {
         peer: IpAddr,
         prefix: Prefix,
         rd: Option<rustbgpd_wire::RouteDistinguisher>,
+        labeled: bool,
     ) -> Result<Option<ExplainAdvertisedRoute>, Status> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.rib_tx
@@ -254,6 +255,7 @@ impl RibService {
                 peer,
                 prefix,
                 rd,
+                labeled,
                 reply: reply_tx,
             })
             .await
@@ -1461,8 +1463,13 @@ impl proto::rib_service_server::RibService for RibService {
                     .map_err(|e| Status::invalid_argument(format!("invalid rd: {e}")))?,
             )
         };
+        if req.labeled && rd.is_some() {
+            return Err(Status::invalid_argument(
+                "rd and labeled are mutually exclusive: a route is VPN or labeled-unicast, not both",
+            ));
+        }
         let Some(explain) = self
-            .query_explain_advertised_route(peer, prefix, rd)
+            .query_explain_advertised_route(peer, prefix, rd, req.labeled)
             .await?
         else {
             return Err(Status::not_found(
@@ -4005,6 +4012,7 @@ mod tests {
             prefix: "203.0.113.0".to_string(),
             prefix_length: 24,
             rd: String::new(),
+            labeled: false,
         });
         let err = svc.explain_advertised_route(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -4019,6 +4027,7 @@ mod tests {
             prefix: "203.0.113.0".to_string(),
             prefix_length: 24,
             rd: String::new(),
+            labeled: false,
         });
 
         let call = tokio::spawn(async move { svc.explain_advertised_route(req).await });
@@ -4028,10 +4037,12 @@ mod tests {
                 peer,
                 prefix,
                 rd,
+                labeled,
                 reply,
             } => {
                 assert_eq!(peer, "192.0.2.1".parse::<IpAddr>().unwrap());
                 assert_eq!(rd, None);
+                assert!(!labeled);
                 assert_eq!(
                     prefix,
                     Prefix::V4(Ipv4Prefix::new("203.0.113.0".parse().unwrap(), 24))

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1683,6 +1683,7 @@ pub async fn explain_advertised(
     address: &str,
     prefix: &str,
     rd: Option<&str>,
+    labeled: bool,
     json: bool,
 ) -> Result<(), CliError> {
     let (addr, len) = output::parse_prefix(prefix).map_err(CliError::Argument)?;
@@ -1694,6 +1695,7 @@ pub async fn explain_advertised(
             prefix: addr,
             prefix_length: len,
             rd: rd.unwrap_or_default().to_string(),
+            labeled,
         })
         .await?
         .into_inner();
@@ -1863,9 +1865,16 @@ mod tests {
         let server = spawn_mock_server(None).await;
         let connection = connect(&server.addr, None).await.unwrap();
 
-        explain_advertised(connection, "192.0.2.1", "203.0.113.0/24", None, false)
-            .await
-            .unwrap();
+        explain_advertised(
+            connection,
+            "192.0.2.1",
+            "203.0.113.0/24",
+            None,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         let req = server
             .state
@@ -1890,6 +1899,7 @@ mod tests {
             "192.0.2.1",
             "10.0.7.0/24",
             Some("65000:1"),
+            false,
             false,
         )
         .await

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1045,6 +1045,10 @@ enum RibAction {
         /// including the RFC 4684 RT-Constrain membership gate
         #[arg(long, requires = "explain")]
         rd: Option<String>,
+        /// Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder
+        /// for the prefix instead of the plain unicast ladder
+        #[arg(long, requires = "explain", conflicts_with = "rd")]
+        labeled: bool,
     },
     /// Show RFC 7999 BLACKHOLE discard install status
     Blackholes,
@@ -2200,6 +2204,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                     family: fam,
                     explain: explain_advertised,
                     rd,
+                    labeled,
                 }) => {
                     if explain {
                         return Err(CliError::Argument(
@@ -2232,6 +2237,7 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                             &address,
                             prefix,
                             rd.as_deref(),
+                            labeled,
                             json,
                         )
                         .await

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -1,7 +1,6 @@
 use super::{
-    AdjRibIn, AdjRibOut, Afi, BgpMetrics, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib,
-    NeighborPolicyStats, PolicyChain, RibManager, RouteContext, Safi, gauge_val,
-    labeled_route_family, labeled_routes_equal, record_export_policy_eval, route_type,
+    AdjRibIn, AdjRibOut, Afi, HashMap, HashSet, IpAddr, Ipv4Addr, LocRib, PolicyChain, RibManager,
+    RouteContext, Safi, gauge_val, labeled_route_family, labeled_routes_equal, route_type,
     should_suppress_ibgp_inner, warn,
 };
 use crate::loc_rib::labeled_tiebreak_orr;
@@ -66,6 +65,12 @@ impl RibManager {
     /// route IS an IP prefix) plus communities, large communities,
     /// `AS_PATH`, peer, and route type.
     ///
+    /// `target` selects the consumer (the unicast `ExportTarget` pattern —
+    /// ONE body, never copied): a concrete peer for live staging, or the
+    /// explain dry run that records the gate ladder and counts nothing.
+    /// Labeled-unicast has no update-group staging, so a `Group` target is
+    /// never constructed for this body.
+    ///
     /// When the target negotiated Add-Path send for the key's family (RFC
     /// 7911), up to `add_path_send_max` candidates per key are ranked — with
     /// the ORR vantage comparator when a vantage is resolved — and staged
@@ -83,9 +88,7 @@ impl RibManager {
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
         keys: &HashSet<Prefix>,
-        target_peer: IpAddr,
-        target_peer_asn: Option<u32>,
-        target_peer_group: Option<&str>,
+        target: &mut super::ExportTarget<'_>,
         target_is_ebgp: bool,
         interpret_rfc1997: bool,
         target_is_rr_client: bool,
@@ -97,14 +100,12 @@ impl RibManager {
         add_path_send_limits: Option<&HashMap<(Afi, Safi), u32>>,
         add_path_send_families: &[(Afi, Safi)],
         export_pol: Option<&PolicyChain>,
-        metrics: &BgpMetrics,
-        policy_stats: &mut NeighborPolicyStats,
-        target_peer_label: &str,
         labeled_announce: &mut Vec<LabeledRibRoute>,
         labeled_withdraw: &mut Vec<LabeledRibRouteKey>,
         force: bool,
     ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
+        let split_horizon_peer = target.split_horizon_peer();
         for key in keys {
             let family = labeled_afi_safi(key);
             // Path IDs currently advertised for this identity — the diff
@@ -121,9 +122,21 @@ impl RibManager {
             };
 
             if !sendable.is_some_and(|f| f.contains(&family)) {
+                target.gate(
+                    "family",
+                    "family_not_sendable",
+                    crate::update::ExportGateVerdict::Stop,
+                    || format!("peer cannot receive {} routes", super::family_label(family)),
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
+            target.gate(
+                "family",
+                "family",
+                crate::update::ExportGateVerdict::Pass,
+                || format!("peer negotiated {}", super::family_label(family)),
+            );
 
             let key_send_max = if add_path_send_families.contains(&family) {
                 add_path_send_limits
@@ -134,6 +147,22 @@ impl RibManager {
             };
 
             if key_send_max > 0 {
+                // ponytail: the multipath arm stages a ranked top-N and is
+                // not gate-traced per candidate — an explain dry run gets
+                // this summary note instead of a per-rank ladder (same
+                // carve-out as the VPN sibling).
+                target.gate(
+                    "add_path",
+                    "add_path_send",
+                    crate::update::ExportGateVerdict::NotApplicable,
+                    || {
+                        format!(
+                            "peer negotiated Add-Path send for this family (up to \
+                             {key_send_max} paths); the gate ladder explains single-best \
+                             export only"
+                        )
+                    },
+                );
                 // Multi-path: collect the per-target candidate set (every
                 // Adj-RIB-In entry for the identity, any received path ID,
                 // that survives split horizon and RFC 4456 reflection),
@@ -142,7 +171,7 @@ impl RibManager {
                     .values()
                     .flat_map(|rib| rib.iter_labeled_for_prefix(key))
                     .filter(|candidate| {
-                        candidate.peer != target_peer
+                        split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &labeled_suppression_probe(candidate),
                                 target_is_ebgp,
@@ -216,6 +245,7 @@ impl RibManager {
                     let origin_asn = candidate
                         .as_path()
                         .and_then(rustbgpd_wire::AsPath::origin_asn);
+                    let (peer_address, peer_asn, peer_group) = target.ctx_peer();
                     let ctx = RouteContext {
                         prefix: Some(candidate.nlri.prefix),
                         next_hop: Some(candidate.next_hop),
@@ -228,23 +258,17 @@ impl RibManager {
                         origin_asn,
                         validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                         aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-                        peer_address: Some(target_peer),
-                        peer_asn: target_peer_asn,
-                        peer_group: target_peer_group,
+                        peer_address,
+                        peer_asn,
+                        peer_group,
                         route_type: Some(route_type(candidate.origin_type)),
                         family: Some(labeled_route_family(&candidate.nlri.prefix)),
                         evpn_route_type: None,
                         local_pref: candidate.local_pref_attr(),
                         med: candidate.med_attr(),
                     };
-                    let (result, evaluation) =
-                        rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
-                    record_export_policy_eval(
-                        metrics,
-                        policy_stats,
-                        target_peer_label,
-                        &evaluation,
-                    );
+                    let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+                    target.record_eval(&evaluation, candidate.peer);
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
                         continue;
                     }
@@ -302,7 +326,7 @@ impl RibManager {
                     .values()
                     .flat_map(|rib| rib.iter_labeled_for_prefix(key))
                     .filter(|candidate| {
-                        candidate.peer != target_peer
+                        split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &labeled_suppression_probe(candidate),
                                 target_is_ebgp,
@@ -320,17 +344,55 @@ impl RibManager {
                         )
                     });
                 let Some(winner) = winner else {
+                    target.gate(
+                        "best_route",
+                        "no_orr_candidate",
+                        crate::update::ExportGateVerdict::Stop,
+                        || {
+                            "no candidate for this identity survives split-horizon / \
+                             reflection filtering for this ORR peer"
+                                .to_string()
+                        },
+                    );
                     withdraw_existing(labeled_withdraw, existing_path_ids);
                     continue;
                 };
+                target.gate(
+                    "best_route",
+                    "orr_vantage_best",
+                    crate::update::ExportGateVerdict::Pass,
+                    || format!("per-vantage best from {}", winner.peer),
+                );
                 winner
             } else {
                 let Some(best) = loc_rib.get_labeled(key) else {
+                    target.gate(
+                        "best_route",
+                        "no_best_route",
+                        crate::update::ExportGateVerdict::Stop,
+                        || "no best route exists for this labeled prefix identity".to_string(),
+                    );
                     withdraw_existing(labeled_withdraw, existing_path_ids);
                     continue;
                 };
                 best
             };
+            if let (Some(trace), None) = (target.trace(), orr_ctx) {
+                trace.push(
+                    "best_route",
+                    super::route_type_label(route_type(best.origin_type)),
+                    crate::update::ExportGateVerdict::Pass,
+                    format!(
+                        "{} (Loc-RIB best from {})",
+                        super::route_type_message(route_type(best.origin_type)),
+                        best.peer
+                    ),
+                );
+            }
+            if let Some(trace) = target.trace() {
+                trace.best_peer = Some(best.peer);
+                trace.best_route_type = Some(route_type(best.origin_type));
+            }
 
             // RFC 9494 §4.4: LLGR-stale toward a non-LLGR eBGP peer is
             // suppressed. See `llgr_stale_export_suppressed`.
@@ -341,17 +403,50 @@ impl RibManager {
                 target_is_ebgp,
                 llgr,
             ) {
+                target.gate(
+                    "llgr",
+                    "llgr_stale_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "LLGR-stale route suppressed toward an eBGP peer that did not \
+                         advertise the Long-Lived Graceful Restart capability for this \
+                         family (RFC 9494 §4.4)"
+                            .to_string()
+                    },
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
+            target.gate(
+                "llgr",
+                "llgr",
+                crate::update::ExportGateVerdict::Pass,
+                || "route is not suppressed by the RFC 9494 LLGR export restriction".to_string(),
+            );
 
             // The two suppression checks below are no-ops for an ORR
             // winner (its candidate set is pre-filtered above); they
             // decide only for the Loc-RIB best of a plain peer.
-            if best.peer == target_peer {
+            if split_horizon_peer == Some(best.peer) {
+                target.gate(
+                    "split_horizon",
+                    "ibgp_split_horizon",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "route is suppressed by split horizon because it originated from \
+                         the target peer"
+                            .to_string()
+                    },
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
+            target.gate(
+                "split_horizon",
+                "split_horizon",
+                crate::update::ExportGateVerdict::Pass,
+                || "route did not originate from the target peer".to_string(),
+            );
 
             if should_suppress_ibgp_inner(
                 &labeled_suppression_probe(best),
@@ -360,22 +455,62 @@ impl RibManager {
                 cluster_id,
                 peer_is_rr_client,
             ) {
+                if let Some(trace) = target.trace() {
+                    let (code, detail) = super::rr_suppression_reason(
+                        &labeled_suppression_probe(best),
+                        target_is_ebgp,
+                        target_is_rr_client,
+                        cluster_id,
+                        peer_is_rr_client,
+                    );
+                    trace.push(
+                        "rr_reflection",
+                        code,
+                        crate::update::ExportGateVerdict::Stop,
+                        detail.to_string(),
+                    );
+                }
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
+            target.gate(
+                "rr_reflection",
+                "rr_reflection",
+                crate::update::ExportGateVerdict::Pass,
+                || "iBGP split-horizon / RFC 4456 reflection rules permit this route".to_string(),
+            );
 
             if super::no_advertise_export_suppressed(best.communities()) {
+                target.gate(
+                    "no_advertise",
+                    "no_advertise_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "source route carries NO_ADVERTISE; RFC 1997 forbids advertising it"
+                            .to_string()
+                    },
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
-            // RFC 1997: NO_EXPORT/NO_EXPORT_SUBCONFED source-route
-            // suppression toward an eBGP target in honor mode (see
-            // `no_export_export_suppressed`; pre-policy only).
+            // RFC 1997: NO_EXPORT/NO_EXPORT_SUBCONFED — same pre-policy
+            // source-route placement; no post-policy twin (policy-added
+            // NO_EXPORT is delivered). See `no_export_export_suppressed`.
             if super::no_export_export_suppressed(
                 best.communities(),
                 target_is_ebgp,
                 interpret_rfc1997,
             ) {
+                target.gate(
+                    "no_export",
+                    "no_export_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "source route carries NO_EXPORT (or NO_EXPORT_SUBCONFED); RFC 1997 \
+                         forbids advertising it to an eBGP peer"
+                            .to_string()
+                    },
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
@@ -388,6 +523,7 @@ impl RibManager {
             };
             let aspath_len = best.as_path().map_or(0, rustbgpd_wire::AsPath::len);
             let origin_asn = best.as_path().and_then(rustbgpd_wire::AsPath::origin_asn);
+            let (peer_address, peer_asn, peer_group) = target.ctx_peer();
             let ctx = RouteContext {
                 prefix: Some(best.nlri.prefix),
                 next_hop: Some(best.next_hop),
@@ -400,21 +536,57 @@ impl RibManager {
                 origin_asn,
                 validation_state: rustbgpd_wire::RpkiValidation::NotFound,
                 aspa_state: rustbgpd_wire::AspaValidation::Unknown,
-                peer_address: Some(target_peer),
-                peer_asn: target_peer_asn,
-                peer_group: target_peer_group,
+                peer_address,
+                peer_asn,
+                peer_group,
                 route_type: Some(route_type(best.origin_type)),
                 family: Some(labeled_route_family(&best.nlri.prefix)),
                 evpn_route_type: None,
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
-            let (result, evaluation) =
-                rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
-            record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
+            let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+            target.record_eval(&evaluation, best.peer);
+            if let Some(trace) = target.trace() {
+                trace.policy_label = export_pol.map(|chain| {
+                    super::policy_label_with_term(
+                        Some(chain),
+                        &ctx,
+                        evaluation.matched_policy.as_deref(),
+                    )
+                });
+            }
             if result.action != rustbgpd_policy::PolicyAction::Permit {
+                if let Some(trace) = target.trace() {
+                    let label = trace.policy_label.clone().unwrap_or_default();
+                    trace.push(
+                        "export_policy",
+                        "policy_denied",
+                        crate::update::ExportGateVerdict::Stop,
+                        format!("export policy {label:?} denied this route"),
+                    );
+                }
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
+            }
+            if let Some(trace) = target.trace() {
+                // Record staged modifications only after the Permit above — a
+                // denied route carries none (mirrors the unicast/VPN arms).
+                trace.modifications = result.modifications.clone();
+                match trace.policy_label.clone() {
+                    Some(label) => trace.push(
+                        "export_policy",
+                        "policy_permitted",
+                        crate::update::ExportGateVerdict::Pass,
+                        format!("export policy {label:?} permitted this route"),
+                    ),
+                    None => trace.push(
+                        "export_policy",
+                        "export_policy",
+                        crate::update::ExportGateVerdict::NotApplicable,
+                        "no export policy configured (default permit)".to_string(),
+                    ),
+                }
             }
 
             let mut modified = best.clone();
@@ -428,6 +600,15 @@ impl RibManager {
                 }
             }
             if super::no_advertise_export_suppressed(modified.communities()) {
+                target.gate(
+                    "no_advertise",
+                    "no_advertise_policy_suppressed",
+                    crate::update::ExportGateVerdict::Stop,
+                    || {
+                        "export policy produced NO_ADVERTISE; RFC 1997 forbids advertising it"
+                            .to_string()
+                    },
+                );
                 withdraw_existing(labeled_withdraw, existing_path_ids);
                 continue;
             }
@@ -442,7 +623,34 @@ impl RibManager {
                     .get_labeled(&out_key)
                     .is_none_or(|existing| !labeled_routes_equal(existing, &modified))
             {
+                if let Some(trace) = target.trace() {
+                    trace.staged_next_hop = Some(modified.next_hop);
+                    trace.staged_path_id = modified.path_id;
+                    trace.suppressed_identical = false;
+                    trace.push(
+                        "adj_rib_out",
+                        "staged_announce",
+                        crate::update::ExportGateVerdict::Pass,
+                        if rib_out.get_labeled(&out_key).is_some() {
+                            "staged route differs from the advertised state — would re-announce"
+                                .to_string()
+                        } else {
+                            "identity not yet advertised to this peer — would announce".to_string()
+                        },
+                    );
+                }
                 labeled_announce.push(modified);
+            } else if let Some(trace) = target.trace() {
+                trace.staged_next_hop = Some(modified.next_hop);
+                trace.staged_path_id = modified.path_id;
+                trace.suppressed_identical = true;
+                trace.push(
+                    "adj_rib_out",
+                    "already_advertised",
+                    crate::update::ExportGateVerdict::Pass,
+                    "identical route already advertised — peer is in sync, no re-announcement"
+                        .to_string(),
+                );
             }
 
             // Clean up stale multi-path entries if this identity was
@@ -572,15 +780,21 @@ impl RibManager {
 
             let mut labeled_announce = Vec::new();
             let mut labeled_withdraw = Vec::new();
+            let mut target = super::ExportTarget::Peer {
+                peer,
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group,
+                metrics: &metrics,
+                policy_stats: &mut *policy_stats,
+                peer_label: &target_peer_label,
+            };
             Self::stage_labeled_routes(
                 &self.loc_rib,
                 &self.ribs,
                 rib_out,
                 &self.peer_is_rr_client,
                 staged_keys,
-                peer,
-                target_peer_asn,
-                target_peer_group,
+                &mut target,
                 target_is_ebgp,
                 interpret_rfc1997,
                 target_is_rr_client,
@@ -592,9 +806,6 @@ impl RibManager {
                 self.peer_add_path_send_limits.get(&peer),
                 &add_path_send_families,
                 export_pol.as_ref(),
-                &metrics,
-                policy_stats,
-                &target_peer_label,
                 &mut labeled_announce,
                 &mut labeled_withdraw,
                 false,

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3818,15 +3818,21 @@ impl RibManager {
             }
 
             if resync && !effective_labeled_keys.is_empty() {
+                let mut target = ExportTarget::Peer {
+                    peer,
+                    peer_asn: target_peer_asn,
+                    peer_group: target_peer_group,
+                    metrics: &metrics,
+                    policy_stats: &mut *policy_stats,
+                    peer_label: &target_peer_label,
+                };
                 Self::stage_labeled_routes(
                     loc_rib,
                     &self.ribs,
                     rib_out,
                     &self.peer_is_rr_client,
                     &effective_labeled_keys,
-                    peer,
-                    target_peer_asn,
-                    target_peer_group,
+                    &mut target,
                     target_is_ebgp,
                     interpret_rfc1997,
                     target_is_rr_client,
@@ -3838,9 +3844,6 @@ impl RibManager {
                     self.peer_add_path_send_limits.get(&peer),
                     &peer_add_path_send_families,
                     export_pol.as_ref(),
-                    &metrics,
-                    policy_stats,
-                    &target_peer_label,
                     &mut labeled_announce,
                     &mut labeled_withdraw,
                     is_force,

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1676,6 +1676,15 @@ impl RibManager {
                         .to_string()
                 },
             );
+            // Policy-added NO_ADVERTISE is a policy suppression: surface it
+            // through the same policy-filtered accounting as the deny arm
+            // above, matching the multipath body.
+            policy_filtered.push(PolicyFilteredRouteKey {
+                target_peer: target.policy_filtered_target(),
+                source_peer: best.peer,
+                prefix: *prefix,
+                path_id: best.path_id,
+            });
             for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }
@@ -1965,6 +1974,15 @@ impl RibManager {
         modified.path_id = 0;
 
         if super::no_advertise_export_suppressed(modified.communities()) {
+            // Policy-added NO_ADVERTISE is a policy suppression: record the
+            // policy-filtered entry, matching the multipath and single-best
+            // bodies.
+            policy_filtered.push(PolicyFilteredRouteKey {
+                target_peer,
+                source_peer: best.peer,
+                prefix: *prefix,
+                path_id: best.path_id,
+            });
             for &path_id in &existing_path_ids {
                 withdraw.push((*prefix, path_id));
             }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2006,8 +2006,9 @@ impl RibManager {
                 peer,
                 prefix,
                 rd,
+                labeled,
                 reply,
-            } => self.handle_explain_advertised_route(peer, prefix, rd, reply),
+            } => self.handle_explain_advertised_route(peer, prefix, rd, labeled, reply),
             RibUpdate::SubscribeRouteEvents { reply } => {
                 self.handle_subscribe_route_events(reply);
             }
@@ -2889,15 +2890,17 @@ impl RibManager {
         peer: IpAddr,
         prefix: Prefix,
         rd: Option<rustbgpd_wire::RouteDistinguisher>,
+        labeled: bool,
         reply: tokio::sync::oneshot::Sender<Option<ExplainAdvertisedRoute>>,
     ) {
         if !self.peer_sendable_families.contains_key(&peer) {
             let _ = reply.send(None);
             return;
         }
-        let explanation = match rd {
-            Some(rd) => self.explain_vpn_export(peer, prefix, rd),
-            None => self.explain_unicast_export(peer, prefix),
+        let explanation = match (rd, labeled) {
+            (Some(rd), _) => self.explain_vpn_export(peer, prefix, rd),
+            (None, true) => self.explain_labeled_export(peer, prefix),
+            (None, false) => self.explain_unicast_export(peer, prefix),
         };
         if reply.send(Some(explanation)).is_err() {
             warn!("query caller dropped before receiving response");
@@ -3244,6 +3247,99 @@ impl RibManager {
             peer,
             &ExactExportKey::Vpn(crate::route::VpnRibRouteKey {
                 nlri_key: key,
+                path_id: explanation.path_id,
+            }),
+            explanation,
+        )
+    }
+
+    /// Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for
+    /// `(prefix, peer)` by dry-running the live labeled staging body
+    /// (`stage_labeled_routes`) over the singleton identity with an
+    /// explain-only target — RR suppression, the LLGR restriction,
+    /// RFC 1997 community suppression, export policy, and the
+    /// advertised-state diff all come from the same code live
+    /// reflection runs. Labeled-unicast has no update-group staging,
+    /// so the explain always diffs the peer's private Adj-RIB-Out.
+    fn explain_labeled_export(&mut self, peer: IpAddr, prefix: Prefix) -> ExplainAdvertisedRoute {
+        let family = match prefix {
+            Prefix::V4(_) => (Afi::Ipv4, Safi::LabeledUnicast),
+            Prefix::V6(_) => (Afi::Ipv6, Safi::LabeledUnicast),
+        };
+        if self
+            .peer_orf_pending
+            .get(&peer)
+            .is_some_and(|gated| gated.contains(&family))
+        {
+            return Self::orf_gated_explain(peer, prefix, None);
+        }
+
+        let sendable = self.peer_sendable_families.get(&peer);
+        let llgr = self.peer_advertised_llgr_families.get(&peer);
+        let target_is_ebgp = self.peer_is_ebgp.get(&peer).copied().unwrap_or(true);
+        let interpret_rfc1997 = self.peer_interpret_rfc1997.contains(&peer);
+        let target_is_rr_client = self.peer_is_rr_client.get(&peer).copied().unwrap_or(false);
+        let peer_asn = self.peer_asn.get(&peer).copied();
+        let peer_group = self.peer_group.get(&peer).map(String::as_str);
+        let orr_ctx = self
+            .peer_orr_vantage
+            .get(&peer)
+            .and_then(|vantage| self.orr.spf.get(vantage))
+            .map(|spf| (&self.orr.topology, spf));
+        let add_path_send_max = self.peer_add_path_send_max.get(&peer).copied().unwrap_or(0);
+        let add_path_send_families = self
+            .peer_add_path_send_families
+            .get(&peer)
+            .cloned()
+            .unwrap_or_default();
+
+        let empty_rib_out;
+        let rib_out = if let Some(out) = self.adj_ribs_out.get(&peer) {
+            out
+        } else {
+            empty_rib_out = AdjRibOut::new(peer);
+            &empty_rib_out
+        };
+
+        let mut trace = distribution::ExportGateTrace::default();
+        let mut target = distribution::ExportTarget::Explain {
+            peer,
+            peer_asn,
+            peer_group,
+            local_role: self.peer_local_roles.get(&peer).copied().flatten(),
+            trace: &mut trace,
+        };
+        let mut keys = HashSet::new();
+        keys.insert(prefix);
+        let mut labeled_announce = Vec::new();
+        let mut labeled_withdraw = Vec::new();
+        Self::stage_labeled_routes(
+            &self.loc_rib,
+            &self.ribs,
+            rib_out,
+            &self.peer_is_rr_client,
+            &keys,
+            &mut target,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            self.cluster_id,
+            sendable,
+            llgr,
+            orr_ctx,
+            add_path_send_max,
+            self.peer_add_path_send_limits.get(&peer),
+            &add_path_send_families,
+            self.export_policy_for(peer),
+            &mut labeled_announce,
+            &mut labeled_withdraw,
+            false,
+        );
+        let explanation = trace.into_explain(peer, prefix, None, None);
+        self.apply_exact_export_overlay_to_explain(
+            peer,
+            &ExactExportKey::Labeled(crate::route::LabeledRibRouteKey {
+                prefix,
                 path_id: explanation.path_id,
             }),
             explanation,

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1425,15 +1425,21 @@ impl RibManager {
             }
         }
         if !all_labeled_keys.is_empty() {
+            let mut target = super::distribution::ExportTarget::Peer {
+                peer,
+                peer_asn: target_peer_asn,
+                peer_group: target_peer_group.as_deref(),
+                metrics: &metrics,
+                policy_stats: &mut *policy_stats,
+                peer_label: &target_peer_label,
+            };
             Self::stage_labeled_routes(
                 loc_rib,
                 &self.ribs,
                 &initial_view,
                 &self.peer_is_rr_client,
                 &all_labeled_keys,
-                peer,
-                target_peer_asn,
-                target_peer_group.as_deref(),
+                &mut target,
                 target_is_ebgp,
                 interpret_rfc1997,
                 target_is_rr_client,
@@ -1445,9 +1451,6 @@ impl RibManager {
                 self.peer_add_path_send_limits.get(&peer),
                 &peer_add_path_send_families,
                 export_pol.as_ref(),
-                &metrics,
-                policy_stats,
-                &target_peer_label,
                 &mut labeled_announce,
                 &mut labeled_withdraw,
                 false, // initial dump — equality check is correct

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -904,15 +904,21 @@ impl RibManager {
                 }
             }
             if !labeled_keys.is_empty() {
+                let mut target = super::distribution::ExportTarget::Peer {
+                    peer,
+                    peer_asn: target_peer_asn,
+                    peer_group: target_peer_group,
+                    metrics: &metrics,
+                    policy_stats: &mut *policy_stats,
+                    peer_label: &target_peer_label,
+                };
                 Self::stage_labeled_routes(
                     loc_rib,
                     &self.ribs,
                     &refresh_view,
                     &self.peer_is_rr_client,
                     &labeled_keys,
-                    peer,
-                    target_peer_asn,
-                    target_peer_group,
+                    &mut target,
                     target_is_ebgp,
                     interpret_rfc1997,
                     target_is_rr_client,
@@ -924,9 +930,6 @@ impl RibManager {
                     self.peer_add_path_send_limits.get(&peer),
                     &peer_add_path_send_families,
                     export_pol.as_ref(),
-                    &metrics,
-                    policy_stats,
-                    &target_peer_label,
                     &mut labeled_announce,
                     &mut labeled_withdraw,
                     false, // route refresh re-emits via empty refresh_view

--- a/crates/rib/src/manager/tests/export_explain.rs
+++ b/crates/rib/src/manager/tests/export_explain.rs
@@ -946,3 +946,205 @@ async fn vpn_explain_without_rtc_marks_rt_gate_not_applicable() {
     drop(tx);
     handle.await.unwrap();
 }
+
+// --- Labeled-unicast (SAFI 4) explain: the ladder is recorded by a dry
+// run of `stage_labeled_routes` itself, the same body live reflection
+// executes, so these tests pin the labeled truthfulness mechanism.
+
+async fn feed_labeled_routes(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    announced: Vec<crate::route::LabeledRibRoute>,
+) {
+    tx.send(RibUpdate::LabeledRoutesReceived {
+        session_id: 0,
+        peer,
+        announced,
+        withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+}
+
+fn labeled_with_communities(
+    mut route: crate::route::LabeledRibRoute,
+    communities: Vec<u32>,
+) -> crate::route::LabeledRibRoute {
+    Arc::make_mut(&mut route.attributes).push(PathAttribute::Communities(communities));
+    route
+}
+
+#[tokio::test]
+async fn labeled_split_horizon_gate_stops_route_to_its_source() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let _rx_s = explain_peer_up(
+        &tx,
+        source,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+
+    let route = make_labeled_rib_route(Ipv4Addr::new(10, 0, 0, 1), 61, 100, 100);
+    let prefix = route.nlri.prefix;
+    feed_labeled_routes(&tx, source, vec![route]).await;
+
+    let explain = query_explain_advertised_labeled_route(&tx, source, prefix).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    let stop = stopped_gate(&explain).expect("ladder must stop");
+    assert_eq!(
+        (stop.gate, stop.code),
+        ("split_horizon", "ibgp_split_horizon")
+    );
+    assert_eq!(explain.reasons[0].code, "ibgp_split_horizon");
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn labeled_no_advertise_gate_stops_source_route() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let _rx_s = explain_peer_up(
+        &tx,
+        source,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+    let _rx_t = explain_peer_up(
+        &tx,
+        target,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+
+    let route = labeled_with_communities(
+        make_labeled_rib_route(Ipv4Addr::new(10, 0, 0, 1), 62, 100, 100),
+        vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE],
+    );
+    let prefix = route.nlri.prefix;
+    feed_labeled_routes(&tx, source, vec![route]).await;
+
+    let explain = query_explain_advertised_labeled_route(&tx, target, prefix).await;
+    assert_eq!(explain.decision, crate::update::ExplainDecision::Deny);
+    let stop = stopped_gate(&explain).expect("ladder must stop");
+    assert_eq!(
+        (stop.gate, stop.code),
+        ("no_advertise", "no_advertise_suppressed")
+    );
+    assert_eq!(explain.reasons[0].code, "no_advertise_suppressed");
+    // The full labeled ladder is named, in live body order, up to the stop.
+    let names: Vec<&str> = explain.gates.iter().map(|step| step.gate).collect();
+    assert_eq!(
+        names,
+        [
+            "family",
+            "best_route",
+            "llgr",
+            "split_horizon",
+            "rr_reflection",
+            "no_advertise"
+        ]
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn labeled_llgr_gate_stops_stale_route_toward_non_llgr_ebgp_peer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let no_llgr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let with_llgr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let _rx_s = explain_peer_up(
+        &tx,
+        source,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+    let _rx_a = explain_peer_up(
+        &tx,
+        no_llgr,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        vec![],
+    )
+    .await;
+    let _rx_b = explain_peer_up(
+        &tx,
+        with_llgr,
+        labeled_sendable(),
+        true,
+        false,
+        None,
+        vec![],
+        labeled_sendable(),
+    )
+    .await;
+
+    let route = labeled_with_communities(
+        make_labeled_rib_route(Ipv4Addr::new(10, 0, 0, 1), 63, 100, 100),
+        vec![rustbgpd_wire::COMMUNITY_LLGR_STALE],
+    );
+    let prefix = route.nlri.prefix;
+    feed_labeled_routes(&tx, source, vec![route]).await;
+
+    let denied = query_explain_advertised_labeled_route(&tx, no_llgr, prefix).await;
+    assert_eq!(denied.decision, crate::update::ExplainDecision::Deny);
+    let stop = stopped_gate(&denied).expect("ladder must stop");
+    assert_eq!((stop.gate, stop.code), ("llgr", "llgr_stale_suppressed"));
+    assert_eq!(denied.reasons[0].code, "llgr_stale_suppressed");
+
+    // A peer that advertised the LLGR capability for the family clears it.
+    let permitted = query_explain_advertised_labeled_route(&tx, with_llgr, prefix).await;
+    assert_eq!(
+        permitted.decision,
+        crate::update::ExplainDecision::Advertise
+    );
+    assert!(stopped_gate(&permitted).is_none());
+    assert!(
+        permitted
+            .gates
+            .iter()
+            .any(|step| step.gate == "llgr" && step.verdict == ExportGateVerdict::Pass)
+    );
+    assert_eq!(permitted.route_peer, Some(source));
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/manager/tests/mod.rs
+++ b/crates/rib/src/manager/tests/mod.rs
@@ -354,6 +354,7 @@ async fn query_explain_advertised_route(
         peer,
         prefix,
         rd: None,
+        labeled: false,
         reply: reply_tx,
     })
     .await
@@ -373,6 +374,27 @@ async fn query_explain_advertised_vpn_route(
         peer,
         prefix,
         rd: Some(rd),
+        labeled: false,
+        reply: reply_tx,
+    })
+    .await
+    .unwrap();
+    reply_rx.await.unwrap().unwrap()
+}
+
+/// Labeled-unicast export explain helper (`labeled` set) for the
+/// export-explain tests.
+async fn query_explain_advertised_labeled_route(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    prefix: Prefix,
+) -> crate::update::ExplainAdvertisedRoute {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(RibUpdate::ExplainAdvertisedRoute {
+        peer,
+        prefix,
+        rd: None,
+        labeled: true,
         reply: reply_tx,
     })
     .await

--- a/crates/rib/src/manager/tests/policy.rs
+++ b/crates/rib/src/manager/tests/policy.rs
@@ -1515,3 +1515,114 @@ async fn export_memo_shares_identical_modified_attrs_and_keys_peer_varying_chain
     drop(tx);
     handle.await.unwrap();
 }
+
+/// A single-best export where the policy *adds* `NO_ADVERTISE` (permit +
+/// `communities_add`) is a policy suppression: it must surface in the
+/// policy-filtered view exactly like the deny arm. The multipath body
+/// already recorded it; the single-best tail silently withheld the route
+/// with no filtered-routes entry.
+#[tokio::test]
+async fn single_best_policy_added_no_advertise_emits_policy_filtered_event() {
+    use rustbgpd_policy::{Policy, PolicyAction, PolicyChain, PolicyStatement, RouteModifications};
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let chain = Some(PolicyChain::new(vec![Policy {
+        entries: vec![PolicyStatement {
+            prefix: Some(Prefix::V4(prefix)),
+            ge: None,
+            le: None,
+            action: PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: RouteModifications {
+                communities_add: vec![rustbgpd_wire::COMMUNITY_NO_ADVERTISE],
+                ..RouteModifications::default()
+            },
+        }],
+        default_action: PolicyAction::Permit,
+    }]));
+
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+
+    let target = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let (out_tx, mut out_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: target,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: chain,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    })
+    .await
+    .unwrap();
+    drain_eor(&mut out_rx).await;
+
+    let source = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: source,
+        announced: vec![make_route(prefix, Ipv4Addr::new(10, 0, 0, 1))],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+
+    let history = query_route_event_history(
+        &tx,
+        Some(target),
+        Some(Afi::Ipv4),
+        Some(Prefix::V4(prefix)),
+        10,
+    )
+    .await;
+    let policy_filtered = history
+        .iter()
+        .filter(|event| event.event_type == RouteEventType::PolicyFiltered)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        policy_filtered.len(),
+        1,
+        "policy-added NO_ADVERTISE must record a policy-filtered entry"
+    );
+    assert_eq!(policy_filtered[0].peer, Some(source));
+    assert_eq!(policy_filtered[0].target_peer, Some(target));
+    assert_eq!(policy_filtered[0].reason, "policy_denied");
+
+    // The route itself was withheld — nothing was announced to the peer.
+    assert!(
+        out_rx.try_recv().is_err(),
+        "NO_ADVERTISE-suppressed route must not be announced"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -1495,6 +1495,10 @@ pub enum RibUpdate {
         /// `Some` = explain the VPNv4/VPNv6 (SAFI 128) route identified
         /// by `(rd, prefix)` instead of the plain unicast prefix.
         rd: Option<rustbgpd_wire::RouteDistinguisher>,
+        /// `true` = explain the labeled-unicast (SAFI 4, RFC 8277) route
+        /// for `prefix` instead of the plain unicast prefix. Mutually
+        /// exclusive with `rd` (callers validate; `rd` wins here).
+        labeled: bool,
         /// Response channel.
         reply: oneshot::Sender<Option<ExplainAdvertisedRoute>>,
     },

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1501,6 +1501,10 @@ rbgp rib --prefix 203.0.113.0/24 advertised 10.0.0.2 --explain
 # membership gate.
 rbgp rib --prefix 10.1.0.0/24 advertised 10.0.0.2 --explain --rd 65000:1
 
+# Labeled unicast (SAFI 4, RFC 8277): explain the labeled export ladder
+# for the prefix instead of the plain unicast one.
+rbgp rib --prefix 10.1.0.0/24 advertised 10.0.0.2 --explain --labeled
+
 # JSON for scripting
 rbgp --json rib --prefix 203.0.113.0/24 advertised 10.0.0.2 --explain
 ```
@@ -1515,8 +1519,10 @@ RFC 5291 filter) -> `export_policy` (per-chain verdict, labeled
 advertised state: `staged_announce` = would send, `already_advertised`
 = identical route already advertised, peer in sync). The VPN ladder
 follows the live VPN staging order and adds `rt_membership`
-(RFC 4684). A family still held by the initial-ORF gate (RFC 5291
-section 6) stops at `orf_gate` before any per-prefix work.
+(RFC 4684); the labeled-unicast ladder follows the live labeled staging
+order (`family` first, no `rt_membership`/`orf`). A family still held by
+the initial-ORF gate (RFC 5291 section 6) stops at `orf_gate` before any
+per-prefix work.
 
 Truthfulness: the explanation is produced by a read-only dry run of
 the *same staging body* live distribution executes -- including for

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -652,6 +652,7 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -669,6 +670,7 @@ _arguments "${_arguments_options[@]}" : \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
 '--explain[Explain whether this exact prefix would be advertised to the peer]' \
+'(--rd)--labeled[Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7515,7 +7515,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__advertised)
-            opts="-a -s -j -h --family --explain --rd --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --explain --rd --labeled --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -311,6 +311,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from advertised" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -319,6 +320,7 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcomman
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l explain -d 'Explain whether this exact prefix would be advertised to the peer'
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l labeled -d 'Explain the labeled-unicast (SAFI 4, RFC 8277) export ladder for the prefix instead of the plain unicast ladder'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from sent" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1494,6 +1494,10 @@ message ExplainAdvertisedRouteRequest {
   // (rd, prefix) identity - including the RFC 4684 RT-Constrain
   // membership gate - instead of the unicast ladder. Empty = unicast.
   string rd = 4;
+  // When true, the explain runs the labeled-unicast (SAFI 4, RFC 8277)
+  // export ladder for the prefix instead of the unicast ladder.
+  // Mutually exclusive with rd.
+  bool labeled = 5;
 }
 
 // Verdict of one export gate for one (route, peer) explain.


### PR DESCRIPTION
## Gap

`stage_labeled_routes` used the older direct-parameter form (metrics / policy_stats / record_export_policy_eval) instead of the `ExportTarget` consumer selection the unicast and VPN staging bodies share, so labeled-unicast (SAFI 4, RFC 8277) export decisions emitted no explain gate-trace steps. A labeled route suppressed at export — NO_ADVERTISE, LLGR-stale, RFC 4456 split-horizon/reflection, export policy — gave the operator no reason line.

Same theme in unicast: the single-best and ORR single-best staging tails withheld a route whose export policy *added* NO_ADVERTISE without the policy-filtered entry the multipath body records, so the route vanished from the peer with no filtered-routes entry or `policy_filtered` route event.

## Change

- Convert `stage_labeled_routes` to take `&mut ExportTarget`, emitting the same gate ladder as the VPN sibling at every existing suppression branch (family, best-route/ORR-vantage selection, LLGR, split horizon, RR reflection, NO_ADVERTISE/NO_EXPORT, export policy with term-labels, post-policy NO_ADVERTISE, Adj-RIB-Out diff). No suppression logic changed; live callers (recompute, resync, route refresh, initial dump) construct `ExportTarget::Peer` and behave as before. Explain dry runs use the real staging body, so the explanation cannot drift from the live decision.
- Add `explain_labeled_export`: dry-runs the staging body over the singleton identity with an explain-only target, including the exact-export overlay. Selector exposed as `ExplainAdvertisedRouteRequest.labeled` (mutually exclusive with `rd`) and `rbgp rib advertised --explain --labeled`.
- Record policy-filtered entries at both single-best post-policy NO_ADVERTISE drops in `unicast.rs`, matching the deny arm and the multipath body.
- Docs: OPERATIONS.md explain section covers the labeled ladder; shell completions regenerated.

## Tests

- `labeled_no_advertise_gate_stops_source_route` — stop at `no_advertise`/`no_advertise_suppressed`, full ladder order pinned.
- `labeled_llgr_gate_stops_stale_route_toward_non_llgr_ebgp_peer` — stop at `llgr`/`llgr_stale_suppressed`; an LLGR-negotiated peer clears it to Advertise.
- `labeled_split_horizon_gate_stops_route_to_its_source` — stop at `split_horizon`/`ibgp_split_horizon`.
- `single_best_policy_added_no_advertise_emits_policy_filtered_event` — break-to-red verified: fails without the unicast fix, passes with it.

Gates (exit codes): clippy --workspace --all-targets -D warnings 0; test -p rustbgpd-rib 0 (887 passed); check --features bench-internals --benches 0; test --workspace 0; doc --workspace --no-deps 0.