### PR TITLE
fix(rib): decide grouped RS-control on the source route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to the reconnect loop immediately and resyncs from a fresh initial
   snapshot + `sync_response`.
 
+- **Grouped route-server control decisions are now made on the source
+  route, matching the ungrouped path.** The update-groups emission path
+  evaluated RFC 7947 control communities (`0:PEER` suppression,
+  `RS:0:PEER` large-community forms, prepend requests) on the
+  post-export-policy route, so a policy that stripped a control
+  community could leak a route the source member prohibited, and
+  policy-added control communities could spuriously suppress or
+  prepend. Suppression and prepend are now decided from the source
+  route's communities captured at staging time; the egress scrub still
+  runs post-policy so policy-added control forms are removed without
+  acting. Tag-only transitions (policy strips or adds the tag while the
+  route is otherwise unchanged) now emit the exact per-member withdraw /
+  re-announce delta instead of being equality-suppressed.
+
 ### Changed
 
 - **BREAKING (library API): registry-tracking wire/fsm enums are now

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -3704,9 +3704,9 @@ impl RibManager {
                     } else if let Some(stage) = group_stage.get(&gid) {
                         // An rs-control member shares the pre-built
                         // emission unless this pass staged a tagged
-                        // route (memoized scan) — then its
-                        // announce/withdraw set can diverge per target
-                        // and it walks the matrix itself.
+                        // route or tag-only transition (memoized scan)
+                        // — then its announce/withdraw set can diverge
+                        // per target and it walks the matrix itself.
                         let rs_diverges = rs_control.is_some_and(|(rs_asn, _)| {
                             *rs_tagged_pass
                                 .entry((gid, rs_asn))
@@ -3721,6 +3721,14 @@ impl RibManager {
                         } else {
                             super::update_groups::emit_group_deltas_for_member(
                                 &stage.deltas,
+                                peer,
+                                rs_control,
+                                &mut announce,
+                                &mut withdraw,
+                                &mut nh_override_flags,
+                            );
+                            super::update_groups::emit_rs_tag_transitions(
+                                &stage.rs_transitions,
                                 peer,
                                 rs_control,
                                 &mut announce,

--- a/crates/rib/src/manager/distribution/rs_control.rs
+++ b/crates/rib/src/manager/distribution/rs_control.rs
@@ -89,7 +89,7 @@ pub(super) fn rs_control_export_suppressed(
 /// Prepend count toward `peer_asn`: the largest matching
 /// `RS:101|102|103:PEER` (target-specific) or `RS:10x:0` (every
 /// target) large community, `0` when none match.
-pub(super) fn rs_control_prepend_count(
+pub(in crate::manager) fn rs_control_prepend_count(
     large_communities: &[LargeCommunity],
     rs_asn: u32,
     peer_asn: u32,
@@ -140,33 +140,36 @@ pub(in crate::manager) fn rs_control_route_tagged(
             .any(|lc| is_large_control(lc, rs_asn))
 }
 
-/// Per-target suppression at the group emit seam: `rs` is
+/// Per-target suppression at the group emit seams: `rs` is
 /// `(rs_asn, target_peer_asn)` for an enabled session, `None` when the
-/// knob is off (never suppressed).
-pub(in crate::manager) fn rs_control_route_suppressed(
-    route: &crate::route::Route,
+/// knob is off (never suppressed). The community slices MUST be the
+/// SOURCE route's — the staged group-table route is post-policy, and
+/// deciding on it would leak a source-prohibited route when policy
+/// strips the tag (or spuriously steer on a policy-added one).
+pub(in crate::manager) fn rs_control_suppressed(
+    communities: &[u32],
+    large_communities: &[LargeCommunity],
     rs: Option<(u32, u32)>,
 ) -> bool {
     rs.is_some_and(|(rs_asn, peer_asn)| {
-        rs_control_export_suppressed(
-            route.communities(),
-            route.large_communities(),
-            rs_asn,
-            peer_asn,
-        )
+        rs_control_export_suppressed(communities, large_communities, rs_asn, peer_asn)
     })
 }
 
-/// Per-target egress rewrite (prepend + scrub) at the group emit seam,
-/// for a route already cleared by [`rs_control_route_suppressed`].
+/// Per-target egress rewrite at the group emit seams, for a route
+/// already cleared by [`rs_control_suppressed`]: prepend decided on
+/// the SOURCE route's large communities (like the suppression gate),
+/// scrub applied to the post-policy `route` so policy-added control
+/// communities are scrubbed too — the ungrouped path's exact split.
 /// No-op (and allocation-free) for untagged routes or a disabled
 /// session.
 pub(in crate::manager) fn rs_control_route_rewrite(
     route: &mut crate::route::Route,
+    source_large_communities: &[LargeCommunity],
     rs: Option<(u32, u32)>,
 ) {
     if let Some((rs_asn, peer_asn)) = rs {
-        let prepend = rs_control_prepend_count(route.large_communities(), rs_asn, peer_asn);
+        let prepend = rs_control_prepend_count(source_large_communities, rs_asn, peer_asn);
         apply_rs_control_egress(route, rs_asn, prepend);
     }
 }

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -1605,8 +1605,10 @@ impl RibManager {
         // route (pre-policy, like the RFC 1997 gates above) decide
         // per-target announcement. Active only for sessions with
         // `rs_control_communities` (the RS-side local ASN arrives via
-        // `SetPeerRsControl` — enabled peers are always on the ungrouped
-        // per-peer path); every other session keeps full transparency.
+        // `SetPeerRsControl`); group staging passes `None` here and
+        // defers to the member-emit seams, which make the same
+        // source-based decision from the captured source attributes.
+        // Every other session keeps full transparency.
         if let (Some(rs_asn), (_, Some(peer_asn), _)) = (rs_control_asn, target.ctx_peer())
             && super::rs_control::rs_control_export_suppressed(
                 best.communities(),

--- a/crates/rib/src/manager/peer_lifecycle.rs
+++ b/crates/rib/src/manager/peer_lifecycle.rs
@@ -1135,22 +1135,31 @@ impl RibManager {
         let mut vpn_group_replayed = false;
         if let Some(group) = member_of.and_then(|gid| self.group_ribs.get(&gid)) {
             // LAN-474: per-target divergence at the replay seam — a
-            // control-tagged table entry may be suppressed toward this
-            // member or rewritten (prepend + scrub) for it; untagged
+            // table entry whose captured SOURCE communities tag it may
+            // be suppressed toward this member or rewritten (prepend
+            // from the source, scrub post-policy) for it; untagged
             // entries replay as-is.
             let rs_control = rs_control_asn.zip(target_peer_asn);
             for route in group.table.iter() {
+                let (source_communities, source_large_communities) =
+                    group.source_control((route.prefix, route.path_id));
                 if route.peer == peer
                     || self.selection_deferred(prefix_family(&route.prefix))
-                    || super::distribution::rs_control::rs_control_route_suppressed(
-                        route, rs_control,
+                    || super::distribution::rs_control::rs_control_suppressed(
+                        source_communities,
+                        source_large_communities,
+                        rs_control,
                     )
                 {
                     continue;
                 }
                 nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
                 let mut route = route.clone();
-                super::distribution::rs_control::rs_control_route_rewrite(&mut route, rs_control);
+                super::distribution::rs_control::rs_control_route_rewrite(
+                    &mut route,
+                    source_large_communities,
+                    rs_control,
+                );
                 announce.push(route);
             }
             // VPN join replay: table minus own-sourced, filtered by the

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -977,14 +977,19 @@ impl RibManager {
             // apply to a grouped member.
             if let Some(group) = self.group_ribs.get(&gid) {
                 // LAN-474: same per-target divergence as the join
-                // replay — suppressed entries skipped, announced tagged
-                // entries rewritten per target.
+                // replay — source-suppressed entries skipped, announced
+                // tagged entries rewritten per target (prepend from the
+                // captured source, scrub post-policy).
                 let rs_control = rs_control_asn.zip(target_peer_asn);
                 for route in group.table.iter() {
+                    let (source_communities, source_large_communities) =
+                        group.source_control((route.prefix, route.path_id));
                     if route.peer == peer
                         || prefix_family(&route.prefix) != family
-                        || super::distribution::rs_control::rs_control_route_suppressed(
-                            route, rs_control,
+                        || super::distribution::rs_control::rs_control_suppressed(
+                            source_communities,
+                            source_large_communities,
+                            rs_control,
                         )
                     {
                         continue;
@@ -992,7 +997,9 @@ impl RibManager {
                     nh_override_flags.push(group.nh_override((route.prefix, route.path_id)));
                     let mut route = route.clone();
                     super::distribution::rs_control::rs_control_route_rewrite(
-                        &mut route, rs_control,
+                        &mut route,
+                        source_large_communities,
+                        rs_control,
                     );
                     announce.push(route);
                 }

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -441,6 +441,7 @@ fn lazy_clean_group_prior_defers_only_for_a_resolved_eligible_stage() {
             new: Some((route.clone(), None)),
             old_source: Some(source),
             policy_label: None,
+            source_attrs: None,
         }],
     )]);
 
@@ -998,6 +999,7 @@ fn clean_group_all_success_preserves_shared_payload_and_target_snapshot_fence() 
         new: Some((route.clone(), None)),
         old_source: Some(source),
         policy_label: None,
+        source_attrs: None,
     }];
     let announce: Arc<[Route]> = vec![route].into();
     let next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]> = vec![None].into();
@@ -1045,6 +1047,7 @@ fn clean_group_cached_failure_materializes_prior_and_emits_owed_withdrawal() {
         new: Some((route.clone(), None)),
         old_source: Some(source),
         policy_label: None,
+        source_attrs: None,
     }];
     let announce: Arc<[Route]> = vec![route].into();
     let next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]> = vec![None].into();
@@ -1108,6 +1111,7 @@ fn clean_group_overlay_blocks_fast_path_and_retains_unrelated_family() {
         new: Some((route.clone(), None)),
         old_source: Some(source),
         policy_label: None,
+        source_attrs: None,
     }];
     let announce: Arc<[Route]> = vec![route].into();
     let next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]> = vec![None].into();

--- a/crates/rib/src/manager/tests/rs_control.rs
+++ b/crates/rib/src/manager/tests/rs_control.rs
@@ -56,6 +56,19 @@ async fn rs_peer_up(
     peer_asn: u32,
     rs_control_asn: Option<u32>,
 ) -> mpsc::Receiver<OutboundRouteUpdate> {
+    rs_peer_up_with_policy(tx, peer, peer_asn, rs_control_asn, None).await
+}
+
+/// [`rs_peer_up`] with an export policy — the policy-interaction seams
+/// (control decisions on the SOURCE route, scrub on the post-policy
+/// route) need sessions whose export chain mutates communities.
+async fn rs_peer_up_with_policy(
+    tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    peer_asn: u32,
+    rs_control_asn: Option<u32>,
+    export_policy: Option<rustbgpd_policy::PolicyChain>,
+) -> mpsc::Receiver<OutboundRouteUpdate> {
     tx.send(RibUpdate::SetPeerRsControl {
         peer,
         session_id: 0,
@@ -70,7 +83,7 @@ async fn rs_peer_up(
         peer_asn,
         peer_router_id: Ipv4Addr::UNSPECIFIED,
         outbound_tx: out_tx,
-        export_policy: None,
+        export_policy,
         sendable_families: ipv4_sendable(),
         is_ebgp: true,
         route_reflector_client: false,
@@ -443,4 +456,202 @@ async fn prepend_toward_target_asn_only() {
 
     drop(tx);
     handle.await.unwrap();
+}
+
+/// One-statement permit-everything export chain applying `mods` to
+/// every route.
+fn modifying_export_chain(
+    mods: rustbgpd_policy::RouteModifications,
+) -> rustbgpd_policy::PolicyChain {
+    rustbgpd_policy::PolicyChain::new(vec![rustbgpd_policy::Policy {
+        entries: vec![rustbgpd_policy::PolicyStatement {
+            prefix: None,
+            ge: None,
+            le: None,
+            action: rustbgpd_policy::PolicyAction::Permit,
+            match_community: vec![],
+            match_as_path: None,
+            match_neighbor_set: None,
+            match_route_type: None,
+            match_evpn_route_type: None,
+            match_rpki_validation: None,
+            match_aspa_validation: None,
+            match_as_path_length_ge: None,
+            match_as_path_length_le: None,
+            match_local_pref_ge: None,
+            match_local_pref_le: None,
+            match_med_ge: None,
+            match_med_le: None,
+            match_next_hop: None,
+            modifications: mods,
+        }],
+        default_action: rustbgpd_policy::PolicyAction::Permit,
+    }])
+}
+
+/// The RFC 7947 decision is made on the SOURCE route: an export policy
+/// that strips the "do not announce to PEER" community must not make
+/// the route leak to that peer — the source member prohibited it, and
+/// the ungrouped path's pre-policy gate honors that. Both sessions
+/// share one update group (identical chain), so this drives the
+/// grouped emit seam.
+#[tokio::test]
+async fn policy_stripped_suppression_community_still_suppresses_toward_target() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let client_a: IpAddr = "192.0.2.241".parse().unwrap();
+    let client_b: IpAddr = "192.0.2.242".parse().unwrap();
+
+    // Both members strip the control community on export.
+    let strip = rustbgpd_policy::RouteModifications {
+        large_communities_remove: vec![large(0, 65001)],
+        ..rustbgpd_policy::RouteModifications::default()
+    };
+    let chain = modifying_export_chain(strip);
+    let mut a_rx =
+        rs_peer_up_with_policy(&tx, client_a, 65001, Some(RS_AS), Some(chain.clone())).await;
+    let mut b_rx = rs_peer_up_with_policy(&tx, client_b, 65002, Some(RS_AS), Some(chain)).await;
+    assert_eq!(
+        query_update_group_label(&tx, client_a).await,
+        query_update_group_label(&tx, client_b).await,
+        "identical chains must share one update group — this test drives the grouped seam"
+    );
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 124, 0), 24);
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 44));
+    let steered = tagged(
+        make_route_with_as_path(prefix, Ipv4Addr::new(198, 51, 100, 44), vec![65010]),
+        vec![],
+        vec![large(0, 65001)], // source says: do not announce to 65001
+    );
+    announce_unicast(&tx, source, vec![steered]).await;
+    let _ = query_best_routes(&tx).await;
+
+    assert!(
+        a_rx.try_recv().is_err(),
+        "route must stay suppressed toward the named peer even though the \
+         export policy stripped the control community (decision is source-based)"
+    );
+    let update = b_rx.try_recv().expect("other client still receives");
+    assert_eq!(update.announce.len(), 1);
+    assert!(update.announce[0].large_communities().is_empty());
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// A control community ADDED by export policy is scrubbed from the
+/// wire (the scrub runs post-policy) but must not steer: suppression
+/// and prepend are decided on the SOURCE route, which carried no tags.
+#[tokio::test]
+async fn policy_added_control_communities_scrub_but_do_not_steer() {
+    let (tx, rx) = mpsc::channel(64);
+    let manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let client_a: IpAddr = "192.0.2.243".parse().unwrap();
+    let client_b: IpAddr = "192.0.2.244".parse().unwrap();
+
+    // Policy stamps a deny-to-65001 and a prepend-toward-65002 tag onto
+    // every route; neither may act.
+    let add = rustbgpd_policy::RouteModifications {
+        large_communities_add: vec![large(0, 65001), large(102, 65002)],
+        ..rustbgpd_policy::RouteModifications::default()
+    };
+    let chain = modifying_export_chain(add);
+    let mut a_rx =
+        rs_peer_up_with_policy(&tx, client_a, 65001, Some(RS_AS), Some(chain.clone())).await;
+    let mut b_rx = rs_peer_up_with_policy(&tx, client_b, 65002, Some(RS_AS), Some(chain)).await;
+
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 125, 0), 24);
+    let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 45));
+    let plain = make_route_with_as_path(prefix, Ipv4Addr::new(198, 51, 100, 45), vec![65010]);
+    announce_unicast(&tx, source, vec![plain]).await;
+    let _ = query_best_routes(&tx).await;
+
+    let update = a_rx
+        .try_recv()
+        .expect("a policy-added deny tag must not suppress — the source carried no tags");
+    assert_eq!(update.announce.len(), 1);
+    assert!(
+        update.announce[0].large_communities().is_empty(),
+        "policy-added control communities must still be scrubbed from the wire"
+    );
+    assert_eq!(sequence_asns(&update.announce[0]), vec![65010]);
+
+    let update = b_rx.try_recv().expect("other client receives");
+    assert_eq!(update.announce.len(), 1);
+    assert!(update.announce[0].large_communities().is_empty());
+    assert_eq!(
+        sequence_asns(&update.announce[0]),
+        vec![65010],
+        "a policy-added prepend tag must not prepend — the source carried no tags"
+    );
+
+    drop(tx);
+    handle.await.unwrap();
+}
+
+/// Grouped/ungrouped equivalence for the policy-strip interaction: the
+/// per-peer path is the group path's correctness oracle, so an
+/// identical (tagged route, stripping policy) scenario must produce
+/// identical per-member streams with grouping on and off.
+#[tokio::test]
+async fn grouped_matches_ungrouped_for_stripped_suppression_tag() {
+    async fn run(
+        force_ungrouped: bool,
+    ) -> Vec<(Vec<(Prefix, Vec<LargeCommunity>)>, Vec<(Prefix, u32)>)> {
+        let (tx, rx) = mpsc::channel(64);
+        let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+        manager.test_force_ungrouped = force_ungrouped;
+        let handle = tokio::spawn(manager.run());
+        let client_a: IpAddr = "192.0.2.245".parse().unwrap();
+        let client_b: IpAddr = "192.0.2.246".parse().unwrap();
+
+        let strip = rustbgpd_policy::RouteModifications {
+            large_communities_remove: vec![large(0, 65001)],
+            ..rustbgpd_policy::RouteModifications::default()
+        };
+        let chain = modifying_export_chain(strip);
+        let mut a_rx =
+            rs_peer_up_with_policy(&tx, client_a, 65001, Some(RS_AS), Some(chain.clone())).await;
+        let mut b_rx = rs_peer_up_with_policy(&tx, client_b, 65002, Some(RS_AS), Some(chain)).await;
+
+        let prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 126, 0), 24);
+        let source = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 46));
+        let plain = make_route_with_as_path(prefix, Ipv4Addr::new(198, 51, 100, 46), vec![65010]);
+        // Pass 1: untagged — everyone receives. Pass 2: the source
+        // re-announces with a deny-to-65001 tag the policy strips —
+        // the named member must see a withdraw, the other an update.
+        announce_unicast(&tx, source, vec![plain.clone()]).await;
+        let _ = query_best_routes(&tx).await;
+        let steered = tagged(plain, vec![], vec![large(0, 65001)]);
+        announce_unicast(&tx, source, vec![steered]).await;
+        let _ = query_best_routes(&tx).await;
+
+        let mut streams = Vec::new();
+        for out_rx in [&mut a_rx, &mut b_rx] {
+            let mut announced = Vec::new();
+            let mut withdrawn = Vec::new();
+            while let Ok(update) = out_rx.try_recv() {
+                announced.extend(
+                    update
+                        .announce
+                        .iter()
+                        .map(|route| (route.prefix, route.large_communities().to_vec())),
+                );
+                withdrawn.extend(update.withdraw.iter().copied());
+            }
+            streams.push((announced, withdrawn));
+        }
+        drop(tx);
+        handle.await.unwrap();
+        streams
+    }
+
+    assert_eq!(
+        run(false).await,
+        run(true).await,
+        "grouped and ungrouped paths must agree on source-based RFC 7947 decisions"
+    );
 }

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -31,9 +31,10 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use rustbgpd_policy::{NextHopAction, PolicyAction, PolicyChain, PolicyEvaluation};
-use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
+use rustbgpd_wire::{Afi, BgpRole, LargeCommunity, PathAttribute, Prefix, Safi};
 use rustc_hash::FxHashMap;
 use tracing::{debug, info, warn};
 
@@ -223,6 +224,67 @@ pub(in crate::manager) struct GroupDelta {
     /// no chain). Retained on the staged entry so a later join can
     /// replay the member's export counters without re-running policy.
     pub(in crate::manager) policy_label: Option<String>,
+    /// Pre-policy SOURCE attributes of an announce delta (`None` for a
+    /// withdrawal, or when the source carries no communities). RFC 7947
+    /// control decisions — per-target suppression and prepend — are
+    /// made on the source route, exactly like the ungrouped path's
+    /// pre-policy gate; only the scrub reads the post-policy `new`.
+    pub(in crate::manager) source_attrs: Option<Arc<Vec<PathAttribute>>>,
+}
+
+/// Capture a source route's attributes for RFC 7947 decisions at the
+/// member-emit seams. `None` — no communities at all — keeps the
+/// common case allocation-free (the capture itself is an `Arc` clone).
+fn capture_source_attrs(source: &Route) -> Option<Arc<Vec<PathAttribute>>> {
+    (!source.communities().is_empty() || !source.large_communities().is_empty())
+        .then(|| Arc::clone(&source.attributes))
+}
+
+/// Communities and large communities carried by a captured source
+/// attribute list (empty slices when nothing was captured).
+pub(in crate::manager) fn source_control_input(
+    attrs: Option<&Arc<Vec<PathAttribute>>>,
+) -> (&[u32], &[LargeCommunity]) {
+    let Some(attrs) = attrs else {
+        return (&[], &[]);
+    };
+    let communities = attrs
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::Communities(values) => Some(values.as_slice()),
+            _ => None,
+        })
+        .unwrap_or(&[]);
+    let large_communities = attrs
+        .iter()
+        .find_map(|attr| match attr {
+            PathAttribute::LargeCommunities(values) => Some(values.as_slice()),
+            _ => None,
+        })
+        .unwrap_or(&[]);
+    (communities, large_communities)
+}
+
+/// A tag-only transition staged by a pass: the post-policy route was
+/// equality-suppressed against the group table (nothing changed on the
+/// shared wire) while the SOURCE control communities changed — a
+/// difference policy made invisible post-policy. Non-rs members see
+/// nothing (their wire form is the unchanged staged route), but an
+/// rs-control member's suppress/prepend verdict may flip, so these
+/// ride next to the deltas through the per-member emit seam.
+#[derive(Debug, Clone)]
+pub(in crate::manager) struct RsTagTransition {
+    pub(in crate::manager) prefix: Prefix,
+    pub(in crate::manager) path_id: u32,
+    /// The staged (post-policy) route, re-emitted toward members whose
+    /// verdict flips to announce.
+    pub(in crate::manager) route: Route,
+    /// Next-hop-override residue for the staged entry.
+    pub(in crate::manager) nh: Option<NextHopAction>,
+    /// Captured source attributes before this pass.
+    pub(in crate::manager) prior_source_attrs: Option<Arc<Vec<PathAttribute>>>,
+    /// Captured source attributes after this pass.
+    pub(in crate::manager) source_attrs: Option<Arc<Vec<PathAttribute>>>,
 }
 
 /// The `Arc`-shared unicast announce payload of one group staging pass:
@@ -297,6 +359,11 @@ pub(in crate::manager) struct GroupStageOutput {
     pub(in crate::manager) shared_nh: std::sync::Arc<[Option<NextHopAction>]>,
     /// Withdraw keys for non-exception members.
     pub(in crate::manager) shared_withdraw: Vec<(Prefix, u32)>,
+    /// Tag-only transitions of this pass ([`RsTagTransition`]): keys
+    /// whose staged route was equality-suppressed while the source
+    /// control communities changed. Deliberately outside the shared
+    /// emission — only rs-control members act on them.
+    pub(in crate::manager) rs_transitions: Vec<RsTagTransition>,
     /// Members whose emission differs from the shared one: the new
     /// source of an announce delta (announce → skip/withdraw) or the
     /// old source of a withdraw delta (withdraw → skip).
@@ -319,21 +386,32 @@ impl GroupStageOutput {
         !self.exceptions.contains(&member)
     }
 
-    /// Whether any announce delta of this pass carries a control-form
-    /// community for `rs_asn` (LAN-474). A pass with none — the
-    /// overwhelming majority — lets `rs_control_communities` members
-    /// ride the shared emission untouched; a tagged pass drops them to
-    /// the per-member matrix walk where suppression/prepend/scrub
-    /// diverge per target. Callers memoize per (group, `rs_asn`).
+    /// Whether this pass carries a control-form community for `rs_asn`
+    /// (LAN-474). A pass with none — the overwhelming majority — lets
+    /// `rs_control_communities` members ride the shared emission
+    /// untouched; a tagged pass drops them to the per-member matrix
+    /// walk where suppression/prepend/scrub diverge per target. Tagged
+    /// on EITHER side of policy: source tags drive suppress/prepend,
+    /// post-policy tags need scrubbing; a tag-only transition counts on
+    /// either side of the pass. Callers memoize per (group, `rs_asn`).
     pub(in crate::manager) fn has_tagged_route(&self, rs_asn: u32) -> bool {
+        use super::distribution::rs_control::rs_control_route_tagged;
+        let attrs_tagged = |attrs: Option<&Arc<Vec<PathAttribute>>>| {
+            let (communities, large_communities) = source_control_input(attrs);
+            rs_control_route_tagged(communities, large_communities, rs_asn)
+        };
         self.deltas.iter().any(|delta| {
             delta.new.as_ref().is_some_and(|(route, _)| {
-                super::distribution::rs_control::rs_control_route_tagged(
-                    route.communities(),
-                    route.large_communities(),
-                    rs_asn,
-                )
+                attrs_tagged(delta.source_attrs.as_ref())
+                    || rs_control_route_tagged(
+                        route.communities(),
+                        route.large_communities(),
+                        rs_asn,
+                    )
             })
+        }) || self.rs_transitions.iter().any(|transition| {
+            attrs_tagged(transition.prior_source_attrs.as_ref())
+                || attrs_tagged(transition.source_attrs.as_ref())
         })
     }
 
@@ -447,12 +525,14 @@ impl GroupEvalAccumulator {
 /// directly.
 ///
 /// `rs_control` is `(rs_asn, member_asn)` for an
-/// `rs_control_communities` member (LAN-474): a tagged route the
-/// control communities suppress toward this member emits a withdraw of
-/// whatever other-sourced entry the member may hold (over-withdraw is
-/// the safe direction), and an announced tagged route is rewritten
-/// (prepend + scrub) per target. `None` — or an untagged route — is
-/// byte-identical to the shared emission.
+/// `rs_control_communities` member (LAN-474): a route whose SOURCE
+/// control communities (`GroupDelta::source_attrs` — captured
+/// pre-policy, like the ungrouped path's gate) suppress it toward this
+/// member emits a withdraw of whatever other-sourced entry the member
+/// may hold (over-withdraw is the safe direction), and an announced
+/// route is rewritten per target — prepend decided on the source,
+/// scrub on the post-policy route. `None` — or an untagged source and
+/// route — is byte-identical to the shared emission.
 pub(in crate::manager) fn emit_group_deltas_for_member(
     deltas: &[GroupDelta],
     member: IpAddr,
@@ -461,10 +541,12 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
     withdraw: &mut Vec<(Prefix, u32)>,
     nh_override_flags: &mut Vec<Option<NextHopAction>>,
 ) {
-    use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_route_suppressed};
+    use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_suppressed};
     for delta in deltas {
         match &delta.new {
             Some((route, nh)) => {
+                let (source_communities, source_large_communities) =
+                    source_control_input(delta.source_attrs.as_ref());
                 if route.peer == member {
                     // Split horizon applied at emit: the new best is the
                     // member's own route. If the member previously held a
@@ -476,7 +558,11 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
                     if delta.old_source.is_some_and(|source| source != member) {
                         withdraw.push((delta.prefix, delta.path_id));
                     }
-                } else if rs_control_route_suppressed(route, rs_control) {
+                } else if rs_control_suppressed(
+                    source_communities,
+                    source_large_communities,
+                    rs_control,
+                ) {
                     // RFC 7947 §2.3.2 per-target suppression: same
                     // matrix shape as the split-horizon arm — displace
                     // whatever other-sourced entry the member may hold.
@@ -485,7 +571,7 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
                     }
                 } else {
                     let mut route = route.clone();
-                    rs_control_route_rewrite(&mut route, rs_control);
+                    rs_control_route_rewrite(&mut route, source_large_communities, rs_control);
                     nh_override_flags.push(nh.clone());
                     announce.push(route);
                 }
@@ -499,6 +585,53 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
                     withdraw.push((delta.prefix, delta.path_id));
                 }
             }
+        }
+    }
+}
+
+/// Per-member emit for a pass's tag-only transitions
+/// ([`RsTagTransition`]): the old/new source verdicts decide the
+/// member's exact stream delta — withdraw when suppression turns on,
+/// re-announce (rewritten) when it turns off or the prepend count
+/// changes, nothing otherwise — matching what the per-peer path's
+/// restage + Adj-RIB-Out diff would emit. A no-op for members without
+/// `rs_control_communities`: their wire form is the unchanged staged
+/// route.
+pub(in crate::manager) fn emit_rs_tag_transitions(
+    transitions: &[RsTagTransition],
+    member: IpAddr,
+    rs_control: Option<(u32, u32)>,
+    announce: &mut Vec<Route>,
+    withdraw: &mut Vec<(Prefix, u32)>,
+    nh_override_flags: &mut Vec<Option<NextHopAction>>,
+) {
+    use super::distribution::rs_control::{
+        rs_control_prepend_count, rs_control_route_rewrite, rs_control_suppressed,
+    };
+    let Some((rs_asn, member_asn)) = rs_control else {
+        return;
+    };
+    for transition in transitions {
+        if transition.route.peer == member {
+            continue;
+        }
+        let (old_communities, old_large) =
+            source_control_input(transition.prior_source_attrs.as_ref());
+        let (new_communities, new_large) = source_control_input(transition.source_attrs.as_ref());
+        let was = rs_control_suppressed(old_communities, old_large, rs_control);
+        let now = rs_control_suppressed(new_communities, new_large, rs_control);
+        if now {
+            if !was {
+                withdraw.push((transition.prefix, transition.path_id));
+            }
+        } else if was
+            || rs_control_prepend_count(old_large, rs_asn, member_asn)
+                != rs_control_prepend_count(new_large, rs_asn, member_asn)
+        {
+            let mut route = transition.route.clone();
+            rs_control_route_rewrite(&mut route, new_large, rs_control);
+            nh_override_flags.push(transition.nh.clone());
+            announce.push(route);
         }
     }
 }
@@ -656,6 +789,14 @@ pub(in crate::manager) struct GroupRibOut {
     /// Next-hop-override flags for staged entries (`Some` values only)
     /// so joins/replays don't re-run policy to recover them.
     nh_overrides: FxHashMap<(Prefix, u32), NextHopAction>,
+    /// Captured pre-policy SOURCE attributes per staged entry (entries
+    /// only for sources carrying communities; the `Arc` is shared with
+    /// the Adj-RIB-In/Loc-RIB copy). RFC 7947 decisions at the table
+    /// replay seams — resync, join, refresh, regroup baseline — read
+    /// these, never the staged (post-policy) route: policy may have
+    /// stripped a control community (deciding post-policy leaks a
+    /// source-prohibited route) or added one (spurious steering).
+    source_attrs: FxHashMap<(Prefix, u32), Arc<Vec<PathAttribute>>>,
     /// Staged-entry count per source peer — O(1) per-member advertised
     /// count synthesis (`len − own`), one slot per staged family
     /// (v4-unicast, v6-unicast, vpnv4, vpnv6) for the BMP stat-17
@@ -736,6 +877,7 @@ impl GroupRibOut {
         Self {
             table: AdjRibOut::with_capacity(GROUP_FILTERED_PLACEHOLDER, capacity),
             nh_overrides: FxHashMap::default(),
+            source_attrs: FxHashMap::default(),
             source_counts: FxHashMap::default(),
             tombstones: HashSet::new(),
             vpn_tombstones: HashSet::new(),
@@ -854,11 +996,20 @@ impl GroupRibOut {
                     self.nh_overrides.remove(&key);
                 }
             }
+            match &delta.source_attrs {
+                Some(attrs) => {
+                    self.source_attrs.insert(key, Arc::clone(attrs));
+                }
+                None => {
+                    self.source_attrs.remove(&key);
+                }
+            }
             self.staged_labels.insert(key, delta.policy_label.clone());
             self.table.insert(route.clone());
         } else {
             self.table.withdraw(&delta.prefix, delta.path_id);
             self.nh_overrides.remove(&key);
+            self.source_attrs.remove(&key);
             self.staged_labels.remove(&key);
         }
     }
@@ -890,6 +1041,59 @@ impl GroupRibOut {
     /// The next-hop-override flag staged for a table entry.
     pub(in crate::manager) fn nh_override(&self, key: (Prefix, u32)) -> Option<NextHopAction> {
         self.nh_overrides.get(&key).cloned()
+    }
+
+    /// RFC 7947 control-decision input for a staged table entry: the
+    /// SOURCE route's communities as captured at staging (empty when
+    /// the source carried none). Table replay seams must decide
+    /// suppression/prepend on this, never on the post-policy entry.
+    pub(in crate::manager) fn source_control(
+        &self,
+        key: (Prefix, u32),
+    ) -> (&[u32], &[LargeCommunity]) {
+        source_control_input(self.source_attrs.get(&key))
+    }
+
+    /// Tag-only transition check for a pass that staged NO delta for
+    /// `prefix` (the post-policy route was equality-suppressed): if the
+    /// key stays staged while the SOURCE control communities changed —
+    /// a difference policy erased post-policy — rs-control members'
+    /// suppress/prepend verdicts may flip even though the shared wire
+    /// form did not, so the pass records an [`RsTagTransition`].
+    fn rs_tag_transition(
+        &self,
+        prefix: Prefix,
+        source_attrs: Option<&Arc<Vec<PathAttribute>>>,
+    ) -> Option<RsTagTransition> {
+        let staged = self.table.get(&prefix, 0)?;
+        let key = (prefix, 0);
+        let prior = self.source_attrs.get(&key);
+        (source_control_input(source_attrs) != source_control_input(prior)).then(|| {
+            RsTagTransition {
+                prefix,
+                path_id: 0,
+                route: staged.clone(),
+                nh: self.nh_override(key),
+                prior_source_attrs: prior.cloned(),
+                source_attrs: source_attrs.cloned(),
+            }
+        })
+    }
+
+    /// Commit a pass's tag-only transitions into the source-attribute
+    /// residue (the delta-borne updates ride [`Self::apply_delta`]).
+    fn commit_rs_transitions(&mut self, transitions: &[RsTagTransition]) {
+        for transition in transitions {
+            let key = (transition.prefix, transition.path_id);
+            match &transition.source_attrs {
+                Some(attrs) => {
+                    self.source_attrs.insert(key, Arc::clone(attrs));
+                }
+                None => {
+                    self.source_attrs.remove(&key);
+                }
+            }
+        }
     }
 
     /// Number of unicast routes `member` currently has advertised: the
@@ -1014,22 +1218,24 @@ impl GroupRibOut {
         rs_control: Option<(u32, u32)>,
         rejected: &HashSet<ExactExportKey>,
     ) -> FxHashMap<(Prefix, u32), Route> {
-        use super::distribution::rs_control::{
-            rs_control_route_rewrite, rs_control_route_suppressed,
-        };
+        use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_suppressed};
         self.table
             .iter()
             .filter(|route| {
+                let (communities, large_communities) =
+                    self.source_control((route.prefix, route.path_id));
                 route.peer != member
                     && !rejected.contains(&ExactExportKey::Unicast(route.prefix, route.path_id))
-                    // LAN-474: a key suppressed toward the member was
-                    // never on its wire — the snapshot records true
-                    // wire state, not the shared table.
-                    && !rs_control_route_suppressed(route, rs_control)
+                    // LAN-474: a key whose SOURCE communities suppress
+                    // it toward the member was never on its wire — the
+                    // snapshot records true wire state, not the shared
+                    // table.
+                    && !rs_control_suppressed(communities, large_communities, rs_control)
             })
             .map(|route| {
+                let (_, large_communities) = self.source_control((route.prefix, route.path_id));
                 let mut route = route.clone();
-                rs_control_route_rewrite(&mut route, rs_control);
+                rs_control_route_rewrite(&mut route, large_communities, rs_control);
                 ((route.prefix, route.path_id), route)
             })
             .collect()
@@ -1408,6 +1614,12 @@ impl RibManager {
             let mut filtered: Vec<PolicyFilteredRouteKey> = Vec::new();
             for prefix in prefixes {
                 let old_source = group.table.get(prefix, 0).map(|r| r.peer);
+                // RFC 7947 decisions at the member-emit seams are made
+                // on the pre-policy SOURCE (the Loc-RIB best this pass
+                // stages from); capture its attributes for the deltas
+                // and the table residue.
+                let source_attrs = self.loc_rib.get(prefix).and_then(capture_source_attrs);
+                let deltas_before = out.deltas.len();
                 let mut target = super::distribution::ExportTarget::Group {
                     evals: &mut out.evals,
                     local_role: group.local_role,
@@ -1451,6 +1663,7 @@ impl RibManager {
                         new: Some((route, nh)),
                         old_source,
                         policy_label: label.clone(),
+                        source_attrs: source_attrs.clone(),
                     });
                 }
                 for (p, path_id) in withdraw.drain(..) {
@@ -1460,7 +1673,14 @@ impl RibManager {
                         new: None,
                         old_source,
                         policy_label: None,
+                        source_attrs: None,
                     });
+                }
+                if out.deltas.len() == deltas_before
+                    && let Some(transition) =
+                        group.rs_tag_transition(*prefix, source_attrs.as_ref())
+                {
+                    out.rs_transitions.push(transition);
                 }
                 labeled_filtered.extend(filtered.drain(..).map(|key| (key, label.clone())));
             }
@@ -1472,6 +1692,7 @@ impl RibManager {
         for delta in &out.deltas {
             group.apply_delta(delta);
         }
+        group.commit_rs_transitions(&out.rs_transitions);
         group.record_otc_blocked(prefixes, &out.otc_blocked);
         group.record_policy_filtered(prefixes, &labeled_filtered);
         if !group.dirty_members.is_empty() {
@@ -1669,13 +1890,15 @@ impl RibManager {
     ///   bypassing the equality diff, withdraw nothing.
     ///
     /// `rs_control` is `(rs_asn, member_asn)` for an
-    /// `rs_control_communities` member (LAN-474): table entries the
-    /// control communities suppress toward this member are skipped —
-    /// and withdrawn when the member may have them on the wire (plain
-    /// dirty, or a baseline that records the key) — and announced
-    /// entries are rewritten (prepend + scrub) per target. Baselines
-    /// snapshot through the same filter ([`GroupRibOut::member_view_snapshot`]),
-    /// so the regroup one-shot diff compares wire state to wire state.
+    /// `rs_control_communities` member (LAN-474): table entries whose
+    /// captured SOURCE communities ([`GroupRibOut::source_control`])
+    /// suppress them toward this member are skipped — and withdrawn
+    /// when the member may have them on the wire (plain dirty, or a
+    /// baseline that records the key) — and announced entries are
+    /// rewritten (prepend from the source, scrub post-policy) per
+    /// target. Baselines snapshot through the same filter
+    /// ([`GroupRibOut::member_view_snapshot`]), so the regroup one-shot
+    /// diff compares wire state to wire state.
     #[expect(
         clippy::too_many_arguments,
         reason = "the resync assembly takes the member's full pending-withdraw context"
@@ -1692,16 +1915,15 @@ impl RibManager {
         withdraw: &mut Vec<(Prefix, u32)>,
         nh_override_flags: &mut Vec<Option<NextHopAction>>,
     ) {
-        use super::distribution::rs_control::{
-            rs_control_route_rewrite, rs_control_route_suppressed,
-        };
+        use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_suppressed};
         let mut suppressed_withdraws: HashSet<(Prefix, u32)> = HashSet::new();
         for route in group.table.iter() {
             if route.peer == member {
                 continue;
             }
             let key = (route.prefix, route.path_id);
-            if rs_control_route_suppressed(route, rs_control) {
+            let (source_communities, source_large_communities) = group.source_control(key);
+            if rs_control_suppressed(source_communities, source_large_communities, rs_control) {
                 // Not on this member's wire going forward. Withdraw when
                 // it may be there now: always on a plain dirty resync
                 // (missed sends are unknown — over-withdraw is the safe
@@ -1714,7 +1936,7 @@ impl RibManager {
                 continue;
             }
             let mut route = route.clone();
-            rs_control_route_rewrite(&mut route, rs_control);
+            rs_control_route_rewrite(&mut route, source_large_communities, rs_control);
             if !is_force
                 && let Some(base) = baseline
                 && base.get(&key).is_some_and(|old| routes_equal(old, &route))
@@ -1725,11 +1947,14 @@ impl RibManager {
             announce.push(route);
         }
         // A key the member still retains (staged, not own-sourced, not
-        // suppressed toward it) must not be withdrawn — everything else
-        // in the candidate sets is a safe (possibly spurious) withdraw.
+        // source-suppressed toward it) must not be withdrawn —
+        // everything else in the candidate sets is a safe (possibly
+        // spurious) withdraw.
         let member_retains = |key: &(Prefix, u32)| {
             group.table.get(&key.0, key.1).is_some_and(|route| {
-                route.peer != member && !rs_control_route_suppressed(route, rs_control)
+                let (communities, large_communities) = group.source_control(*key);
+                route.peer != member
+                    && !rs_control_suppressed(communities, large_communities, rs_control)
             })
         };
         let mut keys: HashSet<(Prefix, u32)> = suppressed_withdraws;
@@ -3122,12 +3347,15 @@ mod tests {
     }
 
     fn announce_delta(p: Prefix, src: IpAddr, old: Option<IpAddr>) -> GroupDelta {
+        let new = route(p, src);
+        let source_attrs = capture_source_attrs(&new);
         GroupDelta {
             prefix: p,
             path_id: 0,
-            new: Some((route(p, src), None)),
+            new: Some((new, None)),
             old_source: old,
             policy_label: None,
+            source_attrs,
         }
     }
 
@@ -3138,6 +3366,7 @@ mod tests {
             new: None,
             old_source: old,
             policy_label: None,
+            source_attrs: None,
         }
     }
 


### PR DESCRIPTION
The grouped emission path evaluated RFC 7947 control communities on the post-export-policy route at five seams (delta emit matrix, dirty/regroup resync, regroup baseline snapshot, join initial dump, refresh replay), while the ungrouped path decides suppression/prepend on the pre-policy source route and only scrubs post-policy. An export policy stripping 0:PEER / RS:0:PEER could therefore leak a route the source member prohibited, and policy-added control communities could spuriously suppress or prepend — with RS control default-on for route-server clients.

Suppression and prepend are now decided from source-route communities captured at staging (Arc-shared with the Loc-RIB copy; residue map sibling to nh_overrides/staged_labels), the egress scrub still runs on the post-policy route, and all replay seams read the stored source capture. Tag-only transitions — policy strips or adds the tag while the post-policy form is otherwise unchanged, previously equality-suppressed into silence — now emit the exact per-member withdraw / rewritten re-announce delta, matching the per-peer restage+diff byte-for-byte. The tagged-pass memo considers source capture, post-policy route, and transitions. VPN grouped path unaffected: RS control is unicast-only daemon-wide.

Three regression tests proven red on main before the fix (policy-stripped tag must still suppress; policy-added tag must scrub without steering; grouped/ungrouped equivalence), all green after. Full workspace suite green.