### PR TITLE
build(release): ship rs-config-render in the release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,8 @@ jobs:
 
       - name: Package binaries
         run: |
-          # Pack the daemon and CLI into a single per-arch tarball with a
+          # Pack the daemon, CLI, and route-server config renderer into
+          # a single per-arch tarball with a
           # version-less filename. This is what powers the static
           # `https://github.com/lance0/rustbgpd/releases/latest/download/rustbgpd-<arch>.tar.gz`
           # URL pattern in docs/deployment.md — operators never have to
@@ -94,7 +95,7 @@ jobs:
           #
           # Tarball layout (the share/ tree mirrors what packagers
           # install under /usr/share):
-          #   rustbgpd, rbgp                          binaries
+          #   rustbgpd, rbgp, rs-config-render        binaries
           #   LICENSE-MIT, LICENSE-APACHE             licenses
           #   rustbgpd.schema.json                    config JSON Schema
           #   share/man/man1/rbgp.1                   CLI man page
@@ -112,6 +113,7 @@ jobs:
           mkdir -p dist staging/share/man/man1 staging/share/man/man8 staging/share/completions
           cp target/${{ matrix.target }}/release/rustbgpd staging/
           cp target/${{ matrix.target }}/release/rbgp staging/
+          cp target/${{ matrix.target }}/release/rs-config-render staging/
           cp LICENSE-MIT LICENSE-APACHE staging/
           cp docs/rustbgpd.schema.json staging/
           if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
@@ -128,7 +130,8 @@ jobs:
             "$RBGP" completions "$shell" > staging/share/completions/rbgp.$shell
           done
           tar -C staging -czf dist/rustbgpd-${SUFFIX}.tar.gz \
-            rustbgpd rbgp LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share
+            rustbgpd rbgp rs-config-render \
+            LICENSE-MIT LICENSE-APACHE rustbgpd.schema.json share
           # Also publish the config JSON Schema as a standalone asset so
           # editors can reference the stable
           # `releases/latest/download/rustbgpd.schema.json` URL. Both
@@ -138,7 +141,7 @@ jobs:
           cd dist
           sha256sum rustbgpd-${SUFFIX}.tar.gz > checksums-${SUFFIX}.txt
 
-      - name: Assert tarball has nonempty licenses, man pages, and completions
+      - name: Assert tarball has nonempty binaries, licenses, man pages, and completions
         run: |
           set -euo pipefail
           SUFFIX=${{ matrix.suffix }}
@@ -148,7 +151,8 @@ jobs:
           # `pipefail` that non-zero tar status fails the check on the first
           # present entry (LICENSE-MIT) even though it is there.
           entries="$(tar -tzf "dist/rustbgpd-${SUFFIX}.tar.gz")"
-          for f in LICENSE-MIT LICENSE-APACHE \
+          for f in rustbgpd rbgp rs-config-render \
+                   LICENSE-MIT LICENSE-APACHE \
                    share/man/man1/rbgp.1 share/man/man8/rustbgpd.8 \
                    share/completions/rbgp.bash share/completions/rbgp.zsh \
                    share/completions/rbgp.fish; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release tarballs ship `rs-config-render`.** The route-server
+  config renderer was built by the release workflow but never staged
+  into `rustbgpd-<arch>.tar.gz` — v0.60.0 tarballs contain only
+  `rustbgpd` and `rbgp`. The binary is now packed alongside them, and
+  the tarball content assertion checks all three binaries for
+  presence and non-emptiness.
+
 ## [0.60.0] — 2026-07-18
 
 > **Release framing — why this is v0.60.0.** This release marks the

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -576,9 +576,10 @@ docker run --rm --entrypoint rbgp rustbgpd:dev --help
     [GitHub Releases](https://github.com/lance0/rustbgpd/releases) — each
     tag should publish version-less `rustbgpd-linux-amd64.tar.gz` and
     `rustbgpd-linux-arm64.tar.gz` plus per-arch `checksums-<arch>.txt`.
-    Each tarball contains `rustbgpd`, `rbgp`, `LICENSE-MIT`, and
-    `LICENSE-APACHE` (license presence is asserted by the workflow;
-    the runtime image likewise ships both licenses at `/`).
+    Each tarball contains `rustbgpd`, `rbgp`, `rs-config-render`,
+    `LICENSE-MIT`, and `LICENSE-APACHE` (binary and license presence
+    is asserted by the workflow; the runtime image likewise ships both
+    licenses at `/`).
     The version-less filenames are what powers the static
     `releases/latest/download/` URLs in `docs/deployment.md`; if the
     filenames drift, deployment.md silently breaks for new operators.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,11 +38,12 @@ note.
 Tagged releases publish `rustbgpd-linux-amd64.tar.gz` and
 `rustbgpd-linux-arm64.tar.gz` under
 [GitHub Releases](https://github.com/lance0/rustbgpd/releases). Each
-ships `rustbgpd` (the daemon) and `rbgp` (the CLI), plus man pages
+ships `rustbgpd` (the daemon), `rbgp` (the CLI), and
+`rs-config-render` (the route-server config renderer), plus man pages
 and shell completions under `share/`:
 
 ```
-rustbgpd, rbgp                          binaries
+rustbgpd, rbgp, rs-config-render        binaries
 LICENSE-MIT, LICENSE-APACHE             licenses
 rustbgpd.schema.json                    config JSON Schema
 share/man/man1/rbgp.1                   CLI man page

--- a/tools/rs-config-render/README.md
+++ b/tools/rs-config-render/README.md
@@ -21,6 +21,11 @@ $ rustbgpd --check /var/lib/rs/candidate/config.toml
 
 [arouteserver]: https://github.com/pierky/arouteserver
 
+Release tarballs (`rustbgpd-<arch>.tar.gz` on the [releases
+page](https://github.com/lance0/rustbgpd/releases)) ship the
+`rs-config-render` binary alongside `rustbgpd` and `rbgp`; from
+source, `cargo build --release -p rs-config-render`.
+
 The end-to-end operator walkthrough — arouteserver through the
 Alice-LG looking glass — is
 [`docs/cookbook/ixp-filter-pipeline.md`](../../docs/cookbook/ixp-filter-pipeline.md).


### PR DESCRIPTION
The v0.60.0 release tarballs contain `rustbgpd` and `rbgp` but not
`rs-config-render` — the route-server config renderer that the
arouteserver adoption path depends on. The release workflow already
builds it (`cargo build --workspace --release`); it was just never
staged into the tarball.

- Stage `rs-config-render` into `rustbgpd-<arch>.tar.gz` alongside
  `rustbgpd` and `rbgp` on both matrix legs.
- Extend the SIGPIPE-safe tarball content assertion (single `tar -tzf`
  capture, grep against the captured text — pattern preserved) to check
  all three binaries for presence and non-emptiness, so a missing
  binary fails the build instead of shipping silently.
- No man pages or completions for the renderer: the tool does not
  generate any.
- Sync the tarball-content claims in `docs/deployment.md` and
  `docs/RELEASE_CHECKLIST.md`, note tarball availability in the tool
  README, and add a CHANGELOG `[Unreleased]` entry.

Verified locally: `cargo build --release -p rs-config-render` produces
`target/release/rs-config-render`; the exact staging + assertion
script was dry-run against a locally assembled tarball (passes, and
fails when the binary is omitted); `bash -n` on every `run:` block;
YAML parses. The Actions workflow itself only runs on a tag push, so
it could not be exercised end to end.