### PR TITLE
fix(rib): discard a mid-walk destination prestage on membership adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Membership changes during destination pre-staging now discard the
+  partial group table, so joiners always see a fully staged group. A
+  peer whose (attributes, policy) key equaled a mid-walk prestaged
+  destination could join the partially staged group through any
+  ordinary membership seam (session registration, per-peer policy
+  install, membership recompute), replay the partial table as its
+  initial view, and then have the remaining staging slices' deltas
+  discarded — routes recorded as advertised but never emitted, with
+  no later heal. The join now drops the prestage (the held prepare
+  reply resolves as skipped) and rebuilds the group on the ordinary
+  path. Discards are also exact now: the preparation records the
+  group id it actually staged, and both an explicit discard and a
+  cohort commit that resolved a different destination remove that
+  recorded group instead of re-deriving one from current attributes
+  (which could drift and leak the staged, memberless group).
+
 - `TransportAuthSecret` equality is now constant-time. The derived
   `PartialEq` compared secret bytes with an early-out; the manual
   implementation compares in time dependent only on the longer input's

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -1267,6 +1267,17 @@ impl RibManager {
                     let Some((source, destination)) = transition else {
                         return CleanPolicyTransitionAdvance::Fallback(pending);
                     };
+                    // The cohort's destination is now known: consume the
+                    // completed-prestage record. A match hands ownership to
+                    // the transition (the Maintained/memberless arm of the
+                    // staging phase marks it for fallback cleanup); a
+                    // mismatch means the prepared group will never be
+                    // adopted — discard it now, by the exact staged gid.
+                    if let Some(prepared) = self.prepared_destination.take()
+                        && prepared != destination
+                    {
+                        self.discard_uncommitted_policy_transition_group(prepared);
+                    }
                     pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
                         source,
                         destination,
@@ -2555,6 +2566,12 @@ impl RibManager {
             ));
             return;
         };
+        // A stale completed preparation that was never consumed (its
+        // cohort never arrived) is discarded before a new one begins;
+        // the record must only ever name the latest staged group.
+        if let Some(stale) = self.prepared_destination.take() {
+            self.discard_uncommitted_policy_transition_group(stale);
+        }
         // A leftover unowned group under this id may be partially staged
         // from an aborted attempt; recreate it deterministically. An OWNED
         // group is maintained by definition — nothing to stage.
@@ -2573,6 +2590,33 @@ impl RibManager {
                 });
             }
         }
+    }
+
+    /// Discard a mid-walk destination prestage that a membership event is
+    /// about to land on. The partial table was built with staging deltas
+    /// discarded (correct only while memberless), so a member joining it
+    /// would replay a partial view and then miss every remaining walk
+    /// slice — routes recorded as advertised but never emitted. Dropping
+    /// the prestage costs only the optimization; the held prepare reply
+    /// resolves `Err` so the transition stages under its fence instead.
+    pub(super) fn discard_destination_prestage_on_membership(&mut self, gid: usize) {
+        let Some(prestage) = self
+            .pending_destination_prestage
+            .take_if(|prestage| prestage.destination == gid)
+        else {
+            return;
+        };
+        self.discard_uncommitted_policy_transition_group(gid);
+        if let Some(reply) = prestage.reply {
+            let _ = reply.send(Err(
+                "prepared destination group adopted by a membership change; preparation discarded"
+                    .to_string(),
+            ));
+        }
+        debug!(
+            destination = gid,
+            "discarded mid-walk destination prestage on membership adoption"
+        );
     }
 
     /// One budgeted, unfenced staging slice of a pending destination
@@ -2605,6 +2649,10 @@ impl RibManager {
                     prefixes = prestage.prefixes.len(),
                     "prepared clean-transition destination group without the fence"
                 );
+                // Record the exact staged gid: every later discard (and the
+                // committing cohort's adopt-or-discard decision) keys off
+                // this, never a re-derivation from current attributes.
+                self.prepared_destination = Some(prestage.destination);
                 if let Some(reply) = prestage.reply.take() {
                     let _ = reply.send(Ok(()));
                 }
@@ -2619,21 +2667,17 @@ impl RibManager {
 
     /// Discard a prepared destination that will never be committed
     /// ([`crate::update::RibUpdate::DiscardPreparedExportPolicyDestination`]).
-    /// Only a memberless group is removed; a committed destination has
-    /// members and stays.
-    pub(super) fn discard_prepared_export_destination(
-        &mut self,
-        peer: IpAddr,
-        export_policy: Option<&rustbgpd_policy::PolicyChain>,
-    ) {
+    /// Removes exactly the gid(s) the preparation actually staged (the
+    /// mid-walk one and/or the completed record) — never a re-derivation
+    /// from current attributes, which can resolve a different gid and
+    /// leak the staged group. Only a memberless group is removed; an
+    /// adopted destination has members and stays.
+    pub(super) fn discard_prepared_export_destination(&mut self) {
         if let Some(prestage) = self.pending_destination_prestage.take() {
             self.discard_uncommitted_policy_transition_group(prestage.destination);
-            return;
         }
-        if let Some((_, destination)) =
-            self.clean_policy_transition_destination(peer, export_policy)
-        {
-            self.discard_uncommitted_policy_transition_group(destination);
+        if let Some(prepared) = self.prepared_destination.take() {
+            self.discard_uncommitted_policy_transition_group(prepared);
         }
     }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -440,6 +440,12 @@ pub struct RibManager {
     /// mutation traffic is queued — churn keeps flowing, and keeps the
     /// staged table current, while this walk covers the snapshot.
     pending_destination_prestage: Option<distribution::DestinationPrestage>,
+    /// The exact group id a COMPLETED prestage staged, recorded so every
+    /// discard removes the group that was actually built (never a
+    /// re-derivation from current attributes, which can drift) and so a
+    /// committing cohort that resolves a different destination discards
+    /// the unadopted group instead of leaking it.
+    prepared_destination: Option<usize>,
     /// Withdrawn NLRI identities accumulated across the currently-draining
     /// batch. Retired only after distribution so the exact overlay can
     /// suppress any rejected-only wire withdrawal first.
@@ -1209,6 +1215,7 @@ impl RibManager {
             pending_route_batches: VecDeque::new(),
             pending_clean_policy_transition: None,
             pending_destination_prestage: None,
+            prepared_destination: None,
             pending_exact_export_withdrawals: HashSet::new(),
             pending_distribute_changed: HashSet::new(),
             pending_distribute_affected: HashSet::new(),
@@ -2131,10 +2138,9 @@ impl RibManager {
                 export_policy,
                 reply,
             } => self.begin_destination_prestage(peer, export_policy.as_ref(), reply),
-            RibUpdate::DiscardPreparedExportPolicyDestination {
-                peer,
-                export_policy,
-            } => self.discard_prepared_export_destination(peer, export_policy.as_ref()),
+            RibUpdate::DiscardPreparedExportPolicyDestination { .. } => {
+                self.discard_prepared_export_destination();
+            }
             RibUpdate::RefreshPeerOutbound { peer, reply } => {
                 self.handle_refresh_peer_outbound(peer, reply);
             }

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -4420,3 +4420,352 @@ async fn transition_immediately_after_prepare_commits_without_leaks() {
     drop(tx);
     handle.await.unwrap();
 }
+
+/// Regression test for membership-during-prestage (LAN-463): a peer whose
+/// export policy is content-equal to a mid-walk prestaged destination joins
+/// that group via the ordinary registration seam. The join must not adopt
+/// the partial table — the prestage is discarded and the group rebuilt, so
+/// the joiner's initial dump carries the full table.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the regression fixture preserves full session, route, and prestage-race setup"
+)]
+#[tokio::test]
+async fn prestage_mid_walk_join_of_prestaged_destination() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // One test-sized (1-prefix) slice per prestage advance.
+    manager.flush_poll_budget = std::time::Duration::ZERO;
+    let handle = tokio::spawn(manager.run());
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for peer in peers {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(peer_up(&tx, spec).await);
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 99);
+    let announced = (0..3)
+        .map(|i| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113 + i, 0), 24),
+                source,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 3);
+    }
+
+    // Queue the prestage AND a stranger's PeerUp (content-equal policy)
+    // back-to-back: mutation traffic outranks the walk, so the join lands
+    // on the still-partial prestaged table.
+    let (reply, prepare_response) = oneshot::channel();
+    tx.send(RibUpdate::PrepareExportPolicyDestination {
+        peer: peers[0],
+        export_policy: Some(next_policy.clone()),
+        reply,
+    })
+    .await
+    .unwrap();
+    let stranger = IpAddr::V4(Ipv4Addr::new(10, 99, 0, 3));
+    let (stranger_tx, mut stranger_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: stranger,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: stranger_tx,
+        export_policy: Some(next_policy.clone()),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    // The prepare reply resolves either way (Ok if the walk finished before
+    // the join landed, Err when the join discarded it); it must never hang.
+    let _ = prepare_response.await;
+
+    // The stranger owns the group now.
+    let group = query_update_group(&tx, stranger).await;
+    assert!(group.starts_with("group:"), "stranger ungrouped: {group}");
+    assert_eq!(
+        query_uncommitted_policy_transition_groups(&tx).await,
+        0,
+        "prestaged group became OWNED mid-walk"
+    );
+
+    // Churn one more prefix so every member gets one ordinary delta.
+    let churned = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 120, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(churned, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+
+    // Collect everything the stranger was ever sent.
+    let mut stranger_announced: Vec<Prefix> = Vec::new();
+    let mut got_eor = false;
+    while let Ok(Some(update)) =
+        tokio::time::timeout(std::time::Duration::from_millis(300), stranger_rx.recv()).await
+    {
+        stranger_announced.extend(update.announce.iter().map(|r| r.prefix));
+        got_eor |= !update.end_of_rib.is_empty();
+    }
+    assert!(got_eor, "stranger never finished its initial dump");
+    assert_eq!(
+        stranger_announced.len(),
+        4,
+        "UNDER-ADVERTISE: stranger received {stranger_announced:?}, \
+         but the group table holds 4 routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Control for the membership-during-prestage regression test above: the
+/// same join with no prestage in flight replays the full group table.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the regression fixture preserves full session, route, and join setup"
+)]
+#[tokio::test]
+async fn prestage_control_join_without_prestage() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // One test-sized (1-prefix) slice per prestage advance.
+    manager.flush_poll_budget = std::time::Duration::ZERO;
+    let handle = tokio::spawn(manager.run());
+    let old_policy = community_chain(0xFDE8_0001);
+    let next_policy = community_chain(0xFDE8_0002);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for peer in peers {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(peer_up(&tx, spec).await);
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 99);
+    let announced = (0..3)
+        .map(|i| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113 + i, 0), 24),
+                source,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 3);
+    }
+
+    // The same join as the regression test above, with no prestage queued.
+    let stranger = IpAddr::V4(Ipv4Addr::new(10, 99, 0, 3));
+    let (stranger_tx, mut stranger_rx) = mpsc::channel(64);
+    tx.send(RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id: 0,
+        peer: stranger,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: stranger_tx,
+        export_policy: Some(next_policy.clone()),
+        sendable_families: ipv4_sendable(),
+        is_ebgp: false,
+        route_reflector_client: true,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    // The stranger owns its group.
+    let group = query_update_group(&tx, stranger).await;
+    assert!(group.starts_with("group:"), "stranger ungrouped: {group}");
+    assert_eq!(
+        query_uncommitted_policy_transition_groups(&tx).await,
+        0,
+        "no unowned group may remain after the join"
+    );
+
+    // Churn one more prefix so every member gets one ordinary delta.
+    let churned = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 120, 0), 24);
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(churned, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+
+    // Collect everything the stranger was ever sent.
+    let mut stranger_announced: Vec<Prefix> = Vec::new();
+    let mut got_eor = false;
+    while let Ok(Some(update)) =
+        tokio::time::timeout(std::time::Duration::from_millis(300), stranger_rx.recv()).await
+    {
+        stranger_announced.extend(update.announce.iter().map(|r| r.prefix));
+        got_eor |= !update.end_of_rib.is_empty();
+    }
+    assert!(got_eor, "stranger never finished its initial dump");
+    assert_eq!(
+        stranger_announced.len(),
+        4,
+        "UNDER-ADVERTISE: stranger received {stranger_announced:?}, \
+         but the group table holds 4 routes"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A completed prestage whose cohort later resolves a DIFFERENT destination
+/// must not leak the staged memberless group: the transition discards the
+/// exact prestaged gid when it commits elsewhere.
+#[tokio::test]
+async fn prestage_discarded_when_cohort_resolves_different_destination() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.flush_poll_budget = std::time::Duration::ZERO;
+    let handle = tokio::spawn(manager.run());
+    let old_policy = community_chain(0xFDE8_0001);
+    let prepared_policy = community_chain(0xFDE8_0002);
+    let committed_policy = community_chain(0xFDE8_0003);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for peer in peers {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(peer_up(&tx, spec).await);
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 99);
+    let announced = (0..3)
+        .map(|i| {
+            crate::test_support::make_route(
+                Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113 + i, 0), 24),
+                source,
+            )
+        })
+        .collect();
+    tx.send(RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    })
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 3);
+    }
+
+    // Prepare one destination and let the walk complete.
+    let (prepare_reply, prepare_response) = oneshot::channel();
+    tx.send(RibUpdate::PrepareExportPolicyDestination {
+        peer: peers[0],
+        export_policy: Some(prepared_policy.clone()),
+        reply: prepare_reply,
+    })
+    .await
+    .unwrap();
+    prepare_response.await.unwrap().unwrap();
+
+    // The cohort then commits under a DIFFERENT policy (different group key).
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(committed_policy.clone()),
+            })
+            .collect(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        response.await.unwrap().unwrap(),
+        crate::update::ExportPolicyCohortOutcome::Committed
+    );
+    // The prestaged group (never adopted by the cohort) must be gone.
+    assert_eq!(
+        query_uncommitted_policy_transition_groups(&tx).await,
+        0,
+        "the prestaged destination leaked past a commit that resolved elsewhere"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -2344,6 +2344,14 @@ impl RibManager {
     /// are key-equal) and builds the shared table with one staging pass
     /// — the policy work every subsequent join replays for free.
     fn join_group(&mut self, gid: usize, peer: IpAddr) {
+        // Every membership seam funnels through here (registration,
+        // recompute, per-peer policy install): a join landing on the gid
+        // of a mid-walk destination prestage must discard the prestage
+        // BEFORE the member replays any table — adopting the partial
+        // table would record the remaining walk's routes as advertised
+        // without ever emitting them (LAN-463). The discard makes the
+        // group absent again, so the ordinary rebuild below runs.
+        self.discard_destination_prestage_on_membership(gid);
         if !self.group_ribs.contains_key(&gid) {
             let group = GroupRibOut::new(
                 // `share()`, not `clone()`: the snapshot must keep


### PR DESCRIPTION
## Problem

`advance_destination_prestage` builds a prospective clean-transition destination group in unfenced slices, discarding staging deltas — correct only while the group is memberless. No membership seam checked for the in-progress prestage, so a peer whose (attributes, policy) key equaled the prestaged destination could join the partial group mid-walk via ordinary registration, per-peer policy install, or membership recompute. The joiner replayed the partial table as its initial view, and the remaining walk slices staged into the now-owned group with deltas still discarded: routes recorded as advertised, never emitted, no heal, no fallback (table lengths still match at transition time). Silent under-advertisement.

Separately, discarding a prepared destination re-derived the group id from current attributes instead of using the id the preparation actually staged, and a cohort commit that resolved a different destination never discarded the prestaged group — leaking a staged, memberless group.

## Fix

- **Membership adoption discards the prestage.** Every join funnels through `join_group`; a join landing on the prestaged gid drops the partial group table before the member replays anything (the held prepare reply resolves as skipped) and rebuilds the group on the ordinary path. The prestage is a best-effort optimization: losing it on the race costs one fenced staging walk; adopting it loses routes.
- **Exact-gid discard.** The completed preparation records the gid it staged (`prepared_destination`). An explicit discard, a new preparation, and the transition's Classify completion (when the cohort resolved a different destination) all remove that recorded gid; the attribute re-derivation in `discard_prepared_export_destination` is gone. A matching destination hands ownership to the transition's existing fallback cleanup (`created_destination`).
- A debug log marks a prestage discarded by membership adoption.

No peer-manager changes: the RIB keys everything off the recorded gid, so the existing `DiscardPreparedExportPolicyDestination` senders are unchanged.

## Tests

- `prestage_mid_walk_join_of_prestaged_destination` — failed before the fix (joiner received 1 of 4 routes), now delivers 4/4.
- `prestage_control_join_without_prestage` — control, unchanged (4/4 before and after).
- `prestage_discarded_when_cohort_resolves_different_destination` — failed before the fix (1 leaked uncommitted group after commit), now 0.
- All 88 update_groups tests (including the destination pre-staging tests) green.

## Gates (exit codes)

- `cargo clippy --workspace --all-targets -- -D warnings` = 0
- `scripts/check-clippy-reasons.py` = 0
- `scripts/check-v1-stable-surface.py` = 0
- `cargo test -p rustbgpd-rib` = 0 (894 passed)
- `cargo check -p rustbgpd-rib --features bench-internals --benches` = 0
- `cargo test --workspace` = 0
- `cargo doc --workspace --no-deps` = 0