### PR TITLE
test(interop): M90 arouteserver differential lab

### DIFF
--- a/tests/interop/configs/gobgp-m90-member1.toml
+++ b/tests/interop/configs/gobgp-m90-member1.toml
@@ -1,0 +1,25 @@
+# M90 member1 (AS64500, 192.0.2.11) — announces the same canned set to
+# both route servers: rustbgpd (192.0.2.9) and BIRD (192.0.2.10).
+[global.config]
+as = 64500
+router-id = "192.0.2.11"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.9"
+peer-as = 64496
+description = "rustbgpd-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.10"
+peer-as = 64496
+description = "bird-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"

--- a/tests/interop/configs/gobgp-m90-member2.toml
+++ b/tests/interop/configs/gobgp-m90-member2.toml
@@ -1,0 +1,25 @@
+# M90 member2 (AS64501, 192.0.2.12) — announces the same canned set to
+# both route servers: rustbgpd (192.0.2.9) and BIRD (192.0.2.10).
+[global.config]
+as = 64501
+router-id = "192.0.2.12"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.9"
+peer-as = 64496
+description = "rustbgpd-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.10"
+peer-as = 64496
+description = "bird-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"

--- a/tests/interop/configs/gobgp-m90-member3.toml
+++ b/tests/interop/configs/gobgp-m90-member3.toml
@@ -1,0 +1,25 @@
+# M90 member3 (AS64502, 192.0.2.13) — announces the same canned set to
+# both route servers: rustbgpd (192.0.2.9) and BIRD (192.0.2.10).
+[global.config]
+as = 64502
+router-id = "192.0.2.13"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.9"
+peer-as = 64496
+description = "rustbgpd-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"
+
+[[neighbors]]
+[neighbors.config]
+neighbor-address = "192.0.2.10"
+peer-as = 64496
+description = "bird-rs"
+
+[[neighbors.afi-safis]]
+[neighbors.afi-safis.config]
+afi-safi-name = "ipv4-unicast"

--- a/tests/interop/m90-differential.clab.yml
+++ b/tests/interop/m90-differential.clab.yml
@@ -1,0 +1,116 @@
+# Containerlab topology: arouteserver differential lab
+# (M90 — ADR-0110 phase 1: one general.yml/clients.yml, two daemons)
+#
+# One IXP peering LAN (192.0.2.0/24, RFC 5737) bridged through a
+# dedicated switch node, carrying:
+#   - rustbgpd route server  192.0.2.9   (config rendered by
+#     tools/rs-config-render from the site's template-context dump)
+#   - BIRD 2 route server    192.0.2.10  (config rendered by
+#     arouteserver proper from the SAME general.yml/clients.yml)
+#   - three GoBGP members    192.0.2.11-13 (AS64500-AS64502), each
+#     peering with BOTH route servers and injecting the canned
+#     announcement set from m90-differential/announcements.json
+#
+# Both route servers carry BGP identifier 192.0.2.10 (the single
+# router_id in general.yml renders into both configs). They never peer
+# with each other, and the members hold one session per server, so the
+# duplicate identifier is harmless.
+#
+# Configs are rendered and copied in by the driver script AFTER deploy
+# (docker cp), because both renders are themselves part of the test —
+# nothing is bind-mounted into the route-server nodes.
+#
+# Usage:
+#   docker build --target dev -t rustbgpd:dev .
+#   docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
+#   docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
+#   containerlab deploy -t tests/interop/m90-differential.clab.yml
+#   bash tests/interop/scripts/test-m90-differential.sh
+#   containerlab destroy -t tests/interop/m90-differential.clab.yml
+
+name: m90-differential
+
+topology:
+  nodes:
+    # Plain bridge over all five access ports (the m65 CE idiom):
+    # a multipoint peering LAN out of containerlab's p2p links.
+    switch:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      exec:
+        - ip link add br0 type bridge mcast_snooping 0
+        - ip link set eth1 master br0
+        - ip link set eth2 master br0
+        - ip link set eth3 master br0
+        - ip link set eth4 master br0
+        - ip link set eth5 master br0
+        - ip link set eth1 up
+        - ip link set eth2 up
+        - ip link set eth3 up
+        - ip link set eth4 up
+        - ip link set eth5 up
+        - ip link set br0 up
+
+    rustbgpd:
+      kind: linux
+      image: rustbgpd:dev
+      cmd: sleep infinity
+      exec:
+        - ip addr add 192.0.2.9/24 dev eth1
+        - ip link set eth1 up
+        - mkdir -p /etc/rustbgpd /var/lib/rustbgpd
+      env:
+        RUST_LOG: info
+
+    bird:
+      kind: linux
+      image: bird:2-bookworm
+      cmd: sleep infinity
+      exec:
+        - ip addr add 192.0.2.10/24 dev eth1
+        - ip link set eth1 up
+        - mkdir -p /etc/bird /run/bird
+
+    member1:
+      kind: linux
+      image: gobgp:interop
+      cmd: sleep infinity
+      binds:
+        - ./configs/gobgp-m90-member1.toml:/config/gobgp.toml:ro
+      exec:
+        - ip addr add 192.0.2.11/24 dev eth1
+        - ip link set eth1 up
+
+    member2:
+      kind: linux
+      image: gobgp:interop
+      cmd: sleep infinity
+      binds:
+        - ./configs/gobgp-m90-member2.toml:/config/gobgp.toml:ro
+      exec:
+        - ip addr add 192.0.2.12/24 dev eth1
+        - ip link set eth1 up
+
+    member3:
+      kind: linux
+      image: gobgp:interop
+      cmd: sleep infinity
+      binds:
+        - ./configs/gobgp-m90-member3.toml:/config/gobgp.toml:ro
+      exec:
+        - ip addr add 192.0.2.13/24 dev eth1
+        - ip link set eth1 up
+
+  links:
+    - endpoints: ["switch:eth1", "rustbgpd:eth1"]
+    - endpoints: ["switch:eth2", "bird:eth1"]
+    - endpoints: ["switch:eth3", "member1:eth1"]
+    - endpoints: ["switch:eth4", "member2:eth1"]
+    - endpoints: ["switch:eth5", "member3:eth1"]
+
+# rustbgpd RS: AS 64496, 192.0.2.9 (BGP identifier 192.0.2.10)
+# BIRD RS:     AS 64496, 192.0.2.10
+# member1: AS64500, 192.0.2.11 — IRR-clean
+# member2: AS64501, 192.0.2.12 — out-of-set announcements
+# member3: AS64502, 192.0.2.13 — hygiene violations

--- a/tests/interop/m90-differential/README.md
+++ b/tests/interop/m90-differential/README.md
@@ -1,0 +1,91 @@
+# M90 — arouteserver differential lab (ADR-0110 phase 1)
+
+One `general.yml`/`clients.yml` pair drives **both** route servers:
+
+- **BIRD 2** gets its config from **arouteserver proper**, run
+  containerized at lab runtime from the official `pierky/arouteserver`
+  image;
+- **rustbgpd** gets its config from
+  [`tools/rs-config-render`](../../../tools/rs-config-render/README.md),
+  fed the site's `arouteserver template-context` dump (`context.yml`).
+
+Three GoBGP members (AS64500–AS64502) peer with both servers over a
+bridged 192.0.2.0/24 peering LAN and announce the canned set in
+[`announcements.json`](announcements.json). The lab proves that every
+announcement gets an **identical accept/reject verdict on both
+daemons**, and that for every rejection rustbgpd's
+`rbgp policy explain` names the **generated policy term** the manifest
+predicts (plus the canonical `policy_reject` reason token in
+`rbgp rib received <member> --rejected`). The expected verdicts were
+derived by hand from the renderer's emission logic — shared hygiene
+policy first (its term order is fixed: AS_SET, never-via-RS, path
+length, bogons, black list, prefix-length windows), then the
+per-client IRR policy ending in a fail-closed `rest` term — so the
+lab's job is to prove BIRD agrees with that reading.
+
+The member roster covers three distinct outcomes:
+
+| Member | ASN | Behavior | Rejecting term(s) |
+|--------|-----|----------|--------------------|
+| member1 | AS64500 | IRR-clean, but also announces the peering LAN | `rs-hygiene` / `reject-black-list-prefix` |
+| member2 | AS64501 | announces outside its IRR set (another member's prefix, an unregistered more-specific) | `client-as64501-1` / `rest` |
+| member3 | AS64502 | bogon, too-long prefix, default route, never-via-RS ASN in path | `reject-bogon-prefix`, `reject-v4-len-outside-window`, `reject-never-via-rs` |
+
+## Running it
+
+```bash
+docker build --target dev -t rustbgpd:dev .
+docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
+docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
+containerlab deploy -t tests/interop/m90-differential.clab.yml
+bash tests/interop/scripts/test-m90-differential.sh
+containerlab destroy -t tests/interop/m90-differential.clab.yml
+```
+
+The driver renders both configs itself (nothing is bind-mounted into
+the route-server nodes): `arouteserver bird` in the pinned container
+for BIRD, `cargo run -p rs-config-render` for rustbgpd, followed by
+the pipeline's own gates (`rustbgpd --check`, `rbgp policy check` on
+every generated `.rpol`).
+
+**Image pin:** the `pierky/arouteserver` digest in
+`scripts/test-m90-differential.sh` is a deliberate all-zeros tripwire
+until the verification run pins the real digest (or exports
+`M90_ARS_IMAGE`).
+
+## The canonical context path
+
+`context.yml` is checked in hand-authored (matching the renderer's
+fingerprint-pinned 17-key shape, same as its golden fixture) so the
+rustbgpd side renders deterministically offline. The canonical way to
+produce it is arouteserver itself, with the same mounts the driver
+uses for the BIRD render:
+
+```bash
+arouteserver template-context --cfg arouteserver.yml --output context.yml
+```
+
+The lab never trusts the fixture alone: the BIRD side always re-runs
+arouteserver proper from `general.yml`/`clients.yml` at runtime, so if
+the fixture drifts from the site files the differential verdicts
+diverge and the lab fails.
+
+## Site quirks (deliberate)
+
+- **Documentation ranges everywhere** (RFC 5398 ASNs, RFC 5737
+  prefixes), per repo convention — which forces two site-level
+  choices:
+  - `reject_invalid_as_in_as_path: False` in `general.yml`: the
+    documentation ASN blocks sit inside the invalid-ASN range both
+    pipelines reject by default;
+  - a lab-local [`bogons.yml`](bogons.yml): arouteserver's default
+    bogons list rightly treats the RFC 5737 prefixes as bogons.
+- **`bgpq4-stub.sh`** answers the IRR queries with canned data (the
+  documentation AS-SETs have no live registry objects); its answers
+  must stay in lockstep with the `irrdb_info` bundles in
+  `context.yml`.
+- RPKI origin validation is off — the differential under test is the
+  IRR/hygiene pipeline; ROV interop has its own lab (M83).
+- Both route servers carry the same BGP identifier (the one
+  `router_id` in `general.yml` renders into both configs); they never
+  peer with each other, so this is harmless.

--- a/tests/interop/m90-differential/README.md
+++ b/tests/interop/m90-differential/README.md
@@ -48,22 +48,33 @@ for BIRD, `cargo run -p rs-config-render` for rustbgpd, followed by
 the pipeline's own gates (`rustbgpd --check`, `rbgp policy check` on
 every generated `.rpol`).
 
-**Image pin:** the `pierky/arouteserver` digest in
-`scripts/test-m90-differential.sh` is a deliberate all-zeros tripwire
-until the verification run pins the real digest (or exports
-`M90_ARS_IMAGE`).
+**Image pin:** the driver runs
+`pierky/arouteserver@sha256:ba0e9c0b541c63acf0765a08fd2e09c2bba9dc64af1f5bbdce7819e8d1c34d66`
+(`:latest` as of 2026-07-18, arouteserver 1.23.2). Override with
+`M90_ARS_IMAGE` to test another build.
 
 ## The canonical context path
 
 `context.yml` is checked in hand-authored (matching the renderer's
 fingerprint-pinned 17-key shape, same as its golden fixture) so the
-rustbgpd side renders deterministically offline. The canonical way to
-produce it is arouteserver itself, with the same mounts the driver
-uses for the BIRD render:
+rustbgpd side renders deterministically offline. arouteserver's own
+dump of the same site is
 
 ```bash
 arouteserver template-context --cfg arouteserver.yml --output context.yml
 ```
+
+(same mounts as the driver's BIRD render), but as of arouteserver
+1.23.2 that command emits a *sectioned report* (per-key heading +
+underline + YAML fragment), not one YAML document, and its section
+names differ from the renderer's pinned top-level keys (e.g.
+`arin_whois_db_records` vs `arin_whois_records`; `irrdb_info` as a
+list of hash-keyed bundles vs a map). So the dump is not a drop-in
+replacement for this fixture; converting it is an rs-config-render
+follow-up. The fixture's *data* was verified in lockstep against a
+real 1.23.2 dump when the image was pinned: filtering knobs, client
+roster, bogons, never-via ASNs, and every per-client IRR asn/prefix
+bundle match.
 
 The lab never trusts the fixture alone: the BIRD side always re-runs
 arouteserver proper from `general.yml`/`clients.yml` at runtime, so if

--- a/tests/interop/m90-differential/announcements.json
+++ b/tests/interop/m90-differential/announcements.json
@@ -1,0 +1,116 @@
+[
+  {
+    "client": "member1",
+    "asn": 64500,
+    "ip": "192.0.2.11",
+    "bird_protocol": "AS64500_1",
+    "prefix": "198.51.100.0/24",
+    "expect": "accept",
+    "why": "exact IRR route object, origin 64500 registered"
+  },
+  {
+    "client": "member1",
+    "asn": 64500,
+    "ip": "192.0.2.11",
+    "bird_protocol": "AS64500_1",
+    "prefix": "203.0.113.0/27",
+    "expect": "accept",
+    "why": "covered by route object 203.0.113.0/26 le 28; length 27 inside the 8-28 window"
+  },
+  {
+    "client": "member1",
+    "asn": 64500,
+    "ip": "192.0.2.11",
+    "bird_protocol": "AS64500_1",
+    "prefix": "192.0.2.0/24",
+    "expect": "reject",
+    "policy": "rs-hygiene",
+    "term": "reject-black-list-prefix",
+    "why": "the IXP peering LAN is in global_black_list_pref; hygiene runs before the client IRR policy"
+  },
+  {
+    "client": "member2",
+    "asn": 64501,
+    "ip": "192.0.2.12",
+    "bird_protocol": "AS64501_1",
+    "prefix": "203.0.113.128/25",
+    "expect": "accept",
+    "why": "exact IRR route object, origin 64501 registered"
+  },
+  {
+    "client": "member2",
+    "asn": 64501,
+    "ip": "192.0.2.12",
+    "bird_protocol": "AS64501_1",
+    "prefix": "198.51.100.0/24",
+    "expect": "reject",
+    "policy": "client-as64501-1",
+    "term": "rest",
+    "why": "member1's prefix, absent from member2's IRR set; passes hygiene, falls through accept-authorized to the fail-closed tail"
+  },
+  {
+    "client": "member2",
+    "asn": 64501,
+    "ip": "192.0.2.12",
+    "bird_protocol": "AS64501_1",
+    "prefix": "203.0.113.192/26",
+    "expect": "reject",
+    "policy": "client-as64501-1",
+    "term": "rest",
+    "why": "unregistered more-specific of member2's own exact /25 route object (allow_longer_prefixes off)"
+  },
+  {
+    "client": "member3",
+    "asn": 64502,
+    "ip": "192.0.2.13",
+    "bird_protocol": "AS64502_1",
+    "prefix": "203.0.113.64/26",
+    "expect": "accept",
+    "why": "sanity: the violator's registered route object is still accepted"
+  },
+  {
+    "client": "member3",
+    "asn": 64502,
+    "ip": "192.0.2.13",
+    "bird_protocol": "AS64502_1",
+    "prefix": "10.64.0.0/16",
+    "expect": "reject",
+    "policy": "rs-hygiene",
+    "term": "reject-bogon-prefix",
+    "why": "inside bogon 10.0.0.0/8 (subtree match); bogon term precedes the length-window term"
+  },
+  {
+    "client": "member3",
+    "asn": 64502,
+    "ip": "192.0.2.13",
+    "bird_protocol": "AS64502_1",
+    "prefix": "203.0.113.64/30",
+    "expect": "reject",
+    "policy": "rs-hygiene",
+    "term": "reject-v4-len-outside-window",
+    "why": "length 30 exceeds the ipv4_pref_len max of 28 (even though it sits under member3's route object)"
+  },
+  {
+    "client": "member3",
+    "asn": 64502,
+    "ip": "192.0.2.13",
+    "bird_protocol": "AS64502_1",
+    "prefix": "0.0.0.0/0",
+    "expect": "reject",
+    "policy": "rs-hygiene",
+    "term": "reject-v4-len-outside-window",
+    "why": "default route; length 0 is below the ipv4_pref_len min of 8"
+  },
+  {
+    "client": "member3",
+    "asn": 64502,
+    "ip": "192.0.2.13",
+    "bird_protocol": "AS64502_1",
+    "prefix": "198.51.100.128/25",
+    "aspath": "65551",
+    "expect": "reject",
+    "policy": "rs-hygiene",
+    "term": "reject-never-via-rs",
+    "why": "wire AS_PATH is 64502 65551; 65551 is in never_via_route_servers_asns, and the hygiene term fires before any origin/IRR evaluation"
+  }
+]

--- a/tests/interop/m90-differential/arouteserver.yml
+++ b/tests/interop/m90-differential/arouteserver.yml
@@ -1,0 +1,12 @@
+# M90 differential lab — arouteserver program configuration.
+#
+# Consumed inside the pierky/arouteserver container with the lab
+# directory mounted at /site (see scripts/test-m90-differential.sh).
+# The bgpq4 stub replaces real IRR resolution: the site's AS-SETs are
+# RFC 5398 documentation objects with no live registry data.
+cfg_general: /site/general.yml
+cfg_clients: /site/clients.yml
+cfg_bogons: /site/bogons.yml
+cache_dir: /site/cache
+cache_expiry: 3600
+bgpq3_path: /site/bgpq4-stub.sh

--- a/tests/interop/m90-differential/arouteserver.yml
+++ b/tests/interop/m90-differential/arouteserver.yml
@@ -10,3 +10,7 @@ cfg_bogons: /site/bogons.yml
 cache_dir: /site/cache
 cache_expiry: 3600
 bgpq3_path: /site/bgpq4-stub.sh
+# Without these, arouteserver looks for log.ini and templates/ next to
+# this file and aborts; the image ships both at the standard path.
+logging_config_file: /etc/arouteserver/log.ini
+templates_dir: /etc/arouteserver/templates

--- a/tests/interop/m90-differential/bgpq4-stub.sh
+++ b/tests/interop/m90-differential/bgpq4-stub.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# M90 differential lab — canned bgpq4 replacement.
+#
+# arouteserver shells out to bgpq4 (configured via `bgpq3_path`) for
+# two query shapes:
+#   - origin-ASN expansion of an AS-SET (invoked with -t): JSON object
+#     mapping the requested label to a list of AS numbers;
+#   - prefix expansion (no -t): JSON object mapping the requested
+#     label to a list of prefix records (bgpq4 -j shape: "exact" /
+#     "greater-equal" / "less-equal" keys).
+#
+# The lab's AS-SETs are RFC 5398 documentation objects with no live
+# IRR data, so this stub answers from the canned site model instead.
+# The answers here MUST stay in lockstep with the irrdb_info bundles
+# in context.yml — that lockstep is exactly what the differential
+# verdicts prove end to end.
+#
+# Argument handling: the requested object is the last argument; the
+# JSON label follows -l when present (bgpq4's default is "NN"); -t
+# selects ASN mode. Unknown flags are skipped, so minor differences in
+# arouteserver's bgpq4 invocation across versions do not break the
+# stub as long as those three conventions hold.
+
+label="NN"
+asn_mode=0
+object=""
+prev=""
+for arg in "$@"; do
+    case "$prev" in
+        -l) label="$arg" ;;
+    esac
+    case "$arg" in
+        -t) asn_mode=1 ;;
+    esac
+    prev="$arg"
+    object="$arg"
+done
+
+emit_asns() {
+    printf '{"%s": [%s]}\n' "$label" "$1"
+}
+
+emit_prefixes() {
+    printf '{"%s": [%s]}\n' "$label" "$1"
+}
+
+if [ "$asn_mode" = "1" ]; then
+    case "$object" in
+        AS-M90-ONE|AS64500)   emit_asns "64500" ;;
+        AS-M90-TWO|AS64501)   emit_asns "64501" ;;
+        AS-M90-THREE|AS64502) emit_asns "64502" ;;
+        *) echo "bgpq4-stub: unknown ASN-mode object: $object" >&2; exit 1 ;;
+    esac
+else
+    case "$object" in
+        AS-M90-ONE|AS64500)
+            emit_prefixes '{"prefix": "198.51.100.0/24", "exact": true}, {"prefix": "203.0.113.0/26", "exact": false, "greater-equal": 26, "less-equal": 28}' ;;
+        AS-M90-TWO|AS64501)
+            emit_prefixes '{"prefix": "203.0.113.128/25", "exact": true}' ;;
+        AS-M90-THREE|AS64502)
+            emit_prefixes '{"prefix": "203.0.113.64/26", "exact": true}' ;;
+        *) echo "bgpq4-stub: unknown prefix-mode object: $object" >&2; exit 1 ;;
+    esac
+fi

--- a/tests/interop/m90-differential/bgpq4-stub.sh
+++ b/tests/interop/m90-differential/bgpq4-stub.sh
@@ -2,27 +2,29 @@
 # M90 differential lab — canned bgpq4 replacement.
 #
 # arouteserver shells out to bgpq4 (configured via `bgpq3_path`) for
-# two query shapes:
-#   - origin-ASN expansion of an AS-SET (invoked with -t): JSON object
-#     mapping the requested label to a list of AS numbers;
-#   - prefix expansion (no -t): JSON object mapping the requested
-#     label to a list of prefix records (bgpq4 -j shape: "exact" /
-#     "greater-equal" / "less-equal" keys).
+# two query shapes (arouteserver 1.23.2, pierky/arouteserver image
+# pinned in scripts/test-m90-differential.sh):
+#   - origin-ASN expansion of an AS-SET:
+#         bgpq4 -h <host> -S <sources> -3 -j -f 1 -l asn_list <object>
+#     answer: {"asn_list": [<asn>, ...]} (bare integers);
+#   - prefix expansion:
+#         bgpq4 -h <host> -S <sources> -3 -j -4|-6 -A -l prefix_list <object>
+#     answer: {"prefix_list": [<record>, ...]} (bgpq4 -j shape:
+#     "exact" / "greater-equal" / "less-equal" keys).
+# The mode marker is the -l label, NOT a -t flag; queries for a bare
+# ASxxx object skip bgpq4 entirely in ASN mode but still hit it in
+# prefix mode. IPv6 prefix queries (-6) get an empty list: the site is
+# IPv4-only, and answering them with IPv4 records would poison the
+# rendered IPv6 prefix sets.
 #
 # The lab's AS-SETs are RFC 5398 documentation objects with no live
 # IRR data, so this stub answers from the canned site model instead.
 # The answers here MUST stay in lockstep with the irrdb_info bundles
 # in context.yml — that lockstep is exactly what the differential
 # verdicts prove end to end.
-#
-# Argument handling: the requested object is the last argument; the
-# JSON label follows -l when present (bgpq4's default is "NN"); -t
-# selects ASN mode. Unknown flags are skipped, so minor differences in
-# arouteserver's bgpq4 invocation across versions do not break the
-# stub as long as those three conventions hold.
 
-label="NN"
-asn_mode=0
+label=""
+ip_ver=4
 object=""
 prev=""
 for arg in "$@"; do
@@ -30,35 +32,42 @@ for arg in "$@"; do
         -l) label="$arg" ;;
     esac
     case "$arg" in
-        -t) asn_mode=1 ;;
+        -6) ip_ver=6 ;;
     esac
     prev="$arg"
     object="$arg"
 done
 
-emit_asns() {
+emit() {
     printf '{"%s": [%s]}\n' "$label" "$1"
 }
 
-emit_prefixes() {
-    printf '{"%s": [%s]}\n' "$label" "$1"
-}
-
-if [ "$asn_mode" = "1" ]; then
-    case "$object" in
-        AS-M90-ONE|AS64500)   emit_asns "64500" ;;
-        AS-M90-TWO|AS64501)   emit_asns "64501" ;;
-        AS-M90-THREE|AS64502) emit_asns "64502" ;;
-        *) echo "bgpq4-stub: unknown ASN-mode object: $object" >&2; exit 1 ;;
-    esac
-else
-    case "$object" in
-        AS-M90-ONE|AS64500)
-            emit_prefixes '{"prefix": "198.51.100.0/24", "exact": true}, {"prefix": "203.0.113.0/26", "exact": false, "greater-equal": 26, "less-equal": 28}' ;;
-        AS-M90-TWO|AS64501)
-            emit_prefixes '{"prefix": "203.0.113.128/25", "exact": true}' ;;
-        AS-M90-THREE|AS64502)
-            emit_prefixes '{"prefix": "203.0.113.64/26", "exact": true}' ;;
-        *) echo "bgpq4-stub: unknown prefix-mode object: $object" >&2; exit 1 ;;
-    esac
-fi
+case "$label" in
+    asn_list)
+        case "$object" in
+            AS-M90-ONE|AS64500)   emit "64500" ;;
+            AS-M90-TWO|AS64501)   emit "64501" ;;
+            AS-M90-THREE|AS64502) emit "64502" ;;
+            *) echo "bgpq4-stub: unknown ASN-mode object: $object" >&2; exit 1 ;;
+        esac
+        ;;
+    prefix_list)
+        if [ "$ip_ver" = "6" ]; then
+            emit ""
+            exit 0
+        fi
+        case "$object" in
+            AS-M90-ONE|AS64500)
+                emit '{"prefix": "198.51.100.0/24", "exact": true}, {"prefix": "203.0.113.0/26", "exact": false, "greater-equal": 26, "less-equal": 28}' ;;
+            AS-M90-TWO|AS64501)
+                emit '{"prefix": "203.0.113.128/25", "exact": true}' ;;
+            AS-M90-THREE|AS64502)
+                emit '{"prefix": "203.0.113.64/26", "exact": true}' ;;
+            *) echo "bgpq4-stub: unknown prefix-mode object: $object" >&2; exit 1 ;;
+        esac
+        ;;
+    *)
+        echo "bgpq4-stub: no -l label in query: $*" >&2
+        exit 1
+        ;;
+esac

--- a/tests/interop/m90-differential/bogons.yml
+++ b/tests/interop/m90-differential/bogons.yml
@@ -1,0 +1,20 @@
+# M90 differential lab — arouteserver bogons override.
+#
+# arouteserver's DEFAULT bogons list correctly includes the RFC 5737
+# documentation prefixes (192.0.2.0/24, 198.51.100.0/24,
+# 203.0.113.0/24) — exactly the space this lab announces from, per the
+# repo's documentation-range convention. Using the default list would
+# make BIRD reject every announcement as a bogon while the rustbgpd
+# side (whose context.yml carries this trimmed list) accepts them.
+# This override keeps only entries that are NOT lab actor space, and
+# it must stay in lockstep with the `bogons:` key of context.yml.
+bogons:
+  - prefix: "10.0.0.0"
+    length: 8
+    comment: "RFC 1918"
+  - prefix: "192.168.0.0"
+    length: 16
+    comment: "RFC 1918"
+  - prefix: "fc00::"
+    length: 7
+    comment: "unique local"

--- a/tests/interop/m90-differential/clients.yml
+++ b/tests/interop/m90-differential/clients.yml
@@ -1,0 +1,42 @@
+# M90 differential lab — arouteserver member roster (clients.yml).
+#
+# Three members with deliberately distinct filtering outcomes:
+#   - AS64500 member1 (192.0.2.11): IRR-clean; its announcements pass.
+#   - AS64501 member2 (192.0.2.12): announces prefixes outside its own
+#     IRR set (another member's prefix + an unregistered more-specific).
+#   - AS64502 member3 (192.0.2.13): hygiene violator (bogon, too-long
+#     and default prefixes, never-via-route-servers ASN in the path).
+#
+# The AS-SET names resolve through the lab's canned bgpq4 stub
+# (bgpq4-stub.sh) — documentation ASNs have no real IRR objects.
+clients:
+  - asn: 64500
+    ip: "192.0.2.11"
+    description: "member1 - IRR-clean member"
+    cfg:
+      filtering:
+        irrdb:
+          as_sets:
+            - "AS-M90-ONE"
+        max_prefix:
+          limit_ipv4: 100
+  - asn: 64501
+    ip: "192.0.2.12"
+    description: "member2 - announces outside its IRR set"
+    cfg:
+      filtering:
+        irrdb:
+          as_sets:
+            - "AS-M90-TWO"
+        max_prefix:
+          limit_ipv4: 100
+  - asn: 64502
+    ip: "192.0.2.13"
+    description: "member3 - hygiene violator"
+    cfg:
+      filtering:
+        irrdb:
+          as_sets:
+            - "AS-M90-THREE"
+        max_prefix:
+          limit_ipv4: 100

--- a/tests/interop/m90-differential/context.yml
+++ b/tests/interop/m90-differential/context.yml
@@ -1,0 +1,124 @@
+# M90 differential lab — hand-authored `arouteserver template-context`
+# fixture for the site described by general.yml + clients.yml.
+#
+# CANONICAL PATH: this file is what
+#     arouteserver template-context --cfg arouteserver.yml --output context.yml
+# dumps for the same general.yml/clients.yml (with the lab's bogons.yml
+# and bgpq4 stub in place). It is checked in by hand so the rustbgpd
+# side renders deterministically offline; regenerating it via
+# arouteserver is the canonical refresh path, and the M90 driver ALWAYS
+# runs arouteserver proper for the BIRD side, so drift between this
+# fixture and the site files shows up as a verdict mismatch.
+#
+# Shape: top-level keys pinned by rs-config-render's
+# EXPECTED_TOP_LEVEL_KEYS fingerprint (copied from the renderer's
+# golden fixture, tools/rs-config-render/tests/fixtures/context-small.yml).
+ip_ver: null
+list_ip_vers: [4, 6]
+live_tests: false
+rtt_based_functions_are_used: false
+perform_graceful_shutdown: false
+any_reject_cause_map_community_set: false
+asn3216_map: {}
+arin_whois_records: {}
+registrobr_whois_records: {}
+rpki_roas: {}
+reject_reasons:
+  "1": "Invalid AS_PATH length"
+  "2": "Prefix is bogon"
+never_via_route_servers_asns: [65551]
+bogons:
+  # Must match the lab's bogons.yml (NOT arouteserver's default list,
+  # which rightly treats the RFC 5737 documentation prefixes as
+  # bogons — this lab announces from exactly that space).
+  - {prefix: "10.0.0.0", length: 8, comment: "RFC 1918"}
+  - {prefix: "192.168.0.0", length: 16, comment: "RFC 1918"}
+  - {prefix: "fc00::", length: 7, comment: "unique local"}
+cfg:
+  rs_as: 64496
+  router_id: "192.0.2.10"
+  prepend_rs_as: false
+  path_hiding: true
+  passive: true
+  gtsm: false
+  multihop: null
+  add_path: false
+  rfc8950: false
+  graceful_shutdown:
+    enabled: false
+  blackhole_filtering:
+    policy_ipv4: null
+    policy_ipv6: null
+  rtt_thresholds: null
+  communities: {}
+  filtering:
+    next_hop:
+      policy: strict
+    ipv4_pref_len: {min: 8, max: 28}
+    ipv6_pref_len: {min: 12, max: 48}
+    global_black_list_pref:
+      - {prefix: "192.0.2.0", length: 24, comment: "IXP peering LAN"}
+    max_as_path_len: 32
+    reject_invalid_as_in_as_path: false
+    transit_free:
+      action: null
+      asns: null
+    irrdb:
+      enforce_origin_in_as_set: true
+      enforce_prefix_in_as_set: true
+      allow_longer_prefixes: false
+      tag_as_set: true
+    rpki_bgp_origin_validation:
+      enabled: false
+      reject_invalid: true
+    max_prefix:
+      action: shutdown
+      peering_db: {enabled: false}
+    reject_policy:
+      policy: reject
+asns:
+  AS64500: {as_sets: ["AS-M90-ONE"]}
+  AS64501: {as_sets: ["AS-M90-TWO"]}
+  AS64502: {as_sets: ["AS-M90-THREE"]}
+clients:
+  - id: AS64500_1
+    asn: 64500
+    ip: "192.0.2.11"
+    description: "member1 - IRR-clean member"
+    cfg:
+      filtering:
+        irrdb:
+          as_set_bundle_ids: ["AS64500_bundle"]
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+  - id: AS64501_1
+    asn: 64501
+    ip: "192.0.2.12"
+    description: "member2 - announces outside its IRR set"
+    cfg:
+      filtering:
+        irrdb:
+          as_set_bundle_ids: ["AS64501_bundle"]
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+  - id: AS64502_1
+    asn: 64502
+    ip: "192.0.2.13"
+    description: "member3 - hygiene violator"
+    cfg:
+      filtering:
+        irrdb:
+          as_set_bundle_ids: ["AS64502_bundle"]
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+irrdb_info:
+  AS64500_bundle:
+    asns: [64500]
+    prefixes:
+      - {prefix: "198.51.100.0", length: 24, exact: true, comment: "route object 198.51.100.0/24"}
+      - {prefix: "203.0.113.0", length: 26, le: 28, comment: "route object 203.0.113.0/26 le 28"}
+  AS64501_bundle:
+    asns: [64501]
+    prefixes:
+      - {prefix: "203.0.113.128", length: 25, exact: true, comment: "route object 203.0.113.128/25"}
+  AS64502_bundle:
+    asns: [64502]
+    prefixes:
+      - {prefix: "203.0.113.64", length: 26, exact: true, comment: "route object 203.0.113.64/26"}

--- a/tests/interop/m90-differential/general.yml
+++ b/tests/interop/m90-differential/general.yml
@@ -1,0 +1,55 @@
+# M90 differential lab — arouteserver site policy (general.yml).
+#
+# This one file (plus clients.yml) drives BOTH route servers in the lab:
+#   - BIRD:      rendered by arouteserver proper (`arouteserver bird`);
+#   - rustbgpd:  rendered by tools/rs-config-render from the
+#                `arouteserver template-context` dump of the same site
+#                (checked in as context.yml, see the README).
+#
+# All ASNs are RFC 5398 documentation ASNs and all prefixes are
+# RFC 5737 documentation prefixes. Because the documentation ASN block
+# (64496-64511, 65536-65551) sits inside the invalid-ASN range both
+# pipelines reject by default, `reject_invalid_as_in_as_path` is
+# explicitly disabled — otherwise every member announcement would be
+# rejected for carrying its own (documentation) origin ASN. The same
+# reasoning requires the lab's own bogons.yml: arouteserver's default
+# bogons list correctly treats the RFC 5737 prefixes as bogons.
+cfg:
+  rs_as: 64496
+  router_id: "192.0.2.10"
+  passive: True
+  path_hiding: True
+  gtsm: False
+  add_path: False
+  filtering:
+    next_hop:
+      policy: "strict"
+    ipv4_pref_len:
+      min: 8
+      max: 28
+    global_black_list_pref:
+      # The lab's own peering LAN — announcing it is the classic
+      # member misconfiguration both stacks must reject.
+      - prefix: "192.0.2.0"
+        length: 24
+        comment: "IXP peering LAN"
+    max_as_path_len: 32
+    # Disabled deliberately: member ASNs are RFC 5398 documentation
+    # ASNs, which fall inside the invalid-ASN block (see header).
+    reject_invalid_as_in_as_path: False
+    irrdb:
+      enforce_origin_in_as_set: True
+      enforce_prefix_in_as_set: True
+      allow_longer_prefixes: False
+    rpki_bgp_origin_validation:
+      # Off: the differential under test is the IRR/hygiene pipeline;
+      # ROV interop already has its own labs (M83).
+      enabled: False
+    never_via_route_servers:
+      peering_db: False
+      asns:
+        - 65551
+    max_prefix:
+      action: "shutdown"
+      peering_db:
+        enabled: False

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# M90 interop test — arouteserver differential lab (ADR-0110 phase 1).
+#
+# One general.yml/clients.yml pair (tests/interop/m90-differential/)
+# drives BOTH route servers:
+#   - BIRD 2: config rendered at runtime by arouteserver PROPER, run
+#     containerized from the official pierky/arouteserver image with
+#     the lab's bogons.yml override and canned bgpq4 stub (the site's
+#     AS-SETs are RFC 5398 documentation objects with no live IRR
+#     data);
+#   - rustbgpd: config rendered by tools/rs-config-render from the
+#     site's `arouteserver template-context` dump. The checked-in
+#     m90-differential/context.yml is that dump, hand-authored against
+#     the renderer's fingerprint-pinned shape; regenerating it via
+#         arouteserver template-context --cfg arouteserver.yml \
+#             --output context.yml
+#     (same mounts as the BIRD render below) is the canonical refresh
+#     path. Because the BIRD side ALWAYS re-runs arouteserver proper
+#     at lab runtime, drift between context.yml and the site files
+#     surfaces as a verdict mismatch — the differential is the guard.
+#
+# Three GoBGP members then announce the canned set from
+# announcements.json, and every entry is asserted on BOTH daemons:
+#   - accept: present on BIRD from that member's protocol, present in
+#     `rbgp rib received <member>`, absent from the rejected store;
+#   - reject: absent on BIRD from that member's protocol, present in
+#     `rbgp rib received <member> --rejected` with reason
+#     policy_reject, and `rbgp policy explain` names the generated
+#     policy AND term from the manifest (hygiene-before-IRR ordering
+#     makes the attribution deterministic).
+#
+# Also asserted along the way: the rendered rustbgpd config passes
+# `rustbgpd --check`, every generated .rpol file passes its own
+# in-language tests under `rbgp policy check`, and the render receipt
+# lists all three members.
+#
+# Prerequisites:
+#   - docker build --target dev -t rustbgpd:dev .
+#   - docker build -t bird:2-bookworm -f tests/interop/Dockerfile.bird tests/interop
+#   - docker build -t gobgp:interop -f tests/interop/Dockerfile.gobgp tests/interop
+#   - containerlab deploy -t tests/interop/m90-differential.clab.yml
+#   - grpcurl + jq installed on the host; cargo (builds rs-config-render)
+#   - the pierky/arouteserver image pinned below (pulled by digest)
+#
+# Usage:
+#   bash tests/interop/scripts/test-m90-differential.sh
+
+TOPO="m90-differential"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
+
+LAB_DIR="$SCRIPT_DIR/../m90-differential"
+MANIFEST="$LAB_DIR/announcements.json"
+
+BIRD="clab-${TOPO}-bird"
+RS_ADDR="192.0.2.9"
+
+# TODO(verification run): pin the digest of the official
+# pierky/arouteserver image (docker pull pierky/arouteserver:latest,
+# then docker inspect --format '{{index .RepoDigests 0}}'). The
+# all-zeros digest below is a deliberate tripwire — the guard in
+# render_bird_config refuses to run until it is replaced or
+# M90_ARS_IMAGE is exported.
+ARS_IMAGE="${M90_ARS_IMAGE:-pierky/arouteserver@sha256:0000000000000000000000000000000000000000000000000000000000000000}"
+# BIRD 2 target for arouteserver's renderer. Debian bookworm's bird2
+# package (the bird:2-bookworm image) is BIRD 2.13; adjust to the
+# nearest version `arouteserver bird --help` actually offers.
+BIRD_TARGET_VERSION="${M90_BIRD_TARGET_VERSION:-2.13}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# rbgp against the RS over the UDS listener the rendered config
+# declares (operator principal; the render emits no TCP listener).
+rs_ctl() {
+    docker exec "$RUSTBGPD" rbgp -s unix:///var/lib/rustbgpd/grpc.sock "$@" 2>/dev/null
+}
+
+member_container() { echo "clab-${TOPO}-${1:?}"; }
+
+# Poll until a command succeeds; usage: poll <tries> <sleep> <label> cmd...
+poll() {
+    local tries=${1:?} pause=${2:?} label=${3:?}
+    shift 3
+    for i in $(seq 1 "$tries"); do
+        if "$@" >/dev/null 2>&1; then
+            ok "$label (attempt $i)"
+            return 0
+        fi
+        sleep "$pause"
+    done
+    fail "$label — timed out after $((tries * pause))s"
+    return 1
+}
+
+# BIRD's full view of one exact net.
+bird_route_all() {
+    docker exec "$BIRD" birdc "show route ${1:?} all" 2>/dev/null
+}
+
+# True if BIRD holds a path for the net from the given arouteserver
+# client protocol (protocol names follow the client ids: AS64500_1 ...).
+bird_has_from()   { bird_route_all "${1:?}" | grep -qF "[${2:?} "; }
+bird_lacks_from() { ! bird_has_from "$1" "$2"; }
+
+rs_accepted_has()   { rs_ctl rib received "${1:?}" | grep -qF "${2:?}"; }
+rs_accepted_lacks() { ! rs_accepted_has "$1" "$2"; }
+
+# True if the member's rejected-route store retains the prefix with the
+# canonical policy_reject reason token.
+rs_rejected_has() {
+    rs_ctl rib received "${1:?}" --rejected -j \
+        | jq -e --arg p "${2:?}" \
+            '[.rejected_routes[] | select(.prefix == $p and .reason == "policy_reject")] | length > 0' \
+        >/dev/null 2>&1
+}
+rs_rejected_lacks() { ! rs_rejected_has "$1" "$2"; }
+
+rs_established_count() {
+    rs_ctl neighbor -j | jq '[.[] | select(.state == "Established")] | length' 2>/dev/null || echo 0
+}
+
+bird_established_count() {
+    docker exec "$BIRD" birdc show protocols 2>/dev/null | grep -c "Established" || true
+}
+
+rs_sessions_up()   { [ "$(rs_established_count)" -ge 3 ]; }
+bird_sessions_up() { [ "$(bird_established_count)" -ge 3 ]; }
+
+# ---------------------------------------------------------------------------
+# Phase 0a: render the BIRD side with arouteserver proper
+# ---------------------------------------------------------------------------
+
+ARS_WORK=""
+
+render_bird_config() {
+    log "Rendering bird.conf with arouteserver proper (containerized)..."
+
+    if [[ "$ARS_IMAGE" == *0000000000000000* ]]; then
+        echo "ERROR: the pierky/arouteserver image digest is still the TODO tripwire." >&2
+        echo "Pin it in this script or export M90_ARS_IMAGE=<image@sha256:...>." >&2
+        exit 1
+    fi
+
+    ARS_WORK=$(mktemp -d)
+    cp "$LAB_DIR/general.yml" "$LAB_DIR/clients.yml" "$LAB_DIR/bogons.yml" \
+        "$LAB_DIR/arouteserver.yml" "$LAB_DIR/bgpq4-stub.sh" "$ARS_WORK/"
+    mkdir -p "$ARS_WORK/cache" "$ARS_WORK/out"
+    chmod +x "$ARS_WORK/bgpq4-stub.sh"
+    # The image may run unprivileged; the mount must be writable for
+    # the IRR cache and the rendered output.
+    chmod -R a+rwX "$ARS_WORK"
+
+    if docker run --rm -v "$ARS_WORK:/site" "$ARS_IMAGE" \
+        arouteserver bird --cfg /site/arouteserver.yml \
+        --target-version "$BIRD_TARGET_VERSION" \
+        -o /site/out/bird.conf; then
+        ok "arouteserver bird render completed"
+    else
+        fail "arouteserver bird render failed"
+        exit 1
+    fi
+    if [ -s "$ARS_WORK/out/bird.conf" ]; then
+        ok "bird.conf rendered and non-empty"
+    else
+        fail "bird.conf missing or empty after the arouteserver run"
+        exit 1
+    fi
+
+    docker cp "$ARS_WORK/out/bird.conf" "$BIRD":/etc/bird/bird.conf
+}
+
+# ---------------------------------------------------------------------------
+# Phase 0b: render the rustbgpd side with rs-config-render
+# ---------------------------------------------------------------------------
+
+RENDER_DIR=""
+
+render_rustbgpd_config() {
+    log "Rendering rustbgpd config with rs-config-render from context.yml..."
+    RENDER_DIR=$(mktemp -d)
+
+    if cargo run --release -q -p rs-config-render -- \
+        --context "$LAB_DIR/context.yml" --out-dir "$RENDER_DIR"; then
+        ok "rs-config-render completed (exit 0 — no refusal, no implausible set, no shape drift)"
+    else
+        fail "rs-config-render failed"
+        exit 1
+    fi
+
+    if jq -e '.clients | length == 3' "$RENDER_DIR/render-receipt.json" >/dev/null 2>&1; then
+        ok "render receipt lists all 3 members"
+    else
+        fail "render receipt missing or does not list 3 members"
+        cat "$RENDER_DIR/render-receipt.json" >&2 || true
+    fi
+
+    docker cp "$RENDER_DIR/config.toml" "$RUSTBGPD":/etc/rustbgpd/config.toml
+    docker cp "$RENDER_DIR/policy" "$RUSTBGPD":/etc/rustbgpd/policy
+
+    # The pipeline's own gate (cookbook step 3): the rendered config
+    # must pass full validation before it may serve members.
+    if docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check /etc/rustbgpd/config.toml >/dev/null 2>&1; then
+        ok "rendered config passes rustbgpd --check"
+    else
+        fail "rendered config FAILS rustbgpd --check"
+        docker exec "$RUSTBGPD" /usr/local/bin/rustbgpd --check /etc/rustbgpd/config.toml >&2 || true
+        exit 1
+    fi
+
+    # Every generated policy carries in-language tests derived from the
+    # site's own data; all must pass offline.
+    local rpol
+    for rpol in rs-hygiene client-as64500-1 client-as64501-1 client-as64502-1; do
+        if docker exec "$RUSTBGPD" rbgp policy check "/etc/rustbgpd/policy/${rpol}.rpol" >/dev/null 2>&1; then
+            ok "rbgp policy check ${rpol}.rpol"
+        else
+            fail "rbgp policy check ${rpol}.rpol failed"
+            docker exec "$RUSTBGPD" rbgp policy check "/etc/rustbgpd/policy/${rpol}.rpol" >&2 || true
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: launch daemons and wait for the six sessions
+# ---------------------------------------------------------------------------
+
+start_daemons() {
+    log "Starting BIRD..."
+    docker exec "$BIRD" sh -c \
+        'mkdir -p /run/bird && (bird -d -c /etc/bird/bird.conf >>/tmp/bird.log 2>&1 &)'
+
+    log "Starting rustbgpd..."
+    docker exec -d "$RUSTBGPD" sh -c \
+        '/usr/local/bin/rustbgpd /etc/rustbgpd/config.toml >>/var/log/rustbgpd.log 2>&1'
+    local up=0
+    for i in $(seq 1 20); do
+        if rs_ctl global >/dev/null 2>&1; then
+            ok "rustbgpd gRPC (UDS) ready (attempt $i)"
+            up=1
+            break
+        fi
+        sleep 1
+    done
+    if [ "$up" -ne 1 ]; then
+        fail "rustbgpd gRPC (UDS) not reachable within 20s"
+        docker exec "$RUSTBGPD" tail -40 /var/log/rustbgpd.log >&2 || true
+        exit 1
+    fi
+
+    log "Starting GoBGP members..."
+    local m
+    for m in member1 member2 member3; do
+        docker exec -d "$(member_container "$m")" sh -c \
+            'nohup gobgpd -f /config/gobgp.toml >/tmp/gobgpd.log 2>&1'
+    done
+
+    poll 45 2 "rustbgpd RS: 3 member sessions Established" rs_sessions_up \
+        || rs_ctl neighbor >&2 || true
+    poll 45 2 "BIRD RS: 3 member sessions Established" bird_sessions_up \
+        || docker exec "$BIRD" birdc show protocols >&2 || true
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: inject the canned announcement set
+# ---------------------------------------------------------------------------
+
+inject_announcements() {
+    log "Injecting the canned announcement set from announcements.json..."
+    local entry client ip prefix aspath
+    while IFS= read -r entry; do
+        client=$(jq -r '.client' <<<"$entry")
+        ip=$(jq -r '.ip' <<<"$entry")
+        prefix=$(jq -r '.prefix' <<<"$entry")
+        aspath=$(jq -r '.aspath // empty' <<<"$entry")
+        # GoBGP prepends the member's own ASN toward the eBGP route
+        # servers, so an injected `aspath 65551` goes on the wire as
+        # "<member-asn> 65551".
+        if [ -n "$aspath" ]; then
+            docker exec "$(member_container "$client")" \
+                gobgp global rib add -a ipv4 "$prefix" origin igp \
+                nexthop "$ip" aspath "$aspath" \
+                && ok "$client injected $prefix (aspath $aspath)" \
+                || fail "$client failed to inject $prefix (aspath $aspath)"
+        else
+            docker exec "$(member_container "$client")" \
+                gobgp global rib add -a ipv4 "$prefix" origin igp \
+                nexthop "$ip" \
+                && ok "$client injected $prefix" \
+                || fail "$client failed to inject $prefix"
+        fi
+    done < <(jq -c '.[]' "$MANIFEST")
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: per-entry differential verdicts
+# ---------------------------------------------------------------------------
+
+assert_accepts() {
+    log "Asserting ACCEPT verdicts on both daemons..."
+    local entry client ip prefix proto
+    while IFS= read -r entry; do
+        client=$(jq -r '.client' <<<"$entry")
+        ip=$(jq -r '.ip' <<<"$entry")
+        prefix=$(jq -r '.prefix' <<<"$entry")
+        proto=$(jq -r '.bird_protocol' <<<"$entry")
+
+        poll 15 2 "BIRD accepts $prefix from $client ($proto)" \
+            bird_has_from "$prefix" "$proto"
+        poll 15 2 "rustbgpd accepts $prefix from $client ($ip)" \
+            rs_accepted_has "$ip" "$prefix"
+        if rs_rejected_lacks "$ip" "$prefix"; then
+            ok "rustbgpd rejected store clean of $prefix for $client"
+        else
+            fail "accepted $prefix from $client also sits in the rejected store"
+        fi
+    done < <(jq -c '.[] | select(.expect == "accept")' "$MANIFEST")
+}
+
+assert_rejects() {
+    log "Asserting REJECT verdicts on both daemons..."
+    # All accepts have converged on both daemons by now, so absence of
+    # a sibling announcement from the same session is meaningful (plus
+    # a short settle for in-flight UPDATEs).
+    sleep 2
+
+    local entry client ip prefix proto policy term explain
+    while IFS= read -r entry; do
+        client=$(jq -r '.client' <<<"$entry")
+        ip=$(jq -r '.ip' <<<"$entry")
+        prefix=$(jq -r '.prefix' <<<"$entry")
+        proto=$(jq -r '.bird_protocol' <<<"$entry")
+        policy=$(jq -r '.policy' <<<"$entry")
+        term=$(jq -r '.term' <<<"$entry")
+
+        # Positive signal first: the rejection is retained with the
+        # canonical reason token.
+        poll 15 2 "rustbgpd retains rejected $prefix from $client (reason policy_reject)" \
+            rs_rejected_has "$ip" "$prefix"
+        if rs_accepted_lacks "$ip" "$prefix"; then
+            ok "rustbgpd accepted view clean of $prefix for $client"
+        else
+            fail "rejected $prefix from $client leaked into the accepted view"
+        fi
+
+        # The explain surface must name the generated policy and term.
+        explain=$(rs_ctl policy explain --neighbor "$ip" --prefix "$prefix" || true)
+        if grep -qF -- "$policy" <<<"$explain" && grep -qw -- "$term" <<<"$explain"; then
+            ok "explain names $policy / $term for $prefix"
+        else
+            fail "explain does not name $policy / $term for $prefix"
+            echo "$explain" >&2
+        fi
+
+        if bird_lacks_from "$prefix" "$proto"; then
+            ok "BIRD rejects $prefix from $client (no path via $proto)"
+        else
+            fail "BIRD ACCEPTED $prefix from $client — differential verdict mismatch"
+            bird_route_all "$prefix" >&2 || true
+        fi
+    done < <(jq -c '.[] | select(.expect == "reject")' "$MANIFEST")
+}
+
+assert_sessions_survived() {
+    log "Post-verdict sanity: no session was torn down by the canned set..."
+    if rs_sessions_up; then
+        ok "rustbgpd still holds 3 Established member sessions"
+    else
+        fail "rustbgpd lost a member session ($(rs_established_count)/3 Established)"
+    fi
+    if bird_sessions_up; then
+        ok "BIRD still holds 3 Established member sessions"
+    else
+        fail "BIRD lost a member session ($(bird_established_count)/3 Established)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+cleanup_workdirs() {
+    [ -n "$ARS_WORK" ] && rm -rf "$ARS_WORK" || true
+    [ -n "$RENDER_DIR" ] && rm -rf "$RENDER_DIR" || true
+}
+
+main() {
+    log "M90 interop test: arouteserver differential lab (ADR-0110 phase 1)"
+    log "Topology: $TOPO"
+
+    if [ ! -f "$MANIFEST" ]; then
+        echo "ERROR: manifest not found at $MANIFEST" >&2
+        exit 1
+    fi
+    # Chain onto test-lib's EXIT trap rather than replacing it.
+    trap 'cleanup_workdirs; _cleanup_on_exit' EXIT
+
+    render_bird_config
+    render_rustbgpd_config
+    start_daemons
+    inject_announcements
+    assert_accepts
+    assert_rejects
+    assert_sessions_survived
+
+    print_summary
+}
+
+main "$@"

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -9,15 +9,15 @@
 #     AS-SETs are RFC 5398 documentation objects with no live IRR
 #     data);
 #   - rustbgpd: config rendered by tools/rs-config-render from the
-#     site's `arouteserver template-context` dump. The checked-in
-#     m90-differential/context.yml is that dump, hand-authored against
-#     the renderer's fingerprint-pinned shape; regenerating it via
-#         arouteserver template-context --cfg arouteserver.yml \
-#             --output context.yml
-#     (same mounts as the BIRD render below) is the canonical refresh
-#     path. Because the BIRD side ALWAYS re-runs arouteserver proper
-#     at lab runtime, drift between context.yml and the site files
-#     surfaces as a verdict mismatch — the differential is the guard.
+#     site's template-context model. The checked-in
+#     m90-differential/context.yml is hand-authored against the
+#     renderer's fingerprint-pinned shape; arouteserver 1.23.2's own
+#     `template-context` emits a sectioned report that is NOT a
+#     drop-in for it (see the lab README), so the fixture is
+#     hand-maintained with its data verified against a real dump.
+#     Because the BIRD side ALWAYS re-runs arouteserver proper at lab
+#     runtime, drift between context.yml and the site files surfaces
+#     as a verdict mismatch — the differential is the guard.
 #
 # Three GoBGP members then announce the canned set from
 # announcements.json, and every entry is asserted on BOTH daemons:
@@ -56,17 +56,14 @@ MANIFEST="$LAB_DIR/announcements.json"
 BIRD="clab-${TOPO}-bird"
 RS_ADDR="192.0.2.9"
 
-# TODO(verification run): pin the digest of the official
-# pierky/arouteserver image (docker pull pierky/arouteserver:latest,
-# then docker inspect --format '{{index .RepoDigests 0}}'). The
-# all-zeros digest below is a deliberate tripwire — the guard in
-# render_bird_config refuses to run until it is replaced or
-# M90_ARS_IMAGE is exported.
-ARS_IMAGE="${M90_ARS_IMAGE:-pierky/arouteserver@sha256:0000000000000000000000000000000000000000000000000000000000000000}"
+# Pinned official image: pierky/arouteserver:latest as of 2026-07-18
+# (arouteserver 1.23.2). Refresh with `docker pull` + `docker inspect
+# --format '{{index .RepoDigests 0}}'`, or override via M90_ARS_IMAGE.
+ARS_IMAGE="${M90_ARS_IMAGE:-pierky/arouteserver@sha256:ba0e9c0b541c63acf0765a08fd2e09c2bba9dc64af1f5bbdce7819e8d1c34d66}"
 # BIRD 2 target for arouteserver's renderer. Debian bookworm's bird2
-# package (the bird:2-bookworm image) is BIRD 2.13; adjust to the
-# nearest version `arouteserver bird --help` actually offers.
-BIRD_TARGET_VERSION="${M90_BIRD_TARGET_VERSION:-2.13}"
+# package (the bird:2-bookworm image) is BIRD 2.0.12; 2.0.11 is the
+# nearest version `arouteserver bird --help` offers.
+BIRD_TARGET_VERSION="${M90_BIRD_TARGET_VERSION:-2.0.11}"
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
ADR-0110 phase-1 item 3: one general.yml/clients.yml site drives both a BIRD route server (rendered by arouteserver proper) and rustbgpd (rendered by rs-config-render from the template-context), and a canned 11-announcement set must produce identical accept/reject verdicts on both — with rustbgpd's explain naming the generated policy term for every rejection.

The site: 3 members with discriminating outcomes (clean IRR member, out-of-set announcer, hygiene violator), strict next-hop, peering-LAN black-list, never-via-RS ASN, prefix-length window. Verdicts derived by hand from the renderer's emission logic (hygiene-before-IRR term ordering); prefix-containment math machine-checked. Two design notes baked into the site files: RFC 5398 documentation ASNs fall inside the default invalid-ASN reject range (check disabled, documented), and arouteserver's default bogon list contains the RFC 5737 prefixes the lab announces from (lab-local bogons list mirrors into the context fixture).

Draft: authored but not yet executed — the box is currently running a benchmark campaign that the lab run would contaminate. Before undraft, the verification run must confirm the assumptions listed in tests/interop/m90-differential/README.md, chiefly: the pinned arouteserver image digest (all-zeros tripwire until pinned — the script refuses to run), the bgpq4 stub invocation shape, BIRD protocol naming (ASxxxxx_1), GoBGP aspath-injection syntax, and that the hand-authored context fixture matches a real template-context dump (the fingerprint gate guards shape drift).