### PR TITLE
docs: sync adapter filtered-view and rejection-reason coverage with the shipped surface

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -388,9 +388,10 @@ The in-daemon Birdwatcher-shaped looking glass HTTP server has been removed.
 The daemon's durable API is gRPC + `rbgp`; its four status, peer, and
 accepted-route endpoints (`/status`, `/protocols/bgp`,
 `/routes/protocol/{id}`, `/routes/peer/{peer}`) now live in the maintained
-external `examples/birdwatcher-adapter`. This is not yet a complete Alice-LG
-backend: the adapter's filtered/noexport views are absent (the structured
-reject reasons behind them are served by `PolicyService.ListRejectedRoutes`). A
+external `examples/birdwatcher-adapter`, which also serves a filtered-route
+view (`/routes/filtered/{id}`, from `PolicyService.ListRejectedRoutes` with
+structured reject reasons). This is not yet a complete Alice-LG backend:
+noexport views are absent. A
 config that still sets `[global.telemetry.looking_glass]` fails to load with a
 migration error. See the adapter README for the endpoint→gRPC mapping.
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -422,12 +422,13 @@ that is the signal to fall back to the durable cursor.
 
 **Reference consumers in-tree:** `examples/event-bridge/` (gRPC →
 JSON-lines event bridge, the minimal Shape-A skeleton) and
-`examples/birdwatcher-adapter/` (a Birdwatcher-shaped status, peer, and
-accepted-route REST subset sourced entirely from the public gRPC API,
-including per-route `age` from `received_at_epoch_seconds`). It is not a
-complete Alice-LG backend: the structured reject reasons are now served by
-`PolicyService.ListRejectedRoutes` (LAN-472), but the adapter's
-filtered/noexport views still need wiring. The adapter is the honest template: if
+`examples/birdwatcher-adapter/` (a Birdwatcher-shaped status, peer,
+accepted-route, and filtered-route REST subset sourced entirely from the
+public gRPC API, including per-route `age` from `received_at_epoch_seconds`
+and `GET /routes/filtered/{id}` served from
+`PolicyService.ListRejectedRoutes` with structured reject reasons). It is
+not a complete Alice-LG backend: noexport views are not wired. The adapter
+is the honest template: if
 the public API is missing a field an external tool needs, the fix is an
 additive proto field, not a daemon-internal shortcut — that is how
 `received_at_epoch_seconds` landed.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -165,10 +165,35 @@ to gRPC.
 
 The in-daemon looking glass HTTP server has been removed. The external
 `examples/birdwatcher-adapter` binary serves a Birdwatcher-shaped read-only
-status, peer, and accepted-route subset over the daemon's gRPC API. It is not a
-complete Alice-LG backend. The adapter is unauthenticated and exposes neighbor
-state, received routes, and peer addresses, so apply the same network-level
-access controls as Prometheus.
+status, peer, accepted-route, and filtered-route subset over the daemon's
+gRPC API. It is not a complete Alice-LG backend (noexport views are not
+wired).
+
+**Disclosure surface.** Beyond neighbor state, received routes, and peer
+addresses, the adapter's `GET /routes/filtered/{id}` endpoint serves
+rejected announcements from `PolicyService.ListRejectedRoutes`: each
+retained rejection's prefix, next hop, AS path, communities, RPKI/ASPA
+validation state, and the policy rejection reason (canonical reason token,
+human-readable detail string, and a synthesized reject-reason large
+community). `GET /protocols/bgp` carries real per-neighbor filtered counts.
+The adapter's HTTP listener is unauthenticated and has no TLS; it binds
+`127.0.0.1:8080` by default and listens elsewhere only if you pass
+`--listen` / `BIRDWATCHER_ADAPTER_LISTEN`. Anyone who can reach it can
+enumerate what your import policy rejects and why — treat that as
+looking-glass data you are choosing to publish.
+
+Mitigations, in preference order:
+
+- Keep the loopback default, or bind the adapter to a management network,
+  and put an authenticating reverse proxy in front of it before any wider
+  exposure — the same network-level discipline as Prometheus.
+- Point the adapter at a dedicated gRPC listener and cap it:
+  `ListRejectedRoutes` is a `sensitive_read`-tier method, so `max_tier =
+  "read"` on that listener denies the filtered view while keeping liveness
+  reads working.
+- Disable retention daemon-side with `[policy.reject_retention]
+  enabled = false`: the reject store is never populated and the filtered
+  view is served empty as a configuration fact.
 
 ## TCP MD5 and GTSM
 

--- a/docs/cookbook/monitoring-feed.md
+++ b/docs/cookbook/monitoring-feed.md
@@ -141,12 +141,13 @@ $ ls /var/lib/rustbgpd/mrt/
 feed.20260703.120001.123456789.mrt.gz
 ```
 
-**Looking glass (optional):** for status, peer, and accepted-route views in an
-Alice-LG-style frontend, run the
+**Looking glass (optional):** for status, peer, accepted-route, and
+filtered-route views in an Alice-LG-style frontend, run the
 [`examples/birdwatcher-adapter/`](../../examples/birdwatcher-adapter/)
 against a gRPC TCP listener. (The in-daemon
-`[global.telemetry.looking_glass]` server has been removed.) The adapter does
-not yet supply filtered/noexport views or structured reject reasons.
+`[global.telemetry.looking_glass]` server has been removed.) The filtered
+view is served from `PolicyService.ListRejectedRoutes` with structured
+reject reasons; noexport views are not yet supplied.
 
 ## Watch
 


### PR DESCRIPTION
Four operator docs still described the birdwatcher adapter's filtered/noexport views as unwired, predating the shipped filtered-route surface (#984). Corrections against the current code:

- `docs/EMBEDDING.md`: the adapter reference-consumer note now lists the filtered-route subset (`GET /routes/filtered/{id}` from `PolicyService.ListRejectedRoutes`); only noexport views remain unwired.
- `docs/CONFIGURATION.md` (`[global.telemetry.looking_glass]` removal note): same correction — filtered view served, noexport absent.
- `docs/cookbook/monitoring-feed.md`: the looking-glass pointer no longer claims filtered views and structured reject reasons are missing.
- `docs/SECURITY.md`: looking-glass section updated and extended with an explicit disclosure: what the filtered view exposes (rejected prefixes, next hops, AS paths, communities, RPKI/ASPA state, rejection reason token/detail/synthesized community), on which listener (unauthenticated plain-HTTP, loopback `127.0.0.1:8080` default, `--listen` override), and the mitigations in preference order (bind scope + authenticating proxy; `max_tier = "read"` listener cap denying the `sensitive_read`-tier RPC; `[policy.reject_retention] enabled = false`).

Docs only; no code changes. `git diff --check` clean.