### PR TITLE
docs: sync ROADMAP and API inventory with shipped surfaces

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,15 +121,22 @@ the data-driven filtering/tooling wrapper, not the daemon.
   blocker. **Direction decided (ADR-0110, 2026-07-17):** hybrid — an external
   renderer consuming `arouteserver template-context` output feeds the existing
   parse-then-swap reload seam (inherits the whole industry ingest pipeline, no
-  upstream gate); native ingestion demand-gated. Phase 1 = the renderer + the
-  a differential BIRD/rustbgpd interop lab (the origin-as accessor gap claimed at drafting was stale — already shipped)
-  (LAN-467, umbrella).
+  upstream gate); native ingestion demand-gated. The phase-1 renderer is
+  **Shipped (#986)** as `tools/rs-config-render` — template-context ingestion
+  is fingerprint-pinned with fail-stale refusal, and the emitted config is
+  verified by a real `rustbgpd --check`. Remaining phase 1 = the differential
+  BIRD/rustbgpd interop lab (the origin-as accessor gap claimed at drafting
+  was stale — already shipped) (LAN-467, umbrella).
 - ~~RFC 7947/8195 community-based announcement control~~ **Shipped (#968):**
   per-target announce / announce-only / announce-to-none / prepend via
   standard + large control communities, egress scrub, rs-client-default knob
   (LAN-466).
-- Reject-reason retention → Alice-LG looking glass — the member-support
-  surface; the reasons are already computed by the explain ladder (LAN-472).
+- ~~Reject-reason retention → Alice-LG looking glass~~ **Shipped (#981,
+  #984):** bounded per-peer reject-reason retention behind
+  `PolicyService.ListRejectedRoutes` and `rbgp rib received <peer> --rejected`,
+  and the birdwatcher adapter now serves its filtered-route views from it
+  (reject reasons mapped to large communities under `64496:65520:*`; the
+  noexport view remains) (LAN-472).
 - ~~Ship ADR-0107 NEXT_HOP self-consistency~~ **Shipped (#964):**
   `next_hop_ownership = "strict_peer"` fail-closed ingress gate; ADR-0107
   Accepted; same-AS mode stays deferred behind the fleet inventory (LAN-473).
@@ -144,14 +151,17 @@ the data-driven filtering/tooling wrapper, not the daemon.
   **Shipped (#962)** (`bgp_peer_outbound_queue_depth`, `bgp_peer_update_group`)
   → ~~slow-peer detection~~ **Shipped (#967)** (threshold+duration detector,
   `bgp_peer_slow`, neighbor-state flag, opt-in own-group isolation via a
-  `SlowPeer` membership) → gNMI dial-out still open (LAN-471). The operator
-  triage chain "which client is slow, which group is it in, is it isolated"
-  now exists end-to-end; dial-out streams it to a collector.
+  `SlowPeer` membership) → ~~gNMI dial-out~~ **Shipped (#982)**
+  (`[gnmi_dialout]` streaming push to central collectors, LAN-471). The
+  operator triage chain "which client is slow, which group is it in, is it
+  isolated" now exists end-to-end and streams to a collector.
 
-**3. Release hygiene (timing-critical).** Absorb `#[non_exhaustive]` onto the
-growing wire/fsm protocol enums into the in-flight 0.15.0 breaking cut, rather
-than trickle breaking bumps one variant at a time — the `Capability::PathsLimit`
-pattern will recur as IANA/RFC registries grow (LAN-468).
+**3. Release hygiene (timing-critical).** ~~Absorb `#[non_exhaustive]` onto
+the growing wire/fsm protocol enums~~ **Shipped (#983):** the
+registry-tracking enums are marked ahead of the in-flight 0.15.0 breaking cut,
+with fail-safe wildcard arms across consumers, so the
+`Capability::PathsLimit` pattern no longer forces a breaking bump per variant
+as IANA/RFC registries grow (LAN-468).
 
 Deliberately *not* on this frontier (verified already-shipped or hard-deferred):
 RPKI/ASPA, Roles/OTC, graceful-shutdown, blackhole, Prefix-ORF, the BMP trio,
@@ -171,18 +181,24 @@ config workflow, or span-and-suggestion config errors at all. **The gap is
 not features — it is discoverability, first-30-minutes friction, and
 migration-in.** Three tracks, ranked:
 
-**1. Discoverability of shipped differentiators.** A landing page for the
+**1. Discoverability of shipped differentiators.** ~~A landing page for the
 explain trilogy plus README positioning (LAN-478); an end-to-end
 arouteserver → rs-config-render → looking-glass tutorial and docs-index
-wiring for `tools/` (LAN-479).
+wiring for `tools/` (LAN-479).~~ **Shipped (#989):** `docs/explain.md`
+explain/introspection catalog with README positioning, and the
+`docs/cookbook/ixp-filter-pipeline.md` end-to-end tutorial with docs-index
+wiring for `tools/`.
 
-**2. First-30-minutes friction.** A pre-built-binary install path ahead of
-`cargo build` in the bare-metal quickstart (LAN-480); `rbgp doctor`
-first-deploy environment checks — BGP listener bound, RTR/BMP reachability,
-run-context detection, state-dir disk (LAN-482).
+**2. First-30-minutes friction.** ~~A pre-built-binary install path~~
+**Shipped (#989):** checksum-verified release-tarball install ahead of
+`cargo build` in the quickstart (LAN-480); ~~`rbgp doctor` first-deploy
+environment checks~~ **Shipped (#992):** BGP listener bound, RTR/BMP
+reachability, run-context detection, state-dir disk probes (LAN-482).
 
-**3. Fewer footguns, smoother migration in.** Did-you-mean suggestions for
-unknown config keys, reusing the `.rpol` suggestion machinery (LAN-481);
+**3. Fewer footguns, smoother migration in.** ~~Did-you-mean suggestions for
+unknown config keys~~ **Shipped (#993):** unknown-key config errors now carry
+a did-you-mean line inside the existing diagnostic frame, ranked by the same
+Levenshtein machinery as the `.rpol` suggestions (LAN-481);
 config version history + `rollback N`, completing the
 check/compare/confirm/rollback workflow no open-source daemon offers whole
 (LAN-483); a bounded BIRD/FRR/GoBGP config importer — structure only, with a
@@ -192,11 +208,12 @@ the existing shadow-trial runbook (LAN-484).
 Deliberately *not* here: a web UI, Terraform/Ansible providers (maintenance
 surface without demonstrated demand — revisit on operator pull), and
 BIRD-filter-language translation (the importer stops at structure).
-- Positioning: frame the published matrix receipt against the documented
-  market history (route servers were won and lost on reload behavior; the
-  validate-then-apply transaction model vs the blank-config reload failure
-  class; the config-converter vacuum) in COMPARISON.md — externally
-  verifiable, neutral-tone, citation-backed (LAN-485).
+- ~~Positioning: frame the published matrix receipt against the documented
+  market history in COMPARISON.md~~ **Shipped (#991):** "Why reload behavior
+  decided this market" — reload/convergence history, the blank-config reload
+  failure class vs the validate-then-apply transaction model, and the
+  config-converter vacuum, externally verifiable and citation-backed
+  (LAN-485).
 
 ### Immediate: post-v0.50 audit remediation (2026-07-09)
 
@@ -460,12 +477,13 @@ Details in the "Recently shipped" section below and ADR-0097.
   gRPC-added peers), ASPA/ROV/reject-AS_SET hygiene, RFC 8097 OV_* tagging,
   and a curated `examples/route-server` profile. The canonical semantic diff
   engine, `rbgp diff`, BIRD/FRR/GoBGP/MRT adapters, and BMP Adj-RIB-Out import
-  are also shipped. Remaining demand-shaped work: a real shadow/canary receipt,
+  are also shipped, as is the ARouteServer target (`tools/rs-config-render`).
+  Remaining demand-shaped work: a real shadow/canary receipt,
   completion of the Alice-LG contract beyond the current Birdwatcher-shaped
-  status/peer/accepted-route subset (structured reject reasons now ship via
-  `PolicyService.ListRejectedRoutes`; the adapter's filtered/noexport views
-  remain), a 1000+-peer route-server scale receipt, and an
-  ARouteServer target.
+  status/peer/accepted-route/filtered-route subset (structured reject reasons
+  ship via `PolicyService.ListRejectedRoutes` and back the adapter's
+  filtered-route views; the noexport view remains), and a 1000+-peer
+  route-server scale receipt.
 - **RFC 9857 SR-Policy-state-in-BGP-LS** (receive/reflect/API) — published
   RFC, no open-source implementation found, drops onto the existing
   BGP-LS substrate; deepens the controller feed (TE controllers reading
@@ -477,13 +495,15 @@ Details in the "Recently shipped" section below and ADR-0097.
 adoption tooling. ADR-0101/M83 covers RFC 7947 transparency, Add-Path and
 `per_client_best` path-hiding mitigation, RFC 9234 OTC, ASPA/ROV hygiene, and
 multi-stack BIRD/GoBGP/FRR/StayRTR proof. Next useful slices are an Alice-LG
-contract completion for the adapter's filtered/noexport views (the structured
-reject reasons behind them now ship via `PolicyService.ListRejectedRoutes` and
-`rbgp rib received <peer> --rejected`), a 1000+-peer route-server scale
-receipt, shadow/canary RIB-diff
-tooling (`rbgp diff` against an incumbent's MRT/BMP feed), and an ARouteServer
-target once the pilot surface is stable. The current external adapter already
-serves the Birdwatcher-shaped status, peer, and accepted-route subset.
+contract completion for the adapter's noexport view (the structured
+reject reasons ship via `PolicyService.ListRejectedRoutes` and
+`rbgp rib received <peer> --rejected`, and the adapter serves filtered-route
+views from them, mapped to large communities under `64496:65520:*`), a
+1000+-peer route-server scale receipt, and shadow/canary RIB-diff
+tooling (`rbgp diff` against an incumbent's MRT/BMP feed). The ARouteServer
+target ships as `tools/rs-config-render`. The current external adapter already
+serves the Birdwatcher-shaped status, peer, accepted-route, and filtered-route
+subset.
 
 **Researched and rejected** (recorded so they aren't re-litigated):
 confederations (RFC 5065 — no demand signal in two years of issues and

--- a/docs/API.md
+++ b/docs/API.md
@@ -161,7 +161,7 @@ for `grpc_authz` logs and the related Prometheus metrics live in
 | `GlobalService` | `GetGlobal` | — |
 | `ConfigService` | `DiffRuntimeConfig`, `PlanConfigTransaction`, `GetConfigTransactionStatus`, `GetEffectiveConfig` | `ApplyConfigTransaction` (pure `[[fib_tables]]`, pure `[[dynamic_neighbors]]`, static `[[neighbors]]` add/delete/modify, catalog-only policy/neighbor-set/peer-group/global-chain changes, pure live policy-chain impact for static neighbors and accepted dynamic peers, or peer-group/session reshape impact for static members and live dynamic sessions; mixed or unsupported candidates rejected without mutation), `ConfirmConfigTransaction`, `AbortConfigTransaction` |
 | `NeighborService` | `ListNeighbors`, `GetNeighborState`, `ListDynamicNeighbors` | `AddNeighbor`, `DeleteNeighbor`, `EnableNeighbor`, `DisableNeighbor`, `SoftResetIn`, `AddDynamicNeighbor`, `DeleteDynamicNeighbor`, `SetGracefulShutdown` |
-| `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy`, `TestPolicy`, `GetPolicyStats` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
+| `PolicyService` | `ListPolicies`, `GetPolicy`, `ListNeighborSets`, `GetNeighborSet`, `GetGlobalPolicyChains`, `GetNeighborPolicyChains`, `ExplainImportPolicy`, `ListRejectedRoutes`, `TestPolicy`, `GetPolicyStats` | `SetPolicy`, `DeletePolicy`, `SetNeighborSet`, `DeleteNeighborSet`, `SetGlobalImportChain`, `SetGlobalExportChain`, `ClearGlobalImportChain`, `ClearGlobalExportChain`, `SetNeighborImportChain`, `SetNeighborExportChain`, `ClearNeighborImportChain`, `ClearNeighborExportChain` |
 | `PeerGroupService` | `ListPeerGroups`, `GetPeerGroup` | `SetPeerGroup`, `DeletePeerGroup`, `SetNeighborPeerGroup`, `ClearNeighborPeerGroup` |
 | `RibService` | All read/list/explain RPCs (incl. `ListFibTables`) | `SetFibTable`, `DeleteFibTable` |
 | `EventService` | All RPCs | None |
@@ -703,6 +703,7 @@ changes do not retroactively re-evaluate existing Adj-RIB-In state; use
 | `SetNeighborImportChain` / `SetNeighborExportChain` | Replace one neighbor's chain assignment |
 | `ClearNeighborImportChain` / `ClearNeighborExportChain` | Remove one neighbor's chain assignment |
 | `ExplainImportPolicy` | Explain why a prefix was permitted / denied / withdrawn / evicted / stale / not-seen on import for a given neighbor, reading the per-session import-decision cache (ADR-0073). For `.rpol` chain members the statement trace names the deciding term and carries per-term trace lines (ADR-0096). Side-effect-free; IPv4/IPv6 unicast only. `SensitiveRead` tier. |
+| `ListRejectedRoutes` | List every rejected inbound route a peer's session has retained, each tagged with its canonical reject-reason token (`policy_reject`, `otc_route_leak`, `next_hop_ownership`, `as_path_loop`, `rr_loop`, `treat_as_withdraw`), a sub-reason detail, and a best-effort attribute summary. The enumeration complement to `ExplainImportPolicy`'s point lookup. Retention is a bounded per-peer LRU (`[policy.reject_retention]`); the response reports `retention_enabled` and `capacity` so an empty listing is distinguishable from retention being off. Side-effect-free; IPv4/IPv6 unicast only. CLI: `rbgp rib received <peer> --rejected`. `SensitiveRead` tier. |
 | `TestPolicy` | Dry-run a candidate `.rpol` policy (source sent in the request, compiled server-side) read-only over a live Adj-RIB-In / Loc-RIB snapshot: accepted/rejected/modified counts, per-term hit counters, before/after attribute diff samples. No route, session, or counter impact; IPv4/IPv6 unicast (ADR-0096). CLI: `rbgp policy test`. `SensitiveRead` tier. |
 | `GetPolicyStats` | Read the live per-term hit counters of the installed policy chains (since chain install; direction `import`, `export`, or `both` — import chains also report their install generation). CLI: `rbgp policy stats`. `SensitiveRead` tier. |
 
@@ -737,6 +738,27 @@ Each `matches` entry carries an outcome — `PERMIT` / `DENY` / `WITHDRAWN` /
 policy plus the modifications it applied. Compare a match's
 `policy_generation` to the response's `current_policy_generation` to spot a
 `STALE` decision recorded before a policy reload.
+
+### List a peer's rejected routes
+
+Answer "show me everything of mine you filtered, and why" without knowing a
+prefix in advance — the looking-glass filtered-route surface. Side-effect-free.
+Returns `NOT_FOUND` when the peer has no live session (the session-local
+retention store is gone, which is honestly distinct from "nothing rejected").
+
+```bash
+grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
+  -d '{"peer_address": "10.0.0.2"}' \
+  localhost:50051 rustbgpd.v1.PolicyService/ListRejectedRoutes
+```
+
+Each retained rejection carries the prefix identity, the canonical reason
+token with its sub-reason detail (e.g. the matched policy name for
+`policy_reject`), the announcement's next hop, AS_PATH, communities, RPKI/ASPA
+validation states, and the rejection timestamp. `retention_enabled: false`
+means the empty listing is a configuration fact; when the route count equals
+`capacity`, the listing shows the most recent rejections only. CLI:
+`rbgp rib received <peer> --rejected`.
 
 ### Create or replace a named policy
 

--- a/docs/grpc-method-inventory.md
+++ b/docs/grpc-method-inventory.md
@@ -88,7 +88,7 @@ shape itself does not raise the tier.
 | `DeleteDynamicNeighbor` | `mutating` | Removes a prefix range; stops future accepts only — established dynamic peers keep running and drain when they next return to Idle. |
 | `SetGracefulShutdown` | `operator_only` | Network-wide when `address` is empty; listed here because the proto puts it in `NeighborService`. |
 
-### PolicyService (21 RPCs)
+### PolicyService (22 RPCs)
 
 | RPC | Tier | Notes |
 |-----|------|-------|
@@ -110,6 +110,7 @@ shape itself does not raise the tier.
 | `SetNeighborExportChain` | `mutating` | Per-neighbor. |
 | `ClearNeighborImportChain` | `mutating` | Per-neighbor. |
 | `ExplainImportPolicy` | `sensitive_read` | ADR-0073. Reads the per-session import-decision cache to explain why a prefix was permitted / denied / withdrawn on import. Side-effect-free; no RIB or counter mutation. |
+| `ListRejectedRoutes` | `sensitive_read` | Enumerates a peer's retained rejected inbound routes with their reject-reason tokens and a compact attribute summary (`[policy.reject_retention]`, bounded per-peer LRU). Discloses policy structure and what a member announced. Side-effect-free; no RIB or counter mutation. |
 | `TestPolicy` | `sensitive_read` | ADR-0096. Compiles a submitted .rpol policy server-side and dry-runs it read-only over a live-RIB snapshot (counts, per-term hits, before/after diffs). Side-effect-free; no RIB, session, or counter mutation. |
 | `GetPolicyStats` | `sensitive_read` | ADR-0096 Decision 3.3. Snapshots the live per-term guard-hit counters of installed import/export chains (since chain install; reset on chain replace — import chains also report their install generation). Discloses policy structure and traffic shape. Side-effect-free; does not reset counters. |
 | `ClearNeighborExportChain` | `mutating` | Per-neighbor. |
@@ -217,13 +218,13 @@ shape itself does not raise the tier.
 | Tier | Count | % |
 |------|------:|--:|
 | `read` | 0 | 0.0% |
-| `sensitive_read` | 57 | 58.2% |
-| `mutating` | 19 | 19.4% |
-| `operator_only` | 22 | 22.4% |
-| **Total** | **98** | **100%** |
+| `sensitive_read` | 58 | 58.6% |
+| `mutating` | 19 | 19.2% |
+| `operator_only` | 22 | 22.2% |
+| **Total** | **99** | **100%** |
 
-(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 98
-total is 94 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
+(Counts include `SetGracefulShutdown` as one `NeighborService` RPC; the 99
+total is 95 native `rustbgpd.v1` RPCs plus 4 `gnmi.gNMI` RPCs.)
 
 ## Notes for ADR-0064
 
@@ -298,7 +299,7 @@ specific method if the model warrants it.
 
 ## Code matrix
 
-`crates/api/src/authz.rs` contains the same 98-method classification
+`crates/api/src/authz.rs` contains the same 99-method classification
 as a static Rust table. `docs/grpc-method-inventory.json` is the
 machine-readable export for auditors, tooling, and generated clients. The
 `authz` tests parse `proto/rustbgpd.proto` and fail if a new RPC is added


### PR DESCRIPTION
ROADMAP rows for gNMI dial-out, reject-reason retention, the rs-config-render tool, non_exhaustive hygiene, and the operator-experience tranche were still marked open after shipping; corrected in the existing strikethrough/Shipped style. docs/grpc-method-inventory.md synced to the test-enforced JSON (PolicyService 22 RPCs, 99 total, percentages recomputed). docs/API.md gains ListRejectedRoutes in the established per-RPC style plus a grpcurl example and the read-only-listener table row.

Verification: scripts/check-v1-stable-surface.py OK; authz matrix test green with the JSON untouched; per-service header counts sum to the JSON's total.