### PR TITLE
fix(rib): defer expensive PeerUp initial dumps behind queued imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Post-flap re-announce latency: initial table dumps no longer
+  head-of-line block redistribution.** A peer's outbound registration at
+  `PeerUp` performed its full-table initial dump synchronously on the
+  RIB actor, so a mass reconnect (e.g. 50 route-server members
+  re-establishing after a flap) serialized N full-table passes ahead of
+  the re-announcements already queued behind the burst — survivors saw
+  the flapped prefixes only after the last dump finished (~9.5 s flat at
+  the 700x400k receipt shape, scaling with peers x table). When the
+  actor has queued work, the registration (and its dump) now defers to
+  the run loop, which completes one per iteration strictly after every
+  queued mutation batch has drained: imports and their fan-out to
+  established peers always preempt the reconnecting peers' full-table
+  catch-up. A quiet actor, or a table under 10k routes (whose dump is
+  sub-10-ms-class), still registers inline — registration-timing
+  semantics only change where deferring buys real latency back.
+  Session-semantic flags (eBGP / RR-client / RFC 9234 role /
+  per-client-best / RFC 1997 interpretation) always install immediately
+  at `PeerUp`, so inbound processing never runs with absent flags
+  during the deferral window. A session that drops, is superseded, or
+  fails over while
+  deferred resolves to its surviving live session, including the
+  inbound ROUTE-REFRESH re-solicitation on failover. GR/LLGR stale
+  retention, EoR emission, RFC 4724 selection deferral, and the RFC
+  5291 ORF gate are unchanged. Local flapstorm at 300 peers x 300k
+  prefixes, 30 flapped: survivor re-announce completion 4.43-4.56 s ->
+  0.32-0.33 s (first arrival 4.24-4.40 s -> 0.17 s), withdraws
+  unchanged at ~0.15 s. The flapstorm harness now also reports
+  per-survivor first re-announce arrival (`first_reann_s`), separating
+  delivery-start latency from fan-out completion.
+
 ### Changed
 
 - **jemalloc is now the default allocator feature.** Shipped artifacts

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -811,6 +811,20 @@ async fn run_flapstorm(ctx: &Arc<Ctx>, stubs: &mut [Stub], k: u32, pid: i32) {
             .map(|tc| tc.saturating_sub(t_reann) as f64 / 1e6)
             .collect();
         let reannounce = stats_line(&format!("flap {round} reannounce_s"), reann_s);
+        // First re-announce arrival per survivor: distinguishes a steady
+        // drain (first ≪ completion: fan-out throughput) from an
+        // idle-then-burst gate (first ≈ completion: a daemon-side timer).
+        let first_s: Vec<f64> = survivors
+            .clone()
+            .filter_map(|i| {
+                let events = ctx.obs[i].events.lock().unwrap();
+                events
+                    .iter()
+                    .find(|e| e.t_us >= t_reann && e.base_ann > 0)
+                    .map(|e| e.t_us.saturating_sub(t_reann) as f64 / 1e6)
+            })
+            .collect();
+        stats_line(&format!("flap {round} first_reann_s"), first_s);
         for observer in ctx.obs.iter().skip(k as usize) {
             observer.flap_mode.store(FLAP_OFF, Ordering::Release);
         }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -280,6 +280,18 @@ pub struct RibManager {
     pending_eor: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Families with an outstanding enhanced route refresh response retry.
     pending_refresh: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
+    /// Outbound registrations (initial table dumps) deferred behind queued
+    /// actor work, completed one per run-loop iteration between drained
+    /// mutation batches (LAN-475). Peer-keyed (deduplicated): the advance
+    /// registers the peer's CURRENT last live session, so a session
+    /// superseded or failed over while queued resolves to its survivor.
+    pending_initial_registrations: VecDeque<IpAddr>,
+    /// Loc-RIB size below which a `PeerUp` initial dump always completes
+    /// inline even with queued actor work — a small dump costs microseconds,
+    /// so deferring it buys nothing and only perturbs registration-timing
+    /// semantics. Defaults to [`INITIAL_DUMP_DEFER_MIN_ROUTES`]; tests pin
+    /// it to 0 to exercise the deferral without bulk data.
+    initial_dump_defer_min_routes: usize,
     /// Active inbound enhanced route refresh windows by peer/family.
     refresh_in_progress: HashMap<IpAddr, HashSet<(Afi, Safi)>>,
     /// Per-peer/per-family deadlines for active enhanced route refresh windows.
@@ -830,6 +842,13 @@ const RESYNC_PEERS_PER_TICK: usize = 8;
 const DIRTY_RESYNC_BACKLOG_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 const ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
 const EVPN_ROUTE_EVENT_HISTORY_CAPACITY: usize = 4096;
+/// Loc-RIB size at which a `PeerUp` initial dump is expensive enough to
+/// defer behind queued actor work (LAN-475). Below this an inline dump is
+/// sub-10-ms-class (measured ~2M NLRI/s staged-dump throughput at the IXP
+/// receipt shape), so even a 50-peer reconnect burst serializes well under
+/// a second; above it, mass-reconnect dump serialization visibly delays
+/// re-announcement fan-out and the deferral engages.
+const INITIAL_DUMP_DEFER_MIN_ROUTES: usize = 10_000;
 
 fn initial_route_page_version() -> RoutePageVersion {
     let state = std::collections::hash_map::RandomState::new();
@@ -1174,6 +1193,8 @@ impl RibManager {
             force_outbound_peers: HashSet::new(),
             pending_eor: HashMap::new(),
             pending_refresh: HashMap::new(),
+            pending_initial_registrations: VecDeque::new(),
+            initial_dump_defer_min_routes: INITIAL_DUMP_DEFER_MIN_ROUTES,
             refresh_in_progress: HashMap::new(),
             refresh_deadlines: HashMap::new(),
             refresh_stale_routes: HashMap::new(),
@@ -1620,6 +1641,35 @@ impl RibManager {
             }
             if poll_start.elapsed() >= self.flush_poll_budget {
                 return true;
+            }
+        }
+    }
+
+    /// Complete one deferred outbound registration (LAN-475), targeting the
+    /// peer's CURRENT last live session. Entries whose peer no longer has a
+    /// live session (torn down while queued) or whose session already
+    /// registered are discarded until one real registration completes (or
+    /// the queue empties). A closed outbound channel does NOT skip the
+    /// registration — the synchronous path never skipped it either; its
+    /// sends fail harmlessly and the session's `PeerDown` cleans up.
+    fn advance_pending_initial_registration(&mut self) {
+        while let Some(peer) = self.pending_initial_registrations.pop_front() {
+            let target = self
+                .live_sessions
+                .get(&peer)
+                .and_then(|sessions| sessions.last())
+                .map(|record| record.session_id);
+            match target {
+                Some(session_id) if self.outbound_session_ids.get(&peer) != Some(&session_id) => {
+                    self.complete_outbound_registration(peer);
+                    return;
+                }
+                _ => {
+                    debug!(
+                        %peer,
+                        "dropping deferred outbound registration — session gone or already registered"
+                    );
+                }
             }
         }
     }
@@ -5023,6 +5073,24 @@ impl RibManager {
                 }
                 self.drain_readiness_queries(None);
                 self.advance_destination_prestage();
+                self.drain_queries(QUERY_BUDGET_PER_CHUNK);
+                tokio::task::yield_now().await;
+                continue;
+            }
+
+            // Deferred outbound registrations (LAN-475): complete one
+            // initial table dump per iteration, and only after every queued
+            // mutation batch has drained — imports and their fan-out to
+            // established peers always preempt the reconnecting peers'
+            // full-table catch-up, so a mass reconnect cannot head-of-line
+            // block re-announcement delivery to survivors.
+            if !self.pending_initial_registrations.is_empty() {
+                if self.drain_ready_updates() {
+                    self.drain_readiness_queries(None);
+                    continue;
+                }
+                self.drain_readiness_queries(None);
+                self.advance_pending_initial_registration();
                 self.drain_queries(QUERY_BUDGET_PER_CHUNK);
                 tokio::task::yield_now().await;
                 continue;

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -76,9 +76,21 @@ impl RibManager {
         event: &str,
     ) -> SessionTeardownDisposition {
         let Some(&registered) = self.outbound_session_ids.get(&peer) else {
-            // No registration — nothing to protect and nothing to fail
-            // over to (`live_sessions` is empty for the peer whenever no
-            // registration exists; a full teardown clears both together).
+            // No registration. Ordinarily `live_sessions` is empty for the
+            // peer here and the full teardown proceeds; during the LAN-475
+            // deferral window sessions are tracked but not yet registered,
+            // so classify against them: prune the stamped session, and when
+            // another live session remains take the ordinary failover path
+            // (reset + re-register + inbound ROUTE-REFRESH request) — the
+            // survivor's registration may simply defer again.
+            let survivor_remains = self.live_sessions.get_mut(&peer).is_some_and(|sessions| {
+                sessions.retain(|s| s.session_id != session_id);
+                !sessions.is_empty()
+            });
+            if survivor_remains {
+                return SessionTeardownDisposition::FailOver;
+            }
+            self.live_sessions.remove(&peer);
             return SessionTeardownDisposition::NoRegistration;
         };
         if registered != session_id {
@@ -564,7 +576,9 @@ impl RibManager {
         // retention is the exception to the reset: routes deliberately
         // held stale for a restarting peer stay put — deadline-bounded
         // and swept on End-of-RIB, exactly as on a plain GR reconnect.
-        if self.outbound_peers.contains_key(&peer) {
+        if self.outbound_peers.contains_key(&peer)
+            || self.pending_initial_registrations.contains(&peer)
+        {
             if let Some(previous_session_id) = self.outbound_session_ids.get(&peer).copied()
                 && let Some(selection) = self.selection_deferral.as_mut()
             {
@@ -651,7 +665,7 @@ impl RibManager {
     /// classification.
     #[expect(
         clippy::too_many_lines,
-        reason = "active-session registration installs every negotiated outbound capability"
+        reason = "session classification (GR, LLGR, RTC, selection deferral) stays in one auditable pass"
     )]
     fn register_active_session(&mut self, peer: IpAddr, registration: ActiveSessionRegistration) {
         let Some(record) = self
@@ -665,29 +679,37 @@ impl RibManager {
         let session_id = record.session_id;
         let peer_asn = record.peer_asn;
         let peer_router_id = record.peer_router_id;
-        let outbound_tx = record.outbound_tx.clone();
-        let export_policy = record.export_policy.clone();
         let sendable_families = record.sendable_families.clone();
+        let negotiated_orf_recv = record.negotiated_orf_recv.clone();
+        let gr_context = record.gr_context.clone();
         let is_ebgp = record.is_ebgp;
         let route_reflector_client = record.route_reflector_client;
         let local_role = record.local_role;
-        let orr_vantage = record.orr_vantage;
         let per_client_best = record.per_client_best;
         let interpret_rfc1997 = record.interpret_rfc1997;
-        let rs_control_asn = record.rs_control_asn;
-        let add_path_send_families = record.add_path_send_families.clone();
-        let add_path_send_max = record.add_path_send_max;
-        let add_path_send_limits = record.add_path_send_limits.clone();
-        let negotiated_orf_recv = record.negotiated_orf_recv.clone();
-        let negotiated_llgr_families = record.negotiated_llgr_families.clone();
-        let gr_context = record.gr_context.clone();
-        let exact_export_encoder = record.exact_export_encoder.clone();
-        #[cfg(test)]
-        let exact_export_encoder =
-            exact_export_encoder.or_else(|| Some(super::permissive_test_exact_export_encoder()));
 
         self.peer_asn.insert(peer, peer_asn);
         self.peer_bgp_id.insert(peer, peer_router_id);
+        // Session-semantic flags install IMMEDIATELY, not with the deferred
+        // outbound registration: inbound processing (RFC 9234 role checks,
+        // RR reflection's source classification, community interpretation,
+        // per-client-best candidate handling) consults them for routes that
+        // can arrive before a deferred outbound registration completes
+        // (LAN-475). Insert/remove for the optional knobs: a replacement
+        // session that dropped one must not inherit it.
+        self.peer_is_ebgp.insert(peer, is_ebgp);
+        self.peer_is_rr_client.insert(peer, route_reflector_client);
+        self.peer_local_roles.insert(peer, local_role);
+        if per_client_best {
+            self.peer_per_client_best.insert(peer);
+        } else {
+            self.peer_per_client_best.remove(&peer);
+        }
+        if interpret_rfc1997 {
+            self.peer_interpret_rfc1997.insert(peer);
+        } else {
+            self.peer_interpret_rfc1997.remove(&peer);
+        }
 
         // RFC 5291 §6: gate the initial advertisement for ORF-receive families
         // until the peer sends a ROUTE-REFRESH, so we don't flood the full
@@ -822,6 +844,64 @@ impl RibManager {
             "all ordinary selection waiters satisfied or excluded",
         );
 
+        // LAN-475: the initial table dump is a full O(table) staged pass on
+        // the single-threaded RIB actor. A mass reconnect (e.g. tens of
+        // route-server members re-establishing after a flap) queues one
+        // `PeerUp` per session, and completing every dump inline serializes
+        // N full-table passes ahead of the imports already queued behind the
+        // burst — survivors then see the re-announcements only after the
+        // last dump finishes. When the actor has queued work AND the dump
+        // is actually expensive (large table), defer the outbound
+        // registration to the run loop, which advances one registration at
+        // a time between drained mutation batches. A quiet actor, or a
+        // small table whose dump costs microseconds, completes inline
+        // exactly as before — registration-timing semantics only change
+        // where deferring buys real latency back.
+        let actor_busy = !self.rx.is_empty() || !self.pending_initial_registrations.is_empty();
+        let dump_expensive = self.loc_rib.len() >= self.initial_dump_defer_min_routes;
+        if actor_busy && dump_expensive {
+            if !self.pending_initial_registrations.contains(&peer) {
+                debug!(
+                    %peer,
+                    session_id,
+                    "deferring outbound registration behind queued actor work"
+                );
+                self.pending_initial_registrations.push_back(peer);
+            }
+        } else {
+            self.complete_outbound_registration(peer);
+        }
+    }
+
+    /// Install the active session's outbound registration and send its
+    /// initial table dump. The second half of `register_active_session`,
+    /// either inline (quiet actor) or deferred to the run loop (LAN-475);
+    /// re-reads the live-session record so a deferred completion always
+    /// registers the CURRENT session's negotiated state.
+    pub(super) fn complete_outbound_registration(&mut self, peer: IpAddr) {
+        let Some(record) = self
+            .live_sessions
+            .get(&peer)
+            .and_then(|sessions| sessions.last())
+        else {
+            debug_assert!(false, "complete_outbound_registration with no live session");
+            return;
+        };
+        let session_id = record.session_id;
+        let outbound_tx = record.outbound_tx.clone();
+        let export_policy = record.export_policy.clone();
+        let sendable_families = record.sendable_families.clone();
+        let orr_vantage = record.orr_vantage;
+        let rs_control_asn = record.rs_control_asn;
+        let add_path_send_families = record.add_path_send_families.clone();
+        let add_path_send_max = record.add_path_send_max;
+        let add_path_send_limits = record.add_path_send_limits.clone();
+        let negotiated_llgr_families = record.negotiated_llgr_families.clone();
+        let exact_export_encoder = record.exact_export_encoder.clone();
+        #[cfg(test)]
+        let exact_export_encoder =
+            exact_export_encoder.or_else(|| Some(super::permissive_test_exact_export_encoder()));
+
         debug!(%peer, "peer up — registering for outbound updates");
         let peer_label = peer.to_string();
         self.metrics.set_rib_prefixes(&peer_label, "all", 0);
@@ -836,9 +916,10 @@ impl RibManager {
         self.peer_sendable_families.insert(peer, sendable_families);
         self.peer_advertised_llgr_families
             .insert(peer, negotiated_llgr_families);
-        self.peer_is_ebgp.insert(peer, is_ebgp);
-        self.peer_is_rr_client.insert(peer, route_reflector_client);
-        self.peer_local_roles.insert(peer, local_role);
+        // (peer_is_ebgp / peer_is_rr_client / peer_local_roles /
+        // peer_per_client_best / peer_interpret_rfc1997 install in
+        // `register_active_session` — inbound semantics must not wait for
+        // a deferred outbound registration.)
         if let Some(encoder) = exact_export_encoder {
             self.peer_export_encoders.insert(peer, encoder);
         } else {
@@ -872,24 +953,11 @@ impl RibManager {
             self.peer_add_path_send_limits
                 .insert(peer, add_path_send_limits);
         }
-        // Per-registration like the vantage: a replacement session that
-        // dropped the knob must not inherit it.
-        if per_client_best {
-            self.peer_per_client_best.insert(peer);
-        } else {
-            self.peer_per_client_best.remove(&peer);
-        }
-        // Per-registration like `per_client_best`: a replacement session
-        // that dropped the knob must not inherit it.
-        if interpret_rfc1997 {
-            self.peer_interpret_rfc1997.insert(peer);
-        } else {
-            self.peer_interpret_rfc1997.remove(&peer);
-        }
-        // Per-registration like the knobs above — and installed before
-        // `recompute_update_group` below reads it (an enabled session is
-        // disqualified from grouping) and before `send_initial_table`
-        // stages the first Adj-RIB-Out.
+        // Per-registration knob (like `per_client_best`, installed in the
+        // immediate half) — installed before `recompute_update_group`
+        // below reads it (an enabled session is disqualified from
+        // grouping) and before `send_initial_table` stages the first
+        // Adj-RIB-Out.
         if let Some(rs_asn) = rs_control_asn {
             self.peer_rs_control.insert(peer, rs_asn);
         } else {

--- a/crates/rib/src/manager/tests/lifecycle.rs
+++ b/crates/rib/src/manager/tests/lifecycle.rs
@@ -1713,3 +1713,235 @@ async fn unregistered_session_message_keeps_legacy_accept_behavior() {
 // registers two peers (source + target, both RR clients), and drives
 // RibUpdate events to exercise the stale lifecycle.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// LAN-475: deferred outbound registration — a mass reconnect must not
+// head-of-line block re-announcement delivery to established peers behind
+// the reconnecting peers' full-table initial dumps.
+// ---------------------------------------------------------------------------
+
+fn test_peer_up(
+    peer: IpAddr,
+    session_id: u64,
+    outbound_tx: mpsc::Sender<OutboundRouteUpdate>,
+) -> RibUpdate {
+    RibUpdate::PeerUp {
+        per_client_best: false,
+        interpret_rfc1997: true,
+        session_id,
+        peer,
+        peer_asn: 65000,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: Vec::new(),
+        negotiated_llgr_families: Vec::new(),
+    }
+}
+
+fn test_routes_received(peer: IpAddr, announced: Vec<Route>) -> RibUpdate {
+    RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer,
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    }
+}
+
+/// With queued actor work, a re-established peer's registration (and its
+/// full-table initial dump) is deferred, and the peer's inbound routes
+/// distribute to already-established peers BEFORE the dump runs — the
+/// LAN-475 property. The deferred dump then completes and reflects the
+/// current table. Driven synchronously for determinism.
+#[tokio::test]
+async fn deferred_registration_lets_queued_imports_distribute_first() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    // Exercise the deferral without bulk data: treat any table as expensive.
+    manager.initial_dump_defer_min_routes = 0;
+
+    let survivor = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let third = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let restarter = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let third_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let restarter_prefix = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+
+    // Survivor establishes on a quiet actor: registration is synchronous,
+    // exactly the pre-LAN-475 behavior.
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(16);
+    manager.handle_update(test_peer_up(survivor, 1, survivor_tx));
+    let eor = survivor_rx
+        .try_recv()
+        .expect("quiet-actor PeerUp dumps synchronously");
+    assert!(!eor.end_of_rib.is_empty());
+
+    // A third peer's route lands in the table (feeds the eventual dump).
+    manager.handle_update(test_routes_received(
+        third,
+        vec![make_route(third_prefix, Ipv4Addr::new(10, 0, 0, 3))],
+    ));
+    drain_route_chunks(&mut manager);
+    let update = survivor_rx
+        .try_recv()
+        .expect("survivor gets the third peer's route");
+    assert_eq!(update.announce.len(), 1);
+
+    // Queue work on the actor channel (a mass-reconnect burst in miniature),
+    // then re-establish the restarter: its registration must defer.
+    tx.try_send(test_routes_received(third, vec![])).unwrap();
+    let (restarter_tx, mut restarter_rx) = mpsc::channel(16);
+    manager.handle_update(test_peer_up(restarter, 2, restarter_tx));
+    assert!(
+        restarter_rx.try_recv().is_err(),
+        "busy-actor PeerUp must not dump inline"
+    );
+    assert_eq!(manager.pending_initial_registrations.len(), 1);
+
+    // The restarter's re-announcements import and distribute to the
+    // survivor while the restarter's own dump is still pending.
+    manager.handle_update(test_routes_received(
+        restarter,
+        vec![make_route(restarter_prefix, Ipv4Addr::new(10, 0, 0, 2))],
+    ));
+    drain_route_chunks(&mut manager);
+    let update = survivor_rx
+        .try_recv()
+        .expect("re-announced route reaches the survivor before the deferred dump");
+    assert!(
+        update
+            .announce
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(restarter_prefix)),
+        "survivor receives the re-announced prefix"
+    );
+    assert!(
+        restarter_rx.try_recv().is_err(),
+        "the deferred dump has still not run"
+    );
+
+    // The deferred registration completes: the restarter receives the
+    // current table (the third peer's route, not its own) and an EoR.
+    manager.advance_pending_initial_registration();
+    assert!(manager.pending_initial_registrations.is_empty());
+    let dump = restarter_rx.try_recv().expect("deferred dump delivered");
+    assert!(
+        dump.announce
+            .iter()
+            .any(|route| route.prefix == Prefix::V4(third_prefix)),
+        "dump reflects the table at completion time"
+    );
+    let mut saw_eor = !dump.end_of_rib.is_empty();
+    while let Ok(update) = restarter_rx.try_recv() {
+        saw_eor |= !update.end_of_rib.is_empty();
+    }
+    assert!(saw_eor, "initial dump still ends with End-of-RIB");
+}
+
+/// A peer whose session goes down while its registration is deferred must
+/// not be registered by the later advance; a full teardown still applies
+/// (no survivor session), matching the pre-deferral invariant.
+#[tokio::test]
+async fn deferred_registration_dropped_when_session_dies_first() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.initial_dump_defer_min_routes = 0;
+
+    let restarter = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    tx.try_send(test_routes_received(restarter, vec![]))
+        .unwrap();
+    let (restarter_tx, mut restarter_rx) = mpsc::channel(16);
+    manager.handle_update(test_peer_up(restarter, 7, restarter_tx));
+    assert_eq!(manager.pending_initial_registrations.len(), 1);
+
+    manager.handle_update(RibUpdate::PeerDown {
+        peer: restarter,
+        session_id: 7,
+    });
+    manager.advance_pending_initial_registration();
+    assert!(manager.pending_initial_registrations.is_empty());
+    assert!(
+        restarter_rx.try_recv().is_err(),
+        "no dump for a session that died before its deferred registration"
+    );
+    assert!(!manager.outbound_peers.contains_key(&restarter));
+}
+
+/// End-to-end through the run loop: a reconnect burst (`PeerUp`s and the
+/// re-announcements queued behind them) still delivers the re-announced
+/// routes to the survivor AND completes every deferred initial dump.
+#[tokio::test]
+async fn run_loop_advances_deferred_registrations() {
+    let (tx, rx) = mpsc::channel(64);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.initial_dump_defer_min_routes = 0;
+    let handle = tokio::spawn(manager.run());
+
+    let survivor = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let (survivor_tx, mut survivor_rx) = mpsc::channel(64);
+    tx.send(test_peer_up(survivor, 1, survivor_tx))
+        .await
+        .unwrap();
+    drain_eor(&mut survivor_rx).await;
+
+    // Reconnect burst: two peers re-establish and re-announce.
+    let r1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let r2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3));
+    let p1 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 1, 0), 24);
+    let p2 = Ipv4Prefix::new(Ipv4Addr::new(192, 168, 2, 0), 24);
+    let (r1_tx, mut r1_rx) = mpsc::channel(64);
+    let (r2_tx, mut r2_rx) = mpsc::channel(64);
+    tx.send(test_peer_up(r1, 2, r1_tx)).await.unwrap();
+    tx.send(test_peer_up(r2, 3, r2_tx)).await.unwrap();
+    tx.send(test_routes_received(
+        r1,
+        vec![make_route(p1, Ipv4Addr::new(10, 0, 0, 2))],
+    ))
+    .await
+    .unwrap();
+    tx.send(test_routes_received(
+        r2,
+        vec![make_route(p2, Ipv4Addr::new(10, 0, 0, 3))],
+    ))
+    .await
+    .unwrap();
+
+    // The survivor receives both re-announced prefixes...
+    let deadline = std::time::Duration::from_secs(5);
+    let mut seen = HashSet::new();
+    while seen.len() < 2 {
+        let update = tokio::time::timeout(deadline, survivor_rx.recv())
+            .await
+            .expect("survivor delivery must not stall")
+            .unwrap();
+        for route in update.announce.iter() {
+            seen.insert(route.prefix);
+        }
+    }
+    assert!(seen.contains(&Prefix::V4(p1)) && seen.contains(&Prefix::V4(p2)));
+
+    // ...and both reconnecting peers' deferred initial dumps complete
+    // (liveness: the run loop advances the queue), ending in EoR.
+    for rx in [&mut r1_rx, &mut r2_rx] {
+        let mut saw_eor = false;
+        while !saw_eor {
+            let update = tokio::time::timeout(deadline, rx.recv())
+                .await
+                .expect("deferred initial dump must complete from the run loop")
+                .unwrap();
+            saw_eor = !update.end_of_rib.is_empty();
+        }
+    }
+
+    drop(tx);
+    handle.await.unwrap();
+}


### PR DESCRIPTION
Fixes the post-flap re-announce plateau from the IXP matrix receipt (S3: survivors saw withdraws in ~0.3 s but re-announcements at a flat p50 ~9.5–9.8 s).

**Mechanism (proven, not the suspected timer):** `handle_peer_up → register_active_session → send_initial_table` ran each reconnecting peer's full-table initial dump synchronously on the RIB actor. A 50-peer reconnect burst queued 50 × O(table) dumps ahead of the re-announcements — survivors received nothing until the last dump finished (the flat p50≈p95≈max signature is shared-emission completion). Attribution: plateau scales with flapped-peers × table (0.03 s at 20×20k → 4.5 s at 300×300k → 9.7 s at 700×400k), a new `first_reann_s` harness instrument shows idle-then-burst, and the daemon log shows registrations serializing at ~145 ms each across exactly the idle window. GR/EoR deferral refuted (no GR capability in the scenario; timers never arm).

**Fix:** PeerUp defers the outbound registration + dump to the run loop only when the actor has queued work AND `loc_rib.len() >= 10_000` (documented constant, test seam). The loop completes one registration per iteration strictly after all queued mutation batches drain — imports and survivor fan-out always preempt reconnect catch-up. Quiet actor or small table: byte-identical inline behavior. Session-semantic flags (eBGP/RR-client/role/per-client-best/RFC 1997) still install immediately at PeerUp. Teardown during the window prunes the unregistered session via the ordinary FailOver path. GR/LLGR retention, EoR emission, RFC 4724 selection deferral, ORF gates untouched — all 911 rib tests pass unmodified.

**Measured:** flapstorm 300×300k K=30 re-announce p50 4.43–4.56 s → **0.32–0.33 s**; first arrival 4.4 s → 0.17 s; withdraws unchanged (~0.15 s). Full 700-peer S3 matrix rerun + receipt refresh follow this merge.

3 new lifecycle tests (deferral lets queued imports distribute first; deferred registration dropped when the session dies; run loop advances the queue). Harness gains the additive `first_reann_s` diagnostic (headline metrics unchanged). Full gate suite green foreground with exit codes, independently re-verified.