### PR TITLE
feat(telemetry): policy-artifact freshness timestamps for pipeline staleness alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Policy artifact freshness metrics (ADR-0110): alert when the
+  filter-render pipeline is stuck instead of discovering it later.**
+  `bgp_policy_generation_loaded_timestamp_seconds` stamps every
+  successful full policy apply (initial load, SIGHUP reload — including
+  content-unchanged re-accepts — and config transactions);
+  `bgp_policy_dataset_loaded_timestamp_seconds{dataset}` stamps each
+  external dataset's last accepted generation swap. Both deliberately
+  freeze across rejected loads — the moment the daemon *accepted*
+  artifacts is the source of truth, not file mtime — so
+  `time() - <gauge>` is a truthful staleness age even while a broken
+  render keeps rewriting files. Per-dataset series (including the
+  existing `bgp_policy_dataset_refresh_errors_total`) are now reaped
+  when a dataset is removed from config. Alert expressions documented
+  in `OPERATIONS.md` ("Policy artifact freshness").
+
 - **Looking-glass filtered-route surface: rejected inbound routes are
   retained with their reject reason (LAN-472).** Every rejected unicast
   announcement — import-policy deny (including RPKI/ASPA-driven denies),

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -21,6 +21,14 @@ static NEXT_METRICS_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 /// recreating, from zero) the series like `with_label_values` does.
 static POLICY_ROUTES_REAP_EPOCH: AtomicU64 = AtomicU64::new(0);
 
+/// Current unix time in whole seconds, saturating at the `i64` gauge
+/// range (0 if the clock reads before the epoch).
+fn unix_now_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+}
+
 /// Bounded label contract for aggregate ORR topology-input diagnostics.
 const ORR_INPUT_CLASSIFICATIONS: [&str; 5] = [
     "included_default",
@@ -203,6 +211,10 @@ pub struct BgpMetrics {
     // ── Policy dataset refresh failures (LAN-305) ─────────────
     policy_dataset_refresh_errors: IntCounterVec,
     policy_eval_errors: IntCounterVec,
+
+    // ── Policy artifact freshness (ADR-0110) ──────────────────
+    policy_generation_loaded_timestamp: IntGauge,
+    policy_dataset_loaded_timestamp: IntGaugeVec,
 
     // ── Enhanced Route Refresh ────────────────────────────────
     route_refresh_in_progress: IntGaugeVec,
@@ -1077,6 +1089,28 @@ impl BgpMetrics {
         )
         .expect("valid metric definition");
 
+        let policy_generation_loaded_timestamp = IntGauge::new(
+            "bgp_policy_generation_loaded_timestamp_seconds",
+            "Unix time of the last successful full policy apply (initial load, \
+             SIGHUP reload, or config transaction). A rejected load keeps the \
+             prior generation live and does NOT advance this timestamp, so \
+             `time() - <this>` is the age of the last artifacts the daemon \
+             actually accepted.",
+        )
+        .expect("valid metric definition");
+
+        let policy_dataset_loaded_timestamp = IntGaugeVec::new(
+            Opts::new(
+                "bgp_policy_dataset_loaded_timestamp_seconds",
+                "Unix time the named external policy dataset last swapped in a \
+                 loaded generation (initial load or refresh). A failed refresh \
+                 keeps the prior snapshot serving and does NOT advance this \
+                 timestamp.",
+            ),
+            &["dataset"],
+        )
+        .expect("valid metric definition");
+
         let route_refresh_in_progress = IntGaugeVec::new(
             Opts::new(
                 "bgp_route_refresh_in_progress",
@@ -1779,6 +1813,12 @@ impl BgpMetrics {
             .register(Box::new(policy_eval_errors.clone()))
             .expect("metric not already registered");
         registry
+            .register(Box::new(policy_generation_loaded_timestamp.clone()))
+            .expect("metric not already registered");
+        registry
+            .register(Box::new(policy_dataset_loaded_timestamp.clone()))
+            .expect("metric not already registered");
+        registry
             .register(Box::new(route_refresh_in_progress.clone()))
             .expect("metric not already registered");
         registry
@@ -2031,6 +2071,8 @@ impl BgpMetrics {
             validation_import_refreshes,
             policy_dataset_refresh_errors,
             policy_eval_errors,
+            policy_generation_loaded_timestamp,
+            policy_dataset_loaded_timestamp,
             route_refresh_in_progress,
             route_refresh_stale_entries,
             evpn_local_originations,
@@ -3046,6 +3088,41 @@ impl BgpMetrics {
         self.policy_dataset_refresh_errors
             .with_label_values(&[dataset])
             .inc();
+    }
+
+    /// Record a successful full policy apply (initial load, SIGHUP
+    /// reload, or config transaction): stamp the current unix time.
+    ///
+    /// Never called on a rejected load — staleness alerting depends on
+    /// the timestamp freezing while the prior generation stays live.
+    pub fn record_policy_generation_loaded(&self) {
+        self.policy_generation_loaded_timestamp
+            .set(unix_now_seconds());
+    }
+
+    /// Record a successful load/swap of the named external policy
+    /// dataset: stamp the current unix time. The label is bounded by
+    /// the config's declared dataset names.
+    ///
+    /// Never called on a failed refresh — the prior snapshot keeps
+    /// serving and the timestamp keeps its last-accepted value.
+    pub fn record_policy_dataset_loaded(&self, dataset: &str) {
+        self.policy_dataset_loaded_timestamp
+            .with_label_values(&[dataset])
+            .set(unix_now_seconds());
+    }
+
+    /// Drop the per-dataset series (loaded-timestamp gauge and
+    /// refresh-failure counter) for a dataset removed from config, so
+    /// the exposition stops advertising freshness for a dataset that
+    /// no longer exists.
+    pub fn reap_policy_dataset_series(&self, dataset: &str) {
+        let _ = self
+            .policy_dataset_loaded_timestamp
+            .remove_label_values(&[dataset]);
+        let _ = self
+            .policy_dataset_refresh_errors
+            .remove_label_values(&[dataset]);
     }
 
     /// Count one route denied by a policy evaluation error (LAN-301,
@@ -4145,6 +4222,38 @@ mod tests {
         let text = gather_text(&m);
         assert!(text.contains("bgp_policy_eval_errors_total"));
         assert!(text.contains(r#"kind="overflow""#));
+    }
+
+    /// ADR-0110 freshness gauges: a successful apply stamps a nonzero
+    /// unix time, the dataset series is labeled by dataset name, and
+    /// reaping a removed dataset drops BOTH its series (loaded
+    /// timestamp and refresh-failure counter).
+    #[test]
+    fn policy_freshness_timestamps_stamp_and_reap() {
+        let m = BgpMetrics::new();
+        m.record_policy_generation_loaded();
+        assert!(m.policy_generation_loaded_timestamp.get() > 0);
+
+        m.record_policy_dataset_loaded("customers");
+        m.record_policy_dataset_refresh_error("customers");
+        assert!(
+            m.policy_dataset_loaded_timestamp
+                .with_label_values(&["customers"])
+                .get()
+                > 0
+        );
+        let text = gather_text(&m);
+        assert!(text.contains("bgp_policy_generation_loaded_timestamp_seconds"));
+        assert!(
+            text.contains(r#"bgp_policy_dataset_loaded_timestamp_seconds{dataset="customers"}"#)
+        );
+        assert!(text.contains(r#"bgp_policy_dataset_refresh_errors_total{dataset="customers"}"#));
+
+        m.reap_policy_dataset_series("customers");
+        let text = gather_text(&m);
+        assert!(!text.contains(r#"dataset="customers""#));
+        // The unlabeled generation timestamp is untouched by dataset reaps.
+        assert!(m.policy_generation_loaded_timestamp.get() > 0);
     }
 
     /// Reaping a peer must invalidate the thread-local memoized counter

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -539,6 +539,45 @@ them on its dedicated lane. It cannot preempt an O(table) general query that
 was already executing when the request arrived; that actor call must return
 before either the transition or readiness probe can advance.
 
+### Policy artifact freshness
+
+For deployments whose policy is rendered by an external pipeline
+(IRR toolchain, config generator, cron + SIGHUP), these metrics answer
+"when did the daemon last *accept* new policy artifacts" — which is the
+staleness signal that matters. File mtimes only say when something was
+written to disk; a render that produces a config the daemon rejects
+leaves the old generation live, and these timestamps deliberately do
+not advance on a rejected load.
+
+| Metric | What it tells you |
+|--------|-------------------|
+| `bgp_policy_generation_loaded_timestamp_seconds` | Unix time of the last successful full policy apply — initial load, SIGHUP reload (stamped even when the reloaded content is unchanged: the daemon re-accepted it), or config transaction. Frozen across rejected reloads |
+| `bgp_policy_dataset_loaded_timestamp_seconds{dataset}` | Unix time the named `[policy.datasets.<name>]` external dataset last swapped in a loaded generation (initial load, or a refresh whose content changed). A failed refresh keeps the prior snapshot serving and does not advance this. Series reaped when the dataset is removed from config |
+| `bgp_policy_dataset_refresh_errors_total{dataset}` | Failed dataset refresh attempts; the prior snapshot keeps serving. Series reaped when the dataset is removed from config |
+
+**Alerting on pipeline staleness.** Export ages, not the raw
+timestamps, and let Prometheus do the arithmetic. If your pipeline
+refreshes every 6 hours, page when nothing has been accepted for a few
+missed cycles:
+
+```promql
+# Full policy apply older than 3 refresh intervals (here: 3 × 6h).
+time() - bgp_policy_generation_loaded_timestamp_seconds > 3 * 21600
+
+# A dataset whose last accepted swap is stale, or whose refreshes are
+# actively failing.
+time() - bgp_policy_dataset_loaded_timestamp_seconds > 3 * 21600
+increase(bgp_policy_dataset_refresh_errors_total[6h]) > 0
+```
+
+The dataset timestamp advances only when a refresh swaps in *changed*
+content, so pair the dataset-age expression with the refresh-error
+counter: age alone can also mean "the data legitimately hasn't
+changed", while age plus rising errors means the pipeline output is
+being rejected. The full-apply timestamp has no such caveat — it is
+stamped on every successful SIGHUP — so it is the primary "pipeline
+stuck or daemon rejecting everything" pager.
+
 ### Ingress rejection / route-leak detection
 
 Mechanisms that block routes for protocol-correctness reasons: most

--- a/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
+++ b/docs/adr/0110-irr-peeringdb-filtering-pipeline.md
@@ -227,7 +227,13 @@ item). None blocks a first pilot at OpenBGPD-equivalence level.
    naming the generated term for every rejection.
 4. Overlay/dataset freshness observability: expose generation timestamp
    and age for reloaded policy artifacts, so "pipeline stuck" is a
-   metric, not a surprise.
+   metric, not a surprise. *Delivered:*
+   `bgp_policy_generation_loaded_timestamp_seconds` (last successful
+   full policy apply) and
+   `bgp_policy_dataset_loaded_timestamp_seconds{dataset}` (last
+   accepted dataset swap), both frozen across rejected loads;
+   alert expressions in `OPERATIONS.md` ("Policy artifact
+   freshness").
 
 **Phase 2 — parity and upstream (after a pilot transcript exists):**
 max-prefix restart-timer action; reject-reason retention wiring for the

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -312,6 +312,7 @@ Prometheus (`prometheus_addr`, `/metrics`; dashboards in
 | `bgp_rpki_vrp_total` | non-zero once the RTR cache syncs |
 | `bgp_update_group_fallback_peers` | ≥ your `per_client_best` member count (they never group) |
 | `bgp_rib_outbound_registered_peers` | = established member count |
+| `bgp_policy_generation_loaded_timestamp_seconds` | recent — ages past your render/SIGHUP cadence when the filter pipeline is stuck; see "Policy artifact freshness" in [`OPERATIONS.md`](../OPERATIONS.md) for the alert expressions |
 
 ## Member support: the filtered-route view
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -510,6 +510,12 @@ impl PeerManager {
         let (session_notification_event_tx, session_notification_event_rx) = mpsc::channel(4096);
         let (session_events_tx, _) = broadcast::channel(4096);
         let (policy_events_tx, _) = broadcast::channel(4096);
+        // ADR-0110 freshness: constructing the manager is the initial
+        // policy apply — stamp the generation and every bound dataset.
+        metrics.record_policy_generation_loaded();
+        for handle in current_config.policy.dataset_bindings.handles() {
+            metrics.record_policy_dataset_loaded(handle.name());
+        }
         Self {
             peers: HashMap::new(),
             session_index: HashMap::new(),
@@ -846,6 +852,9 @@ impl PeerManager {
                                 self.dynamic_ranges =
                                     Self::parse_dynamic_ranges(&self.current_config);
                                 self.config_snapshot_staged = true;
+                                // ADR-0110 freshness: the staged config
+                                // transaction is live from this point.
+                                self.metrics.record_policy_generation_loaded();
                                 Ok(previous)
                             });
                             let _ = reply.send(result);
@@ -869,6 +878,9 @@ impl PeerManager {
                                     self.dynamic_ranges =
                                         Self::parse_dynamic_ranges(&self.current_config);
                                     self.config_snapshot_staged = false;
+                                    // ADR-0110 freshness: rollback re-applies
+                                    // the previous (accepted) config.
+                                    self.metrics.record_policy_generation_loaded();
                                     self.reap_dynamic_peers_not_allowed_by_current_ranges()
                                         .await;
                                     let _ = reply.send(Ok(()));
@@ -1378,6 +1390,12 @@ impl PeerManager {
                         // reflects any accepted runtime CRUD, so a plain re-parse is
                         // correct — no merge/provenance needed.
                         self.dynamic_ranges = Self::parse_dynamic_ranges(&self.current_config);
+                        // ADR-0110 freshness: every successful reload flows
+                        // through this snapshot replacement — stamp the
+                        // generation even when policy content is unchanged
+                        // (the daemon re-accepted the artifacts). A rejected
+                        // reload aborts before this command is ever sent.
+                        self.metrics.record_policy_generation_loaded();
                         if let Some(ack) = ack {
                             let _ = ack.send(());
                         }

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1501,6 +1501,12 @@ impl PeerManager {
             );
             self.metrics.record_policy_dataset_refresh_error(dataset);
         }
+        // ADR-0110 freshness: each swapped dataset was just accepted —
+        // stamp its loaded timestamp. Failed refreshes above deliberately
+        // keep their last-accepted timestamp so `time() - <gauge>` ages.
+        for dataset in swapped {
+            self.metrics.record_policy_dataset_loaded(dataset);
+        }
         if swapped.is_empty() {
             return Ok(());
         }
@@ -2160,6 +2166,34 @@ impl PeerManager {
             .await
             .map_err(CatalogMutationError::internal)?;
 
+        // ADR-0110 freshness: adopting `next_config` is the accept moment
+        // for this policy generation. Sync the per-dataset series against
+        // the new binding set: a dataset introduced by this apply gets a
+        // loaded timestamp; one removed from config gets its series reaped
+        // (content bumps are stamped on the RefreshDatasetDependents path).
+        // A rejected apply returns above without stamping anything.
+        for handle in next_config.policy.dataset_bindings.handles() {
+            if self
+                .current_config
+                .policy
+                .dataset_bindings
+                .get(handle.name())
+                .is_none()
+            {
+                self.metrics.record_policy_dataset_loaded(handle.name());
+            }
+        }
+        for handle in self.current_config.policy.dataset_bindings.handles() {
+            if next_config
+                .policy
+                .dataset_bindings
+                .get(handle.name())
+                .is_none()
+            {
+                self.metrics.reap_policy_dataset_series(handle.name());
+            }
+        }
+        self.metrics.record_policy_generation_loaded();
         self.current_config = next_config;
         Ok(applied.len())
     }

--- a/src/peer_manager/tests.rs
+++ b/src/peer_manager/tests.rs
@@ -5258,6 +5258,268 @@ async fn sync_rpol_policies_rejection_keeps_old_registry_for_live_and_new_sessio
     rib_drainer.await.unwrap();
 }
 
+/// Read one policy-freshness metric from the gathered exposition:
+/// the unlabeled family value, or the child whose `dataset` label
+/// matches. `None` when the family/series is absent.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "unix-seconds gauges and small test counters fit i64"
+)]
+fn policy_metric_value(metrics: &BgpMetrics, family: &str, dataset: Option<&str>) -> Option<i64> {
+    metrics
+        .registry()
+        .gather()
+        .iter()
+        .find(|f| f.name() == family)?
+        .get_metric()
+        .iter()
+        .find(|m| match dataset {
+            Some(dataset) => m
+                .get_label()
+                .iter()
+                .any(|l| l.name() == "dataset" && l.value() == dataset),
+            None => true,
+        })
+        .map(|m| {
+            // Counter families follow the `_total` naming convention;
+            // everything read here otherwise is a gauge.
+            if family.ends_with("_total") {
+                m.get_counter().value() as i64
+            } else {
+                m.get_gauge().value() as i64
+            }
+        })
+}
+
+/// Block until the wall clock has advanced past `after` (unix
+/// seconds), so a subsequent timestamp stamp is distinguishable
+/// from one taken at `after`.
+async fn wait_for_unix_second_after(after: i64) {
+    loop {
+        let now = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_secs(),
+        )
+        .expect("unix seconds fit i64");
+        if now > after {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// ADR-0110 load-bearing staleness assertion: a rejected rpol sync
+/// keeps the old generation live AND freezes
+/// `bgp_policy_generation_loaded_timestamp_seconds` — the timestamp
+/// must NOT advance on a failed swap, otherwise `time() - <gauge>`
+/// alerting can never see a stuck pipeline. A subsequent successful
+/// sync advances it.
+#[tokio::test]
+async fn rejected_rpol_sync_freezes_policy_generation_timestamp() {
+    use rustbgpd_policy::rpol::{RpolFile, RpolPolicyEntry, RpolPolicySet};
+
+    fn registry(name: &str, source: &str) -> RpolPolicySet {
+        let file = std::sync::Arc::new(RpolFile::parse(source).expect("clean rpol"));
+        let mut set = RpolPolicySet::default();
+        set.policies.insert(
+            name.to_string(),
+            RpolPolicyEntry {
+                file,
+                params: 0,
+                path: "policies/core.rpol".to_string(),
+            },
+        );
+        set
+    }
+
+    const FAMILY: &str = "bgp_policy_generation_loaded_timestamp_seconds";
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, mut rib_rx) = mpsc::channel(64);
+    let rib_drainer = tokio::spawn(async move {
+        while let Some(update) = rib_rx.recv().await {
+            if let RibUpdate::ReplacePeerExportPolicy { reply, .. } = update {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    // Initial load: constructing the manager stamped the generation.
+    let initial = policy_metric_value(&mgr.metrics, FAMILY, None).expect("stamped at construction");
+    assert!(initial > 0);
+
+    let peer: IpAddr = "10.0.0.2".parse().unwrap();
+    let counters = Arc::new(FakePeerCounters::default());
+    insert_test_managed_peer(
+        &mut mgr,
+        peer,
+        acking_counted_policy_handle(peer, counters.clone()),
+        false,
+    );
+    let mut neighbor = config_neighbor(peer, 65002);
+    neighbor.import_policy_chain = vec!["edge-in".to_string()];
+    mgr.current_config.neighbors = vec![neighbor];
+    mgr.current_config.policy.rpol = registry(
+        "edge-in",
+        "policy edge-in { term all { set local-pref 150; accept } }",
+    );
+
+    // Let the wall clock tick so a (buggy) stamp on the failed swap
+    // below would be distinguishable from the construction stamp.
+    wait_for_unix_second_after(initial).await;
+
+    // Candidate registry renames the policy, so the static peer's
+    // chain no longer resolves: the sync is rejected — and the
+    // timestamp must stay frozen at the last ACCEPTED apply.
+    mgr.sync_rpol_policies(
+        vec!["policies/core.rpol".to_string()],
+        registry(
+            "edge-in-renamed",
+            "policy edge-in-renamed { term all { set local-pref 250; accept } }",
+        ),
+        rustbgpd_policy::datasets::DatasetBindings::default(),
+    )
+    .await
+    .expect_err("chain resolution failure must reject the sync");
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, FAMILY, None),
+        Some(initial),
+        "a rejected swap must not advance the loaded timestamp"
+    );
+
+    // A successful sync IS an accept: the timestamp advances.
+    mgr.sync_rpol_policies(
+        vec!["policies/core.rpol".to_string()],
+        registry(
+            "edge-in",
+            "policy edge-in { term all { set local-pref 250; accept } }",
+        ),
+        rustbgpd_policy::datasets::DatasetBindings::default(),
+    )
+    .await
+    .expect("sync succeeds");
+    let advanced = policy_metric_value(&mgr.metrics, FAMILY, None).expect("still present");
+    assert!(
+        advanced > initial,
+        "successful swap must stamp a newer time"
+    );
+
+    drop(mgr);
+    rib_drainer.await.unwrap();
+}
+
+/// ADR-0110: `RefreshDatasetDependents` stamps
+/// `bgp_policy_dataset_loaded_timestamp_seconds{dataset}` for each
+/// swapped dataset, while a failed refresh only increments the
+/// failure counter — it never creates/advances the loaded timestamp.
+#[tokio::test]
+async fn dataset_refresh_stamps_swapped_and_freezes_failed() {
+    const LOADED: &str = "bgp_policy_dataset_loaded_timestamp_seconds";
+    const FAILURES: &str = "bgp_policy_dataset_refresh_errors_total";
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    mgr.refresh_dataset_dependents(
+        &["customers".to_string()],
+        &[("bogons".to_string(), "unreadable".to_string())],
+    )
+    .await
+    .expect("refresh fan-out with no peers succeeds");
+
+    let stamped =
+        policy_metric_value(&mgr.metrics, LOADED, Some("customers")).expect("swapped stamped");
+    assert!(stamped > 0);
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, LOADED, Some("bogons")),
+        None,
+        "a failed refresh must not create a loaded-timestamp series"
+    );
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, FAILURES, Some("bogons")),
+        Some(1)
+    );
+}
+
+/// ADR-0110 reap discipline: a dataset removed from config on a
+/// successful rpol sync drops BOTH its per-dataset series (loaded
+/// timestamp and failure counter); a dataset introduced by the sync
+/// gets its initial stamp.
+#[tokio::test]
+async fn rpol_sync_reaps_removed_dataset_series() {
+    use rustbgpd_policy::datasets::{DatasetBindings, DatasetData, DatasetHandle, DatasetKind};
+    use rustbgpd_policy::rpol::RpolPolicySet;
+    use rustbgpd_policy::sets::AsnSet;
+
+    const LOADED: &str = "bgp_policy_dataset_loaded_timestamp_seconds";
+    const FAILURES: &str = "bgp_policy_dataset_refresh_errors_total";
+    let (_tx, rx) = mpsc::channel(16);
+    let (rib_tx, _rib_rx) = mpsc::channel(64);
+    let mut mgr = PeerManager::new(
+        rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+
+    // Sync #1 introduces the dataset: its series appears.
+    let mut bindings = DatasetBindings::default();
+    bindings.insert(std::sync::Arc::new(DatasetHandle::new(
+        "customers",
+        DatasetKind::Asn,
+        DatasetData::Asn(AsnSet::new(std::iter::once(64500))),
+    )));
+    mgr.sync_rpol_policies(Vec::new(), RpolPolicySet::default(), bindings)
+        .await
+        .expect("sync with a new dataset succeeds");
+    assert!(policy_metric_value(&mgr.metrics, LOADED, Some("customers")).is_some());
+    mgr.metrics.record_policy_dataset_refresh_error("customers");
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, FAILURES, Some("customers")),
+        Some(1)
+    );
+
+    // Sync #2 removes it from config: both series are reaped.
+    mgr.sync_rpol_policies(
+        Vec::new(),
+        RpolPolicySet::default(),
+        DatasetBindings::default(),
+    )
+    .await
+    .expect("sync removing the dataset succeeds");
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, LOADED, Some("customers")),
+        None,
+        "removed dataset must not keep advertising freshness"
+    );
+    assert_eq!(
+        policy_metric_value(&mgr.metrics, FAILURES, Some("customers")),
+        None
+    );
+}
+
 /// Like `acking_policy_handle`, but counting `QueryState` and Route Refresh
 /// sends so policy fan-out coverage can be asserted per peer.
 fn acking_counted_policy_handle(peer_addr: IpAddr, counters: Arc<FakePeerCounters>) -> PeerHandle {


### PR DESCRIPTION
Exposes when the daemon last ACCEPTED policy artifacts, so a stuck IRR/render pipeline pages instead of rotting: `bgp_policy_generation_loaded_timestamp_seconds` (last successful full policy apply) and `bgp_policy_dataset_loaded_timestamp_seconds{dataset}` (last accepted dataset generation swap) — timestamps, not ages, per Prometheus convention, with example alert expressions in OPERATIONS.md.

Stamped at every config-adoption seam (constructor initial load, SIGHUP replace choke point, config-txn stage/restore, the shared rpol-sync commit, per-dataset dependent refresh) — including content-unchanged re-accepts, so the generation gauge has no false-page caveat. **The load-bearing property is the inverse: a rejected apply/refresh stamps nothing** — proven by a wall-clock-tick freeze test (`rejected_rpol_sync_freezes_policy_generation_timestamp`) plus a failed-dataset-refresh freeze test. Dataset series (timestamp + the pre-existing refresh-error counter, which also gains documentation and reap) are removed when a dataset leaves config.

The 39-family peer-reap sync-guard is unaffected (new families are dataset-labeled/unlabeled). Cookbook watch-table row added; ADR-0110 phase-1 item 4 marked delivered. All gates green foreground, independently re-verified post-rebase.