### PR TITLE
feat(wire): RFC 7606 revised error handling — treat-as-withdraw and attribute-discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,25 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `unscoped_link_local`). The RFC 7948 `same-AS` and
   `explicit-authorized` relationships remain deferred per the ADR.
   (LAN-473)
+- **RFC 7606 revised BGP UPDATE error handling** — a malformed path
+  attribute no longer resets the session by default. The wire crate
+  classifies every attribute error with an RFC 7606 disposition
+  (`wire::validate::ErrorDisposition`): treat-as-withdraw (ORIGIN, AS_PATH,
+  NEXT_HOP, MED, communities, flag conflicts, missing mandatory attributes,
+  attribute-section overruns) withdraws the routes carried in the UPDATE
+  while the session stays Established; attribute-discard (ATOMIC_AGGREGATE,
+  AGGREGATOR, duplicate occurrences per §3 (g), and eBGP-received
+  LOCAL_PREF / ORIGINATOR_ID / CLUSTER_LIST) drops the attribute and
+  processes the rest. Session reset is retained only where the NLRI cannot
+  be trusted: section-length inconsistencies, malformed or duplicated
+  MP_REACH_NLRI / MP_UNREACH_NLRI, unparseable NLRI fields, and the §5.2
+  no-reachable-NLRI escalation. New `UpdateMessage::parse_revised` /
+  `decode_path_attributes_revised` APIs carry the per-attribute error
+  taxonomy; `UpdateError` gains a `disposition` field. The transport's
+  AS_PATH-loop and reflection-loop discard paths now share the same
+  treat-as-withdraw engine. Malformations are logged at `warn` with peer,
+  attribute type, and disposition. See `docs/RFC_NOTES.md` for the
+  per-attribute table and interpretation decisions.
 
 - **Cross-daemon IXP receipt-matrix tooling** (`bench/scale/matrix/` +
   reloadstall harness extensions). The reload-stall harness gains an

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -13,7 +13,7 @@ use rustbgpd_policy::{
 use rustbgpd_telemetry::reason_labels::{
     NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason,
 };
-use rustbgpd_wire::{AspaValidationContext, ParsedUpdate};
+use rustbgpd_wire::{AspaValidationContext, ErrorDisposition, ParsedUpdate};
 use std::sync::Arc;
 use std::time::SystemTime;
 /// Increment `bgp_policy_routes_total{peer, policy, direction=import,
@@ -543,6 +543,290 @@ impl PeerSession {
             first_as_check_exempt: matches!(local_role, Some(BgpRole::RouteServerClient)),
         }
     }
+    /// RFC 7606 treat-as-withdraw primitive: drop every announcement carried
+    /// in the UPDATE, withdraw any previously accepted route those
+    /// announcements replace, process the explicit withdrawals normally
+    /// (unicast, `FlowSpec`, EVPN, BGP-LS, L3VPN, labeled-unicast, and RTC —
+    /// no family may accumulate stale state downstream), and leave the
+    /// session Established. Shared by the AS_PATH-loop, reflection-loop,
+    /// and RFC 7606 malformed-attribute paths.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one withdraw-conversion pass per address family over the same sequence"
+    )]
+    async fn treat_update_as_withdraw(&mut self, parsed: &ParsedUpdate) {
+        let rejected_unicast = self.eligible_unicast_announcements(parsed);
+        let mut loop_withdrawn: Vec<(Prefix, u32)> = parsed
+            .withdrawn
+            .iter()
+            .map(|e| (Prefix::V4(e.prefix), e.path_id))
+            .collect();
+        let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
+        let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
+        let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
+        let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
+        let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
+        let mut loop_l3vpn_rejected: Vec<VpnRibRouteKey> = Vec::new();
+        let mut loop_labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
+        let mut loop_labeled_rejected: Vec<LabeledRibRouteKey> = Vec::new();
+        let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
+        let mut loop_rtc_rejected: Vec<RtcRibRouteKey> = Vec::new();
+        for attr in &parsed.attributes {
+            if let PathAttribute::MpUnreachNlri(mp) = attr {
+                let family = (mp.afi, mp.safi);
+                if self.negotiated_families.contains(&family) {
+                    loop_withdrawn.extend(mp.withdrawn.iter().map(|e| (e.prefix, e.path_id)));
+                    loop_fs_withdrawn.extend(
+                        mp.flowspec_withdrawn
+                            .iter()
+                            .cloned()
+                            .map(|rule| FlowSpecKey { afi: mp.afi, rule }),
+                    );
+                    loop_evpn_withdrawn.extend(mp.evpn_withdrawn.iter().map(EvpnRoute::key));
+                    if let Some(bgpls_family) = bgpls_family_from_safi(mp.safi) {
+                        loop_bgpls_withdrawn.extend(mp.bgpls_withdrawn.iter().map(|nlri| {
+                            BgpLsRouteKey {
+                                family: bgpls_family,
+                                nlri: nlri.key(),
+                                path_id: 0,
+                            }
+                        }));
+                    }
+                    if mp.safi == Safi::MplsVpn {
+                        loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| {
+                            VpnRibRouteKey {
+                                nlri_key: entry.nlri.key(),
+                                path_id: entry.path_id,
+                            }
+                        }));
+                    }
+                    if mp.safi == Safi::LabeledUnicast {
+                        loop_labeled_withdrawn.extend(mp.labeled_withdrawn.iter().map(|entry| {
+                            LabeledRibRouteKey {
+                                prefix: entry.nlri.key(),
+                                path_id: entry.path_id,
+                            }
+                        }));
+                    }
+                    if mp.safi == Safi::RtConstrain {
+                        loop_rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| {
+                            RtcRibRouteKey {
+                                nlri: *nlri,
+                                path_id: 0,
+                            }
+                        }));
+                    }
+                }
+            }
+            if let PathAttribute::MpReachNlri(mp) = attr
+                && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
+                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+            {
+                loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| BgpLsRouteKey {
+                    family: bgpls_family,
+                    nlri: nlri.key(),
+                    path_id: 0,
+                }));
+            }
+            // A loop-rejected announcement replaces only an exact route
+            // that this session previously accepted.
+            if let PathAttribute::MpReachNlri(mp) = attr
+                && mp.safi == Safi::MplsVpn
+                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+            {
+                loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| VpnRibRouteKey {
+                    nlri_key: entry.nlri.key(),
+                    path_id: entry.path_id,
+                }));
+            }
+            if let PathAttribute::MpReachNlri(mp) = attr
+                && mp.safi == Safi::LabeledUnicast
+                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+            {
+                loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
+                    LabeledRibRouteKey {
+                        prefix: entry.nlri.key(),
+                        path_id: entry.path_id,
+                    }
+                }));
+            }
+            if let PathAttribute::MpReachNlri(mp) = attr
+                && mp.safi == Safi::RtConstrain
+                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+            {
+                loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
+                    nlri: *nlri,
+                    path_id: 0,
+                }));
+            }
+        }
+        for &(prefix, path_id) in &loop_withdrawn {
+            self.forget_known_path(prefix, path_id);
+        }
+        for (prefix, path_id) in rejected_unicast {
+            if self.forget_known_path(prefix, path_id) {
+                loop_withdrawn.push((prefix, path_id));
+            }
+        }
+        if self.import_explain_enabled {
+            for &(prefix, path_id) in &loop_withdrawn {
+                let afi = match prefix {
+                    Prefix::V4(_) => Afi::Ipv4,
+                    Prefix::V6(_) => Afi::Ipv6,
+                };
+                self.import_decision_cache
+                    .mark_withdrawn(&ImportDecisionKey {
+                        afi,
+                        safi: Safi::Unicast,
+                        prefix,
+                        path_id,
+                    });
+            }
+        }
+        for rule in &loop_fs_withdrawn {
+            self.known_flowspec.remove(rule);
+        }
+        for key in &loop_evpn_withdrawn {
+            self.known_evpn.remove(key);
+        }
+        for key in &loop_bgpls_withdrawn {
+            self.known_bgpls.remove(key);
+        }
+        for key in loop_bgpls_rejected {
+            if self.known_bgpls.remove(&key) {
+                loop_bgpls_withdrawn.push(key);
+            }
+        }
+        for key in &loop_l3vpn_withdrawn {
+            self.known_vpn.remove(key);
+        }
+        for key in loop_l3vpn_rejected {
+            if self.known_vpn.remove(&key) {
+                loop_l3vpn_withdrawn.push(key);
+            }
+        }
+        for key in &loop_labeled_withdrawn {
+            self.known_labeled.remove(key);
+        }
+        for key in loop_labeled_rejected {
+            if self.known_labeled.remove(&key) {
+                loop_labeled_withdrawn.push(key);
+            }
+        }
+        for key in &loop_rtc_withdrawn {
+            self.known_rtc.remove(key);
+        }
+        for key in loop_rtc_rejected {
+            if self.known_rtc.remove(&key) {
+                loop_rtc_withdrawn.push(key);
+            }
+        }
+        if !loop_withdrawn.is_empty()
+            || !loop_fs_withdrawn.is_empty()
+            || !loop_evpn_withdrawn.is_empty()
+        {
+            let refresh_delta = self.capture_routes_refresh_delta(
+                &[],
+                &loop_withdrawn,
+                &[],
+                &loop_fs_withdrawn,
+                &[],
+                &loop_evpn_withdrawn,
+            );
+            if self
+                .deliver_routes_to_rib(RibUpdate::RoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vec![],
+                    withdrawn: loop_withdrawn,
+                    flowspec_announced: vec![],
+                    flowspec_withdrawn: loop_fs_withdrawn,
+                    evpn_announced: vec![],
+                    evpn_withdrawn: loop_evpn_withdrawn,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
+        }
+        if !loop_bgpls_withdrawn.is_empty() {
+            let refresh_delta = self.capture_bgpls_refresh_delta(&[], &loop_bgpls_withdrawn);
+            if self
+                .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vec![],
+                    withdrawn: loop_bgpls_withdrawn,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
+        }
+        if !loop_l3vpn_withdrawn.is_empty() {
+            let refresh_delta = self.capture_vpn_refresh_delta(&[], &loop_l3vpn_withdrawn);
+            if self
+                .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vec![],
+                    withdrawn: loop_l3vpn_withdrawn,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
+        }
+        if !loop_labeled_withdrawn.is_empty() {
+            let refresh_delta = self.capture_labeled_refresh_delta(&[], &loop_labeled_withdrawn);
+            if self
+                .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vec![],
+                    withdrawn: loop_labeled_withdrawn,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
+        }
+        if !loop_rtc_withdrawn.is_empty() {
+            let refresh_delta = self.capture_rtc_refresh_delta(&[], &loop_rtc_withdrawn);
+            if self
+                .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
+                    peer: self.peer_ip,
+                    session_id: self.session_identity.id,
+                    announced: vec![],
+                    withdrawn: loop_rtc_withdrawn,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(delta) = refresh_delta {
+                self.apply_refresh_accounting_delta(delta);
+            }
+        }
+        self.drive_fsm(Event::UpdateReceived).await;
+    }
     /// Parse an UPDATE message, validate attributes, apply import policy,
     /// enforce max-prefix limit, send routes to RIB, and feed the
     /// appropriate event to the FSM.
@@ -558,19 +842,43 @@ impl PeerSession {
         let add_path_ipv4 = self
             .add_path_receive_families
             .contains(&(Afi::Ipv4, Safi::Unicast));
-        // 1. Structural decode
-        let parsed = match update.parse(
+        // 1. Structural decode — RFC 7606 revised error handling: recoverable
+        // per-attribute malformations are collected alongside the parse
+        // instead of aborting it. `Err` stays reserved for session-reset-class
+        // problems (RFC 7606 §3 (j), §5.3): syntactically incorrect NLRI /
+        // Withdrawn Routes fields, or a malformed or duplicated
+        // MP_REACH_NLRI / MP_UNREACH_NLRI whose NLRI cannot be located.
+        let is_ebgp = self
+            .negotiated
+            .as_ref()
+            .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
+        let revised = match update.parse_revised(
             four_octet_as,
+            !is_ebgp,
             add_path_ipv4,
             &self.add_path_receive_families,
         ) {
-            Ok(p) => p,
+            Ok(r) => r,
             Err(e) => {
                 warn!(peer = %self.peer_label, error = %e, "UPDATE decode error");
                 self.drive_fsm(Event::DecodeError(e)).await;
                 return;
             }
         };
+        let malformed = revised.malformed;
+        let parsed = revised.update;
+        for m in &malformed {
+            warn!(
+                peer = %self.peer_label,
+                attr_type = m.type_code,
+                disposition = m.disposition.as_str(),
+                error = %m.error,
+                "malformed path attribute (RFC 7606 revised error handling)"
+            );
+        }
+        // RFC 7606 §3 (h): when multiple attribute errors exist, the approach
+        // with the strongest action wins.
+        let mut disposition = malformed.iter().map(|m| m.disposition).max();
         // Observe recoverable BGP-LS NLRI discards (RFC 9552 fault management,
         // PR #616): known NLRIs with out-of-order descriptor TLVs are dropped
         // while the session survives. Fatal framing errors take the Err arm
@@ -594,14 +902,11 @@ impl PeerSession {
             .any(|a| matches!(a, PathAttribute::MpReachNlri(_)));
         let has_body_nlri = !parsed.announced.is_empty();
         let has_nlri = has_body_nlri || has_mp_nlri;
-        let is_ebgp = self
-            .negotiated
-            .as_ref()
-            .is_some_and(|n| n.peer_asn != self.config.peer.local_asn);
         let validation_options = rustbgpd_wire::UpdateValidationOptions {
             allow_ipv4_link_local_mp_reach_next_hop: self.is_scoped_link_local_peer()
                 && self.use_extended_nexthop_ipv4(),
         };
+        let mut validation_payload: Option<(u8, Vec<u8>)> = None;
         if let Err(update_err) = rustbgpd_wire::validate::validate_update_attributes_with_options(
             &parsed.attributes,
             has_nlri,
@@ -612,18 +917,67 @@ impl PeerSession {
             warn!(
                 peer = %self.peer_label,
                 subcode = update_err.subcode,
+                disposition = update_err.disposition.as_str(),
                 "UPDATE validation error"
             );
-            let notif = NotificationMessage::new(
-                NotificationCode::UpdateMessage,
-                update_err.subcode,
-                bytes::Bytes::from(update_err.data),
+            if update_err.disposition == ErrorDisposition::SessionReset {
+                let notif = NotificationMessage::new(
+                    NotificationCode::UpdateMessage,
+                    update_err.subcode,
+                    bytes::Bytes::from(update_err.data),
+                );
+                self.drive_fsm(Event::UpdateValidationError(notif)).await;
+                return;
+            }
+            disposition = disposition.max(Some(update_err.disposition));
+            validation_payload = Some((update_err.subcode, update_err.data));
+        }
+        // Apply the strongest RFC 7606 disposition. Attribute-discard needs no
+        // action here — the offending attributes were already omitted from
+        // `parsed.attributes` and the UPDATE proceeds without them (§2).
+        // Treat-as-withdraw removes every route the UPDATE carries while the
+        // session stays Established.
+        if disposition >= Some(ErrorDisposition::TreatAsWithdraw) {
+            // RFC 7606 §5.2: an UPDATE with path attributes but no reachable
+            // NLRI encoded gives no confidence that its NLRI was parsed
+            // successfully; for any error stronger than attribute-discard the
+            // session-reset approach MUST be used instead.
+            if parsed.announced.is_empty() && !has_mp_nlri {
+                warn!(
+                    peer = %self.peer_label,
+                    "treat-as-withdraw with no reachable NLRI — session reset (RFC 7606 §5.2)"
+                );
+                if let Some(m) = malformed
+                    .iter()
+                    .find(|m| m.disposition == ErrorDisposition::TreatAsWithdraw)
+                {
+                    self.drive_fsm(Event::DecodeError(m.error.clone())).await;
+                } else {
+                    let (subcode, data) = validation_payload.unwrap_or((
+                        rustbgpd_wire::notification::update_subcode::MALFORMED_ATTRIBUTE_LIST,
+                        Vec::new(),
+                    ));
+                    let notif = NotificationMessage::new(
+                        NotificationCode::UpdateMessage,
+                        subcode,
+                        bytes::Bytes::from(data),
+                    );
+                    self.drive_fsm(Event::UpdateValidationError(notif)).await;
+                }
+                return;
+            }
+            warn!(
+                peer = %self.peer_label,
+                announced = parsed.announced.len(),
+                "treat-as-withdraw — withdrawing the routes carried in the malformed UPDATE"
             );
-            self.drive_fsm(Event::UpdateValidationError(notif)).await;
+            self.treat_update_as_withdraw(&parsed).await;
             return;
         }
-        // 3. End-of-RIB detection (RFC 4724 §2)
-        if parsed.announced.is_empty() && parsed.withdrawn.is_empty() {
+        // 3. End-of-RIB detection (RFC 4724 §2). An UPDATE that only became
+        // empty because malformed attributes were discarded is junk, not an
+        // EoR signal — require a clean decode.
+        if parsed.announced.is_empty() && parsed.withdrawn.is_empty() && malformed.is_empty() {
             // IPv4 EoR: empty UPDATE (no NLRI, no withdrawn, no attributes)
             if parsed.attributes.is_empty() {
                 info!(peer = %self.peer_label, family = "ipv4_unicast", "received End-of-RIB");
@@ -825,7 +1179,6 @@ impl PeerSession {
             }
         });
         if as_path_loop {
-            let rejected_unicast = self.eligible_unicast_announcements(&parsed);
             // Count rejected announced prefixes (body NLRI + MP_REACH_NLRI)
             let rejected_count = parsed.announced.len()
                 + parsed
@@ -854,281 +1207,7 @@ impl PeerSession {
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the AS_PATH-loop branch must
             // not silently drop withdrawals for any family, or stale non-unicast state
             // accumulates downstream until the next session reset / refresh.
-            let mut loop_withdrawn: Vec<(Prefix, u32)> = parsed
-                .withdrawn
-                .iter()
-                .map(|e| (Prefix::V4(e.prefix), e.path_id))
-                .collect();
-            let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
-            let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
-            let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
-            let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
-            let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
-            let mut loop_l3vpn_rejected: Vec<VpnRibRouteKey> = Vec::new();
-            let mut loop_labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
-            let mut loop_labeled_rejected: Vec<LabeledRibRouteKey> = Vec::new();
-            let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
-            let mut loop_rtc_rejected: Vec<RtcRibRouteKey> = Vec::new();
-            for attr in &parsed.attributes {
-                if let PathAttribute::MpUnreachNlri(mp) = attr {
-                    let family = (mp.afi, mp.safi);
-                    if self.negotiated_families.contains(&family) {
-                        loop_withdrawn.extend(mp.withdrawn.iter().map(|e| (e.prefix, e.path_id)));
-                        loop_fs_withdrawn.extend(
-                            mp.flowspec_withdrawn
-                                .iter()
-                                .cloned()
-                                .map(|rule| FlowSpecKey { afi: mp.afi, rule }),
-                        );
-                        loop_evpn_withdrawn.extend(mp.evpn_withdrawn.iter().map(EvpnRoute::key));
-                        if let Some(bgpls_family) = bgpls_family_from_safi(mp.safi) {
-                            loop_bgpls_withdrawn.extend(mp.bgpls_withdrawn.iter().map(|nlri| {
-                                BgpLsRouteKey {
-                                    family: bgpls_family,
-                                    nlri: nlri.key(),
-                                    path_id: 0,
-                                }
-                            }));
-                        }
-                        if mp.safi == Safi::MplsVpn {
-                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| {
-                                VpnRibRouteKey {
-                                    nlri_key: entry.nlri.key(),
-                                    path_id: entry.path_id,
-                                }
-                            }));
-                        }
-                        if mp.safi == Safi::LabeledUnicast {
-                            loop_labeled_withdrawn.extend(mp.labeled_withdrawn.iter().map(
-                                |entry| LabeledRibRouteKey {
-                                    prefix: entry.nlri.key(),
-                                    path_id: entry.path_id,
-                                },
-                            ));
-                        }
-                        if mp.safi == Safi::RtConstrain {
-                            loop_rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| {
-                                RtcRibRouteKey {
-                                    nlri: *nlri,
-                                    path_id: 0,
-                                }
-                            }));
-                        }
-                    }
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| {
-                        BgpLsRouteKey {
-                            family: bgpls_family,
-                            nlri: nlri.key(),
-                            path_id: 0,
-                        }
-                    }));
-                }
-                // A loop-rejected announcement replaces only an exact route
-                // that this session previously accepted.
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::MplsVpn
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| {
-                        VpnRibRouteKey {
-                            nlri_key: entry.nlri.key(),
-                            path_id: entry.path_id,
-                        }
-                    }));
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::LabeledUnicast
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
-                        LabeledRibRouteKey {
-                            prefix: entry.nlri.key(),
-                            path_id: entry.path_id,
-                        }
-                    }));
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::RtConstrain
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
-                        nlri: *nlri,
-                        path_id: 0,
-                    }));
-                }
-            }
-            for &(prefix, path_id) in &loop_withdrawn {
-                self.forget_known_path(prefix, path_id);
-            }
-            for (prefix, path_id) in rejected_unicast {
-                if self.forget_known_path(prefix, path_id) {
-                    loop_withdrawn.push((prefix, path_id));
-                }
-            }
-            if self.import_explain_enabled {
-                for &(prefix, path_id) in &loop_withdrawn {
-                    let afi = match prefix {
-                        Prefix::V4(_) => Afi::Ipv4,
-                        Prefix::V6(_) => Afi::Ipv6,
-                    };
-                    self.import_decision_cache
-                        .mark_withdrawn(&ImportDecisionKey {
-                            afi,
-                            safi: Safi::Unicast,
-                            prefix,
-                            path_id,
-                        });
-                }
-            }
-            for rule in &loop_fs_withdrawn {
-                self.known_flowspec.remove(rule);
-            }
-            for key in &loop_evpn_withdrawn {
-                self.known_evpn.remove(key);
-            }
-            for key in &loop_bgpls_withdrawn {
-                self.known_bgpls.remove(key);
-            }
-            for key in loop_bgpls_rejected {
-                if self.known_bgpls.remove(&key) {
-                    loop_bgpls_withdrawn.push(key);
-                }
-            }
-            for key in &loop_l3vpn_withdrawn {
-                self.known_vpn.remove(key);
-            }
-            for key in loop_l3vpn_rejected {
-                if self.known_vpn.remove(&key) {
-                    loop_l3vpn_withdrawn.push(key);
-                }
-            }
-            for key in &loop_labeled_withdrawn {
-                self.known_labeled.remove(key);
-            }
-            for key in loop_labeled_rejected {
-                if self.known_labeled.remove(&key) {
-                    loop_labeled_withdrawn.push(key);
-                }
-            }
-            for key in &loop_rtc_withdrawn {
-                self.known_rtc.remove(key);
-            }
-            for key in loop_rtc_rejected {
-                if self.known_rtc.remove(&key) {
-                    loop_rtc_withdrawn.push(key);
-                }
-            }
-            if !loop_withdrawn.is_empty()
-                || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty()
-            {
-                let refresh_delta = self.capture_routes_refresh_delta(
-                    &[],
-                    &loop_withdrawn,
-                    &[],
-                    &loop_fs_withdrawn,
-                    &[],
-                    &loop_evpn_withdrawn,
-                );
-                if self
-                    .deliver_routes_to_rib(RibUpdate::RoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_withdrawn,
-                        flowspec_announced: vec![],
-                        flowspec_withdrawn: loop_fs_withdrawn,
-                        evpn_announced: vec![],
-                        evpn_withdrawn: loop_evpn_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_bgpls_withdrawn.is_empty() {
-                let refresh_delta = self.capture_bgpls_refresh_delta(&[], &loop_bgpls_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_bgpls_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_l3vpn_withdrawn.is_empty() {
-                let refresh_delta = self.capture_vpn_refresh_delta(&[], &loop_l3vpn_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_l3vpn_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_labeled_withdrawn.is_empty() {
-                let refresh_delta =
-                    self.capture_labeled_refresh_delta(&[], &loop_labeled_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_labeled_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_rtc_withdrawn.is_empty() {
-                let refresh_delta = self.capture_rtc_refresh_delta(&[], &loop_rtc_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_rtc_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            self.drive_fsm(Event::UpdateReceived).await;
+            self.treat_update_as_withdraw(&parsed).await;
             return;
         }
         // Route reflector loop detection (RFC 4456 §8):
@@ -1148,7 +1227,6 @@ impl PeerSession {
                 .any(|a| matches!(a, PathAttribute::ClusterList(ids) if ids.contains(&cluster_id)))
         });
         if originator_loop || cluster_loop {
-            let rejected_unicast = self.eligible_unicast_announcements(&parsed);
             let reason = if originator_loop {
                 RrLoopReason::OriginatorId
             } else {
@@ -1164,281 +1242,7 @@ impl PeerSession {
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the reflected-loop
             // detection must not silently drop withdrawals for any family,
             // or stale state accumulates downstream.
-            let mut loop_withdrawn: Vec<(Prefix, u32)> = parsed
-                .withdrawn
-                .iter()
-                .map(|e| (Prefix::V4(e.prefix), e.path_id))
-                .collect();
-            let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
-            let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
-            let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
-            let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
-            let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
-            let mut loop_l3vpn_rejected: Vec<VpnRibRouteKey> = Vec::new();
-            let mut loop_labeled_withdrawn: Vec<LabeledRibRouteKey> = Vec::new();
-            let mut loop_labeled_rejected: Vec<LabeledRibRouteKey> = Vec::new();
-            let mut loop_rtc_withdrawn: Vec<RtcRibRouteKey> = Vec::new();
-            let mut loop_rtc_rejected: Vec<RtcRibRouteKey> = Vec::new();
-            for attr in &parsed.attributes {
-                if let PathAttribute::MpUnreachNlri(mp) = attr {
-                    let family = (mp.afi, mp.safi);
-                    if self.negotiated_families.contains(&family) {
-                        loop_withdrawn.extend(mp.withdrawn.iter().map(|e| (e.prefix, e.path_id)));
-                        loop_fs_withdrawn.extend(
-                            mp.flowspec_withdrawn
-                                .iter()
-                                .cloned()
-                                .map(|rule| FlowSpecKey { afi: mp.afi, rule }),
-                        );
-                        loop_evpn_withdrawn.extend(mp.evpn_withdrawn.iter().map(EvpnRoute::key));
-                        if let Some(bgpls_family) = bgpls_family_from_safi(mp.safi) {
-                            loop_bgpls_withdrawn.extend(mp.bgpls_withdrawn.iter().map(|nlri| {
-                                BgpLsRouteKey {
-                                    family: bgpls_family,
-                                    nlri: nlri.key(),
-                                    path_id: 0,
-                                }
-                            }));
-                        }
-                        if mp.safi == Safi::MplsVpn {
-                            loop_l3vpn_withdrawn.extend(mp.vpn_withdrawn.iter().map(|entry| {
-                                VpnRibRouteKey {
-                                    nlri_key: entry.nlri.key(),
-                                    path_id: entry.path_id,
-                                }
-                            }));
-                        }
-                        if mp.safi == Safi::LabeledUnicast {
-                            loop_labeled_withdrawn.extend(mp.labeled_withdrawn.iter().map(
-                                |entry| LabeledRibRouteKey {
-                                    prefix: entry.nlri.key(),
-                                    path_id: entry.path_id,
-                                },
-                            ));
-                        }
-                        if mp.safi == Safi::RtConstrain {
-                            loop_rtc_withdrawn.extend(mp.rtc_withdrawn.iter().map(|nlri| {
-                                RtcRibRouteKey {
-                                    nlri: *nlri,
-                                    path_id: 0,
-                                }
-                            }));
-                        }
-                    }
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && let Some(bgpls_family) = bgpls_family_from_safi(mp.safi)
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_bgpls_rejected.extend(mp.bgpls_announced.iter().map(|nlri| {
-                        BgpLsRouteKey {
-                            family: bgpls_family,
-                            nlri: nlri.key(),
-                            path_id: 0,
-                        }
-                    }));
-                }
-                // A loop-rejected announcement replaces only an exact route
-                // that this session previously accepted.
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::MplsVpn
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_l3vpn_rejected.extend(mp.vpn_announced.iter().map(|entry| {
-                        VpnRibRouteKey {
-                            nlri_key: entry.nlri.key(),
-                            path_id: entry.path_id,
-                        }
-                    }));
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::LabeledUnicast
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_labeled_rejected.extend(mp.labeled_announced.iter().map(|entry| {
-                        LabeledRibRouteKey {
-                            prefix: entry.nlri.key(),
-                            path_id: entry.path_id,
-                        }
-                    }));
-                }
-                if let PathAttribute::MpReachNlri(mp) = attr
-                    && mp.safi == Safi::RtConstrain
-                    && self.negotiated_families.contains(&(mp.afi, mp.safi))
-                {
-                    loop_rtc_rejected.extend(mp.rtc_announced.iter().map(|nlri| RtcRibRouteKey {
-                        nlri: *nlri,
-                        path_id: 0,
-                    }));
-                }
-            }
-            for &(prefix, path_id) in &loop_withdrawn {
-                self.forget_known_path(prefix, path_id);
-            }
-            for (prefix, path_id) in rejected_unicast {
-                if self.forget_known_path(prefix, path_id) {
-                    loop_withdrawn.push((prefix, path_id));
-                }
-            }
-            if self.import_explain_enabled {
-                for &(prefix, path_id) in &loop_withdrawn {
-                    let afi = match prefix {
-                        Prefix::V4(_) => Afi::Ipv4,
-                        Prefix::V6(_) => Afi::Ipv6,
-                    };
-                    self.import_decision_cache
-                        .mark_withdrawn(&ImportDecisionKey {
-                            afi,
-                            safi: Safi::Unicast,
-                            prefix,
-                            path_id,
-                        });
-                }
-            }
-            for rule in &loop_fs_withdrawn {
-                self.known_flowspec.remove(rule);
-            }
-            for key in &loop_evpn_withdrawn {
-                self.known_evpn.remove(key);
-            }
-            for key in &loop_bgpls_withdrawn {
-                self.known_bgpls.remove(key);
-            }
-            for key in loop_bgpls_rejected {
-                if self.known_bgpls.remove(&key) {
-                    loop_bgpls_withdrawn.push(key);
-                }
-            }
-            for key in &loop_l3vpn_withdrawn {
-                self.known_vpn.remove(key);
-            }
-            for key in loop_l3vpn_rejected {
-                if self.known_vpn.remove(&key) {
-                    loop_l3vpn_withdrawn.push(key);
-                }
-            }
-            for key in &loop_labeled_withdrawn {
-                self.known_labeled.remove(key);
-            }
-            for key in loop_labeled_rejected {
-                if self.known_labeled.remove(&key) {
-                    loop_labeled_withdrawn.push(key);
-                }
-            }
-            for key in &loop_rtc_withdrawn {
-                self.known_rtc.remove(key);
-            }
-            for key in loop_rtc_rejected {
-                if self.known_rtc.remove(&key) {
-                    loop_rtc_withdrawn.push(key);
-                }
-            }
-            if !loop_withdrawn.is_empty()
-                || !loop_fs_withdrawn.is_empty()
-                || !loop_evpn_withdrawn.is_empty()
-            {
-                let refresh_delta = self.capture_routes_refresh_delta(
-                    &[],
-                    &loop_withdrawn,
-                    &[],
-                    &loop_fs_withdrawn,
-                    &[],
-                    &loop_evpn_withdrawn,
-                );
-                if self
-                    .deliver_routes_to_rib(RibUpdate::RoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_withdrawn,
-                        flowspec_announced: vec![],
-                        flowspec_withdrawn: loop_fs_withdrawn,
-                        evpn_announced: vec![],
-                        evpn_withdrawn: loop_evpn_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_bgpls_withdrawn.is_empty() {
-                let refresh_delta = self.capture_bgpls_refresh_delta(&[], &loop_bgpls_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::BgpLsRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_bgpls_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_l3vpn_withdrawn.is_empty() {
-                let refresh_delta = self.capture_vpn_refresh_delta(&[], &loop_l3vpn_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::VpnRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_l3vpn_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_labeled_withdrawn.is_empty() {
-                let refresh_delta =
-                    self.capture_labeled_refresh_delta(&[], &loop_labeled_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::LabeledRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_labeled_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            if !loop_rtc_withdrawn.is_empty() {
-                let refresh_delta = self.capture_rtc_refresh_delta(&[], &loop_rtc_withdrawn);
-                if self
-                    .deliver_routes_to_rib(RibUpdate::RtcRoutesReceived {
-                        peer: self.peer_ip,
-                        session_id: self.session_identity.id,
-                        announced: vec![],
-                        withdrawn: loop_rtc_withdrawn,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                if let Some(delta) = refresh_delta {
-                    self.apply_refresh_accounting_delta(delta);
-                }
-            }
-            self.drive_fsm(Event::UpdateReceived).await;
+            self.treat_update_as_withdraw(&parsed).await;
             return;
         }
         // Normalize the attributes that policy and the RIB are allowed to

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -562,7 +562,9 @@ impl PeerSession {
             .map(|e| (Prefix::V4(e.prefix), e.path_id))
             .collect();
         let mut loop_fs_withdrawn: Vec<FlowSpecKey> = Vec::new();
+        let mut loop_fs_rejected: Vec<FlowSpecKey> = Vec::new();
         let mut loop_evpn_withdrawn: Vec<EvpnRouteKey> = Vec::new();
+        let mut loop_evpn_rejected: Vec<EvpnRouteKey> = Vec::new();
         let mut loop_bgpls_withdrawn: Vec<BgpLsRouteKey> = Vec::new();
         let mut loop_bgpls_rejected: Vec<BgpLsRouteKey> = Vec::new();
         let mut loop_l3vpn_withdrawn: Vec<VpnRibRouteKey> = Vec::new();
@@ -659,6 +661,23 @@ impl PeerSession {
                     path_id: 0,
                 }));
             }
+            // FlowSpec and EVPN announcements get the same rejected→withdraw
+            // conversion as the other MP families: RFC 7606 §2 requires the
+            // UPDATE's routes to be treated as withdrawn, so a previously
+            // accepted route re-announced here must leave the RIB. The
+            // family-specific announced vectors are only populated for their
+            // own SAFI, so the negotiated-family check is the only guard.
+            if let PathAttribute::MpReachNlri(mp) = attr
+                && self.negotiated_families.contains(&(mp.afi, mp.safi))
+            {
+                loop_fs_rejected.extend(
+                    mp.flowspec_announced
+                        .iter()
+                        .cloned()
+                        .map(|rule| FlowSpecKey { afi: mp.afi, rule }),
+                );
+                loop_evpn_rejected.extend(mp.evpn_announced.iter().map(EvpnRoute::key));
+            }
         }
         for &(prefix, path_id) in &loop_withdrawn {
             self.forget_known_path(prefix, path_id);
@@ -686,8 +705,18 @@ impl PeerSession {
         for rule in &loop_fs_withdrawn {
             self.known_flowspec.remove(rule);
         }
+        for rule in loop_fs_rejected {
+            if self.known_flowspec.remove(&rule) {
+                loop_fs_withdrawn.push(rule);
+            }
+        }
         for key in &loop_evpn_withdrawn {
             self.known_evpn.remove(key);
+        }
+        for key in loop_evpn_rejected {
+            if self.known_evpn.remove(&key) {
+                loop_evpn_withdrawn.push(key);
+            }
         }
         for key in &loop_bgpls_withdrawn {
             self.known_bgpls.remove(key);

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -14936,3 +14936,115 @@ async fn rfc7606_discarded_attrs_do_not_fake_end_of_rib() {
     );
     assert_eq!(session.fsm.state(), SessionState::Established);
 }
+
+/// RFC 7606 §2: treat-as-withdraw must cover EVPN too — a previously
+/// accepted EVPN route re-announced in an UPDATE with a malformed attribute
+/// is withdrawn from the RIB, and the session stays Established.
+#[tokio::test]
+async fn rfc7606_treat_as_withdraw_covers_previously_accepted_evpn_routes() {
+    use rustbgpd_wire::{
+        EthernetSegmentIdentifier, EthernetTagId, EvpnMacIp, EvpnRoute, MacAddress, MpReachNlri,
+        MplsLabel, RouteDistinguisher,
+    };
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    session.negotiated_families.push((Afi::L2Vpn, Safi::Evpn));
+    rfc7606_drain(&mut rib_rx);
+    let evpn_route = EvpnRoute::MacIp(EvpnMacIp {
+        rd: RouteDistinguisher([0x00, 0x00, 0xFD, 0xE8, 0x00, 0x00, 0x00, 0x64]),
+        esi: EthernetSegmentIdentifier::ZERO,
+        ethernet_tag: EthernetTagId(0),
+        mac: MacAddress([0xaa, 0xbb, 0xcc, 0x00, 0x00, 0x01]),
+        ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))),
+        label1: MplsLabel::new(100),
+        label2: None,
+    });
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::MpReachNlri(MpReachNlri {
+            afi: Afi::L2Vpn,
+            safi: Safi::Evpn,
+            next_hop: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            link_local_next_hop: None,
+            announced: vec![],
+            flowspec_announced: vec![],
+            evpn_announced: vec![evpn_route.clone()],
+            bgpls_announced: vec![],
+            labeled_announced: vec![],
+            vpn_announced: vec![],
+            rtc_announced: vec![],
+        }),
+    ];
+    let clean = UpdateMessage::build(&[], &[], &attrs, true, false, Ipv4UnicastMode::Body);
+    session.process_update(clean.clone()).await;
+    let RibUpdate::RoutesReceived { evpn_announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected the clean EVPN announcement to be accepted");
+    };
+    assert_eq!(evpn_announced.len(), 1);
+    assert!(session.known_evpn.contains(&evpn_route.key()));
+    // Re-announce the same EVPN route with a malformed MED appended.
+    let mut attr_bytes = clean.path_attributes.to_vec();
+    attr_bytes.extend([0x80, 4, 3, 0, 0, 1]);
+    session
+        .process_update(UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from(attr_bytes),
+            nlri: Bytes::new(),
+        })
+        .await;
+    let RibUpdate::RoutesReceived {
+        evpn_announced,
+        evpn_withdrawn,
+        ..
+    } = rib_rx.try_recv().unwrap()
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived for the EVPN route");
+    };
+    assert!(evpn_announced.is_empty());
+    assert_eq!(evpn_withdrawn, vec![evpn_route.key()]);
+    assert!(
+        session.known_evpn.is_empty(),
+        "the previously accepted EVPN route must leave the session's accepted set"
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+/// RFC 4724 §2 MP End-of-RIB: an UPDATE whose only content is an empty
+/// `MP_UNREACH_NLRI` marks End-of-RIB for that family and the session stays
+/// Established.
+#[tokio::test]
+async fn mp_eor_empty_mp_unreach_marks_end_of_rib() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    // Hand-crafted MP_UNREACH_NLRI: flags 0x80, type 15, len 3,
+    // AFI=2 (IPv6), SAFI=1 (unicast), no NLRI.
+    session
+        .process_update(UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from_static(&[0x80, 15, 3, 0, 2, 1]),
+            nlri: Bytes::new(),
+        })
+        .await;
+    assert!(
+        session
+            .received_eor_families
+            .contains(&(Afi::Ipv6, Safi::Unicast)),
+        "an empty MP_UNREACH must mark End-of-RIB for its family"
+    );
+    match rib_rx.try_recv().unwrap() {
+        RibUpdate::EndOfRib { afi, safi, .. } => {
+            assert_eq!(afi, Afi::Ipv6);
+            assert_eq!(safi, Safi::Unicast);
+        }
+        _ => panic!("expected EndOfRib"),
+    }
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -14743,3 +14743,196 @@ async fn next_hop_ownership_disabled_by_default_accepts_foreign_next_hop() {
         "default (unset) must preserve transparent behavior"
     );
 }
+
+// ---------------------------------------------------------------------
+// RFC 7606 revised error handling — treat-as-withdraw / attribute-discard
+// ---------------------------------------------------------------------
+
+/// Craft raw attribute bytes: valid `ORIGIN` + `AS_PATH` (65002, 4-octet) +
+/// `NEXT_HOP`, followed by `extra`.
+fn rfc7606_attr_bytes(extra: &[u8]) -> Vec<u8> {
+    let mut attrs = vec![0x40, 1, 1, 0]; // ORIGIN = IGP
+    attrs.extend([0x40, 2, 6, 2, 1, 0, 0, 0xFD, 0xEA]); // AS_PATH seq [65002]
+    attrs.extend([0x40, 3, 4, 10, 0, 0, 2]); // NEXT_HOP 10.0.0.2
+    attrs.extend_from_slice(extra);
+    attrs
+}
+
+/// Drain the establishment-time RIB messages (`SetPeerExportContext`, `PeerUp`,
+/// ...) so tests observe only what `process_update` produces.
+fn rfc7606_drain(rib_rx: &mut mpsc::Receiver<RibUpdate>) {
+    while rib_rx.try_recv().is_ok() {}
+}
+
+fn rfc7606_update(attr_bytes: Vec<u8>, announced: &[Ipv4Prefix]) -> UpdateMessage {
+    let mut nlri = Vec::new();
+    rustbgpd_wire::nlri::encode_nlri(announced, &mut nlri);
+    UpdateMessage {
+        withdrawn_routes: Bytes::new(),
+        path_attributes: Bytes::from(attr_bytes),
+        nlri: Bytes::from(nlri),
+    }
+}
+
+/// RFC 7606 §7.4 + §2: a malformed MED treats the UPDATE as though its
+/// routes had been withdrawn — previously accepted routes for the same
+/// NLRI are removed — and the session stays Established.
+#[tokio::test]
+async fn rfc7606_treat_as_withdraw_removes_routes_and_keeps_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix_a = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let prefix_b = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    // Announce both prefixes cleanly.
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[]),
+            &[prefix_a, prefix_b],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected initial accepted routes");
+    };
+    assert_eq!(announced.len(), 2);
+    // Re-announce with a malformed MED appended (length 3, must be 4).
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0x80, 4, 3, 0, 0, 1]),
+            &[prefix_a, prefix_b],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived {
+        announced,
+        withdrawn,
+        ..
+    } = rib_rx.try_recv().unwrap()
+    else {
+        panic!("expected treat-as-withdraw RoutesReceived");
+    };
+    assert!(
+        announced.is_empty(),
+        "a malformed MED must not admit any announcement"
+    );
+    assert_eq!(withdrawn.len(), 2);
+    assert!(withdrawn.contains(&(Prefix::V4(prefix_a), 0)));
+    assert!(withdrawn.contains(&(Prefix::V4(prefix_b), 0)));
+    assert_eq!(session.known_prefix_count(), 0);
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "treat-as-withdraw must keep the session Established"
+    );
+}
+
+/// RFC 7606 §7.7: a malformed AGGREGATOR is attribute-discard — the UPDATE
+/// (and its announcements) proceed without the attribute, and the session
+/// stays Established.
+#[tokio::test]
+async fn rfc7606_attribute_discard_keeps_announcement_and_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    // AGGREGATOR with length 5 (must be 8 under 4-octet-AS negotiation).
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0xC0, 7, 5, 0, 0, 0xFD, 0xEA, 1]),
+            &[prefix],
+        ))
+        .await;
+    let RibUpdate::RoutesReceived { announced, .. } = rib_rx.try_recv().unwrap() else {
+        panic!("expected the announcement to survive attribute-discard");
+    };
+    assert_eq!(announced.len(), 1);
+    assert_eq!(announced[0].prefix, Prefix::V4(prefix));
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}
+
+/// RFC 7606 §7.11: a malformed `MP_REACH_NLRI` means the NLRI cannot be
+/// located — the session-reset approach is retained.
+#[tokio::test]
+async fn rfc7606_malformed_mp_reach_still_resets_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    // MP_REACH_NLRI truncated to 2 bytes (minimum is 5).
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0x80, 14, 2, 0, 1]),
+            &[prefix],
+        ))
+        .await;
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "malformed MP_REACH_NLRI must reset the session"
+    );
+    // Teardown emits PeerDown/GR messages; none of them may carry routes.
+    while let Ok(msg) = rib_rx.try_recv() {
+        assert!(
+            !matches!(msg, RibUpdate::RoutesReceived { .. }),
+            "no routes may be delivered"
+        );
+    }
+}
+
+/// RFC 7606 §5.2: an UPDATE carrying path attributes but no reachable NLRI
+/// gives no confidence its NLRI parsed; a treat-as-withdraw-class error must
+/// escalate to session reset.
+#[tokio::test]
+async fn rfc7606_malformed_attr_without_reachable_nlri_resets_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    // Malformed MED, no NLRI anywhere in the UPDATE.
+    session
+        .process_update(rfc7606_update(
+            rfc7606_attr_bytes(&[0x80, 4, 3, 0, 0, 1]),
+            &[],
+        ))
+        .await;
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "treat-as-withdraw with no reachable NLRI must reset (RFC 7606 §5.2)"
+    );
+    while let Ok(msg) = rib_rx.try_recv() {
+        assert!(
+            !matches!(msg, RibUpdate::RoutesReceived { .. }),
+            "no routes may be delivered"
+        );
+    }
+}
+
+/// An UPDATE whose only attributes were discarded as malformed must not be
+/// mistaken for an End-of-RIB marker.
+#[tokio::test]
+async fn rfc7606_discarded_attrs_do_not_fake_end_of_rib() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    // Only a malformed ATOMIC_AGGREGATE (attribute-discard), nothing else.
+    session
+        .process_update(rfc7606_update(vec![0x40, 6, 1, 0xAB], &[]))
+        .await;
+    assert!(rib_rx.try_recv().is_err());
+    assert!(
+        !session
+            .received_eor_families
+            .contains(&(Afi::Ipv4, Safi::Unicast)),
+        "an all-attributes-discarded UPDATE is junk, not an EoR"
+    );
+    assert_eq!(session.fsm.state(), SessionState::Established);
+}

--- a/crates/wire/fuzz/fuzz_targets/decode_update.rs
+++ b/crates/wire/fuzz/fuzz_targets/decode_update.rs
@@ -15,6 +15,11 @@ fuzz_target!(|data: &[u8]| {
         let _ = update.parse(true, false, &[]);
         let _ = update.parse(false, false, &[]);
         let _ = update.parse(true, true, &[]);
+        // RFC 7606 revised decode: recoverable per-attribute error handling
+        // (iBGP and eBGP disposition branches).
+        let _ = update.parse_revised(true, true, false, &[]);
+        let _ = update.parse_revised(true, false, false, &[]);
+        let _ = update.parse_revised(false, true, true, &[]);
         let _ = update.parse(
             true,
             false,

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -3,6 +3,7 @@ use crate::constants::{as_path_segment, attr_flags, attr_type};
 use crate::error::{DecodeError, EncodeError};
 use crate::nlri::{NlriEntry, Prefix};
 use crate::notification::update_subcode;
+use crate::validate::{ErrorDisposition, malformed_attr_disposition};
 use bytes::Bytes;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -793,49 +794,7 @@ pub fn decode_path_attributes_counted(
     let mut attrs = Vec::new();
     let mut bgpls_discarded = 0_u32;
     while !buf.is_empty() {
-        // Need at least flags(1) + type(1) = 2
-        if buf.len() < 2 {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: "truncated attribute header".to_string(),
-            });
-        }
-        let flags = buf[0];
-        let type_code = buf[1];
-        buf = &buf[2..];
-        let extended = (flags & attr_flags::EXTENDED_LENGTH) != 0;
-        let value_len = if extended {
-            if buf.len() < 2 {
-                return Err(DecodeError::MalformedField {
-                    message_type: "UPDATE",
-                    detail: "truncated extended-length attribute".to_string(),
-                });
-            }
-            let len = u16::from_be_bytes([buf[0], buf[1]]) as usize;
-            buf = &buf[2..];
-            len
-        } else {
-            if buf.is_empty() {
-                return Err(DecodeError::MalformedField {
-                    message_type: "UPDATE",
-                    detail: "truncated attribute length".to_string(),
-                });
-            }
-            let len = buf[0] as usize;
-            buf = &buf[1..];
-            len
-        };
-        if buf.len() < value_len {
-            return Err(DecodeError::MalformedField {
-                message_type: "UPDATE",
-                detail: format!(
-                    "attribute type {type_code} value truncated: need {value_len}, have {}",
-                    buf.len()
-                ),
-            });
-        }
-        let value = &buf[..value_len];
-        buf = &buf[value_len..];
+        let (flags, type_code, value) = split_next_attribute(&mut buf)?;
         let attr = decode_attribute_value(
             flags,
             type_code,
@@ -847,6 +806,207 @@ pub fn decode_path_attributes_counted(
         attrs.push(attr);
     }
     Ok((attrs, bgpls_discarded))
+}
+/// Split the next `flags(1) + type(1) + length(1|2) + value` attribute off
+/// the front of `buf`, advancing it past the attribute. On error `buf` is
+/// left unchanged.
+fn split_next_attribute<'a>(buf: &mut &'a [u8]) -> Result<(u8, u8, &'a [u8]), DecodeError> {
+    // Need at least flags(1) + type(1) = 2
+    if buf.len() < 2 {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: "truncated attribute header".to_string(),
+        });
+    }
+    let flags = buf[0];
+    let type_code = buf[1];
+    let mut rest = &buf[2..];
+    let extended = (flags & attr_flags::EXTENDED_LENGTH) != 0;
+    let value_len = if extended {
+        if rest.len() < 2 {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: "truncated extended-length attribute".to_string(),
+            });
+        }
+        let len = u16::from_be_bytes([rest[0], rest[1]]) as usize;
+        rest = &rest[2..];
+        len
+    } else {
+        if rest.is_empty() {
+            return Err(DecodeError::MalformedField {
+                message_type: "UPDATE",
+                detail: "truncated attribute length".to_string(),
+            });
+        }
+        let len = rest[0] as usize;
+        rest = &rest[1..];
+        len
+    };
+    if rest.len() < value_len {
+        return Err(DecodeError::MalformedField {
+            message_type: "UPDATE",
+            detail: format!(
+                "attribute type {type_code} value truncated: need {value_len}, have {}",
+                rest.len()
+            ),
+        });
+    }
+    let value = &rest[..value_len];
+    *buf = &rest[value_len..];
+    Ok((flags, type_code, value))
+}
+/// A malformed path attribute recovered during [`decode_path_attributes_revised`].
+///
+/// Carries enough context for the session layer to log the malformation and
+/// apply the RFC 7606 disposition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MalformedAttribute {
+    /// Attribute type code of the offending attribute (0 if the attribute
+    /// header itself was too truncated to carry one).
+    pub type_code: u8,
+    /// RFC 7606 disposition for this malformation.
+    pub disposition: ErrorDisposition,
+    /// The underlying decode error.
+    pub error: DecodeError,
+}
+/// Result of [`decode_path_attributes_revised`]: the attributes that decoded
+/// cleanly plus the malformations recovered per RFC 7606.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevisedAttributeDecode {
+    /// Attributes that decoded cleanly (malformed ones are omitted).
+    pub attributes: Vec<PathAttribute>,
+    /// BGP-LS NLRIs dropped for out-of-order descriptor TLVs (RFC 9552).
+    pub bgpls_nlri_discarded: u32,
+    /// Malformed attributes recovered without aborting the decode, each with
+    /// its RFC 7606 disposition. Empty means the UPDATE was clean.
+    pub malformed: Vec<MalformedAttribute>,
+}
+/// Decode path attributes with RFC 7606 revised error handling.
+///
+/// Unlike [`decode_path_attributes`], a malformed attribute does not abort
+/// the decode: the offending attribute is isolated (its length field is
+/// self-consistent, so the remaining attributes can still be located) and
+/// recorded in [`RevisedAttributeDecode::malformed`] with its RFC 7606 §7
+/// disposition. The caller applies the strongest recorded disposition
+/// (§3 (h)).
+///
+/// Differences from the legacy decoder, all per RFC 7606:
+///
+/// - §3 (g): a duplicate attribute type keeps the first occurrence and
+///   discards the rest; duplicate `MP_REACH_NLRI`/`MP_UNREACH_NLRI` is fatal.
+/// - §4: an attribute whose length overruns the section is treat-as-withdraw
+///   (the NLRI field was already located from the UPDATE section lengths),
+///   and attribute parsing stops.
+/// - §7.6/§7.7: `ATOMIC_AGGREGATE` with a non-zero length and `AGGREGATOR`
+///   with a length other than 6/8 (by the 4-octet-AS negotiation) are
+///   attribute-discard. The legacy decoder passes both through opaquely.
+///
+/// `is_ibgp` selects the internal-neighbor branch of
+/// [`malformed_attr_disposition`] for `LOCAL_PREF` / `ORIGINATOR_ID` /
+/// `CLUSTER_LIST`.
+///
+/// # Errors
+///
+/// Returns `Err` only for session-reset-class problems: a malformed or
+/// duplicated `MP_REACH_NLRI`/`MP_UNREACH_NLRI` (§7.11 — the NLRI cannot be
+/// reliably located).
+pub fn decode_path_attributes_revised(
+    mut buf: &[u8],
+    four_octet_as: bool,
+    is_ibgp: bool,
+    add_path_families: &[(Afi, Safi)],
+) -> Result<RevisedAttributeDecode, DecodeError> {
+    let mut attrs = Vec::new();
+    let mut bgpls_discarded = 0_u32;
+    let mut malformed = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    while !buf.is_empty() {
+        let (flags, type_code, value) = match split_next_attribute(&mut buf) {
+            Ok(split) => split,
+            Err(error) => {
+                // RFC 7606 §4: framing overrun/underrun inside the attribute
+                // section is treat-as-withdraw — the section boundaries (and
+                // thus the NLRI field) were already fixed by the UPDATE
+                // length fields. Nothing after this point can be parsed.
+                malformed.push(MalformedAttribute {
+                    type_code: if buf.len() >= 2 { buf[1] } else { 0 },
+                    disposition: ErrorDisposition::TreatAsWithdraw,
+                    error,
+                });
+                break;
+            }
+        };
+        if !seen.insert(type_code) {
+            // RFC 7606 §3 (g): duplicate MP_REACH/MP_UNREACH is fatal; any
+            // other duplicate keeps the first occurrence and discards the
+            // rest while the UPDATE continues to be processed.
+            let error = DecodeError::UpdateAttributeError {
+                subcode: update_subcode::MALFORMED_ATTRIBUTE_LIST,
+                data: vec![],
+                detail: format!("duplicate attribute type {type_code}"),
+            };
+            if matches!(
+                type_code,
+                attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI
+            ) {
+                return Err(error);
+            }
+            malformed.push(MalformedAttribute {
+                type_code,
+                disposition: ErrorDisposition::AttributeDiscard,
+                error,
+            });
+            continue;
+        }
+        // RFC 7606 §7.6/§7.7 length checks. The legacy decoder stores both
+        // types opaquely as Unknown(RawAttribute) with no length validation,
+        // so these checks live only on the revised path.
+        let expected_aggregator_len = if four_octet_as { 8 } else { 6 };
+        let bad_aggregate_len = match type_code {
+            attr_type::ATOMIC_AGGREGATE => !value.is_empty(),
+            attr_type::AGGREGATOR => value.len() != expected_aggregator_len,
+            _ => false,
+        };
+        if bad_aggregate_len {
+            malformed.push(MalformedAttribute {
+                type_code,
+                disposition: ErrorDisposition::AttributeDiscard,
+                error: DecodeError::UpdateAttributeError {
+                    subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
+                    data: attr_error_data(flags, type_code, value),
+                    detail: format!("attribute type {type_code} length {}", value.len()),
+                },
+            });
+            continue;
+        }
+        match decode_attribute_value(
+            flags,
+            type_code,
+            value,
+            four_octet_as,
+            add_path_families,
+            &mut bgpls_discarded,
+        ) {
+            Ok(attr) => attrs.push(attr),
+            Err(error) => {
+                let disposition = malformed_attr_disposition(type_code, is_ibgp);
+                if disposition == ErrorDisposition::SessionReset {
+                    return Err(error);
+                }
+                malformed.push(MalformedAttribute {
+                    type_code,
+                    disposition,
+                    error,
+                });
+            }
+        }
+    }
+    Ok(RevisedAttributeDecode {
+        attributes: attrs,
+        bgpls_nlri_discarded: bgpls_discarded,
+        malformed,
+    })
 }
 /// Decode a single attribute value given its flags, type code, and raw bytes.
 #[expect(
@@ -5004,6 +5164,252 @@ mod tests {
             buf[0],
             attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
             "locally-constructed OTC must emit 0xC0, never 0xE0"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // RFC 7606 revised error handling — decode_path_attributes_revised
+    // -----------------------------------------------------------------
+    fn attr_bytes(flags: u8, type_code: u8, value: &[u8]) -> Vec<u8> {
+        let mut buf = vec![flags, type_code, u8::try_from(value.len()).unwrap()];
+        buf.extend_from_slice(value);
+        buf
+    }
+    fn valid_origin_bytes() -> Vec<u8> {
+        attr_bytes(attr_flags::TRANSITIVE, attr_type::ORIGIN, &[0])
+    }
+    fn valid_as_path_bytes() -> Vec<u8> {
+        // One 4-octet AS_SEQUENCE segment holding ASN 65001.
+        attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::AS_PATH,
+            &[2, 1, 0, 0, 0xFD, 0xE9],
+        )
+    }
+    fn valid_next_hop_bytes() -> Vec<u8> {
+        attr_bytes(attr_flags::TRANSITIVE, attr_type::NEXT_HOP, &[10, 0, 0, 2])
+    }
+    /// Craft `<valid ORIGIN, AS_PATH, NEXT_HOP> + extra` attribute bytes.
+    fn valid_attrs_plus(extra: &[u8]) -> Vec<u8> {
+        let mut buf = valid_origin_bytes();
+        buf.extend(valid_as_path_bytes());
+        buf.extend(valid_next_hop_bytes());
+        buf.extend_from_slice(extra);
+        buf
+    }
+    #[test]
+    fn revised_malformed_med_is_treat_as_withdraw() {
+        // RFC 7606 §7.4: MULTI_EXIT_DISC with length != 4 → treat-as-withdraw.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL,
+            attr_type::MULTI_EXIT_DISC,
+            &[0, 0, 1],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 3, "valid attributes must survive");
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::MULTI_EXIT_DISC);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+        // The legacy decoder still aborts on the same bytes.
+        assert!(decode_path_attributes(&buf, true, &[]).is_err());
+    }
+    #[test]
+    fn revised_malformed_communities_is_treat_as_withdraw() {
+        // RFC 7606 §7.8: Community length not a non-zero multiple of 4.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::COMMUNITIES,
+            &[0, 0, 0, 1, 2],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 3);
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+    #[test]
+    fn revised_malformed_as_path_is_treat_as_withdraw_not_reset() {
+        // RFC 7606 §7.2: a malformed AS_PATH is treat-as-withdraw — 7606
+        // moved it OFF the session-reset ladder. Segment claims two ASNs
+        // but carries bytes for one.
+        let mut buf = valid_origin_bytes();
+        buf.extend(attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::AS_PATH,
+            &[2, 2, 0, 0, 0xFD, 0xE9],
+        ));
+        buf.extend(valid_next_hop_bytes());
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 2);
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::AS_PATH);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+    #[test]
+    fn revised_malformed_aggregator_is_attribute_discard() {
+        // RFC 7606 §7.7: AGGREGATOR length must be 8 under 4-octet-AS
+        // negotiation; anything else is attribute-discard. The legacy
+        // decoder passes AGGREGATOR through opaquely, so this check only
+        // exists on the revised path.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::AGGREGATOR,
+            &[0, 0, 0xFD, 0xE9, 10],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 3);
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::AGGREGATOR);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+        // A correct-length AGGREGATOR still passes through untouched.
+        let good = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::AGGREGATOR,
+            &[0, 0, 0xFD, 0xE9, 10, 0, 0, 1],
+        ));
+        let decoded = decode_path_attributes_revised(&good, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 4);
+        assert!(decoded.malformed.is_empty());
+    }
+    #[test]
+    fn revised_malformed_atomic_aggregate_is_attribute_discard() {
+        // RFC 7606 §7.6: ATOMIC_AGGREGATE length must be 0.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::ATOMIC_AGGREGATE,
+            &[0xAB],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 3);
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+    }
+    #[test]
+    fn revised_local_pref_disposition_depends_on_session_type() {
+        // RFC 7606 §7.5: malformed LOCAL_PREF is attribute-discard from an
+        // external neighbor, treat-as-withdraw from an internal one.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::LOCAL_PREF,
+            &[0, 0, 1],
+        ));
+        let ibgp = decode_path_attributes_revised(&buf, true, true, &[]).unwrap();
+        assert_eq!(
+            ibgp.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+        let ebgp = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(
+            ebgp.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+    }
+    #[test]
+    fn revised_flag_conflict_is_treat_as_withdraw() {
+        // RFC 7606 §3 (c): Optional/Transitive bits conflicting with the
+        // attribute's specified values → treat-as-withdraw.
+        let mut buf = attr_bytes(
+            attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+            attr_type::ORIGIN,
+            &[0],
+        );
+        buf.extend(valid_as_path_bytes());
+        buf.extend(valid_next_hop_bytes());
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 2);
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::ORIGIN);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+    #[test]
+    fn revised_malformed_mp_reach_is_session_reset() {
+        // RFC 7606 §7.11: a malformed MP_REACH_NLRI means the NLRI cannot
+        // be located — session reset stays the only safe approach.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL,
+            attr_type::MP_REACH_NLRI,
+            &[0, 1],
+        ));
+        assert!(decode_path_attributes_revised(&buf, true, false, &[]).is_err());
+    }
+    #[test]
+    fn revised_duplicate_attribute_keeps_first_and_discards_rest() {
+        // RFC 7606 §3 (g): occurrences other than the first are discarded
+        // and the UPDATE continues to be processed.
+        let mut buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::OPTIONAL,
+            attr_type::MULTI_EXIT_DISC,
+            &[0, 0, 0, 5],
+        ));
+        buf.extend(attr_bytes(
+            attr_flags::OPTIONAL,
+            attr_type::MULTI_EXIT_DISC,
+            &[0, 0, 0, 9],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert!(decoded.attributes.contains(&PathAttribute::Med(5)));
+        assert!(!decoded.attributes.contains(&PathAttribute::Med(9)));
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::AttributeDiscard
+        );
+    }
+    #[test]
+    fn revised_duplicate_mp_unreach_is_session_reset() {
+        // RFC 7606 §3 (g): duplicate MP_REACH_NLRI / MP_UNREACH_NLRI is a
+        // Malformed Attribute List NOTIFICATION.
+        let mp_unreach = attr_bytes(attr_flags::OPTIONAL, attr_type::MP_UNREACH_NLRI, &[0, 2, 1]);
+        let mut buf = mp_unreach.clone();
+        buf.extend(mp_unreach);
+        assert!(decode_path_attributes_revised(&buf, true, false, &[]).is_err());
+    }
+    #[test]
+    fn revised_attribute_overrun_is_treat_as_withdraw_and_stops() {
+        // RFC 7606 §4: an attribute length that overruns the section is
+        // treat-as-withdraw; nothing beyond it can be parsed.
+        let mut buf = valid_origin_bytes();
+        buf.extend([attr_flags::OPTIONAL, attr_type::MULTI_EXIT_DISC, 200, 1, 2]);
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(
+            decoded.attributes.len(),
+            1,
+            "attributes before the overrun survive"
+        );
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::MULTI_EXIT_DISC);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+    #[test]
+    fn revised_clean_update_reports_nothing() {
+        let buf = valid_attrs_plus(&[]);
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.attributes.len(), 3);
+        assert!(decoded.malformed.is_empty());
+        // Matches the legacy decoder on clean input.
+        assert_eq!(
+            decoded.attributes,
+            decode_path_attributes(&buf, true, &[]).unwrap()
         );
     }
 }

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -961,13 +961,21 @@ pub fn decode_path_attributes_revised(
         }
         // RFC 7606 §7.6/§7.7 length checks. The legacy decoder stores both
         // types opaquely as Unknown(RawAttribute) with no length validation,
-        // so these checks live only on the revised path.
+        // so these checks live only on the revised path. The attribute-discard
+        // shortcut applies only when the flags are correct: a flag conflict
+        // must fall through to decode_attribute_value, whose flags error is
+        // classified treat-as-withdraw below (§3 (c) — the stronger action
+        // wins per §3 (h)).
+        let flags_ok = expected_flags(type_code).is_none_or(|expected| {
+            (flags & (attr_flags::OPTIONAL | attr_flags::TRANSITIVE)) == expected
+        });
         let expected_aggregator_len = if four_octet_as { 8 } else { 6 };
-        let bad_aggregate_len = match type_code {
-            attr_type::ATOMIC_AGGREGATE => !value.is_empty(),
-            attr_type::AGGREGATOR => value.len() != expected_aggregator_len,
-            _ => false,
-        };
+        let bad_aggregate_len = flags_ok
+            && match type_code {
+                attr_type::ATOMIC_AGGREGATE => !value.is_empty(),
+                attr_type::AGGREGATOR => value.len() != expected_aggregator_len,
+                _ => false,
+            };
         if bad_aggregate_len {
             malformed.push(MalformedAttribute {
                 type_code,
@@ -990,7 +998,20 @@ pub fn decode_path_attributes_revised(
         ) {
             Ok(attr) => attrs.push(attr),
             Err(error) => {
-                let disposition = malformed_attr_disposition(type_code, is_ibgp);
+                // RFC 7606 §3 (c): an Optional/Transitive flag conflict is
+                // treat-as-withdraw for every attribute — the §7.6/§7.7
+                // attribute-discard covers length malformations only. max()
+                // keeps MP_REACH/MP_UNREACH at session-reset (§5.3 lists
+                // inconsistent flags among what makes the MP attribute
+                // itself incorrect).
+                let mut disposition = malformed_attr_disposition(type_code, is_ibgp);
+                if matches!(
+                    &error,
+                    DecodeError::UpdateAttributeError { subcode, .. }
+                        if *subcode == update_subcode::ATTRIBUTE_FLAGS_ERROR
+                ) {
+                    disposition = disposition.max(ErrorDisposition::TreatAsWithdraw);
+                }
                 if disposition == ErrorDisposition::SessionReset {
                     return Err(error);
                 }
@@ -1099,11 +1120,15 @@ fn decode_attribute_value(
             Ok(PathAttribute::LocalPref(lp))
         }
         attr_type::COMMUNITIES => {
-            if !value.len().is_multiple_of(4) {
+            // RFC 7606 §7.8: the length must be a NON-ZERO multiple of 4.
+            if value.is_empty() || !value.len().is_multiple_of(4) {
                 return Err(DecodeError::UpdateAttributeError {
                     subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
                     data: attr_error_data(flags, type_code, value),
-                    detail: format!("COMMUNITIES length {} not a multiple of 4", value.len()),
+                    detail: format!(
+                        "COMMUNITIES length {} not a non-zero multiple of 4",
+                        value.len()
+                    ),
                 });
             }
             let communities = value
@@ -1113,12 +1138,13 @@ fn decode_attribute_value(
             Ok(PathAttribute::Communities(communities))
         }
         attr_type::EXTENDED_COMMUNITIES => {
-            if !value.len().is_multiple_of(8) {
+            // RFC 7606 §7.14: the length must be a NON-ZERO multiple of 8.
+            if value.is_empty() || !value.len().is_multiple_of(8) {
                 return Err(DecodeError::UpdateAttributeError {
                     subcode: update_subcode::ATTRIBUTE_LENGTH_ERROR,
                     data: attr_error_data(flags, type_code, value),
                     detail: format!(
-                        "EXTENDED_COMMUNITIES length {} not a multiple of 8",
+                        "EXTENDED_COMMUNITIES length {} not a non-zero multiple of 8",
                         value.len()
                     ),
                 });
@@ -3719,11 +3745,12 @@ mod tests {
         assert_eq!(attrs[0], PathAttribute::Communities(vec![c1, c2]));
     }
     #[test]
-    fn decode_communities_empty() {
-        // flags=0xC0, type=8, len=0
+    fn decode_communities_empty_rejected() {
+        // flags=0xC0, type=8, len=0 — RFC 7606 §7.8: the length must be a
+        // NON-ZERO multiple of 4, so a vacuous Communities attribute is
+        // malformed (treat-as-withdraw on the revised path).
         let buf = [0xC0, 0x08, 0x00];
-        let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
-        assert_eq!(attrs[0], PathAttribute::Communities(vec![]));
+        assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
     #[test]
     fn decode_communities_odd_length_rejected() {
@@ -3774,10 +3801,10 @@ mod tests {
         assert_eq!(attrs[0], PathAttribute::ExtendedCommunities(vec![ec1, ec2]));
     }
     #[test]
-    fn decode_extended_communities_empty() {
+    fn decode_extended_communities_empty_rejected() {
+        // RFC 7606 §7.14: the length must be a NON-ZERO multiple of 8.
         let buf = [0xC0, 0x10, 0x00];
-        let attrs = decode_path_attributes(&buf, true, &[]).unwrap();
-        assert_eq!(attrs[0], PathAttribute::ExtendedCommunities(vec![]));
+        assert!(decode_path_attributes(&buf, true, &[]).is_err());
     }
     #[test]
     fn decode_extended_communities_bad_length() {
@@ -5297,6 +5324,59 @@ mod tests {
             decoded.malformed[0].disposition,
             ErrorDisposition::AttributeDiscard
         );
+    }
+    #[test]
+    fn revised_flag_conflict_on_aggregator_is_treat_as_withdraw() {
+        // RFC 7606 §3 (c): a flag conflict is treat-as-withdraw for every
+        // attribute — §7.6/§7.7 attribute-discard covers length
+        // malformations only. AGGREGATOR expects Optional|Transitive; send
+        // Transitive only, with a CORRECT length.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::AGGREGATOR,
+            &[0, 0, 0xFD, 0xE9, 10, 0, 0, 1],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(decoded.malformed.len(), 1);
+        assert_eq!(decoded.malformed[0].type_code, attr_type::AGGREGATOR);
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+        // Flag conflict AND bad length: §3 (h) — the stronger action
+        // (treat-as-withdraw) still wins over the length discard.
+        let buf = valid_attrs_plus(&attr_bytes(
+            attr_flags::TRANSITIVE,
+            attr_type::AGGREGATOR,
+            &[0, 0, 0xFD],
+        ));
+        let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+        assert_eq!(
+            decoded.malformed[0].disposition,
+            ErrorDisposition::TreatAsWithdraw
+        );
+    }
+    #[test]
+    fn revised_zero_length_communities_are_treat_as_withdraw() {
+        // RFC 7606 §7.8 / §7.14: the length must be a NON-ZERO multiple of
+        // 4 (Communities) / 8 (Extended Communities).
+        for type_code in [attr_type::COMMUNITIES, attr_type::EXTENDED_COMMUNITIES] {
+            let buf = valid_attrs_plus(&attr_bytes(
+                attr_flags::OPTIONAL | attr_flags::TRANSITIVE,
+                type_code,
+                &[],
+            ));
+            // Legacy decoder now rejects the vacuous attribute outright.
+            assert!(decode_path_attributes(&buf, true, &[]).is_err());
+            let decoded = decode_path_attributes_revised(&buf, true, false, &[]).unwrap();
+            assert_eq!(decoded.attributes.len(), 3);
+            assert_eq!(decoded.malformed.len(), 1);
+            assert_eq!(decoded.malformed[0].type_code, type_code);
+            assert_eq!(
+                decoded.malformed[0].disposition,
+                ErrorDisposition::TreatAsWithdraw
+            );
+        }
     }
     #[test]
     fn revised_local_pref_disposition_depends_on_session_type() {

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -211,8 +211,8 @@ impl std::str::FromStr for AspaValidation {
 
 // Re-export attribute types
 pub use attribute::{
-    AsPath, AsPathSegment, ExtendedCommunity, LargeCommunity, MpReachNlri, MpUnreachNlri, Origin,
-    PathAttribute, RawAttribute, is_private_asn,
+    AsPath, AsPathSegment, ExtendedCommunity, LargeCommunity, MalformedAttribute, MpReachNlri,
+    MpUnreachNlri, Origin, PathAttribute, RawAttribute, RevisedAttributeDecode, is_private_asn,
 };
 pub use bgpls::{
     BGP_LS_AFI, BGP_LS_ROUTE_DISTINGUISHER_LEN, BGP_LS_SAFI, BGP_LS_VPN_SAFI, BgpLsNlri,
@@ -235,8 +235,11 @@ pub use orf::{
     OrfPayload, OrfSendReceive, OrfType, WhenToRefresh,
 };
 pub use pmsi::{PmsiTunnel, PmsiTunnelIdentifier, PmsiTunnelType};
-pub use update::ParsedUpdate;
-pub use validate::{UpdateError, UpdateValidationOptions, is_valid_ipv6_nexthop};
+pub use update::{ParsedUpdate, RevisedParsedUpdate};
+pub use validate::{
+    ErrorDisposition, UpdateError, UpdateValidationOptions, is_valid_ipv6_nexthop,
+    malformed_attr_disposition,
+};
 
 // Re-export FlowSpec types
 pub use flowspec::{

--- a/crates/wire/src/update.rs
+++ b/crates/wire/src/update.rs
@@ -46,6 +46,17 @@ pub struct ParsedUpdate {
     /// silent drop with peer context.
     pub bgpls_nlri_discarded: u32,
 }
+/// A parsed UPDATE from [`UpdateMessage::parse_revised`]: the cleanly decoded
+/// parts plus the malformed attributes recovered per RFC 7606.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevisedParsedUpdate {
+    /// The parsed UPDATE. Malformed attributes are omitted from
+    /// `update.attributes`.
+    pub update: ParsedUpdate,
+    /// Malformed attributes recovered without aborting the parse, each with
+    /// its RFC 7606 disposition. Empty means the UPDATE decoded cleanly.
+    pub malformed: Vec<crate::attribute::MalformedAttribute>,
+}
 impl UpdateMessage {
     /// Decode an UPDATE message body from a buffer.
     /// The header must already be consumed; `body_len` is
@@ -147,6 +158,63 @@ impl UpdateMessage {
             attributes,
             announced,
             bgpls_nlri_discarded,
+        })
+    }
+    /// Parse the raw UPDATE with RFC 7606 revised error handling.
+    ///
+    /// Like [`parse()`](Self::parse), but a malformed path attribute does not
+    /// abort the parse: it is omitted from `update.attributes` and recorded in
+    /// `malformed` with its RFC 7606 disposition (see
+    /// [`crate::attribute::decode_path_attributes_revised`]). The caller
+    /// applies the strongest recorded disposition (§3 (h)).
+    ///
+    /// `is_ibgp` selects the internal-neighbor disposition branch for
+    /// `LOCAL_PREF` / `ORIGINATOR_ID` / `CLUSTER_LIST` (§7.5, §7.9, §7.10).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DecodeError` only for session-reset-class problems: malformed
+    /// or duplicated `MP_REACH_NLRI`/`MP_UNREACH_NLRI` (§7.11), or
+    /// syntactically incorrect body NLRI / Withdrawn Routes fields (§5.3 —
+    /// treat-as-withdraw is impossible when the NLRI itself cannot be parsed,
+    /// §3 (j)).
+    pub fn parse_revised(
+        &self,
+        four_octet_as: bool,
+        is_ibgp: bool,
+        add_path_ipv4: bool,
+        add_path_families: &[(Afi, Safi)],
+    ) -> Result<RevisedParsedUpdate, DecodeError> {
+        let withdrawn = if add_path_ipv4 {
+            crate::nlri::decode_nlri_addpath(&self.withdrawn_routes)?
+        } else {
+            crate::nlri::decode_nlri(&self.withdrawn_routes)?
+                .into_iter()
+                .map(|prefix| Ipv4NlriEntry { path_id: 0, prefix })
+                .collect()
+        };
+        let decoded = crate::attribute::decode_path_attributes_revised(
+            &self.path_attributes,
+            four_octet_as,
+            is_ibgp,
+            add_path_families,
+        )?;
+        let announced = if add_path_ipv4 {
+            crate::nlri::decode_nlri_addpath(&self.nlri)?
+        } else {
+            crate::nlri::decode_nlri(&self.nlri)?
+                .into_iter()
+                .map(|prefix| Ipv4NlriEntry { path_id: 0, prefix })
+                .collect()
+        };
+        Ok(RevisedParsedUpdate {
+            update: ParsedUpdate {
+                withdrawn,
+                attributes: decoded.attributes,
+                announced,
+                bgpls_nlri_discarded: decoded.bgpls_nlri_discarded,
+            },
+            malformed: decoded.malformed,
         })
     }
     /// Encode a complete UPDATE message (header + body) into a buffer.
@@ -561,5 +629,39 @@ mod tests {
             msg.encode(&mut buf),
             Err(EncodeError::MessageTooLong { .. })
         ));
+    }
+
+    #[test]
+    fn parse_revised_recovers_malformed_attribute_and_keeps_nlri() {
+        // ORIGIN + AS_PATH + NEXT_HOP + malformed MED (length 3), one
+        // announced prefix. RFC 7606: the malformed attribute is reported
+        // with its disposition; the NLRI still parses.
+        let mut attrs = vec![0x40, 1, 1, 0]; // ORIGIN
+        attrs.extend([0x40, 2, 6, 2, 1, 0, 0, 0xFD, 0xE9]); // AS_PATH (65001)
+        attrs.extend([0x40, 3, 4, 10, 0, 0, 2]); // NEXT_HOP
+        attrs.extend([0x80, 4, 3, 0, 0, 1]); // MED, bad length
+        let msg = UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::from(attrs),
+            nlri: Bytes::from_static(&[24, 203, 0, 113]),
+        };
+        // The legacy parse still aborts on the same bytes.
+        assert!(msg.parse(true, false, &[]).is_err());
+        let revised = msg.parse_revised(true, false, false, &[]).unwrap();
+        assert_eq!(revised.update.attributes.len(), 3);
+        assert_eq!(revised.update.announced.len(), 1);
+        assert_eq!(revised.malformed.len(), 1);
+        assert_eq!(revised.malformed[0].type_code, 4);
+    }
+    #[test]
+    fn parse_revised_still_rejects_unparseable_nlri() {
+        // RFC 7606 §5.3 / §3 (j): treat-as-withdraw is impossible when the
+        // NLRI field itself cannot be parsed — hard error (session reset).
+        let msg = UpdateMessage {
+            withdrawn_routes: Bytes::new(),
+            path_attributes: Bytes::new(),
+            nlri: Bytes::from_static(&[33, 10, 0, 0, 0]), // prefix length 33
+        };
+        assert!(msg.parse_revised(true, false, false, &[]).is_err());
     }
 }

--- a/crates/wire/src/validate.rs
+++ b/crates/wire/src/validate.rs
@@ -4,15 +4,69 @@ use crate::constants::{attr_flags, attr_type};
 use crate::notification::update_subcode;
 use std::collections::HashSet;
 use std::net::IpAddr;
+/// RFC 7606 §2 error-handling approach for a malformed UPDATE, ordered from
+/// the weakest action to the strongest. The `Ord` derive implements the
+/// §3 (h) rule directly: when multiple attribute errors exist, the approach
+/// with the strongest action wins — `max()` over the dispositions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorDisposition {
+    /// Discard the malformed attribute and keep processing the UPDATE.
+    /// Only for attributes with no effect on route selection (RFC 7606 §2).
+    AttributeDiscard,
+    /// Treat the UPDATE as though all contained routes had been withdrawn;
+    /// the session stays Established (RFC 7606 §2).
+    TreatAsWithdraw,
+    /// NOTIFICATION + session reset — the RFC 4271 §6.3 behavior, retained
+    /// only where the NLRI cannot be trusted (RFC 7606 §3 (j), §5).
+    SessionReset,
+}
+impl ErrorDisposition {
+    /// Stable label for logs.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AttributeDiscard => "attribute-discard",
+            Self::TreatAsWithdraw => "treat-as-withdraw",
+            Self::SessionReset => "session-reset",
+        }
+    }
+}
+/// RFC 7606 §7 per-attribute disposition for a malformed path attribute.
+///
+/// `is_ibgp` selects the internal-neighbor branch for `LOCAL_PREF`,
+/// `ORIGINATOR_ID`, and `CLUSTER_LIST` (§7.5, §7.9, §7.10): from an external
+/// neighbor they are attribute-discard; from an internal neighbor a
+/// malformation is treat-as-withdraw.
+///
+/// `MP_REACH_NLRI` / `MP_UNREACH_NLRI` stay session-reset (§7.11: the NLRI
+/// cannot be reliably located). `ATOMIC_AGGREGATE` and `AGGREGATOR` are
+/// attribute-discard (§7.6, §7.7). Everything else — including `AS_PATH`
+/// (§7.2) — is treat-as-withdraw.
+#[must_use]
+pub fn malformed_attr_disposition(type_code: u8, is_ibgp: bool) -> ErrorDisposition {
+    match type_code {
+        attr_type::MP_REACH_NLRI | attr_type::MP_UNREACH_NLRI => ErrorDisposition::SessionReset,
+        attr_type::ATOMIC_AGGREGATE | attr_type::AGGREGATOR => ErrorDisposition::AttributeDiscard,
+        attr_type::LOCAL_PREF | attr_type::ORIGINATOR_ID | attr_type::CLUSTER_LIST if !is_ibgp => {
+            ErrorDisposition::AttributeDiscard
+        }
+        _ => ErrorDisposition::TreatAsWithdraw,
+    }
+}
 /// Error produced by UPDATE attribute validation.
 ///
-/// Contains the NOTIFICATION subcode and data bytes per RFC 4271 §6.3.
+/// Contains the NOTIFICATION subcode and data bytes per RFC 4271 §6.3, plus
+/// the RFC 7606 disposition a revised-error-handling caller should apply.
+/// Legacy callers that ignore `disposition` keep the RFC 4271 behavior
+/// (every validation error is a session reset).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateError {
     /// NOTIFICATION subcode for this validation error.
     pub subcode: u8,
     /// Raw bytes for the NOTIFICATION data field.
     pub data: Vec<u8>,
+    /// RFC 7606 disposition for this error.
+    pub disposition: ErrorDisposition,
 }
 /// Context-dependent UPDATE validation knobs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -109,6 +163,7 @@ fn check_duplicate_types(attrs: &[PathAttribute]) -> Result<(), UpdateError> {
             return Err(UpdateError {
                 subcode: update_subcode::MALFORMED_ATTRIBUTE_LIST,
                 data: vec![],
+                disposition: ErrorDisposition::SessionReset,
             });
         }
     }
@@ -123,6 +178,7 @@ fn check_unrecognized_wellknown(attrs: &[PathAttribute]) -> Result<(), UpdateErr
                 return Err(UpdateError {
                     subcode: update_subcode::UNRECOGNIZED_WELLKNOWN,
                     data: attr_error_data(raw.flags, raw.type_code, &raw.data),
+                    disposition: ErrorDisposition::TreatAsWithdraw,
                 });
             }
         }
@@ -146,6 +202,7 @@ fn check_mandatory_present(
             return Err(UpdateError {
                 subcode: update_subcode::MISSING_WELLKNOWN,
                 data: vec![tc],
+                disposition: ErrorDisposition::TreatAsWithdraw,
             });
         }
     }
@@ -155,6 +212,7 @@ fn check_mandatory_present(
         return Err(UpdateError {
             subcode: update_subcode::MISSING_WELLKNOWN,
             data: vec![attr_type::NEXT_HOP],
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     Ok(())
@@ -167,6 +225,7 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
         return Err(UpdateError {
             subcode: update_subcode::INVALID_NEXT_HOP,
             data: octets.to_vec(),
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     // 127.0.0.0/8
@@ -174,6 +233,7 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
         return Err(UpdateError {
             subcode: update_subcode::INVALID_NEXT_HOP,
             data: octets.to_vec(),
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     // 224.0.0.0/4 (multicast)
@@ -181,6 +241,7 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
         return Err(UpdateError {
             subcode: update_subcode::INVALID_NEXT_HOP,
             data: octets.to_vec(),
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     // 255.255.255.255
@@ -188,6 +249,7 @@ fn check_next_hop(addr: std::net::Ipv4Addr) -> Result<(), UpdateError> {
         return Err(UpdateError {
             subcode: update_subcode::INVALID_NEXT_HOP,
             data: octets.to_vec(),
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     Ok(())
@@ -220,6 +282,7 @@ fn check_mp_reach_next_hop(
                 return Err(UpdateError {
                     subcode: update_subcode::INVALID_NEXT_HOP,
                     data: v6.octets().to_vec(),
+                    disposition: ErrorDisposition::TreatAsWithdraw,
                 });
             }
         }
@@ -230,6 +293,7 @@ fn check_mp_reach_next_hop(
         return Err(UpdateError {
             subcode: update_subcode::INVALID_NEXT_HOP,
             data: ll.octets().to_vec(),
+            disposition: ErrorDisposition::TreatAsWithdraw,
         });
     }
     Ok(())
@@ -259,6 +323,7 @@ fn check_as_path(path: &AsPath) -> Result<(), UpdateError> {
             return Err(UpdateError {
                 subcode: update_subcode::MALFORMED_AS_PATH,
                 data: vec![],
+                disposition: ErrorDisposition::TreatAsWithdraw,
             });
         }
     }
@@ -756,5 +821,88 @@ mod tests {
             }),
         ];
         assert!(validate_update_attributes(&attrs, false, false, true).is_ok());
+    }
+
+    // --- RFC 7606 dispositions ---
+    #[test]
+    fn dispositions_follow_rfc7606_section7() {
+        use ErrorDisposition::{AttributeDiscard, SessionReset, TreatAsWithdraw};
+        // §7.11: MP attributes stay session reset.
+        assert_eq!(
+            malformed_attr_disposition(attr_type::MP_REACH_NLRI, true),
+            SessionReset
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::MP_UNREACH_NLRI, false),
+            SessionReset
+        );
+        // §7.6 / §7.7: aggregation attributes are attribute-discard.
+        assert_eq!(
+            malformed_attr_disposition(attr_type::AGGREGATOR, true),
+            AttributeDiscard
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::ATOMIC_AGGREGATE, false),
+            AttributeDiscard
+        );
+        // §7.5 / §7.9 / §7.10: discard from external, withdraw from internal.
+        assert_eq!(
+            malformed_attr_disposition(attr_type::LOCAL_PREF, true),
+            TreatAsWithdraw
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::LOCAL_PREF, false),
+            AttributeDiscard
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::ORIGINATOR_ID, false),
+            AttributeDiscard
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::CLUSTER_LIST, true),
+            TreatAsWithdraw
+        );
+        // §7.2 / §7.4 / §7.8: everything else — including AS_PATH — is
+        // treat-as-withdraw, not session reset.
+        assert_eq!(
+            malformed_attr_disposition(attr_type::AS_PATH, false),
+            TreatAsWithdraw
+        );
+        assert_eq!(
+            malformed_attr_disposition(attr_type::MULTI_EXIT_DISC, false),
+            TreatAsWithdraw
+        );
+        // §3 (h): strongest action wins — the derive order IS the ladder.
+        assert!(SessionReset > TreatAsWithdraw);
+        assert!(TreatAsWithdraw > AttributeDiscard);
+    }
+    #[test]
+    fn validation_errors_carry_rfc7606_dispositions() {
+        // Missing mandatory well-known attribute (§3 (d)) → treat-as-withdraw.
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        ];
+        let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
+        assert_eq!(err.disposition, ErrorDisposition::TreatAsWithdraw);
+        // Malformed AS_PATH (§7.2) → treat-as-withdraw.
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 1)),
+        ];
+        let err = validate_update_attributes(&attrs, true, true, true).unwrap_err();
+        assert_eq!(err.disposition, ErrorDisposition::TreatAsWithdraw);
+        // Duplicate attribute at the validation layer stays session reset:
+        // the revised decode already deduplicated per §3 (g), so reaching
+        // this check means the caller bypassed it.
+        let attrs = vec![
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::Origin(Origin::Egp),
+        ];
+        let err = validate_update_attributes(&attrs, false, false, true).unwrap_err();
+        assert_eq!(err.disposition, ErrorDisposition::SessionReset);
     }
 }

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -15,7 +15,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 
 | Area | Standards | Scope |
 |------|-----------|-------|
-| Core BGP | RFC 4271, RFC 6793 (4-byte ASN) | FSM + UPDATE validation, dual-stack IPv4/IPv6 unicast (SAFI 1) |
+| Core BGP | RFC 4271, RFC 6793 (4-byte ASN), RFC 7606 (revised error handling) | FSM + UPDATE validation with treat-as-withdraw / attribute-discard, dual-stack IPv4/IPv6 unicast (SAFI 1) |
 | MP-BGP + extensions | RFC 4760, RFC 7911 (Add-Path), RFC 8654 (Extended Messages), RFC 8950 (Extended Next Hop) | Multiprotocol negotiation and modern capability set |
 | Route refresh / filtering | RFC 2918, RFC 7313 (Enhanced RR), RFC 5291/5292 (ORF) | Receive-side Address-Prefix ORF |
 | Communities | RFC 1997 (well-known), RFC 4360 (Extended), RFC 8092 (Large) | Match plus policy set/remove; `NO_ADVERTISE` and `NO_EXPORT`/`NO_EXPORT_SUBCONFED` egress enforcement for unicast, VPNv4/VPNv6, labeled-unicast, RTC, and BGP-LS |
@@ -339,6 +339,55 @@ prevents pathologically short hold times that would cause false flaps.
 RFC 4271 recommends a minimum of 3 seconds; we enforce it.
 
 ---
+
+## RFC 7606 — Revised BGP UPDATE Error Handling
+
+Implemented on the inbound UPDATE path: a malformed path attribute no longer
+tears the session down by default. `wire::validate::ErrorDisposition`
+classifies every attribute error as attribute-discard, treat-as-withdraw, or
+session-reset; the transport applies the strongest disposition found in the
+message (§3 (h)).
+
+- **Treat-as-withdraw** (§2): the UPDATE's routes — body NLRI and every
+  MP family — are withdrawn from the Adj-RIB-In (previously accepted
+  routes for the same NLRI are removed), announcements are dropped,
+  explicit withdrawals still apply, and the session stays Established.
+  Covers ORIGIN, AS_PATH (§7.2 — no longer a session reset), NEXT_HOP,
+  MULTI_EXIT_DISC, communities of all sizes, attribute-flag conflicts
+  (§3 (c)), missing mandatory attributes (§3 (d)), and attribute-section
+  framing overruns (§4).
+- **Attribute-discard** (§2): ATOMIC_AGGREGATE with a non-zero length and
+  AGGREGATOR with a length other than 6/8 (§7.6, §7.7) are dropped and the
+  UPDATE proceeds. Malformed LOCAL_PREF / ORIGINATOR_ID / CLUSTER_LIST from
+  an *external* neighbor are discarded (§7.5, §7.9, §7.10); from an internal
+  neighbor they are treat-as-withdraw. Duplicate attributes keep the first
+  occurrence and discard the rest (§3 (g)).
+- **Session-reset** is retained only where the NLRI cannot be trusted:
+  UPDATE section-length inconsistencies (§3 (b), unchanged), a malformed or
+  duplicated MP_REACH_NLRI / MP_UNREACH_NLRI (§7.11, §3 (g)), syntactically
+  incorrect NLRI or Withdrawn Routes fields (§5.3), and the §5.2 escalation
+  (a treat-as-withdraw-class error in an UPDATE that encodes no reachable
+  NLRI).
+
+Interpretation decisions:
+
+- An unrecognized attribute claiming to be well-known (Optional=0, unknown
+  type) is handled treat-as-withdraw. RFC 7606 §3 (c) only literally covers
+  flag conflicts on *recognized* attributes, but resetting the session for a
+  tunneled unknown attribute is exactly the amplification §1 warns about;
+  FRR makes the same call.
+- Dispositions are keyed by attribute type code, not by which specific check
+  failed — a flag conflict on AGGREGATOR is attribute-discard, not
+  treat-as-withdraw. Discard is the weaker action and AGGREGATOR never
+  affects route selection here.
+- An UPDATE whose only attributes were discarded as malformed is not
+  mistaken for an End-of-RIB marker (RFC 4724 §2 detection requires a clean
+  decode).
+- Malformed attributes are logged at `warn` with peer, attribute type, and
+  disposition (§6 debugging facility). Per-disposition counters are a
+  follow-up.
+- AS4_PATH / AS4_AGGREGATOR are not decoded as typed attributes (they pass
+  through opaquely), so no malformation can be detected for them today.
 
 ## Milestone 1 — RFC 4271 Sections
 

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -376,10 +376,13 @@ Interpretation decisions:
   flag conflicts on *recognized* attributes, but resetting the session for a
   tunneled unknown attribute is exactly the amplification §1 warns about;
   FRR makes the same call.
-- Dispositions are keyed by attribute type code, not by which specific check
-  failed — a flag conflict on AGGREGATOR is attribute-discard, not
-  treat-as-withdraw. Discard is the weaker action and AGGREGATOR never
-  affects route selection here.
+- Flag conflicts (§3 (c)) are treat-as-withdraw for every attribute,
+  including ATOMIC_AGGREGATE and AGGREGATOR — their §7.6/§7.7
+  attribute-discard covers length malformations only. On MP_REACH_NLRI /
+  MP_UNREACH_NLRI a flag conflict stays session-reset (§5.3 lists
+  inconsistent flags among what makes the MP attribute itself incorrect).
+- Zero-length Communities / Extended Communities are malformed (§7.8 /
+  §7.14 require a non-zero multiple of 4 / 8) — treat-as-withdraw.
 - An UPDATE whose only attributes were discarded as malformed is not
   mistaken for an End-of-RIB marker (RFC 4724 §2 detection requires a clean
   decode).


### PR DESCRIPTION
Implements RFC 7606 revised BGP UPDATE error handling: malformed path attributes no longer reset the session where the NLRI is still trustworthy.

**Wire crate** (rides the pending 0.15.0 breaking cut):
- `ErrorDisposition` enum whose `Ord` derive implements the §3(h) strongest-action ladder directly (`max()` over dispositions); `malformed_attr_disposition(type_code, is_ibgp)` per-attribute classifier (§7: MP attrs stay session-reset, aggregation attrs discard on length errors, LOCAL_PREF/ORIGINATOR_ID/CLUSTER_LIST split by session type, everything else treat-as-withdraw).
- `decode_path_attributes_revised` / `UpdateMessage::parse_revised`: §3(g) duplicate handling (first kept, duplicate MP = reset), §4 overrun = TaW-and-stop, §3(c) flag conflicts lift to TaW (including on aggregation attrs, where §7.6/§7.7's discard applies to length malformations only), zero-length COMMUNITIES/EXTENDED_COMMUNITIES rejected per §7.8/§7.14.
- `UpdateError` gains a `disposition` field (breaking for struct-literal construction — 0.15.0). Legacy decoder untouched: MRT/BMP/CLI/bench callers keep RFC 4271 semantics.

**Session path**: the two previously-duplicated ~275-line discard blocks (AS_PATH-loop / RR-loop) are extracted into one shared `treat_update_as_withdraw` engine (verified equivalence — every family's rejected→withdraw conversion preserved, and the engine now also covers EVPN and FlowSpec, closing a pre-existing stale-route gap in the loop paths). `process_update` applies the strongest disposition; §5.2 escalates to reset when a TaW-or-worse error leaves no reachable NLRI; EoR detection requires a clean decode so discarded attrs cannot fake End-of-RIB.

**Tests**: 13 wire-level disposition tests (each §7 row, flag conflicts, duplicates, overrun-stop, ladder ordering), 7 session-level tests (TaW removes previously-accepted routes with session Established — including EVPN; discard keeps announcement; malformed MP still resets; §5.2; fake-EoR; MP-EoR detection). Fuzz target extended to `parse_revised`; 30s runs clean.

Docs: RFC_NOTES.md section + standards-table row; CHANGELOG.