### PR TITLE
test(interop): pin M89 source IPv6 next hops to close the exactness race

### DIFF
--- a/tests/interop/configs/frr-bgpd-m89-source-a.conf
+++ b/tests/interop/configs/frr-bgpd-m89-source-a.conf
@@ -17,6 +17,16 @@ router bgp 65002
  !
  address-family ipv6 unicast
   neighbor 10.89.1.1 activate
+  neighbor 10.89.1.1 route-map M89-V6-NH out
   network 2001:db8:89::/48
  exit-address-family
+!
+! Pin the IPv6 next hop explicitly. On a loaded runner bgpd can establish the
+! session and send its initial IPv6 UPDATE before zebra reports a usable global
+! address on eth1; the resulting link-local-only MP_REACH next hop is rejected
+! by the route server (Invalid NEXT_HOP, treat-as-withdraw) and FRR never
+! re-advertises, leaving the exactness proof one path short for good. The
+! explicit global removes that startup race.
+route-map M89-V6-NH permit 10
+ set ipv6 next-hop global fd89:1::2
 !

--- a/tests/interop/configs/frr-bgpd-m89-source-b.conf
+++ b/tests/interop/configs/frr-bgpd-m89-source-b.conf
@@ -17,6 +17,12 @@ router bgp 65003
  !
  address-family ipv6 unicast
   neighbor 10.89.2.1 activate
+  neighbor 10.89.2.1 route-map M89-V6-NH out
   network 2001:db8:89::/48
  exit-address-family
+!
+! Pin the IPv6 next hop explicitly; see frr-bgpd-m89-source-a.conf for the
+! startup race this removes.
+route-map M89-V6-NH permit 10
+ set ipv6 next-hop global fd89:2::2
 !

--- a/tests/interop/configs/frr-bgpd-m89-source-c.conf
+++ b/tests/interop/configs/frr-bgpd-m89-source-c.conf
@@ -17,6 +17,12 @@ router bgp 65004
  !
  address-family ipv6 unicast
   neighbor 10.89.3.1 activate
+  neighbor 10.89.3.1 route-map M89-V6-NH out
   network 2001:db8:89::/48
  exit-address-family
+!
+! Pin the IPv6 next hop explicitly; see frr-bgpd-m89-source-a.conf for the
+! startup race this removes.
+route-map M89-V6-NH permit 10
+ set ipv6 next-hop global fd89:3::2
 !

--- a/tests/interop/scripts/test-m89-paths-limit-frr.sh
+++ b/tests/interop/scripts/test-m89-paths-limit-frr.sh
@@ -94,16 +94,25 @@ recheck_all_sessions() {
 
 candidate_shape_is_exact() {
     local family=${1:?} prefix=${2:?}
+    # Next hops are pinned per family: v4 is the session address, v6 is the
+    # route-map-set global (see frr-bgpd-m89-source-a.conf). A link-local or
+    # unspecified v6 next hop here would mean the sources raced their zebra
+    # address sync again.
+    local nh1=10.89.1.2 nh2=10.89.2.2 nh3=10.89.3.2
+    if [ "$family" = ipv6_unicast ]; then
+        nh1=fd89:1::2 nh2=fd89:2::2 nh3=fd89:3::2
+    fi
     {
         rbgp rib received 10.89.1.2 -a "$family" -j 2>/dev/null
         rbgp rib received 10.89.2.2 -a "$family" -j 2>/dev/null
         rbgp rib received 10.89.3.2 -a "$family" -j 2>/dev/null
-    } | jq -se --arg prefix "$prefix" 'add | map(select(.prefix == $prefix)) |
+    } | jq -se --arg prefix "$prefix" --arg nh1 "$nh1" --arg nh2 "$nh2" --arg nh3 "$nh3" '
+        add | map(select(.prefix == $prefix)) |
         length == 3
-        and ([.[] | {peer: .peer_address, as_path}] | sort_by(.peer)) == [
-            {"peer":"10.89.1.2","as_path":[65002]},
-            {"peer":"10.89.2.2","as_path":[65003]},
-            {"peer":"10.89.3.2","as_path":[65004]}
+        and ([.[] | {peer: .peer_address, as_path, next_hop}] | sort_by(.peer)) == [
+            {"peer":"10.89.1.2","as_path":[65002],"next_hop":$nh1},
+            {"peer":"10.89.2.2","as_path":[65003],"next_hop":$nh2},
+            {"peer":"10.89.3.2","as_path":[65004],"next_hop":$nh3}
         ]
     ' >/dev/null
 }


### PR DESCRIPTION
Root-causes the M89 IPv6 Paths-Limit exactness failures (both CI runs today, plus local reproductions): NOT a daemon bug — under load, an FRR source's bgpd establishes and sends its initial IPv6 UPDATE before zebra reports a usable global address on the peering interface, producing a link-local-only MP_REACH next hop. rustbgpd correctly rejects it (Invalid NEXT_HOP per RFC 2545, RFC 7606 treat-as-withdraw keeping the session up), and FRR's adj-out considers the route sent so it never re-advertises — the exactness proof stays one path short for the whole window, which is why in-job retries also failed. Which source loses the race varies run to run; the race window is why 2-core CI runners and busy local moments failed while idle runs passed.

Evidence trail: captured failing run shows the daemon's subcode-8 treat-as-withdraw WARN 1.05 s post-establish with the source's v6 table empty and v4 fine; deterministic repro by omitting the source's global v6 address; stuck-state proven (adding the address later — FRR still never re-sends). Paths-Limit accounting, the non_exhaustive change, and the deferral/slow-peer work all exonerated by the captures.

Fix is lab-side: outbound `route-map M89-V6-NH` on each source pins `set ipv6 next-hop global fd89:N::2`, removing the zebra-timing dependency; the test's exactness check now also pins exact per-source next hops in both families so any recurrence fails loudly instead of timing out. Verified 8/8 clean: 5× the real topology + 3× the forced race-window shape (deterministically failing pre-fix), 24/24 checks each.