### PR TITLE
feat(rs-render): ingest real arouteserver template-context output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`rs-config-render` ingests real `arouteserver template-context`
+  output.** arouteserver 1.23.2 emits a sectioned report (per-key
+  heading + YAML fragment), not the single YAML document the renderer
+  previously required; the renderer now auto-detects and ingests both
+  forms, normalizing the report's section names, hash-keyed
+  `irrdb_info` bundle list, and `!!set`-typed `as_set_bundle_ids`, and
+  deduping the overlapping AS-SET/origin-ASN bundle union. The
+  sectioned shape is fingerprint-pinned like the single-document form
+  (same exit-code discipline), and per-client `black_list_pref` /
+  IRR `white_list_*` knobs are now refused instead of silently
+  dropped. A verbatim dump from the digest-pinned image is checked in,
+  the test suite pins render parity between the two forms, and
+  `tests/interop/m90-differential/prove-context-ingestion.sh` proves
+  the advertised pipeline (`template-context` in the pinned container
+  → `rs-config-render` → `rustbgpd --check` + `rbgp policy check`)
+  end to end with true exit codes.
+
 - **arouteserver differential interop lab (M90).** One
   `general.yml`/`clients.yml` pair drives both route servers — BIRD 2
   configured by containerized arouteserver 1.23.2 (digest-pinned),

--- a/docs/cookbook/ixp-filter-pipeline.md
+++ b/docs/cookbook/ixp-filter-pipeline.md
@@ -47,6 +47,15 @@ Install and configure arouteserver itself per its
 [documentation][arouteserver] (`arouteserver setup`, then your
 `general.yml` / `clients.yml`).
 
+The command's output format is arouteserver's, not ours: 1.23.2 emits
+a *sectioned report* (per-key heading plus a YAML fragment). The
+renderer auto-detects and ingests that form directly, alongside the
+single-document YAML equivalent its fixtures use — no conversion step.
+This exact pipeline runs for real against the pinned official
+arouteserver image in
+[`tests/interop/m90-differential/prove-context-ingestion.sh`](../../tests/interop/m90-differential/prove-context-ingestion.sh),
+which asserts both input forms render identical configuration.
+
 ## 2. Render rustbgpd configuration
 
 ```bash

--- a/tests/interop/m90-differential/README.md
+++ b/tests/interop/m90-differential/README.md
@@ -56,29 +56,32 @@ every generated `.rpol`).
 ## The canonical context path
 
 `context.yml` is checked in hand-authored (matching the renderer's
-fingerprint-pinned 17-key shape, same as its golden fixture) so the
-rustbgpd side renders deterministically offline. arouteserver's own
-dump of the same site is
+fingerprint-pinned 17-key single-document shape, same as its golden
+fixture) so the rustbgpd side renders deterministically offline.
+arouteserver's own dump of the same site is
 
 ```bash
 arouteserver template-context --cfg arouteserver.yml --output context.yml
 ```
 
-(same mounts as the driver's BIRD render), but as of arouteserver
-1.23.2 that command emits a *sectioned report* (per-key heading +
-underline + YAML fragment), not one YAML document, and its section
-names differ from the renderer's pinned top-level keys (e.g.
-`arin_whois_db_records` vs `arin_whois_records`; `irrdb_info` as a
-list of hash-keyed bundles vs a map). So the dump is not a drop-in
-replacement for this fixture; converting it is an rs-config-render
-follow-up. The fixture's *data* was verified in lockstep against a
-real 1.23.2 dump when the image was pinned: filtering knobs, client
-roster, bogons, never-via ASNs, and every per-client IRR asn/prefix
-bundle match.
+(same mounts as the driver's BIRD render). As of arouteserver 1.23.2
+that command emits a *sectioned report* (per-key heading + underline +
+YAML fragment) whose section names and value shapes differ from the
+single-document form (e.g. `arin_whois_db_records` vs
+`arin_whois_records`; `irrdb_info` as a list of hash-keyed bundles vs
+a map); `rs-config-render` auto-detects and ingests **both** forms. A
+real dump from the pinned image is checked in verbatim as
+[`context-sectioned.yml`](context-sectioned.yml), and
+[`prove-context-ingestion.sh`](prove-context-ingestion.sh) re-runs the
+dump against the pinned image and asserts, with true exit codes, that
+it still matches the checked-in dump byte for byte and that both
+fixtures render identical configuration (modulo the context-shape
+fingerprint header). The renderer's test suite pins the same parity
+offline.
 
-The lab never trusts the fixture alone: the BIRD side always re-runs
+The lab never trusts the fixtures alone: the BIRD side always re-runs
 arouteserver proper from `general.yml`/`clients.yml` at runtime, so if
-the fixture drifts from the site files the differential verdicts
+a fixture drifts from the site files the differential verdicts
 diverge and the lab fails.
 
 ## Site quirks (deliberate)

--- a/tests/interop/m90-differential/context-sectioned.yml
+++ b/tests/interop/m90-differential/context-sectioned.yml
@@ -1,0 +1,771 @@
+ip_ver
+------
+null
+...
+
+
+cfg
+---
+cfg:
+  add_path: false
+  blackhole_filtering:
+    add_noexport: true
+    announce_to_client: true
+    policy_ipv4: null
+    policy_ipv6: null
+    rewrite_next_hop_ipv4: null
+    rewrite_next_hop_ipv6: null
+  communities:
+    add_noadvertise_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    add_noadvertise_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    add_noexport_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    add_noexport_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    announce_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    announce_to_peers_with_rtt_higher_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    announce_to_peers_with_rtt_lower_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    blackholing:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    do_not_announce_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    do_not_announce_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    do_not_announce_to_peers_with_rtt_higher_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    do_not_announce_to_peers_with_rtt_lower_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    origin_not_present_in_as_set:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    origin_present_in_as_set:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prefix_not_present_in_as_set:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prefix_present_in_as_set:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prefix_validated_via_arin_whois_db_dump:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prefix_validated_via_registrobr_whois_db_dump:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prefix_validated_via_rpki_roas:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    prepend_once_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_once_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    prepend_once_to_peers_with_rtt_higher_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_once_to_peers_with_rtt_lower_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_thrice_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_thrice_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    prepend_thrice_to_peers_with_rtt_higher_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_thrice_to_peers_with_rtt_lower_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_twice_to_any:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_twice_to_peer:
+      ext: null
+      lrg: null
+      peer_as: true
+      std: null
+      type: inbound
+    prepend_twice_to_peers_with_rtt_higher_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    prepend_twice_to_peers_with_rtt_lower_than:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: inbound
+    reject_cause:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_1:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_10:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_11:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_12:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_13:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_14:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_15:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_2:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_3:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_4:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_5:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_6:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_7:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_8:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    reject_cause_map_9:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    rejected_route_announced_by:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    route_validated_via_white_list:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    rpki_bgp_origin_validation_invalid:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    rpki_bgp_origin_validation_not_performed:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: outbound
+    rpki_bgp_origin_validation_unknown:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+    rpki_bgp_origin_validation_valid:
+      ext: null
+      lrg: null
+      peer_as: false
+      std: null
+      type: internal
+  custom_communities: {}
+  filtering:
+    global_black_list_pref:
+    - comment: IXP peering LAN
+      exact: false
+      ge: null
+      le: null
+      length: 24
+      max_length: 32
+      prefix: 192.0.2.0
+    ipv4_pref_len:
+      max: 28
+      min: 8
+    ipv6_pref_len:
+      max: 48
+      min: 12
+    irrdb:
+      allow_longer_prefixes: false
+      enforce_origin_in_as_set: true
+      enforce_prefix_in_as_set: true
+      peering_db: false
+      tag_as_set: true
+      use_arin_bulk_whois_data:
+        enabled: false
+        source: null
+      use_registrobr_bulk_whois_data:
+        enabled: false
+        source: ftp://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt
+      use_rpki_roas_as_route_objects:
+        enabled: false
+    max_as_path_len: 32
+    max_prefix:
+      action: shutdown
+      count_rejected_routes: true
+      general_limit_ipv4: 170000
+      general_limit_ipv6: 12000
+      peering_db:
+        enabled: false
+        increment:
+          absolute: 100
+          relative: 15
+      restart_after: 15
+    never_via_route_servers:
+      asns:
+      - 65551
+      peering_db: false
+    next_hop:
+      policy: strict
+    reject_invalid_as_in_as_path: false
+    reject_policy:
+      policy: reject
+    roles:
+      enabled: false
+      strict_mode: false
+    rpki_bgp_origin_validation:
+      enabled: false
+      reject_invalid: true
+    transit_free:
+      action: null
+      asns: null
+  graceful_shutdown:
+    enabled: false
+    local_pref: 0
+  gtsm: false
+  multihop: null
+  passive: true
+  path_hiding: true
+  prepend_rs_as: false
+  rfc1997_wellknown_communities:
+    policy: pass
+  rfc8950: false
+  router_id: 192.0.2.10
+  rpki_roas:
+    allowed_trust_anchors:
+    - APNIC RPKI Root
+    - AfriNIC RPKI Root
+    - LACNIC RPKI Root
+    - RIPE NCC RPKI Root
+    - apnic
+    - afrinic
+    - lacnic
+    - ripe
+    ignore_cache_files_older_than: 21600
+    ripe_rpki_validator_url:
+    - https://console.rpki-client.org/vrps.json
+    - https://rpki.gin.ntt.net/api/export.json
+    - https://rpki-validator.ripe.net/api/export.json
+    source: ripe-rpki-validator-cache
+  rs_as: 64496
+  rtt_thresholds: null
+
+
+bogons
+------
+bogons:
+- comment: RFC 1918
+  exact: false
+  ge: null
+  le: null
+  length: 8
+  max_length: 32
+  prefix: 10.0.0.0
+- comment: RFC 1918
+  exact: false
+  ge: null
+  le: null
+  length: 16
+  max_length: 32
+  prefix: 192.168.0.0
+- comment: unique local
+  exact: false
+  ge: null
+  le: null
+  length: 7
+  max_length: 128
+  prefix: 'fc00::'
+
+
+clients
+-------
+clients:
+- 16bit_mapped_asn: null
+  asn: 64500
+  cfg:
+    add_path: false
+    attach_custom_communities: null
+    blackhole_filtering:
+      announce_to_client: true
+    custom_options: null
+    filtering:
+      black_list_pref: null
+      ipv4_pref_len: &id001
+        max: 28
+        min: 8
+      ipv6_pref_len: &id002
+        max: 48
+        min: 12
+      irrdb:
+        as_set_bundle_ids: !!set
+          ? 25d771a4428d196b80d0a609b73650953432e63a9fe29a30f5bde367b02e91fa2730b4aac9d8254f7514e981fdbb44f24befd83859f956ce6b69fa29fa87d762
+          : null
+          ? a10e82f50d922732a6340bbcb610cb4ad1c7f7432c875659c5eebcd8783374713f953c5ea032b4ae0535daf085d1891b255a29bcd5ee49b72d1a2365a554b71d
+          : null
+        as_sets:
+        - AS-M90-ONE
+        enforce_origin_in_as_set: true
+        enforce_prefix_in_as_set: true
+        white_list_asn: null
+        white_list_pref: null
+        white_list_route: null
+      max_as_path_len: 32
+      max_prefix:
+        action: shutdown
+        count_rejected_routes: true
+        limit_ipv4: 100
+        limit_ipv6: 12000
+        peering_db:
+          enabled: false
+          increment:
+            absolute: 100
+            relative: 15
+        restart_after: 15
+      next_hop:
+        authorized_addresses_list: null
+        policy: strict
+      reject_invalid_as_in_as_path: false
+      reject_policy:
+        policy: reject
+      roles:
+        enabled: false
+        local_role: rs
+        strict_mode: false
+      rpki_bgp_origin_validation:
+        enabled: false
+        reject_invalid: true
+    graceful_shutdown:
+      enabled: false
+    gtsm: false
+    multihop: null
+    passive: true
+    prepend_rs_as: false
+    rfc8950: false
+  description: member1 - IRR-clean member
+  id: AS64500_1
+  ip: 192.0.2.11
+  password: null
+- 16bit_mapped_asn: null
+  asn: 64501
+  cfg:
+    add_path: false
+    attach_custom_communities: null
+    blackhole_filtering:
+      announce_to_client: true
+    custom_options: null
+    filtering:
+      black_list_pref: null
+      ipv4_pref_len: *id001
+      ipv6_pref_len: *id002
+      irrdb:
+        as_set_bundle_ids: !!set
+          ? 5a5be9a41cd6ec1de0017a58713d7572c914c2de926e273124e84fa47445982843162879345154c188fc77a1278094c51a623ec20e19560fb17e5d8ae39feeca
+          : null
+          ? f86b61b28b5255c383c7be5ffef7c4388a3499b3ff69a00760d6018760bac5770ca7747c21f66d59ff304d8944cc8114257b3c7910759f428ed85f402b011308
+          : null
+        as_sets:
+        - AS-M90-TWO
+        enforce_origin_in_as_set: true
+        enforce_prefix_in_as_set: true
+        white_list_asn: null
+        white_list_pref: null
+        white_list_route: null
+      max_as_path_len: 32
+      max_prefix:
+        action: shutdown
+        count_rejected_routes: true
+        limit_ipv4: 100
+        limit_ipv6: 12000
+        peering_db:
+          enabled: false
+          increment:
+            absolute: 100
+            relative: 15
+        restart_after: 15
+      next_hop:
+        authorized_addresses_list: null
+        policy: strict
+      reject_invalid_as_in_as_path: false
+      reject_policy:
+        policy: reject
+      roles:
+        enabled: false
+        local_role: rs
+        strict_mode: false
+      rpki_bgp_origin_validation:
+        enabled: false
+        reject_invalid: true
+    graceful_shutdown:
+      enabled: false
+    gtsm: false
+    multihop: null
+    passive: true
+    prepend_rs_as: false
+    rfc8950: false
+  description: member2 - announces outside its IRR set
+  id: AS64501_1
+  ip: 192.0.2.12
+  password: null
+- 16bit_mapped_asn: null
+  asn: 64502
+  cfg:
+    add_path: false
+    attach_custom_communities: null
+    blackhole_filtering:
+      announce_to_client: true
+    custom_options: null
+    filtering:
+      black_list_pref: null
+      ipv4_pref_len: *id001
+      ipv6_pref_len: *id002
+      irrdb:
+        as_set_bundle_ids: !!set
+          ? 0bc1901455a1b347485ca19202f83ed0417c085dcc45e0e3befbe3043f1c7fb6506d6b4d65cc3e93db0376a8b360154a2bbbd905dff863e5f9c319b5718f11f1
+          : null
+          ? f20eabc5a79f5a6440d9c261afc56598619d1372cc2bd1fb0a2ece8b736771e0cf982b4b2069e09730a56eb5ed8a761d8b3e6b200a8cf02b485b2f0aac1f9c98
+          : null
+        as_sets:
+        - AS-M90-THREE
+        enforce_origin_in_as_set: true
+        enforce_prefix_in_as_set: true
+        white_list_asn: null
+        white_list_pref: null
+        white_list_route: null
+      max_as_path_len: 32
+      max_prefix:
+        action: shutdown
+        count_rejected_routes: true
+        limit_ipv4: 100
+        limit_ipv6: 12000
+        peering_db:
+          enabled: false
+          increment:
+            absolute: 100
+            relative: 15
+        restart_after: 15
+      next_hop:
+        authorized_addresses_list: null
+        policy: strict
+      reject_invalid_as_in_as_path: false
+      reject_policy:
+        policy: reject
+      roles:
+        enabled: false
+        local_role: rs
+        strict_mode: false
+      rpki_bgp_origin_validation:
+        enabled: false
+        reject_invalid: true
+    graceful_shutdown:
+      enabled: false
+    gtsm: false
+    multihop: null
+    passive: true
+    prepend_rs_as: false
+    rfc8950: false
+  description: member3 - hygiene violator
+  id: AS64502_1
+  ip: 192.0.2.13
+  password: null
+
+
+asns
+----
+asns: {}
+
+
+irrdb_info
+----------
+- asns:
+  - 64502
+  descr: AS-M90-THREE
+  id: 0bc1901455a1b347485ca19202f83ed0417c085dcc45e0e3befbe3043f1c7fb6506d6b4d65cc3e93db0376a8b360154a2bbbd905dff863e5f9c319b5718f11f1
+  name: AS_M90_THREE
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 26
+    max_length: 32
+    prefix: 203.0.113.64
+  used_by: client AS64502_1
+- asns:
+  - 64500
+  descr: AS-M90-ONE
+  id: 25d771a4428d196b80d0a609b73650953432e63a9fe29a30f5bde367b02e91fa2730b4aac9d8254f7514e981fdbb44f24befd83859f956ce6b69fa29fa87d762
+  name: AS_M90_ONE
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 24
+    max_length: 32
+    prefix: 198.51.100.0
+  - comment: null
+    exact: false
+    ge: 26
+    le: 28
+    length: 26
+    max_length: 32
+    prefix: 203.0.113.0
+  used_by: client AS64500_1
+- asns:
+  - 64501
+  descr: AS-M90-TWO
+  id: 5a5be9a41cd6ec1de0017a58713d7572c914c2de926e273124e84fa47445982843162879345154c188fc77a1278094c51a623ec20e19560fb17e5d8ae39feeca
+  name: AS_M90_TWO
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 25
+    max_length: 32
+    prefix: 203.0.113.128
+  used_by: client AS64501_1
+- asns:
+  - 64500
+  descr: AS64500
+  id: a10e82f50d922732a6340bbcb610cb4ad1c7f7432c875659c5eebcd8783374713f953c5ea032b4ae0535daf085d1891b255a29bcd5ee49b72d1a2365a554b71d
+  name: AS64500
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 24
+    max_length: 32
+    prefix: 198.51.100.0
+  - comment: null
+    exact: false
+    ge: 26
+    le: 28
+    length: 26
+    max_length: 32
+    prefix: 203.0.113.0
+  used_by: client AS64500_1
+- asns:
+  - 64502
+  descr: AS64502
+  id: f20eabc5a79f5a6440d9c261afc56598619d1372cc2bd1fb0a2ece8b736771e0cf982b4b2069e09730a56eb5ed8a761d8b3e6b200a8cf02b485b2f0aac1f9c98
+  name: AS64502
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 26
+    max_length: 32
+    prefix: 203.0.113.64
+  used_by: client AS64502_1
+- asns:
+  - 64501
+  descr: AS64501
+  id: f86b61b28b5255c383c7be5ffef7c4388a3499b3ff69a00760d6018760bac5770ca7747c21f66d59ff304d8944cc8114257b3c7910759f428ed85f402b011308
+  name: AS64501
+  prefixes:
+  - comment: null
+    exact: true
+    ge: null
+    le: null
+    length: 25
+    max_length: 32
+    prefix: 203.0.113.128
+  used_by: client AS64501_1
+
+
+rpki_roas
+---------
+[]
+
+
+arin_whois_db_records
+---------------------
+{}
+
+
+registrobr_whois_db_records
+---------------------------
+{}
+
+
+never_via_route_servers_asns
+----------------------------
+- 65551

--- a/tests/interop/m90-differential/context.yml
+++ b/tests/interop/m90-differential/context.yml
@@ -1,13 +1,16 @@
 # M90 differential lab — hand-authored `arouteserver template-context`
-# fixture for the site described by general.yml + clients.yml.
+# fixture for the site described by general.yml + clients.yml, in the
+# renderer's single-document form.
 #
-# CANONICAL PATH: this file is what
-#     arouteserver template-context --cfg arouteserver.yml --output context.yml
-# dumps for the same general.yml/clients.yml (with the lab's bogons.yml
-# and bgpq4 stub in place). It is checked in by hand so the rustbgpd
-# side renders deterministically offline; regenerating it via
-# arouteserver is the canonical refresh path, and the M90 driver ALWAYS
-# runs arouteserver proper for the BIRD side, so drift between this
+# The REAL dump of the same site is checked in verbatim next to this
+# file as context-sectioned.yml (captured from the pinned
+# pierky/arouteserver image via
+#     arouteserver template-context --cfg arouteserver.yml --output ...
+# with the lab's bogons.yml and bgpq4 stub in place); rs-config-render
+# ingests both forms and must render them identically — the renderer's
+# test suite and prove-context-ingestion.sh assert exactly that, so
+# the two fixtures cannot drift apart silently. The M90 driver ALWAYS
+# runs arouteserver proper for the BIRD side, so drift between either
 # fixture and the site files shows up as a verdict mismatch.
 #
 # Shape: top-level keys pinned by rs-config-render's
@@ -89,7 +92,7 @@ clients:
       filtering:
         irrdb:
           as_set_bundle_ids: ["AS64500_bundle"]
-        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 12000, action: shutdown}
   - id: AS64501_1
     asn: 64501
     ip: "192.0.2.12"
@@ -98,7 +101,7 @@ clients:
       filtering:
         irrdb:
           as_set_bundle_ids: ["AS64501_bundle"]
-        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 12000, action: shutdown}
   - id: AS64502_1
     asn: 64502
     ip: "192.0.2.13"
@@ -107,18 +110,18 @@ clients:
       filtering:
         irrdb:
           as_set_bundle_ids: ["AS64502_bundle"]
-        max_prefix: {limit_ipv4: 100, limit_ipv6: 0, action: shutdown}
+        max_prefix: {limit_ipv4: 100, limit_ipv6: 12000, action: shutdown}
 irrdb_info:
   AS64500_bundle:
     asns: [64500]
     prefixes:
-      - {prefix: "198.51.100.0", length: 24, exact: true, comment: "route object 198.51.100.0/24"}
-      - {prefix: "203.0.113.0", length: 26, le: 28, comment: "route object 203.0.113.0/26 le 28"}
+      - {prefix: "198.51.100.0", length: 24, exact: true}
+      - {prefix: "203.0.113.0", length: 26, le: 28}
   AS64501_bundle:
     asns: [64501]
     prefixes:
-      - {prefix: "203.0.113.128", length: 25, exact: true, comment: "route object 203.0.113.128/25"}
+      - {prefix: "203.0.113.128", length: 25, exact: true}
   AS64502_bundle:
     asns: [64502]
     prefixes:
-      - {prefix: "203.0.113.64", length: 26, exact: true, comment: "route object 203.0.113.64/26"}
+      - {prefix: "203.0.113.64", length: 26, exact: true}

--- a/tests/interop/m90-differential/prove-context-ingestion.sh
+++ b/tests/interop/m90-differential/prove-context-ingestion.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# M90 — prove the literal template-context ingestion pipeline.
+#
+# Executes, for real, the exact pipeline the IXP filter cookbook
+# advertises, against the pinned official arouteserver image:
+#
+#   1. `arouteserver template-context` in the pinned container, from
+#      the lab's general.yml/clients.yml (with its bogons.yml and
+#      bgpq4 stub — the site's AS-SETs are documentation objects);
+#   2. `rs-config-render` directly on that dump (the sectioned report
+#      arouteserver 1.23.2 emits);
+#   3. `rustbgpd --check` + `rbgp policy check` on the rendered output;
+#
+# and asserts:
+#   - the fresh dump matches the checked-in context-sectioned.yml
+#     fixture byte for byte (the dump is deterministic);
+#   - the render of the real dump is identical to the render of the
+#     hand-authored single-document context.yml, file by file, modulo
+#     the context-shape fingerprint header line (the two input forms
+#     legitimately fingerprint differently);
+#   - both render receipts carry the same per-client cardinalities,
+#     limits, and warnings.
+#
+# Self-contained: needs docker, jq, and cargo — no containerlab. The
+# full differential lab (verdict parity against BIRD) is
+# scripts/test-m90-differential.sh.
+#
+# Usage:
+#   bash tests/interop/m90-differential/prove-context-ingestion.sh
+
+set -euo pipefail
+
+LAB_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$LAB_DIR/../../.." && pwd)"
+
+# Same pin as scripts/test-m90-differential.sh.
+ARS_IMAGE="${M90_ARS_IMAGE:-pierky/arouteserver@sha256:ba0e9c0b541c63acf0765a08fd2e09c2bba9dc64af1f5bbdce7819e8d1c34d66}"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+step() { echo "==> $*"; }
+ok() { echo "    ok: $*"; pass=$((pass + 1)); }
+die() { echo "    FAIL: $*" >&2; exit 1; }
+
+step "arouteserver template-context (pinned image, real run)"
+cp "$LAB_DIR/general.yml" "$LAB_DIR/clients.yml" "$LAB_DIR/bogons.yml" \
+    "$LAB_DIR/arouteserver.yml" "$LAB_DIR/bgpq4-stub.sh" "$WORK/"
+mkdir -p "$WORK/cache" "$WORK/out"
+chmod +x "$WORK/bgpq4-stub.sh"
+chmod -R a+rwX "$WORK"
+docker run --rm -v "$WORK:/site" "$ARS_IMAGE" \
+    arouteserver template-context --cfg /site/arouteserver.yml \
+    --output /site/out/context.yml \
+    || die "arouteserver template-context failed"
+[ -s "$WORK/out/context.yml" ] || die "template-context output missing or empty"
+ok "template-context dumped $(wc -l <"$WORK/out/context.yml") lines"
+
+step "fresh dump matches the checked-in sectioned fixture"
+diff -u "$LAB_DIR/context-sectioned.yml" "$WORK/out/context.yml" \
+    || die "context-sectioned.yml has drifted from what the pinned image emits"
+ok "byte-identical to context-sectioned.yml"
+
+step "rs-config-render on the REAL dump"
+cargo run -q -p rs-config-render --manifest-path "$REPO_DIR/Cargo.toml" -- \
+    --context "$WORK/out/context.yml" --out-dir "$WORK/render-real" \
+    || die "render of the real dump failed"
+ok "real dump rendered (exit 0 — no refusal, no implausible set, no shape drift)"
+
+step "rs-config-render on the hand-authored single-document context"
+cargo run -q -p rs-config-render --manifest-path "$REPO_DIR/Cargo.toml" -- \
+    --context "$LAB_DIR/context.yml" --out-dir "$WORK/render-hand" \
+    || die "render of the hand-authored context failed"
+ok "hand-authored context rendered"
+
+step "renders are identical (modulo the context-shape fingerprint line)"
+real_files=$(cd "$WORK/render-real" && find . -type f ! -name render-receipt.json | sort)
+hand_files=$(cd "$WORK/render-hand" && find . -type f ! -name render-receipt.json | sort)
+[ "$real_files" = "$hand_files" ] || die "file sets differ: [$real_files] vs [$hand_files]"
+for f in $real_files; do
+    diff -u <(grep -v 'fingerprint' "$WORK/render-real/$f") \
+            <(grep -v 'fingerprint' "$WORK/render-hand/$f") \
+        || die "render divergence in $f"
+    ok "identical: ${f#./}"
+done
+diff <(jq -S '{clients, warnings}' "$WORK/render-real/render-receipt.json") \
+     <(jq -S '{clients, warnings}' "$WORK/render-hand/render-receipt.json") \
+    || die "render receipts diverge"
+ok "receipts carry identical clients + warnings"
+
+step "pipeline gates on the real-dump render"
+cargo run -q -p rustbgpd --manifest-path "$REPO_DIR/Cargo.toml" -- \
+    --check "$WORK/render-real/config.toml" \
+    || die "rendered config fails rustbgpd --check"
+ok "rustbgpd --check passes"
+for rpol in "$WORK"/render-real/policy/*.rpol; do
+    cargo run -q -p rustbgpctl --bin rbgp --manifest-path "$REPO_DIR/Cargo.toml" -- \
+        policy check "$rpol" \
+        || die "rbgp policy check failed for $(basename "$rpol")"
+    ok "rbgp policy check $(basename "$rpol")"
+done
+
+echo
+echo "PROOF PASS: $pass checks — the advertised pipeline (arouteserver"
+echo "template-context -> rs-config-render -> rustbgpd --check) runs end to"
+echo "end on the real pinned image, and both input forms render identically."

--- a/tests/interop/scripts/test-m90-differential.sh
+++ b/tests/interop/scripts/test-m90-differential.sh
@@ -11,13 +11,15 @@
 #   - rustbgpd: config rendered by tools/rs-config-render from the
 #     site's template-context model. The checked-in
 #     m90-differential/context.yml is hand-authored against the
-#     renderer's fingerprint-pinned shape; arouteserver 1.23.2's own
-#     `template-context` emits a sectioned report that is NOT a
-#     drop-in for it (see the lab README), so the fixture is
-#     hand-maintained with its data verified against a real dump.
-#     Because the BIRD side ALWAYS re-runs arouteserver proper at lab
-#     runtime, drift between context.yml and the site files surfaces
-#     as a verdict mismatch — the differential is the guard.
+#     renderer's fingerprint-pinned single-document shape so this lab
+#     renders deterministically offline; the renderer equally ingests
+#     the sectioned report arouteserver 1.23.2 emits (a real dump is
+#     checked in as context-sectioned.yml, and the lab's
+#     prove-context-ingestion.sh proves both forms render
+#     identically against the pinned image). Because the BIRD side
+#     ALWAYS re-runs arouteserver proper at lab runtime, drift
+#     between context.yml and the site files surfaces as a verdict
+#     mismatch — the differential is the guard.
 #
 # Three GoBGP members then announce the canned set from
 # announcements.json, and every entry is asserted on BOTH daemons:

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -25,6 +25,28 @@ The end-to-end operator walkthrough — arouteserver through the
 Alice-LG looking glass — is
 [`docs/cookbook/ixp-filter-pipeline.md`](../../docs/cookbook/ixp-filter-pipeline.md).
 
+## Input formats
+
+The renderer auto-detects and ingests both on-disk forms of
+`template-context` output:
+
+- **The sectioned report** — what `arouteserver template-context`
+  actually emits (pinned against 1.23.2): one section per context key,
+  each a heading line plus a dash underline followed by a YAML
+  fragment. Ingestion normalizes the report's quirks into the internal
+  model: the `*_whois_db_records` section names, `irrdb_info` as a
+  list of hash-keyed bundles, and per-client `as_set_bundle_ids` as a
+  YAML `!!set`. Overlapping bundles (arouteserver resolves both a
+  client's AS-SET and its bare origin-ASN object) dedupe in the union.
+- **A single YAML document** with the context's top-level keys — the
+  form the test fixtures use and the shape the fingerprint below pins.
+
+Both forms of the same site render identical output — proven per
+commit against a checked-in real dump
+([`tests/interop/m90-differential/context-sectioned.yml`](../../tests/interop/m90-differential/context-sectioned.yml)),
+and against a live run of the pinned arouteserver image by
+[`tests/interop/m90-differential/prove-context-ingestion.sh`](../../tests/interop/m90-differential/prove-context-ingestion.sh).
+
 ## What it emits
 
 | File | Contents |
@@ -75,7 +97,7 @@ from "fix the data":
 | 1 | unreadable/unparseable context |
 | 2 | **refused** — the context uses a knob the renderer will not silently drop |
 | 3 | **aborted** — a generated set is empty or under the plausibility floor |
-| 4 | **shape mismatch** — the context's top-level key structure drifted from the pinned fingerprint |
+| 4 | **shape mismatch** — the context's top-level structure (document keys or report sections) drifted from the pinned fingerprint |
 
 Refused knobs: RTT-based communities and `rtt_thresholds` (the daemon
 has no RTT source; permanent), `next_hop.policy` other than `strict`
@@ -84,8 +106,11 @@ has no RTT source; permanent), `next_hop.policy` other than `strict`
 follow-up; the daemon retains rejected routes with reasons natively —
 see the route-server cookbook's filtered-route view), `prepend_rs_as`,
 `perform_graceful_shutdown`, `max_prefix.action` `block`/`warning`,
-and disabling both IRR enforcement knobs. `max_prefix.action:
-restart` renders as teardown-only with a warning.
+per-client `black_list_pref` and IRR `white_list_*` entries (dropping
+a black list would fail open; dropping a white list would reject
+routes the site intends to accept), and disabling both IRR
+enforcement knobs. `max_prefix.action: restart` renders as
+teardown-only with a warning.
 
 An empty per-client prefix or origin set aborts the whole render: an
 empty set under the default-reject tail is fail-closed for that client,
@@ -94,9 +119,11 @@ member that deregistered everything. Raise the floor with
 `--min-prefixes`/`--min-origins` to also catch implausible shrinkage.
 
 The context shape is not a semver-stable API. The renderer fingerprints
-the top-level key structure and refuses on drift, naming the added and
-missing keys; `--allow-shape-drift` proceeds after review. The
-supported shape is pinned in `EXPECTED_TOP_LEVEL_KEYS` (`src/lib.rs`).
+the top-level structure — document keys for the single-document form,
+section names for the sectioned report — and refuses on drift, naming
+the added and missing entries; `--allow-shape-drift` proceeds after
+review. The supported shapes are pinned in `EXPECTED_TOP_LEVEL_KEYS`
+and `EXPECTED_SECTION_NAMES` (`src/lib.rs`).
 
 ## Options
 

--- a/tools/rs-config-render/src/lib.rs
+++ b/tools/rs-config-render/src/lib.rs
@@ -67,6 +67,28 @@ pub const EXPECTED_TOP_LEVEL_KEYS: &[&str] = &[
     "rtt_based_functions_are_used",
 ];
 
+/// Section names of the supported *sectioned* `template-context`
+/// report, sorted.
+///
+/// `arouteserver template-context` (pinned against 1.23.2) does not
+/// emit one YAML document: it emits a report of sections, each a
+/// heading line plus a dash underline followed by a YAML fragment.
+/// The section roster is this format's shape, gated exactly like the
+/// single-document top-level keys: a section added, removed, or
+/// renamed upstream refuses the render until reviewed.
+pub const EXPECTED_SECTION_NAMES: &[&str] = &[
+    "arin_whois_db_records",
+    "asns",
+    "bogons",
+    "cfg",
+    "clients",
+    "ip_ver",
+    "irrdb_info",
+    "never_via_route_servers_asns",
+    "registrobr_whois_db_records",
+    "rpki_roas",
+];
+
 /// Rejects 0, AS_TRANS (23456), the 16-bit documentation / private /
 /// reserved block (64496-65551), and the 32-bit private + reserved
 /// range (4200000000-4294967295; every 10-digit AS number starting
@@ -393,12 +415,20 @@ struct ClientFiltering {
     max_prefix: Option<ClientMaxPrefix>,
     #[serde(default)]
     reject_policy: Option<RejectPolicy>,
+    #[serde(default)]
+    black_list_pref: Option<serde_yaml::Value>,
 }
 
 #[derive(Deserialize, Default)]
 struct ClientIrrdb {
     #[serde(default)]
     as_set_bundle_ids: Vec<String>,
+    #[serde(default)]
+    white_list_asn: Option<serde_yaml::Value>,
+    #[serde(default)]
+    white_list_pref: Option<serde_yaml::Value>,
+    #[serde(default)]
+    white_list_route: Option<serde_yaml::Value>,
 }
 
 #[derive(Deserialize)]
@@ -492,11 +522,14 @@ impl PrefixEntry {
                 None
             }
         });
-        if let Some(ge) = self.ge {
+        // A ge equal to the entry's own length is a no-op (bgpq4 emits
+        // one on bounded records); suppress it.
+        let ge = self.ge.filter(|ge| *ge > self.length);
+        if let Some(ge) = ge {
             let _ = write!(member, " ge {ge}");
         }
         if let Some(le) = le
-            && (self.ge.is_some() || le != self.length)
+            && (ge.is_some() || le != self.length)
         {
             let _ = write!(member, " le {le}");
         }
@@ -546,50 +579,20 @@ pub fn expected_fingerprint() -> String {
     shape_fingerprint(&keys)
 }
 
-// ---------------------------------------------------------------------------
-// Render
-// ---------------------------------------------------------------------------
-
-struct ResolvedClient<'a> {
-    client: &'a Client,
-    slug: String,
-    description: String,
-    prefixes: Vec<&'a PrefixEntry>,
-    origins: Vec<u32>,
-    enforce_origin: bool,
-    enforce_prefix: bool,
-    strict_next_hop: bool,
-    add_path: bool,
-    per_client_best: bool,
-    gtsm: bool,
-    allow_longer_prefixes: bool,
-    limit_ipv4: Option<u32>,
-    limit_ipv6: Option<u32>,
-}
-
-pub fn render(context_yaml: &str, opts: &Options) -> Result<Rendered, RenderError> {
-    let value: serde_yaml::Value =
-        serde_yaml::from_str(context_yaml).map_err(|e| RenderError::Parse(e.to_string()))?;
-    let mapping = value
-        .as_mapping()
-        .ok_or_else(|| RenderError::Parse("context is not a mapping".to_owned()))?;
-
-    let mut found_keys: Vec<String> = mapping
-        .keys()
-        .map(|k| match k.as_str() {
-            Some(s) => Ok(s.to_owned()),
-            None => Err(RenderError::Parse(
-                "non-string top-level context key".to_owned(),
-            )),
-        })
-        .collect::<Result<_, _>>()?;
-    found_keys.sort();
-
-    let found_fingerprint = shape_fingerprint(&found_keys);
-    let expected = expected_fingerprint();
-    let mut warnings = Vec::new();
+/// Gate a found key/section roster against a pinned one; on drift,
+/// refuse (or warn under `--allow-shape-drift`). Returns the found
+/// fingerprint.
+fn gate_shape(
+    found_keys: &[String],
+    expected_keys: &[&str],
+    opts: &Options,
+    warnings: &mut Vec<String>,
+) -> Result<String, RenderError> {
+    let expected_list: Vec<String> = expected_keys.iter().map(|k| (*k).to_owned()).collect();
+    let expected = shape_fingerprint(&expected_list);
+    let found_fingerprint = shape_fingerprint(found_keys);
     if found_fingerprint != expected {
-        let expected_set: BTreeSet<&str> = EXPECTED_TOP_LEVEL_KEYS.iter().copied().collect();
+        let expected_set: BTreeSet<&str> = expected_keys.iter().copied().collect();
         let found_set: BTreeSet<&str> = found_keys.iter().map(String::as_str).collect();
         let missing = expected_set
             .difference(&found_set)
@@ -612,6 +615,227 @@ pub fn render(context_yaml: &str, opts: &Options) -> Result<Rendered, RenderErro
              (expected {expected}, found {found_fingerprint})"
         ));
     }
+    Ok(found_fingerprint)
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion — the two on-disk forms of `template-context` output
+// ---------------------------------------------------------------------------
+
+fn ingest_single_document(
+    context_yaml: &str,
+    opts: &Options,
+    warnings: &mut Vec<String>,
+) -> Result<(serde_yaml::Value, String), RenderError> {
+    let value: serde_yaml::Value =
+        serde_yaml::from_str(context_yaml).map_err(|e| RenderError::Parse(e.to_string()))?;
+    let mapping = value
+        .as_mapping()
+        .ok_or_else(|| RenderError::Parse("context is not a mapping".to_owned()))?;
+
+    let mut found_keys: Vec<String> = mapping
+        .keys()
+        .map(|k| match k.as_str() {
+            Some(s) => Ok(s.to_owned()),
+            None => Err(RenderError::Parse(
+                "non-string top-level context key".to_owned(),
+            )),
+        })
+        .collect::<Result<_, _>>()?;
+    found_keys.sort();
+
+    let fingerprint = gate_shape(&found_keys, EXPECTED_TOP_LEVEL_KEYS, opts, warnings)?;
+    Ok((value, fingerprint))
+}
+
+/// A section heading is a bare identifier line whose next line is a
+/// dash underline of the same length ("cfg" / "---"). YAML content
+/// never matches: mapping lines carry a colon, list items lead with
+/// "- ", nested lines are indented.
+fn is_heading(line: &str, underline: Option<&str>) -> bool {
+    let name = line.trim_end();
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return false;
+    }
+    underline
+        .map(str::trim_end)
+        .is_some_and(|u| !u.is_empty() && u.len() == name.len() && u.bytes().all(|b| b == b'-'))
+}
+
+fn looks_sectioned(input: &str) -> bool {
+    let lines: Vec<&str> = input.lines().collect();
+    lines
+        .iter()
+        .position(|l| !l.trim().is_empty())
+        .is_some_and(|i| is_heading(lines[i], lines.get(i + 1).copied()))
+}
+
+/// Split a sectioned report into `(section name, YAML fragment)` pairs.
+fn split_sections(input: &str) -> Result<Vec<(String, String)>, RenderError> {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut sections = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if is_heading(lines[i], lines.get(i + 1).copied()) {
+            let name = lines[i].trim_end().to_owned();
+            let mut body = String::new();
+            let mut j = i + 2;
+            while j < lines.len() && !is_heading(lines[j], lines.get(j + 1).copied()) {
+                body.push_str(lines[j]);
+                body.push('\n');
+                j += 1;
+            }
+            sections.push((name, body));
+            i = j;
+        } else if lines[i].trim().is_empty() {
+            i += 1;
+        } else {
+            return Err(RenderError::Parse(format!(
+                "sectioned template-context: content outside any section at line {}",
+                i + 1
+            )));
+        }
+    }
+    Ok(sections)
+}
+
+fn untag(value: serde_yaml::Value) -> serde_yaml::Value {
+    match value {
+        serde_yaml::Value::Tagged(tagged) => tagged.value,
+        other => other,
+    }
+}
+
+/// Normalize one parsed section fragment: fragments either repeat the
+/// section name as a single wrapping key (`cfg:`, `clients:`) or are
+/// bare values (`irrdb_info`, `never_via_route_servers_asns`).
+fn unwrap_section(value: serde_yaml::Value, name: &str) -> serde_yaml::Value {
+    if let serde_yaml::Value::Mapping(mut m) = value {
+        if m.len() == 1
+            && let Some(inner) = m.remove(name)
+        {
+            return inner;
+        }
+        return serde_yaml::Value::Mapping(m);
+    }
+    value
+}
+
+/// The sectioned report's `irrdb_info` is a list of bundle records
+/// carrying their own hash `id`; the internal model keys bundles by
+/// that id.
+fn irrdb_list_to_map(value: serde_yaml::Value) -> Result<serde_yaml::Value, RenderError> {
+    let serde_yaml::Value::Sequence(items) = value else {
+        // Already a map (the single-document form) — pass through.
+        return Ok(value);
+    };
+    let mut map = serde_yaml::Mapping::new();
+    for item in items {
+        let id = item
+            .get("id")
+            .and_then(serde_yaml::Value::as_str)
+            .ok_or_else(|| RenderError::Parse("irrdb_info entry without a string `id`".to_owned()))?
+            .to_owned();
+        map.insert(serde_yaml::Value::String(id), item);
+    }
+    Ok(serde_yaml::Value::Mapping(map))
+}
+
+/// The sectioned report emits each client's `as_set_bundle_ids` as a
+/// YAML `!!set`; the internal model wants a list. Sorted for a
+/// deterministic bundle-union order.
+fn normalize_bundle_id_sets(root: &mut serde_yaml::Mapping) {
+    let Some(clients) = root
+        .get_mut("clients")
+        .and_then(serde_yaml::Value::as_sequence_mut)
+    else {
+        return;
+    };
+    for client in clients {
+        let Some(irrdb) = client
+            .get_mut("cfg")
+            .and_then(|v| v.get_mut("filtering"))
+            .and_then(|v| v.get_mut("irrdb"))
+            .and_then(serde_yaml::Value::as_mapping_mut)
+        else {
+            continue;
+        };
+        let Some(ids) = irrdb.get_mut("as_set_bundle_ids") else {
+            continue;
+        };
+        let current = untag(std::mem::replace(ids, serde_yaml::Value::Null));
+        *ids = match current {
+            serde_yaml::Value::Mapping(set) => {
+                let mut keys: Vec<serde_yaml::Value> = set.into_iter().map(|(k, _)| k).collect();
+                keys.sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+                serde_yaml::Value::Sequence(keys)
+            }
+            other => other,
+        };
+    }
+}
+
+fn ingest_sectioned(
+    input: &str,
+    opts: &Options,
+    warnings: &mut Vec<String>,
+) -> Result<(serde_yaml::Value, String), RenderError> {
+    let sections = split_sections(input)?;
+    let mut names: Vec<String> = sections.iter().map(|(name, _)| name.clone()).collect();
+    names.sort();
+    let fingerprint = gate_shape(&names, EXPECTED_SECTION_NAMES, opts, warnings)?;
+
+    let mut root = serde_yaml::Mapping::new();
+    for (name, body) in sections {
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&body)
+            .map_err(|e| RenderError::Parse(format!("section `{name}`: {e}")))?;
+        let parsed = unwrap_section(parsed, &name);
+        // The sectioned report names the whois-record sections with a
+        // `_db_` infix the internal model does not use.
+        let internal_name = match name.as_str() {
+            "arin_whois_db_records" => "arin_whois_records",
+            "registrobr_whois_db_records" => "registrobr_whois_records",
+            other => other,
+        };
+        let parsed = if internal_name == "irrdb_info" {
+            irrdb_list_to_map(parsed)?
+        } else {
+            parsed
+        };
+        root.insert(serde_yaml::Value::String(internal_name.to_owned()), parsed);
+    }
+    normalize_bundle_id_sets(&mut root);
+    Ok((serde_yaml::Value::Mapping(root), fingerprint))
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+struct ResolvedClient<'a> {
+    client: &'a Client,
+    slug: String,
+    description: String,
+    prefixes: Vec<&'a PrefixEntry>,
+    origins: Vec<u32>,
+    enforce_origin: bool,
+    enforce_prefix: bool,
+    strict_next_hop: bool,
+    add_path: bool,
+    per_client_best: bool,
+    gtsm: bool,
+    allow_longer_prefixes: bool,
+    limit_ipv4: Option<u32>,
+    limit_ipv6: Option<u32>,
+}
+
+pub fn render(context_input: &str, opts: &Options) -> Result<Rendered, RenderError> {
+    let mut warnings = Vec::new();
+    let (value, found_fingerprint) = if looks_sectioned(context_input) {
+        ingest_sectioned(context_input, opts, &mut warnings)?
+    } else {
+        ingest_single_document(context_input, opts, &mut warnings)?
+    };
 
     let ctx: Context =
         serde_yaml::from_value(value).map_err(|e| RenderError::Parse(e.to_string()))?;
@@ -761,6 +985,30 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
                 &mut refusals,
             );
         }
+        // Per-client black/white lists are not rendered; dropping a
+        // black list would fail open, dropping a white list would
+        // reject routes the site intends to accept.
+        if value_present(client.cfg.filtering.black_list_pref.as_ref()) {
+            refusals.push(format!(
+                "client {}: black_list_pref is not rendered; silently dropping it would \
+                 fail open",
+                client.id
+            ));
+        }
+        let irrdb = &client.cfg.filtering.irrdb;
+        for (name, value) in [
+            ("white_list_asn", &irrdb.white_list_asn),
+            ("white_list_pref", &irrdb.white_list_pref),
+            ("white_list_route", &irrdb.white_list_route),
+        ] {
+            if value_present(value.as_ref()) {
+                refusals.push(format!(
+                    "client {}: irrdb.{name} is not rendered; silently dropping it would \
+                     reject routes the site intends to accept",
+                    client.id
+                ));
+            }
+        }
     }
 
     if refusals.is_empty() {
@@ -768,6 +1016,17 @@ fn check_refusals(ctx: &Context, opts: &Options) -> Result<(), RenderError> {
     } else {
         Err(RenderError::Refused(refusals))
     }
+}
+
+/// True when an optional list/mapping knob is actually set (not
+/// absent, null, or empty).
+fn value_present(value: Option<&serde_yaml::Value>) -> bool {
+    value.is_some_and(|v| match v {
+        serde_yaml::Value::Null => false,
+        serde_yaml::Value::Sequence(s) => !s.is_empty(),
+        serde_yaml::Value::Mapping(m) => !m.is_empty(),
+        _ => true,
+    })
 }
 
 fn community_configured(value: &serde_yaml::Value) -> bool {
@@ -826,7 +1085,10 @@ fn resolve_clients<'a>(
         let enforce_origin = ctx.cfg.filtering.irrdb.enforce_origin_in_as_set;
         let enforce_prefix = ctx.cfg.filtering.irrdb.enforce_prefix_in_as_set;
 
-        let mut prefixes = Vec::new();
+        let mut prefixes: Vec<&PrefixEntry> = Vec::new();
+        // A client's bundles overlap (arouteserver resolves both the
+        // AS-SET and the bare origin-ASN object); the union dedupes.
+        let mut seen_prefixes = BTreeSet::new();
         let mut origins = BTreeSet::new();
         for bundle_id in &filtering.irrdb.as_set_bundle_ids {
             let bundle = ctx.irrdb_info.get(bundle_id).ok_or_else(|| {
@@ -835,7 +1097,19 @@ fn resolve_clients<'a>(
                     client.id
                 ))
             })?;
-            prefixes.extend(bundle.prefixes.iter());
+            for prefix in &bundle.prefixes {
+                let key = (
+                    prefix.prefix.clone(),
+                    prefix.length,
+                    prefix.exact,
+                    prefix.ge,
+                    prefix.le,
+                    prefix.max_length,
+                );
+                if seen_prefixes.insert(key) {
+                    prefixes.push(prefix);
+                }
+            }
             for asn in &bundle.asns {
                 origins.insert(asn.value().map_err(RenderError::Parse)?);
             }

--- a/tools/rs-config-render/tests/golden.rs
+++ b/tools/rs-config-render/tests/golden.rs
@@ -8,6 +8,14 @@ use rs_config_render::{Options, RenderError, render};
 
 const FIXTURE: &str = include_str!("fixtures/context-small.yml");
 
+/// A verbatim `arouteserver template-context` dump (pinned
+/// pierky/arouteserver image, arouteserver 1.23.2) of the M90
+/// differential lab's site — the *sectioned report* form.
+const SECTIONED: &str =
+    include_str!("../../../tests/interop/m90-differential/context-sectioned.yml");
+/// The hand-authored single-document context for the same site.
+const M90_HAND: &str = include_str!("../../../tests/interop/m90-differential/context.yml");
+
 fn fixture_value() -> serde_yaml::Value {
     serde_yaml::from_str(FIXTURE).expect("fixture parses")
 }
@@ -315,6 +323,134 @@ fn add_path_replaces_per_client_best() {
     let toml = &rendered.files["config.toml"];
     assert!(toml.contains("[neighbors.add_path]"), "{toml}");
     assert!(!toml.contains("per_client_best"), "{toml}");
+}
+
+// ---------------------------------------------------------------------------
+// Sectioned template-context ingestion (the format arouteserver 1.23.2
+// actually emits)
+// ---------------------------------------------------------------------------
+
+/// Drop the context-shape fingerprint line — the one legitimate
+/// difference between renders of the two input forms.
+fn strip_fingerprint(text: &str) -> String {
+    text.lines()
+        .filter(|line| !line.contains("fingerprint"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn sectioned_dump_renders_identically_to_the_hand_authored_context() {
+    let real = render(SECTIONED, &Options::default()).expect("sectioned dump renders");
+    let hand = render(M90_HAND, &Options::default()).expect("hand-authored context renders");
+    assert_eq!(
+        real.files.keys().collect::<Vec<_>>(),
+        hand.files.keys().collect::<Vec<_>>()
+    );
+    for (path, content) in &real.files {
+        assert_eq!(
+            strip_fingerprint(content),
+            strip_fingerprint(&hand.files[path]),
+            "render divergence between input forms in {path}"
+        );
+    }
+    assert_eq!(real.warnings, hand.warnings);
+    assert_eq!(real.receipt["clients"], hand.receipt["clients"]);
+    // The real dump resolves TWO overlapping bundles per client (the
+    // AS-SET and the bare origin-ASN object); the union must dedupe.
+    assert_eq!(real.receipt["clients"][0]["prefix_set_size"], 2);
+    assert_eq!(real.receipt["clients"][0]["origin_set_size"], 1);
+}
+
+#[test]
+fn sectioned_unknown_section_is_refused_and_overridable() {
+    let doctored = format!("{SECTIONED}\n\nshiny_new_knob\n--------------\ntrue\n");
+    match render(&doctored, &Options::default()) {
+        Err(RenderError::ShapeMismatch {
+            missing,
+            unexpected,
+            ..
+        }) => {
+            assert!(missing.is_empty(), "{missing:?}");
+            assert_eq!(unexpected, vec!["shiny_new_knob".to_owned()]);
+        }
+        other => panic!("expected shape mismatch, got {other:?}"),
+    }
+    let opts = Options {
+        allow_shape_drift: true,
+        ..Options::default()
+    };
+    let rendered = render(&doctored, &opts).expect("drift override renders");
+    assert!(
+        rendered
+            .warnings
+            .iter()
+            .any(|w| w.contains("fingerprint mismatch overridden")),
+        "{:?}",
+        rendered.warnings
+    );
+}
+
+#[test]
+fn sectioned_missing_section_is_refused() {
+    // The never-via section is the report's last; cut it off.
+    let truncated = SECTIONED
+        .split("never_via_route_servers_asns")
+        .next()
+        .expect("fixture carries the never-via section");
+    match render(truncated, &Options::default()) {
+        Err(RenderError::ShapeMismatch { missing, .. }) => {
+            assert_eq!(missing, vec!["never_via_route_servers_asns".to_owned()]);
+        }
+        other => panic!("expected shape mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn sectioned_malformed_section_body_is_a_parse_error() {
+    let corrupted = SECTIONED.replace("\nrpki_roas\n---------\n[]", "\nrpki_roas\n---------\n[");
+    assert_ne!(corrupted, SECTIONED, "corruption target not found");
+    match render(&corrupted, &Options::default()) {
+        Err(err @ RenderError::Parse(_)) => {
+            assert_eq!(err.exit_code(), 1);
+            assert!(err.to_string().contains("rpki_roas"), "{err}");
+        }
+        other => panic!("expected parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn client_black_and_white_lists_are_refused() {
+    use serde_yaml::Value;
+    let entry: Value = serde_yaml::from_str("[{prefix: 203.0.113.0, length: 24}]").unwrap();
+    let cases: &[(&[&str], &str)] = &[
+        (&["cfg", "filtering", "black_list_pref"], "black_list_pref"),
+        (
+            &["cfg", "filtering", "irrdb", "white_list_pref"],
+            "white_list_pref",
+        ),
+        (
+            &["cfg", "filtering", "irrdb", "white_list_asn"],
+            "white_list_asn",
+        ),
+        (
+            &["cfg", "filtering", "irrdb", "white_list_route"],
+            "white_list_route",
+        ),
+    ];
+    for (path, marker) in cases {
+        let mut value = healthy_value();
+        let mut clients = value["clients"].clone();
+        set_path(&mut clients[0], path, entry.clone());
+        set_path(&mut value, &["clients"], clients);
+        let items = refusals(render(&to_yaml(&value), &rtr_options()));
+        assert!(
+            items
+                .iter()
+                .any(|i| i.contains(marker) && i.contains("client AS4242_1")),
+            "no refusal containing {marker:?}: {items:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`tools/rs-config-render` advertises the pipeline `arouteserver template-context → context.yml → rs-config-render`, but the pinned arouteserver 1.23.2 image (`pierky/arouteserver@sha256:ba0e9c…`, the one the M90 differential lab runs) does not emit the single 17-key YAML document the renderer parsed. It emits a **sectioned report**: one section per context key, each a heading line plus a dash underline followed by a YAML fragment, with several structural differences:

- section names `arin_whois_db_records` / `registrobr_whois_db_records` (vs the `_records` keys of the document form), and no `list_ip_vers` / `live_tests` / `rtt_based_functions_are_used` / `perform_graceful_shutdown` / `any_reject_cause_map_community_set` / `asn3216_map` / `reject_reasons` entries;
- `irrdb_info` as a **list** of hash-keyed bundle records, not a map;
- per-client `as_set_bundle_ids` as a YAML `!!set`;
- **two** overlapping bundles per client (the AS-SET and the bare origin-ASN object, same content resolved twice);
- bgpq4-derived prefix records carrying a no-op `ge` equal to the record's own length, and `max_length` on every entry.

The M90 lab's 65/65 differential proof drove the rustbgpd side from a hand-authored document-form fixture, so rendered-policy parity was proven but the production ingestion seam was not.

## Change

The renderer auto-detects the input form and ingests both:

- **Sectioned report**: the section roster is fingerprint-pinned (`EXPECTED_SECTION_NAMES`) with the same refuse-on-drift discipline as the document form — unknown or missing sections exit 4 and are named, `--allow-shape-drift` overrides after review; malformed section bodies exit 1. Normalization maps section names to the internal model, converts the `irrdb_info` list to a map, converts the `!!set` to a sorted list, and dedupes the overlapping bundle union.
- **Single document**: unchanged; existing fixtures and the exit-code table (0/1/2/3/4) are untouched.

Fail-stop additions found while auditing the real dump's content: per-client `black_list_pref` and IRR `white_list_asn`/`white_list_pref`/`white_list_route` are now refused (exit 2) instead of silently dropped — dropping a black list would fail open, dropping a white list would reject routes the site intends to accept. A `ge` bound equal to the entry's own prefix length is suppressed as a no-op in prefix-set members.

## Fixtures and tests

- `tests/interop/m90-differential/context-sectioned.yml`: a **verbatim** `template-context` dump of the M90 site from the digest-pinned image (deterministic — identical across repeated container runs; contains no host paths or identifiers).
- The hand-authored `context.yml` is aligned to the real dump's data (`limit_ipv6` inherits the general 12000 limit; decorative IRR comments dropped).
- `tools/rs-config-render/tests/golden.rs` pins: the sectioned fixture renders **byte-identical** output to the hand-authored context (config.toml + all `.rpol`, modulo the context-shape fingerprint header line) with identical receipts and dedup-proof cardinalities; unknown-section refusal + override; missing-section refusal; malformed-body parse error; black/white-list refusals. 17 integration tests, all passing.

## Executed proof

`tests/interop/m90-differential/prove-context-ingestion.sh` (self-contained: docker + jq + cargo) runs the advertised pipeline for real and exits nonzero on any failure:

1. `arouteserver template-context --cfg …` in the pinned container against the lab's `general.yml`/`clients.yml` → 771-line sectioned dump;
2. asserts the fresh dump is byte-identical to the checked-in fixture;
3. `rs-config-render` on the real dump (exit 0) and on the hand-authored context (exit 0);
4. per-file diff of the two renders modulo the fingerprint line — all five outputs identical, receipts identical;
5. `rustbgpd --check` on the rendered config (config OK) and `rbgp policy check` on every generated `.rpol` (10/10 in-language tests pass).

Result: `PROOF PASS: 15 checks`, exit 0.

## Gates

- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `timeout 2400 cargo test --workspace` — 0
- `cargo doc --workspace --no-deps` — 0
- `cargo test -p rs-config-render` — 0 (17 + 3 unit)
- `bash tests/interop/m90-differential/prove-context-ingestion.sh` — 0

## Docs

`tools/rs-config-render/README.md` (input-formats section, refused-knob table, shape-pinning wording), `docs/cookbook/ixp-filter-pipeline.md` (the advertised command now notes the sectioned format is ingested directly and points at the executed proof), M90 lab README + driver header (the "not a drop-in" caveat replaced by the proven ingestion path), CHANGELOG.