### PR TITLE
refactor(wire,fsm): mark registry-tracking protocol enums non_exhaustive for the 0.15.0/0.3.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,33 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **BREAKING (library API): registry-tracking wire/fsm enums are now
+  `#[non_exhaustive]`** — absorbed into the in-flight `rustbgpd-wire`
+  0.15.0 / `rustbgpd-fsm` 0.3.0 breaking cut. 22 wire enums
+  (`Capability`, `PathAttribute`, `Afi`, `Safi`, `Message`,
+  `MessageType`, `NotificationCode`, `RouteRefreshSubtype`, `EvpnRoute`,
+  `EvpnRouteKey`, `RouteDistinguisherParseError`, `BgpLsNlriType`,
+  `FlowSpecComponent`, `FlowSpecAction`, `OrfType`, `OrfEntries`,
+  `PmsiTunnelType`, `PmsiTunnelIdentifier`, `BgpRole`, `AspaValidation`,
+  `DecodeError`, `EncodeError`) and 2 fsm enums (`TimerType`,
+  `error::FsmError`) now require a wildcard arm in downstream exhaustive
+  matches. This breaks such matches once, in this release; every future
+  registry addition (the recurring `Capability::PathsLimit` shape from
+  0.14.x) then lands as a non-breaking minor instead of another major.
+  Closed-by-construction enums deliberately remain exhaustively
+  matchable: `Origin`, `AsPathSegment`, `Prefix`, `AddPathMode`,
+  `OrfAction`, `OrfMatch`, `OrfSendReceive`, `WhenToRefresh`,
+  `Ipv4UnicastMode`, `ErrorDisposition`, `RpkiValidation`,
+  `EvpnIpPrefixValue`, `FlowSpecPrefix`, `VpnAddressFamily`,
+  `VpnPrefix`, `LabeledAddressFamily`, and fsm `SessionState`. In-tree
+  daemon fallout: every new wildcard arm fails safe (unknown message
+  kind → NOTIFICATION via the FSM decode-error path; unsupported
+  ROUTE-REFRESH subtype → ignored with a warning; unmodeled EVPN
+  withdrawal → export error, never silently dropped; unknown timer kind
+  → no slot, no expiry; unknown BGP Role → conservative upstream ASPA
+  procedure and omitted from config snapshots; display surfaces render
+  `unrecognized`/`unmodeled` labels).
+
 - **IXP route-server receipt matrix refreshed with post-fix flapstorm
   numbers** (`docs/perf/ixp-matrix-2026-07.md`): all four rustbgpd
   cells rerun at the deferred-PeerUp-dump fix head — S3 re-announce

--- a/crates/api/src/event_history_sinks.rs
+++ b/crates/api/src/event_history_sinks.rs
@@ -237,7 +237,7 @@ fn evpn_event_envelope(event: EvpnRouteEvent, timestamp_ns: i64) -> EventEnvelop
         previous_peer: event.previous_peer,
         target_peer: None,
     };
-    let rd = rustbgpd_rib::event::evpn_key_rd(&event.key).to_string();
+    let rd = rustbgpd_rib::event::evpn_key_rd(&event.key).map(|rd| rd.to_string());
     let evpn_route_type = Some(i32::from(event.key.route_type()));
     let proto_event = convert::evpn_event_to_bgp_event(event);
     EventEnvelope {
@@ -247,7 +247,7 @@ fn evpn_event_envelope(event: EvpnRouteEvent, timestamp_ns: i64) -> EventEnvelop
         peers,
         afi_safi: None,
         prefix: None,
-        rd: Some(rd),
+        rd,
         evpn_route_type,
         severity: Severity::Info,
         payload_codec: PayloadCodec::Proto,
@@ -594,7 +594,7 @@ mod tests {
         assert_eq!(envelope.peers.target_peer, None);
         assert_eq!(
             envelope.rd,
-            Some(rustbgpd_rib::event::evpn_key_rd(&event.key).to_string())
+            rustbgpd_rib::event::evpn_key_rd(&event.key).map(|rd| rd.to_string())
         );
         assert_eq!(
             envelope.evpn_route_type,

--- a/crates/api/src/event_service/convert.rs
+++ b/crates/api/src/event_service/convert.rs
@@ -84,7 +84,8 @@ pub fn evpn_event_to_bgp_event(event: rustbgpd_rib::EvpnRouteEvent) -> proto::Bg
     let previous_peer_address = event
         .previous_peer
         .map_or_else(String::new, |peer| peer.to_string());
-    let rd = rustbgpd_rib::event::evpn_key_rd(&event.key).to_string();
+    let rd =
+        rustbgpd_rib::event::evpn_key_rd(&event.key).map_or_else(String::new, |rd| rd.to_string());
     let route_type = u32::from(event.key.route_type());
     let route_key = format_evpn_route_key(&event.key);
     let action = match event_type {
@@ -162,6 +163,8 @@ fn format_evpn_route_key(key: &rustbgpd_wire::EvpnRouteKey) -> String {
             ethernet_tag,
             prefix,
         } => format!("ip-prefix rd={rd} ethernet_tag={ethernet_tag} prefix={prefix}"),
+        // Non-exhaustive: name the gap honestly instead of guessing fields.
+        _ => "unmodeled-route-type".to_string(),
     }
 }
 
@@ -363,6 +366,8 @@ fn bgp_role_label(role: rustbgpd_wire::BgpRole) -> String {
         rustbgpd_wire::BgpRole::RouteServerClient => "route_server_client",
         rustbgpd_wire::BgpRole::Customer => "customer",
         rustbgpd_wire::BgpRole::Peer => "peer",
+        // Non-exhaustive registry enum: label future roles honestly.
+        _ => "unrecognized",
     }
     .to_string()
 }

--- a/crates/api/src/neighbor_service.rs
+++ b/crates/api/src/neighbor_service.rs
@@ -350,6 +350,8 @@ fn bgp_role_to_string(role: Option<BgpRole>) -> String {
         Some(BgpRole::RouteServerClient) => "rs-client".to_string(),
         Some(BgpRole::Customer) => "customer".to_string(),
         Some(BgpRole::Peer) => "peer".to_string(),
+        // Non-exhaustive registry enum: label future roles honestly.
+        Some(_) => "unrecognized".to_string(),
         None => String::new(),
     }
 }

--- a/crates/api/src/rib_service.rs
+++ b/crates/api/src/rib_service.rs
@@ -1760,6 +1760,8 @@ impl proto::rib_service_server::RibService for RibService {
                         EvpnRoute::Imet(e) => e.rd.to_string(),
                         EvpnRoute::Es(e) => e.rd.to_string(),
                         EvpnRoute::IpPrefix(e) => e.rd.to_string(),
+                        // Unmodeled route types never match an RD filter.
+                        _ => return false,
                     };
                     if entry_rd != rd_filter {
                         return false;
@@ -2157,6 +2159,14 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
                     value: format_numeric_ops(ops),
                     offset: 0,
                 },
+                // Non-exhaustive: component types this build does not model
+                // surface as type 0 with empty fields.
+                _ => proto::FlowSpecComponent {
+                    r#type: 0,
+                    prefix: String::new(),
+                    value: String::new(),
+                    offset: 0,
+                },
             }
         })
         .collect();
@@ -2215,7 +2225,7 @@ fn flowspec_route_to_proto(route: &FlowSpecRoute) -> proto::FlowSpecRouteEntry {
     let afi_safi = match route.afi {
         Afi::Ipv4 => proto::AddressFamily::Ipv4Flowspec,
         Afi::Ipv6 => proto::AddressFamily::Ipv6Flowspec,
-        Afi::L2Vpn | Afi::BgpLs => proto::AddressFamily::Unspecified,
+        _ => proto::AddressFamily::Unspecified,
     };
 
     proto::FlowSpecRouteEntry {
@@ -2250,6 +2260,8 @@ fn bgpls_nlri_type_name(nlri_type: BgpLsNlriType) -> String {
         BgpLsNlriType::Ipv4TopologyPrefix => "ipv4_topology_prefix".to_string(),
         BgpLsNlriType::Ipv6TopologyPrefix => "ipv6_topology_prefix".to_string(),
         BgpLsNlriType::Unknown(value) => format!("unknown_{value}"),
+        // Non-exhaustive: NLRI types this build does not model.
+        _ => "unmodeled".to_string(),
     }
 }
 
@@ -2577,6 +2589,19 @@ pub(crate) fn evpn_route_to_proto(route: &EvpnRibRoute) -> proto::EvpnRouteEntry
             e.prefix.to_string(),
             e.gateway.to_string(),
             e.label.value(),
+            0,
+        ),
+        // Non-exhaustive: route types this build does not model render with
+        // empty fields; the numeric route type is still reported alongside.
+        _ => (
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            0,
             0,
         ),
     };

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -192,7 +192,9 @@ pub(crate) fn spawn_fake_rib_with_evpn_history(
                             route_type.is_none_or(|route_type| event.key.route_type() == route_type)
                         })
                         .filter(|event| {
-                            rd.is_none_or(|rd| rustbgpd_rib::event::evpn_key_rd(&event.key) == rd)
+                            rd.is_none_or(|rd| {
+                                rustbgpd_rib::event::evpn_key_rd(&event.key) == Some(rd)
+                            })
                         })
                         .filter(|event| {
                             event_types.is_empty() || event_types.contains(&event.event_type)

--- a/crates/cli/src/commands/ribsnap_bmp.rs
+++ b/crates/cli/src/commands/ribsnap_bmp.rs
@@ -963,6 +963,12 @@ fn convert_attribute<'a>(
             raw.type_code,
             raw.data.to_vec(),
         )),
+        // `PathAttribute` is non-exhaustive: silently dropping an attribute
+        // this build does not model would corrupt the comparison, so fail
+        // the conversion instead.
+        _ => {
+            return Err("path attribute not modeled by this snapshot converter".to_string());
+        }
     }
     Ok(())
 }

--- a/crates/fsm/README.md
+++ b/crates/fsm/README.md
@@ -22,7 +22,11 @@ the peer-advertised and effective family-local limits.
 
 `rustbgpd-fsm 0.3.0` moves with `rustbgpd-wire 0.15.0`: the FSM's public API
 exposes wire types, so the incompatible wire dependency requires the paired
-0.x breaking bump.
+0.x breaking bump. The same cut marks `TimerType` and `error::FsmError`
+`#[non_exhaustive]`, joining `Event`, `Action`, `PeerConfig`, and
+`NegotiatedSession` — match them with a wildcard arm, and future variant
+additions become non-breaking. `SessionState` remains exhaustively
+matchable: the six RFC 4271 §8 states are fixed by the protocol.
 
 ## Key types
 

--- a/crates/fsm/src/action.rs
+++ b/crates/fsm/src/action.rs
@@ -11,6 +11,7 @@ use crate::state::SessionState;
 
 /// Which timer to start or stop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum TimerType {
     /// TCP connect-retry timer (exponential backoff).
     ConnectRetry,

--- a/crates/fsm/src/error.rs
+++ b/crates/fsm/src/error.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 /// a well-defined output.  These errors exist for logging / telemetry when
 /// the FSM encounters protocol violations.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FsmError {
     /// Peer's OPEN message failed validation (bad ASN, hold time, etc.).
     #[error("OPEN validation failed: {reason}")]

--- a/crates/fsm/src/lib.rs
+++ b/crates/fsm/src/lib.rs
@@ -24,6 +24,28 @@
 //! assert_eq!(session.state(), SessionState::Connect);
 //! assert!(!actions.is_empty());
 //! ```
+//!
+//! # Enum exhaustiveness
+//!
+//! [`Event`], [`Action`], [`TimerType`], and [`error::FsmError`] are
+//! `#[non_exhaustive]`: new protocol features add variants without a
+//! semver-major break, so matches outside this crate must carry a
+//! wildcard arm. [`SessionState`] stays exhaustively matchable — the six
+//! RFC 4271 §8 states are fixed by the protocol.
+//!
+//! ```rust
+//! use rustbgpd_fsm::Action;
+//!
+//! fn describe(action: &Action) -> &'static str {
+//!     match action {
+//!         Action::SendKeepalive => "send keepalive",
+//!         Action::CloseTcpConnection => "close TCP connection",
+//!         // Future actions land here; ignore what you do not drive.
+//!         _ => "other",
+//!     }
+//! }
+//! assert_eq!(describe(&Action::SendKeepalive), "send keepalive");
+//! ```
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/crates/policy/src/engine/explain.rs
+++ b/crates/policy/src/engine/explain.rs
@@ -967,6 +967,9 @@ fn render_prec(expr: &MatchExpr, tables: &CompiledChain, min_binding: u8) -> Str
                 rustbgpd_wire::AspaValidation::Valid => "valid",
                 rustbgpd_wire::AspaValidation::Invalid => "invalid",
                 rustbgpd_wire::AspaValidation::Unknown => "unknown",
+                // `AspaValidation` is non-exhaustive: render future states
+                // without claiming a specific one.
+                _ => "unrecognized",
             }
         ),
         MatchExpr::And(children) => {

--- a/crates/rib/src/best_path.rs
+++ b/crates/rib/src/best_path.rs
@@ -21,8 +21,11 @@ fn rpki_preference(v: RpkiValidation) -> u8 {
 fn aspa_preference(v: AspaValidation) -> u8 {
     match v {
         AspaValidation::Valid => 2,
-        AspaValidation::Unknown => 1,
         AspaValidation::Invalid => 0,
+        // `Unknown` — and, `AspaValidation` being non-exhaustive, any future
+        // state, which asserts neither validity nor invalidity — ranks in
+        // the middle.
+        _ => 1,
     }
 }
 

--- a/crates/rib/src/event.rs
+++ b/crates/rib/src/event.rs
@@ -86,15 +86,20 @@ pub struct EvpnRouteEvent {
 }
 
 /// Return the RD embedded in an EVPN route key.
+///
+/// `None` for a route type this build does not model (`EvpnRouteKey` is
+/// non-exhaustive); callers must treat such keys as filter non-matches
+/// and render an absent RD.
 #[must_use]
-pub const fn evpn_key_rd(key: &EvpnRouteKey) -> rustbgpd_wire::RouteDistinguisher {
+pub const fn evpn_key_rd(key: &EvpnRouteKey) -> Option<rustbgpd_wire::RouteDistinguisher> {
     match key {
         EvpnRouteKey::EadPerEs { rd, .. }
         | EvpnRouteKey::EadPerEvi { rd, .. }
         | EvpnRouteKey::MacIp { rd, .. }
         | EvpnRouteKey::Imet { rd, .. }
         | EvpnRouteKey::Es { rd, .. }
-        | EvpnRouteKey::IpPrefix { rd, .. } => *rd,
+        | EvpnRouteKey::IpPrefix { rd, .. } => Some(*rd),
+        _ => None,
     }
 }
 

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -779,6 +779,8 @@ fn family_label(family: (Afi, Safi)) -> String {
         Afi::Ipv6 => "ipv6",
         Afi::L2Vpn => "l2vpn",
         Afi::BgpLs => "bgpls",
+        // Non-exhaustive registry enum: label future AFIs honestly.
+        _ => "unrecognized",
     };
     let safi = match family.1 {
         Safi::Unicast => "unicast",
@@ -790,6 +792,8 @@ fn family_label(family: (Afi, Safi)) -> String {
         Safi::BgpLsVpn => "bgpls_vpn",
         Safi::MplsVpn => "mpls_vpn",
         Safi::RtConstrain => "rtc",
+        // Non-exhaustive registry enum: label future SAFIs honestly.
+        _ => "unrecognized",
     };
     format!("{afi} {safi}")
 }

--- a/crates/rib/src/manager/helpers.rs
+++ b/crates/rib/src/manager/helpers.rs
@@ -205,13 +205,10 @@ pub(super) fn afi_safi_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::Ipv4, Safi::Multicast) => "ipv4_multicast",
         (Afi::Ipv6, Safi::Multicast) => "ipv6_multicast",
         (Afi::Ipv4, Safi::RtConstrain) => "rtc",
-        (Afi::Ipv4 | Afi::Ipv6, Safi::Evpn)
-        | (Afi::Ipv4 | Afi::Ipv6 | Afi::L2Vpn, Safi::BgpLs | Safi::BgpLsVpn)
-        | (Afi::L2Vpn, Safi::Unicast | Safi::Multicast | Safi::FlowSpec)
-        | (Afi::BgpLs, Safi::Unicast | Safi::Multicast | Safi::Evpn | Safi::FlowSpec)
-        | (Afi::L2Vpn | Afi::BgpLs, Safi::MplsVpn | Safi::LabeledUnicast)
-        // RT-Constrain is AFI 1 only (RFC 4684 §7).
-        | (Afi::Ipv6 | Afi::L2Vpn | Afi::BgpLs, Safi::RtConstrain) => "unsupported",
+        // Everything else: invalid AFI/SAFI combinations (e.g. RT-Constrain
+        // is AFI 1 only, RFC 4684 §7) and families from future registry
+        // growth this build does not model.
+        _ => "unsupported",
     }
 }
 

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -3924,7 +3924,7 @@ impl RibManager {
             .filter(|event| {
                 route_type.is_none_or(|route_type| event.key.route_type() == route_type)
             })
-            .filter(|event| rd.is_none_or(|rd| crate::event::evpn_key_rd(&event.key) == rd))
+            .filter(|event| rd.is_none_or(|rd| crate::event::evpn_key_rd(&event.key) == Some(rd)))
             .filter(|event| event_types.is_empty() || event_types.contains(&event.event_type))
             .filter(|event| match peer {
                 Some(peer) => event.peer == Some(peer) || event.previous_peer == Some(peer),

--- a/crates/rib/src/manager/selection_deferral.rs
+++ b/crates/rib/src/manager/selection_deferral.rs
@@ -85,7 +85,6 @@ impl DeferredSelectionKeyCharge for crate::route::FlowSpecKey {
         );
         for component in &self.rule.components {
             let nested = match component {
-                FlowSpecComponent::DestinationPrefix(_) | FlowSpecComponent::SourcePrefix(_) => 0,
                 FlowSpecComponent::IpProtocol(values)
                 | FlowSpecComponent::Port(values)
                 | FlowSpecComponent::DestinationPort(values)
@@ -100,6 +99,11 @@ impl DeferredSelectionKeyCharge for crate::route::FlowSpecKey {
                 FlowSpecComponent::TcpFlags(values) | FlowSpecComponent::Fragment(values) => values
                     .len()
                     .saturating_mul(size_of::<rustbgpd_wire::BitmaskMatch>()),
+                // Prefix components carry no nested op lists; a future
+                // component type (`FlowSpecComponent` is non-exhaustive)
+                // contributes no nested-heap estimate either — a
+                // conservative under-count for the deferral budget gauge.
+                _ => 0,
             };
             bytes = bytes.saturating_add(nested);
         }

--- a/crates/rib/src/manager/tests/evpn.rs
+++ b/crates/rib/src/manager/tests/evpn.rs
@@ -1599,7 +1599,7 @@ async fn evpn_event_history_filters_peer_rd_type_and_limit() {
     let peer1 = IpAddr::V4(peer1_addr);
     let peer2 = IpAddr::V4(peer2_addr);
     let route1 = make_evpn_macip(peer1_addr, mac, Some(0), false);
-    let rd = crate::event::evpn_key_rd(&route1.key());
+    let rd = crate::event::evpn_key_rd(&route1.key()).expect("MAC/IP key carries an RD");
 
     tx.send(RibUpdate::RoutesReceived {
         session_id: 0,

--- a/crates/rib/src/orr.rs
+++ b/crates/rib/src/orr.rs
@@ -235,7 +235,9 @@ fn has_ignored_flex(nlri_type: BgpLsNlriType, attributes: &[BgpLsTlv]) -> bool {
                 _ => false,
             }
         }
-        BgpLsNlriType::Link | BgpLsNlriType::Unknown(_) => false,
+        // Link carries no flex-algo TLVs this check targets; unknown and
+        // future NLRI types are excluded before this point.
+        _ => false,
     })
 }
 
@@ -343,7 +345,13 @@ fn classify_input(
     // Unknown NLRI are retained for reflection, but they are opaque to ORR.
     // Classify that contract here so every caller gets the same uncounted
     // result instead of relying on a separate guard before classification.
-    if matches!(nlri.nlri_type, BgpLsNlriType::Unknown(_)) {
+    if !matches!(
+        nlri.nlri_type,
+        BgpLsNlriType::Node
+            | BgpLsNlriType::Link
+            | BgpLsNlriType::Ipv4TopologyPrefix
+            | BgpLsNlriType::Ipv6TopologyPrefix
+    ) {
         return InputClassification::IgnoredUnknown;
     }
     // Descriptor/topology framing takes precedence over Attribute 29. This
@@ -383,7 +391,9 @@ fn classify_input(
                 descriptor_scope
             }
         }
-        BgpLsNlriType::Unknown(_) => unreachable!("unknown BGP-LS NLRI returned above"),
+        // Unknown and future NLRI types are opaque to ORR; the allow-list
+        // guard above already returned `IgnoredUnknown` for them.
+        _ => return InputClassification::IgnoredUnknown,
     };
     match scope {
         TopologyScope::NonDefault => InputClassification::ExcludedNonDefault,
@@ -532,7 +542,8 @@ impl OrrTopology {
                         metric: prefix_metric(&attributes).unwrap_or(0),
                     }
                 }
-                BgpLsNlriType::Unknown(_) => continue,
+                // Unknown and future NLRI types are not topology elements.
+                _ => continue,
             };
             match seen.get(&route.nlri) {
                 None => {

--- a/crates/rpki/src/aspa_verify.rs
+++ b/crates/rpki/src/aspa_verify.rs
@@ -38,10 +38,10 @@ enum VerificationDirection {
 fn direction_for_role(role: Option<BgpRole>) -> VerificationDirection {
     match role {
         Some(BgpRole::Customer) => VerificationDirection::Downstream,
-        Some(
-            BgpRole::Provider | BgpRole::RouteServer | BgpRole::RouteServerClient | BgpRole::Peer,
-        )
-        | None => VerificationDirection::Upstream,
+        // Provider / RouteServer / RouteServerClient / Peer — and any role
+        // added to the registry later — get the upstream procedure, the
+        // same conservative behavior as an unconfigured role.
+        _ => VerificationDirection::Upstream,
     }
 }
 

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -1231,7 +1231,7 @@ impl SessionExportProfile {
             ExportWithdrawal::Evpn(key) => PreparedWithdrawal::Evpn(PreparedMpWithdrawal::new(
                 Afi::L2Vpn,
                 Safi::Evpn,
-                evpn_route_from_key(*key),
+                evpn_route_from_key(*key).ok_or(ExportProbeError::UnmodeledEvpnRouteType)?,
             )),
             ExportWithdrawal::BgpLs(key) => PreparedWithdrawal::BgpLs(PreparedMpWithdrawal::new(
                 Afi::BgpLs,
@@ -1547,6 +1547,9 @@ pub(crate) enum ExportProbeError {
     Encode(EncodeError),
     MissingIpv6NextHop,
     Ipv4RequiresExtendedNextHop,
+    /// An EVPN route type this build does not model (non-exhaustive
+    /// `EvpnRouteKey`) cannot be converted back into wire NLRI.
+    UnmodeledEvpnRouteType,
 }
 
 impl From<EncodeError> for ExportProbeError {
@@ -1562,6 +1565,9 @@ impl std::fmt::Display for ExportProbeError {
             Self::MissingIpv6NextHop => formatter.write_str("no usable local IPv6 next-hop"),
             Self::Ipv4RequiresExtendedNextHop => formatter
                 .write_str("IPv4 on a scoped link-local session requires Extended Next Hop"),
+            Self::UnmodeledEvpnRouteType => {
+                formatter.write_str("EVPN route type not modeled by this build")
+            }
         }
     }
 }
@@ -1595,12 +1601,15 @@ pub(super) fn bgpls_nlri_from_key(key: &BgpLsRouteKey) -> rustbgpd_wire::bgpls::
     }
 }
 
-pub(super) fn evpn_route_from_key(key: EvpnRouteKey) -> EvpnRoute {
+/// `None` for a route type this build does not model (`EvpnRouteKey` is
+/// non-exhaustive): such a route was never encoded outbound, so there is
+/// nothing to withdraw.
+pub(super) fn evpn_route_from_key(key: EvpnRouteKey) -> Option<EvpnRoute> {
     use rustbgpd_wire::{
         EvpnEadPerEs, EvpnEadPerEvi, EvpnEs, EvpnImet, EvpnIpPrefixRoute, EvpnMacIp, MplsLabel,
     };
     let zero_label = MplsLabel::new(0);
-    match key {
+    let route = match key {
         EvpnRouteKey::EadPerEs {
             rd,
             esi,
@@ -1671,7 +1680,10 @@ pub(super) fn evpn_route_from_key(key: EvpnRouteKey) -> EvpnRoute {
                 label: zero_label,
             })
         }
-    }
+        // Non-exhaustive: no wire NLRI form for unmodeled route types.
+        _ => return None,
+    };
+    Some(route)
 }
 
 /// Exact result consumed by live builders now and the RIB precommit gate in
@@ -1812,7 +1824,11 @@ fn exact_export_result(
 ) -> Result<ExactExportResult, ExactExportError> {
     let probe = probe.map_err(|error| {
         let code = match &error {
-            ExportProbeError::Encode(_) => ExactExportErrorCode::Encoding,
+            // Unmodeled EVPN route types are encoding failures too; the
+            // error text names the precise cause.
+            ExportProbeError::Encode(_) | ExportProbeError::UnmodeledEvpnRouteType => {
+                ExactExportErrorCode::Encoding
+            }
             ExportProbeError::MissingIpv6NextHop => ExactExportErrorCode::MissingIpv6NextHop,
             ExportProbeError::Ipv4RequiresExtendedNextHop => {
                 ExactExportErrorCode::Ipv4RequiresExtendedNextHop

--- a/crates/transport/src/session/fsm.rs
+++ b/crates/transport/src/session/fsm.rs
@@ -565,6 +565,8 @@ impl PeerSession {
                         rustbgpd_fsm::TimerType::ConnectRetry => "connect_retry",
                         rustbgpd_fsm::TimerType::Hold => "hold",
                         rustbgpd_fsm::TimerType::Keepalive => "keepalive",
+                        // Non-exhaustive: keep the metric label bounded.
+                        _ => "unknown",
                     };
                     warn!(
                         peer = %self.peer_label,
@@ -803,7 +805,8 @@ pub(super) fn hard_reset_notification_in_actions(actions: &[Action]) -> bool {
 /// Bounded label string for `bgp_role_mismatch_total{local_role, remote_role}`.
 ///
 /// Returns a static `&'static str` so the metric cardinality stays bounded
-/// (six values: the five RFC 9234 roles plus `"none"`). An absent role
+/// (seven values: the five RFC 9234 roles, `"none"`, and `"unrecognized"`
+/// for registry values this build does not model). An absent role
 /// (peer did not advertise the Role capability, or we didn't configure one)
 /// is reported as `"none"`.
 const fn role_metric_label(role: Option<rustbgpd_wire::BgpRole>) -> &'static str {
@@ -813,6 +816,7 @@ const fn role_metric_label(role: Option<rustbgpd_wire::BgpRole>) -> &'static str
         Some(rustbgpd_wire::BgpRole::RouteServerClient) => "route_server_client",
         Some(rustbgpd_wire::BgpRole::Customer) => "customer",
         Some(rustbgpd_wire::BgpRole::Peer) => "peer",
+        Some(_) => "unrecognized",
         None => "none",
     }
 }

--- a/crates/transport/src/session/io.rs
+++ b/crates/transport/src/session/io.rs
@@ -66,7 +66,10 @@ impl PeerSession {
                     max_len: 0,
                     prefix: None,
                 }],
-                OrfEntries::Raw(_) => continue,
+                // Raw un-negotiated types — and, `OrfEntries` being
+                // non-exhaustive, entry kinds this build does not model —
+                // are ignored (only type 64 is negotiated above).
+                _ => continue,
             };
             let (reply, rx) = oneshot::channel();
             if self
@@ -780,8 +783,31 @@ impl PeerSession {
                                         "ignoring ROUTE-REFRESH with unknown subtype"
                                     );
                                 }
+                                // Non-exhaustive: subtypes this build does not
+                                // implement are ignored like unrecognized wire
+                                // values above.
+                                _ => {
+                                    warn!(
+                                        peer = %self.peer_label,
+                                        ?afi,
+                                        ?safi,
+                                        "ignoring ROUTE-REFRESH with unsupported subtype"
+                                    );
+                                }
                             }
                             Event::RouteRefreshReceived { afi, safi }
+                        }
+                        // `Message` is non-exhaustive: a message kind this
+                        // build does not handle cannot be silently accepted
+                        // on a live session. Route it through the FSM
+                        // decode-error path (NOTIFICATION + teardown), the
+                        // RFC 4271 §6.1 treatment of an unsupported type.
+                        _ => {
+                            self.metrics
+                                .record_message_received(&self.peer_label, "unknown");
+                            Event::DecodeError(rustbgpd_wire::DecodeError::UnknownMessageType(
+                                raw_pdu.get(18).copied().unwrap_or(0),
+                            ))
                         }
                     };
                     self.drive_fsm(event).await;

--- a/crates/transport/src/session/outbound.rs
+++ b/crates/transport/src/session/outbound.rs
@@ -595,7 +595,8 @@ impl PeerSession {
                 let slot = match prepared.afi {
                     Afi::Ipv4 => &mut fs_withdrawals[0],
                     Afi::Ipv6 => &mut fs_withdrawals[1],
-                    Afi::L2Vpn | Afi::BgpLs => {
+                    // FlowSpec is defined for IPv4/IPv6 only (RFC 8955/8956).
+                    _ => {
                         warn!(afi = ?prepared.afi, "ignoring FlowSpec withdrawal with non-IP AFI");
                         continue;
                     }
@@ -728,7 +729,8 @@ impl PeerSession {
             groups.sort_by_key(|(afi, _, _, _)| match afi {
                 Afi::Ipv4 => 0,
                 Afi::Ipv6 => 1,
-                Afi::L2Vpn | Afi::BgpLs => 2,
+                // Non-IP families (and future AFIs) keep a stable tail slot.
+                _ => 2,
             });
             for (afi, safi, ipv4_mode, routes) in groups {
                 if !self.send_vpn_unreach_chunked(afi, safi, ipv4_mode, &routes, export, max_len) {
@@ -776,7 +778,8 @@ impl PeerSession {
             groups.sort_by_key(|(afi, _, _, _)| match afi {
                 Afi::Ipv4 => 0,
                 Afi::Ipv6 => 1,
-                Afi::L2Vpn | Afi::BgpLs => 2,
+                // Non-IP families (and future AFIs) keep a stable tail slot.
+                _ => 2,
             });
             for (afi, safi, ipv4_mode, routes) in groups {
                 if !self

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -6683,9 +6683,6 @@ async fn send_route_update_chunks_flowspec_without_infallible_build() {
     let count: u32 = 500;
     let rule = |afi: Afi, i: u32| FlowSpecRule {
         components: vec![FlowSpecComponent::DestinationPrefix(match afi {
-            Afi::Ipv4 => {
-                FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::from(0x0a00_0000_u32 + i), 32))
-            }
             Afi::Ipv6 => FlowSpecPrefix::V6(Ipv6PrefixOffset {
                 prefix: Ipv6Prefix::new(
                     Ipv6Addr::from(0x2001_0db8_0002_0000_0000_0000_0000_0000_u128 + u128::from(i)),
@@ -6693,7 +6690,8 @@ async fn send_route_update_chunks_flowspec_without_infallible_build() {
                 ),
                 offset: 0,
             }),
-            Afi::L2Vpn | Afi::BgpLs => unreachable!(),
+            // The test feeds IPv4 and IPv6 only.
+            _ => FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::from(0x0a00_0000_u32 + i), 32)),
         })],
     };
     let routes: Vec<FlowSpecRoute> = [Afi::Ipv4, Afi::Ipv6]

--- a/crates/transport/src/timer.rs
+++ b/crates/transport/src/timer.rs
@@ -34,15 +34,18 @@ impl Timers {
         if timer_type == TimerType::Hold {
             self.last_hold_secs = Some(secs);
         }
-        let slot = self.slot_mut(timer_type);
-        *slot = Some(Box::pin(tokio::time::sleep(Duration::from_secs(
-            u64::from(secs),
-        ))));
+        if let Some(slot) = self.slot_mut(timer_type) {
+            *slot = Some(Box::pin(tokio::time::sleep(Duration::from_secs(
+                u64::from(secs),
+            ))));
+        }
     }
 
     /// Stop a running timer.
     pub fn stop(&mut self, timer_type: TimerType) {
-        *self.slot_mut(timer_type) = None;
+        if let Some(slot) = self.slot_mut(timer_type) {
+            *slot = None;
+        }
     }
 
     /// Stop all timers.
@@ -52,11 +55,14 @@ impl Timers {
         self.keepalive = None;
     }
 
-    fn slot_mut(&mut self, timer_type: TimerType) -> &mut Option<Pin<Box<Sleep>>> {
+    /// `None` for a timer kind this build does not run (`TimerType` is
+    /// non-exhaustive): the request is ignored — no slot, no expiry.
+    fn slot_mut(&mut self, timer_type: TimerType) -> Option<&mut Option<Pin<Box<Sleep>>>> {
         match timer_type {
-            TimerType::ConnectRetry => &mut self.connect_retry,
-            TimerType::Hold => &mut self.hold,
-            TimerType::Keepalive => &mut self.keepalive,
+            TimerType::ConnectRetry => Some(&mut self.connect_retry),
+            TimerType::Hold => Some(&mut self.hold),
+            TimerType::Keepalive => Some(&mut self.keepalive),
+            _ => None,
         }
     }
 }

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -184,6 +184,34 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
   `COMMUNITY_GRACEFUL_SHUTDOWN` (RFC 8326), `COMMUNITY_LLGR_STALE` /
   `COMMUNITY_NO_LLGR` (RFC 9494)
 
+## Enum exhaustiveness
+
+The enums that track IANA/RFC registries — `Capability`, `PathAttribute`,
+`Afi`/`Safi`, `Message`/`MessageType`, `NotificationCode`,
+`RouteRefreshSubtype`, the EVPN route/key enums, `BgpLsNlriType`, the
+FlowSpec component/action enums, the ORF type/entries enums, the PMSI
+tunnel enums, `BgpRole`, `AspaValidation`, and the decode/encode error
+enums — are `#[non_exhaustive]`. Match them with a wildcard arm:
+
+```rust
+use rustbgpd_wire::Capability;
+
+fn negotiate(capability: &Capability) {
+    match capability {
+        Capability::RouteRefresh => { /* ... */ }
+        // New registry variants arrive in minor releases without a
+        // semver-major break; ignore what you do not support.
+        _ => {}
+    }
+}
+```
+
+Registry growth (a new capability code, path attribute, AFI/SAFI, EVPN
+route type, …) is therefore a non-breaking addition from 0.15.0 on.
+Closed-by-construction sets — `Origin`, `AsPathSegment`, `Prefix`,
+`AddPathMode`, `ErrorDisposition`, `RpkiValidation`, and the fixed V4/V6
+family enums — remain exhaustively matchable on purpose.
+
 ## Fuzz tested
 
 Twelve fuzz targets exercise the codec continuously in CI:

--- a/crates/wire/src/attribute.rs
+++ b/crates/wire/src/attribute.rs
@@ -670,6 +670,7 @@ impl fmt::Display for LargeCommunity {
 /// Known attributes are decoded into typed variants. Unknown attributes
 /// are preserved as `RawAttribute` for pass-through with the Partial bit.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PathAttribute {
     /// `ORIGIN` attribute (type 1).
     Origin(Origin),

--- a/crates/wire/src/bgpls.rs
+++ b/crates/wire/src/bgpls.rs
@@ -25,6 +25,7 @@ const TLV_HEADER_LEN: usize = 4;
 
 /// BGP-LS NLRI type values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum BgpLsNlriType {
     /// Node NLRI (type 1).
     Node,

--- a/crates/wire/src/capability.rs
+++ b/crates/wire/src/capability.rs
@@ -6,6 +6,7 @@ use crate::error::{DecodeError, EncodeError};
 /// Address Family Identifier (IANA).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum Afi {
     /// IPv4 (AFI 1).
     Ipv4 = 1,
@@ -34,6 +35,7 @@ impl Afi {
 /// Subsequent Address Family Identifier (IANA).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Safi {
     /// Unicast forwarding (SAFI 1).
     Unicast = 1,
@@ -170,6 +172,7 @@ pub struct LlgrFamily {
 /// negotiator, not by this codec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum BgpRole {
     /// Speaker is a transit Provider for the peer.
     Provider = 0,
@@ -207,6 +210,7 @@ impl BgpRole {
 
 /// BGP capability as negotiated in OPEN optional parameters.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Capability {
     /// RFC 4760: Multi-Protocol Extensions.
     MultiProtocol {

--- a/crates/wire/src/error.rs
+++ b/crates/wire/src/error.rs
@@ -5,6 +5,7 @@ use crate::notification::NotificationCode;
 
 /// Errors encountered while decoding a BGP message from bytes.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Not enough bytes are available to decode the message.
     #[error("incomplete message: need {needed} bytes, have {available}")]
@@ -95,6 +96,7 @@ pub enum DecodeError {
 
 /// Errors encountered while encoding a BGP message to bytes.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EncodeError {
     /// Encoded message exceeds the maximum BGP message size.
     #[error("message exceeds maximum size: {size} bytes (max 4096)")]

--- a/crates/wire/src/evpn.rs
+++ b/crates/wire/src/evpn.rs
@@ -202,6 +202,7 @@ impl fmt::Display for RouteDistinguisher {
 /// Errors returned by `RouteDistinguisher::from_str` when a textual RD
 /// fails to parse against the RFC 4364 §4.2 encodings.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RouteDistinguisherParseError {
     /// Input did not contain exactly one `':'` separating administrator and
     /// assigned-number fields.
@@ -475,6 +476,7 @@ pub struct EvpnIpPrefixRoute {
 /// for reflection through a route reflector. For a minimal hashable
 /// identifier suitable as a RIB key, see [`EvpnRouteKey`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum EvpnRoute {
     /// Type 1 — EAD per-ES.
     EadPerEs(EvpnEadPerEs),
@@ -548,6 +550,7 @@ impl EvpnRoute {
 /// EAD per-ES and EAD per-EVI share a wire format but get distinct variants
 /// here so the RIB never accidentally collapses them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum EvpnRouteKey {
     /// Type 1 per-ES key.
     EadPerEs {

--- a/crates/wire/src/flowspec.rs
+++ b/crates/wire/src/flowspec.rs
@@ -90,6 +90,7 @@ pub struct Ipv6PrefixOffset {
 /// Components are identified by type code (1–13) and must be stored in
 /// ascending type order within a [`FlowSpecRule`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum FlowSpecComponent {
     /// Type 1: Destination IP prefix (IPv4 or IPv6 with offset).
     DestinationPrefix(FlowSpecPrefix),
@@ -256,6 +257,7 @@ impl fmt::Display for FlowSpecRule {
 
 /// A traffic action decoded from a `FlowSpec` extended community.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FlowSpecAction {
     /// Traffic-rate (type 0x8006): rate=0.0 means drop.
     TrafficRateBytes {

--- a/crates/wire/src/header.rs
+++ b/crates/wire/src/header.rs
@@ -6,6 +6,7 @@ use crate::error::DecodeError;
 /// BGP message type codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum MessageType {
     /// OPEN message.
     Open = 1,

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -22,6 +22,32 @@
 //! - Maximum message size: 4096 bytes (RFC 4271 §4.1)
 //! - No panics on malformed input — all paths return `Result`
 //! - No `unsafe` code
+//!
+//! # Enum exhaustiveness
+//!
+//! The enums that track IANA/RFC registries (message types, path
+//! attributes, capabilities, AFI/SAFI, EVPN route types, `FlowSpec`
+//! components, notification codes, and the error enums) are
+//! `#[non_exhaustive]`: registry growth adds variants without a
+//! semver-major break, so matches outside this crate must carry a
+//! wildcard arm. Closed-by-construction sets (`Origin`, `AsPathSegment`,
+//! `Prefix`, `AddPathMode`, `ErrorDisposition`, `RpkiValidation`, and
+//! the fixed V4/V6 family enums) remain exhaustively matchable.
+//!
+//! ```rust
+//! use rustbgpd_wire::Capability;
+//!
+//! fn label(capability: &Capability) -> &'static str {
+//!     match capability {
+//!         Capability::RouteRefresh => "route-refresh",
+//!         Capability::ExtendedMessage => "extended-message",
+//!         // Registry growth lands here in future releases; per RFC 5492
+//!         // practice, ignore what you do not support.
+//!         _ => "unsupported",
+//!     }
+//! }
+//! assert_eq!(label(&Capability::RouteRefresh), "route-refresh");
+//! ```
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
@@ -154,6 +180,7 @@ impl std::str::FromStr for RpkiValidation {
 
 /// ASPA path verification state per draft-ietf-sidrops-aspa-verification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum AspaValidation {
     /// All hops in the `AS_PATH` have authorized provider relationships.
     Valid,

--- a/crates/wire/src/message.rs
+++ b/crates/wire/src/message.rs
@@ -11,6 +11,7 @@ use crate::update::UpdateMessage;
 
 /// A decoded BGP message.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Message {
     /// BGP OPEN message.
     Open(OpenMessage),

--- a/crates/wire/src/notification.rs
+++ b/crates/wire/src/notification.rs
@@ -3,6 +3,7 @@
 /// Known codes (1–6) have named variants. Unknown codes from the wire are
 /// preserved via `Unknown(u8)` so the original byte is never lost.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum NotificationCode {
     /// Error in the message header (code 1).
     MessageHeader,

--- a/crates/wire/src/orf.rs
+++ b/crates/wire/src/orf.rs
@@ -25,6 +25,7 @@ use crate::nlri::{Ipv4Prefix, Ipv6Prefix, Prefix};
 /// ORF-Type (RFC 5291 §5 / RFC 5292). Unknown types are preserved so the
 /// codec round-trips forward-defined types losslessly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum OrfType {
     /// Address-Prefix ORF-Type 64 (RFC 5292) — the standard value.
     AddressPrefix,
@@ -206,6 +207,7 @@ pub struct AddressPrefixOrf {
 
 /// Decoded entries of one ORF-Type group inside a ROUTE-REFRESH.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OrfEntries {
     /// Parsed Address-Prefix entries (ORF-Type 64 or 128).
     AddressPrefix(Vec<AddressPrefixOrf>),

--- a/crates/wire/src/pmsi.rs
+++ b/crates/wire/src/pmsi.rs
@@ -59,6 +59,7 @@ use crate::error::DecodeError;
 
 /// PMSI tunnel type (RFC 6514 §11.1, IANA registry RFC 7385).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PmsiTunnelType {
     /// 0 — no tunnel info present (PE listens on a local set).
     NoTunnelInfo,
@@ -120,6 +121,7 @@ impl PmsiTunnelType {
 /// For Ingress Replication, this is the originator's unicast endpoint
 /// IP address. Other tunnel types carry opaque bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PmsiTunnelIdentifier {
     /// No identifier (zero-length on the wire).
     Empty,

--- a/crates/wire/src/route_refresh.rs
+++ b/crates/wire/src/route_refresh.rs
@@ -16,6 +16,7 @@ const TOTAL_LEN: usize = HEADER_LEN + BODY_LEN;
 
 /// ROUTE-REFRESH demarcation subtype (RFC 7313).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum RouteRefreshSubtype {
     /// Normal route refresh request (subtype 0).
     Normal,

--- a/src/policy_admin.rs
+++ b/src/policy_admin.rs
@@ -15,13 +15,17 @@ use crate::config::{
     PolicyStatementConfig, TcpAoConfig, TcpAoKeyringConfig,
 };
 
-const fn wire_role_to_config(role: rustbgpd_wire::BgpRole) -> BgpRoleConfig {
+/// `None` for a registry role this build has no config form for
+/// (`BgpRole` is non-exhaustive): the snapshot omits the role rather
+/// than fabricating one.
+const fn wire_role_to_config(role: rustbgpd_wire::BgpRole) -> Option<BgpRoleConfig> {
     match role {
-        rustbgpd_wire::BgpRole::Provider => BgpRoleConfig::Provider,
-        rustbgpd_wire::BgpRole::RouteServer => BgpRoleConfig::RouteServer,
-        rustbgpd_wire::BgpRole::RouteServerClient => BgpRoleConfig::RouteServerClient,
-        rustbgpd_wire::BgpRole::Customer => BgpRoleConfig::Customer,
-        rustbgpd_wire::BgpRole::Peer => BgpRoleConfig::Peer,
+        rustbgpd_wire::BgpRole::Provider => Some(BgpRoleConfig::Provider),
+        rustbgpd_wire::BgpRole::RouteServer => Some(BgpRoleConfig::RouteServer),
+        rustbgpd_wire::BgpRole::RouteServerClient => Some(BgpRoleConfig::RouteServerClient),
+        rustbgpd_wire::BgpRole::Customer => Some(BgpRoleConfig::Customer),
+        rustbgpd_wire::BgpRole::Peer => Some(BgpRoleConfig::Peer),
+        _ => None,
     }
 }
 
@@ -470,7 +474,7 @@ pub fn apply_config_event(config: &mut Config, event: &ConfigEvent) -> Result<()
                         .then_some(NextHopOwnershipConfig::StrictPeer),
                     interpret_rfc1997: None,
                     rs_control_communities: None,
-                    role: cfg.local_role.map(wire_role_to_config),
+                    role: cfg.local_role.and_then(wire_role_to_config),
                     strict_role: Some(cfg.strict_role),
                     prefix_orf_receive: Some(cfg.prefix_orf_receive),
                     disable_ipv4_unicast: Some(cfg.disable_ipv4_unicast),


### PR DESCRIPTION
Absorbs `#[non_exhaustive]` onto the wire/fsm enums that track IANA/RFC registries into the already-breaking 0.15.0 (wire) / 0.3.0 (fsm) cut, so future variant additions (the `Capability::PathsLimit` pattern) stop forcing breaking bumps.

**Classification, not blanket application** — 24 enums marked (Capability, PathAttribute, Afi/Safi, Message/MessageType, NotificationCode, RouteRefreshSubtype, EVPN route enums, BGP-LS NLRI types, FlowSpec component/action, ORF types, PMSI tunnel enums, BgpRole, AspaValidation, error enums, fsm TimerType/FsmError); 17 deliberately left exhaustive where the set is closed by construction (Origin, AsPathSegment, fixed V4/V6 pairs, Ord-ladder ErrorDisposition, RFC 6811-frozen RpkiValidation — policy ladders should break loudly on new states — and fsm SessionState, because the six §8 states are the protocol).

**33 fail-safe wildcard arms** across policy/rpki/rib/cli/transport/api/daemon, each chosen per-site: unknown Message kind → `DecodeError(UnknownMessageType)` with the real type byte → NOTIFICATION + teardown per RFC 4271 §6.1; unsupported ROUTE-REFRESH subtype / ORF entry kinds → warn-and-ignore per RFC 7313/5291 practice; unknown BgpRole → conservative ASPA procedure + `unrecognized` metric label; unmodeled EVPN withdrawal → typed error, never a silent drop; ORR treats future BGP-LS NLRI types as opaque (replacing an `unreachable!`). Zero `_ => unreachable!()` added; one removed. Three helpers became Option-returning so callers handle the gap explicitly.

Docs: "Enum exhaustiveness" sections with compiled wildcard-match doctests in both lib.rs files; consumer-facing posture notes in both READMEs; CHANGELOG names every enum on both sides of the line for the release notes.

Gates green incl. `cargo publish -p rustbgpd-wire --dry-run` (clean package, aborts at upload) and the wire fuzz build; independently re-verified.