### PR TITLE
perf(rs): route-granular emit-time filter for RS control communities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,14 +107,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   implemented (draft-ietf-grow-ixp-ext-comms). Matched control
   communities are scrubbed from the outbound announcement toward
   enabled sessions; everyone else keeps byte-level transparency.
-  Per-neighbor / per-group knob `rs_control_communities`, default off
-  (opt-in): enabling a session excludes it from update-group sharing,
-  which at large fanout is per-peer Adj-RIB-Out + encode. Enforcement is
-  a per-target export-staging decision (suppression sits beside the
-  RFC 1997 gates with its own `rs_control` explain rung; Add-Path and
-  per-client-best exclude suppressed candidates before ranking), so
-  enabled sessions ride the ungrouped per-peer path — the new
-  `rs_control_communities` update-group disqualifier reason.
+  Per-neighbor / per-group knob `rs_control_communities`, default on
+  for `route_server_client` sessions and off otherwise. Enforcement is
+  a per-target decision (suppression sits beside the RFC 1997 gates
+  with its own `rs_control` explain rung; Add-Path and per-client-best
+  exclude suppressed candidates before ranking). The filter is
+  route-granular at emit (ADR-0101 Decision 3): enabled sessions stay
+  in shared update-groups, untagged routes — the overwhelming
+  majority — ride the shared staged emission byte-identically, and
+  only routes carrying a control-form community diverge per target
+  (suppression/prepend/scrub against each target's ASN) at the group
+  emit seams: the source-flip matrix walk, dirty/regroup resync, and
+  the initial-dump and route-refresh replays. This is what makes the
+  rs-client default safe: a session-level update-group exclusion
+  would cost per-peer Adj-RIB-Out + per-peer encode for every enabled
+  session (~1.3 GiB → >100 GiB RSS on a 700-client full-table route
+  server when tried fleet-wide).
 
 - **Per-peer fanout observability gauges.**
   `bgp_peer_outbound_queue_depth{peer}` reports the coalesced update

--- a/bench/scale/reloadstall/gen-bird-scenario.py
+++ b/bench/scale/reloadstall/gen-bird-scenario.py
@@ -13,7 +13,7 @@ exactly the harness's contract: copy gen-a.conf/gen-b.conf over gen.conf,
 then `birdc configure` (the harness reload_cmd). Like gen-scenario.py's
 historical mode, the import filter carries a content-real but output-neutral
 reject term (an out-of-table prefix that changes between generations) and
-the export filter tags the generation community 65500:1000 / 65500:2000.
+the export filter tags the generation community 65400:1000 / 65400:2000.
 
 NEXT_HOP glue (the classic bgperf BIRD gotcha): 10.9.x.y exists nowhere, so
 without help BIRD marks every route unreachable and exports nothing. The
@@ -59,8 +59,8 @@ def stub_asn(i: int) -> int:
 # the announced 20.0.0.0-26.x base table, so the import change is
 # content-real but output-neutral.
 GENERATIONS = [
-    ("gen-a.conf", "192.0.2.0/24", "(65500, 1000)"),
-    ("gen-b.conf", "198.51.100.0/24", "(65500, 2000)"),
+    ("gen-a.conf", "192.0.2.0/24", "(65400, 1000)"),
+    ("gen-b.conf", "198.51.100.0/24", "(65400, 2000)"),
 ]
 
 for fname, reject_prefix, community in GENERATIONS:

--- a/bench/scale/reloadstall/gen-obgpd-scenario.py
+++ b/bench/scale/reloadstall/gen-obgpd-scenario.py
@@ -14,7 +14,7 @@ gen.conf, then `bgpctl reload` (the harness reload_cmd). Like
 gen-scenario.py's historical mode, each generation carries a flat two-term
 ruleset: a content-real but output-neutral import reject (an out-of-table
 prefix that changes between generations) and a match rule tagging the
-generation community 65500:1000 / 65500:2000 on export.
+generation community 65400:1000 / 65400:2000 on export.
 
 NEXT_HOP qualification: bgpd validates next hops against the kernel FIB even
 with `fib-update no` (see tests/interop/configs/bgpd-m86-c1.conf, where the
@@ -57,8 +57,8 @@ def stub_asn(i: int) -> int:
 
 
 GENERATIONS = [
-    ("gen-a.conf", "192.0.2.0/24", "65500:1000"),
-    ("gen-b.conf", "198.51.100.0/24", "65500:2000"),
+    ("gen-a.conf", "192.0.2.0/24", "65400:1000"),
+    ("gen-b.conf", "198.51.100.0/24", "65400:2000"),
 ]
 
 for fname, reject_prefix, community in GENERATIONS:

--- a/bench/scale/reloadstall/gen-scenario.py
+++ b/bench/scale/reloadstall/gen-scenario.py
@@ -29,7 +29,11 @@ Usage:
     gen-scenario.py <n_peers> <out_dir> [listen_port] [changed_peers]
 
 Emits into <out_dir>: config.toml, member.rpol (live, starts as gen-a),
-gen-a.rpol (community 65500:1000), gen-b.rpol (community 65500:2000).
+gen-a.rpol (community 65400:1000), gen-b.rpol (community 65400:2000).
+Marker communities deliberately avoid the RS ASN's administrator space:
+rs_control_communities defaults on for the route-server-client neighbors,
+and RS-administered standard communities are control forms scrubbed from
+the wire (which would hide the generation markers from the observers).
 The optional `changed_peers` selects the first N neighbors whose effective
 export chain changes. The remaining neighbors receive a content-stable
 per-neighbor `stable-out` chain, while the import chain remains content-stable
@@ -76,12 +80,19 @@ def stub_asn(i: int) -> int:
 # (filename, import-reject prefix, export community) per generation. The mixed
 # mode deliberately keeps the import body equal so its selected changed-member
 # cohort is genuinely export-only.
+#
+# Marker communities MUST NOT be administered by GLOBAL_ASN (or 0): the
+# config's route-server-client neighbors default rs_control_communities on,
+# and standard communities under the RS ASN are RFC 7947 §2.3.2 control
+# forms — scrubbed from the wire toward enabled members, which would blind
+# the harness to its own generation evidence. 65400 is outside the stub
+# ASN range and is not the RS ASN.
 GENERATIONS = [
-    ("gen-a.rpol", "192.0.2.0/24", "65500:1000"),
+    ("gen-a.rpol", "192.0.2.0/24", "65400:1000"),
     (
         "gen-b.rpol",
         "192.0.2.0/24" if mixed_export_only else "198.51.100.0/24",
-        "65500:2000",
+        "65400:2000",
     ),
 ]
 
@@ -98,7 +109,7 @@ for fname, reject_prefix, community in GENERATIONS:
     stable_policy = """
 
 policy stable-out {
-    term tag { add community 65500:9000; accept }
+    term tag { add community 65400:9000; accept }
 }
 """ if mixed_export_only else ""
     (out / fname).write_text(

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -57,9 +57,14 @@ const CHURN_BLOCK: u32 = 16;
 const CHURN_MS: u64 = 125;
 const NLRI_PER_MSG: usize = 900;
 const HOLD_TIME: u16 = 180;
-const COMMUNITY_GEN_A: u32 = (65_500 << 16) | 1_000;
-const COMMUNITY_GEN_B: u32 = (65_500 << 16) | 2_000;
-const COMMUNITY_STABLE: u32 = (65_500 << 16) | 9_000;
+// Marker admin 65400 — deliberately NOT the route server's ASN (65500):
+// rs_control_communities defaults on for rs-clients, and RS-administered
+// standard communities are RFC 7947 control forms scrubbed from the wire,
+// which would hide these markers from the observers. Must match
+// gen-scenario.py's GENERATIONS / stable-out.
+const COMMUNITY_GEN_A: u32 = (65_400 << 16) | 1_000;
+const COMMUNITY_GEN_B: u32 = (65_400 << 16) | 2_000;
+const COMMUNITY_STABLE: u32 = (65_400 << 16) | 9_000;
 const STALL_WINDOW: Duration = Duration::from_secs(120);
 const FLAP_ROUNDS: u32 = 3;
 const FLAP_RECONNECT_SECS: u64 = 10;

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -40,7 +40,8 @@ mod evpn;
 mod export_memo;
 mod flowspec;
 mod labeled;
-mod rs_control;
+// Emit-seam helpers are shared with `update_groups` (LAN-474).
+pub(in crate::manager) mod rs_control;
 mod rtc;
 mod unicast;
 mod vpn;
@@ -1201,6 +1202,13 @@ impl RibManager {
             && !self.peer_unexportable.contains_key(&peer)
             && !self.peer_orf_pending.contains_key(&peer)
             && !self.peer_orf_filters.contains_key(&peer)
+            // LAN-474: the strict transition's shared inventory /
+            // shared encode is one payload for the whole cohort, but an
+            // rs-control member's emission can diverge per target on
+            // tagged routes. Rare event, tiny cohort cost: these
+            // members take the ordinary regroup baseline diff, which
+            // applies the emit-time filter.
+            && !self.peer_rs_control.contains_key(&peer)
     }
 
     /// Advance one bounded production step of the actor-owned transition.
@@ -3325,6 +3333,12 @@ impl RibManager {
         // exactly as before.
         let group_stage = self.stage_update_groups(&best_changed, &mut export_memo);
         let mut shared_unicast_probe_cache = SharedUnicastProbeCache::default();
+        // LAN-474 emit-time filter: whether a group's pass carries any
+        // control-tagged announce delta, memoized per (group, rs_asn) —
+        // one delta scan per group per pass, not per member. Untagged
+        // passes (the overwhelming majority) keep every
+        // `rs_control_communities` member on the shared Arc emission.
+        let mut rs_tagged_pass: HashMap<(usize, u32), bool> = HashMap::new();
         for peer in peers {
             let member_of = self.grouped_member_of(peer);
             // For dirty peers, compute full prefix set from Loc-RIB + AdjRibOut
@@ -3635,11 +3649,21 @@ impl RibManager {
                 // a Φ change, which is why the membership-delta path
                 // defers to this (design §2.4).
                 let member_filter = self.member_rt_filter(peer);
+                // The member's rs-control context (LAN-474): per-target
+                // divergence for tagged routes applies at every grouped
+                // emit seam below; untagged routes emit exactly the
+                // shared shape.
+                let rs_control = self
+                    .peer_rs_control
+                    .get(&peer)
+                    .copied()
+                    .zip(self.peer_asn.get(&peer).copied());
                 if let Some(group) = self.group_ribs.get(&gid) {
                     if resync {
                         Self::assemble_group_resync(
                             group,
                             peer,
+                            rs_control,
                             is_dirty,
                             is_force,
                             self.pending_regroup_baseline
@@ -3674,7 +3698,17 @@ impl RibManager {
                             );
                         }
                     } else if let Some(stage) = group_stage.get(&gid) {
-                        if stage.shared_applies_to(peer) {
+                        // An rs-control member shares the pre-built
+                        // emission unless this pass staged a tagged
+                        // route (memoized scan) — then its
+                        // announce/withdraw set can diverge per target
+                        // and it walks the matrix itself.
+                        let rs_diverges = rs_control.is_some_and(|(rs_asn, _)| {
+                            *rs_tagged_pass
+                                .entry((gid, rs_asn))
+                                .or_insert_with(|| stage.has_tagged_route(rs_asn))
+                        });
+                        if stage.shared_applies_to(peer) && !rs_diverges {
                             // Common case: this member's matrix output IS
                             // the shared emission — enqueue Arc clones.
                             shared_unicast =
@@ -3684,6 +3718,7 @@ impl RibManager {
                             super::update_groups::emit_group_deltas_for_member(
                                 &stage.deltas,
                                 peer,
+                                rs_control,
                                 &mut announce,
                                 &mut withdraw,
                                 &mut nh_override_flags,

--- a/crates/rib/src/manager/distribution/rs_control.rs
+++ b/crates/rib/src/manager/distribution/rs_control.rs
@@ -109,6 +109,68 @@ pub(super) fn rs_control_prepend_count(
     count
 }
 
+/// A standard community in the control space: administered by `0` or
+/// `RS`, excluding the RFC 1997 well-known `0xFFFF____` space.
+fn is_std_control(community: u32, rs_asn: u32) -> bool {
+    let admin = community >> 16;
+    admin != 0xFFFF && (admin == 0 || admin == rs_asn)
+}
+
+/// A large community in the control space: global administrator `RS`
+/// with a control function (`0`, `1`, `101`–`103`).
+fn is_large_control(lc: &LargeCommunity, rs_asn: u32) -> bool {
+    lc.global_admin == rs_asn
+        && (lc.local_data1 <= 1 || PREPEND_FUNCTIONS.iter().any(|&(f, _)| f == lc.local_data1))
+}
+
+/// Route-granular classification for the emit-time filter (LAN-474):
+/// does this route carry ANY control-form community for `rs_asn`? The
+/// domain is exactly the scrub domain — every suppression, override,
+/// and prepend form is also a scrub form — so untagged routes (the
+/// overwhelming majority) provably need no per-target divergence and
+/// keep riding the shared update-group emission.
+pub(in crate::manager) fn rs_control_route_tagged(
+    communities: &[u32],
+    large_communities: &[LargeCommunity],
+    rs_asn: u32,
+) -> bool {
+    communities.iter().any(|&c| is_std_control(c, rs_asn))
+        || large_communities
+            .iter()
+            .any(|lc| is_large_control(lc, rs_asn))
+}
+
+/// Per-target suppression at the group emit seam: `rs` is
+/// `(rs_asn, target_peer_asn)` for an enabled session, `None` when the
+/// knob is off (never suppressed).
+pub(in crate::manager) fn rs_control_route_suppressed(
+    route: &crate::route::Route,
+    rs: Option<(u32, u32)>,
+) -> bool {
+    rs.is_some_and(|(rs_asn, peer_asn)| {
+        rs_control_export_suppressed(
+            route.communities(),
+            route.large_communities(),
+            rs_asn,
+            peer_asn,
+        )
+    })
+}
+
+/// Per-target egress rewrite (prepend + scrub) at the group emit seam,
+/// for a route already cleared by [`rs_control_route_suppressed`].
+/// No-op (and allocation-free) for untagged routes or a disabled
+/// session.
+pub(in crate::manager) fn rs_control_route_rewrite(
+    route: &mut crate::route::Route,
+    rs: Option<(u32, u32)>,
+) {
+    if let Some((rs_asn, peer_asn)) = rs {
+        let prepend = rs_control_prepend_count(route.large_communities(), rs_asn, peer_asn);
+        apply_rs_control_egress(route, rs_asn, prepend);
+    }
+}
+
 /// The control communities present on an outbound attribute set that
 /// must be scrubbed before the wire: standard communities administered
 /// by `0` or `RS` (excluding the RFC 1997 well-known `0xFFFF____`
@@ -121,18 +183,11 @@ fn scrub_lists(
     let std_remove = communities
         .iter()
         .copied()
-        .filter(|&c| {
-            let admin = c >> 16;
-            admin != 0xFFFF && (admin == 0 || admin == rs_asn)
-        })
+        .filter(|&c| is_std_control(c, rs_asn))
         .collect();
     let large_remove = large_communities
         .iter()
-        .filter(|lc| {
-            lc.global_admin == rs_asn
-                && (lc.local_data1 <= 1
-                    || PREPEND_FUNCTIONS.iter().any(|&(f, _)| f == lc.local_data1))
-        })
+        .filter(|lc| is_large_control(lc, rs_asn))
         .copied()
         .collect();
     (std_remove, large_remove)
@@ -152,11 +207,11 @@ fn leftmost_asn(as_path: Option<&AsPath>) -> Option<u32> {
 /// route clone: prepend the announcing client's ASN `prepend` times
 /// and scrub the control communities. Reuses the policy crate's
 /// `apply_modifications` (attribute-drop on emptied community lists,
-/// tested prepend segment handling). `Arc::make_mut` keeps the
-/// pass-scoped `ExportMemo`'s shared attribute `Arc`s copy-on-write —
-/// affected routes pay a per-peer attribute clone (enabled sessions
-/// are already on the ungrouped per-peer path; memo-sharing the
-/// rewrite is a follow-up if profile data ever demands it).
+/// tested prepend segment handling). `Arc::make_mut` keeps shared
+/// attribute `Arc`s (pass-scoped `ExportMemo`, group-table shells)
+/// copy-on-write — only TAGGED routes pay a per-target attribute
+/// clone; untagged routes never reach this rewrite on the grouped
+/// emit-filter path (LAN-474).
 pub(super) fn apply_rs_control_egress(route: &mut crate::route::Route, rs_asn: u32, prepend: u8) {
     let (communities_remove, large_communities_remove) =
         scrub_lists(route.communities(), route.large_communities(), rs_asn);
@@ -300,6 +355,28 @@ mod tests {
         // Wrong global admin never counts.
         let lc = [large(64999, 103, PEER_A)];
         assert_eq!(rs_control_prepend_count(&lc, RS, PEER_A), 0);
+    }
+
+    #[test]
+    fn tagged_predicate_matches_exactly_the_scrub_domain() {
+        // Untagged: no communities, foreign admins, well-known space,
+        // informational large under the RS admin.
+        assert!(!rs_control_route_tagged(&[], &[], RS));
+        assert!(!rs_control_route_tagged(
+            &[
+                std(64999, 42),
+                rustbgpd_wire::COMMUNITY_NO_EXPORT,
+                rustbgpd_wire::COMMUNITY_GRACEFUL_SHUTDOWN
+            ],
+            &[large(RS, 1000, 7), large(64999, 0, PEER_A)],
+            RS
+        ));
+        // Tagged: each control form flips the predicate on its own.
+        assert!(rs_control_route_tagged(&[std(0, PEER_A)], &[], RS));
+        assert!(rs_control_route_tagged(&[std(RS, PEER_A)], &[], RS));
+        assert!(rs_control_route_tagged(&[], &[large(RS, 0, PEER_A)], RS));
+        assert!(rs_control_route_tagged(&[], &[large(RS, 1, PEER_A)], RS));
+        assert!(rs_control_route_tagged(&[], &[large(RS, 102, 0)], RS));
     }
 
     #[test]

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1134,12 +1134,24 @@ impl RibManager {
         let member_of = self.grouped_member_of(peer);
         let mut vpn_group_replayed = false;
         if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {
+            // LAN-474: per-target divergence at the replay seam — a
+            // control-tagged table entry may be suppressed toward this
+            // member or rewritten (prepend + scrub) for it; untagged
+            // entries replay as-is.
+            let rs_control = rs_control_asn.zip(target_peer_asn);
             for route in group.table.iter() {
-                if route.peer == peer || self.selection_deferred(prefix_family(&route.prefix)) {
+                if route.peer == peer
+                    || self.selection_deferred(prefix_family(&route.prefix))
+                    || super::distribution::rs_control::rs_control_route_suppressed(
+                        route, rs_control,
+                    )
+                {
                     continue;
                 }
                 nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
-                announce.push(route.clone());
+                let mut route = route.clone();
+                super::distribution::rs_control::rs_control_route_rewrite(&mut route, rs_control);
+                announce.push(route);
             }
             // VPN join replay: table minus own-sourced, filtered by the
             // joining member's Φ (the RFC 4684 gate the per-peer dump

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -976,12 +976,25 @@ impl RibManager {
             // deferred-ORF withdraw sweep in the per-peer arm can never
             // apply to a grouped member.
             if let Some(group) = self.group_ribs.get(&gid) {
+                // LAN-474: same per-target divergence as the join
+                // replay — suppressed entries skipped, announced tagged
+                // entries rewritten per target.
+                let rs_control = rs_control_asn.zip(target_peer_asn);
                 for route in group.table.iter() {
-                    if route.peer == peer || prefix_family(&route.prefix) != family {
+                    if route.peer == peer
+                        || prefix_family(&route.prefix) != family
+                        || super::distribution::rs_control::rs_control_route_suppressed(
+                            route, rs_control,
+                        )
+                    {
                         continue;
                     }
                     nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
-                    announce.push(route.clone());
+                    let mut route = route.clone();
+                    super::distribution::rs_control::rs_control_route_rewrite(
+                        &mut route, rs_control,
+                    );
+                    announce.push(route);
                 }
                 current_policy_filtered_routes
                     .extend(group.policy_filtered_for_member(peer, &all_prefixes));

--- a/crates/rib/src/manager/tests/rs_control.rs
+++ b/crates/rib/src/manager/tests/rs_control.rs
@@ -1,12 +1,14 @@
 //! RFC 7947 §2.3.2 / RFC 8195 route-server control communities.
 //!
 //! Per-target announce suppression / announce-only / prepend keyed on
-//! the TARGET peer's ASN, enforced at export staging for sessions with
+//! the TARGET peer's ASN, enforced for sessions with
 //! `rs_control_communities` (staged via `SetPeerRsControl` before
 //! `PeerUp`), with the matched control communities scrubbed from the
 //! outbound announcement. Sessions without the knob keep full
-//! transparency, and enabled sessions are disqualified from
-//! update-group sharing. Predicate-level pins live in
+//! transparency. Enabled sessions stay in shared update-groups
+//! (LAN-474): untagged routes ride the shared staged emission, and
+//! only routes carrying a control-form community diverge per target at
+//! the emit seams. Predicate-level pins live in
 //! `distribution::rs_control`; these tests drive the full
 //! message-in/announcement-out path.
 
@@ -126,9 +128,9 @@ fn sequence_asns(route: &Route) -> Vec<u32> {
 /// toward A only (with the `rs_control` explain rung), B receives the
 /// route with the control communities scrubbed and unrelated
 /// communities kept, and a session without the knob receives the
-/// control communities untouched (RFC 7947 transparency). Enabled
-/// sessions are classifier-disqualified from update groups; the
-/// disabled session stays grouped.
+/// control communities untouched (RFC 7947 transparency). All three
+/// sessions share ONE update group (LAN-474): the divergence is
+/// route-granular at emit, not a session-level disqualifier.
 #[tokio::test]
 async fn control_communities_steer_per_target_announcement_and_scrub() {
     let (tx, rx) = mpsc::channel(64);
@@ -142,20 +144,17 @@ async fn control_communities_steer_per_target_announcement_and_scrub() {
     let mut b_rx = rs_peer_up(&tx, client_b, 65002, Some(RS_AS)).await;
     let mut t_rx = rs_peer_up(&tx, transparent, 65100, None).await;
 
-    // Update-group posture: enabled sessions are ungrouped with the
-    // dedicated reason; the disabled session groups normally.
+    // Update-group posture (LAN-474): the knob no longer disqualifies —
+    // enabled and disabled sessions with the same staging fingerprint
+    // share one group.
+    let group_a = query_update_group_label(&tx, client_a).await;
+    let group_b = query_update_group_label(&tx, client_b).await;
+    let group_t = query_update_group_label(&tx, transparent).await;
+    assert!(group_a.starts_with("group:"), "{group_a}");
+    assert_eq!(group_a, group_b, "enabled sessions share the group");
     assert_eq!(
-        query_update_group_label(&tx, client_a).await,
-        "rs_control_communities"
-    );
-    assert_eq!(
-        query_update_group_label(&tx, client_b).await,
-        "rs_control_communities"
-    );
-    let transparent_group = query_update_group_label(&tx, transparent).await;
-    assert!(
-        transparent_group.starts_with("group:"),
-        "{transparent_group}"
+        group_a, group_t,
+        "the emit filter is route-granular — the knob is not a group key dimension"
     );
 
     let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 119, 0), 24);
@@ -212,6 +211,139 @@ async fn control_communities_steer_per_target_announcement_and_scrub() {
     let advertised = &update.announce[0];
     assert_eq!(advertised.communities(), [unrelated]);
     assert_eq!(advertised.large_communities(), [large(0, 65001)]);
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// The LAN-474 shared/divergent split in one table: an untagged route
+/// flows through the SHARED group emission to enabled rs-clients
+/// (grouping stays shared before and after the pass) while a tagged
+/// route announced in the same pass diverges per target — suppressed
+/// toward the named ASN, scrubbed toward the other enabled member,
+/// verbatim toward the transparent session. A member joining late
+/// gets the same filtered view from the group-table replay.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario pins the shared path, both divergence shapes, and the join replay end to end"
+)]
+#[tokio::test]
+async fn untagged_routes_share_the_group_path_while_tagged_diverge() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let client_a: IpAddr = "192.0.2.231".parse().unwrap();
+    let client_b: IpAddr = "192.0.2.232".parse().unwrap();
+    let transparent: IpAddr = "192.0.2.233".parse().unwrap();
+
+    let mut a_rx = rs_peer_up(&tx, client_a, 65001, Some(RS_AS)).await;
+    let mut b_rx = rs_peer_up(&tx, client_b, 65002, Some(RS_AS)).await;
+    let mut t_rx = rs_peer_up(&tx, transparent, 65100, None).await;
+
+    let group_before = query_update_group_label(&tx, client_a).await;
+    assert!(group_before.starts_with("group:"), "{group_before}");
+    assert_eq!(group_before, query_update_group_label(&tx, client_b).await);
+    assert_eq!(
+        group_before,
+        query_update_group_label(&tx, transparent).await
+    );
+
+    let plain_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 122, 0), 24);
+    let tagged_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 123, 0), 24);
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 43));
+    let unrelated = std_c(64999, 42);
+    let plain = make_route_with_as_path(plain_prefix, Ipv4Addr::new(198, 51, 100, 43), vec![65010]);
+    let steered = tagged(
+        make_route_with_as_path(tagged_prefix, Ipv4Addr::new(198, 51, 100, 43), vec![65010]),
+        vec![unrelated],
+        vec![large(0, 65001)], // do not announce to 65001
+    );
+    announce_unicast(&tx, source, vec![plain, steered]).await;
+    let _ = query_best_routes(&tx).await;
+
+    // A (the steered-away target): only the untagged route, no
+    // withdraw residue for a route it never held.
+    let update = a_rx.try_recv().expect("shared route still announced");
+    assert_eq!(
+        update
+            .announce
+            .iter()
+            .map(|route| route.prefix)
+            .collect::<Vec<_>>(),
+        vec![Prefix::V4(plain_prefix)]
+    );
+    assert!(update.withdraw.is_empty());
+
+    // B: both routes, the tagged one scrubbed (unrelated kept).
+    let update = b_rx.try_recv().expect("other enabled client gets both");
+    assert_eq!(update.announce.len(), 2);
+    let advertised = update
+        .announce
+        .iter()
+        .find(|route| route.prefix == Prefix::V4(tagged_prefix))
+        .expect("tagged route announced to B");
+    assert_eq!(advertised.communities(), [unrelated]);
+    assert!(advertised.large_communities().is_empty());
+
+    // Transparent session: both routes, control community verbatim.
+    let update = t_rx.try_recv().expect("transparent session gets both");
+    assert_eq!(update.announce.len(), 2);
+    let advertised = update
+        .announce
+        .iter()
+        .find(|route| route.prefix == Prefix::V4(tagged_prefix))
+        .expect("tagged route announced to T");
+    assert_eq!(advertised.communities(), [unrelated]);
+    assert_eq!(advertised.large_communities(), [large(0, 65001)]);
+
+    // Grouping is untouched by the divergent pass.
+    assert_eq!(query_update_group_label(&tx, client_a).await, group_before);
+    assert_eq!(query_update_group_label(&tx, client_b).await, group_before);
+
+    // Late join with the steered-away ASN: the group-table replay
+    // (initial dump) applies the same filter — only the untagged route.
+    let late: IpAddr = "192.0.2.234".parse().unwrap();
+    tx.send(RibUpdate::SetPeerRsControl {
+        peer: late,
+        session_id: 0,
+        rs_control_asn: Some(RS_AS),
+    })
+    .await
+    .unwrap();
+    let (out_tx, mut late_rx) = mpsc::channel(32);
+    tx.send(RibUpdate::PeerUp {
+        peer: late,
+        session_id: 0,
+        peer_asn: 65001,
+        peer_router_id: Ipv4Addr::UNSPECIFIED,
+        outbound_tx: out_tx,
+        export_policy: None,
+        sendable_families: ipv4_sendable(),
+        is_ebgp: true,
+        route_reflector_client: false,
+        orr_vantage: None,
+        per_client_best: false,
+        interpret_rfc1997: false,
+        add_path_send_families: vec![],
+        add_path_send_max: 0,
+        negotiated_orf_recv: vec![],
+        negotiated_llgr_families: vec![],
+    })
+    .await
+    .unwrap();
+    let _ = query_best_routes(&tx).await;
+    let mut dumped: Vec<Prefix> = Vec::new();
+    let mut saw_eor = false;
+    while let Ok(update) = late_rx.try_recv() {
+        dumped.extend(update.announce.iter().map(|route| route.prefix));
+        saw_eor |= !update.end_of_rib.is_empty();
+    }
+    assert!(saw_eor, "initial dump must end with EoR");
+    assert_eq!(
+        dumped,
+        vec![Prefix::V4(plain_prefix)],
+        "join replay must suppress the tagged route toward the steered-away ASN"
+    );
 
     drop(tx);
     handle.await.unwrap();

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -131,10 +131,6 @@ pub(super) enum GroupMembership {
     /// per-target (the member sourcing the Loc-RIB best gets the
     /// runner-up), so no shared staged winner exists.
     PerClientBest,
-    /// RFC 7947 §2.3.2 route-server control communities interpreted:
-    /// announce/prepend/scrub outcomes are keyed on the TARGET peer's
-    /// ASN per route, so no shared staged winner exists.
-    RsControlCommunities,
     /// ORR vantage bound: per-vantage winners are per-target
     /// (ADR-0095 Decision 5).
     OrrVantage,
@@ -156,7 +152,6 @@ impl GroupMembership {
             Self::PolicyPeerContext => "policy_peer_context".to_string(),
             Self::AddPathSend => "add_path_send".to_string(),
             Self::PerClientBest => "per_client_best".to_string(),
-            Self::RsControlCommunities => "rs_control_communities".to_string(),
             Self::OrrVantage => "orr_vantage".to_string(),
             Self::OrfInstalled => "orf_installed".to_string(),
             Self::SlowPeer => "slow_peer".to_string(),
@@ -324,6 +319,24 @@ impl GroupStageOutput {
         !self.exceptions.contains(&member)
     }
 
+    /// Whether any announce delta of this pass carries a control-form
+    /// community for `rs_asn` (LAN-474). A pass with none — the
+    /// overwhelming majority — lets `rs_control_communities` members
+    /// ride the shared emission untouched; a tagged pass drops them to
+    /// the per-member matrix walk where suppression/prepend/scrub
+    /// diverge per target. Callers memoize per (group, `rs_asn`).
+    pub(in crate::manager) fn has_tagged_route(&self, rs_asn: u32) -> bool {
+        self.deltas.iter().any(|delta| {
+            delta.new.as_ref().is_some_and(|(route, _)| {
+                super::distribution::rs_control::rs_control_route_tagged(
+                    route.communities(),
+                    route.large_communities(),
+                    rs_asn,
+                )
+            })
+        })
+    }
+
     /// Member-scoped withdraw keys of this pass that [`Self::withdrawn_keys`]
     /// (the tombstone feed) never records: the source-flip arm — the
     /// member is the delta's NEW source and the displaced entry was
@@ -432,13 +445,23 @@ impl GroupEvalAccumulator {
 /// `nh_override_flags` stays aligned with `announce` by pushing in the
 /// same arm. A free function so the risk-2 unit matrix can drive it
 /// directly.
+///
+/// `rs_control` is `(rs_asn, member_asn)` for an
+/// `rs_control_communities` member (LAN-474): a tagged route the
+/// control communities suppress toward this member emits a withdraw of
+/// whatever other-sourced entry the member may hold (over-withdraw is
+/// the safe direction), and an announced tagged route is rewritten
+/// (prepend + scrub) per target. `None` — or an untagged route — is
+/// byte-identical to the shared emission.
 pub(in crate::manager) fn emit_group_deltas_for_member(
     deltas: &[GroupDelta],
     member: IpAddr,
+    rs_control: Option<(u32, u32)>,
     announce: &mut Vec<Route>,
     withdraw: &mut Vec<(Prefix, u32)>,
     nh_override_flags: &mut Vec<Option<NextHopAction>>,
 ) {
+    use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_route_suppressed};
     for delta in deltas {
         match &delta.new {
             Some((route, nh)) => {
@@ -453,9 +476,18 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
                     if delta.old_source.is_some_and(|source| source != member) {
                         withdraw.push((delta.prefix, delta.path_id));
                     }
+                } else if rs_control_route_suppressed(route, rs_control) {
+                    // RFC 7947 §2.3.2 per-target suppression: same
+                    // matrix shape as the split-horizon arm — displace
+                    // whatever other-sourced entry the member may hold.
+                    if delta.old_source.is_some_and(|source| source != member) {
+                        withdraw.push((delta.prefix, delta.path_id));
+                    }
                 } else {
+                    let mut route = route.clone();
+                    rs_control_route_rewrite(&mut route, rs_control);
                     nh_override_flags.push(nh.clone());
-                    announce.push(route.clone());
+                    announce.push(route);
                 }
             }
             None => {
@@ -979,15 +1011,27 @@ impl GroupRibOut {
     fn member_view_snapshot(
         &self,
         member: IpAddr,
+        rs_control: Option<(u32, u32)>,
         rejected: &HashSet<ExactExportKey>,
     ) -> FxHashMap<(Prefix, u32), Route> {
+        use super::distribution::rs_control::{
+            rs_control_route_rewrite, rs_control_route_suppressed,
+        };
         self.table
             .iter()
             .filter(|route| {
                 route.peer != member
                     && !rejected.contains(&ExactExportKey::Unicast(route.prefix, route.path_id))
+                    // LAN-474: a key suppressed toward the member was
+                    // never on its wire — the snapshot records true
+                    // wire state, not the shared table.
+                    && !rs_control_route_suppressed(route, rs_control)
             })
-            .map(|route| ((route.prefix, route.path_id), route.clone()))
+            .map(|route| {
+                let mut route = route.clone();
+                rs_control_route_rewrite(&mut route, rs_control);
+                ((route.prefix, route.path_id), route)
+            })
             .collect()
     }
 
@@ -1377,9 +1421,11 @@ impl RibManager {
                     &mut target,
                     group.is_ebgp,
                     group.interpret_rfc1997,
-                    // Control-community sessions are classifier-disqualified
-                    // from grouping (`RsControlCommunities`), so a group
-                    // member never interprets them.
+                    // Group staging is rs-control-agnostic: control
+                    // communities diverge per TARGET, so they are
+                    // enforced at the member-emit seams (LAN-474 —
+                    // matrix walk, resync, join/refresh replay), never
+                    // against the shared staged winner.
                     None,
                     group.is_rr_client,
                     self.cluster_id,
@@ -1621,6 +1667,15 @@ impl RibManager {
     ///   member no longer retains;
     /// - force-only (RFC 8326 `GShut` refresh): re-announce everything,
     ///   bypassing the equality diff, withdraw nothing.
+    ///
+    /// `rs_control` is `(rs_asn, member_asn)` for an
+    /// `rs_control_communities` member (LAN-474): table entries the
+    /// control communities suppress toward this member are skipped —
+    /// and withdrawn when the member may have them on the wire (plain
+    /// dirty, or a baseline that records the key) — and announced
+    /// entries are rewritten (prepend + scrub) per target. Baselines
+    /// snapshot through the same filter ([`GroupRibOut::member_view_snapshot`]),
+    /// so the regroup one-shot diff compares wire state to wire state.
     #[expect(
         clippy::too_many_arguments,
         reason = "the resync assembly takes the member's full pending-withdraw context"
@@ -1628,6 +1683,7 @@ impl RibManager {
     pub(in crate::manager) fn assemble_group_resync(
         group: &GroupRibOut,
         member: IpAddr,
+        rs_control: Option<(u32, u32)>,
         is_dirty: bool,
         is_force: bool,
         baseline: Option<&FxHashMap<(Prefix, u32), Route>>,
@@ -1636,30 +1692,47 @@ impl RibManager {
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<NextHopAction>>,
     ) {
+        use super::distribution::rs_control::{
+            rs_control_route_rewrite, rs_control_route_suppressed,
+        };
+        let mut suppressed_withdraws: HashSet<(Prefix, u32)> = HashSet::new();
         for route in group.table.iter() {
             if route.peer == member {
                 continue;
             }
             let key = (route.prefix, route.path_id);
+            if rs_control_route_suppressed(route, rs_control) {
+                // Not on this member's wire going forward. Withdraw when
+                // it may be there now: always on a plain dirty resync
+                // (missed sends are unknown — over-withdraw is the safe
+                // direction), on a regroup diff only when the baseline
+                // proves the key was sent. Force-only re-announces and
+                // never withdraws.
+                if !is_force && (is_dirty || baseline.is_some_and(|base| base.contains_key(&key))) {
+                    suppressed_withdraws.insert(key);
+                }
+                continue;
+            }
+            let mut route = route.clone();
+            rs_control_route_rewrite(&mut route, rs_control);
             if !is_force
                 && let Some(base) = baseline
-                && base.get(&key).is_some_and(|old| routes_equal(old, route))
+                && base.get(&key).is_some_and(|old| routes_equal(old, &route))
             {
                 continue;
             }
             nh_override_flags.push(group.nh_override(key));
-            announce.push(route.clone());
+            announce.push(route);
         }
-        // A key the member still retains (staged, not own-sourced) must
-        // not be withdrawn — everything else in the candidate sets is a
-        // safe (possibly spurious) withdraw.
+        // A key the member still retains (staged, not own-sourced, not
+        // suppressed toward it) must not be withdrawn — everything else
+        // in the candidate sets is a safe (possibly spurious) withdraw.
         let member_retains = |key: &(Prefix, u32)| {
-            group
-                .table
-                .get(&key.0, key.1)
-                .is_some_and(|route| route.peer != member)
+            group.table.get(&key.0, key.1).is_some_and(|route| {
+                route.peer != member && !rs_control_route_suppressed(route, rs_control)
+            })
         };
-        let mut keys: HashSet<(Prefix, u32)> = HashSet::new();
+        let mut keys: HashSet<(Prefix, u32)> = suppressed_withdraws;
         if let Some(base) = baseline {
             keys.extend(base.keys().filter(|key| !member_retains(key)));
         }
@@ -2209,11 +2282,16 @@ impl RibManager {
                 .get(&peer)
                 .cloned()
                 .unwrap_or_default();
+            let rs_control = self
+                .peer_rs_control
+                .get(&peer)
+                .copied()
+                .zip(self.peer_asn.get(&peer).copied());
             let baseline: Option<RegroupBaseline> = match prev_gid {
                 Some(gid) => {
                     let group = self.group_ribs.get(&gid);
                     let base = group.map(|g| RegroupBaseline {
-                        unicast: g.member_view_snapshot(peer, &rejected),
+                        unicast: g.member_view_snapshot(peer, rs_control, &rejected),
                         vpn: g.member_vpn_view_snapshot(peer, rt_filter.as_ref(), &rejected),
                     });
                     // A member that leaves while dirty may have missed
@@ -2547,9 +2625,6 @@ impl RibManager {
             }
             UpdateGroupClassification::AddPathSend => return GroupMembership::AddPathSend,
             UpdateGroupClassification::PerClientBest => return GroupMembership::PerClientBest,
-            UpdateGroupClassification::RsControlCommunities => {
-                return GroupMembership::RsControlCommunities;
-            }
             UpdateGroupClassification::OrrVantage => return GroupMembership::OrrVantage,
             UpdateGroupClassification::OrfInstalled => return GroupMembership::OrfInstalled,
             UpdateGroupClassification::Groupable(fingerprint) => fingerprint,
@@ -2736,7 +2811,6 @@ impl RibManager {
             // of GroupKey before this disqualifier is relaxed.
             add_path_send: self.peer_has_any_add_path_send(peer),
             per_client_best: self.peer_per_client_best.contains(&peer),
-            rs_control_communities: self.peer_rs_control.contains_key(&peer),
             orr_vantage: self.peer_orr_vantage.get(&peer).copied(),
             orf_installed,
         }
@@ -3100,6 +3174,7 @@ mod tests {
                 emit_group_deltas_for_member(
                     std::slice::from_ref(&delta),
                     MEMBER,
+                    None,
                     &mut announce,
                     &mut withdraw,
                     &mut nh_flags,
@@ -3152,6 +3227,7 @@ mod tests {
         RibManager::assemble_group_resync(
             &group,
             MEMBER,
+            None,
             true,
             false,
             None,
@@ -3193,6 +3269,7 @@ mod tests {
         RibManager::assemble_group_resync(
             &group,
             MEMBER,
+            None,
             true,
             false,
             Some(&baseline),
@@ -3213,6 +3290,7 @@ mod tests {
         RibManager::assemble_group_resync(
             &group,
             MEMBER,
+            None,
             false,
             true,
             Some(&baseline),
@@ -3298,6 +3376,7 @@ mod tests {
         RibManager::assemble_group_resync(
             &group,
             MEMBER,
+            None,
             true,
             false,
             None,
@@ -3768,7 +3847,7 @@ mod tests {
             group.family_counts_for(MEMBER),
             vec![((Afi::Ipv4, Safi::Unicast), 1)]
         );
-        let view = group.member_view_snapshot(MEMBER, &HashSet::new());
+        let view = group.member_view_snapshot(MEMBER, None, &HashSet::new());
         assert_eq!(view.len(), 1);
         assert!(view.contains_key(&(k1, 0)));
 

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -58,10 +58,6 @@ pub struct UpdateGroupClassifierInput {
     pub llgr_families: Vec<(u16, u8)>,
     pub add_path_send: bool,
     pub per_client_best: bool,
-    /// RFC 7947 §2.3.2 control communities: the export outcome (and the
-    /// prepend/scrub rewrite) is keyed on the TARGET peer's ASN per
-    /// route, so no shared staged winner exists for enabled sessions.
-    pub rs_control_communities: bool,
     pub orr_vantage: Option<IpAddr>,
     pub orf_installed: bool,
 }
@@ -93,7 +89,6 @@ pub enum UpdateGroupClassification {
     PolicyPeerContext,
     AddPathSend,
     PerClientBest,
-    RsControlCommunities,
     OrrVantage,
     OrfInstalled,
 }
@@ -106,7 +101,6 @@ impl UpdateGroupClassification {
             Self::PolicyPeerContext => Some("policy_peer_context"),
             Self::AddPathSend => Some("add_path_send"),
             Self::PerClientBest => Some("per_client_best"),
-            Self::RsControlCommunities => Some("rs_control_communities"),
             Self::OrrVantage => Some("orr_vantage"),
             Self::OrfInstalled => Some("orf_installed"),
         }
@@ -126,8 +120,6 @@ pub fn classify_update_group(mut input: UpdateGroupClassifierInput) -> UpdateGro
         UpdateGroupClassification::AddPathSend
     } else if input.per_client_best {
         UpdateGroupClassification::PerClientBest
-    } else if input.rs_control_communities {
-        UpdateGroupClassification::RsControlCommunities
     } else if input.orr_vantage.is_some() {
         UpdateGroupClassification::OrrVantage
     } else if input.orf_installed {
@@ -238,7 +230,6 @@ mod update_group_classifier_tests {
             llgr_families: vec![],
             add_path_send: false,
             per_client_best: false,
-            rs_control_communities: false,
             orr_vantage: None,
             orf_installed: false,
         }

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -104,9 +104,7 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
   deliberately not implemented (draft-ietf-grow-ixp-ext-comms). Full matrix
   and evaluation ladder: the [route-server cookbook](cookbook/route-server.md).
 - Enforcement is gated per session by `rs_control_communities` (default
-  off/opt-in — an enabled session leaves update-group sharing, which at
-  large fanout costs per-peer staging), evaluated pre-policy on the source
-  route like the
+  `route_server_client`), evaluated pre-policy on the source route like the
   RFC 1997 gates (its own `rs_control` explain rung), and covers the unicast
   export shapes: single-best, Add-Path, and per-client-best (suppressed
   candidates are removed before ranking). Non-unicast families are out of
@@ -114,8 +112,10 @@ deviations; [docs/INTEROP.md](INTEROP.md) has the interop matrix,
 - Acted-on control communities are scrubbed from the wire-bound attribute set
   toward enabled sessions (standard admin `0`/`RS` outside the `0xFFFF____`
   well-known space; large `RS:{0,1,101,102,103}:*`); disabled sessions keep
-  RFC 7947 §2.2 byte-level transparency. Enabled sessions are excluded from
-  update-group sharing (`rs_control_communities` disqualifier reason).
+  RFC 7947 §2.2 byte-level transparency. Enabled sessions stay in shared
+  update-groups: the filter is route-granular at emit (ADR-0101 Decision 3),
+  so only routes carrying a control-form community pay per-target divergence
+  while untagged routes share staging and encoding fleet-wide.
 
 ---
 

--- a/docs/adr/0101-route-server-profile.md
+++ b/docs/adr/0101-route-server-profile.md
@@ -92,10 +92,17 @@ Add-Path send, so mitigation (b) existed; the gap was (a).
    `requires_peer_context` and disqualify anyway. The scalable answer
    is the ADR-0099 Decision-2 pattern — steering as a per-member
    **emit-time filter** `pass_m(route)` = f(route communities, member
-   ASN), presence bit in the key, exactly like the VPN RT filter, which
-   keeps the whole steering fleet in one group — **deferred to v2**
-   with this sketch recorded; un-defer trigger: a real >100-member
-   deployment where steering chains measurably shatter grouping.
+   ASN), exactly like the VPN RT filter, which keeps the whole
+   steering fleet in one group — **delivered** for RFC 7947 §2.3.2 /
+   RFC 8195 control communities (LAN-474): routes are classified at
+   emit by a cheap control-form predicate (exactly the scrub domain),
+   untagged routes ride the shared group emission byte-identically,
+   and tagged routes diverge per target at the emit seams (matrix
+   walk, resync, join/refresh replays). No presence bit in the key was
+   needed — a disabled session's emission of an untagged route is
+   identical to an enabled one's, and tagged-route divergence is
+   evaluated per member. `rs_control_communities` defaults on for
+   rs-clients again on the strength of this.
 
 4. **RPKI/ASPA enforcement stays in policy — no hard-coded RS gate.**
    Validation state is computed at import; enforcement is rpol/TOML
@@ -146,9 +153,12 @@ Add-Path send, so mitigation (b) existed; the gap was (a).
   the shared body or disqualify (the ADR-0098 Decision-3 rule extends
   to modes).
 - Deferral register: per-client Loc-RIBs — rejected permanently;
-  community-steering emit-time filter — v2, sketch in Decision 3;
-  peer-parameterized policy matchers — rejected (superseded by the v2
-  filter); default-on mitigation — deferred pending soak history;
+  community-steering emit-time filter — **delivered** (Decision 3;
+  LAN-474 route-granular control-community divergence at the group
+  emit seams);
+  peer-parameterized policy matchers — rejected (superseded by the
+  emit-time filter); default-on mitigation — deferred pending soak
+  history;
   RFC 8097 validation-state extended-community tagging on import —
   **delivered** (the deferred small slice landed: `OV_VALID` /
   `OV_NOT_FOUND` / `OV_INVALID` well-known extended-community names in

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -199,21 +199,22 @@ Informational large communities under the RS ASN with other function
 values pass through.
 
 Enforcement is per-neighbor via `rs_control_communities` — **default
-off (opt-in)**, inheritable from a peer group. Enable it for the
-members that actually steer with control communities; on sessions left
-off, control communities reach that member verbatim (full
+on for `route_server_client` sessions** (the standard IXP posture),
+off otherwise, inheritable from a peer group. On sessions explicitly
+set off, control communities reach that member verbatim (full
 pass-through). Suppression shows up in
 `rbgp neighbor <ip> explain <prefix>` as the `rs_control` gate rung.
 
-Cost note (why the default is off): an enabled session's export
-outcome depends on the target ASN per route, so the whole session
-rides the ungrouped per-peer path (update-group snapshot reason
-`rs_control_communities`) — exactly like `per_client_best`. That is
-per-peer Adj-RIB-Out plus per-peer encode for every enabled session:
-enabling it fleet-wide on a 700-client full-table route server took
-daemon RSS from ~1.3 GiB to over 100 GiB. Enable it only for members
-that use steering; a route-granular emit-time filter (ADR-0101
-Decision 3) is the planned path to making this safe to default on.
+Cost note: the filter is route-granular at emit (ADR-0101 Decision 3).
+Enabled sessions stay in shared update-groups; a distribution pass
+with no control-tagged route — the overwhelming majority — is
+byte-identical to the feature being off, sharing staging and encoding
+fleet-wide. Only routes actually carrying a control-form community
+diverge per target (suppression/prepend/scrub evaluated against each
+target's ASN), paying a per-target clone for those routes alone. This
+replaced the earlier session-level exclusion, whose per-peer
+Adj-RIB-Out + per-peer encode took a 700-client full-table route
+server from ~1.3 GiB to over 100 GiB of RSS when enabled fleet-wide.
 
 ## Verify
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1817,7 +1817,7 @@
           ]
         },
         "rs_control_communities": {
-          "description": "Interpret RFC 7947 §2.3.2 route-server control communities set by\nthis neighbor: per-target announce suppression (`0:PEER`,\n`RS:0:PEER`), announce-only (`RS:PEER` / `RS:1:PEER` overriding\n`0:RS` / `RS:0:0`), and prepend toward a target\n(`RS:101|102|103:PEER`, RFC 8195 large-community forms). Matched\ncontrol communities are scrubbed from this session's outbound\nannouncements. Default: `false` — opt-in per member, because an\nenabled session is excluded from update-group sharing (per-target\noutcomes cannot share a staged winner), which at large fanout\ncosts per-peer Adj-RIB-Out and per-peer encode for the session.",
+          "description": "Interpret RFC 7947 §2.3.2 route-server control communities set by\nthis neighbor: per-target announce suppression (`0:PEER`,\n`RS:0:PEER`), announce-only (`RS:PEER` / `RS:1:PEER` overriding\n`0:RS` / `RS:0:0`), and prepend toward a target\n(`RS:101|102|103:PEER`, RFC 8195 large-community forms). Matched\ncontrol communities are scrubbed from this session's outbound\nannouncements. Default: `true` when `route_server_client` is set,\n`false` otherwise. Enabled sessions stay in shared update-groups:\nonly routes actually carrying a control-form community pay\nper-target divergence at emit; untagged routes (the overwhelming\nmajority) share staging and encoding fleet-wide.",
           "type": [
             "boolean",
             "null"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1257,19 +1257,17 @@ impl Config {
             .interpret_rfc1997
             .or_else(|| group.and_then(|g| g.interpret_rfc1997))
             .unwrap_or(!transport.route_server_client);
-        // RFC 7947 §2.3.2 control communities are OPT-IN, even for
-        // route-server clients: an enabled session is disqualified from
-        // update-group sharing (per-target export divergence), and at
-        // high fanout that costs per-peer Adj-RIB-Out + per-peer encode
-        // for the whole session — a 700-client route server went from
-        // ~1.3 GiB to >100 GiB daemon RSS when this defaulted on for
-        // rs-clients. Enable per member (or group) that actually uses
-        // steering communities; a route-granular emit-time filter
-        // (ADR-0101 Decision 3) is the path back to a safe default.
+        // RFC 7947 §2.3.2 control communities default on for
+        // route-server clients (the standard IXP posture) and off for
+        // everyone else; set explicitly to override either default.
+        // Safe to default on since the route-granular emit-time filter
+        // (ADR-0101 Decision 3): enabled sessions stay in shared
+        // update-groups, and only routes actually carrying a
+        // control-form community pay per-target divergence at emit.
         transport.rs_control_communities = neighbor
             .rs_control_communities
             .or_else(|| group.and_then(|g| g.rs_control_communities))
-            .unwrap_or(false);
+            .unwrap_or(transport.route_server_client);
         transport.route_reflector_client = neighbor
             .route_reflector_client
             .or_else(|| group.and_then(|g| g.route_reflector_client))

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -793,10 +793,11 @@ pub struct Neighbor {
     /// `0:RS` / `RS:0:0`), and prepend toward a target
     /// (`RS:101|102|103:PEER`, RFC 8195 large-community forms). Matched
     /// control communities are scrubbed from this session's outbound
-    /// announcements. Default: `false` — opt-in per member, because an
-    /// enabled session is excluded from update-group sharing (per-target
-    /// outcomes cannot share a staged winner), which at large fanout
-    /// costs per-peer Adj-RIB-Out and per-peer encode for the session.
+    /// announcements. Default: `true` when `route_server_client` is set,
+    /// `false` otherwise. Enabled sessions stay in shared update-groups:
+    /// only routes actually carrying a control-form community pay
+    /// per-target divergence at emit; untagged routes (the overwhelming
+    /// majority) share staging and encoding fleet-wide.
     pub rs_control_communities: Option<bool>,
     /// Local BGP Role for RFC 9234 route-leak prevention. eBGP only.
     pub role: Option<BgpRoleConfig>,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -197,7 +197,6 @@ log_format = "json"
                         target_is_rr_client: true,
                         target_local_role: None,
                         interpret_rfc1997: true,
-                        rs_control_communities: false,
                         sendable_families: vec![(1, 1)],
                         llgr_families: vec![],
                         add_path_send: false,

--- a/src/peer_manager/update_group_plan.rs
+++ b/src/peer_manager/update_group_plan.rs
@@ -70,7 +70,6 @@ fn candidate_input(
         add_path_send: live.input.add_path_send,
         per_client_best: candidate.transport_config.per_client_best,
         interpret_rfc1997: candidate.transport_config.interpret_rfc1997,
-        rs_control_communities: candidate.transport_config.rs_control_communities,
         orr_vantage: candidate.transport_config.orr_vantage,
         orf_installed: live.input.orf_installed,
     }
@@ -371,7 +370,6 @@ mod tests {
             target_is_rr_client: false,
             target_local_role: None,
             interpret_rfc1997: true,
-            rs_control_communities: false,
             sendable_families: vec![(1, 1)],
             llgr_families: vec![],
             add_path_send: false,
@@ -532,7 +530,6 @@ mod tests {
                 target_is_rr_client: true,
                 target_local_role: None,
                 interpret_rfc1997: true,
-                rs_control_communities: false,
                 sendable_families: vec![(1, 1)],
                 llgr_families: vec![],
                 add_path_send: false,


### PR DESCRIPTION
Makes `rs_control_communities` safe to default on (restored: default = `route_server_client`), replacing the session-level update-group disqualifier with a route-granular emit-time filter per ADR-0101 Decision 3.

Group staging stays rs-agnostic; divergence happens only at the member-emit seams. Each pass memoizes per (group, rs_asn) whether any announce delta carries a control-form community — untagged passes (the overwhelming majority) leave enabled members on the shared Arc payload byte-identically; tagged passes drop enabled members to the existing per-member walk for that pass (suppress → withdraw, announce → per-target prepend/scrub clone). Same filter applied at dirty/regroup resync (with wire-true baselines), initial-dump join replay, and route-refresh replay; the strict clean-transition fast path disqualifies rs-control members to the ordinary filter-aware regroup diff. The tagged predicate is pinned test-equal to the scrub domain, so untagged provably means zero divergence. `RsControlCommunities` membership/classifier variant removed; `SlowPeer` and friends untouched.

**Empirical gate (the point of the change):** 200 peers × 115k prefixes with the feature enabled fleet-wide via the restored default — settled RSS ~274 MiB, peak 428 MiB (inside the normal matrix band; the session-level design hit 4.3 GB within 5 s at this shape). Harness exit 0, 200/200 sessions, markers delivered.

Also fixes a harness bug this surfaced: the reloadstall generation markers were standard communities administered by the scenario RS ASN — RFC 7947 control forms, scrubbed by design toward enabled members, blinding the harness to its own completion evidence. Markers moved to a neutral admin (65400) across the harness and all three scenario generators, with comments.

14 rs_control tests incl. a new e2e (untagged shares the group path while tagged diverges, late-join filtered dump) and the predicate/scrub-domain equality pin. ADR-0101 Decision 3 marked delivered; cookbook/schema/RFC_NOTES/CHANGELOG updated; schema regenerated. Full gate suite green, independently re-verified.