### PR TITLE
feat(telemetry): gNMI dial-out streaming push to central collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,28 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and a `bgp_rejected_routes_retained{peer}` gauge (peer-reaped) tracks
   occupancy. Docs: OPERATIONS.md runbook, route-server cookbook
   member-support section, CONFIGURATION.md.
+- **gNMI dial-out streaming telemetry (LAN-471).** New `[gnmi_dialout]`
+  config section: the daemon opens a persistent gRPC connection OUT to
+  each configured collector and pushes the same `SubscribeResponse`
+  stream a dial-in `gnmi.gNMI/Subscribe` STREAM subscription would
+  produce (initial snapshot, `sync_response`, then SAMPLE ticks or
+  ON_CHANGE session-state events) — the central-sink ingestion model
+  large fleets use instead of per-device dial-in. Wire contract:
+  `rustbgpd.gnmi_dialout.v1.GnmiDialout/Publish`
+  (`proto/rustbgpd_dialout.proto`), a device-initiated
+  `stream gnmi.SubscribeResponse` mirroring the de-facto vendor
+  dial-out shape. Per-target TLS/mTLS (`tls_ca_file` /
+  `tls_cert_file` / `tls_key_file`, key files re-read per connection
+  attempt so rotation needs no reload), capped exponential reconnect
+  backoff (`backoff_initial` doubling to `backoff_max`), and a
+  `gnmi_dialout_connected{target}` 0/1 gauge refreshed on both
+  transitions and reaped on target removal. Subscription paths are
+  validated at config load with the exact dial-in Subscribe checks.
+  Reload-applied: SIGHUP reconciles the target set in place (removed
+  stop, added start, changed redial; unchanged targets keep their
+  connection). A collector being down never affects BGP operation.
+  Docs: `docs/GNMI.md` (dial-out section), `docs/CONFIGURATION.md`,
+  `docs/OPERATIONS.md`, `docs/reload-matrix.md`.
 
 - **IXP route-server receipt matrix** (`docs/perf/ixp-matrix-2026-07.md`):
   rustbgpd vs BIRD 3.3.1 vs OpenBGPD 9.1 at 700 peers × 400,400

--- a/crates/api/build.rs
+++ b/crates/api/build.rs
@@ -25,5 +25,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .ok_or("protoc-bin-vendored include path is not valid UTF-8")?,
         ],
     )?;
+    // The dial-out proto imports the gnmi package compiled above. Compile it
+    // separately with `extern_path` so its references resolve to the flat
+    // `crate::gnmi` module instead of prost's package-relative `super::…`
+    // chain (which assumes package-shaped module nesting we don't use), and
+    // into its own out_dir so this invocation cannot clobber the gnmi/
+    // gnmi_ext files the first invocation just wrote.
+    let dialout_out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?).join("dialout");
+    std::fs::create_dir_all(&dialout_out_dir)?;
+    tonic_prost_build::configure()
+        .extern_path(".gnmi", "crate::gnmi")
+        .out_dir(&dialout_out_dir)
+        .compile_protos(
+            &["../../proto/rustbgpd_dialout.proto"],
+            &[
+                "../../proto",
+                well_known_include
+                    .to_str()
+                    .ok_or("protoc-bin-vendored include path is not valid UTF-8")?,
+            ],
+        )?;
     Ok(())
 }

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -1,0 +1,785 @@
+//! gNMI dial-out (LAN-471): device-initiated telemetry push to central
+//! collectors.
+//!
+//! Dial-in gNMI has the collector connect to the device and drive
+//! `gnmi.gNMI/Subscribe`. Large fleets ingest the other way around: every
+//! device dials OUT to a central collector and pushes the same update
+//! stream. This module implements that inversion as a thin transport shim
+//! over the existing Subscribe machinery — each configured target gets a
+//! persistent outbound gRPC connection carrying the
+//! `rustbgpd.gnmi_dialout.v1.GnmiDialout/Publish` stream, whose payload is
+//! the exact `SubscribeResponse` sequence a dial-in STREAM subscription
+//! would have produced (initial snapshot, `sync_response`, then updates).
+//! No update-generation code is duplicated:
+//! [`GnmiService::spawn_stream_subscription`] drives the same
+//! `SAMPLE` / `ON_CHANGE` tasks the Subscribe server uses.
+//!
+//! Robustness contract: a collector being down never affects the daemon.
+//! Each target runs an independent reconnect loop with capped exponential
+//! backoff, logs at `warn` only on state transitions (first failure after
+//! a success, disconnect) and at `debug` for repeated retries, and surfaces
+//! its state as the `gnmi_dialout_connected{target}` gauge.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rustbgpd_telemetry::BgpMetrics;
+use tokio_stream::{StreamExt, wrappers::ReceiverStream};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
+use tracing::{debug, error, info, warn};
+use zeroize::Zeroizing;
+
+use crate::gnmi;
+use crate::gnmi_dialout_proto::gnmi_dialout_client::GnmiDialoutClient;
+pub use crate::gnmi_service::GnmiService;
+use crate::gnmi_service::validate_stream_subscription_list;
+
+/// How long a single connection attempt may sit in TCP/TLS/HTTP-2
+/// establishment before it counts as failed and enters backoff.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One configured dial-out collector target, fully resolved from config.
+/// `PartialEq` drives the reload diff: an unchanged target keeps its live
+/// connection across SIGHUP; any field edit tears down and redials.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DialoutTarget {
+    /// Unique name — the `gnmi_dialout_connected{target}` label and log key.
+    pub name: String,
+    /// Full endpoint URI (`http://host:port` or `https://host:port`).
+    pub endpoint: String,
+    /// Outbound TLS material paths; `None` dials plaintext.
+    pub tls: Option<DialoutTls>,
+    /// The STREAM-mode subscription this target receives, pre-validated by
+    /// [`build_subscription_list`].
+    pub subscriptions: gnmi::SubscriptionList,
+    /// First retry delay after a failure; doubles per consecutive failure.
+    pub backoff_initial: Duration,
+    /// Retry delay cap.
+    pub backoff_max: Duration,
+}
+
+/// TLS material *paths* for one dial-out target. Only paths live here —
+/// key bytes are read per connection attempt into a [`Zeroizing`] buffer
+/// and handed straight to the transport, so no key material is ever held
+/// on a long-lived or `Debug`-printable struct.
+#[derive(Clone, PartialEq)]
+pub struct DialoutTls {
+    /// CA bundle (PEM) used to verify the collector's server certificate.
+    pub ca_file: PathBuf,
+    /// Optional client certificate (PEM) for mutual TLS.
+    pub cert_file: Option<PathBuf>,
+    /// Optional client private key (PEM); paired with `cert_file`.
+    pub key_file: Option<PathBuf>,
+    /// Override the expected TLS server name when dialing by IP address.
+    pub server_name: Option<String>,
+}
+
+// Manual Debug: prints the configured *paths* (operator-supplied config,
+// not secrets) and never any file contents. The redaction pin test below
+// guards against a future refactor moving loaded key bytes onto this
+// struct and deriving Debug over them.
+impl std::fmt::Debug for DialoutTls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DialoutTls")
+            .field("ca_file", &self.ca_file)
+            .field("cert_file", &self.cert_file)
+            .field("key_file", &self.key_file)
+            .field("server_name", &self.server_name)
+            .finish()
+    }
+}
+
+/// Delivery mode for a dial-out subscription (maps onto the same STREAM
+/// sub-modes the dial-in Subscribe server implements).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DialoutMode {
+    /// Periodic resample of the subscribed paths.
+    Sample,
+    /// Event-driven updates (v1: the `session-state` leaf only), sourced
+    /// from the durable event outbox like dial-in `ON_CHANGE`.
+    OnChange,
+}
+
+/// Parse an xpath-style gNMI path string (`a/b[name=x][k=v]/c`) into a
+/// structured [`gnmi::Path`]. This is the config-file spelling of the
+/// same paths a dial-in collector would put in a `SubscribeRequest`.
+///
+/// # Errors
+/// Returns a human-readable message for empty elements, unterminated or
+/// malformed `[key=value]` blocks, and text after a key block that is not
+/// another key block.
+pub fn parse_path(input: &str) -> Result<gnmi::Path, String> {
+    let trimmed = input.strip_prefix('/').unwrap_or(input);
+    if trimmed.is_empty() {
+        return Err("empty gNMI path".to_string());
+    }
+    let mut elems = Vec::new();
+    // Split on '/' outside [key=value] blocks (values may contain '/').
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut parts = Vec::new();
+    for (i, ch) in trimmed.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| format!("unbalanced ']' in gNMI path {input:?}"))?;
+            }
+            '/' if depth == 0 => {
+                parts.push(&trimmed[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return Err(format!("unterminated '[' in gNMI path {input:?}"));
+    }
+    parts.push(&trimmed[start..]);
+
+    for part in parts {
+        let (name, mut rest) = match part.find('[') {
+            Some(pos) => (&part[..pos], &part[pos..]),
+            None => (part, ""),
+        };
+        if name.is_empty() {
+            return Err(format!("empty path element in gNMI path {input:?}"));
+        }
+        let mut key = HashMap::new();
+        while !rest.is_empty() {
+            let Some(stripped) = rest.strip_prefix('[') else {
+                return Err(format!(
+                    "unexpected text {rest:?} after keys in gNMI path element {part:?}"
+                ));
+            };
+            let Some(end) = stripped.find(']') else {
+                return Err(format!("unterminated '[' in gNMI path element {part:?}"));
+            };
+            let pair = &stripped[..end];
+            let Some((k, v)) = pair.split_once('=') else {
+                return Err(format!(
+                    "key block {pair:?} in gNMI path element {part:?} is not key=value"
+                ));
+            };
+            if k.is_empty() {
+                return Err(format!("empty key name in gNMI path element {part:?}"));
+            }
+            key.insert(k.to_string(), v.to_string());
+            rest = &stripped[end + 1..];
+        }
+        elems.push(gnmi::PathElem {
+            name: name.to_string(),
+            key,
+        });
+    }
+
+    Ok(gnmi::Path {
+        elem: elems,
+        ..Default::default()
+    })
+}
+
+/// Build (and fully validate) the STREAM `SubscriptionList` for one
+/// dial-out target from its config-file fields. Runs the same validation
+/// a dial-in `Subscribe` request would, so a bad path or an
+/// ON_CHANGE-unsupported leaf is rejected at config load, not at runtime.
+///
+/// # Errors
+/// Returns a human-readable message for unparseable paths and for lists
+/// the Subscribe server would reject.
+pub fn build_subscription_list(
+    paths: &[String],
+    mode: DialoutMode,
+    sample_interval: Duration,
+) -> Result<gnmi::SubscriptionList, String> {
+    let mode = match mode {
+        DialoutMode::Sample => gnmi::SubscriptionMode::Sample,
+        DialoutMode::OnChange => gnmi::SubscriptionMode::OnChange,
+    };
+    let interval_nanos = u64::try_from(sample_interval.as_nanos()).unwrap_or(u64::MAX);
+    let subscription = paths
+        .iter()
+        .map(|path| {
+            Ok(gnmi::Subscription {
+                path: Some(parse_path(path)?),
+                mode: mode as i32,
+                sample_interval: interval_nanos,
+                suppress_redundant: false,
+                heartbeat_interval: 0,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let list = gnmi::SubscriptionList {
+        prefix: None,
+        subscription,
+        qos: None,
+        mode: gnmi::subscription_list::Mode::Stream as i32,
+        allow_aggregation: false,
+        use_models: Vec::new(),
+        encoding: gnmi::Encoding::JsonIetf as i32,
+        updates_only: false,
+    };
+    validate_stream_subscription_list(&list).map_err(|status| status.message().to_string())?;
+    Ok(list)
+}
+
+/// Build the endpoint URI for a collector `host:port` address.
+#[must_use]
+pub fn endpoint_uri(address: &str, tls: bool) -> String {
+    if tls {
+        format!("https://{address}")
+    } else {
+        format!("http://{address}")
+    }
+}
+
+/// Owns the per-target dial-out tasks. The daemon holds one manager and
+/// calls [`DialoutManager::apply`] at startup and after every successful
+/// SIGHUP reload; the manager diffs the desired target set against the
+/// running one so unchanged targets keep their live connections.
+pub struct DialoutManager {
+    service: GnmiService,
+    metrics: BgpMetrics,
+    tasks: HashMap<String, (DialoutTarget, tokio::task::JoinHandle<()>)>,
+}
+
+impl DialoutManager {
+    /// Create a manager with no running targets.
+    #[must_use]
+    pub fn new(service: GnmiService, metrics: BgpMetrics) -> Self {
+        Self {
+            service,
+            metrics,
+            tasks: HashMap::new(),
+        }
+    }
+
+    /// Reconcile the running dial-out tasks with `targets`: stop removed
+    /// targets (reaping their `gnmi_dialout_connected` series), restart
+    /// changed ones, start added ones, and leave unchanged targets — and
+    /// their live collector connections — untouched.
+    pub fn apply(&mut self, targets: &[DialoutTarget]) {
+        let metrics = &self.metrics;
+        self.tasks.retain(|name, (spec, handle)| {
+            let keep = targets
+                .iter()
+                .any(|target| &target.name == name && target == spec);
+            if !keep {
+                handle.abort();
+                metrics.remove_gnmi_dialout_target(name);
+                info!(target = %name, "gNMI dial-out target stopped");
+            }
+            keep
+        });
+        for target in targets {
+            if !self.tasks.contains_key(&target.name) {
+                let handle = tokio::spawn(run_target(
+                    self.service.clone(),
+                    self.metrics.clone(),
+                    target.clone(),
+                ));
+                self.tasks
+                    .insert(target.name.clone(), (target.clone(), handle));
+            }
+        }
+    }
+}
+
+/// One target's connect / stream / reconnect loop. Never returns under
+/// normal operation; the manager aborts it on removal or shutdown.
+async fn run_target(service: GnmiService, metrics: BgpMetrics, target: DialoutTarget) {
+    // Materialize the series at 0 immediately so a collector that is down
+    // at daemon startup is visible on /metrics before the first success.
+    metrics.set_gnmi_dialout_connected(&target.name, false);
+    let mut backoff = target.backoff_initial.max(Duration::from_millis(1));
+    let mut failure_announced = false;
+    loop {
+        match publish_session(&service, &metrics, &target).await {
+            Ok(()) => {
+                // Connected and then cleanly/abruptly disconnected.
+                metrics.set_gnmi_dialout_connected(&target.name, false);
+                warn!(
+                    target = %target.name,
+                    endpoint = %target.endpoint,
+                    "gNMI dial-out collector disconnected; reconnecting"
+                );
+                backoff = target.backoff_initial.max(Duration::from_millis(1));
+                failure_announced = false;
+            }
+            Err(SessionError::Fatal(message)) => {
+                // Subscription list rejected — config-shaped and validated at
+                // load, so this is unreachable in practice; fail loud, once.
+                error!(
+                    target = %target.name,
+                    error = %message,
+                    "gNMI dial-out subscription rejected; target disabled until reload"
+                );
+                return;
+            }
+            Err(SessionError::Connect(message)) => {
+                // Bounded log volume: one warn per outage, debug afterwards.
+                if failure_announced {
+                    debug!(
+                        target = %target.name,
+                        error = %message,
+                        retry_in_secs = backoff.as_secs_f64(),
+                        "gNMI dial-out connect retry failed"
+                    );
+                } else {
+                    warn!(
+                        target = %target.name,
+                        endpoint = %target.endpoint,
+                        error = %message,
+                        retry_in_secs = backoff.as_secs_f64(),
+                        "gNMI dial-out collector unreachable; retrying with backoff"
+                    );
+                    failure_announced = true;
+                }
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(target.backoff_max.max(target.backoff_initial));
+    }
+}
+
+enum SessionError {
+    /// Connection-level failure (dial, TLS, or stream refusal) — retry.
+    Connect(String),
+    /// The subscription itself is invalid — do not retry.
+    Fatal(String),
+}
+
+/// Dial the collector, run one Publish session to completion, and report
+/// how it ended. `Ok(())` means the stream was established (the gauge was
+/// raised) and later ended; the caller decides reconnect pacing.
+async fn publish_session(
+    service: &GnmiService,
+    metrics: &BgpMetrics,
+    target: &DialoutTarget,
+) -> Result<(), SessionError> {
+    let channel = connect(target).await.map_err(SessionError::Connect)?;
+    let mut client = GnmiDialoutClient::new(channel);
+
+    // Fresh subscription per connection: the spawned task ends when the
+    // outbound stream (holding the receiver) is dropped, and a reconnecting
+    // collector gets a fresh initial snapshot + sync_response — the same
+    // resync contract a dial-in reconnect has.
+    let rx = service
+        .spawn_stream_subscription(&target.subscriptions)
+        .map_err(|status| SessionError::Fatal(status.message().to_string()))?;
+    let name = target.name.clone();
+    let outbound = ReceiverStream::new(rx).map_while(move |item| match item {
+        Ok(response) => Some(response),
+        Err(status) => {
+            // e.g. ON_CHANGE broadcast lag → DataLoss. End the stream so the
+            // reconnect path resyncs from a fresh snapshot.
+            debug!(
+                target = %name,
+                error = %status,
+                "gNMI dial-out subscription ended; stream will resync on reconnect"
+            );
+            None
+        }
+    });
+
+    let mut inbound = client
+        .publish(outbound)
+        .await
+        .map_err(|status| SessionError::Connect(status.message().to_string()))?
+        .into_inner();
+
+    info!(
+        target = %target.name,
+        endpoint = %target.endpoint,
+        "gNMI dial-out collector connected"
+    );
+    metrics.set_gnmi_dialout_connected(&target.name, true);
+
+    // Drain the collector's response stream. Nothing is expected on it
+    // today (PublishResponse is reserved for future flow control); its end
+    // or error is the disconnect signal.
+    loop {
+        match inbound.message().await {
+            Ok(Some(_flow_control)) => {}
+            Ok(None) => return Ok(()),
+            Err(status) => {
+                debug!(target = %target.name, error = %status, "gNMI dial-out stream error");
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Establish the (optionally TLS) channel for a target. Key material is
+/// read per attempt into a zeroizing buffer and handed to the transport —
+/// error strings carry file paths and IO error text only, never contents.
+async fn connect(target: &DialoutTarget) -> Result<Channel, String> {
+    let mut endpoint = Endpoint::from_shared(target.endpoint.clone())
+        .map_err(|e| format!("invalid endpoint {}: {e}", target.endpoint))?
+        .connect_timeout(CONNECT_TIMEOUT);
+    if let Some(tls) = &target.tls {
+        let ca = std::fs::read(&tls.ca_file)
+            .map_err(|e| format!("read TLS CA file {}: {e}", tls.ca_file.display()))?;
+        let mut config = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca));
+        if let (Some(cert_file), Some(key_file)) = (&tls.cert_file, &tls.key_file) {
+            let cert = std::fs::read(cert_file)
+                .map_err(|e| format!("read TLS cert file {}: {e}", cert_file.display()))?;
+            let key = Zeroizing::new(
+                std::fs::read(key_file)
+                    .map_err(|e| format!("read TLS key file {}: {e}", key_file.display()))?,
+            );
+            config = config.identity(Identity::from_pem(cert, key.as_slice()));
+        }
+        if let Some(server_name) = &tls.server_name {
+            config = config.domain_name(server_name.clone());
+        }
+        endpoint = endpoint
+            .tls_config(config)
+            .map_err(|e| format!("TLS config for {}: {e}", target.endpoint))?;
+    }
+    endpoint
+        .connect()
+        .await
+        .map_err(|e| format!("connect {}: {e}", target.endpoint))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::pin::Pin;
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio_stream::{Stream, wrappers::TcpListenerStream};
+    use tonic::{Request, Response, Status, Streaming};
+
+    use super::*;
+    use crate::gnmi_dialout_proto::PublishResponse;
+    use crate::gnmi_dialout_proto::gnmi_dialout_server::{GnmiDialout, GnmiDialoutServer};
+    use crate::test_support::spawn_fake_peer_manager;
+
+    const GLOBAL_AS_PATH: &str = "network-instances/network-instance[name=DEFAULT]/protocols/\
+                                  protocol[identifier=BGP][name=BGP]/bgp/global/state/as";
+    const SESSION_STATE_PATH: &str = "network-instances/network-instance[name=DEFAULT]/protocols/\
+                                      protocol[identifier=BGP][name=BGP]/bgp/neighbors/\
+                                      neighbor[neighbor-address=*]/state/session-state";
+
+    // ── parse_path units ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_path_parses_names_keys_and_wildcards() {
+        let path = parse_path(SESSION_STATE_PATH).expect("valid path");
+        assert_eq!(path.elem.len(), 9);
+        assert_eq!(path.elem[1].name, "network-instance");
+        assert_eq!(path.elem[1].key["name"], "DEFAULT");
+        assert_eq!(path.elem[3].key.len(), 2);
+        assert_eq!(path.elem[3].key["identifier"], "BGP");
+        assert_eq!(path.elem[6].key["neighbor-address"], "*");
+        assert_eq!(path.elem[8].name, "session-state");
+    }
+
+    #[test]
+    fn parse_path_accepts_leading_slash() {
+        let bare = parse_path(GLOBAL_AS_PATH).expect("valid");
+        let slashed = parse_path(&format!("/{GLOBAL_AS_PATH}")).expect("valid");
+        assert_eq!(bare, slashed);
+    }
+
+    #[test]
+    fn parse_path_rejects_malformed_inputs() {
+        for bad in [
+            "",
+            "/",
+            "a//b",
+            "a/b[unterminated",
+            "a/b]c",
+            "a/b[no-equals]",
+            "a/b[=v]",
+            "a/b[k=v]trailing",
+        ] {
+            assert!(parse_path(bad).is_err(), "expected error for {bad:?}");
+        }
+    }
+
+    // ── build_subscription_list units ─────────────────────────────────
+
+    #[test]
+    fn build_subscription_list_validates_like_dial_in_subscribe() {
+        let ok = build_subscription_list(
+            &[GLOBAL_AS_PATH.to_string()],
+            DialoutMode::Sample,
+            Duration::from_secs(10),
+        )
+        .expect("valid sample subscription");
+        assert_eq!(ok.mode, gnmi::subscription_list::Mode::Stream as i32);
+        assert_eq!(ok.subscription.len(), 1);
+
+        build_subscription_list(
+            &[SESSION_STATE_PATH.to_string()],
+            DialoutMode::OnChange,
+            Duration::from_secs(10),
+        )
+        .expect("session-state supports ON_CHANGE");
+
+        // ON_CHANGE is only supported on the session-state leaf.
+        let err = build_subscription_list(
+            &[GLOBAL_AS_PATH.to_string()],
+            DialoutMode::OnChange,
+            Duration::from_secs(10),
+        )
+        .expect_err("global leaf must reject ON_CHANGE");
+        assert!(err.contains("ON_CHANGE"), "unexpected error: {err}");
+
+        // Unsupported / unparseable paths and empty lists fail closed.
+        assert!(
+            build_subscription_list(
+                &["interfaces/interface[name=eth0]/state".to_string()],
+                DialoutMode::Sample,
+                Duration::from_secs(10),
+            )
+            .is_err()
+        );
+        assert!(
+            build_subscription_list(&[], DialoutMode::Sample, Duration::from_secs(10)).is_err()
+        );
+    }
+
+    // ── zero-key-material pin ─────────────────────────────────────────
+
+    #[test]
+    fn dialout_debug_never_prints_key_material() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_path = dir.path().join("client.key");
+        let key_material = "-----BEGIN PRIVATE KEY-----\nFAKEKEYMATERIALFAKEKEYMATERIAL\n";
+        std::fs::write(&key_path, key_material).expect("write key");
+
+        let target = DialoutTarget {
+            name: "collector-a".to_string(),
+            endpoint: "https://192.0.2.10:57400".to_string(),
+            tls: Some(DialoutTls {
+                ca_file: dir.path().join("ca.pem"),
+                cert_file: Some(dir.path().join("client.pem")),
+                key_file: Some(key_path),
+                server_name: Some("collector.example".to_string()),
+            }),
+            subscriptions: gnmi::SubscriptionList::default(),
+            backoff_initial: Duration::from_secs(1),
+            backoff_max: Duration::from_secs(30),
+        };
+        let debug = format!("{target:?}");
+        assert!(debug.contains("client.key"), "paths are config, keep them");
+        assert!(
+            !debug.contains("FAKEKEYMATERIAL") && !debug.contains("PRIVATE KEY"),
+            "Debug output must never include key material: {debug}"
+        );
+    }
+
+    // ── stub collector plumbing ───────────────────────────────────────
+
+    struct StubCollector {
+        received: mpsc::Sender<gnmi::SubscribeResponse>,
+    }
+
+    #[tonic::async_trait]
+    impl GnmiDialout for StubCollector {
+        type PublishStream =
+            Pin<Box<dyn Stream<Item = Result<PublishResponse, Status>> + Send + 'static>>;
+
+        async fn publish(
+            &self,
+            request: Request<Streaming<gnmi::SubscribeResponse>>,
+        ) -> Result<Response<Self::PublishStream>, Status> {
+            let mut inbound = request.into_inner();
+            let received = self.received.clone();
+            tokio::spawn(async move {
+                while let Ok(Some(response)) = inbound.message().await {
+                    let _ = received.send(response).await;
+                }
+            });
+            // End the response stream when the test drops its receiver —
+            // that is the "collector went away" signal for the client.
+            // (Aborting the serve task alone is not enough: hyper detaches
+            // per-connection tasks, so a live stream would survive it.)
+            let done = self.received.clone();
+            let stream = futures::stream::unfold(done, |tx| async move {
+                tx.closed().await;
+                None::<(Result<PublishResponse, Status>, _)>
+            });
+            Ok(Response::new(Box::pin(stream)))
+        }
+    }
+
+    /// Bind (or rebind) a stub collector on `addr` (`None` = ephemeral) and
+    /// return its address, the serve task handle, and the received-message
+    /// channel.
+    async fn spawn_stub_collector(
+        addr: Option<SocketAddr>,
+    ) -> (
+        SocketAddr,
+        tokio::task::JoinHandle<()>,
+        mpsc::Receiver<gnmi::SubscribeResponse>,
+    ) {
+        let bind = addr.unwrap_or_else(|| "127.0.0.1:0".parse().expect("valid addr"));
+        let listener = TcpListener::bind(bind).await.expect("bind stub collector");
+        let addr = listener.local_addr().expect("local addr");
+        let (tx, rx) = mpsc::channel(64);
+        let handle = tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(GnmiDialoutServer::new(StubCollector { received: tx }))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await;
+        });
+        (addr, handle, rx)
+    }
+
+    fn test_service() -> GnmiService {
+        let (peer_tx, _session_events, _policy_events) = spawn_fake_peer_manager();
+        GnmiService::new(65000, "192.0.2.1".to_string(), peer_tx)
+    }
+
+    fn test_target(name: &str, addr: SocketAddr) -> DialoutTarget {
+        DialoutTarget {
+            name: name.to_string(),
+            endpoint: endpoint_uri(&addr.to_string(), false),
+            tls: None,
+            subscriptions: build_subscription_list(
+                &[GLOBAL_AS_PATH.to_string()],
+                DialoutMode::Sample,
+                Duration::from_secs(10),
+            )
+            .expect("valid subscription"),
+            backoff_initial: Duration::from_millis(100),
+            backoff_max: Duration::from_millis(400),
+        }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the connection gauge only ever holds 0 or 1"
+    )]
+    fn gauge_value(metrics: &BgpMetrics, target: &str) -> Option<i64> {
+        metrics
+            .registry()
+            .gather()
+            .iter()
+            .find(|family| family.name() == "gnmi_dialout_connected")?
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == "target" && label.value() == target)
+            })
+            .map(|metric| metric.get_gauge().value() as i64)
+    }
+
+    async fn wait_for_gauge(metrics: &BgpMetrics, target: &str, expected: i64) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if gauge_value(metrics, target) == Some(expected) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "gauge gnmi_dialout_connected{{target={target}}} never reached {expected} \
+                 (last: {:?})",
+                gauge_value(metrics, target)
+            )
+        });
+    }
+
+    async fn expect_update_with_as(rx: &mut mpsc::Receiver<gnmi::SubscribeResponse>) {
+        let deadline = Duration::from_secs(10);
+        loop {
+            let response = tokio::time::timeout(deadline, rx.recv())
+                .await
+                .expect("timed out waiting for a dial-out SubscribeResponse")
+                .expect("stub collector channel closed");
+            if let Some(gnmi::subscribe_response::Response::Update(notification)) =
+                response.response
+            {
+                let update = &notification.update[0];
+                let path = update.path.as_ref().expect("update path");
+                assert_eq!(path.elem.last().expect("leaf").name, "as");
+                return;
+            }
+        }
+    }
+
+    // ── integration: dial out, stream, reconnect ──────────────────────
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dial_out_streams_updates_and_reconnects_after_collector_restart() {
+        let metrics = BgpMetrics::new();
+        let (addr, server, mut received) = spawn_stub_collector(None).await;
+        let mut manager = DialoutManager::new(test_service(), metrics.clone());
+        manager.apply(&[test_target("collector-a", addr)]);
+
+        // Initial snapshot arrives and the gauge rises.
+        expect_update_with_as(&mut received).await;
+        wait_for_gauge(&metrics, "collector-a", 1).await;
+
+        // Kill the collector (stop accepting, then end the live stream):
+        // the gauge must drop (disconnect transition).
+        server.abort();
+        drop(received);
+        wait_for_gauge(&metrics, "collector-a", 0).await;
+
+        // Restart the collector on the same address: the client reconnects
+        // by itself and streams a fresh initial snapshot.
+        let (_addr, server2, mut received2) = spawn_stub_collector(Some(addr)).await;
+        expect_update_with_as(&mut received2).await;
+        wait_for_gauge(&metrics, "collector-a", 1).await;
+
+        server2.abort();
+        manager.apply(&[]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn manager_reaps_gauge_series_on_target_removal() {
+        let metrics = BgpMetrics::new();
+        let (addr, server, mut received) = spawn_stub_collector(None).await;
+        let mut manager = DialoutManager::new(test_service(), metrics.clone());
+        manager.apply(&[test_target("collector-reap", addr)]);
+        expect_update_with_as(&mut received).await;
+        wait_for_gauge(&metrics, "collector-reap", 1).await;
+
+        // Removing the target from config reaps the series entirely —
+        // not just sets it to 0 — so /metrics stops exporting it.
+        manager.apply(&[]);
+        assert_eq!(gauge_value(&metrics, "collector-reap"), None);
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn collector_down_at_startup_keeps_retrying_without_task_exit() {
+        let metrics = BgpMetrics::new();
+        // Reserve an address with nothing listening on it.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        drop(listener);
+
+        let mut manager = DialoutManager::new(test_service(), metrics.clone());
+        manager.apply(&[test_target("collector-late", addr)]);
+
+        // The series is materialized at 0 while the collector is down.
+        wait_for_gauge(&metrics, "collector-late", 0).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(gauge_value(&metrics, "collector-late"), Some(0));
+
+        // The collector comes up later; the retry loop finds it.
+        let (_addr, server, mut received) = spawn_stub_collector(Some(addr)).await;
+        expect_update_with_as(&mut received).await;
+        wait_for_gauge(&metrics, "collector-late", 1).await;
+        server.abort();
+        manager.apply(&[]);
+    }
+}

--- a/crates/api/src/gnmi_dialout.rs
+++ b/crates/api/src/gnmi_dialout.rs
@@ -11,8 +11,8 @@
 //! the exact `SubscribeResponse` sequence a dial-in STREAM subscription
 //! would have produced (initial snapshot, `sync_response`, then updates).
 //! No update-generation code is duplicated:
-//! [`GnmiService::spawn_stream_subscription`] drives the same
-//! `SAMPLE` / `ON_CHANGE` tasks the Subscribe server uses.
+//! `GnmiService::spawn_stream_subscription` (crate-internal) drives the
+//! same `SAMPLE` / `ON_CHANGE` tasks the Subscribe server uses.
 //!
 //! Robustness contract: a collector being down never affects the daemon.
 //! Each target runs an independent reconnect loop with capped exponential

--- a/crates/api/src/gnmi_service.rs
+++ b/crates/api/src/gnmi_service.rs
@@ -65,6 +65,7 @@ type SubscribeStream =
 
 impl GnmiService {
     /// Create a gNMI service backed by the daemon's peer manager.
+    #[must_use]
     pub fn new(
         asn: u32,
         router_id: String,
@@ -491,6 +492,51 @@ impl GnmiService {
         };
         tx.send(Ok(response)).await.is_ok()
     }
+
+    /// Spawn the STREAM-mode subscription described by `list` and return the
+    /// response channel. This is the dial-out reuse seam: the dial-out client
+    /// drives the exact `Subscribe` update-generation tasks (`SAMPLE` /
+    /// `ON_CHANGE`) a dial-in collector would, then forwards the channel over
+    /// its device-initiated connection. The spawned task exits when the
+    /// returned receiver is dropped, so each (re)connection gets a fresh
+    /// initial snapshot + `sync_response` — the same resync contract dial-in
+    /// reconnects have.
+    ///
+    /// # Errors
+    /// Returns the same `Status` a dial-in `Subscribe` would for an invalid
+    /// or non-STREAM subscription list.
+    pub(crate) fn spawn_stream_subscription(
+        &self,
+        list: &gnmi::SubscriptionList,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<gnmi::SubscribeResponse, Status>>, Status> {
+        let plan = validate_stream_subscription_list(list)?;
+        let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIBE_CHANNEL_DEPTH);
+        let service = self.clone();
+        tokio::spawn(async move {
+            match plan.stream_mode {
+                Some(gnmi::SubscriptionMode::OnChange) => service.run_on_change(plan, tx).await,
+                _ => service.run_stream_sample(plan, tx).await,
+            }
+        });
+        Ok(rx)
+    }
+}
+
+/// Validate a dial-out subscription list without spawning anything — shared
+/// by config-load validation (fail fast on a bad `[gnmi_dialout]` path or
+/// mode) and by [`GnmiService::spawn_stream_subscription`]. Dial-out only
+/// makes sense as STREAM: ONCE/POLL are request/response shapes driven by a
+/// dial-in client.
+pub(crate) fn validate_stream_subscription_list(
+    list: &gnmi::SubscriptionList,
+) -> Result<SubscriptionPlan, Status> {
+    let plan = parse_subscription_list(list)?;
+    if plan.mode != gnmi::subscription_list::Mode::Stream {
+        return Err(Status::invalid_argument(
+            "dial-out subscriptions require STREAM mode",
+        ));
+    }
+    Ok(plan)
 }
 
 fn supported_models() -> Vec<gnmi::ModelData> {
@@ -612,7 +658,7 @@ impl SupportedPath {
 }
 
 #[derive(Clone, Debug)]
-struct SubscriptionPlan {
+pub(crate) struct SubscriptionPlan {
     mode: gnmi::subscription_list::Mode,
     /// Per-subscription delivery mode. v1 `ON_CHANGE` is a homogeneous
     /// plan attribute (the upstream `parse_subscription_list` already

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,6 +22,7 @@ pub mod event_history_sinks;
 mod event_service;
 pub mod evpn_service;
 mod global_service;
+pub mod gnmi_dialout;
 mod gnmi_service;
 pub mod health_probe;
 mod injection_service;
@@ -87,4 +88,18 @@ pub mod gnmi_ext {
 )]
 pub mod gnmi {
     tonic::include_proto!("gnmi");
+}
+
+/// Generated gNMI dial-out (device-initiated push) service types.
+#[allow(
+    clippy::all,
+    clippy::pedantic,
+    missing_docs,
+    reason = "tonic-generated protobuf modules control their own lint shape"
+)]
+pub mod gnmi_dialout_proto {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/dialout/rustbgpd.gnmi_dialout.v1.rs"
+    ));
 }

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -89,6 +89,9 @@ pub struct BgpMetrics {
     bfd_session_up: IntGaugeVec,
     bfd_session_flaps_total: IntCounterVec,
 
+    // ── gNMI dial-out (LAN-471) ────────────────────────────────────
+    gnmi_dialout_connected: IntGaugeVec,
+
     // ── Notifications ──────────────────────────────────────────────
     notifications_sent: IntCounterVec,
     notifications_received: IntCounterVec,
@@ -323,6 +326,16 @@ impl BgpMetrics {
                 "BFD session state per peer (1 = Up, 0 = not Up)",
             ),
             &["peer"],
+        )
+        .expect("valid metric definition");
+
+        let gnmi_dialout_connected = IntGaugeVec::new(
+            Opts::new(
+                "gnmi_dialout_connected",
+                "gNMI dial-out collector connection state per configured target \
+                 (1 = Publish stream established, 0 = disconnected/retrying)",
+            ),
+            &["target"],
         )
         .expect("valid metric definition");
 
@@ -1522,6 +1535,9 @@ impl BgpMetrics {
             .register(Box::new(bfd_session_flaps_total.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(gnmi_dialout_connected.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(stale_timer_events.clone()))
             .expect("metric not already registered");
         registry
@@ -1936,6 +1952,7 @@ impl BgpMetrics {
             stale_timer_events,
             bfd_session_up,
             bfd_session_flaps_total,
+            gnmi_dialout_connected,
             notifications_sent,
             notifications_received,
             messages_sent,
@@ -2216,6 +2233,21 @@ impl BgpMetrics {
         if to == "established" {
             self.session_established.with_label_values(&[peer]).inc();
         }
+    }
+
+    /// Set the gNMI dial-out connection gauge for a configured target.
+    /// Refreshed on BOTH transitions (connect and disconnect) so the series
+    /// always reflects the live Publish-stream state.
+    pub fn set_gnmi_dialout_connected(&self, target: &str, connected: bool) {
+        self.gnmi_dialout_connected
+            .with_label_values(&[target])
+            .set(i64::from(connected));
+    }
+
+    /// Reap the dial-out connection series for a target removed from the
+    /// config (SIGHUP reload), so `/metrics` stops exporting stale targets.
+    pub fn remove_gnmi_dialout_target(&self, target: &str) {
+        let _ = self.gnmi_dialout_connected.remove_label_values(&[target]);
     }
 
     /// Record a BFD session state change: set the per-peer up gauge and count a

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -5091,7 +5091,7 @@ mod tests {
         let m = BgpMetrics::new();
         populate_all_peer_families(&m, "10.0.0.1");
         populate_all_peer_families(&m, "10.0.0.2");
-        // 38 peer-labeled families; state transitions hold two series.
+        // 39 peer-labeled families; state transitions hold two series.
         assert_eq!(series_for_peer(&m, "10.0.0.1").len(), 39);
 
         m.reap_peer_series("10.0.0.1");

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -234,7 +234,10 @@ IPv4/IPv6 `Prefix` routes.
     neighbor `session-state` when `[event_history]` is enabled) over UDS or
     mTLS TCP, plus an operator-tier `Set` subset — transaction-backed static
     numbered-neighbor create/update/delete and the commit-confirmed extension
-    via ADR-0076, with unsupported paths returning `Unimplemented`. M54 verifies
+    via ADR-0076, with unsupported paths returning `Unimplemented`. Dial-out is
+    also supported: `[gnmi_dialout]` pushes the same `SubscribeResponse` stream
+    over a device-initiated gRPC connection to central collectors (TLS/mTLS,
+    capped-backoff reconnect, per-target connection gauge). M54 verifies
     both read and Set with `gnmic`; M56 covers the ON_CHANGE flow. FRR's OpenConfig story is
     through broader management frameworks such as `mgmtd` / SONiC-style
     northbound layers rather than a clean per-`bgpd` gNMI service.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2380,6 +2380,77 @@ only when at least one collector monitors `loc_rib`.
 
 ---
 
+## `[gnmi_dialout]`
+
+Optional. Configures gNMI dial-out streaming telemetry: the daemon opens a
+persistent gRPC connection OUT to each configured collector and pushes the
+same OpenConfig telemetry a dial-in `gnmi.gNMI/Subscribe` STREAM
+subscription would produce — an initial snapshot, a `sync_response`
+marker, then updates (periodic samples or ON_CHANGE events). This is the
+device-behind-NAT / central-sink ingestion model large fleets use instead
+of per-device dial-in. The wire contract is
+`rustbgpd.gnmi_dialout.v1.GnmiDialout/Publish` (a device-initiated
+`stream gnmi.SubscribeResponse`; see `proto/rustbgpd_dialout.proto`).
+
+```toml
+[gnmi_dialout]
+
+[[gnmi_dialout.targets]]
+name = "collector-a"                    # unique; metric label + log key
+address = "telemetry.example.net:57400" # host:port, DNS allowed
+paths = [
+  "network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state",
+]
+mode = "on_change"                      # or "sample" (default)
+# sample_interval = 10                  # seconds, SAMPLE mode only
+# backoff_initial = 1                   # seconds, first retry delay
+# backoff_max = 30                      # seconds, retry delay cap
+tls_ca_file = "/etc/rustbgpd/collector-ca.pem"
+tls_cert_file = "/etc/rustbgpd/client.pem"   # optional (mutual TLS)
+tls_key_file = "/etc/rustbgpd/client.key"    # required with tls_cert_file
+# tls_server_name = "collector.example"      # when dialing by IP
+```
+
+### Target fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | yes | -- | Unique target name; the `gnmi_dialout_connected{target}` metric label and log key |
+| `address` | string | yes | -- | Collector `host:port` (DNS names allowed; bracket IPv6 literals) |
+| `paths` | array | yes | -- | OpenConfig gNMI paths in xpath form — the same path surface the dial-in Subscribe server supports (see `docs/GNMI.md`) |
+| `mode` | string | no | `"sample"` | `"sample"` (periodic resample) or `"on_change"` (event-driven; v1 covers the `session-state` leaf and requires `[event_history].enabled = true`) |
+| `sample_interval` | u64 | no | 10 | Seconds between samples in SAMPLE mode, clamped to [1s, 1h] like dial-in |
+| `backoff_initial` | u64 | no | 1 | First reconnect delay in seconds; doubles per consecutive failure |
+| `backoff_max` | u64 | no | 30 | Reconnect delay cap in seconds |
+| `tls_ca_file` | string | no | -- | CA bundle (PEM path) verifying the collector's server certificate; setting it enables TLS |
+| `tls_cert_file` | string | no | -- | Client certificate (PEM path) for mutual TLS; requires `tls_key_file` + `tls_ca_file` |
+| `tls_key_file` | string | no | -- | Client private key (PEM path); required together with `tls_cert_file` |
+| `tls_server_name` | string | no | dialed host | Expected TLS server name when dialing by IP |
+
+**TLS rules.** `tls_cert_file` and `tls_key_file` must be set together, and
+either requires `tls_ca_file`. Without `tls_ca_file` the target dials
+plaintext `http://`. Key material is never logged or held on long-lived
+structs; the key file is re-read on each connection attempt, so rotating
+the file takes effect on the next (re)connect without a reload.
+
+**Validation.** Every path is validated at config load with the exact
+checks a dial-in `Subscribe` request would get — an unsupported path,
+a mixed SAMPLE/ON_CHANGE list, or an ON_CHANGE-unsupported leaf is
+rejected before the daemon starts (or before a SIGHUP reload is applied).
+
+**Robustness.** A collector that is down (at startup or any time later)
+never affects BGP operation: each target retries independently with capped
+exponential backoff, logs one `warn` per outage (`debug` for repeated
+retries), and surfaces its state as the `gnmi_dialout_connected{target}`
+gauge. Every (re)connection starts a fresh subscription — collectors
+resync from the initial snapshot exactly as a dial-in reconnect would.
+
+**Reload.** Reload-applied: SIGHUP reconciles targets in place (removed
+targets stop and their gauge series is reaped, added targets start,
+changed targets redial; unchanged targets keep their live connection).
+
+---
+
 ## `[mrt]`
 
 Optional. Configures periodic MRT TABLE_DUMP_V2 (RFC 6396) RIB snapshots for

--- a/docs/GNMI.md
+++ b/docs/GNMI.md
@@ -252,6 +252,34 @@ accepted.
 Broad subtree requests are bounded; v1 does not use gNMI to stream
 the full route table.
 
+## Dial-out (device-initiated push)
+
+Everything above is dial-in: a collector connects to the daemon. The
+`[gnmi_dialout]` config section inverts only the transport direction —
+the daemon opens a persistent gRPC connection to each configured
+collector and pushes the exact `SubscribeResponse` stream the dial-in
+`Subscribe` server would produce for the same subscription (initial
+snapshot, `sync_response`, then SAMPLE ticks or ON_CHANGE events; same
+supported paths, same ON_CHANGE scope, same validation). This is the
+ingestion model large fleets use: devices behind NAT push to a central
+sink instead of every collector dialing every device.
+
+The wire contract is `rustbgpd.gnmi_dialout.v1.GnmiDialout/Publish`
+(`proto/rustbgpd_dialout.proto`): the device is the gRPC client and
+sends `stream gnmi.SubscribeResponse`; the collector's response stream
+is reserved for future flow control and may stay silent. This mirrors
+the de-facto vendor dial-out shape without impersonating any vendor
+namespace; a collector implements one trivially by serving that proto.
+The OpenConfig grpc-tunnel model solves the same reachability inversion
+at the transport layer and remains a possible future alternative.
+
+Subscriptions are declared in config (paths + `sample`/`on_change` mode
+per target), TLS uses the standard `tls_ca_file`/`tls_cert_file`/
+`tls_key_file` path idiom, reconnects use capped exponential backoff,
+and connection state is exported as `gnmi_dialout_connected{target}`.
+Full field reference: `docs/CONFIGURATION.md` `[gnmi_dialout]`;
+operational behavior: `docs/OPERATIONS.md`.
+
 ## Supported Paths
 
 All paths hang under the default network instance and BGP protocol:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -411,6 +411,20 @@ observational. On reconnect, the client sends a fresh Initiation message;
 the collector rebuilds state from subsequent Peer Up and Route Monitoring
 messages.
 
+### gNMI dial-out collector unreachable
+
+Each `[gnmi_dialout]` target dials its collector independently and
+reconnects with capped exponential backoff (`backoff_initial`, doubling to
+`backoff_max`). A collector that is down — at startup or later — never
+affects BGP operation; telemetry for that target is simply not delivered
+while disconnected. The daemon logs one `warn` when a target becomes
+unreachable and one `info` when it (re)connects; repeated retries log at
+`debug` only. Watch `gnmi_dialout_connected{target}` (0/1) for the live
+connection state. Every (re)connection restarts the subscription, so the
+collector resyncs from a fresh initial snapshot + `sync_response` — the
+disconnect window is not replayed (same contract as a dial-in Subscribe
+reconnect; use the durable event cursor for gap-free history).
+
 ### MRT dump failure
 
 If the output directory is not writable, the MRT manager logs an error and
@@ -561,6 +575,12 @@ without a `reason` label encode the mechanism in the metric name.
 durable queues. Non-zero `bgp_event_stream_lagged_total` means at least one
 client missed events and should combine a fresh snapshot or `ListRouteEvents`
 query with a new live watch.
+
+### gNMI dial-out
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `gnmi_dialout_connected{target}` | 1 while the dial-out Publish stream to this `[gnmi_dialout]` target is established, 0 while disconnected/retrying. Refreshed on both transitions; the series exists (at 0) from startup even when the collector is down, and is reaped when the target is removed from config (SIGHUP) |
 
 ### Durable Event Cursor (ADR-0072)
 

--- a/docs/reload-matrix.md
+++ b/docs/reload-matrix.md
@@ -270,6 +270,12 @@ chains all add/change/remove cleanly via reload.
 | `[bmp]` | restart-required | BMP exporter binds once. |
 | `[mrt]` | restart-required | MRT writer opens its output dir at startup. |
 
+## `[gnmi_dialout]`
+
+| Section | Class | Notes |
+|---|---|---|
+| `[gnmi_dialout]` (whole section) | reload-applied | SIGHUP reconciles the dial-out target set in place: removed targets stop (their `gnmi_dialout_connected{target}` series is reaped), added targets start, changed targets tear down and redial, unchanged targets keep their live collector connection. The new section is validated during reload preflight; a rejected config leaves the running targets untouched. TLS key/cert *file contents* rotate without any reload — the files are re-read on every (re)connection attempt. |
+
 ## `[[evpn_instances]]`, `[[evpn_ip_vrfs]]`, `[[ethernet_segments]]`
 
 SIGHUP reuses the ADR-0063 EVPN runtime coordinator for the same supported

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -1120,7 +1120,7 @@
           "type": "string"
         },
         "paths": {
-          "description": "OpenConfig gNMI paths to subscribe, in xpath form (the same paths\na dial-in collector would put in a `SubscribeRequest`), e.g.\n`network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state`.",
+          "description": "`OpenConfig` gNMI paths to subscribe, in xpath form (the same paths\na dial-in collector would put in a `SubscribeRequest`), e.g.\n`network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state`.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/rustbgpd.schema.json
+++ b/docs/rustbgpd.schema.json
@@ -88,6 +88,18 @@
       "description": "Daemon-wide BGP settings (ASN, router ID, listeners, telemetry).",
       "$ref": "#/$defs/Global"
     },
+    "gnmi_dialout": {
+      "description": "gNMI dial-out streaming telemetry (device-initiated push to\ncentral collectors).",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GnmiDialoutConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
     "managed_netdevs": {
       "description": "Optional rustbgpd-managed EVPN Linux netdev lifecycle\n(ADR-0091). Empty by default — existing deployments keep the\noperator-provisioned / observe-only contract. Configured rows opt\ninto class-scoped bridge, fixed-VNI VXLAN, SVD VXLAN, VLAN upper,\nVRF, and L3VXLAN create/adopt/reap.",
       "$ref": "#/$defs/ManagedNetdevsConfig",
@@ -1044,6 +1056,117 @@
         "router_id",
         "listen_port",
         "telemetry"
+      ]
+    },
+    "GnmiDialoutConfig": {
+      "description": "gNMI dial-out streaming telemetry (LAN-471): the daemon connects OUT\nto each configured collector and pushes the same `SubscribeResponse`\nstream a dial-in `gnmi.gNMI/Subscribe` STREAM subscription would\nproduce. Reload-applied: SIGHUP starts/stops/redials targets in place.",
+      "type": "object",
+      "properties": {
+        "targets": {
+          "description": "Collector targets to dial out to.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/GnmiDialoutTarget"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "GnmiDialoutModeConfig": {
+      "description": "gNMI dial-out delivery mode.",
+      "oneOf": [
+        {
+          "description": "Periodic resample of the subscribed paths.",
+          "type": "string",
+          "const": "sample"
+        },
+        {
+          "description": "Event-driven updates from the durable event outbox.",
+          "type": "string",
+          "const": "on_change"
+        }
+      ]
+    },
+    "GnmiDialoutTarget": {
+      "description": "One gNMI dial-out collector target.",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Collector endpoint as `host:port` (DNS names allowed).",
+          "type": "string"
+        },
+        "backoff_initial": {
+          "description": "First reconnect delay in seconds after a connection failure;\ndoubles per consecutive failure. Default 1.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 1,
+          "minimum": 0
+        },
+        "backoff_max": {
+          "description": "Reconnect delay cap in seconds. Default 30.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 30,
+          "minimum": 0
+        },
+        "mode": {
+          "description": "Delivery mode: `\"sample\"` (periodic resample, default) or\n`\"on_change\"` (event-driven; v1 supports the `session-state` leaf\nand requires `[event_history].enabled = true`).",
+          "$ref": "#/$defs/GnmiDialoutModeConfig",
+          "default": "sample"
+        },
+        "name": {
+          "description": "Unique target name — the `gnmi_dialout_connected{target}` metric\nlabel and the log key for this collector.",
+          "type": "string"
+        },
+        "paths": {
+          "description": "OpenConfig gNMI paths to subscribe, in xpath form (the same paths\na dial-in collector would put in a `SubscribeRequest`), e.g.\n`network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sample_interval": {
+          "description": "SAMPLE resample interval in seconds. Default 10; clamped to\n[1s, 1h] like a dial-in subscription's requested interval.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 10,
+          "minimum": 0
+        },
+        "tls_ca_file": {
+          "description": "CA certificate(s) (PEM file path) used to verify the collector's\nserver certificate. Setting this enables TLS for the target.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tls_cert_file": {
+          "description": "Client certificate (PEM file path) presented to the collector for\nmutual TLS. Requires `tls_key_file` and `tls_ca_file`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tls_key_file": {
+          "description": "Client private key (PEM file path). Required together with\n`tls_cert_file`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tls_server_name": {
+          "description": "Expected TLS server name, overriding the dialed host (needed when\ndialing a collector by IP whose certificate carries a DNS name).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "address",
+        "paths"
       ]
     },
     "GrpcAccessModeConfig": {

--- a/docs/v1-stable-surface.json
+++ b/docs/v1-stable-surface.json
@@ -122,6 +122,7 @@
       {"path": "Config.evpn_instances", "classification": "alpha"},
       {"path": "Config.evpn_ip_vrfs", "classification": "alpha"},
       {"path": "Config.fib_tables", "classification": "alpha"},
+      {"path": "Config.gnmi_dialout", "classification": "outside_v1"},
       {"path": "Config.managed_netdevs", "classification": "alpha"},
       {"path": "Neighbor.bfd", "classification": "outside_v1"},
       {"path": "Neighbor.interface", "classification": "outside_v1"},

--- a/proto/rustbgpd_dialout.proto
+++ b/proto/rustbgpd_dialout.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+// gNMI dial-out: device-initiated telemetry push.
+//
+// In dial-in gNMI the collector connects to the device and drives
+// `gnmi.gNMI/Subscribe`. Dial-out inverts the transport direction only:
+// the device opens a gRPC connection to a central collector and pushes
+// the same `gnmi.SubscribeResponse` stream a dial-in subscription would
+// have produced (initial snapshot, `sync_response`, then updates).
+// This mirrors the de-facto vendor dial-out shape (a device-initiated
+// `Publish(stream SubscribeResponse)` RPC) without impersonating any
+// vendor namespace; the OpenConfig grpc-tunnel model solves the same
+// reachability inversion at the transport layer and remains a possible
+// future alternative.
+package rustbgpd.gnmi_dialout.v1;
+
+import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
+
+// Collector-side service. rustbgpd implements the *client* of this
+// service; a central collector (or the bundled test stub) implements
+// the server.
+service GnmiDialout {
+  // One long-lived stream per configured collector target. The device
+  // sends SubscribeResponse messages exactly as the dial-in Subscribe
+  // server would. The response stream exists for connection liveness
+  // and future flow control; collectors need not send anything.
+  rpc Publish(stream gnmi.SubscribeResponse) returns (stream PublishResponse);
+}
+
+// Reserved for future collector-to-device flow control. Empty today.
+message PublishResponse {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2471,6 +2471,11 @@ pub struct ConfigDiff {
     pub global_changed: bool,
     pub rpki_changed: bool,
     pub bmp_changed: bool,
+    /// `[gnmi_dialout]` changed. Reload-applied: the dial-out manager
+    /// diffs the target set on SIGHUP — removed targets stop (their
+    /// `gnmi_dialout_connected` series is reaped), added targets start,
+    /// changed targets redial, unchanged targets keep their connection.
+    pub gnmi_dialout_changed: bool,
     pub mrt_changed: bool,
     /// `[[evpn_instances]]` blocks added/removed/modified between old and
     /// new. Surfaced as restart-required today — the Phase-2 foundation
@@ -2739,6 +2744,7 @@ impl ConfigDiff {
             || self.honor_graceful_shutdown_changed
             || self.honor_blackhole_changed
             || self.dynamic_neighbors_reload_applied_changed
+            || self.gnmi_dialout_changed
             || (self.fib_tables_changed && !self.fib_tables_requires_restart)
             || self.evpn_runtime_change_class.is_reload_applied()
     }
@@ -3299,6 +3305,11 @@ pub fn classify_config_transaction_v1(diff: &ConfigDiff) -> ConfigTransactionSec
             .unsupported_sections
             .push("EVPN runtime coordinator".to_string());
     }
+    if diff.gnmi_dialout_changed {
+        class
+            .unsupported_sections
+            .push("[gnmi_dialout] (apply via SIGHUP reload)".to_string());
+    }
 
     if diff.global_changed {
         class.restart_required_sections.push("[global]".to_string());
@@ -3494,6 +3505,7 @@ pub fn config_diff_json_value(diff: &ConfigDiff) -> serde_json::Value {
             "honor_graceful_shutdown_changed": diff.honor_graceful_shutdown_changed,
             "honor_blackhole_changed": diff.honor_blackhole_changed,
             "dynamic_neighbors_changed": diff.dynamic_neighbors_reload_applied_changed,
+            "gnmi_dialout_changed": diff.gnmi_dialout_changed,
             "fib_tables_changed": diff.fib_tables_changed && !diff.fib_tables_requires_restart,
             "evpn_runtime_changed": diff.evpn_runtime_change_class.is_reload_applied(),
             "evpn_instances_changed": diff.evpn_runtime_change_class.is_reload_applied() && diff.evpn_instances_changed,
@@ -3710,6 +3722,14 @@ pub fn format_config_diff_with_style(diff: &ConfigDiff, style: &ConfigDiffTextSt
                 style.change_marker
             );
         }
+        if diff.gnmi_dialout_changed {
+            let _ = writeln!(
+                out,
+                "  {} [gnmi_dialout] targets reconciled (removed stop, added start, \
+                 changed redial)",
+                style.change_marker
+            );
+        }
         if let Some(steps) = diff.evpn_runtime_change_class.decomposed_steps() {
             let _ = writeln!(
                 out,
@@ -3892,6 +3912,7 @@ pub fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         global_changed: global_restart_required_changed(old, new),
         rpki_changed: old.rpki != new.rpki,
         bmp_changed: old.bmp != new.bmp,
+        gnmi_dialout_changed: old.gnmi_dialout != new.gnmi_dialout,
         mrt_changed: old.mrt != new.mrt,
         evpn_instances_changed: old.evpn_instances != new.evpn_instances,
         evpn_ip_vrfs_changed: old.evpn_ip_vrfs != new.evpn_ip_vrfs,
@@ -6244,6 +6265,105 @@ fn parse_esi(raw: &str) -> Result<EthernetSegmentIdentifier, &'static str> {
         bytes[i] = u8::from_str_radix(octet, 16).map_err(|_| "invalid hex octet")?;
     }
     Ok(EthernetSegmentIdentifier::new(bytes))
+}
+
+/// Resolve the `[gnmi_dialout]` section into runtime dial-out target
+/// specs. Single source of truth for the section's semantic validation:
+/// `Config::validate` calls this at load (startup AND SIGHUP reload
+/// preflight) so a config that loads always translates, and the daemon /
+/// reload wiring reuses the same resolution to (re)apply targets.
+///
+/// Subscription paths and modes are validated through the api crate's
+/// `build_subscription_list`, which runs the exact checks a dial-in
+/// `Subscribe` request would — a path the Subscribe server would reject
+/// is rejected here, at config load.
+pub(crate) fn gnmi_dialout_targets(
+    config: &Config,
+) -> Result<Vec<rustbgpd_api::gnmi_dialout::DialoutTarget>, String> {
+    use rustbgpd_api::gnmi_dialout as dialout;
+
+    let Some(section) = config.gnmi_dialout.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let mut seen_names = HashSet::new();
+    let mut targets = Vec::with_capacity(section.targets.len());
+    for (i, target) in section.targets.iter().enumerate() {
+        let fail = |reason: String| format!("targets[{i}]: {reason}");
+        if target.name.is_empty() {
+            return Err(fail("name must not be empty".to_string()));
+        }
+        if !seen_names.insert(target.name.as_str()) {
+            return Err(fail(format!("duplicate name {:?}", target.name)));
+        }
+        // host:port shape (DNS names allowed, IPv6 literals bracketed).
+        let addr_ok = target
+            .address
+            .rsplit_once(':')
+            .is_some_and(|(host, port)| !host.is_empty() && port.parse::<u16>().is_ok());
+        if !addr_ok {
+            return Err(fail(format!(
+                "address {:?} must be host:port",
+                target.address
+            )));
+        }
+        match (&target.tls_cert_file, &target.tls_key_file) {
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(fail(
+                    "tls_cert_file and tls_key_file must be set together".to_string(),
+                ));
+            }
+            (Some(_), Some(_)) if target.tls_ca_file.is_none() => {
+                return Err(fail(
+                    "tls_cert_file/tls_key_file require tls_ca_file".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        if target.tls_server_name.is_some() && target.tls_ca_file.is_none() {
+            return Err(fail("tls_server_name requires tls_ca_file".to_string()));
+        }
+        if target.sample_interval == 0 {
+            return Err(fail("sample_interval must be > 0".to_string()));
+        }
+        if target.backoff_initial == 0 {
+            return Err(fail("backoff_initial must be > 0".to_string()));
+        }
+        if target.backoff_max < target.backoff_initial {
+            return Err(fail("backoff_max must be >= backoff_initial".to_string()));
+        }
+        let mode = match target.mode {
+            GnmiDialoutModeConfig::Sample => dialout::DialoutMode::Sample,
+            GnmiDialoutModeConfig::OnChange => dialout::DialoutMode::OnChange,
+        };
+        if mode == dialout::DialoutMode::OnChange && !config.event_history.enabled {
+            return Err(fail(
+                "mode = \"on_change\" requires [event_history].enabled = true \
+                 (the durable event outbox sources the transitions)"
+                    .to_string(),
+            ));
+        }
+        let subscriptions = dialout::build_subscription_list(
+            &target.paths,
+            mode,
+            std::time::Duration::from_secs(target.sample_interval),
+        )
+        .map_err(fail)?;
+        let tls = target.tls_ca_file.as_ref().map(|ca| dialout::DialoutTls {
+            ca_file: PathBuf::from(ca),
+            cert_file: target.tls_cert_file.as_ref().map(PathBuf::from),
+            key_file: target.tls_key_file.as_ref().map(PathBuf::from),
+            server_name: target.tls_server_name.clone(),
+        });
+        targets.push(dialout::DialoutTarget {
+            name: target.name.clone(),
+            endpoint: dialout::endpoint_uri(&target.address, tls.is_some()),
+            tls,
+            subscriptions,
+            backoff_initial: std::time::Duration::from_secs(target.backoff_initial),
+            backoff_max: std::time::Duration::from_secs(target.backoff_max),
+        });
+    }
+    Ok(targets)
 }
 
 #[cfg(test)]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -47,6 +47,10 @@ pub struct Config {
     /// BGP Monitoring Protocol (RFC 7854) export.
     #[serde(default)]
     pub bmp: Option<BmpConfig>,
+    /// gNMI dial-out streaming telemetry (device-initiated push to
+    /// central collectors).
+    #[serde(default)]
+    pub gnmi_dialout: Option<GnmiDialoutConfig>,
     /// Periodic MRT RIB dumps.
     #[serde(default)]
     pub mrt: Option<MrtConfig>,
@@ -358,6 +362,84 @@ pub enum BmpMonitorView {
     /// Loc-RIB instance monitoring with collector-connect table sync
     /// (RFC 9069).
     LocRib,
+}
+
+/// gNMI dial-out streaming telemetry (LAN-471): the daemon connects OUT
+/// to each configured collector and pushes the same `SubscribeResponse`
+/// stream a dial-in `gnmi.gNMI/Subscribe` STREAM subscription would
+/// produce. Reload-applied: SIGHUP starts/stops/redials targets in place.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GnmiDialoutConfig {
+    /// Collector targets to dial out to.
+    #[serde(default)]
+    pub targets: Vec<GnmiDialoutTarget>,
+}
+
+/// One gNMI dial-out collector target.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GnmiDialoutTarget {
+    /// Unique target name — the `gnmi_dialout_connected{target}` metric
+    /// label and the log key for this collector.
+    pub name: String,
+    /// Collector endpoint as `host:port` (DNS names allowed).
+    pub address: String,
+    /// `OpenConfig` gNMI paths to subscribe, in xpath form (the same paths
+    /// a dial-in collector would put in a `SubscribeRequest`), e.g.
+    /// `network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state`.
+    pub paths: Vec<String>,
+    /// Delivery mode: `"sample"` (periodic resample, default) or
+    /// `"on_change"` (event-driven; v1 supports the `session-state` leaf
+    /// and requires `[event_history].enabled = true`).
+    #[serde(default)]
+    pub mode: GnmiDialoutModeConfig,
+    /// SAMPLE resample interval in seconds. Default 10; clamped to
+    /// [1s, 1h] like a dial-in subscription's requested interval.
+    #[serde(default = "default_gnmi_dialout_sample_interval")]
+    pub sample_interval: u64,
+    /// First reconnect delay in seconds after a connection failure;
+    /// doubles per consecutive failure. Default 1.
+    #[serde(default = "default_gnmi_dialout_backoff_initial")]
+    pub backoff_initial: u64,
+    /// Reconnect delay cap in seconds. Default 30.
+    #[serde(default = "default_gnmi_dialout_backoff_max")]
+    pub backoff_max: u64,
+    /// CA certificate(s) (PEM file path) used to verify the collector's
+    /// server certificate. Setting this enables TLS for the target.
+    pub tls_ca_file: Option<String>,
+    /// Client certificate (PEM file path) presented to the collector for
+    /// mutual TLS. Requires `tls_key_file` and `tls_ca_file`.
+    pub tls_cert_file: Option<String>,
+    /// Client private key (PEM file path). Required together with
+    /// `tls_cert_file`.
+    pub tls_key_file: Option<String>,
+    /// Expected TLS server name, overriding the dialed host (needed when
+    /// dialing a collector by IP whose certificate carries a DNS name).
+    pub tls_server_name: Option<String>,
+}
+
+/// gNMI dial-out delivery mode.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GnmiDialoutModeConfig {
+    /// Periodic resample of the subscribed paths.
+    #[default]
+    Sample,
+    /// Event-driven updates from the durable event outbox.
+    OnChange,
+}
+
+fn default_gnmi_dialout_sample_interval() -> u64 {
+    10
+}
+
+fn default_gnmi_dialout_backoff_initial() -> u64 {
+    1
+}
+
+fn default_gnmi_dialout_backoff_max() -> u64 {
+    30
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -2185,6 +2267,8 @@ pub enum ConfigError {
     InvalidNeighborSet { reason: String },
     #[error("invalid BMP collector config: {reason}")]
     InvalidBmpCollector { reason: String },
+    #[error("invalid gNMI dial-out config: {reason}")]
+    InvalidGnmiDialout { reason: String },
     #[error("invalid MRT config: {reason}")]
     InvalidMrtConfig { reason: String },
     #[error("invalid remove_private_as config: {reason}")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4627,6 +4627,191 @@ address = "127.0.0.1:11019"
     assert_eq!(bmp.sys_descr, "production edge");
 }
 
+// -----------------------------------------------------------------------
+// gNMI dial-out config validation (LAN-471)
+// -----------------------------------------------------------------------
+
+const DIALOUT_SESSION_STATE_PATH: &str = "network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=*]/state/session-state";
+
+fn gnmi_dialout_toml(target_fields: &str) -> String {
+    format!(
+        r#"
+[global]
+asn = 65001
+router_id = "10.0.0.1"
+listen_port = 179
+
+[global.telemetry]
+prometheus_addr = "0.0.0.0:9179"
+log_format = "json"
+
+[gnmi_dialout]
+[[gnmi_dialout.targets]]
+name = "collector-a"
+address = "192.0.2.10:57400"
+paths = ["{DIALOUT_SESSION_STATE_PATH}"]
+{target_fields}
+"#
+    )
+}
+
+#[test]
+fn gnmi_dialout_valid_config_accepted_with_defaults() {
+    let config = parse(&gnmi_dialout_toml("")).unwrap();
+    let section = config.gnmi_dialout.as_ref().unwrap();
+    assert_eq!(section.targets.len(), 1);
+    let target = &section.targets[0];
+    assert_eq!(target.name, "collector-a");
+    assert_eq!(target.mode, GnmiDialoutModeConfig::Sample);
+    assert_eq!(target.sample_interval, 10);
+    assert_eq!(target.backoff_initial, 1);
+    assert_eq!(target.backoff_max, 30);
+    assert!(target.tls_ca_file.is_none());
+
+    let targets = super::gnmi_dialout_targets(&config).unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(
+        targets[0].endpoint, "http://192.0.2.10:57400",
+        "no TLS section dials plaintext"
+    );
+}
+
+#[test]
+fn gnmi_dialout_tls_target_builds_https_endpoint() {
+    let config = parse(&gnmi_dialout_toml(
+        "tls_ca_file = \"/etc/rustbgpd/collector-ca.pem\"\n\
+         tls_cert_file = \"/etc/rustbgpd/client.pem\"\n\
+         tls_key_file = \"/etc/rustbgpd/client.key\"\n\
+         tls_server_name = \"collector.example\"",
+    ))
+    .unwrap();
+    let targets = super::gnmi_dialout_targets(&config).unwrap();
+    assert_eq!(targets[0].endpoint, "https://192.0.2.10:57400");
+    let tls = targets[0].tls.as_ref().unwrap();
+    assert_eq!(tls.server_name.as_deref(), Some("collector.example"));
+}
+
+#[test]
+fn gnmi_dialout_duplicate_target_name_rejected() {
+    let toml = gnmi_dialout_toml("")
+        + "\n[[gnmi_dialout.targets]]\nname = \"collector-a\"\naddress = \"192.0.2.11:57400\"\npaths = [\"network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/global/state/as\"]\n";
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+}
+
+#[test]
+fn gnmi_dialout_invalid_address_rejected() {
+    for bad in ["no-port", ":57400", "192.0.2.10:notaport", ""] {
+        let err = parse(&gnmi_dialout_toml("").replace("192.0.2.10:57400", bad)).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidGnmiDialout { .. }),
+            "expected InvalidGnmiDialout for address {bad:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn gnmi_dialout_empty_paths_rejected() {
+    let toml = gnmi_dialout_toml("").replace(
+        &format!("paths = [\"{DIALOUT_SESSION_STATE_PATH}\"]"),
+        "paths = []",
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+}
+
+#[test]
+fn gnmi_dialout_unsupported_path_rejected() {
+    // The same validation a dial-in Subscribe would apply: paths outside
+    // the supported OpenConfig BGP surface fail at config load.
+    let toml = gnmi_dialout_toml("").replace(
+        DIALOUT_SESSION_STATE_PATH,
+        "interfaces/interface[name=eth0]/state",
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+}
+
+#[test]
+fn gnmi_dialout_tls_pairing_rules_enforced() {
+    // Cert without key.
+    let err = parse(&gnmi_dialout_toml(
+        "tls_ca_file = \"/etc/ca.pem\"\ntls_cert_file = \"/etc/client.pem\"",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+    // Cert+key without CA.
+    let err = parse(&gnmi_dialout_toml(
+        "tls_cert_file = \"/etc/client.pem\"\ntls_key_file = \"/etc/client.key\"",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+    // Server-name override without CA (no TLS at all).
+    let err = parse(&gnmi_dialout_toml(
+        "tls_server_name = \"collector.example\"",
+    ))
+    .unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+}
+
+#[test]
+fn gnmi_dialout_on_change_requires_event_history() {
+    let err = parse(&gnmi_dialout_toml("mode = \"on_change\"")).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+
+    // With the durable outbox enabled, ON_CHANGE on the session-state
+    // leaf is accepted.
+    let toml = format!(
+        "{}\n[event_history]\nenabled = true\n",
+        gnmi_dialout_toml("mode = \"on_change\"")
+    );
+    parse(&toml).unwrap();
+}
+
+#[test]
+fn gnmi_dialout_on_change_unsupported_leaf_rejected() {
+    // ON_CHANGE is only supported on the session-state leaf, exactly like
+    // dial-in Subscribe.
+    let toml = format!(
+        "{}\n[event_history]\nenabled = true\n",
+        gnmi_dialout_toml("mode = \"on_change\"").replace(
+            DIALOUT_SESSION_STATE_PATH,
+            "network-instances/network-instance[name=DEFAULT]/protocols/protocol[identifier=BGP][name=BGP]/bgp/global/state/as",
+        )
+    );
+    let err = parse(&toml).unwrap_err();
+    assert!(matches!(err, ConfigError::InvalidGnmiDialout { .. }));
+}
+
+#[test]
+fn gnmi_dialout_timer_bounds_enforced() {
+    for bad in [
+        "sample_interval = 0",
+        "backoff_initial = 0",
+        "backoff_initial = 10\nbackoff_max = 5",
+    ] {
+        let err = parse(&gnmi_dialout_toml(bad)).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidGnmiDialout { .. }),
+            "expected InvalidGnmiDialout for {bad:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn gnmi_dialout_unknown_field_rejected() {
+    assert!(parse(&gnmi_dialout_toml("bogus_field = true")).is_err());
+}
+
+#[test]
+fn gnmi_dialout_absent_section_yields_no_targets() {
+    let toml = gnmi_dialout_toml("");
+    let stripped = toml.split("[gnmi_dialout]").next().unwrap();
+    let config = parse(stripped).unwrap();
+    assert!(config.gnmi_dialout.is_none());
+    assert!(super::gnmi_dialout_targets(&config).unwrap().is_empty());
+}
+
 #[test]
 fn bmp_duplicate_collector_address_rejected() {
     let toml = r#"

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -821,6 +821,14 @@ impl Config {
             }
         }
 
+        // Validate the gNMI dial-out section. The semantic checks live in
+        // the shared translation the daemon wiring uses, so a config that
+        // loads always resolves into runnable dial-out targets — including
+        // running each subscription path through the exact validation a
+        // dial-in Subscribe request would get.
+        super::gnmi_dialout_targets(self)
+            .map_err(|reason| ConfigError::InvalidGnmiDialout { reason })?;
+
         // Validate dynamic neighbor ranges
         let mut seen_prefixes = std::collections::HashSet::new();
         let mut parsed_dynamic_prefixes = Vec::with_capacity(self.dynamic_neighbors.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4302,6 +4302,27 @@ async fn run<T>(
         });
     }
 
+    // gNMI dial-out (LAN-471): device-initiated telemetry push. The manager
+    // reuses the dial-in Subscribe machinery via its own GnmiService handle
+    // (same peer-manager snapshot source + event outbox as the served gNMI
+    // surface) and reconciles targets again after every successful SIGHUP
+    // reload in the outcome arm below. A collector being down never affects
+    // the daemon: each target retries independently with capped backoff.
+    let mut gnmi_dialout_manager = rustbgpd_api::gnmi_dialout::DialoutManager::new(
+        rustbgpd_api::gnmi_dialout::GnmiService::new(
+            config.global.asn,
+            config.global.router_id.clone(),
+            peer_mgr_tx.clone(),
+        )
+        .with_event_history(event_history_handle.clone()),
+        metrics.clone(),
+    );
+    match config::gnmi_dialout_targets(&config) {
+        Ok(targets) => gnmi_dialout_manager.apply(&targets),
+        // Unreachable in practice: Config::load validated the section.
+        Err(reason) => error!(error = %reason, "invalid [gnmi_dialout] section; dial-out disabled"),
+    }
+
     // Signal handlers (unix-only, which is our target)
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .unwrap_or_else(|e| fatal_startup_error("failed to register SIGTERM handler", e));
@@ -4438,7 +4459,23 @@ async fn run<T>(
             } => {
                 reload_in_flight = None;
                 match outcome {
-                    Ok(Some(Ok(advanced))) => config = advanced,
+                    Ok(Some(Ok(advanced))) => {
+                        config = advanced;
+                        // [gnmi_dialout] is reload-applied: reconcile the
+                        // dial-out targets against the advanced config —
+                        // removed targets stop (gauge series reaped), added
+                        // start, changed redial, unchanged keep their live
+                        // collector connections.
+                        match config::gnmi_dialout_targets(&config) {
+                            Ok(targets) => gnmi_dialout_manager.apply(&targets),
+                            // Unreachable in practice: the reload path
+                            // re-validated the config before advancing.
+                            Err(reason) => error!(
+                                error = %reason,
+                                "invalid [gnmi_dialout] after reload; dial-out targets unchanged"
+                            ),
+                        }
+                    }
                     Ok(Some(Err(stage))) => error!(
                         stage,
                         "post-reload sync failed mid-flight; in-memory config not advanced — next SIGHUP will retry"
@@ -6316,6 +6353,7 @@ tcp_ao = {{ key = "secret", send_id = 1, recv_id = 1, algorithm = "hmac(sha256)"
             policy: crate::config::PolicyConfig::default(),
             rpki: None,
             bmp: None,
+            gnmi_dialout: None,
             mrt: None,
             file_path: None,
             dynamic_neighbors: Vec::new(),

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -398,6 +398,7 @@ impl PeerManager {
                 policy: crate::config::PolicyConfig::default(),
                 rpki: None,
                 bmp: None,
+                gnmi_dialout: None,
                 mrt: None,
                 file_path: None,
                 dynamic_neighbors: Vec::new(),

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -421,6 +421,7 @@ fn make_dynamic_manager_config() -> Config {
         }],
         rpki: None,
         bmp: None,
+        gnmi_dialout: None,
         mrt: None,
         file_path: None,
         evpn_instances: Vec::new(),


### PR DESCRIPTION
Adds device-initiated gNMI telemetry: the daemon connects OUT to configured collector endpoints and streams the exact SubscribeResponse sequence a dial-in STREAM subscription would produce (initial snapshot, sync_response, then SAMPLE/ON_CHANGE updates) — no update-generation code duplicated; the dial-out publisher drives the same subscription tasks the ADR-0070 Subscribe server uses.

Config: `[gnmi_dialout]` targets with per-target subscription lists, TLS (existing idiom; zero key material in logs/errors — Debug redaction pinned), capped exponential reconnect backoff. A collector being down never affects the daemon: independent per-target reconnect loops, bounded log volume, and `gnmi_dialout_connected{target}` gauge refreshed on both transitions. Classified outside v1 (config section + new dial-out proto).

Tests: config parse/validation matrix, Debug redaction pins, and an in-process stub-collector integration proving updates arrive AND the stream re-establishes after a collector restart. Docs: OPERATIONS dial-out section + metric row, CONFIGURATION, reload-matrix, CHANGELOG; schema golden regenerated (combined with the reject-retention section post-rebase).

Rebased over #980/#981 (CHANGELOG keep-both, expect-reason keep-main, combined schema regen); full gate battery green foreground including the workspace suite after the regen.