### PR TITLE
test(interop): give the M4 lab a writable config and surface AddNeighbor RPC failures

### DIFF
--- a/tests/interop/m4-frr.clab.yml
+++ b/tests/interop/m4-frr.clab.yml
@@ -25,9 +25,13 @@ topology:
       image: rustbgpd:dev
       cmd: sleep infinity
       binds:
-        - ./configs/rustbgpd-m4-frr.toml:/etc/rustbgpd/config.toml:ro
+        - ./configs/rustbgpd-m4-frr.toml:/etc/rustbgpd/config.template.toml:ro
         - ./scripts/start-rustbgpd.sh:/usr/local/bin/start-rustbgpd.sh:ro
       exec:
+        # Copy the read-only template to a writable container-local path so the
+        # atomic config persist (temp + rename) that AddNeighbor performs works;
+        # a single-file :ro bind makes the rename fail with EBUSY.
+        - cp /etc/rustbgpd/config.template.toml /etc/rustbgpd/config.toml
         - ip addr add 10.0.10.1/24 dev eth1
         - ip link set eth1 up
         - ip addr add 10.0.11.1/24 dev eth2

--- a/tests/interop/scripts/test-m4-frr.sh
+++ b/tests/interop/scripts/test-m4-frr.sh
@@ -179,6 +179,11 @@ test_add_neighbor() {
 
     local result
     result=$(grpc_add_neighbor "10.0.18.2" 65018 "frr-09-dynamic" 2>&1 || true)
+    if printf '%s' "$result" | grep -qi 'error'; then
+        fail "AddNeighbor RPC failed: $result"
+        return
+    fi
+    ok "AddNeighbor RPC accepted"
 
     # Wait for session to establish
     sleep 5


### PR DESCRIPTION
The M4 dynamic-neighbor leg failed deterministically: `AddNeighbor` persists the config atomically (temp + rename), and the lab bound `config.toml` as a single read-only file, so the rename failed with `EBUSY` ("config persistence failed"). The test script swallowed the RPC error (`|| true`) and surfaced it as a 90-second session timeout.

- `m4-frr.clab.yml`: mount the config as `config.template.toml:ro` and copy it to a writable container-local path in `exec`, matching the persistence-aware labs (e.g. M58).
- `test-m4-frr.sh`: assert the `AddNeighbor` RPC result directly, so a failed RPC reports as its own failure instead of a downstream timeout.

Proof: full deploy → test → destroy at this head — **19 passed / 0 failed, exit 0** (previously 16/2 with the EBUSY signature). Lab destroyed cleanly, no containers left.