### PR TITLE
test(rib): assert loc-rib ordered-index maintenance stays off the recompute path; commit paging A/B artifacts

### DIFF
--- a/crates/rib/src/loc_rib.rs
+++ b/crates/rib/src/loc_rib.rs
@@ -240,6 +240,20 @@ impl LocRib {
         self.routes.capacity()
     }
 
+    /// Ordered-index staleness probe: `(indexed prefixes, journaled changes)`.
+    ///
+    /// Exposed only to the test asserting that `recompute` stays off the
+    /// ordered index (journaling membership changes for the next listing to
+    /// replay). That test fails if eager index maintenance is ever restored
+    /// to the recompute hot path.
+    #[cfg(test)]
+    pub(crate) fn ordered_index_probe(&self) -> (usize, usize) {
+        (
+            self.ordered_prefixes.iter_from(None).count(),
+            self.ordered_journal.len(),
+        )
+    }
+
     /// Return `true` if no best routes are stored.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -1999,6 +2013,47 @@ mod tests {
             loc.get(&prefix).unwrap().peer,
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2))
         );
+    }
+
+    /// The deferral itself, not just listing correctness: `recompute` must
+    /// journal membership changes and leave the ordered index untouched
+    /// until a listing syncs it. Restoring eager index maintenance to the
+    /// recompute hot path keeps every listing test green but fails this one.
+    #[test]
+    fn recompute_journals_membership_without_touching_ordered_index() {
+        let n = 16usize; // below the 64-entry journal floor: no rebuild flip
+        let prefix_at = |octet: u8| Ipv4Prefix::new(Ipv4Addr::new(10, 0, octet, 0), 24);
+        let mut loc = LocRib::new();
+
+        for octet in 0..u8::try_from(n).unwrap() {
+            let route = make_route(1, prefix_at(octet), 100);
+            assert!(loc.recompute(route.prefix, std::iter::once(&route)));
+        }
+        assert_eq!(
+            loc.ordered_index_probe(),
+            (0, n),
+            "with no listing run, recompute must only journal — an eagerly \
+             maintained ordered index is the reverted hot-path regression"
+        );
+
+        // One listing replays the journal: index synced, journal drained.
+        assert_eq!(loc.iter_ordered_from(None).count(), n);
+        assert_eq!(loc.ordered_index_probe(), (n, 0));
+
+        // Post-listing mutations (one insert, one withdraw) go back to the
+        // journal; the index stays stale until the next listing.
+        let fresh = make_route(1, prefix_at(200), 100);
+        assert!(loc.recompute(fresh.prefix, std::iter::once(&fresh)));
+        assert!(loc.recompute(Prefix::V4(prefix_at(0)), std::iter::empty()));
+        assert_eq!(
+            loc.ordered_index_probe(),
+            (n, 2),
+            "mutations after a sync must journal, not touch the index"
+        );
+
+        // The next listing resolves both journal entries (-1 +1 = n rows).
+        assert_eq!(loc.iter_ordered_from(None).count(), n);
+        assert_eq!(loc.ordered_index_probe(), (n, 0));
     }
 
     #[test]

--- a/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-final-post-fix.md
+++ b/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-final-post-fix.md
@@ -1,0 +1,27 @@
+# Ordered-index ingest A/B — final post-fix three-group run
+
+v0.51.0 base vs the deferred-maintenance fix across the recompute
+microbenchmark and the long-lived pipeline and bulk-load shapes.
+
+- Run: `20260718T180749Z-8711571252da-vs-451e48297b33-rustbgpd-rib-rib_ops`
+- Base: `8711571252da` (`8711571252daa499a604208b891a6589057d36fc`)
+- Head: `451e48297b33` (`451e48297b3361ce7795814a6f275d4abd06ed7b`)
+- Attempts: 3 (alternating order: odd = base-first, even = head-first)
+- Verdict mode: summary only
+- Regression threshold: mean delta >= 3% with min..max and the last-run 95% CI both entirely above zero, stddev < 10%, with >= 3 completed attempts (delta-only rows whose 95% CI straddles zero stay advisory)
+
+| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI | verdict |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `bulk_initial_load/10000` | 3/3 | 1.60 ms | 1.59 ms | -0.68% | 1.02% | -1.83%..+0.13% | -0.36%..+0.86% | noise |
+| `bulk_initial_load/100000` | 3/3 | 25.65 ms | 27.45 ms | +6.99% | 9.64% | -1.21%..+17.61% | +0.92%..+5.44% | noise |
+| `loc_rib_recompute/1` | 3/3 | 63.0 ns | 93.3 ns | +48.52% | 8.51% | +38.72%..+54.01% | +46.15%..+62.05% | regression |
+| `loc_rib_recompute/2` | 3/3 | 75.4 ns | 111.6 ns | +48.00% | 1.27% | +47.20%..+49.46% | +40.88%..+63.83% | regression |
+| `loc_rib_recompute/4` | 3/3 | 109.4 ns | 146.1 ns | +33.56% | 3.27% | +29.92%..+36.25% | +25.75%..+36.29% | regression |
+| `loc_rib_recompute/8` | 3/3 | 179.4 ns | 217.2 ns | +21.08% | 0.69% | +20.30%..+21.59% | +20.35%..+24.12% | regression |
+| `rib_pipeline/1000` | 3/3 | 279.36 us | 278.75 us | -0.22% | 0.06% | -0.28%..-0.16% | -0.53%..+0.08% | improvement |
+| `rib_pipeline/10000` | 3/3 | 3.51 ms | 3.45 ms | -1.52% | 0.47% | -2.00%..-1.06% | -3.91%..+3.89% | improvement |
+| `rib_pipeline/50000` | 3/3 | 26.14 ms | 25.86 ms | -1.08% | 2.09% | -3.40%..+0.65% | -1.02%..+1.88% | noise |
+
+## Verdict
+
+Confident regression rows: `loc_rib_recompute/1`, `loc_rib_recompute/2`, `loc_rib_recompute/4`, `loc_rib_recompute/8`

--- a/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-initial-repro.md
+++ b/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-initial-repro.md
@@ -1,0 +1,22 @@
+# Ordered-index ingest A/B — initial regression reproduction
+
+Two-attempt pinned-harness reproduction of the nightly tripwire: v0.51.0
+base vs the eagerly maintained ordered index inside `LocRib::recompute`.
+
+- Run: `20260718T161700Z-8711571252da-vs-46fa89e8cafb-rustbgpd-rib-rib_ops`
+- Base: `8711571252da` (`8711571252daa499a604208b891a6589057d36fc`)
+- Head: `46fa89e8cafb` (`46fa89e8cafb8d520bb806d9c6048fe07d3ce6fa`)
+- Attempts: 2 (alternating order: odd = base-first, even = head-first)
+- Verdict mode: summary only
+- Regression threshold: mean delta >= 3% with min..max and the last-run 95% CI both entirely above zero, stddev < 10%, with >= 3 completed attempts (delta-only rows whose 95% CI straddles zero stay advisory)
+
+| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI | verdict |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `loc_rib_recompute/1` | 2/2 | 71.0 ns | 134.9 ns | +90.27% | 11.08% | +82.43%..+98.11% | +88.92%..+107.94% | insufficient-attempts |
+| `loc_rib_recompute/2` | 2/2 | 80.2 ns | 153.4 ns | +91.78% | 11.31% | +83.78%..+99.78% | +90.95%..+107.14% | insufficient-attempts |
+| `loc_rib_recompute/4` | 2/2 | 117.2 ns | 188.4 ns | +60.77% | 0.88% | +60.15%..+61.39% | +58.72%..+66.36% | insufficient-attempts |
+| `loc_rib_recompute/8` | 2/2 | 185.0 ns | 268.5 ns | +45.14% | 0.14% | +45.05%..+45.24% | +42.38%..+49.04% | insufficient-attempts |
+
+## Verdict
+
+No confident regressions by the configured verdict rule.

--- a/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-noop-discriminator.md
+++ b/docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-noop-discriminator.md
@@ -1,0 +1,23 @@
+# Ordered-index ingest A/B — no-op-body discriminator
+
+Discriminator build: the deferred-maintenance head with the journal note
+stubbed to a no-op, isolating the cost of carrying the index feature
+itself from the cost of the deferred maintenance.
+
+- Run: `20260718T173007Z-8711571252da-vs-6f79c4da4c9a-rustbgpd-rib-rib_ops`
+- Base: `8711571252da` (`8711571252daa499a604208b891a6589057d36fc`)
+- Head: `6f79c4da4c9a` (`6f79c4da4c9ad8112dda0890e49865f32d9f013c`)
+- Attempts: 3 (alternating order: odd = base-first, even = head-first)
+- Verdict mode: summary only
+- Regression threshold: mean delta >= 3% with min..max and the last-run 95% CI both entirely above zero, stddev < 10%, with >= 3 completed attempts (delta-only rows whose 95% CI straddles zero stay advisory)
+
+| Benchmark | attempts | base median (mean) | head median (mean) | mean delta | stddev | min..max | last-run 95% CI | verdict |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `loc_rib_recompute/1` | 3/3 | 69.5 ns | 90.1 ns | +29.91% | 6.25% | +22.96%..+35.06% | +14.47%..+35.93% | regression |
+| `loc_rib_recompute/2` | 3/3 | 79.1 ns | 107.8 ns | +37.04% | 14.74% | +20.69%..+49.31% | +16.06%..+26.78% | inconclusive-noisy |
+| `loc_rib_recompute/4` | 3/3 | 114.0 ns | 143.3 ns | +25.86% | 6.08% | +18.86%..+29.88% | +15.58%..+22.26% | regression |
+| `loc_rib_recompute/8` | 3/3 | 187.1 ns | 220.0 ns | +17.62% | 3.96% | +14.71%..+22.13% | +13.00%..+16.70% | regression |
+
+## Verdict
+
+Confident regression rows: `loc_rib_recompute/1`, `loc_rib_recompute/4`, `loc_rib_recompute/8`

--- a/docs/perf/rib-route-paging-2026-07.md
+++ b/docs/perf/rib-route-paging-2026-07.md
@@ -191,11 +191,22 @@ the nightly runner, `rib_pipeline` +8-10%, `bulk_initial_load/10000` +13.5%).
 Maintenance is now deferred: recompute journals membership changes into a
 capacity-reserved buffer and a listing replays the journal — or rebuilds the
 index outright once the journal would match the table size — so the eager trie
-insertion left the hot path entirely.
+insertion left the hot path entirely. The deferral is fenced by a Loc-RIB
+unit test (`recompute_journals_membership_without_touching_ordered_index`)
+that fails if eager index maintenance is ever restored to `recompute`.
 
-Post-fix A/B (pinned harness, three alternating attempts, v0.51.0 base):
-`rib_pipeline` -0.2%/-1.5%/-1.1%, `bulk_initial_load` -0.7% at 10k and a
-non-confident straddle at 100k. A flat residual of roughly 20-30 ns per call
+The three A/B comparison summaries are retained under
+[`artifacts/rib-route-paging-2026-07/ordered-index-ab/`](artifacts/rib-route-paging-2026-07/ordered-index-ab/):
+[`ab-initial-repro.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-initial-repro.md)
+(the eager-maintenance regression reproduced against v0.51.0),
+[`ab-noop-discriminator.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-noop-discriminator.md)
+(the no-op-body discriminator), and
+[`ab-final-post-fix.md`](artifacts/rib-route-paging-2026-07/ordered-index-ab/ab-final-post-fix.md)
+(the three-group run at the fix).
+
+Post-fix A/B (pinned harness, three alternating attempts, v0.51.0 base —
+`ab-final-post-fix.md`): `rib_pipeline` -0.2%/-1.5%/-1.1%, `bulk_initial_load`
+-0.7% at 10k and a non-confident straddle at 100k. A flat residual of roughly 20-30 ns per call
 remains visible only in the `loc_rib_recompute` microbenchmark (+21-49%); a
 discriminator build with the journal note stubbed to a no-op still measures
 +18-30%, attributing the residual to carrying the index feature itself (a


### PR DESCRIPTION
The paged-query listing tests verify that the Loc-RIB ordered index produces correct listings, but they would still pass if eager index maintenance were restored to the `recompute` hot path — the deferral itself had no load-bearing assertion.

## Laziness probe

- `LocRib::ordered_index_probe()` (`#[cfg(test)]`): exposes `(indexed prefixes, journaled changes)`.
- `recompute_journals_membership_without_touching_ordered_index`: after N fresh-prefix recomputes with no listing (N below the 64-entry journal floor), the index must hold 0 entries and the journal N; one `iter_ordered_from` syncs the index (N entries) and drains the journal; post-listing mutations journal again and the index stays stale until the next listing.

Verified load-bearing: with eager `entry_or_default`/`remove` calls temporarily restored inside `recompute`, the test fails at the first assertion; with the deferred implementation it passes.

## Receipt artifacts

The three A/B comparison summaries behind the "Ordered-index ingest cost (2026-07-18 follow-up)" section are now committed under `docs/perf/artifacts/rib-route-paging-2026-07/ordered-index-ab/` (host paths scrubbed; run IDs, tables, and verdicts retained):

- `ab-initial-repro.md` — eager-maintenance regression reproduced against v0.51.0 (`loc_rib_recompute/1..8` +45% to +92%)
- `ab-noop-discriminator.md` — journal note stubbed to a no-op, attributing the flat microbenchmark residual to carrying the index feature itself
- `ab-final-post-fix.md` — three-group run at the fix (`rib_pipeline` and `bulk_initial_load` recovered; accepted microbenchmark residual)

The receipt section links the artifacts; the sealed `SHA256SUMS` set in the parent artifacts directory is untouched (new files live in a subdirectory) and still verifies.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps`, and `cargo check -p rustbgpd-rib --features bench-internals --benches` all pass.