### PR TITLE
feat(build): default the jemalloc allocator feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
       # LAN-198: `config` referenced binary-only modules, so the lib
       # failed to build under `--all-features` while the bin stayed green.
       - run: cargo check -p rustbgpd --all-features --lib
+      # jemalloc became the default feature; keep the stock-glibc build
+      # compiling (debug/fallback builds use it) and keep the
+      # deny(unsafe_code) lint posture — it is only armed when neither
+      # allocator feature is on, so the default build no longer checks it.
+      - run: cargo check -p rustbgpd --no-default-features --all-targets
       - name: Check standalone scale harnesses and receipt classifiers
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **jemalloc is now the default allocator feature.** Shipped artifacts
+  (GHCR image, release tarballs) have built with jemalloc since
+  v0.50.0+; defaulting the feature makes plain `cargo build --release`
+  produce the same allocator configuration, so locally-built binaries
+  and receipts match the shipped product. Motivation: an 8-cycle
+  policy-reload probe (200 peers x 115k prefixes) showed stock-glibc
+  RSS ratcheting 301->555 / 295->639 MiB across reload cycles without
+  returning memory — allocator arena retention of reload transients,
+  with live bytes flat — while jemalloc oscillated at 270-330 MiB and
+  returned memory via background decay. Default builds also expose the
+  `jemalloc_*` allocated/active/resident gauges on `/metrics`. A
+  stock-glibc build remains available with `--no-default-features`
+  (kept compiling in CI).
+
 ### Added
 
 - **Per-peer fanout observability gauges.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,16 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
+# jemalloc is the default allocator: a long-lived routing daemon's
+# reload/resync transients are glibc-malloc's worst case (arenas grow to
+# absorb them and are never returned — RSS ratchets upward across policy
+# reloads while live bytes stay flat), and the shipped artifacts (GHCR
+# image, release tarballs) have built with jemalloc since v0.50.0+.
+# Defaulting it means local builds, receipts, and shipped binaries are
+# the same build, and the jemalloc_* allocator gauges are always on
+# /metrics. Build with --no-default-features for a stock-glibc binary
+# (CI keeps that build compiling; it also re-arms deny(unsafe_code)).
+default = ["jemalloc"]
 bench-internals = []
 jemalloc = ["tikv-jemallocator", "rustbgpd-telemetry/jemalloc"]
 dhat-heap = ["dhat"]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -7,11 +7,19 @@ For the consolidated operator-facing proof index that rolls benchmark, memory,
 interop, dataplane, and soak receipts together, see
 [`OPERATIONAL_PROOF.md`](OPERATIONAL_PROOF.md).
 
-Releases newer than v0.50.0 build the published artifacts — the GHCR
-runtime image and the release tarballs — with this same `--release`
-profile plus `--features jemalloc`, so shipped binaries match the
-benchmarked build (earlier releases shipped a CI-profile, glibc-malloc
-build).
+jemalloc is the default allocator feature, so a plain
+`cargo build --release` produces the same allocator configuration as the
+published artifacts — the GHCR runtime image and the release tarballs
+(which have built with jemalloc since v0.50.0+; earlier releases shipped
+a CI-profile, glibc-malloc build). This matters for memory numbers: an
+8-cycle policy-reload probe at 200 peers × 115k prefixes showed
+stock-glibc RSS climbing 301→555 MiB and 295→639 MiB across two runs
+without returning memory (live bytes flat — allocator arena retention of
+reload transients), while the identical workload under jemalloc
+oscillated at 270–330 MiB and returned memory via background decay.
+Daemon RSS figures measured on glibc builds before 2026-07-17 overstate
+steady-state RSS relative to the shipped binary. A stock-glibc build
+remains available via `--no-default-features`.
 
 **Last measured:** RIB Operations pinned A/B: 2026-05-29; same-host
 current-main reconfirmation and memory attribution correction: 2026-06-02;


### PR DESCRIPTION
Makes `jemalloc` a default cargo feature, so plain `cargo build --release` produces the same allocator configuration as the shipped artifacts (GHCR image and release tarballs, which have built with `--features rustbgpd/jemalloc` since v0.50.0+). Locally-built binaries, receipts, and shipped product are now the same build.

Motivation — 8-cycle policy-reload probe at 200 peers × 115k prefixes, three runs:
- stock glibc: RSS ratchets 301→555 and 295→639 MiB across reload cycles and never returns memory (an empty post-teardown daemon held ~500 MiB); live bytes flat — arena retention of reload transients.
- jemalloc, identical workload: oscillates 270–330 MiB, returns memory via background decay, ends at 229 MiB.
- Reload KPIs unaffected: stall p50 90–185 ms, completion p50 0.23–0.33 s, in family across both allocators at the same shape.

Default builds also expose the `jemalloc_*` allocated/active/resident gauges on `/metrics` (the live-bytes-vs-RSS split used for the attribution above).

A stock-glibc build remains available via `--no-default-features`; CI gains a `cargo check -p rustbgpd --no-default-features --all-targets` leg that keeps it compiling and preserves the `deny(unsafe_code)` lint posture (armed only when neither allocator feature is on). Verified: `strings` on the default release binary confirms jemalloc; full gate suite green including workspace tests under the new default.

BENCHMARKS.md notes that daemon RSS figures measured on glibc builds before 2026-07-17 overstate steady-state RSS relative to the shipped binary.