### PR TITLE
ci: admit declared milestone jumps in the v1-surface upgrade chain

### DIFF
--- a/docs/v1-stable-contract.md
+++ b/docs/v1-stable-contract.md
@@ -148,6 +148,14 @@ of adjacent minor release lines from the canonical `v0.50.0` history origin,
 with an explicit transition into a new major. Future stable-surface migrations
 add a new consecutive-release fixture rather than overwriting this receipt.
 
+A deliberate release-numbering milestone jump — a target line more than one
+step ahead, where the skipped intermediate lines never exist — may be recorded
+by annotating that single exercise with `"milestone_jump": true` and a
+non-empty `"jump_rationale"` string. The annotated exercise must still advance
+to a later release line, keep the chain contiguous, and end at the workspace
+anchor. An unannotated gap remains an error, and the annotation is rejected on
+an exercise that is actually between consecutive release lines.
+
 The v0.51.0 route-server example is also staged byte-for-byte under
 `tests/fixtures/v1-stable/v0.51.0/` and exercised by the current parser. This
 is only a current-parser proof: it is not yet an accepted v0.51.0-to-v0.52.0

--- a/scripts/check-v1-stable-surface.py
+++ b/scripts/check-v1-stable-surface.py
@@ -688,7 +688,7 @@ def tagged_file(tag: str, path: str) -> bytes | None:
 
 
 ReleaseVersion = tuple[int, int, int]
-ReleaseTransition = tuple[ReleaseVersion, ReleaseVersion]
+ReleaseTransition = tuple[ReleaseVersion, ReleaseVersion, bool]
 
 
 def parse_release_tag(tag: str) -> ReleaseVersion:
@@ -710,16 +710,24 @@ def release_line_chain_error(
     if transitions[0][0] != V1_UPGRADE_HISTORY_ORIGIN:
         return "upgrade exercise history must retain the canonical v0.50.0 origin"
 
-    targets = [target for _, target in transitions]
+    targets = [target for _, target, _ in transitions]
     if targets != sorted(targets) or len(targets) != len(set(targets)):
         return "upgrade exercises must be ordered by unique target release"
 
-    for index, (source, target) in enumerate(transitions):
+    for index, (source, target, milestone_jump) in enumerate(transitions):
         if source[2] != 0 or target[2] != 0:
             return "upgrade exercise endpoints must be release-line anchors with patch zero"
         same_major_next_minor = target[0] == source[0] and target[1] == source[1] + 1
         next_major = target[0] == source[0] + 1 and target[1] == 0
-        if not (same_major_next_minor or next_major):
+        if milestone_jump:
+            if same_major_next_minor or next_major:
+                return (
+                    "declared milestone jump is between consecutive release lines; "
+                    "remove the annotation"
+                )
+            if target <= source:
+                return "declared milestone jump must advance to a later release line"
+        elif not (same_major_next_minor or next_major):
             return "upgrade exercise is not between consecutive release lines"
         if index == 0 and next_major:
             return "major-boundary exercise must retain its preceding release-line receipt"
@@ -735,59 +743,136 @@ def release_line_chain_error(
     return None
 
 
+def upgrade_exercise_milestone_jump(exercise: dict) -> bool:
+    milestone_jump = exercise.get("milestone_jump", False)
+    if not isinstance(milestone_jump, bool):
+        fail("upgrade exercise milestone_jump must be a boolean")
+    rationale = exercise.get("jump_rationale")
+    if milestone_jump and (not isinstance(rationale, str) or not rationale.strip()):
+        fail("declared milestone jump requires a non-empty jump_rationale")
+    if not milestone_jump and rationale is not None:
+        fail("jump_rationale requires a declared milestone jump")
+    return milestone_jump
+
+
 def check_release_line_selftests() -> None:
     v0_49 = (0, 49, 0)
     v0_50 = (0, 50, 0)
     v0_51 = (0, 51, 0)
     v0_52 = (0, 52, 0)
+    v0_60 = (0, 60, 0)
     v1_0 = (1, 0, 0)
     cases = [
-        ("patch baseline", [(v0_50, v0_51)], (0, 51, 1), True),
+        ("patch baseline", [(v0_50, v0_51, False)], (0, 51, 1), True),
         (
             "major baseline",
-            [(v0_50, v0_51), (v0_51, v1_0)],
+            [(v0_50, v0_51, False), (v0_51, v1_0, False)],
             (1, 0, 0),
             True,
         ),
         (
             "major patch baseline",
-            [(v0_50, v0_51), (v0_51, v1_0)],
+            [(v0_50, v0_51, False), (v0_51, v1_0, False)],
             (1, 0, 1),
             True,
         ),
-        ("lone major transition", [(v0_50, v1_0)], (1, 0, 0), False),
-        ("nonzero exercise patch", [(v0_50, (0, 51, 1))], (0, 51, 1), False),
-        ("skipped minor", [(v0_49, v0_51)], (0, 51, 0), False),
+        ("lone major transition", [(v0_50, v1_0, False)], (1, 0, 0), False),
+        ("nonzero exercise patch", [(v0_50, (0, 51, 1), False)], (0, 51, 1), False),
+        ("skipped minor", [(v0_49, v0_51, False)], (0, 51, 0), False),
         (
             "unordered chain",
-            [(v0_51, v0_52), (v0_50, v0_51)],
+            [(v0_51, v0_52, False), (v0_50, v0_51, False)],
             (0, 51, 0),
             False,
         ),
         (
             "duplicate target",
-            [(v0_50, v0_51), (v0_50, v0_51)],
+            [(v0_50, v0_51, False), (v0_50, v0_51, False)],
             (0, 51, 0),
             False,
         ),
         (
             "disconnected chain",
-            [(v0_49, v0_50), (v0_51, v0_52)],
+            [(v0_49, v0_50, False), (v0_51, v0_52, False)],
             (0, 52, 0),
             False,
         ),
         (
             "rewritten history origin",
-            [(v0_49, v0_50), (v0_50, v1_0)],
+            [(v0_49, v0_50, False), (v0_50, v1_0, False)],
             (1, 0, 0),
             False,
         ),
-        ("stale target", [(v0_50, v0_51)], (0, 52, 1), False),
+        ("stale target", [(v0_50, v0_51, False)], (0, 52, 1), False),
+        (
+            "declared milestone jump",
+            [(v0_50, v0_51, False), (v0_51, v0_60, True)],
+            (0, 60, 0),
+            True,
+        ),
+        (
+            "undeclared milestone gap",
+            [(v0_50, v0_51, False), (v0_51, v0_60, False)],
+            (0, 60, 0),
+            False,
+        ),
+        (
+            "consecutive declared jump",
+            [(v0_50, v0_51, True)],
+            (0, 51, 0),
+            False,
+        ),
+        (
+            "milestone jump breaks contiguity",
+            [(v0_50, v0_51, False), (v0_52, v0_60, True)],
+            (0, 60, 0),
+            False,
+        ),
     ]
     for label, transitions, baseline_version, expected_valid in cases:
         valid = release_line_chain_error(transitions, baseline_version) is None
         if valid != expected_valid:
             fail(f"internal release-line regression self-test failed: {label}")
+
+    undeclared_gap = release_line_chain_error(
+        [(v0_50, v0_51, False), (v0_51, v0_60, False)], v0_60
+    )
+    if undeclared_gap != "upgrade exercise is not between consecutive release lines":
+        fail(
+            "internal release-line regression self-test failed: "
+            "undeclared milestone gap message"
+        )
+
+    if upgrade_exercise_milestone_jump(
+        {"milestone_jump": True, "jump_rationale": "deliberate release-line jump"}
+    ) is not True:
+        fail(
+            "internal release-line regression self-test failed: "
+            "declared milestone jump annotation"
+        )
+    if upgrade_exercise_milestone_jump({}) is not False:
+        fail(
+            "internal release-line regression self-test failed: "
+            "unannotated exercise default"
+        )
+    for exercise, expected, label in (
+        ({"milestone_jump": True}, "non-empty jump_rationale", "jump without rationale"),
+        (
+            {"milestone_jump": True, "jump_rationale": " "},
+            "non-empty jump_rationale",
+            "jump with blank rationale",
+        ),
+        (
+            {"jump_rationale": "orphan"},
+            "requires a declared milestone jump",
+            "rationale without jump",
+        ),
+    ):
+        expect_checker_failure(
+            lambda exercise=exercise: upgrade_exercise_milestone_jump(exercise),
+            expected,
+            label,
+        )
 
 
 def check_upgrade_exercises(inventory: dict) -> None:
@@ -807,7 +892,9 @@ def check_upgrade_exercises(inventory: dict) -> None:
     for exercise in exercises:
         from_version = parse_release_tag(exercise["from_release"])
         to_version = parse_release_tag(exercise["to_release"])
-        transitions.append((from_version, to_version))
+        transitions.append(
+            (from_version, to_version, upgrade_exercise_milestone_jump(exercise))
+        )
         if exercise.get("result") not in {
             "accepted_without_config_migration",
             "accepted_with_documented_migration",


### PR DESCRIPTION
## Problem

`scripts/check-v1-stable-surface.py` requires every `upgrade_exercises` entry in `docs/v1-stable-surface.json` to step between consecutive release lines (minor+1 or next-major .0). A deliberate release-numbering milestone jump (e.g. a next release line more than one minor ahead, where the intermediate lines never exist) is therefore structurally rejected, and the script gates CI and both fail-closed publish workflows — such a tag could never go green.

## Rule change

An upgrade exercise may now carry `"milestone_jump": true` plus a required non-empty `"jump_rationale"` string. The annotated exercise is exempt from the consecutive-lines requirement only; it must still advance to a later release line, keep the chain contiguous, and the chain must still end at the workspace release-line anchor. No exercise entry is added here — the current inventory (chain ending at v0.51.0) passes unchanged, and the jump receipt gets recorded at release prep.

## What still fails

- An undeclared gap, with the unchanged message `upgrade exercise is not between consecutive release lines`.
- A declared jump with a missing or blank `jump_rationale`.
- A `jump_rationale` on an exercise that does not declare `milestone_jump`.
- A declared jump on an exercise that is actually consecutive (dead-weight annotation).
- A declared jump that does not advance, or that breaks chain contiguity/ordering.

## Test evidence

New self-test cases in `check_release_line_selftests` (the script's existing fixture-style case table plus `expect_checker_failure`): declared milestone jump passes; undeclared milestone gap fails with the exact existing message; consecutive declared jump fails; jump breaking contiguity fails; annotation validation fails closed for missing/blank/orphan rationale. These run on every invocation of the script.

```
$ python3 scripts/check-v1-stable-surface.py
v1 stable-surface inventory: OK
exit=0
```

`docs/v1-stable-contract.md` upgrade-receipt section documents the milestone-jump form.