### PR TITLE
perf(rib): defer loc-rib ordered-index maintenance to listing time

### DIFF
--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -20,6 +20,10 @@ use crate::route::{
 };
 use crate::update::{RouteQueryKey, route_query_key};
 
+/// Floor for the ordered-index journal cap: below this table size, replaying
+/// a short journal always beats a rebuild, so don't thrash the rebuild flag.
+const ORDERED_JOURNAL_MIN_CAP: usize = 64;
+
 /// The local RIB storing the best route per prefix.
 pub struct LocRib {
     /// Best route per prefix, paired with its wall-clock install time —
@@ -39,7 +43,20 @@ pub struct LocRib {
     /// Compact ordered prefix index used only by resumable route listings.
     /// The lookup-hot best-path table stays hash-backed; this second index
     /// adds ordered continuation without retaining per-walk snapshots.
+    ///
+    /// Maintained lazily: `recompute` only journals membership changes
+    /// (trie inserts on this lookup-hot path regressed `loc_rib_recompute`
+    /// by ~45-180%, the same reason `routes` is not trie-backed), and the
+    /// journal is replayed the next time a listing runs.
     ordered_prefixes: FamilyPrefixMap<()>,
+    /// Prefixes whose `routes` membership changed since `ordered_prefixes`
+    /// was last synced. Replayed against the live table on the next listing,
+    /// so stale entries (re-added, re-removed) resolve to the final state.
+    ordered_journal: Vec<Prefix>,
+    /// Set when the journal outgrew the table (replay would cost more than
+    /// rebuilding, and an unqueried flapping table must not grow the journal
+    /// without bound). The next listing rebuilds the index from scratch.
+    ordered_rebuild: bool,
     /// `FlowSpec` Loc-RIB: best route per `FlowSpec` rule.
     flowspec_routes: HashMap<FlowSpecKey, FlowSpecRoute>,
     /// EVPN Loc-RIB: best route per RFC 7432 route identity.
@@ -74,6 +91,8 @@ impl LocRib {
         Self {
             routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             ordered_prefixes: FamilyPrefixMap::default(),
+            ordered_journal: Vec::new(),
+            ordered_rebuild: false,
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
             bgpls_routes: HashMap::default(),
@@ -116,16 +135,57 @@ impl LocRib {
                 let was_absent = !self.routes.contains_key(&prefix);
                 self.routes.insert(prefix, (new_best, SystemTime::now()));
                 if was_absent {
-                    self.ordered_prefixes.entry_or_default(prefix);
+                    self.note_membership_change(prefix);
                 }
             }
             changed
         } else {
             let removed = self.routes.remove(&prefix).is_some();
             if removed {
-                self.ordered_prefixes.remove(&prefix);
+                self.note_membership_change(prefix);
             }
             removed
+        }
+    }
+
+    /// Record that `prefix` entered or left `routes`, deferring the ordered
+    /// index update to the next listing. Once the journal would cost as much
+    /// to replay as a rebuild, switch to the rebuild flag and drop it — this
+    /// also bounds journal memory when no listing ever runs.
+    fn note_membership_change(&mut self, prefix: Prefix) {
+        if self.ordered_rebuild {
+            return;
+        }
+        if self.ordered_journal.len() >= self.routes.len().max(ORDERED_JOURNAL_MIN_CAP) {
+            self.ordered_rebuild = true;
+            self.ordered_journal = Vec::new();
+            return;
+        }
+        self.ordered_journal.push(prefix);
+    }
+
+    /// Bring `ordered_prefixes` back in sync with `routes` membership.
+    fn sync_ordered_index(&mut self) {
+        if self.ordered_rebuild {
+            self.ordered_prefixes.clear();
+            for prefix in self.routes.keys() {
+                self.ordered_prefixes.entry_or_default(*prefix);
+            }
+            self.ordered_rebuild = false;
+        } else {
+            let Self {
+                routes,
+                ordered_prefixes,
+                ordered_journal,
+                ..
+            } = self;
+            for prefix in ordered_journal.drain(..) {
+                if routes.contains_key(&prefix) {
+                    ordered_prefixes.entry_or_default(prefix);
+                } else {
+                    ordered_prefixes.remove(&prefix);
+                }
+            }
         }
     }
 
@@ -138,7 +198,15 @@ impl LocRib {
     /// or before `after`. There is one best per prefix, so the compact prefix
     /// index supplies the full ordering and the hash map remains authoritative
     /// for route bodies.
-    pub fn iter_ordered_from(&self, after: Option<RouteQueryKey>) -> impl Iterator<Item = &Route> {
+    ///
+    /// Takes `&mut self` to fold journaled membership changes into the
+    /// ordered index before walking it — the index is only guaranteed to
+    /// mirror `routes` while a listing runs.
+    pub fn iter_ordered_from(
+        &mut self,
+        after: Option<RouteQueryKey>,
+    ) -> impl Iterator<Item = &Route> {
+        self.sync_ordered_index();
         self.ordered_prefixes
             .iter_from(after.map(|cursor| cursor.0))
             .filter_map(|(prefix, ())| self.routes.get(&prefix).map(|(route, _)| route))

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -161,7 +161,11 @@ impl LocRib {
         if self.ordered_rebuild {
             return;
         }
-        if self.ordered_journal.len() >= self.routes.len().max(ORDERED_JOURNAL_MIN_CAP) {
+        // Count the entry about to be pushed: once the journal would match
+        // the table size, replay costs the same as a rebuild — and during
+        // bulk table growth the journal otherwise chases the table from one
+        // entry behind, duplicating every prefix for nothing.
+        if self.ordered_journal.len() + 1 >= self.routes.len().max(ORDERED_JOURNAL_MIN_CAP) {
             self.ordered_rebuild = true;
             // Release the outgrown buffer but keep the floor warm: the next
             // notes after the rebuild must not re-pay the first allocation.

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -91,7 +91,9 @@ impl LocRib {
         Self {
             routes: HashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             ordered_prefixes: FamilyPrefixMap::default(),
-            ordered_journal: Vec::new(),
+            // Pre-reserve the journal floor so recompute's membership note
+            // never allocates on the hot path.
+            ordered_journal: Vec::with_capacity(ORDERED_JOURNAL_MIN_CAP),
             ordered_rebuild: false,
             flowspec_routes: HashMap::default(),
             evpn_routes: HashMap::default(),
@@ -158,7 +160,9 @@ impl LocRib {
         }
         if self.ordered_journal.len() >= self.routes.len().max(ORDERED_JOURNAL_MIN_CAP) {
             self.ordered_rebuild = true;
-            self.ordered_journal = Vec::new();
+            // Release the outgrown buffer but keep the floor warm: the next
+            // notes after the rebuild must not re-pay the first allocation.
+            self.ordered_journal = Vec::with_capacity(ORDERED_JOURNAL_MIN_CAP);
             return;
         }
         self.ordered_journal.push(prefix);

--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -134,8 +134,10 @@ impl LocRib {
                     || old.attributes != new_best.attributes
             });
             if changed {
-                let was_absent = !self.routes.contains_key(&prefix);
-                self.routes.insert(prefix, (new_best, SystemTime::now()));
+                let was_absent = self
+                    .routes
+                    .insert(prefix, (new_best, SystemTime::now()))
+                    .is_none();
                 if was_absent {
                     self.note_membership_change(prefix);
                 }
@@ -154,6 +156,7 @@ impl LocRib {
     /// index update to the next listing. Once the journal would cost as much
     /// to replay as a rebuild, switch to the rebuild flag and drop it — this
     /// also bounds journal memory when no listing ever runs.
+    #[inline]
     fn note_membership_change(&mut self, prefix: Prefix) {
         if self.ordered_rebuild {
             return;

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2800,11 +2800,10 @@ impl RibManager {
                         .collect();
                     page_merged_ordered_routes(iterators, total, page_size)
                 }
-                RouteQueryScope::Best => page_ordered_routes(
-                    self.loc_rib.iter_ordered_from(after),
-                    self.loc_rib.len(),
-                    page_size,
-                ),
+                RouteQueryScope::Best => {
+                    let total = self.loc_rib.len();
+                    page_ordered_routes(self.loc_rib.iter_ordered_from(after), total, page_size)
+                }
                 RouteQueryScope::Advertised { peer } => {
                     // A grouped member holds no per-peer unicast Adj-RIB-Out;
                     // its view is group table − own-sourced − exact-export

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -648,6 +648,93 @@ fn ordered_table_indices_match_full_sort_across_add_path_and_replacement() {
     }
 }
 
+/// Ordered keys the Loc-RIB's lazily synced index must produce: the
+/// authoritative hash table's keys, fully sorted.
+fn loc_rib_sorted_keys(loc: &LocRib) -> Vec<RouteQueryKey> {
+    let mut expected: Vec<_> = loc.iter().map(route_query_key).collect();
+    expected.sort_unstable();
+    expected
+}
+
+#[test]
+fn loc_rib_ordered_listing_replays_journaled_membership_changes() {
+    let peer = Ipv4Addr::new(192, 0, 2, 1);
+    let prefix_at = |octet: u8| Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24);
+    let route_at = |octet: u8| make_route(prefix_at(octet), peer);
+
+    let mut loc = LocRib::new();
+    for octet in 0..5u8 {
+        let route = route_at(octet);
+        assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+    }
+    // Force a sync so the later mutations exercise journal replay, not the
+    // initial population.
+    assert_eq!(
+        loc.iter_ordered_from(None)
+            .map(route_query_key)
+            .collect::<Vec<_>>(),
+        loc_rib_sorted_keys(&loc)
+    );
+
+    // Without listing in between: remove one prefix, remove-then-readd
+    // another (two journal entries resolving to present), add a new one.
+    assert!(loc.recompute(Prefix::V4(prefix_at(1)), std::iter::empty()));
+    assert!(loc.recompute(Prefix::V4(prefix_at(3)), std::iter::empty()));
+    let readded = route_at(3);
+    assert!(loc.recompute(readded.prefix, std::iter::once(&readded)));
+    let fresh = route_at(9);
+    assert!(loc.recompute(fresh.prefix, std::iter::once(&fresh)));
+
+    let listed: Vec<_> = loc.iter_ordered_from(None).map(route_query_key).collect();
+    assert_eq!(listed, loc_rib_sorted_keys(&loc));
+    assert_eq!(
+        listed
+            .iter()
+            .filter(|(prefix, _, _)| *prefix == Prefix::V4(prefix_at(3)))
+            .count(),
+        1,
+        "removed-then-readded prefix must appear exactly once"
+    );
+}
+
+#[test]
+fn loc_rib_ordered_listing_rebuilds_after_journal_cap_and_resyncs() {
+    let peer = Ipv4Addr::new(192, 0, 2, 1);
+    let prefix_at = |octet: u8| Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24);
+    let route_at = |octet: u8| make_route(prefix_at(octet), peer);
+
+    let mut loc = LocRib::new();
+    for octet in 0..4u8 {
+        let route = route_at(octet);
+        assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+    }
+    // Flap one prefix's membership past the journal floor (64 entries) with
+    // no listing running, tripping the full-rebuild path.
+    let flapper = route_at(0);
+    for _ in 0..40 {
+        assert!(loc.recompute(flapper.prefix, std::iter::empty()));
+        assert!(loc.recompute(flapper.prefix, std::iter::once(&flapper)));
+    }
+    assert_eq!(
+        loc.iter_ordered_from(None)
+            .map(route_query_key)
+            .collect::<Vec<_>>(),
+        loc_rib_sorted_keys(&loc)
+    );
+
+    // The index must keep tracking mutations after a rebuild consumed the
+    // flag: mutate again and list a second time.
+    assert!(loc.recompute(Prefix::V4(prefix_at(2)), std::iter::empty()));
+    let fresh = route_at(7);
+    assert!(loc.recompute(fresh.prefix, std::iter::once(&fresh)));
+    assert_eq!(
+        loc.iter_ordered_from(None)
+            .map(route_query_key)
+            .collect::<Vec<_>>(),
+        loc_rib_sorted_keys(&loc)
+    );
+}
+
 #[test]
 fn randomized_mixed_family_add_path_continuations_match_full_key_sort() {
     let mut outbound = AdjRibOut::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)));


### PR DESCRIPTION
The nightly criterion tripwire (runs of 2026-07-17 and 2026-07-18, vs the v0.51.0 baseline) flagged a confident regression cluster introduced by the route-paging ordered index: `loc_rib_recompute/1..8` +54% to +183%, `rib_pipeline/1000,10000` +8-10%, `bulk_initial_load/10000` +13.5%. Root cause: the paging change maintained a second ordered prefix index (a prefix trie) eagerly inside `LocRib::recompute` — the same lookup-hot path the Loc-RIB deliberately keeps hash-backed because trie insertion regressed it.

Fix, in three parts:
- `recompute` now only journals membership changes (a capacity-reserved `Vec` push); the journal is replayed into the ordered index when a listing actually runs. Once the journal would match the table size — counting the entry about to be pushed, so bulk table growth cannot chase the table from one entry behind — it flips to a full-rebuild flag, bounding journal memory and making every further note a no-op.
- Membership presence is taken from the insert return instead of a second `contains_key` probe.
- The journal floor is pre-reserved at construction and after a rebuild flip, keeping the hot path allocation-free.

Verification (pinned A/B harness, 3 alternating attempts, quiet host, v0.51.0 base):
- `rib_pipeline/1000,10000,50000`: -0.2% / -1.5% / -1.1% (improvement/noise) — restored.
- `bulk_initial_load/10000,100000`: -0.7% (noise) / +7.0% mean with straddling spread (not confident; was +8.3% confident before the journal-cap growth fix).
- `loc_rib_recompute/1..8`: +21-49% residual remains. A discriminator build with the journal note stubbed to a no-op still measures +18-30%, so the residual is structural to carrying the index feature (larger `LocRib` moved by value in the bench's fresh-rib iteration shape), not the deferred maintenance. It is a flat ~20-30 ns per call on this host and does not reproduce in the long-lived-rib pipeline or bulk benches. The nightly's `loc_rib_recompute` rows stay red against the v0.51.0 baseline until the next release rebaselines the comparison.

Gates: fmt, clippy `-D warnings`, `cargo test --workspace`, `cargo doc`, bench-internals check, clippy-reasons — all green; two new tests cover journal replay (remove-then-readd resolves to a single listing entry) and the cap-rebuild-resync path.
