### PR TITLE
perf(rib): stride policy-transition pre-commit phases under the poll budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Every pre-commit phase of a shared policy transition (member
+  classification, destination staging, inventory build, and the
+  exact-export probe) now strides under the same 25 ms wall-clock poll
+  budget as the commit flush, instead of parking after one fixed-size
+  slice per actor poll. The fenced window that excludes interleaved
+  churn during a transition no longer scales with members x table size
+  (400k routes cost ~391 single-slice probe polls — a measured ~1.1 s
+  observer gap at 700 members).
+
 - **Reloads that change import and export policy together now take the
   batched export cohort instead of the per-peer authoritative path.** The
   cohort's eligibility check no longer requires an unchanged import chain:

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1200,26 +1200,37 @@ impl RibManager {
                 if pending.replacements.len() < 2 {
                     return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
-                let end = (cursor + super::POLICY_TRANSITION_MEMBER_SLICE)
-                    .min(pending.replacements.len());
-                for replacement in &pending.replacements[cursor..end] {
-                    if !seen.insert(replacement.peer)
-                        || !self.clean_policy_transition_peer_ready(replacement.peer)
+                // Budgeted stride loop (see the probe phase below): fixed
+                // 8-member classification polls cost ~88 fenced polls at 700
+                // members; stride until the poll budget elapses instead.
+                let poll_start = std::time::Instant::now();
+                loop {
+                    let end = (cursor + super::POLICY_TRANSITION_MEMBER_SLICE)
+                        .min(pending.replacements.len());
+                    for replacement in &pending.replacements[cursor..end] {
+                        if !seen.insert(replacement.peer)
+                            || !self.clean_policy_transition_peer_ready(replacement.peer)
+                        {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        }
+                        let Some(pair) = self.clean_policy_transition_destination(
+                            replacement.peer,
+                            replacement.export_policy.as_ref(),
+                        ) else {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        };
+                        if transition.is_some_and(|expected| expected != pair) {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        }
+                        transition = Some(pair);
+                    }
+                    cursor = end;
+                    if cursor == pending.replacements.len()
+                        || poll_start.elapsed() >= self.flush_poll_budget
                     {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                        break;
                     }
-                    let Some(pair) = self.clean_policy_transition_destination(
-                        replacement.peer,
-                        replacement.export_policy.as_ref(),
-                    ) else {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
-                    };
-                    if transition.is_some_and(|expected| expected != pair) {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
-                    }
-                    transition = Some(pair);
                 }
-                cursor = end;
                 if cursor < pending.replacements.len() {
                     pending.phase = Some(CleanPolicyTransitionPhase::Classify {
                         cursor,
@@ -1278,18 +1289,26 @@ impl RibManager {
                 }
 
                 let snapshot = prefixes.as_ref().expect("initialized above");
-                let end = super::policy_transition_slice_end(
-                    cursor,
-                    snapshot.len(),
-                    super::POLICY_TRANSITION_ROUTE_SLICE,
-                );
-                if cursor < end {
-                    self.stage_policy_transition_group_chunk(
-                        destination,
-                        &snapshot[cursor..end],
-                        &mut memo,
+                // Budgeted stride loop (see the probe phase): stage
+                // route-slices until the poll budget elapses.
+                let poll_start = std::time::Instant::now();
+                loop {
+                    let end = super::policy_transition_slice_end(
+                        cursor,
+                        snapshot.len(),
+                        super::POLICY_TRANSITION_ROUTE_SLICE,
                     );
-                    cursor = end;
+                    if cursor < end {
+                        self.stage_policy_transition_group_chunk(
+                            destination,
+                            &snapshot[cursor..end],
+                            &mut memo,
+                        );
+                        cursor = end;
+                    }
+                    if cursor == snapshot.len() || poll_start.elapsed() >= self.flush_poll_budget {
+                        break;
+                    }
                 }
                 if cursor < snapshot.len() {
                     pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
@@ -1335,23 +1354,31 @@ impl RibManager {
                     return CleanPolicyTransitionAdvance::Continue(pending);
                 }
                 let snapshot = keys.as_ref().expect("initialized above");
-                let end = super::policy_transition_slice_end(
-                    cursor,
-                    snapshot.len(),
-                    super::POLICY_TRANSITION_ROUTE_SLICE,
-                );
-                if self
-                    .extend_clean_policy_transition_inventory(
-                        source,
-                        destination,
-                        &snapshot[cursor..end],
-                        &mut inventory,
-                    )
-                    .is_none()
-                {
-                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                // Budgeted stride loop (see the probe phase): extend the
+                // inventory by route-slices until the poll budget elapses.
+                let poll_start = std::time::Instant::now();
+                loop {
+                    let end = super::policy_transition_slice_end(
+                        cursor,
+                        snapshot.len(),
+                        super::POLICY_TRANSITION_ROUTE_SLICE,
+                    );
+                    if self
+                        .extend_clean_policy_transition_inventory(
+                            source,
+                            destination,
+                            &snapshot[cursor..end],
+                            &mut inventory,
+                        )
+                        .is_none()
+                    {
+                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                    }
+                    cursor = end;
+                    if cursor == snapshot.len() || poll_start.elapsed() >= self.flush_poll_budget {
+                        break;
+                    }
                 }
-                cursor = end;
                 if cursor < snapshot.len() {
                     pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
                         source,
@@ -1384,123 +1411,141 @@ impl RibManager {
                 mut active_probe,
                 mut full_probe_count,
             } => {
-                if let Some(mut probe) = active_probe.take() {
-                    let end = super::policy_transition_slice_end(
-                        probe.cursor,
-                        inventory.announce.len(),
-                        super::POLICY_TRANSITION_ROUTE_SLICE,
-                    );
-                    let candidates = inventory.announce[probe.cursor..end]
-                        .iter()
-                        .zip(inventory.next_hop_override[probe.cursor..end].iter())
-                        .map(|(route, next_hop_override)| {
-                            crate::update::ExactExportCandidate::Unicast {
-                                route,
-                                next_hop_override: next_hop_override.as_ref(),
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    let (results, cardinality_correct) = probe_exact_export_announcements(
-                        probe.peer,
-                        probe.snapshot.as_ref(),
-                        &candidates,
-                    );
-                    if !cardinality_correct || results.iter().any(Result::is_err) {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
-                    }
-                    full_probe_count = full_probe_count.saturating_add(results.len());
-                    probe.encoded_lengths.extend(
-                        results
-                            .into_iter()
-                            .filter_map(|result| result.ok().map(|accepted| accepted.encoded_len)),
-                    );
-                    probe.cursor = end;
-                    if probe.cursor < inventory.announce.len() {
-                        active_probe = Some(probe);
-                    } else {
-                        probe_cache.store(
-                            destination,
-                            Arc::clone(&inventory.announce),
-                            Arc::clone(&inventory.next_hop_override),
-                            Arc::clone(&probe.snapshot),
-                            probe.encoded_lengths,
+                // Budgeted stride loop, matching the commit flush and dirty
+                // resync: one stride is a POLICY_TRANSITION_ROUTE_SLICE probe
+                // slice or one member classification; keep striding until the
+                // poll budget elapses. The transition fence admits only the
+                // read-only readiness lane between polls, so a multi-stride
+                // poll observes the same frozen state as single-stride polls —
+                // fewer, fatter polls shrink the fenced window that stalls
+                // interleaved churn (400k routes = 391 single-slice probe
+                // polls, a measured ~1.1 s of wall at 700 members).
+                let poll_start = std::time::Instant::now();
+                loop {
+                    if let Some(mut probe) = active_probe.take() {
+                        let end = super::policy_transition_slice_end(
+                            probe.cursor,
+                            inventory.announce.len(),
+                            super::POLICY_TRANSITION_ROUTE_SLICE,
                         );
-                        prepared.push(PreparedCleanPolicyTransitionPeer {
-                            peer: probe.peer,
-                            session_id: probe.session_id,
-                            export_policy: probe.export_policy,
-                            snapshot: Some(probe.snapshot),
-                            sender: probe.sender,
-                            permit: probe.permit,
-                        });
-                        cursor += 1;
-                    }
-                } else if cursor < pending.replacements.len() {
-                    let replacement = &pending.replacements[cursor];
-                    let peer = replacement.peer;
-                    let Some(session_id) = self.outbound_session_ids.get(&peer).copied() else {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
-                    };
-                    let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
-                    };
-                    let permit = if inventory.announce.is_empty() {
-                        None
-                    } else {
-                        let Ok(permit) = sender.clone().try_reserve_owned() else {
-                            return CleanPolicyTransitionAdvance::Fallback(pending);
-                        };
-                        Some(permit)
-                    };
-                    let export_policy = replacement.export_policy.clone();
-                    if inventory.announce.is_empty() {
-                        prepared.push(PreparedCleanPolicyTransitionPeer {
-                            peer,
-                            session_id,
-                            export_policy,
-                            snapshot: None,
-                            sender,
-                            permit,
-                        });
-                        cursor += 1;
-                    } else {
-                        let Some(encoder) = self.peer_export_encoders.get(&peer) else {
-                            return CleanPolicyTransitionAdvance::Fallback(pending);
-                        };
-                        let snapshot = encoder.snapshot();
-                        if snapshot.owner_id() != encoder.owner_id() {
+                        let candidates = inventory.announce[probe.cursor..end]
+                            .iter()
+                            .zip(inventory.next_hop_override[probe.cursor..end].iter())
+                            .map(|(route, next_hop_override)| {
+                                crate::update::ExactExportCandidate::Unicast {
+                                    route,
+                                    next_hop_override: next_hop_override.as_ref(),
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        let (results, cardinality_correct) = probe_exact_export_announcements(
+                            probe.peer,
+                            probe.snapshot.as_ref(),
+                            &candidates,
+                        );
+                        if !cardinality_correct || results.iter().any(Result::is_err) {
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         }
-                        if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
-                            destination,
-                            &inventory.announce,
-                            &inventory.next_hop_override,
-                            snapshot.as_ref(),
-                        ) {
-                            if maximum.is_err() {
+                        full_probe_count = full_probe_count.saturating_add(results.len());
+                        probe.encoded_lengths.extend(
+                            results.into_iter().filter_map(|result| {
+                                result.ok().map(|accepted| accepted.encoded_len)
+                            }),
+                        );
+                        probe.cursor = end;
+                        if probe.cursor < inventory.announce.len() {
+                            active_probe = Some(probe);
+                        } else {
+                            probe_cache.store(
+                                destination,
+                                Arc::clone(&inventory.announce),
+                                Arc::clone(&inventory.next_hop_override),
+                                Arc::clone(&probe.snapshot),
+                                probe.encoded_lengths,
+                            );
+                            prepared.push(PreparedCleanPolicyTransitionPeer {
+                                peer: probe.peer,
+                                session_id: probe.session_id,
+                                export_policy: probe.export_policy,
+                                snapshot: Some(probe.snapshot),
+                                sender: probe.sender,
+                                permit: probe.permit,
+                            });
+                            cursor += 1;
+                        }
+                    } else if cursor < pending.replacements.len() {
+                        let replacement = &pending.replacements[cursor];
+                        let peer = replacement.peer;
+                        let Some(session_id) = self.outbound_session_ids.get(&peer).copied() else {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        };
+                        let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
+                        };
+                        let permit = if inventory.announce.is_empty() {
+                            None
+                        } else {
+                            let Ok(permit) = sender.clone().try_reserve_owned() else {
                                 return CleanPolicyTransitionAdvance::Fallback(pending);
-                            }
+                            };
+                            Some(permit)
+                        };
+                        let export_policy = replacement.export_policy.clone();
+                        if inventory.announce.is_empty() {
                             prepared.push(PreparedCleanPolicyTransitionPeer {
                                 peer,
                                 session_id,
                                 export_policy,
-                                snapshot: Some(snapshot),
+                                snapshot: None,
                                 sender,
                                 permit,
                             });
                             cursor += 1;
                         } else {
-                            active_probe = Some(CleanPolicyTransitionProbe {
-                                peer,
-                                session_id,
-                                export_policy,
-                                snapshot,
-                                sender,
-                                permit,
-                                cursor: 0,
-                                encoded_lengths: Vec::with_capacity(inventory.announce.len()),
-                            });
+                            let Some(encoder) = self.peer_export_encoders.get(&peer) else {
+                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                            };
+                            let snapshot = encoder.snapshot();
+                            if snapshot.owner_id() != encoder.owner_id() {
+                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                            }
+                            if let Some(maximum) = probe_cache.reuse_grouped_exact_export_maximum(
+                                destination,
+                                &inventory.announce,
+                                &inventory.next_hop_override,
+                                snapshot.as_ref(),
+                            ) {
+                                if maximum.is_err() {
+                                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                                }
+                                prepared.push(PreparedCleanPolicyTransitionPeer {
+                                    peer,
+                                    session_id,
+                                    export_policy,
+                                    snapshot: Some(snapshot),
+                                    sender,
+                                    permit,
+                                });
+                                cursor += 1;
+                            } else {
+                                active_probe = Some(CleanPolicyTransitionProbe {
+                                    peer,
+                                    session_id,
+                                    export_policy,
+                                    snapshot,
+                                    sender,
+                                    permit,
+                                    cursor: 0,
+                                    encoded_lengths: Vec::with_capacity(inventory.announce.len()),
+                                });
+                            }
                         }
+                    }
+                    if cursor == pending.replacements.len() && active_probe.is_none() {
+                        break;
+                    }
+                    if poll_start.elapsed() >= self.flush_poll_budget {
+                        break;
                     }
                 }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -753,7 +753,9 @@ where
     }
 }
 const QUERY_BUDGET_PER_CHUNK: usize = 8;
-/// Production route budget for one strict shared-policy actor poll.
+/// Production stride of probed routes between wall-clock checks inside one
+/// strict shared-policy actor poll; the poll keeps striding until
+/// [`FLUSH_POLL_BUDGET`] elapses.
 pub(in crate::manager) const POLICY_TRANSITION_PRODUCTION_ROUTE_SLICE: usize = 1_024;
 /// Maximum route identities processed by one strict shared-policy actor poll.
 #[cfg(not(test))]

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -1193,7 +1193,11 @@ async fn clean_policy_transition_builds_and_probes_once_per_wire_cohort() {
 
     let metrics = BgpMetrics::new();
     let (tx, rx) = mpsc::channel(128);
-    let manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, metrics.clone());
+    // This test proves the multi-poll seam exists in the LIVE actor (poll
+    // accounting, readiness interleaving), so pin the flush budget to zero:
+    // one test-sized stride per poll, exactly as before the budget loops.
+    manager.flush_poll_budget = std::time::Duration::ZERO;
     let handle = tokio::spawn(manager.run());
     let probes = Arc::new(AtomicUsize::new(0));
     let reuses = Arc::new(AtomicUsize::new(0));
@@ -3637,6 +3641,50 @@ async fn commit_flush_batches_are_bounded_and_drain_monotonically() {
     for &peer in &peers {
         assert_eq!(manager.grouped_member_of(peer), Some(destination));
     }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+}
+
+/// With wall-clock budget in hand, the probe-and-prepare phase strides the
+/// whole cohort in a handful of polls instead of one route-slice per poll —
+/// the fenced pre-commit window must not scale with table x member count
+/// when the actor has time available.
+#[tokio::test]
+async fn probe_phase_uses_full_poll_budget_before_parking() {
+    const MEMBER_COUNT: usize = 3 * super::super::COMMIT_MEMBERS_PER_POLL + 2;
+    const ROUTE_COUNT: usize = 2;
+    let (mut manager, peers, _receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    // The helper zeroes the budget for deterministic per-stride tests;
+    // restore a generous one so pre-commit phases stride to completion.
+    manager.flush_poll_budget = std::time::Duration::from_mins(1);
+    let next_policy = community_chain(0xFDE8_2106);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+
+    let mut pre_commit_polls = 0_usize;
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_ne!(outcome, "fallback");
+        if kind == "commit" {
+            if outcome == "committed" {
+                break;
+            }
+        } else {
+            pre_commit_polls += 1;
+            assert_eq!(outcome, "continue");
+        }
+    }
+    // Under a zero budget this shape needs one poll per member probe
+    // route-slice (the test slice is a single route) plus classification
+    // polls — dozens. A budgeted poll strides through; allow a small
+    // constant for the distinct phases (classify, probe, validate,
+    // snapshot seams).
+    assert!(
+        pre_commit_polls <= 8,
+        "budgeted pre-commit phases must not scale with members x routes: {pre_commit_polls} polls"
+    );
     assert_eq!(
         response.try_recv().unwrap(),
         Ok(crate::update::ExportPolicyCohortOutcome::Committed)


### PR DESCRIPTION
## Problem

The final 700 × 400,400 acceptance campaign at `331c2b9e` measured a flat ~1.1 s observer max-gap (p50 1.07–1.13 s across all reloads, both modes) with first UPDATEs arriving in ~10 ms and completion at ~1.9 s — a single blocking window mid-transition. Mechanism: the transition's pre-commit phases each park after one fixed-size slice per actor poll — `Classify` (8 members), `StageDestination`/`BuildInventory`/`ProbeAndPrepare` (1,024 routes) — and the transition fence excludes interleaved churn between polls, so the fenced window scales as O(members + table/1024) polls: 391 probe polls alone at 400k routes. Same failure shape the commit flush (#947) and dirty resync (#948) already had fixed.

## Change

All four phases now stride under the shared 25 ms `flush_poll_budget`: keep taking slices until the budget elapses, then park for the readiness seam. The fence's correctness argument is unchanged — only the read-only readiness lane runs between polls, so a multi-stride poll observes the same frozen state as single-stride polls. Slice sizes and phase ordering untouched.

## Tests

- Existing per-stride seam tests stay deterministic via the zero-budget pin; the live-actor cohort test (`clean_policy_transition_builds_and_probes_once_per_wire_cohort`) now pins a zero budget at its spawn site to keep proving the real actor's multi-poll seam.
- New: `probe_phase_uses_full_poll_budget_before_parking` — with budget in hand, the whole pre-commit pipeline for a 26-member cohort takes a small constant number of polls instead of scaling with members × routes.

Gates: clippy `-D warnings`, rib suite, bench-internals check, full workspace, doc, clippy-reason ratchet — all green. The 700-peer campaign re-runs as the acceptance gate; expected max-gap after this lands is the encode+commit cost (~100–200 ms), clearing the <1 s receipt gate with margin.