### PR TITLE
docs: operator discoverability quick wins — explain landing page, IXP pipeline tutorial, prebuilt-binary quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Docs: operator discoverability pass.** New `docs/explain.md` catalog
+  of every explain/introspection surface, an end-to-end IXP tutorial
+  (`docs/cookbook/ixp-filter-pipeline.md`: arouteserver →
+  `rs-config-render` → validated reload → Alice-LG), and a pre-built
+  tarball install path ahead of building from source in README and
+  QUICKSTART.
+
 - Dependency refresh: sha2 0.10 → 0.11 (digest 0.11 migration — the
   effective-config hash renders hex pairwise now), clap_mangen 0.2 → 0.3,
   zeroize 1.9, uuid 1.24, regex 1.13.1, socket2 0.6.5, and

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ fabric use.
 ## Why rustbgpd
 
 - **API-first control plane** -- full gRPC control surface across 11 services plus a thin CLI (`rbgp`) with colored tables, dynamic column alignment, and human-readable uptimes. Dynamic peer management, dynamic-neighbor and FIB-table CRUD, route injection, policy CRUD, peer groups, BFD inspection, EVPN instance queries, streaming events, and daemon control without restarts.
+- **Native route explainability** -- answers "why is this route (not) here?" from the live RIB in one command: import explain, best-path explain with decisive-comparison attribution, export explain that dry-runs the real per-peer gate ladder, and a retained rejected-route view with machine-readable reasons -- where incumbents need an external looking-glass stack for less. See [docs/explain.md](docs/explain.md).
 - **Explicit architecture** -- pure FSM with no I/O, single-owner RIB with no locks, bounded channels between tasks. No `Arc<RwLock>` on routing state. See [ARCHITECTURE.md](ARCHITECTURE.md).
 - **Dual-stack and modern protocol support** -- MP-BGP, Add-Path, Extended Next Hop, Extended Messages, GR/LLGR/Notification GR, Route Refresh/Enhanced Route Refresh, receive-side Prefix ORF, FlowSpec, Route Reflector, large and extended communities.
 - **Typed, compiled policy language** (`.rpol`, ADR-0096) -- named prefix/community sets compiled to indexed matchers, parameterized policies, policy composition, and in-language unit tests (`rbgp policy check`); candidate policies dry-run read-only against the live RIB (`rbgp policy test`), decisions explain themselves per term (`rbgp policy explain`), and installed chains expose live per-term hit counters (`rbgp policy stats`). Mixes freely with the existing TOML policy chains; FRR route-map parity proven route-for-route in interop (M80). See [docs/rpol-language.md](docs/rpol-language.md).
 - **Full BMP monitoring trio** (RFC 7854/8671/9069, ADR-0097) -- per-collector selectable Adj-RIB-In (pre-policy), Adj-RIB-Out (post-policy, byte-exact wire PDUs), and Loc-RIB views on one exporter. Loc-RIB collectors get a chunked table dump + End-of-RIB when they connect; Adj-RIB-In/Out are live streams by design. Optional per-collector BMPv4 TLV framing plus the Path Marking TLV (draft-ietf-grow-bmp-tlv / draft-ietf-grow-bmp-path-marking-tlv, pre-IANA -- code points may renumber; default stays BMP v3). Validated against pmacct, gobmp, and tshark at once (M81).
-- **Operational visibility** -- Prometheus metrics, gNMI / OpenConfig BGP telemetry (`Capabilities` / `Get` / `Subscribe`, RFC 7951 JSON over mTLS) plus a transaction-backed `Set` subset for static numbered-neighbor config, BMP export to collectors (all three RIB views), MRT TABLE_DUMP_V2 snapshots, a Birdwatcher-shaped status/peer/accepted-route REST subset via the external `examples/birdwatcher-adapter`, structured JSON logging, per-peer counters, and the explain trilogy: import explain (per-session decision cache), best-path explain (decisive-comparison attribution), and export explain (the full per-peer gate ladder — split horizon, RFC 4456 reflection, family, LLGR, ORF, RT membership, policy per-term verdict, advertised-state diff — produced by a dry run of the live export body, update groups included).
+- **Operational visibility** -- Prometheus metrics, gNMI / OpenConfig BGP telemetry (`Capabilities` / `Get` / `Subscribe`, RFC 7951 JSON over mTLS) plus a transaction-backed `Set` subset for static numbered-neighbor config, BMP export to collectors (all three RIB views), MRT TABLE_DUMP_V2 snapshots, a Birdwatcher-shaped status/peer/accepted-route REST subset via the external `examples/birdwatcher-adapter`, structured JSON logging, and per-peer counters. The explain surfaces have their own catalog: [docs/explain.md](docs/explain.md).
 - **Update-group fanout** (ADR-0098, ADR-0099) -- peers whose staged output is provably identical automatically share one outbound staging pass and one Arc-shared announce payload; measured ~28x faster 100k-route convergence at 256 uniform RR clients (15.1 s to 0.54 s), and 1.8 s wire-measured convergence / 419 MiB process RSS at 1,000 uniform RR clients x 100k routes ([scale receipt](docs/perf/scale-receipt-2026-07.md)), with a structural per-peer fallback (no knob) and a differential oracle pinning identical wire behavior. v2 extends the sharing to VPNv4/VPNv6 with the RFC 4684 RT filter applied per member at emit: 1,000 clients x 100k VPNv4 converge in 12.6 s / 625 MiB uniform and 3.9 s / 636 MiB with heterogeneous ~10% RT memberships (vs ~73 s / ~31 GiB and ~12.5 s / ~5.7 GiB extrapolated per-peer), and a member's RT-membership flip at 100k staged routes hits the wire in ~15 ms with zero policy evaluations.
 - **Evidence-driven correctness** -- fuzz targets on the wire decoder, property tests on the FSM, automated containerlab interop primarily against FRR plus GoBGP / StayRTR and documented BIRD coverage, extensive workspace tests, architecture decision records for every protocol and design choice.
 - **Reusable wire codec and FSM** -- `rustbgpd-wire` has zero internal dependencies and `rustbgpd-fsm` depends only on `wire`; both are published as daemon-independent crates for Rust BGP tooling that does not need the full router.
@@ -131,11 +132,23 @@ Press `q` to exit the TUI. When you're done: `docker compose down`.
 
 ## Install
 
-### Pre-built tarball
+### Pre-built tarball (no toolchain required)
 
-Tagged releases publish per-arch tarballs (binaries, man pages, and
-bash/zsh/fish completions under `share/`) — see the
-[install walkthrough](docs/deployment.md#install).
+Every tagged release ships static-named per-arch tarballs, so
+`releases/latest/download/` always fetches the current version:
+
+```bash
+SUFFIX=linux-amd64   # or linux-arm64
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-${SUFFIX}.tar.gz"
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
+sha256sum -c "checksums-${SUFFIX}.txt"
+tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
+sudo install -m 0755 rustbgpd rbgp /usr/local/bin/
+```
+
+The tarball also carries man pages and bash/zsh/fish completions under
+`share/` — the [install walkthrough](docs/deployment.md#install) covers
+installing those and pinning a specific version.
 
 ### From source
 
@@ -148,6 +161,9 @@ cargo build --release -p rustbgpd -p rustbgpctl
 ```
 
 ### Docker
+
+Release images are published to GHCR (versioned tags, e.g.
+`ghcr.io/lance0/rustbgpd:0.51.0`), or build locally:
 
 ```bash
 docker build -t rustbgpd .                    # lean runtime: daemon + rbgp, nonroot
@@ -164,7 +180,10 @@ remote mTLS access, standalone Docker, and systemd.
 The [cookbook](docs/cookbook/README.md) has complete receipt-proven recipes for
 the common deployment shapes: iBGP route reflector at scale, L3VPN reflection,
 IXP route server, BMP/event/MRT monitoring feed, EVPN fabric RR, and `.rpol`
-policy.
+policy. IXPs running arouteserver can render rustbgpd configuration from their
+existing `general.yml`/`clients.yml` and wire up an Alice-LG looking glass —
+the [IXP filter-pipeline tutorial](docs/cookbook/ixp-filter-pipeline.md) walks
+it end to end.
 
 For operators coming from FRR, BIRD, or ARouteServer, the CLI keeps familiar
 entry points for the daily checks: `rbgp summary`, `rbgp rib recv <peer>`,
@@ -297,6 +316,7 @@ evolving API.**
 | [docs/deployment.md](docs/deployment.md) | End-to-end install + lifecycle walkthrough: systemd, Docker, containerlab quick-start, upgrade, sample profiles |
 | [docs/reload-matrix.md](docs/reload-matrix.md) | Per-field reload classification: which keys hot-apply, which need a restart, which are rejected at parse time |
 | [docs/OPERATIONS.md](docs/OPERATIONS.md) | Running in production: reload, upgrade, failure modes, debugging |
+| [docs/explain.md](docs/explain.md) | The explain surfaces: why a route was selected, advertised, imported, or rejected |
 | [docs/SECURITY.md](docs/SECURITY.md) | Security posture, firewall guidance, deployment tiers |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Wire codec and RIB performance numbers, scaling analysis |
 | [docs/OPERATIONAL_PROOF.md](docs/OPERATIONAL_PROOF.md) | Consolidated operational proof receipts: CI interop, dataplane, benchmarks, memory, soak |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1254,6 +1254,10 @@ the session.
 
 ### Explain an import decision (ADR-0073)
 
+The task-oriented catalog of every explain surface — which question
+maps to which command, plus the member-support workflow — is
+[explain.md](explain.md); the sections here carry the full semantics.
+
 Answer "why didn't this prefix come in?" — or "what did the chain do to
 it when it did?" — from the per-session import-decision cache:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -8,6 +8,25 @@ For the fastest no-host setup, use the Docker Compose lab in
 
 ## 1. Install
 
+Grab the pre-built release tarball — no Rust toolchain, no compile:
+
+```bash
+SUFFIX=linux-amd64   # or linux-arm64
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-${SUFFIX}.tar.gz"
+curl -fLO "https://github.com/lance0/rustbgpd/releases/latest/download/checksums-${SUFFIX}.txt"
+sha256sum -c "checksums-${SUFFIX}.txt"
+tar -xzf "rustbgpd-${SUFFIX}.tar.gz"
+sudo install -m 0755 rustbgpd rbgp /usr/local/bin/
+
+rustbgpd --version && rbgp --version
+```
+
+The tarball also ships man pages and shell completions under `share/`;
+[deployment.md](deployment.md#install) covers installing those and
+pinning a specific version instead of `latest`.
+
+### Or build from source
+
 ```bash
 # Debian/Ubuntu build dependency for tonic/prost codegen.
 sudo apt-get install -y protobuf-compiler
@@ -15,10 +34,9 @@ sudo apt-get install -y protobuf-compiler
 cargo build --release -p rustbgpd -p rustbgpctl
 ```
 
-The built binaries are:
-
-- `target/release/rustbgpd` — daemon
-- `target/release/rbgp` — CLI
+The built binaries are `target/release/rustbgpd` (daemon) and
+`target/release/rbgp` (CLI); the commands below assume both are on
+`PATH`.
 
 ## 2. Create a config
 
@@ -27,7 +45,7 @@ Generate a starter config from a built-in profile:
 ```bash
 # `lab` = minimal single-box setup:
 # gRPC over a local UDS, state under /tmp, Prometheus probes enabled.
-./target/release/rustbgpd --init-config lab --stdout > config.toml
+rustbgpd --init-config lab --stdout > config.toml
 $EDITOR config.toml
 ```
 
@@ -49,13 +67,13 @@ the route-server cookbook.
 
 ```bash
 # Validate config without starting the daemon.
-./target/release/rustbgpd --check config.toml
+rustbgpd --check config.toml
 
 # Preview what a config reload would change.
-./target/release/rustbgpd --diff new-config.toml config.toml
+rustbgpd --diff new-config.toml config.toml
 
 # Start the daemon.
-./target/release/rustbgpd config.toml
+rustbgpd config.toml
 ```
 
 ## 4. Verify
@@ -145,6 +163,10 @@ An Envoy proxy front-end is also supported for multi-host fan-out; see
 [`docs/SECURITY.md`](SECURITY.md).
 
 ## Docker standalone
+
+Release images are published to GHCR with versioned tags
+(e.g. `ghcr.io/lance0/rustbgpd:0.51.0`); `docker build -t rustbgpd .`
+produces the same lean runtime image locally.
 
 ```bash
 docker run -d --name rustbgpd \

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ Start here if you have never run the daemon.
 | [cookbook/peer-flap-triage.md](cookbook/peer-flap-triage.md) | Runbook: a peer is flapping — what to look at, in order |
 | [cookbook/rr-pair-day2.md](cookbook/rr-pair-day2.md) | Runbook: day-2 operations on a redundant RR pair — GR sanity, adding clients, safe config edits |
 | [cookbook/route-server-migration.md](cookbook/route-server-migration.md) | Shadow cutover runbook: map FRR/BIRD/ARouteServer concepts, run the shadow trial, gate cutover on `rbgp diff advertised` |
+| [cookbook/ixp-filter-pipeline.md](cookbook/ixp-filter-pipeline.md) | End-to-end IXP toolchain: arouteserver → `rs-config-render` → validated reload → Alice-LG looking glass |
+| [explain.md](explain.md) | Answer "why is this route (not) here?": the catalog of every explain surface, with the support-ticket workflow |
 | [deployment.md](deployment.md) | End-to-end install + lifecycle: systemd, Docker, containerlab, validate, reload, upgrade |
 | [ribdiff.md](ribdiff.md) | Drive `rbgp diff advertised` for the shadow trial (also the `rbgp-ribsnap/1` snapshot-format reference) |
 | [evpn-vtep-setup.md](evpn-vtep-setup.md) | Prepare kernel netdev topology (bridge/VXLAN/VRF) for the EVPN VTEP dataplane |
@@ -54,6 +56,7 @@ Start here if you have never run the daemon.
 | [SECURITY.md](SECURITY.md) | Security posture, deployment tiers, firewall guidance |
 | [LIMITATIONS.md](LIMITATIONS.md) | Current product boundaries and known non-goals |
 | [gobgp-parity.md](gobgp-parity.md) | Feature-by-feature parity table against GoBGP |
+| [../crates/cli/README.md#familiar-command-map](../crates/cli/README.md#familiar-command-map) | Familiar command map: the FRR/BIRD show-command mental model translated to `rbgp` |
 | [COMPARISON.md](COMPARISON.md) | Feature comparison across open-source BGP daemons |
 | [kernel-dataplane-runner.md](kernel-dataplane-runner.md) | How the privileged Linux dataplane CI workflow runs |
 | [grafana/](grafana/) | The importable Grafana dashboard JSON |

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -14,6 +14,7 @@ receipts that prove its scenario ([`RECEIPTS.md`](../RECEIPTS.md)).
 | [L3VPN route reflector](l3vpn-route-reflector.md) | VPNv4/VPNv6 reflection for a PE fleet, RT-Constrain filtered | M74, M75, M77, [VPN scale receipt](../perf/scale-receipt-2026-07.md) |
 | [IXP route server](route-server.md) | Transparent redistribution among exchange members: RPKI, RFC 9234 roles, Add-Path + per-client best-path | M19, M83 |
 | [Route-server migration](route-server-migration.md) | Map FRR, BIRD, and ARouteServer concepts into rustbgpd and run a shadow-trial cutover | M19, M83 |
+| [IXP filter pipeline](ixp-filter-pipeline.md) | Keep your arouteserver `general.yml`/`clients.yml`: render member filters with `rs-config-render`, reload fail-stale, serve Alice-LG | M19, M83 |
 | [Controller / monitoring feed](monitoring-feed.md) | Streaming BMP, durable events, and MRT into a controller or collector stack | M24, M81 |
 | [EVPN fabric route reflector](evpn-fabric-rr.md) | Control-plane-only RR for a VXLAN-EVPN leaf/spine fabric | M29, M30, M82, M33 |
 | [Policy quickstart (`.rpol`)](policy-quickstart.md) | First typed policy: tests, dry-run, hot swap, explain | M80, M34 |
@@ -39,3 +40,5 @@ Conventions:
 - Start here if you haven't run the daemon at all yet:
   [`docs/QUICKSTART.md`](../QUICKSTART.md), then come
   back for your scenario.
+- Debugging why a route was (not) selected, advertised, or imported?
+  The explain-surface catalog is [`docs/explain.md`](../explain.md).

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -1,0 +1,183 @@
+# IXP filter pipeline: arouteserver → rs-config-render → rustbgpd → Alice-LG
+
+The toolchain an IXP already runs — [arouteserver] for
+IRR/PeeringDB/RPKI member-filter generation, a looking glass for
+member support — end to end on rustbgpd. You keep your existing
+`general.yml` / `clients.yml` and the arouteserver refresh cadence;
+rustbgpd replaces only the daemon, via one render step
+([`tools/rs-config-render/`](../../tools/rs-config-render/README.md),
+[ADR-0110](../adr/0110-irr-peeringdb-filtering-pipeline.md)).
+
+The pipeline:
+
+```text
+general.yml + clients.yml
+        │  arouteserver template-context     (IRR/PeeringDB/RPKI ingest)
+        ▼
+context.yml
+        │  rs-config-render                  (fail-stale rendering)
+        ▼
+config.toml + policy/*.rpol + render-receipt.json
+        │  rustbgpd --check                  (full config validation)
+        ▼
+swap + SIGHUP                                (parse-then-swap reload)
+        │
+        ▼
+rbgp verification  +  Alice-LG via the birdwatcher adapter
+```
+
+This recipe assumes the [route-server cookbook](route-server.md)
+shapes: transparent `route_server_client` sessions, RFC 9234
+`route_server` role, per-client best-path. Migration mapping from an
+existing BIRD/OpenBGPD deployment is in
+[route-server-migration.md](route-server-migration.md).
+
+## 1. Generate the resolved member data
+
+arouteserver's `template-context` command dumps its fully resolved
+data model — bgpq4-expanded IRR prefix/origin sets, PeeringDB
+max-prefix ceilings, RPKI knobs — as YAML, using your existing site
+files and caches:
+
+```bash
+arouteserver template-context --output /var/lib/rs/context.yml
+```
+
+Install and configure arouteserver itself per its
+[documentation][arouteserver] (`arouteserver setup`, then your
+`general.yml` / `clients.yml`).
+
+## 2. Render rustbgpd configuration
+
+```bash
+rs-config-render --context /var/lib/rs/context.yml \
+    --out-dir /var/lib/rs/candidate --rtr-cache 127.0.0.1:3323
+```
+
+This emits `config.toml` (one `[[neighbors]]` per client with
+per-family max-prefix ceilings and a per-client import chain),
+`policy/rs-hygiene.rpol` (the shared hygiene chain: AS_SET reject,
+bogons, transit-free, path-length cap, RPKI origin validation),
+`policy/client-<id>.rpol` (the client's IRR-derived prefix/origin
+sets), and `render-receipt.json` (fingerprint, cardinalities,
+warnings). `--rtr-cache` is required whenever the context enables
+RPKI origin validation — the context carries no cache address. Build
+the renderer from this repo with `cargo build --release -p
+rs-config-render`.
+
+The renderer is deliberately fail-stale, never fail-open: a refused
+knob (exit 2), an implausibly empty IRR set (exit 3), or context-shape
+drift (exit 4) aborts the whole render and leaves the previous
+configuration running. The full refused-knob table and failure policy
+are in the [renderer README](../../tools/rs-config-render/README.md).
+
+### Try it from this repository
+
+The renderer's checked-in test fixture is a three-client context whose
+third client deliberately carries an empty IRR prefix set, so a render
+demonstrates the fail-closed abort:
+
+```console
+$ cargo run -q -p rs-config-render -- \
+    --context tools/rs-config-render/tests/fixtures/context-small.yml \
+    --out-dir /tmp/rs-out --rtr-cache 127.0.0.1:3323
+rs-config-render: render aborted — implausible generated sets:
+  - client AS51325_1 (AS51325): 0 IRR prefix(es) resolved, floor is 1 — an empty or shrunken set means the upstream IRR answer is broken, not that the client deregistered everything
+no output written; the last good configuration stays live (fail-stale)
+```
+
+What a *successful* render of the same context (minus the broken
+client) emits is checked in verbatim as the golden outputs —
+[`tools/rs-config-render/tests/golden/`](../../tools/rs-config-render/tests/golden/):
+`config.toml`, `rs-hygiene.rpol`, and two `client-*.rpol` files. The
+generated policies carry in-language `test` blocks derived from the
+site's own data, runnable offline:
+
+```console
+$ rbgp policy check tools/rs-config-render/tests/golden/rs-hygiene.rpol
+tools/rs-config-render/tests/golden/rs-hygiene.rpol: 7 passed, 0 failed
+```
+
+## 3. Validate, swap, reload
+
+The deployment loop is the same fail-stale cron shape arouteserver
+deployments already use — every step must succeed or the previous
+configuration stays live:
+
+```bash
+#!/bin/sh -e
+# cron: refresh member filters (arouteserver caches govern data staleness)
+arouteserver template-context --output "$STATE/context.yml"
+rs-config-render --context "$STATE/context.yml" \
+    --out-dir "$STATE/candidate" --rtr-cache 127.0.0.1:3323
+rustbgpd --check "$STATE/candidate/config.toml"
+rsync -a --delete "$STATE/candidate/" /etc/rustbgpd/
+systemctl reload rustbgpd        # SIGHUP: parse-then-swap
+```
+
+Before the first cutover — or any time you want to see what a refresh
+will change — preview the candidate against the running daemon:
+
+```bash
+rbgp config diff /var/lib/rs/candidate/config.toml
+```
+
+Each changed field is annotated hot-applied / session reset / restart
+required. The daemon's reload is itself parse-then-swap: a config that
+fails to parse or validate at SIGHUP leaves the running configuration
+untouched, so a bad swap can never evict working policy.
+
+Alert on the age of `render-receipt.json` — a pipeline stuck for more
+than a couple of refresh intervals should page. The matching metric is
+`bgp_policy_generation_loaded_timestamp_seconds` ("Policy artifact
+freshness" in [OPERATIONS.md](../OPERATIONS.md)).
+
+## 4. Verify member sessions and filters
+
+```bash
+rbgp summary                          # members Established
+rbgp rib received 198.51.100.2        # a member's accepted routes
+rbgp policy stats                     # hygiene/client terms firing
+rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
+```
+
+## 5. Member support: the filtered-route view
+
+The daemon retains each member's rejected routes with canonical
+reason tokens — the "which of my routes are you filtering, and why"
+answer, queryable without knowing a prefix in advance:
+
+```bash
+rbgp rib received 198.51.100.2 --rejected
+```
+
+The [route-server cookbook](route-server.md#member-support-the-filtered-route-view)
+covers this view, its retention knobs, and the follow-up explain
+workflow; the full explain surface catalog is in
+[explain.md](../explain.md).
+
+## 6. Looking glass: Alice-LG via the birdwatcher adapter
+
+The external
+[`examples/birdwatcher-adapter`](../../examples/birdwatcher-adapter/README.md)
+serves a Birdwatcher-shaped REST subset from the daemon's gRPC API —
+status, peers, a member's accepted routes, and the filtered-route view
+above. For the filtered view it synthesizes one reject-reason large
+community (`64496:65520:<id>`, one stable id per reason token) on each
+route, matchable by Alice-LG's `[rejection_reasons]` config exactly
+like arouteserver's reject-reason tagging on BIRD; the adapter README
+carries the mapping table and a ready Alice-LG config snippet.
+
+```bash
+cargo run --release -p birdwatcher-adapter -- \
+    --grpc-addr http://127.0.0.1:50051 \
+    --listen 0.0.0.0:8080
+```
+
+The adapter needs a (read-only) gRPC TCP listener on the daemon, and
+`[policy.reject_retention]` enabled for the filtered view. Honest
+boundary: this is a maintained subset, not yet a complete Alice-LG
+backend — there is no noexport view, and a few Birdwatcher fields are
+served as sentinels (the adapter README lists every gap).
+
+[arouteserver]: https://github.com/pierky/arouteserver

--- a/docs/cookbook/route-server-migration.md
+++ b/docs/cookbook/route-server-migration.md
@@ -127,9 +127,14 @@ Notes:
 
 ARouteServer-generated configs usually encode member inventory, max-prefix
 limits, bogon / hygiene / RPKI policy, route-server transparency, and
-path-hiding settings. There is no direct ARouteServer target in-tree yet.
-
-Practical migration path:
+path-hiding settings. Most of this does not need hand-migration:
+[`tools/rs-config-render/`](../../tools/rs-config-render/README.md) renders
+rustbgpd config and `.rpol` filters directly from `arouteserver
+template-context` output, keeping the existing `general.yml`/`clients.yml`
+workflow — the end-to-end walkthrough is
+[ixp-filter-pipeline.md](ixp-filter-pipeline.md). The renderer refuses knobs
+it cannot map faithfully (see its README); a site relying on those, or
+hand-tuned ARouteServer output, follows the manual path:
 
 1. Export member inventory to `[[neighbors]]` rows.
 2. Convert shared prefix/community lists to `.rpol` `prefix-set` /

--- a/docs/cookbook/route-server.md
+++ b/docs/cookbook/route-server.md
@@ -309,8 +309,10 @@ arouteserver `general.yml`/`clients.yml` and render rustbgpd
 configuration from its resolved data model with
 [`tools/rs-config-render/`](../../tools/rs-config-render/README.md)
 (`arouteserver template-context` → `rs-config-render` →
-`rustbgpd --check` → swap → SIGHUP, fail-stale at every step). Design
-and failure policy:
+`rustbgpd --check` → swap → SIGHUP, fail-stale at every step). The
+end-to-end walkthrough — including the Alice-LG looking glass — is
+[ixp-filter-pipeline.md](ixp-filter-pipeline.md). Design and failure
+policy:
 [ADR-0110](../adr/0110-irr-peeringdb-filtering-pipeline.md).
 
 ## Watch

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -1,0 +1,163 @@
+# Explaining routes: "why is this route (not) here?"
+
+Every stage of a route's life through the daemon can explain itself,
+from the live RIB, in one command — no debug rebuild, no external
+looking-glass daemon, no packet capture. This page is the catalog:
+which question you have, which command answers it, and what the answer
+looks like. Deep semantics live in
+[OPERATIONS.md](OPERATIONS.md); this page gets you to the right
+command.
+
+Every command below also takes `--json` for scripting and portal
+backends.
+
+| Question | Command |
+|----------|---------|
+| Why was this path selected as best? | `rbgp rib --prefix <cidr> --explain` |
+| Why did/didn't this prefix go to that peer? | `rbgp rib --prefix <cidr> advertised <peer> --explain` |
+| What did import policy decide for this prefix from that peer? | `rbgp policy explain --neighbor <peer> --prefix <cidr>` |
+| Which of a member's routes were filtered, and why? | `rbgp rib received <peer> --rejected` |
+| What would this candidate policy do to the live RIB? | `rbgp policy test <file> --policy <name> --direction import` |
+| Which policy terms are actually firing? | `rbgp policy stats` |
+| What would this config change touch? | `rbgp config diff <candidate.toml>` |
+
+For operators coming from FRR/BIRD, the
+[familiar command map](../crates/cli/README.md#familiar-command-map)
+translates the usual show-commands into these.
+
+## Best-path explain — decisive-comparison attribution
+
+Why did this path win? Every losing candidate is annotated with the
+decisive comparison step (`only_path`, `higher_local_pref`,
+`shorter_as_path`, `lower_origin`, `lower_med`, ... down to
+`lower_peer_address`) and the compared values behind it, plus its
+equal-cost multipath classification:
+
+```console
+$ rbgp rib --prefix 203.0.113.0/24 --explain
+Best-path explanation for 203.0.113.0/24
+Best route: peer=10.0.0.2, next_hop=10.0.0.2, as_path=[65002]
+Selected:   only path for this prefix
+No candidates
+```
+
+With competing paths, the candidate table lists each loser with its
+`Reason` / `Detail` (e.g. `local_pref 100 < 200`) and multipath
+eligibility. `--json` returns the same as `best_reason`,
+`best_reason_detail`, and a `candidates[]` array.
+
+Scope the explanation to one peer's Add-Path send view with
+`--explain-peer <addr>`: candidates the peer would actually receive
+get their advertised rank; filtered ones show why they are not sent.
+Details: [OPERATIONS.md](OPERATIONS.md#explain-a-best-path-decision).
+
+## Export explain — the full gate ladder, from the real export body
+
+Why did (or didn't) this exact prefix reach this exact peer? The
+answer is produced by a read-only dry run of the *same staging body*
+live distribution executes — update groups, split horizon per member,
+and all — so it cannot drift from what the wire does:
+
+```console
+$ rbgp rib --prefix 203.0.113.0/24 advertised 10.0.0.2 --explain
+Advertise: 203.0.113.0/24 to 10.0.0.2
+Update group: 3 (shared staging; split horizon applied per member)
+Gate ladder (live evaluation order):
+  [pass] best_route       Loc-RIB best exists
+  [pass] split_horizon    not the source peer
+  [pass] rr_reflection    eBGP peer
+  [pass] family           ipv4-unicast negotiated
+  [pass] llgr             no stale restriction
+  [pass] orf              no peer filter installed
+  [pass] export_policy    ix-egress:announce-members permit
+  [pass] adj_rib_out      staged_announce
+```
+
+(Values above are illustrative; the rung set and order are the live
+ones.) A denial shows `[STOP]` at the gate that held the route back,
+with per-term policy attribution for `.rpol` chains. `--rd <rd>`
+explains the VPNv4/VPNv6 (RD, prefix) ladder including the RFC 4684
+RT-Constrain membership gate; `--labeled` explains the RFC 8277
+labeled-unicast ladder. Rung-by-rung semantics:
+[OPERATIONS.md](OPERATIONS.md#explain-an-export-decision-why-diddidnt-route-x-go-to-peer-y).
+
+## Import explain — the per-session decision cache
+
+What did import policy decide when this prefix arrived from this
+peer — including paths that were denied and are therefore *not in the
+RIB anymore*? Requires `[policy.explain] enabled = true` on the
+daemon (a bounded per-session decision cache):
+
+```console
+$ rbgp policy explain --neighbor 10.0.0.2 --prefix 10.10.1.0/24
+import policy explain — peer 10.0.0.2 prefix 10.10.1.0/24 (policy generation 3)
+  permit
+    policy:  customer-in(200)
+    statements:
+      [0] policy customer-in(200) term customer-routes permit  match: guard route.prefix in customers  set: local_pref 100 -> 200
+        term rpki-guard: route.rpki == invalid => reject [not matched]
+        term customer-routes: route.prefix in customers => set local-pref 200; accept [matched]
+```
+
+Outcomes are `permit` / `deny` / `withdrawn` / `not_seen` / `evicted`
+/ `stale`; a disabled cache or missing session errors distinctly
+instead of pretending `not_seen`. `--path-id` narrows to one Add-Path
+identity. Details:
+[OPERATIONS.md](OPERATIONS.md#explain-an-import-decision-adr-0073).
+
+## The filtered-route view — rejected routes, retained with reasons
+
+The route-server member-support question — "you're eating my
+routes, which ones and why?" — without knowing a prefix in advance.
+The daemon retains rejected inbound routes per session
+(`[policy.reject_retention]`, bounded LRU) with a canonical reason
+token:
+
+```console
+$ rbgp rib received 198.51.100.2 --rejected
+Prefix                 PathId   Reason             Detail                       Next Hop           RPKI       AS Path
+------------------------------------------------------------------------------------------------------------------------
+203.0.113.0/24         0        policy_reject      member-import                198.51.100.2       invalid    64500 64501
+```
+
+Reason tokens: `policy_reject`, `otc_route_leak`,
+`next_hop_ownership`, `as_path_loop`, `rr_loop`,
+`treat_as_withdraw`. The same rows back a looking glass via the
+[birdwatcher adapter](../examples/birdwatcher-adapter/README.md),
+which maps each token to an Alice-LG-matchable large community. The
+member-support workflow around this view is in the
+[route-server cookbook](cookbook/route-server.md#member-support-the-filtered-route-view).
+
+## The support-ticket workflow
+
+"Member AS64500 says their prefix isn't visible." In order:
+
+```bash
+# 1. Is the session even up, and are we retaining anything from them?
+rbgp summary
+rbgp rib received 198.51.100.2 --rejected
+
+# 2. Rejected with a reason token? Get the statement-level why.
+rbgp policy explain --neighbor 198.51.100.2 --prefix 203.0.113.0/24
+
+# 3. Accepted but another member doesn't see it? Walk the export ladder
+#    toward that member.
+rbgp rib --prefix 203.0.113.0/24 advertised 198.51.100.7 --explain
+
+# 4. Accepted but lost best-path selection? See what beat it.
+rbgp rib --prefix 203.0.113.0/24 --explain
+```
+
+Each step either answers the ticket or names the exact gate, term, or
+comparison to look at next.
+
+## Related introspection surfaces
+
+| Surface | What it answers |
+|---------|-----------------|
+| `rbgp policy test <file> --policy <p> --direction <d>` | Read-only dry run of a *candidate* policy against the live RIB: accepted/rejected/modified counts, term hits, per-attribute before/after diffs ([rpol-language.md](rpol-language.md)) |
+| `rbgp policy check <file>` | Offline parse/typecheck plus the file's in-language `test` blocks — no daemon needed |
+| `rbgp policy stats` (alias `counters`) | Live per-term hit counters: which policy terms actually fire |
+| `rbgp config diff <candidate>` / `rbgp config plan` | What a config change would touch, each field annotated hot-applied / session reset / restart required ([OPERATIONS.md](OPERATIONS.md#config-diff-dry-run-reload)) |
+| `rbgp diff advertised --against <snapshot>` | Live Adj-RIB-Out vs a recorded snapshot — the shadow-cutover gate ([ribdiff.md](ribdiff.md)) |
+| `rbgp doctor` | Red/green triage checks plus a redacted support bundle ([OPERATIONS.md](OPERATIONS.md#support-bundles-and-triage-checks-rbgp-doctor)) |

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -21,6 +21,10 @@ $ rustbgpd --check /var/lib/rs/candidate/config.toml
 
 [arouteserver]: https://github.com/pierky/arouteserver
 
+The end-to-end operator walkthrough — arouteserver through the
+Alice-LG looking glass — is
+[`docs/cookbook/ixp-filter-pipeline.md`](../../docs/cookbook/ixp-filter-pipeline.md).
+
 ## What it emits
 
 | File | Contents |


### PR DESCRIPTION
Three S-sized operator-UX wins from the discovery pass, one coherent branch:

- **docs/explain.md**: the explain surfaces finally have a home — question→command catalog (best-path, export gate ladder, import decisions, the `--rejected` filtered view) with one runnable example and output shape each, the member-support-ticket workflow, and the familiar-command-map link surfaced in the docs index. README gains a scannable "native route explainability" positioning bullet.
- **docs/cookbook/ixp-filter-pipeline.md**: the end-to-end IXP walkthrough — arouteserver template-context → rs-config-render → `--check` → swap/SIGHUP → `rbgp` verify → `--rejected` member support → Alice-LG via the birdwatcher adapter's reason→community mapping. Runnable from the repo (the checked-in fixture's fail-stale abort was executed for real and quoted; `rbgp policy check` passes on the golden rpol).
- **Prebuilt-binary quickstart**: README + QUICKSTART now lead the bare-metal path with the real curl+checksum tarball snippet (asset names from release.yml); building from source demoted to the alternative. GHCR pointer follows the code (versioned tags; no :latest is published).

Every documented CLI invocation verified against the built binary (incl. a live daemon best-path explain capture). Bonus: route-server-migration.md's stale "no arouteserver target in-tree" claim corrected. Docs-only; ticket-namespace and attribution greps clean on all new files.