### PR TITLE
fix(release): reflow blockquotes without inlining continuation markers

### DIFF
--- a/scripts/fixtures/release-notes/blockquote-preamble.expected.md
+++ b/scripts/fixtures/release-notes/blockquote-preamble.expected.md
@@ -1,0 +1,6 @@
+
+> **Release framing — why this is v0.60.0.** This release marks the route-server stabilization line, a deliberate milestone jump from v0.51.0. Every finding from an external release review is closed and the flagship receipts are re-validated at this tip (reload stall p50 0.44–0.92 s, completion 1.50–2.12 s at 700 clients × 400,400 routes). A differential interop lab drives BIRD 2 (configured by real arouteserver 1.23.2) and rustbgpd (configured by `rs-config-render` from the same site data) to 65/65 identical accept/reject verdicts, and the renderer now ingests real `template-context` output directly. RFC 1997 and RFC 7606 semantics are complete, the update-group performance arc lands end to end, jemalloc becomes the default allocator, and the `rustbgpd-wire` 0.15.0 / `rustbgpd-fsm` 0.3.0 breaking cut ships in one release.
+
+### Highlights
+
+**Route-server correctness and policy**

--- a/scripts/fixtures/release-notes/blockquote-preamble.in.md
+++ b/scripts/fixtures/release-notes/blockquote-preamble.in.md
@@ -1,0 +1,18 @@
+
+> **Release framing — why this is v0.60.0.** This release marks the
+> route-server stabilization line, a deliberate milestone jump from
+> v0.51.0. Every finding from an external release review is closed and
+> the flagship receipts are re-validated at this tip (reload stall
+> p50 0.44–0.92 s, completion 1.50–2.12 s at 700 clients × 400,400
+> routes). A differential interop lab drives BIRD 2 (configured by real
+> arouteserver 1.23.2) and rustbgpd (configured by `rs-config-render`
+> from the same site data) to 65/65 identical accept/reject verdicts,
+> and the renderer now ingests real `template-context` output directly.
+> RFC 1997 and RFC 7606 semantics are complete, the update-group
+> performance arc lands end to end, jemalloc becomes the default
+> allocator, and the `rustbgpd-wire` 0.15.0 / `rustbgpd-fsm` 0.3.0
+> breaking cut ships in one release.
+
+### Highlights
+
+**Route-server correctness and policy**

--- a/scripts/fixtures/release-notes/edge-cases.expected.md
+++ b/scripts/fixtures/release-notes/edge-cases.expected.md
@@ -18,6 +18,16 @@ enforcement = "legacy"
 roles = { admin = "spki-sha256:..." }
 ```
 
+> A hard-wrapped blockquote paragraph whose continuation lines must join into one line with a single leading marker, not literal `>` characters mid-sentence.
+>
+> A second blockquote paragraph, separated by the blank `>` line above, that stays its own paragraph.
+
+> A blockquote immediately before a heading.
+
+### After the quote
+
+- A bullet right after a blockquote section, unaffected by it.
+
 A small table whose rows must stay verbatim (never joined):
 
 | Field | Meaning |

--- a/scripts/fixtures/release-notes/edge-cases.in.md
+++ b/scripts/fixtures/release-notes/edge-cases.in.md
@@ -24,6 +24,19 @@ enforcement = "legacy"
 roles = { admin = "spki-sha256:..." }
 ```
 
+> A hard-wrapped blockquote paragraph whose continuation lines must
+> join into one line with a single leading marker, not literal `>`
+> characters mid-sentence.
+>
+> A second blockquote paragraph, separated by the blank `>` line above,
+> that stays its own paragraph.
+
+> A blockquote immediately before a heading.
+
+### After the quote
+
+- A bullet right after a blockquote section, unaffected by it.
+
 A small table whose rows must stay verbatim (never joined):
 
 | Field | Meaning |

--- a/scripts/reflow-release-notes.py
+++ b/scripts/reflow-release-notes.py
@@ -17,6 +17,9 @@ preserving everything that carries meaning across line breaks:
   - fenced code blocks (``` ``` ``` / ``~~~``), every line verbatim;
   - table rows (lines starting with ``|``), verbatim;
   - list-item boundaries, including nested bullets (indentation preserved);
+  - blockquote paragraphs: consecutive ``> `` lines at the same nesting
+    depth join into one line with a single leading marker (inner ``> ``
+    stripped); a blank ``>`` line separates quote paragraphs;
   - joining ONLY continuation lines within the same paragraph / list item.
 
 It does not touch `CHANGELOG.md`; it runs at publish time on the already
@@ -40,6 +43,10 @@ LIST_ITEM = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+\S")
 HEADING = re.compile(r"^#{1,6}\s")
 TABLE_ROW = re.compile(r"^\s*\|")
 FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
+# A blockquote prefix: one or more `>` markers, each with an optional space
+# (`> `, `>`, `> > `). Nesting depth = number of `>` in the prefix; only
+# same-depth lines join, so nested quotes never merge into their parent.
+BLOCKQUOTE = re.compile(r"^\s*((?:>\s?)+)")
 
 
 def reflow(text: str) -> str:
@@ -47,12 +54,14 @@ def reflow(text: str) -> str:
     lines = text.split("\n")
     out: list[str] = []
     buf: str | None = None  # current logical (joined) line being built
+    buf_quote_depth = 0  # blockquote nesting depth of `buf` (0 = not a quote)
 
     def flush() -> None:
-        nonlocal buf
+        nonlocal buf, buf_quote_depth
         if buf is not None:
             out.append(buf)
             buf = None
+        buf_quote_depth = 0
 
     in_fence = False
     fence_token = ""
@@ -87,6 +96,25 @@ def reflow(text: str) -> str:
         if HEADING.match(line) or TABLE_ROW.match(line):
             flush()
             out.append(line)
+            continue
+
+        quote = BLOCKQUOTE.match(line)
+        if quote:
+            depth = quote.group(1).count(">")
+            content = line[quote.end() :].strip()
+            if not content:
+                # A blank `>` line separates blockquote paragraphs; verbatim.
+                flush()
+                out.append(line.rstrip())
+                continue
+            if buf is not None and buf_quote_depth == depth:
+                # Continuation of the same blockquote paragraph: join with the
+                # inner `> ` marker stripped.
+                buf = f"{buf} {content}"
+            else:
+                flush()
+                buf = line.rstrip()
+                buf_quote_depth = depth
             continue
 
         if LIST_ITEM.match(line):


### PR DESCRIPTION
## Problem

`scripts/reflow-release-notes.py` treated hard-wrapped blockquote lines (`> ...`) as plain continuation lines, joining them with the inner `> ` markers left inline. The v0.60.0 release body rendered literal `>` characters mid-sentence in the release-framing preamble and had to be hand-fixed on the release page.

## Fix

- Consecutive `> `-prefixed lines at the same nesting depth join into a single line with one leading marker, continuation prefixes stripped.
- A blank `>` line (or any non-quote line) separates blockquote paragraphs.
- Nested quotes (`> >`) only join at matching depth, so they never merge into their parent.

## Tests

- `edge-cases` fixture extended: joined blockquote paragraph, two paragraphs separated by a blank `>` line, blockquote adjacent to heading/list.
- New `blockquote-preamble` fixture: the exact v0.60.0 preamble shape as a regression case.
- `python3 scripts/reflow-release-notes.py --selftest` passes (3/3 fixtures).
- Ran the real `CHANGELOG.md` `[0.60.0]` extract (release.yml awk) through the fixed script: the preamble emerges as one clean `> ` line with no inline markers.