### PR TITLE
docs: close release-audit gaps — changelog interop coverage, wire README, receipt hygiene

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,8 +21,8 @@ ignore = [
     # (the `rbgp top` command). We do not install a custom rand
     # logger anywhere in the workspace, so the unsoundness isn't
     # reachable. Pending a ratatui-termwiz bump that pulls a fixed
-    # rand. Tracked in ROADMAP.md under "Resolve open cargo audit
-    # findings."
+    # rand. Tracked in ROADMAP.md under the "`cargo deny` for
+    # license / dependency / advisory audit" bullet.
     "RUSTSEC-2026-0097",
     # RUSTSEC-2024-0436 — `paste` 1.0.15 unmaintained (the upstream
     # author archived the repo). Informational, no security
@@ -32,6 +32,7 @@ ignore = [
     # `pastey` or the equivalent. We accept this surface because the
     # paste invocation in netlink-packet-utils is a `nla_get_*` /
     # `nla_put_*` macro generator — pure proc-macro, no runtime
-    # behavior to worry about. Tracked in ROADMAP.md.
+    # behavior to worry about. Tracked in ROADMAP.md under the
+    # "`cargo deny` for license / dependency / advisory audit" bullet.
     "RUSTSEC-2024-0436",
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ tests/chaos/runs/
 tests/interop/configs/m44-certs/
 tests/interop/configs/m54-certs/
 .last_review_sha
-bench/scale/matrix/artifacts-run*/
+bench/scale/matrix/artifacts-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **arouteserver differential interop lab (M90).** One
+  `general.yml`/`clients.yml` pair drives both route servers — BIRD 2
+  configured by containerized arouteserver 1.23.2 (digest-pinned),
+  rustbgpd by `rs-config-render` from the site's template-context dump.
+  Three GoBGP members announce a canned set spanning IRR, bogon,
+  prefix-length, black-list, and never-via-RS rejections; the lab
+  passes 65/65 assertions with identical accept/reject verdicts on both
+  daemons, and `rbgp policy explain` names the predicted generated
+  policy term for every rejection.
+
+- **Paths-Limit interop receipt (M89).** Three digest-pinned FRR 10.3.1
+  source ASes originate the same IPv4 and IPv6 prefix through a
+  rustbgpd route server to a real FRR sink, proving the experimental
+  Paths-Limit capability (code 76) per family end to end: exact
+  configured/advertised/received/effective values, exact Adj-RIB-Out
+  and independent sink counts, and typed FRR capability state. Runs in
+  hosted CI sharing the M17 Add-Path build and job.
+
 - **Did-you-mean suggestions for unknown config keys.** A typo'd TOML
   key at any level (root, `[[neighbors]]`, peer groups, nested tables)
   now renders the enclosing table and the closest valid key(s) inside
@@ -817,6 +835,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `bench/scale/reloadstall/gen-scenario.py`.
 
 ### Fixed
+
+- **Interop: FRR zebra startup race pinned out of M10 and M89.** On a
+  loaded runner FRR can send its initial IPv6 UPDATE before zebra
+  reports a global address on the peering interface; the
+  link-local-only MP_REACH next hop is rightly rejected
+  (treat-as-withdraw) and FRR never re-advertises, starving the proofs
+  for the whole convergence window. Explicit outbound route-maps now
+  set the IPv6 global next hop on the FRR sources, removing the
+  interface-address timing dependency.
 
 - **RFC 7606 §5.2: an empty-NLRI `MP_REACH_NLRI` no longer shields a
   malformed UPDATE from session reset.** The "no reachable NLRI"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -215,15 +215,16 @@ BIRD-filter-language translation (the importer stops at structure).
   config-converter vacuum, externally verifiable and citation-backed
   (LAN-485).
 
-### Immediate: post-v0.50 audit remediation (2026-07-09)
+### Completed: post-v0.50 audit remediation (2026-07-09)
 
 A repository-wide read-only audit at `155b24c2` found the workspace test,
 Clippy, formatting, and doc gates green, but adversarial lifecycle and
-failure-path review exposed correctness gaps that the happy-path suites do not
-exercise. This remediation tranche takes priority over new protocol breadth
-and the research-shaped queue below.
+failure-path review exposed correctness gaps that the happy-path suites did
+not exercise. This remediation tranche took priority over new protocol
+breadth and the research-shaped queue below; every item below has since
+landed. The section stays as the audit-finding record.
 
-**Release blockers — finish before the next tag:**
+**Release blockers (all landed):**
 
 - [x] **Commit-confirm recovery state machine.** Preserve the pre-transaction
   journal whenever apply completion is ambiguous (post-persist finalization,

--- a/crates/wire/README.md
+++ b/crates/wire/README.md
@@ -40,6 +40,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 7313 | Enhanced Route Refresh (BoRR / EoRR markers) |
 | 7385 | PMSI Tunnel Type IANA registry — `PmsiTunnelType` preserves unknown values via an `Other(u8)` variant |
 | 7432 | EVPN: Types 1–4 (EAD, MAC/IP, IMET, Ethernet Segment) including MAC Mobility extended community (§7.7) |
+| 7606 | Revised UPDATE error handling: `UpdateMessage::parse_revised` recovers malformed path attributes without aborting the parse, each carrying its §7 per-attribute disposition (treat-as-withdraw / attribute-discard / session-reset) from `malformed_attr_disposition`; malformed or duplicated `MP_REACH_NLRI` / `MP_UNREACH_NLRI` and unparseable NLRI stay session-reset (§5.3, §7.11) |
 | 7674 | Clarification of MP_REACH_NLRI next-hop encoding |
 | 7999 | `BLACKHOLE` well-known community (`0xFFFF_029A`, rendered as `65535:666`) |
 | 7911 | Add-Path: path ID in NLRI encode/decode |
@@ -60,6 +61,7 @@ analyzers, test harnesses, MRT readers, etc.
 | 9234 | BGP Roles (OPEN capability code 9, `BgpRole`) + Only-to-Customer path attribute (type 35, `PathAttribute::OnlyToCustomer`). Codec only; malformed-length OTC is preserved as `Unknown` (not a fatal decode) so transport can apply RFC 7606 treat-as-withdraw. Negotiation + ingress/egress rules live in the daemon (ADR-0071) |
 | 9494 | Long-lived graceful restart capability |
 | 9552 | BGP-LS and BGP-LS-VPN NLRI/TLV codec with opaque preservation of unknown NLRI types and TLVs. The daemon consumes it for the ADR-0077 receive/API tranche. Typed topology read accessors now live in the crate (the `bgpls_topo` module); outbound reflection and topology production remain outside the wire crate |
+| 9687 | Send Hold Timer: NOTIFICATION code 8 (`NotificationCode::SendHoldTimerExpired`, subcode always 0 per §6). Codec only — the timer itself lives in the daemon |
 | 9785 §3 | DF Election preference algorithms + Don't-Preempt bit, extending the RFC 8584 DF Election Extended Community |
 | draft-abraitis-idr-addpath-paths-limit-04 | Experimental Paths-Limit capability (`PathsLimitFamily`, IANA-assigned capability code 76). The draft is expired and archived; interoperability and behavior remain experimental |
 | draft-ietf-idr-link-bandwidth | Link Bandwidth Extended Community (non-transitive two-octet-AS-specific, type 0x40 subtype 0x04): decode + construct of the advertising AS and the IEEE-754 bytes/second bandwidth used to weight unequal-cost multipath |
@@ -165,6 +167,14 @@ let bytes = encode_message(&Message::Open(open)).expect("encode OPEN");
   `_NOT_FOUND` / `_INVALID` constants (type 0x43) for the RPKI prefix-origin
   validation-state extended community, rendered `OV_VALID` / `OV_NOT_FOUND` /
   `OV_INVALID` by `Display` (0.14.0)
+- **Revised error handling (RFC 7606)** — `UpdateMessage::parse_revised`
+  returns `RevisedParsedUpdate`: the cleanly decoded `ParsedUpdate` plus the
+  `MalformedAttribute`s recovered without aborting the parse (collected via
+  `RevisedAttributeDecode`), each carrying an `ErrorDisposition`
+  (`AttributeDiscard` / `TreatAsWithdraw` / `SessionReset`) from
+  `malformed_attr_disposition(type_code, is_ibgp)`. `UpdateError` from
+  attribute validation also exposes the disposition a revised-error-handling
+  caller should apply
 - **`UpdateValidationOptions`** — opt-in relaxations for
   `validate_update_attributes_with_options`, e.g. accepting a link-local-primary
   IPv4 `MP_REACH_NLRI` next-hop on a scoped unnumbered session (RFC 8950)

--- a/docs/perf/actor-ceiling-1m-2026-07.md
+++ b/docs/perf/actor-ceiling-1m-2026-07.md
@@ -8,8 +8,8 @@ sharding). ADR-0105 discloses that the grouped export-policy transition
 runs **two un-chunked O(table) snapshot polls** plus an O(outbound-peers
 + table × dirty-peers) finalize tail inside the single-owner actor, and
 warns that at ~1M routes a single such poll plausibly exceeds the 200 ms
-readiness deadline, depooling the node during a *legitimate* reload
-(LAN-418). This receipt confirms or refutes that empirically.
+readiness deadline, depooling the node during a *legitimate* reload.
+This receipt confirms or refutes that empirically.
 
 > **Question: at ~1M routes, does a single policy-transition actor poll
 > exceed the 200 ms `/readyz` deadline, and if the node depools during a

--- a/docs/perf/exact-export-fanout-2026-07.md
+++ b/docs/perf/exact-export-fanout-2026-07.md
@@ -111,7 +111,8 @@ justify that additional correctness surface.
 The real exact probe remained a per-peer operation after the attribute memo,
 so its cost scaled with fanout even when update-group members shared one staged
 payload. This campaign compares current `main`'s permissive benchmark, the
-pre-cache LAN-361 head, and the wire-equivalence cohort optimization.
+pre-cache attribute-memo head from campaign 1, and the wire-equivalence
+cohort optimization.
 
 ### Compared revisions
 
@@ -228,9 +229,9 @@ member. It must not be described as performing a full exact encode per peer.
 Campaign 2 removed redundant exact encoding across compatible update-group
 members, but the common all-success path still rebuilt every candidate key,
 walked the group's advertised-state delta for every peer, and allocated a
-per-peer prior set that was used only when a probe failed. LAN-395 defers that
-work until the rejection fallback actually needs it and keeps the clean
-grouped path keyless.
+per-peer prior set that was used only when a probe failed. The grouped
+fast-path continuation defers that work until the rejection fallback actually
+needs it and keeps the clean grouped path keyless.
 
 ### Compared revisions
 

--- a/docs/perf/reload-flush-envelope-2026-07.md
+++ b/docs/perf/reload-flush-envelope-2026-07.md
@@ -4,7 +4,7 @@ The 1M actor-ceiling receipt (`actor-ceiling-1m-2026-07.md`) found that a
 policy reload depools the node for ~2 s — not in the policy transition
 (whose polls stay under the 200 ms readiness deadline) but in the
 **post-commit outbound re-advertisement flush**. This receipt answers the
-follow-on question that decides how to fix it (LAN-447):
+follow-on question that decides how the cooperative-flush fix is shaped:
 
 > **Is the reload-flush `/readyz` stall driven by route volume
 > (routes re-advertised) or by the peer fleet (how many peers)?**
@@ -70,7 +70,7 @@ Roughly, stall ≈ f(changed_peers × total_peers), superlinear at the top end,
 ~100–150 changed peers on a 300-client fleet and is left far behind (seconds)
 at 500-client internet-scale fleets.
 
-### What this means for LAN-447
+### What this means for the cooperative-flush fix
 
 The cooperative-flush fix should target the **per-peer distribution loop**,
 not route encoding. The stall does not track how many routes are pushed; it

--- a/docs/perf/rib-rebaseline-2026-07-13.md
+++ b/docs/perf/rib-rebaseline-2026-07-13.md
@@ -33,10 +33,10 @@ longer describes the common grouped path. That path remains inside
 `distribute_changes`, so the old “29.4% Arc clone + try_send tail” attribution
 is not valid on current code. Raw-stack inspection shows exact message
 construction is a low-single-digit bucket; successful rejection-overlay and
-prior-advertisement bookkeeping are the next measured target. LAN-395 records
-the bounded fast-path experiment and a 15% pre-committed gate. LAN-348 was
-canceled by its own gate rather than adding an actor boundary around the wrong
-work.
+prior-advertisement bookkeeping are the next measured target. The bounded
+grouped fast-path experiment carries a 15% pre-committed gate. The earlier
+distribution actor-boundary proposal was canceled by its own gate rather than
+adding an actor boundary around the wrong work.
 
 The large throughput difference from the historical July table is not a
 regression introduced by this receipt. The older harness did not install the
@@ -97,7 +97,7 @@ the offline verification commands.
   raw addresses, paths, and source locations.
 - The current CPU classifier intentionally reports exact-precommit work as
   `distribute residual` rather than inventing attribution from unstable closure
-  numbers. LAN-395 requires stable named helpers and classifier fixtures before
-  publishing a finer phase split.
+  numbers. The grouped fast-path continuation requires stable named helpers
+  and classifier fixtures before publishing a finer phase split.
 - The bgperf2 run is a DHAT-instrumented receipt for attribution, not a release
   performance comparison against BIRD or GoBGP.

--- a/docs/perf/rib-route-paging-2026-07.md
+++ b/docs/perf/rib-route-paging-2026-07.md
@@ -1,6 +1,7 @@
 # RIB route-paging materialization receipt — 2026-07
 
-LAN-391 identified two independent costs in bounded unicast route listings:
+The route-paging investigation identified two independent costs in bounded
+unicast route listings:
 every page scans its complete scope, and a grouped advertised-route page also
 cloned the complete member view before that scan. This first tranche measures
 both costs and removes only the grouped full-view clone. It deliberately does
@@ -173,10 +174,10 @@ full-view clone without changing the cursor contract or adding persistent
 memory, clears every tranche gate, and leaves the best-scope control within the
 declared complete-traversal envelope.
 
-Do not close LAN-391. The 400k grouped p99 proxy is now below 5 ms, but the
-complete-traversal speedups are 9.342x and 8.086x rather than the issue's full
-10x gate. The residual cost is the measured repeated full-table scan shared by
-grouped and best scopes. A continuation should evaluate an ordered index or
+Do not treat the route-paging work as closed. The 400k grouped p99 proxy is
+now below 5 ms, but the complete-traversal speedups are 9.342x and 8.086x
+rather than the full 10x gate. The residual cost is the measured repeated
+full-table scan shared by grouped and best scopes. A continuation should evaluate an ordered index or
 equivalent resumable continuation against its ingest and memory cost; it must
 retain an opaque cursor while replacing the permissive mutation behavior above
 with an explicit fail-closed generation fence.


### PR DESCRIPTION
Closes the concrete items from the release-readiness audit:

1. **CHANGELOG `[Unreleased]`** — adds Added entries for the M90 arouteserver differential interop lab (one `general.yml`/`clients.yml` pair driving both BIRD and rustbgpd, 65/65 assertions, identical verdicts) and the M89 Paths-Limit interop receipt (shared M17 Add-Path CI job), plus a Fixed entry for the M10/M89 FRR zebra startup-race pins (explicit IPv6 next-hop route-maps).
2. **`crates/wire/README.md`** (ships with wire 0.15.0) — RFC 7606 row (revised UPDATE error handling / `parse_revised` dispositions), RFC 9687 row (Send Hold Timer NOTIFICATION code 8), and a Key-types bullet for the revised-decode surface (`RevisedParsedUpdate`, `MalformedAttribute`, `RevisedAttributeDecode`, `ErrorDisposition`, `UpdateError`, `malformed_attr_disposition`).
3. **docs/perf narrative tracker-ID sweep** — the five narrative receipts now describe follow-on work by function instead of tracker IDs, matching the receipts convention; raw artifacts under `docs/perf/artifacts/` untouched.
4. **`.cargo/audit.toml`** — both ignore-entry pointers now reference the ROADMAP bullet that actually tracks them (the `cargo deny` license/dependency/advisory audit bullet); the previously cited section does not exist.
5. **ROADMAP.md** — the post-v0.50 audit remediation section (all boxes checked) is reworded as a completed historical tranche.
6. **`.gitignore`** — `bench/scale/matrix/artifacts-run*/` widened to `artifacts-*/` (matching `.dockerignore`) so the `artifacts-refresh*` working directories stop showing as untracked.