### PR TITLE
fix(transport): capture the full malformed UPDATE and involved NLRI in revised-error diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -836,6 +836,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **RFC 7606 §6: the malformed-UPDATE debug dump is now complete.** The
+  DEBUG-level diagnostic emitted on treat-as-withdraw and
+  attribute-discard events previously hex-dumped each raw UPDATE
+  section with a 512-byte cap and reported only NLRI counts. It now
+  captures the ENTIRE malformed UPDATE message as hex — untruncated,
+  since message size is already protocol-bounded (4096 bytes, or 65535
+  with Extended Messages) — and enumerates the NLRI involved explicitly
+  (prefixes with Add-Path path IDs, per family, announcements and
+  withdrawals), rendered from what the revised parse already produced.
+  Still DEBUG-gated and lazily built, so the clean path and log-spam
+  posture are unchanged; routing dispositions are untouched. The
+  rejected-route retention store keeps its separate, deliberate byte
+  caps.
+
 - **Interop: FRR zebra startup race pinned out of M10 and M89.** On a
   loaded runner FRR can send its initial IPv6 UPDATE before zebra
   reports a global address on the peering interface; the

--- a/crates/transport/src/session/inbound.rs
+++ b/crates/transport/src/session/inbound.rs
@@ -198,22 +198,126 @@ fn strict_peer_next_hop_violation(
     }
     (next_hop != session_addr).then_some(NextHopOwnershipBlockReason::ForeignNextHop)
 }
-/// Bounded hex rendering of one raw UPDATE section for the
-/// malformed-UPDATE debug dump. Truncated output states how many bytes
-/// were omitted so the log is honest about what it shows.
-fn bounded_hex(bytes: &[u8]) -> String {
+/// Hex rendering of the ENTIRE malformed UPDATE for the RFC 7606 §6
+/// debug dump. Never truncated: the message came off the wire, so its
+/// size is protocol-bounded (4096 bytes, or 65535 with Extended
+/// Messages). Re-encodes the decoded sections — a byte-for-byte
+/// reconstruction, since the header is fixed-form and the sections are
+/// verbatim copies of the received body.
+pub(crate) fn full_update_hex(update: &rustbgpd_wire::UpdateMessage) -> String {
     use std::fmt::Write as _;
-    /// Per-section cap: enough to reconstruct any ordinary UPDATE in
-    /// full while keeping an Extended-Messages-sized dump out of the
-    /// logs.
-    const MAX_HEX_DUMP_BYTES: usize = 512;
-    let shown = &bytes[..bytes.len().min(MAX_HEX_DUMP_BYTES)];
-    let mut out = String::with_capacity(shown.len() * 2 + 24);
-    for byte in shown {
+    let mut wire = bytes::BytesMut::with_capacity(update.encoded_len());
+    // A received message always fits the Extended-Messages bound, so
+    // this cannot fail; an empty dump beats a panic on an error path.
+    if update.encode_with_limit(&mut wire, u16::MAX).is_err() {
+        return String::new();
+    }
+    let mut out = String::with_capacity(wire.len() * 2);
+    for byte in &wire {
         let _ = write!(out, "{byte:02x}");
     }
-    if bytes.len() > MAX_HEX_DUMP_BYTES {
-        let _ = write!(out, "…(+{} bytes)", bytes.len() - MAX_HEX_DUMP_BYTES);
+    out
+}
+/// Enumerate every NLRI the revised parse recovered from a malformed
+/// UPDATE — body IPv4 and each MP family, announcements and
+/// withdrawals, with Add-Path path IDs where present — per the
+/// RFC 7606 §6 guidance to list the NLRI involved. Renders only what
+/// the parse already produced: an MP attribute that was itself
+/// malformed is absent here and covered by the full-message hex.
+pub(crate) fn involved_nlri(parsed: &ParsedUpdate) -> String {
+    fn with_path_id(path_id: u32, rendered: String) -> String {
+        if path_id == 0 {
+            rendered
+        } else {
+            format!("{rendered} path-id {path_id}")
+        }
+    }
+    fn section(out: &mut String, label: &str, items: &[String]) {
+        if items.is_empty() {
+            return;
+        }
+        if !out.is_empty() {
+            out.push_str("; ");
+        }
+        out.push_str(label);
+        out.push_str("=[");
+        out.push_str(&items.join(", "));
+        out.push(']');
+    }
+    let mut out = String::new();
+    section(
+        &mut out,
+        "ipv4_unicast_announced",
+        &parsed
+            .announced
+            .iter()
+            .map(|e| with_path_id(e.path_id, e.prefix.to_string()))
+            .collect::<Vec<_>>(),
+    );
+    section(
+        &mut out,
+        "ipv4_unicast_withdrawn",
+        &parsed
+            .withdrawn
+            .iter()
+            .map(|e| with_path_id(e.path_id, e.prefix.to_string()))
+            .collect::<Vec<_>>(),
+    );
+    for attr in &parsed.attributes {
+        let (direction, afi, safi, items) = match attr {
+            PathAttribute::MpReachNlri(mp) => (
+                "announced",
+                mp.afi,
+                mp.safi,
+                mp.announced
+                    .iter()
+                    .map(|e| with_path_id(e.path_id, e.prefix.to_string()))
+                    .chain(mp.flowspec_announced.iter().map(ToString::to_string))
+                    .chain(mp.evpn_announced.iter().map(|r| format!("{r:?}")))
+                    .chain(mp.bgpls_announced.iter().map(|r| format!("{r:?}")))
+                    .chain(
+                        mp.vpn_announced
+                            .iter()
+                            .map(|e| with_path_id(e.path_id, format!("{:?}", e.nlri))),
+                    )
+                    .chain(
+                        mp.labeled_announced
+                            .iter()
+                            .map(|e| with_path_id(e.path_id, format!("{:?}", e.nlri))),
+                    )
+                    .chain(mp.rtc_announced.iter().map(ToString::to_string))
+                    .collect::<Vec<_>>(),
+            ),
+            PathAttribute::MpUnreachNlri(mp) => (
+                "withdrawn",
+                mp.afi,
+                mp.safi,
+                mp.withdrawn
+                    .iter()
+                    .map(|e| with_path_id(e.path_id, e.prefix.to_string()))
+                    .chain(mp.flowspec_withdrawn.iter().map(ToString::to_string))
+                    .chain(mp.evpn_withdrawn.iter().map(|r| format!("{r:?}")))
+                    .chain(mp.bgpls_withdrawn.iter().map(|r| format!("{r:?}")))
+                    .chain(
+                        mp.vpn_withdrawn
+                            .iter()
+                            .map(|e| with_path_id(e.path_id, format!("{:?}", e.nlri))),
+                    )
+                    .chain(
+                        mp.labeled_withdrawn
+                            .iter()
+                            .map(|e| with_path_id(e.path_id, format!("{:?}", e.nlri))),
+                    )
+                    .chain(mp.rtc_withdrawn.iter().map(ToString::to_string))
+                    .collect::<Vec<_>>(),
+            ),
+            _ => continue,
+        };
+        let family = format!("{afi:?}_{safi:?}").to_lowercase();
+        section(&mut out, &format!("{family}_{direction}"), &items);
+    }
+    if out.is_empty() {
+        out.push_str("none");
     }
     out
 }
@@ -978,14 +1082,13 @@ impl PeerSession {
         }
         self.drive_fsm(Event::UpdateReceived).await;
     }
-    /// RFC 7606 §5.2 minimum debugging guidance: retain enough of a
-    /// malformed UPDATE — the NLRI involved and the complete message —
-    /// for offline analysis. DEBUG-only by design: a hostile peer can
-    /// trigger this once per UPDATE, so it must never land at
-    /// info/warn where it would spam operators; the per-section hex is
-    /// byte-bounded for the same reason (Extended Messages reach
-    /// 65535 B). The `tracing` macro skips the hex rendering entirely
-    /// when DEBUG is disabled.
+    /// RFC 7606 §6 debugging facility: capture the entire malformed
+    /// UPDATE message and list the NLRI involved, for offline analysis.
+    /// DEBUG-only by design: a hostile peer can trigger this once per
+    /// UPDATE, so it must never land at info/warn where it would spam
+    /// operators. The full-message hex is protocol-bounded (4096 bytes,
+    /// or 65535 with Extended Messages), so it needs no artificial cap.
+    /// The `tracing` macro skips all rendering when DEBUG is disabled.
     fn debug_dump_malformed_update(
         &self,
         update: &rustbgpd_wire::UpdateMessage,
@@ -993,12 +1096,9 @@ impl PeerSession {
     ) {
         debug!(
             peer = %self.peer_label,
-            announced = parsed.announced.len(),
-            withdrawn = parsed.withdrawn.len(),
-            nlri_hex = %bounded_hex(&update.nlri),
-            withdrawn_routes_hex = %bounded_hex(&update.withdrawn_routes),
-            path_attributes_hex = %bounded_hex(&update.path_attributes),
-            "malformed UPDATE raw sections (RFC 7606 §5.2 debugging guidance)"
+            nlri_involved = %involved_nlri(parsed),
+            update_message_hex = %full_update_hex(update),
+            "malformed UPDATE captured in full (RFC 7606 §6 debugging facility)"
         );
     }
     /// Parse an UPDATE message, validate attributes, apply import policy,

--- a/crates/transport/src/session/tests.rs
+++ b/crates/transport/src/session/tests.rs
@@ -15733,3 +15733,88 @@ async fn list_rejected_routes_command_returns_sorted_snapshot() {
         "the query is a read — the store is untouched"
     );
 }
+
+/// RFC 7606 §6: the malformed-UPDATE debug dump must capture the ENTIRE
+/// UPDATE message (no truncation — the message is protocol-bounded) and
+/// list the NLRI involved explicitly, with Add-Path path IDs and per
+/// family, not just counts.
+#[test]
+fn malformed_update_dump_is_untruncated_and_enumerates_nlri() {
+    // Body NLRI: 80 Add-Path IPv4 announcements (8 bytes each = 640 B,
+    // past the old 512-byte per-section hex cap).
+    let mut nlri = Vec::new();
+    for i in 0..80u32 {
+        nlri.extend_from_slice(&(i + 1).to_be_bytes()); // path ID
+        nlri.push(24);
+        #[expect(clippy::cast_possible_truncation, reason = "i < 80")]
+        nlri.extend_from_slice(&[10, 0, i as u8]);
+    }
+    // One Add-Path withdrawn route: path ID 7, 192.0.2.0/24.
+    let mut withdrawn = Vec::new();
+    withdrawn.extend_from_slice(&7u32.to_be_bytes());
+    withdrawn.push(24);
+    withdrawn.extend_from_slice(&[192, 0, 2]);
+    // Attributes: a malformed ORIGIN (length 2 — §7.1 treat-as-withdraw),
+    // a valid AS_PATH and NEXT_HOP, and a valid MP_UNREACH_NLRI carrying
+    // an IPv6 withdrawal so a second family is involved.
+    let attrs: Vec<u8> = [
+        &[0x40, 0x01, 0x02, 0x00, 0x00][..], // ORIGIN, bad length
+        &[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xFD, 0xE8], // AS_PATH seq [65000]
+        &[0x40, 0x03, 0x04, 192, 0, 2, 1],   // NEXT_HOP
+        &[
+            0x80, 0x0F, 0x08, 0x00, 0x02, 0x01, 32, 0x20, 0x01, 0x0D, 0xB8,
+        ], // MP_UNREACH 2001:db8::/32
+    ]
+    .concat();
+    let update = rustbgpd_wire::UpdateMessage {
+        withdrawn_routes: Bytes::from(withdrawn),
+        path_attributes: Bytes::from(attrs),
+        nlri: Bytes::from(nlri),
+    };
+    let revised = update
+        .parse_revised(true, false, true, &[])
+        .expect("revised parse recovers the malformed ORIGIN");
+    assert!(
+        !revised.malformed.is_empty(),
+        "the malformed ORIGIN must be recovered, not dropped silently"
+    );
+
+    // (a) The full-message hex covers every byte and carries no
+    // truncation marker.
+    let hex = super::inbound::full_update_hex(&update);
+    assert_eq!(
+        hex.len(),
+        update.encoded_len() * 2,
+        "every byte of the UPDATE is hex-dumped"
+    );
+    assert!(!hex.contains('…'), "no truncation marker");
+    assert!(
+        hex.ends_with("00000050180a004f"),
+        "the final NLRI entry (path ID 80, 10.0.79.0/24) is present past \
+         the old 512-byte cap; got tail {}",
+        &hex[hex.len() - 20..]
+    );
+
+    // (b) Every involved NLRI is enumerated: per family, with path IDs.
+    let listed = super::inbound::involved_nlri(&revised.update);
+    assert!(
+        listed.contains("ipv4_unicast_announced"),
+        "family label present: {listed}"
+    );
+    assert!(
+        listed.contains("10.0.0.0/24 path-id 1"),
+        "first announcement with path ID: {listed}"
+    );
+    assert!(
+        listed.contains("10.0.79.0/24 path-id 80"),
+        "last announcement (beyond the old cap) with path ID: {listed}"
+    );
+    assert!(
+        listed.contains("ipv4_unicast_withdrawn") && listed.contains("192.0.2.0/24 path-id 7"),
+        "withdrawal enumerated: {listed}"
+    );
+    assert!(
+        listed.contains("ipv6_unicast_withdrawn") && listed.contains("2001:db8::/32"),
+        "MP family withdrawal enumerated: {listed}"
+    );
+}

--- a/docs/RFC_NOTES.md
+++ b/docs/RFC_NOTES.md
@@ -414,8 +414,13 @@ Interpretation decisions:
   mistaken for an End-of-RIB marker (RFC 4724 §2 detection requires a clean
   decode).
 - Malformed attributes are logged at `warn` with peer, attribute type, and
-  disposition (§6 debugging facility). Per-disposition counters are a
-  follow-up.
+  disposition. The §6 debugging facility is a DEBUG-level dump emitted on
+  every malformed event: the entire UPDATE message as hex (untruncated —
+  message size is protocol-bounded at 4096 bytes, or 65535 with Extended
+  Messages) plus an explicit enumeration of the NLRI involved (prefixes and
+  Add-Path path IDs, per family, announcements and withdrawals). DEBUG-only
+  so a hostile peer cannot spam operators at info/warn; nothing is rendered
+  when DEBUG is disabled. Per-disposition counters are a follow-up.
 - AS4_PATH / AS4_AGGREGATOR are not decoded as typed attributes (they pass
   through opaquely), so no malformation can be detected for them today.
 


### PR DESCRIPTION
## Summary

RFC 7606 §6 says implementations SHOULD provide debugging facilities that capture the entire malformed UPDATE message and list the NLRI involved. The revised-error-handling debug dump previously hex-dumped each raw UPDATE section with a 512-byte cap and reported only announced/withdrawn counts.

The dump now:

- **Captures the entire UPDATE message** as hex, untruncated. Message size is already protocol-bounded (4096 bytes, or 65535 with Extended Messages), so no artificial cap is needed. The message is reconstructed byte-for-byte from the decoded sections via the existing encoder — the header is fixed-form and the sections are verbatim copies of the received body.
- **Enumerates the involved NLRI explicitly** — body IPv4 and every MP family, announcements and withdrawals, with Add-Path path IDs where present — rendered from what the revised parse already produced. No re-parsing. An MP attribute that was itself malformed is absent from the parsed view by construction and is covered by the full-message hex.

Unchanged, deliberately:

- Routing behavior (treat-as-withdraw / attribute-discard / session-reset) is untouched.
- The dump stays DEBUG-only and lazily built (the `tracing` macro skips all rendering when DEBUG is disabled), so the clean path and the log-spam posture are unchanged.
- The rejected-route retention store's per-entry byte caps are a separate, deliberate bound and are not touched.

Both call sites route through the one dump helper, so treat-as-withdraw and attribute-discard events (including validation-error escalations) all get the complete diagnostic.

## Testing

- New test `malformed_update_dump_is_untruncated_and_enumerates_nlri`: an UPDATE with 80 Add-Path IPv4 announcements (640-byte NLRI section, past the old 512-byte cap), an Add-Path withdrawal, a malformed ORIGIN (§7.1 treat-as-withdraw), and an MP_UNREACH IPv6 withdrawal. Asserts the hex dump covers every byte with no truncation marker (including the final NLRI entry beyond the old cap) and that each involved NLRI renders with its path ID and family label. Written red-first against the old truncating dump surface.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps` — all green.