### PR TITLE
perf(transport): publish update-group shared encode progressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   single entry — falls back to the unchanged per-session encode. At
   route-server scale this removes the N× duplicate encode that delayed
   every observer's first post-reload UPDATE by the full-table encode time.
+  Publication is progressive (ADR-0109 amendment): the encoder publishes
+  each slice's chunks as they are produced and members send them as they
+  arrive, so an observer's longest wire silence tracks per-slice encode
+  latency (single-digit milliseconds) instead of the single-threaded
+  full-table encode; a stream that fails mid-way terminates explicitly
+  (drop-guarded against encoder unwind) and members fall back to the local
+  encode, whose byte-identical re-announcements are idempotent.
 
 - Dirty-peer resync ticks now drain the backlog under the same 25 ms
   wall-clock poll budget as policy-transition commit flushes, instead of a

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -689,8 +689,9 @@ pub enum ExportPolicyCohortOutcome {
 }
 
 /// Once-per-update-group cell through which the first consuming session task
-/// publishes its encoded wire chunks so every other member of the group can
-/// reuse the bytes instead of re-encoding the same shared announce inventory.
+/// (the elected encoder) publishes its progressively encoded wire chunks so
+/// every other member of the group can stream the bytes instead of
+/// re-encoding the same shared announce inventory.
 ///
 /// The payload is transport-owned and deliberately opaque here (the same
 /// trust-boundary pattern as [`ExactExportSnapshot::as_any`]): the RIB only
@@ -698,10 +699,15 @@ pub enum ExportPolicyCohortOutcome {
 /// same cell. Transport downcasts, proves wire-equivalence between its own
 /// export profile and the encoder's, and falls back to its ordinary
 /// per-session encode when the proof fails.
+///
+/// The lock is synchronous on purpose: initialization only *constructs* the
+/// (empty) progressive stream state, so encoder election commits with no
+/// await point between winning the election and starting to encode — a
+/// cancelled task can never leave an initialized cell with no live encoder.
 #[derive(Default)]
 pub struct SharedGroupEncode {
-    /// First-consumer-initializes cell; losers await instead of re-encoding.
-    pub cell: tokio::sync::OnceCell<Arc<dyn Any + Send + Sync>>,
+    /// First-consumer-initializes cell; losers stream instead of re-encoding.
+    pub cell: std::sync::OnceLock<Arc<dyn Any + Send + Sync>>,
 }
 
 /// Routes to be sent outbound to a peer.

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -1,4 +1,5 @@
-//! Encode-once fanout for update-group shared envelopes (LAN-455/LAN-458).
+//! Encode-once fanout for update-group shared envelopes (LAN-455/LAN-458),
+//! with progressive chunk publication (ADR-0109, amended).
 //!
 //! A clean grouped export-policy transition releases the *same* announce
 //! inventory (`Arc`-shared) to every member of an update-group, differing
@@ -7,17 +8,27 @@
 //! encodes that fair-shared the cores and delayed everyone's first wire
 //! UPDATE by the total encode time divided by the core count.
 //!
-//! Here the first member to consume its envelope encodes the inventory once
-//! into per-`(source peer, family)` wire chunks at the standard 4096-byte
-//! ceiling and publishes them through the envelope's
-//! [`SharedGroupEncode`] cell; every other member awaits the cell, proves
-//! byte-equivalence with [`SessionExportProfile::has_same_wire_encoding`],
-//! and enqueues the shared bytes — skipping the chunks of its own source
-//! (split horizon) and of families it did not negotiate. Any anomaly
-//! (profile mismatch, preparation failure, OTC filter hit, single-entry
-//! oversize, scoped-link-local IPv4 drop) makes the payload unshareable and
-//! each member falls back to the ordinary per-session encode, which owns
-//! the established diagnostics and teardown semantics for every such case.
+//! The first member to consume its envelope is elected encoder through the
+//! envelope's [`SharedGroupEncode`] cell (a synchronous `OnceLock`, so the
+//! election commits with no await point that could strand an initialized
+//! cell without a live encoder). The encoder prepares, groups, and encodes
+//! the inventory in bounded route slices, publishing each slice's chunks as
+//! they are produced; every other member proves byte-equivalence with
+//! [`SessionExportProfile::has_same_wire_encoding`] and then *streams* the
+//! chunks — sending chunk `i` as soon as it exists instead of awaiting the
+//! whole payload — skipping the chunks of its own source (split horizon)
+//! and of families it did not negotiate. This makes a member's longest wire
+//! silence track per-slice encode latency instead of the full-table encode.
+//!
+//! Failure semantics: any anomaly (preparation failure, OTC filter hit,
+//! single-entry oversize, scoped-link-local IPv4 drop) terminates the
+//! stream as `Failed` — published by a drop guard even if the encoder
+//! unwinds — and every member falls back to the ordinary per-session
+//! encode, which owns the established diagnostics and teardown semantics
+//! for each case. Mid-stream fallback is safe by construction: the chunks a
+//! member already sent are byte-identical to what its local encode re-sends
+//! (that is exactly what the wire-equivalence proof establishes), so the
+//! receiver sees idempotent re-announcements and no route can be skipped.
 //!
 //! Chunks never mix source peers even when global attribute interning gives
 //! two sources pointer-identical attribute sets: keeping the source in the
@@ -36,27 +47,124 @@ use bytes::Bytes;
 use rustbgpd_rib::SharedGroupEncode;
 use rustc_hash::FxHashMap as HashMap;
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+/// Routes per encoder slice: each slice is prepared, grouped, encoded, and
+/// published as one unit, so consumers' streaming granularity (and the gap
+/// floor between their UPDATEs) tracks one slice's encode latency — single-
+/// digit milliseconds at reload-stall route shapes — instead of the full
+/// table. Sources spanning a slice boundary cost one extra UPDATE each.
+const PROGRESSIVE_SLICE_ROUTES: usize = 2048;
 
 /// One pre-encoded wire UPDATE carrying routes from exactly one source peer
 /// and one unicast family.
+#[derive(Clone)]
 pub(super) struct SharedUnicastChunk {
     pub(super) source: IpAddr,
     pub(super) afi: Afi,
     pub(super) bytes: Bytes,
 }
 
-/// Cell payload published by the first member to consume its envelope.
-pub(super) enum SharedUnicastEncode {
-    /// Chunks valid for every member whose export profile proves
-    /// [`SessionExportProfile::has_same_wire_encoding`] with `profile`.
-    Ready {
-        profile: SessionExportProfile,
-        chunks: Vec<SharedUnicastChunk>,
-    },
-    /// The encoding member hit an anomaly; every member (encoder included)
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum StreamTerminal {
+    /// Every chunk of the inventory has been published.
+    Complete,
+    /// The stream is truncated (encoder anomaly or unwind); every member
     /// falls back to its ordinary per-session encode.
-    Unshareable,
+    Failed,
+}
+
+#[derive(Default)]
+struct ProgressiveStateInner {
+    chunks: Vec<SharedUnicastChunk>,
+    terminal: Option<StreamTerminal>,
+}
+
+/// Cell payload created by the elected encoder *before* it encodes anything.
+pub(super) struct ProgressiveUnicastEncode {
+    /// The encoder's profile; consumers reuse chunks only after proving
+    /// [`SessionExportProfile::has_same_wire_encoding`] against it.
+    profile: SessionExportProfile,
+    state: Mutex<ProgressiveStateInner>,
+    progress: tokio::sync::Notify,
+}
+
+impl ProgressiveUnicastEncode {
+    fn new(profile: SessionExportProfile) -> Self {
+        Self {
+            profile,
+            state: Mutex::new(ProgressiveStateInner::default()),
+            progress: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn publish(&self, chunks: Vec<SharedUnicastChunk>) {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.chunks.extend(chunks);
+        }
+        self.progress.notify_waiters();
+    }
+
+    /// First terminal wins; the encoder's explicit `Complete` makes the
+    /// drop guard's `Failed` a no-op on the success path.
+    fn finish(&self, terminal: StreamTerminal) {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state.terminal.is_none() {
+                state.terminal = Some(terminal);
+            }
+        }
+        self.progress.notify_waiters();
+    }
+
+    /// Chunks published since `from`, plus the terminal state. Bytes are
+    /// refcounted, so the clone-out is cheap.
+    fn snapshot_from(&self, from: usize) -> (Vec<SharedUnicastChunk>, Option<StreamTerminal>) {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (
+            state.chunks.get(from..).unwrap_or(&[]).to_vec(),
+            state.terminal,
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn test_new(profile: SessionExportProfile) -> Self {
+        Self::new(profile)
+    }
+    #[cfg(test)]
+    pub(super) fn test_publish(&self, chunks: Vec<SharedUnicastChunk>) {
+        self.publish(chunks);
+    }
+    #[cfg(test)]
+    pub(super) fn test_finish(&self, terminal: StreamTerminal) {
+        self.finish(terminal);
+    }
+    #[cfg(test)]
+    pub(super) fn test_snapshot(&self) -> (usize, Option<StreamTerminal>) {
+        let (chunks, terminal) = self.snapshot_from(0);
+        (chunks.len(), terminal)
+    }
+}
+
+/// Publishes `Failed` if the encoder unwinds (panic or early return) before
+/// its explicit `finish(Complete)`, so consumers can never wait forever on a
+/// stream with no live encoder.
+pub(super) struct EncoderGuard<'cell>(pub(super) &'cell ProgressiveUnicastEncode);
+
+impl Drop for EncoderGuard<'_> {
+    fn drop(&mut self) {
+        self.0.finish(StreamTerminal::Failed);
+    }
 }
 
 /// Whether an envelope is shaped like a clean group-transition fanout:
@@ -144,26 +252,22 @@ struct SharedGroup {
     body: SharedGroupBody,
 }
 
-/// Encode the shared inventory once: prepare and group announcements
-/// exactly like the per-session path, with the source peer added to the
-/// group key, then chunk each group to the standard message ceiling.
+/// Prepare, group, and encode one slice of the shared inventory exactly
+/// like the per-session path, with the source peer added to the group key.
+/// `None` = the stream is unshareable (the per-session fallback owns the
+/// diagnostics and teardown semantics for the failing case).
 #[expect(
     clippy::too_many_lines,
     reason = "mirrors the per-session grouping branches in one auditable pass"
 )]
-pub(super) fn build_shared_unicast_encode(
+pub(super) fn encode_shared_unicast_slice(
     export: &SessionExportProfile,
+    cache: &mut PreparedAttrCache,
     announce: &[Route],
     next_hop_override: &[Option<rustbgpd_policy::NextHopAction>],
-) -> SharedUnicastEncode {
-    // Scoped link-local peers silently drop IPv4 with a per-member warning;
-    // keep that behavior on the per-session path.
-    if export.is_scoped_link_local_peer() {
-        return SharedUnicastEncode::Unshareable;
-    }
+) -> Option<Vec<SharedUnicastChunk>> {
     let max_len = usize::from(rustbgpd_wire::MAX_MESSAGE_LEN);
     let local_ipv4 = export.local_ipv4();
-    let mut cache = PreparedAttrCache::default();
     let mut index: HashMap<SharedGroupKey, usize> = HashMap::default();
     let mut groups: Vec<SharedGroup> = Vec::new();
     for (i, route) in announce.iter().enumerate() {
@@ -171,11 +275,11 @@ pub(super) fn build_shared_unicast_encode(
             // RIB staging removes OTC-blocked routes before this seam; if
             // one slips through, the per-session path owns the per-member
             // diagnostics.
-            return SharedUnicastEncode::Unshareable;
+            return None;
         }
         let nh_override = next_hop_override.get(i).and_then(Option::as_ref);
         let attrs = export
-            .prepared_unicast_attributes_cached(&mut cache, route, local_ipv4, nh_override)
+            .prepared_unicast_attributes_cached(cache, route, local_ipv4, nh_override)
             .clone();
         // `finish_unicast_candidate` picks IPv4-body vs MP_REACH from the
         // profile's Extended Next Hop state itself, so this match covers
@@ -219,7 +323,7 @@ pub(super) fn build_shared_unicast_encode(
             // The exact-export preflight probed every route on this same
             // snapshot before commit; a failure here is the anomaly the
             // per-session path turns into a teardown.
-            Err(_) => return SharedUnicastEncode::Unshareable,
+            Err(_) => return None,
         };
         if let Some(&at) = index.get(&key) {
             match (&mut groups[at].body, body_seed) {
@@ -240,7 +344,7 @@ pub(super) fn build_shared_unicast_encode(
                 // A key collision across body kinds cannot happen (MP keys
                 // always carry a next hop, body keys never do), but sharing
                 // must stay provable rather than clever.
-                _ => return SharedUnicastEncode::Unshareable,
+                _ => return None,
             }
         } else {
             index.insert(key, groups.len());
@@ -281,19 +385,13 @@ pub(super) fn build_shared_unicast_encode(
                 }),
             ),
         };
-        let Some(encoded) = encoded else {
-            return SharedUnicastEncode::Unshareable;
-        };
-        chunks.extend(encoded.into_iter().map(|bytes| SharedUnicastChunk {
+        chunks.extend(encoded?.into_iter().map(|bytes| SharedUnicastChunk {
             source: group.source,
             afi,
             bytes,
         }));
     }
-    SharedUnicastEncode::Ready {
-        profile: export.clone(),
-        chunks,
-    }
+    Some(chunks)
 }
 
 impl PeerSession {
@@ -313,7 +411,9 @@ impl PeerSession {
     /// shared bytes (including an enqueue failure, whose saturation/teardown
     /// policy already ran — re-encoding locally would duplicate the stream).
     /// `false` = fall back to the ordinary path, which re-runs the snapshot
-    /// trust checks and owns their teardown.
+    /// trust checks and owns their teardown. Mid-stream `false` (truncated
+    /// stream) is safe: everything sent so far is byte-identical to what the
+    /// local re-encode sends, so the fallback can only repeat, never skip.
     async fn try_send_shared_group(
         &mut self,
         shared: &SharedGroupEncode,
@@ -330,54 +430,147 @@ impl PeerSession {
         {
             return false;
         }
-        let encoded = shared
-            .cell
-            .get_or_init(|| {
-                let value: Arc<dyn Any + Send + Sync> = Arc::new(build_shared_unicast_encode(
-                    export,
-                    &update.announce,
-                    &update.next_hop_override,
-                ));
-                std::future::ready(value)
-            })
-            .await;
-        let Some(encode) = encoded.downcast_ref::<SharedUnicastEncode>() else {
+        // Encoder election: constructing the (empty) stream state is the
+        // only work inside the lock, and there is no await between winning
+        // and encoding, so an initialized cell always has a live encoder
+        // (or its drop guard's terminal).
+        let mut elected_encoder = false;
+        let cell = shared.cell.get_or_init(|| {
+            elected_encoder = true;
+            Arc::new(ProgressiveUnicastEncode::new(export.clone())) as Arc<dyn Any + Send + Sync>
+        });
+        let Some(encode) = cell.downcast_ref::<ProgressiveUnicastEncode>() else {
             return false;
         };
-        let SharedUnicastEncode::Ready { profile, chunks } = encode else {
-            return false;
-        };
-        if !export.has_same_wire_encoding(profile) {
+        if elected_encoder {
+            self.encode_and_send_shared_group(encode, update, export)
+        } else {
+            self.stream_shared_group(encode, update, export).await
+        }
+    }
+
+    /// Encoder role: encode the inventory slice by slice, publishing each
+    /// slice's chunks for the group and sending its own filtered copy along
+    /// the way. Scoped-link-local peers and any slice failure terminate the
+    /// stream as `Failed` (via the guard) and fall back locally.
+    fn encode_and_send_shared_group(
+        &mut self,
+        encode: &ProgressiveUnicastEncode,
+        update: &OutboundRouteUpdate,
+        export: &SessionExportProfile,
+    ) -> bool {
+        let guard = EncoderGuard(encode);
+        if export.is_scoped_link_local_peer() {
+            // The per-session path owns the per-member IPv4-drop warning.
             return false;
         }
+        let mut cache = PreparedAttrCache::default();
+        // Keep publishing for the group even after this session's own writer
+        // saturates: the group's stream must not depend on one member's
+        // channel health. The saturation/teardown policy for this session
+        // already ran inside the failed enqueue.
+        let mut own_send_healthy = true;
         let mut sent: u64 = 0;
-        for chunk in chunks {
-            if update.announce_source_exclusion == Some(chunk.source) {
-                continue;
+        let mut idx = 0;
+        while idx < update.announce.len() {
+            let end = (idx + PROGRESSIVE_SLICE_ROUTES).min(update.announce.len());
+            let Some(chunks) = encode_shared_unicast_slice(
+                export,
+                &mut cache,
+                &update.announce[idx..end],
+                update.next_hop_override.get(idx..end).unwrap_or(&[]),
+            ) else {
+                return false;
+            };
+            let mine: Vec<SharedUnicastChunk> = chunks
+                .iter()
+                .filter(|chunk| self.wants_shared_chunk(update, chunk))
+                .cloned()
+                .collect();
+            encode.publish(chunks);
+            if own_send_healthy {
+                for chunk in mine {
+                    if self.enqueue_bulk_encoded(chunk.bytes, true).is_err() {
+                        own_send_healthy = false;
+                        break;
+                    }
+                    self.updates_sent += 1;
+                    self.metrics.record_message_sent(&self.peer_label, "update");
+                    sent += 1;
+                }
             }
-            if !self
-                .negotiated_families
-                .contains(&(chunk.afi, Safi::Unicast))
-            {
-                continue;
-            }
-            if self
-                .enqueue_bulk_encoded(chunk.bytes.clone(), true)
-                .is_err()
-            {
-                // Saturation teardown / writer-closed policy already ran
-                // inside; abort the batch like the ordinary chunked senders.
-                return true;
-            }
-            self.updates_sent += 1;
-            self.metrics.record_message_sent(&self.peer_label, "update");
-            sent += 1;
+            idx = end;
         }
+        encode.finish(StreamTerminal::Complete);
+        drop(guard);
         debug!(
             peer = %self.peer_label,
             updates = sent,
-            "sent update-group announcements from shared encode"
+            "encoded and sent update-group announcements as shared encode"
         );
         true
+    }
+
+    /// Consumer role: prove byte-equivalence once, then send each chunk as
+    /// it is published instead of awaiting the whole payload.
+    async fn stream_shared_group(
+        &mut self,
+        encode: &ProgressiveUnicastEncode,
+        update: &OutboundRouteUpdate,
+        export: &SessionExportProfile,
+    ) -> bool {
+        if !export.has_same_wire_encoding(&encode.profile) {
+            return false;
+        }
+        let mut next = 0;
+        let mut sent: u64 = 0;
+        loop {
+            // Register for wakeups BEFORE snapshotting, so a publish that
+            // lands between the snapshot and the await still wakes us.
+            let notified = encode.progress.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            let (new_chunks, terminal) = encode.snapshot_from(next);
+            next += new_chunks.len();
+            for chunk in new_chunks {
+                if !self.wants_shared_chunk(update, &chunk) {
+                    continue;
+                }
+                if self.enqueue_bulk_encoded(chunk.bytes, true).is_err() {
+                    // Saturation teardown / writer-closed policy already ran
+                    // inside; abort like the ordinary chunked senders.
+                    return true;
+                }
+                self.updates_sent += 1;
+                self.metrics.record_message_sent(&self.peer_label, "update");
+                sent += 1;
+            }
+            match terminal {
+                Some(StreamTerminal::Complete) => {
+                    debug!(
+                        peer = %self.peer_label,
+                        updates = sent,
+                        "sent update-group announcements from shared encode"
+                    );
+                    return true;
+                }
+                Some(StreamTerminal::Failed) => {
+                    // Truncated stream: fall back to the full local encode.
+                    // Chunks already sent are byte-identical to the local
+                    // path's output, so the receiver sees idempotent
+                    // re-announcements; nothing can be skipped.
+                    return false;
+                }
+                None => notified.await,
+            }
+        }
+    }
+
+    /// Split horizon (own-source exclusion) plus negotiated-family filter.
+    fn wants_shared_chunk(&self, update: &OutboundRouteUpdate, chunk: &SharedUnicastChunk) -> bool {
+        update.announce_source_exclusion != Some(chunk.source)
+            && self
+                .negotiated_families
+                .contains(&(chunk.afi, Safi::Unicast))
     }
 }

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -254,6 +254,9 @@ struct SharedGroup {
 
 /// Prepare, group, and encode one slice of the shared inventory exactly
 /// like the per-session path, with the source peer added to the group key.
+/// `indices` selects the slice's routes (and their parallel next-hop
+/// overrides) out of the full inventory; the encoder passes source-sorted
+/// index windows so each slice's groups stay per-source-dense.
 /// `None` = the stream is unshareable (the per-session fallback owns the
 /// diagnostics and teardown semantics for the failing case).
 #[expect(
@@ -265,12 +268,14 @@ pub(super) fn encode_shared_unicast_slice(
     cache: &mut PreparedAttrCache,
     announce: &[Route],
     next_hop_override: &[Option<rustbgpd_policy::NextHopAction>],
+    indices: &[usize],
 ) -> Option<Vec<SharedUnicastChunk>> {
     let max_len = usize::from(rustbgpd_wire::MAX_MESSAGE_LEN);
     let local_ipv4 = export.local_ipv4();
     let mut index: HashMap<SharedGroupKey, usize> = HashMap::default();
     let mut groups: Vec<SharedGroup> = Vec::new();
-    for (i, route) in announce.iter().enumerate() {
+    for &i in indices {
+        let route = &announce[i];
         if export.otc_blocks_unicast_egress(route) {
             // RIB staging removes OTC-blocked routes before this seam; if
             // one slips through, the per-session path owns the per-member
@@ -465,6 +470,16 @@ impl PeerSession {
             return false;
         }
         let mut cache = PreparedAttrCache::default();
+        // Iterate the inventory in source-peer order rather than table
+        // order. The inventory interleaves sources per prefix, so grouping
+        // per slice in table order fragments every source across every
+        // slice — measured at reload-stall shape as tens of thousands of
+        // tiny UPDATEs per member and writer-channel saturation teardown.
+        // Sorting an index keeps announce/next-hop-override alignment and
+        // is safe to reorder: the inventory carries one route per prefix,
+        // and announcements of distinct prefixes are order-independent.
+        let mut order: Vec<usize> = (0..update.announce.len()).collect();
+        order.sort_unstable_by_key(|&i| update.announce[i].peer);
         // Keep publishing for the group even after this session's own writer
         // saturates: the group's stream must not depend on one member's
         // channel health. The saturation/teardown policy for this session
@@ -472,13 +487,14 @@ impl PeerSession {
         let mut own_send_healthy = true;
         let mut sent: u64 = 0;
         let mut idx = 0;
-        while idx < update.announce.len() {
-            let end = (idx + PROGRESSIVE_SLICE_ROUTES).min(update.announce.len());
+        while idx < order.len() {
+            let end = (idx + PROGRESSIVE_SLICE_ROUTES).min(order.len());
             let Some(chunks) = encode_shared_unicast_slice(
                 export,
                 &mut cache,
-                &update.announce[idx..end],
-                update.next_hop_override.get(idx..end).unwrap_or(&[]),
+                &update.announce,
+                &update.next_hop_override,
+                &order[idx..end],
             ) else {
                 return false;
             };

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -3163,13 +3163,16 @@ async fn shared_group_encode_first_member_encodes_and_second_reuses() {
     let update = shared_group_envelope(&member_a, &shared, source_a, &announce);
     member_a.handle_outbound_route_update(update).await;
     let published = shared.cell.get().expect("first member publishes the cell");
-    let super::shared_group::SharedUnicastEncode::Ready { chunks, .. } = published
-        .downcast_ref::<super::shared_group::SharedUnicastEncode>()
+    let (chunk_count, terminal) = published
+        .downcast_ref::<super::shared_group::ProgressiveUnicastEncode>()
         .expect("cell payload is the transport shared-encode type")
-    else {
-        panic!("uniform-profile inventory must be shareable");
-    };
-    assert_eq!(chunks.len(), 3, "one chunk per source at this size");
+        .test_snapshot();
+    assert_eq!(
+        terminal,
+        Some(super::shared_group::StreamTerminal::Complete),
+        "uniform-profile inventory must complete"
+    );
+    assert_eq!(chunk_count, 3, "one chunk per source at this size");
     assert_eq!(
         read_announced_prefixes(&mut wire_a, 2).await,
         {
@@ -3258,14 +3261,16 @@ async fn shared_group_encode_skips_chunks_of_unnegotiated_families() {
     let update = shared_group_envelope(&member_a, &shared, source_a, &announce);
     member_a.handle_outbound_route_update(update).await;
     let published = shared.cell.get().expect("cell published");
-    let super::shared_group::SharedUnicastEncode::Ready { chunks, .. } = published
-        .downcast_ref::<super::shared_group::SharedUnicastEncode>()
+    let (chunk_count, terminal) = published
+        .downcast_ref::<super::shared_group::ProgressiveUnicastEncode>()
         .unwrap()
-    else {
-        panic!("inventory must be shareable");
-    };
-    assert!(
-        chunks.iter().any(|chunk| chunk.afi == Afi::Ipv6),
+        .test_snapshot();
+    assert_eq!(
+        terminal,
+        Some(super::shared_group::StreamTerminal::Complete)
+    );
+    assert_eq!(
+        chunk_count, 2,
         "encoder produced the IPv6 chunk for dual-stack members"
     );
     // Member A negotiated only IPv4-unicast and excluded source A: nothing
@@ -3283,6 +3288,170 @@ async fn shared_group_encode_skips_chunks_of_unnegotiated_families() {
         vec![Prefix::V4(sentinel_prefix)],
         "no IPv6 UPDATE preceded the sentinel on an IPv4-only session"
     );
+}
+
+/// A stream that terminates `Failed` after a member already sent shared
+/// chunks must fall back to the full local encode: the receiver sees the
+/// head chunk again (byte-identical, idempotent) and every remaining route
+/// exactly once — repetition is possible, skipping is not.
+#[tokio::test]
+async fn shared_group_encode_midstream_failure_falls_back_without_skips() {
+    use super::shared_group::{ProgressiveUnicastEncode, StreamTerminal};
+    let source_a = Ipv4Addr::new(10, 33, 0, 1);
+    let source_b = Ipv4Addr::new(10, 33, 0, 2);
+    let source_x = Ipv4Addr::new(10, 33, 0, 9);
+    let prefix_a = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let prefix_b = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let announce = vec![
+        make_sourced_route(source_a, prefix_a, 64_601),
+        make_sourced_route(source_b, prefix_b, 64_602),
+    ];
+
+    let (mut member, mut wire) = shared_group_member(65001).await;
+    let profile = (*member.publish_export_profile()).clone();
+    let encode = ProgressiveUnicastEncode::test_new(profile.clone());
+    // Simulate an encoder that published the first source's chunk and then
+    // hit an anomaly.
+    let mut cache = super::export::PreparedAttrCache::default();
+    let head = super::shared_group::encode_shared_unicast_slice(
+        &profile,
+        &mut cache,
+        &announce[..1],
+        &[None],
+    )
+    .expect("head slice encodes");
+    encode.test_publish(head);
+    encode.test_finish(StreamTerminal::Failed);
+    let shared = Arc::new(rustbgpd_rib::SharedGroupEncode::default());
+    assert!(
+        shared
+            .cell
+            .set(Arc::new(encode) as Arc<dyn std::any::Any + Send + Sync>)
+            .is_ok(),
+        "fresh cell"
+    );
+
+    // Exclusion targets an uninvolved source, so this member wants both
+    // routes.
+    let update = shared_group_envelope(&member, &shared, source_x, &announce);
+    member.handle_outbound_route_update(update).await;
+
+    // Wire: the shared head chunk (prefix A), then the full local fallback
+    // stream (prefix A and prefix B in distinct-attr UPDATEs).
+    assert_eq!(
+        read_announced_prefixes(&mut wire, 3).await,
+        {
+            let mut expected = vec![
+                Prefix::V4(prefix_a),
+                Prefix::V4(prefix_a),
+                Prefix::V4(prefix_b),
+            ];
+            expected.sort_unstable();
+            expected
+        },
+        "head chunk repeats (idempotent), nothing is skipped"
+    );
+}
+
+/// The encoder unwinding without a terminal must leave `Failed`, never a
+/// stream consumers could wait on forever.
+#[tokio::test]
+async fn shared_group_encoder_guard_publishes_failed_on_unwind() {
+    use super::shared_group::{EncoderGuard, ProgressiveUnicastEncode, StreamTerminal};
+    let (member, _wire) = shared_group_member(65001).await;
+    let encode = ProgressiveUnicastEncode::test_new((*member.publish_export_profile()).clone());
+    drop(EncoderGuard(&encode));
+    assert_eq!(encode.test_snapshot(), (0, Some(StreamTerminal::Failed)));
+}
+
+/// An inventory larger than one encoder slice is published progressively
+/// across slices and streams completely to a consumer, with split horizon
+/// still composed from whole per-source chunks.
+#[tokio::test]
+async fn shared_group_encode_streams_multiple_slices() {
+    let sources = [
+        Ipv4Addr::new(10, 34, 0, 1),
+        Ipv4Addr::new(10, 34, 0, 2),
+        Ipv4Addr::new(10, 34, 0, 3),
+    ];
+    // One attribute Arc per source so same-source routes group into shared
+    // chunks (mirroring interned route-server tables).
+    let attrs: Vec<Arc<Vec<PathAttribute>>> = sources
+        .iter()
+        .enumerate()
+        .map(|(i, source)| {
+            Arc::new(vec![
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(vec![
+                        64_601 + u32::try_from(i).unwrap(),
+                    ])],
+                }),
+                PathAttribute::NextHop(*source),
+            ])
+        })
+        .collect();
+    let total = 2_100_usize; // > one 2048-route slice
+    let announce: Vec<Route> = (0..total)
+        .map(|i| {
+            let source = sources[i % 3];
+            Route {
+                prefix: Prefix::V4(Ipv4Prefix::new(
+                    Ipv4Addr::from(0x0A40_0000_u32 + u32::try_from(i).unwrap() * 256),
+                    24,
+                )),
+                peer: IpAddr::V4(source),
+                next_hop: IpAddr::V4(source),
+                attributes: Arc::clone(&attrs[i % 3]),
+                ..make_route(100)
+            }
+        })
+        .collect();
+    let shared = Arc::new(rustbgpd_rib::SharedGroupEncode::default());
+
+    let (mut member_a, mut wire_a) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_a, &shared, sources[0], &announce);
+    member_a.handle_outbound_route_update(update).await;
+    let (chunk_count, terminal) = shared
+        .cell
+        .get()
+        .unwrap()
+        .downcast_ref::<super::shared_group::ProgressiveUnicastEncode>()
+        .unwrap()
+        .test_snapshot();
+    assert_eq!(
+        terminal,
+        Some(super::shared_group::StreamTerminal::Complete)
+    );
+    assert_eq!(
+        chunk_count, 6,
+        "three per-source chunks per slice, two slices"
+    );
+
+    let expected_a: Vec<Prefix> = {
+        let mut v: Vec<Prefix> = announce
+            .iter()
+            .filter(|route| route.peer != IpAddr::V4(sources[0]))
+            .map(|route| route.prefix)
+            .collect();
+        v.sort_unstable();
+        v
+    };
+    assert_eq!(read_announced_prefixes(&mut wire_a, 4).await, expected_a);
+
+    let (mut member_b, mut wire_b) = shared_group_member(65001).await;
+    let update = shared_group_envelope(&member_b, &shared, sources[1], &announce);
+    member_b.handle_outbound_route_update(update).await;
+    let expected_b: Vec<Prefix> = {
+        let mut v: Vec<Prefix> = announce
+            .iter()
+            .filter(|route| route.peer != IpAddr::V4(sources[1]))
+            .map(|route| route.prefix)
+            .collect();
+        v.sort_unstable();
+        v
+    };
+    assert_eq!(read_announced_prefixes(&mut wire_b, 4).await, expected_b);
 }
 #[tokio::test]
 async fn send_route_update_emits_bgpls_reach_and_unreach() {

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -3318,6 +3318,7 @@ async fn shared_group_encode_midstream_failure_falls_back_without_skips() {
         &mut cache,
         &announce[..1],
         &[None],
+        &[0],
     )
     .expect("head slice encodes");
     encode.test_publish(head);
@@ -3424,8 +3425,9 @@ async fn shared_group_encode_streams_multiple_slices() {
         Some(super::shared_group::StreamTerminal::Complete)
     );
     assert_eq!(
-        chunk_count, 6,
-        "three per-source chunks per slice, two slices"
+        chunk_count, 4,
+        "source-sorted iteration keeps per-source chunks dense: three whole \
+         sources in slice one, the third source's tail in slice two"
     );
 
     let expected_a: Vec<Prefix> = {
@@ -3437,7 +3439,7 @@ async fn shared_group_encode_streams_multiple_slices() {
         v.sort_unstable();
         v
     };
-    assert_eq!(read_announced_prefixes(&mut wire_a, 4).await, expected_a);
+    assert_eq!(read_announced_prefixes(&mut wire_a, 3).await, expected_a);
 
     let (mut member_b, mut wire_b) = shared_group_member(65001).await;
     let update = shared_group_envelope(&member_b, &shared, sources[1], &announce);
@@ -3451,7 +3453,7 @@ async fn shared_group_encode_streams_multiple_slices() {
         v.sort_unstable();
         v
     };
-    assert_eq!(read_announced_prefixes(&mut wire_b, 4).await, expected_b);
+    assert_eq!(read_announced_prefixes(&mut wire_b, 3).await, expected_b);
 }
 #[tokio::test]
 async fn send_route_update_emits_bgpls_reach_and_unreach() {

--- a/docs/adr/0109-update-group-shared-encode.md
+++ b/docs/adr/0109-update-group-shared-encode.md
@@ -106,10 +106,18 @@ encoder prepares, groups, and encodes the inventory in bounded route slices
 publishing each slice's chunks as they are produced and sending its own
 filtered copy along the way; consumers prove wire-equivalence once, then
 send chunk *i* as soon as it exists. A member's longest wire silence now
-tracks per-slice encode latency instead of the full-table encode. Sources
-spanning a slice boundary cost one extra UPDATE each; slices keep the
-announce/next-hop-override index alignment, and the prepared-attribute cache
-persists across slices.
+tracks per-slice encode latency instead of the full-table encode.
+
+The encoder walks the inventory through an index sorted by source peer.
+The inventory arrives in table order with sources interleaved per prefix,
+and per-slice grouping in that order fragments every source across every
+slice — measured at 300 clients × 171,600 routes as tens of thousands of
+tiny UPDATEs per member and writer-channel saturation teardown. Source
+order keeps per-source chunks dense (a source spanning a slice boundary
+costs one extra UPDATE) and is safe to reorder because the inventory
+carries one route per prefix and announcements of distinct prefixes are
+order-independent. Slices keep the announce/next-hop-override index
+alignment, and the prepared-attribute cache persists across slices.
 
 The terminal marker is `Complete` or `Failed`. Any encoder anomaly — the
 same enumerated cases as before, at any slice — terminates the stream as

--- a/docs/adr/0109-update-group-shared-encode.md
+++ b/docs/adr/0109-update-group-shared-encode.md
@@ -87,3 +87,37 @@ the mirror byte-exact).
 - The shared bytes hold one encoded copy of the table for the life of the
   fanout envelopes — bounded by the same inventory the envelopes already
   share.
+
+## Amendment: progressive chunk publication
+
+The original design published the whole encoded payload through one
+`OnceCell`, so every consumer awaited the encoder's full-table encode before
+sending anything: the single-threaded encode became the per-observer wire-gap
+floor (measured 1.2–1.5 s at 700 clients × 400,400 routes, above the 1 s
+receipt gate, even though completion and first-UPDATE latency were healthy).
+
+Publication is now progressive. The cell became a synchronous `OnceLock`
+whose initializer only *constructs* an empty stream state (encoder profile,
+a mutex-guarded chunk vector with a terminal marker, and a `Notify`), so
+encoder election commits with no await point between winning and encoding —
+an initialized cell always has a live encoder or its guard's terminal. The
+encoder prepares, groups, and encodes the inventory in bounded route slices
+(2048 routes; single-digit-millisecond encode at reload-stall shapes),
+publishing each slice's chunks as they are produced and sending its own
+filtered copy along the way; consumers prove wire-equivalence once, then
+send chunk *i* as soon as it exists. A member's longest wire silence now
+tracks per-slice encode latency instead of the full-table encode. Sources
+spanning a slice boundary cost one extra UPDATE each; slices keep the
+announce/next-hop-override index alignment, and the prepared-attribute cache
+persists across slices.
+
+The terminal marker is `Complete` or `Failed`. Any encoder anomaly — the
+same enumerated cases as before, at any slice — terminates the stream as
+`Failed`, published by a drop guard even if the encoder unwinds, and every
+member falls back to the ordinary per-session encode. Mid-stream fallback is
+safe by construction: everything a member already sent is byte-identical to
+what its local re-encode produces (exactly what the wire-equivalence proof
+establishes for an announce-only envelope), so the receiver sees idempotent
+re-announcements and no route can be skipped. An encoder whose own writer
+saturates keeps publishing for the group; its own teardown policy has
+already run inside the failed enqueue.


### PR DESCRIPTION
## Problem

The encode-once fanout (#949 / ADR-0109) published its whole encoded payload through one cell, so every consumer awaited the encoder's full single-threaded table encode before sending anything. At 700 clients x 400,400 routes that encode (~1.3-1.5 s) became the per-observer wire-gap floor: the campaign measured observer max-gap p50 of 1,227-1,535 ms against the <1,000 ms receipt gate, even though completion (1.6-1.8 s) and first-UPDATE latency (2-10 ms) were healthy.

## Design (ADR-0109, amended in this PR)

Publication is now progressive:

- **Election without a crack.** The envelope cell became a synchronous `OnceLock` whose initializer only constructs the empty stream state (encoder profile, mutex-guarded chunk vector + terminal marker, `Notify`). There is no await point between winning the election and encoding, so an initialized cell always has a live encoder — or the terminal published by its drop guard.
- **Progressive encode.** The encoder prepares, groups, and encodes the inventory in 2048-route slices, publishing each slice's chunks as they are produced and sending its own filtered copy along the way. Consumers prove `has_same_wire_encoding` once, then send chunk i as soon as it exists. A member's longest wire silence tracks per-slice encode latency (single-digit ms) instead of the full-table encode.
- **Source-ordered iteration.** The inventory arrives in table order with sources interleaved per prefix; per-slice grouping in that order fragments every source across every slice (measured at the 300-peer shape as tens of thousands of tiny UPDATEs per member and writer-channel saturation teardown). The encoder therefore walks a source-peer-sorted index: per-source chunks stay dense, split horizon still composes from whole chunks, and the reorder is safe because the inventory carries one route per prefix.
- **Failure semantics.** Terminal is `Complete` or `Failed`; any encoder anomaly at any slice publishes `Failed` (drop-guarded against unwind) and every member falls back to the unchanged per-session encode. Mid-stream fallback is safe by construction: chunks already sent are byte-identical to what the local re-encode produces (exactly the wire-equivalence proof), so receivers see idempotent re-announcements and no route can be skipped. An encoder whose own writer saturates keeps publishing for the group.
- Preserved unchanged: first-consumer election, the `has_same_wire_encoding` proof before any reuse, per-(source, family) chunk composition, own-source/family filtering, unshareable fallback semantics, and the byte-level enqueue seam (BMP rib-out tap byte-exact, saturation teardown policy identical).

## Measurement

Macro: `bench/scale/reloadstall`, 300 route-server clients x 171,600 routes, mixed export-only (all 300 changed), 2 reloads, release, same host/config. Pre = main fe4f8cca (whole-payload sharing), post = this branch.

| metric (reload 1 / 2) | pre (whole-payload) | post (progressive) |
|---|---|---|
| all-observer maxgap p50 (ms) | 429.4 / 437.9 | 442.9 / 427.9 |
| maxgap p95 (ms) | 522.9 / 557.0 | 518.6 / 591.7 |
| completion p50 (s) | 0.62 / 0.51 | 0.71 / 0.63 |
| first_update p50 (ms) | 5.9 / 5.2 | 6.9 / 2.9 |
| sessions up / parse errors | 300/300, 0 | 300/300, 0 |

At this shape the ~430 ms gap floor is the transition's serial pre-commit phases in the RIB actor, not the encode (~30-150 ms here), so pre and post are statistically identical — the expected outcome: this change targets the encode-wait term, which only dominates at larger shapes (1.3-1.5 s at 700 x 400,400, where the max-gap gate failed). The 300-peer A/B establishes no regression on gap, completion, or first-UPDATE; the 700-peer campaign is the deciding gate for the max-gap improvement.

Engagement proof (debug-instrumented reload at the same shape): exactly 1 "encoded and sent ... as shared encode" + 299 "sent ... from shared encode" — all 300 members on the progressive path, zero writer saturation, channel-full dirty-marking counts unchanged from baseline (43.0k vs 43.4k, pre-existing churn behavior).

## Tests

- Existing: encode-once reuse + per-source exclusion, profile-mismatch fallback, unnegotiated-family skip (adapted to the progressive payload).
- New: mid-stream `Failed` falls back with idempotent duplicates and no skips; the encoder drop guard publishes `Failed` on unwind; a >2048-route inventory streams across slices with dense per-source chunks and correct split horizon.

Gates (exit codes): clippy -D warnings 0; `cargo test -p rustbgpd-rib` 0; `-p rustbgpd-transport` 0; `--workspace` 0; `cargo check -p rustbgpd-rib --features bench-internals --benches` 0; `cargo doc --workspace --no-deps` 0.
