### PR TITLE
feat(rib): retain rejected routes with structured reject reasons for the looking-glass surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Looking-glass filtered-route surface: rejected inbound routes are
+  retained with their reject reason (LAN-472).** Every rejected unicast
+  announcement — import-policy deny (including RPKI/ASPA-driven denies),
+  RFC 9234 OTC route-leak drop, ADR-0107 next-hop ownership, AS_PATH /
+  RFC 4456 reflection loop, and RFC 7606 treat-as-withdraw — is kept in
+  a bounded per-session store tagged with a canonical snake_case reason
+  token (`policy_reject`, `otc_route_leak`, `next_hop_ownership`,
+  `as_path_loop`, `rr_loop`, `treat_as_withdraw`) plus detail, next-hop,
+  AS path, communities, and RPKI/ASPA states at rejection time. New
+  `PolicyService.ListRejectedRoutes` RPC (pre-v1, outside the v1-stable
+  surface) and `rbgp rib received <peer> --rejected` CLI answer the IXP
+  member-support question "why isn't my route accepted?" without
+  knowing the prefix in advance — the structured reject-reason source an
+  Alice-LG-style looking glass needs for its filtered view. Entries
+  self-clean when an identity is later accepted or explicitly withdrawn
+  and on session reset; the store is LRU-bounded per peer via the new
+  `[policy.reject_retention]` config (`enabled` default true, `capacity`
+  default 1024 ≈ 0.5 MiB/peer worst case; restart-required per peer),
+  and a `bgp_rejected_routes_retained{peer}` gauge (peer-reaped) tracks
+  occupancy. Docs: OPERATIONS.md runbook, route-server cookbook
+  member-support section, CONFIGURATION.md.
+
 - **IXP route-server receipt matrix** (`docs/perf/ixp-matrix-2026-07.md`):
   rustbgpd vs BIRD 3.3.1 vs OpenBGPD 9.1 at 700 peers × 400,400
   prefixes through the shared reload-stall harness — reload stall +

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,8 +423,9 @@ Details in the "Recently shipped" section below and ADR-0097.
   engine, `rbgp diff`, BIRD/FRR/GoBGP/MRT adapters, and BMP Adj-RIB-Out import
   are also shipped. Remaining demand-shaped work: a real shadow/canary receipt,
   completion of the Alice-LG contract beyond the current Birdwatcher-shaped
-  status/peer/accepted-route subset (filtered/noexport views and structured
-  reject reasons remain), a 1000+-peer route-server scale receipt, and an
+  status/peer/accepted-route subset (structured reject reasons now ship via
+  `PolicyService.ListRejectedRoutes`; the adapter's filtered/noexport views
+  remain), a 1000+-peer route-server scale receipt, and an
   ARouteServer target.
 - **RFC 9857 SR-Policy-state-in-BGP-LS** (receive/reflect/API) — published
   RFC, no open-source implementation found, drops onto the existing
@@ -437,8 +438,10 @@ Details in the "Recently shipped" section below and ADR-0097.
 adoption tooling. ADR-0101/M83 covers RFC 7947 transparency, Add-Path and
 `per_client_best` path-hiding mitigation, RFC 9234 OTC, ASPA/ROV hygiene, and
 multi-stack BIRD/GoBGP/FRR/StayRTR proof. Next useful slices are an Alice-LG
-contract completion for filtered/noexport views plus structured reject
-reasons, a 1000+-peer route-server scale receipt, shadow/canary RIB-diff
+contract completion for the adapter's filtered/noexport views (the structured
+reject reasons behind them now ship via `PolicyService.ListRejectedRoutes` and
+`rbgp rib received <peer> --rejected`), a 1000+-peer route-server scale
+receipt, shadow/canary RIB-diff
 tooling (`rbgp diff` against an incumbent's MRT/BMP feed), and an ARouteServer
 target once the pilot surface is stable. The current external adapter already
 serves the Birdwatcher-shaped status, peer, and accepted-route subset.

--- a/crates/api/src/authz.rs
+++ b/crates/api/src/authz.rs
@@ -358,6 +358,15 @@ pub const METHODS: &[GrpcMethodAuthz] = &[
         "/rustbgpd.v1.PolicyService/ExplainImportPolicy",
         AuthTier::SensitiveRead,
     ),
+    // LAN-472: same tier as ExplainImportPolicy — it reads the same
+    // per-session import diagnostic state, enumerated instead of by
+    // point lookup.
+    method(
+        "rustbgpd.v1.PolicyService",
+        "ListRejectedRoutes",
+        "/rustbgpd.v1.PolicyService/ListRejectedRoutes",
+        AuthTier::SensitiveRead,
+    ),
     method(
         "rustbgpd.v1.PolicyService",
         "TestPolicy",
@@ -841,7 +850,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(matrix_methods, proto_methods);
-        assert_eq!(METHODS.len(), 98);
+        assert_eq!(METHODS.len(), 99);
     }
 
     #[test]
@@ -882,7 +891,7 @@ mod tests {
     #[test]
     fn method_matrix_tier_counts_match_inventory() {
         assert_eq!(method_count_by_tier(AuthTier::Read), 0);
-        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 57);
+        assert_eq!(method_count_by_tier(AuthTier::SensitiveRead), 58);
         assert_eq!(method_count_by_tier(AuthTier::Mutating), 19);
         assert_eq!(method_count_by_tier(AuthTier::OperatorOnly), 22);
     }

--- a/crates/api/src/peer_types.rs
+++ b/crates/api/src/peer_types.rs
@@ -7,8 +7,8 @@ use bytes::Bytes;
 use rustbgpd_fsm::SessionState;
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_transport::{
-    ImportExplainReply, ImportPolicyTermHits, RemovePrivateAs, TcpAoInfoSnapshot, TcpAoKeyring,
-    TransportAuthSecret,
+    ImportExplainReply, ImportPolicyTermHits, RejectedRoutesReply, RemovePrivateAs,
+    TcpAoInfoSnapshot, TcpAoKeyring, TransportAuthSecret,
 };
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use tokio::net::TcpStream;
@@ -1002,6 +1002,11 @@ pub enum PeerManagerCommand {
         enabled: bool,
         /// New `[policy.explain].cache_size`.
         cache_size: usize,
+        /// New `[policy.reject_retention].enabled` (LAN-472; same
+        /// read-at-construction contract as the explain knobs).
+        reject_retention_enabled: bool,
+        /// New `[policy.reject_retention].capacity`.
+        reject_retention_capacity: usize,
         /// Reply channel acknowledging the snapshot update.
         reply: oneshot::Sender<()>,
     },
@@ -1068,6 +1073,16 @@ pub enum PeerManagerCommand {
         path_id: Option<u32>,
         /// Reply channel; `None` = no live session for `address`.
         reply: oneshot::Sender<Option<ImportExplainReply>>,
+    },
+    /// LAN-472: list a peer's retained rejected routes with their
+    /// reject reasons (the looking-glass filtered-route surface).
+    /// Side-effect-free. `reply` carries `None` when the peer has no
+    /// live session (its session-local retention store is gone).
+    ListRejectedRoutes {
+        /// Peer whose retention store to consult.
+        address: IpAddr,
+        /// Reply channel; `None` = no live session for `address`.
+        reply: oneshot::Sender<Option<RejectedRoutesReply>>,
     },
     /// Snapshot the live import-chain per-term hit counters of peer
     /// sessions (ADR-0096 Decision 3.3, import direction). Read-only —

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -3,7 +3,9 @@
 use std::net::IpAddr;
 use std::time::{Duration, UNIX_EPOCH};
 
-use rustbgpd_transport::{CachedOutcome, ImportExplainReply, LookupResult, ResolvedMatch};
+use rustbgpd_transport::{
+    CachedOutcome, ImportExplainReply, LookupResult, RejectedRoutesReply, ResolvedMatch,
+};
 use rustbgpd_wire::{Afi, Ipv4Prefix, Ipv6Prefix, Prefix, Safi};
 use tokio::sync::{mpsc, oneshot};
 use tonic::{Request, Response, Status};
@@ -1399,6 +1401,85 @@ impl proto::policy_service_server::PolicyService for PolicyService {
         }))
     }
 
+    async fn list_rejected_routes(
+        &self,
+        request: Request<proto::ListRejectedRoutesRequest>,
+    ) -> Result<Response<proto::ListRejectedRoutesResponse>, Status> {
+        let req = request.into_inner();
+        let address: IpAddr = req
+            .peer_address
+            .parse()
+            .map_err(|e| Status::invalid_argument(format!("invalid peer_address: {e}")))?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.peer_mgr_tx
+            .send(PeerManagerCommand::ListRejectedRoutes {
+                address,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| Status::internal("peer manager unavailable"))?;
+        let reply: Option<RejectedRoutesReply> = reply_rx
+            .await
+            .map_err(|_| Status::internal("peer manager dropped reply"))?;
+
+        // LAN-472: no live session means the session-local retention
+        // store is gone — honestly distinct from "nothing rejected",
+        // so it is an error, not an empty listing.
+        let Some(reply) = reply else {
+            return Err(Status::not_found(format!(
+                "no live session for peer {address}"
+            )));
+        };
+
+        let routes = reply
+            .entries
+            .into_iter()
+            .map(|(key, entry)| {
+                let (prefix, prefix_length) = match key.prefix {
+                    Prefix::V4(p) => (p.addr.to_string(), u32::from(p.len)),
+                    Prefix::V6(p) => (p.addr.to_string(), u32::from(p.len)),
+                };
+                let afi_safi = match (key.afi, key.safi) {
+                    (Afi::Ipv4, Safi::Unicast) => proto::AddressFamily::Ipv4Unicast,
+                    (Afi::Ipv6, Safi::Unicast) => proto::AddressFamily::Ipv6Unicast,
+                    _ => proto::AddressFamily::Unspecified,
+                } as i32;
+                proto::RejectedRoute {
+                    prefix,
+                    prefix_length,
+                    path_id: key.path_id,
+                    afi_safi,
+                    reason: entry.reason.as_str().to_string(),
+                    reason_detail: entry.detail.unwrap_or_default(),
+                    next_hop: entry.next_hop.map(|nh| nh.to_string()).unwrap_or_default(),
+                    as_path: entry.as_path,
+                    communities: entry.communities,
+                    large_communities: entry
+                        .large_communities
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                    rpki_validation: entry.rpki.to_string(),
+                    aspa_validation: entry.aspa.to_string(),
+                    rejected_at_unix_ns: entry
+                        .rejected_at
+                        .duration_since(UNIX_EPOCH)
+                        .ok()
+                        .and_then(|dur| i64::try_from(dur.as_nanos()).ok())
+                        .unwrap_or(0),
+                }
+            })
+            .collect();
+
+        Ok(Response::new(proto::ListRejectedRoutesResponse {
+            peer_address: req.peer_address,
+            retention_enabled: reply.enabled,
+            capacity: u32::try_from(reply.capacity).unwrap_or(u32::MAX),
+            routes,
+        }))
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "linear request-validate, compile, snapshot, evaluate pipeline; splitting would scatter the dry-run contract"
@@ -2016,6 +2097,91 @@ mod tests {
             .into_inner();
         assert_eq!(resp.matches.len(), 1, "one synthetic match expected");
         resp.matches[0].outcome
+    }
+
+    /// Drive `ListRejectedRoutes` against a fake peer manager that
+    /// answers with `reply` (LAN-472).
+    async fn list_rejected_routes_response(
+        reply: Option<RejectedRoutesReply>,
+    ) -> Result<proto::ListRejectedRoutesResponse, Status> {
+        let (peer_tx, mut peer_rx) = mpsc::channel(8);
+        let svc = PolicyService::new(AccessMode::ReadOnly, peer_tx, None, None);
+        tokio::spawn(async move {
+            while let Some(cmd) = peer_rx.recv().await {
+                match cmd {
+                    PeerManagerCommand::ListRejectedRoutes { reply: tx, .. } => {
+                        let _ = tx.send(reply.clone());
+                    }
+                    _ => panic!("unexpected peer-manager command"),
+                }
+            }
+        });
+        let req = proto::ListRejectedRoutesRequest {
+            peer_address: "10.0.0.2".to_string(),
+        };
+        PolicyServiceRpc::list_rejected_routes(&svc, Request::new(req))
+            .await
+            .map(tonic::Response::into_inner)
+    }
+
+    /// LAN-472: no live session is NOT an empty listing — the
+    /// session-local store is gone, so the RPC reports `NOT_FOUND`.
+    #[tokio::test]
+    async fn list_rejected_routes_no_session_is_not_found() {
+        let err = list_rejected_routes_response(None)
+            .await
+            .expect_err("no session must be an error");
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    /// LAN-472: entries come back with the canonical reason token, the
+    /// detail, the rendered prefix/next-hop, and the enabled/capacity
+    /// facts the CLI renders.
+    #[tokio::test]
+    async fn list_rejected_routes_maps_entries_to_proto() {
+        use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+        use rustbgpd_transport::{ImportDecisionKey, RejectedRouteEntry};
+        let key = ImportDecisionKey {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            prefix: Prefix::V4(Ipv4Prefix::new(
+                std::net::Ipv4Addr::new(198, 51, 100, 0),
+                24,
+            )),
+            path_id: 0,
+        };
+        let entry = RejectedRouteEntry {
+            reason: ImportRejectReason::PolicyReject,
+            detail: Some("member-import".to_string()),
+            next_hop: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2))),
+            as_path: "65002 65010".to_string(),
+            communities: vec![999],
+            large_communities: Vec::new(),
+            rpki: rustbgpd_wire::RpkiValidation::Invalid,
+            aspa: rustbgpd_wire::AspaValidation::Unknown,
+            rejected_at: std::time::UNIX_EPOCH + Duration::from_secs(1),
+        };
+        let resp = list_rejected_routes_response(Some(RejectedRoutesReply {
+            enabled: true,
+            capacity: 1024,
+            entries: vec![(key, entry)],
+        }))
+        .await
+        .expect("listing succeeds");
+        assert!(resp.retention_enabled);
+        assert_eq!(resp.capacity, 1024);
+        assert_eq!(resp.routes.len(), 1);
+        let r = &resp.routes[0];
+        assert_eq!(r.prefix, "198.51.100.0");
+        assert_eq!(r.prefix_length, 24);
+        assert_eq!(r.afi_safi, proto::AddressFamily::Ipv4Unicast as i32);
+        assert_eq!(r.reason, "policy_reject");
+        assert_eq!(r.reason_detail, "member-import");
+        assert_eq!(r.next_hop, "10.0.0.2");
+        assert_eq!(r.as_path, "65002 65010");
+        assert_eq!(r.communities, vec![999]);
+        assert_eq!(r.rpki_validation, "invalid");
+        assert_eq!(r.rejected_at_unix_ns, 1_000_000_000);
     }
 
     /// LAN-320: no live session must NOT read as `not_seen` — during an

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -5,14 +5,16 @@ use crate::output::{
     JsonOrrExplainCandidate,
 };
 use crate::proto::injection_service_client::InjectionServiceClient;
+use crate::proto::policy_service_client::PolicyServiceClient;
 use crate::proto::rib_service_client::RibServiceClient;
 use crate::proto::{
     AddPathRequest, AddressFamily, BgpLsRouteEntry, BlackholeDiscardState, DeletePathRequest,
     ExplainAdvertisedRouteRequest, ExplainBestPathRequest, ExplainBestPathResponse,
     ExplainDecision, ExportGateVerdict, FibRouteState, LabeledRouteEntry, ListBgpLsRequest,
     ListBlackholeDiscardsRequest, ListFibRoutesRequest, ListFibRoutesResponse,
-    ListLabeledRoutesRequest, ListRoutesRequest, ListRtcRoutesRequest, ListVpnRoutesRequest, Route,
-    RtcRouteEntry, VpnRouteEntry,
+    ListLabeledRoutesRequest, ListRejectedRoutesRequest, ListRejectedRoutesResponse,
+    ListRoutesRequest, ListRtcRoutesRequest, ListVpnRoutesRequest, Route, RtcRouteEntry,
+    VpnRouteEntry,
 };
 use serde::Serialize;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
@@ -1658,6 +1660,129 @@ pub async fn received(
     )
     .await?;
     print_routes(&routes, json)
+}
+
+/// LAN-472: list the retained rejected routes for a peer with their
+/// reject reasons — `rbgp rib received <peer> --rejected`. Served by
+/// `PolicyService.ListRejectedRoutes` (the retention store lives on the
+/// peer's session, not in the RIB).
+pub async fn rejected(connection: Connection, address: &str, json: bool) -> Result<(), CliError> {
+    let mut client =
+        PolicyServiceClient::with_interceptor(connection.channel(), connection.interceptor());
+    let resp = client
+        .list_rejected_routes(ListRejectedRoutesRequest {
+            peer_address: address.to_string(),
+        })
+        .await?
+        .into_inner();
+    print_rejected_routes(&resp, json)
+}
+
+#[derive(Serialize)]
+struct JsonRejectedRoute<'a> {
+    prefix: String,
+    path_id: u32,
+    reason: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    reason_detail: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    next_hop: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    as_path: &'a str,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    communities: &'a [u32],
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    large_communities: &'a [String],
+    #[serde(skip_serializing_if = "str::is_empty")]
+    rpki_validation: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    aspa_validation: &'a str,
+    rejected_at_unix_ns: i64,
+}
+
+#[derive(Serialize)]
+struct JsonRejectedRoutes<'a> {
+    peer_address: &'a str,
+    retention_enabled: bool,
+    capacity: u32,
+    rejected_routes: Vec<JsonRejectedRoute<'a>>,
+}
+
+fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Result<(), CliError> {
+    if json {
+        let rejected_routes = resp
+            .routes
+            .iter()
+            .map(|r| JsonRejectedRoute {
+                prefix: format!("{}/{}", r.prefix, r.prefix_length),
+                path_id: r.path_id,
+                reason: &r.reason,
+                reason_detail: &r.reason_detail,
+                next_hop: &r.next_hop,
+                as_path: &r.as_path,
+                communities: &r.communities,
+                large_communities: &r.large_communities,
+                rpki_validation: &r.rpki_validation,
+                aspa_validation: &r.aspa_validation,
+                rejected_at_unix_ns: r.rejected_at_unix_ns,
+            })
+            .collect();
+        return output::print_json_pretty(&JsonRejectedRoutes {
+            peer_address: &resp.peer_address,
+            retention_enabled: resp.retention_enabled,
+            capacity: resp.capacity,
+            rejected_routes,
+        });
+    }
+    if !resp.retention_enabled {
+        println!(
+            "Rejected-route retention is disabled for {} ([policy.reject_retention] enabled = false)",
+            resp.peer_address
+        );
+        return Ok(());
+    }
+    if resp.routes.is_empty() {
+        println!("No rejected routes retained for {}", resp.peer_address);
+        return Ok(());
+    }
+    println!(
+        "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} AS Path",
+        "Prefix", "PathId", "Reason", "Detail", "Next Hop", "RPKI"
+    );
+    println!("{}", "-".repeat(120));
+    for r in &resp.routes {
+        println!(
+            "{:<22} {:<8} {:<18} {:<28} {:<18} {:<10} {}",
+            format!("{}/{}", r.prefix, r.prefix_length),
+            r.path_id,
+            r.reason,
+            if r.reason_detail.is_empty() {
+                "-"
+            } else {
+                &r.reason_detail
+            },
+            if r.next_hop.is_empty() {
+                "-"
+            } else {
+                &r.next_hop
+            },
+            if r.rpki_validation.is_empty() {
+                "-"
+            } else {
+                &r.rpki_validation
+            },
+            r.as_path,
+        );
+    }
+    let shown = resp.routes.len();
+    if u32::try_from(shown).unwrap_or(u32::MAX) >= resp.capacity {
+        println!(
+            "(store at capacity {} — showing the most recent rejections; \
+             raise [policy.reject_retention] capacity for full coverage)",
+            resp.capacity
+        );
+    }
+    Ok(())
 }
 
 pub async fn advertised(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1028,6 +1028,11 @@ enum RibAction {
         /// Address family filter
         #[arg(short = 'a', long)]
         family: Option<String>,
+        /// Show the retained rejected routes with their reject reasons
+        /// instead of the accepted Adj-RIB-In (the looking-glass
+        /// filtered-route view; [policy.reject_retention])
+        #[arg(long)]
+        rejected: bool,
     },
     /// Show advertised routes to a neighbor
     #[command(visible_alias = "sent")]
@@ -2190,11 +2195,15 @@ async fn run(cli: Cli, binary_name: &'static str) -> Result<(), CliError> {
                 Some(RibAction::Received {
                     address,
                     family: fam,
+                    rejected,
                 }) => {
                     if explain {
                         return Err(CliError::Argument(
                             "--explain is only valid for the default best-routes view (rib --prefix X --explain)".into(),
                         ));
+                    }
+                    if rejected {
+                        return commands::rib::rejected(connection, &address, json).await;
                     }
                     let f = resolve_family(&fam.or(family))?;
                     commands::rib::received(connection, &address, f, &filters, json).await
@@ -3198,6 +3207,24 @@ mod tests {
         } = cli.command
         {
             assert_eq!(address, "10.0.0.1");
+        } else {
+            panic!("expected Rib Received command");
+        }
+    }
+
+    #[test]
+    fn test_parse_rib_received_rejected() {
+        let cli =
+            Cli::try_parse_from(["rbgp", "rib", "received", "10.0.0.1", "--rejected"]).unwrap();
+        if let Command::Rib {
+            action: Some(RibAction::Received {
+                address, rejected, ..
+            }),
+            ..
+        } = cli.command
+        {
+            assert_eq!(address, "10.0.0.1");
+            assert!(rejected);
         } else {
             panic!("expected Rib Received command");
         }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1714,6 +1714,19 @@ impl rustbgpd_api::proto::policy_service_server::PolicyService for MockPolicySer
         ))
     }
 
+    async fn list_rejected_routes(
+        &self,
+        request: Request<server_proto::ListRejectedRoutesRequest>,
+    ) -> Result<Response<server_proto::ListRejectedRoutesResponse>, Status> {
+        let req = request.into_inner();
+        Ok(Response::new(server_proto::ListRejectedRoutesResponse {
+            peer_address: req.peer_address,
+            retention_enabled: true,
+            capacity: 1024,
+            routes: Vec::new(),
+        }))
+    }
+
     async fn explain_import_policy(
         &self,
         request: Request<server_proto::ExplainImportPolicyRequest>,

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -100,6 +100,7 @@ pub struct BgpMetrics {
     // ── Outbound queue (per-peer writer back-pressure) ─────────────
     peer_outbound_queue_depth: IntGaugeVec,
     peer_slow: IntGaugeVec,
+    rejected_routes_retained: IntGaugeVec,
 
     // ── RIB ──────────────────────────────────────────────────────
     rib_prefixes: IntGaugeVec,
@@ -423,6 +424,18 @@ impl BgpMetrics {
                  persistently not draining its outbound queue (backlog above \
                  the configured threshold for the configured duration). \
                  Cleared on drain and on session teardown.",
+            ),
+            &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let rejected_routes_retained = IntGaugeVec::new(
+            Opts::new(
+                "bgp_rejected_routes_retained",
+                "Rejected inbound routes currently retained for the \
+                 looking-glass filtered-route surface (LAN-472), per peer. \
+                 Bounded by [policy.reject_retention] capacity; refreshed on \
+                 every retention mutation and reset on session reset.",
             ),
             &["peer"],
         )
@@ -1539,6 +1552,9 @@ impl BgpMetrics {
             .register(Box::new(peer_slow.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(rejected_routes_retained.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(rib_attr_intern_global_size.clone()))
             .expect("metric not already registered");
         registry
@@ -1926,6 +1942,7 @@ impl BgpMetrics {
             messages_received,
             peer_outbound_queue_depth,
             peer_slow,
+            rejected_routes_retained,
             rib_prefixes,
             rib_adj_out_prefixes,
             rib_loc_prefixes,
@@ -2092,6 +2109,7 @@ impl BgpMetrics {
         Self::reap_peer_series_from_vec(&self.messages_received, peer);
         Self::reap_peer_series_from_vec(&self.peer_outbound_queue_depth, peer);
         Self::reap_peer_series_from_vec(&self.peer_slow, peer);
+        Self::reap_peer_series_from_vec(&self.rejected_routes_retained, peer);
         Self::reap_peer_series_from_vec(&self.peer_update_group, peer);
         Self::reap_peer_series_from_vec(&self.rib_prefixes, peer);
         Self::reap_peer_series_from_vec(&self.rib_adj_out_prefixes, peer);
@@ -2324,6 +2342,26 @@ impl BgpMetrics {
     #[must_use]
     pub fn peer_slow(&self, peer: &str) -> i64 {
         self.peer_slow.with_label_values(&[peer]).get()
+    }
+
+    /// Set a peer's retained rejected-route count
+    /// (`bgp_rejected_routes_retained`, LAN-472). Refreshed on every
+    /// retention-store mutation — inserts, accept/withdraw removals,
+    /// and the session-reset clear — so the gauge tracks the store in
+    /// both directions and can never stay latched.
+    pub fn set_rejected_routes_retained(&self, peer: &str, count: usize) {
+        self.rejected_routes_retained
+            .with_label_values(&[peer])
+            .set(i64::try_from(count).unwrap_or(i64::MAX));
+    }
+
+    /// Read a peer's retained rejected-route gauge. Test/diagnostic
+    /// helper.
+    #[must_use]
+    pub fn rejected_routes_retained(&self, peer: &str) -> i64 {
+        self.rejected_routes_retained
+            .with_label_values(&[peer])
+            .get()
     }
 
     /// Set the number of prefixes in the Loc-RIB for an AFI/SAFI.
@@ -4959,6 +4997,7 @@ mod tests {
         m.set_adj_rib_out_prefixes(peer, "ipv4_unicast", 7);
         m.set_peer_outbound_queue_depth(peer, 3);
         m.set_peer_slow(peer, true);
+        m.set_rejected_routes_retained(peer, 4);
         m.set_peer_update_group(peer, 1);
         m.record_max_prefix_exceeded(peer);
         m.record_outbound_route_drop(peer);
@@ -5020,8 +5059,8 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 37 peer-labeled families; state transitions hold two series.
-        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 38);
+        // 38 peer-labeled families; state transitions hold two series.
+        assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 39);
 
         m.reap_peer_series("10.0.0.1");
 
@@ -5031,7 +5070,7 @@ mod tests {
             "peer-labeled families not reaped: {leftovers:?}"
         );
         // The other peer's series are untouched.
-        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 38);
+        assert_eq!(series_for_peer(&m, "10.0.0.2").len(), 39);
     }
 
     #[test]

--- a/crates/telemetry/src/reason_labels.rs
+++ b/crates/telemetry/src/reason_labels.rs
@@ -179,6 +179,78 @@ impl std::fmt::Display for RrLoopReason {
     }
 }
 
+/// Import reject-reason vocabulary for the looking-glass filtered-route
+/// retention surface (LAN-472).
+///
+/// One token per inbound rejection *mechanism*, mirroring the reject
+/// classes the import path actually implements. Sub-mechanism detail
+/// (which OTC rule, which ownership violation, which policy) travels in
+/// a separate free-form detail field sourced from the sibling enums in
+/// this module or the matched policy name — the token itself stays
+/// low-cardinality and stable.
+///
+/// Surfaces sharing this vocabulary:
+///
+/// - the `reason` field of `PolicyService.ListRejectedRoutes` /
+///   `rbgp rib received <peer> --rejected`;
+/// - the retention-store log lines.
+///
+/// Max-prefix is deliberately absent: exceeding the limit tears the
+/// session down (ADR-0108), so there is no per-route rejection to
+/// retain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ImportRejectReason {
+    /// The import policy chain denied the route (including RPKI/ASPA
+    /// driven denies — the entry's validation states carry that
+    /// context; the deciding policy travels in the detail field).
+    PolicyReject,
+    /// RFC 9234 Only-to-Customer route-leak protection dropped the
+    /// announcement ([`OtcBlockReason`] detail).
+    OtcRouteLeak,
+    /// ADR-0107 strict-peer `NEXT_HOP` ownership gate
+    /// ([`NextHopOwnershipBlockReason`] detail).
+    NextHopOwnership,
+    /// RFC 4271 §9.1.2 `AS_PATH` loop — our ASN in the received path.
+    AsPathLoop,
+    /// RFC 4456 §8 route-reflection loop ([`RrLoopReason`] detail).
+    RrLoop,
+    /// RFC 7606 treat-as-withdraw: a malformed attribute forced every
+    /// route in the UPDATE to be handled as withdrawn.
+    TreatAsWithdraw,
+}
+
+impl ImportRejectReason {
+    /// Every canonical import reject reason, for vocabulary walks in
+    /// tests and docs.
+    pub const ALL: [Self; 6] = [
+        Self::PolicyReject,
+        Self::OtcRouteLeak,
+        Self::NextHopOwnership,
+        Self::AsPathLoop,
+        Self::RrLoop,
+        Self::TreatAsWithdraw,
+    ];
+
+    /// The canonical reason string shared by every surface.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PolicyReject => "policy_reject",
+            Self::OtcRouteLeak => "otc_route_leak",
+            Self::NextHopOwnership => "next_hop_ownership",
+            Self::AsPathLoop => "as_path_loop",
+            Self::RrLoop => "rr_loop",
+            Self::TreatAsWithdraw => "treat_as_withdraw",
+        }
+    }
+}
+
+impl std::fmt::Display for ImportRejectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Exact outbound encoder rejection reasons shared by metrics and RIB logs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ExactExportReason {
@@ -215,7 +287,10 @@ impl std::fmt::Display for ExactExportReason {
 
 #[cfg(test)]
 mod tests {
-    use super::{ExactExportReason, NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason};
+    use super::{
+        ExactExportReason, ImportRejectReason, NextHopOwnershipBlockReason, OtcBlockReason,
+        RrLoopReason,
+    };
 
     fn assert_snake_case(label: &str) {
         assert!(!label.is_empty(), "reason label must not be empty");
@@ -253,6 +328,15 @@ mod tests {
     fn rr_loop_reasons_are_snake_case_and_distinct() {
         let mut seen = std::collections::HashSet::new();
         for reason in RrLoopReason::ALL {
+            assert_snake_case(reason.as_str());
+            assert!(seen.insert(reason.as_str()), "duplicate label");
+        }
+    }
+
+    #[test]
+    fn import_reject_reasons_are_snake_case_and_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for reason in ImportRejectReason::ALL {
             assert_snake_case(reason.as_str());
             assert!(seen.insert(reason.as_str()), "duplicate label");
         }
@@ -298,6 +382,18 @@ mod tests {
         );
         let rr: Vec<&str> = RrLoopReason::ALL.iter().map(|r| r.as_str()).collect();
         assert_eq!(rr, ["originator_id", "cluster_list"]);
+        let import_reject: Vec<&str> = ImportRejectReason::ALL.iter().map(|r| r.as_str()).collect();
+        assert_eq!(
+            import_reject,
+            [
+                "policy_reject",
+                "otc_route_leak",
+                "next_hop_ownership",
+                "as_path_loop",
+                "rr_loop",
+                "treat_as_withdraw",
+            ]
+        );
         let exact: Vec<&str> = ExactExportReason::ALL.iter().map(|r| r.as_str()).collect();
         assert_eq!(
             exact,

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -416,6 +416,15 @@ pub struct TransportConfig {
     /// for `PolicyService.ExplainImportPolicy`. Operator knob:
     /// `[policy.explain] cache_size`.
     pub explain_cache_size: usize,
+    /// Whether rejected inbound routes are retained with their reject
+    /// reason for the looking-glass filtered-route surface (LAN-472).
+    /// Operator knob: `[policy.reject_retention] enabled`.
+    pub reject_retention_enabled: bool,
+    /// Per-session rejected-route retention capacity (LAN-472). Bounds
+    /// the number of `(AFI, SAFI, prefix, path_id)` rejections retained
+    /// for `PolicyService.ListRejectedRoutes`. Operator knob:
+    /// `[policy.reject_retention] capacity`.
+    pub reject_retention_capacity: usize,
     /// Emit RFC 8671 post-policy Adj-RIB-Out BMP route monitoring for
     /// every outbound UPDATE. Set when at least one BMP collector
     /// monitors `rib_out_post`; kept off otherwise so the lossy BMP
@@ -482,6 +491,9 @@ impl TransportConfig {
             cluster_id: None,
             explain_enabled: true,
             explain_cache_size: crate::session::import_decision_cache::DEFAULT_EXPLAIN_CACHE_SIZE,
+            reject_retention_enabled: true,
+            reject_retention_capacity:
+                crate::session::rejected_routes::DEFAULT_REJECT_RETENTION_CAPACITY,
             bmp_rib_out: false,
             slow_peer_threshold_pct: DEFAULT_SLOW_PEER_THRESHOLD_PCT,
             slow_peer_duration: DEFAULT_SLOW_PEER_DURATION_SECS,

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -23,6 +23,7 @@ use crate::error::TransportError;
 use crate::event_sink::TransportEventSink;
 use crate::session::PeerSession;
 use crate::session::import_decision_cache::ImportExplainReply;
+use crate::session::rejected_routes::RejectedRoutesReply;
 
 /// Error returned by a peer-session command round-trip.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -378,6 +379,14 @@ pub enum PeerCommand {
         /// Reply channel carrying the resolved matches plus this
         /// session's current import-policy generation.
         reply: oneshot::Sender<ImportExplainReply>,
+    },
+    /// LAN-472: list this session's retained rejected routes with their
+    /// reject reasons — the looking-glass filtered-route surface.
+    /// Read-only — must not mutate session state or counters.
+    ListRejectedRoutes {
+        /// Reply channel carrying the retention snapshot plus whether
+        /// retention is enabled at all on this session.
+        reply: oneshot::Sender<RejectedRoutesReply>,
     },
     /// Snapshot this session's live import-chain per-term hit counters
     /// (ADR-0096 Decision 3.3, the import-side read surface). Read-only
@@ -1424,6 +1433,29 @@ impl PeerHandle {
                     path_id,
                     reply: reply_tx,
                 })
+                .await
+                .ok()?;
+            reply_rx.await.ok()
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    /// LAN-472: bounded snapshot of this session's retained rejected
+    /// routes. Same timeout contract as
+    /// [`Self::explain_import_policy_timeout`]: `None` on timeout, full
+    /// command channel, or exited session task — the caller renders
+    /// that as "no live session".
+    pub async fn list_rejected_routes_timeout(
+        &self,
+        deadline: Duration,
+    ) -> Option<RejectedRoutesReply> {
+        let commands = self.commands.clone();
+        tokio::time::timeout(deadline, async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            commands
+                .send(PeerCommand::ListRejectedRoutes { reply: reply_tx })
                 .await
                 .ok()?;
             reply_rx.await.ok()

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -50,7 +50,10 @@ pub use listener::{
 // ADR-0073: import-decision explain types crossing into the api +
 // binary layers (PeerManagerCommand reply, PolicyService mapping).
 pub use session::import_decision_cache::{
-    CachedDecision, CachedOutcome, CachedPolicyContext, ImportExplainReply, LookupResult,
-    ResolvedMatch,
+    CachedDecision, CachedOutcome, CachedPolicyContext, ImportDecisionKey, ImportExplainReply,
+    LookupResult, ResolvedMatch,
 };
+// LAN-472: rejected-route retention types crossing into the api +
+// binary layers (PeerManagerCommand reply, PolicyService mapping).
+pub use session::rejected_routes::{RejectedRouteEntry, RejectedRoutesReply};
 pub use socket_opts::{TcpAoInfoSnapshot, TcpAoKeyState, TcpAoSupport, probe_tcp_ao_support};

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -621,6 +621,17 @@ impl PeerSession {
                 });
                 ControlFlow::Continue(())
             }
+            PeerCommand::ListRejectedRoutes { reply } => {
+                // LAN-472: read-only retention snapshot. Bounded by the
+                // configured cap, so the clone stays diagnostic-sized;
+                // the inbound UPDATE hot path is untouched.
+                let _ = reply.send(super::rejected_routes::RejectedRoutesReply {
+                    enabled: self.reject_retention_enabled,
+                    capacity: self.rejected_routes.capacity(),
+                    entries: self.rejected_routes.snapshot(),
+                });
+                ControlFlow::Continue(())
+            }
             PeerCommand::QueryImportPolicyTermHits { reply } => {
                 // Read-only snapshot of the live counters (ADR-0096
                 // Decision 3.3). No counter moves; a session without an

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -684,6 +684,13 @@ impl PeerSession {
                     // re-advertised yet. (import_policy_generation is NOT reset:
                     // it tracks policy reloads, which outlive a session flap.)
                     self.import_decision_cache.clear();
+                    // Same per-session contract for the rejected-route
+                    // retention store (LAN-472): a reject recorded on the
+                    // dying session must not answer a filtered-route query
+                    // on the reconnected one. The gauge follows the store.
+                    self.rejected_routes.clear();
+                    self.metrics
+                        .set_rejected_routes_retained(&self.peer_label, 0);
                     // Reset framing limit for the next session (RFC 8654 §2:
                     // extended messages are per-session, not persistent).
                     self.read_buf

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -1,4 +1,5 @@
 use super::import_decision_cache::{CachedDecision, CachedPolicyContext, ImportDecisionKey};
+use super::rejected_routes::RejectedRouteEntry;
 use super::{
     Afi, AsPath, BgpLsFamily, BgpLsRibRoute, BgpLsRouteKey, BgpRole, Event, EvpnRibRoute,
     EvpnRoute, EvpnRouteKey, FlowSpecKey, FlowSpecRoute, Instant, IpAddr, Ipv4Addr,
@@ -11,7 +12,7 @@ use rustbgpd_policy::{
     RouteType,
 };
 use rustbgpd_telemetry::reason_labels::{
-    NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason,
+    ImportRejectReason, NextHopOwnershipBlockReason, OtcBlockReason, RrLoopReason,
 };
 use rustbgpd_wire::{AspaValidationContext, ErrorDisposition, ParsedUpdate};
 use std::sync::Arc;
@@ -459,6 +460,68 @@ impl PeerSession {
         None
     }
 
+    /// LAN-472: retain one rejected unicast identity in the bounded
+    /// per-session store. AFI derives from the prefix; SAFI is unicast —
+    /// retention covers the unicast member-support surface only,
+    /// matching the v1 `ExplainImportPolicy` scope.
+    fn retain_rejected_route(&mut self, prefix: Prefix, path_id: u32, entry: RejectedRouteEntry) {
+        let afi = match prefix {
+            Prefix::V4(_) => Afi::Ipv4,
+            Prefix::V6(_) => Afi::Ipv6,
+        };
+        self.rejected_routes.insert(
+            ImportDecisionKey {
+                afi,
+                safi: Safi::Unicast,
+                prefix,
+                path_id,
+            },
+            entry,
+        );
+    }
+
+    /// Build a retention entry for a pre-policy gate rejection from the
+    /// parsed UPDATE's attributes (LAN-472). Called only after a reject
+    /// actually occurred, so the AS-path string build and community
+    /// clones cost nothing on the clean hot path. Validation states are
+    /// left at their defaults: the gate fired before (and independently
+    /// of) RPKI/ASPA evaluation.
+    fn gate_reject_entry(
+        parsed: &ParsedUpdate,
+        reason: ImportRejectReason,
+        detail: Option<&str>,
+        next_hop: Option<IpAddr>,
+    ) -> RejectedRouteEntry {
+        let mut as_path = String::new();
+        let mut communities: Vec<u32> = Vec::new();
+        let mut large_communities: Vec<rustbgpd_wire::LargeCommunity> = Vec::new();
+        for attr in &parsed.attributes {
+            match attr {
+                PathAttribute::AsPath(p) if as_path.is_empty() => {
+                    as_path = p.to_aspath_string();
+                }
+                PathAttribute::Communities(c) if communities.is_empty() => {
+                    communities.clone_from(c);
+                }
+                PathAttribute::LargeCommunities(c) if large_communities.is_empty() => {
+                    large_communities.clone_from(c);
+                }
+                _ => {}
+            }
+        }
+        RejectedRouteEntry {
+            reason,
+            detail: detail.map(str::to_owned),
+            next_hop,
+            as_path,
+            communities,
+            large_communities,
+            rpki: rustbgpd_wire::RpkiValidation::NotFound,
+            aspa: rustbgpd_wire::AspaValidation::Unknown,
+            rejected_at: SystemTime::now(),
+        }
+    }
+
     /// Deliver a `RoutesReceived` batch to the RIB manager — block, never
     /// drop (ADR-0078). The fast path is a `try_send`; when the channel
     /// is full the saturation counter increments and the session task
@@ -554,7 +617,12 @@ impl PeerSession {
         clippy::too_many_lines,
         reason = "one withdraw-conversion pass per address family over the same sequence"
     )]
-    async fn treat_update_as_withdraw(&mut self, parsed: &ParsedUpdate) {
+    async fn treat_update_as_withdraw(
+        &mut self,
+        parsed: &ParsedUpdate,
+        reject_reason: ImportRejectReason,
+        reject_detail: Option<&str>,
+    ) {
         let rejected_unicast = self.eligible_unicast_announcements(parsed);
         let mut loop_withdrawn: Vec<(Prefix, u32)> = parsed
             .withdrawn
@@ -682,7 +750,7 @@ impl PeerSession {
         for &(prefix, path_id) in &loop_withdrawn {
             self.forget_known_path(prefix, path_id);
         }
-        for (prefix, path_id) in rejected_unicast {
+        for &(prefix, path_id) in &rejected_unicast {
             if self.forget_known_path(prefix, path_id) {
                 loop_withdrawn.push((prefix, path_id));
             }
@@ -701,6 +769,35 @@ impl PeerSession {
                         path_id,
                     });
             }
+        }
+        // LAN-472: the retention store follows the same conversion.
+        // Explicit withdrawals (and replaced identities) clear any
+        // retained reject first, then every unicast announcement this
+        // UPDATE carried is retained under the shared gate reason —
+        // same-identity overlap nets to the reject, the current truth.
+        if self.reject_retention_enabled {
+            if !self.rejected_routes.is_empty() {
+                for &(prefix, path_id) in &loop_withdrawn {
+                    let afi = match prefix {
+                        Prefix::V4(_) => Afi::Ipv4,
+                        Prefix::V6(_) => Afi::Ipv6,
+                    };
+                    self.rejected_routes.remove(&ImportDecisionKey {
+                        afi,
+                        safi: Safi::Unicast,
+                        prefix,
+                        path_id,
+                    });
+                }
+            }
+            if !rejected_unicast.is_empty() {
+                let entry = Self::gate_reject_entry(parsed, reject_reason, reject_detail, None);
+                for &(prefix, path_id) in &rejected_unicast {
+                    self.retain_rejected_route(prefix, path_id, entry.clone());
+                }
+            }
+            self.metrics
+                .set_rejected_routes_retained(&self.peer_label, self.rejected_routes.len());
         }
         for rule in &loop_fs_withdrawn {
             self.known_flowspec.remove(rule);
@@ -1000,7 +1097,8 @@ impl PeerSession {
                 announced = parsed.announced.len(),
                 "treat-as-withdraw — withdrawing the routes carried in the malformed UPDATE"
             );
-            self.treat_update_as_withdraw(&parsed).await;
+            self.treat_update_as_withdraw(&parsed, ImportRejectReason::TreatAsWithdraw, None)
+                .await;
             return;
         }
         // 3. End-of-RIB detection (RFC 4724 §2). An UPDATE that only became
@@ -1236,7 +1334,8 @@ impl PeerSession {
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the AS_PATH-loop branch must
             // not silently drop withdrawals for any family, or stale non-unicast state
             // accumulates downstream until the next session reset / refresh.
-            self.treat_update_as_withdraw(&parsed).await;
+            self.treat_update_as_withdraw(&parsed, ImportRejectReason::AsPathLoop, None)
+                .await;
             return;
         }
         // Route reflector loop detection (RFC 4456 §8):
@@ -1271,7 +1370,12 @@ impl PeerSession {
             // Covers unicast, FlowSpec, EVPN, and BGP-LS — the reflected-loop
             // detection must not silently drop withdrawals for any family,
             // or stale state accumulates downstream.
-            self.treat_update_as_withdraw(&parsed).await;
+            self.treat_update_as_withdraw(
+                &parsed,
+                ImportRejectReason::RrLoop,
+                Some(reason.as_str()),
+            )
+            .await;
             return;
         }
         // Normalize the attributes that policy and the RIB are allowed to
@@ -1372,6 +1476,14 @@ impl PeerSession {
         // per-route context / modification clone never happens
         // (ADR-0073 write-path cost control).
         let mut import_decisions: Vec<(ImportDecisionKey, CachedDecision)> = Vec::new();
+        // LAN-472: policy denies retained for the looking-glass reject
+        // surface, accumulated here (body-NLRI closure borrows `self`
+        // immutably) and drained into the bounded store after the
+        // explicit-withdrawal removal pass below. Entry construction
+        // happens only on an actual deny, so the clean permit path pays
+        // nothing.
+        let retention_enabled = self.reject_retention_enabled;
+        let mut rejected_retained: Vec<(Prefix, u32, RejectedRouteEntry)> = Vec::new();
         // A denied announcement replaces any prior accepted path under the
         // same wire identity; retire it after explicit withdrawals below.
         let mut denied_unicast: Vec<(Prefix, u32)> = Vec::new();
@@ -1453,6 +1565,25 @@ impl PeerSession {
                         ));
                     }
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
+                        if retention_enabled {
+                            rejected_retained.push((
+                                prefix,
+                                entry.path_id,
+                                RejectedRouteEntry {
+                                    reason: ImportRejectReason::PolicyReject,
+                                    detail: evaluation.matched_policy.clone(),
+                                    next_hop: Some(body_next_hop),
+                                    as_path: parsed_as_path
+                                        .map(AsPath::to_aspath_string)
+                                        .unwrap_or_default(),
+                                    communities: update_communities.to_vec(),
+                                    large_communities: update_large_communities.to_vec(),
+                                    rpki: rpki_state,
+                                    aspa: body_aspa_state,
+                                    rejected_at: SystemTime::now(),
+                                },
+                            ));
+                        }
                         denied_unicast.push((prefix, entry.path_id));
                         return None;
                     }
@@ -2079,6 +2210,25 @@ impl PeerSession {
                                 aspa_context,
                             });
                         } else {
+                            if retention_enabled {
+                                rejected_retained.push((
+                                    entry.prefix,
+                                    entry.path_id,
+                                    RejectedRouteEntry {
+                                        reason: ImportRejectReason::PolicyReject,
+                                        detail: evaluation.matched_policy.clone(),
+                                        next_hop: Some(mp.next_hop),
+                                        as_path: parsed_as_path
+                                            .map(AsPath::to_aspath_string)
+                                            .unwrap_or_default(),
+                                        communities: update_communities.to_vec(),
+                                        large_communities: update_large_communities.to_vec(),
+                                        rpki: mp_rpki_state,
+                                        aspa: mp_aspa_state,
+                                        rejected_at: SystemTime::now(),
+                                    },
+                                ));
+                            }
                             denied_unicast.push((entry.prefix, entry.path_id));
                         }
                     }
@@ -2166,6 +2316,72 @@ impl PeerSession {
         for &(prefix, path_id) in &withdrawn {
             self.forget_known_path(prefix, path_id);
         }
+        // LAN-472: an explicit withdrawal clears any retained reject for
+        // the identity — the peer no longer announces it, so "why isn't
+        // it accepted?" is moot. Runs before the reject inserts below,
+        // so a same-UPDATE withdraw+reject nets to the reject (the
+        // current truth). `withdrawn` holds only explicit withdrawals at
+        // this point; the rejected identities are appended after.
+        if self.reject_retention_enabled && !self.rejected_routes.is_empty() {
+            for &(prefix, path_id) in &withdrawn {
+                let afi = match prefix {
+                    Prefix::V4(_) => Afi::Ipv4,
+                    Prefix::V6(_) => Afi::Ipv6,
+                };
+                self.rejected_routes.remove(&ImportDecisionKey {
+                    afi,
+                    safi: Safi::Unicast,
+                    prefix,
+                    path_id,
+                });
+            }
+        }
+        // LAN-472: retain the pre-policy safety rejections under their
+        // gate reason. One shared entry per gate — the per-UPDATE
+        // attribute summary is identical across the rejected identities,
+        // and the AS-path string is built only here, on the reject path.
+        if self.reject_retention_enabled {
+            if let OtcIngressAction::DropUnicastAnnouncements(otc_reason) = otc_action
+                && !otc_rejected_unicast.is_empty()
+            {
+                let entry = RejectedRouteEntry {
+                    reason: ImportRejectReason::OtcRouteLeak,
+                    detail: Some(otc_reason.as_str().to_owned()),
+                    next_hop: None,
+                    as_path: parsed_as_path
+                        .map(AsPath::to_aspath_string)
+                        .unwrap_or_default(),
+                    communities: update_communities.to_vec(),
+                    large_communities: update_large_communities.to_vec(),
+                    rpki: rustbgpd_wire::RpkiValidation::NotFound,
+                    aspa: rustbgpd_wire::AspaValidation::Unknown,
+                    rejected_at: SystemTime::now(),
+                };
+                for &(prefix, path_id) in &otc_rejected_unicast {
+                    self.retain_rejected_route(prefix, path_id, entry.clone());
+                }
+            }
+            if let Some((ownership_reason, violating_next_hop, _)) = next_hop_ownership_rejection
+                && !ownership_rejected_unicast.is_empty()
+            {
+                let entry = RejectedRouteEntry {
+                    reason: ImportRejectReason::NextHopOwnership,
+                    detail: Some(ownership_reason.as_str().to_owned()),
+                    next_hop: Some(violating_next_hop),
+                    as_path: parsed_as_path
+                        .map(AsPath::to_aspath_string)
+                        .unwrap_or_default(),
+                    communities: update_communities.to_vec(),
+                    large_communities: update_large_communities.to_vec(),
+                    rpki: rustbgpd_wire::RpkiValidation::NotFound,
+                    aspa: rustbgpd_wire::AspaValidation::Unknown,
+                    rejected_at: SystemTime::now(),
+                };
+                for &(prefix, path_id) in &ownership_rejected_unicast {
+                    self.retain_rejected_route(prefix, path_id, entry.clone());
+                }
+            }
+        }
         // A pre-policy safety rejection replaces any prior accepted route
         // under the same wire identity. Explicit withdrawals above win on
         // overlap; first-seen rejected announcements remain silent.
@@ -2219,6 +2435,30 @@ impl PeerSession {
         }
         for route in &announced {
             self.remember_known_path(route.prefix, route.path_id);
+        }
+        // LAN-472: retain the policy denies (body + MP unicast), clear
+        // any stale reject for identities accepted this UPDATE, then
+        // refresh the gauge once. Empty when retention is disabled.
+        for (prefix, path_id, entry) in rejected_retained {
+            self.retain_rejected_route(prefix, path_id, entry);
+        }
+        if self.reject_retention_enabled {
+            if !self.rejected_routes.is_empty() {
+                for route in &announced {
+                    let afi = match route.prefix {
+                        Prefix::V4(_) => Afi::Ipv4,
+                        Prefix::V6(_) => Afi::Ipv6,
+                    };
+                    self.rejected_routes.remove(&ImportDecisionKey {
+                        afi,
+                        safi: Safi::Unicast,
+                        prefix: route.prefix,
+                        path_id: route.path_id,
+                    });
+                }
+            }
+            self.metrics
+                .set_rejected_routes_retained(&self.peer_label, self.rejected_routes.len());
         }
         for key in &flowspec_withdrawn {
             self.known_flowspec.remove(key);

--- a/crates/transport/src/session/mod.rs
+++ b/crates/transport/src/session/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod inbound;
 mod io;
 mod outbound;
 mod refresh_accounting;
+pub mod rejected_routes;
 mod shared_group;
 mod writer;
 
@@ -350,6 +351,15 @@ pub(crate) struct PeerSession {
     /// the per-session import counters (see `fsm.rs`). A daemon restart
     /// drops it with the process.
     import_decision_cache: import_decision_cache::ImportDecisionCache,
+    /// Whether rejected inbound routes are retained (LAN-472
+    /// `[policy.reject_retention].enabled`). Read on the inbound UPDATE
+    /// path to skip retention entirely when disabled.
+    reject_retention_enabled: bool,
+    /// Bounded per-session store of rejected inbound routes with their
+    /// reject reason (LAN-472) — the looking-glass filtered-route
+    /// surface behind `PolicyService.ListRejectedRoutes`. Cleared on
+    /// session reset alongside the import-decision cache (`fsm.rs`).
+    rejected_routes: rejected_routes::RejectedRouteStore,
     /// Session-local import-policy generation. Bumped whenever the
     /// effective import chain is hot-applied
     /// ([`PeerCommand::UpdateImportPolicy`]). Cache entries stamp the
@@ -798,6 +808,7 @@ impl PeerSession {
 
     #[expect(
         clippy::too_many_arguments,
+        clippy::too_many_lines,
         reason = "session constructor owns the transport dependency boundary explicitly"
     )]
     pub(crate) fn new_at_tcp_ao_generation(
@@ -822,6 +833,8 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let reject_retention_enabled = config.reject_retention_enabled;
+        let reject_retention_capacity = config.reject_retention_capacity;
         let tcp_ao_protected = config.tcp_ao.is_some();
         let tcp_ao_key_metadata = tcp_ao_key_metadata(&config, None);
         let import_needs_as_path_string =
@@ -914,6 +927,10 @@ impl PeerSession {
             import_decision_cache: import_decision_cache::ImportDecisionCache::with_capacity(
                 explain_cache_size,
             ),
+            reject_retention_enabled,
+            rejected_routes: rejected_routes::RejectedRouteStore::with_capacity(
+                reject_retention_capacity,
+            ),
             import_policy_generation: 0,
         }
     }
@@ -947,6 +964,8 @@ impl PeerSession {
         let fsm = Session::new(config.peer.clone());
         let explain_enabled = config.explain_enabled;
         let explain_cache_size = config.explain_cache_size;
+        let reject_retention_enabled = config.reject_retention_enabled;
+        let reject_retention_capacity = config.reject_retention_capacity;
         let tcp_ao_protected = config.tcp_ao.is_some() || tcp_ao_info.is_some();
         let tcp_ao_stream_was_accepted = tcp_ao_info.is_some();
         let tcp_ao_key_metadata = tcp_ao_key_metadata(&config, tcp_ao_info.as_ref());
@@ -1051,6 +1070,10 @@ impl PeerSession {
             import_explain_enabled: explain_enabled,
             import_decision_cache: import_decision_cache::ImportDecisionCache::with_capacity(
                 explain_cache_size,
+            ),
+            reject_retention_enabled,
+            rejected_routes: rejected_routes::RejectedRouteStore::with_capacity(
+                reject_retention_capacity,
             ),
             import_policy_generation: 0,
         }

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -1,0 +1,273 @@
+//! Bounded per-session retention of rejected inbound routes (LAN-472).
+//!
+//! The member-support half of the filtered-route surface: when the
+//! import path rejects a unicast announcement — policy deny, OTC
+//! route-leak, next-hop ownership, `AS_PATH`/RR loop, or RFC 7606
+//! treat-as-withdraw — the identity is retained here together with its
+//! canonical [`ImportRejectReason`] token and a compact attribute
+//! summary, so `PolicyService.ListRejectedRoutes` (and through it
+//! `rbgp rib received <peer> --rejected` and an Alice-LG-style looking
+//! glass) can answer "why isn't my route accepted?" without the
+//! operator having to know the prefix in advance.
+//!
+//! Deliberately a sibling of, not an extension to, the ADR-0073
+//! [`super::import_decision_cache`]: that LRU mixes permits with denies
+//! (a busy peer's accepted prefixes would evict the rejects this
+//! surface exists to answer for) and offers only point lookups. This
+//! store holds rejects exclusively and supports enumeration.
+//!
+//! Lifecycle: an entry is inserted (or refreshed) on rejection, removed
+//! when the same `(AFI, SAFI, prefix, path_id)` identity is later
+//! accepted or explicitly withdrawn, and the whole store resets on
+//! session reset — the same per-session contract as the decision cache.
+//!
+//! Bound: per-peer LRU cap from `[policy.reject_retention] capacity`
+//! ([`DEFAULT_REJECT_RETENTION_CAPACITY`] = 1024). A reject storm
+//! therefore converges on "the most recent `capacity` rejects", never
+//! unbounded growth. Memory math: each entry is one key (~64 B) plus
+//! the reason/validation scalars, the AS-path string, and the community
+//! vectors — a few hundred bytes for realistic routes, call it ≤ 512 B.
+//! `1024 × 512 B ≈ 0.5 MiB` worst case per peer; a 500-peer route
+//! server bounds at ~256 MiB only if *every* peer keeps a full storm
+//! retained, and operators can lower the cap per deployment.
+
+use std::net::IpAddr;
+use std::num::NonZeroUsize;
+use std::time::SystemTime;
+
+use lru::LruCache;
+use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+use rustbgpd_wire::{AspaValidation, LargeCommunity, RpkiValidation};
+
+use super::import_decision_cache::ImportDecisionKey;
+
+/// Default per-peer retention cap. Sized for the realistic
+/// member-support case (an IXP member's leaked/misconfigured
+/// announcements number in the tens to low thousands), not full-table
+/// retention. See the module docs for the memory bound math.
+pub const DEFAULT_REJECT_RETENTION_CAPACITY: usize = 1024;
+
+/// One retained rejection: the canonical reason token plus the compact
+/// attribute summary a looking glass renders.
+///
+/// Attribute fields are best-effort: the policy-deny path fills them
+/// all; the pre-policy safety gates (loops, treat-as-withdraw) fill
+/// what was decodable — the reason token is always present and is the
+/// load-bearing answer.
+#[derive(Debug, Clone)]
+pub struct RejectedRouteEntry {
+    /// Canonical rejection mechanism token.
+    pub reason: ImportRejectReason,
+    /// Sub-mechanism detail: the matched policy name for
+    /// `policy_reject`, the canonical sub-reason token for the OTC /
+    /// ownership / RR-loop gates, absent otherwise.
+    pub detail: Option<String>,
+    /// Wire next-hop the rejected announcement carried, when decoded.
+    pub next_hop: Option<IpAddr>,
+    /// Lossless `AS_PATH` rendering (`AsPath::to_aspath_string`), empty
+    /// when the UPDATE carried none or the attribute was not decodable.
+    pub as_path: String,
+    /// Standard communities from the rejected UPDATE.
+    pub communities: Vec<u32>,
+    /// Large communities from the rejected UPDATE.
+    pub large_communities: Vec<LargeCommunity>,
+    /// RPKI origin-validation state at rejection time.
+    pub rpki: RpkiValidation,
+    /// ASPA path-verification state at rejection time.
+    pub aspa: AspaValidation,
+    /// Wall-clock time of the rejection.
+    pub rejected_at: SystemTime,
+}
+
+/// The session's reply to a `ListRejectedRoutes` query.
+#[derive(Debug, Clone)]
+pub struct RejectedRoutesReply {
+    /// Whether this session retains rejected routes at all
+    /// (`[policy.reject_retention] enabled`, snapshotted at session
+    /// build). `false` means an empty listing is a configuration fact,
+    /// not "nothing was rejected".
+    pub enabled: bool,
+    /// The session's retention cap, so the caller can render "showing
+    /// the most recent N" honestly when the store is full.
+    pub capacity: usize,
+    /// Every retained rejection, sorted by key for stable output.
+    pub entries: Vec<(ImportDecisionKey, RejectedRouteEntry)>,
+}
+
+/// Bounded per-session LRU of rejected inbound routes.
+///
+/// Not `Send`/`Sync` on its own — the session owns it and services
+/// queries on its command path, exactly like the import-decision cache.
+#[derive(Debug)]
+pub struct RejectedRouteStore {
+    entries: LruCache<ImportDecisionKey, RejectedRouteEntry>,
+    capacity: usize,
+}
+
+impl RejectedRouteStore {
+    /// Create a store with the given per-peer capacity, clamped to at
+    /// least 1 (same convention as the decision cache).
+    #[must_use]
+    pub fn with_capacity(cap: usize) -> Self {
+        let cap = cap.max(1);
+        Self {
+            entries: LruCache::new(NonZeroUsize::new(cap).expect("clamped to at least 1")),
+            capacity: cap,
+        }
+    }
+
+    /// Insert or refresh a rejection. On overflow the least-recently
+    /// rejected entry is evicted — under a storm the store converges on
+    /// the most recent rejects, which is what a "why isn't my route in
+    /// right now?" query wants.
+    pub fn insert(&mut self, key: ImportDecisionKey, entry: RejectedRouteEntry) {
+        self.entries.push(key, entry);
+    }
+
+    /// Remove the entry for an identity that was subsequently accepted
+    /// or explicitly withdrawn. No-op when absent.
+    pub fn remove(&mut self, key: &ImportDecisionKey) {
+        self.entries.pop(key);
+    }
+
+    /// Drop everything — session reset, same contract as
+    /// [`super::import_decision_cache::ImportDecisionCache::clear`].
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Number of retained rejections (the gauge value).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The configured cap, echoed on the query reply.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Clone out every retained rejection, sorted by
+    /// `(AFI, SAFI, prefix, path_id)` for a stable listing. Bounded by
+    /// the cap, so the clone is fine for a diagnostic query path.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<(ImportDecisionKey, RejectedRouteEntry)> {
+        let mut out: Vec<_> = self
+            .entries
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        out.sort_by(|(a, _), (b, _)| {
+            (a.afi as u16, a.safi as u8, a.prefix, a.path_id).cmp(&(
+                b.afi as u16,
+                b.safi as u8,
+                b.prefix,
+                b.path_id,
+            ))
+        });
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use rustbgpd_wire::{Afi, Ipv4Prefix, Prefix, Safi};
+
+    use super::*;
+
+    fn key(octet: u8) -> ImportDecisionKey {
+        ImportDecisionKey {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(10, 0, 0, octet), 32)),
+            path_id: 0,
+        }
+    }
+
+    fn entry(reason: ImportRejectReason) -> RejectedRouteEntry {
+        RejectedRouteEntry {
+            reason,
+            detail: None,
+            next_hop: None,
+            as_path: String::new(),
+            communities: Vec::new(),
+            large_communities: Vec::new(),
+            rpki: RpkiValidation::NotFound,
+            aspa: AspaValidation::Unknown,
+            rejected_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn insert_then_snapshot_returns_entry() {
+        let mut store = RejectedRouteStore::with_capacity(4);
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].0, key(1));
+        assert_eq!(snap[0].1.reason, ImportRejectReason::PolicyReject);
+    }
+
+    #[test]
+    fn cap_evicts_least_recent_reject() {
+        let mut store = RejectedRouteStore::with_capacity(2);
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        store.insert(key(2), entry(ImportRejectReason::OtcRouteLeak));
+        store.insert(key(3), entry(ImportRejectReason::AsPathLoop));
+        assert_eq!(store.len(), 2, "bounded at capacity");
+        let keys: Vec<_> = store.snapshot().into_iter().map(|(k, _)| k).collect();
+        assert!(!keys.contains(&key(1)), "oldest reject evicted");
+        assert!(keys.contains(&key(2)) && keys.contains(&key(3)));
+    }
+
+    #[test]
+    fn reinsert_refreshes_lru_position() {
+        let mut store = RejectedRouteStore::with_capacity(2);
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        store.insert(key(2), entry(ImportRejectReason::PolicyReject));
+        // Refresh key(1); key(2) becomes the LRU victim.
+        store.insert(key(1), entry(ImportRejectReason::RrLoop));
+        store.insert(key(3), entry(ImportRejectReason::PolicyReject));
+        let keys: Vec<_> = store.snapshot().into_iter().map(|(k, _)| k).collect();
+        assert!(keys.contains(&key(1)), "refreshed entry survives");
+        assert!(!keys.contains(&key(2)), "stale entry evicted");
+    }
+
+    #[test]
+    fn remove_and_clear() {
+        let mut store = RejectedRouteStore::with_capacity(4);
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        store.insert(key(2), entry(ImportRejectReason::PolicyReject));
+        store.remove(&key(1));
+        assert_eq!(store.len(), 1);
+        store.remove(&key(9)); // absent → no-op
+        store.clear();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn snapshot_is_sorted_by_key() {
+        let mut store = RejectedRouteStore::with_capacity(8);
+        store.insert(key(9), entry(ImportRejectReason::PolicyReject));
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        store.insert(key(5), entry(ImportRejectReason::PolicyReject));
+        let keys: Vec<_> = store.snapshot().into_iter().map(|(k, _)| k).collect();
+        assert_eq!(keys, vec![key(1), key(5), key(9)]);
+    }
+
+    #[test]
+    fn zero_capacity_is_clamped_to_at_least_one() {
+        let mut store = RejectedRouteStore::with_capacity(0);
+        store.insert(key(1), entry(ImportRejectReason::PolicyReject));
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.capacity(), 1);
+    }
+}

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -11392,6 +11392,21 @@ async fn import_policy_filters_rpki_invalid_with_snapshot() {
         }
         _ => panic!("expected RoutesReceived"),
     }
+    // LAN-472: the RPKI-driven deny is retained for the looking-glass
+    // surface with the policy_reject reason and the Invalid validation
+    // state the member-support answer hinges on.
+    {
+        use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+        let entries = session.rejected_routes.snapshot();
+        assert_eq!(entries.len(), 1, "the RPKI-invalid deny is retained");
+        let (key, entry) = &entries[0];
+        assert_eq!(
+            key.prefix,
+            Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24))
+        );
+        assert_eq!(entry.reason, ImportRejectReason::PolicyReject);
+        assert_eq!(entry.rpki, rustbgpd_wire::RpkiValidation::Invalid);
+    }
 }
 /// Verify that import policy `match_aspa_validation = "invalid"` + `action = "deny"`
 /// drops ASPA-invalid routes when a `ValidationSnapshot` with an ASPA table is provided.
@@ -15160,4 +15175,404 @@ async fn slow_peer_detection_disabled_by_zero_duration() {
     assert!(!session.slow_peer);
     assert!(session.slow_peer_backlog_since.is_none());
     assert!(session.slow_peer_timer.is_none());
+}
+
+// ───────────────── LAN-472: rejected-route retention ─────────────────
+
+/// Longhand `PolicyStatement` builder for the retention tests below —
+/// only the fields under test vary.
+use super::import_decision_cache::ImportDecisionKey as RetentionKey;
+
+fn retention_statement(prefix: Option<Prefix>, action: PolicyAction) -> PolicyStatement {
+    PolicyStatement {
+        prefix,
+        ge: None,
+        le: None,
+        action,
+        match_community: vec![],
+        match_as_path: None,
+        match_neighbor_set: None,
+        match_route_type: None,
+        match_evpn_route_type: None,
+        match_rpki_validation: None,
+        match_aspa_validation: None,
+        match_as_path_length_ge: None,
+        match_as_path_length_le: None,
+        match_local_pref_ge: None,
+        match_local_pref_le: None,
+        match_med_ge: None,
+        match_med_le: None,
+        match_next_hop: None,
+        modifications: RouteModifications::default(),
+    }
+}
+
+fn retention_session_with_chain(
+    chain: Option<PolicyChain>,
+    mutate_config: impl FnOnce(&mut TransportConfig),
+) -> (PeerSession, BgpMetrics) {
+    let mut peer_config = PeerConfig::new(65001, 65002, Ipv4Addr::new(10, 0, 0, 1));
+    peer_config.connect_retry_secs = 30;
+    peer_config.families = vec![(Afi::Ipv4, Safi::Unicast)];
+    peer_config.gr_restart_time = 120;
+    let mut config = TransportConfig::new(peer_config, "10.0.0.2:179".parse().unwrap());
+    mutate_config(&mut config);
+    let metrics = BgpMetrics::new();
+    let (_cmd_tx, cmd_rx) = mpsc::channel(8);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mut session = PeerSession::new(
+        config,
+        metrics.clone(),
+        cmd_rx,
+        rib_tx,
+        chain,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    let negotiated = negotiated_session(65002, false);
+    session
+        .negotiated_families
+        .clone_from(&negotiated.negotiated_families);
+    session.negotiated = Some(negotiated);
+    (session, metrics)
+}
+
+fn retention_update(announce: &[Ipv4Prefix], withdraw: &[Ipv4Prefix]) -> UpdateMessage {
+    let attrs = vec![
+        PathAttribute::Origin(Origin::Igp),
+        PathAttribute::AsPath(AsPath {
+            segments: vec![AsPathSegment::AsSequence(vec![65002])],
+        }),
+        PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+    ];
+    let announced: Vec<Ipv4NlriEntry> = announce
+        .iter()
+        .map(|&prefix| Ipv4NlriEntry { path_id: 0, prefix })
+        .collect();
+    let withdrawn: Vec<Ipv4NlriEntry> = withdraw
+        .iter()
+        .map(|&prefix| Ipv4NlriEntry { path_id: 0, prefix })
+        .collect();
+    UpdateMessage::build(
+        &announced,
+        &withdrawn,
+        &attrs,
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    )
+}
+
+fn retention_key(prefix: Ipv4Prefix) -> RetentionKey {
+    RetentionKey {
+        afi: Afi::Ipv4,
+        safi: Safi::Unicast,
+        prefix: Prefix::V4(prefix),
+        path_id: 0,
+    }
+}
+
+/// LAN-472 pin: a policy deny retains the route with reason
+/// `policy_reject` and the attribute summary the member-support surface
+/// renders; a permitted sibling in the same UPDATE is not retained. The
+/// gauge tracks the store, and a subsequent explicit withdrawal clears
+/// both.
+#[tokio::test]
+async fn reject_retention_records_policy_deny_and_clears_on_withdraw() {
+    use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+    let denied = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let permitted = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![retention_statement(
+            Some(Prefix::V4(denied)),
+            PolicyAction::Deny,
+        )],
+        default_action: PolicyAction::Permit,
+    }]);
+    let (mut session, metrics) = retention_session_with_chain(Some(chain), |_| {});
+    session
+        .process_update(retention_update(&[denied, permitted], &[]))
+        .await;
+
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 1, "only the denied prefix is retained");
+    let (key, entry) = &entries[0];
+    assert_eq!(*key, retention_key(denied));
+    assert_eq!(entry.reason, ImportRejectReason::PolicyReject);
+    assert_eq!(entry.next_hop, Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))));
+    assert_eq!(entry.as_path, "65002");
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+
+    // Explicit withdrawal clears the retained reject — the question
+    // "why isn't my route accepted?" is moot once the peer stops
+    // announcing it. The gauge follows in both directions.
+    session
+        .process_update(retention_update(&[], &[denied]))
+        .await;
+    assert!(
+        session.rejected_routes.is_empty(),
+        "withdrawal clears the retained reject"
+    );
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+}
+
+/// LAN-472 pin: when a previously rejected identity is later accepted
+/// (policy outcome changes with the announcement contents), the stale
+/// reject entry is cleared — the surface never claims a live route is
+/// filtered.
+#[tokio::test]
+async fn reject_retention_clears_when_route_is_later_accepted() {
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    // Deny when community 999 is attached; permit otherwise.
+    let mut deny_communities = retention_statement(None, PolicyAction::Deny);
+    deny_communities.match_community =
+        vec![rustbgpd_policy::CommunityMatch::Standard { value: 999 }];
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![deny_communities],
+        default_action: PolicyAction::Permit,
+    }]);
+    let (mut session, metrics) = retention_session_with_chain(Some(chain), |_| {});
+
+    let tagged = UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::Communities(vec![999]),
+        ],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(tagged).await;
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].1.communities,
+        vec![999],
+        "the rejected UPDATE's communities are retained for the surface"
+    );
+
+    // Re-announce without the community — accepted, entry cleared.
+    session
+        .process_update(retention_update(&[prefix], &[]))
+        .await;
+    assert!(
+        session.rejected_routes.is_empty(),
+        "acceptance clears the stale reject entry"
+    );
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+}
+
+/// LAN-472 pin: the store is bounded by the configured capacity — a
+/// reject storm converges on the most recent rejections instead of
+/// growing without bound (this repo's reload-stall week was exactly
+/// this class of bug).
+#[tokio::test]
+async fn reject_retention_cap_evicts_oldest_reject() {
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, metrics) = retention_session_with_chain(Some(chain), |config| {
+        config.reject_retention_capacity = 2;
+    });
+    let first = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let second = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let third = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    session
+        .process_update(retention_update(&[first, second, third], &[]))
+        .await;
+    let keys: Vec<RetentionKey> = session
+        .rejected_routes
+        .snapshot()
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    assert_eq!(keys.len(), 2, "bounded at the configured capacity");
+    assert!(
+        !keys.contains(&retention_key(first)),
+        "oldest reject evicted under the cap"
+    );
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 2);
+}
+
+/// LAN-472 pin: `[policy.reject_retention] enabled = false` records
+/// nothing, and the command surface reports the disabled state as a
+/// configuration fact rather than an empty answer.
+#[tokio::test]
+async fn reject_retention_disabled_records_nothing_and_reports_disabled() {
+    let denied = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, metrics) = retention_session_with_chain(Some(chain), |config| {
+        config.reject_retention_enabled = false;
+    });
+    session
+        .process_update(retention_update(&[denied], &[]))
+        .await;
+    assert!(session.rejected_routes.is_empty());
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let flow = session
+        .handle_command(PeerCommand::ListRejectedRoutes { reply: reply_tx })
+        .await;
+    assert_eq!(flow, ControlFlow::Continue(()));
+    let reply = reply_rx.await.expect("session replied");
+    assert!(!reply.enabled, "disabled state is a configuration fact");
+    assert!(reply.entries.is_empty());
+}
+
+/// LAN-472 pin: an AS_PATH-loop rejection (which funnels through the
+/// shared RFC 7606 treat-as-withdraw primitive, like the RR-loop and
+/// malformed-attribute paths) retains the announced identities under
+/// the loop reason.
+#[tokio::test]
+async fn reject_retention_records_as_path_loop_reason() {
+    use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+    let looped = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let (mut session, metrics) = retention_session_with_chain(None, |_| {});
+    // AS_PATH contains our own ASN (65001) → RFC 4271 §9.1.2 loop.
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry {
+            path_id: 0,
+            prefix: looped,
+        }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002, 65001])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+        ],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].0, retention_key(looped));
+    assert_eq!(entries[0].1.reason, ImportRejectReason::AsPathLoop);
+    assert_eq!(entries[0].1.as_path, "65002 65001");
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+}
+
+/// LAN-472 pin: an RFC 9234 OTC ingress drop (a pre-policy hygiene
+/// gate) retains the announced identity with the OTC reason token and
+/// the canonical sub-reason detail.
+#[tokio::test]
+async fn reject_retention_records_otc_ingress_drop_with_detail() {
+    use rustbgpd_telemetry::reason_labels::ImportRejectReason;
+    let dropped = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let (mut session, metrics) = retention_session_with_chain(None, |_| {});
+    session.config.peer.local_role = Some(BgpRole::RouteServer);
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry {
+            path_id: 0,
+            prefix: dropped,
+        }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![AsPathSegment::AsSequence(vec![65002])],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::OnlyToCustomer(65002),
+        ],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].0, retention_key(dropped));
+    assert_eq!(entries[0].1.reason, ImportRejectReason::OtcRouteLeak);
+    assert_eq!(
+        entries[0].1.detail.as_deref(),
+        Some("ingress_from_customer_rsclient"),
+        "the canonical OTC sub-reason token rides in the detail field"
+    );
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+}
+
+/// LAN-472 pin: the retention store is per-session diagnostic state —
+/// `Action::SessionDown` flushes it and zeroes the gauge, mirroring the
+/// ADR-0073 import-decision-cache contract.
+#[tokio::test]
+async fn session_down_flushes_reject_retention_and_gauge() {
+    let denied = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, metrics) = retention_session_with_chain(Some(chain), |_| {});
+    session
+        .process_update(retention_update(&[denied], &[]))
+        .await;
+    assert_eq!(session.rejected_routes.len(), 1);
+    assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 1);
+
+    session.execute_actions(vec![Action::SessionDown]).await;
+    assert!(
+        session.rejected_routes.is_empty(),
+        "reject retention must be flushed on SessionDown"
+    );
+    assert_eq!(
+        metrics.rejected_routes_retained("10.0.0.2:179"),
+        0,
+        "the gauge follows the flush"
+    );
+}
+
+/// LAN-472 pin: the `ListRejectedRoutes` session command returns the
+/// retained entries (sorted by key) with the enabled flag and the
+/// configured capacity, and is a read — it must not move the
+/// permit/deny counters or the store.
+#[tokio::test]
+async fn list_rejected_routes_command_returns_sorted_snapshot() {
+    let a = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let b = Ipv4Prefix::new(Ipv4Addr::new(192, 0, 2, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, _metrics) = retention_session_with_chain(Some(chain), |_| {});
+    session.process_update(retention_update(&[a, b], &[])).await;
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let flow = session
+        .handle_command(PeerCommand::ListRejectedRoutes { reply: reply_tx })
+        .await;
+    assert_eq!(flow, ControlFlow::Continue(()));
+    let reply = reply_rx.await.expect("session replied");
+    assert!(reply.enabled);
+    assert_eq!(
+        reply.capacity,
+        super::rejected_routes::DEFAULT_REJECT_RETENTION_CAPACITY
+    );
+    let keys: Vec<RetentionKey> = reply.entries.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(
+        keys,
+        vec![retention_key(b), retention_key(a)],
+        "entries are sorted by key for stable output"
+    );
+    assert_eq!(
+        session.rejected_routes.len(),
+        2,
+        "the query is a read — the store is untouched"
+    );
 }

--- a/crates/transport/tests/session_lifecycle.rs
+++ b/crates/transport/tests/session_lifecycle.rs
@@ -104,6 +104,8 @@ fn transport_config(addr: SocketAddr) -> TransportConfig {
         cluster_id: None,
         explain_enabled: true,
         explain_cache_size: 4096,
+        reject_retention_enabled: true,
+        reject_retention_capacity: 1024,
         bmp_rib_out: false,
         slow_peer_threshold_pct: rustbgpd_transport::DEFAULT_SLOW_PEER_THRESHOLD_PCT,
         slow_peer_duration: rustbgpd_transport::DEFAULT_SLOW_PEER_DURATION_SECS,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -372,7 +372,8 @@ The daemon's durable API is gRPC + `rbgp`; its four status, peer, and
 accepted-route endpoints (`/status`, `/protocols/bgp`,
 `/routes/protocol/{id}`, `/routes/peer/{peer}`) now live in the maintained
 external `examples/birdwatcher-adapter`. This is not yet a complete Alice-LG
-backend: filtered/noexport views and structured reject reasons are absent. A
+backend: the adapter's filtered/noexport views are absent (the structured
+reject reasons behind them are served by `PolicyService.ListRejectedRoutes`). A
 config that still sets `[global.telemetry.looking_glass]` fails to load with a
 migration error. See the adapter README for the endpoint→gRPC mapping.
 
@@ -1913,6 +1914,38 @@ reset and is **not durable across restart** (for durable history use the
 event-history outbox, ADR-0072). Both fields are **restart-required
 per-peer** on reload; see [`reload-matrix.md`](reload-matrix.md) and the
 "Explain an import decision" runbook in [`OPERATIONS.md`](OPERATIONS.md).
+
+### Rejected-route retention (`[policy.reject_retention]`)
+
+Optional. Controls the per-session rejected-route retention store that
+backs `rbgp rib received <peer> --rejected` and
+`PolicyService.ListRejectedRoutes` — the looking-glass filtered-route
+surface. Every rejected inbound unicast announcement — policy deny
+(including RPKI/ASPA-driven denies), RFC 9234 OTC route-leak drop,
+strict-peer next-hop ownership, AS_PATH/reflection loop, and RFC 7606
+treat-as-withdraw — is retained with its canonical reason token, so a
+member's "why isn't my route accepted?" is answerable without knowing
+the prefix in advance. An identity that is later accepted or explicitly
+withdrawn drops out of the store.
+
+```toml
+[policy.reject_retention]
+enabled = true
+capacity = 1024
+```
+
+| Field      | Type    | Required | Default | Description |
+|------------|---------|----------|---------|-------------|
+| `enabled`  | bool    | no       | `true`  | Gates retention entirely. When `false`, the reject paths skip entry construction (one boolean check per gate) and the query surface reports the disabled state as a configuration fact rather than an empty answer. |
+| `capacity` | integer | no       | `1024`  | Per-peer retention cap, LRU on rejection recency — a reject storm converges on the most recent `capacity` rejections. Each entry is one rejected `(AFI, SAFI, prefix, path_id)` with its reason and a compact attribute summary, ≤ ~512 bytes realistic worst case ⇒ ~0.5 MiB bound per peer at the default. Raise it toward the expected member announcement count for full coverage on route-server fleets. |
+
+Like `[policy.explain]`, this is **diagnostic state only** — it never
+affects which routes are accepted. Scope is IPv4 / IPv6 unicast
+(max-prefix violations tear the session down, so there is no per-route
+rejection to retain). The store resets on peer session reset. Both
+fields are **restart-required per-peer** on reload; see
+[`reload-matrix.md`](reload-matrix.md) and the "Answer a member's 'why
+is my route filtered?'" runbook in [`OPERATIONS.md`](OPERATIONS.md).
 
 ---
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -425,8 +425,9 @@ JSON-lines event bridge, the minimal Shape-A skeleton) and
 `examples/birdwatcher-adapter/` (a Birdwatcher-shaped status, peer, and
 accepted-route REST subset sourced entirely from the public gRPC API,
 including per-route `age` from `received_at_epoch_seconds`). It is not a
-complete Alice-LG backend: filtered/noexport views and structured reject
-reasons still need public API support. The adapter is the honest template: if
+complete Alice-LG backend: the structured reject reasons are now served by
+`PolicyService.ListRejectedRoutes` (LAN-472), but the adapter's
+filtered/noexport views still need wiring. The adapter is the honest template: if
 the public API is missing a field an external tool needs, the fix is an
 additive proto field, not a daemon-internal shortcut — that is how
 `received_at_epoch_seconds` landed.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1256,6 +1256,47 @@ never affects which routes are accepted):
   reliable full-table explain, raise it toward the peer's
   expected retained-prefix count and budget the memory.
 
+### Answer a member's "why is my route filtered?" (LAN-472)
+
+The enumeration complement to `policy explain`: when a route-server
+member calls asking why their prefix isn't in the RS — and neither of
+you knows exactly which announcement is at fault — list everything of
+theirs the import path rejected, tagged with the reason:
+
+```bash
+rbgp rib received 10.0.0.2 --rejected
+rbgp rib received 10.0.0.2 --rejected --json   # Alice-LG-style tooling feed
+```
+
+Each row carries the rejected prefix (with Add-Path `path_id`), the
+canonical reason token, a detail field, the wire next-hop, the AS path,
+and RPKI/ASPA validation states at rejection time:
+
+| Reason | Meaning / detail field |
+|---|---|
+| `policy_reject` | The import chain denied it (detail: the matched policy name; the row's RPKI/ASPA columns show whether a validation state drove the deny). Follow up with `rbgp policy explain` on the prefix for the statement-level trace. |
+| `otc_route_leak` | RFC 9234 Only-to-Customer ingress drop (detail: the canonical OTC sub-reason, e.g. `ingress_from_customer_rsclient`). |
+| `next_hop_ownership` | Strict-peer next-hop ownership gate, RFC 7948 §4.8 / ADR-0107 (detail: e.g. `foreign_next_hop`; the next-hop column shows the violating value). |
+| `as_path_loop` | Our ASN in the received AS_PATH (RFC 4271 §9.1.2). |
+| `rr_loop` | Reflection loop, RFC 4456 §8 (detail: `originator_id` or `cluster_list`). |
+| `treat_as_withdraw` | RFC 7606: a malformed attribute forced the whole UPDATE's routes to be handled as withdrawn. |
+
+Retention is per-session and self-maintaining: an identity that is
+later **accepted** or **explicitly withdrawn** drops out (the listing
+never claims a live route is filtered), and the store resets on session
+flap. It is bounded per peer (`[policy.reject_retention] capacity`,
+default 1024, LRU on rejection recency) — when the listing reports the
+store at capacity, it shows the most recent rejections and the CLI says
+so. Max-prefix violations don't appear here: exceeding the limit tears
+the session down (Cease/1), which is its own, louder signal.
+
+`bgp_rejected_routes_retained{peer}` gauges the store per peer — a
+sustained high value on a member session is the "their filters are
+rejecting a lot" signal worth proactive outreach before the support
+call. `[policy.reject_retention] enabled = false` disables retention
+entirely (the CLI then reports the disabled state, never an empty
+answer); both knobs are restart-required per peer.
+
 ### Enable / disable a peer
 
 ```bash
@@ -1752,8 +1793,9 @@ frontends, run the external `examples/birdwatcher-adapter` binary. It serves the
 Birdwatcher-shaped endpoints (`/status`, `/protocols/bgp`,
 `/routes/protocol/{id}`, `/routes/peer/{peer}`) from the daemon's gRPC API.
 Alice-LG consumes these shapes, but this is not a usable complete backend:
-Alice-LG also fetches filtered and noexport route views that are not exposed,
-and the public API does not yet provide structured reject reasons. The
+Alice-LG also fetches filtered and noexport route views that the adapter does
+not expose yet (the structured reject reasons behind them are available from
+`PolicyService.ListRejectedRoutes`). The
 in-daemon `[global.telemetry.looking_glass]` server has been removed.
 
 ### EVPN Route Reflector + Bidirectional VTEP

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -408,8 +408,9 @@ IX peer C  ──┘
 - **RPKI validation state** — each route annotated with Valid/Invalid/NotFound
 - **Birdwatcher-shaped REST subset** — the external
   [`examples/birdwatcher-adapter`](../examples/birdwatcher-adapter/) serves
-  accepted-route, peer, and status views from the gRPC API; filtered/noexport
-  views and structured reject reasons remain before it is a complete Alice-LG
+  accepted-route, peer, and status views from the gRPC API; structured
+  reject reasons are available (`PolicyService.ListRejectedRoutes`), and the
+  adapter's filtered/noexport views remain before it is a complete Alice-LG
   backend
 - **Best-path explain** — `rbgp rib --prefix X --explain` shows why a
   route was selected over alternatives

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -313,19 +313,49 @@ Prometheus (`prometheus_addr`, `/metrics`; dashboards in
 | `bgp_update_group_fallback_peers` | ≥ your `per_client_best` member count (they never group) |
 | `bgp_rib_outbound_registered_peers` | = established member count |
 
+## Member support: the filtered-route view
+
+The de-facto IXP member-support flow (what Alice-LG renders from
+arouteserver's `reject_reason` tagging on BIRD) is "show the member
+their *filtered* routes, tagged with why". rustbgpd retains rejected
+inbound routes per member session with a canonical reason token —
+`policy_reject`, `otc_route_leak`, `next_hop_ownership`,
+`as_path_loop`, `rr_loop`, `treat_as_withdraw` — queryable without
+knowing the prefix in advance:
+
+```console
+$ rbgp rib received 198.51.100.2 --rejected
+Prefix                 PathId   Reason             Detail                       Next Hop           RPKI       AS Path
+------------------------------------------------------------------------------------------------------------------------
+203.0.113.0/24         0        policy_reject      member-import                198.51.100.2       invalid    64500 64501
+```
+
+`--json` emits the same rows for a looking-glass or portal backend
+(`PolicyService.ListRejectedRoutes` is the underlying RPC — the
+structured reject-reason source an Alice-LG-style adapter needs for its
+filtered view). Retention is bounded per member
+(`[policy.reject_retention] capacity`, default 1024, LRU on recency),
+self-cleans when a rejected identity is later accepted or withdrawn,
+and `bgp_rejected_routes_retained{peer}` gauges it for proactive "your
+filters are eating this member's routes" alerting. For the
+statement-level *why* on a specific prefix, follow up with
+`rbgp policy explain`. See the runbook in
+[`OPERATIONS.md`](../OPERATIONS.md).
+
 ## Failure modes
 
 **A member's routes never appear (`rbgp rib received <addr>` is empty
-but the session is Established).** Import hygiene dropped them. Run the
-import decision cache explain:
+but the session is Established).** Import hygiene dropped them. List
+the retained rejections, then drill into the deciding term:
 
 ```console
+$ rbgp rib received 198.51.100.2 --rejected
 $ rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
 ```
 
-It names the deciding term — typically `reject-rpki-invalid` (fix the
-member's ROA or your RTR feed) or an `ixp-hygiene` rule (AS_SET or
-ASPA-invalid in the announcement).
+The explain names the deciding term — typically `reject-rpki-invalid`
+(fix the member's ROA or your RTR feed) or an `ixp-hygiene` rule
+(AS_SET or ASPA-invalid in the announcement).
 
 **A prefix is hidden from one member but present in the Loc-RIB.** That
 member's own export policy denies the single best path. In `single-best`

--- a/docs/grpc-method-inventory.json
+++ b/docs/grpc-method-inventory.json
@@ -6,10 +6,10 @@
   "additional_protos": [
     "proto/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto"
   ],
-  "method_count": 98,
+  "method_count": 99,
   "tier_counts": {
     "read": 0,
-    "sensitive_read": 57,
+    "sensitive_read": 58,
     "mutating": 19,
     "operator_only": 22
   },
@@ -55,6 +55,7 @@
     { "service": "rustbgpd.v1.PolicyService", "method": "SetNeighborExportChain", "path": "/rustbgpd.v1.PolicyService/SetNeighborExportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborImportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborImportChain", "tier": "mutating" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ExplainImportPolicy", "path": "/rustbgpd.v1.PolicyService/ExplainImportPolicy", "tier": "sensitive_read" },
+    { "service": "rustbgpd.v1.PolicyService", "method": "ListRejectedRoutes", "path": "/rustbgpd.v1.PolicyService/ListRejectedRoutes", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "TestPolicy", "path": "/rustbgpd.v1.PolicyService/TestPolicy", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "GetPolicyStats", "path": "/rustbgpd.v1.PolicyService/GetPolicyStats", "tier": "sensitive_read" },
     { "service": "rustbgpd.v1.PolicyService", "method": "ClearNeighborExportChain", "path": "/rustbgpd.v1.PolicyService/ClearNeighborExportChain", "tier": "mutating" },

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -259,6 +259,8 @@ chains all add/change/remove cleanly via reload.
 | `export_chain` (named) | live | Reorder, add, or remove named exports. |
 | `[policy.explain] enabled` (ADR-0073) | restart-required (per peer) | Read by `build_transport_config` when a session is constructed, so the new value is adopted into the config snapshot (sessions established *after* the reload honour it) but live sessions keep their current import-explain write behaviour until they re-establish. Logged as `WARN` during reload when changed. Diagnostic retention only — never affects which routes are accepted. |
 | `[policy.explain] cache_size` (ADR-0073) | restart-required (per peer) | Same — the per-session LRU is sized at session construction. A live session's cache is not resized in place; the new capacity applies on its next establishment. |
+| `[policy.reject_retention] enabled` (LAN-472) | restart-required (per peer) | Same contract as `[policy.explain]`: read by `build_transport_config` at session construction. Live sessions keep their current rejected-route retention behaviour until they re-establish. Diagnostic retention only — never affects which routes are accepted. |
+| `[policy.reject_retention] capacity` (LAN-472) | restart-required (per peer) | Same — the per-session rejected-route store is sized at session construction; the new capacity applies on the peer's next establishment. |
 
 ## `[rpki]`, `[bmp]`, `[mrt]`
 

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -142,6 +142,10 @@
         "export_chain": [],
         "import_chain": [],
         "neighbor_sets": {},
+        "reject_retention": {
+          "capacity": 1024,
+          "enabled": true
+        },
         "rpol_files": [],
         "rpol_roots": []
       }
@@ -2299,6 +2303,14 @@
           },
           "default": {}
         },
+        "reject_retention": {
+          "description": "Rejected-route retention tuning for the looking-glass\nfiltered-route surface (LAN-472). Diagnostic retention only —\ndoes not affect which routes are accepted.",
+          "$ref": "#/$defs/PolicyRejectRetentionConfig",
+          "default": {
+            "capacity": 1024,
+            "enabled": true
+          }
+        },
         "rpol_files": {
           "description": "`.rpol` policy-language files (ADR-0096) compiled at config\nload. Relative paths resolve against the config file's\ndirectory and are rewritten to absolute paths after load (so\nruntime config snapshots and transaction candidates stay\nloadable regardless of the daemon's working directory).\nCompile diagnostics are config load errors. The policies they\ndefine share one namespace with `[policy.definitions]`; chains\nreference them by name, parameterized policies by call-form\n(`\"customer-in(200)\"`).",
           "type": "array",
@@ -2331,6 +2343,25 @@
         },
         "enabled": {
           "description": "Whether the per-session import-decision cache is populated.\nDefault `true`. This is the performance control: when `false`\nthe inbound UPDATE path skips building and storing any decision\nsnapshot — a single boolean check, no per-NLRI attribute /\nmodification clone. Turn it off on hot full-table peers where\nthe explain surface isn't worth the write-path cost.",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "PolicyRejectRetentionConfig": {
+      "description": "Tuning for the per-session rejected-route retention store that backs\n`rbgp rib received <peer> --rejected` /\n`PolicyService.ListRejectedRoutes` (LAN-472) — the looking-glass\nfiltered-route surface.\n\nLike `[policy.explain]`, this is **diagnostic retention**, not\npolicy evaluation behaviour: shrinking or disabling the store\nchanges only what the reject surface can answer, never which routes\nthe import path admits.",
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "description": "Per-peer retention capacity (entries). Each entry is one\nrejected `(AFI, SAFI, prefix, path_id)` identity with its reason\nand a compact attribute summary (≤ ~512 bytes realistic worst\ncase, dominated by the AS-path string and community sets).\nDefault 1024 ⇒ ~0.5 MiB bound per peer under a full reject\nstorm; the store is LRU on rejection recency, so a storm\nconverges on the most recent rejections. Raise it toward the\nexpected member announcement count for reliable full coverage on\nroute-server fleets and own the memory.",
+          "type": "integer",
+          "format": "uint",
+          "default": 1024,
+          "minimum": 0
+        },
+        "enabled": {
+          "description": "Whether rejected inbound routes are retained with their reject\nreason. Default `true`. When `false` the inbound UPDATE path\nskips retention entirely — a single boolean check per gate, no\nentry construction.",
           "type": "boolean",
           "default": true
         }

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -61,7 +61,7 @@
   ],
   "config": {
     "stable_fields": [
-      {"definition": "Config", "fields": ["bmp", "dynamic_neighbors", "event_history", "global", "mrt", "neighbors", "peer_groups", "policy", "rpki", "security"], "schema_sha256": "4832ea48a84f88e269c116375d32e95a68f3bd32cba1cda710bd9304af6bf9c1"},
+      {"definition": "Config", "fields": ["bmp", "dynamic_neighbors", "event_history", "global", "mrt", "neighbors", "peer_groups", "policy", "rpki", "security"], "schema_sha256": "41a05262948c181c6278a6735710714da374fd5d65bd79cc78a36b75c367f9f9"},
       {"definition": "Global", "fields": ["asn", "cluster_id", "dynamic_neighbor_limit", "honor_graceful_shutdown", "listen_port", "multipath_relax", "router_id", "runtime_state_dir", "telemetry", "worker_threads"], "schema_sha256": "89760ebeef12ffad5357ae56cee8b3e2ff950b957102168aed59f7517b0899b0"},
       {"definition": "TelemetryConfig", "fields": ["grpc_tcp", "grpc_uds", "log_format", "prometheus_addr"], "schema_sha256": "95ed5115adecb2c4fda72873482c6fee1d8b7df7a0844712a5408f04505e793d"},
       {"definition": "GrpcTcpListenerConfig", "fields": ["access_mode", "address", "enabled", "max_tier", "principal", "tls_cert_file", "tls_client_ca_file", "tls_key_file", "token_file"], "schema_sha256": "2c5304b180fea247a211160087b6eed583e2834558faa02efc3473410a8695b2"},
@@ -146,7 +146,7 @@
       {"service": "RibService", "methods": ["ListBgpLsRoutes", "ListVpnRoutes", "ListLabeledRoutes", "ListRtcRoutes", "ListTopologyNodes", "ListTopologyLinks", "ListOrrStatus"], "signature_sha256": "6e4fc15d26b9de73655759d98c31cf68e25b0e5fca712e676d59c01c710fe290", "message_graph_sha256": "53e84ecef4708a9f117f839732bd564c07b6c37905173d36583ec203cc92de4d"}
     ],
     "explicitly_unstable_message_fields": ["BgpEvent.bfd", "BgpEvent.dataplane", "BgpEvent.dataplane_route", "BgpEvent.evpn", "ConfigTransactionApplyResponse.update_group_impact", "ConfigTransactionPlanResponse.update_group_impact", "DeleteNeighborRequest.interface", "GetNeighborStateRequest.interface", "NeighborConfig.interface", "NeighborConfig.paths_limit_receive_max", "NeighborState.paths_limits", "NeighborState.slow_peer", "PathsLimitState.*", "PeerGroupDefinition.paths_limit_receive_max", "UpdateGroupFamilyImpact.*", "UpdateGroupImpactPlan.*", "UpdateGroupImpactRollup.*"],
-    "explicitly_outside_v1": ["gnmi.gNMI", "BfdService", "EvpnService", "InjectionService.AddFlowSpec", "InjectionService.DeleteFlowSpec", "InjectionService.AddEvpnRoute", "InjectionService.DeleteEvpnRoute", "RibService.ListBlackholeDiscards", "RibService.ListEvpnRoutes", "RibService.ListFibRoutes", "RibService.ListFibTables", "RibService.SetFibTable", "RibService.DeleteFibTable", "RibService.ListFlowSpecRoutes", "EventService.ListEvpnEvents"]
+    "explicitly_outside_v1": ["gnmi.gNMI", "BfdService", "EvpnService", "InjectionService.AddFlowSpec", "InjectionService.DeleteFlowSpec", "InjectionService.AddEvpnRoute", "InjectionService.DeleteEvpnRoute", "RibService.ListBlackholeDiscards", "RibService.ListEvpnRoutes", "RibService.ListFibRoutes", "RibService.ListFibTables", "RibService.SetFibTable", "RibService.DeleteFibTable", "RibService.ListFlowSpecRoutes", "EventService.ListEvpnEvents", "PolicyService.ListRejectedRoutes"]
   },
   "cli": {
     "stability_scope": "command_path_and_name_only",

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -49,9 +49,13 @@ the `Route.received_at_epoch_seconds` proto field (RIB receive time), the same
 source the in-daemon server used.
 
 The scope is status, peer, and accepted-route views only. Alice-LG's
-filtered/noexport views are not implemented, and the public API does not yet
-provide the structured per-route reject reasons needed to implement them
-honestly.
+filtered/noexport views are not implemented in this adapter yet. The
+structured per-route reject reasons they need are now available from
+`PolicyService.ListRejectedRoutes` (per-peer retained rejects with
+canonical reason tokens; see `[policy.reject_retention]` in
+`docs/CONFIGURATION.md`), so a real `routes.filtered` count and a
+filtered view are implementable — wiring them into this adapter is
+future work.
 
 ### Field-level gaps
 

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -4,8 +4,9 @@
 //! subset consumed by Alice-LG and similar looking glass frontends, sourcing
 //! all data from a running rustbgpd over gRPC. This replaces the removed
 //! in-daemon `[global.telemetry.looking_glass]` server's four endpoints. It is
-//! not a complete Alice-LG backend: filtered/noexport views and structured
-//! reject reasons are not exposed.
+//! not a complete Alice-LG backend: filtered/noexport views are not wired up
+//! here yet (the structured reject reasons they need are available from
+//! `PolicyService.ListRejectedRoutes`).
 //!
 //! **Supported endpoints** (single-table mode):
 //! - `GET /status` — daemon status

--- a/examples/completions/_rbgp
+++ b/examples/completions/_rbgp
@@ -620,6 +620,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \
@@ -635,6 +636,7 @@ _arguments "${_arguments_options[@]}" : \
 '-s+[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--addr=[gRPC server address or unix\:///path/to/socket]:ADDR:_default' \
 '--token-file=[Bearer token file for authenticated gRPC endpoints]:TOKEN_FILE:_default' \
+'--rejected[Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; \[policy.reject_retention\])]' \
 '-j[Output in JSON format]' \
 '--json[Output in JSON format]' \
 '--no-color[Disable colored output]' \

--- a/examples/completions/rbgp.bash
+++ b/examples/completions/rbgp.bash
@@ -7923,7 +7923,7 @@ _rbgp() {
             return 0
             ;;
         rbgp__subcmd__rib__subcmd__received)
-            opts="-a -s -j -h --family --addr --token-file --json --no-color --help"
+            opts="-a -s -j -h --family --rejected --addr --token-file --json --no-color --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/examples/completions/rbgp.fish
+++ b/examples/completions/rbgp.fish
@@ -297,12 +297,14 @@ complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and not __fish_seen_subco
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from received" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s a -l family -d 'Address family filter' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s s -l addr -d 'gRPC server address or unix:///path/to/socket' -r
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l token-file -d 'Bearer token file for authenticated gRPC endpoints' -r
+complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l rejected -d 'Show the retained rejected routes with their reject reasons instead of the accepted Adj-RIB-In (the looking-glass filtered-route view; [policy.reject_retention])'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s j -l json -d 'Output in JSON format'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -l no-color -d 'Disable colored output'
 complete -c rbgp -n "__fish_rbgp_using_subcommand rib; and __fish_seen_subcommand_from recv" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -683,6 +683,24 @@ service PolicyService {
   // any policy counter, does not log a new policy decision.
   rpc ExplainImportPolicy(ExplainImportPolicyRequest) returns (ExplainImportPolicyResponse);
 
+  // ListRejectedRoutes — the looking-glass filtered-route surface
+  // (LAN-472): every rejected inbound route the peer's session has
+  // retained, tagged with its canonical reject-reason token. The
+  // enumeration complement to ExplainImportPolicy's point lookup —
+  // "show me everything of mine you filtered, and why" without
+  // knowing a prefix in advance. Backs `rbgp rib received <peer>
+  // --rejected` and Alice-LG-style member-support views.
+  //
+  // Retention is bounded per peer ([policy.reject_retention]
+  // capacity, LRU on rejection recency) and covers unicast only,
+  // matching the v1 ExplainImportPolicy scope. Returns NOT_FOUND
+  // when the peer has no live session (the session-local store is
+  // gone, honestly distinct from "nothing rejected").
+  //
+  // Side-effect free read. Does not touch RIB, does not increment
+  // any policy counter, does not log a new policy decision.
+  rpc ListRejectedRoutes(ListRejectedRoutesRequest) returns (ListRejectedRoutesResponse);
+
   // TestPolicy — dry-run a candidate .rpol policy against a snapshot
   // of the live RIB (ADR-0096 Decision 6). The daemon compiles the
   // submitted source server-side (compile diagnostics are returned in
@@ -1186,6 +1204,74 @@ message ExplainImportPolicyResponse {
   // when it does not, every matching path_id appears (Add-Path
   // disambiguation).
   repeated ImportExplainMatch matches = 6;
+}
+
+message ListRejectedRoutesRequest {
+  // IPv4 or IPv6 literal of the peer whose retention store should be
+  // consulted. Required.
+  string peer_address = 1;
+}
+
+// One retained rejection (LAN-472). Attribute fields are best-effort:
+// the policy-deny path fills them all; the pre-policy safety gates
+// fill what was decodable. The reason token is always present.
+message RejectedRoute {
+  string prefix          = 1;
+  uint32 prefix_length   = 2;
+  uint32 path_id         = 3;
+  AddressFamily afi_safi = 4;
+
+  // Canonical snake_case reject-reason token, from the release-stable
+  // reason-label vocabulary: policy_reject, otc_route_leak,
+  // next_hop_ownership, as_path_loop, rr_loop, treat_as_withdraw.
+  string reason = 5;
+
+  // Sub-mechanism detail: the matched policy name for policy_reject,
+  // the canonical sub-reason token for the OTC / ownership / RR-loop
+  // gates (e.g. ingress_peer_mismatch, foreign_next_hop,
+  // cluster_list). Empty when the mechanism has no finer grain.
+  string reason_detail = 6;
+
+  // Wire next-hop the rejected announcement carried; empty when it
+  // was not decodable or not meaningful for the gate.
+  string next_hop = 7;
+
+  // Lossless AS_PATH rendering (AS_SET / confed segments survive);
+  // empty when the UPDATE carried none.
+  string as_path = 8;
+
+  repeated uint32 communities = 9;
+  // Large communities as "asn:local1:local2" strings.
+  repeated string large_communities = 10;
+
+  // RPKI origin-validation state at rejection time, as a stable
+  // snake_case string: "valid", "invalid", "not_found", "unknown".
+  string rpki_validation = 11;
+  // ASPA path-verification state at rejection time, as a stable
+  // snake_case string: "valid", "invalid", "unknown", "unverified".
+  string aspa_validation = 12;
+
+  // Rejection wall-clock time as Unix nanoseconds (the durable event
+  // outbox's timestamp_ns convention).
+  int64 rejected_at_unix_ns = 13;
+}
+
+message ListRejectedRoutesResponse {
+  // Echo of the request scope.
+  string peer_address = 1;
+
+  // Whether the session retains rejected routes at all
+  // ([policy.reject_retention] enabled). false means an empty listing
+  // is a configuration fact, not "nothing was rejected".
+  bool retention_enabled = 2;
+
+  // The session's retention cap. When routes.len() == capacity the
+  // listing shows the most recent `capacity` rejections, not
+  // necessarily all of them.
+  uint32 capacity = 3;
+
+  // Every retained rejection, sorted by (afi, safi, prefix, path_id).
+  repeated RejectedRoute routes = 4;
 }
 
 message TestPolicyRequest {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1290,6 +1290,10 @@ impl Config {
         // of `[policy.explain]`.
         transport.explain_enabled = self.policy.explain.enabled;
         transport.explain_cache_size = self.policy.explain.cache_size;
+        // LAN-472: same threading hazard for the rejected-route
+        // retention knobs — both construction paths must see them.
+        transport.reject_retention_enabled = self.policy.reject_retention.enabled;
+        transport.reject_retention_capacity = self.policy.reject_retention.capacity;
 
         let (import_policy, export_policy) = self.effective_policy_chains_for_neighbor(neighbor)?;
 
@@ -2553,6 +2557,11 @@ pub struct ConfigDiff {
     /// peer only on its next session establishment). Diagnostic
     /// retention only; never affects which routes are accepted.
     pub policy_explain_changed: bool,
+    /// `[policy.reject_retention]` (`enabled` / `capacity`, LAN-472)
+    /// changed. Same restart-required-per-peer contract as
+    /// `[policy.explain]`: read at session construction, diagnostic
+    /// retention only.
+    pub policy_reject_retention_changed: bool,
     /// Shape-aware ADR-0063 / ADR-0085 classification for EVPN runtime
     /// table changes. The raw `evpn_*_changed` booleans above still say
     /// which TOML tables moved; this field says whether SIGHUP can route
@@ -2747,6 +2756,7 @@ impl ConfigDiff {
             || self.dynamic_neighbor_tcp_ao_changed
             || self.bfd_changed
             || self.policy_explain_changed
+            || self.policy_reject_retention_changed
             || self.fib_tables_requires_restart
             || self.managed_netdevs_changed
             || self.security_grpc_changed
@@ -3367,6 +3377,11 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .restart_required_sections
             .push("[policy.explain]".to_string());
     }
+    if diff.policy_reject_retention_changed {
+        class
+            .restart_required_sections
+            .push("[policy.reject_retention]".to_string());
+    }
     class
 }
 
@@ -3504,6 +3519,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "dynamic_neighbor_tcp_ao_changed": diff.dynamic_neighbor_tcp_ao_changed,
             "bfd_changed": diff.bfd_changed,
             "policy_explain_changed": diff.policy_explain_changed,
+            "policy_reject_retention_changed": diff.policy_reject_retention_changed,
         },
         "informational": serde_json::Value::Object(serde_json::Map::new()),
     })
@@ -3762,6 +3778,9 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
     if diff.policy_explain_changed {
         restart_sections.push("[policy.explain] (per-peer; applies on next session)");
     }
+    if diff.policy_reject_retention_changed {
+        restart_sections.push("[policy.reject_retention] (per-peer; applies on next session)");
+    }
     if !restart_sections.is_empty() {
         let _ = writeln!(out, "{}", style.restart_header);
         for section in &restart_sections {
@@ -3779,6 +3798,10 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
 }
 
 /// Compare two full configurations and return a structured diff.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one flag computation per config section, kept together with the struct literal"
+)]
 pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
     let neighbor_tcp_ao_changed = neighbor_tcp_ao_restart_required_changed(old, new);
     let dynamic_neighbor_tcp_ao_changed =
@@ -3886,6 +3909,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         neighbor_tcp_ao_changed,
         bfd_changed,
         policy_explain_changed: old.policy.explain != new.policy.explain,
+        policy_reject_retention_changed: old.policy.reject_retention != new.policy.reject_retention,
         evpn_runtime_change_class,
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1296,6 +1296,11 @@ pub struct PolicyConfig {
     /// retention only — does not affect which routes are accepted.
     #[serde(default)]
     pub explain: PolicyExplainConfig,
+    /// Rejected-route retention tuning for the looking-glass
+    /// filtered-route surface (LAN-472). Diagnostic retention only —
+    /// does not affect which routes are accepted.
+    #[serde(default)]
+    pub reject_retention: PolicyRejectRetentionConfig,
     /// `.rpol` policy-language files (ADR-0096) compiled at config
     /// load. Relative paths resolve against the config file's
     /// directory and are rewritten to absolute paths after load (so
@@ -1425,6 +1430,54 @@ impl Default for PolicyExplainConfig {
         Self {
             enabled: default_explain_enabled(),
             cache_size: default_explain_cache_size(),
+        }
+    }
+}
+
+/// Tuning for the per-session rejected-route retention store that backs
+/// `rbgp rib received <peer> --rejected` /
+/// `PolicyService.ListRejectedRoutes` (LAN-472) — the looking-glass
+/// filtered-route surface.
+///
+/// Like `[policy.explain]`, this is **diagnostic retention**, not
+/// policy evaluation behaviour: shrinking or disabling the store
+/// changes only what the reject surface can answer, never which routes
+/// the import path admits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyRejectRetentionConfig {
+    /// Whether rejected inbound routes are retained with their reject
+    /// reason. Default `true`. When `false` the inbound UPDATE path
+    /// skips retention entirely — a single boolean check per gate, no
+    /// entry construction.
+    #[serde(default = "default_reject_retention_enabled")]
+    pub enabled: bool,
+    /// Per-peer retention capacity (entries). Each entry is one
+    /// rejected `(AFI, SAFI, prefix, path_id)` identity with its reason
+    /// and a compact attribute summary (≤ ~512 bytes realistic worst
+    /// case, dominated by the AS-path string and community sets).
+    /// Default 1024 ⇒ ~0.5 MiB bound per peer under a full reject
+    /// storm; the store is LRU on rejection recency, so a storm
+    /// converges on the most recent rejections. Raise it toward the
+    /// expected member announcement count for reliable full coverage on
+    /// route-server fleets and own the memory.
+    #[serde(default = "default_reject_retention_capacity")]
+    pub capacity: usize,
+}
+
+fn default_reject_retention_enabled() -> bool {
+    true
+}
+
+fn default_reject_retention_capacity() -> usize {
+    1024
+}
+
+impl Default for PolicyRejectRetentionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_reject_retention_enabled(),
+            capacity: default_reject_retention_capacity(),
         }
     }
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5390,6 +5390,50 @@ fn resolve_neighbor_threads_policy_explain_settings() {
 }
 
 #[test]
+fn resolve_neighbor_threads_reject_retention_settings() {
+    // LAN-472: the resolved-neighbor transport path must thread the
+    // [policy.reject_retention] knobs, mirroring the [policy.explain]
+    // threading above.
+    let mut config = parse(valid_toml()).unwrap();
+    config.policy.reject_retention.enabled = false;
+    config.policy.reject_retention.capacity = 64;
+    let resolved = config.resolve_neighbor(&config.neighbors[0]).unwrap();
+    assert!(
+        !resolved.transport_config.reject_retention_enabled,
+        "enabled must propagate through resolve_neighbor"
+    );
+    assert_eq!(resolved.transport_config.reject_retention_capacity, 64);
+}
+
+#[test]
+fn diff_config_flags_reject_retention_as_restart_required() {
+    // LAN-472: a [policy.reject_retention] edit is restart-required-per-
+    // peer and must be visible in `--diff` (JSON + text), matching the
+    // [policy.explain] contract.
+    let old = parse(valid_toml()).unwrap();
+    let mut new = old.clone();
+    new.policy.reject_retention.enabled = false;
+    new.policy.reject_retention.capacity = 128;
+
+    let diff = super::diff_config(&old, &new);
+    assert!(diff.policy_reject_retention_changed);
+    assert!(diff.has_restart_required_changes());
+    assert!(
+        !diff.has_reload_applied_changes(),
+        "a reject-retention-only edit does not hot-apply"
+    );
+
+    let json = super::config_diff_json_value(&diff);
+    assert_eq!(
+        json["restart_required"]["policy_reject_retention_changed"],
+        true
+    );
+
+    let text = super::format_config_diff_with_style(&diff, &super::ConfigDiffTextStyle::default());
+    assert!(text.contains("[policy.reject_retention]"), "{text}");
+}
+
+#[test]
 fn diff_config_flags_policy_explain_as_restart_required() {
     // ADR-0073: a [policy.explain] edit is restart-required-per-peer and
     // must be visible in `--diff` (JSON + text), not silently dropped.

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -690,6 +690,10 @@ impl PeerManager {
         // write-path gate at its `true` default regardless of config.
         transport.explain_enabled = self.current_config.policy.explain.enabled;
         transport.explain_cache_size = self.current_config.policy.explain.cache_size;
+        // LAN-472: rejected-route retention wiring — same threading
+        // hazard as the explain knobs above.
+        transport.reject_retention_enabled = self.current_config.policy.reject_retention.enabled;
+        transport.reject_retention_capacity = self.current_config.policy.reject_retention.capacity;
         // RFC 8671: tap outbound UPDATEs for BMP only when some collector
         // actually monitors the post-policy Adj-RIB-Out stream ([bmp]
         // changes require a restart, so read-at-construction is
@@ -978,13 +982,23 @@ impl PeerManager {
                             let result = self.hot_update_peer(config).await;
                             let _ = reply.send(result);
                         }
-                        PeerManagerCommand::SyncExplainConfig { enabled, cache_size, reply } => {
-                            // ADR-0073: make the explain snapshot fresh before
-                            // any subsequent reconcile/peer-group command on
-                            // this FIFO channel constructs a session via
-                            // build_transport_config.
+                        PeerManagerCommand::SyncExplainConfig {
+                            enabled,
+                            cache_size,
+                            reject_retention_enabled,
+                            reject_retention_capacity,
+                            reply,
+                        } => {
+                            // ADR-0073 / LAN-472: make the diagnostic-retention
+                            // snapshot fresh before any subsequent
+                            // reconcile/peer-group command on this FIFO channel
+                            // constructs a session via build_transport_config.
                             self.current_config.policy.explain.enabled = enabled;
                             self.current_config.policy.explain.cache_size = cache_size;
+                            self.current_config.policy.reject_retention.enabled =
+                                reject_retention_enabled;
+                            self.current_config.policy.reject_retention.capacity =
+                                reject_retention_capacity;
                             let _ = reply.send(());
                         }
                         PeerManagerCommand::SyncRpolPolicies { rpol_files, rpol, dataset_bindings, reply } => {
@@ -1039,6 +1053,25 @@ impl PeerManager {
                                         .explain_import_policy_timeout(
                                             afi, safi, prefix, path_id, EXPLAIN_QUERY_TIMEOUT,
                                         )
+                                        .await
+                                }
+                                None => None,
+                            };
+                            let _ = reply.send(result);
+                        }
+                        PeerManagerCommand::ListRejectedRoutes { address, reply } => {
+                            // LAN-472: same resolution + bounded-forward
+                            // shape as ExplainImportPolicy — no live
+                            // session folds to None, rendered by the RPC
+                            // layer as NOT_FOUND.
+                            let result = match self
+                                .unique_peer_key_for_address(address)
+                                .and_then(|key| self.peers.get(&key))
+                            {
+                                Some(managed) => {
+                                    managed
+                                        .handle
+                                        .list_rejected_routes_timeout(EXPLAIN_QUERY_TIMEOUT)
                                         .await
                                 }
                                 None => None,

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -4525,6 +4525,39 @@ fn build_transport_config_threads_policy_explain_settings() {
 }
 
 #[test]
+fn build_transport_config_threads_reject_retention_settings() {
+    // LAN-472: both [policy.reject_retention] knobs must propagate from
+    // the daemon config snapshot into the per-session TransportConfig —
+    // same threading hazard as the [policy.explain] siblings above.
+    let (_, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let metrics = BgpMetrics::new();
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        metrics,
+        rib_tx,
+        None,
+    );
+    mgr.current_config.policy.reject_retention.enabled = false;
+    mgr.current_config.policy.reject_retention.capacity = 64;
+
+    let config = make_config(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 65002);
+    let transport = mgr.build_transport_config(&config);
+    assert!(
+        !transport.reject_retention_enabled,
+        "enabled must propagate"
+    );
+    assert_eq!(
+        transport.reject_retention_capacity, 64,
+        "capacity must propagate"
+    );
+}
+
+#[test]
 fn build_transport_config_preserves_route_server_client() {
     let (_, rx) = mpsc::channel(16);
     let (rib_tx, _rib_rx) = mpsc::channel(64);
@@ -10275,6 +10308,8 @@ async fn export_only_snapshot_services_readiness_without_admitting_mutations() {
         .send(PeerManagerCommand::SyncExplainConfig {
             enabled: false,
             cache_size: 17,
+            reject_retention_enabled: true,
+            reject_retention_capacity: 1024,
             reply: mutation_reply,
         })
         .await

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1076,7 +1076,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // tracks neighbors / policy chains / peer-groups, not this
     // diagnostic-retention knob, so detect it explicitly rather than
     // letting an explain-only reload report "no changes detected".
-    let explain_changed = current.policy.explain != new_config.policy.explain;
+    let explain_changed = current.policy.explain != new_config.policy.explain
+        || current.policy.reject_retention != new_config.policy.reject_retention;
     let fib_tables_changed = new_config.fib_tables != current.fib_tables;
     let dynamic_neighbors_changed = new_config.dynamic_neighbors != current.dynamic_neighbors;
     if !policy_diff.has_changes()
@@ -1170,6 +1171,7 @@ pub(crate) async fn reload_config_with_tcp_ao(
     // explain-only reload already returns `new_config` directly above.
     if explain_changed {
         working_config.policy.explain = new_config.policy.explain.clone();
+        working_config.policy.reject_retention = new_config.policy.reject_retention.clone();
 
         // Push the new explain snapshot to the peer manager *before* any
         // reconcile step below constructs a session. `build_transport_config`
@@ -1186,6 +1188,8 @@ pub(crate) async fn reload_config_with_tcp_ao(
             .send(PeerManagerCommand::SyncExplainConfig {
                 enabled: new_config.policy.explain.enabled,
                 cache_size: new_config.policy.explain.cache_size,
+                reject_retention_enabled: new_config.policy.reject_retention.enabled,
+                reject_retention_capacity: new_config.policy.reject_retention.capacity,
                 reply: ack_tx,
             })
             .await


### PR DESCRIPTION
Completes the filtered-route/reject-reason surface: rejected inbound routes are retained per-peer with their structured rejection reason, queryable end-to-end — the member-support answer to "why isn't my route in the RS?"

**Retention**: a bounded LRU sibling to the import-decision cache (deliberately separate — the explain LRU mixes permits with denies and has no enumeration), keyed by the ADR-0073 identity, entry = reason token + detail + next-hop + AS path + communities + RPKI/ASPA states + timestamp. Bound math: ≤~512 B/entry × default cap 1024 ≈ 0.5 MiB/peer worst case; accept/withdraw removes the identity; session reset flushes. Taps at policy denies (both eval sites), OTC, next-hop ownership, and the shared treat-as-withdraw primitive (AS-path loop / RR loop / RFC 7606) — entry construction only on a deny, so the clean hot path pays one boolean.

**Reason vocabulary**: pinned snake_case `ImportRejectReason` (policy_reject, otc_route_leak, next_hop_ownership, as_path_loop, rr_loop, treat_as_withdraw) with existing sub-reason enums as detail; RPKI-invalid surfaces as policy_reject carrying rpki=invalid (RPKI is policy-decided here). Max-prefix deliberately absent (session-teardown class).

**Query surface**: `PolicyService.ListRejectedRoutes` at sensitive_read (ExplainImportPolicy precedent) → `rbgp rib received <peer> --rejected` (table + JSON). Pre-v1 posture: RPC in explicitly_outside_v1; config-schema pin re-derived (verified additive-only: new optional `[policy.reject_retention]` section). Method inventory 98→99.

**Config**: `[policy.reject_retention] enabled` (default true) + `capacity` (default 1024), threaded through both construction paths + reload snapshot, diff renders, reload-matrix rows, schema regenerated. **Metric**: `bgp_rejected_routes_retained{peer}` with both-direction refresh, session-reset zero, peer reap (sync-guard 38→39).

18+ tests across transport/api/config/peer-manager/telemetry/CLI incl. cap eviction, accept/withdraw clearing, disabled mode, per-reason recording, NOT_FOUND mapping. Docs: OPERATIONS member-support runbook, route-server cookbook Alice-LG section, CONFIGURATION, CHANGELOG; five stale "no structured reject reasons" claims corrected across docs + birdwatcher-adapter.

Full gate suite green foreground, independently re-verified (incl. authz matrix 36/36).