### PR TITLE
fix: reconcile acked-import window in cohort export-failure repair; harden parse-diagnostic redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   cohort commit that resolved a different destination remove that
   recorded group instead of re-deriving one from current attributes
   (which could drift and leak the staged, memberless group).
+- A cohort export hot-apply failure on a member whose import delta was
+  already acknowledged now reconciles the acked-import window after
+  reasserting the member's prior import chain: routes the session
+  accepted under the new chain between setup and the failed export apply
+  get a Route Refresh when the session is Established, or arm
+  `pending_refresh` for the retry pipeline when it is not. Previously a
+  successful inline repair left that window unreconciled — no refresh
+  fired and no retry intent was armed.
+
+- Config parse diagnostics no longer echo secret material past the exact
+  known keywords: a typo'd secret key rejected by unknown-field
+  validation (`md5password`, `tcpao`) is recognized by a normalized
+  key-prefix check and redacted, and an error inside a multi-line string
+  value walks back to the string's opening line so a secret two or more
+  lines below `md5_password = """` is redacted too. Ordinary lines,
+  including non-secret unknown fields, keep the full echoed snippet.
 
 - `TransportAuthSecret` equality is now constant-time. The derived
   `PartialEq` compared secret bytes with an early-out; the manual

--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -120,12 +120,26 @@ fn error_span_and_label(source: &str, error: &ConfigError) -> Option<(Range<usiz
 /// line mentioning `tcp_ao` or as a bare `key = "..."` line inside a
 /// `tcp_ao` table).
 fn line_mentions_secret(line: &str) -> bool {
-    line.contains("md5_password")
-        || line.contains("tcp_ao")
-        || line
-            .trim_start()
-            .strip_prefix("key")
-            .is_some_and(|rest| rest.trim_start().starts_with('='))
+    if line.contains("md5_password") || line.contains("tcp_ao") {
+        return true;
+    }
+    // Typo'd or aliased secret keys (`md5password`, `Key`, `tcpao`) fail
+    // deny_unknown_fields and would otherwise be echoed verbatim, secret
+    // value and all. Normalize the key-ish prefix (text before `=`,
+    // separator/quote characters dropped, lowercased) and redact when it
+    // carries a secret marker. Only the key side is inspected, so ordinary
+    // lines (`hold_time = 90`, `holdtime = 90`) keep echoing.
+    let Some((key, _)) = line.split_once('=') else {
+        return false;
+    };
+    let key: String = key
+        .chars()
+        .filter(|c| !matches!(c, '_' | '-' | '.' | '"' | '\'' | ' ' | '\t'))
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    ["password", "key", "ao"]
+        .iter()
+        .any(|marker| key.contains(marker))
 }
 
 /// Render a source snippet with an underlined span, rustc-style.
@@ -164,7 +178,20 @@ fn render_snippet(
         let prev_start = source[..prev_end].rfind('\n').map_or(0, |i| i + 1);
         &source[prev_start..prev_end]
     };
-    let redact = line_mentions_secret(line_text) || line_mentions_secret(prev_text);
+    // A secret inside a multi-line string (`md5_password = """` with the
+    // value on later lines) puts the error span two or more lines past the
+    // keyword, defeating both checks above. Walk back (bounded) to the
+    // nearest line above that carries a multi-line string delimiter — for an
+    // error inside such a string that is its opening line — and redact when
+    // that opener names a secret.
+    let redact = line_mentions_secret(line_text)
+        || line_mentions_secret(prev_text)
+        || source[..line_start]
+            .lines()
+            .rev()
+            .take(64)
+            .find(|line| line.contains("\"\"\"") || line.contains("'''"))
+            .is_some_and(line_mentions_secret);
 
     let mut out = String::new();
     let _ = writeln!(out, "error: {heading}");
@@ -474,6 +501,93 @@ algorithm = \"hmac(sha256)\"
             rendered.contains("config.toml:10:") || rendered.contains("config.toml:11:"),
             "got: {rendered}"
         );
+    }
+
+    #[test]
+    fn parse_error_snippet_redacts_typod_secret_key() {
+        // `md5password` (no underscore) is an unknown field, not a parse
+        // error at the keyword the heuristic knows — the diagnostic still
+        // must not echo the secret value.
+        let source = "\
+[global]
+asn = 65000
+router_id = \"1.2.3.4\"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = \"0.0.0.0:9179\"
+log_format = \"json\"
+
+[security.grpc]
+enforcement = \"legacy\"
+
+[[neighbors]]
+address = \"10.0.0.1\"
+remote_asn = 65001
+md5password = \"hunter2-typo-secret\"
+";
+        let err: ConfigError = toml::from_str::<super::super::Config>(source)
+            .unwrap_err()
+            .into();
+        let rendered = render_diagnostic(source, "config.toml", &err).unwrap();
+        assert!(!rendered.contains("hunter2-typo-secret"), "got: {rendered}");
+        assert!(rendered.contains("redacted"), "got: {rendered}");
+    }
+
+    #[test]
+    fn parse_error_snippet_redacts_multiline_secret_value() {
+        // The secret sits two lines below the `md5_password = \"\"\"` opener,
+        // past the one-line lookback; the multi-line walk-back must still
+        // redact it.
+        let source = "\
+[global]
+asn = 65000
+router_id = \"1.2.3.4\"
+
+[[neighbors]]
+address = \"10.0.0.1\"
+remote_asn = 65001
+md5_password = \"\"\"
+padding-line
+hunter2-multiline\\qsecret
+\"\"\"
+";
+        let err: ConfigError = toml::from_str::<super::super::Config>(source)
+            .unwrap_err()
+            .into();
+        let rendered = render_diagnostic(source, "config.toml", &err).unwrap();
+        assert!(!rendered.contains("hunter2-multiline"), "got: {rendered}");
+        assert!(rendered.contains("redacted"), "got: {rendered}");
+    }
+
+    #[test]
+    fn unknown_field_snippet_echoes_non_secret_line() {
+        // A typo'd non-secret key must keep the ordinary echoed snippet —
+        // the redaction heuristic only fires on secret-shaped keys.
+        let source = "\
+[global]
+asn = 65000
+router_id = \"1.2.3.4\"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = \"0.0.0.0:9179\"
+log_format = \"json\"
+
+[security.grpc]
+enforcement = \"legacy\"
+
+[[neighbors]]
+address = \"10.0.0.1\"
+remote_asn = 65001
+holdtime = 90
+";
+        let err: ConfigError = toml::from_str::<super::super::Config>(source)
+            .unwrap_err()
+            .into();
+        let rendered = render_diagnostic(source, "config.toml", &err).unwrap();
+        assert!(rendered.contains("holdtime = 90"), "got: {rendered}");
+        assert!(!rendered.contains("redacted"), "got: {rendered}");
     }
 
     #[test]

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -717,6 +717,44 @@ impl PeerManager {
                                 .expect("cohort peer existed after import restore")
                                 .import_policy
                                 .clone_from(&prior.policy.import_policy);
+                            // The session ran the NEW import chain from the
+                            // setup hot-apply until this reassert, so routes
+                            // accepted in that window sit in Adj-RIB-In/LocRib
+                            // evaluated under the wrong chain. Reconcile it the
+                            // way the deferred-refresh phase does: fire the
+                            // refresh now when Established, otherwise arm
+                            // `pending_refresh` for the retry pipeline.
+                            let refresh_commands = self
+                                .peers
+                                .get(peer_key)
+                                .expect("cohort peer existed after import restore")
+                                .handle
+                                .commands_sender();
+                            let established = self
+                                .await_with_readiness(
+                                    rustbgpd_transport::PeerHandle::query_state_with(
+                                        refresh_commands,
+                                        PEER_QUERY_TIMEOUT,
+                                    ),
+                                )
+                                .await
+                                .is_some_and(|state| state.fsm_state == SessionState::Established);
+                            self.drain_readiness_queries().await;
+                            let refreshed = established
+                                && match self.soft_reset_in(peer_key.clone(), Vec::new()).await {
+                                    Ok(()) => true,
+                                    Err(refresh_error) => {
+                                        warn!(
+                                            peer = %peer_key,
+                                            error = %refresh_error,
+                                            "post-reassert route refresh failed after cohort export apply failure; arming pending refresh"
+                                        );
+                                        false
+                                    }
+                                };
+                            if !refreshed && let Some(managed) = self.peers.get_mut(peer_key) {
+                                managed.pending_refresh = true;
+                            }
                             Ok(())
                         }
                         Err(restore_error) => {
@@ -852,9 +890,15 @@ impl PeerManager {
                     // Mirror the authoritative path's fatal refresh handling:
                     // arm `pending_refresh` for the retry pipeline, then
                     // unwind the snapshot. `forward_completed` stays false for
-                    // this member and the ones after it — their Adj-RIB-In
-                    // never moved, so the restore correctly picks the
-                    // no-refresh-back rollback branch for them.
+                    // this member and the ones after it — their sessions have
+                    // been running the new import chain since the setup
+                    // hot-apply, and the restore fires their refresh-back
+                    // through the ordinary `import_changed` path when it
+                    // reasserts the prior chain; the false flag only selects
+                    // the failure-handling restore variant
+                    // (`RefreshFailureHandling::BestEffortRestorePrior` plus
+                    // the prior pending-flag restore) over the
+                    // committed-forward `BestEffortRearm` one.
                     if let Some(managed) = self.peers.get_mut(peer_key) {
                         managed.pending_refresh = true;
                     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -8854,10 +8854,24 @@ fn import_tolerant_cohort_test_session(
     counters: Arc<CohortSessionCounters>,
     fail_export_on_attempt: Option<usize>,
 ) -> PeerHandle {
+    import_tolerant_cohort_test_session_with_states(addr, counters, fail_export_on_attempt, None)
+}
+
+/// Like `import_tolerant_cohort_test_session`, but the session answers
+/// Established only for the first `established_queries` state queries and
+/// Connect afterwards (`None` = always Established), so tests can model a
+/// session that drops out of Established mid-transaction.
+fn import_tolerant_cohort_test_session_with_states(
+    addr: IpAddr,
+    counters: Arc<CohortSessionCounters>,
+    fail_export_on_attempt: Option<usize>,
+    established_queries: Option<usize>,
+) -> PeerHandle {
     use rustbgpd_transport::PeerCommand;
 
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
     let task = tokio::spawn(async move {
+        let mut state_queries = 0usize;
         while let Some(command) = session_rx.recv().await {
             match command {
                 PeerCommand::UpdateImportPolicy { policy, reply } => {
@@ -8881,7 +8895,13 @@ fn import_tolerant_cohort_test_session(
                     let _ = reply.send(Ok(()));
                 }
                 PeerCommand::QueryState { reply } => {
-                    let _ = reply.send(policy_test_peer_state(addr, SessionState::Established));
+                    state_queries += 1;
+                    let state = if established_queries.is_some_and(|limit| state_queries > limit) {
+                        SessionState::Connect
+                    } else {
+                        SessionState::Established
+                    };
+                    let _ = reply.send(policy_test_peer_state(addr, state));
                 }
                 PeerCommand::Shutdown => break,
                 _ => {}
@@ -9233,11 +9253,13 @@ async fn import_tolerant_cohort_rib_failure_restores_both_chains() {
     );
 }
 
-/// LAN-462: an export hot-apply failure on a member whose import delta was
-/// already acknowledged must reassert that member's prior import chain
-/// directly (its bookkeeping had advanced) while the previously captured
-/// members restore through the ordinary rollback — and the failing member
-/// still gets no RIB compensation, matching the export-only discipline.
+/// LAN-462/LAN-464: an export hot-apply failure on a member whose import
+/// delta was already acknowledged must reassert that member's prior import
+/// chain directly (its bookkeeping had advanced) AND fire a Route Refresh to
+/// reconcile routes the session accepted under the new chain during the
+/// window, while the previously captured members restore through the
+/// ordinary rollback — and the failing member still gets no RIB
+/// compensation, matching the export-only discipline.
 #[tokio::test]
 async fn import_tolerant_cohort_export_failure_reasserts_failing_member_import() {
     use rustbgpd_api::peer_types::ResolvedPeerPolicy;
@@ -9311,8 +9333,8 @@ async fn import_tolerant_cohort_export_failure_reasserts_failing_member_import()
         "the export failure must surface with a successful rollback: {result:?}"
     );
 
-    // The failing member: forward import install + direct prior reassert, no
-    // forward refresh (it was deferred and never fired), no RIB compensation.
+    // The failing member: forward import install + direct prior reassert, a
+    // post-reassert refresh for the acked-import window, no RIB compensation.
     assert_eq!(failing_counters.import_installs.load(Ordering::SeqCst), 2);
     assert_eq!(
         *failing_counters.live_import.lock().unwrap(),
@@ -9320,7 +9342,11 @@ async fn import_tolerant_cohort_export_failure_reasserts_failing_member_import()
         "the failing member's prior import chain must be reasserted"
     );
     assert_eq!(failing_counters.export_installs.load(Ordering::SeqCst), 2);
-    assert_eq!(failing_counters.refreshes.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        failing_counters.refreshes.load(Ordering::SeqCst),
+        1,
+        "the repair must fire a refresh for routes accepted under the new import chain during the window"
+    );
     // The captured member restores through the ordinary rollback: reassert,
     // RIB restore, then the conservative post-reassert refresh.
     assert_eq!(first_counters.import_installs.load(Ordering::SeqCst), 2);
@@ -9339,6 +9365,100 @@ async fn import_tolerant_cohort_export_failure_reasserts_failing_member_import()
         assert!(!peer_state.pending_refresh);
         assert!(!peer_state.pending_export_apply);
     }
+
+    for peer in [first, failing] {
+        manager.delete_peer(key(peer), false).await.unwrap();
+    }
+}
+
+/// LAN-464 companion: when the failing member is no longer Established at
+/// repair time, the acked-import-window reconciliation cannot refresh
+/// immediately — it must arm `pending_refresh` instead so the retry pipeline
+/// fires it once the session is reachable again.
+#[tokio::test]
+async fn cohort_export_failure_repair_arms_pending_refresh_when_not_established() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 46, 0, 1));
+    let failing = IpAddr::V4(Ipv4Addr::new(10, 46, 0, 2));
+    let first_counters = Arc::new(CohortSessionCounters::default());
+    let failing_counters = Arc::new(CohortSessionCounters::default());
+    let (rib_tx, mut rib_rx) = mpsc::channel::<RibUpdate>(16);
+    let _rib_task = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(
+        &mut manager,
+        first,
+        import_tolerant_cohort_test_session(first, Arc::clone(&first_counters), None),
+        false,
+    );
+    // Established for the cohort-selection state query only: by the time the
+    // repair checks the session again it reports Connect.
+    insert_test_managed_peer(
+        &mut manager,
+        failing,
+        import_tolerant_cohort_test_session_with_states(
+            failing,
+            Arc::clone(&failing_counters),
+            Some(1),
+            Some(1),
+        ),
+        false,
+    );
+
+    let shared_export = deny_policy_chain();
+    let changed_import = validation_policy_chain(ImportValidationDependency::Rpki);
+    let result = manager
+        .apply_resolved_policy_snapshot(
+            [first, failing]
+                .into_iter()
+                .map(|address| ResolvedPeerPolicy {
+                    address,
+                    interface: None,
+                    import_policy: Some(changed_import.clone()),
+                    export_policy: Some(shared_export.clone()),
+                })
+                .collect(),
+        )
+        .await;
+    assert!(
+        result.as_ref().is_err_and(|error| {
+            error.contains(&format!(
+                "failed to apply resolved policy to {failing}: export:"
+            ))
+        }),
+        "the export failure must surface: {result:?}"
+    );
+
+    // The failing member: prior import chain reasserted, no immediate
+    // refresh (not Established), retry intent armed instead.
+    assert_eq!(failing_counters.import_installs.load(Ordering::SeqCst), 2);
+    assert_eq!(*failing_counters.live_import.lock().unwrap(), None);
+    assert_eq!(failing_counters.refreshes.load(Ordering::SeqCst), 0);
+    let failing_state = manager.peers.get(&key(failing)).unwrap();
+    assert!(
+        failing_state.pending_refresh,
+        "a non-Established failing member must carry the refresh intent as pending_refresh"
+    );
+    // The captured member still restores through the ordinary rollback.
+    assert_eq!(first_counters.refreshes.load(Ordering::SeqCst), 1);
+    assert!(!manager.peers.get(&key(first)).unwrap().pending_refresh);
 
     for peer in [first, failing] {
         manager.delete_peer(key(peer), false).await.unwrap();


### PR DESCRIPTION
## Cohort export-failure repair reconciles the acked-import window (LAN-464)

When a cohort member's import delta was acknowledged during setup and the export hot-apply then failed, the inline repair reasserted the member's prior import chain but armed nothing on repair success: routes the session accepted under the NEW import chain between setup and the failed export apply stayed unreconciled — no Route Refresh, no `pending_refresh`, and the member is not in `captured` so the rollback never touches it. The authoritative per-peer path fires a refresh for the identical shape.

The repair now mirrors the deferred-refresh phase: after a successful import reassert it queries session state and fires `soft_reset_in` when Established, otherwise (or when the refresh itself fails) arms `pending_refresh` for the retry pipeline. The reassert-FAILURE cross-side carry is unchanged.

Tests:
- `import_tolerant_cohort_export_failure_reasserts_failing_member_import` previously codified the gap (`refreshes == 0`); it now asserts the repair refresh fires exactly once.
- New `cohort_export_failure_repair_arms_pending_refresh_when_not_established` covers the non-Established repair, via a session-model knob that bounds how many state queries answer Established.

## Parse-diagnostic redaction hardening

Two shapes bypassed the secret-line redaction in `src/config/diagnostic.rs`:

- **Typo'd secret key**: `md5password = "..."` (no underscore) fails unknown-field validation and the diagnostic echoed the line, secret value included. `line_mentions_secret` now also normalizes the key-ish prefix (text before `=`, separators/quotes dropped, lowercased) and redacts when it contains `password`, `key`, or `ao`. Only the key side is inspected, so ordinary lines — including non-secret unknown fields like `holdtime = 90` — keep the full echoed snippet.
- **Multi-line string value**: with `md5_password = """` the secret (and any error inside it) sits two or more lines below the keyword, past the one-line lookback. `render_snippet` now walks back (bounded, 64 lines) to the nearest multi-line string delimiter line above the error and redacts when that opener names a secret.

Tests: negative assertions for both bypass shapes (secret absent, `redacted` present) plus the non-secret unknown-field echo check.

## Comment correction

The deferred-refresh failure comment in `try_apply_export_only_policy_cohort` claimed later import-delta members need no refresh-back because "their Adj-RIB-In never moved". Their sessions have been running the new chain since the setup hot-apply; the restore does fire their refresh-back through the ordinary `import_changed` path, and `forward_completed = false` only selects the failure-handling restore variant. The comment now states the actual mechanism.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `scripts/check-clippy-reasons.py`, `scripts/check-v1-stable-surface.py` — 0
- `cargo test --bin rustbgpd` (1533 passed), `cargo test --workspace`, `cargo doc --workspace --no-deps` — 0