### PR TITLE
fix(transport): bound rejected-route retention; require reachable NLRI for treat-as-withdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RFC 7606 §5.2: an empty-NLRI `MP_REACH_NLRI` no longer shields a
+  malformed UPDATE from session reset.** The "no reachable NLRI"
+  escalation gate tested MP_REACH attribute *presence*, not content —
+  an UPDATE carrying a structurally valid MP_REACH with zero NLRI plus
+  a treat-as-withdraw-class attribute error stayed Established via the
+  treat-as-withdraw arm, which had nothing to withdraw. The gate now
+  inspects the parsed MP_REACH payload across every family's announced
+  vector; the attribute validator keeps its presence-based
+  mandatory-attribute semantics unchanged, and an MP_REACH that does
+  carry NLRI still takes treat-as-withdraw (no over-reset). Malformed
+  UPDATEs are additionally dumped at DEBUG per the §5.2 debugging
+  guidance: NLRI/withdrawn counts plus the raw message sections
+  hex-encoded, bounded at 512 bytes per section so an Extended-Messages
+  peer cannot spam the logs.
+
 - **Rejected-route retention now enforces its per-entry byte budget.**
   The `[policy.reject_retention]` store was bounded in entry count
   (LRU, 1024/peer) but each entry retained unbounded wire-derived data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Rejected-route retention now enforces its per-entry byte budget.**
+  The `[policy.reject_retention]` store was bounded in entry count
+  (LRU, 1024/peer) but each entry retained unbounded wire-derived data
+  — a hostile peer with a maximal AS_PATH and community lists (worse
+  under RFC 8654 Extended Messages) could push entries to multiple KB
+  across hundreds of peers, default-on. Entries are now truncated at
+  capture time: the rendered AS-path and detail strings are capped
+  (96 / 64 bytes, `…` marker appended), and the community vectors are
+  capped (16 standard / 8 large) with the dropped counts recorded and
+  surfaced (`ListRejectedRoutes` `communities_dropped` /
+  `large_communities_dropped`, and in `rbgp rib received --rejected`
+  JSON) so renderers can say "…and N more". The documented
+  ≤ 512 B/entry ⇒ ~0.5 MiB/peer bound is now an enforced fact, pinned
+  by a size-budget test against the real type sizes. One bounded
+  attribute summary is also built per UPDATE and shared across every
+  rejected identity, replacing the per-identity re-render and
+  deep-clone of the full attribute set.
+
 - **Post-flap re-announce latency: initial table dumps no longer
   head-of-line block redistribution.** A peer's outbound registration at
   `PeerUp` performed its full-table initial dump synchronously on the

--- a/crates/api/src/policy_service.rs
+++ b/crates/api/src/policy_service.rs
@@ -1455,11 +1455,13 @@ impl proto::policy_service_server::PolicyService for PolicyService {
                     next_hop: entry.next_hop.map(|nh| nh.to_string()).unwrap_or_default(),
                     as_path: entry.as_path,
                     communities: entry.communities,
+                    communities_dropped: entry.communities_dropped,
                     large_communities: entry
                         .large_communities
                         .iter()
                         .map(ToString::to_string)
                         .collect(),
+                    large_communities_dropped: entry.large_communities_dropped,
                     rpki_validation: entry.rpki.to_string(),
                     aspa_validation: entry.aspa.to_string(),
                     rejected_at_unix_ns: entry
@@ -2156,7 +2158,9 @@ mod tests {
             next_hop: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2))),
             as_path: "65002 65010".to_string(),
             communities: vec![999],
+            communities_dropped: 3,
             large_communities: Vec::new(),
+            large_communities_dropped: 0,
             rpki: rustbgpd_wire::RpkiValidation::Invalid,
             aspa: rustbgpd_wire::AspaValidation::Unknown,
             rejected_at: std::time::UNIX_EPOCH + Duration::from_secs(1),
@@ -2180,6 +2184,8 @@ mod tests {
         assert_eq!(r.next_hop, "10.0.0.2");
         assert_eq!(r.as_path, "65002 65010");
         assert_eq!(r.communities, vec![999]);
+        assert_eq!(r.communities_dropped, 3);
+        assert_eq!(r.large_communities_dropped, 0);
         assert_eq!(r.rpki_validation, "invalid");
         assert_eq!(r.rejected_at_unix_ns, 1_000_000_000);
     }

--- a/crates/cli/src/commands/rib.rs
+++ b/crates/cli/src/commands/rib.rs
@@ -1691,13 +1691,24 @@ struct JsonRejectedRoute<'a> {
     as_path: &'a str,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     communities: &'a [u32],
+    // Retention truncates community lists under a per-entry byte
+    // budget; a non-zero count means "…and N more" were dropped.
+    #[serde(skip_serializing_if = "dropped_count_is_zero")]
+    communities_dropped: u32,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     large_communities: &'a [String],
+    #[serde(skip_serializing_if = "dropped_count_is_zero")]
+    large_communities_dropped: u32,
     #[serde(skip_serializing_if = "str::is_empty")]
     rpki_validation: &'a str,
     #[serde(skip_serializing_if = "str::is_empty")]
     aspa_validation: &'a str,
     rejected_at_unix_ns: i64,
+}
+
+// serde's skip_serializing_if requires a fn(&T) -> bool.
+fn dropped_count_is_zero(count: &u32) -> bool {
+    *count == 0
 }
 
 #[derive(Serialize)]
@@ -1721,7 +1732,9 @@ fn print_rejected_routes(resp: &ListRejectedRoutesResponse, json: bool) -> Resul
                 next_hop: &r.next_hop,
                 as_path: &r.as_path,
                 communities: &r.communities,
+                communities_dropped: r.communities_dropped,
                 large_communities: &r.large_communities,
+                large_communities_dropped: r.large_communities_dropped,
                 rpki_validation: &r.rpki_validation,
                 aspa_validation: &r.aspa_validation,
                 rejected_at_unix_ns: r.rejected_at_unix_ns,

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -509,17 +509,23 @@ impl PeerSession {
                 _ => {}
             }
         }
-        RejectedRouteEntry {
+        let mut entry = RejectedRouteEntry {
             reason,
             detail: detail.map(str::to_owned),
             next_hop,
             as_path,
             communities,
+            communities_dropped: 0,
             large_communities,
+            large_communities_dropped: 0,
             rpki: rustbgpd_wire::RpkiValidation::NotFound,
             aspa: rustbgpd_wire::AspaValidation::Unknown,
             rejected_at: SystemTime::now(),
-        }
+        };
+        // Bound before the caller clones it across every rejected
+        // identity, so the clones are ≤ the per-entry budget too.
+        entry.enforce_bounds();
+        entry
     }
 
     /// Deliver a `RoutesReceived` batch to the RIB manager — block, never
@@ -1483,6 +1489,32 @@ impl PeerSession {
         // happens only on an actual deny, so the clean permit path pays
         // nothing.
         let retention_enabled = self.reject_retention_enabled;
+        // One bounded attribute summary per UPDATE: the AS-path render
+        // and community copies happen exactly once, truncated to the
+        // retention byte caps up front, and every rejected identity
+        // below clones this ≤ 512 B prototype (overriding the per-route
+        // fields) instead of re-deriving unbounded wire data per
+        // identity. Built only when retention is on and only from
+        // already-parsed attributes, so the clean path pays nothing.
+        let reject_proto = retention_enabled.then(|| {
+            let mut proto = RejectedRouteEntry {
+                reason: ImportRejectReason::PolicyReject,
+                detail: None,
+                next_hop: None,
+                as_path: parsed_as_path
+                    .map(AsPath::to_aspath_string)
+                    .unwrap_or_default(),
+                communities: update_communities.to_vec(),
+                communities_dropped: 0,
+                large_communities: update_large_communities.to_vec(),
+                large_communities_dropped: 0,
+                rpki: rustbgpd_wire::RpkiValidation::NotFound,
+                aspa: rustbgpd_wire::AspaValidation::Unknown,
+                rejected_at: SystemTime::now(),
+            };
+            proto.enforce_bounds();
+            proto
+        });
         let mut rejected_retained: Vec<(Prefix, u32, RejectedRouteEntry)> = Vec::new();
         // A denied announcement replaces any prior accepted path under the
         // same wire identity; retire it after explicit withdrawals below.
@@ -1565,24 +1597,13 @@ impl PeerSession {
                         ));
                     }
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
-                        if retention_enabled {
-                            rejected_retained.push((
-                                prefix,
-                                entry.path_id,
-                                RejectedRouteEntry {
-                                    reason: ImportRejectReason::PolicyReject,
-                                    detail: evaluation.matched_policy.clone(),
-                                    next_hop: Some(body_next_hop),
-                                    as_path: parsed_as_path
-                                        .map(AsPath::to_aspath_string)
-                                        .unwrap_or_default(),
-                                    communities: update_communities.to_vec(),
-                                    large_communities: update_large_communities.to_vec(),
-                                    rpki: rpki_state,
-                                    aspa: body_aspa_state,
-                                    rejected_at: SystemTime::now(),
-                                },
-                            ));
+                        if let Some(proto) = reject_proto.as_ref() {
+                            let mut reject_entry = proto.clone();
+                            reject_entry.detail.clone_from(&evaluation.matched_policy);
+                            reject_entry.next_hop = Some(body_next_hop);
+                            reject_entry.rpki = rpki_state;
+                            reject_entry.aspa = body_aspa_state;
+                            rejected_retained.push((prefix, entry.path_id, reject_entry));
                         }
                         denied_unicast.push((prefix, entry.path_id));
                         return None;
@@ -2210,24 +2231,13 @@ impl PeerSession {
                                 aspa_context,
                             });
                         } else {
-                            if retention_enabled {
-                                rejected_retained.push((
-                                    entry.prefix,
-                                    entry.path_id,
-                                    RejectedRouteEntry {
-                                        reason: ImportRejectReason::PolicyReject,
-                                        detail: evaluation.matched_policy.clone(),
-                                        next_hop: Some(mp.next_hop),
-                                        as_path: parsed_as_path
-                                            .map(AsPath::to_aspath_string)
-                                            .unwrap_or_default(),
-                                        communities: update_communities.to_vec(),
-                                        large_communities: update_large_communities.to_vec(),
-                                        rpki: mp_rpki_state,
-                                        aspa: mp_aspa_state,
-                                        rejected_at: SystemTime::now(),
-                                    },
-                                ));
+                            if let Some(proto) = reject_proto.as_ref() {
+                                let mut reject_entry = proto.clone();
+                                reject_entry.detail.clone_from(&evaluation.matched_policy);
+                                reject_entry.next_hop = Some(mp.next_hop);
+                                reject_entry.rpki = mp_rpki_state;
+                                reject_entry.aspa = mp_aspa_state;
+                                rejected_retained.push((entry.prefix, entry.path_id, reject_entry));
                             }
                             denied_unicast.push((entry.prefix, entry.path_id));
                         }
@@ -2337,26 +2347,17 @@ impl PeerSession {
             }
         }
         // LAN-472: retain the pre-policy safety rejections under their
-        // gate reason. One shared entry per gate — the per-UPDATE
-        // attribute summary is identical across the rejected identities,
-        // and the AS-path string is built only here, on the reject path.
-        if self.reject_retention_enabled {
+        // gate reason. One shared entry per gate, derived from the
+        // bounded per-UPDATE prototype — the attribute summary is
+        // identical across the rejected identities, so each identity
+        // clones the ≤ 512 B prototype instead of re-deriving it.
+        if let Some(proto) = reject_proto.as_ref() {
             if let OtcIngressAction::DropUnicastAnnouncements(otc_reason) = otc_action
                 && !otc_rejected_unicast.is_empty()
             {
-                let entry = RejectedRouteEntry {
-                    reason: ImportRejectReason::OtcRouteLeak,
-                    detail: Some(otc_reason.as_str().to_owned()),
-                    next_hop: None,
-                    as_path: parsed_as_path
-                        .map(AsPath::to_aspath_string)
-                        .unwrap_or_default(),
-                    communities: update_communities.to_vec(),
-                    large_communities: update_large_communities.to_vec(),
-                    rpki: rustbgpd_wire::RpkiValidation::NotFound,
-                    aspa: rustbgpd_wire::AspaValidation::Unknown,
-                    rejected_at: SystemTime::now(),
-                };
+                let mut entry = proto.clone();
+                entry.reason = ImportRejectReason::OtcRouteLeak;
+                entry.detail = Some(otc_reason.as_str().to_owned());
                 for &(prefix, path_id) in &otc_rejected_unicast {
                     self.retain_rejected_route(prefix, path_id, entry.clone());
                 }
@@ -2364,19 +2365,10 @@ impl PeerSession {
             if let Some((ownership_reason, violating_next_hop, _)) = next_hop_ownership_rejection
                 && !ownership_rejected_unicast.is_empty()
             {
-                let entry = RejectedRouteEntry {
-                    reason: ImportRejectReason::NextHopOwnership,
-                    detail: Some(ownership_reason.as_str().to_owned()),
-                    next_hop: Some(violating_next_hop),
-                    as_path: parsed_as_path
-                        .map(AsPath::to_aspath_string)
-                        .unwrap_or_default(),
-                    communities: update_communities.to_vec(),
-                    large_communities: update_large_communities.to_vec(),
-                    rpki: rustbgpd_wire::RpkiValidation::NotFound,
-                    aspa: rustbgpd_wire::AspaValidation::Unknown,
-                    rejected_at: SystemTime::now(),
-                };
+                let mut entry = proto.clone();
+                entry.reason = ImportRejectReason::NextHopOwnership;
+                entry.detail = Some(ownership_reason.as_str().to_owned());
+                entry.next_hop = Some(violating_next_hop);
                 for &(prefix, path_id) in &ownership_rejected_unicast {
                     self.retain_rejected_route(prefix, path_id, entry.clone());
                 }

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -198,6 +198,25 @@ fn strict_peer_next_hop_violation(
     }
     (next_hop != session_addr).then_some(NextHopOwnershipBlockReason::ForeignNextHop)
 }
+/// Bounded hex rendering of one raw UPDATE section for the
+/// malformed-UPDATE debug dump. Truncated output states how many bytes
+/// were omitted so the log is honest about what it shows.
+fn bounded_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    /// Per-section cap: enough to reconstruct any ordinary UPDATE in
+    /// full while keeping an Extended-Messages-sized dump out of the
+    /// logs.
+    const MAX_HEX_DUMP_BYTES: usize = 512;
+    let shown = &bytes[..bytes.len().min(MAX_HEX_DUMP_BYTES)];
+    let mut out = String::with_capacity(shown.len() * 2 + 24);
+    for byte in shown {
+        let _ = write!(out, "{byte:02x}");
+    }
+    if bytes.len() > MAX_HEX_DUMP_BYTES {
+        let _ = write!(out, "…(+{} bytes)", bytes.len() - MAX_HEX_DUMP_BYTES);
+    }
+    out
+}
 /// Policy-context fields extracted from a route's path attributes in a
 /// single pass over the attribute vector. This replaces what used to be
 /// eight independent `find_map` / `iter` scans of the same vector on the
@@ -959,6 +978,29 @@ impl PeerSession {
         }
         self.drive_fsm(Event::UpdateReceived).await;
     }
+    /// RFC 7606 §5.2 minimum debugging guidance: retain enough of a
+    /// malformed UPDATE — the NLRI involved and the complete message —
+    /// for offline analysis. DEBUG-only by design: a hostile peer can
+    /// trigger this once per UPDATE, so it must never land at
+    /// info/warn where it would spam operators; the per-section hex is
+    /// byte-bounded for the same reason (Extended Messages reach
+    /// 65535 B). The `tracing` macro skips the hex rendering entirely
+    /// when DEBUG is disabled.
+    fn debug_dump_malformed_update(
+        &self,
+        update: &rustbgpd_wire::UpdateMessage,
+        parsed: &ParsedUpdate,
+    ) {
+        debug!(
+            peer = %self.peer_label,
+            announced = parsed.announced.len(),
+            withdrawn = parsed.withdrawn.len(),
+            nlri_hex = %bounded_hex(&update.nlri),
+            withdrawn_routes_hex = %bounded_hex(&update.withdrawn_routes),
+            path_attributes_hex = %bounded_hex(&update.path_attributes),
+            "malformed UPDATE raw sections (RFC 7606 §5.2 debugging guidance)"
+        );
+    }
     /// Parse an UPDATE message, validate attributes, apply import policy,
     /// enforce max-prefix limit, send routes to RIB, and feed the
     /// appropriate event to the FSM.
@@ -1008,6 +1050,9 @@ impl PeerSession {
                 "malformed path attribute (RFC 7606 revised error handling)"
             );
         }
+        if !malformed.is_empty() {
+            self.debug_dump_malformed_update(&update, &parsed);
+        }
         // RFC 7606 §3 (h): when multiple attribute errors exist, the approach
         // with the strongest action wins.
         let mut disposition = malformed.iter().map(|m| m.disposition).max();
@@ -1027,13 +1072,34 @@ impl PeerSession {
                 u64::from(parsed.bgpls_nlri_discarded),
             );
         }
-        // 2. Semantic validation
-        let has_mp_nlri = parsed
+        // 2. Semantic validation. Two distinct MP_REACH_NLRI facts feed
+        // two different consumers and must not be conflated: the
+        // attribute validator keys mandatory-attribute rules off
+        // attribute PRESENCE (an UPDATE that carries an MP_REACH at all
+        // must carry ORIGIN / AS_PATH), while the RFC 7606 §5.2
+        // reachability gate below needs NLRI CONTENT — an MP_REACH that
+        // encodes zero NLRI provides no reachable NLRI, and its mere
+        // presence must not shield a treat-as-withdraw-class error from
+        // the mandated session reset (treat-as-withdraw would withdraw
+        // nothing).
+        let has_mp_reach_attr = parsed
             .attributes
             .iter()
             .any(|a| matches!(a, PathAttribute::MpReachNlri(_)));
+        let mp_reach_carries_nlri = parsed.attributes.iter().any(|a| match a {
+            PathAttribute::MpReachNlri(mp) => {
+                !mp.announced.is_empty()
+                    || !mp.flowspec_announced.is_empty()
+                    || !mp.evpn_announced.is_empty()
+                    || !mp.bgpls_announced.is_empty()
+                    || !mp.vpn_announced.is_empty()
+                    || !mp.labeled_announced.is_empty()
+                    || !mp.rtc_announced.is_empty()
+            }
+            _ => false,
+        });
         let has_body_nlri = !parsed.announced.is_empty();
-        let has_nlri = has_body_nlri || has_mp_nlri;
+        let has_nlri = has_body_nlri || has_mp_reach_attr;
         let validation_options = rustbgpd_wire::UpdateValidationOptions {
             allow_ipv4_link_local_mp_reach_next_hop: self.is_scoped_link_local_peer()
                 && self.use_extended_nexthop_ipv4(),
@@ -1052,6 +1118,7 @@ impl PeerSession {
                 disposition = update_err.disposition.as_str(),
                 "UPDATE validation error"
             );
+            self.debug_dump_malformed_update(&update, &parsed);
             if update_err.disposition == ErrorDisposition::SessionReset {
                 let notif = NotificationMessage::new(
                     NotificationCode::UpdateMessage,
@@ -1073,8 +1140,10 @@ impl PeerSession {
             // RFC 7606 §5.2: an UPDATE with path attributes but no reachable
             // NLRI encoded gives no confidence that its NLRI was parsed
             // successfully; for any error stronger than attribute-discard the
-            // session-reset approach MUST be used instead.
-            if parsed.announced.is_empty() && !has_mp_nlri {
+            // session-reset approach MUST be used instead. "Encoded" means
+            // actual NLRI content — an MP_REACH_NLRI attribute carrying zero
+            // NLRI counts as no reachable NLRI.
+            if parsed.announced.is_empty() && !mp_reach_carries_nlri {
                 warn!(
                     peer = %self.peer_label,
                     "treat-as-withdraw with no reachable NLRI — session reset (RFC 7606 §5.2)"

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -35,7 +35,7 @@
 //! hundreds of peers. The rendered AS-path and detail strings are
 //! capped at [`MAX_RETAINED_AS_PATH_BYTES`] / [`MAX_RETAINED_DETAIL_BYTES`]
 //! (a `…` marker replaces the tail); the community vectors are capped
-//! at [`MAX_RETAINED_COMMUNITIES`] / [`MAX_RETAINED_LARGE_COMMUNITIES`]
+//! at `MAX_RETAINED_COMMUNITIES` / `MAX_RETAINED_LARGE_COMMUNITIES`
 //! with the dropped count recorded so the operator surface can render
 //! "…and N more". Memory math with the caps enforced: worst-case heap
 //! is 96 + 64 + 16×4 + 8×12 = 320 B, plus the inline key + entry
@@ -120,13 +120,13 @@ pub struct RejectedRouteEntry {
     /// when the UPDATE carried none or the attribute was not decodable.
     pub as_path: String,
     /// Standard communities from the rejected UPDATE, capped at
-    /// [`MAX_RETAINED_COMMUNITIES`].
+    /// `MAX_RETAINED_COMMUNITIES`.
     pub communities: Vec<u32>,
     /// Count of standard communities dropped by the retention cap;
     /// 0 means `communities` is complete.
     pub communities_dropped: u32,
     /// Large communities from the rejected UPDATE, capped at
-    /// [`MAX_RETAINED_LARGE_COMMUNITIES`].
+    /// `MAX_RETAINED_LARGE_COMMUNITIES`.
     pub large_communities: Vec<LargeCommunity>,
     /// Count of large communities dropped by the retention cap;
     /// 0 means `large_communities` is complete.
@@ -142,7 +142,7 @@ pub struct RejectedRouteEntry {
 impl RejectedRouteEntry {
     /// Enforce the per-entry byte bound: truncate the string fields
     /// (marker appended) and cap the community vectors, recording the
-    /// dropped counts. [`RejectedRouteStore::insert`] applies this to
+    /// dropped counts. `RejectedRouteStore::insert` applies this to
     /// every entry, so the documented ≤ 512 B budget is a property of
     /// the store, not an assumption about callers. Idempotent — an
     /// already-bounded entry is untouched. Callers that clone one

--- a/crates/transport/src/session/rejected_routes.rs
+++ b/crates/transport/src/session/rejected_routes.rs
@@ -21,12 +21,25 @@
 //! accepted or explicitly withdrawn, and the whole store resets on
 //! session reset — the same per-session contract as the decision cache.
 //!
-//! Bound: per-peer LRU cap from `[policy.reject_retention] capacity`
-//! ([`DEFAULT_REJECT_RETENTION_CAPACITY`] = 1024). A reject storm
-//! therefore converges on "the most recent `capacity` rejects", never
-//! unbounded growth. Memory math: each entry is one key (~64 B) plus
-//! the reason/validation scalars, the AS-path string, and the community
-//! vectors — a few hundred bytes for realistic routes, call it ≤ 512 B.
+//! Bound: two independent caps, both enforced.
+//!
+//! Entry count: per-peer LRU cap from `[policy.reject_retention]
+//! capacity` ([`DEFAULT_REJECT_RETENTION_CAPACITY`] = 1024). A reject
+//! storm therefore converges on "the most recent `capacity` rejects",
+//! never unbounded growth.
+//!
+//! Entry size: [`RejectedRouteStore::insert`] truncates every entry's
+//! wire-derived owned data — a hostile peer with maximal `AS_PATH` /
+//! community attributes (worse under RFC 8654 Extended Messages) must
+//! not be able to inflate retained entries to multiple KB across
+//! hundreds of peers. The rendered AS-path and detail strings are
+//! capped at [`MAX_RETAINED_AS_PATH_BYTES`] / [`MAX_RETAINED_DETAIL_BYTES`]
+//! (a `…` marker replaces the tail); the community vectors are capped
+//! at [`MAX_RETAINED_COMMUNITIES`] / [`MAX_RETAINED_LARGE_COMMUNITIES`]
+//! with the dropped count recorded so the operator surface can render
+//! "…and N more". Memory math with the caps enforced: worst-case heap
+//! is 96 + 64 + 16×4 + 8×12 = 320 B, plus the inline key + entry
+//! structs — ≤ 512 B per entry, pinned by the size-budget test below.
 //! `1024 × 512 B ≈ 0.5 MiB` worst case per peer; a 500-peer route
 //! server bounds at ~256 MiB only if *every* peer keeps a full storm
 //! retained, and operators can lower the cap per deployment.
@@ -46,6 +59,45 @@ use super::import_decision_cache::ImportDecisionKey;
 /// announcements number in the tens to low thousands), not full-table
 /// retention. See the module docs for the memory bound math.
 pub const DEFAULT_REJECT_RETENTION_CAPACITY: usize = 1024;
+
+/// Byte cap on a retained entry's rendered `as_path` string, marker
+/// included. 96 bytes shows the first ~15 hops of even an all-4-octet
+/// path — the leading portion is what identifies the announcement; a
+/// hostile maximal `AS_PATH` is exactly what this cap exists to shed.
+pub const MAX_RETAINED_AS_PATH_BYTES: usize = 96;
+
+/// Byte cap on a retained entry's `detail` string, marker included.
+/// Policy names and gate sub-reason tokens fit comfortably.
+pub const MAX_RETAINED_DETAIL_BYTES: usize = 64;
+
+/// Cap on retained standard communities; the excess is counted in
+/// [`RejectedRouteEntry::communities_dropped`].
+pub const MAX_RETAINED_COMMUNITIES: usize = 16;
+
+/// Cap on retained large communities; the excess is counted in
+/// [`RejectedRouteEntry::large_communities_dropped`].
+pub const MAX_RETAINED_LARGE_COMMUNITIES: usize = 8;
+
+/// Marker appended to a string field the retention bound truncated.
+pub const RETENTION_TRUNCATION_MARKER: char = '…';
+
+/// Truncate `s` to at most `max` bytes on a char boundary, replacing
+/// the tail with [`RETENTION_TRUNCATION_MARKER`]. Rebuilds the string
+/// so the retained allocation is exact — `String::truncate` alone
+/// would keep the original (unbounded) capacity alive.
+fn truncate_marked(s: &mut String, max: usize) {
+    if s.len() <= max {
+        return;
+    }
+    let mut end = max - RETENTION_TRUNCATION_MARKER.len_utf8();
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut bounded = String::with_capacity(end + RETENTION_TRUNCATION_MARKER.len_utf8());
+    bounded.push_str(&s[..end]);
+    bounded.push(RETENTION_TRUNCATION_MARKER);
+    *s = bounded;
+}
 
 /// One retained rejection: the canonical reason token plus the compact
 /// attribute summary a looking glass renders.
@@ -67,16 +119,56 @@ pub struct RejectedRouteEntry {
     /// Lossless `AS_PATH` rendering (`AsPath::to_aspath_string`), empty
     /// when the UPDATE carried none or the attribute was not decodable.
     pub as_path: String,
-    /// Standard communities from the rejected UPDATE.
+    /// Standard communities from the rejected UPDATE, capped at
+    /// [`MAX_RETAINED_COMMUNITIES`].
     pub communities: Vec<u32>,
-    /// Large communities from the rejected UPDATE.
+    /// Count of standard communities dropped by the retention cap;
+    /// 0 means `communities` is complete.
+    pub communities_dropped: u32,
+    /// Large communities from the rejected UPDATE, capped at
+    /// [`MAX_RETAINED_LARGE_COMMUNITIES`].
     pub large_communities: Vec<LargeCommunity>,
+    /// Count of large communities dropped by the retention cap;
+    /// 0 means `large_communities` is complete.
+    pub large_communities_dropped: u32,
     /// RPKI origin-validation state at rejection time.
     pub rpki: RpkiValidation,
     /// ASPA path-verification state at rejection time.
     pub aspa: AspaValidation,
     /// Wall-clock time of the rejection.
     pub rejected_at: SystemTime,
+}
+
+impl RejectedRouteEntry {
+    /// Enforce the per-entry byte bound: truncate the string fields
+    /// (marker appended) and cap the community vectors, recording the
+    /// dropped counts. [`RejectedRouteStore::insert`] applies this to
+    /// every entry, so the documented ≤ 512 B budget is a property of
+    /// the store, not an assumption about callers. Idempotent — an
+    /// already-bounded entry is untouched. Callers that clone one
+    /// summary across many rejected identities should call it once
+    /// before cloning so the clones are bounded too.
+    pub fn enforce_bounds(&mut self) {
+        truncate_marked(&mut self.as_path, MAX_RETAINED_AS_PATH_BYTES);
+        if let Some(detail) = self.detail.as_mut() {
+            truncate_marked(detail, MAX_RETAINED_DETAIL_BYTES);
+        }
+        if self.communities.len() > MAX_RETAINED_COMMUNITIES {
+            self.communities_dropped =
+                u32::try_from(self.communities.len() - MAX_RETAINED_COMMUNITIES)
+                    .unwrap_or(u32::MAX);
+            self.communities.truncate(MAX_RETAINED_COMMUNITIES);
+            self.communities.shrink_to_fit();
+        }
+        if self.large_communities.len() > MAX_RETAINED_LARGE_COMMUNITIES {
+            self.large_communities_dropped =
+                u32::try_from(self.large_communities.len() - MAX_RETAINED_LARGE_COMMUNITIES)
+                    .unwrap_or(u32::MAX);
+            self.large_communities
+                .truncate(MAX_RETAINED_LARGE_COMMUNITIES);
+            self.large_communities.shrink_to_fit();
+        }
+    }
 }
 
 /// The session's reply to a `ListRejectedRoutes` query.
@@ -119,8 +211,11 @@ impl RejectedRouteStore {
     /// Insert or refresh a rejection. On overflow the least-recently
     /// rejected entry is evicted — under a storm the store converges on
     /// the most recent rejects, which is what a "why isn't my route in
-    /// right now?" query wants.
-    pub fn insert(&mut self, key: ImportDecisionKey, entry: RejectedRouteEntry) {
+    /// right now?" query wants. The entry's byte bound is enforced here
+    /// ([`RejectedRouteEntry::enforce_bounds`]), so nothing retained
+    /// can exceed the documented per-entry budget.
+    pub fn insert(&mut self, key: ImportDecisionKey, mut entry: RejectedRouteEntry) {
+        entry.enforce_bounds();
         self.entries.push(key, entry);
     }
 
@@ -199,7 +294,9 @@ mod tests {
             next_hop: None,
             as_path: String::new(),
             communities: Vec::new(),
+            communities_dropped: 0,
             large_communities: Vec::new(),
+            large_communities_dropped: 0,
             rpki: RpkiValidation::NotFound,
             aspa: AspaValidation::Unknown,
             rejected_at: SystemTime::UNIX_EPOCH,
@@ -269,5 +366,75 @@ mod tests {
         store.insert(key(1), entry(ImportRejectReason::PolicyReject));
         assert_eq!(store.len(), 1);
         assert_eq!(store.capacity(), 1);
+    }
+
+    /// Maximal wire-derived data is truncated at insert time: strings
+    /// carry the marker, community vectors carry the dropped counts,
+    /// and an already-bounded entry passes through untouched.
+    #[test]
+    fn insert_enforces_byte_bounds_with_truncation_markers() {
+        let mut store = RejectedRouteStore::with_capacity(4);
+        let mut oversized = entry(ImportRejectReason::PolicyReject);
+        oversized.as_path = (0..2000).map(|_| "65001 ").collect();
+        oversized.detail = Some("p".repeat(500));
+        oversized.communities = (0..300).collect();
+        oversized.large_communities = (0..300)
+            .map(|i| LargeCommunity {
+                global_admin: 65001,
+                local_data1: i,
+                local_data2: 0,
+            })
+            .collect();
+        store.insert(key(1), oversized);
+        let (_, bounded) = &store.snapshot()[0];
+        assert!(bounded.as_path.len() <= MAX_RETAINED_AS_PATH_BYTES);
+        assert!(bounded.as_path.ends_with(RETENTION_TRUNCATION_MARKER));
+        let detail = bounded.detail.as_deref().unwrap();
+        assert!(detail.len() <= MAX_RETAINED_DETAIL_BYTES);
+        assert!(detail.ends_with(RETENTION_TRUNCATION_MARKER));
+        assert_eq!(bounded.communities.len(), MAX_RETAINED_COMMUNITIES);
+        assert_eq!(
+            bounded.communities_dropped as usize,
+            300 - MAX_RETAINED_COMMUNITIES
+        );
+        assert_eq!(
+            bounded.large_communities.len(),
+            MAX_RETAINED_LARGE_COMMUNITIES
+        );
+        assert_eq!(
+            bounded.large_communities_dropped as usize,
+            300 - MAX_RETAINED_LARGE_COMMUNITIES
+        );
+        assert!(
+            bounded.communities.capacity() <= MAX_RETAINED_COMMUNITIES,
+            "truncation must release the oversized allocation"
+        );
+
+        let mut small = entry(ImportRejectReason::OtcRouteLeak);
+        small.as_path = "65001 65002".to_owned();
+        small.communities = vec![1, 2, 3];
+        store.insert(key(2), small);
+        let snap = store.snapshot();
+        let (_, kept) = snap.iter().find(|(k, _)| *k == key(2)).unwrap();
+        assert_eq!(kept.as_path, "65001 65002", "under-cap fields untouched");
+        assert_eq!(kept.communities_dropped, 0);
+    }
+
+    /// Pin the documented ≤ 512 B per-entry budget against the real
+    /// type sizes: worst-case retained heap under the caps plus the
+    /// inline key + entry structs must fit. Fails on any field or cap
+    /// change that would silently break the module-doc math.
+    #[test]
+    fn worst_case_entry_fits_documented_byte_budget() {
+        let worst_heap = MAX_RETAINED_AS_PATH_BYTES
+            + MAX_RETAINED_DETAIL_BYTES
+            + MAX_RETAINED_COMMUNITIES * size_of::<u32>()
+            + MAX_RETAINED_LARGE_COMMUNITIES * size_of::<LargeCommunity>();
+        let inline = size_of::<ImportDecisionKey>() + size_of::<RejectedRouteEntry>();
+        assert!(
+            worst_heap + inline <= 512,
+            "worst-case entry {worst_heap} heap + {inline} inline bytes exceeds the \
+             documented 512 B budget — retune the retention caps"
+        );
     }
 }

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -14931,6 +14931,82 @@ async fn rfc7606_malformed_attr_without_reachable_nlri_resets_session() {
     }
 }
 
+/// Structurally valid IPv6-unicast `MP_REACH_NLRI` raw attribute:
+/// next-hop `2001:db8::1`, then the given NLRI prefix bytes (an empty
+/// slice encodes an `MP_REACH` that carries zero NLRI).
+fn rfc7606_mp_reach(nlri: &[u8]) -> Vec<u8> {
+    let mut attr = vec![0x80, 14, 0]; // optional flags, type, len (patched)
+    attr.extend([0, 2, 1, 16]); // AFI=IPv6, SAFI=unicast, NH-Len=16
+    attr.extend([0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    attr.push(0); // reserved
+    attr.extend_from_slice(nlri);
+    attr[2] = u8::try_from(attr.len() - 3).expect("attribute fits one length octet");
+    attr
+}
+
+/// RFC 7606 §5.2: an `MP_REACH_NLRI` attribute that is present but
+/// encodes ZERO NLRI provides no reachable NLRI — a
+/// treat-as-withdraw-class error must escalate to session reset exactly
+/// as when the attribute is absent. Attribute presence must not shield
+/// the reset: treat-as-withdraw would withdraw nothing here.
+#[tokio::test]
+async fn rfc7606_empty_mp_reach_with_taw_error_resets_session() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    // Malformed MED (treat-as-withdraw) + an empty-NLRI MP_REACH; no
+    // body NLRI anywhere.
+    let mut extra = vec![0x80, 4, 3, 0, 0, 1];
+    extra.extend(rfc7606_mp_reach(&[]));
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&extra), &[]))
+        .await;
+    assert_ne!(
+        session.fsm.state(),
+        SessionState::Established,
+        "an empty-NLRI MP_REACH encodes no reachable NLRI; the error must reset (RFC 7606 §5.2)"
+    );
+    while let Ok(msg) = rib_rx.try_recv() {
+        assert!(
+            !matches!(msg, RibUpdate::RoutesReceived { .. }),
+            "no routes may be delivered"
+        );
+    }
+}
+
+/// Regression guard for the §5.2 tightening above: an `MP_REACH` that
+/// DOES carry NLRI keeps the ordinary treat-as-withdraw behavior — the
+/// session stays Established and no announcement is admitted.
+#[tokio::test]
+async fn rfc7606_nonempty_mp_reach_with_taw_error_stays_established() {
+    let (mut session, mut rib_rx) = make_test_session_with_rib(65001, 65002);
+    let (client, _server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    rfc7606_drain(&mut rib_rx);
+    // Malformed MED + MP_REACH announcing 2001:db8::/32.
+    let mut extra = vec![0x80, 4, 3, 0, 0, 1];
+    extra.extend(rfc7606_mp_reach(&[32, 0x20, 0x01, 0x0d, 0xb8]));
+    session
+        .process_update(rfc7606_update(rfc7606_attr_bytes(&extra), &[]))
+        .await;
+    assert_eq!(
+        session.fsm.state(),
+        SessionState::Established,
+        "reachable MP NLRI keeps the treat-as-withdraw path (no over-reset)"
+    );
+    while let Ok(msg) = rib_rx.try_recv() {
+        if let RibUpdate::RoutesReceived { announced, .. } = msg {
+            assert!(
+                announced.is_empty(),
+                "treat-as-withdraw must not admit the announcement"
+            );
+        }
+    }
+}
+
 /// An UPDATE whose only attributes were discarded as malformed must not be
 /// mistaken for an End-of-RIB marker.
 #[tokio::test]

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -15369,6 +15369,89 @@ async fn reject_retention_clears_when_route_is_later_accepted() {
     assert_eq!(metrics.rejected_routes_retained("10.0.0.2:179"), 0);
 }
 
+/// A hostile UPDATE with maximal attributes — a long `AS_PATH` and
+/// hundreds of (large) communities — must produce a bounded retained
+/// entry: the AS-path string is truncated with the marker and the
+/// community vectors are capped with the dropped counts recorded, so
+/// the per-entry byte budget holds at capture time regardless of what
+/// the peer sends.
+#[tokio::test]
+async fn reject_retention_bounds_maximal_attribute_entry() {
+    use super::rejected_routes::{
+        MAX_RETAINED_AS_PATH_BYTES, MAX_RETAINED_COMMUNITIES, MAX_RETAINED_LARGE_COMMUNITIES,
+        RETENTION_TRUNCATION_MARKER,
+    };
+    use rustbgpd_wire::LargeCommunity;
+    let prefix = Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24);
+    let chain = PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Deny,
+    }]);
+    let (mut session, _metrics) = retention_session_with_chain(Some(chain), |_| {});
+    // Two 250-ASN AS_SEQUENCE segments (255 is the per-segment wire
+    // max), 200 standard and 100 large communities.
+    let segment: Vec<u32> = (0..250).map(|i| 4_200_000_000 + i).collect();
+    let update = UpdateMessage::build(
+        &[Ipv4NlriEntry { path_id: 0, prefix }],
+        &[],
+        &[
+            PathAttribute::Origin(Origin::Igp),
+            PathAttribute::AsPath(AsPath {
+                segments: vec![
+                    AsPathSegment::AsSequence(segment.clone()),
+                    AsPathSegment::AsSequence(segment),
+                ],
+            }),
+            PathAttribute::NextHop(Ipv4Addr::new(10, 0, 0, 2)),
+            PathAttribute::Communities((0..200).collect()),
+            PathAttribute::LargeCommunities(
+                (0..100)
+                    .map(|i| LargeCommunity {
+                        global_admin: 65001,
+                        local_data1: i,
+                        local_data2: 0,
+                    })
+                    .collect(),
+            ),
+        ],
+        true,
+        false,
+        Ipv4UnicastMode::Body,
+    );
+    session.process_update(update).await;
+    let entries = session.rejected_routes.snapshot();
+    assert_eq!(entries.len(), 1, "the denied prefix is retained");
+    let entry = &entries[0].1;
+    assert!(
+        entry.as_path.len() <= MAX_RETAINED_AS_PATH_BYTES,
+        "AS-path string must be capped, got {} bytes",
+        entry.as_path.len()
+    );
+    assert!(
+        entry.as_path.ends_with(RETENTION_TRUNCATION_MARKER),
+        "truncated AS-path must carry the marker"
+    );
+    assert!(
+        entry.as_path.starts_with("4200000000 "),
+        "the leading hops survive truncation"
+    );
+    assert_eq!(entry.communities.len(), MAX_RETAINED_COMMUNITIES);
+    assert_eq!(
+        entry.communities_dropped as usize,
+        200 - MAX_RETAINED_COMMUNITIES,
+        "dropped standard communities are counted for the surface"
+    );
+    assert_eq!(
+        entry.large_communities.len(),
+        MAX_RETAINED_LARGE_COMMUNITIES
+    );
+    assert_eq!(
+        entry.large_communities_dropped as usize,
+        100 - MAX_RETAINED_LARGE_COMMUNITIES,
+        "dropped large communities are counted for the surface"
+    );
+}
+
 /// LAN-472 pin: the store is bounded by the configured capacity — a
 /// reject storm converges on the most recent rejections instead of
 /// growing without bound (this repo's reload-stall week was exactly

--- a/proto/rustbgpd.proto
+++ b/proto/rustbgpd.proto
@@ -1236,13 +1236,19 @@ message RejectedRoute {
   // was not decodable or not meaningful for the gate.
   string next_hop = 7;
 
-  // Lossless AS_PATH rendering (AS_SET / confed segments survive);
-  // empty when the UPDATE carried none.
+  // AS_PATH rendering (AS_SET / confed segments survive); empty when
+  // the UPDATE carried none. Retention enforces a per-entry byte
+  // budget, so a maximal path is truncated with a trailing "…".
   string as_path = 8;
 
+  // Communities are capped at retention time under the same per-entry
+  // byte budget; the *_dropped counters carry how many were cut so a
+  // renderer can say "…and N more". 0 means the list is complete.
   repeated uint32 communities = 9;
   // Large communities as "asn:local1:local2" strings.
   repeated string large_communities = 10;
+  uint32 communities_dropped = 14;
+  uint32 large_communities_dropped = 15;
 
   // RPKI origin-validation state at rejection time, as a stable
   // snake_case string: "valid", "invalid", "not_found", "unknown".


### PR DESCRIPTION
Two session-layer hardening fixes.

Rejected-route retention was bounded only in entry count; each entry retained unbounded as_path/communities/detail from the wire, so the documented ~0.5 MiB/peer figure was an assumption. Bounds are now enforced at the store chokepoint: as_path capped at 96 bytes (char-boundary truncate + marker, allocation released), detail at 64, communities at 16, large communities at 8 with dropped-counts surfaced through new additive proto fields and the rbgp --rejected JSON. A byte-budget test asserts worst-case heap+inline ≤ 512 B against real type sizes. One bounded prototype entry per UPDATE replaces the per-identity re-render/deep-clone.

RFC 7606 §5.2: the session-reset gate keyed off MP_REACH attribute presence, so an empty-NLRI MP_REACH plus a treat-as-withdraw-class error stayed Established via a withdraw of nothing. Split into attribute-presence (still feeds mandatory-attribute validation, unchanged) and NLRI-content across all per-family announced vectors, which now drives the gate. Regression proven red on main (Established == Established assertion failure), green after; sibling test pins no over-reset for non-empty MP_REACH. Malformed UPDATEs now emit the §5.2 minimum debugging dump at DEBUG only — counts plus hex sections capped at 512 bytes with an honest remainder suffix.