### PR TITLE
perf(peer-manager): admit import-changing peers to the export policy cohort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Reloads that change import and export policy together now take the
+  batched export cohort instead of the per-peer authoritative path.** The
+  cohort's eligibility check no longer requires an unchanged import chain:
+  a member's changed import chain is hot-applied to its session during
+  cohort setup, and the corresponding inbound Route Refresh is deferred
+  until the batched RIB commit acknowledges (firing once per member;
+  members whose import chain did not change still get no refresh). On
+  cohort failure the rollback restores both chains and re-arms the
+  existing per-peer retry intent. Previously any import-chain content
+  change disqualified every peer, so a routine import+export reload on a
+  large fleet serialized N full-table export restages and Route Refreshes
+  behind one another instead of sharing one batched transition.
+
 - **Grouped policy-reload re-advertisement now encodes each update-group's
   wire UPDATE stream once instead of once per member** (ADR-0109). The
   clean export-policy transition hands every member envelope one

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -1356,7 +1356,21 @@ impl PeerHandle {
         policy: Option<PolicyChain>,
         deadline: Duration,
     ) -> Result<(), PeerCommandError> {
-        let commands = self.commands.clone();
+        Self::update_import_policy_with(self.commands.clone(), policy, deadline).await
+    }
+
+    /// Owned-sender variant of [`Self::update_import_policy_timeout`]. See
+    /// [`Self::update_export_policy_with`] for rationale.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session is unreachable, replies with one, or
+    /// does not acknowledge inside `deadline`.
+    pub async fn update_import_policy_with(
+        commands: mpsc::Sender<PeerCommand>,
+        policy: Option<PolicyChain>,
+        deadline: Duration,
+    ) -> Result<(), PeerCommandError> {
         match tokio::time::timeout(deadline, async move {
             let (reply_tx, reply_rx) = oneshot::channel();
             commands

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -421,14 +421,20 @@ impl PeerManager {
         selected
     }
 
+    /// Local (no session round-trip) cohort eligibility: the peer exists, its
+    /// export chain moves, and no prior retry intent is pending. The import
+    /// chain is allowed to move too (LAN-462): cohort setup hot-applies that
+    /// delta per member and defers its Route Refresh past the batched RIB
+    /// commit, so an import+export reload no longer disqualifies the fleet.
+    /// The returned pair stays export-only because only the export move keys
+    /// cohort identity — the RIB batch touches nothing else.
     fn local_export_only_policy_pair<'a>(
         &'a self,
         target: &'a ResolvedPeerPolicy,
     ) -> Option<(&'a Option<PolicyChain>, &'a Option<PolicyChain>)> {
         let peer_key = PeerKey::new(target.address, target.interface.clone());
         let managed = self.peers.get(&peer_key)?;
-        (managed.import_policy == target.import_policy
-            && managed.export_policy != target.export_policy
+        (managed.export_policy != target.export_policy
             && !managed.pending_refresh
             && !managed.pending_export_apply)
             .then_some((&managed.export_policy, &target.export_policy))
@@ -500,9 +506,14 @@ impl PeerManager {
     }
 
     /// Fast path for the dominant reload shape: two or more Established peers
-    /// keep identical import policy and move only their export chain. Session
-    /// hot-apply still precedes the RIB commit, but one batched RIB command lets
-    /// equivalent clean update-group members share transition work.
+    /// share one export-chain move. Session hot-apply still precedes the RIB
+    /// commit, but one batched RIB command lets equivalent clean update-group
+    /// members share transition work. A member's import chain may move too
+    /// (LAN-462): the changed chain is hot-applied during setup through the
+    /// same session command the authoritative per-peer path uses, and its
+    /// Route Refresh is deferred until after the batched RIB commit, so an
+    /// import+export reload no longer collapses the whole fleet onto the
+    /// per-peer authoritative transaction.
     ///
     /// Returning `None` means the whole target set is ineligible and the
     /// caller must use the existing per-peer transaction unchanged. Returning
@@ -521,6 +532,7 @@ impl PeerManager {
             return None;
         }
         let mut peer_keys = Vec::with_capacity(targets.len());
+        let mut import_deltas = Vec::with_capacity(targets.len());
         let mut seen = BTreeSet::new();
         for target in targets {
             let peer_key = PeerKey::new(target.address, target.interface.clone());
@@ -528,18 +540,20 @@ impl PeerManager {
                 return None;
             }
             let managed = self.peers.get(&peer_key)?;
-            if managed.import_policy != target.import_policy
-                || managed.export_policy == target.export_policy
+            if managed.export_policy == target.export_policy
                 || managed.pending_refresh
                 || managed.pending_export_apply
             {
                 return None;
             }
+            import_deltas.push(managed.import_policy != target.import_policy);
             peer_keys.push(peer_key);
         }
 
         let mut captured = Vec::with_capacity(targets.len());
-        for (target, peer_key) in targets.iter().zip(&peer_keys) {
+        for ((target, peer_key), &import_changed) in
+            targets.iter().zip(&peer_keys).zip(&import_deltas)
+        {
             let prior = {
                 let managed = self
                     .peers
@@ -557,6 +571,60 @@ impl PeerManager {
                     forward_completed: false,
                 }
             };
+            // LAN-462: hot-apply a changed import chain through the same
+            // session command the authoritative per-peer path uses
+            // (`update_import_policy`), but do NOT fire `soft_reset_in` here —
+            // the Route Refresh is deferred until after the cohort RIB commit
+            // (see the deferred-refresh phase below for the correctness
+            // argument).
+            if import_changed {
+                let import_commands = self
+                    .peers
+                    .get(peer_key)
+                    .expect("cohort peer existed before import hot-apply")
+                    .handle
+                    .commands_sender();
+                let import_result = self
+                    .await_with_readiness(
+                        rustbgpd_transport::PeerHandle::update_import_policy_with(
+                            import_commands,
+                            target.import_policy.clone(),
+                            PEER_POLICY_UPDATE_TIMEOUT,
+                        ),
+                    )
+                    .await;
+                if let Err(error) = import_result {
+                    // Mirror the authoritative forward-import bail: bookkeeping
+                    // retains the prior chain so the next call still sees the
+                    // delta and retries, and `pending_refresh` carries the
+                    // unfired refresh intent across the ambiguous session state
+                    // (the command may have installed the new chain before its
+                    // reply was lost). The export command was never sent for
+                    // this member, so only already-captured peers need
+                    // restoring.
+                    if let Some(managed) = self.peers.get_mut(peer_key) {
+                        managed.pending_refresh = true;
+                    }
+                    let prior_restore = self
+                        .restore_resolved_policies(captured, rollback_rib_budget)
+                        .await;
+                    return Some(Err(match prior_restore {
+                        Ok(()) => format!(
+                            "failed to apply resolved policy to {}: import: {error}; already-applied peers restored",
+                            target.address
+                        ),
+                        Err(restore_error) => format!(
+                            "failed to apply resolved policy to {}: import: {error}; restoring already-applied peers also failed: {restore_error}",
+                            target.address
+                        ),
+                    }));
+                }
+                self.peers
+                    .get_mut(peer_key)
+                    .expect("cohort peer existed after import hot-apply")
+                    .import_policy
+                    .clone_from(&target.import_policy);
+            }
             let commands = self
                 .peers
                 .get(peer_key)
@@ -593,16 +661,60 @@ impl PeerManager {
                     .map_err(|restore_error| {
                         format!("{} session restore failed: {restore_error}", target.address)
                     });
+                // LAN-462: the failing member's import chain was already
+                // acknowledged (and bookkeeping advanced) during setup, so
+                // reassert its prior import chain too, unwinding in reverse
+                // of the import-then-export forward order.
+                let failing_import_restore = if import_changed {
+                    let import_restore_commands = self
+                        .peers
+                        .get(peer_key)
+                        .expect("cohort peer existed while restoring acked import hot-apply")
+                        .handle
+                        .commands_sender();
+                    match self
+                        .await_with_readiness(
+                            rustbgpd_transport::PeerHandle::update_import_policy_with(
+                                import_restore_commands,
+                                prior.policy.import_policy.clone(),
+                                PEER_POLICY_UPDATE_TIMEOUT,
+                            ),
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            self.peers
+                                .get_mut(peer_key)
+                                .expect("cohort peer existed after import restore")
+                                .import_policy
+                                .clone_from(&prior.policy.import_policy);
+                            Ok(())
+                        }
+                        Err(restore_error) => {
+                            // Cross-side carry (the authoritative bail
+                            // discipline): the session may hold either chain,
+                            // bookkeeping stays on the new one so a retry sees
+                            // the delta, and `pending_refresh` keeps the
+                            // unfired refresh intent armed.
+                            if let Some(managed) = self.peers.get_mut(peer_key) {
+                                managed.pending_refresh = true;
+                            }
+                            Err(format!(
+                                "{} import restore failed: {restore_error}",
+                                target.address
+                            ))
+                        }
+                    }
+                } else {
+                    Ok(())
+                };
                 let prior_restore = self
                     .restore_resolved_policies(captured, rollback_rib_budget)
                     .await;
-                let restore_error = match (failing_restore, prior_restore) {
-                    (Ok(()), Ok(())) => None,
-                    (Err(error), Ok(())) | (Ok(()), Err(error)) => Some(error),
-                    (Err(failing_error), Err(prior_error)) => {
-                        Some(format!("{failing_error}; {prior_error}"))
-                    }
-                };
+                let restore_error = [failing_restore, failing_import_restore, prior_restore]
+                    .into_iter()
+                    .filter_map(Result::err)
+                    .reduce(|folded, error| format!("{folded}; {error}"));
                 return Some(Err(match restore_error {
                     None => format!(
                         "failed to apply resolved policy to {}: export: {error}; already-applied peers restored",
@@ -664,8 +776,72 @@ impl PeerManager {
             }));
         }
 
-        for captured in &mut captured {
-            captured.forward_completed = true;
+        // LAN-462: fire the deferred Route Refresh for members whose import
+        // chain moved, now that the cohort RIB commit (or its authoritative
+        // handoff) succeeded. Correctness: the window where the session runs
+        // the new import chain while Adj-RIB-In still holds routes accepted
+        // under the old one already exists today in the authoritative
+        // per-peer path, between the import hot-apply and the peer's refresh
+        // answer; deferring the refresh past the commit only lengthens that
+        // window by seconds and converges identically once the peer
+        // re-sends. The re-ingest is output-neutral whenever the import
+        // change does not alter stored routes (LocRib suppresses
+        // interned-attr-equal replacements). Members whose import chain was
+        // unchanged get no refresh at all, exactly as today.
+        for (index, (target, peer_key)) in targets.iter().zip(&peer_keys).enumerate() {
+            if !import_deltas[index] {
+                captured[index].forward_completed = true;
+                continue;
+            }
+            let commands = self
+                .peers
+                .get(peer_key)
+                .expect("cohort peer existed before deferred refresh")
+                .handle
+                .commands_sender();
+            let established = self
+                .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_with(
+                    commands,
+                    PEER_QUERY_TIMEOUT,
+                ))
+                .await
+                .is_some_and(|state| state.fsm_state == SessionState::Established);
+            self.drain_readiness_queries().await;
+            if established {
+                if let Err(error) = self.soft_reset_in(peer_key.clone(), Vec::new()).await {
+                    // Mirror the authoritative path's fatal refresh handling:
+                    // arm `pending_refresh` for the retry pipeline, then
+                    // unwind the snapshot. `forward_completed` stays false for
+                    // this member and the ones after it — their Adj-RIB-In
+                    // never moved, so the restore correctly picks the
+                    // no-refresh-back rollback branch for them.
+                    if let Some(managed) = self.peers.get_mut(peer_key) {
+                        managed.pending_refresh = true;
+                    }
+                    let rollback = self
+                        .restore_resolved_policies(captured, rollback_rib_budget)
+                        .await;
+                    return Some(Err(match rollback {
+                        Ok(()) => format!(
+                            "failed to apply resolved policy to {}: route refresh: {error}; already-applied peers restored",
+                            target.address
+                        ),
+                        Err(restore_error) => format!(
+                            "failed to apply resolved policy to {}: route refresh: {error}; restoring already-applied peers also failed: {restore_error}",
+                            target.address
+                        ),
+                    }));
+                }
+            } else {
+                // Idle/Connect (nothing in Adj-RIB-In yet) or an ambiguous
+                // state query: arm `pending_refresh` so a later call fires the
+                // refresh once the session is reachable — the same handling
+                // the authoritative path applies to a non-Established peer.
+                if let Some(managed) = self.peers.get_mut(peer_key) {
+                    managed.pending_refresh = true;
+                }
+            }
+            captured[index].forward_completed = true;
         }
         Some(Ok(captured))
     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -1003,6 +1003,24 @@ fn deny_policy_chain() -> PolicyChain {
     }])
 }
 
+/// A deny chain padded to `depth + 1` copies of the deny policy —
+/// content-distinct per depth. Per-peer distinct export targets keep a
+/// snapshot off the import-tolerant export cohort (LAN-462 relaxed its
+/// import-equality requirement, so a uniform import+export move now
+/// partitions) and on the per-peer authoritative path these regressions pin.
+fn distinct_deny_policy_chain(depth: usize) -> PolicyChain {
+    use rustbgpd_policy::{Policy, PolicyAction};
+
+    PolicyChain::new(
+        (0..=depth)
+            .map(|_| Policy {
+                entries: Vec::new(),
+                default_action: PolicyAction::Deny,
+            })
+            .collect(),
+    )
+}
+
 fn validation_policy_chain(dependency: ImportValidationDependency) -> PolicyChain {
     use rustbgpd_policy::{Policy, PolicyAction, PolicyStatement, RouteModifications};
     use rustbgpd_wire::{AspaValidation, RpkiValidation};
@@ -6549,15 +6567,23 @@ async fn assert_non_established_rollback_rib_outcome(
         reply.send(reply_result).unwrap();
     });
 
+    // Distinct export targets keep this snapshot off the LAN-462
+    // import-tolerant cohort (no repeated export pair) and on the per-peer
+    // authoritative transaction whose rollback this regression pins.
     let result = mgr
         .apply_resolved_policy_snapshot(
             [flapping, failing]
                 .into_iter()
-                .map(|address| ResolvedPeerPolicy {
+                .enumerate()
+                .map(|(index, address)| ResolvedPeerPolicy {
                     address,
                     interface: None,
                     import_policy: Some(next.clone()),
-                    export_policy: Some(next.clone()),
+                    export_policy: Some(if index == 0 {
+                        next.clone()
+                    } else {
+                        distinct_deny_policy_chain(1)
+                    }),
                 })
                 .collect(),
         )
@@ -7483,13 +7509,31 @@ async fn content_equal_policy_fanout_skips_unaffected_peers() {
     let (replaces_a, replaces_b) = (rib_replaces_a.clone(), rib_replaces_b.clone());
     let rib_drainer = tokio::spawn(async move {
         while let Some(update) = rib_rx.recv().await {
-            if let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } = update {
-                if peer == a {
-                    replaces_a.fetch_add(1, Ordering::SeqCst);
-                } else {
-                    replaces_b.fetch_add(1, Ordering::SeqCst);
+            match update {
+                RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
+                    if peer == a {
+                        replaces_a.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        replaces_b.fetch_add(1, Ordering::SeqCst);
+                    }
+                    let _ = reply.send(Ok(()));
                 }
-                let _ = reply.send(Ok(()));
+                // LAN-462: the initial uniform install rides the batched
+                // import-tolerant cohort — one member replacement per peer.
+                RibUpdate::ReplacePeerExportPolicies {
+                    replacements,
+                    reply,
+                } => {
+                    for replacement in replacements {
+                        if replacement.peer == a {
+                            replaces_a.fetch_add(1, Ordering::SeqCst);
+                        } else {
+                            replaces_b.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                    let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                }
+                _ => {}
             }
         }
     });
@@ -8492,15 +8536,19 @@ async fn timed_out_policy_rollback_rearms_import_and_export_retry_intent() {
         );
     }
     let next = deny_policy_chain();
+    // Distinct export targets keep this snapshot off the LAN-462
+    // import-tolerant cohort (no repeated export pair) and on the per-peer
+    // authoritative transaction whose rollback this regression pins.
     let apply = manager.apply_resolved_policy_snapshot(
         peers
             .iter()
             .copied()
-            .map(|address| ResolvedPeerPolicy {
+            .enumerate()
+            .map(|(index, address)| ResolvedPeerPolicy {
                 address,
                 interface: None,
                 import_policy: Some(next.clone()),
-                export_policy: Some(next.clone()),
+                export_policy: Some(distinct_deny_policy_chain(index)),
             })
             .collect(),
     );
@@ -8584,15 +8632,19 @@ async fn policy_rollback_skips_refresh_when_rib_restore_cannot_register() {
     }
 
     let next = deny_policy_chain();
+    // Distinct export targets keep this snapshot off the LAN-462
+    // import-tolerant cohort (no repeated export pair) and on the per-peer
+    // authoritative transaction whose rollback this regression pins.
     let apply = manager.apply_resolved_policy_snapshot(
         peers
             .iter()
             .copied()
-            .map(|address| ResolvedPeerPolicy {
+            .enumerate()
+            .map(|(index, address)| ResolvedPeerPolicy {
                 address,
                 interface: None,
                 import_policy: Some(next.clone()),
-                export_policy: Some(next.clone()),
+                export_policy: Some(distinct_deny_policy_chain(index)),
             })
             .collect(),
     );
@@ -8771,6 +8823,511 @@ async fn export_only_snapshot_reasserts_prior_import_after_remainder_ack_loss() 
     let (batches, singles) = rib_task.await.unwrap();
     assert_eq!(batches, vec![vec![first, second]]);
     assert_eq!(singles, vec![second, first]);
+}
+
+/// Session model for the LAN-462 import-tolerant cohort tests: acks import,
+/// export, refresh, and state queries while counting each, tracks the live
+/// import chain, and optionally fails one export attempt.
+#[derive(Default)]
+struct CohortSessionCounters {
+    import_installs: AtomicUsize,
+    export_installs: AtomicUsize,
+    refreshes: AtomicUsize,
+    live_import: Mutex<Option<rustbgpd_policy::PolicyChain>>,
+}
+
+fn import_tolerant_cohort_test_session(
+    addr: IpAddr,
+    counters: Arc<CohortSessionCounters>,
+    fail_export_on_attempt: Option<usize>,
+) -> PeerHandle {
+    use rustbgpd_transport::PeerCommand;
+
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let task = tokio::spawn(async move {
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::UpdateImportPolicy { policy, reply } => {
+                    counters.import_installs.fetch_add(1, Ordering::SeqCst);
+                    *counters.live_import.lock().unwrap() = policy;
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    let attempt = counters.export_installs.fetch_add(1, Ordering::SeqCst) + 1;
+                    let result = if fail_export_on_attempt == Some(attempt) {
+                        Err(rustbgpd_transport::PeerCommandError::CommandFailed(
+                            "injected export-policy apply failure".to_string(),
+                        ))
+                    } else {
+                        Ok(())
+                    };
+                    let _ = reply.send(result);
+                }
+                PeerCommand::SendRouteRefresh { reply, .. } => {
+                    counters.refreshes.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(policy_test_peer_state(addr, SessionState::Established));
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// LAN-462: a reload that moves import AND export chains must still engage the
+/// batched cohort (previously the import delta disqualified every member and
+/// the whole fleet fell onto the per-peer authoritative path), and each
+/// import-moving member's Route Refresh must fire exactly once, only after the
+/// cohort RIB commit acknowledges. Import-unchanged members get no refresh.
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the regression pins partition engagement, deferred-refresh ordering, and the unchanged-member exemption together"
+)]
+async fn import_tolerant_cohort_defers_refresh_past_committed_batch() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 42, 0, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 42, 0, 2));
+    let export_only = IpAddr::V4(Ipv4Addr::new(10, 42, 0, 3));
+    let peers = [first, second, export_only];
+    let counters: Vec<Arc<CohortSessionCounters>> = peers
+        .iter()
+        .map(|_| Arc::new(CohortSessionCounters::default()))
+        .collect();
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for (peer, counter) in peers.iter().zip(&counters) {
+        insert_test_managed_peer(
+            &mut manager,
+            *peer,
+            import_tolerant_cohort_test_session(*peer, Arc::clone(counter), None),
+            false,
+        );
+    }
+
+    let shared_export = deny_policy_chain();
+    let changed_import = validation_policy_chain(ImportValidationDependency::Rpki);
+    let targets = vec![
+        ResolvedPeerPolicy {
+            address: first,
+            interface: None,
+            import_policy: Some(changed_import.clone()),
+            export_policy: Some(shared_export.clone()),
+        },
+        ResolvedPeerPolicy {
+            address: second,
+            interface: None,
+            import_policy: Some(changed_import.clone()),
+            export_policy: Some(shared_export.clone()),
+        },
+        ResolvedPeerPolicy {
+            address: export_only,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(shared_export.clone()),
+        },
+    ];
+    let apply = manager.apply_resolved_policy_snapshot(targets);
+    let refresh_watch = counters.clone();
+    let drive_rib = async {
+        let RibUpdate::ReplacePeerExportPolicies {
+            replacements,
+            reply,
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected cohort RIB command");
+        };
+        assert_eq!(
+            replacements.len(),
+            peers.len(),
+            "the partition must cover the whole fleet despite import deltas"
+        );
+        assert!(
+            refresh_watch
+                .iter()
+                .all(|counter| counter.refreshes.load(Ordering::SeqCst) == 0),
+            "no Route Refresh may fire before the cohort RIB commit acknowledges"
+        );
+        reply
+            .send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed))
+            .unwrap();
+    };
+    let (result, ()) = tokio::join!(apply, drive_rib);
+    let priors = result.expect("import+export cohort snapshot must commit");
+
+    assert_eq!(priors.len(), peers.len());
+    assert!(
+        matches!(rib_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "no per-peer authoritative RIB command may run after the committed batch"
+    );
+    for (peer, counter) in peers.iter().zip(&counters) {
+        let expected_refreshes = usize::from(*peer != export_only);
+        assert_eq!(
+            counter.refreshes.load(Ordering::SeqCst),
+            expected_refreshes,
+            "deferred refresh fires exactly once per import-moving member ({peer})"
+        );
+        assert_eq!(
+            counter.import_installs.load(Ordering::SeqCst),
+            expected_refreshes,
+            "import hot-apply runs only for import-moving members ({peer})"
+        );
+        assert_eq!(counter.export_installs.load(Ordering::SeqCst), 1);
+        let peer_state = manager.peers.get(&key(*peer)).unwrap();
+        assert_eq!(peer_state.export_policy, Some(shared_export.clone()));
+        assert!(!peer_state.pending_refresh);
+        assert!(!peer_state.pending_export_apply);
+    }
+    assert_eq!(
+        manager.peers.get(&key(first)).unwrap().import_policy,
+        Some(changed_import.clone())
+    );
+    assert_eq!(
+        manager.peers.get(&key(second)).unwrap().import_policy,
+        Some(changed_import)
+    );
+    assert_eq!(
+        manager.peers.get(&key(export_only)).unwrap().import_policy,
+        None
+    );
+
+    for peer in peers {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
+}
+
+/// LAN-462: when the RIB batch hands the cohort back for the per-peer
+/// authoritative RIB seam (`RequiresAuthoritativePerPeerApply`), the deferred
+/// refresh still fires exactly once per member — after the handoff completes —
+/// with no double refresh from the handoff itself.
+#[tokio::test]
+async fn import_tolerant_cohort_handoff_fires_deferred_refresh_once() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 43, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 43, 0, 2)),
+    ];
+    let counters: Vec<Arc<CohortSessionCounters>> = peers
+        .iter()
+        .map(|_| Arc::new(CohortSessionCounters::default()))
+        .collect();
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for (peer, counter) in peers.iter().zip(&counters) {
+        insert_test_managed_peer(
+            &mut manager,
+            *peer,
+            import_tolerant_cohort_test_session(*peer, Arc::clone(counter), None),
+            false,
+        );
+    }
+
+    let shared_export = deny_policy_chain();
+    let changed_import = validation_policy_chain(ImportValidationDependency::Rpki);
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .map(|&address| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: Some(changed_import.clone()),
+                export_policy: Some(shared_export.clone()),
+            })
+            .collect(),
+    );
+    let refresh_watch = counters.clone();
+    let drive_rib = async {
+        let RibUpdate::ReplacePeerExportPolicies { reply, .. } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected cohort RIB command");
+        };
+        reply
+            .send(Ok(
+                rustbgpd_rib::ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply,
+            ))
+            .unwrap();
+        for expected_peer in peers {
+            let RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } =
+                rib_rx.recv().await.unwrap()
+            else {
+                panic!("expected ordinary per-peer RIB command");
+            };
+            assert_eq!(peer, expected_peer);
+            assert!(
+                refresh_watch
+                    .iter()
+                    .all(|counter| counter.refreshes.load(Ordering::SeqCst) == 0),
+                "no Route Refresh may fire before the authoritative handoff completes"
+            );
+            reply.send(Ok(())).unwrap();
+        }
+    };
+    let (result, ()) = tokio::join!(apply, drive_rib);
+    result.expect("handoff cohort snapshot must commit");
+
+    for counter in &counters {
+        assert_eq!(
+            counter.refreshes.load(Ordering::SeqCst),
+            1,
+            "the deferred refresh fires exactly once per member — no handoff double refresh"
+        );
+        assert_eq!(counter.import_installs.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.export_installs.load(Ordering::SeqCst), 1);
+    }
+    for peer in peers {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
+}
+
+/// LAN-462: a cohort RIB commit failure must restore BOTH chains — the import
+/// delta hot-applied during setup and the export chain — and fire no forward
+/// refresh (only the rollback's post-reassert refresh), leaving no pending
+/// retry intent behind after a clean restore.
+#[tokio::test]
+async fn import_tolerant_cohort_rib_failure_restores_both_chains() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 44, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 44, 0, 2)),
+    ];
+    let counters: Vec<Arc<CohortSessionCounters>> = peers
+        .iter()
+        .map(|_| Arc::new(CohortSessionCounters::default()))
+        .collect();
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let rib_task = tokio::spawn(async move {
+        let mut singles = Vec::new();
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    let _ = reply.send(Err("injected cohort failure".to_string()));
+                }
+                RibUpdate::ReplacePeerExportPolicy { peer, reply, .. } => {
+                    singles.push(peer);
+                    let _ = reply.send(Ok(()));
+                }
+                _ => {}
+            }
+        }
+        singles
+    });
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for (peer, counter) in peers.iter().zip(&counters) {
+        insert_test_managed_peer(
+            &mut manager,
+            *peer,
+            import_tolerant_cohort_test_session(*peer, Arc::clone(counter), None),
+            false,
+        );
+    }
+
+    let shared_export = deny_policy_chain();
+    let changed_import = validation_policy_chain(ImportValidationDependency::Rpki);
+    let result = manager
+        .apply_resolved_policy_snapshot(
+            peers
+                .iter()
+                .map(|&address| ResolvedPeerPolicy {
+                    address,
+                    interface: None,
+                    import_policy: Some(changed_import.clone()),
+                    export_policy: Some(shared_export.clone()),
+                })
+                .collect(),
+        )
+        .await;
+    assert!(
+        result.as_ref().is_err_and(|error| {
+            error.contains("failed to update export policy cohort: injected cohort failure")
+                && error.contains("already-applied peers restored")
+        }),
+        "the RIB failure must surface with a successful rollback: {result:?}"
+    );
+
+    for (peer, counter) in peers.iter().zip(&counters) {
+        assert_eq!(
+            counter.import_installs.load(Ordering::SeqCst),
+            2,
+            "the session must observe the forward install and the rollback reassert ({peer})"
+        );
+        assert_eq!(
+            *counter.live_import.lock().unwrap(),
+            None,
+            "the rollback must reassert the prior import chain ({peer})"
+        );
+        assert_eq!(counter.export_installs.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            counter.refreshes.load(Ordering::SeqCst),
+            1,
+            "the rollback refresh runs only after the prior chain is reasserted ({peer})"
+        );
+        let peer_state = manager.peers.get(&key(*peer)).unwrap();
+        assert_eq!(peer_state.import_policy, None);
+        assert_eq!(peer_state.export_policy, None);
+        assert!(!peer_state.pending_refresh);
+        assert!(!peer_state.pending_export_apply);
+    }
+
+    for peer in peers {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
+    drop(manager);
+    let singles = rib_task.await.unwrap();
+    assert_eq!(
+        singles,
+        vec![peers[1], peers[0]],
+        "rollback RIB restores run newest-first"
+    );
+}
+
+/// LAN-462: an export hot-apply failure on a member whose import delta was
+/// already acknowledged must reassert that member's prior import chain
+/// directly (its bookkeeping had advanced) while the previously captured
+/// members restore through the ordinary rollback — and the failing member
+/// still gets no RIB compensation, matching the export-only discipline.
+#[tokio::test]
+async fn import_tolerant_cohort_export_failure_reasserts_failing_member_import() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 45, 0, 1));
+    let failing = IpAddr::V4(Ipv4Addr::new(10, 45, 0, 2));
+    let first_counters = Arc::new(CohortSessionCounters::default());
+    let failing_counters = Arc::new(CohortSessionCounters::default());
+    let rib_single_restores = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let restores = Arc::clone(&rib_single_restores);
+    let _rib_task = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::ReplacePeerExportPolicy { reply, .. } => {
+                    restores.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::ReplacePeerExportPolicies { .. } => {
+                    panic!("the RIB batch must not run after a session-side cohort failure");
+                }
+                _ => {}
+            }
+        }
+    });
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(
+        &mut manager,
+        first,
+        import_tolerant_cohort_test_session(first, Arc::clone(&first_counters), None),
+        false,
+    );
+    insert_test_managed_peer(
+        &mut manager,
+        failing,
+        import_tolerant_cohort_test_session(failing, Arc::clone(&failing_counters), Some(1)),
+        false,
+    );
+
+    let shared_export = deny_policy_chain();
+    let changed_import = validation_policy_chain(ImportValidationDependency::Rpki);
+    let result = manager
+        .apply_resolved_policy_snapshot(
+            [first, failing]
+                .into_iter()
+                .map(|address| ResolvedPeerPolicy {
+                    address,
+                    interface: None,
+                    import_policy: Some(changed_import.clone()),
+                    export_policy: Some(shared_export.clone()),
+                })
+                .collect(),
+        )
+        .await;
+    assert!(
+        result.as_ref().is_err_and(|error| {
+            error.contains(&format!(
+                "failed to apply resolved policy to {failing}: export:"
+            )) && error.contains("already-applied peers restored")
+        }),
+        "the export failure must surface with a successful rollback: {result:?}"
+    );
+
+    // The failing member: forward import install + direct prior reassert, no
+    // forward refresh (it was deferred and never fired), no RIB compensation.
+    assert_eq!(failing_counters.import_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        *failing_counters.live_import.lock().unwrap(),
+        None,
+        "the failing member's prior import chain must be reasserted"
+    );
+    assert_eq!(failing_counters.export_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(failing_counters.refreshes.load(Ordering::SeqCst), 0);
+    // The captured member restores through the ordinary rollback: reassert,
+    // RIB restore, then the conservative post-reassert refresh.
+    assert_eq!(first_counters.import_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(*first_counters.live_import.lock().unwrap(), None);
+    assert_eq!(first_counters.export_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(first_counters.refreshes.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        rib_single_restores.load(Ordering::SeqCst),
+        1,
+        "no RIB compensation may be planned for the member whose forward apply failed"
+    );
+    for peer in [first, failing] {
+        let peer_state = manager.peers.get(&key(peer)).unwrap();
+        assert_eq!(peer_state.import_policy, None);
+        assert_eq!(peer_state.export_policy, None);
+        assert!(!peer_state.pending_refresh);
+        assert!(!peer_state.pending_export_apply);
+    }
+
+    for peer in [first, failing] {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
 }
 
 #[tokio::test]
@@ -9251,15 +9808,19 @@ async fn policy_rollback_registers_every_rib_restore_before_refresh_and_lifecycl
     }
 
     let next = deny_policy_chain();
+    // Distinct export targets keep this snapshot off the LAN-462
+    // import-tolerant cohort (no repeated export pair) and on the per-peer
+    // authoritative transaction whose rollback ordering this proof pins.
     let apply = manager.apply_resolved_policy_snapshot(
         peers
             .iter()
             .copied()
-            .map(|address| ResolvedPeerPolicy {
+            .enumerate()
+            .map(|(index, address)| ResolvedPeerPolicy {
                 address,
                 interface: None,
                 import_policy: Some(next.clone()),
-                export_policy: Some(next.clone()),
+                export_policy: Some(distinct_deny_policy_chain(index)),
             })
             .collect(),
     );


### PR DESCRIPTION
## Mechanism

A reload that changes import chain content alongside export made `local_export_only_policy_pair` disqualify every peer from the export-only cohort (it required `managed.import_policy == target.import_policy`), so `cohort_targets < 2` and the entire fleet took `apply_resolved_policy_snapshot_authoritatively` one peer at a time: per-peer import hot-apply, export hot-apply, a full-table RIB export restage, and a wire Route Refresh — serialized across N peers.

## Change

- **Cohort eligibility** no longer requires an unchanged import chain; only the export move keys cohort identity, and members with pending retry intent stay excluded.
- **Setup** hot-applies a member's changed import chain through the same session command the authoritative path uses (`update_import_policy`), without firing `soft_reset_in`. A forward import failure mirrors the authoritative bail: bookkeeping retains the prior chain and `pending_refresh` carries the unfired refresh intent.
- **Deferred refresh** fires once per import-moving member after the cohort RIB commit (or its authoritative per-peer handoff) acknowledges. The window where the session runs the new import chain while Adj-RIB-In holds old-policy routes already exists in the authoritative path between hot-apply and the peer's refresh answer; deferring past commit lengthens it and converges identically, and the re-ingest is output-neutral when import changes don't alter stored routes (LocRib interned-attr equality suppression). Non-Established members arm `pending_refresh` instead, exactly like the authoritative path.
- **Rollback** restores both chains: the ordinary restore path already reasserts the captured prior import chain, and the failing-member repair reasserts its acknowledged import delta directly, carrying retry intent through the existing `pending_refresh`/`pending_export_apply` discipline. Import-unchanged members behave exactly as before, including getting no refresh.
- Adds the owned-sender `PeerHandle::update_import_policy_with` mirroring `update_export_policy_with` so the cohort transaction can hot-apply import chains against the readiness lane.

The reload contract holds: Route Refresh still originates inside the policy-apply seam for both SIGHUP and gRPC, sequenced after the commit.

## Tests

- `import_tolerant_cohort_defers_refresh_past_committed_batch` — an import+export move partitions the whole fleet (`cohort_targets == fleet`, no authoritative singles); no refresh before the Committed reply; exactly one refresh per import-moving member and none for import-unchanged members.
- `import_tolerant_cohort_handoff_fires_deferred_refresh_once` — the `RequiresAuthoritativePerPeerApply` handoff still fires each deferred refresh exactly once, after the handoff completes.
- `import_tolerant_cohort_rib_failure_restores_both_chains` — a failed batch commit restores import and export chains (forward install + reassert observed on the session), fires only the post-reassert rollback refresh, and leaves no pending intent after a clean restore.
- `import_tolerant_cohort_export_failure_reasserts_failing_member_import` — an export hot-apply failure reasserts the failing member's acknowledged import delta directly, with no RIB compensation for that member.
- Pre-existing authoritative-rollback regressions now pin their path via per-peer distinct export targets (`distinct_deny_policy_chain`), since a uniform import+export move legitimately partitions after this change.

## Measurement

`bench/scale/reloadstall` historical import+export mode, 100 peers x 57,000 routes, 2 reloads, release builds, same host (`gen-scenario.py 100 /tmp/rls/lan462 1793`):

| Metric | main (`fe4f8cca`) | this branch |
| --- | --- | --- |
| completion p50 (reload 1 / 2) | 3.29 s / 3.10 s | **0.10 s / 0.09 s** |
| completion max | 6.24 s / 5.96 s | 0.11 s / 0.10 s |
| reload wall (SIGHUP -> `config reload complete`) | 6.24 s / 5.96 s | **0.092 s / 0.084 s** |
| `partitioned resolved policy snapshot` lines | 0 | 2 per reload (`cohort_targets=100`, `remainder=0`) |
| `soft reset in requested` lines | 200 (serialized, inside the per-peer loop) | 200 (once per member, after the commit) |
| sessions up / parse errors | 100/100, 0 | 100/100, 0 |

All-observer max-gap and RSS are unchanged within noise. The 700-peer x 400k-route shape that measured 273 s on this path scales the same serialization; the cohort replaces it with one batched transition.