### PR TITLE
feat(examples): wire birdwatcher-adapter filtered routes to the reject-retention API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **birdwatcher-adapter: filtered-route views.** The external looking
+  glass adapter now serves `GET /routes/filtered/{id}` from
+  `PolicyService.ListRejectedRoutes` and a real per-neighbor
+  `routes.filtered` count on `GET /protocols/bgp` (previously a `0`
+  sentinel). Each filtered route carries a synthesized reject-reason
+  large community `64496:65520:<id>` — one stable id per canonical
+  reason token, matchable by Alice-LG's `[rejection]` /
+  `[rejection_reasons]` config — plus human-readable `reject_reason` /
+  `reject_reason_detail` fields. Retention disabled and no-live-session
+  both serve an empty view (configuration facts, not errors). The
+  mapping table and an Alice-LG config snippet are in the adapter
+  README.
+
 ### Fixed
 
 - **Post-flap re-announce latency: initial table dumps no longer

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1808,14 +1808,16 @@ loser would survive the equal-cost multipath cut.
 
 ### Looking glass (Birdwatcher-shaped REST subset)
 
-For status, peer, and accepted-route views in external looking glass
-frontends, run the external `examples/birdwatcher-adapter` binary. It serves the
-Birdwatcher-shaped endpoints (`/status`, `/protocols/bgp`,
-`/routes/protocol/{id}`, `/routes/peer/{peer}`) from the daemon's gRPC API.
-Alice-LG consumes these shapes, but this is not a usable complete backend:
-Alice-LG also fetches filtered and noexport route views that the adapter does
-not expose yet (the structured reject reasons behind them are available from
-`PolicyService.ListRejectedRoutes`). The
+For status, peer, accepted-route, and filtered-route views in external
+looking glass frontends, run the external `examples/birdwatcher-adapter`
+binary. It serves the Birdwatcher-shaped endpoints (`/status`,
+`/protocols/bgp` with real per-neighbor filtered counts,
+`/routes/protocol/{id}`, `/routes/peer/{peer}`, `/routes/filtered/{id}`)
+from the daemon's gRPC API. The filtered view surfaces the
+`PolicyService.ListRejectedRoutes` reject-retention store with a
+synthesized reject-reason large community per route (mapping table and
+Alice-LG rejection config in the adapter's README). Alice-LG's noexport
+view is not exposed (no NO_EXPORT-excluded route set is retained). The
 in-daemon `[global.telemetry.looking_glass]` server has been removed.
 
 ### EVPN Route Reflector + Bidirectional VTEP

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -408,10 +408,10 @@ IX peer C  ──┘
 - **RPKI validation state** — each route annotated with Valid/Invalid/NotFound
 - **Birdwatcher-shaped REST subset** — the external
   [`examples/birdwatcher-adapter`](../examples/birdwatcher-adapter/) serves
-  accepted-route, peer, and status views from the gRPC API; structured
-  reject reasons are available (`PolicyService.ListRejectedRoutes`), and the
-  adapter's filtered/noexport views remain before it is a complete Alice-LG
-  backend
+  accepted-route, filtered-route (with reject-reason communities synthesized
+  from `PolicyService.ListRejectedRoutes` structured reasons), peer (with
+  real filtered counts), and status views from the gRPC API; only the
+  noexport view remains before it is a complete Alice-LG backend
 - **Best-path explain** — `rbgp rib --prefix X --explain` shows why a
   route was selected over alternatives
 

--- a/examples/birdwatcher-adapter/README.md
+++ b/examples/birdwatcher-adapter/README.md
@@ -2,10 +2,12 @@
 
 Standalone HTTP server that exposes a **Birdwatcher-shaped read-only subset**
 for [Alice-LG](https://github.com/alice-lg/alice-lg) and similar looking glass
-frontends. It serves status, peer, and accepted-route views from a running
-rustbgpd over gRPC. The four endpoint paths and response shapes match the
-removed in-daemon `[global.telemetry.looking_glass]` server this adapter
-replaces; this is not a complete Alice-LG backend.
+frontends. It serves status, peer, accepted-route, and filtered-route views
+from a running rustbgpd over gRPC. The status/peer/accepted endpoint paths and
+response shapes match the removed in-daemon
+`[global.telemetry.looking_glass]` server this adapter replaces; the filtered
+view is served from the daemon's reject-retention store. This is not a
+complete Alice-LG backend (no noexport view).
 
 Rationale: the daemon's durable API identity is **gRPC + `rbgp`**.
 Partial compatibility with someone else's REST API inside daemon core
@@ -39,34 +41,85 @@ every RPC the adapter calls is a read.
 | REST endpoint (birdwatcher)  | Backing gRPC RPC(s)                                            |
 |------------------------------|----------------------------------------------------------------|
 | `GET /status`                | `GlobalService.GetGlobal` + `ControlService.GetHealth`         |
-| `GET /protocols/bgp`         | `NeighborService.ListNeighbors`                                |
+| `GET /protocols/bgp`         | `NeighborService.ListNeighbors` + `PolicyService.ListRejectedRoutes` (per-neighbor `routes.filtered` count) |
 | `GET /routes/protocol/{id}`  | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
 | `GET /routes/peer/{peer}`    | `RibService.ListReceivedRoutes` (paged, all unicast families)  |
+| `GET /routes/filtered/{id}`  | `PolicyService.ListRejectedRoutes` (unpaged — the store is bounded at the `[policy.reject_retention]` capacity, default 1024/peer) |
 
-All four endpoints from the removed in-daemon server are servable over today's
-gRPC API — there are no placeholder 501 responses. Route `age` is served from
-the `Route.received_at_epoch_seconds` proto field (RIB receive time), the same
-source the in-daemon server used.
+There are no placeholder 501 responses. Route `age` is served from the
+`Route.received_at_epoch_seconds` proto field (RIB receive time) on the
+accepted view and from the rejection wall-clock time on the filtered view.
+Alice-LG's noexport view is not implemented (the daemon does not retain a
+NO_EXPORT-excluded route set).
 
-The scope is status, peer, and accepted-route views only. Alice-LG's
-filtered/noexport views are not implemented in this adapter yet. The
-structured per-route reject reasons they need are now available from
-`PolicyService.ListRejectedRoutes` (per-peer retained rejects with
-canonical reason tokens; see `[policy.reject_retention]` in
-`docs/CONFIGURATION.md`), so a real `routes.filtered` count and a
-filtered view are implementable — wiring them into this adapter is
-future work.
+## Filtered routes and reject reasons
+
+`/routes/filtered/{id}` (accepts `bgp_<addr>` protocol ids and bare peer IPs)
+serves every rejected inbound route the peer's session has retained, with
+canonical reason tokens from `PolicyService.ListRejectedRoutes`
+(`[policy.reject_retention]` in `docs/CONFIGURATION.md`; unicast only,
+LRU-bounded per peer — at the cap the view shows the most recent rejections).
+Semantics worth knowing:
+
+- **Retention disabled** (`[policy.reject_retention] enabled = false`): the
+  view is empty with a log line — a configuration fact, not an error.
+- **No live session**: the session-local store is gone; the view is empty.
+- The daemon deliberately does **not** tag reject-reason communities onto
+  retained routes; the adapter synthesizes the community representation at
+  the serving edge (below), so the daemon surface stays structured.
+
+### Reject-reason → large-community mapping
+
+Alice-LG identifies why a route was filtered by matching a large community
+against its rejection config (the BIRD/arouteserver convention). The adapter
+appends one synthesized triplet `64496:65520:<id>` per route — global
+administrator `64496` (RFC 5398 documentation ASN, can never collide with a
+community the route actually carried on the wire), function `65520` (the
+arouteserver reject-reason function value), and a stable id per reason token:
+
+| Reason token         | Large community  | Meaning                                        |
+|----------------------|------------------|------------------------------------------------|
+| `policy_reject`      | `64496:65520:1`  | Denied by import policy (detail = policy name) |
+| `otc_route_leak`     | `64496:65520:2`  | RFC 9234 Only-to-Customer role leak            |
+| `next_hop_ownership` | `64496:65520:3`  | Route-server strict NEXT_HOP ownership         |
+| `as_path_loop`       | `64496:65520:4`  | Own AS in the received AS_PATH                 |
+| `rr_loop`            | `64496:65520:5`  | Reflection loop (ORIGINATOR_ID / CLUSTER_LIST) |
+| `treat_as_withdraw`  | `64496:65520:6`  | RFC 7606 treat-as-withdraw attribute handling  |
+| *(unrecognized)*     | `64496:65520:0`  | Future token this adapter build predates       |
+
+The ids are append-only. Each filtered route also carries human-readable
+`reject_reason` / `reject_reason_detail` fields (plus `rpki_validation` /
+`aspa_validation`) as extra JSON keys — visible to curl users, ignored by
+parsers that don't know them.
+
+Alice-LG config to render the reasons:
+
+```ini
+[rejection]
+asn = 64496
+reject_id = 65520
+
+[rejection_reasons]
+0 = Route was filtered
+1 = Denied by import policy
+2 = Only-to-Customer role leak (RFC 9234)
+3 = NEXT_HOP is not the peer's own address
+4 = Receiver's AS appears in the AS_PATH
+5 = Route reflection loop
+6 = Malformed attributes (treat-as-withdraw, RFC 7606)
+```
 
 ### Field-level gaps
 
 | Field | Adapter value | Limitation |
 |---|---|---|
 | status `last_reconfig` | `""` | Reconfiguration time is not tracked. |
-| protocol `routes.filtered` | `0` | Sentinel only; this is not a filtered-route count. |
 | protocol `routes.preferred` | `0` | Sentinel only; preferred-route count is not exposed. |
 | route `interface` | `""` | Interface identity is not exposed for these routes. |
 | route `metric` | `0` | Sentinel only; this is not an IGP metric. |
 | route `primary` | `false` | Sentinel only; primary-route status is not exposed. |
+| filtered route `bgp.origin` | `""` | ORIGIN is not retained for rejected routes. |
+| filtered route `bgp.local_pref`, `bgp.med` | `0` | Not retained for rejected routes. |
 
 Error behavior differs only on failure: when the daemon is unreachable
 the adapter returns `502 Bad Gateway` (the in-daemon server returned
@@ -75,6 +128,7 @@ the adapter returns `502 Bad Gateway` (the in-daemon server returned
 ## Testing
 
 - Unit tests: `cargo test -p birdwatcher-adapter`
-- End-to-end smoke test of the status/peer/accepted-route subset:
+- End-to-end smoke test of the status/peer/accepted/filtered-route subset:
   `cargo test --test birdwatcher_adapter_smoke` (root package; spawns a real
-  daemon plus this adapter).
+  daemon plus this adapter, announces a clean route and a loop-poisoned one,
+  and asserts both the accepted and filtered views).

--- a/examples/birdwatcher-adapter/src/main.rs
+++ b/examples/birdwatcher-adapter/src/main.rs
@@ -1,18 +1,20 @@
 //! Birdwatcher-shaped REST looking glass adapter for rustbgpd.
 //!
-//! Standalone HTTP server that serves the status, peer, and accepted-route
-//! subset consumed by Alice-LG and similar looking glass frontends, sourcing
-//! all data from a running rustbgpd over gRPC. This replaces the removed
-//! in-daemon `[global.telemetry.looking_glass]` server's four endpoints. It is
-//! not a complete Alice-LG backend: filtered/noexport views are not wired up
-//! here yet (the structured reject reasons they need are available from
-//! `PolicyService.ListRejectedRoutes`).
+//! Standalone HTTP server that serves the status, peer, accepted-route, and
+//! filtered-route subset consumed by Alice-LG and similar looking glass
+//! frontends, sourcing all data from a running rustbgpd over gRPC. This
+//! replaces the removed in-daemon `[global.telemetry.looking_glass]` server's
+//! four endpoints and adds the filtered view on top. It is not a complete
+//! Alice-LG backend: noexport views are not wired up.
 //!
 //! **Supported endpoints** (single-table mode):
 //! - `GET /status` — daemon status
-//! - `GET /protocols/bgp` — BGP neighbor list
+//! - `GET /protocols/bgp` — BGP neighbor list (with real filtered counts)
 //! - `GET /routes/protocol/{id}` — received routes by neighbor address
 //! - `GET /routes/peer/{peer}` — received routes by peer IP
+//! - `GET /routes/filtered/{id}` — rejected routes retained by the peer's
+//!   session (`PolicyService.ListRejectedRoutes`), tagged with a synthesized
+//!   reject-reason large community (see the README mapping table)
 //!
 //! Response shapes use Birdwatcher field names so Alice-LG can parse this
 //! subset without adapter code. Fields that have no rustbgpd equivalent are
@@ -32,7 +34,7 @@ use tracing::{error, info};
 #[derive(Parser, Debug)]
 #[command(
     name = "birdwatcher-adapter",
-    about = "Birdwatcher-shaped status, peer, and accepted-route REST subset, served from rustbgpd's gRPC API"
+    about = "Birdwatcher-shaped status, peer, accepted-route, and filtered-route REST subset, served from rustbgpd's gRPC API"
 )]
 struct Args {
     /// rustbgpd gRPC endpoint, e.g. `http://127.0.0.1:50051`.
@@ -78,6 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/protocols/bgp", get(protocols_bgp))
         .route("/routes/protocol/{id}", get(routes_protocol))
         .route("/routes/peer/{peer}", get(routes_peer))
+        .route("/routes/filtered/{id}", get(routes_filtered))
         .with_state(state);
 
     info!(addr = %args.listen, "starting Birdwatcher-shaped looking glass subset");
@@ -157,10 +160,25 @@ async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, Sta
     // Birdwatcher returns protocols as a map keyed by protocol name.
     // Alice-LG iterates this map and reads fields like `neighbor_address`,
     // `neighbor_as`, `state`, `description`, `routes`, `state_changed`.
+    let mut policy = proto::policy_service_client::PolicyServiceClient::new(state.channel.clone());
     let mut protocols = serde_json::Map::new();
     for n in &resp.neighbors {
         let cfg = n.config.clone().unwrap_or_default();
         let protocol_id = format!("bgp_{}", cfg.address).replace(':', "_");
+        // Real filtered count from the session's reject-retention store.
+        // NOT_FOUND = no live session = no store, honestly zero. The store
+        // is bounded ([policy.reject_retention] capacity, default 1024), so
+        // one unpaged call returns everything.
+        let filtered = match policy
+            .list_rejected_routes(proto::ListRejectedRoutesRequest {
+                peer_address: cfg.address.clone(),
+            })
+            .await
+        {
+            Ok(r) => r.into_inner().routes.len(),
+            Err(s) if s.code() == tonic::Code::NotFound => 0,
+            Err(e) => return Err(bad_gateway("ListRejectedRoutes", &e)),
+        };
         protocols.insert(
             protocol_id,
             serde_json::json!({
@@ -175,7 +193,7 @@ async fn protocols_bgp(State(state): State<AppState>) -> Result<Json<Value>, Sta
                     // Same sources the in-daemon server used: current
                     // Adj-RIB-In count and current advertised count.
                     "imported": n.prefixes_received,
-                    "filtered": 0,
+                    "filtered": filtered,
                     "exported": n.prefixes_sent,
                     "preferred": 0
                 }
@@ -242,6 +260,164 @@ async fn serve_routes_for_peer(state: &AppState, peer: IpAddr) -> Result<Json<Va
         "api": api_block(),
         "routes": routes,
     })))
+}
+
+// ---------------------------------------------------------------------------
+// GET /routes/filtered/{id}  — Alice-LG filtered-route view
+//                            →  PolicyService.ListRejectedRoutes
+// ---------------------------------------------------------------------------
+
+async fn routes_filtered(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    // Accepts both the "bgp_<addr>" protocol id and a bare peer IP.
+    let addr_str = id.strip_prefix("bgp_").unwrap_or(&id).replace('_', ":");
+    let peer_addr: IpAddr = addr_str.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let mut client = proto::policy_service_client::PolicyServiceClient::new(state.channel.clone());
+    let resp = match client
+        .list_rejected_routes(proto::ListRejectedRoutesRequest {
+            peer_address: peer_addr.to_string(),
+        })
+        .await
+    {
+        Ok(r) => r.into_inner(),
+        // No live session: the session-local retention store is gone.
+        // An empty filtered view is the correct answer, not an error.
+        Err(s) if s.code() == tonic::Code::NotFound => {
+            info!(peer = %peer_addr, "no live session; serving empty filtered view");
+            return Ok(Json(serde_json::json!({
+                "api": api_block(),
+                "routes": [],
+            })));
+        }
+        Err(e) => return Err(bad_gateway("ListRejectedRoutes", &e)),
+    };
+    Ok(Json(filtered_routes_body(&resp, peer_addr)))
+}
+
+/// Build the filtered-view response body from a `ListRejectedRoutes`
+/// reply. The store is bounded (`[policy.reject_retention]` capacity,
+/// default 1024) and the RPC is unpaged — one call returns everything.
+fn filtered_routes_body(resp: &proto::ListRejectedRoutesResponse, peer: IpAddr) -> Value {
+    if !resp.retention_enabled {
+        info!(
+            peer = %peer,
+            "reject retention disabled ([policy.reject_retention]); \
+             serving empty filtered view"
+        );
+    }
+    let routes: Vec<Value> = resp
+        .routes
+        .iter()
+        .map(|r| rejected_route_to_birdwatcher(r, peer))
+        .collect();
+    serde_json::json!({
+        "api": api_block(),
+        "routes": routes,
+    })
+}
+
+/// Synthesized reject-reason large community, `64496:65520:<reason id>`.
+///
+/// Alice-LG identifies why a route was filtered by matching communities
+/// against its `[rejection]`/`[rejection_reasons]` config (the BIRD /
+/// arouteserver convention — reject reasons ride on a large community).
+/// rustbgpd deliberately retains structured reason tokens instead of
+/// polluting the RIB with tag communities, so this adapter synthesizes
+/// the community representation at the edge:
+///
+/// - global administrator `64496`: RFC 5398 documentation ASN — can
+///   never collide with a community a route actually carried;
+/// - function `65520`: the arouteserver reject-reason function value;
+/// - value: a stable id per canonical reason token (`0` = token not
+///   recognized by this adapter build, still marked rejected).
+///
+/// The token vocabulary is release-stable; ids here are append-only.
+fn reject_reason_community(reason: &str) -> [u64; 3] {
+    let id = match reason {
+        "policy_reject" => 1,
+        "otc_route_leak" => 2,
+        "next_hop_ownership" => 3,
+        "as_path_loop" => 4,
+        "rr_loop" => 5,
+        "treat_as_withdraw" => 6,
+        _ => 0,
+    };
+    [64496, 65520, id]
+}
+
+/// Convert a retained rejection to the birdwatcher route JSON shape.
+///
+/// Same shape as `route_to_birdwatcher`, with the reject reason surfaced
+/// twice: as the synthesized large community (what Alice-LG matches) and
+/// as human-readable `reject_reason` / `reject_reason_detail` fields
+/// (extra keys, ignored by parsers that don't know them). Attribute
+/// fields are best-effort — the pre-policy safety gates retain what was
+/// decodable — so absent attributes render as the usual empty sentinels.
+fn rejected_route_to_birdwatcher(route: &proto::RejectedRoute, peer: IpAddr) -> Value {
+    let communities: Vec<Vec<u32>> = route
+        .communities
+        .iter()
+        .map(|c| vec![(*c >> 16) & 0xffff, *c & 0xffff])
+        .collect();
+
+    // Wire large communities the route carried, then the synthesized
+    // reason triplet appended last.
+    let mut large_communities: Vec<Vec<u64>> = route
+        .large_communities
+        .iter()
+        .filter_map(|lc| {
+            let parts: Vec<u64> = lc.split(':').filter_map(|p| p.parse().ok()).collect();
+            (parts.len() == 3).then_some(parts)
+        })
+        .collect();
+    large_communities.push(reject_reason_community(&route.reason).to_vec());
+
+    // The retained AS_PATH is a lossless display string ("65001 {65002
+    // 65003}"); birdwatcher wants an ASN array, so flatten it (AS_SET
+    // members included) best-effort.
+    let as_path: Vec<u32> = route
+        .as_path
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|p| !p.is_empty())
+        .filter_map(|p| p.parse().ok())
+        .collect();
+
+    let from_protocol = format!("bgp_{peer}").replace(':', "_");
+    let age = if route.rejected_at_unix_ns > 0 {
+        format_epoch_secs(u64::try_from(route.rejected_at_unix_ns).unwrap_or(0) / 1_000_000_000)
+    } else {
+        String::new()
+    };
+
+    serde_json::json!({
+        "network": format!("{}/{}", route.prefix, route.prefix_length),
+        "gateway": route.next_hop,
+        "from_protocol": from_protocol,
+        "interface": "",
+        "metric": 0,
+        "age": age,
+        "type": ["BGP", "unicast", "univ"],
+        "primary": false,
+        "learnt_from": peer.to_string(),
+        "reject_reason": route.reason,
+        "reject_reason_detail": route.reason_detail,
+        "rpki_validation": route.rpki_validation,
+        "aspa_validation": route.aspa_validation,
+        "bgp": {
+            // ORIGIN is not retained for rejected routes; empty parses
+            // as unknown in Alice-LG.
+            "origin": "",
+            "as_path": as_path,
+            "next_hop": route.next_hop,
+            "local_pref": 0,
+            "med": 0,
+            "communities": communities,
+            "large_communities": large_communities,
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -430,6 +606,116 @@ mod tests {
         assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
         assert_eq!(json["learnt_from"], "2001:db8::1");
         assert_eq!(json["bgp"]["origin"], "IGP");
+    }
+
+    /// Every canonical reason token maps to its pinned triplet, and an
+    /// unknown (future) token degrades to the generic id 0. The ids are
+    /// part of the adapter's documented Alice-LG contract — changing one
+    /// silently breaks deployed `[rejection_reasons]` configs.
+    #[test]
+    fn reject_reason_community_mapping_is_stable() {
+        for (token, id) in [
+            ("policy_reject", 1),
+            ("otc_route_leak", 2),
+            ("next_hop_ownership", 3),
+            ("as_path_loop", 4),
+            ("rr_loop", 5),
+            ("treat_as_withdraw", 6),
+            ("some_future_token", 0),
+        ] {
+            assert_eq!(
+                reject_reason_community(token),
+                [64496, 65520, id],
+                "token {token:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_route_conversion_matches_birdwatcher_shape() {
+        let route = proto::RejectedRoute {
+            prefix: "10.66.0.0".to_string(),
+            prefix_length: 24,
+            reason: "policy_reject".to_string(),
+            reason_detail: "customer-in".to_string(),
+            next_hop: "192.0.2.99".to_string(),
+            // Lossless display form incl. an AS_SET — must flatten.
+            as_path: "65020 {65030 65031}".to_string(),
+            communities: vec![(65001 << 16) | 666],
+            large_communities: vec!["65001:1000:1".to_string()],
+            rpki_validation: "not_found".to_string(),
+            aspa_validation: "unverified".to_string(),
+            // 2026-01-02 03:04:05 UTC
+            rejected_at_unix_ns: 1_767_323_045_000_000_000,
+            ..Default::default()
+        };
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        let json = rejected_route_to_birdwatcher(&route, peer);
+
+        assert_eq!(json["network"], "10.66.0.0/24");
+        assert_eq!(json["gateway"], "192.0.2.99");
+        assert_eq!(json["from_protocol"], "bgp_192.0.2.1");
+        assert_eq!(json["learnt_from"], "192.0.2.1");
+        assert_eq!(json["age"], "2026-01-02 03:04:05");
+        assert_eq!(json["reject_reason"], "policy_reject");
+        assert_eq!(json["reject_reason_detail"], "customer-in");
+        assert_eq!(json["rpki_validation"], "not_found");
+        assert_eq!(json["aspa_validation"], "unverified");
+        assert_eq!(
+            json["bgp"]["as_path"],
+            serde_json::json!([65020, 65030, 65031])
+        );
+        assert_eq!(
+            json["bgp"]["communities"],
+            serde_json::json!([[65001, 666]])
+        );
+        // Wire large communities first, synthesized reason triplet last.
+        assert_eq!(
+            json["bgp"]["large_communities"],
+            serde_json::json!([[65001, 1000, 1], [64496, 65520, 1]])
+        );
+    }
+
+    /// Sparse retention entries (pre-policy safety gates keep only what
+    /// was decodable) render with empty sentinels, and the reason
+    /// community is still present.
+    #[test]
+    fn rejected_route_conversion_handles_sparse_entry() {
+        let route = proto::RejectedRoute {
+            prefix: "2001:db8:bad::".to_string(),
+            prefix_length: 48,
+            reason: "treat_as_withdraw".to_string(),
+            ..Default::default()
+        };
+        let peer: IpAddr = "2001:db8::1".parse().unwrap();
+        let json = rejected_route_to_birdwatcher(&route, peer);
+        assert_eq!(json["network"], "2001:db8:bad::/48");
+        assert_eq!(json["from_protocol"], "bgp_2001_db8__1");
+        assert_eq!(json["age"], "");
+        assert_eq!(json["bgp"]["as_path"], serde_json::json!([]));
+        assert_eq!(
+            json["bgp"]["large_communities"],
+            serde_json::json!([[64496, 65520, 6]])
+        );
+    }
+
+    /// Retention disabled and enabled-but-empty both produce the full
+    /// envelope with an empty routes array — configuration facts, not
+    /// errors.
+    #[test]
+    fn filtered_body_empty_and_disabled_cases() {
+        let peer: IpAddr = "192.0.2.1".parse().unwrap();
+        for enabled in [false, true] {
+            let resp = proto::ListRejectedRoutesResponse {
+                peer_address: peer.to_string(),
+                retention_enabled: enabled,
+                capacity: 1024,
+                routes: vec![],
+            };
+            let body = filtered_routes_body(&resp, peer);
+            assert!(body["api"].is_object(), "{body}");
+            assert_eq!(body["routes"], serde_json::json!([]), "{body}");
+        }
     }
 
     #[test]

--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -10,9 +10,13 @@
 //! response shapes.
 //!
 //! A second neighbor (127.0.0.1) is driven by a minimal in-test BGP
-//! speaker that establishes a real session and announces one route, so
-//! the per-route `age` field is exercised end-to-end: the adapter must
-//! render a non-empty receive timestamp for the announced route.
+//! speaker that establishes a real session and announces two routes: a
+//! clean one (exercises the per-route `age` receive timestamp) and one
+//! carrying the daemon's own AS in its AS_PATH, which the loop check
+//! rejects and the reject-retention store keeps — exercising the
+//! `/routes/filtered/{id}` view (reason token + synthesized reason
+//! community) and the real `routes.filtered` neighbor-summary count
+//! end-to-end.
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -166,10 +170,12 @@ description = "live peer"
 
 /// Minimal BGP speaker: connect to the daemon's listen port, complete
 /// the OPEN/KEEPALIVE handshake as legacy AS 65020 (no capabilities —
-/// implicit IPv4 unicast), and announce one route. The returned stream
-/// must stay alive for the session to survive; the daemon's own
-/// messages are left unread (a handful of bytes, well within the
-/// socket buffer for the test's lifetime).
+/// implicit IPv4 unicast), and announce two routes: 10.99.0.0/24 with a
+/// clean path (accepted) and 10.98.0.0/24 with the daemon's own AS in
+/// the path (rejected as an AS_PATH loop, lands in reject retention).
+/// The returned stream must stay alive for the session to survive; the
+/// daemon's own messages are left unread (a handful of bytes, well
+/// within the socket buffer for the test's lifetime).
 fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
     use rustbgpd_wire::attribute::{AsPath, AsPathSegment, Origin, PathAttribute};
     use rustbgpd_wire::message::{Message, encode_message};
@@ -184,29 +190,34 @@ fn establish_bgp_and_announce(bgp_port: u16) -> TcpStream {
         bgp_identifier: "10.0.0.2".parse().unwrap(),
         capabilities: Vec::new(),
     });
-    let mut attrs = Vec::new();
-    rustbgpd_wire::attribute::encode_path_attributes(
-        &[
-            PathAttribute::Origin(Origin::Igp),
-            PathAttribute::AsPath(AsPath {
-                segments: vec![AsPathSegment::AsSequence(vec![65020])],
-            }),
-            // Non-loopback: the daemon's UPDATE validation rejects a
-            // loopback NEXT_HOP (subcode 8).
-            PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
-        ],
-        &mut attrs,
-        false,
-        false,
-    )
-    .expect("encode path attributes");
-    let update = Message::Update(UpdateMessage {
-        withdrawn_routes: bytes::Bytes::new(),
-        path_attributes: attrs.into(),
-        // 10.99.0.0/24
-        nlri: bytes::Bytes::from_static(&[24, 10, 99, 0]),
-    });
-    for msg in [&open, &Message::Keepalive, &update] {
+    let encode_update = |as_sequence: Vec<u32>, nlri: &'static [u8]| {
+        let mut attrs = Vec::new();
+        rustbgpd_wire::attribute::encode_path_attributes(
+            &[
+                PathAttribute::Origin(Origin::Igp),
+                PathAttribute::AsPath(AsPath {
+                    segments: vec![AsPathSegment::AsSequence(as_sequence)],
+                }),
+                // Non-loopback: the daemon's UPDATE validation rejects a
+                // loopback NEXT_HOP (subcode 8).
+                PathAttribute::NextHop("192.0.2.99".parse().unwrap()),
+            ],
+            &mut attrs,
+            false,
+            false,
+        )
+        .expect("encode path attributes");
+        Message::Update(UpdateMessage {
+            withdrawn_routes: bytes::Bytes::new(),
+            path_attributes: attrs.into(),
+            nlri: bytes::Bytes::from_static(nlri),
+        })
+    };
+    // 10.99.0.0/24, clean path → accepted.
+    let accepted = encode_update(vec![65020], &[24, 10, 99, 0]);
+    // 10.98.0.0/24, daemon's own AS 65001 in path → as_path_loop reject.
+    let looped = encode_update(vec![65020, 65001], &[24, 10, 98, 0]);
+    for msg in [&open, &Message::Keepalive, &accepted, &looped] {
         let encoded = encode_message(msg).expect("encode BGP message");
         stream.write_all(&encoded).expect("write BGP message");
     }
@@ -235,7 +246,7 @@ fn epoch_from_timestamp(s: &str) -> u64 {
 }
 
 #[test]
-fn adapter_serves_birdwatcher_shaped_status_peer_and_accepted_route_subset() {
+fn adapter_serves_birdwatcher_shaped_status_peer_accepted_and_filtered_route_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
     let grpc_port = free_port();
     let adapter_port = free_port();
@@ -348,4 +359,44 @@ fn adapter_serves_birdwatcher_shaped_status_peer_and_accepted_route_subset() {
     // The receive timestamp must parse and sit in the recent past.
     let age_epoch = epoch_from_timestamp(age);
     assert!(age_epoch > 0, "age must be a parseable timestamp: {age:?}");
+
+    // /routes/filtered/{id} — the looped announcement was rejected and
+    // retained; the adapter must serve it with the reason token and the
+    // synthesized reject-reason large community.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let filtered = loop {
+        let filtered = get_json(adapter_port, "/routes/filtered/bgp_127.0.0.1", "adapter");
+        if filtered["routes"].as_array().is_some_and(|r| r.len() == 1) {
+            break filtered;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "rejected route did not appear on the filtered view\nadapter: {filtered}\ndaemon stderr:\n{}",
+            daemon.stderr()
+        );
+        thread::sleep(Duration::from_millis(200));
+    };
+    let reject = &filtered["routes"][0];
+    assert_eq!(reject["network"], "10.98.0.0/24", "{filtered}");
+    assert_eq!(reject["reject_reason"], "as_path_loop", "{filtered}");
+    let large_communities = &reject["bgp"]["large_communities"];
+    assert!(
+        large_communities
+            .as_array()
+            .is_some_and(|lcs| lcs.contains(&serde_json::json!([64496, 65520, 4]))),
+        "filtered route must carry the synthesized as_path_loop community: {filtered}"
+    );
+
+    // /protocols/bgp — the neighbor summary serves the real filtered
+    // count from the same retention store.
+    let protocols = get_json(adapter_port, "/protocols/bgp", "adapter");
+    assert_eq!(
+        protocols["protocols"]["bgp_127.0.0.1"]["routes"]["filtered"], 1,
+        "{protocols}"
+    );
+
+    // A configured peer with no live session has no retention store —
+    // the filtered view is empty, not an error.
+    let down = get_json(adapter_port, "/routes/filtered/bgp_192.0.2.10", "adapter");
+    assert_eq!(down["routes"], serde_json::json!([]), "{down}");
 }


### PR DESCRIPTION
Completes the Alice-LG looking-glass contract end-to-end: `GET /routes/filtered/{id}` and the neighbor-summary `routes.filtered` count are now backed by `PolicyService.ListRejectedRoutes` (the per-peer bounded reject-retention store) instead of a zero sentinel.

Reject reasons surface both ways Alice-LG consumers expect: a synthesized large community `64496:65520:<id>` per reason token (global admin = the RFC 5398 documentation ASN, collision-impossible with real wire communities; function value follows the arouteserver reject-reason convention; ids append-only with 0 reserved for unrecognized future tokens) appended after any genuine large communities, plus human-readable `reject_reason`/`reject_reason_detail` and RPKI/ASPA state as extra JSON keys.

Semantics: retention disabled or no live session → empty filtered view with a log line (configuration facts, not errors); other gRPC failures stay 502. `routes.noexport` is documented absent rather than stubbed with fake data. Unpaged by design — the store caps at the configured retention capacity.

Tests: mapping-stability unit matrix (all 6 tokens + unknown), conversion shape/sparse-entry units, and the e2e extended so a real in-test speaker announces a loop-poisoned route and the adapter serves it in the filtered view with community [64496,65520,4] and summary count 1. Docs: README endpoint + mapping tables with an Alice-LG config snippet, stale claims refreshed in OPERATIONS/USE_CASES, CHANGELOG. All gates green foreground, independently re-verified.